### PR TITLE
chore(monorepo): pnpm workspaces — minimal structural change [A1]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,23 +22,24 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Reads `packageManager` from root package.json so this stays
+      # in lockstep with what local devs install via corepack.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: pnpm
-          cache-dependency-path: app/web/pnpm-lock.yaml
+          cache-dependency-path: pnpm-lock.yaml
 
+      # Install at the workspace root so every workspace package
+      # (currently `web`; soon `shared`, `shared-ui`, `mobile`)
+      # gets its node_modules wired correctly.
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        working-directory: app/web
 
       - name: Type-check + build
-        run: pnpm build
-        working-directory: app/web
+        run: pnpm --filter web build
 
       # Hand the built bundle to the backend job so `go:embed` finds it.
       - uses: actions/upload-artifact@v5

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "opendray-v2-monorepo",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Root package for the opendray-v2 pnpm workspaces. Houses no source code; each surface lives under app/<workspace>/.",
+  "scripts": {
+    "build:web": "pnpm --filter web build",
+    "dev:web": "pnpm --filter web dev",
+    "lint:web": "pnpm --filter web lint"
+  },
+  "engines": {
+    "node": ">=22",
+    "pnpm": ">=10"
+  },
+  "packageManager": "pnpm@10.27.0"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,9 @@ settings:
 
 importers:
 
-  .:
+  .: {}
+
+  app/web:
     dependencies:
       '@hookform/resolvers':
         specifier: ^5.2.2
@@ -1102,6 +1104,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# Monorepo workspace definition. Each entry under app/* is its own
+# package with its own package.json. Today only `web` exists; the
+# upcoming additions are `shared`, `shared-ui`, and `mobile` (see
+# docs/adr/0015-mobile-platform.md).
+packages:
+  - "app/*"


### PR DESCRIPTION
## Summary

**A1** of the mobile-platform plan (see [ADR 0015](https://github.com/Opendray/opendray_v2/blob/feat/mobile-platform/docs/adr/0015-mobile-platform.md)). Establishes the pnpm workspace skeleton without renaming anything or moving source code. Every existing build flow continues to work; this PR is the foundation that A2 (\`shared/\`), A3 (\`shared-ui/\`), B1 (\`mobile/\`) build on.

## Changes

- New \`pnpm-workspace.yaml\` at the repo root: \`packages: [\"app/*\"]\`
- New root \`package.json\`: workspace manifest only, three convenience scripts (\`build:web\`, \`dev:web\`, \`lint:web\`), node/pnpm engines declared
- \`app/web/pnpm-lock.yaml\` → \`pnpm-lock.yaml\` (moved to repo root via \`git mv\` to preserve history)
- \`.github/workflows/ci.yml\`:
  - \`cache-dependency-path: pnpm-lock.yaml\` (was \`app/web/pnpm-lock.yaml\`)
  - \`pnpm install --frozen-lockfile\` runs at the workspace root, no \`working-directory: app/web\`
  - Build invoked as \`pnpm --filter web build\`

## Deliberately NOT touched

| Item | Reason |
|---|---|
| \`app/web/package.json\` \`name: \"web\"\` | Keep diff small; rename to \`@opendray/web\` later in A4 alongside \`shared\` and \`shared-ui\` |
| \`app/web/vite.config.ts\` outDir → \`../../internal/web/dist\` | Unchanged so \`internal/web/embed.go\` keeps working with no Go-side change |
| \`.gitignore\` | \`**/node_modules/\` already covers the root case |

## Verification

| Check | Result |
|---|---|
| \`pnpm install --frozen-lockfile\` at repo root | ✅ Lockfile up to date |
| \`pnpm --filter web build\` | ✅ Bundles into \`internal/web/dist/\` with same files |
| \`go build ./cmd/opendray\` | ✅ Clean (embed resolves) |

## Risk

🟢 Low. Structural-only; no source changes. The only execution surface that could regress is CI's pnpm install/build steps, which this PR also exercises immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)