### PR TITLE
feat(mobile,docs): orphan badge parity + new Project memory tutorial

### DIFF
--- a/app/mobile/lib/features/memory_cleanup/cleanup_inbox_screen.dart
+++ b/app/mobile/lib/features/memory_cleanup/cleanup_inbox_screen.dart
@@ -5,6 +5,17 @@ import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/memory_cleanup_api.dart';
 import 'package:path/path.dart' as p;
 
+/// A scope_key looks "orphan" when it has fewer than 2 non-empty
+/// path segments — e.g. `/Users/` left behind by old truncated
+/// mirror imports. Not a real project, shouldn't be treated as one.
+/// Mirrors web's same-name helper in
+/// app/web/src/pages/CleanupInbox.tsx.
+bool _isLikelyOrphanScope(String cwd) {
+  if (cwd.isEmpty) return false;
+  final parts = cwd.split('/').where((s) => s.isNotEmpty).toList();
+  return parts.length < 2;
+}
+
 // CleanupInboxScreen surfaces pending memory_cleanup_decisions
 // across every project in one list. Reachable from More → Memory
 // → Cleanup so operators don't have to drill into a specific
@@ -207,6 +218,36 @@ class _ProjectGroup extends StatelessWidget {
                         overflow: TextOverflow.ellipsis,
                       ),
                     ),
+                    if (_isLikelyOrphanScope(scopeKey)) ...[
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 6, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .surfaceContainerHighest,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Tooltip(
+                          message:
+                              'Truncated scope_key (old mirror import). '
+                              'Not a real project — approve-stale these '
+                              'or use Project Reset to clear.',
+                          child: Text(
+                            'orphan',
+                            style: TextStyle(
+                              fontSize: 9,
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .onSurfaceVariant,
+                              fontWeight: FontWeight.w600,
+                              letterSpacing: 0.4,
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                    ],
                     Container(
                       padding: const EdgeInsets.symmetric(
                           horizontal: 8, vertical: 2),

--- a/app/web/src/tutorial/sections/14-project-memory/01-overview.md
+++ b/app/web/src/tutorial/sections/14-project-memory/01-overview.md
@@ -1,0 +1,69 @@
+# Project memory — overview
+
+Project memory is the **per-cwd, structured layer** that sits on
+top of the discrete-fact memory store covered in section 11.
+Each Claude / Codex / Gemini session you spawn through opendray
+boots up reading the same five-layer banner derived from the
+current project's state — so a new agent walks in with the same
+context the previous one was working with.
+
+If section 11 is "what does the agent remember as discrete
+facts?", this section is "what does the agent know about THIS
+PROJECT specifically?".
+
+## The five layers
+
+Every spawn injects a ~4-5 KB markdown banner composed of:
+
+| Layer | Source | Who edits | UI surface |
+|---|---|---|---|
+| **Tech stack & structure** | Auto-scanned marker files (`go.mod`, `package.json`, `pubspec.yaml`, …) + git HEAD + top-level dirs | Scanner only — refreshed when stale ≥ 6h on next spawn | Project → **Tech** tab (read-only) |
+| **Project goal** | Operator-written paragraph: "what we are building" | You (agents can _propose_ via MCP, you approve) | Project → **Goal** tab |
+| **Project plan** | Operator-written paragraph: "what we are doing now / next" | Same as goal | Project → **Plan** tab |
+| **Recent activity** | LLM-summarised `git log --since 7d --stat` + hot-path file list | Scanner only — refreshed every 24h | Project → **Activity** tab (read-only) |
+| **Recent journal** | Last 5 session-end summaries (auto-written when sessions stop) | Auto — one per session_end event | Project → **Journal** tab |
+
+## Why this exists separately from L5 facts
+
+Section 11's memory store treats every entry as a **discrete
+fact** ranked by top-K similarity. That shape works for "user
+prefers pnpm" but not for "here's the multi-paragraph plan we
+agreed on Monday". Project memory uses:
+
+- **Replace-in-place** for goal / plan (you edit the whole doc)
+- **Append-only** for journal (one row per session_end)
+- **Overwrite-on-scan** for tech_stack + recent_activity
+
+…all stored in different tables (`project_docs`,
+`project_doc_proposals`, `session_logs`) so each can be queried
+and managed independently. The Project page surfaces them as
+tabs; the spawn injector composes them into one banner.
+
+## When to use each layer
+
+You're trying to record… | Put it in… | Why
+---|---|---
+**A long-term project intention** ("ship cross-CLI memory") | Goal | One paragraph, replaces, shows in spawn banner verbatim
+**Current sprint / what's next** ("Phase 2: M6 spawn injection") | Plan | Same as goal; updated as work progresses
+**A discrete preference / fact** ("we use pnpm; bcrypt cost=12") | Memory store (section 11) | Top-K retrieval; embeds into ambient banner only when relevant
+**A decision made this session** ("chose bcrypt over argon2 because…") | `decision_record` MCP tool → journal as `kind=decision` | Permanent audit trail per session
+**Just what happened in this session** | Auto-journal (no action needed) | Session-end event triggers it
+
+## Cross-CLI: same project, any agent
+
+Claude / Codex / Gemini all read the same Project memory through
+their respective native injection channels (`--append-system-prompt`,
+`$CODEX_HOME/AGENTS.md`, `GEMINI.md`). Tell **Claude** the project
+goal once via the Project → Goal tab; the next **Codex** spawn in
+the same cwd quotes it back to you on demand. This is the whole
+point of unified memory — no manual re-explanation per CLI switch.
+
+## Where to next
+
+- **02 — Day-to-day workflow** walks you through setting goal/plan,
+  reviewing agent-proposed edits, and reading journal entries.
+- **03 — Scanner & cleaner** covers the auto-managed L1 / L4 / L5
+  maintenance (tech_stack scanner, git activity summariser, LLM
+  cleanup librarian).
+- **04 — Reset & troubleshooting** covers the Reset action,
+  orphan scope_keys, and the M22 isolation guarantees.

--- a/app/web/src/tutorial/sections/14-project-memory/02-workflow.md
+++ b/app/web/src/tutorial/sections/14-project-memory/02-workflow.md
@@ -1,0 +1,112 @@
+# Project memory — day-to-day workflow
+
+## Opening Project memory
+
+Three entry points, all land on the same screen scoped to one cwd:
+
+- **Web**: sidebar → **Memory** → **Project** button (or
+  `Cmd-K → Project memory`)
+- **Web from a running session**: right-hand Inspector → **Memory**
+  tab → "Open project memory" button
+- **Mobile**: bottom nav → **Memory** → top **Project** button (or
+  session detail → 🏁 icon → jumps straight to the right cwd)
+
+If you arrive without a cwd in the URL, you'll see a picker
+listing every project that has stored memory. Truncated old data
+shows up as `orphan` and is visually muted — see section 04 for
+how to clean those up.
+
+## Goal — the long-term intention
+
+The **Goal** tab is a single markdown editor. One paragraph is
+ideal:
+
+> Ship the v2 backup format with WAL-aware incremental snapshots.
+
+The agent reads this verbatim on every spawn into this cwd, so
+keep it crisp. Avoid:
+
+- ❌ "TODO: figure out backup" → too vague to act on
+- ❌ A 5-paragraph essay → bloats the spawn banner
+- ✅ "Ship the v2 backup format with WAL-aware incremental
+  snapshots." → concrete, one sentence
+
+Updated by: usually you. Last-edit timestamp + `updated_by` show
+right above the editor. If an agent calls the `project_goal_set`
+MCP tool, you see a **proposal** in the Inbox tab (see below) —
+no silent overwrite.
+
+## Plan — current state and what's next
+
+The **Plan** tab is the same shape but meant to change more
+often. Format suggestion (not enforced):
+
+```
+Phase 1: <currently working on this>
+Phase 2: <next>
+Phase 3: <after that>
+
+Blocker: <if any>
+```
+
+When you finish Phase 1 you edit this doc directly to bump the
+phases forward. The agent on the next spawn sees the updated
+plan without you having to repeat anything in chat.
+
+## Inbox — agent-proposed edits
+
+The MCP tools `project_goal_set` and `project_plan_set` deliberately
+don't update the live doc directly — they file a **proposal** that
+appears in the **Inbox** tab. Each proposal shows:
+
+- Strong red warning: "Approve will REPLACE the current X
+  entirely. This isn't a merge."
+- Side-by-side diff: current content vs proposed content
+- The agent's stated reason for the edit
+- "Approve" (with a confirm dialog) and "Reject" buttons
+
+The diff matters: agents are eager and may try to rewrite your
+hand-crafted goal with their interpretation. Reject when you
+disagree, approve when their version is genuinely better.
+
+## Journal — what happened, automatically
+
+The **Journal** tab lists every session_end event for this cwd.
+Each entry has:
+
+- Session metadata: id (last 8 chars), provider, duration, exit
+  code
+- Recent operator inputs (last 5 user-typed messages of that
+  session)
+- _Agent activity summary_ — 1-3 paragraphs of LLM-summarised
+  "what the agent actually did" (files edited, decisions made,
+  problems debugged, blockers hit). **Only present when the
+  session had substantive work** — a 30-second "hi" exchange is
+  correctly skipped per the "too sparse" guard in the prompt.
+
+You don't write to this tab; opendray writes it on every
+`session.stopped` / `session.ended` event.
+
+If you want to record something manually (e.g. an architectural
+decision you made out-of-band), use the MCP `decision_record`
+tool from any agent session — it writes a `kind=decision` row
+that appears here.
+
+## Practical rhythm
+
+Most operators settle into this loop:
+
+1. Start a project: write a 1-sentence **Goal** and 3-phase **Plan**.
+2. Spawn an agent (Claude / Codex / Gemini) → it boots already
+   knowing what the project is about.
+3. Work. The agent's session-end automatically appends a
+   journal entry.
+4. Plan changes mid-work → edit **Plan**. Next spawn sees the
+   update.
+5. Agent proposes a new plan → review in **Inbox**, approve or
+   reject.
+6. Days later, a new agent (or you on a new machine) spawns →
+   reads all 5 layers, picks up where the last one left off.
+
+Section 03 covers the scanner and cleaner that maintain the
+auto-managed layers without your direct involvement.

--- a/app/web/src/tutorial/sections/14-project-memory/03-scanner-and-cleaner.md
+++ b/app/web/src/tutorial/sections/14-project-memory/03-scanner-and-cleaner.md
@@ -1,0 +1,143 @@
+# Scanner & cleaner — auto-managed memory
+
+Three pieces of the memory system run autonomously without your
+input — they're worth understanding because they shape the spawn
+banner every agent sees and the cleanup queue you triage.
+
+## Project scanner (L1 — tech_stack)
+
+Lives in `internal/projectscan/`. Cheap, deterministic, no LLM
+involvement.
+
+**Triggers**:
+
+- Every spawn checks the row's `updated_at`; if older than **6h**,
+  triggers a sync re-scan **before** the agent boots.
+- `POST /api/v1/project-scan/run` if you want to force it.
+
+**What it captures**:
+
+- Tech stacks via marker files: `go.mod` → Go; `package.json` →
+  Node.js; `pubspec.yaml` → Flutter; `pyproject.toml` → Python;
+  `Cargo.toml` → Rust; `Gemfile` → Ruby; `pom.xml` → Java;
+  `Dockerfile` → Docker; `migrations/*.sql` → PostgreSQL.
+- Versions when discoverable (parses the marker files lightly).
+- Current git branch + HEAD short-hash.
+- Top-level directory layout (depth 1, skipping `.git`, `node_modules`,
+  `target`, etc.).
+- Entry points heuristics (cmd binaries for Go, `lib/main.dart`
+  for Flutter, etc.).
+
+Output lands as `project_docs.kind='tech_stack'` and gets
+rendered into every spawn banner verbatim under `### Tech stack
+& structure`.
+
+**Why a 6h cache**: a re-scan is cheap (~50ms) but spawn latency
+matters. 6h is enough to absorb dependency adds and commit
+movement within a working day. If you need newer data right
+after, just spawn (next session triggers the refresh).
+
+## Git activity summariser (L4 — recent_activity)
+
+Lives in `internal/gitactivity/`. **LLM-driven**, more expensive,
+runs less often.
+
+**Triggers**:
+
+- A 24h scheduler ticker in the background.
+- Every spawn checks staleness; if older than **12h**, kicks an
+  **async** refresh (the current spawn sees the prior summary;
+  the next one sees the fresh one).
+
+**What it does**:
+
+1. Shells `git log --since="7 days ago" --stat --no-merges` with
+   strict field separators so the output parses unambiguously.
+2. Builds a deterministic preamble (commit count, file count,
+   net lines, hot-path files by commit count).
+3. Sends the structured data to the configured summarizer
+   provider (LM Studio, ChatGPT-OAuth, or any OpenAI-compatible
+   endpoint).
+4. Asks for 1-3 paragraphs of narrative + a "for the incoming
+   session: avoid X / focus on Y" hint section.
+5. Persists as `project_docs.kind='recent_activity'`.
+
+Result appears in the Project → **Activity** tab and in spawn
+banners under `### Recent activity`.
+
+If no summarizer provider is configured, the summariser falls
+back to raw stats (window + commit count + hot paths) — still
+useful, just less narrative.
+
+## Cleanup librarian (L5 maintenance)
+
+Lives in `internal/memory/cleaner/`. Maintains the section 11
+discrete-fact store, **not** the project_docs above.
+
+**Why**: agents that have `memory_store` access tend to write
+ephemeral noise alongside durable facts. Even with the **M12
+gatekeeper** rejecting "currently debugging X"-class entries at
+write-time, you'll still accumulate facts that age out — old
+project plans, stale infra details, duplicates the dedup
+threshold barely missed.
+
+**Triggers**:
+
+- 24h scheduler ticker (configurable via
+  `[memory.cleaner].interval_seconds`).
+- Manual: Project → **Cleanup** tab → "Run cleanup now" button.
+
+**What it does**:
+
+1. Picks up to `batch_size` (default 20) aged-eligible memories
+   for one scope at a time.
+2. Asks the LLM to judge each: `keep` / `stale` / `duplicate`
+   (with `merge_into` target).
+3. Writes one row per judgment to `memory_cleanup_decisions`
+   with status `pending`.
+4. **Does NOT execute anything.** All deletions / merges wait
+   for your approval.
+
+**Triage UI**:
+
+- Project → **Cleanup** tab — decisions for this cwd only.
+- More → Memory → **Cleanup inbox** — cross-project, grouped by
+  scope_key, useful when you've been off for a while and many
+  decisions queued up.
+
+Each decision row shows:
+
+- Verdict badge (`stale` red, `duplicate` muted, `keep` outline)
+- The memory text snapshot (frozen at decision time)
+- The LLM's reason (read this!)
+- Optional `merge_into` target (for duplicates)
+- Approve / Reject buttons
+
+**Approve**: executes the action. `stale` → memory deleted.
+`duplicate` → merged into target (target's `deduped_count++`).
+`keep` → memory frozen from re-judgment for `skip_if_decided_within_hours`
+(default 168 = 1 week).
+
+**Reject**: decision marked rejected; memory stays as-is. LLM
+will re-judge later.
+
+**Calibration check**: skim 10-20 decisions and ask "do the
+reasons match how I'd judge these?". If ≥ 80% feel right, the
+librarian is calibrated. If not, the cleaner prompt or the
+summarizer model needs adjustment.
+
+## What's NOT auto-managed
+
+These need your hand:
+
+- **Goal**, **Plan**: you write them. Agents propose; you
+  approve in Inbox.
+- **Cleanup approvals**: every delete/merge/freeze is
+  operator-gated.
+- **Reset**: wiping a project's memory needs the explicit
+  destructive button (see section 04).
+
+The auto / manual split is intentional — the auto pieces are
+either deterministic (scanner) or operator-reviewable (cleaner
+proposes, you approve). You never hit "the system silently
+threw away the plan I wrote yesterday".

--- a/app/web/src/tutorial/sections/14-project-memory/04-reset-and-troubleshooting.md
+++ b/app/web/src/tutorial/sections/14-project-memory/04-reset-and-troubleshooting.md
@@ -1,0 +1,177 @@
+# Reset & troubleshooting
+
+## Reset project memory
+
+A first-class action that wipes all per-cwd state in one
+transaction. Useful when:
+
+- You're done with a project and want to clear its memory.
+- A project's goal / plan got fundamentally wrong and the
+  fastest fix is "start over".
+- You want a clean slate for a benchmark / demo.
+
+**Where**:
+
+- Web: Project screen header → outlined **Reset** button (red text)
+- Mobile: Project screen AppBar → 🔄 IconButton
+
+**Dialog**:
+
+The reset confirm dialog shows the cwd in a red banner with the
+warning **"Always deleted: goal, plan, proposals, journal,
+cleanup decisions"**. Two opt-in checkboxes:
+
+| Checkbox | What it does | Default |
+|---|---|---|
+| Also delete scanner docs | Wipes `tech_stack` + `recent_activity` too | **off** — they auto-rebuild on next spawn anyway |
+| Also delete pgvector memories | Wipes the section 11 facts for this scope_key | **off** — these are long-term agent-stored facts that may be valuable; explicit opt-in |
+
+The button is labeled **"Delete forever"** and styled
+destructive. Confirmation is a single click — there's no
+"type the cwd to confirm" because the explicit checkbox flow
+plus the cwd-in-banner is enough for this risk level. The toast
+on success shows concrete deletion counts per table.
+
+Under the hood: `POST /api/v1/project-docs/reset` runs the doc /
+proposal / journal / cleanup-decision delete in a single
+transaction; the optional memory wipe is a separate
+`POST /api/v1/memory/delete-by-scope` call from the UI when the
+checkbox is on.
+
+## Orphan scope_keys
+
+When inspecting the **Cleanup inbox** or the Project picker you
+may see entries marked `orphan`:
+
+```
+PROJECT  /Users/    [orphan]    15 pending
+```
+
+These are bug data from an old mirror import that truncated
+source paths down to fragments like `/Users/`. They're not real
+project cwds — opening them as a project lands on an empty
+ProjectScreen, which is pointless.
+
+The orphan heuristic: a scope_key with fewer than 2 non-empty
+path segments. `/Users/` has 1 (just "Users"). Real projects
+like `/tmp/foo` or `/Users/me/work/repo` have ≥ 2.
+
+**Handling**:
+
+- **Cleanup inbox**: orphan groups show the `orphan` badge and
+  drop the "Open project" deep-link. You can still approve /
+  reject the underlying decisions row-by-row — `stale` verdicts
+  on orphan entries are the quickest way to clear the rot.
+- **Project picker**: orphans are sorted to the bottom of the
+  list, visually muted (opacity-60), and marked with a warning
+  icon. You can still navigate into them if you really need to.
+
+To bulk-delete: nothing built-in yet. SQL works:
+
+```sql
+DELETE FROM memories
+  WHERE scope='project'
+    AND array_length(string_to_array(trim(both '/' from scope_key), '/'), 1) < 2;
+DELETE FROM memory_cleanup_decisions
+  WHERE memory_scope='project'
+    AND array_length(string_to_array(trim(both '/' from memory_scope_key), '/'), 1) < 2;
+```
+
+## Project isolation guarantees (M22)
+
+The journaler that auto-writes session-end summaries (L4 of L5)
+runs an LLM over the transcript. A misconfigured reader could
+pick up an unrelated session's jsonl and the LLM would
+confidently summarise the wrong work — silent
+misinformation worse than no summary.
+
+Three defenses in `internal/session/transcript.go`:
+
+1. **Fail-closed on missing UUID file**: if the session row's
+   `claude_session_id` is set but the named `*.jsonl` doesn't
+   exist, the reader returns nil — never substitutes "latest
+   mtime in dir".
+2. **Time-window filter**: even when the right file is opened,
+   each parsed turn must fall within `[startedAt - 30s,
+   endedAt + 30s]`. Accumulated content from earlier spawns is
+   filtered out.
+3. **Cwd canary**: the first jsonl entry with a `cwd` field must
+   exactly match the calling session's cwd. One mismatch and
+   the whole file is rejected.
+
+When any defense trips, the journaler degrades to metadata-only
+(no `Agent activity summary` section appended). "We don't know
+what happened" is the correct failure mode — never a
+confidently-wrong summary.
+
+If you suspect a contaminated journal entry, the SQL check:
+
+```sql
+SELECT id, cwd, content FROM session_logs
+ WHERE content LIKE '%Agent activity summary%'
+   AND content LIKE '%<some file path you didn''t expect to see>%';
+```
+
+…and cross-reference the mentioned file paths against the actual
+session's jsonl tool_use blocks. New entries on M22 build should
+be clean; old data from before M22 may need manual deletion.
+
+## SQL recipes
+
+### See everything for one cwd
+
+```sql
+SELECT 'project_docs' AS source, COUNT(*) AS n FROM project_docs
+ WHERE cwd = '/your/path'
+UNION ALL
+SELECT 'session_logs', COUNT(*) FROM session_logs
+ WHERE cwd = '/your/path'
+UNION ALL
+SELECT 'cleanup_decisions', COUNT(*) FROM memory_cleanup_decisions
+ WHERE memory_scope = 'project' AND memory_scope_key = '/your/path'
+UNION ALL
+SELECT 'memories', COUNT(*) FROM memories
+ WHERE scope = 'project' AND scope_key = '/your/path';
+```
+
+### Check tech_stack staleness
+
+```sql
+SELECT cwd,
+       NOW() - updated_at AS age,
+       length(content) AS bytes
+  FROM project_docs
+ WHERE kind = 'tech_stack'
+ ORDER BY updated_at;
+```
+
+Anything `age > 6 hours` will trigger a sync re-scan on the next
+spawn into that cwd.
+
+### Cleaner decision quality skim
+
+```sql
+SELECT verdict, status,
+       substring(memory_text_snapshot, 1, 50) AS preview,
+       substring(reason, 1, 80) AS llm_reason
+  FROM memory_cleanup_decisions
+ ORDER BY created_at DESC LIMIT 20;
+```
+
+Skim the `llm_reason` column. If ≥ 80% read as sensible to you,
+the librarian is calibrated. If not, the cleaner prompt or model
+needs adjustment.
+
+## When to ask for help
+
+- Spawn injection text looks corrupt or wrong project → check
+  the cwd matches the spawn's cwd (case-sensitive!) and the
+  scanner has refreshed.
+- Journal entries missing the `Agent activity summary` section
+  → could be M22 isolation kicked in (good!), or summarizer
+  provider not configured, or session was too short for the
+  LLM "too sparse" guard. Check the server log for
+  `journaler: transcript fetch failed` or `journaler: llm
+  summarise failed`.
+- Cleanup decisions pile up → either you're behind on triage or
+  the librarian is misclassifying. Skim 20 and decide.


### PR DESCRIPTION
## Summary

Two small follow-ups to PR #56 / #57 / #58 (the unified-memory
sweep):

**Mobile orphan parity.** Cleanup inbox on mobile now shows the
same `orphan` badge that web added in PR #57 for truncated
scope_keys like `/Users/`. Same heuristic (< 2 non-empty path
segments), same visual treatment. Tooltip explains it's old
mirror-import data and points to Project Reset as the cleanup path.

(Mobile didn't need the auto-pick fix from PR #57 — mobile's
project picker uses an explicit `initialCwd` from callers and
never auto-jumps.)

**Tutorial section 14 — Project memory.** Four-part operator
guide for everything that landed in M5-M24:

- 01-overview — five-layer model, when to use which layer
- 02-workflow — Goal/Plan editing, Inbox proposal review with
  diff, Journal reading
- 03-scanner-and-cleaner — auto-managed L1/L4 + the LLM
  cleanup librarian
- 04-reset-and-troubleshooting — the new Reset action,
  orphan handling, M22 isolation guarantees, SQL recipes

Picked up automatically by the existing `sections.ts` Vite glob —
no registry change needed.

## Verified

- `flutter analyze` clean
- `pnpm build` clean — new markdown renders via existing tutorial
  plumbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)