### PR TITLE
chore(oss): scrub home-lab references + add docker-compose.test.yml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,8 +55,20 @@ go test -race ./...                       # backend
 cd app/web && pnpm build                  # web (TS strict + Vite prod build)
 ```
 
-Some tests reach a real Postgres at `192.168.3.88` (home-lab convention).
-Set `OPENDRAY_DEV_DB_URL` to point at your own DB or let them skip.
+A subset of tests in `internal/memory/summarizer/` exercises a real
+Postgres. They `t.Skip` when `OPENDRAY_DEV_DB_URL` is unset, so the
+default `go test ./...` is always green even without a database.
+
+To run them locally, start the bundled dev DB and export the DSN:
+
+```bash
+docker compose -f docker-compose.test.yml up -d
+export OPENDRAY_DEV_DB_URL='postgres://opendray:opendray@127.0.0.1:5432/opendray?sslmode=disable'
+go test -race ./internal/memory/summarizer/...
+```
+
+Or point `OPENDRAY_DEV_DB_URL` at any Postgres 15+ instance you control.
+Never hard-code DSNs in source — they will leak via git history.
 
 ## Pull Request Process
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ post-v1.0 roadmap.
 ## Quickstart
 
 ```bash
-# 1. Postgres on 192.168.3.88 (per CLAUDE.md home-lab conventions).
-#    Credentials live in Vaultwarden item: homelab-db-opendray-v2.
+# 1. Start a Postgres for local dev (or point [database].url at your own).
+docker compose -f docker-compose.test.yml up -d   # 127.0.0.1:5432
 
 # 2. Local config — already gitignored.
 cp config.example.toml config.toml

--- a/app/web/src/tutorial/sections/11-memory/01-overview.md
+++ b/app/web/src/tutorial/sections/11-memory/01-overview.md
@@ -34,7 +34,7 @@ and write through.
    └────────────┘         │       │                 │
                           └───────┼─────────────────┘
                                   ▼
-                          PostgreSQL (192.168.3.88)
+                          PostgreSQL
 ```
 
 Every spawned session gets a `opendray-memory` MCP server

--- a/app/web/src/tutorial/sections/13-ambient-memory/04-injection.md
+++ b/app/web/src/tutorial/sections/13-ambient-memory/04-injection.md
@@ -29,7 +29,7 @@ spawn. Format:
 opendray injected the following durable facts from prior
 sessions in this project:
 - User prefers pnpm over npm for package management
-- DB at 192.168.3.88:5432, dev_user role
+- DB at db.example.com:5432, dev_user role
 - ...
 End of memory preface.
 ```

--- a/config.example.toml
+++ b/config.example.toml
@@ -7,8 +7,11 @@
 listen = "127.0.0.1:8770"
 
 [database]
-# Use a project-scoped postgres role per home-lab DB conventions.
-url = "postgres://opendray_user:CHANGEME@192.168.3.88:5432/opendray?sslmode=disable"
+# Point at any reachable Postgres 15+. Use a project-scoped role
+# (CRUD only, not a superuser) and rotate credentials out of band.
+# For local development, `docker compose -f docker-compose.test.yml up -d`
+# starts a Postgres on 127.0.0.1:5432 matching this DSN.
+url = "postgres://opendray:opendray@127.0.0.1:5432/opendray?sslmode=disable"
 
 [admin]
 # Admin auth (single human). Prefer env vars in production.

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,38 @@
+# Local Postgres for development and tests.
+#
+# Quickstart:
+#
+#   docker compose -f docker-compose.test.yml up -d
+#
+# This binds 127.0.0.1:5432, matching config.example.toml's [database].url
+# and the OPENDRAY_DEV_DB_URL env used by integration tests:
+#
+#   export OPENDRAY_DEV_DB_URL='postgres://opendray:opendray@127.0.0.1:5432/opendray?sslmode=disable'
+#   go test -race ./...
+#
+# Stop and wipe:
+#
+#   docker compose -f docker-compose.test.yml down -v
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: opendray-test-pg
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: opendray
+      POSTGRES_PASSWORD: opendray
+      POSTGRES_DB: opendray
+    ports:
+      # Bind to loopback only — never expose this dev DB on a LAN/WAN.
+      - "127.0.0.1:5432:5432"
+    volumes:
+      - opendray_test_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U opendray -d opendray"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  opendray_test_pgdata:

--- a/docs/design.md
+++ b/docs/design.md
@@ -142,7 +142,7 @@ If at planning time a feature pulls toward an anti-goal, drop the feature.
 | Layer | Tech | Rationale |
 |---|---|---|
 | **Backend / gateway** | Go 1.25+ | Single static binary, excellent concurrency for PTY + WebSocket fanout, ecosystem maturity (chi, pgx, gorilla/websocket, creack/pty). Hot-reload trade-off accepted: integration system runs external processes that hot-reload independently. |
-| **Database** | PostgreSQL | Already operational on `192.168.3.88:5432`; pgx/v5 stable; JSON columns for opaque metadata. |
+| **Database** | PostgreSQL 15+ | pgx/v5 stable; JSON columns for opaque metadata; pgvector for memory embeddings. |
 | **Mobile** | Flutter 3 + Riverpod | v1 investment, proven UX, single codebase iOS+Android. |
 | **Web** | Vue 3 + Vite | TBD — see §19, may consolidate to Flutter Web. |
 | **Internal RPC / event bus** | In-process Go channels | Keep simple; do not adopt NATS/Kafka without a real reason. |
@@ -722,7 +722,7 @@ Two separate tables, by design:
 
 ### Recommended layout
 - `opendray` binary on Mac (PTY needs a real TTY).
-- PostgreSQL on `192.168.3.88:5432` (existing).
+- PostgreSQL 15+ reachable from the binary's host.
 - Cloudflare Tunnel routes `opendray.<your-domain>` to the local port.
 - LXC option deferred until a non-Mac deployment is actually needed.
 

--- a/internal/memory/capture/service_test.go
+++ b/internal/memory/capture/service_test.go
@@ -92,7 +92,7 @@ func TestRunner_RunForSession_HappyPath(t *testing.T) {
 		res: summarizer.SummarizeResult{
 			Facts: []summarizer.Fact{
 				{Text: "User prefers pnpm", Category: summarizer.CategoryPreference, Confidence: 0.95},
-				{Text: "Dev DB at 192.168.3.88", Category: summarizer.CategoryIdentifier, Confidence: 0.98},
+				{Text: "Dev DB at db.example.com", Category: summarizer.CategoryIdentifier, Confidence: 0.98},
 			},
 			InputTokens:  100,
 			OutputTokens: 30,
@@ -113,7 +113,7 @@ func TestRunner_RunForSession_HappyPath(t *testing.T) {
 	r.history = mockHistory{
 		entries: []TranscriptEntry{
 			{Ts: time.Now().Add(-2 * time.Minute), Text: "I prefer pnpm"},
-			{Ts: time.Now().Add(-1 * time.Minute), Text: "DB is 192.168.3.88"},
+			{Ts: time.Now().Add(-1 * time.Minute), Text: "DB is db.example.com"},
 			{Ts: time.Now(), Text: "Anything else?"},
 		},
 	}

--- a/internal/memory/injector/inject_test.go
+++ b/internal/memory/injector/inject_test.go
@@ -74,7 +74,7 @@ func TestRender_TopKRecent_Renders(t *testing.T) {
 	mem := &fakeMemoryReader{
 		mems: []memory.Memory{
 			{ID: "1", Text: "User prefers pnpm"},
-			{ID: "2", Text: "DB at 192.168.3.88"},
+			{ID: "2", Text: "DB at db.example.com"},
 			{ID: "3", Text: "first line\nsecond line"},
 		},
 	}
@@ -91,7 +91,7 @@ func TestRender_TopKRecent_Renders(t *testing.T) {
 	if !strings.Contains(out, "User prefers pnpm") {
 		t.Errorf("missing fact1: %q", out)
 	}
-	if !strings.Contains(out, "DB at 192.168.3.88") {
+	if !strings.Contains(out, "DB at db.example.com") {
 		t.Errorf("missing fact2: %q", out)
 	}
 	// Multi-line fact should be truncated to first line.

--- a/internal/memory/summarizer/prompt.go
+++ b/internal/memory/summarizer/prompt.go
@@ -56,12 +56,12 @@ Output:
 {"facts":[]}
 
 Conversation:
-USER: My production DB is at 192.168.3.88:5432, please use the dev_user role.
+USER: My production DB is at db.example.com:5432, please use the dev_user role.
 ASSISTANT: Understood, I'll use dev_user for queries.
 
 Output:
 {"facts":[
-  {"text":"Production DB host is 192.168.3.88:5432","category":"identifier","confidence":0.98},
+  {"text":"Production DB host is db.example.com:5432","category":"identifier","confidence":0.98},
   {"text":"User wants the dev_user role for DB access","category":"preference","confidence":0.9}
 ]}
 

--- a/internal/memory/summarizer/prompt_test.go
+++ b/internal/memory/summarizer/prompt_test.go
@@ -39,10 +39,10 @@ func TestMessagesToTranscriptText(t *testing.T) {
 		{Role: RoleUser, Text: "I prefer pnpm.", Timestamp: now},
 		{Role: RoleAssistant, Text: "Noted.", Timestamp: now},
 		{Role: RoleSystem, Text: "should be dropped", Timestamp: now},
-		{Role: RoleUser, Text: "Also: dev DB is 192.168.3.88.", Timestamp: now},
+		{Role: RoleUser, Text: "Also: dev DB is db.example.com.", Timestamp: now},
 	}
 	got := MessagesToTranscriptText(msgs)
-	want := "USER: I prefer pnpm.\nASSISTANT: Noted.\nUSER: Also: dev DB is 192.168.3.88."
+	want := "USER: I prefer pnpm.\nASSISTANT: Noted.\nUSER: Also: dev DB is db.example.com."
 	if got != want {
 		t.Errorf("transcript flatten mismatch:\n got: %q\nwant: %q", got, want)
 	}

--- a/internal/memory/summarizer/provider_anthropic_test.go
+++ b/internal/memory/summarizer/provider_anthropic_test.go
@@ -64,7 +64,7 @@ func newAnthropicHappyPath(t *testing.T, facts []Fact) *httptest.Server {
 func TestAnthropicProvider_Summarize_HappyPath(t *testing.T) {
 	wantFacts := []Fact{
 		{Text: "User prefers pnpm", Category: CategoryPreference, Confidence: 0.95},
-		{Text: "DB is at 192.168.3.88", Category: CategoryIdentifier, Confidence: 0.98},
+		{Text: "DB is at db.example.com", Category: CategoryIdentifier, Confidence: 0.98},
 	}
 	srv := newAnthropicHappyPath(t, wantFacts)
 	defer srv.Close()
@@ -79,7 +79,7 @@ func TestAnthropicProvider_Summarize_HappyPath(t *testing.T) {
 	}
 
 	res, err := p.Summarize(context.Background(), []Message{
-		{Role: RoleUser, Text: "I prefer pnpm and the DB is at 192.168.3.88"},
+		{Role: RoleUser, Text: "I prefer pnpm and the DB is at db.example.com"},
 		{Role: RoleAssistant, Text: "Got it."},
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

OSS-readiness step 1: remove the home-lab IP (`192.168.3.88`) from `HEAD` and replace it with a portable dev-DB story (docker-compose) so external contributors can clone-and-run.

This unblocks flipping the repo public. Two follow-ups remain (separate PRs):
1. BFG history rewrite to scrub the IP from earlier commits
2. Rotate the home-lab `opd2_user` password (out-of-band)

## What changed

### Source / fixtures (9 occurrences across 5 files)
| File | Before | After |
|---|---|---|
| `internal/memory/injector/inject_test.go` | `DB at 192.168.3.88` | `DB at db.example.com` |
| `internal/memory/capture/service_test.go` | `Dev DB at 192.168.3.88` / `DB is 192.168.3.88` | `db.example.com` |
| `internal/memory/summarizer/prompt.go` | `192.168.3.88:5432` (LLM prompt example) | `db.example.com:5432` |
| `internal/memory/summarizer/prompt_test.go` | `dev DB is 192.168.3.88` | `dev DB is db.example.com` |
| `internal/memory/summarizer/provider_anthropic_test.go` | `DB is at 192.168.3.88` | `DB is at db.example.com` |

`db.example.com` is the RFC 2606 reserved domain — guaranteed to never resolve, immediately recognisable as a placeholder.

These are **string literals** in test fixtures (input + assertion) and one few-shot example in the LLM system prompt. Replaced consistently so all assertions still pass.

### Docs
| File | Change |
|---|---|
| `README.md` | Quickstart now says `docker compose up` instead of "Postgres on 192.168.3.88" |
| `CONTRIBUTING.md` | Test section rewritten — points at `docker-compose.test.yml` + DSN export |
| `config.example.toml` | DSN now `127.0.0.1:5432` matching the compose file |
| `docs/design.md` | Stack table + deploy note: removed specific IP, kept "PostgreSQL 15+" |
| `app/web/src/tutorial/sections/11-memory/01-overview.md` | Architecture diagram: `PostgreSQL (192.168.3.88)` → `PostgreSQL` |
| `app/web/src/tutorial/sections/13-ambient-memory/04-injection.md` | Sample fact: `DB at 192.168.3.88:5432` → `DB at db.example.com:5432` |

### New file
`docker-compose.test.yml` — Postgres 17-alpine, bound to `127.0.0.1:5432` (loopback only, never LAN), with healthcheck. 30 lines.

```yaml
services:
  postgres:
    image: postgres:17-alpine
    environment:
      POSTGRES_USER: opendray
      POSTGRES_PASSWORD: opendray
      POSTGRES_DB: opendray
    ports: ["127.0.0.1:5432:5432"]
    healthcheck: ...
```

## What's NOT in this PR (intentional)

| | Reason |
|---|---|
| Update `.github/workflows/ci.yml` to run with a Postgres service | The CI workflow doesn't exist on `main` yet — added by #2. Will land as part of #2's rebase. |
| BFG history rewrite | Separate PR; deliberately scheduled for "the day before public flip" so all OSS-prep PRs land before history is rewritten. |
| `opd2_user` password rotation | Out-of-band operational task — no code change. |
| Migrate `internal/memory/summarizer/store_test.go` to testcontainers | Larger refactor; dev DB env-var pattern is fine for now. |

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test -race -timeout=2m ./...` — 19 packages green, DB tests SKIP cleanly
- [x] `go build ./cmd/opendray` — clean
- [x] No `192.168.3.88` references remain in source / docs / config (`grep -rn`)
- [ ] CI passes on this PR
- [ ] After merge: `docker compose -f docker-compose.test.yml up -d` works end-to-end on a fresh clone

## Risk

🟢 Low. Pure string replacement in fixtures + new YAML file. No behavioural change to runtime code (the LLM prompt change is a few-shot example — the model treats `db.example.com:5432` and `192.168.3.88:5432` identically as "looks like infra config").

🤖 Generated with [Claude Code](https://claude.com/claude-code)