### PR TITLE
fix(auth): bcrypt admin password via [admin].password_hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `[admin].password_hash` config field for bcrypt-hashed admin passwords
+  (`OPENDRAY_ADMIN_PASSWORD_HASH` env override). Generate hashes with the
+  new `opendray hash-password` subcommand.
+- `opendray hash-password` subcommand — reads a password from stdin and
+  prints a bcrypt hash suitable for pasting into `[admin].password_hash`.
 - LICENSE file (Apache 2.0) — previously declared in README only.
 - SECURITY.md — threat model, default posture, deployment checklist, report channel.
 - CONTRIBUTING.md — dev setup, test commands, PR + commit conventions.
 - CHANGELOG.md — this file.
 
 ### Changed
+- Admin auth verifies `password_hash` via `bcrypt.CompareHashAndPassword`
+  when set, falling back to the existing constant-time plaintext compare
+  for installs that haven't migrated. The auth service emits a one-time
+  startup warning when the plaintext path is in use.
 - Renumbered ADR `0011-memory-subsystem.md` → `0014-memory-subsystem.md` to
   resolve the duplicate-0011 collision with `0011-channel-rich-content-and-bridge.md`.
   Updated cross-references in README, ADR 0013, and the embed-onnx stub.
+
+### Security
+- Operators can now retire the plaintext admin password by switching to
+  `[admin].password_hash`. See `SECURITY.md` § "Migrating from plaintext
+  to bcrypt" for the upgrade path. The plaintext field remains supported
+  for back-compat — no breaking change for existing installs.
 
 ## [v1.0-rc] — 2026-05-05
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,21 +23,49 @@ exposed to the public internet without a reverse proxy and TLS.
 |---|---|---|
 | `listen` | `127.0.0.1:8770` | Loopback only; safe for local dev. |
 | Admin auth | Bearer token, 24h TTL | Issued by `/api/v1/auth/login` against `[admin]` config. |
-| Admin password | Constant-time compared to plaintext value in config | Single-admin self-host model. Prefer `OPENDRAY_ADMIN_PASSWORD` env over committing to `config.toml`. |
+| Admin password | bcrypt-verified (`[admin].password_hash`) when set; constant-time plaintext compare otherwise | Generate a hash with `opendray hash-password` and put it in `[admin].password_hash` to retire the plaintext path. The plaintext path remains for back-compat; the auth service warns at startup when it's in use. |
 | Integration API keys | bcrypt-hashed in DB | One key per integration; revocable. |
 | Backup encryption | AES-256-GCM, PBKDF2-HMAC-SHA256, 200,000 iterations | Key derived from `OPENDRAY_BACKUP_KEY`; **must** live in env, never in config. |
 | WebSocket auth | Bearer token in query parameter | All WS endpoints require auth before any data flows. |
 | Database | External Postgres (no bundled mode) | Operator chooses TLS posture via `?sslmode=` in DSN. |
 
-When `[admin].password` is unset (and no env override), the server **rejects
-every login attempt** rather than booting with no auth.
+When neither `[admin].password` nor `[admin].password_hash` is set (and
+no env override), the server **rejects every login attempt** rather than
+booting with no auth.
+
+### Migrating from plaintext to bcrypt
+
+Existing installs with `[admin].password` continue working. To upgrade:
+
+```bash
+# 1. Generate a hash from your current password.
+opendray hash-password
+enter password and press enter (visible while typing):
+mysecret
+$2a$10$0HPI0HSvwtcrTEuXuqgKmuc6tH8/Gxl2GbzyR0G2H9GJ9mXgY78xS
+
+# 2. Paste the hash into config.toml as password_hash, then remove
+#    the plaintext password line. Restart opendray.
+
+# 3. Verify the auth service is no longer warning about plaintext
+#    on the login flow.
+```
+
+`hash-password` reads from stdin, so `echo` and shell history are the only
+places the plaintext appears — both shorter-lived than a `config.toml` on
+disk. Pipe a password file in if you'd rather avoid even that:
+
+```bash
+opendray hash-password < /dev/shm/password.txt
+```
 
 ## Deployment Checklist
 
 1. **Reverse proxy.** Place OpenDray behind Cloudflare Tunnel, nginx, Caddy,
    or Traefik. Terminate TLS at the proxy. Keep `listen = "127.0.0.1:8770"`.
-2. **Strong admin password.** ≥ 16 random characters. Prefer
-   `OPENDRAY_ADMIN_PASSWORD` env var over `config.toml`.
+2. **Strong admin password.** ≥ 16 random characters. Use
+   `[admin].password_hash` (bcrypt) rather than the plaintext
+   `[admin].password` field. Generate via `opendray hash-password`.
 3. **Backup key in env only.** Set `OPENDRAY_BACKUP_KEY` via the OS secret
    manager, systemd `LoadCredential`, or Vault. Never commit it. Losing the
    key makes encrypted backups unrecoverable.

--- a/cmd/opendray/hashpassword.go
+++ b/cmd/opendray/hashpassword.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// runHashPassword implements `opendray hash-password`: read a password
+// from stdin, bcrypt-hash it, and print the hash to stdout. Output is
+// one line suitable for pasting into config.toml as:
+//
+//	[admin]
+//	password_hash = "$2a$12$..."
+//
+// Reads from stdin so passwords don't end up in shell history. Two
+// flows:
+//
+//	# interactive — stdin is a TTY
+//	$ opendray hash-password
+//	enter password (no echo): <type, press enter>
+//	$2a$10$…
+//
+//	# piped — stdin is a pipe
+//	$ echo 'mypw' | opendray hash-password
+//	$2a$10$…
+//
+// Exit codes: 0 on success, 1 on read or hash error, 2 on usage error.
+func runHashPassword(args []string) int {
+	fs := flag.NewFlagSet("hash-password", flag.ExitOnError)
+	cost := fs.Int("cost", bcrypt.DefaultCost, "bcrypt cost factor (4..31; default = bcrypt.DefaultCost)")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, `opendray hash-password — generate a bcrypt hash for the admin password
+
+usage:
+  opendray hash-password                    # interactive (reads stdin)
+  echo 'mypw' | opendray hash-password      # piped
+
+flags:
+  -cost   bcrypt cost (default: package default)`)
+	}
+	_ = fs.Parse(args)
+
+	if *cost < bcrypt.MinCost || *cost > bcrypt.MaxCost {
+		fmt.Fprintf(os.Stderr, "hash-password: cost must be in [%d, %d]\n", bcrypt.MinCost, bcrypt.MaxCost)
+		return 2
+	}
+
+	if isTerminal(os.Stdin) {
+		// Best-effort prompt for interactive use. Echo cannot be
+		// suppressed without pulling in golang.org/x/term as a new
+		// dependency; skipping that for now to keep the change
+		// minimal. Operators concerned about shoulder-surfing can
+		// pipe the password in instead.
+		fmt.Fprintln(os.Stderr, "enter password and press enter (visible while typing):")
+	}
+
+	password, err := readLine(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hash-password: %v\n", err)
+		return 1
+	}
+	if password == "" {
+		fmt.Fprintln(os.Stderr, "hash-password: empty password")
+		return 1
+	}
+	if !utf8.ValidString(password) {
+		fmt.Fprintln(os.Stderr, "hash-password: password is not valid UTF-8")
+		return 1
+	}
+	// bcrypt has a 72-byte input cap; longer is silently truncated.
+	// Refuse up front so an operator with a 100-char password isn't
+	// surprised that only the first 72 bytes determine the hash.
+	if len(password) > 72 {
+		fmt.Fprintln(os.Stderr, "hash-password: bcrypt has a 72-byte input limit; choose a shorter password")
+		return 1
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), *cost)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hash-password: %v\n", err)
+		return 1
+	}
+	fmt.Println(string(hash))
+	return 0
+}
+
+func readLine(r io.Reader) (string, error) {
+	br := bufio.NewReader(r)
+	line, err := br.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", fmt.Errorf("read stdin: %w", err)
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}
+
+// isTerminal reports whether the file is a terminal. Implemented via
+// os.Stat + ModeCharDevice to avoid pulling golang.org/x/term as a
+// new module dep just for this one check.
+func isTerminal(f *os.File) bool {
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}

--- a/cmd/opendray/main.go
+++ b/cmd/opendray/main.go
@@ -2,13 +2,14 @@
 //
 // Subcommands:
 //
-//	opendray serve   [-config FILE]   start the gateway
-//	opendray migrate [-config FILE]   apply pending DB migrations and exit
-//	opendray notes   <subcommand> ... operate on the file-system notes vault (no gateway needed)
-//	opendray skill   <subcommand> ... inspect / load agent skills (no gateway needed)
-//	opendray mcp     <subcommand> ... inspect MCP server registry (no gateway needed)
-//	opendray mcp-memory               stdio MCP server bridging agents to opendray memory (run by Claude/Codex/etc.)
-//	opendray version                  print build info and exit
+//	opendray serve         [-config FILE]   start the gateway
+//	opendray migrate       [-config FILE]   apply pending DB migrations and exit
+//	opendray hash-password                  bcrypt-hash a password for [admin].password_hash
+//	opendray notes         <subcommand> ... operate on the file-system notes vault (no gateway needed)
+//	opendray skill         <subcommand> ... inspect / load agent skills (no gateway needed)
+//	opendray mcp           <subcommand> ... inspect MCP server registry (no gateway needed)
+//	opendray mcp-memory                     stdio MCP server bridging agents to opendray memory (run by Claude/Codex/etc.)
+//	opendray version                        print build info and exit
 package main
 
 import (
@@ -39,6 +40,8 @@ func main() {
 			defer a.Close()
 			return a.Migrate(ctx)
 		}))
+	case "hash-password":
+		os.Exit(runHashPassword(args))
 	case "notes":
 		os.Exit(runNotes(args))
 	case "skill":
@@ -88,11 +91,12 @@ func usage() {
 	fmt.Fprintln(os.Stderr, `opendray — multiplexer + integration gateway for AI agent CLIs
 
 usage:
-  opendray serve   [-config FILE]
-  opendray migrate [-config FILE]
-  opendray notes   <subcommand> [args]   (run "opendray notes --help" for details)
-  opendray skill   <subcommand> [args]   (run "opendray skill --help" for details)
-  opendray mcp     <subcommand> [args]   (run "opendray mcp --help" for details)
+  opendray serve         [-config FILE]
+  opendray migrate       [-config FILE]
+  opendray hash-password                   (bcrypt-hash stdin → [admin].password_hash)
+  opendray notes         <subcommand> [args]   (run "opendray notes --help" for details)
+  opendray skill         <subcommand> [args]   (run "opendray skill --help" for details)
+  opendray mcp           <subcommand> [args]   (run "opendray mcp --help" for details)
   opendray mcp-memory                     (stdio MCP server — invoked by an agent CLI, not by humans)
   opendray version`)
 }

--- a/config.example.toml
+++ b/config.example.toml
@@ -2,7 +2,8 @@
 #
 # Any field can be overridden by an OPENDRAY_-prefixed env variable —
 # OPENDRAY_LISTEN, OPENDRAY_DATABASE_URL, OPENDRAY_ADMIN_USER,
-# OPENDRAY_ADMIN_PASSWORD, OPENDRAY_LOG_LEVEL, OPENDRAY_LOG_FORMAT.
+# OPENDRAY_ADMIN_PASSWORD, OPENDRAY_ADMIN_PASSWORD_HASH,
+# OPENDRAY_LOG_LEVEL, OPENDRAY_LOG_FORMAT.
 
 listen = "127.0.0.1:8770"
 
@@ -18,8 +19,18 @@ url = "postgres://opendray:opendray@127.0.0.1:5432/opendray?sslmode=disable"
 
 [admin]
 # Admin auth (single human). Prefer env vars in production.
-user      = "admin"
-password  = "CHANGEME"
+user = "admin"
+
+# Recommended: store a bcrypt hash, not a plaintext password.
+# Generate with: `opendray hash-password` (reads from stdin).
+# When password_hash is set, `password` is ignored.
+# password_hash = "$2a$10$..."
+
+# Back-compat: plaintext password. Used only when password_hash is
+# empty. The auth service emits a one-time warning at startup when
+# this path is in use.
+password = "CHANGEME"
+
 token_ttl = "24h"  # bearer token absolute lifetime; empty = 24h default
 
 [log]

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/opendray/opendray-v2/internal/config"
 	"github.com/opendray/opendray-v2/internal/eventbus"
 )
@@ -63,24 +65,38 @@ func New(cfg config.AdminConfig, bus *eventbus.Hub, log *slog.Logger) *Service {
 	if ttl <= 0 {
 		ttl = defaultTokenTTL
 	}
-	return &Service{
+	s := &Service{
 		cfg:    cfg,
 		ttl:    ttl,
 		bus:    bus,
 		log:    log.With("component", "auth"),
 		tokens: make(map[string]TokenInfo),
 	}
+	if cfg.PasswordHash == "" && cfg.Password != "" {
+		s.log.Warn("admin password is plaintext in config; generate a hash with `opendray hash-password` and replace [admin].password with [admin].password_hash")
+	}
+	return s
 }
 
-// Login validates user/password using constant-time comparison and
-// issues a fresh token on success. Empty admin config rejects all.
+// Login validates user/password and issues a fresh token on success.
+// Empty admin config rejects all.
+//
+// Verification path:
+//   - If cfg.PasswordHash is set, password is verified with
+//     bcrypt.CompareHashAndPassword (constant-time inside bcrypt).
+//   - Else if cfg.Password is set, password is constant-time compared
+//     against the plaintext config value (back-compat path; emits a
+//     one-time warning at construction time).
+//   - Else the admin is unconfigured and Login rejects everything.
+//
+// Username comparison is always constant-time.
 func (s *Service) Login(user, password string) (string, TokenInfo, error) {
-	if s.cfg.User == "" || s.cfg.Password == "" {
+	if s.cfg.User == "" || (s.cfg.Password == "" && s.cfg.PasswordHash == "") {
 		s.publishLogin(user, false, "admin not configured")
 		return "", TokenInfo{}, ErrInvalidCredentials
 	}
 	userOK := subtle.ConstantTimeCompare([]byte(user), []byte(s.cfg.User)) == 1
-	passOK := subtle.ConstantTimeCompare([]byte(password), []byte(s.cfg.Password)) == 1
+	passOK := s.verifyPassword(password)
 	if !userOK || !passOK {
 		s.publishLogin(user, false, "credentials mismatch")
 		return "", TokenInfo{}, ErrInvalidCredentials
@@ -188,6 +204,25 @@ func TokenFromContext(ctx context.Context) string {
 
 type userCtxKey struct{}
 type tokenCtxKey struct{}
+
+// verifyPassword checks the supplied password against either the
+// configured bcrypt hash or, as a back-compat path, the plaintext
+// password. The bcrypt route is preferred whenever PasswordHash is
+// non-empty; the plaintext route is constant-time-compared.
+func (s *Service) verifyPassword(password string) bool {
+	if s.cfg.PasswordHash != "" {
+		err := bcrypt.CompareHashAndPassword(
+			[]byte(s.cfg.PasswordHash), []byte(password),
+		)
+		return err == nil
+	}
+	if s.cfg.Password == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare(
+		[]byte(password), []byte(s.cfg.Password),
+	) == 1
+}
 
 func bearerToken(r *http.Request) string {
 	h := r.Header.Get("Authorization")

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/opendray/opendray-v2/internal/config"
 )
 
@@ -53,6 +55,72 @@ func TestLogin_AdminNotConfigured(t *testing.T) {
 	s := New(config.AdminConfig{}, nil, nil)
 	if _, _, err := s.Login("admin", "secret"); err != ErrInvalidCredentials {
 		t.Fatalf("expected reject when admin unconfigured")
+	}
+}
+
+// bcryptHash returns a bcrypt hash of plaintext at MinCost, suitable
+// for tests that need a real hash without being slow. Production code
+// should never use MinCost — operators get bcrypt.DefaultCost through
+// the hash-password subcommand.
+func bcryptHash(t *testing.T, plaintext string) string {
+	t.Helper()
+	hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt hash: %v", err)
+	}
+	return string(hash)
+}
+
+func TestLogin_PasswordHash_Success(t *testing.T) {
+	cfg := config.AdminConfig{User: "admin", PasswordHash: bcryptHash(t, "secret")}
+	s := New(cfg, nil, nil)
+	tok, info, err := s.Login("admin", "secret")
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if tok == "" {
+		t.Fatal("token empty")
+	}
+	if info.Username != "admin" {
+		t.Errorf("username=%q", info.Username)
+	}
+}
+
+func TestLogin_PasswordHash_WrongPassword(t *testing.T) {
+	cfg := config.AdminConfig{User: "admin", PasswordHash: bcryptHash(t, "secret")}
+	s := New(cfg, nil, nil)
+	if _, _, err := s.Login("admin", "wrong"); err != ErrInvalidCredentials {
+		t.Fatalf("err=%v, want ErrInvalidCredentials", err)
+	}
+}
+
+// PasswordHash takes precedence — supplying the right plaintext for
+// the legacy field while the hash is set must NOT authenticate.
+func TestLogin_PasswordHashWinsOverPlaintext(t *testing.T) {
+	cfg := config.AdminConfig{
+		User:         "admin",
+		Password:     "old-plaintext",                   // would auth under back-compat…
+		PasswordHash: bcryptHash(t, "secret"),           // …but hash is set, so this is ignored.
+	}
+	s := New(cfg, nil, nil)
+	if _, _, err := s.Login("admin", "old-plaintext"); err != ErrInvalidCredentials {
+		t.Fatalf("plaintext should be ignored when PasswordHash is set; got err=%v", err)
+	}
+	if _, _, err := s.Login("admin", "secret"); err != nil {
+		t.Fatalf("hash path should authenticate; got err=%v", err)
+	}
+}
+
+func TestLogin_BackCompatPlaintext(t *testing.T) {
+	// Existing installs with [admin].password set and no
+	// password_hash must continue to authenticate.
+	cfg := config.AdminConfig{User: "admin", Password: "still-works"}
+	s := New(cfg, nil, nil)
+	if _, _, err := s.Login("admin", "still-works"); err != nil {
+		t.Fatalf("legacy plaintext path broken: %v", err)
+	}
+	if _, _, err := s.Login("admin", "wrong"); err != ErrInvalidCredentials {
+		t.Fatalf("legacy plaintext should still reject wrong password: %v", err)
 	}
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -96,11 +96,13 @@ func TestLogin_PasswordHash_WrongPassword(t *testing.T) {
 
 // PasswordHash takes precedence — supplying the right plaintext for
 // the legacy field while the hash is set must NOT authenticate.
+// Password "old-plaintext" would otherwise auth under the back-compat
+// path; PasswordHash being set forces the bcrypt branch.
 func TestLogin_PasswordHashWinsOverPlaintext(t *testing.T) {
 	cfg := config.AdminConfig{
 		User:         "admin",
-		Password:     "old-plaintext",                   // would auth under back-compat…
-		PasswordHash: bcryptHash(t, "secret"),           // …but hash is set, so this is ignored.
+		Password:     "old-plaintext",
+		PasswordHash: bcryptHash(t, "secret"),
 	}
 	s := New(cfg, nil, nil)
 	if _, _, err := s.Login("admin", "old-plaintext"); err != ErrInvalidCredentials {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -247,9 +247,18 @@ type BackupConfig struct {
 }
 
 type AdminConfig struct {
-	User     string `toml:"user" json:"user"`
+	User string `toml:"user" json:"user"`
+	// Password is the plaintext admin password. Only consulted when
+	// PasswordHash is empty. Kept as a back-compat path for existing
+	// installs; new installs should prefer PasswordHash. The auth
+	// service emits a one-time warning at startup when Password is
+	// used.
 	Password string `toml:"password" json:"password"`
-	TokenTTL string `toml:"token_ttl" json:"token_ttl"` // e.g. "24h", "12h", "30m"
+	// PasswordHash is a bcrypt hash of the admin password
+	// (`$2a$…` / `$2b$…` / `$2y$…`). When set, Password is ignored.
+	// Generate with: `opendray hash-password`.
+	PasswordHash string `toml:"password_hash" json:"password_hash"`
+	TokenTTL     string `toml:"token_ttl" json:"token_ttl"` // e.g. "24h", "12h", "30m"
 }
 
 // Duration parses TokenTTL; returns 0 if unset.
@@ -328,6 +337,9 @@ func applyEnv(cfg *Config) {
 	}
 	if v := os.Getenv("OPENDRAY_ADMIN_PASSWORD"); v != "" {
 		cfg.Admin.Password = v
+	}
+	if v := os.Getenv("OPENDRAY_ADMIN_PASSWORD_HASH"); v != "" {
+		cfg.Admin.PasswordHash = v
 	}
 	if v := os.Getenv("OPENDRAY_ADMIN_TOKEN_TTL"); v != "" {
 		cfg.Admin.TokenTTL = v


### PR DESCRIPTION
**Draft.** Closes audit finding **[F]**: admin password is plaintext-compared, never hashed.

## Summary

- New `[admin].password_hash` config field. When set, `Login` verifies via `bcrypt.CompareHashAndPassword`.
- New `opendray hash-password` subcommand reads stdin and prints a bcrypt hash for pasting into config.
- Plaintext `[admin].password` keeps working — back-compat preserved, **no breaking change** for existing installs. Auth service emits a one-time `slog.Warn` at construction when the plaintext path is in use.
- 4 new auth tests cover both paths plus the precedence rule.

## Behaviour matrix

| `password` | `password_hash` | Result |
|---|---|---|
| unset | unset | reject (`admin not configured`) |
| `"x"` | unset | constant-time plaintext compare + startup WARN |
| unset | `$2a$…` | bcrypt verify (preferred) |
| `"x"` | `$2a$…` | bcrypt verify only — plaintext is ignored |

## Files

| File | Change |
|---|---|
| `internal/config/config.go` | `AdminConfig.PasswordHash` field + `OPENDRAY_ADMIN_PASSWORD_HASH` env override |
| `internal/auth/auth.go` | `Service.verifyPassword()` helper; precedence rule (hash wins); construction-time warning |
| `internal/auth/auth_test.go` | 4 new tests; `bcryptHash(t, plaintext)` helper computes hashes at MinCost — no committed hash literals |
| `cmd/opendray/hashpassword.go` (new) | `opendray hash-password` subcommand; bcrypt + 72-byte cap + UTF-8 + cost flag |
| `cmd/opendray/main.go` | wires the new subcommand |
| `config.example.toml` | documents the new field with migration hint |
| `SECURITY.md` | default-posture row updated; "Migrating from plaintext to bcrypt" section added |
| `CHANGELOG.md` | [Unreleased] Added/Changed/Security entries |

## Why a stdin-only subcommand (no TTY-prompt-with-echo-off)

Suppressing terminal echo cleanly requires `golang.org/x/term`, which isn't currently a module dep. I avoided adding it for this single feature. The subcommand:

- Detects TTY vs pipe via `os.Stat + ModeCharDevice` (no new dep).
- On a TTY: prints "enter password and press enter (visible while typing)" — operator decides whether to type or pipe.
- On a pipe: silent read.

If you'd like proper echo suppression, I can submit a follow-up that adds `x/term` and switches to `term.ReadPassword`. Out of scope here to keep the dep delta = 0 (bcrypt is a subpackage of `golang.org/x/crypto`, which is already a direct dep at `v0.50.0`).

## Migration path for operators

```bash
# 1. Generate a hash (interactive)
opendray hash-password
enter password and press enter (visible while typing):
mysecret
$2a$10$0HPI0HSvwtcrTEuXuqgKmuc6tH8/Gxl2GbzyR0G2H9GJ9mXgY78xS

# 2. Edit config.toml:
#    - paste the hash into [admin].password_hash
#    - delete the [admin].password line
#    Restart opendray.

# 3. Verify the WARN is gone from logs.
```

## Test plan (Linivek to run with toolchain)

- [ ] `go vet ./...`
- [ ] `go test -race ./internal/auth/... -run TestLogin`
- [ ] `go test -race ./internal/config/... -run TestLoad`
- [ ] `go build ./cmd/opendray && ./opendray hash-password <<<'test'` — emits a `$2a$...` line
- [ ] Smoke `opendray hash-password -cost 4 <<<'short'` — exits 0, fast (cost-4 takes ~1ms)
- [ ] Smoke `opendray hash-password <<<''` — exits 1 with "empty password"
- [ ] Smoke `opendray hash-password -cost 50 <<<'x'` — exits 2 with "cost must be in [4, 31]"
- [ ] Manual: replace `[admin].password` with `password_hash`, restart, confirm login still works + no plaintext warning

## Risk

🟡 Medium. Touches the auth flow — wrong precedence, wrong constant-time semantics, or a typo in the bcrypt call would lock the admin out. Mitigations:

1. Existing plaintext path is preserved verbatim in the `else` branch of `verifyPassword`.
2. Tests cover all four matrix cells.
3. Drafted as **draft** PR until CI green + manual smoke.
4. The change is opt-in — operators choose when to add `password_hash`.

## Related

- Audit finding [F] (CLOSED by this PR if merged).
- Audit finding [H] (per-install PBKDF2 salt for backups) is the sibling security item; planned for a separate PR.