### PR TITLE
feat(mobile): Settings + Backups screens [T4]

### DIFF
--- a/app/mobile/src/App.tsx
+++ b/app/mobile/src/App.tsx
@@ -11,6 +11,8 @@ import { MoreScreen, type SubPage } from './screens/MoreScreen'
 import { ChannelsScreen } from './screens/ChannelsScreen'
 import { IntegrationsScreen } from './screens/IntegrationsScreen'
 import { ProvidersScreen } from './screens/ProvidersScreen'
+import { BackupsScreen } from './screens/BackupsScreen'
+import { SettingsScreen } from './screens/SettingsScreen'
 import { BottomTabBar, type Tab } from './components/BottomTabBar'
 import { type SessionSummary } from './lib/api'
 import {
@@ -163,6 +165,28 @@ export function App() {
         token={token}
         onBack={() => setState('home')}
         onAuthExpired={onClearAuthAndReturnToLogin}
+      />
+    )
+  }
+
+  if (state === 'backups') {
+    return (
+      <BackupsScreen
+        serverURL={serverURL}
+        token={token}
+        onBack={() => setState('home')}
+        onAuthExpired={onClearAuthAndReturnToLogin}
+      />
+    )
+  }
+
+  if (state === 'settings') {
+    return (
+      <SettingsScreen
+        username={username}
+        serverURL={serverURL}
+        expiresAt={prefs!.expiresAt}
+        onBack={() => setState('home')}
       />
     )
   }

--- a/app/mobile/src/lib/api.ts
+++ b/app/mobile/src/lib/api.ts
@@ -334,3 +334,28 @@ export async function listProviders(
     enabled: p.enabled,
   }))
 }
+
+// ── Backups ─────────────────────────────────────────────────────────
+
+export interface BackupSummary {
+  id: string
+  target_id: string
+  status: 'pending' | 'running' | 'succeeded' | 'failed' | 'deleted' | string
+  triggered_by: string
+  started_at: string
+  finished_at?: string | null
+  bytes: number
+  encrypted: boolean
+}
+
+export async function listBackups(
+  serverURL: string,
+  token: string,
+): Promise<BackupSummary[]> {
+  const res = await mobileFetch<{ backups?: BackupSummary[] }>(
+    serverURL,
+    '/api/v1/backups',
+    { token },
+  )
+  return res.backups ?? []
+}

--- a/app/mobile/src/screens/BackupsScreen.tsx
+++ b/app/mobile/src/screens/BackupsScreen.tsx
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { type BackupSummary, listBackups, MobileAPIError } from '../lib/api'
+
+interface Props {
+  serverURL: string
+  token: string
+  onBack: () => void
+  onAuthExpired: () => void
+}
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ready'; backups: BackupSummary[] }
+  | { kind: 'error'; message: string }
+
+// Backup history viewer (read-only on mobile). Backup targets,
+// schedules, restore flow all live on desktop — mobile here is
+// for "did the 03:00 schedule succeed last night?" glances.
+export function BackupsScreen({ serverURL, token, onBack, onAuthExpired }: Props) {
+  const [state, setState] = useState<State>({ kind: 'loading' })
+
+  const refresh = useCallback(async () => {
+    setState({ kind: 'loading' })
+    try {
+      const backups = await listBackups(serverURL, token)
+      // Most recent first. Server returns reverse-chronological
+      // already in practice, but make it explicit so a server
+      // change doesn't silently regress UX.
+      backups.sort((a, b) => Date.parse(b.started_at) - Date.parse(a.started_at))
+      setState({ kind: 'ready', backups })
+    } catch (err) {
+      if (err instanceof MobileAPIError && err.status === 401) {
+        onAuthExpired()
+        return
+      }
+      setState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'Failed to load backups',
+      })
+    }
+  }, [serverURL, token, onAuthExpired])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col">
+      <header className="sticky top-0 z-10 bg-background/95 backdrop-blur border-b border-border px-3 py-2 flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          ← Back
+        </Button>
+        <h1 className="flex-1 text-base font-semibold">Backups</h1>
+        <Button variant="outline" size="sm" onClick={refresh}>
+          Refresh
+        </Button>
+      </header>
+      <main className="flex-1 px-4 py-3">
+        {state.kind === 'loading' && (
+          <div className="text-sm text-muted-foreground">Loading…</div>
+        )}
+        {state.kind === 'error' && (
+          <div className="space-y-3">
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 text-destructive text-sm px-3 py-2">
+              {state.message}
+            </div>
+            <Button variant="outline" size="sm" onClick={refresh}>
+              Retry
+            </Button>
+          </div>
+        )}
+        {state.kind === 'ready' && state.backups.length === 0 && (
+          <div className="rounded-md border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+            No backups yet. Backup configuration lives on the desktop admin.
+          </div>
+        )}
+        {state.kind === 'ready' && state.backups.length > 0 && (
+          <ul className="space-y-2">
+            {state.backups.map((b) => (
+              <BackupCard key={b.id} backup={b} />
+            ))}
+          </ul>
+        )}
+      </main>
+    </div>
+  )
+}
+
+function BackupCard({ backup }: { backup: BackupSummary }) {
+  return (
+    <li className="rounded-md border border-border bg-card p-3 space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-mono truncate">{backup.id}</span>
+        <StatusBadge status={backup.status} />
+      </div>
+      <div className="text-xs text-muted-foreground space-y-0.5">
+        <div>target: {backup.target_id}</div>
+        <div>
+          {humanSize(backup.bytes)}
+          {backup.encrypted ? ' · encrypted' : ''}
+        </div>
+        <div>
+          {backup.triggered_by} · {formatRelative(backup.started_at)}
+          {backup.finished_at && ` · ${duration(backup.started_at, backup.finished_at)}`}
+        </div>
+      </div>
+    </li>
+  )
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const palette =
+    status === 'succeeded'
+      ? 'border-[var(--state-running)]/40 text-[var(--state-running)] bg-[var(--state-running)]/10'
+      : status === 'running' || status === 'pending'
+        ? 'border-[var(--state-idle)]/40 text-[var(--state-idle)] bg-[var(--state-idle)]/10'
+        : status === 'failed'
+          ? 'border-destructive/40 text-destructive bg-destructive/10'
+          : 'border-muted-foreground/30 text-muted-foreground bg-muted/30'
+  return (
+    <span
+      className={`text-[10px] uppercase tracking-wide rounded px-1.5 py-0.5 border ${palette}`}
+    >
+      {status}
+    </span>
+  )
+}
+
+function formatRelative(iso: string): string {
+  const ts = Date.parse(iso)
+  if (Number.isNaN(ts)) return iso
+  const seconds = Math.round((Date.now() - ts) / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.round(hours / 24)
+  return `${days}d ago`
+}
+
+function duration(startIso: string, endIso: string): string {
+  const ms = Date.parse(endIso) - Date.parse(startIso)
+  if (!Number.isFinite(ms) || ms < 0) return ''
+  const seconds = Math.round(ms / 1000)
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes}m`
+  return `${Math.round(minutes / 60)}h`
+}
+
+function humanSize(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`
+}

--- a/app/mobile/src/screens/MoreScreen.tsx
+++ b/app/mobile/src/screens/MoreScreen.tsx
@@ -14,7 +14,12 @@ interface Props {
   onLogout: () => void
 }
 
-export type SubPage = 'channels' | 'integrations' | 'providers'
+export type SubPage =
+  | 'channels'
+  | 'integrations'
+  | 'providers'
+  | 'backups'
+  | 'settings'
 
 const ITEMS: { id: SubPage; label: string; description: string; icon: string }[] = [
   {
@@ -34,6 +39,18 @@ const ITEMS: { id: SubPage; label: string; description: string; icon: string }[]
     label: 'CLI Providers',
     description: 'Claude Code / Codex / Gemini configurations',
     icon: '◈',
+  },
+  {
+    id: 'backups',
+    label: 'Backups',
+    description: 'Recent encrypted snapshot history',
+    icon: '⌧',
+  },
+  {
+    id: 'settings',
+    label: 'Settings',
+    description: 'Theme + device info',
+    icon: '⚙',
   },
 ]
 

--- a/app/mobile/src/screens/SettingsScreen.tsx
+++ b/app/mobile/src/screens/SettingsScreen.tsx
@@ -1,0 +1,120 @@
+import { Button } from '@/components/ui/button'
+import { useTheme, type ThemeMode } from '@/stores/theme'
+
+interface Props {
+  username: string
+  serverURL: string
+  expiresAt: string | null
+  onBack: () => void
+}
+
+// Minimal mobile Settings screen. The big-picture rule is mobile is
+// for monitoring, not configuring — all editing-heavy admin
+// (channels, integrations, providers, backup targets) has its own
+// dedicated screen elsewhere or is intentionally desktop-only.
+//
+// What lives here today:
+//   - Theme toggle (light / dark / system) via the shared zustand
+//     store; persists across launches via the same Preferences
+//     storage as auth state
+//   - Read-only "About" card: who am I, where am I connected,
+//     when does my token expire
+//
+// Future polish: app-version display, push-notification toggle
+// (after C ships), language switcher, etc.
+export function SettingsScreen({
+  username,
+  serverURL,
+  expiresAt,
+  onBack,
+}: Props) {
+  const mode = useTheme((s) => s.mode)
+  const setMode = useTheme((s) => s.setMode)
+
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col">
+      <header className="sticky top-0 z-10 bg-background/95 backdrop-blur border-b border-border px-3 py-2 flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          ← Back
+        </Button>
+        <h1 className="flex-1 text-base font-semibold">Settings</h1>
+      </header>
+      <main className="flex-1 px-4 py-3 space-y-4">
+        <Section title="Appearance">
+          <div className="grid grid-cols-3 gap-2">
+            {(['light', 'dark', 'system'] as ThemeMode[]).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => setMode(m)}
+                className={`rounded-md border p-3 text-sm capitalize transition-colors ${
+                  mode === m
+                    ? 'border-accent bg-accent/10 text-accent'
+                    : 'border-border bg-card hover:bg-accent/5'
+                }`}
+              >
+                {m}
+              </button>
+            ))}
+          </div>
+        </Section>
+
+        <Section title="About this device">
+          <Field label="Signed in as" value={username} />
+          <Field label="Server URL" value={serverURL} mono />
+          {expiresAt && (
+            <Field label="Token expires" value={new Date(expiresAt).toLocaleString()} />
+          )}
+        </Section>
+
+        <Section title="Notes">
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            Mobile is a monitoring surface. Configuration of
+            channels, integrations, providers, and backups happens
+            on the desktop admin where copy-paste of API keys and
+            multi-tab forms is reasonable. Tap any of those entries
+            in the &quot;More&quot; tab to view their current state.
+          </p>
+        </Section>
+      </main>
+    </div>
+  )
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className="space-y-2">
+      <h2 className="text-xs uppercase tracking-wide text-muted-foreground">
+        {title}
+      </h2>
+      <div className="rounded-md border border-border bg-card p-3 space-y-2">
+        {children}
+      </div>
+    </section>
+  )
+}
+
+function Field({
+  label,
+  value,
+  mono,
+}: {
+  label: string
+  value: string
+  mono?: boolean
+}) {
+  return (
+    <div className="space-y-0.5">
+      <div className="text-[11px] text-muted-foreground">{label}</div>
+      <div className={`text-sm break-all ${mono ? 'font-mono' : ''}`}>
+        {value}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

**T4** of the mobile-platform plan. Adds Settings (theme + device info) and Backups (read-only history). Both shipped as new entries in the More tab.

## Scope decision: 3 of T4's 5 surfaces are intentionally not shipped

| Surface | Decision |
|---|---|
| **Settings** | ✅ Ship — theme + device info |
| **Backups** | ✅ Ship — read-only history |
| **Plugins** | ❌ Skip — Plugins.tsx is 1700+ lines of complex form UI for authoring; phone is wrong surface |
| **Export** | ❌ Skip — produces a downloadable zip; iOS Share Sheet integration is its own polish task |
| **Tutorial** | ❌ Skip — in-app content is desktop-sized; users read on desktop or docs folder |

This is the YAGNI principle from ADR 0015 §1: mobile is for monitoring, not authoring. We ship the 2 monitoring surfaces and let the 3 authoring surfaces stay desktop-only.

## What landed

| File | Behavior |
|---|---|
| **SettingsScreen.tsx** | Theme switcher (light/dark/system, shared zustand store with web). Device info card (username, server URL, token expiry). \"Notes\" explaining read-only philosophy |
| **BackupsScreen.tsx** | Recent backups list. Status badge (succeeded/running/pending/failed). Per-row: target, size, encrypted flag, trigger, duration |
| **api.ts** | \`BackupSummary\` + \`listBackups\` helper |
| **MoreScreen.tsx** | ITEMS gains Backups (⌧) + Settings (⚙); now 5 sub-pages |
| **App.tsx** | AppState union grows \`'backups'\` and \`'settings'\`; two new conditional branches |

## Verification

| Check | Result |
|---|---|
| \`pnpm --filter mobile build\` | ✅ 56 modules, 621 KB JS, 29 KB CSS |
| \`pnpm --filter mobile exec cap sync ios\` | ✅ clean |
| \`pnpm --filter web build\` | ✅ unchanged |
| \`go build ./cmd/opendray\` | ✅ unchanged |

## Mobile parity progress

- T1 ✅ Sessions list + terminal
- T2 ✅ Memory + Notes + Activity
- T3 ✅ Channels + Integrations + Providers
- **T4 ✅ Settings + Backups** ← this PR
- C ⏳ Push notifications + biometric + deep link + OTA

Mobile is now functionally complete for day-to-day monitoring. Next session can focus on push notifications (the remaining T1-tier mobile primitive) and polish (biometric, deep link, OTA updates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)