### PR TITLE
ci: add release workflow — goreleaser + cosign + SBOM (supersedes #35)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+name: Release
+
+# Triggered automatically on tag push (v*) — produces a draft GitHub
+# release with goreleaser archives, cosign-signed checksums, and an
+# anchore-generated SBOM. The release lands as DRAFT (per
+# .goreleaser.yml release.draft: true) so a human reviews notes before
+# flipping it to public.
+#
+# workflow_dispatch is wired for two scenarios:
+#   * Re-running the pipeline against an existing tag (e.g. v1.0.0,
+#     which was tagged before this workflow existed).
+#   * Smoke-testing the workflow without cutting a real release —
+#     point it at a v0.0.0-test tag in your fork.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v1.0.0). Must already exist.'
+        required: true
+        type: string
+
+permissions:
+  contents: write   # create / append to GitHub release
+  id-token: write   # cosign keyless OIDC (Sigstore Fulcio)
+  # NOTE: `packages: write` intentionally omitted — least-privilege.
+  # Add it back in the PR that introduces a GHCR push step.
+
+concurrency:
+  group: release-${{ github.event.inputs.tag || github.ref }}
+  cancel-in-progress: false   # never cancel a release mid-flight
+
+jobs:
+  release:
+    name: Release ${{ github.event.inputs.tag || github.ref_name }}
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.event.inputs.tag || github.ref_name }}
+    steps:
+      # ── Validate the tag input on manual dispatch BEFORE doing any
+      #    heavy work (checkout, setup-go, goreleaser). A typo like
+      #    `1.0.0` (missing v) or `V1.0.0` (uppercase) fails here in
+      #    seconds instead of minutes-deep in goreleaser.
+      - name: Validate tag format (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          echo "$INPUT_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]' \
+            || { echo "ERROR: tag must match v<semver> (e.g. v1.0.0), got: $INPUT_TAG"; exit 1; }
+
+      - uses: actions/checkout@v5
+        with:
+          # Goreleaser walks the git history to compute the version +
+          # changelog. Shallow clone trips it up; full history is the
+          # safe default for releases.
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      # ── Frontend tooling — goreleaser's pre-build hooks invoke
+      #    `pnpm install --frozen-lockfile` and `pnpm build` so the
+      #    React SPA is in internal/web/dist before the Go build.
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: app/web/pnpm-lock.yaml
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+
+      # ── Goreleaser: archives + checksums in ./dist, draft release on GH.
+      #    SHA-pinned for supply-chain integrity. Intentionally pinned
+      #    on v6 (not v7) to avoid the v7 ESM/Node 24 breaking change
+      #    until we explicitly validate it.
+      - name: Run goreleaser
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a  # v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── Cosign keyless: sign the SHA256SUMS produced by goreleaser.
+      #    No long-lived signing key — Sigstore Fulcio mints a short-
+      #    lived cert tied to this workflow's OIDC identity. Verifying
+      #    later: cosign verify-blob --certificate ...pem --signature
+      #    ...sig --certificate-identity-regexp ... SHA256SUMS
+      #    SHA-pinned for supply-chain integrity.
+      - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac  # v3
+      - name: Sign checksums
+        run: |
+          cosign sign-blob --yes \
+            --output-signature dist/SHA256SUMS.sig \
+            --output-certificate dist/SHA256SUMS.pem \
+            dist/SHA256SUMS
+
+      - name: Upload cosign artefacts to release
+        if: success()
+        run: |
+          gh release upload "$TAG" \
+            dist/SHA256SUMS.sig \
+            dist/SHA256SUMS.pem \
+            --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── SBOM (SPDX). Belt-and-braces: anchore's auto-attach has
+      #    historically been flaky, so generate explicitly + upload via
+      #    gh release. Soft failure (continue-on-error) so a transient
+      #    SBOM hiccup doesn't block the rest of the release.
+      #    SHA-pinned for supply-chain integrity.
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0
+        continue-on-error: true
+        with:
+          artifact-name: sbom-opendray.spdx.json
+          output-file: dist/sbom-opendray.spdx.json
+
+      - name: Upload SBOM to release
+        if: always() && hashFiles('dist/sbom-opendray.spdx.json') != ''
+        run: gh release upload "$TAG" dist/sbom-opendray.spdx.json --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `.github/workflows/release.yml` — automated release pipeline.
+  Triggers on `v*` tag push (or manually via workflow_dispatch with a
+  tag input). Produces a goreleaser draft release with:
+    * cross-compiled archives (linux/darwin × amd64/arm64) +
+      `SHA256SUMS`
+    * cosign keyless OIDC signatures (`SHA256SUMS.sig`,
+      `SHA256SUMS.pem`) via Sigstore Fulcio — no long-lived key
+    * SPDX SBOM via anchore/sbom-action
+  Permissions limited to `contents: write` (release upload) and
+  `id-token: write` (cosign OIDC). Supply-chain hardening: SHA-pinned
+  cosign-installer, sbom-action, and goreleaser-action; fail-fast
+  tag-format validation on workflow_dispatch.
 - LICENSE file (Apache 2.0) — previously declared in README only.
 - SECURITY.md — threat model, default posture, deployment checklist, report channel.
 - CONTRIBUTING.md — dev setup, test commands, PR + commit conventions.


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` — automated release pipeline triggered on `v*` tag push or manual `workflow_dispatch`. Produces a goreleaser draft GitHub release with cross-compiled archives (linux/darwin × amd64/arm64), cosign keyless OIDC signatures (Sigstore Fulcio), and an SPDX SBOM via anchore.

**This PR supersedes #35** (originally by @navidrast). The workflow content is preserved verbatim except for the seven hardenings applied inline — 3 review blockers from the original #35 review, plus 4 supply-chain follow-ups bundled in to avoid a fast-follow PR.

## Hardenings applied to the original #35

| # | Change | Rationale |
|---|---|---|
| 1 | Drop `permissions.packages: write` | Least-privilege. Reserved-but-unused — would only matter once a GHCR push step exists. Add it back in that PR where the scope is reviewable. Over-privileged `GITHUB_TOKEN` is real attack surface if any pinned step is ever compromised. |
| 2 | Add `if: success()` on the cosign-artefact upload step | Without this, a failed `Sign checksums` step still triggers the upload, producing a misleading `gh release upload: file not found` that hides the real cosign failure. Explicit guard keeps the failure mode unambiguous. |
| 3 | Validate `workflow_dispatch.inputs.tag` format up-front | A typo (`1.0.0` missing `v`, `V1.0.0` uppercase, etc.) currently wastes 3-5 minutes before goreleaser fails deep in the run with an unhelpful error. One-step grep guard fails at second 5 with a clear message. |
| 4 | Drop `COSIGN_EXPERIMENTAL=1` env var | Retired in cosign v2 (late 2023); modern cosign ignores it silently. Removing it avoids future-maintainer confusion. |
| 5 | SHA-pin `sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac` (v3) | Supply chain — this action directly underwrites the attestation story. A compromised tag-roll could silently substitute a different signing path. |
| 6 | SHA-pin `anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610` (v0) | Supply chain — same reasoning; if the SBOM action is swapped, builds keep working but provenance silently weakens. |
| 7 | SHA-pin `goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a` (v6) | Supply chain. Intentionally pinned on **v6**, not v7 — v7.0.0 is an ESM + Node 24 rewrite (`feat!: node 24, update deps, rm yarn, ESM`) and warrants its own validation PR. |

## Cosign signature verification (post-merge)

```bash
cosign verify-blob \
  --certificate dist/SHA256SUMS.pem \
  --signature dist/SHA256SUMS.sig \
  --certificate-identity-regexp 'github.com/Opendray/opendray_v2/\.github/workflows/release\.yml@refs/tags/v.*' \
  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
  dist/SHA256SUMS
```

The Sigstore cert binds the signature to **this repo, this workflow file, on a `refs/tags/v*` ref**. A signature claiming to be an OpenDray release but produced from another workflow / branch / repo fails the regex check.

## What is NOT in this PR (intentionally deferred)

- **GHCR Docker image push.** Needs a `:latest` policy decision and adds 15+ lines (buildx + login + metadata + build-push). Will reintroduce `packages: write` then.
- **SLSA provenance attestation.** Needs an org-level decision on attestor identity. Future ADR.
- **`goreleaser-action` v6 → v7 upgrade.** Separate PR with its own validation against the ESM/Node 24 break.
- **Required-status-check enforcement.** Doesn't fit — release runs on tags, not branches.

## Test plan

- [ ] CI green on this PR (YAML must parse; workflow itself does not run because triggers are tag-only)
- [ ] After merge: `workflow_dispatch` against `v1.0.0`. Expected:
  - A new `Release` workflow run appears
  - goreleaser produces `dist/opendray_1.0.0_{linux,darwin}_{amd64,arm64}.tar.gz` etc.
  - cosign step uploads `SHA256SUMS.sig` and `SHA256SUMS.pem` to the existing v1.0.0 draft release
  - SBOM uploaded as `sbom-opendray.spdx.json`
  - `gh release view v1.0.0` lists all artefacts
- [ ] Verify the cosign signature with the command above
- [ ] If the workflow fails: it lands as a workflow run failure, no draft release artefacts get added, no harm done. Triage from the run log.

## Risk

🟡 Medium. The workflow doesn't run on this PR (tag-only triggers), so merging is safe. Risk concentrates on the *next* tag push or the workflow_dispatch retroactive run. Worst case: workflow fails partway, leaves a partial draft release, operator manually finishes via `goreleaser release --clean` (the path that worked for v1.0.0 today).

---

Closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)