### PR TITLE
ci: add release workflow — goreleaser + cosign + SBOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Release
+
+# Triggered automatically on tag push (v*) — produces a draft GitHub
+# release with goreleaser archives, cosign-signed checksums, and an
+# anchore-generated SBOM. The release lands as DRAFT (per
+# .goreleaser.yml release.draft: true) so a human reviews notes before
+# flipping it to public.
+#
+# workflow_dispatch is wired for two scenarios:
+#   * Re-running the pipeline against an existing tag (e.g. v1.0.0,
+#     which was tagged before this workflow existed).
+#   * Smoke-testing the workflow without cutting a real release —
+#     point it at a v0.0.0-test tag in your fork.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v1.0.0). Must already exist.'
+        required: true
+        type: string
+
+permissions:
+  contents: write   # create / append to GitHub release
+  id-token: write   # cosign keyless OIDC (Sigstore Fulcio)
+  packages: write   # reserved for future GHCR push (not used yet)
+
+concurrency:
+  group: release-${{ github.event.inputs.tag || github.ref }}
+  cancel-in-progress: false   # never cancel a release mid-flight
+
+jobs:
+  release:
+    name: Release ${{ github.event.inputs.tag || github.ref_name }}
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.event.inputs.tag || github.ref_name }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Goreleaser walks the git history to compute the version +
+          # changelog. Shallow clone trips it up; full history is the
+          # safe default for releases.
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      # ── Frontend tooling — goreleaser's pre-build hooks invoke
+      #    `pnpm install --frozen-lockfile` and `pnpm build` so the
+      #    React SPA is in internal/web/dist before the Go build.
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: app/web/pnpm-lock.yaml
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+
+      # ── Goreleaser: archives + checksums in ./dist, draft release on GH
+      - name: Run goreleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── Cosign keyless: sign the SHA256SUMS produced by goreleaser.
+      #    No long-lived signing key — Sigstore Fulcio mints a short-
+      #    lived cert tied to this workflow's OIDC identity. Verifying
+      #    later: cosign verify-blob --certificate ...pem --signature
+      #    ...sig --certificate-identity-regexp ... SHA256SUMS
+      - uses: sigstore/cosign-installer@v3
+      - name: Sign checksums
+        run: |
+          cosign sign-blob --yes \
+            --output-signature dist/SHA256SUMS.sig \
+            --output-certificate dist/SHA256SUMS.pem \
+            dist/SHA256SUMS
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+
+      - name: Upload cosign artefacts to release
+        run: |
+          gh release upload "$TAG" \
+            dist/SHA256SUMS.sig \
+            dist/SHA256SUMS.pem \
+            --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── SBOM (SPDX). Belt-and-braces: anchore's auto-attach has
+      #    historically been flaky, so generate explicitly + upload via
+      #    gh release. Soft failure (continue-on-error) so a transient
+      #    SBOM hiccup doesn't block the rest of the release.
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        continue-on-error: true
+        with:
+          artifact-name: sbom-opendray.spdx.json
+          output-file: dist/sbom-opendray.spdx.json
+
+      - name: Upload SBOM to release
+        if: always() && hashFiles('dist/sbom-opendray.spdx.json') != ''
+        run: gh release upload "$TAG" dist/sbom-opendray.spdx.json --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `.github/workflows/release.yml` — automated release pipeline. Triggers
+  on `v*` tag push (or manually via workflow_dispatch with a tag input).
+  Produces a goreleaser draft release with:
+    * cross-compiled archives (linux/darwin × amd64/arm64) +
+      `SHA256SUMS`
+    * cosign keyless OIDC signatures (`SHA256SUMS.sig`,
+      `SHA256SUMS.pem`)
+    * SPDX SBOM via anchore/sbom-action
+  Permissions: `contents: write` for the release upload,
+  `id-token: write` for cosign OIDC. Concurrency-grouped per tag so
+  re-running for an existing tag never races itself.
 - LICENSE file (Apache 2.0) — previously declared in README only.
 - SECURITY.md — threat model, default posture, deployment checklist, report channel.
 - CONTRIBUTING.md — dev setup, test commands, PR + commit conventions.


### PR DESCRIPTION
## Summary

Wires the existing `.goreleaser.yml` + `Dockerfile` (from PR #4) into a GitHub Actions pipeline that fires on `v*` tag push. Until now, the release toolchain in the repo only ran when an operator ran `goreleaser release --clean` locally — which is exactly what would be needed to ship `v1.0.0` artifacts today (no automated release exists for that tag yet; see workflow_dispatch note below).

## What the workflow produces

| Artifact | How |
|---|---|
| **Cross-compiled archives** (linux/darwin × amd64/arm64) | goreleaser builds from `.goreleaser.yml` |
| **`SHA256SUMS`** | goreleaser default |
| **`SHA256SUMS.sig` + `SHA256SUMS.pem`** | cosign keyless OIDC via Sigstore Fulcio — no long-lived signing key, identity tied to this workflow |
| **`sbom-opendray.spdx.json`** | anchore/sbom-action, SPDX JSON |
| **Draft GitHub release** | per `.goreleaser.yml` `release.draft: true` — human reviews notes before flipping public |

## Verification command for the cosign signature

```bash
cosign verify-blob \
  --certificate dist/SHA256SUMS.pem \
  --signature dist/SHA256SUMS.sig \
  --certificate-identity-regexp 'github.com/Opendray/opendray_v2/\.github/workflows/release\.yml@refs/tags/v.*' \
  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
  dist/SHA256SUMS
```

The cert binds the signature to: this repo, this workflow file, on a `refs/tags/v*` ref. A signature claiming to be a release but produced by another workflow / branch / repo fails the regex check.

## Permissions

| Scope | Why |
|---|---|
| `contents: write` | Create / upload to the GitHub release |
| `id-token: write` | cosign keyless OIDC (Fulcio short-lived cert) |
| `packages: write` | **Reserved.** Not used yet. Declared so a follow-up adding GHCR push doesn't need to re-amend permissions. |

## Triggers

```yaml
on:
  push:
    tags: ['v*']
  workflow_dispatch:
    inputs:
      tag:
        description: 'Tag to release (e.g. v1.0.0). Must already exist.'
        required: true
        type: string
```

Two reasons workflow_dispatch is wired:

1. **Retroactive v1.0.0.** That tag was pushed before this workflow existed. After this PR merges: Actions → Release → Run workflow → enter `v1.0.0` → the existing draft release gets the archives + sig + SBOM uploaded.
2. **Smoke-testing.** Cut a `v0.0.0-test` tag in a fork, dispatch against it, see the pipeline run end-to-end without producing a real release.

## Concurrency

```yaml
concurrency:
  group: release-${{ github.event.inputs.tag || github.ref }}
  cancel-in-progress: false
```

Two simultaneous triggers for the same tag serialise. `cancel-in-progress: false` because aborting a release mid-upload leaves a half-built draft.

## Out of scope (deferred)

| Item | Reason |
|---|---|
| GHCR Docker image push | Adds 15+ lines (buildx + login-action + metadata-action + build-push-action), needs a `:latest` policy decision. Existing `Dockerfile` already lets operators `docker build .` from the tag locally. Small follow-up PR. |
| SLSA provenance attestation | Supported by goreleaser; needs org-level decision on attestor identity. Future ADR. |
| Required-status-check enforcement | Doesn't fit — release runs on tags, not branches; main's gate is `workflows/ci.yml`. |

## Validation note

Drafted from the read-only audit env. The YAML parses but I haven't actually run it. The first real-world run is the test plan — if anything trips, it surfaces on the next `v*` tag push, can be fixed before the draft release is published.

The lowest-risk way to confirm it works **before** the next real release: run via workflow_dispatch against `v1.0.0` after merge. If it succeeds, v1.0.0 gets its artifacts and the workflow is proven for future tags.

## Test plan

- [ ] CI green on this PR (the YAML must at least parse and the workflow_dispatch input register)
- [ ] After merge: dispatch against `v1.0.0`. Expected outcome:
  - A new run of the `Release` workflow appears
  - Goreleaser produces `dist/opendray_1.0.0_linux_amd64.tar.gz` etc.
  - cosign step uploads `SHA256SUMS.sig` and `SHA256SUMS.pem` to the release
  - SBOM uploaded as `sbom-opendray.spdx.json`
  - `gh release view v1.0.0` lists all artifacts
- [ ] Verify the cosign signature with the command in the PR description
- [ ] If the workflow fails: it lands as a workflow run failure, no draft release artifacts get added, no harm done. Triage from the run log.

## Risk

🟡 Medium. The workflow doesn't run on this PR (it's gated to tag push / dispatch), so merging is safe. Risk concentrates on the *next* tag push or the workflow_dispatch retroactive run. Worst case: workflow fails partway, leaves a partial draft release, operator manually finishes via `goreleaser release --clean` (the path that worked for v1.0.0).