### PR TITLE
feat(mobile): revamp Backups — health banner + summary + smart empty + run polling

### DIFF
--- a/app/mobile/ios/Podfile.lock
+++ b/app/mobile/ios/Podfile.lock
@@ -7,12 +7,15 @@ PODS:
   - local_auth_darwin (0.0.1):
     - Flutter
     - FlutterMacOS
+  - package_info_plus (0.4.5):
+    - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
+  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
@@ -23,12 +26,15 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/image_picker_ios/ios"
   local_auth_darwin:
     :path: ".symlinks/plugins/local_auth_darwin/darwin"
+  package_info_plus:
+    :path: ".symlinks/plugins/package_info_plus/ios"
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
 
 PODFILE CHECKSUM: f8c2dcdfb50bb67645580d28a6bf814fca30bdec
 

--- a/app/mobile/lib/core/api/backups_api.dart
+++ b/app/mobile/lib/core/api/backups_api.dart
@@ -95,6 +95,39 @@ class BackupSchedule {
   final DateTime createdAt;
 }
 
+// Feature health snapshot from /api/v1/backup-status. Used to show
+// a "you're good to go" / "you're broken" banner at the top of the
+// Backups screen so operators don't push Run now and watch it fail
+// silently when pg_dump isn't on the server's PATH.
+class BackupStatusReport {
+  BackupStatusReport({
+    required this.ok,
+    required this.keyFingerprint,
+    required this.pgDumpVersion,
+    required this.pgRestoreVersion,
+    this.pgDumpError,
+  });
+
+  factory BackupStatusReport.fromJson(Map<String, dynamic> json) =>
+      BackupStatusReport(
+        ok: json['ok'] as bool? ?? false,
+        keyFingerprint: json['key_fingerprint'] as String? ?? '',
+        pgDumpVersion: json['pg_dump_version'] as String? ?? '',
+        pgRestoreVersion: json['pg_restore_version'] as String? ?? '',
+        pgDumpError: json['pg_dump_error'] as String?,
+      );
+
+  // True when pg_dump resolved cleanly. Anything else and Run now
+  // can't actually produce a backup.
+  final bool ok;
+  // Short identifier for the OPENDRAY_BACKUP_KEY currently configured.
+  // Empty string when the feature is disabled (no key set server-side).
+  final String keyFingerprint;
+  final String pgDumpVersion;
+  final String pgRestoreVersion;
+  final String? pgDumpError;
+}
+
 class BackupTarget {
   BackupTarget({
     required this.id,
@@ -136,6 +169,20 @@ class BackupTarget {
 class BackupsApi {
   BackupsApi(this._dio);
   final Dio _dio;
+
+  // GET /backup-status — feature health snapshot. Cheap (no I/O
+  // beyond exec pg_dump --version once), safe to call on every page
+  // load. Returns null only when the endpoint itself is unreachable,
+  // which we treat as "show generic load error" rather than guessing.
+  Future<BackupStatusReport> status() async {
+    try {
+      final res =
+          await _dio.get<Map<String, dynamic>>('/api/v1/backup-status');
+      return BackupStatusReport.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
 
   Future<List<BackupRow>> list({int limit = 50, String? status}) async {
     try {

--- a/app/mobile/lib/features/backups/backups_screen.dart
+++ b/app/mobile/lib/features/backups/backups_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
@@ -19,9 +21,31 @@ class BackupsScreen extends ConsumerStatefulWidget {
   ConsumerState<BackupsScreen> createState() => _BackupsScreenState();
 }
 
+// Combined page data loaded in parallel. Keeping a single bundle
+// instead of four separate AsyncValues means the banner / summary /
+// list paint together — no progressive-load flicker on a phone
+// where the whole screen fits above the fold.
+class _PageData {
+  _PageData({
+    required this.status,
+    required this.rows,
+    required this.targets,
+    required this.schedules,
+  });
+
+  final BackupStatusReport status;
+  final List<BackupRow> rows;
+  final List<BackupTarget> targets;
+  final List<BackupSchedule> schedules;
+}
+
 class _BackupsScreenState extends ConsumerState<BackupsScreen> {
-  AsyncValue<List<BackupRow>> _state = const AsyncValue.loading();
+  AsyncValue<_PageData> _state = const AsyncValue.loading();
   bool _running = false;
+  // Active poll for a single-row run-now → succeeded/failed
+  // transition. Cancelled when the screen disposes or the row
+  // settles, so we never leak a pending Timer past pop.
+  Timer? _runPoll;
 
   @override
   void initState() {
@@ -29,19 +53,72 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
     _load();
   }
 
+  @override
+  void dispose() {
+    _runPoll?.cancel();
+    super.dispose();
+  }
+
   Future<void> _load() async {
     setState(() => _state = const AsyncValue.loading());
     try {
-      final list = await ref.read(backupsApiProvider).list(limit: 50);
+      final api = ref.read(backupsApiProvider);
+      // Fan out — four cheap GETs, ~200ms total on a LAN. If the
+      // status endpoint dies the whole screen errors; if a sub-list
+      // fails we still want a usable header, so non-status calls
+      // degrade to empty.
+      final results = await Future.wait<Object>([
+        api.status(),
+        api.list(limit: 50).catchError((_) => <BackupRow>[]),
+        api.listTargets().catchError((_) => <BackupTarget>[]),
+        api.listSchedules().catchError((_) => <BackupSchedule>[]),
+      ]);
       if (!mounted) return;
-      list.sort((a, b) => b.startedAt.compareTo(a.startedAt));
-      setState(() => _state = AsyncValue.data(list));
+      final rows = (results[1] as List<BackupRow>)
+        ..sort((a, b) => b.startedAt.compareTo(a.startedAt));
+      setState(() => _state = AsyncValue.data(_PageData(
+            status: results[0] as BackupStatusReport,
+            rows: rows,
+            targets: results[2] as List<BackupTarget>,
+            schedules: results[3] as List<BackupSchedule>,
+          )));
     } on ApiException catch (e) {
       if (mounted) {
         setState(() => _state = AsyncValue.error(e, StackTrace.current));
       }
     } on Object catch (e, st) {
       if (mounted) setState(() => _state = AsyncValue.error(e, st));
+    }
+  }
+
+  // Lightweight in-place refresh: re-fetches rows + status without
+  // flashing the spinner. Used by the run-now poll and pull-to-
+  // refresh paths. Targets/schedules don't change during a single
+  // dump, so they're skipped.
+  Future<void> _softRefresh() async {
+    final current = _state.valueOrNull;
+    if (current == null) {
+      await _load();
+      return;
+    }
+    try {
+      final api = ref.read(backupsApiProvider);
+      final results = await Future.wait<Object>([
+        api.status(),
+        api.list(limit: 50),
+      ]);
+      if (!mounted) return;
+      final rows = (results[1] as List<BackupRow>)
+        ..sort((a, b) => b.startedAt.compareTo(a.startedAt));
+      setState(() => _state = AsyncValue.data(_PageData(
+            status: results[0] as BackupStatusReport,
+            rows: rows,
+            targets: current.targets,
+            schedules: current.schedules,
+          )));
+    } on Object {
+      // Swallow soft-refresh errors — the page is already
+      // rendered, no point flashing a full-screen error.
     }
   }
 
@@ -74,12 +151,13 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
       if (!mounted) return;
       messenger.showSnackBar(
         SnackBar(
-          content: Text('Backup queued (${row.id}).'),
+          content: Text('Backup queued (${row.id}). Watching for progress…'),
           duration: const Duration(seconds: 2),
           behavior: SnackBarBehavior.floating,
         ),
       );
       await _load();
+      if (mounted) _startRunPoll(row.id, messenger);
     } on ApiException catch (e) {
       if (!mounted) return;
       messenger.showSnackBar(
@@ -91,6 +169,64 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
     } finally {
       if (mounted) setState(() => _running = false);
     }
+  }
+
+  // After a successful runNow() the row is `pending`. The server
+  // transitions it through `running` → `succeeded`/`failed` async.
+  // Poll every 3s for up to 60s (a typical pg_dump on a dev DB
+  // finishes in well under that; long-running ones get the snackbar
+  // hint and the operator can pull-to-refresh themselves).
+  void _startRunPoll(String rowId, ScaffoldMessengerState messenger) {
+    _runPoll?.cancel();
+    var ticks = 0;
+    const maxTicks = 20; // 20 * 3s = 60s budget.
+    _runPoll = Timer.periodic(const Duration(seconds: 3), (t) async {
+      ticks++;
+      if (!mounted) {
+        t.cancel();
+        return;
+      }
+      await _softRefresh();
+      if (!mounted) {
+        t.cancel();
+        return;
+      }
+      final row = _state.valueOrNull?.rows.firstWhere(
+        (r) => r.id == rowId,
+        orElse: () => BackupRow(
+          id: '',
+          targetId: '',
+          status: '',
+          triggeredBy: '',
+          startedAt: DateTime.now().toUtc(),
+          bytes: 0,
+          encrypted: false,
+        ),
+      );
+      final settled =
+          row != null && (row.status == 'succeeded' || row.status == 'failed');
+      if (settled) {
+        t.cancel();
+        _runPoll = null;
+        final ok = row.status == 'succeeded';
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text(ok
+                ? 'Backup succeeded (${_formatBytes(row.bytes)}).'
+                : 'Backup failed: ${row.error ?? "unknown error"}'),
+            duration: const Duration(seconds: 3),
+            behavior: SnackBarBehavior.floating,
+            backgroundColor: ok ? null : Theme.of(context).colorScheme.error,
+          ),
+        );
+      } else if (ticks >= maxTicks) {
+        t.cancel();
+        _runPoll = null;
+        // Don't fire a "still running" snackbar — too noisy.
+        // The row is on screen with the running chip; operator can
+        // pull-to-refresh.
+      }
+    });
   }
 
   Future<void> _showDetail(BackupRow b) async {
@@ -298,12 +434,14 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
         ],
       ),
       body: _state.when(
-        data: _buildList,
+        data: _buildBody,
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => _ErrorView(error: e.toString(), onRetry: _load),
       ),
       floatingActionButton: FloatingActionButton.extended(
-        onPressed: _running ? null : _runNow,
+        // Disable Run now when pg_dump is broken or no targets are
+        // configured — clicking it would just produce a failed row.
+        onPressed: _canRunNow() ? _runNow : null,
         icon: _running
             ? const SizedBox(
                 width: 16,
@@ -316,29 +454,88 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
     );
   }
 
-  Widget _buildList(List<BackupRow> list) {
-    if (list.isEmpty) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Text(
-            'No backups yet.\n\nTap "Run now" to take a fresh snapshot.',
-            textAlign: TextAlign.center,
-            style: Theme.of(context).textTheme.bodyMedium,
-          ),
-        ),
-      );
-    }
+  bool _canRunNow() {
+    if (_running) return false;
+    final data = _state.valueOrNull;
+    if (data == null) return false;
+    if (!data.status.ok) return false;
+    final hasEnabledTarget = data.targets.any((t) => t.enabled);
+    return hasEnabledTarget;
+  }
+
+  Widget _buildBody(_PageData data) {
+    final list = data.rows;
+    // Always render a scrollable surface so pull-to-refresh works
+    // even when the list is empty.
     return RefreshIndicator(
       onRefresh: _load,
-      child: ListView.separated(
-        itemCount: list.length,
-        separatorBuilder: (_, __) => Divider(
-          height: 1,
-          color: Theme.of(context).dividerColor,
-        ),
-        itemBuilder: (_, i) =>
-            _BackupTile(row: list[i], onTap: () => _showDetail(list[i])),
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          _StatusBanner(status: data.status),
+          _SummaryCard(
+            status: data.status,
+            targets: data.targets,
+            schedules: data.schedules,
+            rows: data.rows,
+          ),
+          if (list.isEmpty)
+            _emptyState(data)
+          else
+            ...list.map(
+              (r) => Column(
+                children: [
+                  _BackupTile(row: r, onTap: () => _showDetail(r)),
+                  Divider(height: 1, color: Theme.of(context).dividerColor),
+                ],
+              ),
+            ),
+          // Footer padding so the FAB doesn't cover the last row.
+          const SizedBox(height: 96),
+        ],
+      ),
+    );
+  }
+
+  Widget _emptyState(_PageData data) {
+    final hasTargets = data.targets.any((t) => t.enabled);
+    final pgOk = data.status.ok;
+    final theme = Theme.of(context);
+    String headline;
+    String body;
+    IconData icon;
+    if (!pgOk) {
+      icon = Icons.error_outline;
+      headline = "Backups can't run yet";
+      body = data.status.pgDumpError ??
+          'pg_dump is not available on the server. '
+              'Install postgresql-client and restart opendray.';
+    } else if (!hasTargets) {
+      icon = Icons.cloud_off_outlined;
+      headline = 'No backup targets configured';
+      body =
+          'Open the More menu → Targets to add a destination (local / S3 / SMB / SFTP / WebDAV / rclone). '
+          'Then come back and tap "Run now".';
+    } else {
+      icon = Icons.archive_outlined;
+      headline = 'No backups yet';
+      body = 'Tap "Run now" to take a fresh snapshot, or open '
+          'Schedules to set up recurring runs.';
+    }
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 40),
+      child: Column(
+        children: [
+          Icon(icon, size: 48, color: theme.colorScheme.outline),
+          const SizedBox(height: 12),
+          Text(headline,
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center),
+          const SizedBox(height: 6),
+          Text(body,
+              style: theme.textTheme.bodySmall,
+              textAlign: TextAlign.center),
+        ],
       ),
     );
   }
@@ -347,6 +544,217 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
 enum _DetailAction { close, delete }
 
 enum _AppBarAction { schedules, targets }
+
+// Feature-health banner. Renders red when pg_dump is unavailable
+// (with the underlying error so the operator can fix it from the
+// server), green otherwise with the pg_dump version + cipher key
+// fingerprint so they can confirm "backups can run AND will be
+// encrypted with the key I think they're encrypted with."
+class _StatusBanner extends StatelessWidget {
+  const _StatusBanner({required this.status});
+  final BackupStatusReport status;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ok = status.ok;
+    final color = ok ? Colors.green : theme.colorScheme.error;
+    final bg = color.withValues(alpha: 0.10);
+    final border = color.withValues(alpha: 0.45);
+    return Container(
+      margin: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(ok ? Icons.check_circle_outline : Icons.error_outline,
+                  size: 18, color: color),
+              const SizedBox(width: 8),
+              Text(
+                ok ? 'Backups ready' : 'Backups cannot run',
+                style: TextStyle(
+                  color: color,
+                  fontWeight: FontWeight.w600,
+                  fontSize: 13,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          if (ok) ...[
+            _kvRow(context, 'pg_dump', status.pgDumpVersion),
+            const SizedBox(height: 4),
+            _kvRow(
+              context,
+              'key fingerprint',
+              status.keyFingerprint.isEmpty ? '—' : status.keyFingerprint,
+              mono: true,
+            ),
+          ] else
+            Text(
+              status.pgDumpError ??
+                  'pg_dump is not on PATH. Install postgresql-client '
+                      'on the server and restart opendray.',
+              style: theme.textTheme.bodySmall?.copyWith(color: color),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _kvRow(BuildContext context, String label, String value,
+      {bool mono = false}) {
+    final muted = Theme.of(context).textTheme.bodySmall;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 110,
+          child: Text(label, style: muted),
+        ),
+        Expanded(
+          child: SelectableText(
+            value,
+            style: TextStyle(
+              fontSize: 12,
+              fontFamily: mono ? 'monospace' : null,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// "Where do I stand" overview: targets, schedules, total runs,
+// disk usage. Each tile tappable into the corresponding sub-page
+// where it makes sense.
+class _SummaryCard extends StatelessWidget {
+  const _SummaryCard({
+    required this.status,
+    required this.targets,
+    required this.schedules,
+    required this.rows,
+  });
+  final BackupStatusReport status;
+  final List<BackupTarget> targets;
+  final List<BackupSchedule> schedules;
+  final List<BackupRow> rows;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final targetsEnabled = targets.where((t) => t.enabled).length;
+    final schedulesEnabled = schedules.where((s) => s.enabled).length;
+    final liveRows = rows.where((r) => r.status != 'deleted').toList();
+    final totalBytes =
+        liveRows.fold<int>(0, (acc, r) => acc + (r.bytes > 0 ? r.bytes : 0));
+    return Container(
+      margin: const EdgeInsets.fromLTRB(12, 12, 12, 4),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: theme.dividerColor),
+      ),
+      child: Row(
+        children: [
+          _SummaryTile(
+            icon: Icons.cloud_outlined,
+            label: 'Targets',
+            value: '$targetsEnabled / ${targets.length}',
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => const BackupTargetsScreen(),
+              ),
+            ),
+          ),
+          _Divider(),
+          _SummaryTile(
+            icon: Icons.schedule_outlined,
+            label: 'Schedules',
+            value: '$schedulesEnabled / ${schedules.length}',
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => const BackupSchedulesScreen(),
+              ),
+            ),
+          ),
+          _Divider(),
+          _SummaryTile(
+            icon: Icons.archive_outlined,
+            label: 'Backups',
+            value: '${liveRows.length}',
+            sub: _formatBytes(totalBytes),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Divider extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 1,
+      height: 44,
+      color: Theme.of(context).dividerColor,
+    );
+  }
+}
+
+class _SummaryTile extends StatelessWidget {
+  const _SummaryTile({
+    required this.icon,
+    required this.label,
+    required this.value,
+    this.sub,
+    this.onTap,
+  });
+  final IconData icon;
+  final String label;
+  final String value;
+  final String? sub;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Expanded(
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
+          child: Column(
+            children: [
+              Icon(icon, size: 18, color: theme.colorScheme.outline),
+              const SizedBox(height: 4),
+              Text(label,
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: theme.colorScheme.outline)),
+              const SizedBox(height: 2),
+              Text(value,
+                  style: const TextStyle(
+                      fontSize: 14, fontWeight: FontWeight.w600)),
+              if (sub != null)
+                Text(sub!,
+                    style: theme.textTheme.bodySmall
+                        ?.copyWith(color: theme.colorScheme.outline)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
 
 class _BackupTile extends StatelessWidget {
   const _BackupTile({required this.row, required this.onTap});


### PR DESCRIPTION
## Summary

Before: mobile Backups screen was a thin observability surface — list rows + Run-now FAB. Operators with a missing pg_dump or no configured target would tap Run now, see "Backup queued", and watch nothing happen. Looked functional, felt broken.

Four changes turn it into a usable backup console:

1. **Status banner** — consumes `/api/v1/backup-status`. Green when pg_dump + cipher key are good (shows version + fingerprint); red when broken (shows underlying error so the operator can fix it server-side).
2. **Summary card** — Targets `enabled/total` · Schedules `enabled/total` · Backups `count + size`. Tappable into the corresponding sub-screen.
3. **Smart empty state** — branches by config: pg_dump broken / no enabled target / configured-but-never-ran. Each with a specific actionable hint.
4. **Run-now progress polling** — after the pending row is inserted, poll list every 3s for up to 60s. Fires a result snackbar (size on success, error on failure) when the row settles. Timer cancelled on dispose.

Plus: FAB disabled when there's no usable config — no more guaranteed-fail clicks.

## Out of scope

- Download / Restore / Export / Import remain web-only (multi-GB uploads from a phone are not practical)
- Per-kind target create/edit form already exists on its own sub-screen
- Inventory card ("what's in a backup") deferred — needs a new lightweight endpoint, not load-bearing for the "page is useful now" goal

## Test plan

- [ ] Open Backups with pg_dump available → green banner, version + fingerprint visible
- [ ] Stop pg_dump (or rename it on PATH) → red banner with error
- [ ] No targets configured → empty state says "No backup targets configured", FAB disabled
- [ ] Tap Targets tile → opens Backup Targets sub-screen
- [ ] Tap Schedules tile → opens Backup Schedules sub-screen
- [ ] Run now with a healthy local target → row inserts as pending, polls every 3s, settles into succeeded with size snackbar within 60s
- [ ] Pull-to-refresh on existing list → reloads without error
- [ ] Pop the screen while a poll is active → no exceptions in the log (Timer cancels in dispose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)