### PR TITLE
ci: gate long-lived feature branches with the same checks as main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, "feat/**"]
   pull_request:
-    branches: [main]
+    branches: [main, "feat/**"]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Pre-requisite for the upcoming \`feat/mobile-platform\` long-lived branch.

Adds \`feat/**\` to both the \`push\` and \`pull_request\` trigger lists in \`.github/workflows/ci.yml\` so internal sub-PRs targeting a long-lived feature branch go through the same **Frontend / Backend / Lint** gates as PRs to main.

## Why

Without this, work on \`feat/mobile-platform\` would either:
- Bypass CI entirely while in flight (silent regression risk), or
- Have to merge straight to main piece-by-piece — which defeats the point of a long-lived integration branch (large drafts would land on main unfinished).

The glob \`feat/**\` is permissive enough that any future feature line gets coverage automatically. Concurrency group keys off \`github.ref\`, so different branches don't cancel each other's runs.

## Diff

\`\`\`diff
 on:
   push:
-    branches: [main]
+    branches: [main, \"feat/**\"]
   pull_request:
-    branches: [main]
+    branches: [main, \"feat/**\"]
\`\`\`

No behavioral change for main.

## Test plan

- [ ] CI passes on this PR (it will, since the trigger condition for PRs to main is unchanged on the matching path)
- [ ] After merge: open a no-op PR targeting any \`feat/*\` branch (will happen naturally with the first mobile-platform sub-PR) and confirm CI fires

## Risk

🟢 None. YAML-only change, single trigger field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)