### PR TITLE
docs: add SECURITY/CONTRIBUTING/CHANGELOG/LICENSE + renumber ADR 0011

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to OpenDray v2 are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- LICENSE file (Apache 2.0) — previously declared in README only.
+- SECURITY.md — threat model, default posture, deployment checklist, report channel.
+- CONTRIBUTING.md — dev setup, test commands, PR + commit conventions.
+- CHANGELOG.md — this file.
+
+### Changed
+- Renumbered ADR `0011-memory-subsystem.md` → `0014-memory-subsystem.md` to
+  resolve the duplicate-0011 collision with `0011-channel-rich-content-and-bridge.md`.
+  Updated cross-references in README, ADR 0013, and the embed-onnx stub.
+
+## [v1.0-rc] — 2026-05-05
+
+Feature-complete release candidate. v1 (`Opendray/opendray`) keeps running
+in production; switchover happens after v1.0 ships.
+
+### Added (since the greenfield start)
+
+- **M0 — composition root:** `internal/app/`, config loader (`internal/config/`),
+  pgx pool + hand-rolled migration runner (`internal/store/`), event bus
+  (`internal/eventbus/`), structured logging via slog.
+- **M1 — sessions:** PTY lifecycle, ring-buffer streaming, WS handler,
+  resume-via-reconnect (per ADR 0003).
+- **M2 — CLI catalog:** provider manifests + per-id user config
+  (`internal/catalog/`).
+- **M2.5 — admin auth:** bearer tokens with constant-time password compare
+  and 24h TTL (`internal/auth/`).
+- **M3 — integrations:** external-app registry, `/api/v1/proxy/{prefix}/*`
+  reverse proxy, integration call log (`internal/integration/`, ADR 0006,
+  ADR 0010).
+- **M4 — channels:** channel hub + Telegram, Slack, Discord, DingTalk,
+  Feishu, WeChat, WeCom (`internal/channel/`, ADR 0005, ADR 0011-channel).
+- **Memory:** built-in pgvector cross-CLI memory layer
+  (`internal/memory/`, ADR 0014). Three-CLI mirror keeps Claude / Codex /
+  Gemini transcripts aligned. ONNX local-embedding optional via
+  `-tags local_onnx`.
+- **Ambient memory:** auto-capture from active sessions + auto-injection
+  on session start (ADR 0013).
+- **Backup + export:** AES-256-GCM encrypted PostgreSQL dumps,
+  S3/WebDAV/SFTP/rclone targets, admin export/import bundles
+  (`internal/backup/`, ADR 0012).
+- **Web admin (W0–W5):** React 19 + Vite + Tailwind v4 + shadcn/ui +
+  TanStack Router/Query + Zustand + xterm.js. Single SPA bundled into
+  the Go binary via `go:embed` (ADR 0007, ADR 0008).
+- **Events stream:** admin-bearer-authed `/api/v1/integrations/_events`
+  WebSocket (ADR 0009).
+
+### Deferred to post-v1.0
+
+- Mobile (Flutter) client — replaced by responsive web in v2 phase 2.
+- Slack inbound (M5+).
+- Deploy automation (release toolchain — goreleaser, Dockerfile,
+  systemd unit) lands in a follow-up PR.
+- e2e Playwright harness.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing to OpenDray v2
+
+Thanks for your interest. v2 is in `v1.0-rc`; the cutover from
+[Opendray/opendray](https://github.com/Opendray/opendray) (v1) happens after
+this release ships.
+
+## Prerequisites
+
+| Tool | Version | Purpose |
+|---|---|---|
+| Go | 1.25+ | Backend + embedded web bundle |
+| pnpm | 10+ | Web SPA build (`app/web/`) |
+| Node.js | 22+ | pnpm runtime (build only — not needed at deploy) |
+| PostgreSQL | 15+ | Required at runtime; v2 has no bundled mode |
+
+## Development Setup
+
+```bash
+git clone https://github.com/Opendray/opendray_v2.git
+cd opendray_v2
+
+# 1. Postgres reachable; credentials in your secret manager.
+cp config.example.toml config.toml
+$EDITOR config.toml         # set [database].url, [admin].password
+
+# 2. Build the web bundle so the Go binary has something to embed.
+cd app/web && pnpm install && pnpm build && cd ../..
+
+# 3. Apply the schema.
+go run ./cmd/opendray migrate -config config.toml
+
+# 4. Run.
+go run ./cmd/opendray serve -config config.toml
+# REST + WS:  http://127.0.0.1:8770/api/v1/...
+# Web admin:  http://127.0.0.1:8770/admin/
+```
+
+For HMR-driven frontend work, run the Vite dev server alongside:
+
+```bash
+cd app/web && pnpm dev          # http://localhost:5173 (proxies /api to :8770)
+go run ./cmd/opendray serve -config ../../config.toml   # in another terminal
+```
+
+## Project Structure
+
+See [`README.md`](README.md) for the layout. Subsystem responsibilities are
+described in [`docs/design.md`](docs/design.md); every binding decision lives
+in [`docs/adr/`](docs/adr/).
+
+## Tests
+
+```bash
+go test -race ./...                       # backend
+cd app/web && pnpm build                  # web (TS strict + Vite prod build)
+```
+
+Some tests reach a real Postgres at `192.168.3.88` (home-lab convention).
+Set `OPENDRAY_DEV_DB_URL` to point at your own DB or let them skip.
+
+## Pull Request Process
+
+1. Fork or branch from `main`.
+2. Make focused changes — one PR, one concern.
+3. Run checks locally:
+   ```bash
+   go vet ./...
+   go test -race ./...
+   ```
+4. Open a pull request against `main`. Describe the change, link any related
+   ADR, and include a test plan.
+5. CI must pass before merge.
+
+### Commit messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `ci:`, `chore:`. Optional
+scope in parens: `feat(memory):`, `fix(backup):`.
+
+### Architecture changes
+
+Anything that crosses subsystem boundaries, changes a public API, or
+introduces a new external dependency needs an ADR in `docs/adr/`. Use the
+existing files as a template — short context, decision, consequences,
+optional code references.
+
+## Code Style
+
+- **Go:** Standard library style. `gofmt` is enforced. Wrap errors with
+  context using `fmt.Errorf("op: %w", err)`. Return new structs; never
+  mutate in place.
+- **TypeScript:** TS strict mode + the rules already enforced by the Vite +
+  ESLint setup in `app/web/`.
+
+## Reporting a security vulnerability
+
+See [`SECURITY.md`](SECURITY.md). Don't open a public issue.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+Apache License 2.0 ([`LICENSE`](LICENSE)).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a
+      fee for, acceptance of support, warranty, indemnity, or other
+      liability obligations and/or rights consistent with this License.
+      However, in accepting such obligations, You may act only on Your
+      own behalf and on Your sole responsibility, not on behalf of any
+      other Contributor, and only if You agree to indemnify, defend,
+      and hold each Contributor harmless for any liability incurred by,
+      or claims asserted against, such Contributor by reason of your
+      accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Linivek
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing permissions
+   and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ internal/
 ├── eventbus/        in-process pub/sub
 ├── gateway/         chi HTTP router + middleware + slog
 ├── integration/     external-app registry + reverse proxy + events WS (M3)
-├── memory/          cross-CLI persistent memory (ADR 0011)
+├── memory/          cross-CLI persistent memory (ADR 0014)
 ├── session/         PTY lifecycle + ring buffer + WS stream (M1)
 ├── store/           pgx pool + hand-rolled migration runner (M0)
 ├── version/         build-time identification
@@ -134,4 +134,5 @@ work in v2.
 
 ## License
 
-Apache 2.0 (carried over from v1).
+Apache 2.0 — see [`LICENSE`](LICENSE). v2 is licensed independently of v1
+(which is MIT).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+## Threat Model
+
+OpenDray spawns pseudo-terminal (PTY) sessions that run AI coding CLIs (Claude
+Code, Codex, Gemini, OpenCode, shell) **with the same privileges as the
+OpenDray process**. A PTY is root-equivalent for the user running the server.
+
+Concretely:
+
+- Any authenticated admin can execute arbitrary commands on the host.
+- The WebSocket terminal stream carries raw PTY I/O; intercepting it is
+  equivalent to a shell session hijack.
+- Integration API keys can proxy arbitrary HTTP traffic through OpenDray to
+  any registered upstream — operators choose what gets registered.
+
+**Always run OpenDray behind authentication.** It is not designed to be
+exposed to the public internet without a reverse proxy and TLS.
+
+## Default Security Posture
+
+| Setting | Default | Notes |
+|---|---|---|
+| `listen` | `127.0.0.1:8770` | Loopback only; safe for local dev. |
+| Admin auth | Bearer token, 24h TTL | Issued by `/api/v1/auth/login` against `[admin]` config. |
+| Admin password | Constant-time compared to plaintext value in config | Single-admin self-host model. Prefer `OPENDRAY_ADMIN_PASSWORD` env over committing to `config.toml`. |
+| Integration API keys | bcrypt-hashed in DB | One key per integration; revocable. |
+| Backup encryption | AES-256-GCM, PBKDF2-HMAC-SHA256, 200,000 iterations | Key derived from `OPENDRAY_BACKUP_KEY`; **must** live in env, never in config. |
+| WebSocket auth | Bearer token in query parameter | All WS endpoints require auth before any data flows. |
+| Database | External Postgres (no bundled mode) | Operator chooses TLS posture via `?sslmode=` in DSN. |
+
+When `[admin].password` is unset (and no env override), the server **rejects
+every login attempt** rather than booting with no auth.
+
+## Deployment Checklist
+
+1. **Reverse proxy.** Place OpenDray behind Cloudflare Tunnel, nginx, Caddy,
+   or Traefik. Terminate TLS at the proxy. Keep `listen = "127.0.0.1:8770"`.
+2. **Strong admin password.** ≥ 16 random characters. Prefer
+   `OPENDRAY_ADMIN_PASSWORD` env var over `config.toml`.
+3. **Backup key in env only.** Set `OPENDRAY_BACKUP_KEY` via the OS secret
+   manager, systemd `LoadCredential`, or Vault. Never commit it. Losing the
+   key makes encrypted backups unrecoverable.
+4. **Postgres SSL.** Use `sslmode=verify-full` with a non-localhost database.
+5. **Least privilege.** Run OpenDray as a dedicated unprivileged user.
+6. **Token TTL.** Keep `[admin].token_ttl ≤ 24h`. Rotate on compromise via
+   server restart (active tokens are invalidated).
+7. **Cloudflare Tunnel binding.** Bind to `127.0.0.1`, not `0.0.0.0` —
+   `middleware.RealIP` trusts `X-Forwarded-For`, which is spoofable on a
+   public bind.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in OpenDray, please report it
+privately. Do **not** open a public GitHub issue.
+
+- **GitHub Security Advisories:** [Open a private advisory](https://github.com/Opendray/opendray_v2/security/advisories)
+- **Email:** security@opendray.dev
+
+We aim to acknowledge reports within 48 hours and ship fixes for critical
+issues within 7 days.
+
+## Supported Versions
+
+| Version | Supported |
+|---|---|
+| v1.0-rc onward | ✅ |
+| v1 (`Opendray/opendray`) | Maintenance only — security fixes for the cutover quarter, then archived per ADR 0001. |
+
+## CVE History
+
+None as of v1.0-rc.

--- a/docs/adr/0013-ambient-memory.md
+++ b/docs/adr/0013-ambient-memory.md
@@ -2,11 +2,11 @@
 
 **Status**: Accepted, 2026-05-05
 **Authors**: Linivek, Claude (planner + impl)
-**Builds on**: ADR 0011 (memory subsystem)
+**Builds on**: ADR 0014 (memory subsystem)
 
 ## Context
 
-ADR 0011 established opendray's persistent memory layer (pgvector
+ADR 0014 established opendray's persistent memory layer (pgvector
 + MCP bridge + 3-CLI mirror). It works perfectly for facts the
 user explicitly tells the model to remember — but in practice
 99% of "valuable durable context" surfaces in conversation

--- a/docs/adr/0014-memory-subsystem.md
+++ b/docs/adr/0014-memory-subsystem.md
@@ -1,4 +1,4 @@
-# ADR 0011 — Built-in cross-CLI memory subsystem
+# ADR 0014 — Built-in cross-CLI memory subsystem
 
 **Status**: Accepted (phase 1 + phase 2 step 1 shipped)
 **Date**: 2026-05-04

--- a/internal/memory/embedder_onnx_stub.go
+++ b/internal/memory/embedder_onnx_stub.go
@@ -32,7 +32,7 @@ func NewLocalONNXEmbedder(_ LocalONNXConfig) (*LocalONNXEmbedder, error) {
 	return nil, errors.New(
 		"memory: LocalONNX embedder not compiled into this binary. " +
 			"Rebuild with `-tags local_onnx` and provide CGO_LDFLAGS for onnxruntime + libtokenizers. " +
-			"See docs/adr/0011-memory-subsystem.md and the Memory tutorial for setup.",
+			"See docs/adr/0014-memory-subsystem.md and the Memory tutorial for setup.",
 	)
 }
 


### PR DESCRIPTION
## Summary

- New: `LICENSE`, `SECURITY.md`, `CONTRIBUTING.md`, `CHANGELOG.md`
- Renumber `docs/adr/0011-memory-subsystem.md` → `0014-memory-subsystem.md` (resolves the duplicate-0011 collision with `0011-channel-rich-content-and-bridge.md`)
- Fix README "License" section: v1 is MIT, so "carried over from v1" was inaccurate

## Why

GitHub community-health profile sits at 14%. README and SECURITY tab both expect a `LICENSE` file but none was committed. ADR 0011 collides between `channel-rich-content-and-bridge` (dated 2026-05-03) and `memory-subsystem` (dated 2026-05-04), and downstream cross-references (`README.md:73`, `docs/adr/0013-ambient-memory.md`, `internal/memory/embedder_onnx_stub.go:35`) variously meant *one or the other* — actively confusing.

## Files

| File | Change |
|---|---|
| `LICENSE` | Apache 2.0 standard text. README claims this license; this PR makes it real. |
| `SECURITY.md` | Threat model (PTY = root-equivalent for the running user, admin auth is plaintext-compared per `internal/auth/auth.go:82-83`, integration API keys are bcrypt-hashed but admin password is not), default posture table, deployment checklist (Cloudflare Tunnel + 127.0.0.1 binding warning re `middleware.RealIP`), responsible-disclosure channel pointing at Security Advisories. |
| `CONTRIBUTING.md` | Dev setup matching the README's quickstart, test commands, Conventional Commits convention, "architecture changes need an ADR" rule. |
| `CHANGELOG.md` | Keep-a-Changelog format. `[Unreleased]` covers this PR. `[v1.0-rc]` backfills the M0–M4 + memory + backup + web milestones already on main, with ADR cross-references. |
| `docs/adr/0011-memory-subsystem.md` → `0014-memory-subsystem.md` | Renamed via `git mv` (rename detection should keep history). `# ADR 0011` header bumped to `# ADR 0014`. |
| `docs/adr/0013-ambient-memory.md` | "Builds on: ADR 0011 (memory subsystem)" → "ADR 0014 (memory subsystem)". |
| `README.md` | "(ADR 0011)" reference for memory → "(ADR 0014)". License section reworded. |
| `internal/memory/embedder_onnx_stub.go:35` | Filename in the error message updated from `0011-memory-subsystem.md` to `0014-memory-subsystem.md`. |

## Notes

- `docs/design.md:335` still references "ADR 0011" — that one correctly refers to the **channel** ADR (the surviving 0011), not memory. Left as-is.
- Memory subsystem becomes 0014 (not 0013) so the existing 0013 (ambient-memory) doesn't have to renumber. Dependency order is documented in each ADR's `Builds on:` line, not implied by number.
- `SECURITY.md` calls out the plaintext admin-password compare in the default-posture table. That's by design for a single-admin self-host but worth being explicit so operators aren't surprised when they audit the auth flow. Tightening that auth (bcrypt-at-startup) is a follow-up PR.

## Risk

🟢 Zero code risk — the only `.go` change is a filename literal in an error message string. Apache 2.0 license file is the standard text from apache.org. ADR rename uses `git mv` so blame survives.

## Test plan

- [ ] `LICENSE` renders correctly on the GitHub repo home page
- [ ] Community-health percentage moves from 14% → ≥80%
- [ ] No broken markdown links in `SECURITY.md` / `CONTRIBUTING.md` / `CHANGELOG.md` (just internal repo refs)
- [ ] `grep -rn "ADR 0011" --include="*.md"` returns only the channel ADR's own header + the legitimate `docs/design.md:335` reference
- [ ] `go build ./...` still passes (only one Go file touched, just an error-message string)