### PR TITLE
feat(memory): Reset project memory — operator-driven cleanup per cwd

### DIFF
--- a/app/mobile/lib/core/api/project_docs_api.dart
+++ b/app/mobile/lib/core/api/project_docs_api.dart
@@ -60,6 +60,35 @@ class ProjectDocsApi {
     }
   }
 
+  /// Wipes per-cwd project memory state. Always deletes goal+plan,
+  /// proposals, session_logs, and cleanup_decisions for the cwd.
+  /// Optionally scanner-managed docs (tech_stack + recent_activity)
+  /// which would otherwise auto-rebuild on next spawn.
+  ///
+  /// Memories (pgvector) live in a separate subsystem — call
+  /// MemoryApi.deleteByScope('project', cwd) separately when the
+  /// operator opts in.
+  Future<Map<String, int>> resetCwd({
+    required String cwd,
+    bool includeScannerDocs = false,
+    bool includeCleanupDecisions = true,
+  }) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/project-docs/reset',
+        data: {
+          'cwd': cwd,
+          'include_scanner_docs': includeScannerDocs,
+          'include_cleanup_decisions': includeCleanupDecisions,
+        },
+      );
+      final raw = res.data ?? const <String, dynamic>{};
+      return raw.map((k, v) => MapEntry(k, (v is int) ? v : 0));
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
   // ── proposals ──────────────────────────────────────────────────
 
   Future<List<DocProposal>> listPendingProposals({String? cwd}) async {

--- a/app/mobile/lib/features/project/project_screen.dart
+++ b/app/mobile/lib/features/project/project_screen.dart
@@ -233,6 +233,14 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
     return Scaffold(
       appBar: AppBar(
         title: const Text('Project'),
+        actions: [
+          if (_selectedKey != null && _selectedKey!.isNotEmpty)
+            IconButton(
+              icon: const Icon(Icons.restart_alt),
+              tooltip: 'Reset project memory',
+              onPressed: () => _confirmReset(_selectedKey!),
+            ),
+        ],
         bottom: TabBar(
           controller: _tabs,
           isScrollable: true,
@@ -720,6 +728,141 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
           SnackBar(content: Text('Reject failed: $e')),
         );
         await _loadAll(_selectedKey!);
+      }
+    }
+  }
+
+  /// Shows the reset confirmation dialog, then on confirm calls the
+  /// reset endpoint + (optionally) deleteMemoriesByScope. Mirrors
+  /// the web ResetButton flow in app/web.../ProjectScreen.tsx.
+  Future<void> _confirmReset(String cwd) async {
+    var includeScanner = false;
+    var includeMemories = false;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) {
+        return StatefulBuilder(
+          builder: (ctx, setDialogState) {
+            return AlertDialog(
+              title: const Text('Reset project memory?'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: Theme.of(ctx).colorScheme.errorContainer,
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Icon(Icons.warning_amber_rounded,
+                            size: 18,
+                            color: Theme.of(ctx).colorScheme.onErrorContainer),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              SelectableText(
+                                cwd,
+                                style: const TextStyle(
+                                  fontFamily: 'monospace',
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                              const SizedBox(height: 4),
+                              const Text(
+                                'Always deleted: goal, plan, proposals, '
+                                'journal, cleanup decisions.',
+                                style: TextStyle(fontSize: 11),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  CheckboxListTile(
+                    contentPadding: EdgeInsets.zero,
+                    dense: true,
+                    value: includeScanner,
+                    title: const Text('Also delete scanner docs',
+                        style: TextStyle(fontSize: 13)),
+                    subtitle: const Text(
+                      'tech_stack + recent_activity (auto-rebuild on next spawn).',
+                      style: TextStyle(fontSize: 11),
+                    ),
+                    onChanged: (v) =>
+                        setDialogState(() => includeScanner = v ?? false),
+                  ),
+                  CheckboxListTile(
+                    contentPadding: EdgeInsets.zero,
+                    dense: true,
+                    value: includeMemories,
+                    title: const Text('Also delete pgvector memories',
+                        style: TextStyle(fontSize: 13)),
+                    subtitle: const Text(
+                      'Long-term facts for this scope_key. Cannot be recovered.',
+                      style: TextStyle(fontSize: 11),
+                    ),
+                    onChanged: (v) =>
+                        setDialogState(() => includeMemories = v ?? false),
+                  ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(ctx).pop(false),
+                  child: const Text('Cancel'),
+                ),
+                FilledButton.tonal(
+                  style: FilledButton.styleFrom(
+                    backgroundColor: Theme.of(ctx).colorScheme.errorContainer,
+                    foregroundColor: Theme.of(ctx).colorScheme.onErrorContainer,
+                  ),
+                  onPressed: () => Navigator.of(ctx).pop(true),
+                  child: const Text('Delete forever'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+    if (confirmed != true) return;
+    try {
+      final counts = await ref.read(projectDocsApiProvider).resetCwd(
+            cwd: cwd,
+            includeScannerDocs: includeScanner,
+          );
+      var memCount = 0;
+      if (includeMemories) {
+        memCount = await ref.read(memoryApiProvider).deleteByScope(
+              scope: MemoryScope.project,
+              scopeKey: cwd,
+            );
+      }
+      if (!mounted) return;
+      final parts = <String>[
+        '${counts['project_docs'] ?? 0} doc',
+        '${counts['session_logs'] ?? 0} journal',
+        '${counts['memory_cleanup_decisions'] ?? 0} cleanup',
+      ];
+      if (includeMemories) parts.add('$memCount memories');
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Reset: ${parts.join(' · ')}')),
+      );
+      await _loadAll(cwd);
+    } on ApiException catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Reset failed: $e')),
+        );
       }
     }
   }

--- a/app/shared/src/lib/projectDocs.ts
+++ b/app/shared/src/lib/projectDocs.ts
@@ -136,3 +136,39 @@ export async function appendSessionLog(input: {
 export async function deleteSessionLog(id: string): Promise<void> {
   await api(`/api/v1/session-logs/${id}`, { method: 'DELETE' })
 }
+
+// ── reset ─────────────────────────────────────────────────────
+
+export interface ResetProjectMemoryOptions {
+  cwd: string
+  /** Also wipe tech_stack + recent_activity (default false; they auto-rebuild on next spawn). */
+  include_scanner_docs?: boolean
+  /** Also wipe memory_cleanup_decisions for this cwd (default true). */
+  include_cleanup_decisions?: boolean
+}
+
+export interface ResetProjectMemoryCounts {
+  project_docs: number
+  project_doc_proposals: number
+  session_logs: number
+  memory_cleanup_decisions: number
+}
+
+/**
+ * Wipes per-cwd project memory state in a transaction:
+ * project_docs (goal/plan, optionally scanner-managed docs too),
+ * project_doc_proposals, session_logs, and memory_cleanup_decisions
+ * for this cwd.
+ *
+ * Does NOT touch the pgvector `memories` table — call
+ * deleteMemoriesByScope('project', cwd) separately when the
+ * operator opts in.
+ */
+export async function resetProjectMemory(
+  opts: ResetProjectMemoryOptions,
+): Promise<ResetProjectMemoryCounts> {
+  return api<ResetProjectMemoryCounts>('/api/v1/project-docs/reset', {
+    method: 'POST',
+    body: opts,
+  })
+}

--- a/app/web/src/components/project/ProjectScreen.tsx
+++ b/app/web/src/components/project/ProjectScreen.tsx
@@ -17,6 +17,7 @@ import {
   Check,
   Inbox,
   Loader2,
+  RotateCcw,
   Save,
   Sparkles,
   Trash2,
@@ -47,6 +48,7 @@ import {
   listSessionLogs,
   putProjectDoc,
   rejectProposal,
+  resetProjectMemory,
 } from '@/lib/projectDocs'
 import {
   type CleanupDecision,
@@ -55,6 +57,7 @@ import {
   rejectDecision,
   runCleanup,
 } from '@/lib/memoryCleanup'
+import { deleteMemoriesByScope } from '@/lib/memory'
 
 interface ProjectScreenProps {
   cwd: string
@@ -115,27 +118,41 @@ export function ProjectScreen({ cwd }: ProjectScreenProps) {
   return (
     <div className="flex h-full flex-col">
       <div className="border-b px-4 py-3">
-        <div className="text-muted-foreground font-mono text-xs">{cwd}</div>
-        <div className="mt-1 flex items-center gap-3 text-xs">
-          <span>{(docsQuery.data ?? []).length} docs</span>
-          <span>·</span>
-          <span>{(logsQuery.data ?? []).length} journal entries</span>
-          {inboxCount > 0 && (
-            <>
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-muted-foreground font-mono text-xs">{cwd}</div>
+            <div className="mt-1 flex items-center gap-3 text-xs">
+              <span>{(docsQuery.data ?? []).length} docs</span>
               <span>·</span>
-              <Badge variant="danger" className="text-[10px]">
-                {inboxCount} pending proposal{inboxCount > 1 ? 's' : ''}
-              </Badge>
-            </>
-          )}
-          {cleanupCount > 0 && (
-            <>
-              <span>·</span>
-              <Badge variant="muted" className="text-[10px]">
-                {cleanupCount} cleanup pending
-              </Badge>
-            </>
-          )}
+              <span>{(logsQuery.data ?? []).length} journal entries</span>
+              {inboxCount > 0 && (
+                <>
+                  <span>·</span>
+                  <Badge variant="danger" className="text-[10px]">
+                    {inboxCount} pending proposal{inboxCount > 1 ? 's' : ''}
+                  </Badge>
+                </>
+              )}
+              {cleanupCount > 0 && (
+                <>
+                  <span>·</span>
+                  <Badge variant="muted" className="text-[10px]">
+                    {cleanupCount} cleanup pending
+                  </Badge>
+                </>
+              )}
+            </div>
+          </div>
+          <ResetButton
+            cwd={cwd}
+            onDone={() => {
+              qc.invalidateQueries({ queryKey: ['project-docs', cwd] })
+              qc.invalidateQueries({ queryKey: ['project-doc-proposals', cwd] })
+              qc.invalidateQueries({ queryKey: ['session-logs', cwd] })
+              qc.invalidateQueries({ queryKey: ['cleanup-decisions'] })
+              qc.invalidateQueries({ queryKey: ['memories'] })
+            }}
+          />
         </div>
       </div>
 
@@ -725,6 +742,143 @@ function CleanupDecisionCard({
         </Button>
       </div>
     </div>
+  )
+}
+
+// ─── Reset project memory ────────────────────────────────────
+
+interface ResetButtonProps {
+  cwd: string
+  onDone: () => void
+}
+
+function ResetButton({ cwd, onDone }: ResetButtonProps) {
+  const [open, setOpen] = useState(false)
+  const [includeScanner, setIncludeScanner] = useState(false)
+  const [includeMemories, setIncludeMemories] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  const handleReset = async () => {
+    setBusy(true)
+    try {
+      const counts = await resetProjectMemory({
+        cwd,
+        include_scanner_docs: includeScanner,
+        include_cleanup_decisions: true,
+      })
+      let memoryCount = 0
+      if (includeMemories) {
+        memoryCount = await deleteMemoriesByScope('project', cwd)
+      }
+      const parts = [
+        `${counts.project_docs} doc${counts.project_docs === 1 ? '' : 's'}`,
+        `${counts.session_logs} journal`,
+        `${counts.project_doc_proposals} proposal${counts.project_doc_proposals === 1 ? '' : 's'}`,
+        `${counts.memory_cleanup_decisions} cleanup`,
+      ]
+      if (includeMemories) parts.push(`${memoryCount} memories`)
+      toast.success(`Reset: deleted ${parts.join(' · ')}`)
+      onDone()
+      setOpen(false)
+    } catch (e) {
+      toast.error('Reset failed', {
+        description: e instanceof Error ? e.message : String(e),
+      })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <>
+      <Button
+        size="sm"
+        variant="outline"
+        className="text-destructive hover:text-destructive flex-none"
+        onClick={() => setOpen(true)}
+      >
+        <RotateCcw className="mr-1 h-3 w-3" />
+        Reset
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Reset project memory?</DialogTitle>
+            <DialogDescription>
+              Deletes all stored project context for this cwd.
+              This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="text-destructive bg-destructive/10 mb-3 flex items-start gap-2 rounded-md p-3 text-xs">
+            <AlertTriangle className="mt-0.5 h-3 w-3 flex-none" />
+            <div>
+              <strong className="font-mono">{cwd}</strong>
+              <br />
+              Always deleted: goal, plan, proposals, journal,
+              cleanup decisions.
+            </div>
+          </div>
+          <div className="space-y-2 text-sm">
+            <label className="flex cursor-pointer items-start gap-2">
+              <input
+                type="checkbox"
+                checked={includeScanner}
+                onChange={(e) => setIncludeScanner(e.target.checked)}
+                className="mt-0.5"
+              />
+              <span>
+                <strong>Also delete scanner docs</strong> (tech_stack +
+                recent_activity).
+                <br />
+                <span className="text-muted-foreground text-xs">
+                  Auto-rebuild on next spawn anyway — leaving unchecked is
+                  usually fine.
+                </span>
+              </span>
+            </label>
+            <label className="flex cursor-pointer items-start gap-2">
+              <input
+                type="checkbox"
+                checked={includeMemories}
+                onChange={(e) => setIncludeMemories(e.target.checked)}
+                className="mt-0.5"
+              />
+              <span>
+                <strong>Also delete pgvector memories</strong> for this
+                scope_key.
+                <br />
+                <span className="text-muted-foreground text-xs">
+                  Long-term facts the agent stored (user preferences,
+                  project facts). Cannot be recovered.
+                </span>
+              </span>
+            </label>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="default"
+              className="bg-destructive hover:bg-destructive/90"
+              onClick={handleReset}
+              disabled={busy}
+            >
+              {busy ? (
+                <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+              ) : (
+                <Trash2 className="mr-1 h-3 w-3" />
+              )}
+              Delete forever
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }
 

--- a/internal/projectdoc/handler.go
+++ b/internal/projectdoc/handler.go
@@ -50,6 +50,7 @@ func (h *Handlers) Mount(r chi.Router) {
 		r.Get("/", h.listDocs)
 		r.Get("/{kind}", h.getDoc)
 		r.Put("/{kind}", h.putDoc)
+		r.Post("/reset", h.resetCwd)
 	})
 	r.Route("/project-doc-proposals", func(r chi.Router) {
 		r.Get("/pending", h.listPending)
@@ -122,6 +123,53 @@ func (h *Handlers) putDoc(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, doc)
+}
+
+// resetCwd wipes per-cwd project memory state — goal/plan
+// (optionally scanner-managed docs too), proposals queue, journal,
+// and the M13 cleanup decisions for this cwd. Memories (pgvector
+// facts) are NOT touched here; the UI calls
+// POST /memory/delete-by-scope separately when the operator opts
+// in. Two-step on purpose: memories live in a different subsystem
+// with its own dispatch/disabled-mode rules.
+//
+// Body:
+//
+//	{
+//	  "cwd": "/path/to/project",            (required)
+//	  "include_scanner_docs": false,        (default false — they auto-rebuild on next spawn)
+//	  "include_cleanup_decisions": true     (default true — closely tied to this cwd)
+//	}
+//
+// Returns ResetCounts so the UI can show "deleted X docs, Y journal
+// entries, …" in the toast.
+func (h *Handlers) resetCwd(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Cwd                     string `json:"cwd"`
+		IncludeScannerDocs      bool   `json:"include_scanner_docs"`
+		IncludeCleanupDecisions *bool  `json:"include_cleanup_decisions,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if body.Cwd == "" {
+		writeError(w, http.StatusBadRequest, errors.New("cwd required"))
+		return
+	}
+	includeCleanup := true
+	if body.IncludeCleanupDecisions != nil {
+		includeCleanup = *body.IncludeCleanupDecisions
+	}
+	counts, err := h.svc.ResetCwd(r.Context(), body.Cwd, ResetCwdOptions{
+		IncludeScannerDocs:      body.IncludeScannerDocs,
+		IncludeCleanupDecisions: includeCleanup,
+	})
+	if err != nil {
+		h.respondErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, counts)
 }
 
 // ─── proposals ────────────────────────────────────────────────────

--- a/internal/projectdoc/projectdoc.go
+++ b/internal/projectdoc/projectdoc.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -483,6 +484,96 @@ func (s *Service) DeleteLog(ctx context.Context, id string) error {
 		return ErrNotFound
 	}
 	return nil
+}
+
+// ResetCwdOptions controls which tables/kinds the reset wipes.
+type ResetCwdOptions struct {
+	// IncludeScannerDocs deletes tech_stack + recent_activity rows
+	// too. Default false: scanner doc kinds auto-rebuild on the
+	// next spawn anyway, and operators usually want to keep them
+	// (they're objective project facts, not user content).
+	IncludeScannerDocs bool
+
+	// IncludeCleanupDecisions deletes memory_cleanup_decisions rows
+	// keyed to this cwd. Defaults to true since they're tightly
+	// scoped to the cwd's memories — kept as an option in case a
+	// future caller wants to preserve the audit trail.
+	IncludeCleanupDecisions bool
+}
+
+// ResetCounts is what ResetCwd returns: counts of rows deleted per
+// table so the UI can show "deleted X docs, Y journal entries, …".
+type ResetCounts struct {
+	ProjectDocs       int64 `json:"project_docs"`
+	Proposals         int64 `json:"project_doc_proposals"`
+	SessionLogs       int64 `json:"session_logs"`
+	CleanupDecisions  int64 `json:"memory_cleanup_decisions"`
+}
+
+// ResetCwd wipes per-cwd project memory state in a single
+// transaction. Always deletes session_logs + project_doc_proposals
+// (no use without their parent project_docs anyway) + operator-
+// editable docs (goal/plan). Optionally also wipes scanner-managed
+// docs (tech_stack/recent_activity — auto-rebuild on next spawn)
+// and the M13 cleanup decisions queue.
+//
+// memories rows are NOT deleted here — they live in the memory
+// subsystem with its own scope_key indexing. Callers (the
+// `/project-docs/reset` HTTP handler) chain memory.DeleteByScope
+// when the operator opts in.
+func (s *Service) ResetCwd(ctx context.Context, cwd string, opts ResetCwdOptions) (ResetCounts, error) {
+	if cwd == "" {
+		return ResetCounts{}, fmt.Errorf("projectdoc: reset: cwd required")
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return ResetCounts{}, fmt.Errorf("projectdoc: reset begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var counts ResetCounts
+
+	// project_docs — always wipe goal+plan; scanner docs gated by opt.
+	var docCmd pgconn.CommandTag
+	if opts.IncludeScannerDocs {
+		docCmd, err = tx.Exec(ctx, `DELETE FROM project_docs WHERE cwd = $1`, cwd)
+	} else {
+		docCmd, err = tx.Exec(ctx,
+			`DELETE FROM project_docs WHERE cwd = $1 AND kind IN ('goal','plan')`, cwd)
+	}
+	if err != nil {
+		return ResetCounts{}, fmt.Errorf("projectdoc: reset docs: %w", err)
+	}
+	counts.ProjectDocs = docCmd.RowsAffected()
+
+	propCmd, err := tx.Exec(ctx,
+		`DELETE FROM project_doc_proposals WHERE cwd = $1`, cwd)
+	if err != nil {
+		return ResetCounts{}, fmt.Errorf("projectdoc: reset proposals: %w", err)
+	}
+	counts.Proposals = propCmd.RowsAffected()
+
+	logCmd, err := tx.Exec(ctx,
+		`DELETE FROM session_logs WHERE cwd = $1`, cwd)
+	if err != nil {
+		return ResetCounts{}, fmt.Errorf("projectdoc: reset logs: %w", err)
+	}
+	counts.SessionLogs = logCmd.RowsAffected()
+
+	if opts.IncludeCleanupDecisions {
+		cdCmd, err := tx.Exec(ctx,
+			`DELETE FROM memory_cleanup_decisions
+			 WHERE memory_scope = 'project' AND memory_scope_key = $1`, cwd)
+		if err != nil {
+			return ResetCounts{}, fmt.Errorf("projectdoc: reset cleanup decisions: %w", err)
+		}
+		counts.CleanupDecisions = cdCmd.RowsAffected()
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return ResetCounts{}, fmt.Errorf("projectdoc: reset commit: %w", err)
+	}
+	return counts, nil
 }
 
 // ─── spawn-time injection ──────────────────────────────────────

--- a/internal/projectdoc/projectdoc.go
+++ b/internal/projectdoc/projectdoc.go
@@ -504,10 +504,10 @@ type ResetCwdOptions struct {
 // ResetCounts is what ResetCwd returns: counts of rows deleted per
 // table so the UI can show "deleted X docs, Y journal entries, …".
 type ResetCounts struct {
-	ProjectDocs       int64 `json:"project_docs"`
-	Proposals         int64 `json:"project_doc_proposals"`
-	SessionLogs       int64 `json:"session_logs"`
-	CleanupDecisions  int64 `json:"memory_cleanup_decisions"`
+	ProjectDocs      int64 `json:"project_docs"`
+	Proposals        int64 `json:"project_doc_proposals"`
+	SessionLogs      int64 `json:"session_logs"`
+	CleanupDecisions int64 `json:"memory_cleanup_decisions"`
 }
 
 // ResetCwd wipes per-cwd project memory state in a single


### PR DESCRIPTION
## Summary

Operator-reported confusion after PR #57: deleting from the Memory
page didn't clear goal/plan/journal in the Project panel.
Different tables, different surfaces, no unified "wipe this
project" action existed. This makes it a first-class feature
across backend + web + mobile.

## What it does

A new **Reset** button on the Project screen (web: button in the
cwd header; mobile: IconButton in AppBar) opens a confirmation
dialog with:

- Strong warning banner showing the cwd in monospace
- "Always deleted: goal, plan, proposals, journal, cleanup
  decisions"
- Optional checkboxes:
  - **Scanner docs** (tech_stack + recent_activity) — default off
    since they auto-rebuild on next spawn
  - **pgvector memories** — default off since they're long-term
    agent-stored facts (user preferences etc.) — irreversible
- "Delete forever" destructive-styled action button
- Toast/snackbar with concrete counts per category on success

## Backend

New `POST /api/v1/project-docs/reset` endpoint backed by
`projectdoc.Service.ResetCwd()`. Single-transaction bulk delete
across project_docs, project_doc_proposals, session_logs,
memory_cleanup_decisions. Memories (pgvector) handled separately
by the existing `/memory/delete-by-scope` endpoint — UI chains
them when the operator opts in.

## Verified

- `go build ./... && go test ./internal/projectdoc/...` clean
- `pnpm build` (web) clean
- `flutter analyze` (mobile) — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)