### PR TITLE
fix(test): bound dialAndRegister ack read with deadline

### DIFF
--- a/internal/channel/bridge/bridge_test.go
+++ b/internal/channel/bridge/bridge_test.go
@@ -67,9 +67,20 @@ func dialAndRegister(t *testing.T, wsURL, token, platform string, caps []channel
 	if err := conn.WriteMessage(websocket.TextMessage, raw); err != nil {
 		t.Fatalf("write register: %v", err)
 	}
+	// Bound the ack wait so a dropped/lost ack on a loaded CI runner
+	// fails this helper in seconds rather than hanging the whole
+	// `go test -timeout=5m` budget.
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
 	_, ackRaw, err := conn.ReadMessage()
 	if err != nil {
 		t.Fatalf("read ack: %v", err)
+	}
+	// Reset the deadline so the caller can read further frames
+	// without tripping over our short ack window.
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		t.Fatalf("clear read deadline: %v", err)
 	}
 	var ack map[string]any
 	_ = json.Unmarshal(ackRaw, &ack)


### PR DESCRIPTION
## Summary

Second main-restoring hotfix in this OSS-prep cycle. After #8 fixed the capability-propagation race in \`TestSendCard\`, a different but related race in \`TestDeclaredCapabilities_OnlyWhatAdapterClaimed\` timed out at 5m on the post-#9 main CI.

Root cause: \`dialAndRegister\` calls \`conn.ReadMessage()\` for the register ack with no deadline. On a loaded GitHub Actions runner, the broker's ack-write can be delayed enough that the entire 5m \`go test -timeout\` budget is consumed by this one helper.

## Fix

Set a 5s read deadline before the ack read, clear it afterward so callers can still receive subsequent frames:

\`\`\`diff
+if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+    t.Fatalf(\"set read deadline: %v\", err)
+}
 _, ackRaw, err := conn.ReadMessage()
+if err := conn.SetReadDeadline(time.Time{}); err != nil {
+    t.Fatalf(\"clear read deadline: %v\", err)
+}
\`\`\`

5s is generous — local ack is < 100ms — but bounded. If the broker truly fails to ack within 5s, the helper now \`t.Fatalf\`s with a clear error instead of consuming the whole timeout budget.

## Verification

\`go test -race -count=5 -run TestDeclaredCapabilities_OnlyWhatAdapterClaimed ./internal/channel/bridge/...\` — 5/5 PASS

## Why this wasn't caught by #8

#8 only fixed the SendCard test by adding a \`waitFor\` between dial and SendCard. It didn't touch \`dialAndRegister\` itself, which is shared infrastructure. Both tests use that helper — the bug was always there, but only \`TestSendCard\` failed deterministically (capability check fails fast); \`TestDeclaredCapabilities\` failed by hanging.

## Risk

🟢 Trivial. Test-only change, 11 lines added, no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)