### PR TITLE
fix(test): wait for capability propagation inside dialAndRegister

### DIFF
--- a/internal/channel/bridge/bridge_test.go
+++ b/internal/channel/bridge/bridge_test.go
@@ -47,7 +47,7 @@ func fixture(t *testing.T, cfg Config) (*Broker, *Bridge, string, func()) {
 	return broker, br, wsURL, cleanup
 }
 
-func dialAndRegister(t *testing.T, wsURL, token, platform string, caps []channel.Capability) *websocket.Conn {
+func dialAndRegister(t *testing.T, br *Bridge, wsURL, token, platform string, caps []channel.Capability) *websocket.Conn {
 	t.Helper()
 	header := http.Header{}
 	header.Set("X-Bridge-Token", token)
@@ -87,6 +87,21 @@ func dialAndRegister(t *testing.T, wsURL, token, platform string, caps []channel
 	if ack["ok"] != true {
 		t.Fatalf("register failed: %v", ack)
 	}
+	// The ack confirms the broker received our register frame, but
+	// applying capabilities to the bridge's state map happens on a
+	// different goroutine. Block until every declared capability
+	// has propagated so callers can immediately call Send/SendCard
+	// without racing the broker. 2s is generous on every runner we
+	// observe; local typically lands in < 5ms.
+	waitFor(t, 2*time.Second, func() bool {
+		got := channel.Capabilities(br)
+		for _, c := range caps {
+			if !containsCap(got, c) {
+				return false
+			}
+		}
+		return true
+	})
 	return conn
 }
 
@@ -138,7 +153,7 @@ func TestRegister_AttachesBridgeAndDeliversInbound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	conn := dialAndRegister(t, wsURL, "secret", "wechat",
+	conn := dialAndRegister(t, br, wsURL, "secret", "wechat",
 		[]channel.Capability{channel.CapText, channel.CapCard, channel.CapButtons})
 	defer conn.Close()
 
@@ -200,7 +215,7 @@ func TestSendCard_GatedByCapability(t *testing.T) {
 	}
 
 	// Adapter only declares "text" — no card capability.
-	conn := dialAndRegister(t, wsURL, "secret", "wechat",
+	conn := dialAndRegister(t, br, wsURL, "secret", "wechat",
 		[]channel.Capability{channel.CapText})
 	defer conn.Close()
 
@@ -218,18 +233,9 @@ func TestSendCard_WhenSupportedShipsFrame(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	conn := dialAndRegister(t, wsURL, "secret", "wechat",
+	conn := dialAndRegister(t, br, wsURL, "secret", "wechat",
 		[]channel.Capability{channel.CapText, channel.CapCard})
 	defer conn.Close()
-
-	// dialAndRegister returns once the WS message is sent, but
-	// capability propagation into br's state is async — wait for
-	// CapCard to surface before issuing the SendCard. Without
-	// this, the test races and intermittently fails with
-	// "capability not supported" under loaded CI runners.
-	waitFor(t, 2*time.Second, func() bool {
-		return containsCap(channel.Capabilities(br), channel.CapCard)
-	})
 
 	// Drain async frames from the adapter side.
 	frames := make(chan map[string]any, 4)
@@ -290,14 +296,9 @@ func TestDeclaredCapabilities_OnlyWhatAdapterClaimed(t *testing.T) {
 		t.Errorf("pre-attach caps = %v, want only [text]", got)
 	}
 
-	conn := dialAndRegister(t, wsURL, "secret", "wechat",
+	conn := dialAndRegister(t, br, wsURL, "secret", "wechat",
 		[]channel.Capability{channel.CapText, channel.CapButtons})
 	defer conn.Close()
-
-	// Wait briefly for attach side-effects.
-	waitFor(t, 1*time.Second, func() bool {
-		return containsCap(channel.Capabilities(br), channel.CapButtons)
-	})
 
 	got := channel.Capabilities(br)
 	if !containsCap(got, channel.CapButtons) || containsCap(got, channel.CapCard) {


### PR DESCRIPTION
## Summary

Third (and hopefully final) fix for the bridge-test race that's been intermittently red-CIing main. After #8 (added waitFor before SendCard in TestSendCard_WhenSupported) and #10 (bounded the ack read deadline), \`TestSendCard_GatedByCapability\` still hung 5m on CI runners.

Same shape: \`dialAndRegister\` returns once the broker acks the register frame, but capability propagation into the bridge's state map runs on a different goroutine. Any test that calls \`Send\`/\`SendCard\` immediately after \`dialAndRegister\` can race.

**Approach this time**: stop fixing one callsite at a time. Push the wait into the helper.

## Change

\`dialAndRegister\` now, after the ack, blocks until every declared capability is observable via \`channel.Capabilities(br)\`. 2s budget; local lands in <5ms.

Signature changes from
\`\`\`go
dialAndRegister(t, wsURL, token, platform, caps)
\`\`\`
to
\`\`\`go
dialAndRegister(t, br, wsURL, token, platform, caps)
\`\`\`
All 4 callsites updated.

The helper now being safe means we can also drop:
- The \`waitFor\` before SendCard in TestSendCard_WhenSupported (added by #8) — redundant
- The \`waitFor\` for CapButtons in TestDeclaredCapabilities — redundant

So the diff is +20/-19 lines but **deletes** more lines of fragile per-callsite synchronization than it adds.

## Why #8/#10 weren't enough

| PR | What it fixed | What it didn't |
|---|---|---|
| #8 | TestSendCard_WhenSupported (deterministic fail) | Other tests using the same helper still raced |
| #10 | dialAndRegister no longer hangs forever on dropped ack | Doesn't address post-ack capability propagation |
| **#12 (this)** | The shared helper now waits for capability state | (covers all current and future callers) |

## Verification

- \`go test -race -count=20 -timeout=2m ./internal/channel/bridge/...\` — 20/20 PASS
- \`go vet ./...\` — clean
- \`golangci-lint run --config .golangci.yml ./internal/channel/bridge/...\` — 0 issues
- \`go build ./...\` — clean

## Risk

🟢 Trivial. Test-only change, signature change isolated to a single test helper, all 4 callers updated atomically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)