### PR TITLE
chore(v1.0): GA hardening — pool cap, WS origin guard, smoke tests

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -12,6 +12,9 @@ listen = "127.0.0.1:8770"
 # For local development, `docker compose -f docker-compose.test.yml up -d`
 # starts a Postgres on 127.0.0.1:5432 matching this DSN.
 url = "postgres://opendray:opendray@127.0.0.1:5432/opendray?sslmode=disable"
+# Optional: cap the pgx connection pool. Empty / 0 = 16 (store default).
+# Bump for high-fanout integration traffic; trim on shared PG instances.
+# max_conns = 16
 
 [admin]
 # Admin auth (single human). Prefer env vars in production.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -80,7 +80,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	if err != nil {
 		return nil, err
 	}
-	st, err := store.Open(ctx, cfg.Database.URL)
+	st, err := store.Open(ctx, cfg.Database.URL, cfg.Database.MaxConns)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,102 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opendray/opendray-v2/internal/config"
+)
+
+// TestNew_FailsOnUnreachableDB verifies the composition root surfaces
+// a clear error when the Postgres URL points nowhere — and that it
+// does so quickly rather than hanging on retries.
+func TestNew_FailsOnUnreachableDB(t *testing.T) {
+	cfg := config.Config{
+		Listen: "127.0.0.1:0",
+		Database: config.DatabaseConfig{
+			URL: "postgres://x:y@127.0.0.1:1/db?sslmode=disable&connect_timeout=1",
+		},
+		Admin: config.AdminConfig{User: "admin", Password: "x"},
+		Log:   config.LogConfig{Level: "error", Format: "text"},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := New(ctx, cfg)
+	if err == nil {
+		t.Fatal("expected error for unreachable DB, got nil")
+	}
+	// New() should bail out at the store.Open step with a wrapped
+	// error mentioning the store layer — not panic, not block.
+	if !strings.Contains(err.Error(), "store:") {
+		t.Errorf("error should be wrapped with 'store:', got: %v", err)
+	}
+}
+
+func TestNewLogger_LevelParsing(t *testing.T) {
+	tests := []struct {
+		level   string
+		wantNil bool
+	}{
+		{"debug", false},
+		{"info", false},
+		{"warn", false},
+		{"error", false},
+		{"INFO", false},     // case-insensitive
+		{"unknown", false},  // falls back to info, no error
+		{"", false},         // default
+	}
+	for _, tc := range tests {
+		t.Run("level="+tc.level, func(t *testing.T) {
+			lg, ring, err := newLogger(config.LogConfig{
+				Level:  tc.level,
+				Format: "text",
+			})
+			if err != nil {
+				t.Fatalf("newLogger(%q): %v", tc.level, err)
+			}
+			if tc.wantNil {
+				if lg != nil {
+					t.Error("expected nil logger")
+				}
+				return
+			}
+			if lg == nil {
+				t.Error("logger nil")
+			}
+			if ring == nil {
+				t.Error("ring buffer nil")
+			}
+		})
+	}
+}
+
+func TestNewLogger_JSONFormat(t *testing.T) {
+	lg, ring, err := newLogger(config.LogConfig{
+		Level:  "info",
+		Format: "json",
+	})
+	if err != nil {
+		t.Fatalf("newLogger json: %v", err)
+	}
+	if lg == nil || ring == nil {
+		t.Error("logger or ring buffer nil")
+	}
+	// Don't assert on JSON output shape — that's slog's job. We
+	// only care that the JSON branch wires up without erroring.
+}
+
+func TestNewLogger_BadFilePath(t *testing.T) {
+	// A file path under a missing directory should surface a real
+	// error instead of silently returning a no-op writer.
+	_, _, err := newLogger(config.LogConfig{
+		Level: "info",
+		File:  "/nonexistent-dir-" + t.Name() + "/opendray.log",
+	})
+	if err == nil {
+		t.Error("expected error for unwritable log path, got nil")
+	}
+}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -45,9 +45,9 @@ func TestNewLogger_LevelParsing(t *testing.T) {
 		{"info", false},
 		{"warn", false},
 		{"error", false},
-		{"INFO", false},     // case-insensitive
-		{"unknown", false},  // falls back to info, no error
-		{"", false},         // default
+		{"INFO", false},    // case-insensitive
+		{"unknown", false}, // falls back to info, no error
+		{"", false},        // default
 	}
 	for _, tc := range tests {
 		t.Run("level="+tc.level, func(t *testing.T) {

--- a/internal/channel/bridge/handler.go
+++ b/internal/channel/bridge/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/opendray/opendray-v2/internal/channel"
+	"github.com/opendray/opendray-v2/internal/wsutil"
 )
 
 // Handlers wires the bridge WS endpoint into an admin-less router.
@@ -45,7 +46,7 @@ func NewHandlers(b *Broker, log *slog.Logger) *Handlers {
 			// Bridge adapters connect from outside the browser — origin
 			// checks would block legitimate use. The token in the
 			// register frame is the real auth.
-			CheckOrigin: func(*http.Request) bool { return true },
+			CheckOrigin: wsutil.AllowAnyOrigin(),
 		},
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -220,6 +221,10 @@ type VaultConfig struct {
 
 type DatabaseConfig struct {
 	URL string `toml:"url" json:"url"`
+	// MaxConns caps the pgx connection pool. Empty / 0 → store defaults
+	// (16). Tune up for high-fanout integration traffic; tune down on
+	// shared PG instances where opendray must not crowd out peers.
+	MaxConns int `toml:"max_conns" json:"max_conns"`
 }
 
 // BackupConfig drives the disaster-recovery backup + admin export
@@ -312,6 +317,11 @@ func applyEnv(cfg *Config) {
 	}
 	if v := os.Getenv("OPENDRAY_DATABASE_URL"); v != "" {
 		cfg.Database.URL = v
+	}
+	if v := os.Getenv("OPENDRAY_DATABASE_MAX_CONNS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Database.MaxConns = n
+		}
 	}
 	if v := os.Getenv("OPENDRAY_ADMIN_USER"); v != "" {
 		cfg.Admin.User = v

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,3 +57,73 @@ func TestLoad_MissingDatabaseURL(t *testing.T) {
 		t.Fatal("expected validation error for missing database url")
 	}
 }
+
+func TestLoad_DatabaseMaxConns(t *testing.T) {
+	t.Run("from toml", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.toml")
+		if err := os.WriteFile(path, []byte(`
+[database]
+url = "postgres://x:y@localhost/z"
+max_conns = 32
+
+[admin]
+user = "admin"
+password = "secret"
+`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got.Database.MaxConns != 32 {
+			t.Errorf("MaxConns = %d, want 32", got.Database.MaxConns)
+		}
+	})
+
+	t.Run("env override beats toml", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.toml")
+		if err := os.WriteFile(path, []byte(`
+[database]
+url = "postgres://x:y@localhost/z"
+max_conns = 8
+`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("OPENDRAY_DATABASE_MAX_CONNS", "64")
+		got, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got.Database.MaxConns != 64 {
+			t.Errorf("MaxConns = %d, want 64", got.Database.MaxConns)
+		}
+	})
+
+	t.Run("invalid env ignored", func(t *testing.T) {
+		t.Setenv("OPENDRAY_DATABASE_URL", "postgres://x")
+		t.Setenv("OPENDRAY_DATABASE_MAX_CONNS", "not-a-number")
+		got, err := Load("")
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got.Database.MaxConns != 0 {
+			t.Errorf("MaxConns = %d, want 0 (invalid env value should be ignored)",
+				got.Database.MaxConns)
+		}
+	})
+
+	t.Run("negative env ignored", func(t *testing.T) {
+		t.Setenv("OPENDRAY_DATABASE_URL", "postgres://x")
+		t.Setenv("OPENDRAY_DATABASE_MAX_CONNS", "-5")
+		got, err := Load("")
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got.Database.MaxConns != 0 {
+			t.Errorf("MaxConns = %d, want 0", got.Database.MaxConns)
+		}
+	})
+}

--- a/internal/githost/githost_test.go
+++ b/internal/githost/githost_test.go
@@ -1,0 +1,168 @@
+package githost
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func devDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	url := os.Getenv("OPENDRAY_DEV_DB_URL")
+	if url == "" {
+		url = "postgres://opd2_user:UGuZjQVFtXR3MtKJ6Q@192.168.3.88:5432/opendray_v2?sslmode=disable"
+	}
+	pool, err := pgxpool.New(context.Background(), url)
+	if err != nil {
+		t.Skipf("dev DB unreachable, skipping: %v", err)
+	}
+	if err := pool.Ping(context.Background()); err != nil {
+		t.Skipf("dev DB ping failed, skipping: %v", err)
+	}
+	return pool
+}
+
+// uniqHost generates a host string unique to this test run so parallel
+// CI matrix jobs / leftover rows from earlier failures don't collide
+// on the (host) UNIQUE constraint. PID disambiguates concurrent
+// processes; nanosecond timestamp disambiguates within a process.
+func uniqHost(prefix string) string {
+	return prefix + "-test-" +
+		strconv.Itoa(os.Getpid()) + "-" +
+		time.Now().Format("150405.000000000")
+}
+
+func TestService_CRUDFlow(t *testing.T) {
+	pool := devDB(t)
+	defer pool.Close()
+
+	svc := NewService(pool, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	host := uniqHost("github")
+	created, err := svc.Create(ctx, CreateRequest{
+		Kind:  KindGitHub,
+		Host:  host,
+		Name:  "test fixture",
+		Token: "ghp_smoke_test_token_value_long_enough",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = svc.Delete(context.Background(), created.ID)
+	})
+
+	if created.ID == "" {
+		t.Fatal("Create returned empty ID")
+	}
+	if created.Token != "" {
+		t.Errorf("Create response should redact token, got %q", created.Token)
+	}
+	// redact() formats as "•••• <last4>"; assert it doesn't leak the
+	// full token and ends with the last 4 chars of the input.
+	if strings.Contains(created.TokenMask, "smoke_test_token") {
+		t.Errorf("TokenMask leaks original token: %q", created.TokenMask)
+	}
+	if !strings.HasSuffix(created.TokenMask, "ough") {
+		t.Errorf("TokenMask should end with last4 of input, got %q",
+			created.TokenMask)
+	}
+
+	got, err := svc.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Host != host {
+		t.Errorf("Host = %q, want %q", got.Host, host)
+	}
+	if got.Token != "" {
+		t.Error("Get should redact token in response")
+	}
+
+	// GetByHost returns the unredacted token (used by upstream API calls).
+	withTok, err := svc.GetByHost(ctx, host)
+	if err != nil {
+		t.Fatalf("GetByHost: %v", err)
+	}
+	if withTok.Token == "" {
+		t.Error("GetByHost should return unredacted token")
+	}
+
+	all, err := svc.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	found := false
+	for _, h := range all {
+		if h.ID == created.ID {
+			found = true
+			if h.Token != "" {
+				t.Error("List should redact tokens")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("List did not include the created row %q", created.ID)
+	}
+
+	enabled := false
+	updated, err := svc.Update(ctx, created.ID, UpdateRequest{Enabled: &enabled})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Enabled {
+		t.Error("Update did not toggle Enabled to false")
+	}
+
+	if err := svc.Delete(ctx, created.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := svc.Get(ctx, created.ID); err == nil {
+		t.Error("Get after Delete should error")
+	}
+}
+
+func TestService_ValidationErrors(t *testing.T) {
+	pool := devDB(t)
+	defer pool.Close()
+	svc := NewService(pool, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	tests := []struct {
+		name string
+		req  CreateRequest
+	}{
+		{"missing host", CreateRequest{Kind: KindGitHub, Token: "tok"}},
+		{"missing token", CreateRequest{Kind: KindGitHub, Host: "x.example.com"}},
+		{"invalid kind", CreateRequest{Kind: "svn", Host: "x", Token: "t"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := svc.Create(ctx, tc.req); err == nil {
+				t.Error("expected validation error, got nil")
+			}
+		})
+	}
+}
+
+func TestService_GetMissing(t *testing.T) {
+	pool := devDB(t)
+	defer pool.Close()
+	svc := NewService(pool, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	_, err := svc.Get(ctx, "doesnotexist-xyz")
+	if err == nil {
+		t.Fatal("expected ErrNotFound for unknown id")
+	}
+}

--- a/internal/githost/githost_test.go
+++ b/internal/githost/githost_test.go
@@ -11,11 +11,15 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// devDB returns a pgxpool against the dev DB addressed by
+// OPENDRAY_DEV_DB_URL. Tests t.Skip when the env is unset (CI default)
+// or when the DB is unreachable. Never hardcode credentials — see
+// docs/quickstart.md for spinning up the bundled Postgres.
 func devDB(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	url := os.Getenv("OPENDRAY_DEV_DB_URL")
 	if url == "" {
-		url = "postgres://opd2_user:UGuZjQVFtXR3MtKJ6Q@192.168.3.88:5432/opendray_v2?sslmode=disable"
+		t.Skip("OPENDRAY_DEV_DB_URL not set; export a writable Postgres DSN to run this test")
 	}
 	pool, err := pgxpool.New(context.Background(), url)
 	if err != nil {

--- a/internal/integration/events.go
+++ b/internal/integration/events.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/opendray/opendray-v2/internal/eventbus"
+	"github.com/opendray/opendray-v2/internal/wsutil"
 )
 
 const (
@@ -33,7 +34,12 @@ func NewEventsHandler(bus *eventbus.Hub, log *slog.Logger) *EventsHandler {
 	return &EventsHandler{
 		bus:      bus,
 		log:      log.With("component", "integration.events"),
-		upgrader: websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
+		// Integration consumers may be server-to-server (no Origin
+		// header) or run from a browser-based admin tab. Auth is the
+		// bearer token in ?token=; routing this through wsutil
+		// documents the deliberate any-origin policy and gives a
+		// single grep target if we ever want to lock it down.
+		upgrader: websocket.Upgrader{CheckOrigin: wsutil.AllowAnyOrigin()},
 	}
 }
 

--- a/internal/integration/events.go
+++ b/internal/integration/events.go
@@ -32,8 +32,8 @@ func NewEventsHandler(bus *eventbus.Hub, log *slog.Logger) *EventsHandler {
 		log = slog.Default()
 	}
 	return &EventsHandler{
-		bus:      bus,
-		log:      log.With("component", "integration.events"),
+		bus: bus,
+		log: log.With("component", "integration.events"),
 		// Integration consumers may be server-to-server (no Origin
 		// header) or run from a browser-based admin tab. Auth is the
 		// bearer token in ?token=; routing this through wsutil

--- a/internal/session/handler.go
+++ b/internal/session/handler.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/gorilla/websocket"
+
+	"github.com/opendray/opendray-v2/internal/wsutil"
 )
 
 // Service is the session-manager surface used by HTTP handlers,
@@ -45,9 +47,12 @@ func NewHandlers(svc Service, log *slog.Logger) *Handlers {
 		svc: svc,
 		log: log.With("component", "session.http"),
 		upgrader: websocket.Upgrader{
-			// Same-origin / LAN client; admin auth runs at gateway
-			// middleware. M3 will tighten CheckOrigin alongside auth.
-			CheckOrigin: func(*http.Request) bool { return true },
+			// Admin SPA in the browser. Token is in the ?token= query
+			// (browsers can't set custom headers on WS handshake), so
+			// CSWSH is mitigated by also checking Origin: same-host or
+			// LAN private ranges only. Non-browser clients (mobile,
+			// curl) send no Origin and are admitted as before.
+			CheckOrigin: wsutil.SameOriginCheck(),
 		},
 	}
 }

--- a/internal/settings/handler.go
+++ b/internal/settings/handler.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/opendray/opendray-v2/internal/applog"
 	"github.com/opendray/opendray-v2/internal/config"
+	"github.com/opendray/opendray-v2/internal/wsutil"
 )
 
 // Handler exposes settings endpoints. Mount under an admin-only
@@ -40,7 +41,10 @@ func NewHandler(svc *Service, ring *applog.Buffer, log *slog.Logger) *Handler {
 		log:  log.With("component", "settings.http"),
 		ring: ring,
 		upgrader: websocket.Upgrader{
-			CheckOrigin: func(*http.Request) bool { return true },
+			// Admin-only WS (logs/stream). Same CSWSH mitigation as
+			// session/: bearer-token in ?token=, plus Origin must be
+			// same-host or a LAN private range.
+			CheckOrigin: wsutil.SameOriginCheck(),
 		},
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -9,6 +9,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -34,6 +35,13 @@ func Open(ctx context.Context, dsn string, maxConns int) (*Store, error) {
 	}
 	if maxConns <= 0 {
 		maxConns = DefaultMaxConns
+	}
+	// Cap at int32 max — pgxpool.Config.MaxConns is int32 and a
+	// pathological TOML value (e.g. max_conns = 3000000000) would
+	// otherwise wrap to a negative int32 and silently fall back to
+	// pgx's own default.
+	if maxConns > math.MaxInt32 {
+		maxConns = math.MaxInt32
 	}
 	cfg.MaxConns = int32(maxConns)
 	cfg.MaxConnLifetime = 30 * time.Minute

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,12 +18,24 @@ type Store struct {
 	pool *pgxpool.Pool
 }
 
-// Open creates a pgx pool and pings the database.
-func Open(ctx context.Context, dsn string) (*Store, error) {
+// DefaultMaxConns is the cap applied when caller passes 0 to Open.
+// Calibrated for a single-admin home-lab deployment with a few
+// integration consumers; bump via config.database.max_conns when the
+// fanout grows.
+const DefaultMaxConns = 16
+
+// Open creates a pgx pool and pings the database. maxConns ≤ 0 falls
+// back to DefaultMaxConns so callers can pass the raw config value
+// without conditional branching.
+func Open(ctx context.Context, dsn string, maxConns int) (*Store, error) {
 	cfg, err := pgxpool.ParseConfig(dsn)
 	if err != nil {
 		return nil, fmt.Errorf("store: parse dsn: %w", err)
 	}
+	if maxConns <= 0 {
+		maxConns = DefaultMaxConns
+	}
+	cfg.MaxConns = int32(maxConns)
 	cfg.MaxConnLifetime = 30 * time.Minute
 	cfg.MaxConnIdleTime = 5 * time.Minute
 	cfg.HealthCheckPeriod = time.Minute

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -8,15 +8,18 @@ import (
 	"time"
 )
 
-// devDSN matches the convention used elsewhere in the repo
-// (memory/summarizer/store_test.go): OPENDRAY_DEV_DB_URL, falling
-// back to the home-lab default. Tests t.Skip when the DB is
-// unreachable so CI on a fresh laptop still passes.
-func devDSN() string {
-	if v := os.Getenv("OPENDRAY_DEV_DB_URL"); v != "" {
-		return v
+// devDSN returns the dev-DB DSN from OPENDRAY_DEV_DB_URL, or t.Skips
+// when unset. Never hardcode credentials — committed credentials are
+// forever. To run these tests locally, start the bundled Postgres
+// (`docker compose -f docker-compose.test.yml up -d`) and export
+// OPENDRAY_DEV_DB_URL accordingly. See docs/quickstart.md.
+func devDSN(t *testing.T) string {
+	t.Helper()
+	v := os.Getenv("OPENDRAY_DEV_DB_URL")
+	if v == "" {
+		t.Skip("OPENDRAY_DEV_DB_URL not set; export a writable Postgres DSN to run this test")
 	}
-	return "postgres://opd2_user:UGuZjQVFtXR3MtKJ6Q@192.168.3.88:5432/opendray_v2?sslmode=disable"
+	return v
 }
 
 func TestOpen_BadDSN(t *testing.T) {
@@ -50,7 +53,7 @@ func TestOpen_UnreachableDB(t *testing.T) {
 func TestOpen_Success(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	st, err := Open(ctx, devDSN(), 0)
+	st, err := Open(ctx, devDSN(t), 0)
 	if err != nil {
 		t.Skipf("dev DB unreachable, skipping: %v", err)
 	}
@@ -69,7 +72,7 @@ func TestOpen_MaxConnsApplied(t *testing.T) {
 	defer cancel()
 
 	t.Run("explicit positive maxConns honoured", func(t *testing.T) {
-		st, err := Open(ctx, devDSN(), 7)
+		st, err := Open(ctx, devDSN(t), 7)
 		if err != nil {
 			t.Skipf("dev DB unreachable, skipping: %v", err)
 		}
@@ -81,7 +84,7 @@ func TestOpen_MaxConnsApplied(t *testing.T) {
 	})
 
 	t.Run("zero falls back to DefaultMaxConns", func(t *testing.T) {
-		st, err := Open(ctx, devDSN(), 0)
+		st, err := Open(ctx, devDSN(t), 0)
 		if err != nil {
 			t.Skipf("dev DB unreachable, skipping: %v", err)
 		}
@@ -94,7 +97,7 @@ func TestOpen_MaxConnsApplied(t *testing.T) {
 	})
 
 	t.Run("negative also falls back", func(t *testing.T) {
-		st, err := Open(ctx, devDSN(), -1)
+		st, err := Open(ctx, devDSN(t), -1)
 		if err != nil {
 			t.Skipf("dev DB unreachable, skipping: %v", err)
 		}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,114 @@
+package store
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// devDSN matches the convention used elsewhere in the repo
+// (memory/summarizer/store_test.go): OPENDRAY_DEV_DB_URL, falling
+// back to the home-lab default. Tests t.Skip when the DB is
+// unreachable so CI on a fresh laptop still passes.
+func devDSN() string {
+	if v := os.Getenv("OPENDRAY_DEV_DB_URL"); v != "" {
+		return v
+	}
+	return "postgres://opd2_user:UGuZjQVFtXR3MtKJ6Q@192.168.3.88:5432/opendray_v2?sslmode=disable"
+}
+
+func TestOpen_BadDSN(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := Open(ctx, "not a valid dsn", 0)
+	if err == nil {
+		t.Fatal("expected parse error for malformed DSN")
+	}
+	if !strings.Contains(err.Error(), "store: parse dsn") {
+		t.Errorf("error should be wrapped with parse-dsn context, got: %v", err)
+	}
+}
+
+func TestOpen_UnreachableDB(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	// 127.0.0.1:1 is RFC2606 reserved + always-refused; ConnectTimeout
+	// keeps the test snappy. Returns parse-OK but ping-fail.
+	dsn := "postgres://x:y@127.0.0.1:1/db?sslmode=disable&connect_timeout=1"
+	_, err := Open(ctx, dsn, 0)
+	if err == nil {
+		t.Fatal("expected ping failure against unreachable host")
+	}
+	if !strings.Contains(err.Error(), "store: ping") &&
+		!strings.Contains(err.Error(), "store: open pool") {
+		t.Errorf("error should be wrapped, got: %v", err)
+	}
+}
+
+func TestOpen_Success(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	st, err := Open(ctx, devDSN(), 0)
+	if err != nil {
+		t.Skipf("dev DB unreachable, skipping: %v", err)
+	}
+	defer st.Close()
+
+	if st.Pool() == nil {
+		t.Fatal("Pool() returned nil after successful Open")
+	}
+	if err := st.Ping(ctx); err != nil {
+		t.Errorf("Ping after Open: %v", err)
+	}
+}
+
+func TestOpen_MaxConnsApplied(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	t.Run("explicit positive maxConns honoured", func(t *testing.T) {
+		st, err := Open(ctx, devDSN(), 7)
+		if err != nil {
+			t.Skipf("dev DB unreachable, skipping: %v", err)
+		}
+		defer st.Close()
+		got := st.Pool().Config().MaxConns
+		if got != 7 {
+			t.Errorf("Pool.MaxConns = %d, want 7", got)
+		}
+	})
+
+	t.Run("zero falls back to DefaultMaxConns", func(t *testing.T) {
+		st, err := Open(ctx, devDSN(), 0)
+		if err != nil {
+			t.Skipf("dev DB unreachable, skipping: %v", err)
+		}
+		defer st.Close()
+		got := st.Pool().Config().MaxConns
+		if int(got) != DefaultMaxConns {
+			t.Errorf("Pool.MaxConns = %d, want DefaultMaxConns(%d)",
+				got, DefaultMaxConns)
+		}
+	})
+
+	t.Run("negative also falls back", func(t *testing.T) {
+		st, err := Open(ctx, devDSN(), -1)
+		if err != nil {
+			t.Skipf("dev DB unreachable, skipping: %v", err)
+		}
+		defer st.Close()
+		got := st.Pool().Config().MaxConns
+		if int(got) != DefaultMaxConns {
+			t.Errorf("Pool.MaxConns = %d, want DefaultMaxConns(%d)",
+				got, DefaultMaxConns)
+		}
+	})
+}
+
+func TestClose_NilSafe(t *testing.T) {
+	// A *Store whose pool was never set must not panic on Close —
+	// matters for half-constructed test fixtures.
+	(&Store{}).Close()
+}

--- a/internal/web/embed_test.go
+++ b/internal/web/embed_test.go
@@ -1,0 +1,67 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHandler_Smoke covers the two operating modes: the dist tree was
+// built (production) and the dist tree is empty (fresh checkout, dev
+// mode). Both paths must return predictable, non-panicking responses.
+func TestHandler_Smoke(t *testing.T) {
+	h := Handler()
+
+	if h == nil {
+		t.Fatal("Handler() returned nil")
+	}
+
+	t.Run("root path responds without panic", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		h.ServeHTTP(rr, req)
+
+		// In a fresh checkout (no pnpm build) the handler returns 503;
+		// in a built repo it returns 200 with the SPA HTML. Either is
+		// a successful "not panicked" smoke result.
+		switch rr.Code {
+		case http.StatusOK:
+			ct := rr.Header().Get("Content-Type")
+			if !strings.HasPrefix(ct, "text/html") {
+				t.Errorf("expected text/html, got %q", ct)
+			}
+			if rr.Body.Len() == 0 {
+				t.Error("empty body for root path with built dist")
+			}
+		case http.StatusServiceUnavailable:
+			body := rr.Body.String()
+			if !strings.Contains(body, "pnpm build") {
+				t.Errorf("503 body should mention build instructions, got: %q", body)
+			}
+		default:
+			t.Errorf("unexpected status %d", rr.Code)
+		}
+	})
+
+	t.Run("unknown deep link falls back to index (or 503)", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/sessions/ses_doesnotexist", nil)
+		h.ServeHTTP(rr, req)
+
+		// SPA fallback should never 404 — the client router handles
+		// unknown paths. Accept 200 (built) or 503 (unbuilt).
+		if rr.Code != http.StatusOK && rr.Code != http.StatusServiceUnavailable {
+			t.Errorf("SPA fallback returned %d, want 200 or 503", rr.Code)
+		}
+	})
+}
+
+// TestDistExists is a non-fatal probe: it just verifies the function
+// is callable and returns a bool. The actual value depends on whether
+// the dist tree was checked in / built before `go test` ran.
+func TestDistExists(t *testing.T) {
+	got := DistExists()
+	t.Logf("DistExists() = %v (test environment: dist %s)", got,
+		map[bool]string{true: "present", false: "missing"}[got])
+}

--- a/internal/wsutil/origin.go
+++ b/internal/wsutil/origin.go
@@ -1,0 +1,81 @@
+// Package wsutil holds tiny helpers shared across opendray's
+// websocket endpoints. The first inhabitant is the origin checker
+// used by every Upgrader to mitigate cross-site WS hijacking.
+package wsutil
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// SameOriginCheck returns a websocket.Upgrader.CheckOrigin function
+// suitable for browser-facing WS endpoints (admin SPA). It accepts:
+//
+//   - Empty Origin header (non-browser clients: curl, server-to-server,
+//     mobile native — these can't be tricked by a malicious page).
+//   - Origin host equal to the request's Host header (same-origin).
+//   - Origin host that is a loopback or RFC1918 / RFC4193 private
+//     address (LAN deployment is the canonical opendray topology).
+//   - Origin host present in the optional `extra` allow-list (exact
+//     match on host[:port]).
+//
+// This is defence-in-depth on top of bearer-token auth. Token in the
+// `?token=` query string is the primary authentication; this guard
+// blocks Cross-Site WebSocket Hijacking *if* the token ever leaks into
+// a referrer or document.URL on a third-party page.
+//
+// For non-browser endpoints (bridge adapters, integration server-to-
+// server consumers) prefer AllowAnyOrigin so legitimate non-browser
+// clients aren't broken.
+func SameOriginCheck(extra ...string) func(*http.Request) bool {
+	allow := make(map[string]struct{}, len(extra))
+	for _, h := range extra {
+		h = strings.ToLower(strings.TrimSpace(h))
+		if h != "" {
+			allow[h] = struct{}{}
+		}
+	}
+	return func(r *http.Request) bool {
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			return true
+		}
+		u, err := url.Parse(origin)
+		if err != nil || u.Host == "" {
+			return false
+		}
+		host := strings.ToLower(u.Host)
+		if host == strings.ToLower(r.Host) {
+			return true
+		}
+		if _, ok := allow[host]; ok {
+			return true
+		}
+		// Strip the port for IP-based checks. Hostnames like
+		// "localhost" are handled here too.
+		hostname := u.Hostname()
+		if hostname == "localhost" {
+			return true
+		}
+		if ip := net.ParseIP(hostname); ip != nil {
+			if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// AllowAnyOrigin returns a CheckOrigin that always returns true. Use
+// for WS endpoints whose primary auth is a per-frame token *and* whose
+// legitimate clients are non-browser (e.g. external bridge adapters
+// running in Python, or integration apps doing server-to-server WS).
+//
+// Centralising the bypass through this helper makes the intent
+// explicit and greppable — every call site documents *why* it doesn't
+// need an origin check.
+func AllowAnyOrigin() func(*http.Request) bool {
+	return func(*http.Request) bool { return true }
+}

--- a/internal/wsutil/origin_test.go
+++ b/internal/wsutil/origin_test.go
@@ -104,6 +104,18 @@ func TestSameOriginCheck(t *testing.T) {
 			originHdr: "evil.example.com",
 			want:      false,
 		},
+		{
+			name:      "scheme-only origin (empty authority) rejected",
+			hostHdr:   "opendray.local:8770",
+			originHdr: "http://",
+			want:      false,
+		},
+		{
+			name:      "https origin against same host allowed",
+			hostHdr:   "opendray.local:8770",
+			originHdr: "https://opendray.local:8770",
+			want:      true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/wsutil/origin_test.go
+++ b/internal/wsutil/origin_test.go
@@ -1,0 +1,134 @@
+package wsutil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSameOriginCheck(t *testing.T) {
+	tests := []struct {
+		name      string
+		extra     []string
+		hostHdr   string
+		originHdr string
+		want      bool
+	}{
+		{
+			name: "empty origin allowed (non-browser client)",
+			want: true,
+		},
+		{
+			name:      "exact same-origin allowed",
+			hostHdr:   "opendray.local:8770",
+			originHdr: "http://opendray.local:8770",
+			want:      true,
+		},
+		{
+			name:      "different origin rejected",
+			hostHdr:   "opendray.local:8770",
+			originHdr: "https://evil.example.com",
+			want:      false,
+		},
+		{
+			name:      "loopback allowed",
+			hostHdr:   "opendray.local:8770",
+			originHdr: "http://127.0.0.1:5173",
+			want:      true,
+		},
+		{
+			name:      "ipv6 loopback allowed",
+			hostHdr:   "opendray.local:8770",
+			originHdr: "http://[::1]:5173",
+			want:      true,
+		},
+		{
+			name:      "localhost name allowed",
+			hostHdr:   "opendray.local:8770",
+			originHdr: "http://localhost:5173",
+			want:      true,
+		},
+		{
+			name:      "RFC1918 192.168/16 allowed",
+			hostHdr:   "opendray.local:8770",
+			originHdr: "http://192.168.3.21:8770",
+			want:      true,
+		},
+		{
+			name:      "RFC1918 10/8 allowed",
+			hostHdr:   "opendray.local:8770",
+			originHdr: "http://10.0.0.5:8770",
+			want:      true,
+		},
+		{
+			name:      "RFC1918 172.16/12 allowed",
+			hostHdr:   "opendray.local:8770",
+			originHdr: "http://172.20.5.5:8770",
+			want:      true,
+		},
+		{
+			name:      "172.32 (outside 172.16-31) rejected",
+			hostHdr:   "opendray.local:8770",
+			originHdr: "http://172.32.5.5:8770",
+			want:      false,
+		},
+		{
+			name:      "public IP rejected",
+			hostHdr:   "opendray.local:8770",
+			originHdr: "http://8.8.8.8",
+			want:      false,
+		},
+		{
+			name:      "explicit allowlist match",
+			extra:     []string{"my-tunnel.example.com"},
+			hostHdr:   "opendray.local:8770",
+			originHdr: "https://my-tunnel.example.com",
+			want:      true,
+		},
+		{
+			name:      "explicit allowlist case-insensitive",
+			extra:     []string{"My-Tunnel.Example.Com"},
+			hostHdr:   "opendray.local:8770",
+			originHdr: "https://my-tunnel.example.com",
+			want:      true,
+		},
+		{
+			name:      "malformed origin rejected",
+			hostHdr:   "opendray.local:8770",
+			originHdr: "://not a url",
+			want:      false,
+		},
+		{
+			name:      "host-only origin (no scheme) rejected",
+			hostHdr:   "opendray.local:8770",
+			originHdr: "evil.example.com",
+			want:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			check := SameOriginCheck(tc.extra...)
+			r := httptest.NewRequest(http.MethodGet, "http://x/ws", nil)
+			if tc.hostHdr != "" {
+				r.Host = tc.hostHdr
+			}
+			if tc.originHdr != "" {
+				r.Header.Set("Origin", tc.originHdr)
+			}
+			if got := check(r); got != tc.want {
+				t.Errorf("got %v, want %v (origin=%q host=%q)",
+					got, tc.want, tc.originHdr, tc.hostHdr)
+			}
+		})
+	}
+}
+
+func TestAllowAnyOrigin(t *testing.T) {
+	check := AllowAnyOrigin()
+	r := httptest.NewRequest(http.MethodGet, "http://x/ws", nil)
+	r.Header.Set("Origin", "https://evil.example.com")
+	if !check(r) {
+		t.Error("AllowAnyOrigin should always return true")
+	}
+}


### PR DESCRIPTION
## Background

The v1.0-rc project review identified several hardening items worth tackling before GA. This PR implements three of them:

1. **`MaxConns` cap on the pgx pool** — prevent high-fanout integration traffic from exhausting the connection pool
2. **Tighten `CheckOrigin` on 4 WebSocket endpoints** — add same-origin / LAN defense in front of token auth on the admin SPA, defense-in-depth
3. **Smoke tests for `app` / `store` / `web` / `githost`** — these four core packages had zero test coverage before

## Changes

### 1. `pgx` pool MaxConns
- `internal/config/config.go`: add `DatabaseConfig.MaxConns` + `OPENDRAY_DATABASE_MAX_CONNS` env override
- `internal/store/store.go`: `Open(ctx, dsn, maxConns int)`; 0 / negative falls back to `DefaultMaxConns = 16`
- `internal/app/app.go`: caller passes `cfg.Database.MaxConns`
- `config.example.toml`: added comment documenting the new optional field

### 2. WS Origin defense
- New package `internal/wsutil`:
  - `SameOriginCheck(extra ...string)` — accepts empty Origin (non-browser clients) / matching Host header / loopback / RFC1918 + RFC4193 private nets / link-local / explicit allowlist
  - `AllowAnyOrigin()` — explicit bypass, only used by server-to-server endpoints with token auth, so the "wide open" decision is grep-able
- 4 handlers switched to call helpers:
  - `session/handler.go`, `settings/handler.go` → `SameOriginCheck()` (admin SPA)
  - `integration/events.go`, `channel/bridge/handler.go` → `AllowAnyOrigin()` (external consumers)

### 3. Smoke tests
| Package | Key cases |
|---|---|
| `internal/app` | `New()` fails fast when DB unreachable; logger level / format / bad-path matrix |
| `internal/store` | bad DSN / unreachable host / happy path / MaxConns is actually applied / nil-safe Close |
| `internal/web` | SPA handler does not panic in either built / unbuilt-dist state; unknown paths fall back to index |
| `internal/githost` | Full CRUD + redact + validation (against dev DB) |

DB-touching tests follow the project convention: read DSN from `OPENDRAY_DEV_DB_URL`, `t.Skip` when unset or unreachable. Local contributors can use the bundled `docker-compose.test.yml` (added in #7) to spin up a Postgres on `127.0.0.1:5432`.

## Out of scope

- **Convert 5 `crypto/rand` panics to error returns** (also flagged in the review): evaluated and intentionally not changing. `crypto/rand` does not realistically fail post-boot on Linux/Darwin, and refactoring would propagate signature changes through every caller of the 5 ID generators. This matches Go ecosystem practice (`uuid.New()` and similar also panic). If we ever want to revisit, it warrants its own PR.
- **Per-route enforcement of integration scopes**, **`integration/calllog` perf**, **frontend large-file splitting**: deferred to v1.0 → v1.1 work, out of this hardening pass.

## Test plan

- [x] `go test -race -count=1 ./...` — all 44 packages green
- [x] `go vet ./...` — clean
- [x] `pnpm tsc --noEmit` — clean
- [x] All 4 new smoke-test packages pass against a local dev DB; correctly skip when DB unreachable
- [x] Independent review via `code-reviewer` agent, fixed a CI-matrix concurrency issue around PIDs

## Impact

- **Runtime**: default `MaxConns=16` is close to pgx's previous implicit default — no abrupt behavioural change
- **API compatibility**: WS handshake now performs an Origin check, but same-origin browser admin SPA traffic is unaffected; non-browser clients (which omit Origin) continue to work
- **Config**: `database.max_conns` is a new optional field — fully backwards-compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)