### PR TITLE
fix(memory): JSON tags on worker Config + CallSummary

### DIFF
--- a/internal/memory/worker/store.go
+++ b/internal/memory/worker/store.go
@@ -101,19 +101,19 @@ func (s *store) Upsert(ctx context.Context, c Config) error {
 // CallSummary is one row from memory_worker_calls for the UI's
 // metrics list.
 type CallSummary struct {
-	ID           int64
-	Task         TaskKind
-	WorkerKind   WorkerKind
-	ProviderID   string
-	AccountID    string
-	StartedAt    time.Time
-	DurationMS   int64
-	Success      bool
-	ErrorMessage string
-	InputBytes   int
-	OutputBytes  int
-	TokensIn     int
-	TokensOut    int
+	ID           int64      `json:"id"`
+	Task         TaskKind   `json:"task"`
+	WorkerKind   WorkerKind `json:"worker_kind"`
+	ProviderID   string     `json:"provider_id"`
+	AccountID    string     `json:"account_id"`
+	StartedAt    time.Time  `json:"started_at"`
+	DurationMS   int64      `json:"duration_ms"`
+	Success      bool       `json:"success"`
+	ErrorMessage string     `json:"error_message"`
+	InputBytes   int        `json:"input_bytes"`
+	OutputBytes  int        `json:"output_bytes"`
+	TokensIn     int        `json:"tokens_in"`
+	TokensOut    int        `json:"tokens_out"`
 }
 
 // RecordCall persists a metrics row. Best-effort: failures here

--- a/internal/memory/worker/worker.go
+++ b/internal/memory/worker/worker.go
@@ -146,13 +146,13 @@ type Worker interface {
 // Config carries the per-task configuration read from
 // memory_workers. The Resolver builds a Worker from this.
 type Config struct {
-	Task         TaskKind
-	Kind         WorkerKind
-	SummarizerID string // when Kind==WorkerSummarizer; "" → registry default
-	ProviderID   string // when Kind==WorkerAgent: "claude" | "gemini"
-	AccountID    string // when ProviderID=="claude"; "" → catalog's default account
-	Enabled      bool
-	UpdatedAt    time.Time
+	Task         TaskKind   `json:"task"`
+	Kind         WorkerKind `json:"kind"`
+	SummarizerID string     `json:"summarizer_id"` // when Kind==WorkerSummarizer; "" → registry default
+	ProviderID   string     `json:"provider_id"`   // when Kind==WorkerAgent: "claude" | "gemini"
+	AccountID    string     `json:"account_id"`    // when ProviderID=="claude"; "" → catalog's default account
+	Enabled      bool       `json:"enabled"`
+	UpdatedAt    time.Time  `json:"updated_at"`
 }
 
 // Valid returns nil if the config is internally consistent.


### PR DESCRIPTION
## Summary

The four Memory → Workers cards rendered with no task titles and
permanently-disabled badges because the API returned PascalCase
JSON while the web TS client expects snake_case:

\`\`\`json
{"Task":"cleaner","Kind":"summarizer","Enabled":true, ...}
\`\`\`

Add the missing \`json:\"...\"\` tags on \`worker.Config\` and
\`worker.CallSummary\` so the wire matches the schema both
clients (web + mobile) declare. Mobile's factory was already
PascalCase-tolerant; web was snake-only and broke on render.

## Verified

- Restart server, hit \`GET /api/v1/memory/workers/\` — keys are
  now \`task\`, \`kind\`, \`enabled\`, \`summarizer_id\`,
  \`provider_id\`, \`account_id\`, \`updated_at\`.
- Web Memory → Workers page now shows the four task labels +
  descriptions + accurate enabled state + current kind in the
  dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)