### PR TITLE
chore: add release toolchain — goreleaser + Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,46 @@
+# What NOT to send to Docker build context.
+#
+# Speeds up `docker build` and avoids leaking dev artefacts into the
+# image (the .env / config.toml are gitignored anyway, doubly belt-and-
+# braces here).
+
+# Local secrets / config (also in .gitignore)
+config.toml
+.env
+.env.*
+!.env.example
+
+# IDE / OS noise
+.idea/
+.vscode/
+.DS_Store
+*.swp
+
+# Build outputs
+node_modules/
+app/web/node_modules/
+app/web/dist/
+internal/web/dist/
+dist/
+bin/
+out/
+
+# Test / coverage artefacts
+coverage.out
+*.test
+*.prof
+
+# Git internals — Docker doesn't need them
+.git/
+.gitignore
+.gitattributes
+
+# CI / docs that don't ship inside the image
+.github/
+docs/
+examples/
+
+# Editor / shell history
+.bash_history
+.zsh_history
+.history/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,70 @@
+# goreleaser config for opendray v2.
+#
+# Builds a single binary that already contains the React SPA via
+# go:embed. Pre-build hooks `pnpm install` + `pnpm build` so the embed
+# tree is populated before `go build` runs.
+#
+# `goreleaser release` is intended to run from CI on tag push; the
+# Release workflow that triggers it lives separately.
+version: 2
+
+project_name: opendray
+
+before:
+  hooks:
+    # `verify` reads go.sum without modifying any tracked files — safe
+    # to run on a release tag. `tidy` would rewrite go.mod/go.sum and
+    # surprise the build at the worst possible moment.
+    - go mod verify
+    # Build the web bundle so internal/web/dist/ is populated before
+    # the Go build embeds it. CI runs from a clean checkout so the
+    # dist tree is always rebuilt; this matches the README quickstart.
+    - sh -c 'cd app/web && pnpm install --frozen-lockfile'
+    - sh -c 'cd app/web && pnpm build'
+
+builds:
+  - id: opendray
+    main: ./cmd/opendray
+    binary: opendray
+    env:
+      - CGO_ENABLED=0
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/opendray/opendray-v2/internal/version.Version={{.Version}}
+      - -X github.com/opendray/opendray-v2/internal/version.Commit={{.ShortCommit}}
+      - -X github.com/opendray/opendray-v2/internal/version.Date={{.Date}}
+
+archives:
+  - id: default
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats: [tar.gz]
+    files:
+      - LICENSE
+      - README.md
+      - CHANGELOG.md
+      - config.example.toml
+
+checksum:
+  name_template: "SHA256SUMS"
+  algorithm: sha256
+
+snapshot:
+  version_template: "{{ .Tag }}-snapshot-{{ .ShortCommit }}"
+
+changelog:
+  # CHANGELOG.md is hand-curated per Keep-a-Changelog; goreleaser's
+  # auto-generated changelog would compete with it. Disable here so
+  # the release notes come exclusively from the tag annotation /
+  # Release notes field on GitHub.
+  disable: true
+
+release:
+  draft: true
+  prerelease: auto
+  name_template: "v{{ .Version }}"
+  header: |
+    See [CHANGELOG.md](https://github.com/Opendray/opendray_v2/blob/main/CHANGELOG.md) for the full release notes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+# Multi-stage build for opendray v2.
+#
+# Stage 1 builds the React SPA via pnpm.
+# Stage 2 builds the Go binary, embedding the SPA via go:embed.
+# Stage 3 is the runtime — distroless, non-root, single binary.
+#
+# Build:
+#   docker build -t opendray:dev .
+#
+# Run:
+#   docker run --rm -p 8770:8770 \
+#     -e OPENDRAY_DATABASE_URL='postgres://...' \
+#     -e OPENDRAY_ADMIN_PASSWORD='...' \
+#     -v /etc/opendray/config.toml:/etc/opendray/config.toml:ro \
+#     opendray:dev serve -config /etc/opendray/config.toml
+
+# ── Stage 1: web bundle ───────────────────────────────────────────────
+FROM node:22-alpine AS web
+
+# pnpm via corepack (ships with Node 22); pinned to v10 to match
+# CONTRIBUTING.md and the version action installs in CI.
+RUN corepack enable && corepack prepare pnpm@10 --activate
+
+WORKDIR /src
+
+# Cache deps independently of source changes.
+COPY app/web/package.json app/web/pnpm-lock.yaml ./app/web/
+RUN cd app/web && pnpm install --frozen-lockfile
+
+# Build the bundle. Output lands at internal/web/dist (vite.config.ts
+# writes there relative to app/web — internal/web/dist/ doesn't need
+# to be populated here, the gobuild stage copies it via --from=web).
+COPY app/web ./app/web
+RUN cd app/web && pnpm build
+
+# ── Stage 2: go binary ────────────────────────────────────────────────
+FROM golang:1.25-alpine AS gobuild
+
+WORKDIR /src
+
+# Cache modules independently of source.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Bring in the rest of the source plus the dist/ from stage 1.
+COPY . .
+COPY --from=web /src/internal/web/dist ./internal/web/dist
+
+ARG VERSION=0.0.0-docker
+ARG COMMIT=unknown
+ARG DATE=unknown
+
+RUN CGO_ENABLED=0 go build \
+    -trimpath \
+    -ldflags="-s -w \
+      -X github.com/opendray/opendray-v2/internal/version.Version=${VERSION} \
+      -X github.com/opendray/opendray-v2/internal/version.Commit=${COMMIT} \
+      -X github.com/opendray/opendray-v2/internal/version.Date=${DATE}" \
+    -o /out/opendray \
+    ./cmd/opendray
+
+# ── Stage 3: runtime ──────────────────────────────────────────────────
+# Distroless static-debian12 ships /etc/passwd with `nonroot:65532` and
+# nothing else — no shell, no package manager, minimal CVE surface.
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=gobuild /out/opendray /usr/local/bin/opendray
+
+USER nonroot:nonroot
+EXPOSE 8770
+
+# Default to `serve`; operator overrides via `docker run … <subcommand>`.
+ENTRYPOINT ["/usr/local/bin/opendray"]
+CMD ["serve"]


### PR DESCRIPTION
## Summary

- `.goreleaser.yml` — v2 schema, linux/darwin × amd64/arm64, version-injection ldflags, archives include LICENSE + README + CHANGELOG + config.example
- `Dockerfile` — 3-stage build (Node-22 web → golang-1.25 binary → distroless/static:nonroot), runs as `nonroot:65532`, no shell
- `.dockerignore` — standard exclusions, prevents leaking dev state into the image

## What's NOT in this PR (intentional)

| | Why deferred |
|---|---|
| `.github/workflows/release.yml` | An automated release workflow without signing/SBOM ships unsigned binaries — worse than no automation. The signing layer (cosign + anchore SBOM) warrants its own PR with secrets configured. |
| GHCR auto-push on tag | Same reason — needs `packages: write` + signed images. `docker build` works locally today; automated push is a follow-up. |
| SLSA / provenance attestation | `goreleaser` supports it but enabling without org-level decisions on attestor identity is premature. |

This PR only adds the artefacts. After merge, an operator can:

```bash
# Validate the config
goreleaser check

# Full local snapshot release
goreleaser release --clean --snapshot

# Full Dockerfile build
docker build -t opendray:dev .
docker run --rm opendray:dev version
```

…all without any new automation firing.

## File-by-file

### `.goreleaser.yml`

- **Version pin**: `version: 2` (current goreleaser major).
- **Targets**: `linux × {amd64, arm64}` and `darwin × {amd64, arm64}`. No Windows — `creack/pty` doesn't support ConPTY (same constraint as v1).
- **Pre-build hooks**: `pnpm install --frozen-lockfile` then `pnpm build` so `internal/web/dist` is populated before the Go build embeds it. Mirrors the dependency from the CI workflow in #2/#3.
- **Build flags**: `CGO_ENABLED=0` (the ONNX integration is `-tags local_onnx`, deliberately opt-in), `-trimpath`, `-s -w`.
- **Version injection**: `-X github.com/opendray/opendray-v2/internal/version.{Version,Commit,Date}=…` so `opendray version` matches the git tag. Confirmed against `internal/version/version.go` which exposes those exact symbol names.
- **Archives**: bundle `LICENSE`, `README.md`, `CHANGELOG.md`, `config.example.toml` alongside the binary.
- **Release**: `draft: true` + `prerelease: auto` so a human flips publish after eyeballing notes. `changelog.disable: true` because `CHANGELOG.md` is hand-curated per Keep-a-Changelog (added in #1) — auto-generated would compete with it.

### `Dockerfile`

3 stages, named:

1. **`web`** — `node:22-alpine`, corepack-pinned `pnpm@10` (matches `CONTRIBUTING.md` from #1 + the CI workflow). Layered: deps first (cache friendly), source second.
2. **`gobuild`** — `golang:1.25-alpine`. Pulls the `web` stage's `dist/` via `COPY --from=web` so `go:embed all:dist` resolves. Build args (`VERSION`/`COMMIT`/`DATE`) so the same Dockerfile produces a properly-stamped image whether invoked by `goreleaser ko` or a manual `docker build`.
3. **runtime** — `gcr.io/distroless/static-debian12:nonroot`. No shell, no package manager, single binary, runs as `nonroot:65532`. `ENTRYPOINT` is the binary, `CMD` defaults to `serve`.

`EXPOSE 8770` matches `config.example.toml`'s default `listen`.

### `.dockerignore`

- Excludes `config.toml`, `.env*`, `node_modules/`, `dist/`, `bin/`, `coverage.out`, `.git/`, `.github/`, `docs/`, `examples/`.
- `app/web/node_modules/` and `internal/web/dist/` excluded — both regenerated inside the build.

## Test plan

- [ ] `goreleaser check` against the config — schema valid
- [ ] `goreleaser release --clean --snapshot` — produces archives in `dist/`
- [ ] `docker build -t opendray:dev .` — builds clean
- [ ] `docker run --rm opendray:dev version` — emits a version banner with the build args
- [ ] After merge: open a follow-up issue tracking the deferred items (release workflow, signing, GHCR push)

## Risk

🟡 Medium-low. No code changes; pure operator-facing config. Risk concentrates in:
- The Dockerfile builds correctly only if `app/web/pnpm-lock.yaml` and `go.sum` are committed and current — both are.
- `goreleaser` schema validation is the only "compile-time" gate without running it; if the config is invalid it'll fail on first tag push, not on this PR's CI.

I'd suggest running `goreleaser check` locally before merging just to confirm the config parses.