### PR TITLE
ci: add minimal CI workflow (frontend build + go vet/test/build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# Cancel an in-flight run when a newer commit is pushed to the same
+# ref. Avoids burning runner minutes on superseded commits.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Frontend (web)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: app/web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: app/web
+
+      - name: Type-check + build
+        run: pnpm build
+        working-directory: app/web
+
+      # Hand the built bundle to the backend job so `go:embed` finds it.
+      - uses: actions/upload-artifact@v5
+        with:
+          name: web-dist
+          path: internal/web/dist
+          retention-days: 1
+          if-no-files-found: error
+
+  backend:
+    name: Backend (Go)
+    needs: frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/download-artifact@v5
+        with:
+          name: web-dist
+          path: internal/web/dist
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+
+      - run: go vet ./...
+
+      # DB-touching tests in internal/memory/summarizer/ skip cleanly
+      # when OPENDRAY_DEV_DB_URL is unset (CI default). A follow-up PR
+      # will add a Postgres service + migration step so they can run
+      # in CI; for now the local `docker-compose.test.yml` flow is the
+      # authoritative path for those tests.
+      - name: go test -race
+        # 5m hard cap. Without this a hung test would burn the
+        # GitHub Actions 6h default before failing.
+        run: go test -race -timeout=5m -coverprofile=coverage.out ./...
+
+      - name: go build
+        run: go build -o /dev/null ./cmd/opendray


### PR DESCRIPTION
## Summary

Adds the first `.github/workflows/ci.yml` to opendray_v2.

The repo has shipped 46 commits straight to main with no automated gate beyond the README's instruction. This is the smallest useful CI: every PR + every push to main now goes through `pnpm build` (TS strict + Vite prod bundle), `go vet`, `go test -race`, and `go build`.

## Jobs

### Frontend (web)
- pnpm 10 + Node 22 (matches the CONTRIBUTING.md prereqs from PR #1)
- `pnpm install --frozen-lockfile` — catches lockfile drift
- `pnpm build` (= `tsc -b && vite build` per `app/web/package.json`)
- Uploads `internal/web/dist` as the `web-dist` artifact
- `if-no-files-found: error` — fails the job if the build produced nothing, catching the empty-`dist` footgun (the `go:embed` fallback at `internal/web/embed.go:38-53` would otherwise silently serve a 503)

### Backend (Go)
- `needs: frontend` so `go:embed all:dist` resolves
- Downloads the `web-dist` artifact in place at `internal/web/dist`
- `go 1.25` (matches the `go.mod` toolchain directive)
- `go vet ./...`
- `go test -race -coverprofile=coverage.out ./...`
- `go build -o /dev/null ./cmd/opendray` — build smoke

## Permissions

`contents: read` at the workflow level. No secret access. The workflow only validates the tree; nothing writes to the repo.

## Action versions

Pinned to majors that ship Node 24:

- `actions/checkout@v5`, `actions/setup-go@v6`, `actions/upload-artifact@v5`, `actions/download-artifact@v5`, `actions/setup-node@v4`, `pnpm/action-setup@v4`.

This avoids the deprecation warning GitHub will start enforcing on 2026-06-02.

## Notes for follow-ups (intentionally not in this PR)

| Concern | Plan |
|---|---|
| `golangci-lint` | Planned PR #C, stacks on this. Kept separate so the initial CI signal is "vet + tests pass" rather than "vet + tests + 275 pre-existing lint findings". |
| CodeQL | Needs Advanced Security on private repos (paid). Defer until repo flips public. |
| Dev-DB test (`internal/memory/summarizer/store_test.go:14`) | Falls back to a homelab IP when `OPENDRAY_DEV_DB_URL` is unset; CI ping fails and the test `t.Skipf`s. Slow (~30s timeout) but not a CI blocker. Planned PR #E replaces the fallback with `t.Skip` when env unset. |
| Branch protection requiring this check | Needs Pro/Team plan on a private repo. Once enabled, add `Frontend (web)` + `Backend (Go)` to required status checks on `main`. |

## Test plan

- [ ] CI runs and finishes (whether green or red)
- [ ] If green: confirm both jobs ran
- [ ] If red: triage the failure — most likely the dev-DB test timeout if it's >5min, otherwise a real regression worth investigating
- [ ] After merge: run a no-op PR (rebase / whitespace) to confirm CI fires on `pull_request`

## Risk

🟢 Low. YAML only; no Go or TS changes. GitHub validates the workflow syntax on push. Worst case: workflow has a typo and never runs (no impact on the existing process).