### PR TITLE
fix(test): wait for capability propagation in bridge SendCard test

### DIFF
--- a/internal/channel/bridge/bridge_test.go
+++ b/internal/channel/bridge/bridge_test.go
@@ -211,6 +211,15 @@ func TestSendCard_WhenSupportedShipsFrame(t *testing.T) {
 		[]channel.Capability{channel.CapText, channel.CapCard})
 	defer conn.Close()
 
+	// dialAndRegister returns once the WS message is sent, but
+	// capability propagation into br's state is async — wait for
+	// CapCard to surface before issuing the SendCard. Without
+	// this, the test races and intermittently fails with
+	// "capability not supported" under loaded CI runners.
+	waitFor(t, 2*time.Second, func() bool {
+		return containsCap(channel.Capabilities(br), channel.CapCard)
+	})
+
 	// Drain async frames from the adapter side.
 	frames := make(chan map[string]any, 4)
 	go func() {


### PR DESCRIPTION
## Summary

🚨 **main is currently red** after #2 merged. Root cause: a real race condition in `TestSendCard_WhenSupportedShipsFrame`, exposed only on GitHub-Actions runners under load.

This PR makes the test wait for capability propagation before issuing `SendCard`, mirroring the existing pattern in `TestDeclaredCapabilities_OnlyWhatAdapterClaimed`.

## What was happening

```
bridge_test.go:239: channel: capability not supported
FAIL  github.com/opendray/opendray-v2/internal/channel/bridge  0.050s
```

`dialAndRegister` returns once the WebSocket REGISTER frame has been **sent** to the bridge — but the bridge applies capabilities **asynchronously** to its state map. On a fast-enough runner the propagation happens before `SendCard` checks, on slow runners (or under `-race` with heavy scheduling) it doesn't.

## The fix

```diff
 conn := dialAndRegister(t, wsURL, "secret", "wechat",
     []channel.Capability{channel.CapText, channel.CapCard})
 defer conn.Close()

+waitFor(t, 2*time.Second, func() bool {
+    return containsCap(channel.Capabilities(br), channel.CapCard)
+})
+
 // Drain async frames from the adapter side.
```

Same pattern, same `waitFor` helper, same `containsCap` predicate as the test 40 lines below. No behavioural change to non-test code.

## Verification

- `go test -race -count=10 -run TestSendCard_WhenSupportedShipsFrame ./internal/channel/bridge/...` — 10/10 PASS
- `go test -race -count=3 ./internal/channel/bridge/...` — 3/3 PASS
- The original failure reproduces consistently on `main` HEAD without this fix (`gh run view 25431096850`)

## Risk

🟢 Trivial. Test-only change, 9 lines added, no production code touched.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: re-trigger any blocked PRs (#3, #4) so they pick up the fix via rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)