### PR TITLE
fix(ci): GHCR job emits tags on workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,15 +190,24 @@ jobs:
       # incorrectly move :latest. Mitigation: dispatch only the
       # current/latest tag, or accept that follow-up rebuilds
       # require a manual `docker tag` to fix :latest afterwards.
+      # `value=${{ env.TAG }}` overrides on every rule so the same
+      # ruleset works for both trigger paths:
+      #   * push on a `v*` tag — github.ref is `refs/tags/vX.Y.Z`,
+      #     metadata-action would derive the semver itself.
+      #   * workflow_dispatch — github.ref is `refs/heads/main`, so
+      #     the action's default tag-derivation finds nothing and
+      #     emits zero tags (buildx then fails with "tag is needed
+      #     when pushing to registry"). Forcing `value=` from the
+      #     dispatch input bypasses ref inspection entirely.
       - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
         id: meta
         with:
           images: ghcr.io/opendray/opendray
           flavor: latest=auto
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=ref,event=tag
+            type=semver,pattern={{version}},value=${{ env.TAG }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ env.TAG }}
+            type=raw,value=${{ env.TAG }}
 
       - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Release workflow's `ghcr` job now produces image tags on
+  `workflow_dispatch`. `docker/metadata-action` was reading
+  `github.ref` (a branch when dispatched manually), so `type=semver`
+  rules emitted zero tags and buildx failed with "tag is needed when
+  pushing to registry". Each rule now passes `value=${{ env.TAG }}`
+  so the same ruleset works for both `push:tags` and
+  `workflow_dispatch` entry points.
+
 ### Added
 
 - Release workflow gains a `ghcr` job that builds the multi-arch


### PR DESCRIPTION
## Summary

Fixes a workflow bug introduced in #39 (GHCR push job): on
`workflow_dispatch`, `docker/metadata-action` was reading
`github.ref` = `refs/heads/main` (not a tag), so the `type=semver`
rules emitted zero tags and `buildx build` failed with:

> ERROR: failed to build: tag is needed when pushing to registry

Reproduced in [run 25697466554](https://github.com/Opendray/opendray_v2/actions/runs/25697466554) — release job succeeded, GHCR job failed in 19s.

## Fix

Pass `value=${{ env.TAG }}` on every rule so the action uses the
already-resolved `TAG` env (which handles both `push:tags` and
`workflow_dispatch`). Replaced the redundant `type=ref,event=tag`
with `type=raw,value=${{ env.TAG }}` so the literal `:vX.Y.Z` tag
is still produced.

**Tag set unchanged** — still `:1.0.0`, `:1.0`, `:v1.0.0`, plus
`:latest` for non-prerelease semver.

**No behavioural change on the `push:tags` path** — same metadata
produced, same buildx args, same tag set. The override is a no-op
when the action would have derived the same value itself.

## Test plan

- [ ] Merge and `workflow_dispatch` Release against `v1.0.0`.
- [ ] Confirm GHCR job's buildx command line includes `--tag ghcr.io/opendray/opendray:1.0.0` (and the rest of the set).
- [ ] Confirm images appear at https://github.com/Opendray/opendray_v2/pkgs/container/opendray.
- [ ] `docker pull ghcr.io/opendray/opendray:1.0.0` + `--platform linux/arm64` smoke test.

## Notes for reviewer

I'm fixing this on the same release-pipeline path I introduced in #39 so the existing trace from run 25697466554 is the regression test — that run failed with empty tags, this PR makes it not-empty. Happy to amend if you prefer a different shape (e.g. keeping `type=ref,event=tag` and only overriding the semver rules, or using `${{ steps.meta_build.outputs.VERSION }}` instead of `env.TAG`).