### PR TITLE
feat(mobile): Memory + Notes + Activity screens + bottom tab nav [T2]

### DIFF
--- a/app/mobile/src/App.tsx
+++ b/app/mobile/src/App.tsx
@@ -4,6 +4,10 @@ import { OnboardingScreen } from './screens/OnboardingScreen'
 import { LoginScreen } from './screens/LoginScreen'
 import { SessionsScreen } from './screens/SessionsScreen'
 import { SessionDetailScreen } from './screens/SessionDetailScreen'
+import { MemoryScreen } from './screens/MemoryScreen'
+import { NotesScreen } from './screens/NotesScreen'
+import { ActivityScreen } from './screens/ActivityScreen'
+import { BottomTabBar, type Tab } from './components/BottomTabBar'
 import { type SessionSummary } from './lib/api'
 import {
   type StoredPrefs,
@@ -20,15 +24,13 @@ type AppState = 'loading' | 'onboarding' | 'login' | 'home' | 'session'
 //
 //   serverURL absent              → onboarding
 //   serverURL set, no/expired tok → login
-//   serverURL set, valid token    → home
-//
-// B5 will replace HomeScreen with the real Sessions list. B4 will
-// add a biometric gate between launch and home (auto-unlock the
-// stored token via Face ID / Touch ID).
+//   serverURL set, valid token    → home (with 4 tabs)
+//   home tab + tap session card   → session detail (full-screen)
 export function App() {
   const [state, setState] = useState<AppState>('loading')
   const [prefs, setPrefs] = useState<StoredPrefs | null>(null)
   const [activeSession, setActiveSession] = useState<SessionSummary | null>(null)
+  const [tab, setTab] = useState<Tab>('sessions')
 
   useEffect(() => {
     void bootstrap()
@@ -77,7 +79,7 @@ export function App() {
       <LoginScreen
         serverURL={prefs!.serverURL!}
         onAuthed={async () => {
-          // setAuth has already written; re-read so HomeScreen has the
+          // setAuth has already written; re-read so home tabs see the
           // canonical values.
           const fresh = await getPrefs()
           setPrefs(fresh)
@@ -101,6 +103,8 @@ export function App() {
     setState('login')
   }
 
+  // Session detail is full-screen — no bottom tab bar — so the
+  // terminal can use every available pixel.
   if (state === 'session' && activeSession) {
     return (
       <SessionDetailScreen
@@ -116,17 +120,52 @@ export function App() {
     )
   }
 
+  // Home shell — content fills the screen above the bottom tab bar.
+  // Each tab manages its own header + scrollable content; we just
+  // render the right component based on the active tab.
+  const serverURL = prefs!.serverURL!
+  const token = prefs!.token!
+  const username = prefs!.username ?? 'admin'
+
   return (
-    <SessionsScreen
-      serverURL={prefs!.serverURL!}
-      token={prefs!.token!}
-      username={prefs!.username ?? 'admin'}
-      onLogout={onClearAuthAndReturnToLogin}
-      onAuthExpired={onClearAuthAndReturnToLogin}
-      onOpenSession={(s) => {
-        setActiveSession(s)
-        setState('session')
-      }}
-    />
+    <div className="flex flex-col min-h-screen">
+      <div className="flex-1 flex flex-col min-h-0">
+        {tab === 'sessions' && (
+          <SessionsScreen
+            serverURL={serverURL}
+            token={token}
+            username={username}
+            onLogout={onClearAuthAndReturnToLogin}
+            onAuthExpired={onClearAuthAndReturnToLogin}
+            onOpenSession={(s) => {
+              setActiveSession(s)
+              setState('session')
+            }}
+          />
+        )}
+        {tab === 'memory' && (
+          <MemoryScreen
+            serverURL={serverURL}
+            token={token}
+            onAuthExpired={onClearAuthAndReturnToLogin}
+          />
+        )}
+        {tab === 'notes' && (
+          <NotesScreen
+            serverURL={serverURL}
+            token={token}
+            onAuthExpired={onClearAuthAndReturnToLogin}
+          />
+        )}
+        {tab === 'activity' && (
+          <ActivityScreen
+            serverURL={serverURL}
+            token={token}
+            onAuthExpired={onClearAuthAndReturnToLogin}
+          />
+        )}
+      </div>
+      <BottomTabBar active={tab} onChange={setTab} />
+    </div>
   )
 }

--- a/app/mobile/src/components/BottomTabBar.tsx
+++ b/app/mobile/src/components/BottomTabBar.tsx
@@ -1,0 +1,48 @@
+// Bottom tab bar — lets the user switch between top-level mobile
+// surfaces (Sessions, Memory, Notes, Activity) without navigating
+// through a hamburger menu. Mobile UX standard.
+//
+// Sits above the home indicator via the `pb-safe` Tailwind utility
+// added in #27. Active-tab indicator is the accent color underline.
+
+export type Tab = 'sessions' | 'memory' | 'notes' | 'activity'
+
+interface Props {
+  active: Tab
+  onChange: (tab: Tab) => void
+}
+
+const TABS: { id: Tab; label: string; icon: string }[] = [
+  { id: 'sessions', label: 'Sessions', icon: '▢' },
+  { id: 'memory', label: 'Memory', icon: '◇' },
+  { id: 'notes', label: 'Notes', icon: '☰' },
+  { id: 'activity', label: 'Activity', icon: '⏱' },
+]
+
+export function BottomTabBar({ active, onChange }: Props) {
+  return (
+    <nav className="border-t border-border bg-card pb-safe">
+      <ul className="flex">
+        {TABS.map((t) => {
+          const isActive = t.id === active
+          return (
+            <li key={t.id} className="flex-1">
+              <button
+                type="button"
+                onClick={() => onChange(t.id)}
+                className={`w-full flex flex-col items-center gap-0.5 py-2 px-1 text-[10px] tracking-wide select-none transition-colors ${
+                  isActive
+                    ? 'text-accent'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                <span className="text-base leading-none">{t.icon}</span>
+                <span>{t.label}</span>
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}

--- a/app/mobile/src/lib/api.ts
+++ b/app/mobile/src/lib/api.ts
@@ -132,3 +132,126 @@ export async function listSessions(
   )
   return res.sessions ?? []
 }
+
+// ── Memory ──────────────────────────────────────────────────────────
+
+export interface MemoryRecord {
+  id: string
+  scope: 'session' | 'project' | 'global'
+  scope_key: string
+  text: string
+  embedder: string
+  created_at: string
+  updated_at: string
+}
+
+export async function listMemories(
+  serverURL: string,
+  token: string,
+  opts: { scope?: string; scopeKey?: string; n?: number } = {},
+): Promise<MemoryRecord[]> {
+  const sp = new URLSearchParams()
+  sp.set('scope', opts.scope ?? 'global')
+  if (opts.scopeKey) sp.set('scope_key', opts.scopeKey)
+  sp.set('n', String(opts.n ?? 100))
+  const res = await mobileFetch<{ memories?: MemoryRecord[] }>(
+    serverURL,
+    `/api/v1/memory/list?${sp.toString()}`,
+    { token },
+  )
+  return res.memories ?? []
+}
+
+export interface SearchHit {
+  record: MemoryRecord
+  similarity: number
+}
+
+export async function searchMemories(
+  serverURL: string,
+  token: string,
+  query: string,
+  scope: 'session' | 'project' | 'global' = 'global',
+  topK = 20,
+): Promise<SearchHit[]> {
+  const res = await mobileFetch<{ hits?: SearchHit[] }>(
+    serverURL,
+    '/api/v1/memory/search',
+    {
+      method: 'POST',
+      token,
+      body: { query, scope, top_k: topK },
+    },
+  )
+  return res.hits ?? []
+}
+
+// ── Notes ───────────────────────────────────────────────────────────
+
+export interface NoteSummary {
+  path: string
+  title: string
+  modified: string
+  size: number
+}
+
+export interface FullNote extends NoteSummary {
+  body: string
+}
+
+export async function listNotes(
+  serverURL: string,
+  token: string,
+): Promise<NoteSummary[]> {
+  const res = await mobileFetch<{ notes?: NoteSummary[] }>(
+    serverURL,
+    '/api/v1/notes/list',
+    { token },
+  )
+  return res.notes ?? []
+}
+
+export async function getNote(
+  serverURL: string,
+  token: string,
+  notePath: string,
+): Promise<FullNote> {
+  return mobileFetch<FullNote>(
+    serverURL,
+    `/api/v1/notes/get?path=${encodeURIComponent(notePath)}`,
+    { token },
+  )
+}
+
+// ── Audit / activity ────────────────────────────────────────────────
+
+export interface AuditEntry {
+  id: number
+  ts: string
+  actor_kind: string
+  actor_id?: string
+  action: string
+  subject_kind?: string
+  subject_id?: string
+  metadata?: unknown
+}
+
+export async function listAudit(
+  serverURL: string,
+  token: string,
+  opts: { action?: string; since?: string; limit?: number } = {},
+): Promise<AuditEntry[]> {
+  const sp = new URLSearchParams()
+  if (opts.action) sp.set('action', opts.action)
+  if (opts.since) sp.set('since', opts.since)
+  if (opts.limit) sp.set('limit', String(opts.limit))
+  const path = sp.toString()
+    ? `/api/v1/audit?${sp.toString()}`
+    : '/api/v1/audit'
+  const res = await mobileFetch<{ entries?: AuditEntry[] }>(
+    serverURL,
+    path,
+    { token },
+  )
+  return res.entries ?? []
+}

--- a/app/mobile/src/screens/ActivityScreen.tsx
+++ b/app/mobile/src/screens/ActivityScreen.tsx
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { type AuditEntry, listAudit, MobileAPIError } from '../lib/api'
+
+interface Props {
+  serverURL: string
+  token: string
+  onAuthExpired: () => void
+}
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ready'; entries: AuditEntry[] }
+  | { kind: 'error'; message: string }
+
+// Audit log viewer. Reads /api/v1/audit (default 50 most recent),
+// renders one card per entry. Filtering / search is a polish task.
+export function ActivityScreen({ serverURL, token, onAuthExpired }: Props) {
+  const [state, setState] = useState<State>({ kind: 'loading' })
+
+  const refresh = useCallback(async () => {
+    setState({ kind: 'loading' })
+    try {
+      const entries = await listAudit(serverURL, token, { limit: 100 })
+      setState({ kind: 'ready', entries })
+    } catch (err) {
+      if (err instanceof MobileAPIError && err.status === 401) {
+        onAuthExpired()
+        return
+      }
+      setState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'Failed to load activity',
+      })
+    }
+  }, [serverURL, token, onAuthExpired])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col">
+      <header className="sticky top-0 z-10 bg-background/95 backdrop-blur border-b border-border px-4 py-3 flex items-center justify-between">
+        <h1 className="text-lg font-semibold leading-tight">Activity</h1>
+        <Button variant="outline" size="sm" onClick={refresh}>
+          Refresh
+        </Button>
+      </header>
+      <main className="flex-1 px-4 py-3">
+        {state.kind === 'loading' && (
+          <div className="text-sm text-muted-foreground">Loading…</div>
+        )}
+        {state.kind === 'error' && (
+          <div className="space-y-3">
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 text-destructive text-sm px-3 py-2">
+              {state.message}
+            </div>
+            <Button variant="outline" size="sm" onClick={refresh}>
+              Retry
+            </Button>
+          </div>
+        )}
+        {state.kind === 'ready' && state.entries.length === 0 && (
+          <div className="rounded-md border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+            No recent activity.
+          </div>
+        )}
+        {state.kind === 'ready' && state.entries.length > 0 && (
+          <ul className="space-y-2">
+            {state.entries.map((e) => (
+              <EntryCard key={e.id} entry={e} />
+            ))}
+          </ul>
+        )}
+      </main>
+    </div>
+  )
+}
+
+function EntryCard({ entry }: { entry: AuditEntry }) {
+  const subject = entry.subject_kind
+    ? `${entry.subject_kind}${entry.subject_id ? `:${entry.subject_id}` : ''}`
+    : null
+  const actor = entry.actor_id
+    ? `${entry.actor_kind}:${entry.actor_id}`
+    : entry.actor_kind
+  return (
+    <li className="rounded-md border border-border bg-card p-3 text-sm space-y-1">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="font-mono text-[11px] text-accent truncate">{entry.action}</span>
+        <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
+          {formatRelative(entry.ts)}
+        </span>
+      </div>
+      <div className="text-[11px] text-muted-foreground space-y-0.5">
+        <div>by {actor}</div>
+        {subject && <div className="truncate">on {subject}</div>}
+      </div>
+    </li>
+  )
+}
+
+function formatRelative(iso: string): string {
+  const ts = Date.parse(iso)
+  if (Number.isNaN(ts)) return iso
+  const seconds = Math.round((Date.now() - ts) / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.round(hours / 24)
+  return `${days}d ago`
+}

--- a/app/mobile/src/screens/MemoryScreen.tsx
+++ b/app/mobile/src/screens/MemoryScreen.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  type MemoryRecord,
+  type SearchHit,
+  listMemories,
+  MobileAPIError,
+  searchMemories,
+} from '../lib/api'
+
+interface Props {
+  serverURL: string
+  token: string
+  onAuthExpired: () => void
+}
+
+type Mode =
+  | { kind: 'list'; loading: boolean; items: MemoryRecord[]; error?: string }
+  | { kind: 'search'; loading: boolean; hits: SearchHit[]; error?: string }
+
+// Memory facts viewer + search. Read-only on mobile (creates / edits
+// happen on desktop or via the agent's MCP tools). Default scope is
+// `global` — that's what most user-typed facts end up in.
+export function MemoryScreen({ serverURL, token, onAuthExpired }: Props) {
+  const [mode, setMode] = useState<Mode>({ kind: 'list', loading: true, items: [] })
+  const [query, setQuery] = useState('')
+
+  const loadList = useCallback(async () => {
+    setMode({ kind: 'list', loading: true, items: [] })
+    try {
+      const items = await listMemories(serverURL, token, { scope: 'global', n: 100 })
+      setMode({ kind: 'list', loading: false, items })
+    } catch (err) {
+      if (err instanceof MobileAPIError && err.status === 401) {
+        onAuthExpired()
+        return
+      }
+      setMode({
+        kind: 'list',
+        loading: false,
+        items: [],
+        error: err instanceof Error ? err.message : 'Failed to load memories',
+      })
+    }
+  }, [serverURL, token, onAuthExpired])
+
+  useEffect(() => {
+    void loadList()
+  }, [loadList])
+
+  async function runSearch(e: React.FormEvent) {
+    e.preventDefault()
+    const q = query.trim()
+    if (!q) {
+      void loadList()
+      return
+    }
+    setMode({ kind: 'search', loading: true, hits: [] })
+    try {
+      const hits = await searchMemories(serverURL, token, q, 'global', 30)
+      setMode({ kind: 'search', loading: false, hits })
+    } catch (err) {
+      if (err instanceof MobileAPIError && err.status === 401) {
+        onAuthExpired()
+        return
+      }
+      setMode({
+        kind: 'search',
+        loading: false,
+        hits: [],
+        error: err instanceof Error ? err.message : 'Search failed',
+      })
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col">
+      <header className="sticky top-0 z-10 bg-background/95 backdrop-blur border-b border-border px-4 py-3">
+        <h1 className="text-lg font-semibold leading-tight">Memory</h1>
+        <form onSubmit={runSearch} className="mt-2 flex gap-2">
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search facts…"
+            autoCapitalize="off"
+            autoCorrect="off"
+            spellCheck={false}
+            inputMode="search"
+          />
+          <Button type="submit" variant="outline" size="sm">
+            {query ? 'Search' : 'List'}
+          </Button>
+        </form>
+      </header>
+      <main className="flex-1 px-4 py-3">
+        <Body mode={mode} onRetry={loadList} />
+      </main>
+    </div>
+  )
+}
+
+function Body({ mode, onRetry }: { mode: Mode; onRetry: () => void }) {
+  if (mode.loading) {
+    return <div className="text-sm text-muted-foreground">Loading…</div>
+  }
+  if (mode.error) {
+    return (
+      <div className="space-y-3">
+        <div className="rounded-md border border-destructive/30 bg-destructive/10 text-destructive text-sm px-3 py-2">
+          {mode.error}
+        </div>
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+  if (mode.kind === 'list') {
+    if (mode.items.length === 0) {
+      return (
+        <Empty>
+          No global memories yet. Talk to a CLI session and ask the agent to
+          remember something — it&rsquo;ll show up here.
+        </Empty>
+      )
+    }
+    return (
+      <ul className="space-y-2">
+        {mode.items.map((m) => (
+          <FactCard key={m.id} text={m.text} updated={m.updated_at} />
+        ))}
+      </ul>
+    )
+  }
+  // search
+  if (mode.hits.length === 0) {
+    return <Empty>No matches.</Empty>
+  }
+  return (
+    <ul className="space-y-2">
+      {mode.hits.map((h) => (
+        <FactCard
+          key={h.record.id}
+          text={h.record.text}
+          updated={h.record.updated_at}
+          similarity={h.similarity}
+        />
+      ))}
+    </ul>
+  )
+}
+
+function FactCard({
+  text,
+  updated,
+  similarity,
+}: {
+  text: string
+  updated: string
+  similarity?: number
+}) {
+  return (
+    <li className="rounded-md border border-border bg-card p-3 text-sm space-y-1">
+      <div className="whitespace-pre-wrap break-words">{text}</div>
+      <div className="text-[11px] text-muted-foreground flex items-center justify-between gap-2">
+        <span>{formatRelative(updated)}</span>
+        {similarity !== undefined && (
+          <span className="tabular-nums">
+            {(similarity * 100).toFixed(0)}% match
+          </span>
+        )}
+      </div>
+    </li>
+  )
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-md border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+      {children}
+    </div>
+  )
+}
+
+function formatRelative(iso: string): string {
+  const ts = Date.parse(iso)
+  if (Number.isNaN(ts)) return iso
+  const seconds = Math.round((Date.now() - ts) / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.round(hours / 24)
+  return `${days}d ago`
+}

--- a/app/mobile/src/screens/NotesScreen.tsx
+++ b/app/mobile/src/screens/NotesScreen.tsx
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  type FullNote,
+  type NoteSummary,
+  getNote,
+  listNotes,
+  MobileAPIError,
+} from '../lib/api'
+
+interface Props {
+  serverURL: string
+  token: string
+  onAuthExpired: () => void
+}
+
+type View =
+  | { kind: 'list'; loading: boolean; notes: NoteSummary[]; error?: string }
+  | { kind: 'detail'; loading: boolean; note?: FullNote; path: string; error?: string }
+
+// Notes vault viewer (read-only on mobile). The desktop admin handles
+// markdown editing — small-screen rich-text edit is a separate
+// project. Mobile shows the file tree as a flat list and the body as
+// monospace text; markdown rendering is a future polish task.
+export function NotesScreen({ serverURL, token, onAuthExpired }: Props) {
+  const [view, setView] = useState<View>({ kind: 'list', loading: true, notes: [] })
+
+  const loadList = useCallback(async () => {
+    setView({ kind: 'list', loading: true, notes: [] })
+    try {
+      const notes = await listNotes(serverURL, token)
+      // Most-recent-modified-first reads better on mobile than the
+      // raw filesystem order.
+      notes.sort((a, b) => Date.parse(b.modified) - Date.parse(a.modified))
+      setView({ kind: 'list', loading: false, notes })
+    } catch (err) {
+      if (err instanceof MobileAPIError && err.status === 401) {
+        onAuthExpired()
+        return
+      }
+      setView({
+        kind: 'list',
+        loading: false,
+        notes: [],
+        error: err instanceof Error ? err.message : 'Failed to load notes',
+      })
+    }
+  }, [serverURL, token, onAuthExpired])
+
+  useEffect(() => {
+    void loadList()
+  }, [loadList])
+
+  async function openNote(path: string) {
+    setView({ kind: 'detail', loading: true, path })
+    try {
+      const note = await getNote(serverURL, token, path)
+      setView({ kind: 'detail', loading: false, path, note })
+    } catch (err) {
+      if (err instanceof MobileAPIError && err.status === 401) {
+        onAuthExpired()
+        return
+      }
+      setView({
+        kind: 'detail',
+        loading: false,
+        path,
+        error: err instanceof Error ? err.message : 'Failed to load note',
+      })
+    }
+  }
+
+  if (view.kind === 'detail') {
+    return (
+      <div className="min-h-screen bg-background text-foreground flex flex-col">
+        <header className="sticky top-0 z-10 bg-background/95 backdrop-blur border-b border-border px-3 py-2 flex items-center gap-2">
+          <Button variant="ghost" size="sm" onClick={loadList}>
+            ← Back
+          </Button>
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-medium truncate">
+              {view.note?.title ?? view.path.split('/').pop()}
+            </div>
+            <div className="text-[10px] text-muted-foreground truncate">{view.path}</div>
+          </div>
+        </header>
+        <main className="flex-1 px-4 py-3 overflow-auto">
+          {view.loading && (
+            <div className="text-sm text-muted-foreground">Loading…</div>
+          )}
+          {view.error && (
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 text-destructive text-sm px-3 py-2">
+              {view.error}
+            </div>
+          )}
+          {view.note && (
+            <pre className="whitespace-pre-wrap break-words font-mono text-[12px] leading-relaxed text-foreground">
+              {view.note.body}
+            </pre>
+          )}
+        </main>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col">
+      <header className="sticky top-0 z-10 bg-background/95 backdrop-blur border-b border-border px-4 py-3">
+        <h1 className="text-lg font-semibold leading-tight">Notes</h1>
+        <p className="text-xs text-muted-foreground">
+          Read-only on mobile. Edit on desktop.
+        </p>
+      </header>
+      <main className="flex-1 px-4 py-3">
+        {view.loading && (
+          <div className="text-sm text-muted-foreground">Loading…</div>
+        )}
+        {view.error && (
+          <div className="space-y-3">
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 text-destructive text-sm px-3 py-2">
+              {view.error}
+            </div>
+            <Button variant="outline" size="sm" onClick={loadList}>
+              Retry
+            </Button>
+          </div>
+        )}
+        {!view.loading && !view.error && view.notes.length === 0 && (
+          <div className="rounded-md border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+            Vault is empty. Create notes from the desktop admin.
+          </div>
+        )}
+        {!view.loading && view.notes.length > 0 && (
+          <ul className="space-y-2">
+            {view.notes.map((n) => (
+              <li key={n.path}>
+                <button
+                  type="button"
+                  onClick={() => openNote(n.path)}
+                  className="w-full text-left rounded-md border border-border bg-card p-3 active:bg-accent/10 transition-colors"
+                >
+                  <div className="text-sm font-medium truncate">{n.title || n.path}</div>
+                  <div className="text-[11px] text-muted-foreground truncate">
+                    {n.path}
+                  </div>
+                  <div className="text-[10px] text-muted-foreground">
+                    {humanSize(n.size)} · {formatRelative(n.modified)}
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+    </div>
+  )
+}
+
+function formatRelative(iso: string): string {
+  const ts = Date.parse(iso)
+  if (Number.isNaN(ts)) return iso
+  const seconds = Math.round((Date.now() - ts) / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.round(hours / 24)
+  return `${days}d ago`
+}
+
+function humanSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}


### PR DESCRIPTION
## Summary

**T2** of the mobile-platform plan. Adds three new top-level surfaces (Memory, Notes, Activity) and a **bottom-tab navigator**, so the mobile app becomes more than a single-screen experience.

\`\`\`
┌─────────────────────────────┐
│   {active tab content}       │   <— full-screen scrollable content
├─────────────────────────────┤
│ ▢ Sessions ◇ Memory ☰ Notes ⏱ │   <— bottom tab bar (sits above home indicator)
└─────────────────────────────┘
\`\`\`

## New screens

| Screen | What it does |
|---|---|
| **MemoryScreen** | Lists 100 most-recent global-scope memory facts. Search bar hits \`/api/v1/memory/search\` and renders similarity-ranked hits with a \"% match\" badge |
| **NotesScreen** | Lists vault notes (most-recent-modified first). Tap → fetches \`/api/v1/notes/get\` → renders body in monospace \`<pre>\` (markdown rendering deferred — heavy bundle for low payoff on phone) |
| **ActivityScreen** | Most-recent 100 audit entries via \`/api/v1/audit\`. Refresh button. Filters / pagination deferred to C if needed |

All three are read-only — content creation / editing happens on desktop or via the agent's tools, per ADR 0015.

## New navigation

\`BottomTabBar.tsx\` — 4 tabs (Sessions / Memory / Notes / Activity). Active tab uses \`--accent\` color. \`pb-safe\` keeps labels above iOS home indicator. Stays mounted while user switches tabs (no remount overhead).

\`App.tsx\` rewritten: state machine gains a \`tab: Tab\` field. Home state now shells around the active tab. Session detail (B6) still routes to a full-screen variant without the tab bar — terminal needs every pixel.

## Modified

- \`app/mobile/src/lib/api.ts\` — endpoint helpers + types for memory / notes / audit. Same mobile-fetch pattern as B5 (\`serverURL\` + \`token\` explicit, no \`shared/api.ts\` coupling)

## What T2 does NOT do

- **Markdown rendering on Notes** — deferred. \`react-markdown\` is ~160 KB; \`<pre>\` is legible enough for phone scanning
- **Activity filters / pagination** — flat 100-entry list. Filters land in C if needed
- **Note editing** — explicit non-goal per ADR 0015
- **Tab badges** (unread counts) — polish; deferred

## Verification

| Check | Result |
|---|---|
| \`pnpm --filter mobile build\` | ✅ 50 modules, 604 KB JS, 27.7 KB CSS |
| \`pnpm --filter mobile exec cap sync ios\` | ✅ clean |
| \`pnpm --filter web build\` | ✅ unchanged |
| \`go build ./cmd/opendray\` | ✅ unchanged |

## Mobile parity progress

- T1 ✅ Sessions list + terminal
- **T2 ✅ Memory + Notes + Activity** ← this PR
- T3 ⏳ Channels + Integrations + Providers
- T4 ⏳ Settings + Backups + Plugins + Export + Tutorial

🤖 Generated with [Claude Code](https://claude.com/claude-code)