### PR TITLE
fix(mobile): simulator-tested polish — icons, fonts, safe-area, layout

### DIFF
--- a/app/mobile/package.json
+++ b/app/mobile/package.json
@@ -19,6 +19,7 @@
     "@tailwindcss/vite": "^4.2.4",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
+    "lucide-react": "^1.14.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "shared": "workspace:*",

--- a/app/mobile/src/App.tsx
+++ b/app/mobile/src/App.tsx
@@ -192,10 +192,17 @@ export function App() {
   }
 
   // ── Home shell with tab bar ──────────────────────────────────────
+  //
+  // Outer is fixed-height (h-screen — the safe-area-aware viewport
+  // since #root has the safe insets applied as padding) and clips
+  // overflow so the BottomTabBar always sits flush at the bottom.
+  // Inner content area scrolls on its own; each tab screen still
+  // declares min-h-screen for the case it's mounted standalone in
+  // the future, but inside this shell it just fills the scroll area.
 
   return (
-    <div className="flex flex-col min-h-screen">
-      <div className="flex-1 flex flex-col min-h-0">
+    <div className="h-full flex flex-col overflow-hidden">
+      <div className="flex-1 overflow-y-auto">
         {tab === 'sessions' && (
           <SessionsScreen
             serverURL={serverURL}

--- a/app/mobile/src/components/BottomTabBar.tsx
+++ b/app/mobile/src/components/BottomTabBar.tsx
@@ -3,7 +3,20 @@
 // through a hamburger menu. Mobile UX standard.
 //
 // Sits above the home indicator via the `pb-safe` Tailwind utility
-// added in #27. Active-tab indicator is the accent color underline.
+// added in #27. Active-tab uses the accent color.
+//
+// Uses lucide-react icons (SVG) instead of Unicode glyphs because
+// iOS 26.3 / WKWebView falls back to .notdef ([?] boxes) for the
+// uncommon symbol-block code points we'd otherwise rely on.
+
+import {
+  Activity as ActivityIcon,
+  Brain,
+  FileText,
+  MoreHorizontal,
+  Terminal,
+  type LucideIcon,
+} from 'lucide-react'
 
 export type Tab = 'sessions' | 'memory' | 'notes' | 'activity' | 'more'
 
@@ -12,12 +25,12 @@ interface Props {
   onChange: (tab: Tab) => void
 }
 
-const TABS: { id: Tab; label: string; icon: string }[] = [
-  { id: 'sessions', label: 'Sessions', icon: '▢' },
-  { id: 'memory', label: 'Memory', icon: '◇' },
-  { id: 'notes', label: 'Notes', icon: '☰' },
-  { id: 'activity', label: 'Activity', icon: '⏱' },
-  { id: 'more', label: 'More', icon: '⋯' },
+const TABS: { id: Tab; label: string; icon: LucideIcon }[] = [
+  { id: 'sessions', label: 'Sessions', icon: Terminal },
+  { id: 'memory', label: 'Memory', icon: Brain },
+  { id: 'notes', label: 'Notes', icon: FileText },
+  { id: 'activity', label: 'Activity', icon: ActivityIcon },
+  { id: 'more', label: 'More', icon: MoreHorizontal },
 ]
 
 export function BottomTabBar({ active, onChange }: Props) {
@@ -26,18 +39,19 @@ export function BottomTabBar({ active, onChange }: Props) {
       <ul className="flex">
         {TABS.map((t) => {
           const isActive = t.id === active
+          const Icon = t.icon
           return (
             <li key={t.id} className="flex-1">
               <button
                 type="button"
                 onClick={() => onChange(t.id)}
-                className={`w-full flex flex-col items-center gap-0.5 py-2 px-1 text-[10px] tracking-wide select-none transition-colors ${
+                className={`w-full flex flex-col items-center gap-1 py-1.5 px-1 text-[10px] tracking-wide select-none transition-colors ${
                   isActive
                     ? 'text-accent'
                     : 'text-muted-foreground hover:text-foreground'
                 }`}
               >
-                <span className="text-base leading-none">{t.icon}</span>
+                <Icon className="w-5 h-5" />
                 <span>{t.label}</span>
               </button>
             </li>

--- a/app/mobile/src/index.css
+++ b/app/mobile/src/index.css
@@ -89,11 +89,19 @@
   --radius-lg: calc(var(--radius) + 2px);
   --radius-xl: calc(var(--radius) + 6px);
 
-  --font-sans:
-    "Inter Variable", "Inter", -apple-system, "Segoe UI", Roboto, sans-serif;
-  --font-mono:
-    "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, Menlo, Consolas,
-    monospace;
+  /* Mobile-first font stack — minimal, OS-led.
+     `system-ui` resolves to:
+       - iOS / iPadOS / macOS → SF Pro (handles Latin + CJK + emoji
+         via system substitution natively)
+       - Android → Roboto + Noto CJK + Noto Color Emoji
+       - Windows → Segoe UI + Segoe UI Emoji
+     We don't list Inter here on purpose. Variable webfonts in
+     WKWebView can claim coverage for non-Latin codepoints (rendering
+     them as .notdef instead of falling through), which is exactly
+     why CJK appeared as `[?]` on the first attempts. Letting the
+     OS pick the right family per script is the most reliable path. */
+  --font-sans: system-ui, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, monospace;
 }
 
 @layer base {
@@ -123,8 +131,13 @@
     overscroll-behavior: none; /* kill rubber-band on iOS WebView */
   }
   #root {
+    /* Top + horizontal safe-area on #root: every screen's sticky
+       header automatically clears the Dynamic Island / notch.
+       Bottom inset is intentionally NOT applied here — bottom-
+       anchored elements (BottomTabBar, fixed input bars) handle it
+       themselves via the `pb-safe` utility, otherwise the padding
+       stacks and pushes those bars off-screen. */
     padding-top: env(safe-area-inset-top);
-    padding-bottom: env(safe-area-inset-bottom);
     padding-left: env(safe-area-inset-left);
     padding-right: env(safe-area-inset-right);
   }

--- a/app/mobile/src/screens/MoreScreen.tsx
+++ b/app/mobile/src/screens/MoreScreen.tsx
@@ -1,10 +1,25 @@
 // "More" tab — overflow list of secondary surfaces. Lower-frequency
-// admin pages (Channels / Integrations / Providers / Settings) live
-// here so the bottom tab bar stays at 5 entries instead of 9+.
+// admin pages (Channels / Integrations / Providers / Settings /
+// Backups) live here so the bottom tab bar stays at 5 entries
+// instead of 9+.
 //
 // Each row navigates to a full-screen sub-page via the App.tsx
 // state machine, mirroring how SessionsScreen → SessionDetailScreen
 // works (full-screen, no bottom tab visible during sub-page).
+//
+// Icons use lucide-react (SVG) — same reason as BottomTabBar:
+// iOS 26.3 doesn't render the symbol-block Unicode glyphs we'd
+// otherwise want.
+
+import {
+  ChevronRight,
+  HardDrive,
+  type LucideIcon,
+  MessageSquare,
+  Plug,
+  Settings as SettingsIcon,
+  Terminal,
+} from 'lucide-react'
 
 interface Props {
   username: string
@@ -21,36 +36,41 @@ export type SubPage =
   | 'backups'
   | 'settings'
 
-const ITEMS: { id: SubPage; label: string; description: string; icon: string }[] = [
+const ITEMS: {
+  id: SubPage
+  label: string
+  description: string
+  icon: LucideIcon
+}[] = [
   {
     id: 'channels',
     label: 'Channels',
     description: 'Telegram / Discord / Slack adapters',
-    icon: '✉',
+    icon: MessageSquare,
   },
   {
     id: 'integrations',
     label: 'Integrations',
     description: 'External apps registered against the gateway',
-    icon: '⇄',
+    icon: Plug,
   },
   {
     id: 'providers',
     label: 'CLI Providers',
     description: 'Claude Code / Codex / Gemini configurations',
-    icon: '◈',
+    icon: Terminal,
   },
   {
     id: 'backups',
     label: 'Backups',
     description: 'Recent encrypted snapshot history',
-    icon: '⌧',
+    icon: HardDrive,
   },
   {
     id: 'settings',
     label: 'Settings',
     description: 'Theme + device info',
-    icon: '⚙',
+    icon: SettingsIcon,
   },
 ]
 
@@ -68,24 +88,27 @@ export function MoreScreen({
       </header>
       <main className="flex-1 px-4 py-3 space-y-4">
         <ul className="space-y-2">
-          {ITEMS.map((it) => (
-            <li key={it.id}>
-              <button
-                type="button"
-                onClick={() => onOpen(it.id)}
-                className="w-full text-left rounded-md border border-border bg-card text-card-foreground p-3 active:bg-accent/10 transition-colors flex items-center gap-3"
-              >
-                <span className="text-xl text-accent">{it.icon}</span>
-                <div className="flex-1 min-w-0">
-                  <div className="text-sm font-medium">{it.label}</div>
-                  <div className="text-xs text-muted-foreground truncate">
-                    {it.description}
+          {ITEMS.map((it) => {
+            const Icon = it.icon
+            return (
+              <li key={it.id}>
+                <button
+                  type="button"
+                  onClick={() => onOpen(it.id)}
+                  className="w-full text-left rounded-md border border-border bg-card text-card-foreground p-3 active:bg-accent/10 transition-colors flex items-center gap-3"
+                >
+                  <Icon className="w-5 h-5 text-accent shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium">{it.label}</div>
+                    <div className="text-xs text-muted-foreground truncate">
+                      {it.description}
+                    </div>
                   </div>
-                </div>
-                <span className="text-muted-foreground">›</span>
-              </button>
-            </li>
-          ))}
+                  <ChevronRight className="w-4 h-4 text-muted-foreground shrink-0" />
+                </button>
+              </li>
+            )
+          })}
         </ul>
 
         <div className="rounded-md border border-border bg-card p-3 text-xs space-y-1">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
+      lucide-react:
+        specifier: ^1.14.0
+        version: 1.14.0(react@19.2.5)
       react:
         specifier: ^19.2.5
         version: 19.2.5


### PR DESCRIPTION
## Summary

Five fixes from running v0 mobile on iPhone 17 Pro / iOS 26.3 simulator. Each is a real bug caught by actually launching the app:

1. **Lucide icons** replace \`▢ ◇ ☰ ⏱ ⋯\` (rendered as \`[?]\` on iOS 26.3 default fonts)
2. **Font stack rewritten to \`system-ui, sans-serif\`** — Inter Variable was claiming CJK coverage with \`.notdef\` glyphs and refusing to fall through to PingFang SC
3. **\`#root\` drops bottom safe-area inset** — was double-counting with BottomTabBar's \`pb-safe\`, pushing tab labels off-screen
4. **Home shell \`h-full\` not \`h-screen\`** — \`h-screen\` didn't account for #root's top inset, extending past viewport
5. (Recap of #27) **CapacitorHttp** patches fetch through native, bypassing WebView CORS

## Verification

- iPhone 17 Pro simulator: tab bar shows 5 lucide icons + labels above home indicator; CJK paths render correctly via system-ui SF Pro fallback
- \`pnpm --filter mobile build\` clean (625 KB JS)
- web + go builds unaffected

## Path forward

These polish fixes land on top of the v0 stripped mobile screens. **Next PRs deepen each screen toward feature parity** with web — current screens are scaffolds, not finished products.

🤖 Generated with [Claude Code](https://claude.com/claude-code)