### PR TITLE
feat(mobile): Settings screen + light theme + appearance picker

### DIFF
--- a/app/mobile/lib/core/theme/app_theme.dart
+++ b/app/mobile/lib/core/theme/app_theme.dart
@@ -1,17 +1,37 @@
 import 'package:flutter/material.dart';
 
-// Material 3 dark theme, single design language with the web SPA.
-// Color palette mirrors app/web/src/index.css custom properties so
-// screens look like one product across surfaces.
+// Material 3 themes for the mobile app. Single design language with
+// the web SPA: the dark palette mirrors app/web/src/index.css custom
+// properties so screens look like one product across surfaces.
+//
+// The light variant was added in PR #51 to let operators flip the
+// app to match their phone's system appearance. The same accent
+// (#e6ae57) drives both variants — only the surface / text / border
+// tokens swap.
 class AppTheme {
   AppTheme._();
 
-  static const _accent = Color(0xFFE6AE57); // #e6ae57 — opendray accent
-  static const _bg = Color(0xFF0E0F11);
-  static const _card = Color(0xFF161718);
-  static const _border = Color(0xFF2A2C30);
-  static const _muted = Color(0xFF8B9098);
+  // Shared accent. Used as primary in both variants.
+  static const _accent = Color(0xFFE6AE57);
   static const _destructive = Color(0xFFE07A5F);
+
+  // ── Dark palette ────────────────────────────────────────────
+  static const _darkBg = Color(0xFF0E0F11);
+  static const _darkCard = Color(0xFF161718);
+  static const _darkBorder = Color(0xFF2A2C30);
+  static const _darkMuted = Color(0xFF8B9098);
+  static const _darkInput = Color(0xFF111214);
+
+  // ── Light palette ───────────────────────────────────────────
+  // Chosen to keep readable contrast against the same accent. Off-
+  // white background (not pure #FFFFFF) reduces glare under bright
+  // sunlight, common when the operator uses the phone outdoors.
+  static const _lightBg = Color(0xFFF7F7F5);
+  static const _lightCard = Color(0xFFFFFFFF);
+  static const _lightBorder = Color(0xFFE3E4E7);
+  static const _lightMuted = Color(0xFF6B7280);
+  static const _lightInput = Color(0xFFFAFAF9);
+  static const _lightText = Color(0xFF111418);
 
   static ThemeData dark() {
     const scheme = ColorScheme.dark(
@@ -19,51 +39,109 @@ class AppTheme {
       onPrimary: Color(0xFF1A1308),
       secondary: _accent,
       onSecondary: Color(0xFF1A1308),
-      surface: _card,
+      surface: _darkCard,
       onSurface: Colors.white,
-      surfaceContainerHighest: _card,
+      surfaceContainerHighest: _darkCard,
       error: _destructive,
       onError: Colors.white,
-      outline: _border,
-      outlineVariant: _border,
+      outline: _darkBorder,
+      outlineVariant: _darkBorder,
     );
 
+    return _build(
+      brightness: Brightness.dark,
+      scheme: scheme,
+      bg: _darkBg,
+      card: _darkCard,
+      border: _darkBorder,
+      muted: _darkMuted,
+      inputFill: _darkInput,
+      bodyColor: Colors.white,
+      appBarFg: Colors.white,
+      navUnselected: _darkMuted,
+    );
+  }
+
+  static ThemeData light() {
+    const scheme = ColorScheme.light(
+      primary: _accent,
+      onPrimary: Color(0xFF1A1308),
+      secondary: _accent,
+      onSecondary: Color(0xFF1A1308),
+      surface: _lightCard,
+      onSurface: _lightText,
+      surfaceContainerHighest: _lightCard,
+      error: _destructive,
+      onError: Colors.white,
+      outline: _lightBorder,
+      outlineVariant: _lightBorder,
+    );
+
+    return _build(
+      brightness: Brightness.light,
+      scheme: scheme,
+      bg: _lightBg,
+      card: _lightCard,
+      border: _lightBorder,
+      muted: _lightMuted,
+      inputFill: _lightInput,
+      bodyColor: _lightText,
+      appBarFg: _lightText,
+      navUnselected: _lightMuted,
+    );
+  }
+
+  // _build is the shared chassis — every visual choice that doesn't
+  // depend on brightness lives here so light/dark can never drift
+  // structurally. Only the color tokens are parameterised.
+  static ThemeData _build({
+    required Brightness brightness,
+    required ColorScheme scheme,
+    required Color bg,
+    required Color card,
+    required Color border,
+    required Color muted,
+    required Color inputFill,
+    required Color bodyColor,
+    required Color appBarFg,
+    required Color navUnselected,
+  }) {
     return ThemeData(
       useMaterial3: true,
       colorScheme: scheme,
-      scaffoldBackgroundColor: _bg,
-      brightness: Brightness.dark,
-      textTheme: const TextTheme(
-        bodyLarge: TextStyle(color: Colors.white),
-        bodyMedium: TextStyle(color: Colors.white),
-        bodySmall: TextStyle(color: _muted),
-        labelMedium: TextStyle(color: _muted),
+      scaffoldBackgroundColor: bg,
+      brightness: brightness,
+      textTheme: TextTheme(
+        bodyLarge: TextStyle(color: bodyColor),
+        bodyMedium: TextStyle(color: bodyColor),
+        bodySmall: TextStyle(color: muted),
+        labelMedium: TextStyle(color: muted),
       ),
-      appBarTheme: const AppBarTheme(
-        backgroundColor: _bg,
-        foregroundColor: Colors.white,
+      appBarTheme: AppBarTheme(
+        backgroundColor: bg,
+        foregroundColor: appBarFg,
         elevation: 0,
         centerTitle: false,
       ),
       cardTheme: CardThemeData(
-        color: _card,
+        color: card,
         elevation: 0,
         margin: EdgeInsets.zero,
         shape: RoundedRectangleBorder(
-          side: const BorderSide(color: _border),
+          side: BorderSide(color: border),
           borderRadius: BorderRadius.circular(12),
         ),
       ),
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
-        fillColor: const Color(0xFF111214),
+        fillColor: inputFill,
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(10),
-          borderSide: const BorderSide(color: _border),
+          borderSide: BorderSide(color: border),
         ),
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(10),
-          borderSide: const BorderSide(color: _border),
+          borderSide: BorderSide(color: border),
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(10),
@@ -88,14 +166,14 @@ class AppTheme {
           ),
         ),
       ),
-      bottomNavigationBarTheme: const BottomNavigationBarThemeData(
-        backgroundColor: _card,
+      bottomNavigationBarTheme: BottomNavigationBarThemeData(
+        backgroundColor: card,
         selectedItemColor: _accent,
-        unselectedItemColor: _muted,
+        unselectedItemColor: navUnselected,
         type: BottomNavigationBarType.fixed,
         showUnselectedLabels: true,
       ),
-      dividerColor: _border,
+      dividerColor: border,
     );
   }
 }

--- a/app/mobile/lib/core/theme/theme_controller.dart
+++ b/app/mobile/lib/core/theme/theme_controller.dart
@@ -1,0 +1,74 @@
+// ThemeController — the single source of truth for the mobile
+// app's appearance choice. Persists to shared_preferences so the
+// operator's pick survives app restarts; broadcasts via Riverpod
+// so MaterialApp.router rebuilds whenever the value flips.
+//
+// Three states (System / Light / Dark) map directly to
+// flutter's ThemeMode. We don't expose any half-way "accent
+// override" or font-size choice yet — keep the picker simple
+// until there's a real need.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// _prefsKey is the SharedPreferences slot we own. Versioned (`v1`)
+// in case a future change to the persistence format needs to
+// invalidate old values without overwriting them in place.
+const _prefsKey = 'opendray.appearance.theme_mode.v1';
+
+class ThemeController extends StateNotifier<ThemeMode> {
+  ThemeController() : super(ThemeMode.system) {
+    _restore();
+  }
+
+  // _restore reads the stashed pick and applies it. Failures fall
+  // back to system (the constructor default) — we'd rather pick
+  // up the operator's OS appearance than crash because a malformed
+  // shared_preferences entry got written by a buggy older build.
+  Future<void> _restore() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(_prefsKey);
+      final parsed = _parse(raw);
+      if (parsed != null && parsed != state) {
+        state = parsed;
+      }
+    } on Object {
+      // Best-effort: stay on the default system theme.
+    }
+  }
+
+  // setMode flips the live state and fires off the persistence
+  // write. Persistence is async but the UI doesn't wait — the
+  // pick takes effect instantly via state notification.
+  Future<void> setMode(ThemeMode mode) async {
+    state = mode;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_prefsKey, _serialise(mode));
+    } on Object {
+      // Persistence is best-effort — if shared_preferences is
+      // unavailable, the in-memory pick still works for this
+      // session.
+    }
+  }
+
+  static String _serialise(ThemeMode mode) => switch (mode) {
+        ThemeMode.system => 'system',
+        ThemeMode.light => 'light',
+        ThemeMode.dark => 'dark',
+      };
+
+  static ThemeMode? _parse(String? raw) => switch (raw) {
+        'system' => ThemeMode.system,
+        'light' => ThemeMode.light,
+        'dark' => ThemeMode.dark,
+        _ => null,
+      };
+}
+
+final themeControllerProvider =
+    StateNotifierProvider<ThemeController, ThemeMode>(
+  (ref) => ThemeController(),
+);

--- a/app/mobile/lib/features/more/more_screen.dart
+++ b/app/mobile/lib/features/more/more_screen.dart
@@ -10,6 +10,7 @@ import 'package:opendray/features/integrations/integrations_screen.dart';
 import 'package:opendray/features/mcp/mcp_screen.dart';
 import 'package:opendray/features/more/about_screen.dart';
 import 'package:opendray/features/providers/providers_screen.dart';
+import 'package:opendray/features/settings/settings_screen.dart';
 import 'package:opendray/features/skills/skills_screen.dart';
 
 // "More" tab — overflow menu for everything that doesn't earn its
@@ -81,6 +82,12 @@ class MoreScreen extends ConsumerWidget {
             title: 'Backups',
             subtitle: 'Latest backup status & run-now',
             onTap: () => _push(context, const BackupsScreen()),
+          ),
+          _MenuTile(
+            icon: Icons.tune_outlined,
+            title: 'Settings',
+            subtitle: 'Appearance, account',
+            onTap: () => _push(context, const SettingsScreen()),
           ),
           _MenuTile(
             icon: Icons.info_outline,

--- a/app/mobile/lib/features/settings/settings_screen.dart
+++ b/app/mobile/lib/features/settings/settings_screen.dart
@@ -1,0 +1,142 @@
+// SettingsScreen — the operator's home for app-level preferences
+// that aren't tied to a specific server resource. Reached via
+// More → Settings.
+//
+// PR #51 ships the Appearance section. The Account section
+// (change password / change username) lands in PR #52 — its
+// placeholder is included here so the layout doesn't shift when
+// it arrives.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/theme/theme_controller.dart';
+
+class SettingsScreen extends ConsumerWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final mode = ref.watch(themeControllerProvider);
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: SafeArea(
+        bottom: false,
+        child: ListView(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          children: [
+            const _SectionHeader('Appearance'),
+            // RadioGroup is the Flutter 3.32+ way to share group
+            // state across Radio<T> descendants without each tile
+            // duplicating groupValue/onChanged.
+            RadioGroup<ThemeMode>(
+              groupValue: mode,
+              onChanged: (m) {
+                if (m == null) return;
+                ref.read(themeControllerProvider.notifier).setMode(m);
+              },
+              child: const Column(
+                children: [
+                  _ThemeOption(
+                    title: 'System',
+                    subtitle: "Follow your phone's appearance setting",
+                    icon: Icons.brightness_auto_outlined,
+                    value: ThemeMode.system,
+                  ),
+                  _ThemeOption(
+                    title: 'Light',
+                    subtitle: 'Always use the light palette',
+                    icon: Icons.light_mode_outlined,
+                    value: ThemeMode.light,
+                  ),
+                  _ThemeOption(
+                    title: 'Dark',
+                    subtitle: 'Always use the dark palette',
+                    icon: Icons.dark_mode_outlined,
+                    value: ThemeMode.dark,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            const _SectionHeader('Account'),
+            ListTile(
+              leading: const Icon(Icons.lock_outline),
+              title: const Text('Change password'),
+              subtitle: Text(
+                'Coming soon',
+                style: theme.textTheme.bodySmall,
+              ),
+              enabled: false,
+              // Tap target intentionally inert until PR #52 lands —
+              // surface the feature path so operators know to come
+              // back here later.
+            ),
+            const SizedBox(height: 24),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.label);
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 6),
+      child: Text(
+        label.toUpperCase(),
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.outline,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.8,
+          fontSize: 11,
+        ),
+      ),
+    );
+  }
+}
+
+class _ThemeOption extends StatelessWidget {
+  const _ThemeOption({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.value,
+  });
+
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final ThemeMode value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListTile(
+      leading: Icon(icon),
+      title: Text(title),
+      subtitle: Text(
+        subtitle,
+        style: theme.textTheme.bodySmall,
+      ),
+      trailing: Radio<ThemeMode>(value: value),
+      // ListTile.onTap forwards through RadioGroup's onChanged
+      // automatically via the Radio widget — no manual wiring
+      // needed.
+      onTap: () {
+        // Find the ancestor RadioGroup and report this value as
+        // the new selection. Reaching through context keeps the
+        // option widget itself stateless.
+        final group = RadioGroup.maybeOf<ThemeMode>(context);
+        group?.onChanged(value);
+      },
+    );
+  }
+}

--- a/app/mobile/lib/main.dart
+++ b/app/mobile/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:opendray/core/routing/app_router.dart';
 import 'package:opendray/core/theme/app_theme.dart';
+import 'package:opendray/core/theme/theme_controller.dart';
 
 void main() {
   runApp(const ProviderScope(child: OpendrayApp()));
@@ -14,12 +15,16 @@ class OpendrayApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(routerProvider);
+    // Watch the controller so a picker change in Settings rebuilds
+    // MaterialApp with the new themeMode immediately — no app
+    // restart needed.
+    final themeMode = ref.watch(themeControllerProvider);
     return MaterialApp.router(
       title: 'opendray',
       debugShowCheckedModeBanner: false,
-      theme: AppTheme.dark(),
+      theme: AppTheme.light(),
       darkTheme: AppTheme.dark(),
-      themeMode: ThemeMode.dark,
+      themeMode: themeMode,
       routerConfig: router,
     );
   }

--- a/app/mobile/pubspec.yaml
+++ b/app/mobile/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   package_info_plus: ^8.1.1
   path: ^1.9.1
   pretty_dio_logger: ^1.4.0
+  shared_preferences: ^2.3.4
   web_socket_channel: ^3.0.1
   xterm: ^4.0.0
   yaml: ^3.1.2


### PR DESCRIPTION
## Summary

Mobile app no longer forces dark mode. New Settings screen with a System / Light / Dark picker, persisted to shared_preferences.

Foundation for PR #52 — the Settings screen exposes an Account section placeholder pointing at "Change password (coming soon)" so the layout doesn't shift when that lands.

## What's new

- `AppTheme.light()` variant. Same accent (#e6ae57), same component shapes; only surface / text / border tokens swap. Both variants share a `_build()` chassis so they can't structurally drift.
- `ThemeController` (Riverpod StateNotifier). Holds `ThemeMode`, persists picks to shared_preferences under `opendray.appearance.theme_mode.v1`. Best-effort load on init; best-effort save on change.
- `main.dart` watches the controller — MaterialApp.router swaps theme/darkTheme/themeMode reactively.
- `SettingsScreen` at `features/settings/`. Appearance section with a 3-option RadioGroup; Account section as a disabled-tile placeholder for PR #52.
- More menu gains a "Settings" tile between Backups and About.

## New dependency

`shared_preferences ^2.3.4` — the lightweight standard key-value store. Right tool for app preferences (flutter_secure_storage is already a dep but overkill for non-secret state).

## Test plan

- [x] `flutter analyze` 0 issues
- [x] `flutter build apk --debug` ok
- [ ] **iOS simulator**:
  - [ ] More → Settings → pick Light → entire app flips immediately
  - [ ] Pick System → restart simulator at OS-light → app stays light
  - [ ] Pick Dark → app re-flips
  - [ ] Force-quit + relaunch → last pick survives
- [ ] **Real device with OS appearance toggle**:
  - [ ] System mode follows OS light/dark switch live

🤖 Generated with [Claude Code](https://claude.com/claude-code)