### PR TITLE
docs: post-v1.0.0 tag bookkeeping (CHANGELOG + README status)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolve the duplicate-0011 collision with `0011-channel-rich-content-and-bridge.md`.
   Updated cross-references in README, ADR 0013, and the embed-onnx stub.
 
-## [v1.0-rc] — 2026-05-05
+## [v1.0.0] — 2026-05-09
 
-Feature-complete release candidate. v1 (`Opendray/opendray`) keeps running
-in production; switchover happens after v1.0 ships.
+First stable release. Tagged at commit `fe96fd8` on `main`. Web frontend
++ backend feature-complete; mobile + Slack inbound + automated release
+workflow deferred to v1.x per the post-v1.0 roadmap. v1
+(`Opendray/opendray`) keeps running in production through this quarter
+per ADR 0001.
+
+The feature inventory below was originally captured under
+`[v1.0-rc] — 2026-05-05`; section was promoted to `[v1.0.0]` on tag.
 
 ### Added (since the greenfield start)
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 
 ## Status
 
-v2 v1.0-rc — Phase 1 (backend) + Phase 2 (web frontend) feature-complete
-on `main`. Mobile + Slack + deploy automation deferred per the
+**v1.0.0** — first stable release tagged on 2026-05-09. Phase 1 (backend)
++ Phase 2 (web frontend) feature-complete on `main`. Mobile + Slack
+inbound + automated release workflow deferred to v1.x per the
 post-v1.0 roadmap.
 
 ## Quickstart


### PR DESCRIPTION
## Summary

Catches CHANGELOG + README up to today's `v1.0.0` tag (pushed at `fe96fd8`).

- `CHANGELOG.md`: rename `## [v1.0-rc] — 2026-05-05` → `## [v1.0.0] — 2026-05-09`. Feature list under it is unchanged — that section was the canonical inventory of what shipped, just promoted in heading.
- `README.md`: Status line updated from "v2 v1.0-rc" to "v1.0.0 — first stable release tagged on 2026-05-09".

## Why this is a separate PR from the tag

Tagging is a one-shot — `v1.0.0` now points at `fe96fd8` forever per SemVer's immutability rule. Moving the tag to include this commit would break that promise and confuse anyone who already cloned. Adding this PR on top is the right shape: the tag stays put, docs catch up.

`opendray version` reads from `internal/version/version.go`'s ldflags-injected vars; goreleaser fills them from the tag at build time, so binaries built from the tag print `1.0.0` regardless of what the README says. The docs are purely human-facing.

## Out of scope (deferred follow-ups)

| Item | Status |
|---|---|
| `.github/workflows/release.yml` (auto-trigger goreleaser on tag push) | Separate PR. Without it, operators run `goreleaser release --clean` locally to produce binaries from the tag. |
| cosign signing + SBOM attachment | Separate PR. Adds a `packages: write` token + signing infra. |
| Mobile + Slack inbound | The `feat/mobile-platform` branch was deleted from the remote without merging to main. Whether that work is staged elsewhere or planned to re-emerge is a v1.x question for the mobile lane. |

## Test plan

- [ ] CI green (no Go change; markdown + a Status line)
- [ ] CHANGELOG renders cleanly on GitHub with the new heading
- [ ] `git show v1.0.0` still points at `fe96fd8` (this PR doesn't touch the tag)
- [ ] After merge: README's Status line reads "v1.0.0" on the repo home page

## Risk

🟢 Zero. Two markdown edits.