### PR TITLE
docs: add operator-guide.md + integration-guide.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ Zustand + xterm.js) and per-W milestone notes.
 - [`docs/design.md`](docs/design.md) — mission, architecture, subsystems,
   API, data model, roadmap
 - [`docs/adr/`](docs/adr/) — every binding architecture decision, dated
+- [`docs/operator-guide.md`](docs/operator-guide.md) — deploy + ops reference for production-ish setups
+- [`docs/integration-guide.md`](docs/integration-guide.md) — how to write an external integration in any language
 - `docs/api.md` — REST + WS reference (generated, lands post-v1.0)
-- `docs/integration-guide.md` — how to write an integration
-- `docs/operator-guide.md` — deploy + ops
 
 ## Tests
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1,0 +1,335 @@
+# Integration Guide
+
+This guide is for developers building an **integration** — an external
+application that talks to an opendray-v2 gateway over HTTP and
+WebSockets, in any language.
+
+If you're operating a deployment, see [`docs/operator-guide.md`](operator-guide.md).
+If you're contributing to opendray itself, see [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+## What is an integration?
+
+An integration is a separate process — your app — that registers with
+opendray and consumes its capabilities:
+
+- Create and drive PTY sessions backed by Claude Code, Codex, Gemini,
+  or arbitrary shells
+- Subscribe to event streams (session output, idle, ended, channel
+  events, etc.)
+- Be reverse-proxied through opendray for inbound traffic
+
+opendray itself does not embed integration code. Every integration is
+external; this keeps the gateway lean and language-agnostic.
+
+The full design is in [`docs/design.md`](design.md) §7–§11 and
+[`docs/adr/0006-integration-auth-and-paths.md`](adr/0006-integration-auth-and-paths.md).
+
+## Quick walk-through
+
+A 6-step concrete flow for a hypothetical Slack-style bot that posts
+to Slack when a session ends:
+
+1. **Operator registers your integration** with admin auth, picking a
+   `route_prefix` and a list of scopes
+2. opendray returns a **plaintext API key once** (not stored, not
+   shown again — you save it securely)
+3. **You expose `GET /health`** so opendray can probe you every 30s
+4. **You subscribe to events** via WebSocket using the API key
+5. **When `session.ended` fires**, your bot posts to Slack
+6. **When the user replies in Slack**, you `POST /api/v1/sessions/{id}/input`
+   to drive the conversation back into opendray
+
+## Registration
+
+Only an admin can register an integration. Endpoint:
+
+```http
+POST /api/v1/integrations
+Authorization: Bearer <admin_token>
+Content-Type: application/json
+
+{
+  "name":         "slack-bot",
+  "base_url":     "http://slack-bot-server:3000",
+  "route_prefix": "slack-bot",
+  "scopes":       ["session:read", "session:input", "event:subscribe:session.*"],
+  "version":      "1.0.0"
+}
+```
+
+Required fields:
+
+| Field | Notes |
+|---|---|
+| `name` | Human-readable label |
+| `base_url` | Where opendray reverse-proxies inbound requests addressed to your `route_prefix`. Optional — pure consumers can omit it. |
+| `route_prefix` | Unique slug. Reserved: `_events`, `_kinds`, `_internal`, `_*`. |
+| `scopes` | Array of allow-listed capabilities (see below). |
+| `version` | Free-form, your choice. opendray surfaces it in admin UI. |
+
+Response (HTTP 201):
+
+```json
+{
+  "id":      "int_abc123",
+  "api_key": "odk_live_KJq8ne3...",   // ← shown once, save it
+  "name":    "slack-bot",
+  ...
+}
+```
+
+The `api_key` is the **only** time the plaintext is visible. opendray
+stores a bcrypt hash (cost 12) and discards the plaintext. Lose the
+key and you'll need to rotate via:
+
+```http
+POST /api/v1/integrations/{id}/rotate-key
+Authorization: Bearer <admin_token>
+```
+
+…which invalidates the old key immediately and returns a new one.
+
+## Authentication
+
+Every request your integration makes uses the API key as a bearer
+token:
+
+```http
+GET /api/v1/sessions
+Authorization: Bearer odk_live_KJq8ne3...
+```
+
+For WebSocket endpoints (browsers can't set custom headers on the
+handshake), use the query-parameter form:
+
+```
+ws://opendray:8770/api/v1/integrations/_events?token=odk_live_KJq8ne3...&topics=session.*
+```
+
+opendray validates the bearer token by:
+1. Trying admin first (in-memory token lookup)
+2. Falling back to integration (bcrypt-compare against every
+   integration's hash, then attaching the matched integration's scopes
+   to the request principal)
+
+Requests with no `Authorization` header / no `token` query param fail
+with 401.
+
+## Scopes
+
+Scopes gate what your integration can do. Defined values:
+
+| Scope | What it allows |
+|---|---|
+| `session:read` | List sessions, read buffers and metadata |
+| `session:create` | Spawn new sessions |
+| `session:input` | Send keyboard input to a session |
+| `channel:send` | Post messages to channel adapters |
+| `channel:receive` | Receive inbound messages from channel adapters |
+| `provider:read` | List CLI providers + per-provider config |
+| `event:subscribe:<topic>` | Subscribe to one event topic on the WS endpoint |
+
+`event:subscribe:*` and `event:subscribe:session.*` work as wildcards
+(prefix match).
+
+**Today (M3)**: only `event:subscribe:<topic>` is enforced — every
+other scope is _declared_ but every business endpoint accepts any
+valid integration token. Per-route scope enforcement on session /
+channel / provider endpoints is on the v1.1 roadmap.
+
+Default scopes for a new integration:
+`["session:read", "event:subscribe:session.*"]`.
+
+## REST endpoints exposed for integrations
+
+All under `/api/v1/`. Full method/route table below; the dual-auth
+group accepts both admin and integration tokens.
+
+### Admin-only
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/integrations` | Register |
+| `GET` | `/integrations` | List |
+| `GET` | `/integrations/{id}` | Detail |
+| `PATCH` | `/integrations/{id}` | Update (`base_url`, `scopes`, `version`, `enabled`) |
+| `DELETE` | `/integrations/{id}` | Deregister |
+| `POST` | `/integrations/{id}/rotate-key` | Issue new API key |
+| `GET` | `/integrations/_calls` | Call-log audit |
+
+### Dual-auth (admin or integration token)
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/sessions` | Create a new PTY session |
+| `GET` | `/sessions` | List sessions |
+| `GET` | `/sessions/{id}` | Session detail |
+| `DELETE` | `/sessions/{id}` | Terminate |
+| `POST` | `/sessions/{id}/input` | Send keyboard input |
+| `POST` | `/sessions/{id}/resize` | Resize PTY |
+| `WS` | `/sessions/{id}/stream` | Bidirectional terminal stream |
+| `GET` | `/sessions/{id}/buffer` | Replay the ring buffer |
+| `GET` | `/providers` | List CLI providers |
+| `PATCH` | `/providers/{id}/config` | Set per-provider config |
+| `GET` | `/channels` | List channels |
+| `WS` | `/integrations/_events` | Subscribe to event topics |
+
+## WebSocket events
+
+Subscribe by query string:
+
+```
+WS /api/v1/integrations/_events?token=odk_live_...&topics=session.output,session.ended
+```
+
+- `topics` is comma-separated; wildcards via trailing `.*` (e.g.
+  `session.*`)
+- The handler enforces `event:subscribe:<topic>` for each requested
+  topic — admin tokens bypass the check
+
+### Frame schema
+
+Every event frame is a JSON object:
+
+```json
+{
+  "topic": "session.output",
+  "ts":    "2026-04-27T14:01:00.123Z",
+  "data":  { ... topic-specific payload ... }
+}
+```
+
+### Standard topics
+
+| Topic prefix | Source |
+|---|---|
+| `session.*` | `output`, `idle`, `ended` from the PTY session manager |
+| `channel.*` | `message_received`, `command_received`, `message_sent` from channels |
+| `integration.*` | `registered`, `health_change`, `rotated` from the registry |
+
+### Connection management
+
+- Server pings every 20s; clients should respond with pong (handled
+  automatically by most WS libraries)
+- Per-message write timeout is 5s
+- The connection drops on auth failure, scope violation, or topic
+  parse error — reconnect with backoff
+
+## Reverse proxy
+
+If you set a `base_url` on registration, opendray exposes a passthrough:
+
+```
+ANY /api/v1/proxy/{your-prefix}/*
+```
+
+Example: with `route_prefix = "slack-bot"` and `base_url = "http://slack-bot-server:3000"`,
+a request to:
+
+```
+GET http://opendray:8770/api/v1/proxy/slack-bot/api/v1/dogs/123
+```
+
+…is forwarded to:
+
+```
+GET http://slack-bot-server:3000/api/v1/dogs/123
+```
+
+opendray injects three headers:
+- `X-OpenDray-Forwarded-For` — the original client IP
+- `X-Integration-ID` — your integration's ID (so you know it's coming
+  from opendray, not direct)
+- `X-OpenDray-API: v1`
+
+…and **strips** the inbound `Authorization` header before forwarding,
+so admins can hit your integration through opendray without leaking
+their token to your process.
+
+If your integration is disabled or unhealthy, opendray returns HTTP
+503 and never forwards the request.
+
+## Health probe
+
+opendray probes every registered integration's `GET /health` every
+30 seconds. Expected response:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "status":     "healthy",      // "healthy" | "degraded" | "unhealthy"
+  "version":    "1.0.0",
+  "busy_ratio": 0.1             // 0.0..1.0, optional
+}
+```
+
+A non-200 response or a non-`healthy` status flips the integration's
+health flag in opendray's registry; the next reverse-proxy request
+will return 503 instead of forwarding.
+
+## Worked example: Slack-style bot
+
+```bash
+# 1. Operator registers
+curl -X POST http://opendray:8770/api/v1/integrations \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name":         "slack-bot",
+    "base_url":     "http://slack-bot-server:3000",
+    "route_prefix": "slack-bot",
+    "scopes":       ["session:read", "session:input", "event:subscribe:session.*"],
+    "version":      "1.0.0"
+  }'
+# → returns api_key, save it as $BOT_KEY
+
+# 2. Bot subscribes to session events (using websocat / Python websockets / etc.)
+websocat "ws://opendray:8770/api/v1/integrations/_events?token=$BOT_KEY&topics=session.output,session.ended"
+# ← {"topic":"session.ended","ts":"...","data":{"session_id":"sess_42","exit_code":0}}
+
+# 3. On session.ended, bot posts to Slack via Slack's own API
+#    (this part is bot-internal, opendray doesn't see it)
+
+# 4. User replies in Slack; bot routes back to opendray
+curl -X POST "http://opendray:8770/api/v1/sessions/sess_42/input" \
+  -H "Authorization: Bearer $BOT_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"text":"@bot: continue from where you left off"}'
+
+# 5. Operator can hit the bot's status page through opendray's proxy
+curl "http://opendray:8770/api/v1/proxy/slack-bot/status" \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+## Reference implementation
+
+A working TypeScript demo client lives at
+[`examples/integrations/demo-client/`](../examples/integrations/demo-client).
+It shows:
+
+- First-run registration flow + secure local API-key storage (mode 0600)
+- Key rotation recovery (auto-trigger on 401 → admin rotates → new key
+  persisted)
+- Session creation, input, event subscription
+- The full 9-step lifecycle from `register` to `unregister`
+
+Files to read in order:
+- `examples/integrations/demo-client/src/index.ts` — top-level flow
+- `examples/integrations/demo-client/src/client.ts` — `OpendrayClient`
+  REST + WS abstraction (a model for your own SDK)
+- `examples/integrations/demo-client/src/state.ts` — local key persistence
+
+The demo deliberately avoids any framework dependency — it's pure
+node `fetch` + the `ws` library. Port to your language of choice.
+
+## See also
+
+- [`docs/design.md`](design.md) §7–§12 — integration design rationale
+- [`docs/adr/0006-integration-auth-and-paths.md`](adr/0006-integration-auth-and-paths.md) —
+  dual-auth model, scope deferral, API-key format decisions
+- [`docs/adr/0010-integration-call-log.md`](adr/0010-integration-call-log.md) —
+  call-log audit trail
+- [`docs/operator-guide.md`](operator-guide.md) — running opendray
+- [`SECURITY.md`](../SECURITY.md) — vulnerability disclosure

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -1,0 +1,277 @@
+# Operator Guide
+
+This guide is for operators running an opendray-v2 deployment in
+production-like settings. Developer-flavoured setup is in
+[`docs/quickstart.md`](quickstart.md).
+
+## Topology
+
+opendray ships as a **single static Go binary** with the React admin
+SPA embedded via `go:embed`. Architecture:
+
+```
+        ┌─────────────────────────┐
+client ─┤  HTTPS reverse proxy    │
+        │  (Cloudflare Tunnel,    │
+        │   nginx, Caddy, etc.)   │
+        └────────────┬────────────┘
+                     │ HTTP, plaintext
+                     ▼
+        ┌─────────────────────────┐
+        │  opendray binary :8770  │
+        │  ├── /api/v1/*          │
+        │  ├── /admin/* (SPA)     │
+        │  └── /api/v1/health     │
+        └────────────┬────────────┘
+                     │ TCP, pgx/v5
+                     ▼
+        ┌─────────────────────────┐
+        │  PostgreSQL 15+         │
+        └─────────────────────────┘
+```
+
+opendray itself does not terminate TLS. Run it behind Cloudflare
+Tunnel, nginx, Caddy, or any other reverse proxy.
+
+## CLI subcommands
+
+```
+opendray serve     [-config FILE]    # start the gateway
+opendray migrate   [-config FILE]    # apply pending DB migrations and exit
+opendray notes     <subcommand>      # filesystem notes vault ops
+opendray skill     <subcommand>      # inspect/load agent skills
+opendray mcp       <subcommand>      # inspect MCP server registry
+opendray mcp-memory                  # stdio MCP server (used by Claude/Codex)
+opendray version                     # print build info and exit
+```
+
+Only `serve` runs an HTTP listener. Every other subcommand exits as
+soon as its task is done.
+
+## Configuration reference
+
+The full default config is in [`config.example.toml`](../config.example.toml).
+Every field can be overridden by an `OPENDRAY_*` env variable. Env wins
+over file.
+
+### Top-level
+
+| TOML key | Env override | Default | Notes |
+|---|---|---|---|
+| `listen` | `OPENDRAY_LISTEN` | `127.0.0.1:8770` | HTTP listen address |
+
+### `[database]`
+
+| Key | Env | Default | Notes |
+|---|---|---|---|
+| `url` | `OPENDRAY_DATABASE_URL` | _(required)_ | PostgreSQL 15+ DSN. Use a project-scoped role with CRUD-only privileges, never a superuser. |
+| `max_conns` | `OPENDRAY_DATABASE_MAX_CONNS` | `16` | Pool cap for the pgx connection pool. |
+
+### `[admin]`
+
+| Key | Env | Default | Notes |
+|---|---|---|---|
+| `user` | `OPENDRAY_ADMIN_USER` | `admin` | Single-admin model — there's no multi-user system in v1. |
+| `password` | `OPENDRAY_ADMIN_PASSWORD` | _(required)_ | Compared with `subtle.ConstantTimeCompare` against the request body. **Stored plaintext** in the config file or env — there is no hash-at-rest. |
+| `token_ttl` | `OPENDRAY_ADMIN_TOKEN_TTL` | `24h` | Bearer token absolute lifetime. |
+
+### `[log]`
+
+| Key | Env | Default | Notes |
+|---|---|---|---|
+| `level` | `OPENDRAY_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error` |
+| `format` | `OPENDRAY_LOG_FORMAT` | `text` | `text` (slog default) or `json` |
+| `file` | _(none)_ | _(stdout only)_ | Optional rotating log file (10 MB max, keeps 5 archives). |
+
+Every level/format also writes to an in-memory ring buffer
+(~2,000 records) served at `/admin/logs` for live tailing.
+
+### `[session]`
+
+| Key | Env | Default | Notes |
+|---|---|---|---|
+| `idle_threshold` | `OPENDRAY_SESSION_IDLE_THRESHOLD` | `30s` | A session that emits no stdout for this long fires `session.idle`. |
+| `idle_interval` | `OPENDRAY_SESSION_IDLE_INTERVAL` | `5s` | Idle-detector poll cadence. |
+
+### `[vault]` and `[mcp]`
+
+Filesystem paths for the notes vault and MCP server registry. See
+`config.example.toml`; rarely changed.
+
+### `[backup]`
+
+Optional encrypted-backup subsystem. Disabled by default.
+
+| Key | Env | Default | Notes |
+|---|---|---|---|
+| `enabled` | `OPENDRAY_BACKUP_ENABLED` | `false` | Master toggle. |
+| `local_dir` | `OPENDRAY_BACKUP_LOCAL_DIR` | `~/.opendray/backups` | Default local target root. |
+| `export_dir` | `OPENDRAY_BACKUP_EXPORT_DIR` | OS-specific | Staging dir for `/export` zip bundles. |
+| `pg_dump_path` | `OPENDRAY_BACKUP_PG_DUMP_PATH` | _(PATH lookup)_ | Override `pg_dump` binary location. Must match the server's major version. |
+| `pg_restore_path` | `OPENDRAY_BACKUP_PG_RESTORE_PATH` | _(PATH lookup)_ | Override `pg_restore` location. |
+
+Plus one **env-only** secret:
+
+| Env | Default | Notes |
+|---|---|---|
+| `OPENDRAY_BACKUP_KEY` | _(required when backups are enabled)_ | Master passphrase, AES-256-GCM key derivation. **Never write this in `config.toml`** — by design the loader rejects it there. |
+
+## Database lifecycle
+
+Migrations live in `internal/store/migrations/*.sql`, embedded into
+the binary at build time. There are 23 migrations as of this writing,
+named `0001_initial.sql` through `0023_*.sql`.
+
+The runner:
+- Maintains a `schema_migrations(version, applied_at)` table.
+- Applies any unapplied versions in lexical filename order.
+- Each migration runs in its own transaction.
+
+```bash
+opendray migrate -config config.toml
+```
+
+It's idempotent — already-applied versions are skipped, so it's safe
+to re-run on every deploy. There are **no down-migrations**; rollback
+is manual via raw SQL. To re-run a specific migration after a fix:
+
+```sql
+DELETE FROM schema_migrations WHERE version = '0014_backups';
+```
+
+…then re-run `opendray migrate`.
+
+## Health endpoint
+
+`GET /api/v1/health` (no auth required):
+
+```json
+{
+  "status": "ok",
+  "version": "1.0.0",
+  "commit": "abc1234",
+  "uptime_s": 12345,
+  "db_ok": true
+}
+```
+
+- HTTP 200 + `db_ok: true` → ready for traffic
+- HTTP 503 + `db_ok: false` → degraded; the gateway is up but Postgres
+  ping failed within 2 seconds
+
+This single endpoint serves both liveness and readiness for k8s-style
+probes.
+
+## Logging
+
+Standard library `log/slog` with two handlers:
+
+- **Text** (default) — human-readable
+- **JSON** — for ingestion by log shippers (Vector, Fluentd, etc.)
+
+Outputs:
+- Always to stdout/stderr
+- Optionally to a rotating file (`[log].file`, 10 MB × 5 archives)
+- Always to an in-memory ring buffer surfaced at `/admin/logs`
+
+Set `[log].level = "debug"` to enable verbose component-level traces.
+Production: keep at `info` with `format = "json"` if shipping logs.
+
+## Backup subsystem
+
+Two surfaces:
+
+1. **Disaster-recovery backups** — full PostgreSQL dumps via `pg_dump`,
+   encrypted client-side with AES-256-GCM, written to a configured
+   target (local FS, SMB, WebDAV, SFTP, rclone, or S3).
+2. **Data exports** — admin-triggered zip bundles of memories /
+   integrations / custom tasks, downloaded via signed URL.
+
+Enabling:
+
+```bash
+export OPENDRAY_BACKUP_ENABLED=1
+export OPENDRAY_BACKUP_KEY="$(openssl rand -base64 32)"
+
+# pg_dump must match the server's major version. On macOS:
+export OPENDRAY_BACKUP_PG_DUMP_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_dump
+export OPENDRAY_BACKUP_PG_RESTORE_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_restore
+
+opendray serve -config config.toml
+```
+
+The admin sidebar grows a Backups page (`/backups`) and an Export page
+(`/export`). The full lifecycle (target setup, schedules, restore
+flow) is documented in ADR 0012 and the in-app **Tutorial → Backups**
+section.
+
+State persists in three DB tables (created by migration `0014_backups.sql`):
+- `backup_targets` — destination configs
+- `backup_schedules` — recurring specs
+- `backups` — audit log of every dump
+
+Rotate `OPENDRAY_BACKUP_KEY` carefully: backups encrypted with the old
+key remain decryptable only with the old key. Keep the old passphrase
+out of band until those backups are rotated out of retention.
+
+## Process lifecycle
+
+opendray traps `SIGINT` and `SIGTERM` and runs a graceful shutdown
+(15-second window):
+
+1. HTTP server stops accepting new requests
+2. In-flight HTTP requests get up to 60 seconds to finish (per-request
+   read/write timeout)
+3. `Manager.Shutdown` sends `SIGTERM` to every running PTY session
+4. `Hub.Shutdown` drains pending channel notifications (Telegram, etc.)
+5. Background subsystems drain with per-subsystem timeouts:
+   - Health checker: 2s
+   - Audit sink: 5s
+   - Vault sync: 2s
+   - Backup scheduler: 2s (if enabled)
+   - Capture engine: 2s
+
+The grace window is **15 seconds** total for the supervisor to forward
+to subsystems plus the per-subsystem timeouts above. Plan your
+deploy/restart cycle so requests finish or fail fast — long-running
+PTY sessions get a SIGTERM and may not complete in 15s; the agent
+process is responsible for handling that.
+
+## Sessions / PTY
+
+opendray runs interactive PTYs via `creack/pty`, which works on macOS
+and Linux (and other Unix-likes). **Windows is not supported** — there
+is no PTY abstraction.
+
+Each session has:
+- A 1 MiB ring buffer of stdout for replay (`/api/v1/sessions/{id}/buffer`)
+- A virtual-terminal emulator (`vt10x.Terminal`) for screen snapshots
+- An idle detector firing `session.idle` events on the event bus
+
+Session states: `pending` → `running` → (`idle`?) → (`stopped` | `ended`).
+
+## Admin auth model
+
+There's one human admin. The flow:
+
+1. Client `POST /api/v1/auth/login` with `{user, password}`
+2. opendray `subtle.ConstantTimeCompare`s both fields against the
+   configured pair (no hashing — config carries plaintext)
+3. On match, opendray issues a 32-byte random bearer token
+4. Token lives in process memory only (`map[string]TokenInfo`); it's
+   **lost on restart** — every operator restart forces re-login on
+   active web sessions
+5. Tokens expire absolutely after `[admin].token_ttl` (default 24h)
+6. WebSocket endpoints accept the token via `?token=` query parameter
+   (browsers can't set custom headers on WS handshakes)
+
+Failed and successful logins both publish events (`admin.login_failed`,
+`admin.login_success`) that the audit sink persists.
+
+## Where to look next
+
+- [`config.example.toml`](../config.example.toml) — full annotated config
+- [`docs/quickstart.md`](quickstart.md) — developer setup
+- [`docs/integration-guide.md`](integration-guide.md) — building external integrations
+- [`docs/adr/`](adr/) — architecture decisions
+- [`docs/design.md`](design.md) — full design spec


### PR DESCRIPTION
## Summary

Fills two placeholders the README has been pointing at since v1.0-rc:

- **\`docs/operator-guide.md\`** (~210 lines) — full deploy + ops reference
- **\`docs/integration-guide.md\`** (~280 lines) — language-agnostic guide for building external integrations

## What's covered

### Operator guide

- Topology diagram (binary + reverse-proxied TLS + Postgres)
- CLI subcommands (serve / migrate / notes / skill / mcp / mcp-memory / version)
- **Full configuration reference**: every TOML field paired with its \`OPENDRAY_*\` env override and default
- Database lifecycle: how migrations run, idempotence, lack of down-migrations
- \`/api/v1/health\` shape, dual-purpose readiness + liveness
- Logging: handlers, outputs, in-memory ring buffer at \`/admin/logs\`
- Backup subsystem: \`OPENDRAY_BACKUP_KEY\` (env-only by design), pg_dump version-matching gotcha, the three DB tables migration 0014 creates
- Process lifecycle: 15s graceful shutdown breakdown including per-subsystem timeouts
- Sessions / PTY: macOS + Linux only (no Windows), ring buffer, state machine
- Admin auth: plaintext-in-config rationale, in-memory tokens, WS \`?token=\` quirk

### Integration guide

- \"What is an integration?\" framing
- 6-step concrete walk-through
- Registration: full POST contract with example request/response
- API key: bcrypt at rest, \`?token=\` and \`Authorization: Bearer\` dual presentation, rotate-key endpoint
- Scope catalogue + current enforcement (only \`event:subscribe:<topic>\` is enforced today; full per-route enforcement is v1.1)
- REST endpoint table split into admin-only vs dual-auth
- WebSocket \`/integrations/_events\` endpoint: query string format, frame schema, topics, ping/pong + write timeout
- Reverse proxy: header injection, \`Authorization\` stripping, 503-on-unhealthy
- \`/health\` probe contract opendray sends to integrations
- Worked example: Slack-style bot end-to-end with curl + websocat
- Pointer to \`examples/integrations/demo-client/\` (TypeScript reference)

### README

The Documentation index entries are now real links instead of bare paths. \`docs/api.md\` placeholder remains (still post-v1.0).

## Verification

- All internal links resolve to existing files (verified including the cross-refs to ADR files whose filenames differed from initial guesses — \`0006-integration-auth-and-paths.md\` and \`0010-integration-call-log.md\`)
- No personal-infrastructure / credential strings in the new content
- \`go vet\`, \`golangci-lint\`, \`go build\` — all clean (sanity pass; no code change)

## Risk

🟢 None. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)