### PR TITLE
fix(bridge): close done channel from captured local in readPump

### DIFF
--- a/internal/channel/bridge/bridge.go
+++ b/internal/channel/bridge/bridge.go
@@ -234,14 +234,20 @@ func (b *Bridge) attach(conn *websocket.Conn, declared []channel.Capability, pla
 		b.cancel()
 	}
 	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
 	b.conn = conn
 	b.cancel = cancel
-	b.done = make(chan struct{})
+	b.done = done
 	b.caps = caps
 	b.platform = platform
 	b.mu.Unlock()
 
-	go b.readPump(ctx, conn)
+	// Pass `done` as a captured local so readPump's deferred close
+	// still fires even if Stop() (which clears b.done) wins the race
+	// for b.mu. Reading b.done from inside readPump would race with
+	// that clear and silently leak a never-closed channel — Stop
+	// would then block forever on its own done receive.
+	go b.readPump(ctx, conn, done)
 	go b.pingPump(ctx, conn)
 	b.log.Info("bridge adapter attached", "platform", platform, "caps", declared)
 }
@@ -390,15 +396,11 @@ func (b *Bridge) writeFrame(payload map[string]any) error {
 }
 
 // readPump reads one frame at a time and dispatches it to the right
-// inbound path. Closes b.done on exit.
-func (b *Bridge) readPump(ctx context.Context, conn *websocket.Conn) {
-	b.mu.Lock()
-	done := b.done
-	b.mu.Unlock()
+// inbound path. Closes the supplied done channel on exit so Stop()
+// can wait for the goroutine to actually finish.
+func (b *Bridge) readPump(ctx context.Context, conn *websocket.Conn, done chan struct{}) {
 	defer func() {
-		if done != nil {
-			close(done)
-		}
+		close(done)
 		_ = conn.Close()
 	}()
 


### PR DESCRIPTION
## Summary

Production-code race that's been intermittently red-CIing this branch despite three prior test-side patches (#8, #10, #12). All three were on the test/registration helper side; this one is in \`Bridge.Stop()\` vs \`Bridge.attach()\`'s goroutine spawn.

## Reproduction

\`go test -race -count=20 -timeout=2m -run TestSendCard_GatedByCapability ./internal/channel/bridge/...\` triggers it locally. The test panic shows \`Stop()\` parked on \`<-done\` for the entire 2m timeout.

## Root cause

\`\`\`
goroutine 68 [select, 5min]:
    bridge.(*Bridge).Stop(...)
        bridge.go:205  // <-done blocks forever
\`\`\`

The interleaving:

1. \`attach()\` unlocks \`b.mu\` after setting \`b.done = c1\`
2. \`attach()\` spawns \`go b.readPump(ctx, conn)\` — the goroutine has not yet been scheduled
3. \`Stop()\` (defer cleanup goroutine) acquires \`b.mu\`, captures \`done = c1\`, sets \`b.done = nil\`, unlocks, blocks on \`<-done\`
4. \`readPump\` finally runs, locks \`b.mu\`, reads \`b.done\` — now **nil** because Stop already cleared it
5. \`readPump\`'s deferred close skips: \`if done != nil { close(done) }\`
6. Stop's \`<-done\` never fires

## Fix

Pass \`done\` as an explicit parameter to \`readPump\`, captured at the same critical section that creates it. The goroutine no longer touches \`b.done\` at all, so Stop's clear is harmless. The deferred close is now unconditional.

Bonus: the race detector now stays quiet — passing \`b.done\` to a goroutine outside the lock would have been an unsynchronized read.

## Why #8/#10/#12 missed it

| PR | Scope |
|---|---|
| #8 | SendCard test's pre-call capability race |
| #10 | dialAndRegister's ack ReadMessage deadline |
| #12 | Capability-propagation wait inside the helper |
| **#14 (this)** | Production code: Bridge.Stop vs attach goroutine spawn |

All four are different bugs that happened to share one symptom (test hangs).

## Verification

- \`go test -race -count=30 -timeout=2m -run TestSendCard_GatedByCapability ./internal/channel/bridge/...\` — 30/30 PASS
- \`go test -race -count=20 -timeout=3m ./internal/channel/bridge/...\` — full package, all PASS
- \`go vet ./...\` — clean
- \`go build ./...\` — clean

## Risk

🟡 Low-medium. Production code touch (12 insertions / 10 deletions) but tightly scoped to one Bridge method's goroutine boundary. Race detector stays happy. The fix is the standard Go idiom for "spawn a goroutine that uses a state variable" — capture at spawn time, don't dereference shared state inside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)