### PR TITLE
feat(mobile): Channels + Integrations + Providers + More tab [T3]

### DIFF
--- a/app/mobile/src/App.tsx
+++ b/app/mobile/src/App.tsx
@@ -7,6 +7,10 @@ import { SessionDetailScreen } from './screens/SessionDetailScreen'
 import { MemoryScreen } from './screens/MemoryScreen'
 import { NotesScreen } from './screens/NotesScreen'
 import { ActivityScreen } from './screens/ActivityScreen'
+import { MoreScreen, type SubPage } from './screens/MoreScreen'
+import { ChannelsScreen } from './screens/ChannelsScreen'
+import { IntegrationsScreen } from './screens/IntegrationsScreen'
+import { ProvidersScreen } from './screens/ProvidersScreen'
 import { BottomTabBar, type Tab } from './components/BottomTabBar'
 import { type SessionSummary } from './lib/api'
 import {
@@ -17,15 +21,23 @@ import {
   tokenExpired,
 } from './lib/storage'
 
-type AppState = 'loading' | 'onboarding' | 'login' | 'home' | 'session'
+type AppState =
+  | 'loading'
+  | 'onboarding'
+  | 'login'
+  | 'home'
+  | 'session'
+  | SubPage
 
 // Top-level state machine. Drives which screen renders based on what
 // we have persisted in Capacitor Preferences:
 //
 //   serverURL absent              → onboarding
 //   serverURL set, no/expired tok → login
-//   serverURL set, valid token    → home (with 4 tabs)
-//   home tab + tap session card   → session detail (full-screen)
+//   serverURL set, valid token    → home (5 bottom tabs)
+//   home + tap session card       → session detail (full-screen)
+//   "More" tab + tap entry        → channels / integrations / providers
+//                                    (full-screen, no tab bar)
 export function App() {
   const [state, setState] = useState<AppState>('loading')
   const [prefs, setPrefs] = useState<StoredPrefs | null>(null)
@@ -79,8 +91,6 @@ export function App() {
       <LoginScreen
         serverURL={prefs!.serverURL!}
         onAuthed={async () => {
-          // setAuth has already written; re-read so home tabs see the
-          // canonical values.
           const fresh = await getPrefs()
           setPrefs(fresh)
           setState('home')
@@ -103,13 +113,17 @@ export function App() {
     setState('login')
   }
 
-  // Session detail is full-screen — no bottom tab bar — so the
-  // terminal can use every available pixel.
+  const serverURL = prefs!.serverURL!
+  const token = prefs!.token!
+  const username = prefs!.username ?? 'admin'
+
+  // ── Full-screen sub-pages (no bottom tab bar) ────────────────────
+
   if (state === 'session' && activeSession) {
     return (
       <SessionDetailScreen
-        serverURL={prefs!.serverURL!}
-        token={prefs!.token!}
+        serverURL={serverURL}
+        token={token}
         sessionId={activeSession.id}
         session={activeSession}
         onBack={() => {
@@ -120,12 +134,40 @@ export function App() {
     )
   }
 
-  // Home shell — content fills the screen above the bottom tab bar.
-  // Each tab manages its own header + scrollable content; we just
-  // render the right component based on the active tab.
-  const serverURL = prefs!.serverURL!
-  const token = prefs!.token!
-  const username = prefs!.username ?? 'admin'
+  if (state === 'channels') {
+    return (
+      <ChannelsScreen
+        serverURL={serverURL}
+        token={token}
+        onBack={() => setState('home')}
+        onAuthExpired={onClearAuthAndReturnToLogin}
+      />
+    )
+  }
+
+  if (state === 'integrations') {
+    return (
+      <IntegrationsScreen
+        serverURL={serverURL}
+        token={token}
+        onBack={() => setState('home')}
+        onAuthExpired={onClearAuthAndReturnToLogin}
+      />
+    )
+  }
+
+  if (state === 'providers') {
+    return (
+      <ProvidersScreen
+        serverURL={serverURL}
+        token={token}
+        onBack={() => setState('home')}
+        onAuthExpired={onClearAuthAndReturnToLogin}
+      />
+    )
+  }
+
+  // ── Home shell with tab bar ──────────────────────────────────────
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -162,6 +204,15 @@ export function App() {
             serverURL={serverURL}
             token={token}
             onAuthExpired={onClearAuthAndReturnToLogin}
+          />
+        )}
+        {tab === 'more' && (
+          <MoreScreen
+            username={username}
+            serverURL={serverURL}
+            expiresAt={prefs!.expiresAt}
+            onOpen={(page) => setState(page)}
+            onLogout={onClearAuthAndReturnToLogin}
           />
         )}
       </div>

--- a/app/mobile/src/components/BottomTabBar.tsx
+++ b/app/mobile/src/components/BottomTabBar.tsx
@@ -5,7 +5,7 @@
 // Sits above the home indicator via the `pb-safe` Tailwind utility
 // added in #27. Active-tab indicator is the accent color underline.
 
-export type Tab = 'sessions' | 'memory' | 'notes' | 'activity'
+export type Tab = 'sessions' | 'memory' | 'notes' | 'activity' | 'more'
 
 interface Props {
   active: Tab
@@ -17,6 +17,7 @@ const TABS: { id: Tab; label: string; icon: string }[] = [
   { id: 'memory', label: 'Memory', icon: '◇' },
   { id: 'notes', label: 'Notes', icon: '☰' },
   { id: 'activity', label: 'Activity', icon: '⏱' },
+  { id: 'more', label: 'More', icon: '⋯' },
 ]
 
 export function BottomTabBar({ active, onChange }: Props) {

--- a/app/mobile/src/lib/api.ts
+++ b/app/mobile/src/lib/api.ts
@@ -255,3 +255,82 @@ export async function listAudit(
   )
   return res.entries ?? []
 }
+
+// ── Channels ────────────────────────────────────────────────────────
+
+export interface ChannelSummary {
+  id: string
+  kind: string
+  enabled: boolean
+  running: boolean
+  muted: boolean
+  capabilities?: string[]
+}
+
+export async function listChannels(
+  serverURL: string,
+  token: string,
+): Promise<ChannelSummary[]> {
+  const res = await mobileFetch<{ channels?: ChannelSummary[] }>(
+    serverURL,
+    '/api/v1/channels',
+    { token },
+  )
+  return res.channels ?? []
+}
+
+// ── Integrations ────────────────────────────────────────────────────
+
+export interface IntegrationSummary {
+  id: string
+  name: string
+  base_url: string
+  route_prefix: string
+  scopes: string[]
+  version?: string
+  enabled: boolean
+  health_status: 'healthy' | 'degraded' | 'unhealthy' | 'unknown' | string
+  health_last_seen?: string
+}
+
+export async function listIntegrations(
+  serverURL: string,
+  token: string,
+): Promise<IntegrationSummary[]> {
+  const res = await mobileFetch<{ integrations?: IntegrationSummary[] }>(
+    serverURL,
+    '/api/v1/integrations',
+    { token },
+  )
+  return res.integrations ?? []
+}
+
+// ── Providers ───────────────────────────────────────────────────────
+
+export interface ProviderSummary {
+  id: string
+  name: string
+  manifest_hash: string
+  enabled: boolean
+}
+
+export async function listProviders(
+  serverURL: string,
+  token: string,
+): Promise<ProviderSummary[]> {
+  // Server returns the full Provider shape; we only need the few
+  // fields we render. Avoid pulling the whole types from shared.
+  const res = await mobileFetch<{
+    providers?: Array<{
+      manifest: { id: string; name: string }
+      manifest_hash: string
+      enabled: boolean
+    }>
+  }>(serverURL, '/api/v1/providers', { token })
+  return (res.providers ?? []).map((p) => ({
+    id: p.manifest.id,
+    name: p.manifest.name,
+    manifest_hash: p.manifest_hash,
+    enabled: p.enabled,
+  }))
+}

--- a/app/mobile/src/screens/ChannelsScreen.tsx
+++ b/app/mobile/src/screens/ChannelsScreen.tsx
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { type ChannelSummary, listChannels, MobileAPIError } from '../lib/api'
+
+interface Props {
+  serverURL: string
+  token: string
+  onBack: () => void
+  onAuthExpired: () => void
+}
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ready'; channels: ChannelSummary[] }
+  | { kind: 'error'; message: string }
+
+// Channels viewer (read-only on mobile). Lists every configured
+// channel adapter with running / enabled / muted state. Editing
+// channel config (bot tokens, webhooks, etc.) is desktop territory.
+export function ChannelsScreen({ serverURL, token, onBack, onAuthExpired }: Props) {
+  const [state, setState] = useState<State>({ kind: 'loading' })
+
+  const refresh = useCallback(async () => {
+    setState({ kind: 'loading' })
+    try {
+      const channels = await listChannels(serverURL, token)
+      setState({ kind: 'ready', channels })
+    } catch (err) {
+      if (err instanceof MobileAPIError && err.status === 401) {
+        onAuthExpired()
+        return
+      }
+      setState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'Failed to load channels',
+      })
+    }
+  }, [serverURL, token, onAuthExpired])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col">
+      <header className="sticky top-0 z-10 bg-background/95 backdrop-blur border-b border-border px-3 py-2 flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          ← Back
+        </Button>
+        <h1 className="flex-1 text-base font-semibold">Channels</h1>
+        <Button variant="outline" size="sm" onClick={refresh}>
+          Refresh
+        </Button>
+      </header>
+      <main className="flex-1 px-4 py-3">
+        {state.kind === 'loading' && (
+          <div className="text-sm text-muted-foreground">Loading…</div>
+        )}
+        {state.kind === 'error' && (
+          <div className="space-y-3">
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 text-destructive text-sm px-3 py-2">
+              {state.message}
+            </div>
+            <Button variant="outline" size="sm" onClick={refresh}>
+              Retry
+            </Button>
+          </div>
+        )}
+        {state.kind === 'ready' && state.channels.length === 0 && (
+          <div className="rounded-md border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+            No channels configured. Configure adapters from the desktop admin.
+          </div>
+        )}
+        {state.kind === 'ready' && state.channels.length > 0 && (
+          <ul className="space-y-2">
+            {state.channels.map((c) => (
+              <li
+                key={c.id}
+                className="rounded-md border border-border bg-card p-3 space-y-1"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-sm font-medium truncate">{c.id}</span>
+                  <ChannelStateBadge channel={c} />
+                </div>
+                <div className="text-xs text-muted-foreground">{c.kind}</div>
+                {c.capabilities && c.capabilities.length > 0 && (
+                  <div className="flex gap-1 flex-wrap">
+                    {c.capabilities.map((cap) => (
+                      <span
+                        key={cap}
+                        className="text-[10px] uppercase tracking-wide rounded px-1.5 py-0.5 border border-border text-muted-foreground"
+                      >
+                        {cap}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+    </div>
+  )
+}
+
+function ChannelStateBadge({ channel }: { channel: ChannelSummary }) {
+  if (!channel.enabled) {
+    return <Badge color="border-muted-foreground/30 text-muted-foreground bg-muted/30">disabled</Badge>
+  }
+  if (channel.muted) {
+    return <Badge color="border-[var(--state-idle)]/40 text-[var(--state-idle)] bg-[var(--state-idle)]/10">muted</Badge>
+  }
+  if (channel.running) {
+    return <Badge color="border-[var(--state-running)]/40 text-[var(--state-running)] bg-[var(--state-running)]/10">running</Badge>
+  }
+  return <Badge color="border-destructive/40 text-destructive bg-destructive/10">stopped</Badge>
+}
+
+function Badge({
+  color,
+  children,
+}: {
+  color: string
+  children: React.ReactNode
+}) {
+  return (
+    <span
+      className={`text-[10px] uppercase tracking-wide rounded px-1.5 py-0.5 border ${color}`}
+    >
+      {children}
+    </span>
+  )
+}

--- a/app/mobile/src/screens/IntegrationsScreen.tsx
+++ b/app/mobile/src/screens/IntegrationsScreen.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  type IntegrationSummary,
+  listIntegrations,
+  MobileAPIError,
+} from '../lib/api'
+
+interface Props {
+  serverURL: string
+  token: string
+  onBack: () => void
+  onAuthExpired: () => void
+}
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ready'; integrations: IntegrationSummary[] }
+  | { kind: 'error'; message: string }
+
+// Integrations viewer (read-only on mobile). Registration / key
+// rotation / scope edits happen on desktop where a 16-character API
+// key is easier to copy.
+export function IntegrationsScreen({
+  serverURL,
+  token,
+  onBack,
+  onAuthExpired,
+}: Props) {
+  const [state, setState] = useState<State>({ kind: 'loading' })
+
+  const refresh = useCallback(async () => {
+    setState({ kind: 'loading' })
+    try {
+      const integrations = await listIntegrations(serverURL, token)
+      setState({ kind: 'ready', integrations })
+    } catch (err) {
+      if (err instanceof MobileAPIError && err.status === 401) {
+        onAuthExpired()
+        return
+      }
+      setState({
+        kind: 'error',
+        message:
+          err instanceof Error ? err.message : 'Failed to load integrations',
+      })
+    }
+  }, [serverURL, token, onAuthExpired])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col">
+      <header className="sticky top-0 z-10 bg-background/95 backdrop-blur border-b border-border px-3 py-2 flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          ← Back
+        </Button>
+        <h1 className="flex-1 text-base font-semibold">Integrations</h1>
+        <Button variant="outline" size="sm" onClick={refresh}>
+          Refresh
+        </Button>
+      </header>
+      <main className="flex-1 px-4 py-3">
+        {state.kind === 'loading' && (
+          <div className="text-sm text-muted-foreground">Loading…</div>
+        )}
+        {state.kind === 'error' && (
+          <div className="space-y-3">
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 text-destructive text-sm px-3 py-2">
+              {state.message}
+            </div>
+            <Button variant="outline" size="sm" onClick={refresh}>
+              Retry
+            </Button>
+          </div>
+        )}
+        {state.kind === 'ready' && state.integrations.length === 0 && (
+          <div className="rounded-md border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+            No integrations registered. Register from the desktop admin.
+          </div>
+        )}
+        {state.kind === 'ready' && state.integrations.length > 0 && (
+          <ul className="space-y-2">
+            {state.integrations.map((i) => (
+              <li
+                key={i.id}
+                className="rounded-md border border-border bg-card p-3 space-y-1"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-sm font-medium truncate">{i.name}</span>
+                  <HealthBadge status={i.health_status} enabled={i.enabled} />
+                </div>
+                <div className="text-xs text-muted-foreground space-y-0.5">
+                  <div className="truncate">{i.base_url}</div>
+                  <div>prefix: <span className="font-mono text-foreground">{i.route_prefix}</span></div>
+                  {i.version && <div>version: {i.version}</div>}
+                  <div>
+                    {i.scopes.length} scope{i.scopes.length === 1 ? '' : 's'}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+    </div>
+  )
+}
+
+function HealthBadge({
+  status,
+  enabled,
+}: {
+  status: string
+  enabled: boolean
+}) {
+  if (!enabled) {
+    return (
+      <span className="text-[10px] uppercase tracking-wide rounded px-1.5 py-0.5 border border-muted-foreground/30 text-muted-foreground bg-muted/30">
+        disabled
+      </span>
+    )
+  }
+  const palette =
+    status === 'healthy'
+      ? 'border-[var(--state-running)]/40 text-[var(--state-running)] bg-[var(--state-running)]/10'
+      : status === 'degraded'
+        ? 'border-[var(--state-idle)]/40 text-[var(--state-idle)] bg-[var(--state-idle)]/10'
+        : 'border-destructive/40 text-destructive bg-destructive/10'
+  return (
+    <span
+      className={`text-[10px] uppercase tracking-wide rounded px-1.5 py-0.5 border ${palette}`}
+    >
+      {status}
+    </span>
+  )
+}

--- a/app/mobile/src/screens/MoreScreen.tsx
+++ b/app/mobile/src/screens/MoreScreen.tsx
@@ -1,0 +1,97 @@
+// "More" tab — overflow list of secondary surfaces. Lower-frequency
+// admin pages (Channels / Integrations / Providers / Settings) live
+// here so the bottom tab bar stays at 5 entries instead of 9+.
+//
+// Each row navigates to a full-screen sub-page via the App.tsx
+// state machine, mirroring how SessionsScreen → SessionDetailScreen
+// works (full-screen, no bottom tab visible during sub-page).
+
+interface Props {
+  username: string
+  serverURL: string
+  expiresAt: string | null
+  onOpen: (page: SubPage) => void
+  onLogout: () => void
+}
+
+export type SubPage = 'channels' | 'integrations' | 'providers'
+
+const ITEMS: { id: SubPage; label: string; description: string; icon: string }[] = [
+  {
+    id: 'channels',
+    label: 'Channels',
+    description: 'Telegram / Discord / Slack adapters',
+    icon: '✉',
+  },
+  {
+    id: 'integrations',
+    label: 'Integrations',
+    description: 'External apps registered against the gateway',
+    icon: '⇄',
+  },
+  {
+    id: 'providers',
+    label: 'CLI Providers',
+    description: 'Claude Code / Codex / Gemini configurations',
+    icon: '◈',
+  },
+]
+
+export function MoreScreen({
+  username,
+  serverURL,
+  expiresAt,
+  onOpen,
+  onLogout,
+}: Props) {
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col">
+      <header className="sticky top-0 z-10 bg-background/95 backdrop-blur border-b border-border px-4 py-3">
+        <h1 className="text-lg font-semibold leading-tight">More</h1>
+      </header>
+      <main className="flex-1 px-4 py-3 space-y-4">
+        <ul className="space-y-2">
+          {ITEMS.map((it) => (
+            <li key={it.id}>
+              <button
+                type="button"
+                onClick={() => onOpen(it.id)}
+                className="w-full text-left rounded-md border border-border bg-card text-card-foreground p-3 active:bg-accent/10 transition-colors flex items-center gap-3"
+              >
+                <span className="text-xl text-accent">{it.icon}</span>
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium">{it.label}</div>
+                  <div className="text-xs text-muted-foreground truncate">
+                    {it.description}
+                  </div>
+                </div>
+                <span className="text-muted-foreground">›</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        <div className="rounded-md border border-border bg-card p-3 text-xs space-y-1">
+          <div className="text-muted-foreground">Signed in as</div>
+          <div className="font-medium">{username}</div>
+          <div className="text-muted-foreground pt-2">Server</div>
+          <div className="break-all">{serverURL}</div>
+          {expiresAt && (
+            <>
+              <div className="text-muted-foreground pt-2">Token expires</div>
+              <div>{new Date(expiresAt).toLocaleString()}</div>
+            </>
+          )}
+        </div>
+
+        <button
+          type="button"
+          onClick={onLogout}
+          className="w-full rounded-md border border-destructive/30 bg-destructive/10 text-destructive text-sm px-3 py-2.5 active:bg-destructive/20 transition-colors"
+        >
+          Sign out
+        </button>
+      </main>
+    </div>
+  )
+}

--- a/app/mobile/src/screens/ProvidersScreen.tsx
+++ b/app/mobile/src/screens/ProvidersScreen.tsx
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  type ProviderSummary,
+  listProviders,
+  MobileAPIError,
+} from '../lib/api'
+
+interface Props {
+  serverURL: string
+  token: string
+  onBack: () => void
+  onAuthExpired: () => void
+}
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ready'; providers: ProviderSummary[] }
+  | { kind: 'error'; message: string }
+
+// CLI providers viewer (read-only on mobile). Configuration forms
+// (api keys, model selection) live on desktop.
+export function ProvidersScreen({
+  serverURL,
+  token,
+  onBack,
+  onAuthExpired,
+}: Props) {
+  const [state, setState] = useState<State>({ kind: 'loading' })
+
+  const refresh = useCallback(async () => {
+    setState({ kind: 'loading' })
+    try {
+      const providers = await listProviders(serverURL, token)
+      setState({ kind: 'ready', providers })
+    } catch (err) {
+      if (err instanceof MobileAPIError && err.status === 401) {
+        onAuthExpired()
+        return
+      }
+      setState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'Failed to load providers',
+      })
+    }
+  }, [serverURL, token, onAuthExpired])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col">
+      <header className="sticky top-0 z-10 bg-background/95 backdrop-blur border-b border-border px-3 py-2 flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          ← Back
+        </Button>
+        <h1 className="flex-1 text-base font-semibold">CLI Providers</h1>
+        <Button variant="outline" size="sm" onClick={refresh}>
+          Refresh
+        </Button>
+      </header>
+      <main className="flex-1 px-4 py-3">
+        {state.kind === 'loading' && (
+          <div className="text-sm text-muted-foreground">Loading…</div>
+        )}
+        {state.kind === 'error' && (
+          <div className="space-y-3">
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 text-destructive text-sm px-3 py-2">
+              {state.message}
+            </div>
+            <Button variant="outline" size="sm" onClick={refresh}>
+              Retry
+            </Button>
+          </div>
+        )}
+        {state.kind === 'ready' && state.providers.length === 0 && (
+          <div className="rounded-md border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+            No providers configured.
+          </div>
+        )}
+        {state.kind === 'ready' && state.providers.length > 0 && (
+          <ul className="space-y-2">
+            {state.providers.map((p) => (
+              <li
+                key={p.id}
+                className="rounded-md border border-border bg-card p-3 space-y-1"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-sm font-medium truncate">{p.name}</span>
+                  <span
+                    className={`text-[10px] uppercase tracking-wide rounded px-1.5 py-0.5 border ${
+                      p.enabled
+                        ? 'border-[var(--state-running)]/40 text-[var(--state-running)] bg-[var(--state-running)]/10'
+                        : 'border-muted-foreground/30 text-muted-foreground bg-muted/30'
+                    }`}
+                  >
+                    {p.enabled ? 'enabled' : 'disabled'}
+                  </span>
+                </div>
+                <div className="text-xs text-muted-foreground space-y-0.5">
+                  <div className="font-mono truncate">{p.id}</div>
+                  <div className="font-mono text-[10px] truncate text-muted-foreground/70">
+                    manifest {p.manifest_hash.slice(0, 12)}…
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

**T3** of the mobile-platform plan. Adds three secondary admin surfaces (Channels, Integrations, CLI Providers) and a new **\"More\" bottom tab** that overflows them. Keeps the bottom-tab bar manageable while making every web admin route reachable on mobile.

## Bottom tab bar

\`\`\`
▢ Sessions  ◇ Memory  ☰ Notes  ⏱ Activity  ⋯ More
\`\`\`

\"More\" → vertical list of cards. Tap → full-screen sub-page (\`Back\` button, no bottom tab visible). Same pattern as B6's session detail.

## New screens

| Screen | Behavior |
|---|---|
| **MoreScreen** | 3 nav cards (Channels / Integrations / Providers). Server-info card (username / URL / token expiry). Big destructive Sign-out button at bottom |
| **ChannelsScreen** | Read-only adapter list. State badges: running / muted / stopped / disabled. Capabilities chips |
| **IntegrationsScreen** | Read-only registration list. Health badge: healthy / degraded / unhealthy / disabled. Shows base_url, route_prefix (mono), version, scope count |
| **ProvidersScreen** | Read-only CLI provider list. enabled/disabled badge + manifest hash |

All three are read-only — same rationale as ADR 0015: bot tokens / API keys / model config are awkward to copy-paste on a phone. Desktop is the authoring surface, mobile is for monitoring.

## Modified

- \`BottomTabBar.tsx\` — 4 → 5 tabs
- \`api.ts\` — \`listChannels\` / \`listIntegrations\` / \`listProviders\` + summary types
- \`App.tsx\` — \`AppState\` union grows \`channels\` / \`integrations\` / \`providers\` via the \`SubPage\` type from MoreScreen

## Verification

| Check | Result |
|---|---|
| \`pnpm --filter mobile build\` | ✅ 54 modules, 615 KB JS, 28.6 KB CSS |
| \`pnpm --filter mobile exec cap sync ios\` | ✅ clean |
| \`pnpm --filter web build\` | ✅ unchanged |
| \`go build ./cmd/opendray\` | ✅ unchanged |

## Mobile parity progress

- T1 ✅ Sessions list + terminal
- T2 ✅ Memory + Notes + Activity
- **T3 ✅ Channels + Integrations + Providers** ← this PR
- T4 ⏳ Settings + Backups + Plugins + Export + Tutorial
- C ⏳ Push notif + biometric + deep link + OTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)