### PR TITLE
docs: restore CHANGELOG entries dropped in #33 conflict resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `id-token: write` (cosign OIDC). Supply-chain hardening: SHA-pinned
   cosign-installer, sbom-action, and goreleaser-action; fail-fast
   tag-format validation on workflow_dispatch.
+- `deploy/` directory with reference deploy artefacts:
+  - `deploy/systemd/opendray.service` — production-ready systemd unit
+    with sandboxing (`NoNewPrivileges`, `ProtectSystem=strict`, etc.),
+    `migrate`-then-`serve` startup, 20s graceful-stop window.
+  - `deploy/lxc/proxmox-pty-notes.md` — Proxmox-specific guide covering
+    privileged vs unprivileged container PTY behaviour, the cgroup +
+    bind-mount config required for unprivileged LXCs, networking +
+    pgvector + pg_dump-version checks, and a pre-go-live checklist.
+  - `deploy/README.md` — index pointing operators at the right artefact
+    for their topology.
+  - operator-guide.md "Where to look next" section now links to `deploy/`.
+- ADR 0016 (Proposed): backup-format v2 design for per-install PBKDF2
+  salt. Captures the four binding decisions (in-header storage,
+  version-byte bump 1→2, per-Seal salt provenance, indefinite v1
+  read compat) and the three-PR rollout. Implementation pending.
 - LICENSE file (Apache 2.0) — previously declared in README only.
 - SECURITY.md — threat model, default posture, deployment checklist, report channel.
 - CONTRIBUTING.md — dev setup, test commands, PR + commit conventions.


### PR DESCRIPTION
## Summary

Restores two `### Added` entries that were inadvertently dropped from `CHANGELOG.md` `[Unreleased]` during the manual GitHub-UI conflict resolution on PR #33.

When PR #33 was rebased on top of (already-merged) PR #26, both PRs had added a new bullet to `### Added`. The intended resolution was "keep both" — but the actual merge ended up with neither, leaving only the original LICENSE / SECURITY.md / CONTRIBUTING.md / CHANGELOG.md bullets on main.

PR #26's `### Changed` entry (cipher.go comment pointing at ADR 0016) survived the conflict; only the `### Added` entries were lost.

## What's restored

| Entry | Original PR |
|---|---|
| `deploy/` directory with systemd unit + Proxmox LXC notes | #33 |
| ADR 0016 (Proposed): backup-format v2 design for per-install PBKDF2 salt | #26 |

Both bullets are restored **verbatim** from the original PR diffs — no editorial changes.

## Why it matters

CHANGELOG is the canonical record of what shipped under each version. Two real, merged-to-main artefacts had no CHANGELOG entry, so anyone reading the file would think those changes never happened. This is exactly the silent-rot failure mode that Keep-a-Changelog discipline is supposed to prevent.

## Risk

🟢 Zero. Pure docs; no Go / config / infra change.

## Test plan

- [ ] CI green (markdown only)
- [ ] CHANGELOG renders cleanly on GitHub
- [ ] After merge: confirm `[Unreleased] > Added` lists six bullets in this order:
  1. `.github/workflows/release.yml` (from #36)
  2. `deploy/` directory (restored from #33)
  3. ADR 0016 (restored from #26)
  4. LICENSE
  5. SECURITY.md
  6. CONTRIBUTING.md
  7. CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)