### PR TITLE
feat(auth+store): mobile login TTL + device_tokens schema [B2]

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -20,7 +20,11 @@ url = "postgres://opendray:opendray@127.0.0.1:5432/opendray?sslmode=disable"
 # Admin auth (single human). Prefer env vars in production.
 user      = "admin"
 password  = "CHANGEME"
-token_ttl = "24h"  # bearer token absolute lifetime; empty = 24h default
+token_ttl = "24h"  # browser bearer token absolute lifetime; empty = 24h default
+# Mobile bearer tokens (issued via /api/v1/auth/mobile-login from the
+# Capacitor app) live longer because the device gates access via
+# biometrics + secure storage. Empty = 30d default.
+# mobile_token_ttl = "30d"
 
 [log]
 level  = "info"   # debug | info | warn | error

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -73,7 +73,8 @@ over file.
 |---|---|---|---|
 | `user` | `OPENDRAY_ADMIN_USER` | `admin` | Single-admin model — there's no multi-user system in v1. |
 | `password` | `OPENDRAY_ADMIN_PASSWORD` | _(required)_ | Compared with `subtle.ConstantTimeCompare` against the request body. **Stored plaintext** in the config file or env — there is no hash-at-rest. |
-| `token_ttl` | `OPENDRAY_ADMIN_TOKEN_TTL` | `24h` | Bearer token absolute lifetime. |
+| `token_ttl` | `OPENDRAY_ADMIN_TOKEN_TTL` | `24h` | Bearer token absolute lifetime for browser logins (`/api/v1/auth/login`). |
+| `mobile_token_ttl` | `OPENDRAY_ADMIN_MOBILE_TOKEN_TTL` | `30d` (`720h`) | Bearer token absolute lifetime for the Capacitor mobile app (`/api/v1/auth/mobile-login`). Longer because the device gates access via biometrics + secure storage. |
 
 ### `[log]`
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	defaultTokenTTL = 24 * time.Hour
-	tokenByteLen    = 32
+	defaultTokenTTL       = 24 * time.Hour
+	defaultMobileTokenTTL = 30 * 24 * time.Hour
+	tokenByteLen          = 32
 )
 
 // ErrInvalidCredentials is returned by Login when user/password do not
@@ -46,10 +47,11 @@ type TokenInfo struct {
 // Service is the admin auth surface. Construct via New and pass
 // Middleware to chi.Router.Use for protected groups.
 type Service struct {
-	cfg config.AdminConfig
-	ttl time.Duration
-	bus *eventbus.Hub
-	log *slog.Logger
+	cfg       config.AdminConfig
+	ttl       time.Duration
+	mobileTTL time.Duration
+	bus       *eventbus.Hub
+	log       *slog.Logger
 
 	mu     sync.RWMutex
 	tokens map[string]TokenInfo
@@ -63,18 +65,37 @@ func New(cfg config.AdminConfig, bus *eventbus.Hub, log *slog.Logger) *Service {
 	if ttl <= 0 {
 		ttl = defaultTokenTTL
 	}
+	mobileTTL := cfg.MobileDuration()
+	if mobileTTL <= 0 {
+		mobileTTL = defaultMobileTokenTTL
+	}
 	return &Service{
-		cfg:    cfg,
-		ttl:    ttl,
-		bus:    bus,
-		log:    log.With("component", "auth"),
-		tokens: make(map[string]TokenInfo),
+		cfg:       cfg,
+		ttl:       ttl,
+		mobileTTL: mobileTTL,
+		bus:       bus,
+		log:       log.With("component", "auth"),
+		tokens:    make(map[string]TokenInfo),
 	}
 }
 
 // Login validates user/password using constant-time comparison and
 // issues a fresh token on success. Empty admin config rejects all.
+// Uses the configured `[admin].token_ttl` (default 24h).
 func (s *Service) Login(user, password string) (string, TokenInfo, error) {
+	return s.loginWithTTL(user, password, s.ttl)
+}
+
+// LoginMobile is identical to Login except the token's absolute
+// lifetime is `[admin].mobile_token_ttl` (default 30d). The longer
+// TTL is reasonable on mobile because the device gates access via
+// biometrics + secure storage; on a desktop browser the shorter
+// default applies. See ADR 0015 §5.
+func (s *Service) LoginMobile(user, password string) (string, TokenInfo, error) {
+	return s.loginWithTTL(user, password, s.mobileTTL)
+}
+
+func (s *Service) loginWithTTL(user, password string, ttl time.Duration) (string, TokenInfo, error) {
 	if s.cfg.User == "" || s.cfg.Password == "" {
 		s.publishLogin(user, false, "admin not configured")
 		return "", TokenInfo{}, ErrInvalidCredentials
@@ -94,7 +115,7 @@ func (s *Service) Login(user, password string) (string, TokenInfo, error) {
 	info := TokenInfo{
 		Username:  s.cfg.User,
 		IssuedAt:  now,
-		ExpiresAt: now.Add(s.ttl),
+		ExpiresAt: now.Add(ttl),
 	}
 	s.mu.Lock()
 	s.tokens[tok] = info

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -56,6 +56,62 @@ func TestLogin_AdminNotConfigured(t *testing.T) {
 	}
 }
 
+func TestLoginMobile_UsesMobileTTL(t *testing.T) {
+	cfg := config.AdminConfig{
+		User:           "admin",
+		Password:       "secret",
+		TokenTTL:       "1h",
+		MobileTokenTTL: "168h", // 7d
+	}
+	s := New(cfg, nil, nil)
+
+	_, browserInfo, err := s.Login("admin", "secret")
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	_, mobileInfo, err := s.LoginMobile("admin", "secret")
+	if err != nil {
+		t.Fatalf("LoginMobile: %v", err)
+	}
+
+	browserSpan := browserInfo.ExpiresAt.Sub(browserInfo.IssuedAt)
+	mobileSpan := mobileInfo.ExpiresAt.Sub(mobileInfo.IssuedAt)
+	if browserSpan >= mobileSpan {
+		t.Errorf("expected mobile TTL > browser TTL; got browser=%s mobile=%s",
+			browserSpan, mobileSpan)
+	}
+	wantBrowser := time.Hour
+	wantMobile := 168 * time.Hour
+	if browserSpan != wantBrowser {
+		t.Errorf("browser TTL = %s, want %s", browserSpan, wantBrowser)
+	}
+	if mobileSpan != wantMobile {
+		t.Errorf("mobile TTL = %s, want %s", mobileSpan, wantMobile)
+	}
+}
+
+func TestLoginMobile_DefaultsToThirtyDays(t *testing.T) {
+	// MobileTokenTTL unset → 30d default; TokenTTL unset → 24h default.
+	cfg := config.AdminConfig{User: "admin", Password: "secret"}
+	s := New(cfg, nil, nil)
+	_, info, err := s.LoginMobile("admin", "secret")
+	if err != nil {
+		t.Fatalf("LoginMobile: %v", err)
+	}
+	span := info.ExpiresAt.Sub(info.IssuedAt)
+	want := 30 * 24 * time.Hour
+	if span != want {
+		t.Errorf("default mobile TTL = %s, want %s", span, want)
+	}
+}
+
+func TestLoginMobile_WrongCredentialsRejected(t *testing.T) {
+	s := newSvc(t, 0)
+	if _, _, err := s.LoginMobile("admin", "wrong"); err != ErrInvalidCredentials {
+		t.Fatalf("err=%v, want ErrInvalidCredentials", err)
+	}
+}
+
 func TestValidate_OK(t *testing.T) {
 	s := newSvc(t, 0)
 	tok, _, _ := s.Login("admin", "secret")

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -32,6 +32,7 @@ func NewHandlers(svc *Service, log *slog.Logger) *Handlers {
 // — chi panics on a second Mount() of the same prefix.
 func (h *Handlers) MountPublic(r chi.Router) {
 	r.Post("/auth/login", h.login)
+	r.Post("/auth/mobile-login", h.mobileLogin)
 }
 
 // MountProtected mounts endpoints that require a valid bearer token.
@@ -54,12 +55,27 @@ type loginResponse struct {
 }
 
 func (h *Handlers) login(w http.ResponseWriter, r *http.Request) {
+	h.handleLogin(w, r, h.svc.Login)
+}
+
+// mobileLogin issues a longer-TTL token (default 30d) for the
+// Capacitor app. Same request/response shape as /auth/login;
+// only the token lifetime differs. See ADR 0015 §5.
+func (h *Handlers) mobileLogin(w http.ResponseWriter, r *http.Request) {
+	h.handleLogin(w, r, h.svc.LoginMobile)
+}
+
+func (h *Handlers) handleLogin(
+	w http.ResponseWriter,
+	r *http.Request,
+	loginFn func(user, password string) (string, TokenInfo, error),
+) {
 	var req loginRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
-	tok, info, err := h.svc.Login(req.Username, req.Password)
+	tok, info, err := loginFn(req.Username, req.Password)
 	if errors.Is(err, ErrInvalidCredentials) {
 		writeError(w, http.StatusUnauthorized, err)
 		return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -250,11 +250,23 @@ type AdminConfig struct {
 	User     string `toml:"user" json:"user"`
 	Password string `toml:"password" json:"password"`
 	TokenTTL string `toml:"token_ttl" json:"token_ttl"` // e.g. "24h", "12h", "30m"
+	// MobileTokenTTL is the absolute lifetime of bearer tokens issued
+	// to the mobile app via /api/v1/auth/mobile-login. Empty/0 falls
+	// back to a 30-day default (vs 24h for browser tokens) so users
+	// don't have to re-enter their password every day on devices that
+	// already gate access behind biometrics + secure storage.
+	MobileTokenTTL string `toml:"mobile_token_ttl" json:"mobile_token_ttl"`
 }
 
 // Duration parses TokenTTL; returns 0 if unset.
 func (a AdminConfig) Duration() time.Duration {
 	d, _ := time.ParseDuration(a.TokenTTL)
+	return d
+}
+
+// MobileDuration parses MobileTokenTTL; returns 0 if unset.
+func (a AdminConfig) MobileDuration() time.Duration {
+	d, _ := time.ParseDuration(a.MobileTokenTTL)
 	return d
 }
 
@@ -332,6 +344,9 @@ func applyEnv(cfg *Config) {
 	if v := os.Getenv("OPENDRAY_ADMIN_TOKEN_TTL"); v != "" {
 		cfg.Admin.TokenTTL = v
 	}
+	if v := os.Getenv("OPENDRAY_ADMIN_MOBILE_TOKEN_TTL"); v != "" {
+		cfg.Admin.MobileTokenTTL = v
+	}
 	if v := os.Getenv("OPENDRAY_LOG_LEVEL"); v != "" {
 		cfg.Log.Level = v
 	}
@@ -399,6 +414,11 @@ func (c Config) Validate() error {
 	if c.Admin.TokenTTL != "" {
 		if _, err := time.ParseDuration(c.Admin.TokenTTL); err != nil {
 			return fmt.Errorf("config: admin.token_ttl: %w", err)
+		}
+	}
+	if c.Admin.MobileTokenTTL != "" {
+		if _, err := time.ParseDuration(c.Admin.MobileTokenTTL); err != nil {
+			return fmt.Errorf("config: admin.mobile_token_ttl: %w", err)
 		}
 	}
 	return nil

--- a/internal/store/migrations/0024_device_tokens.sql
+++ b/internal/store/migrations/0024_device_tokens.sql
@@ -1,0 +1,44 @@
+-- 0024_device_tokens.sql
+--
+-- Schema for the mobile device-token registry. Used by the future
+-- push-notification subsystem to look up which devices to alert on
+-- session.idle / session.ended / errors. The schema lands now (B2)
+-- so the surface is stable before the producer side ships in
+-- phase C; no rows are populated yet.
+--
+-- See ADR 0015 §6 for the full mobile-protocol design.
+CREATE TABLE IF NOT EXISTS device_tokens (
+  id          TEXT        PRIMARY KEY,             -- e.g. dev_<base32>
+  platform    TEXT        NOT NULL,                -- "ios" | "android" | "web" (push-capable)
+  -- The vendor-issued push token (APNs device token or FCM registration ID).
+  -- Length is platform-specific; ~64 hex for APNs, ~150+ chars for FCM v1.
+  push_token  TEXT        NOT NULL,
+  -- The auth principal that registered this device. Today this is the
+  -- single-admin username; phase-C work may extend to integration IDs
+  -- if integrations want to receive their own pushes.
+  principal   TEXT        NOT NULL,
+  -- Optional human-readable label set during registration ("Kev's
+  -- iPhone 17", "Pixel 9 Pro"). UI surfaces this in the device list
+  -- so the operator can revoke individual devices.
+  label       TEXT        NOT NULL DEFAULT '',
+  -- App build that registered the token. Helps debug "why does this
+  -- one device get duplicate notifications" — usually it's an old
+  -- build that hasn't called DELETE on its previous token.
+  app_version TEXT        NOT NULL DEFAULT '',
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  -- Updated whenever the same device re-registers (token refresh).
+  -- A device that hasn't heartbeated in N days is a candidate for
+  -- silent revocation.
+  last_seen   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Lookup index for "fan out a notification to every device of a
+-- principal" — the dominant query pattern.
+CREATE INDEX IF NOT EXISTS device_tokens_principal_idx
+  ON device_tokens (principal);
+
+-- Uniqueness on the platform+push_token pair so that a device that
+-- re-registers (token refresh) UPSERTs into a single row instead of
+-- accumulating duplicates.
+CREATE UNIQUE INDEX IF NOT EXISTS device_tokens_platform_push_token_uq
+  ON device_tokens (platform, push_token);


### PR DESCRIPTION
## Summary

**B2** of the mobile-platform plan ([ADR 0015 §5, §6](https://github.com/Opendray/opendray_v2/blob/feat/mobile-platform/docs/adr/0015-mobile-platform.md)). Two backend additions, both backwards-compatible, both required before B3 (mobile auth flow).

## 1. \`/api/v1/auth/mobile-login\` + \`mobile_token_ttl\`

Sibling to \`/auth/login\` that issues a longer-TTL token (default **30d** vs 24h). Reasoning: mobile gates access via biometrics + Keychain/EncryptedSharedPreferences — daily password re-entry is hostile UX without a security gain.

| Surface | Default TTL | Endpoint |
|---|---|---|
| Browser | 24h (\`token_ttl\`) | \`POST /api/v1/auth/login\` |
| Mobile | 30d (\`mobile_token_ttl\`) | \`POST /api/v1/auth/mobile-login\` |

Same request/response shape on both endpoints. Implementation refactored \`Service.Login\` and \`Service.LoginMobile\` to share an internal \`loginWithTTL\` helper — no logic duplication.

3 new tests cover:
- Browser TTL ≠ Mobile TTL
- Default 30d when \`mobile_token_ttl\` unset
- Wrong credentials rejected on mobile-login (same as login)

## 2. Migration \`0024_device_tokens.sql\`

Schema for the future push-notification subsystem. **No producer/consumer code in this PR** — the table stays empty until phase C wires it up.

Lands now (before B3-B5) so the schema is stable before any mobile code starts referencing it. Phase C only adds writers/readers, never schema changes.

| Column | Purpose |
|---|---|
| \`id\` | PK (\`dev_<base32>\`) |
| \`platform\` | \`ios\` / \`android\` / \`web\` |
| \`push_token\` | APNs / FCM opaque token |
| \`principal\` | Today: admin username; phase C may extend to integration IDs |
| \`label\` | Human-readable, e.g. \"Kev's iPhone 17\" |
| \`app_version\` | Helps debug stale-build duplicates |
| \`created_at\`, \`last_seen\` | |

Indexes:
- \`device_tokens_principal_idx\` for the \"fan out to every device of a principal\" query
- \`device_tokens_platform_push_token_uq\` UNIQUE so token-refresh re-registration UPSERTs into a single row instead of duplicating

## Docs

- \`docs/operator-guide.md\`: configuration table now lists \`mobile_token_ttl\`
- \`config.example.toml\`: commented-out \`mobile_token_ttl\` line with rationale

## Verification

| Check | Result |
|---|---|
| \`go vet ./...\` | ✅ clean |
| \`go test -race -count=1 -timeout=5m ./internal/auth/...\` | ✅ all tests + 3 new pass |
| \`go build ./cmd/opendray\` | ✅ clean |
| \`golangci-lint run\` | ✅ 0 issues |
| Frontend (web) + (mobile) builds | ✅ unaffected |

## Risk

🟢 Low. Additive surface only. Existing \`/auth/login\` behavior unchanged. Migration is forward-only with \`IF NOT EXISTS\` guards (idempotent re-runs safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)