### PR TITLE
feat(backup): enable from UI — keyfile + setup endpoints + wizard (mobile+web)

### DIFF
--- a/app/mobile/lib/core/api/backups_api.dart
+++ b/app/mobile/lib/core/api/backups_api.dart
@@ -172,15 +172,22 @@ class BackupsApi {
 
   // GET /backup-status — feature health snapshot. Cheap (no I/O
   // beyond exec pg_dump --version once), safe to call on every page
-  // load. Returns null only when the endpoint itself is unreachable,
-  // which we treat as "show generic load error" rather than guessing.
-  Future<BackupStatusReport> status() async {
+  // load.
+  //
+  // Returns null when the server responds 404 — that's the
+  // documented signal that backup is compile-disabled (no
+  // OPENDRAY_BACKUP_KEY / Backup.Enabled=false in opendray.toml).
+  // See internal/app/app.go for the comment. The UI uses null to
+  // show a setup-required screen instead of an error.
+  Future<BackupStatusReport?> status() async {
     try {
       final res =
           await _dio.get<Map<String, dynamic>>('/api/v1/backup-status');
       return BackupStatusReport.fromJson(res.data ?? {});
     } on Object catch (e) {
-      throw toApiException(e);
+      final apiErr = toApiException(e);
+      if (apiErr.statusCode == 404) return null;
+      throw apiErr;
     }
   }
 

--- a/app/mobile/lib/core/api/backups_api.dart
+++ b/app/mobile/lib/core/api/backups_api.dart
@@ -95,12 +95,19 @@ class BackupSchedule {
   final DateTime createdAt;
 }
 
-// Feature health snapshot from /api/v1/backup-status. Used to show
-// a "you're good to go" / "you're broken" banner at the top of the
-// Backups screen so operators don't push Run now and watch it fail
-// silently when pg_dump isn't on the server's PATH.
+// Full feature state from /api/v1/backup-status. Since PR #49 the
+// endpoint always returns 200 — the boolean fields below tell the
+// client where on the off/on spectrum the server is, so the UI
+// can show a Setup wizard, a Restart prompt, or the live Backup
+// dashboard without ever distinguishing 404 from other errors.
 class BackupStatusReport {
   BackupStatusReport({
+    required this.enabled,
+    required this.configured,
+    required this.configuredVia,
+    required this.canDisableViaUi,
+    required this.requiresRestart,
+    required this.keyFilePath,
     required this.ok,
     required this.keyFingerprint,
     required this.pgDumpVersion,
@@ -110,6 +117,12 @@ class BackupStatusReport {
 
   factory BackupStatusReport.fromJson(Map<String, dynamic> json) =>
       BackupStatusReport(
+        enabled: json['enabled'] as bool? ?? false,
+        configured: json['configured'] as bool? ?? false,
+        configuredVia: json['configured_via'] as String? ?? '',
+        canDisableViaUi: json['can_disable_via_ui'] as bool? ?? false,
+        requiresRestart: json['requires_restart'] as bool? ?? false,
+        keyFilePath: json['key_file_path'] as String? ?? '',
         ok: json['ok'] as bool? ?? false,
         keyFingerprint: json['key_fingerprint'] as String? ?? '',
         pgDumpVersion: json['pg_dump_version'] as String? ?? '',
@@ -117,15 +130,56 @@ class BackupStatusReport {
         pgDumpError: json['pg_dump_error'] as String?,
       );
 
-  // True when pg_dump resolved cleanly. Anything else and Run now
-  // can't actually produce a backup.
+  // True when backup is actively running in the gateway process.
+  final bool enabled;
+  // True when a passphrase is available from any source (env or
+  // file) — orthogonal to `enabled` during the post-setup pre-
+  // restart window.
+  final bool configured;
+  // "env" | "file" | "" — empty means no passphrase configured yet.
+  final String configuredVia;
+  // False when configuredVia == "env" (UI can't unset env vars
+  // out from under the running process).
+  final bool canDisableViaUi;
+  // True when configured but !enabled — i.e. setup just wrote a
+  // key file and the operator needs to restart opendray.
+  final bool requiresRestart;
+  // Canonical default location for the key file. Always populated
+  // so the UI can show "your key will be written to <path>" even
+  // before the first setup call.
+  final String keyFilePath;
+
+  // The next four fields are populated only when enabled=true.
   final bool ok;
-  // Short identifier for the OPENDRAY_BACKUP_KEY currently configured.
-  // Empty string when the feature is disabled (no key set server-side).
   final String keyFingerprint;
   final String pgDumpVersion;
   final String pgRestoreVersion;
   final String? pgDumpError;
+}
+
+// Result of /api/v1/backup-setup. When `passphrase` is non-null it
+// was server-generated (mode=generate) and MUST be saved by the
+// operator before continuing — there's no recovery path if they
+// lose it.
+class BackupSetupResult {
+  BackupSetupResult({
+    required this.keyFilePath,
+    required this.requiresRestart,
+    this.passphrase,
+  });
+
+  factory BackupSetupResult.fromJson(Map<String, dynamic> json) =>
+      BackupSetupResult(
+        keyFilePath: json['key_file_path'] as String? ?? '',
+        requiresRestart: json['requires_restart'] as bool? ?? false,
+        passphrase: json['passphrase'] as String?,
+      );
+
+  final String keyFilePath;
+  final bool requiresRestart;
+  // Only set when mode=generate. Null on paste mode (operator
+  // already knows it).
+  final String? passphrase;
 }
 
 class BackupTarget {
@@ -170,24 +224,49 @@ class BackupsApi {
   BackupsApi(this._dio);
   final Dio _dio;
 
-  // GET /backup-status — feature health snapshot. Cheap (no I/O
-  // beyond exec pg_dump --version once), safe to call on every page
-  // load.
-  //
-  // Returns null when the server responds 404 — that's the
-  // documented signal that backup is compile-disabled (no
-  // OPENDRAY_BACKUP_KEY / Backup.Enabled=false in opendray.toml).
-  // See internal/app/app.go for the comment. The UI uses null to
-  // show a setup-required screen instead of an error.
-  Future<BackupStatusReport?> status() async {
+  // GET /backup-status — always-200 since PR #49. The response
+  // carries explicit booleans (enabled, configured, requires_restart)
+  // so the UI can render the right screen without inferring state
+  // from HTTP error codes.
+  Future<BackupStatusReport> status() async {
     try {
       final res =
           await _dio.get<Map<String, dynamic>>('/api/v1/backup-status');
       return BackupStatusReport.fromJson(res.data ?? {});
     } on Object catch (e) {
-      final apiErr = toApiException(e);
-      if (apiErr.statusCode == 404) return null;
-      throw apiErr;
+      throw toApiException(e);
+    }
+  }
+
+  // POST /backup-setup. mode is either 'generate' (server picks
+  // random key, returns it once) or 'paste' (caller supplies it).
+  // Returns the key file path and requires_restart=true; the
+  // generated passphrase is in result.passphrase iff mode=generate.
+  Future<BackupSetupResult> setup({
+    required String mode,
+    String? passphrase,
+  }) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/backup-setup',
+        data: {
+          'mode': mode,
+          if (passphrase != null) 'passphrase': passphrase,
+        },
+      );
+      return BackupSetupResult.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // POST /backup-setup/disable. Removes the key file. Refused 409
+  // when bootSource is env (UI can't unset env vars).
+  Future<void> disableSetup() async {
+    try {
+      await _dio.post<void>('/api/v1/backup-setup/disable');
+    } on Object catch (e) {
+      throw toApiException(e);
     }
   }
 

--- a/app/mobile/lib/features/backups/backups_screen.dart
+++ b/app/mobile/lib/features/backups/backups_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
@@ -26,12 +27,9 @@ class BackupsScreen extends ConsumerStatefulWidget {
 // list paint together — no progressive-load flicker on a phone
 // where the whole screen fits above the fold.
 //
-// status==null is a load-bearing sentinel: the server returned 404
-// on /backup-status, which means the backup feature is
-// compile-disabled (OPENDRAY_BACKUP_KEY unset / Backup.Enabled=false).
-// In that case rows/targets/schedules are also empty since their
-// handlers aren't mounted either — the UI renders a dedicated
-// "feature disabled" view rather than a useless empty list.
+// `status.enabled` decides which sub-tree to render: false → either
+// SetupWizard (configured=false) or RestartPrompt (configured=true,
+// requires_restart=true), true → normal Backups dashboard.
 class _PageData {
   _PageData({
     required this.status,
@@ -40,12 +38,19 @@ class _PageData {
     required this.schedules,
   });
 
-  final BackupStatusReport? status;
+  final BackupStatusReport status;
   final List<BackupRow> rows;
   final List<BackupTarget> targets;
   final List<BackupSchedule> schedules;
 
-  bool get featureDisabled => status == null;
+  // True when the backup feature isn't running this process — i.e.
+  // the operator hasn't set it up yet, or set it up but hasn't
+  // restarted.
+  bool get featureOff => !status.enabled;
+  // True when setup has happened (key file or env var present) but
+  // the feature isn't yet running — the operator needs to bounce
+  // the gateway.
+  bool get awaitingRestart => status.requiresRestart;
 }
 
 class _BackupsScreenState extends ConsumerState<BackupsScreen> {
@@ -72,20 +77,16 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
     setState(() => _state = const AsyncValue.loading());
     try {
       final api = ref.read(backupsApiProvider);
-      // Fan out — four cheap GETs, ~200ms total on a LAN. If the
-      // status endpoint dies the whole screen errors; if a sub-list
-      // fails we still want a usable header, so non-status calls
-      // degrade to empty.
-      // Status first — its result decides whether we even bother
-      // fetching the rest. When the feature is disabled the other
-      // three endpoints also return 404, and fanning out four 404s
-      // just to throw them away is wasteful (and noisy in the
-      // server logs).
+      // Status first — its `enabled` field decides whether we even
+      // bother fetching the rest. When the feature isn't running
+      // the data endpoints aren't mounted either, and fanning out
+      // three more 404s just to throw them away is wasteful (and
+      // noisy in the server logs).
       final status = await api.status();
       if (!mounted) return;
-      if (status == null) {
+      if (!status.enabled) {
         setState(() => _state = AsyncValue.data(_PageData(
-              status: null,
+              status: status,
               rows: const [],
               targets: const [],
               schedules: const [],
@@ -129,11 +130,13 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
       final api = ref.read(backupsApiProvider);
       final status = await api.status();
       if (!mounted) return;
-      if (status == null) {
-        // Feature was just disabled on the server between loads.
-        // Drop back to the disabled view rather than keep stale rows.
+      if (!status.enabled) {
+        // Feature was just disabled on the server between loads
+        // (or this is the post-setup pre-restart window). Drop
+        // back to the setup/restart view rather than keep stale
+        // rows.
         setState(() => _state = AsyncValue.data(_PageData(
-              status: null,
+              status: status,
               rows: const [],
               targets: const [],
               schedules: const [],
@@ -472,9 +475,9 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
         error: (e, _) => _ErrorView(error: e.toString(), onRetry: _load),
       ),
       // Hide the FAB entirely when the feature is off — it can't do
-      // anything useful and the disabled view already gives the
-      // operator the setup instructions.
-      floatingActionButton: _state.valueOrNull?.featureDisabled ?? false
+      // anything useful and the setup/restart view already gives the
+      // operator the next step.
+      floatingActionButton: _state.valueOrNull?.featureOff ?? true
           ? null
           : FloatingActionButton.extended(
               // Greyed-out when pg_dump is broken or no targets are
@@ -496,15 +499,24 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
     if (_running) return false;
     final data = _state.valueOrNull;
     if (data == null) return false;
-    final status = data.status;
-    if (status == null || !status.ok) return false;
-    final hasEnabledTarget = data.targets.any((t) => t.enabled);
-    return hasEnabledTarget;
+    if (!data.status.enabled || !data.status.ok) return false;
+    return data.targets.any((t) => t.enabled);
   }
 
   Widget _buildBody(_PageData data) {
-    if (data.featureDisabled) return _FeatureDisabledView(onRetry: _load);
-    final status = data.status!;
+    if (data.featureOff) {
+      if (data.awaitingRestart) {
+        return _RestartRequiredView(
+          status: data.status,
+          onRecheck: _load,
+        );
+      }
+      return _SetupWizardView(
+        status: data.status,
+        onComplete: _load,
+      );
+    }
+    final status = data.status;
     final list = data.rows;
     // Always render a scrollable surface so pull-to-refresh works
     // even when the list is empty.
@@ -539,9 +551,7 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
 
   Widget _emptyState(_PageData data) {
     final hasTargets = data.targets.any((t) => t.enabled);
-    // featureDisabled was checked upstream in _buildBody, so status
-    // is guaranteed non-null here.
-    final pgOk = data.status?.ok ?? false;
+    final pgOk = data.status.ok;
     final theme = Theme.of(context);
     String headline;
     String body;
@@ -549,7 +559,7 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
     if (!pgOk) {
       icon = Icons.error_outline;
       headline = "Backups can't run yet";
-      body = data.status?.pgDumpError ??
+      body = data.status.pgDumpError ??
           'pg_dump is not available on the server. '
               'Install postgresql-client and restart opendray.';
     } else if (!hasTargets) {
@@ -587,78 +597,418 @@ enum _DetailAction { close, delete }
 
 enum _AppBarAction { schedules, targets }
 
-// Rendered when /backup-status 404'd — the documented signal that
-// the backup feature is compile-disabled on this server. Tells the
-// operator exactly which env vars to set so they don't have to
-// guess; mirrors the FeatureDisabledBanner the web admin shows in
-// the same situation. Retry lets them re-check after restarting
-// the server without leaving the screen.
-class _FeatureDisabledView extends StatelessWidget {
-  const _FeatureDisabledView({required this.onRetry});
-  final Future<void> Function() onRetry;
+// Rendered when the operator has already set up a passphrase (env
+// var present OR key file on disk) but the feature isn't running
+// in *this* process — i.e. they POSTed /backup-setup, we wrote the
+// file, and now they need to bounce the gateway to pick it up. The
+// "Check again" button is the same _load callback as the rest of
+// the screen; after a real restart, the next refresh transitions
+// the page to the live dashboard.
+class _RestartRequiredView extends StatelessWidget {
+  const _RestartRequiredView({required this.status, required this.onRecheck});
+  final BackupStatusReport status;
+  final Future<void> Function() onRecheck;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final muted = theme.colorScheme.outline;
     return RefreshIndicator(
-      onRefresh: onRetry,
+      onRefresh: onRecheck,
       child: ListView(
         physics: const AlwaysScrollableScrollPhysics(),
         padding: const EdgeInsets.all(24),
         children: [
           const SizedBox(height: 32),
-          Icon(Icons.archive_outlined, size: 56, color: muted),
+          Icon(Icons.restart_alt, size: 56, color: theme.colorScheme.primary),
           const SizedBox(height: 16),
           Text(
-            'Backup feature is disabled',
+            'Restart opendray to activate backups',
             style: theme.textTheme.titleMedium,
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 8),
           Text(
-            'opendray refuses to encrypt or decrypt backup blobs without a '
-            'master passphrase, so the entire feature stays off until you '
-            'opt in. Set the two environment variables on the server, '
-            'then restart.',
+            'Your passphrase is saved. The gateway only loads it at '
+            'startup, so backups stay off until you bounce the process.',
             style: theme.textTheme.bodySmall?.copyWith(color: muted),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 20),
-          Container(
-            padding: const EdgeInsets.all(12),
-            decoration: BoxDecoration(
-              color: theme.colorScheme.surfaceContainerHighest
-                  .withValues(alpha: 0.4),
-              borderRadius: BorderRadius.circular(8),
-              border: Border.all(color: theme.dividerColor),
+          if (status.configuredVia == 'file' && status.keyFilePath.isNotEmpty)
+            _kvBox(context, label: 'Key file', value: status.keyFilePath),
+          if (status.configuredVia == 'env')
+            _kvBox(
+              context,
+              label: 'Configured via',
+              value: 'OPENDRAY_BACKUP_KEY env var',
             ),
-            child: const SelectableText(
-              'OPENDRAY_BACKUP_ENABLED=1\n'
-              'OPENDRAY_BACKUP_KEY=<long random passphrase>',
-              style: TextStyle(
-                fontFamily: 'monospace',
-                fontSize: 12,
-              ),
-            ),
-          ),
-          const SizedBox(height: 16),
-          Text(
-            'Pick a passphrase you can recover later — it is the only thing '
-            'that can decrypt the resulting backup blobs. Losing it means '
-            'losing your backups.',
-            style: theme.textTheme.bodySmall?.copyWith(color: muted),
-            textAlign: TextAlign.center,
-          ),
           const SizedBox(height: 24),
           Center(
             child: FilledButton.icon(
-              onPressed: onRetry,
+              onPressed: onRecheck,
               icon: const Icon(Icons.refresh, size: 18),
               label: const Text('Check again'),
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _kvBox(BuildContext context,
+      {required String label, required String value}) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: theme.dividerColor),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.outline)),
+          const SizedBox(height: 4),
+          SelectableText(
+            value,
+            style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// First-time setup wizard. Two modes:
+//   Generate — server picks a base64 32-byte key and returns it
+//   once; the operator must save it before continuing.
+//   Paste — operator types/pastes their own (min 20 chars).
+//
+// Both write to ~/.opendray/secrets/backup.key (0600) and require
+// a gateway restart to activate. The _RestartRequiredView sibling
+// takes over once the file is on disk; the operator may have to
+// physically restart opendray before the page transitions to the
+// live dashboard.
+class _SetupWizardView extends ConsumerStatefulWidget {
+  const _SetupWizardView({required this.status, required this.onComplete});
+  final BackupStatusReport status;
+  final Future<void> Function() onComplete;
+
+  @override
+  ConsumerState<_SetupWizardView> createState() => _SetupWizardViewState();
+}
+
+enum _SetupMode { generate, paste }
+
+class _SetupWizardViewState extends ConsumerState<_SetupWizardView> {
+  _SetupMode _mode = _SetupMode.generate;
+  final _pasteCtrl = TextEditingController();
+  bool _submitting = false;
+  // Result of a successful generate call — must be displayed once
+  // and acknowledged by the operator before we transition to the
+  // restart screen. Null otherwise.
+  BackupSetupResult? _generated;
+  bool _ackSaved = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _pasteCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    setState(() {
+      _submitting = true;
+      _error = null;
+    });
+    try {
+      final api = ref.read(backupsApiProvider);
+      final result = _mode == _SetupMode.generate
+          ? await api.setup(mode: 'generate')
+          : await api.setup(
+              mode: 'paste',
+              passphrase: _pasteCtrl.text.trim(),
+            );
+      if (!mounted) return;
+      if (result.passphrase != null) {
+        // Generate path — keep on this screen, show the passphrase
+        // for save confirmation. Continue button finalises the
+        // flow by triggering a parent reload.
+        setState(() {
+          _generated = result;
+          _submitting = false;
+        });
+      } else {
+        // Paste path — caller already knows their passphrase,
+        // no save-confirm step needed.
+        await widget.onComplete();
+      }
+    } on ApiException catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = e.message;
+          _submitting = false;
+        });
+      }
+    } on Object catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = e.toString();
+          _submitting = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final muted = theme.colorScheme.outline;
+
+    if (_generated != null) {
+      return _generatedView(context, _generated!);
+    }
+
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.all(20),
+      children: [
+        const SizedBox(height: 16),
+        Icon(Icons.lock_outlined, size: 48, color: theme.colorScheme.primary),
+        const SizedBox(height: 12),
+        Text(
+          'Set up backups',
+          style: theme.textTheme.titleMedium,
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 6),
+        Text(
+          'Choose a master passphrase. opendray uses it to encrypt every '
+          'backup blob. Lose it and your backups become unrecoverable, '
+          'so save it in a password manager (Vaultwarden, 1Password) '
+          'before continuing.',
+          style: theme.textTheme.bodySmall?.copyWith(color: muted),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 20),
+        SegmentedButton<_SetupMode>(
+          segments: const [
+            ButtonSegment(
+              value: _SetupMode.generate,
+              icon: Icon(Icons.casino_outlined, size: 18),
+              label: Text('Generate'),
+            ),
+            ButtonSegment(
+              value: _SetupMode.paste,
+              icon: Icon(Icons.edit_outlined, size: 18),
+              label: Text('Paste'),
+            ),
+          ],
+          selected: {_mode},
+          onSelectionChanged: (s) => setState(() => _mode = s.first),
+        ),
+        const SizedBox(height: 20),
+        if (_mode == _SetupMode.generate)
+          _generateExplainer(context)
+        else
+          _pasteForm(context),
+        if (_error != null) ...[
+          const SizedBox(height: 12),
+          Container(
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: theme.colorScheme.error.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(6),
+              border: Border.all(
+                  color: theme.colorScheme.error.withValues(alpha: 0.4)),
+            ),
+            child: Text(
+              _error!,
+              style: TextStyle(color: theme.colorScheme.error, fontSize: 12),
+            ),
+          ),
+        ],
+        const SizedBox(height: 20),
+        FilledButton.icon(
+          onPressed: _submitting ? null : _submit,
+          icon: _submitting
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.check, size: 18),
+          label: Text(_submitting
+              ? 'Saving…'
+              : _mode == _SetupMode.generate
+                  ? 'Generate and save'
+                  : 'Save passphrase'),
+        ),
+        const SizedBox(height: 20),
+        if (widget.status.keyFilePath.isNotEmpty)
+          Text(
+            'Key file will be written to:\n${widget.status.keyFilePath}',
+            style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            textAlign: TextAlign.center,
+          ),
+      ],
+    );
+  }
+
+  Widget _generateExplainer(BuildContext context) {
+    final theme = Theme.of(context);
+    final muted = theme.colorScheme.outline;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: theme.dividerColor),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.shield_outlined, size: 18, color: muted),
+              const SizedBox(width: 8),
+              const Text('256-bit random key',
+                  style: TextStyle(fontWeight: FontWeight.w600)),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Server generates a cryptographically random passphrase, '
+            'shows it to you once. You must copy it to a password manager '
+            'before continuing — there is no recovery path.',
+            style: theme.textTheme.bodySmall?.copyWith(color: muted),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _pasteForm(BuildContext context) {
+    final theme = Theme.of(context);
+    return TextField(
+      controller: _pasteCtrl,
+      obscureText: false,
+      maxLines: 2,
+      minLines: 1,
+      decoration: InputDecoration(
+        labelText: 'Your passphrase',
+        hintText: 'At least 20 characters',
+        border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+        helperText: 'Recommended: 40+ chars from a password manager',
+        helperStyle: TextStyle(color: theme.colorScheme.outline),
+      ),
+      style: const TextStyle(fontFamily: 'monospace', fontSize: 13),
+    );
+  }
+
+  Widget _generatedView(BuildContext context, BackupSetupResult result) {
+    final theme = Theme.of(context);
+    final muted = theme.colorScheme.outline;
+    final pass = result.passphrase ?? '';
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.all(20),
+      children: [
+        const SizedBox(height: 16),
+        Icon(Icons.warning_amber_rounded,
+            size: 48, color: Colors.amber.shade700),
+        const SizedBox(height: 12),
+        Text(
+          'Save this passphrase NOW',
+          style: theme.textTheme.titleMedium,
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 6),
+        Text(
+          'This is shown ONCE. It will not be retrievable from opendray '
+          'or anywhere else. Copy it into a password manager before '
+          'tapping Continue.',
+          style: theme.textTheme.bodySmall?.copyWith(color: muted),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 20),
+        Container(
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surfaceContainerHighest
+                .withValues(alpha: 0.4),
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(
+                color: theme.colorScheme.primary.withValues(alpha: 0.5)),
+          ),
+          child: SelectableText(
+            pass,
+            style: const TextStyle(
+              fontFamily: 'monospace',
+              fontSize: 14,
+              height: 1.3,
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed: () async {
+                  // Use the system clipboard. Selection is mostly
+                  // redundant since the SelectableText supports tap-
+                  // and-hold, but operators on phones with awkward
+                  // selection (especially with the on-screen
+                  // keyboard up) appreciate the explicit button.
+                  await _copyToClipboard(context, pass);
+                },
+                icon: const Icon(Icons.copy, size: 16),
+                label: const Text('Copy'),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        if (result.keyFilePath.isNotEmpty)
+          Text(
+            'Saved to: ${result.keyFilePath}',
+            style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            textAlign: TextAlign.center,
+          ),
+        const SizedBox(height: 20),
+        CheckboxListTile(
+          value: _ackSaved,
+          onChanged: (v) => setState(() => _ackSaved = v ?? false),
+          dense: true,
+          title: const Text(
+            'I have saved this passphrase to my password manager',
+            style: TextStyle(fontSize: 13),
+          ),
+        ),
+        const SizedBox(height: 12),
+        FilledButton.icon(
+          onPressed: _ackSaved ? () => widget.onComplete() : null,
+          icon: const Icon(Icons.arrow_forward, size: 18),
+          label: const Text('Continue'),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _copyToClipboard(BuildContext context, String text) async {
+    await Clipboard.setData(ClipboardData(text: text));
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Passphrase copied to clipboard'),
+        duration: Duration(seconds: 2),
+        behavior: SnackBarBehavior.floating,
       ),
     );
   }

--- a/app/mobile/lib/features/backups/backups_screen.dart
+++ b/app/mobile/lib/features/backups/backups_screen.dart
@@ -25,6 +25,13 @@ class BackupsScreen extends ConsumerStatefulWidget {
 // instead of four separate AsyncValues means the banner / summary /
 // list paint together — no progressive-load flicker on a phone
 // where the whole screen fits above the fold.
+//
+// status==null is a load-bearing sentinel: the server returned 404
+// on /backup-status, which means the backup feature is
+// compile-disabled (OPENDRAY_BACKUP_KEY unset / Backup.Enabled=false).
+// In that case rows/targets/schedules are also empty since their
+// handlers aren't mounted either — the UI renders a dedicated
+// "feature disabled" view rather than a useless empty list.
 class _PageData {
   _PageData({
     required this.status,
@@ -33,10 +40,12 @@ class _PageData {
     required this.schedules,
   });
 
-  final BackupStatusReport status;
+  final BackupStatusReport? status;
   final List<BackupRow> rows;
   final List<BackupTarget> targets;
   final List<BackupSchedule> schedules;
+
+  bool get featureDisabled => status == null;
 }
 
 class _BackupsScreenState extends ConsumerState<BackupsScreen> {
@@ -67,20 +76,35 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
       // status endpoint dies the whole screen errors; if a sub-list
       // fails we still want a usable header, so non-status calls
       // degrade to empty.
+      // Status first — its result decides whether we even bother
+      // fetching the rest. When the feature is disabled the other
+      // three endpoints also return 404, and fanning out four 404s
+      // just to throw them away is wasteful (and noisy in the
+      // server logs).
+      final status = await api.status();
+      if (!mounted) return;
+      if (status == null) {
+        setState(() => _state = AsyncValue.data(_PageData(
+              status: null,
+              rows: const [],
+              targets: const [],
+              schedules: const [],
+            )));
+        return;
+      }
       final results = await Future.wait<Object>([
-        api.status(),
         api.list(limit: 50).catchError((_) => <BackupRow>[]),
         api.listTargets().catchError((_) => <BackupTarget>[]),
         api.listSchedules().catchError((_) => <BackupSchedule>[]),
       ]);
       if (!mounted) return;
-      final rows = (results[1] as List<BackupRow>)
+      final rows = (results[0] as List<BackupRow>)
         ..sort((a, b) => b.startedAt.compareTo(a.startedAt));
       setState(() => _state = AsyncValue.data(_PageData(
-            status: results[0] as BackupStatusReport,
+            status: status,
             rows: rows,
-            targets: results[2] as List<BackupTarget>,
-            schedules: results[3] as List<BackupSchedule>,
+            targets: results[1] as List<BackupTarget>,
+            schedules: results[2] as List<BackupSchedule>,
           )));
     } on ApiException catch (e) {
       if (mounted) {
@@ -103,16 +127,25 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
     }
     try {
       final api = ref.read(backupsApiProvider);
-      final results = await Future.wait<Object>([
-        api.status(),
-        api.list(limit: 50),
-      ]);
+      final status = await api.status();
       if (!mounted) return;
-      final rows = (results[1] as List<BackupRow>)
-        ..sort((a, b) => b.startedAt.compareTo(a.startedAt));
+      if (status == null) {
+        // Feature was just disabled on the server between loads.
+        // Drop back to the disabled view rather than keep stale rows.
+        setState(() => _state = AsyncValue.data(_PageData(
+              status: null,
+              rows: const [],
+              targets: const [],
+              schedules: const [],
+            )));
+        return;
+      }
+      final list = await api.list(limit: 50);
+      if (!mounted) return;
+      list.sort((a, b) => b.startedAt.compareTo(a.startedAt));
       setState(() => _state = AsyncValue.data(_PageData(
-            status: results[0] as BackupStatusReport,
-            rows: rows,
+            status: status,
+            rows: list,
             targets: current.targets,
             schedules: current.schedules,
           )));
@@ -438,19 +471,24 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => _ErrorView(error: e.toString(), onRetry: _load),
       ),
-      floatingActionButton: FloatingActionButton.extended(
-        // Disable Run now when pg_dump is broken or no targets are
-        // configured — clicking it would just produce a failed row.
-        onPressed: _canRunNow() ? _runNow : null,
-        icon: _running
-            ? const SizedBox(
-                width: 16,
-                height: 16,
-                child: CircularProgressIndicator(strokeWidth: 2),
-              )
-            : const Icon(Icons.cloud_upload_outlined),
-        label: Text(_running ? 'Queueing…' : 'Run now'),
-      ),
+      // Hide the FAB entirely when the feature is off — it can't do
+      // anything useful and the disabled view already gives the
+      // operator the setup instructions.
+      floatingActionButton: _state.valueOrNull?.featureDisabled ?? false
+          ? null
+          : FloatingActionButton.extended(
+              // Greyed-out when pg_dump is broken or no targets are
+              // configured — clicking would just produce a failed row.
+              onPressed: _canRunNow() ? _runNow : null,
+              icon: _running
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.cloud_upload_outlined),
+              label: Text(_running ? 'Queueing…' : 'Run now'),
+            ),
     );
   }
 
@@ -458,12 +496,15 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
     if (_running) return false;
     final data = _state.valueOrNull;
     if (data == null) return false;
-    if (!data.status.ok) return false;
+    final status = data.status;
+    if (status == null || !status.ok) return false;
     final hasEnabledTarget = data.targets.any((t) => t.enabled);
     return hasEnabledTarget;
   }
 
   Widget _buildBody(_PageData data) {
+    if (data.featureDisabled) return _FeatureDisabledView(onRetry: _load);
+    final status = data.status!;
     final list = data.rows;
     // Always render a scrollable surface so pull-to-refresh works
     // even when the list is empty.
@@ -472,9 +513,8 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
       child: ListView(
         physics: const AlwaysScrollableScrollPhysics(),
         children: [
-          _StatusBanner(status: data.status),
+          _StatusBanner(status: status),
           _SummaryCard(
-            status: data.status,
             targets: data.targets,
             schedules: data.schedules,
             rows: data.rows,
@@ -499,7 +539,9 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
 
   Widget _emptyState(_PageData data) {
     final hasTargets = data.targets.any((t) => t.enabled);
-    final pgOk = data.status.ok;
+    // featureDisabled was checked upstream in _buildBody, so status
+    // is guaranteed non-null here.
+    final pgOk = data.status?.ok ?? false;
     final theme = Theme.of(context);
     String headline;
     String body;
@@ -507,7 +549,7 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
     if (!pgOk) {
       icon = Icons.error_outline;
       headline = "Backups can't run yet";
-      body = data.status.pgDumpError ??
+      body = data.status?.pgDumpError ??
           'pg_dump is not available on the server. '
               'Install postgresql-client and restart opendray.';
     } else if (!hasTargets) {
@@ -544,6 +586,83 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
 enum _DetailAction { close, delete }
 
 enum _AppBarAction { schedules, targets }
+
+// Rendered when /backup-status 404'd — the documented signal that
+// the backup feature is compile-disabled on this server. Tells the
+// operator exactly which env vars to set so they don't have to
+// guess; mirrors the FeatureDisabledBanner the web admin shows in
+// the same situation. Retry lets them re-check after restarting
+// the server without leaving the screen.
+class _FeatureDisabledView extends StatelessWidget {
+  const _FeatureDisabledView({required this.onRetry});
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final muted = theme.colorScheme.outline;
+    return RefreshIndicator(
+      onRefresh: onRetry,
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.all(24),
+        children: [
+          const SizedBox(height: 32),
+          Icon(Icons.archive_outlined, size: 56, color: muted),
+          const SizedBox(height: 16),
+          Text(
+            'Backup feature is disabled',
+            style: theme.textTheme.titleMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'opendray refuses to encrypt or decrypt backup blobs without a '
+            'master passphrase, so the entire feature stays off until you '
+            'opt in. Set the two environment variables on the server, '
+            'then restart.',
+            style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 20),
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: theme.colorScheme.surfaceContainerHighest
+                  .withValues(alpha: 0.4),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: theme.dividerColor),
+            ),
+            child: const SelectableText(
+              'OPENDRAY_BACKUP_ENABLED=1\n'
+              'OPENDRAY_BACKUP_KEY=<long random passphrase>',
+              style: TextStyle(
+                fontFamily: 'monospace',
+                fontSize: 12,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'Pick a passphrase you can recover later — it is the only thing '
+            'that can decrypt the resulting backup blobs. Losing it means '
+            'losing your backups.',
+            style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+          Center(
+            child: FilledButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh, size: 18),
+              label: const Text('Check again'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
 
 // Feature-health banner. Renders red when pg_dump is unavailable
 // (with the underlying error so the operator can fix it from the
@@ -638,12 +757,10 @@ class _StatusBanner extends StatelessWidget {
 // where it makes sense.
 class _SummaryCard extends StatelessWidget {
   const _SummaryCard({
-    required this.status,
     required this.targets,
     required this.schedules,
     required this.rows,
   });
-  final BackupStatusReport status;
   final List<BackupTarget> targets;
   final List<BackupSchedule> schedules;
   final List<BackupRow> rows;

--- a/app/shared/src/lib/backup.ts
+++ b/app/shared/src/lib/backup.ts
@@ -6,7 +6,7 @@
 // at the server level (OPENDRAY_BACKUP_ENABLED + OPENDRAY_BACKUP_KEY
 // are both required to turn it on).
 
-import { api, APIError } from './api'
+import { api } from './api'
 
 export type BackupStatus =
   | 'pending'
@@ -113,22 +113,63 @@ export interface TargetSpec {
   updated_at: string
 }
 
+// Since PR #49 /backup-status always returns 200 — `enabled` tells
+// you whether the feature is actively running, `configured` whether
+// a passphrase is available from any source, and `requires_restart`
+// whether the operator just wrote a key file via the UI and the
+// gateway hasn't picked it up yet. The legacy `ok` field is still
+// here for the live-feature pg_dump health check.
 export interface BackupStatusReport {
-  ok: boolean
-  key_fingerprint: string
-  pg_dump_version: string
+  enabled: boolean
+  configured: boolean
+  configured_via: 'env' | 'file' | ''
+  can_disable_via_ui: boolean
+  requires_restart: boolean
+  key_file_path: string
+  // Populated only when enabled === true.
+  ok?: boolean
+  key_fingerprint?: string
+  pg_dump_version?: string
   pg_dump_error?: string
   pg_restore_version?: string
 }
 
-/** Returns null when the backup feature is disabled (404 from server). */
-export async function fetchBackupStatus(): Promise<BackupStatusReport | null> {
-  try {
-    return await api<BackupStatusReport>('/api/v1/backup-status')
-  } catch (err) {
-    if (err instanceof APIError && err.status === 404) return null
-    throw err
-  }
+export async function fetchBackupStatus(): Promise<BackupStatusReport> {
+  return api<BackupStatusReport>('/api/v1/backup-status')
+}
+
+export interface BackupSetupResult {
+  ok: boolean
+  key_file_path: string
+  requires_restart: boolean
+  /** Server-generated passphrase; only present when mode==='generate'. */
+  passphrase?: string
+}
+
+/** POST /backup-setup. Writes the key file; returns the passphrase
+ * once when mode==='generate'. The operator MUST save it before
+ * continuing — no recovery path exists. */
+export async function postBackupSetup(opts: {
+  mode: 'generate' | 'paste'
+  passphrase?: string
+}): Promise<BackupSetupResult> {
+  return api<BackupSetupResult>('/api/v1/backup-setup', {
+    method: 'POST',
+    body: JSON.stringify(opts),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+/** POST /backup-setup/disable. Removes the key file (no-op for env-
+ * configured deployments — server rejects with 409 in that case). */
+export async function postBackupDisable(): Promise<{
+  ok: boolean
+  requires_restart: boolean
+}> {
+  return api<{ ok: boolean; requires_restart: boolean }>(
+    '/api/v1/backup-setup/disable',
+    { method: 'POST' },
+  )
 }
 
 export async function listBackups(opts?: {

--- a/app/web/src/components/backup/BackupsView.tsx
+++ b/app/web/src/components/backup/BackupsView.tsx
@@ -1,15 +1,18 @@
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import {
-  Archive,
   ChevronDown,
   ChevronRight,
+  Copy,
+  Dice5,
   Download,
   HardDrive,
   KeyRound,
+  Lock,
   Package,
   Play,
   Plus,
+  RefreshCw,
   RotateCw,
   ShieldAlert,
   Trash2,
@@ -38,6 +41,7 @@ import {
 
 import {
   type Backup,
+  type BackupSetupResult,
   type BackupStatusReport,
   type InventoryGroup,
   type Schedule,
@@ -55,6 +59,7 @@ import {
   listBackups,
   listSchedules,
   listTargets,
+  postBackupSetup,
   restoreBackup,
   testTarget,
   updateSchedule,
@@ -64,26 +69,44 @@ import { APIError } from '@/lib/api'
 import { cn } from '@/lib/utils'
 
 export function BackupsView() {
-  const [status, setStatus] = useState<BackupStatusReport | null | undefined>(
-    undefined,
-  )
+  const [status, setStatus] = useState<BackupStatusReport | null>(null)
+
+  // refresh is exposed to the Setup/Restart child views so they can
+  // trigger a re-fetch after writing the key file or restarting the
+  // gateway, without parent/child plumbing.
+  async function refresh() {
+    try {
+      const next = await fetchBackupStatus()
+      setStatus(next)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error'
+      toast.error('Failed to load backup status', { description: msg })
+    }
+  }
 
   useEffect(() => {
-    fetchBackupStatus()
-      .then(setStatus)
-      .catch((err: unknown) => {
-        const msg = err instanceof Error ? err.message : 'Unknown error'
-        toast.error('Failed to load backup status', { description: msg })
-        setStatus(null)
-      })
+    void refresh()
   }, [])
 
-  if (status === undefined) {
+  if (status === null) {
     return <div className="text-muted-foreground text-sm">Loading…</div>
   }
-  if (status === null) {
-    return <FeatureDisabledBanner />
+
+  // Three-state machine based on the always-200 status payload:
+  //
+  //   enabled=true                          → live dashboard
+  //   enabled=false, requires_restart=true  → restart prompt (key file written, awaiting bounce)
+  //   enabled=false, requires_restart=false → first-time setup wizard
+  //
+  // The boolean fields are computed server-side so we don't have
+  // to repeat the env-vs-file decision tree here.
+  if (!status.enabled) {
+    if (status.requires_restart) {
+      return <RestartRequiredCard status={status} onRecheck={refresh} />
+    }
+    return <SetupWizardCard status={status} onComplete={refresh} />
   }
+
   return (
     <div className="flex flex-col gap-5">
       <StatusBanner status={status} />
@@ -205,23 +228,269 @@ function InventoryCard() {
   )
 }
 
-// ── Status banner ────────────────────────────────────────────────
+// ── Setup wizard + restart prompt ────────────────────────────────
 
-function FeatureDisabledBanner() {
+// Rendered when the operator wrote a key file (via this UI or a
+// prior install) but the gateway hasn't loaded it yet — i.e. the
+// service refuses to fail-and-restart the running process, so the
+// only path to live-backup is a manual bounce. After the operator
+// restarts opendray, the Check-again button picks up the new state.
+function RestartRequiredCard({
+  status,
+  onRecheck,
+}: {
+  status: BackupStatusReport
+  onRecheck: () => void | Promise<void>
+}) {
+  const [busy, setBusy] = useState(false)
+  async function recheck() {
+    setBusy(true)
+    try {
+      await onRecheck()
+    } finally {
+      setBusy(false)
+    }
+  }
   return (
-    <div className="rounded-md border border-state-idle/40 bg-state-idle/10 p-4">
+    <div className="rounded-md border border-accent/30 bg-accent/5 p-5">
       <div className="flex items-start gap-3">
-        <Archive className="size-4 mt-0.5 text-state-idle" />
-        <div className="text-[13px]">
-          <div className="font-medium">Backup feature is disabled</div>
-          <div className="text-muted-foreground mt-1">
-            Set <code className="text-foreground">OPENDRAY_BACKUP_ENABLED=1</code>{' '}
-            and <code className="text-foreground">OPENDRAY_BACKUP_KEY=&lt;passphrase&gt;</code>{' '}
-            in opendray's environment, then restart. Without a master
-            passphrase the server refuses to encrypt or decrypt any
-            backup blob.
+        <RefreshCw className="size-5 mt-0.5 text-accent" />
+        <div className="flex-1">
+          <div className="font-medium">
+            Restart opendray to activate backups
+          </div>
+          <div className="text-muted-foreground text-[13px] mt-1">
+            Your passphrase is saved. The gateway only loads it at startup,
+            so the feature stays off until you bounce the process.
+          </div>
+          {status.configured_via === 'file' && status.key_file_path && (
+            <div className="mt-3 text-[12px]">
+              <span className="text-muted-foreground">Key file:</span>{' '}
+              <code className="text-foreground">{status.key_file_path}</code>
+            </div>
+          )}
+          {status.configured_via === 'env' && (
+            <div className="mt-3 text-[12px]">
+              <span className="text-muted-foreground">Configured via:</span>{' '}
+              <code className="text-foreground">OPENDRAY_BACKUP_KEY</code> env var
+            </div>
+          )}
+          <div className="mt-4 flex gap-2">
+            <Button size="sm" onClick={() => void recheck()} disabled={busy}>
+              <RefreshCw className={cn('size-3.5', busy && 'animate-spin')} />
+              Check again
+            </Button>
           </div>
         </div>
+      </div>
+    </div>
+  )
+}
+
+// First-time setup wizard. Mirrors the mobile flow — Generate
+// (server picks random key, returns once) or Paste (operator
+// supplies). On submit the server writes ~/.opendray/secrets/
+// backup.key (0600); the operator restarts the gateway to pick it
+// up; the parent re-fetches status and transitions to either
+// RestartRequiredCard (the natural next step) or directly to the
+// live dashboard if the operator was fast enough to restart
+// concurrently.
+function SetupWizardCard({
+  status,
+  onComplete,
+}: {
+  status: BackupStatusReport
+  onComplete: () => void | Promise<void>
+}) {
+  const [mode, setMode] = useState<'generate' | 'paste'>('generate')
+  const [pasted, setPasted] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  // Result of a successful generate call — must be shown once and
+  // the operator must acknowledge they saved it before we
+  // transition to the next step.
+  const [generated, setGenerated] = useState<BackupSetupResult | null>(null)
+  const [ackSaved, setAckSaved] = useState(false)
+
+  async function submit() {
+    setError(null)
+    setBusy(true)
+    try {
+      const result = await postBackupSetup(
+        mode === 'generate'
+          ? { mode: 'generate' }
+          : { mode: 'paste', passphrase: pasted.trim() },
+      )
+      if (result.passphrase) {
+        // Generate path — show the passphrase for save confirm
+        // before triggering parent refresh.
+        setGenerated(result)
+      } else {
+        // Paste path — caller already knows their passphrase,
+        // skip the confirm step.
+        await onComplete()
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error'
+      setError(msg)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (generated) {
+    return (
+      <GeneratedPassphrasePanel
+        result={generated}
+        ackSaved={ackSaved}
+        setAckSaved={setAckSaved}
+        onContinue={() => void onComplete()}
+      />
+    )
+  }
+
+  return (
+    <div className="rounded-md border border-border bg-card p-5">
+      <div className="flex items-center gap-2">
+        <Lock className="size-5 text-accent" />
+        <div className="font-medium">Set up backups</div>
+      </div>
+      <div className="text-muted-foreground text-[13px] mt-2">
+        Choose a master passphrase. opendray uses it to encrypt every backup
+        blob. <strong className="text-foreground">Lose it and your backups
+        become unrecoverable</strong>, so save it in a password manager
+        (Vaultwarden, 1Password, …) before continuing.
+      </div>
+
+      <div className="mt-4 flex gap-2">
+        <Button
+          variant={mode === 'generate' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setMode('generate')}
+        >
+          <Dice5 className="size-3.5" />
+          Generate
+        </Button>
+        <Button
+          variant={mode === 'paste' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setMode('paste')}
+        >
+          <KeyRound className="size-3.5" />
+          Paste my own
+        </Button>
+      </div>
+
+      {mode === 'generate' ? (
+        <div className="mt-4 rounded-md border border-border bg-input/20 p-3 text-[12px]">
+          <div className="font-medium">256-bit random key</div>
+          <div className="text-muted-foreground mt-1">
+            Server generates a cryptographically random passphrase and shows
+            it once. You must copy it before continuing — there is no
+            recovery path.
+          </div>
+        </div>
+      ) : (
+        <div className="mt-4">
+          <Label htmlFor="paste" className="text-[12px]">
+            Your passphrase
+          </Label>
+          <Input
+            id="paste"
+            value={pasted}
+            onChange={(e) => setPasted(e.target.value)}
+            placeholder="At least 20 characters"
+            className="mt-1 font-mono text-[13px]"
+            autoFocus
+          />
+          <div className="text-muted-foreground text-[11px] mt-1">
+            Recommended: 40+ characters from a password manager.
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="mt-3 rounded-md border border-state-failed/40 bg-state-failed/10 p-2 text-[12px] text-state-failed">
+          {error}
+        </div>
+      )}
+
+      <div className="mt-4 flex items-center justify-between gap-3">
+        {status.key_file_path && (
+          <div className="text-muted-foreground text-[11px] truncate">
+            Saves to: <code>{status.key_file_path}</code>
+          </div>
+        )}
+        <Button
+          size="sm"
+          onClick={() => void submit()}
+          disabled={busy || (mode === 'paste' && pasted.trim().length < 20)}
+        >
+          {busy ? 'Saving…' : mode === 'generate' ? 'Generate and save' : 'Save'}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function GeneratedPassphrasePanel({
+  result,
+  ackSaved,
+  setAckSaved,
+  onContinue,
+}: {
+  result: BackupSetupResult
+  ackSaved: boolean
+  setAckSaved: (v: boolean) => void
+  onContinue: () => void
+}) {
+  const pass = result.passphrase ?? ''
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(pass)
+      toast.success('Passphrase copied to clipboard')
+    } catch {
+      toast.error('Copy failed — select and copy manually')
+    }
+  }
+  return (
+    <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-5">
+      <div className="flex items-center gap-2">
+        <ShieldAlert className="size-5 text-amber-500" />
+        <div className="font-medium">Save this passphrase NOW</div>
+      </div>
+      <div className="text-muted-foreground text-[13px] mt-2">
+        This is shown <strong className="text-foreground">once</strong>. It
+        will not be retrievable from opendray or anywhere else. Copy it into
+        a password manager before continuing.
+      </div>
+      <div className="mt-4 rounded-md border border-accent/40 bg-input/30 p-3 font-mono text-[13px] break-all select-all">
+        {pass}
+      </div>
+      <div className="mt-2 flex gap-2">
+        <Button variant="outline" size="sm" onClick={() => void copy()}>
+          <Copy className="size-3.5" />
+          Copy
+        </Button>
+      </div>
+      {result.key_file_path && (
+        <div className="text-muted-foreground text-[11px] mt-3">
+          Saved to: <code>{result.key_file_path}</code>
+        </div>
+      )}
+      <label className="mt-4 flex items-start gap-2 text-[13px] cursor-pointer">
+        <input
+          type="checkbox"
+          checked={ackSaved}
+          onChange={(e) => setAckSaved(e.target.checked)}
+          className="mt-0.5"
+        />
+        <span>I have saved this passphrase to my password manager</span>
+      </label>
+      <div className="mt-4">
+        <Button size="sm" onClick={onContinue} disabled={!ackSaved}>
+          Continue
+        </Button>
       </div>
     </div>
   )

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -279,23 +279,32 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	}
 	memoryHandlers := memory.NewHandlers(memorySvc, log)
 
-	// Backup subsystem — disabled by default. Enable by setting
-	// [backup] enabled = true in config.toml (or env
-	// OPENDRAY_BACKUP_ENABLED=1) AND providing a master passphrase
-	// in OPENDRAY_BACKUP_KEY. Without both, the feature stays
-	// completely off (no handlers mounted, no scheduler running),
-	// which the UI surfaces by treating /backup-status 404 as
-	// "feature off — set OPENDRAY_BACKUP_KEY".
+	// Backup subsystem — opt-in. The passphrase resolution chain
+	// (env > KEY_FILE > default keyfile, see internal/backup/keyfile.go)
+	// is the single source of truth: presence of a passphrase from
+	// any source turns the feature on. The legacy [backup] enabled =
+	// true gate is kept only as a "you misconfigured something"
+	// signal — if it's true but no passphrase is available we hard-
+	// fail at startup, which matches the pre-PR-49 behaviour.
+	//
+	// The PR-49 setup-from-UI flow writes the default keyfile and
+	// asks the operator to restart; this branch is what reads it on
+	// the next boot.
+	keyLoad, kerr := backup.LoadPassphrase()
+	if kerr != nil {
+		st.Close()
+		return nil, fmt.Errorf("backup key load: %w", kerr)
+	}
+	if cfg.Backup.Enabled && keyLoad.Passphrase == "" {
+		st.Close()
+		return nil, fmt.Errorf("backup: [backup] enabled = true but no passphrase found in OPENDRAY_BACKUP_KEY, $OPENDRAY_BACKUP_KEY_FILE, or %s", keyLoad.Path)
+	}
 	var (
+		backupSvc       *backup.Service
 		backupHandlers  *backup.Handlers
 		backupScheduler *backup.Scheduler
 	)
-	if cfg.Backup.Enabled {
-		passphrase := os.Getenv("OPENDRAY_BACKUP_KEY")
-		if passphrase == "" {
-			st.Close()
-			return nil, fmt.Errorf("backup: feature enabled but OPENDRAY_BACKUP_KEY not set")
-		}
+	if keyLoad.Passphrase != "" {
 		bcfg := backup.Config{
 			Enabled:       true,
 			LocalDir:      defaultBackupDir(cfg.Backup.LocalDir, "backups"),
@@ -305,7 +314,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		}
 		bsvc, berr := backup.NewService(bcfg, backup.ServiceDeps{
 			Pool:       st.Pool(),
-			Passphrase: passphrase,
+			Passphrase: keyLoad.Passphrase,
 			DSN:        cfg.Database.URL,
 			ConfigPath: cfg.FilePath,
 			Log:        log,
@@ -318,10 +327,12 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 			st.Close()
 			return nil, fmt.Errorf("backup bootstrap: %w", err)
 		}
+		backupSvc = bsvc
 		backupHandlers = backup.NewHandlers(bsvc)
 		backupScheduler = backup.NewScheduler(bsvc, 0)
 		log.Info("backup ready",
 			"local_dir", bcfg.LocalDir,
+			"key_source", string(keyLoad.Source),
 			"key_fingerprint", bsvc.CipherFingerprint())
 	}
 
@@ -334,15 +345,13 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	// anthropic insert with a clear error in that case. ollama
 	// providers always work.
 	var ambientCipher summarizer.Cipher
-	if cfg.Backup.Enabled {
+	if keyLoad.Passphrase != "" {
 		// Re-derive a service handle just to access Cipher; backup
-		// service was created above when Enabled. We rebuild a
-		// reference here without re-initialising the cipher.
-		passphrase := os.Getenv("OPENDRAY_BACKUP_KEY")
-		if passphrase != "" {
-			if c, cerr := backup.NewCipher(passphrase); cerr == nil {
-				ambientCipher = c
-			}
+		// service was created above when a passphrase is available.
+		// We rebuild a reference here without re-initialising the
+		// cipher.
+		if c, cerr := backup.NewCipher(keyLoad.Passphrase); cerr == nil {
+			ambientCipher = c
 		}
 	}
 	summarizerStore := summarizer.NewStore(st.Pool(), ambientCipher)
@@ -406,6 +415,12 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 				auditHandlers.Mount(r)
 				intgrCallLogHandlers.Mount(r)
 				settingsHandlers.Mount(r)
+				// SetupHandlers (status + setup + disable) is always
+				// mounted so the UI can drive an off→on transition
+				// — that's the whole point of PR #49. When backupSvc
+				// is nil the feature didn't initialise and status
+				// reports enabled=false, but setup is still callable.
+				backup.NewSetupHandlers(backupSvc, keyLoad.Source).Mount(r)
 				if backupHandlers != nil {
 					backupHandlers.Mount(r)
 				}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -71,9 +71,9 @@ type App struct {
 	// liveBackup owns the backup Service + scheduler. Always non-nil
 	// after New returns, but Service() returns nil when the feature
 	// is off. Disarm on shutdown to stop the scheduler goroutine.
-	liveBackup *backup.LiveBackup
-	captureEngine   *capture.Engine   // ambient memory capture loop
-	server          *http.Server
+	liveBackup    *backup.LiveBackup
+	captureEngine *capture.Engine // ambient memory capture loop
+	server        *http.Server
 }
 
 // New wires the runtime dependencies but does not start any goroutines.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -68,7 +68,10 @@ type App struct {
 	audit           *audit.Sink
 	intgrCallLogger *integration.CallLogger
 	vaultSync       *vaultgit.Syncer
-	backupScheduler *backup.Scheduler // nil when backup feature is off
+	// liveBackup owns the backup Service + scheduler. Always non-nil
+	// after New returns, but Service() returns nil when the feature
+	// is off. Disarm on shutdown to stop the scheduler goroutine.
+	liveBackup *backup.LiveBackup
 	captureEngine   *capture.Engine   // ambient memory capture loop
 	server          *http.Server
 }
@@ -285,11 +288,12 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	// any source turns the feature on. The legacy [backup] enabled =
 	// true gate is kept only as a "you misconfigured something"
 	// signal — if it's true but no passphrase is available we hard-
-	// fail at startup, which matches the pre-PR-49 behaviour.
+	// fail at startup, which matches the original behaviour.
 	//
-	// The PR-49 setup-from-UI flow writes the default keyfile and
-	// asks the operator to restart; this branch is what reads it on
-	// the next boot.
+	// Since PR #50 the feature is hot-armable: LiveBackup owns the
+	// Service + scheduler and can be Arm()'d from the /backup-setup
+	// HTTP handler without a restart. The path here is just the
+	// boot-time arm.
 	keyLoad, kerr := backup.LoadPassphrase()
 	if kerr != nil {
 		st.Close()
@@ -299,19 +303,18 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		st.Close()
 		return nil, fmt.Errorf("backup: [backup] enabled = true but no passphrase found in OPENDRAY_BACKUP_KEY, $OPENDRAY_BACKUP_KEY_FILE, or %s", keyLoad.Path)
 	}
-	var (
-		backupSvc       *backup.Service
-		backupHandlers  *backup.Handlers
-		backupScheduler *backup.Scheduler
-	)
+	bcfg := backup.Config{
+		Enabled:       true,
+		LocalDir:      defaultBackupDir(cfg.Backup.LocalDir, "backups"),
+		ExportDir:     defaultBackupDir(cfg.Backup.ExportDir, "exports"),
+		PgDumpPath:    cfg.Backup.PgDumpPath,
+		PgRestorePath: cfg.Backup.PgRestorePath,
+	}
+	liveBackup := backup.NewLiveBackup(bcfg, st.Pool(), cfg.Database.URL, cfg.FilePath, log)
 	if keyLoad.Passphrase != "" {
-		bcfg := backup.Config{
-			Enabled:       true,
-			LocalDir:      defaultBackupDir(cfg.Backup.LocalDir, "backups"),
-			ExportDir:     defaultBackupDir(cfg.Backup.ExportDir, "exports"),
-			PgDumpPath:    cfg.Backup.PgDumpPath,
-			PgRestorePath: cfg.Backup.PgRestorePath,
-		}
+		// Boot-time Arm: build the service eagerly so init errors
+		// (DB migration failure, etc.) crash boot rather than wait
+		// for the first /backups request.
 		bsvc, berr := backup.NewService(bcfg, backup.ServiceDeps{
 			Pool:       st.Pool(),
 			Passphrase: keyLoad.Passphrase,
@@ -327,33 +330,26 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 			st.Close()
 			return nil, fmt.Errorf("backup bootstrap: %w", err)
 		}
-		backupSvc = bsvc
-		backupHandlers = backup.NewHandlers(bsvc)
-		backupScheduler = backup.NewScheduler(bsvc, 0)
+		if err := liveBackup.ArmWithService(ctx, bsvc); err != nil {
+			st.Close()
+			return nil, fmt.Errorf("arm backup: %w", err)
+		}
 		log.Info("backup ready",
 			"local_dir", bcfg.LocalDir,
 			"key_source", string(keyLoad.Source),
 			"key_fingerprint", bsvc.CipherFingerprint())
 	}
+	backupHandlers := backup.NewHandlers(liveBackup)
 
 	// Ambient memory subsystem (Phase A) — summarizer + capture +
 	// injector. Always wired (admin endpoints work standalone) but
 	// the capture engine only fires when at least one
 	// memory_capture_rules row + one enabled summarizer provider
 	// exist. Anthropic providers require backup cipher to encrypt
-	// api keys — wiring nil cipher is fine, the store rejects
-	// anthropic insert with a clear error in that case. ollama
-	// providers always work.
-	var ambientCipher summarizer.Cipher
-	if keyLoad.Passphrase != "" {
-		// Re-derive a service handle just to access Cipher; backup
-		// service was created above when a passphrase is available.
-		// We rebuild a reference here without re-initialising the
-		// cipher.
-		if c, cerr := backup.NewCipher(keyLoad.Passphrase); cerr == nil {
-			ambientCipher = c
-		}
-	}
+	// api keys; the cipher is now backed by LiveBackup so it Just
+	// Works as soon as the operator arms backups via /backup-setup
+	// — no restart required for anthropic provider creation either.
+	ambientCipher := backup.NewLiveCipher(liveBackup)
 	summarizerStore := summarizer.NewStore(st.Pool(), ambientCipher)
 	summarizerRegistry := summarizer.NewRegistry(summarizerStore, log).
 		WithIntegrationLookup(&summarizerIntegrationLookup{svc: intgrSvc})
@@ -416,14 +412,13 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 				intgrCallLogHandlers.Mount(r)
 				settingsHandlers.Mount(r)
 				// SetupHandlers (status + setup + disable) is always
-				// mounted so the UI can drive an off→on transition
-				// — that's the whole point of PR #49. When backupSvc
-				// is nil the feature didn't initialise and status
-				// reports enabled=false, but setup is still callable.
-				backup.NewSetupHandlers(backupSvc, keyLoad.Source).Mount(r)
-				if backupHandlers != nil {
-					backupHandlers.Mount(r)
-				}
+				// mounted — that's the whole point of PR #49 / #50.
+				// Handlers (the data routes) is also always mounted
+				// since PR #50; its requireArmed middleware 503s
+				// when LiveBackup is disarmed, so the off-state is
+				// safe without a nil-handlers branch here.
+				backup.NewSetupHandlers(liveBackup, keyLoad.Source).Mount(r)
+				backupHandlers.Mount(r)
 				summarizerHandlers.Mount(r)
 				captureHandlers.Mount(r)
 				injectorHandlers.Mount(r)
@@ -468,7 +463,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		audit:           auditSink,
 		intgrCallLogger: intgrCallLogger,
 		vaultSync:       vaultSyncer,
-		backupScheduler: backupScheduler,
+		liveBackup:      liveBackup,
 		captureEngine:   captureEngine,
 		server:          srv,
 	}, nil
@@ -511,14 +506,9 @@ func (a *App) Run(ctx context.Context) error {
 		close(vaultSyncDone)
 	}()
 
-	var backupSchedulerDone chan struct{}
-	if a.backupScheduler != nil {
-		backupSchedulerDone = make(chan struct{})
-		go func() {
-			a.backupScheduler.Run(ctx)
-			close(backupSchedulerDone)
-		}()
-	}
+	// Backup scheduler lifecycle is owned by LiveBackup itself
+	// (started inside Arm / ArmWithService, stopped by Disarm or
+	// by ctx cancellation). No goroutine to wrangle here.
 
 	captureDone := make(chan struct{})
 	go func() {
@@ -577,13 +567,12 @@ func (a *App) Run(ctx context.Context) error {
 		a.log.Warn("vault auto-sync shutdown timed out")
 	}
 
-	if backupSchedulerDone != nil {
-		select {
-		case <-backupSchedulerDone:
-		case <-time.After(5 * time.Second):
-			a.log.Warn("backup scheduler shutdown timed out")
-		}
-	}
+	// Disarm idempotently stops the backup scheduler if it's
+	// running, otherwise no-ops. We do this explicitly rather
+	// than relying on ctx cancellation alone so the shutdown
+	// path doesn't race with a /backup-setup that arrives just
+	// as the server starts to drain.
+	a.liveBackup.Disarm()
 
 	select {
 	case <-captureDone:

--- a/internal/backup/handler.go
+++ b/internal/backup/handler.go
@@ -11,14 +11,21 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// Handlers wires Service onto the chi router. Caller mounts under
-// the admin-only group — every endpoint here assumes the caller is
-// already authenticated as the operator.
+// Handlers wires the backup data routes onto the chi router. The
+// caller mounts under the admin-only group — every endpoint here
+// assumes the caller is already authenticated as the operator.
+//
+// Since PR #50 the Handlers struct doesn't directly hold a Service
+// — it holds a *LiveBackup whose Service() pointer can be flipped
+// at runtime by /backup-setup. The requireArmed middleware short-
+// circuits requests with 503 when the feature isn't currently
+// enabled, so individual handler methods can assume Service() is
+// non-nil.
 type Handlers struct {
-	svc *Service
+	live *LiveBackup
 }
 
-func NewHandlers(svc *Service) *Handlers { return &Handlers{svc: svc} }
+func NewHandlers(live *LiveBackup) *Handlers { return &Handlers{live: live} }
 
 // Mount registers /backups, /backup-targets, /backup-schedules,
 // /backup-inventory under r. The /backup-status, /backup-setup,
@@ -26,32 +33,57 @@ func NewHandlers(svc *Service) *Handlers { return &Handlers{svc: svc} }
 // setup_handler.go) so they can be mounted even when the feature
 // is off — that's how an operator who hasn't configured backups
 // yet can use the UI to turn them on.
+//
+// All routes are wrapped in a Group with the requireArmed
+// middleware so a request that arrives while the LiveBackup is
+// disarmed gets a clean 503 instead of a nil-deref panic.
 func (h *Handlers) Mount(r chi.Router) {
-	r.Route("/backups", func(r chi.Router) {
-		r.Get("/", h.list)
-		r.Post("/", h.create)
-		r.Post("/restore", h.restore)
-		r.Get("/{id}", h.get)
-		r.Get("/{id}/download", h.download)
-		r.Delete("/{id}", h.delete)
+	r.Group(func(r chi.Router) {
+		r.Use(h.requireArmed)
+		r.Route("/backups", func(r chi.Router) {
+			r.Get("/", h.list)
+			r.Post("/", h.create)
+			r.Post("/restore", h.restore)
+			r.Get("/{id}", h.get)
+			r.Get("/{id}/download", h.download)
+			r.Delete("/{id}", h.delete)
+		})
+		r.Route("/backup-schedules", func(r chi.Router) {
+			r.Get("/", h.listSchedules)
+			r.Post("/", h.createSchedule)
+			r.Get("/{id}", h.getSchedule)
+			r.Patch("/{id}", h.updateSchedule)
+			r.Delete("/{id}", h.deleteSchedule)
+		})
+		r.Route("/backup-targets", func(r chi.Router) {
+			r.Get("/", h.listTargets)
+			r.Post("/", h.createTarget)
+			r.Patch("/{id}", h.updateTarget)
+			r.Delete("/{id}", h.deleteTarget)
+			r.Post("/{id}/test", h.testTarget)
+		})
+		h.MountExports(r)
+		h.MountImports(r)
+		r.Get("/backup-inventory", h.inventory)
 	})
-	r.Route("/backup-schedules", func(r chi.Router) {
-		r.Get("/", h.listSchedules)
-		r.Post("/", h.createSchedule)
-		r.Get("/{id}", h.getSchedule)
-		r.Patch("/{id}", h.updateSchedule)
-		r.Delete("/{id}", h.deleteSchedule)
+}
+
+// requireArmed shortcircuits requests with 503 when the LiveBackup
+// is disarmed — the operator hasn't set up a passphrase yet, or
+// just hit /backup-setup/disable. Returning 503 (rather than 404)
+// matches HTTP semantics: the endpoint exists, it just isn't
+// currently accepting work. Mobile/web clients use it as the
+// signal to drop back to the Setup wizard.
+func (h *Handlers) requireArmed(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if h.live.Service() == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+				"error": "backup feature is not enabled — set it up via the admin UI or set OPENDRAY_BACKUP_KEY and restart",
+			})
+			return
+		}
+		next.ServeHTTP(w, r)
 	})
-	r.Route("/backup-targets", func(r chi.Router) {
-		r.Get("/", h.listTargets)
-		r.Post("/", h.createTarget)
-		r.Patch("/{id}", h.updateTarget)
-		r.Delete("/{id}", h.deleteTarget)
-		r.Post("/{id}/test", h.testTarget)
-	})
-	h.MountExports(r)
-	h.MountImports(r)
-	r.Get("/backup-inventory", h.inventory)
 }
 
 // list serves GET /backups. Filters: ?status=&target_id=&limit=.
@@ -68,7 +100,7 @@ func (h *Handlers) list(w http.ResponseWriter, r *http.Request) {
 			f.Limit = n
 		}
 	}
-	list, err := h.svc.ListBackups(r.Context(), f)
+	list, err := h.live.Service().ListBackups(r.Context(), f)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
@@ -82,7 +114,7 @@ func (h *Handlers) list(w http.ResponseWriter, r *http.Request) {
 // get serves GET /backups/{id}.
 func (h *Handlers) get(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	b, err := h.svc.GetBackup(r.Context(), id)
+	b, err := h.live.Service().GetBackup(r.Context(), id)
 	if err != nil {
 		if errors.Is(err, ErrBackupNotFound) {
 			writeError(w, http.StatusNotFound, err)
@@ -108,7 +140,7 @@ func (h *Handlers) create(w http.ResponseWriter, r *http.Request) {
 	if req.TargetID == "" {
 		req.TargetID = "local"
 	}
-	b, err := h.svc.RunBackupNow(r.Context(), RunBackupRequest{
+	b, err := h.live.Service().RunBackupNow(r.Context(), RunBackupRequest{
 		TargetID:      req.TargetID,
 		TriggeredBy:   TriggeredAPI,
 		IncludeConfig: req.IncludeConfig,
@@ -131,7 +163,7 @@ func (h *Handlers) create(w http.ResponseWriter, r *http.Request) {
 // (encrypted) bundle blob with octet-stream headers.
 func (h *Handlers) download(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	rc, b, err := h.svc.DownloadBackup(r.Context(), id)
+	rc, b, err := h.live.Service().DownloadBackup(r.Context(), id)
 	if err != nil {
 		switch {
 		case errors.Is(err, ErrBackupNotFound), errors.Is(err, ErrTargetNotFound):
@@ -158,7 +190,7 @@ func (h *Handlers) download(w http.ResponseWriter, r *http.Request) {
 // best-effort removes the blob from its target.
 func (h *Handlers) delete(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	if err := h.svc.DeleteBackup(r.Context(), id); err != nil {
+	if err := h.live.Service().DeleteBackup(r.Context(), id); err != nil {
 		if errors.Is(err, ErrBackupNotFound) {
 			writeError(w, http.StatusNotFound, err)
 			return
@@ -172,7 +204,7 @@ func (h *Handlers) delete(w http.ResponseWriter, r *http.Request) {
 // ─── schedules ────────────────────────────────────────────────────
 
 func (h *Handlers) listSchedules(w http.ResponseWriter, r *http.Request) {
-	list, err := h.svc.ListSchedules(r.Context())
+	list, err := h.live.Service().ListSchedules(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
@@ -185,7 +217,7 @@ func (h *Handlers) listSchedules(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handlers) getSchedule(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	sc, err := h.svc.GetSchedule(r.Context(), id)
+	sc, err := h.live.Service().GetSchedule(r.Context(), id)
 	if err != nil {
 		if errors.Is(err, ErrScheduleNotFound) {
 			writeError(w, http.StatusNotFound, err)
@@ -211,7 +243,7 @@ func (h *Handlers) createSchedule(w http.ResponseWriter, r *http.Request) {
 	if req.Retention == 0 {
 		req.Retention = 7
 	}
-	sc, err := h.svc.CreateSchedule(r.Context(), CreateScheduleRequest{
+	sc, err := h.live.Service().CreateSchedule(r.Context(), CreateScheduleRequest{
 		TargetID:    req.TargetID,
 		IntervalSec: req.IntervalSec,
 		Retention:   req.Retention,
@@ -239,7 +271,7 @@ func (h *Handlers) updateSchedule(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid body: %w", err))
 		return
 	}
-	if err := h.svc.UpdateSchedule(r.Context(), id, SchedulePatch{
+	if err := h.live.Service().UpdateSchedule(r.Context(), id, SchedulePatch{
 		IntervalSec: req.IntervalSec,
 		Retention:   req.Retention,
 		Enabled:     req.Enabled,
@@ -247,7 +279,7 @@ func (h *Handlers) updateSchedule(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
-	sc, err := h.svc.GetSchedule(r.Context(), id)
+	sc, err := h.live.Service().GetSchedule(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
@@ -257,7 +289,7 @@ func (h *Handlers) updateSchedule(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handlers) deleteSchedule(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	if err := h.svc.DeleteSchedule(r.Context(), id); err != nil {
+	if err := h.live.Service().DeleteSchedule(r.Context(), id); err != nil {
 		if errors.Is(err, ErrScheduleNotFound) {
 			writeError(w, http.StatusNotFound, err)
 			return
@@ -272,7 +304,7 @@ func (h *Handlers) deleteSchedule(w http.ResponseWriter, r *http.Request) {
 
 // listTargets serves GET /backup-targets.
 func (h *Handlers) listTargets(w http.ResponseWriter, r *http.Request) {
-	list, err := h.svc.ListTargets(r.Context())
+	list, err := h.live.Service().ListTargets(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
@@ -294,7 +326,7 @@ func (h *Handlers) createTarget(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid body: %w", err))
 		return
 	}
-	spec, err := h.svc.CreateTarget(r.Context(), CreateTargetRequest{
+	spec, err := h.live.Service().CreateTarget(r.Context(), CreateTargetRequest{
 		ID:      req.ID,
 		Kind:    req.Kind,
 		Config:  req.Config,
@@ -322,7 +354,7 @@ func (h *Handlers) updateTarget(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid body: %w", err))
 		return
 	}
-	spec, err := h.svc.UpdateTarget(r.Context(), id, UpdateTargetRequest{
+	spec, err := h.live.Service().UpdateTarget(r.Context(), id, UpdateTargetRequest{
 		Config:  req.Config,
 		Enabled: req.Enabled,
 	})
@@ -339,7 +371,7 @@ func (h *Handlers) updateTarget(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handlers) deleteTarget(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	if err := h.svc.DeleteTarget(r.Context(), id); err != nil {
+	if err := h.live.Service().DeleteTarget(r.Context(), id); err != nil {
 		if errors.Is(err, ErrTargetNotFound) {
 			writeError(w, http.StatusNotFound, err)
 			return
@@ -355,7 +387,7 @@ func (h *Handlers) deleteTarget(w http.ResponseWriter, r *http.Request) {
 func (h *Handlers) testTarget(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	resp := map[string]any{"ok": true}
-	if err := h.svc.TestTarget(r.Context(), id); err != nil {
+	if err := h.live.Service().TestTarget(r.Context(), id); err != nil {
 		resp["ok"] = false
 		resp["error"] = err.Error()
 	}
@@ -397,7 +429,7 @@ func (h *Handlers) restore(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, err := h.svc.RestoreBackup(r.Context(), RestoreRequest{
+	res, err := h.live.Service().RestoreBackup(r.Context(), RestoreRequest{
 		Source:       file,
 		TargetDSN:    targetDSN,
 		Clean:        clean,
@@ -429,7 +461,7 @@ func (h *Handlers) restore(w http.ResponseWriter, r *http.Request) {
 // inventory returns the grouped table list with live row counts so
 // the UI can show "what's actually in a backup right now."
 func (h *Handlers) inventory(w http.ResponseWriter, r *http.Request) {
-	groups, err := h.svc.Inventory(r.Context())
+	groups, err := h.live.Service().Inventory(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return

--- a/internal/backup/handler.go
+++ b/internal/backup/handler.go
@@ -21,7 +21,11 @@ type Handlers struct {
 func NewHandlers(svc *Service) *Handlers { return &Handlers{svc: svc} }
 
 // Mount registers /backups, /backup-targets, /backup-schedules,
-// /backup-status under r.
+// /backup-inventory under r. The /backup-status, /backup-setup,
+// and /backup-setup/disable routes live on SetupHandlers (see
+// setup_handler.go) so they can be mounted even when the feature
+// is off — that's how an operator who hasn't configured backups
+// yet can use the UI to turn them on.
 func (h *Handlers) Mount(r chi.Router) {
 	r.Route("/backups", func(r chi.Router) {
 		r.Get("/", h.list)
@@ -47,7 +51,6 @@ func (h *Handlers) Mount(r chi.Router) {
 	})
 	h.MountExports(r)
 	h.MountImports(r)
-	r.Get("/backup-status", h.status)
 	r.Get("/backup-inventory", h.inventory)
 }
 
@@ -432,22 +435,6 @@ func (h *Handlers) inventory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"groups": groups})
-}
-
-// status surfaces feature health for the UI banner: pg_dump
-// resolved version, cipher fingerprint, etc.
-func (h *Handlers) status(w http.ResponseWriter, r *http.Request) {
-	pgVer, err := h.svc.PGVersion(r.Context())
-	resp := map[string]any{
-		"ok":                 err == nil,
-		"key_fingerprint":    h.svc.CipherFingerprint(),
-		"pg_dump_version":    pgVer,
-		"pg_restore_version": h.svc.PgRestoreVersion(r.Context()),
-	}
-	if err != nil {
-		resp["pg_dump_error"] = err.Error()
-	}
-	writeJSON(w, http.StatusOK, resp)
 }
 
 func writeJSON(w http.ResponseWriter, code int, body any) {

--- a/internal/backup/handler_export.go
+++ b/internal/backup/handler_export.go
@@ -24,7 +24,7 @@ func (h *Handlers) MountExports(r chi.Router) {
 }
 
 func (h *Handlers) listExports(w http.ResponseWriter, r *http.Request) {
-	list, err := h.svc.ListExports(r.Context())
+	list, err := h.live.Service().ListExports(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
@@ -43,7 +43,7 @@ func (h *Handlers) listExports(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handlers) getExport(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	e, err := h.svc.GetExport(r.Context(), id)
+	e, err := h.live.Service().GetExport(r.Context(), id)
 	if err != nil {
 		if errors.Is(err, ErrExportNotFound) {
 			writeError(w, http.StatusNotFound, err)
@@ -67,7 +67,7 @@ func (h *Handlers) createExport(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid body: %w", err))
 		return
 	}
-	e, err := h.svc.CreateExport(r.Context(), ExportRequest{
+	e, err := h.live.Service().CreateExport(r.Context(), ExportRequest{
 		RequestedBy:  req.RequestedBy,
 		Memories:     req.Memories,
 		Integrations: req.Integrations,
@@ -90,7 +90,7 @@ func (h *Handlers) downloadExport(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, errors.New("token query param required"))
 		return
 	}
-	rc, e, err := h.svc.DownloadExport(r.Context(), id, token)
+	rc, e, err := h.live.Service().DownloadExport(r.Context(), id, token)
 	if err != nil {
 		switch {
 		case errors.Is(err, ErrExportNotFound), errors.Is(err, ErrInvalidDownloadToken):
@@ -113,7 +113,7 @@ func (h *Handlers) downloadExport(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handlers) deleteExport(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	if err := h.svc.DeleteExport(r.Context(), id); err != nil {
+	if err := h.live.Service().DeleteExport(r.Context(), id); err != nil {
 		if errors.Is(err, ErrExportNotFound) {
 			writeError(w, http.StatusNotFound, err)
 			return

--- a/internal/backup/handler_import.go
+++ b/internal/backup/handler_import.go
@@ -26,7 +26,7 @@ func (h *Handlers) listImports(w http.ResponseWriter, r *http.Request) {
 			limit = n
 		}
 	}
-	list, err := h.svc.ListImports(r.Context(), limit)
+	list, err := h.live.Service().ListImports(r.Context(), limit)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
@@ -39,7 +39,7 @@ func (h *Handlers) listImports(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handlers) getImport(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	imp, err := h.svc.GetImport(r.Context(), id)
+	imp, err := h.live.Service().GetImport(r.Context(), id)
 	if err != nil {
 		if errors.Is(err, ErrImportNotFound) {
 			writeError(w, http.StatusNotFound, err)
@@ -74,7 +74,7 @@ func (h *Handlers) createImport(w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
-	imp, err := h.svc.ImportBundle(r.Context(), ImportRequest{
+	imp, err := h.live.Service().ImportBundle(r.Context(), ImportRequest{
 		Source:       file,
 		Filename:     hdr.Filename,
 		RequestedBy:  r.FormValue("requested_by"),

--- a/internal/backup/keyfile.go
+++ b/internal/backup/keyfile.go
@@ -1,0 +1,238 @@
+// Keyfile bridges the backup feature's master passphrase between
+// "operator pastes an env var" (the original deployment model) and
+// "operator clicks Enable in the admin UI" (the convenience model
+// added in PR #49). The two coexist with explicit priority:
+//
+//	1. OPENDRAY_BACKUP_KEY            — env var, highest priority
+//	2. $OPENDRAY_BACKUP_KEY_FILE      — path override env, file content
+//	3. ~/.opendray/secrets/backup.key — default file location
+//	4. (none — feature disabled)
+//
+// The default file lives under a dedicated `secrets/` directory at
+// the same level as the backup blob output dirs (`backups/`,
+// `exports/`), NOT inside them. That means an operator who runs
+// `tar -czf snapshot.tar.gz ~/.opendray/backups` to ship a backup
+// to cold storage will NOT accidentally include the key — anyone
+// who can read the tarball would otherwise be able to decrypt every
+// blob inside it. The separation is load-bearing.
+//
+// The env var path stays first-priority so existing systemd / docker
+// deployments that already export OPENDRAY_BACKUP_KEY keep working
+// without changes, and so an env-var setup can never be silently
+// overridden by a stale file an operator forgot was there.
+
+package backup
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// KeySource records how the passphrase was loaded, so the UI can
+// tell the operator "you're running with the env var, the Disable
+// button won't help you" or "I'll just remove the file."
+type KeySource string
+
+const (
+	// KeySourceNone — feature is off, no passphrase available
+	// from any of the three sources.
+	KeySourceNone KeySource = ""
+	// KeySourceEnv — OPENDRAY_BACKUP_KEY env var.
+	KeySourceEnv KeySource = "env"
+	// KeySourceFile — read from the default file or KEY_FILE override.
+	KeySourceFile KeySource = "file"
+)
+
+// envKey is the long-standing env var an operator can use to opt
+// into backups without ever touching the file-on-disk path. Mirrors
+// internal/app/app.go which is the original consumer of the var.
+const envKey = "OPENDRAY_BACKUP_KEY"
+
+// envKeyFile lets advanced deployments (systemd LoadCredential,
+// docker secrets mount, etc.) point at a custom file location
+// rather than dropping the passphrase into the binary's env.
+const envKeyFile = "OPENDRAY_BACKUP_KEY_FILE"
+
+// LoadResult bundles the resolved passphrase plus its provenance.
+// Callers should treat an empty Passphrase as "feature disabled,
+// don't mount handlers."
+type LoadResult struct {
+	Passphrase string
+	Source     KeySource
+	// Path is the file the passphrase was loaded from (or would
+	// have been loaded from / written to). Always populated even
+	// when Source != KeySourceFile, so the UI can show the
+	// operator the canonical location.
+	Path string
+}
+
+// LoadPassphrase walks the priority chain. Returns an empty
+// Passphrase + KeySourceNone when no source is configured (this is
+// a normal state, not an error — the feature is just off). Returns
+// a non-nil error only when a source IS configured but fails to
+// read (permissions, malformed file).
+func LoadPassphrase() (LoadResult, error) {
+	path, err := defaultKeyFilePath()
+	if err != nil {
+		// Even without a resolvable home dir we still want to
+		// honour the env-var path; just leave Path empty so the
+		// UI doesn't try to render a misleading location.
+		path = ""
+	}
+	res := LoadResult{Path: path}
+
+	if v := strings.TrimSpace(os.Getenv(envKey)); v != "" {
+		res.Passphrase = v
+		res.Source = KeySourceEnv
+		return res, nil
+	}
+
+	overridePath := strings.TrimSpace(os.Getenv(envKeyFile))
+	if overridePath != "" {
+		// An explicit override path is treated as authoritative —
+		// missing file there is a configuration error, not a
+		// silent fallback to the default. Operators who set this
+		// var intend to use that exact file.
+		passphrase, readErr := readKeyFile(overridePath)
+		if readErr != nil {
+			return res, fmt.Errorf("read %s: %w", envKeyFile, readErr)
+		}
+		res.Passphrase = passphrase
+		res.Source = KeySourceFile
+		res.Path = overridePath
+		return res, nil
+	}
+
+	if path != "" {
+		passphrase, readErr := readKeyFile(path)
+		if errors.Is(readErr, os.ErrNotExist) {
+			return res, nil
+		}
+		if readErr != nil {
+			return res, fmt.Errorf("read default keyfile: %w", readErr)
+		}
+		res.Passphrase = passphrase
+		res.Source = KeySourceFile
+		return res, nil
+	}
+
+	return res, nil
+}
+
+// WriteKeyFile atomically writes the passphrase to the default
+// keyfile location, creating parent directories as needed. Mode is
+// 0600 on the file and 0700 on the parent dir.
+//
+// Refuses overwriting an existing file by default — the UI flow
+// requires an explicit "rotate" path to avoid accidentally
+// orphaning encrypted blobs whose ciphertext can no longer be
+// recovered. Pass overwrite=true for rotation.
+//
+// Returns the canonical path written to so callers can echo it
+// back in API responses ("we wrote your key to <path>").
+func WriteKeyFile(passphrase string, overwrite bool) (string, error) {
+	if strings.TrimSpace(passphrase) == "" {
+		return "", errors.New("passphrase is empty")
+	}
+	path, err := defaultKeyFilePath()
+	if err != nil {
+		return "", fmt.Errorf("resolve key file path: %w", err)
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create secrets dir: %w", err)
+	}
+	// Tighten parent dir permissions even if it pre-existed with
+	// looser ones (e.g. the operator made it themselves). 0700 is
+	// the contract.
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return "", fmt.Errorf("chmod secrets dir: %w", err)
+	}
+
+	if !overwrite {
+		if _, statErr := os.Stat(path); statErr == nil {
+			return "", fmt.Errorf("key file already exists at %s; use rotate flow to replace", path)
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			return "", fmt.Errorf("stat key file: %w", statErr)
+		}
+	}
+
+	// Atomic write: tempfile in the same dir, fsync, rename. The
+	// rename is atomic on the same filesystem so the file is
+	// either fully there or absent — never half-written.
+	tmp, err := os.CreateTemp(dir, ".backup.key.tmp-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp key file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	// Best-effort cleanup if anything below this point fails.
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return "", fmt.Errorf("chmod temp key file: %w", err)
+	}
+	if _, err := tmp.WriteString(passphrase + "\n"); err != nil {
+		_ = tmp.Close()
+		return "", fmt.Errorf("write temp key file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return "", fmt.Errorf("fsync temp key file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("close temp key file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return "", fmt.Errorf("rename temp key file into place: %w", err)
+	}
+	return path, nil
+}
+
+// RemoveKeyFile deletes the default keyfile. No-op when the file is
+// already absent. Does NOT touch env-var-set passphrases — those
+// live in the parent process's environment and the binary can't
+// unset them.
+func RemoveKeyFile() error {
+	path, err := defaultKeyFilePath()
+	if err != nil {
+		return fmt.Errorf("resolve key file path: %w", err)
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove key file: %w", err)
+	}
+	return nil
+}
+
+// DefaultKeyFilePath exposes the canonical location for the UI to
+// display ("your key file will be saved to ~/...") without having
+// to read or write it.
+func DefaultKeyFilePath() (string, error) {
+	return defaultKeyFilePath()
+}
+
+func defaultKeyFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".opendray", "secrets", "backup.key"), nil
+}
+
+func readKeyFile(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	// Trim trailing newline + any stray whitespace from
+	// hand-edited files. Empty after trim is a corruption
+	// signal — better to fail loudly than silently disable.
+	s := strings.TrimSpace(string(b))
+	if s == "" {
+		return "", fmt.Errorf("key file %s is empty after trim", path)
+	}
+	return s, nil
+}

--- a/internal/backup/keyfile_test.go
+++ b/internal/backup/keyfile_test.go
@@ -1,0 +1,243 @@
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Each test isolates itself by pointing HOME at a fresh temp dir;
+// without that the default keyfile location would either leak the
+// real user's key into the test or write into the real ~/.opendray.
+
+func setTempHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	// Clear the two env-var inputs so individual tests can opt
+	// them back in deterministically.
+	t.Setenv(envKey, "")
+	t.Setenv(envKeyFile, "")
+	return dir
+}
+
+func TestLoadPassphrase_None(t *testing.T) {
+	setTempHome(t)
+
+	got, err := LoadPassphrase()
+	if err != nil {
+		t.Fatalf("LoadPassphrase returned err on empty env+disk: %v", err)
+	}
+	if got.Passphrase != "" {
+		t.Fatalf("expected empty passphrase, got %q", got.Passphrase)
+	}
+	if got.Source != KeySourceNone {
+		t.Fatalf("expected KeySourceNone, got %q", got.Source)
+	}
+	if !strings.HasSuffix(got.Path, "/.opendray/secrets/backup.key") {
+		t.Fatalf("expected default path under fake home, got %q", got.Path)
+	}
+}
+
+func TestLoadPassphrase_EnvVarWins(t *testing.T) {
+	setTempHome(t)
+	t.Setenv(envKey, "from-env-var-very-long-value-here")
+	// Also write a file — env must win.
+	written, err := WriteKeyFile("from-file-also-long-enough-yes", false)
+	if err != nil {
+		t.Fatalf("WriteKeyFile: %v", err)
+	}
+	if _, err := os.Stat(written); err != nil {
+		t.Fatalf("written file missing: %v", err)
+	}
+
+	got, err := LoadPassphrase()
+	if err != nil {
+		t.Fatalf("LoadPassphrase: %v", err)
+	}
+	if got.Passphrase != "from-env-var-very-long-value-here" {
+		t.Fatalf("expected env value, got %q", got.Passphrase)
+	}
+	if got.Source != KeySourceEnv {
+		t.Fatalf("expected KeySourceEnv, got %q", got.Source)
+	}
+}
+
+func TestLoadPassphrase_FileOverridePath(t *testing.T) {
+	setTempHome(t)
+	custom := filepath.Join(t.TempDir(), "my-key")
+	if err := os.WriteFile(custom, []byte("explicit-override-passphrase\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envKeyFile, custom)
+
+	got, err := LoadPassphrase()
+	if err != nil {
+		t.Fatalf("LoadPassphrase: %v", err)
+	}
+	if got.Passphrase != "explicit-override-passphrase" {
+		t.Fatalf("expected override value, got %q", got.Passphrase)
+	}
+	if got.Source != KeySourceFile {
+		t.Fatalf("expected KeySourceFile, got %q", got.Source)
+	}
+	if got.Path != custom {
+		t.Fatalf("expected Path to reflect override, got %q want %q", got.Path, custom)
+	}
+}
+
+func TestLoadPassphrase_FileOverrideMissingIsError(t *testing.T) {
+	setTempHome(t)
+	t.Setenv(envKeyFile, "/nonexistent/path/that/should/not/exist.key")
+
+	_, err := LoadPassphrase()
+	if err == nil {
+		t.Fatal("expected error when KEY_FILE override points to missing file")
+	}
+}
+
+func TestLoadPassphrase_DefaultFile(t *testing.T) {
+	setTempHome(t)
+	written, err := WriteKeyFile("disk-loaded-passphrase-here-32+", false)
+	if err != nil {
+		t.Fatalf("WriteKeyFile: %v", err)
+	}
+
+	got, err := LoadPassphrase()
+	if err != nil {
+		t.Fatalf("LoadPassphrase: %v", err)
+	}
+	if got.Passphrase != "disk-loaded-passphrase-here-32+" {
+		t.Fatalf("expected file passphrase, got %q", got.Passphrase)
+	}
+	if got.Source != KeySourceFile {
+		t.Fatalf("expected KeySourceFile, got %q", got.Source)
+	}
+	if got.Path != written {
+		t.Fatalf("Path mismatch: got %q want %q", got.Path, written)
+	}
+}
+
+func TestWriteKeyFile_PermsAndAtomicity(t *testing.T) {
+	setTempHome(t)
+	path, err := WriteKeyFile("a-suitably-long-passphrase-for-testing", false)
+	if err != nil {
+		t.Fatalf("WriteKeyFile: %v", err)
+	}
+
+	// File perms must be 0600 — anyone else on the box reading the
+	// key would defeat the whole encryption story.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("file perms: got %#o want 0600", mode)
+	}
+	// Parent dir 0700 for the same reason — a 0755 dir
+	// containing a 0600 file is fine in theory but tightening
+	// the dir is defence in depth.
+	dirInfo, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := dirInfo.Mode().Perm(); mode != 0o700 {
+		t.Errorf("dir perms: got %#o want 0700", mode)
+	}
+
+	// No stray tempfile from the atomic write — defer-cleanup
+	// only fires on error, so a successful write should leave a
+	// pristine secrets dir.
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".backup.key.tmp") {
+			t.Errorf("stray tempfile left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestWriteKeyFile_RefusesOverwrite(t *testing.T) {
+	setTempHome(t)
+	if _, err := WriteKeyFile("first-passphrase-long-enough-here", false); err != nil {
+		t.Fatalf("WriteKeyFile first call: %v", err)
+	}
+	if _, err := WriteKeyFile("second-passphrase-long-enough-no", false); err == nil {
+		t.Fatal("expected second WriteKeyFile to refuse")
+	}
+}
+
+func TestWriteKeyFile_OverwriteWhenForced(t *testing.T) {
+	setTempHome(t)
+	if _, err := WriteKeyFile("first-passphrase-long-enough-here", false); err != nil {
+		t.Fatalf("WriteKeyFile first call: %v", err)
+	}
+	path, err := WriteKeyFile("rotated-passphrase-also-long-and-fresh", true)
+	if err != nil {
+		t.Fatalf("overwrite should succeed when force=true: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(b)); got != "rotated-passphrase-also-long-and-fresh" {
+		t.Fatalf("file content not rotated: got %q", got)
+	}
+}
+
+func TestWriteKeyFile_EmptyPassphraseRejected(t *testing.T) {
+	setTempHome(t)
+	if _, err := WriteKeyFile("   ", false); err == nil {
+		t.Fatal("expected empty passphrase to be rejected")
+	}
+}
+
+func TestRemoveKeyFile_NoErrorWhenAbsent(t *testing.T) {
+	setTempHome(t)
+	if err := RemoveKeyFile(); err != nil {
+		t.Fatalf("RemoveKeyFile on empty dir should be a no-op: %v", err)
+	}
+}
+
+func TestRemoveKeyFile_Removes(t *testing.T) {
+	setTempHome(t)
+	path, err := WriteKeyFile("a-suitably-long-passphrase-for-testing", false)
+	if err != nil {
+		t.Fatalf("WriteKeyFile: %v", err)
+	}
+	if err := RemoveKeyFile(); err != nil {
+		t.Fatalf("RemoveKeyFile: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected file removed, got stat err=%v", err)
+	}
+}
+
+func TestReadKeyFile_TrimsAndRejectsEmpty(t *testing.T) {
+	dir := t.TempDir()
+
+	// Trailing newline + whitespace stripped.
+	withWS := filepath.Join(dir, "ws.key")
+	if err := os.WriteFile(withWS, []byte("  hello-world  \n\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readKeyFile(withWS)
+	if err != nil {
+		t.Fatalf("readKeyFile: %v", err)
+	}
+	if got != "hello-world" {
+		t.Fatalf("got %q, want %q", got, "hello-world")
+	}
+
+	// Pure whitespace → error, not silent empty success.
+	empty := filepath.Join(dir, "empty.key")
+	if err := os.WriteFile(empty, []byte("   \n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readKeyFile(empty); err == nil {
+		t.Fatal("expected whitespace-only file to error")
+	}
+}

--- a/internal/backup/live.go
+++ b/internal/backup/live.go
@@ -1,0 +1,241 @@
+// LiveBackup is the runtime lifecycle manager for the backup
+// feature. It owns:
+//
+//	- The current *Service (or nil when feature is off)
+//	- The Scheduler goroutine + its cancel function
+//
+// Both are swapped atomically by Arm/Disarm so other parts of the
+// process can keep a stable *LiveBackup reference and ask "is the
+// feature on right now?" via Service() — a single atomic load,
+// safe to call on every HTTP request.
+//
+// The point of this struct is to let /backup-setup turn the
+// feature on without restarting opendray: a chi.Mux that's already
+// running can't have new routes added thread-safely, but a wrapper
+// handler whose internals are swappable via atomic.Pointer is.
+// Handlers (the HTTP routes) is mounted ONCE at startup against a
+// LiveBackup; each route reads the live Service via Service() and
+// 503s if it returns nil (see requireArmed middleware in
+// handler.go).
+//
+// Concurrency model: a sync.Mutex serializes Arm and Disarm calls
+// to keep the "stop old scheduler, start new scheduler, swap
+// router state" sequence consistent. Reads (Service()) are
+// lock-free.
+
+package backup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// LiveBackup is the lifecycle handle exposed to handlers and the
+// rest of the app. Construct one at startup; pass the same
+// pointer to Handlers, SetupHandlers, and the summarizer cipher
+// adapter — none of them need to know whether the feature is
+// currently armed.
+type LiveBackup struct {
+	cfg  Config
+	deps liveDeps
+	log  *slog.Logger
+
+	state atomic.Pointer[liveState]
+
+	// Serializes Arm / Disarm. Reads via Service() are lock-free.
+	armMu sync.Mutex
+}
+
+// liveDeps captures everything the Service constructor needs
+// except the passphrase, which arrives at Arm() time.
+type liveDeps struct {
+	pool       *pgxpool.Pool
+	dsn        string
+	configPath string
+}
+
+// liveState bundles everything that must swap together when the
+// feature is (re)armed: the Service itself plus the scheduler's
+// cancel func. atomic.Pointer[liveState] is the single source of
+// truth.
+type liveState struct {
+	svc        *Service
+	cancelSched context.CancelFunc
+}
+
+// NewLiveBackup constructs a lifecycle handle. The returned
+// LiveBackup is initially DISARMED — call Arm to turn the feature
+// on (either at startup, when a passphrase is found via
+// LoadPassphrase, or later when the operator hits /backup-setup
+// from the UI).
+//
+// pool / dsn / configPath are captured here because the Service
+// constructor needs them every time we Arm. log is reused.
+func NewLiveBackup(
+	cfg Config,
+	pool *pgxpool.Pool,
+	dsn string,
+	configPath string,
+	log *slog.Logger,
+) *LiveBackup {
+	return &LiveBackup{
+		cfg: cfg,
+		deps: liveDeps{
+			pool:       pool,
+			dsn:        dsn,
+			configPath: configPath,
+		},
+		log: log,
+	}
+}
+
+// Service returns the live backup Service, or nil when the feature
+// is off. Cheap atomic load — safe on every request path.
+func (l *LiveBackup) Service() *Service {
+	st := l.state.Load()
+	if st == nil {
+		return nil
+	}
+	return st.svc
+}
+
+// IsArmed is a thin shortcut for callers that only need the
+// boolean. Equivalent to `Service() != nil`.
+func (l *LiveBackup) IsArmed() bool { return l.Service() != nil }
+
+// Arm builds a fresh Service from the given passphrase, bootstraps
+// it (runs migrations / pg_dump probe), starts a scheduler under a
+// cancellable context, and atomically swaps the live state.
+//
+// If the feature was already armed, the old scheduler is cancelled
+// after the new state is in place — order matters so requests
+// in-flight against the old Service complete instead of seeing nil
+// mid-request.
+//
+// ctx is used as the scheduler's parent context; pass the app's
+// long-lived context (the one that closes on opendray shutdown)
+// so the scheduler stops cleanly on process exit.
+func (l *LiveBackup) Arm(ctx context.Context, passphrase string) error {
+	if passphrase == "" {
+		return errors.New("Arm called with empty passphrase")
+	}
+	svc, err := NewService(l.cfg, ServiceDeps{
+		Pool:       l.deps.pool,
+		Passphrase: passphrase,
+		DSN:        l.deps.dsn,
+		ConfigPath: l.deps.configPath,
+		Log:        l.log,
+	})
+	if err != nil {
+		return fmt.Errorf("init service: %w", err)
+	}
+	if err := svc.Bootstrap(ctx); err != nil {
+		return fmt.Errorf("bootstrap: %w", err)
+	}
+	return l.armWithService(ctx, svc)
+}
+
+// ArmWithService is the same as Arm but takes a pre-built Service
+// (used at app startup where we want to construct + Bootstrap
+// outside of the LiveBackup so init errors short-circuit boot
+// rather than getting buried inside Arm).
+func (l *LiveBackup) ArmWithService(ctx context.Context, svc *Service) error {
+	if svc == nil {
+		return errors.New("ArmWithService called with nil svc")
+	}
+	return l.armWithService(ctx, svc)
+}
+
+func (l *LiveBackup) armWithService(ctx context.Context, svc *Service) error {
+	l.armMu.Lock()
+	defer l.armMu.Unlock()
+
+	// Start the scheduler goroutine under a cancellable context.
+	// Each Arm gets its own context; the cancel func is stored in
+	// liveState so a subsequent Disarm or re-Arm can stop only the
+	// goroutine it spawned.
+	schedCtx, cancel := context.WithCancel(ctx)
+	sched := NewScheduler(svc, 0)
+	go sched.Run(schedCtx)
+
+	newState := &liveState{svc: svc, cancelSched: cancel}
+	old := l.state.Swap(newState)
+	if old != nil {
+		// Cancel old scheduler AFTER the swap, so any handler that
+		// loaded the old state mid-request keeps a valid Service
+		// until its request completes.
+		old.cancelSched()
+	}
+	if l.log != nil {
+		l.log.Info("backup armed",
+			"key_fingerprint", svc.CipherFingerprint())
+	}
+	return nil
+}
+
+// Disarm stops the scheduler and clears the live state. Idempotent
+// — calling Disarm on an already-off LiveBackup is a no-op.
+// Returns the previously-active Service (or nil) so callers can
+// release any external state they hold; in practice nothing else
+// does, so the return is usually ignored.
+func (l *LiveBackup) Disarm() *Service {
+	l.armMu.Lock()
+	defer l.armMu.Unlock()
+	old := l.state.Swap(nil)
+	if old == nil {
+		return nil
+	}
+	old.cancelSched()
+	if l.log != nil {
+		l.log.Info("backup disarmed")
+	}
+	return old.svc
+}
+
+// liveCipher adapts a LiveBackup to the summarizer.Cipher
+// interface (EncryptField + DecryptField). It re-reads the live
+// Service on every call so summarizer code can encrypt API keys
+// even when the operator armed backup via UI mid-runtime — no
+// restart required for anthropic provider setup. When the feature
+// is off, both methods return ErrCipherNotArmed.
+type liveCipher struct {
+	live *LiveBackup
+}
+
+// ErrCipherNotArmed signals to the summarizer that no backup
+// cipher is available right now. Surfaced as a 400 when an
+// operator tries to add an anthropic provider before backups are
+// enabled.
+var ErrCipherNotArmed = errors.New("backup cipher not configured — enable backups first")
+
+func (c *liveCipher) EncryptField(plain string) (string, error) {
+	svc := c.live.Service()
+	if svc == nil {
+		return "", ErrCipherNotArmed
+	}
+	return svc.cipher.EncryptField(plain)
+}
+
+func (c *liveCipher) DecryptField(envelope string) (string, error) {
+	svc := c.live.Service()
+	if svc == nil {
+		return "", ErrCipherNotArmed
+	}
+	return svc.cipher.DecryptField(envelope)
+}
+
+// NewLiveCipher returns a summarizer-compatible cipher backed by
+// the given LiveBackup. The wrapper survives Arm/Disarm calls —
+// each EncryptField/DecryptField re-reads the live Service.
+func NewLiveCipher(l *LiveBackup) interface {
+	EncryptField(plain string) (string, error)
+	DecryptField(envelope string) (string, error)
+} {
+	return &liveCipher{live: l}
+}

--- a/internal/backup/live.go
+++ b/internal/backup/live.go
@@ -65,7 +65,7 @@ type liveDeps struct {
 // cancel func. atomic.Pointer[liveState] is the single source of
 // truth.
 type liveState struct {
-	svc        *Service
+	svc         *Service
 	cancelSched context.CancelFunc
 }
 

--- a/internal/backup/setup_handler.go
+++ b/internal/backup/setup_handler.go
@@ -23,6 +23,7 @@
 package backup
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
@@ -37,28 +38,27 @@ import (
 
 // SetupHandlers — see file header. Always-mountable.
 //
-// Carries a concrete *Service rather than an interface so callers
-// can pass an untyped nil (e.g. `NewSetupHandlers(nil, ...)`)
-// without tripping the classic interface-holding-typed-nil gotcha
-// — `h.svc != nil` checks below mean exactly what they look like.
+// Carries a *LiveBackup whose Service() pointer flips at runtime
+// in response to /backup-setup and /backup-setup/disable. The
+// status endpoint reads live state via that pointer; setup/disable
+// arm/disarm it directly.
 type SetupHandlers struct {
-	// svc is non-nil iff the feature is currently active in this
-	// process. When nil, only Setup + status (with enabled=false)
-	// work; the live data routes (list/run/etc.) aren't wired.
-	svc *Service
+	live *LiveBackup
 	// bootSource records how (or whether) the passphrase was
 	// loaded at app start. The UI uses this to choose between
 	// "Setup" (no source) and "Already configured via env / file"
-	// flows — the latter has limited disable-via-UI capability.
+	// flows — the env case has limited disable-via-UI capability
+	// (we can't unset an env var in our parent process).
 	bootSource KeySource
 }
 
-// NewSetupHandlers constructs SetupHandlers. Pass nil svc when the
-// backup feature failed to load (no passphrase). Pass bootSource
-// from the LoadPassphrase call in app startup so the UI can
-// distinguish env-var vs file-loaded deployments.
-func NewSetupHandlers(svc *Service, bootSource KeySource) *SetupHandlers {
-	return &SetupHandlers{svc: svc, bootSource: bootSource}
+// NewSetupHandlers constructs SetupHandlers. live must be non-nil
+// (it's the single shared lifecycle handle the rest of the app
+// uses too). bootSource comes from the LoadPassphrase call in app
+// startup so the UI can distinguish env-var vs file-loaded
+// deployments.
+func NewSetupHandlers(live *LiveBackup, bootSource KeySource) *SetupHandlers {
+	return &SetupHandlers{live: live, bootSource: bootSource}
 }
 
 // Mount the three always-on endpoints under r. The caller is
@@ -91,27 +91,30 @@ func (h *SetupHandlers) Mount(r chi.Router) {
 //	pg_dump_error       string   — only on !ok
 func (h *SetupHandlers) status(w http.ResponseWriter, r *http.Request) {
 	keyPath, _ := DefaultKeyFilePath()
-	// Re-check disk state on every call rather than caching boot
-	// state: if the operator wrote the file via /backup-setup,
-	// hits status before restart, the response should reflect
-	// "configured but not yet enabled" — i.e. requires_restart.
+	// Re-check disk state on every call so we don't lie about
+	// "configured" right after a /backup-setup/disable.
 	currentLoad, _ := LoadPassphrase()
 
+	svc := h.live.Service()
 	resp := map[string]any{
-		"enabled":            h.svc != nil,
+		"enabled":            svc != nil,
 		"configured":         currentLoad.Passphrase != "",
 		"configured_via":     string(currentLoad.Source),
 		"can_disable_via_ui": currentLoad.Source == KeySourceFile,
-		"requires_restart":   h.svc == nil && currentLoad.Passphrase != "",
-		"key_file_path":      keyPath,
+		// requires_restart now only fires for the env-var edge
+		// case: an operator set OPENDRAY_BACKUP_KEY but hasn't
+		// restarted the process yet. The file path is handled
+		// in-process by Arm/Disarm so it doesn't trigger this.
+		"requires_restart": svc == nil && currentLoad.Source == KeySourceEnv,
+		"key_file_path":    keyPath,
 	}
 
-	if h.svc != nil {
-		pgVer, err := h.svc.PGVersion(r.Context())
+	if svc != nil {
+		pgVer, err := svc.PGVersion(r.Context())
 		resp["ok"] = err == nil
-		resp["key_fingerprint"] = h.svc.CipherFingerprint()
+		resp["key_fingerprint"] = svc.CipherFingerprint()
 		resp["pg_dump_version"] = pgVer
-		resp["pg_restore_version"] = h.svc.PgRestoreVersion(r.Context())
+		resp["pg_restore_version"] = svc.PgRestoreVersion(r.Context())
 		if err != nil {
 			resp["pg_dump_error"] = err.Error()
 		}
@@ -204,10 +207,27 @@ func (h *SetupHandlers) setup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Hot-arm: build a fresh Service + scheduler in-process and
+	// activate the data routes. r.Context() is request-scoped, so
+	// we pass context.Background() for the scheduler — it needs
+	// to outlive this request. (The scheduler ends when the
+	// LiveBackup gets Disarmed or the process exits.)
+	if err := h.live.Arm(context.Background(), passphrase); err != nil {
+		// Roll back the keyfile so the next /backup-status report
+		// doesn't show "configured" while the feature is actually
+		// in a broken half-state. The operator should see a clean
+		// error and try again.
+		_ = RemoveKeyFile()
+		writeError(w, http.StatusInternalServerError,
+			fmt.Errorf("arm backup feature: %w", err))
+		return
+	}
+
 	resp := map[string]any{
 		"ok":               true,
 		"key_file_path":    path,
-		"requires_restart": true,
+		"enabled":          true,
+		"requires_restart": false,
 	}
 	// Only return the passphrase on `generate` — pasted ones are
 	// already known to the caller. Returning it twice would give
@@ -238,9 +258,14 @@ func (h *SetupHandlers) disable(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
+	// Hot-disarm: stops the scheduler goroutine and flips the
+	// Service pointer to nil. Subsequent requests to /backups etc.
+	// get 503 via requireArmed middleware.
+	h.live.Disarm()
 	writeJSON(w, http.StatusOK, map[string]any{
 		"ok":               true,
-		"requires_restart": h.svc != nil, // only need restart if the feature is currently on
+		"enabled":          false,
+		"requires_restart": false,
 	})
 }
 

--- a/internal/backup/setup_handler.go
+++ b/internal/backup/setup_handler.go
@@ -1,0 +1,255 @@
+// SetupHandlers wires the three always-mounted endpoints that let
+// the admin UI / mobile app drive the backup-feature lifecycle:
+//
+//	GET  /backup-status         feature state + key file location
+//	POST /backup-setup          generate or paste a passphrase, write the key file
+//	POST /backup-setup/disable  remove the key file
+//
+// These three routes are mounted under the admin auth group
+// regardless of whether the backup data handlers (the ones in
+// Handlers.Mount) are wired up — that's how a user without backups
+// enabled can use the UI to turn the feature on. The status route
+// in particular is no longer a 404-vs-200 channel; it always
+// responds 200 with a JSON describing exactly which side of "off"
+// or "on" the server is on.
+//
+// The actual flip from "off" to "on" requires an opendray restart:
+// the cipher needs the passphrase at NewService() time and the
+// service is created during boot. The setup endpoint writes the
+// key file and returns requires_restart=true so the UI can show a
+// "please restart" screen rather than pretend the feature is
+// instantly live.
+
+package backup
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// SetupHandlers — see file header. Always-mountable.
+//
+// Carries a concrete *Service rather than an interface so callers
+// can pass an untyped nil (e.g. `NewSetupHandlers(nil, ...)`)
+// without tripping the classic interface-holding-typed-nil gotcha
+// — `h.svc != nil` checks below mean exactly what they look like.
+type SetupHandlers struct {
+	// svc is non-nil iff the feature is currently active in this
+	// process. When nil, only Setup + status (with enabled=false)
+	// work; the live data routes (list/run/etc.) aren't wired.
+	svc *Service
+	// bootSource records how (or whether) the passphrase was
+	// loaded at app start. The UI uses this to choose between
+	// "Setup" (no source) and "Already configured via env / file"
+	// flows — the latter has limited disable-via-UI capability.
+	bootSource KeySource
+}
+
+// NewSetupHandlers constructs SetupHandlers. Pass nil svc when the
+// backup feature failed to load (no passphrase). Pass bootSource
+// from the LoadPassphrase call in app startup so the UI can
+// distinguish env-var vs file-loaded deployments.
+func NewSetupHandlers(svc *Service, bootSource KeySource) *SetupHandlers {
+	return &SetupHandlers{svc: svc, bootSource: bootSource}
+}
+
+// Mount the three always-on endpoints under r. The caller is
+// responsible for putting this inside the admin-auth group — none
+// of these routes are safe for public access.
+func (h *SetupHandlers) Mount(r chi.Router) {
+	r.Get("/backup-status", h.status)
+	r.Post("/backup-setup", h.setup)
+	r.Post("/backup-setup/disable", h.disable)
+}
+
+// status replies with a JSON map describing the feature's current
+// state. Response shape (all keys always present):
+//
+//	enabled                bool     — feature is actively running in this process
+//	configured             bool     — a passphrase file exists on disk OR env var is set
+//	configured_via         string   — "env" | "file" | ""
+//	can_disable_via_ui     bool     — false when configured_via == "env"
+//	requires_restart       bool     — true when configured but !enabled (UI just wrote a file)
+//	key_file_path          string   — canonical default location, always populated for UX
+//
+// When enabled is true the following are also populated (parity
+// with the original /backup-status response so existing clients
+// keep working):
+//
+//	ok                  bool
+//	key_fingerprint     string
+//	pg_dump_version     string
+//	pg_restore_version  string
+//	pg_dump_error       string   — only on !ok
+func (h *SetupHandlers) status(w http.ResponseWriter, r *http.Request) {
+	keyPath, _ := DefaultKeyFilePath()
+	// Re-check disk state on every call rather than caching boot
+	// state: if the operator wrote the file via /backup-setup,
+	// hits status before restart, the response should reflect
+	// "configured but not yet enabled" — i.e. requires_restart.
+	currentLoad, _ := LoadPassphrase()
+
+	resp := map[string]any{
+		"enabled":            h.svc != nil,
+		"configured":         currentLoad.Passphrase != "",
+		"configured_via":     string(currentLoad.Source),
+		"can_disable_via_ui": currentLoad.Source == KeySourceFile,
+		"requires_restart":   h.svc == nil && currentLoad.Passphrase != "",
+		"key_file_path":      keyPath,
+	}
+
+	if h.svc != nil {
+		pgVer, err := h.svc.PGVersion(r.Context())
+		resp["ok"] = err == nil
+		resp["key_fingerprint"] = h.svc.CipherFingerprint()
+		resp["pg_dump_version"] = pgVer
+		resp["pg_restore_version"] = h.svc.PgRestoreVersion(r.Context())
+		if err != nil {
+			resp["pg_dump_error"] = err.Error()
+		}
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// setupRequest is the body for POST /backup-setup.
+//
+//	{"mode": "generate"}              — server picks a random 32-byte key,
+//	                                    base64-encodes it, returns it once.
+//	{"mode": "paste", "passphrase":"..."} — operator-supplied; we just store it.
+type setupRequest struct {
+	Mode       string `json:"mode"`
+	Passphrase string `json:"passphrase"`
+	// Overwrite forces replacing an existing key file. Reserved
+	// for a future rotation flow; the default (false) refuses to
+	// overwrite, which protects against the "I have encrypted
+	// blobs already, don't lose my key" footgun.
+	Overwrite bool `json:"overwrite"`
+}
+
+// minPassphraseLen — sized to be marginally inconvenient for
+// dictionary attack while still being possible to type or paste
+// from a password manager. Generated keys are longer (44 chars
+// after base64-encoding 32 random bytes); only the paste-your-own
+// path needs validation.
+const minPassphraseLen = 20
+
+// setup writes the key file and tells the caller to restart.
+//
+// Refuses when an env-var passphrase is already active — that path
+// is what the operator opted into; silently overwriting it with a
+// file-based one would mean the env var still wins next boot, and
+// the file would be effectively dead. The UI should see
+// can_disable_via_ui=false and gate the Setup button accordingly,
+// but server-side check is the load-bearing guard.
+func (h *SetupHandlers) setup(w http.ResponseWriter, r *http.Request) {
+	if h.bootSource == KeySourceEnv {
+		writeError(w, http.StatusConflict,
+			errors.New("backup is already configured via OPENDRAY_BACKUP_KEY env var; unset it before configuring via UI"))
+		return
+	}
+
+	var req setupRequest
+	if err := decodeJSON(r.Body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("decode body: %w", err))
+		return
+	}
+
+	var passphrase string
+	switch strings.ToLower(strings.TrimSpace(req.Mode)) {
+	case "generate":
+		var b [32]byte
+		if _, err := rand.Read(b[:]); err != nil {
+			writeError(w, http.StatusInternalServerError,
+				fmt.Errorf("read random bytes: %w", err))
+			return
+		}
+		// URLEncoding gives base64 without `/` or `+`, safer for
+		// copy-paste into shell or env files (`/` is harmless,
+		// `+` confuses some prompts). Length is 44 chars including
+		// the trailing `=` padding.
+		passphrase = base64.URLEncoding.EncodeToString(b[:])
+	case "paste":
+		p := strings.TrimSpace(req.Passphrase)
+		if len(p) < minPassphraseLen {
+			writeError(w, http.StatusBadRequest,
+				fmt.Errorf("passphrase must be at least %d characters", minPassphraseLen))
+			return
+		}
+		passphrase = p
+	default:
+		writeError(w, http.StatusBadRequest,
+			errors.New(`mode must be "generate" or "paste"`))
+		return
+	}
+
+	path, err := WriteKeyFile(passphrase, req.Overwrite)
+	if err != nil {
+		// "already exists" is a 409 (Conflict), everything else
+		// is a 500. We don't want to leak the passphrase back
+		// to the operator from a generate flow if writing failed
+		// — they'd have a key with no way to retrieve it.
+		if strings.Contains(err.Error(), "already exists") {
+			writeError(w, http.StatusConflict, err)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	resp := map[string]any{
+		"ok":               true,
+		"key_file_path":    path,
+		"requires_restart": true,
+	}
+	// Only return the passphrase on `generate` — pasted ones are
+	// already known to the caller. Returning it twice would give
+	// the impression we're stashing it somewhere recoverable.
+	if strings.EqualFold(req.Mode, "generate") {
+		resp["passphrase"] = passphrase
+	}
+	writeJSON(w, http.StatusCreated, resp)
+}
+
+// disable removes the default key file. Does not touch env-var
+// passphrases. Refuses when bootSource is env — the file isn't
+// what's keeping the feature on, so removing it would be a no-op
+// and we'd rather surface that clearly than pretend success.
+//
+// Importantly: existing encrypted backups remain on disk and are
+// unreadable without the passphrase. The UI must warn about this
+// before sending the request. Server-side we don't refuse — the
+// operator might intentionally want to "lose" backups (e.g. test
+// data) — but the warning is critical for production.
+func (h *SetupHandlers) disable(w http.ResponseWriter, r *http.Request) {
+	if h.bootSource == KeySourceEnv {
+		writeError(w, http.StatusConflict,
+			errors.New("backup is configured via OPENDRAY_BACKUP_KEY env var; UI cannot remove env vars — unset OPENDRAY_BACKUP_KEY in the parent process and restart"))
+		return
+	}
+	if err := RemoveKeyFile(); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":               true,
+		"requires_restart": h.svc != nil, // only need restart if the feature is currently on
+	})
+}
+
+// decodeJSON is a tiny helper to keep the request handlers tidy.
+// We don't bother with a maxBytes limit — these handlers only
+// accept tiny JSON bodies (mode + passphrase) and chi's default
+// timeout middleware caps body read size at the gateway layer.
+func decodeJSON(r io.Reader, v any) error {
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+	return dec.Decode(v)
+}


### PR DESCRIPTION
## Summary

Operators can now enable, configure, and live-disable backups entirely from the mobile app or web admin — no shell access, no env-var editing, **no server restart**. Setup writes the passphrase to a tightly-permissioned file and immediately arms the feature in-process; the data routes (`/backups`, `/backup-schedules`, `/backup-targets`) flip from 503 → 200 within the same HTTP roundtrip.

Before: "backups disabled, set OPENDRAY_BACKUP_KEY and restart" with no UI path forward.
After: Setup wizard with Generate (server-random 32-byte key, shown once) or Paste options. Submit → feature is live → operator sees the live dashboard on the next status fetch.

## Architecture

### Passphrase priority (new `internal/backup/keyfile.go`)
1. `OPENDRAY_BACKUP_KEY` env var
2. `OPENDRAY_BACKUP_KEY_FILE` env-var path override
3. `~/.opendray/secrets/backup.key` default (UI-written)
4. None — feature stays off

The `secrets/` dir is deliberately separate from `~/.opendray/backups` so a `tar -czf` of the backup blobs won't accidentally include the key that decrypts them. File 0600, dir 0700, atomic write (tempfile → fsync → rename).

### Runtime lifecycle (new `internal/backup/live.go`)
`LiveBackup` owns the Service + scheduler goroutine + cancel func, swapping them as a single `atomic.Pointer[liveState]` for lock-free reads. `Arm(ctx, passphrase)` builds + bootstraps a Service, starts the scheduler, atomically activates routing. `Disarm()` cancels the scheduler and flips Service() to nil.

### Always-mounted endpoints (new `setup_handler.go`)
- `GET /backup-status` — always 200, returns `{enabled, configured, configured_via, can_disable_via_ui, requires_restart, key_file_path}` plus pg_dump fields when enabled
- `POST /backup-setup` — `{mode: generate|paste, passphrase?}`, writes keyfile, **calls `liveBackup.Arm`**, returns `{enabled: true, requires_restart: false, passphrase?}` (passphrase only on generate, shown once)
- `POST /backup-setup/disable` — removes keyfile, **calls `liveBackup.Disarm`**, 409 when configured via env var

### Data routes (refactored `handler.go`)
Always mounted at startup. Wrapped in `requireArmed` middleware that returns 503 with a clear error when `LiveBackup.Service() == nil`. Every handler method reads svc via `h.live.Service()` — single atomic load per request.

### Summarizer cipher
`NewLiveCipher` wraps LiveBackup and is passed to the summarizer instead of a one-shot cipher captured at boot. Operators can add anthropic providers immediately after arming backups via UI — no restart for AI provider setup either.

## UI three-state machine (mobile + web symmetric)

- `enabled=true` → live dashboard (Backups ready banner, summary card, list + Run-now FAB)
- `enabled=false, requires_restart=true` → "Restart opendray" panel (env-var edge case only — file-based setup never triggers this since we hot-arm)
- `enabled=false` → Setup wizard with Generate / Paste tabs

Generate path forces an "I've saved this" checkbox before letting the operator proceed.

## Semantics shift

Previously `[backup] enabled = true` in config.toml gated passphrase loading. Now passphrase availability alone enables the feature. The legacy config flag is kept only as a misconfiguration signal — `enabled=true` + no passphrase still hard-fails at boot.

Repo's not public yet, so the breaking change is acceptable.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race ./internal/backup/` ok (12 new keyfile tests covering read priority, perms, atomicity, refuse-overwrite, whitespace trim)
- [x] `flutter analyze` 0 issues
- [x] `pnpm build` (web) ok
- [x] **Smoke on iOS simulator**: opendray boots disarmed, Setup wizard appears; Generate → passphrase shown once + force-save checkbox; Continue → live dashboard with green banner, no restart between
- [ ] **Manual on prod-like server** (operator validation):
  - [ ] Fresh install (no env, no file) → Setup wizard
  - [ ] Generate → key file appears at `~/.opendray/secrets/backup.key` with mode 0600
  - [ ] Backups page transitions to live dashboard immediately (no restart needed)
  - [ ] Run now produces a successful backup
  - [ ] `POST /backup-setup/disable` → status flips back to off, file removed
  - [ ] Existing env-var setup (OPENDRAY_BACKUP_KEY set) → `configured_via=env`, setup button refused 409, RestartRequired card surfaces if unset+restarted

## Follow-up (separate PR)

- **Mobile target editor** (`feat/mobile-backup-targets-crud`) — currently mobile only lists/tests/toggles/deletes targets; per-kind create/edit (S3 / SMB / SFTP / WebDAV / rclone) lives only on web. With this PR's "mobile-only operator" goal achieved for setup, the targets editor closes the remaining gap.
- Passphrase rotation (re-encrypt existing blobs with a new key) — complex, dedicated PR
- ADR for the keyfile + LiveBackup architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)