### PR TITLE
docs: add docs/quickstart.md with full setup walkthrough

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,9 @@ this release ships.
 
 ## Development Setup
 
+> For a full walkthrough including troubleshooting, see [`docs/quickstart.md`](docs/quickstart.md). The condensed path is below.
+
+
 ```bash
 git clone https://github.com/Opendray/opendray_v2.git
 cd opendray_v2

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ post-v1.0 roadmap.
 
 ## Quickstart
 
+For a full walkthrough with prereqs and troubleshooting, see [`docs/quickstart.md`](docs/quickstart.md). The condensed path:
+
 ```bash
 # 1. Start a Postgres for local dev (or point [database].url at your own).
 docker compose -f docker-compose.test.yml up -d   # 127.0.0.1:5432
@@ -106,6 +108,7 @@ Zustand + xterm.js) and per-W milestone notes.
 
 ## Documentation
 
+- [`docs/quickstart.md`](docs/quickstart.md) — full quickstart with prereqs, troubleshooting, and the docker-compose dev DB
 - [`docs/design.md`](docs/design.md) — mission, architecture, subsystems,
   API, data model, roadmap
 - [`docs/adr/`](docs/adr/) — every binding architecture decision, dated

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,171 @@
+# Quickstart
+
+Get a local opendray-v2 instance running in about five minutes.
+
+## Prerequisites
+
+| Tool | Version | Why |
+|---|---|---|
+| Go | 1.25+ | Backend + embedded web bundle |
+| pnpm | 10+ | Web SPA build |
+| Node.js | 22+ | pnpm runtime (build only — not needed at deploy time) |
+| Docker | recent | Local Postgres for dev / tests (optional if you bring your own DB) |
+
+Verify:
+
+```bash
+go version              # go1.25.x
+pnpm --version          # 10.x
+node --version          # v22.x
+docker --version        # 24.x or newer
+```
+
+## 5-minute path
+
+```bash
+git clone https://github.com/Opendray/opendray_v2.git
+cd opendray_v2
+
+# 1. Start the bundled Postgres (or skip and use your own — see below).
+docker compose -f docker-compose.test.yml up -d
+docker compose -f docker-compose.test.yml ps   # postgres should be (healthy)
+
+# 2. Local config — gitignored, safe to edit.
+cp config.example.toml config.toml
+# Defaults already point at the docker-compose Postgres on 127.0.0.1:5432.
+# Only thing you must change: [admin].password. Use anything for local dev.
+
+# 3. Build the web bundle so the Go binary embeds it.
+cd app/web
+pnpm install --frozen-lockfile
+pnpm build
+cd ../..
+
+# 4. Apply the schema (one-shot — re-running is a no-op).
+go run ./cmd/opendray migrate -config config.toml
+
+# 5. Run the gateway.
+go run ./cmd/opendray serve -config config.toml
+```
+
+You should now have:
+
+| URL | What |
+|---|---|
+| `http://127.0.0.1:8770/admin/` | Web admin SPA — log in with `admin` + the password you set |
+| `http://127.0.0.1:8770/api/v1/...` | REST + WebSocket API |
+
+Stop the server with `Ctrl-C`. Stop the Postgres with `docker compose -f docker-compose.test.yml down` (add `-v` to also delete data).
+
+## Frontend hot-reload (optional)
+
+For iterating on the React SPA without rebuilding the Go binary:
+
+```bash
+# Terminal 1 — Vite dev server with HMR
+cd app/web
+pnpm dev                # http://localhost:5173
+
+# Terminal 2 — Go gateway
+go run ./cmd/opendray serve -config config.toml
+```
+
+Vite proxies `/api` calls (REST + WebSocket) to `:8770`, so the dev experience is identical to production.
+
+## Using your own Postgres
+
+If you already have a Postgres 15+ instance, skip step 1 and edit `config.toml` instead:
+
+```toml
+[database]
+url = "postgres://your_user:your_pass@your_host:5432/your_db?sslmode=disable"
+```
+
+Recommendations:
+- Create a project-scoped role with only the CRUD privileges opendray needs — never use `postgres` / superuser.
+- Rotate credentials out of band; don't commit them.
+- Connection pool size is configurable via `[database].max_conns` (default `16`).
+
+## Running the test suite
+
+```bash
+# All packages, race detector on. DB-touching tests skip cleanly when env unset.
+go test -race ./...
+
+# Run the DB-backed integration tests (memory/summarizer + githost + store + app)
+# against the docker-compose Postgres:
+export OPENDRAY_DEV_DB_URL='postgres://opendray:opendray@127.0.0.1:5432/opendray?sslmode=disable'
+go test -race ./...
+
+# Linting (matches CI):
+golangci-lint run --config .golangci.yml ./...
+
+# Frontend type-check + production build:
+cd app/web && pnpm build
+```
+
+## Optional: encrypted DB backups + data exports
+
+```bash
+# Master passphrase — must be in env, never in config.toml.
+export OPENDRAY_BACKUP_KEY="$(openssl rand -base64 32)"
+export OPENDRAY_BACKUP_ENABLED=1
+
+# pg_dump / pg_restore must match the Postgres server's major version.
+# Example for an Apple Silicon dev machine pointing at PG17:
+export OPENDRAY_BACKUP_PG_DUMP_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_dump
+export OPENDRAY_BACKUP_PG_RESTORE_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_restore
+```
+
+Restart `opendray serve`; a Backups page appears in the admin sidebar (`/backups`) along with `/export` for zip-bundle data exports and imports. See `docs/adr/0012-*.md` and the in-app **Tutorial → Backups** section for the full lifecycle.
+
+## Building a single distributable binary
+
+The repo ships a `Dockerfile` (multi-stage, distroless, non-root) and a `goreleaser` config for cross-platform releases:
+
+```bash
+# Snapshot release — builds linux/darwin × amd64/arm64 archives in dist/
+goreleaser release --clean --snapshot
+
+# Container image (requires Docker daemon)
+docker build -t opendray:dev .
+docker run --rm -p 8770:8770 \
+  -e OPENDRAY_DATABASE_URL="postgres://opendray:opendray@host.docker.internal:5432/opendray?sslmode=disable" \
+  -e OPENDRAY_ADMIN_PASSWORD="$(openssl rand -base64 24)" \
+  opendray:dev
+```
+
+For tagged releases, `goreleaser release` produces a draft GitHub release; a maintainer reviews the notes and publishes.
+
+## Troubleshooting
+
+### `pnpm build` fails / `internal/web/dist` is empty
+
+The Go binary uses `//go:embed all:dist` and refuses to start with an empty `dist/`. Run `cd app/web && pnpm build` and confirm the directory is populated. If you only need the API and want to skip the web build, run the Vite dev server (`pnpm dev`) instead.
+
+### `go run ./cmd/opendray migrate` reports `connection refused`
+
+Postgres is not running, or the DSN in `config.toml` is wrong. Check `docker compose -f docker-compose.test.yml ps` — the `postgres` service should be `(healthy)`. If it's not, `docker compose -f docker-compose.test.yml logs postgres` will explain.
+
+### `go test ./internal/memory/summarizer/...` says `--- SKIP`
+
+Expected behaviour. Those tests need a real Postgres; export `OPENDRAY_DEV_DB_URL` (see *Running the test suite* above) and re-run.
+
+### Port 5432 / 8770 already in use
+
+```bash
+lsof -i :5432    # find the process bound to 5432
+lsof -i :8770
+```
+
+Kill the conflicting process or change the port:
+- Postgres: edit `docker-compose.test.yml` (e.g. `"127.0.0.1:5433:5432"`) and update `config.toml`.
+- Gateway: edit `listen = "127.0.0.1:8770"` in `config.toml` (or set `OPENDRAY_LISTEN`).
+
+## Next steps
+
+- [`README.md`](../README.md) — high-level project overview
+- [`docs/design.md`](design.md) — architecture, subsystems, data model, roadmap
+- [`docs/adr/`](adr/) — every binding architecture decision, dated
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — how to send a PR
+- [`SECURITY.md`](../SECURITY.md) — vulnerability disclosure


### PR DESCRIPTION
## Summary

Adds a standalone, troubleshooting-aware quickstart so a fresh contributor can go from \`git clone\` to a running gateway in five minutes — leveraging the docker-compose dev Postgres added in #7.

## What landed

- **\`docs/quickstart.md\`** (new, ~170 lines) — long-form companion to the README's condensed Quickstart
- **\`README.md\`** — single-line pointer added to the Documentation index and at the top of the Quickstart section
- **\`CONTRIBUTING.md\`** — single-line pointer added to Development Setup

## Sections in the new doc

1. **Prerequisites** — the four tools and their version checks
2. **5-minute path** — \`docker compose up\` → \`cp config\` → \`pnpm build\` → \`migrate\` → \`serve\`
3. **Frontend hot-reload** — Vite dev + Go gateway split
4. **Bring-your-own Postgres** — for users who already have an instance
5. **Running the test suite** — without and with \`OPENDRAY_DEV_DB_URL\` exported
6. **Optional: backups + exports** — env setup pulled from the README's existing block
7. **Building a single distributable binary** — goreleaser + Docker, referencing #4's artifacts
8. **Troubleshooting** — empty \`dist/\`, connection refused, SKIP'd tests, port conflicts on 5432/8770
9. **Next steps** — links to design.md, ADRs, CONTRIBUTING, SECURITY

## What's NOT in this PR

- The README's condensed Quickstart is unchanged. The new doc is a long-form companion, not a replacement.
- No \`docs/operator-guide.md\` or \`docs/integration-guide.md\` content yet — those are still placeholders in the Documentation index, planned post-v1.0.

## Verification

- [x] No leftover \`192.168.3.88\` references — \`grep\` clean
- [x] All relative links point at files that exist (\`README.md\`, \`CONTRIBUTING.md\`, \`SECURITY.md\`, \`docs/design.md\`, \`docs/adr/\`)
- [x] DSN in the doc matches \`config.example.toml\` and \`docker-compose.test.yml\`

## Risk

🟢 None. Documentation only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)