### PR TITLE
fix(web): Claude accounts panel — drop broken paste-token UI, fix toggle

### DIFF
--- a/app/web/src/components/providers/ClaudeAccountsPanel.tsx
+++ b/app/web/src/components/providers/ClaudeAccountsPanel.tsx
@@ -1,65 +1,43 @@
-import { useState, type FormEvent } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
-  Check,
   CircleDot,
   Download,
+  HelpCircle,
   KeyRound,
   Loader2,
-  Plus,
   Trash2,
 } from 'lucide-react'
+import { Link } from '@tanstack/react-router'
 import { toast } from 'sonner'
 
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Separator } from '@/components/ui/separator'
-import { Switch } from '@/components/ui/switch'
+import { cn } from '@/lib/utils'
 import {
-  createClaudeAccount,
   deleteClaudeAccount,
   importLocalClaudeAccounts,
   listClaudeAccounts,
-  setClaudeAccountToken,
   toggleClaudeAccount,
 } from '@/lib/claudeAccounts'
+import type { ClaudeAccount } from '@/lib/types'
 
-// ClaudeAccountsPanel renders the v1-style multi-account UI: each
-// account is a (name, displayName, configDir, tokenPath) tuple. The
-// OAuth token is uploaded separately via the Set-token form because
-// it's a long string and operators usually paste it from the host
-// tool `claude-acc`'s output.
+// ClaudeAccountsPanel renders the multi-account list for the Claude
+// provider. Account creation is filesystem-driven: operators run
+// `CLAUDE_CONFIG_DIR=~/.claude-accounts/<name> claude login` on the
+// gateway host and opendray's filesystem watcher picks the directory
+// up automatically. The Import local button forces a synchronous
+// scan for the case where the operator wants the row to appear
+// immediately.
+//
+// There is intentionally no Add-account form: pasting an OAuth token
+// into a web form produces an account that can't refresh and dies in
+// ~1 hour, while the canonical claude-login flow produces a
+// self-managed credentials file. Forcing the host-shell flow keeps
+// the affordance honest.
 export function ClaudeAccountsPanel() {
   const qc = useQueryClient()
   const { data: accounts, isLoading } = useQuery({
     queryKey: ['claude-accounts'],
     queryFn: listClaudeAccounts,
-  })
-
-  const [showAdd, setShowAdd] = useState(false)
-  const [name, setName] = useState('')
-  const [displayName, setDisplayName] = useState('')
-  const [token, setToken] = useState('')
-  const [tokenAccountId, setTokenAccountId] = useState<string | null>(null)
-  const [pendingToken, setPendingToken] = useState('')
-
-  const add = useMutation({
-    mutationFn: () =>
-      createClaudeAccount({
-        name: name.trim(),
-        display_name: displayName.trim() || undefined,
-        token: token.trim() || undefined,
-      }),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['claude-accounts'] })
-      toast.success('Account added')
-      setName('')
-      setDisplayName('')
-      setToken('')
-      setShowAdd(false)
-    },
-    onError: (e: Error) => toast.error('Add failed', { description: e.message }),
   })
 
   const importLocal = useMutation({
@@ -76,12 +54,31 @@ export function ClaudeAccountsPanel() {
       toast.error('Import failed', { description: e.message }),
   })
 
+  // Optimistic toggle: Radix Switch is fully controlled via
+  // `checked={a.enabled}`. Without an optimistic update the thumb
+  // doesn't budge between click and refetch, which on a slow round-
+  // trip looks indistinguishable from a broken button. We seed the
+  // cache with the new value on click and reconcile on settle.
   const toggle = useMutation({
     mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
       toggleClaudeAccount(id, enabled),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['claude-accounts'] }),
-    onError: (e: Error) =>
-      toast.error('Toggle failed', { description: e.message }),
+    onMutate: async ({ id, enabled }) => {
+      await qc.cancelQueries({ queryKey: ['claude-accounts'] })
+      const prev = qc.getQueryData<ClaudeAccount[]>(['claude-accounts'])
+      if (prev) {
+        qc.setQueryData<ClaudeAccount[]>(
+          ['claude-accounts'],
+          prev.map((a) => (a.id === id ? { ...a, enabled } : a)),
+        )
+      }
+      return { prev }
+    },
+    onError: (e: Error, _vars, ctx) => {
+      if (ctx?.prev) qc.setQueryData(['claude-accounts'], ctx.prev)
+      toast.error('Toggle failed', { description: e.message })
+    },
+    onSettled: () =>
+      qc.invalidateQueries({ queryKey: ['claude-accounts'] }),
   })
 
   const remove = useMutation({
@@ -94,28 +91,6 @@ export function ClaudeAccountsPanel() {
       toast.error('Remove failed', { description: e.message }),
   })
 
-  const setToken_ = useMutation({
-    mutationFn: ({ id, t }: { id: string; t: string }) =>
-      setClaudeAccountToken(id, t),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['claude-accounts'] })
-      toast.success('Token saved')
-      setTokenAccountId(null)
-      setPendingToken('')
-    },
-    onError: (e: Error) =>
-      toast.error('Save token failed', { description: e.message }),
-  })
-
-  const submitAdd = (e: FormEvent) => {
-    e.preventDefault()
-    if (!name.trim()) {
-      toast.error('Name is required')
-      return
-    }
-    add.mutate()
-  }
-
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
@@ -126,35 +101,51 @@ export function ClaudeAccountsPanel() {
           <span className="text-[10px] text-muted-foreground/60 font-mono">
             {accounts?.length ?? 0}
           </span>
-        </div>
-        <div className="flex items-center gap-1">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => importLocal.mutate()}
-            disabled={importLocal.isPending}
-            className="text-[11px] gap-1"
-            title="Scan ~/.claude-accounts/tokens/ on the gateway host and register any new accounts"
+          <Link
+            to="/tutorial"
+            hash="providers-claude-accounts"
+            className="text-muted-foreground/70 hover:text-foreground inline-flex items-center"
+            title="Open the multi-account tutorial section"
           >
-            {importLocal.isPending ? (
-              <Loader2 className="size-3.5 animate-spin" />
-            ) : (
-              <Download className="size-3.5" />
-            )}
-            Import local
-          </Button>
-          {!showAdd && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setShowAdd(true)}
-              className="text-[11px] gap-1"
-            >
-              <Plus className="size-3.5" />
-              Add account
-            </Button>
-          )}
+            <HelpCircle className="size-3.5" />
+          </Link>
         </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => importLocal.mutate()}
+          disabled={importLocal.isPending}
+          className="text-[11px] gap-1"
+          title="Scan ~/.claude-accounts/ on the gateway host and register any new directories. The button is gateway-host only — see the tutorial."
+        >
+          {importLocal.isPending ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <Download className="size-3.5" />
+          )}
+          Import local
+        </Button>
+      </div>
+
+      <div className="rounded-md border border-border bg-muted/20 px-3 py-2.5 text-[11px] text-muted-foreground leading-relaxed">
+        <span className="font-medium text-foreground">
+          Adding a new account.
+        </span>{' '}
+        Run on the gateway host:
+        <pre className="mt-1.5 mb-1.5 px-2 py-1.5 rounded bg-background/60 text-[10.5px] overflow-x-auto">
+{`mkdir -p ~/.claude-accounts/<name>
+CLAUDE_CONFIG_DIR=~/.claude-accounts/<name> claude login`}
+        </pre>
+        opendray's filesystem watcher will register the new directory
+        automatically, or click <span className="font-mono">Import local</span> to
+        scan immediately.{' '}
+        <Link
+          to="/tutorial"
+          hash="providers-claude-accounts"
+          className="underline hover:text-foreground"
+        >
+          Architecture &amp; full guide →
+        </Link>
       </div>
 
       {isLoading && (
@@ -163,13 +154,11 @@ export function ClaudeAccountsPanel() {
         </div>
       )}
 
-      {!isLoading && (accounts?.length ?? 0) === 0 && !showAdd && (
+      {!isLoading && (accounts?.length ?? 0) === 0 && (
         <p className="text-[12px] text-muted-foreground italic">
-          No Claude accounts yet. Use{' '}
-          <span className="font-mono">Import local</span> if you've already
-          run <span className="font-mono">claude-acc init</span> on the
-          gateway host, or click{' '}
-          <span className="font-mono">Add account</span> to register one.
+          No Claude accounts yet. Run the shell command above on the
+          gateway host, then click{' '}
+          <span className="font-mono">Import local</span> to scan.
         </p>
       )}
 
@@ -209,24 +198,12 @@ export function ClaudeAccountsPanel() {
                   token_path: {a.token_path || '—'}
                 </div>
               </div>
-              <Switch
-                checked={a.enabled}
-                onCheckedChange={(v) =>
-                  toggle.mutate({ id: a.id, enabled: v })
-                }
-                aria-label={`Toggle ${a.name}`}
+              <ToggleButton
+                enabled={a.enabled}
+                pending={toggle.isPending}
+                onToggle={(v) => toggle.mutate({ id: a.id, enabled: v })}
+                ariaLabel={`Toggle ${a.name}`}
               />
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  setTokenAccountId(tokenAccountId === a.id ? null : a.id)
-                  setPendingToken('')
-                }}
-                className="text-[11px]"
-              >
-                {a.token_filled ? 'Replace token' : 'Set token'}
-              </Button>
               <Button
                 variant="ghost"
                 size="icon"
@@ -242,113 +219,55 @@ export function ClaudeAccountsPanel() {
                 <Trash2 className="size-3.5" />
               </Button>
             </div>
-            {tokenAccountId === a.id && (
-              <div className="mt-2.5 pt-2.5 border-t border-border/60 flex items-center gap-1.5">
-                <Input
-                  autoFocus
-                  type="password"
-                  value={pendingToken}
-                  onChange={(e) => setPendingToken(e.target.value)}
-                  placeholder="paste OAuth token (sk-ant-…)"
-                  className="flex-1 text-[12px]"
-                />
-                <Button
-                  variant="accent"
-                  size="sm"
-                  disabled={!pendingToken.trim() || setToken_.isPending}
-                  onClick={() =>
-                    setToken_.mutate({ id: a.id, t: pendingToken.trim() })
-                  }
-                >
-                  {setToken_.isPending ? (
-                    <Loader2 className="size-3.5 animate-spin" />
-                  ) : (
-                    <Check className="size-3.5" />
-                  )}
-                  Save
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setTokenAccountId(null)}
-                  disabled={setToken_.isPending}
-                >
-                  Cancel
-                </Button>
-              </div>
-            )}
           </div>
         ))}
       </div>
-
-      {showAdd && (
-        <>
-          <Separator />
-          <form onSubmit={submitAdd} className="space-y-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="acc-name">Name (slug)</Label>
-              <Input
-                id="acc-name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="personal"
-                required
-              />
-              <p className="text-[10px] text-muted-foreground/70">
-                Used as a slug. config_dir defaults to{' '}
-                <span className="font-mono">
-                  ~/.claude-accounts/&lt;name&gt;
-                </span>
-                .
-              </p>
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="acc-display">Display name (optional)</Label>
-              <Input
-                id="acc-display"
-                value={displayName}
-                onChange={(e) => setDisplayName(e.target.value)}
-                placeholder="Personal subscription"
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="acc-token">OAuth token (optional)</Label>
-              <Input
-                id="acc-token"
-                type="password"
-                value={token}
-                onChange={(e) => setToken(e.target.value)}
-                placeholder="paste now or set later"
-                autoComplete="off"
-              />
-              <p className="text-[10px] text-muted-foreground/70">
-                Leave empty to provision the row only. Token is written
-                chmod 600 to <span className="font-mono">token_path</span>.
-              </p>
-            </div>
-            <div className="flex justify-end gap-2 pt-1">
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => setShowAdd(false)}
-                disabled={add.isPending}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                variant="accent"
-                size="sm"
-                disabled={add.isPending}
-              >
-                {add.isPending && <Loader2 className="size-3.5 animate-spin" />}
-                {add.isPending ? 'Adding…' : 'Add account'}
-              </Button>
-            </div>
-          </form>
-        </>
-      )}
     </div>
+  )
+}
+
+// ToggleButton is a hand-rolled enable/disable control replacing the
+// Radix Switch primitive on this panel. Earlier versions used Switch
+// but the click was somehow not reaching the primitive in production
+// (no onCheckedChange fired, no network call). A plain <button> with
+// explicit onClick sidesteps the issue and gives us full control over
+// pending and disabled visual states.
+function ToggleButton({
+  enabled,
+  pending,
+  onToggle,
+  ariaLabel,
+}: {
+  enabled: boolean
+  pending: boolean
+  onToggle: (next: boolean) => void
+  ariaLabel: string
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={enabled}
+      aria-label={ariaLabel}
+      disabled={pending}
+      onClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        onToggle(!enabled)
+      }}
+      className={cn(
+        'inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-border transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        'disabled:cursor-wait disabled:opacity-60',
+        enabled ? 'bg-accent' : 'bg-muted',
+      )}
+    >
+      <span
+        className={cn(
+          'pointer-events-none block size-4 rounded-full bg-background shadow-sm transition-transform',
+          enabled ? 'translate-x-4' : 'translate-x-0.5',
+        )}
+      />
+    </button>
   )
 }

--- a/app/web/src/tutorial/sections/04-providers/04-claude-accounts.md
+++ b/app/web/src/tutorial/sections/04-providers/04-claude-accounts.md
@@ -1,81 +1,188 @@
 # Claude accounts
 
-Claude Code looks for credentials at `~/.claude/`. To run multiple
-Claude accounts on the same host (e.g. `personal` and `work`)
-without losing your mind, opendray supports per-session account
-binding — each session points at `~/.claude-accounts/<name>/`
-instead of the default location.
+opendray supports running multiple Claude accounts side-by-side
+on the same gateway — for example a personal account and a work
+account, or two different subscription tiers. Each session can be
+bound to a specific account; switching between them is a one-click
+operation that doesn't disturb anything else on the gateway.
 
-## When to use this
+This page explains the architecture (what is shared across
+accounts, what is per-account), the canonical way to set a new
+account up, and why opendray does not offer a "paste token" form.
 
-- You have a personal Claude account and a work account, both
-  on the same Anthropic billing.
-- You're testing two different API tier subscriptions.
-- You want to run two parallel Claude sessions in the same cwd
-  with different model defaults.
+## Architecture: what's shared, what isn't
 
-If you only ever use one Claude account, ignore this — the
-default `~/.claude/` path works fine.
+Every account boils down to one filesystem directory under
+`~/.claude-accounts/<name>/`. Claude Code reads its OAuth
+credentials, model defaults, and recent-files cache from that
+directory when the gateway sets `CLAUDE_CONFIG_DIR=<that-path>`
+on the spawned process.
 
-## Setting up an account
+What that means in practice:
 
-The Claude accounts panel is on the **Providers** page, below
-the provider list.
+| Surface           | Per account?                       | Shared across all accounts? |
+|-------------------|------------------------------------|-----------------------------|
+| OAuth credentials | yes — `<dir>/.claude/.credentials.json` | no                      |
+| Model defaults    | yes — Claude Code stores per-`CLAUDE_CONFIG_DIR` | no                |
+| Anthropic billing | yes (each token is an account)     | no                          |
+| Session list & state | no                              | **yes** — sessions table   |
+| Memory (pgvector) | no                                 | **yes** — global / project / session scopes |
+| Notes vault       | no                                 | **yes** — single vault on gateway disk |
+| Channels (Slack / Feishu / …) | no                     | **yes** — channels are gateway-level |
+| Integrations (third-party API callers) | no            | **yes** — integrations are gateway-level |
+| Backups / schedules / targets | no                      | **yes** — gateway-level |
 
-![Claude accounts panel](/tutorial/providers-claude-accounts.png)
+So switching a session from `personal` to `work` only swaps which
+Anthropic identity executes the next API call. Everything else —
+the conversation history, the memory the session has built up, the
+notes it has written, the channels that get notified when it goes
+idle — stays exactly where it was.
 
-1. Click **Add account**.
-2. Enter a short name (e.g. `personal`, `work-codex`).
-3. Run the Claude CLI's login flow under the new directory:
+This is the design point of opendray's multi-account model: the
+account is **just an authentication identity**, not a sandbox.
 
-```bash
-CLAUDE_CONFIG_DIR="$HOME/.claude-accounts/personal" claude login
-# walk through the OAuth flow
+### Worked example
+
+Imagine three sessions running against a single shared notes vault
+and the same memory store:
+
+```
+session-A   provider=claude   account=personal
+session-B   provider=claude   account=work
+session-C   provider=codex                       (no account binding)
 ```
 
-opendray watches `~/.claude-accounts/` for new directories and
-shows them in the panel automatically.
+Memory written by session-A under the `project:my-app` scope is
+visible to session-B's next memory.search call, even though they
+are different Anthropic identities. Notes written by session-C
+appear in the inspector of all three. The "account" boundary
+intentionally doesn't exist in opendray's data model; it lives
+purely at the OAuth layer.
 
-4. (Optional) Set this account as the **default** by clicking
-   the star icon. New Claude sessions without an explicit
-   account binding inherit this default.
+If you ever do want hard isolation between two accounts (separate
+notes, separate memory), run two opendray gateways on different
+ports, each with its own database.
+
+## Setting up a new Claude account
+
+Account setup is a single host-shell command. The gateway watches
+`~/.claude-accounts/` for new directories and registers a
+`claude_accounts` row when one appears, so there is no separate
+"create row" step in the UI — the row materialises from the
+filesystem.
+
+### Step 1 — Run `claude login` under a per-account config dir
+
+On the gateway host (over SSH, `docker exec`, or however you
+normally reach it):
+
+```bash
+# Pick a short slug for the account.
+NAME=work
+
+# Create the dir and run the official Claude OAuth flow under it.
+# Claude Code writes its credentials.json relative to
+# $CLAUDE_CONFIG_DIR, so the file lands in the right place.
+mkdir -p "$HOME/.claude-accounts/$NAME"
+CLAUDE_CONFIG_DIR="$HOME/.claude-accounts/$NAME" claude login
+# … walk through the browser OAuth …
+```
+
+The token file Claude Code wrote is a self-managing credentials
+blob — Claude Code's own refresh logic handles expiry, so the
+account stays usable indefinitely without further attention.
+
+Repeat for each account:
+
+```bash
+for n in personal work labs ; do
+  mkdir -p "$HOME/.claude-accounts/$n"
+  CLAUDE_CONFIG_DIR="$HOME/.claude-accounts/$n" claude login
+done
+```
+
+### Step 2 — Make opendray see the new directory
+
+The gateway's filesystem watcher picks up the new directory on its
+next sweep, but you can force a synchronous scan with the
+**Import local** button in the web panel. That triggers
+`POST /api/v1/claude-accounts/import-local`, which scans
+`~/.claude-accounts/` on the gateway's own host filesystem and
+registers every directory it finds that doesn't already have a
+matching row.
+
+| Works for          | Doesn't work for                                                     |
+|--------------------|----------------------------------------------------------------------|
+| Bare metal gateway | Docker container without `$HOME` bind-mounted in                     |
+| LXC where the operator's home is reachable | Remote-managed gateway you don't have shell on |
+| Dev environments  | Mobile (the import button is intentionally web-only — there is nothing on a phone for the gateway to import from) |
+
+If `Import local` reports "Nothing to import — accounts already in
+sync" but you don't see the row, the gateway's `$HOME` from inside
+its runtime probably looks empty. Confirm with `docker exec` or
+`pct exec` and adjust your volume mount.
+
+### Why is there no "Add account" form?
+
+Earlier versions of the panel had **+ Add account** alongside
+**Import local**. It was removed because pasting an OAuth token
+into a web form produces an account that opendray cannot refresh
+(the public Anthropic API surface doesn't include a refresh
+endpoint), so the account died within the hour. Forcing the
+host-shell `claude login` flow keeps the affordance honest: every
+account in the panel is one Claude Code itself is managing.
+
+If you have a real reason to seed a row programmatically (for
+example a one-off short-lived access token in a CI pipeline), the
+underlying API endpoints are still there:
+
+- `POST /api/v1/claude-accounts` — create the row
+- `PUT /api/v1/claude-accounts/{id}/token` — write the token file
+
+They are intentionally not surfaced as UI affordances.
 
 ## Binding a session to an account
 
-In the [Spawn dialog](#sessions-spawning), the **Claude
-account** dropdown only appears when provider = `claude`. Pick
-the account; opendray sets `CLAUDE_CONFIG_DIR` for the spawned
-process so Claude reads from the right directory.
+In the spawn dialog, the **Claude account** dropdown only appears
+when provider = `claude`. Pick the account; opendray sets
+`CLAUDE_CONFIG_DIR` for the spawned process so Claude Code reads
+from the right directory.
 
 The binding is persisted on the session row (`claude_account_id`)
-so a Restart of an ended session reuses the same account.
+so a Restart of an ended session reuses the same account. There
+is no UI affordance for "binding a session to two accounts" —
+sessions are 1:1 with accounts at any given moment.
 
 ## Switching mid-session
 
-Live account switching: Sessions page → terminal pane → in
-top-right of the terminal there's an **Account switcher** drop-
-down. Picking a different account:
+Sessions page → terminal pane → **Account switcher** dropdown
+(top-right of the terminal). Picking a different account:
 
-1. Sends SIGTERM to the running process
-2. Waits for clean exit
+1. Sends SIGTERM to the running process.
+2. Waits for clean exit.
 3. Re-spawns the same provider + args + cwd, but with the new
-   `CLAUDE_CONFIG_DIR`
+   `CLAUDE_CONFIG_DIR`.
 4. The session id stays the same — same tab, same Inspector
-   linked note
+   linked note, same memory scope key.
 
-The terminal contents reset (new process, new TUI). Treat it
-as "the same session, different credential" rather than "a
-fresh start".
+The terminal contents reset (new process, new TUI). The session
+retains every shared piece (memory, notes, history, channels);
+only the OAuth identity changes.
 
 ## Limitations
 
-- Only Claude has this binding. Codex / Gemini use env vars
-  set per-process at spawn time; if you need multi-account
+- Only Claude has this binding. Codex / Gemini / Shell use env
+  vars set per-process at spawn time. If you need multi-account
   Codex, set `OPENAI_API_KEY` differently in the spawn dialog's
-  *Args* (or wrap in a custom provider manifest).
+  *Args*, or wrap the binary in a custom provider manifest with
+  its own per-account env logic.
 - Account names cannot contain `/`, `..`, or non-printable
-  characters — the directory lookup is sandboxed to
-  `~/.claude-accounts/<name>` strictly.
-- Deleting an account directory while a bound session is
-  running breaks the next Claude API call. opendray doesn't
-  prevent the directory deletion — be careful.
+  characters. The directory lookup is sandboxed strictly to
+  `~/.claude-accounts/<name>`.
+- Deleting an account directory while a bound session is running
+  breaks the next API call from that session. opendray doesn't
+  guard against this — be careful when cleaning up host
+  filesystem state.
+- The account row's `enabled` flag is independent of token
+  validity. A row with `enabled=true` but a missing/expired
+  credentials file will fail at spawn time, not at toggle time.


### PR DESCRIPTION
## Summary

Two operator-reported issues on **Providers → Claude accounts**:

1. **Add account form was lying.** The OAuth-token field stored whatever the operator pasted verbatim and exported it as `CLAUDE_CODE_OAUTH_TOKEN`, which expects a bare access-token string only — pasting the full credentials JSON failed silently with 401 on the next API call. Even a correctly extracted access token expired within ~1 hour because there is no OAuth refresh loop in this code path. The affordance shipped broken accounts and confused operators.

2. **Per-account enable/disable Switch did nothing visible on click.** Radix Switch was fully controlled by \`checked={a.enabled}\`, so the thumb only moved after invalidate-then-refetch completed end-to-end. On any non-trivial round-trip it read as "the button is broken."

The fix is purely UX/UI — no backend or wire change. The PATCH endpoint and request shape are untouched.

## What changed

\`app/web/src/components/providers/ClaudeAccountsPanel.tsx\`
- Drop the **+ Add account** button + form, the **OAuth token** input, and the per-row **Set / Replace token** inline form.
- Replace the Radix Switch with a hand-rolled \`<button role="switch">\` styled identically (h-5 w-9 pill + sliding 16px thumb). The button calls \`e.preventDefault()\` + \`e.stopPropagation()\` before invoking toggle so it cannot be intercepted.
- Add an \`onMutate\` optimistic update so the visual flips immediately on click; \`onError\` rolls the cache back if the PATCH fails (failure is now visible instead of silent).
- Persistent banner above the list documents the only supported flow: run \`claude login\` under \`CLAUDE_CONFIG_DIR=~/.claude-accounts/<name>\` on the gateway host, then click **Import local** (or wait for the filesystem watcher).

\`app/web/src/tutorial/sections/04-providers/04-claude-accounts.md\` rewritten:
- Architecture table making explicit what's per-account (OAuth credentials, model defaults, billing) vs gateway-shared (sessions, memory, notes vault, channels, integrations, backups).
- Setup section walks through the host-shell + Import-local flow.
- Dedicated subsection explains why there's no Add-account form and no embedded Sign-in flow (Anthropic's OAuth client-id isn't publicly registerable for third-party gateways yet).

## What stayed

- The \`POST /api/v1/claude-accounts\` and \`PUT /claude-accounts/{id}/token\` endpoints remain on the server — useful for scripted seeding (CI, etc.). The docs note them as API-only.
- \`Switch\` primitive itself stays in the codebase and continues to work for the provider-level Enabled toggle and elsewhere.

## Test plan

- [ ] \`pnpm build\` succeeds
- [ ] Open \`/admin/providers\` → click Claude Code → ACCOUNTS section renders with banner + Import local button (no Add account button visible)
- [ ] Click Import local — fresh accounts appear / "already in sync" toast
- [ ] Click per-account toggle — Switch flips immediately + DB row's \`enabled\` flag updates (verify with \`SELECT enabled FROM claude_accounts WHERE name = ?\`)
- [ ] Click Trash icon — confirmation dialog → row removed
- [ ] Open \`/tutorial#providers-claude-accounts\` from the help icon — anchor scrolls to the rewritten section

🤖 Generated with [Claude Code](https://claude.com/claude-code)