### PR TITLE
ci(release): add GHCR multi-arch image push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,10 @@ on:
 permissions:
   contents: write   # create / append to GitHub release
   id-token: write   # cosign keyless OIDC (Sigstore Fulcio)
-  # NOTE: `packages: write` intentionally omitted — least-privilege.
-  # Add it back in the PR that introduces a GHCR push step.
+  # NOTE: `packages: write` is granted only to the `ghcr` job below.
+  # The `release` job stays at contents+id-token least-privilege; even
+  # if a goreleaser action were ever compromised it could not push to
+  # ghcr.io.
 
 concurrency:
   group: release-${{ github.event.inputs.tag || github.ref }}
@@ -129,3 +131,88 @@ jobs:
         run: gh release upload "$TAG" dist/sbom-opendray.spdx.json --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── GHCR push ────────────────────────────────────────────────────
+  # Builds the multi-arch image from the repo Dockerfile and pushes
+  # to ghcr.io/opendray/opendray with the right semver tag set. Runs
+  # only after the `release` job succeeds, so a goreleaser failure
+  # (broken tag, build error, etc.) prevents an "image without
+  # corresponding GH release" inconsistency.
+  #
+  # Job-scoped permissions: contents: read (private repo checkout),
+  # packages: write (GHCR push). No id-token here — the binary is
+  # already signed at the release-job layer; image signing would be a
+  # follow-up using the same cosign workflow if/when desired.
+  ghcr:
+    name: GHCR push ${{ github.event.inputs.tag || github.ref_name }}
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      TAG: ${{ github.event.inputs.tag || github.ref_name }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      # Computed once so VERSION/COMMIT/DATE all match across the run.
+      # github.event.head_commit.timestamp is null on workflow_dispatch,
+      # so derive DATE in-shell rather than from the event payload.
+      - name: Compute build metadata
+        id: meta_build
+        run: |
+          {
+            echo "VERSION=${TAG#v}"
+            echo "COMMIT=$(git rev-parse --short HEAD)"
+            echo "DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3.7.0
+        with:
+          platforms: arm64
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
+
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # docker/metadata-action computes the right tag set from the
+      # semver tag. flavor: latest=auto skips :latest on pre-releases
+      # (e.g. v1.0.0-rc1) but tags it on stable versions. For
+      # workflow_dispatch against an old tag, the action does NOT
+      # compare against the registry — it only looks at the input
+      # tag's semver — so dispatching v0.5.0 in 2027 would
+      # incorrectly move :latest. Mitigation: dispatch only the
+      # current/latest tag, or accept that follow-up rebuilds
+      # require a manual `docker tag` to fix :latest afterwards.
+      - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
+        id: meta
+        with:
+          images: ghcr.io/opendray/opendray
+          flavor: latest=auto
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=tag
+
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          provenance: true
+          sbom: true
+          build-args: |
+            VERSION=${{ steps.meta_build.outputs.VERSION }}
+            COMMIT=${{ steps.meta_build.outputs.COMMIT }}
+            DATE=${{ steps.meta_build.outputs.DATE }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=opendray
+          cache-to: type=gha,scope=opendray,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Release workflow gains a `ghcr` job that builds the multi-arch
+  Dockerfile (linux/amd64 + linux/arm64) and pushes to
+  `ghcr.io/opendray/opendray` on every tag release. Job-scoped
+  `packages: write` (the parent `release` job stays at
+  contents+id-token least-privilege). Tag set covers `:1.0.0`,
+  `:1.0`, `:v1.0.0`, plus `:latest` for non-prerelease semver.
+  SHA-pinned actions throughout, matching the existing release-
+  pipeline pattern.
+
 - `.github/workflows/release.yml` — automated release pipeline.
   Triggers on `v*` tag push (or manually via workflow_dispatch with a
   tag input). Produces a goreleaser draft release with:


### PR DESCRIPTION
## Summary

Extends `release.yml` with a `ghcr` job that builds the multi-arch image from the repo `Dockerfile` and pushes to `ghcr.io/opendray/opendray` on every tag release. linux/amd64 + linux/arm64. Job-scoped `packages: write` so the parent `release` job stays at `contents+id-token` least-privilege.

Closes the deferred follow-up flagged in PR #36 / the v1.0.0 release notes.

## Tag set produced

```
ghcr.io/opendray/opendray:1.0.0      type=semver,pattern={{version}}
ghcr.io/opendray/opendray:1.0        type=semver,pattern={{major}}.{{minor}}
ghcr.io/opendray/opendray:v1.0.0     type=ref,event=tag  (matches git tag literally)
ghcr.io/opendray/opendray:latest     flavor: latest=auto
                                       — only on non-prerelease semver
```

## Why a separate job (not a step)

| | |
|---|---|
| **Failure isolation** | A goreleaser run that succeeded but a docker push that failed shouldn't roll back the GH release; conversely, a failed goreleaser shouldn't strand a half-pushed image. `needs: release` enforces "binary-release first, image push second". |
| **Permissions** | `release` job stays `contents: write + id-token: write` only. `packages: write` is granted to just the new `ghcr` job. A compromised goreleaser action couldn't push to GHCR. |

## Action pins

All five `docker/*` actions SHA-pinned with `# vX.Y.Z` trailing comments, matching the goreleaser/cosign/anchore pattern Linivek established:

```yaml
docker/setup-qemu-action      c7c53464…  # v3.7.0
docker/setup-buildx-action    8d2750c6…  # v3.12.0
docker/login-action           c94ce9fb…  # v3.7.0
docker/metadata-action        c299e40c…  # v5.10.0
docker/build-push-action      10e90e36…  # v6.19.2
```

## Caveat: workflow_dispatch and `:latest`

`metadata-action` computes `:latest` from the input tag's semver, **not** by comparing against existing registry state. Dispatching `v0.5.0` in 2027 would therefore tag `:latest` → `v0.5.0`. Mitigation documented inline in the workflow:
- For "I forgot to enable GHCR for that release" scenarios, dispatch only the current/latest tag.
- Or follow up with a manual `docker tag` if `:latest` needs to be restored.

For most cases (push events on real tags), this is correct behaviour.

## Build args

VERSION / COMMIT / DATE computed once in a small shell step at the top of the job, so all three are consistent within a single run. `github.event.head_commit.timestamp` is null on `workflow_dispatch`, so DATE is derived in-shell rather than from the event payload:

```yaml
- run: |
    {
      echo "VERSION=${TAG#v}"
      echo "COMMIT=$(git rev-parse --short HEAD)"
      echo "DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
    } >> "$GITHUB_OUTPUT"
```

## Provenance, SBOM, cache

- `provenance: true` — buildx generates SLSA-style provenance attestation on the manifest list (free with buildx, unrelated to the SHA256SUMS cosign sig at the release-job layer).
- `sbom: true` — image-level SBOM attached as an OCI annotation.
- `cache-from / cache-to: type=gha,scope=opendray` — keeps buildx layers cached between release runs, scoped per repo so it doesn't collide with anything else the org runs.

## Out of scope (deliberate)

| | |
|---|---|
| Image cosign signing | Cosign already signs `SHA256SUMS` at the release-job layer. Image-level signing is a separate PR (key vs. keyless on a manifest list, OCI annotation conventions). |
| GHCR retention policy | New images accumulate; tighten with org-level retention or `actions/delete-package-versions` later. |
| Retroactive v1.0.0 push | Once this PR merges, dispatch the workflow with `tag=v1.0.0` to also publish the v1.0.0 image. The existing v1.0.0 GH release artefacts are untouched. |

## Test plan

- [ ] CI green on this PR (the YAML must parse and the new actions must be reachable)
- [ ] After merge: dispatch `tag=v1.0.0` to validate the full pipeline against an existing tag. Expected:
  - `release` job re-runs goreleaser + cosign + SBOM (already produced; clobber-uploaded so no harm)
  - `ghcr` job builds and pushes `:1.0.0`, `:1.0`, `:v1.0.0`, `:latest`
- [ ] `docker pull ghcr.io/opendray/opendray:v1.0.0` succeeds; `opendray version` inside the container prints `1.0.0`
- [ ] `docker manifest inspect ghcr.io/opendray/opendray:v1.0.0` shows both arm64 and amd64

## Risk

🟡 Medium-low. The workflow doesn't run on this PR (gated on tag push / dispatch), so merging is safe. Risk surfaces on first dispatch / next tag — failure modes are: 

1. `docker/login-action` 401: the `GITHUB_TOKEN` isn't allowed to push to GHCR. **Fix:** repo Settings → Packages → enable "Inherit access from source repository", OR org Settings → Packages → confirm the workflow can write. One-time setup, no code change.
2. Wrong tag set: `:latest` moves on a workflow_dispatch against an old tag. **Fix:** as documented above; manual `docker tag` recovery.
3. SHA pin needs bumping in 6 months: standard maintenance.