### PR TITLE
docs(i18n): clean up residual Chinese in English-language tutorial

### DIFF
--- a/app/web/src/components/backup/TargetEditor.tsx
+++ b/app/web/src/components/backup/TargetEditor.tsx
@@ -270,7 +270,7 @@ export function TargetEditor({
             <>
               <Field
                 label="Base URL"
-                hint="Full URL including any path. Examples: https://cloud.example.com/remote.php/dav/files/me/ (Nextcloud), https://nas.local:5006/ (Synology), https://dav.jianguoyun.com/dav/ (坚果云)"
+                hint="Full URL including any path. Examples: https://cloud.example.com/remote.php/dav/files/me/ (Nextcloud), https://nas.local:5006/ (Synology), https://dav.jianguoyun.com/dav/ (Jianguoyun / 坚果云)"
               >
                 <Input
                   value={(config.base_url as string) ?? ''}

--- a/app/web/src/components/settings/ServerSettings.tsx
+++ b/app/web/src/components/settings/ServerSettings.tsx
@@ -1754,12 +1754,12 @@ function BackupSection({
             Each target is one place a backup blob can be written.
             opendray supports <strong>local disk</strong>,{' '}
             <strong>SMB/CIFS</strong> (Windows / NAS),{' '}
-            <strong>S3-compatible</strong> (AWS, R2, B2, MinIO, 阿里
-            OSS, 腾讯 COS, ...), <strong>WebDAV</strong> (Nextcloud,
-            群晖, 坚果云), <strong>SFTP</strong>, plus an{' '}
-            <strong>rclone</strong> passthrough that taps into 70+
-            extra backends (Google Drive, OneDrive, Dropbox, 百度网盘,
-            阿里云盘, ...).
+            <strong>S3-compatible</strong> (AWS, R2, B2, MinIO,
+            Alibaba Cloud OSS, Tencent Cloud COS, ...),{' '}
+            <strong>WebDAV</strong> (Nextcloud, Synology, Jianguoyun),{' '}
+            <strong>SFTP</strong>, plus an <strong>rclone</strong>{' '}
+            passthrough that taps into 70+ extra backends (Google
+            Drive, OneDrive, Dropbox, Baidu Pan, Aliyun Drive, ...).
           </p>
 
           <div className="flex flex-col gap-1.5">

--- a/app/web/src/lib/backup.ts
+++ b/app/web/src/lib/backup.ts
@@ -50,13 +50,13 @@ export const TARGET_KINDS: {
     kind: 's3',
     label: 'S3-compatible',
     description: 'AWS S3 + every S3-compatible service',
-    examples: 'AWS S3 · Cloudflare R2 · Backblaze B2 · MinIO · 阿里云 OSS · 腾讯云 COS · DigitalOcean Spaces · Wasabi',
+    examples: 'AWS S3 · Cloudflare R2 · Backblaze B2 · MinIO · Alibaba Cloud OSS (阿里云 OSS) · Tencent Cloud COS (腾讯云 COS) · DigitalOcean Spaces · Wasabi',
   },
   {
     kind: 'webdav',
     label: 'WebDAV',
     description: 'Self-hosted clouds + file-sharing services',
-    examples: 'Nextcloud · ownCloud · 群晖 DSM · Box.com · 坚果云',
+    examples: 'Nextcloud · ownCloud · Synology DSM (群晖 DSM) · Box.com · Jianguoyun (坚果云)',
   },
   {
     kind: 'sftp',
@@ -68,7 +68,7 @@ export const TARGET_KINDS: {
     kind: 'rclone',
     label: 'rclone passthrough',
     description: 'Tap into 70+ backends configured via the rclone CLI',
-    examples: 'Google Drive · OneDrive · Dropbox · Mega · pCloud · iCloud-WebDAV · 百度网盘 · 阿里云盘',
+    examples: 'Google Drive · OneDrive · Dropbox · Mega · pCloud · iCloud-WebDAV · Baidu Pan (百度网盘) · Aliyun Drive (阿里云盘)',
   },
 ]
 
@@ -269,7 +269,7 @@ export async function deleteSchedule(id: string): Promise<void> {
 
 // ── helpers ──────────────────────────────────────────────────────
 
-// ── exports (C 方案) ─────────────────────────────────────────────
+// ── exports (Plan C) ─────────────────────────────────────────────
 
 export type IntegrationExportMode = 'none' | 'metadata' | 'plaintext'
 

--- a/app/web/src/tutorial/sections/03-channels/01-overview.md
+++ b/app/web/src/tutorial/sections/03-channels/01-overview.md
@@ -24,7 +24,7 @@ shared, so once you've wired up one channel the rest is identical.
 | `discord` | Gateway WS | REST + embeds | no | dev/maker community |
 | `feishu` | webhook | tenant API | **yes** | China / cross-org formal channels |
 | `dingtalk` | (none) | group robot | no | China enterprise group rooms |
-| `wecom` | (none) | group robot | no | 企业微信 group rooms |
+| `wecom` | (none) | group robot | no | WeCom (企业微信) group rooms |
 | `wechat` | (none, push) | wxpusher | no | personal WeChat phone alerts |
 | `bridge` | WebSocket | WebSocket | no (token-auth) | custom platforms (Line / KakaoTalk / your own) |
 

--- a/app/web/src/tutorial/sections/11-memory/01-overview.md
+++ b/app/web/src/tutorial/sections/11-memory/01-overview.md
@@ -58,7 +58,7 @@ three entries:
 
 ## When you'll see it work
 
-1. Open a Claude session, say "记住我喜欢 pnpm"
+1. Open a Claude session, say "remember I prefer pnpm"
 2. Either Claude calls `opendray-memory.memory_store(...)` directly,
    OR it writes a local `.claude/.../memory/preference_pnpm.md` —
    either way, opendray ends up with the fact in pgvector.

--- a/app/web/src/tutorial/sections/11-memory/02-quickstart.md
+++ b/app/web/src/tutorial/sections/11-memory/02-quickstart.md
@@ -49,7 +49,7 @@ servers you've registered.
 In a Claude session:
 
 ```
-me: 我常用的前端框架是 vue 与 react
+me: my preferred frontend frameworks are vue and react
 ```
 
 The agent does either:

--- a/app/web/src/tutorial/sections/11-memory/08-ollama-walkthrough.md
+++ b/app/web/src/tutorial/sections/11-memory/08-ollama-walkthrough.md
@@ -97,7 +97,7 @@ That confirms opendray → ollama → embedding round-trip works.
 Spawn a Claude session in any project (cwd):
 
 ```
-me: "我喜欢用 pnpm 做包管理"
+me: "I prefer pnpm as my package manager"
 claude: Called opendray-memory.memory_store("...")
         → stored as mem_xxx
 ```

--- a/app/web/src/tutorial/sections/12-backup/01-overview.md
+++ b/app/web/src/tutorial/sections/12-backup/01-overview.md
@@ -31,11 +31,11 @@ Six target kinds covering ≈99% of user storage habits:
 
 - **`local`** — directory on the opendray host (default fallback)
 - **`smb`** — Windows shares, home NAS (Synology / QNAP / UNAS)
-- **`s3`** — AWS S3, Cloudflare R2, B2, MinIO, 阿里 OSS, 腾讯 COS, …
-- **`webdav`** — Nextcloud, ownCloud, 群晖 DSM, Box, 坚果云, …
+- **`s3`** — AWS S3, Cloudflare R2, B2, MinIO, Alibaba Cloud OSS (阿里云 OSS), Tencent Cloud COS (腾讯云 COS), …
+- **`webdav`** — Nextcloud, ownCloud, Synology DSM (群晖 DSM), Box, Jianguoyun (坚果云), …
 - **`sftp`** — any SSH-accessible server (VPS, Hetzner Storage Box)
 - **`rclone`** — passthrough to 70+ extra backends (Google Drive,
-  OneDrive, Dropbox, 百度网盘, 阿里云盘, …)
+  OneDrive, Dropbox, Baidu Pan (百度网盘), Aliyun Drive (阿里云盘), …)
 
 See **Targets** for the per-kind field list. All sensitive fields
 (passwords, secret keys, private keys) are AES-256-GCM encrypted

--- a/app/web/src/tutorial/sections/12-backup/03-targets.md
+++ b/app/web/src/tutorial/sections/12-backup/03-targets.md
@@ -11,10 +11,10 @@ ever appears in API responses or PG dumps.
 |---|---|---|
 | `local` | single-machine, Docker volume, mounted external HDD | `~/.opendray/backups/` |
 | `smb` | Windows shares, home NAS (Synology / QNAP / UNAS) | `//192.168.9.8/Claude_Workspace` |
-| `s3` | AWS S3, Cloudflare R2, B2, MinIO, 阿里 OSS, 腾讯 COS, ... | `s3://opendray@s3.amazonaws.com` |
-| `webdav` | Nextcloud, ownCloud, 群晖 DSM, Box, 坚果云 | `https://cloud.example.com/dav/` |
+| `s3` | AWS S3, Cloudflare R2, B2, MinIO, Alibaba Cloud OSS (阿里云 OSS), Tencent Cloud COS (腾讯云 COS), ... | `s3://opendray@s3.amazonaws.com` |
+| `webdav` | Nextcloud, ownCloud, Synology DSM (群晖 DSM), Box, Jianguoyun (坚果云) | `https://cloud.example.com/dav/` |
 | `sftp` | Hetzner Storage Box, self-hosted VPS, home Linux | `backup@vps.example.com:22` |
-| `rclone` | 70+ extra (Google Drive, OneDrive, Dropbox, 百度网盘, 阿里云盘, ...) | `gdrive:opendray-backups` |
+| `rclone` | 70+ extra (Google Drive, OneDrive, Dropbox, Baidu Pan (百度网盘), Aliyun Drive (阿里云盘), ...) | `gdrive:opendray-backups` |
 
 Add or edit targets at **`/backups → Targets`** or **`/settings →
 Backup → Where backups go`**. Both surfaces use the same
@@ -73,8 +73,8 @@ Configure with the right `endpoint` for your provider:
 | AWS S3 | `s3.amazonaws.com` (or `s3.<region>.amazonaws.com`) | e.g. `us-east-1` |
 | Cloudflare R2 | `<account-id>.r2.cloudflarestorage.com` | `auto` |
 | Backblaze B2 | `s3.<region>.backblazeb2.com` | e.g. `us-west-001` |
-| 阿里云 OSS | `oss-<region>.aliyuncs.com` | `oss-cn-shanghai` etc. |
-| 腾讯云 COS | `cos.<region>.myqcloud.com` | `ap-shanghai` etc. |
+| Alibaba Cloud OSS (阿里云 OSS) | `oss-<region>.aliyuncs.com` | `oss-cn-shanghai` etc. |
+| Tencent Cloud COS (腾讯云 COS) | `cos.<region>.myqcloud.com` | `ap-shanghai` etc. |
 | MinIO self-hosted | `minio.local:9000` | `us-east-1` (or any) |
 | DigitalOcean Spaces | `<region>.digitaloceanspaces.com` | e.g. `sgp1` |
 | Wasabi | `s3.<region>.wasabisys.com` | e.g. `us-east-1` |
@@ -114,7 +114,7 @@ Nextcloud:   https://cloud.example.com/remote.php/dav/files/<user>/
 ownCloud:    https://cloud.example.com/remote.php/webdav/
 Synology:    https://nas.local:5006/    (DSM Web Station + WebDAV)
 Box.com:     https://dav.box.com/dav
-坚果云:       https://dav.jianguoyun.com/dav/   (use a "third-party app" password)
+Jianguoyun:  https://dav.jianguoyun.com/dav/   (use a "third-party app" password)
 ```
 
 **When to use**: self-hosted clouds and "I have an app password
@@ -196,7 +196,7 @@ PATH lookup), `config_path` (override `~/.config/rclone/rclone.conf`).
 
 ```
 Google Drive · OneDrive · Dropbox · iCloud-via-WebDAV
-百度网盘 · 阿里云盘 (via aliyundrive-fuse) · pCloud · Mega
+Baidu Pan (百度网盘) · Aliyun Drive (阿里云盘, via aliyundrive-fuse) · pCloud · Mega
 Microsoft Graph (SharePoint) · Yandex Disk · Mail.ru Cloud
 HiDrive · Internet Archive · Jottacloud · Koofr · Mailbox.org
 Mega · Memory (testing) · Microsoft OneDrive · OpenStack Swift
@@ -207,7 +207,7 @@ SeaTable · Seafile · Sharepoint · SugarSync · Tardigrade · Yandex
 
 **When to use**:
 - Consumer cloud storage (Google Drive / OneDrive / Dropbox)
-- Domestic 中国大陆 services (百度网盘 / 阿里云盘) where direct
+- Mainland China services (百度网盘 / 阿里云盘) where direct
   API access is hostile to write-heavy backup tooling
 - Anything else rclone supports natively
 

--- a/app/web/src/tutorial/sections/12-backup/05-export.md
+++ b/app/web/src/tutorial/sections/12-backup/05-export.md
@@ -1,4 +1,4 @@
-# Backup — exports (C 方案)
+# Backup — exports (Plan C)
 
 `/export` is the operator-facing **data export** view. Distinct
 from `/backups` (which is operator-facing disaster recovery), an

--- a/docs/design.md
+++ b/docs/design.md
@@ -113,7 +113,7 @@ In strict priority order. Decisions that trade higher VP for lower VP go to the 
 | 2 | **Subscription cost arbitrage** | $20/mo Claude Pro replaces per-token API billing |
 | 3 | **Multi-CLI orchestration** | Parallel claude / codex / gemini, route + compare |
 | 4 | **Integration ecosystem** | Other apps register and consume AI without polluting OpenDray |
-| 5 | **Async / channel-based workflow** | Telegram / Slack / iMessage 双向 |
+| 5 | **Async / channel-based workflow** | Telegram / Slack / iMessage (bi-directional) |
 | 6 | **Reliable remote dev loop** | File browser, source control, in-app browser preview |
 
 ---


### PR DESCRIPTION
## Summary

Cleans up residual Chinese characters that had crept into the English-language tutorial / docs / UI helper text. Found 11 affected files; the PR audits them all and applies one of two patterns:

| Pattern | Where applied | Examples |
|---|---|---|
| **Replace with English** | Pure residual / sample dialogue / one-off phrases | `(C 方案)` → `(Plan C)`, `say "记住我喜欢 pnpm"` → `say "remember I prefer pnpm"`, `双向` → `(bi-directional)` |
| **Bracketed dual-language** | Cloud / IM service names that have an English official name AND a widely-recognised Chinese name | `Alibaba Cloud OSS (阿里云 OSS)`, `Synology DSM (群晖 DSM)`, `Jianguoyun (坚果云)`, `Baidu Pan (百度网盘)`, `Aliyun Drive (阿里云盘)`, `WeCom (企业微信)` |

The dual-language form was chosen to match the existing convention in `app/web/src/lib/channelKinds.ts` (`Feishu (飞书)`, `DingTalk (钉钉)`, etc.).

## What is intentionally NOT changed

| Category | Why |
|---|---|
| `docs/channels/{dingtalk,feishu,wechat,wecom}.md` | Original Chinese-platform docs — Chinese content is the platforms' own field names, useful to operators reading the platforms' admin UIs in Chinese |
| `app/web/src/tutorial/sections/03-channels/{05-feishu,06-dingtalk,07-wecom,08-wechat}.md` | Tutorial mirrors of the above — same reasoning |
| `app/web/src/lib/channelKinds.ts` (label / hint) | UI strings displayed in the channel-add form; Chinese already in `English (中文)` form |
| `app/web/src/tutorial/sections/04-providers/03-custom.md` | Demonstrates how to add a `_zh` translation to a provider definition; the Chinese is the *example value* of an i18n field |
| `app/web/src/tutorial/sections/11-memory/04-configuration.md` line 42 | Demonstrates BM25 cross-language retrieval (Chinese input matched by English query); the Chinese sample is the demo's point |
| `app/web/src/tutorial/sections.ts:60-65` | Has Chinese in a comment and a regex that intentionally allows CJK in slug anchors — feature, not a bug |
| `app/web/public/tutorial/README.md` | Caption for a Chinese-UI screenshot |

## File-level changes

| File | Lines changed | Notes |
|---|---|---|
| `app/web/src/tutorial/sections/12-backup/05-export.md` | 1 | Title: `(C 方案)` → `(Plan C)` |
| `app/web/src/lib/backup.ts` | 4 | 3 example strings + 1 section comment |
| `app/web/src/tutorial/sections/12-backup/01-overview.md` | 5 | s3 / webdav / rclone bullet examples |
| `app/web/src/tutorial/sections/12-backup/03-targets.md` | 16 | Tables + WebDAV-host example block (English-only on the alignment-sensitive code block) |
| `app/web/src/tutorial/sections/11-memory/01-overview.md` | 1 | Sample dialogue translated |
| `app/web/src/tutorial/sections/11-memory/02-quickstart.md` | 1 | Sample dialogue translated |
| `app/web/src/tutorial/sections/11-memory/08-ollama-walkthrough.md` | 1 | Sample dialogue translated |
| `app/web/src/tutorial/sections/03-channels/01-overview.md` | 1 | `企业微信 group rooms` → `WeCom (企业微信) group rooms` |
| `app/web/src/components/backup/TargetEditor.tsx` | 1 | Field hint dual-language |
| `app/web/src/components/settings/ServerSettings.tsx` | 12 | JSX paragraph reflowed; net same line count |
| `docs/design.md` | 1 | `双向` → `(bi-directional)` |

Net diff: **+28 / −28** — exact 1:1 string replacements, no structural changes.

## Test plan

- [ ] CI green (Frontend / Backend / Lint)
- [ ] After merge, navigate to https://localhost:8770/admin/tutorial → 'Backup → Plan C' (formerly 'Backup → exports (C 方案)') renders correctly with the new title
- [ ] Server settings → 'Where backups go' paragraph reflows cleanly with `<strong>` tags intact
- [ ] Memory tutorial sample dialogues read naturally in English
- [ ] Chinese-platform channel docs (DingTalk / Feishu / WeChat / WeCom) untouched — verify by spot-check

## Risk

🟢 Low. Pure string replacement; no logic, type, or routing touched. The TS/TSX edits are inside string literals or JSX text — no chance of import / type / runtime change. The two TS edits in `backup.ts` and the JSX paragraph in `ServerSettings.tsx` are the only places where syntax matters; both reviewed and the JSX pattern preserves the existing `<strong>...</strong>` + `{' '}` whitespace control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)