### PR TITLE
ci: add golangci-lint with minimal standard config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    name: Frontend (web)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: app/web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: app/web
+
+      - name: Type-check + build
+        run: pnpm build
+        working-directory: app/web
+
+      # Hand the built bundle to the backend job so `go:embed` finds it.
+      - uses: actions/upload-artifact@v5
+        with:
+          name: web-dist
+          path: internal/web/dist
+          retention-days: 1
+          if-no-files-found: error
+
+  backend:
+    name: Backend (Go)
+    needs: frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/download-artifact@v5
+        with:
+          name: web-dist
+          path: internal/web/dist
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+
+      - run: go vet ./...
+
+      - name: go test -race
+        run: go test -race -coverprofile=coverage.out ./...
+
+      - name: go build
+        run: go build -o /dev/null ./cmd/opendray

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,25 @@ jobs:
 
       - name: go build
         run: go build -o /dev/null ./cmd/opendray
+
+  lint:
+    name: Lint (Go)
+    # Lint runs the typecheck pass too, so it needs the embed tree
+    # populated — same dependency on the frontend artifact as Backend.
+    needs: frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/download-artifact@v5
+        with:
+          name: web-dist
+          path: internal/web/dist
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+
+      - uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,17 @@
+version: "2"
+
+run:
+  timeout: 5m
+  go: "1.25"
+
+linters:
+  default: standard
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0


### PR DESCRIPTION
**Stacked on #2.** Base will auto-rebase to `main` after #2 merges.

## Summary

- New `.golangci.yml` (v2 schema) with the canonical "standard" linter set + gofmt/goimports formatters.
- New `Lint (Go)` job in `ci.yml`, mirroring Backend (Go)'s frontend-artifact dependency so the typecheck pass actually runs.

## Why

The audit flagged that this v1.0-rc has zero static-lint enforcement: `go vet` is the only check today and there's no `.golangci.yml`. Standard linters catch a strictly larger surface (unused vars, error-check holes, import drift) for very little ongoing maintenance.

Combined with the ~14 packages that have zero unit tests (audit finding), static lint is defense-in-depth where coverage is thin.

## Config

```yaml
version: "2"

run:
  timeout: 5m
  go: "1.25"

linters:
  default: standard

formatters:
  enable:
    - gofmt
    - goimports
```

The v2 `default: standard` enables: `errcheck`, `govet`, `ineffassign`, `staticcheck`, `unused`. (`gosimple` from v1 was folded into `staticcheck` in v2.) `gofmt` and `goimports` moved to the separate `formatters` block in the v2 schema.

Kept intentionally minimal — no `gocyclo`, `revive`, `gosec`, or naming linters. Easier to start green and add rules deliberately than to drown in findings on day one.

## Job dependency

The Lint (Go) job needs `internal/web/dist` populated for the same reason the Backend (Go) job does: the typecheck pass that golangci-lint runs has to resolve `internal/web/embed.go`'s `//go:embed all:dist`. Without the Vite build artifact, typecheck fails before any actual linter runs (this is exactly the issue I hit on the v1 equivalent of this PR).

So:

```yaml
lint:
  needs: frontend
  steps:
    - actions/checkout@v5
    - actions/download-artifact@v5  # web-dist
    - actions/setup-go@v6
    - golangci/golangci-lint-action@v8
```

## Test plan

- [ ] CI green on Lint (Go) — standard linters pass on the current tree
- [ ] If CI red on Lint (Go): triage findings. This PR is intentionally non-blocking until that backlog is cleared (Lint (Go) is *not* in any required-status-checks list yet).
- [ ] After both this and #2 land + Lint (Go) is green: promote to a required check via branch protection (needs Pro/Team plan on private repo).

## Risk

🟢 Low. YAML + a small TOML/YAML config file. Doesn't block any other check; if the linter finds problems it surfaces them as job output. CI will validate the workflow syntax automatically.