### PR TITLE
fix(security): drop hardcoded dev-DB credential, skip when env unset

### DIFF
--- a/internal/memory/summarizer/store_test.go
+++ b/internal/memory/summarizer/store_test.go
@@ -11,15 +11,19 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// devDB returns a pgxpool against the home-lab dev database, or
-// nil when OPENDRAY_DEV_DB_URL isn't set (tests will t.Skip).
+// devDB returns a pgxpool against the dev database addressed by the
+// OPENDRAY_DEV_DB_URL env var. Tests that depend on a real Postgres
+// skip cleanly when the env is unset (CI default) or when the DB is
+// unreachable.
+//
+// Set OPENDRAY_DEV_DB_URL to a writable Postgres DSN to run these
+// tests against your own database. The DSN must NOT be hard-coded
+// here — committed credentials are forever.
 func devDB(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	url := os.Getenv("OPENDRAY_DEV_DB_URL")
 	if url == "" {
-		// Default: same DSN as config.toml. CI / non-dev should
-		// skip these tests, but local dev usually has DB up.
-		url = "postgres://opd2_user:UGuZjQVFtXR3MtKJ6Q@192.168.3.88:5432/opendray_v2?sslmode=disable"
+		t.Skip("OPENDRAY_DEV_DB_URL not set; export a writable Postgres DSN to run this test")
 	}
 	pool, err := pgxpool.New(context.Background(), url)
 	if err != nil {


### PR DESCRIPTION
## Summary

`internal/memory/summarizer/store_test.go` fell back to a hardcoded DSN with a real home-lab credential when `OPENDRAY_DEV_DB_URL` was unset. This PR removes the fallback and `t.Skip`s up front.

## What this PR does

```diff
 func devDB(t *testing.T) *pgxpool.Pool {
     t.Helper()
     url := os.Getenv("OPENDRAY_DEV_DB_URL")
     if url == "" {
-        // Default: same DSN as config.toml. CI / non-dev should
-        // skip these tests, but local dev usually has DB up.
-        url = "postgres://opd2_user:UGuZjQVFtXR3MtKJ6Q@192.168.3.88:5432/opendray_v2?sslmode=disable"
+        t.Skip("OPENDRAY_DEV_DB_URL not set; export a writable Postgres DSN to run this test")
     }
     pool, err := pgxpool.New(context.Background(), url)
```

That's it for code changes. Comment block above the function rewritten so future authors don't repeat the pattern.

## Why three problems, not one

1. **Credential leak.** The fallback DSN was the actual home-lab `opd2_user` password. Repo is private today; on the day it flips public the password is already-leaked.
2. **CI speed.** Without the env var, CI would attempt the connection to the home-lab IP (`192.168.3.88`), time out (~30s), and only then skip. Per-test wasted build time on every CI run.
3. **Anti-pattern.** The "default to dev creds, skip on failure" shape encourages the same in future tests. Skipping up front when env unset is the right primitive.

## Operational follow-up — Linivek only, NOT in this PR

**Rotate `opd2_user` in the home-lab Postgres.** The leaked password is in git history forever; this PR removes it from `HEAD` but every clone made before the merge still has it. Rotation is the only real fix.

Suggested sequence:
1. Generate a new password for `opd2_user`.
2. `ALTER USER opd2_user WITH PASSWORD '…';` on the home-lab DB.
3. Update Vaultwarden item `homelab-db-opendray-v2`.
4. Update `OPENDRAY_DEV_DB_URL` (if exported in your dev shell rc) and any local `config.toml`.

## Scope check — IPs and DSNs across the package

The IP `192.168.3.88` appears in **other files** but only as fixture text in test assertions and sample prompts (the LLM is trained to recognise realistic-looking infra strings):

| File:line | Context |
|---|---|
| `internal/memory/capture/service_test.go:95,116` | Sample memory text |
| `internal/memory/summarizer/prompt_test.go:42,45` | Sample conversation turn |
| `internal/memory/summarizer/prompt.go:59,64` | Built-in prompt example |
| `internal/memory/injector/inject_test.go:77,94` | Sample injection test |
| `internal/memory/summarizer/provider_anthropic_test.go:67` | Sample provider response |

None of these contain credentials. They're test fixtures designed to look like real infra strings. Left as-is.

## Risk

🟢 Low. Removes code, doesn't add any. The only behaviour change is "test skips earlier and faster when env unset" — every CI without the env var was already skipping, just after a 30s timeout.

## Test plan

- [ ] CI green (the only test in this file path is now skipped without the env var)
- [ ] `OPENDRAY_DEV_DB_URL=postgres://… go test ./internal/memory/summarizer/... -run TestStore -race` — should pass against a real DB
- [ ] `go test ./internal/memory/summarizer/... -run TestStore -race` (no env) — should `--- SKIP` immediately, < 1s