### PR TITLE
fix(memory): drop --bare from agent worker spawn (auth-blocker)

### DIFF
--- a/docs/adr/0018-unified-cross-cli-memory.md
+++ b/docs/adr/0018-unified-cross-cli-memory.md
@@ -193,16 +193,17 @@ fills it via `--session-id` flag at spawn).
   staleness check that triggers sync refresh when overdue.
 - Operator approval queues (proposals + cleanup) require touch.
   Inactive operators leave goal/plan proposals pending forever;
-  mitigated only by cleanup-staleness sweeps (TODO: M25).
+  mitigated by cleanup-staleness sweeps once a worker is configured
+  (M25, shipped).
 
 ## Follow-ups
 
-- **M25 — pluggable Memory worker**. Today all four LLM touch
-  points go through the same `summarizer.Registry` HTTP path.
-  M25 will add an `AgentWorker` implementation that spawns a
-  headless Claude/Codex/Gemini session in `--print` mode to do
-  the work, with per-task-kind switching (operator picks
-  summarizer vs agent per touch-point in mobile Settings).
+- **M25 — pluggable Memory worker** *(shipped)*. The four LLM
+  touch-points now route through `worker.Registry`, which resolves
+  per-task config (DB-backed) to either the existing summarizer
+  HTTP path or a freshly-spawned `claude --print` / `gemini --print`
+  agent. See ADR 0019 for the architecture and the Memory → Workers
+  UI for operator flow.
 - **Codex session UUID capture**. Codex has no `--session-id`
   flag; currently relies on cwd-based matching + M22 time-window
   filtering. Robust for single-session-per-cwd; multi-concurrent

--- a/docs/adr/0019-pluggable-memory-worker.md
+++ b/docs/adr/0019-pluggable-memory-worker.md
@@ -64,7 +64,7 @@ gracefully).
 
 **AgentWorker** spawns a headless CLI:
 
-- `claude --print --append-system-prompt <prompt> --session-id <uuid> --bare`
+- `claude --print --append-system-prompt <prompt> --session-id <uuid>`
 - `gemini --print --session-id <uuid> --include-directories <scratch>`
 
 Input goes to stdin; stdout is captured until EOF; Request.Timeout
@@ -74,6 +74,17 @@ tasks (cleaner) prepend the schema to the system prompt instead
 of using `response_format` (agent CLIs don't natively support it).
 Worker sessions deliberately don't create a `sessions` table row —
 they're out-of-band invocations, invisible to the journaler.
+
+**Why not `--bare`?** The Claude CLI's `--bare` flag (skip hooks /
+plugins / CLAUDE.md auto-discovery) is tempting but forces auth
+through `ANTHROPIC_API_KEY` only — opendray's multi-account flow
+stores OAuth tokens (`CLAUDE_CODE_OAUTH_TOKEN`) which `--bare`
+silently ignores, causing exit 1 "Not logged in". The isolation
+properties `--bare` would give us are already provided by the
+scratch CWD (CLAUDE.md auto-discovery has nothing to find) and
+the `--print` mode (no tool use means PostToolUse / Stop hooks
+don't fire). Plugin sync cost is accepted in exchange for OAuth
+auth working.
 
 Codex is unsupported because it has no `--print` equivalent.
 

--- a/docs/memory-system.md
+++ b/docs/memory-system.md
@@ -253,17 +253,40 @@ Settings → Server → Memory.
 | Memory growing unbounded | Cleaner disabled; or operator not approving decisions | Enable cleaner, work through inbox |
 | Cross-project leakage suspected | Pre-M22 contamination; or new M22 bypass | Run hallucination check SQL above; if confirmed, file issue |
 
+## Pluggable LLM workers (M25, shipped)
+
+Each of the four memory touch-points (gatekeeper / cleaner /
+gitactivity / transcript) can independently be served by either:
+
+- **SummarizerWorker** — the original OpenAI-compat HTTP path
+  (LM Studio / OpenAI / ollama). ~1s latency.
+- **AgentWorker** — a headless `claude --print` or `gemini --print`
+  spawn keyed to one of your multi-account OAuth tokens. ~5-15s
+  latency, frontier-model quality, draws from your Claude / Gemini
+  subscription quota.
+
+Operators flip per task on the **Memory → Workers** page (web +
+mobile). Default rows are all `summarizer` — zero behavioural
+change for existing installs. Per-call latency + outcome lands in
+`memory_worker_calls`; a 24h rollup is surfaced on each card.
+
+Gatekeeper stays summarizer-only by design — agent spawn (5-15s)
+violates its <500ms latency budget. Codex is unsupported (no
+`--print` mode).
+
+See ADR 0019 for the architecture, the **Memory → Workers**
+tutorial (sections 15.1-15.3) for operator workflow, and the
+implementation under `internal/memory/worker/`.
+
 ## Roadmap
 
-- **M25 — pluggable Memory worker**. Today all four LLM touch
-  points hit a single HTTP endpoint. M25 will let you route some
-  touch-points through a headless Claude / Codex / Gemini agent
-  session for higher quality (at higher cost). Per-task-kind
-  switching in mobile Settings → Memory → Workers.
-- **Codex session UUID capture**. Codex lacks `--session-id`;
-  M25 may parse `session_meta.id` from the first rollout line
-  post-spawn to get the same isolation guarantees Claude/Gemini
-  already have.
+- **Codex session UUID capture**. Codex lacks `--session-id`; a
+  future patch could parse `session_meta.id` from the first
+  rollout line post-spawn to get the same isolation guarantees
+  Claude/Gemini already have.
 - **Self-healing cleaner**. Extend the cleaner to detect cross-cwd
   file references in journal summaries (hallucination signal)
   using opendray's own LLM provider chain.
+- **Per-cwd worker overrides**. Today the worker config is global
+  per task; a future revision may let operators pin a specific
+  cwd to a heavier worker (e.g. "use Claude only for project X").

--- a/internal/memory/worker/agent.go
+++ b/internal/memory/worker/agent.go
@@ -136,16 +136,18 @@ func (w *AgentWorker) Run(ctx context.Context, req Request) (Response, error) {
 	}()
 
 	if err := cmd.Wait(); err != nil {
-		stderrTrunc := truncate(stderr.String(), 400)
-		// Distinguish timeout from other errors for the metrics
-		// table — operators want to know whether to bump the
-		// timeout or chase a model error.
+		// Claude / Gemini CLIs print auth + 4xx errors to stdout
+		// (not stderr), so include both streams in the error
+		// message — operators can't debug "exit status 1 (stderr: )"
+		// blind.
+		stderrTrunc := truncate(stderr.String(), 200)
+		stdoutTrunc := truncate(stdout.String(), 400)
 		if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
-			return Response{}, fmt.Errorf("agent worker: timeout after %s (stderr: %s)",
-				timeout, stderrTrunc)
+			return Response{}, fmt.Errorf("agent worker: timeout after %s (stdout: %s, stderr: %s)",
+				timeout, stdoutTrunc, stderrTrunc)
 		}
-		return Response{}, fmt.Errorf("agent worker: %s --print: %w (stderr: %s)",
-			w.cfg.ProviderID, err, stderrTrunc)
+		return Response{}, fmt.Errorf("agent worker: %s --print: %w (stdout: %s, stderr: %s)",
+			w.cfg.ProviderID, err, stdoutTrunc, stderrTrunc)
 	}
 	dur := time.Since(t0).Milliseconds()
 
@@ -168,11 +170,14 @@ func (w *AgentWorker) buildCommand(req Request, sessionID string) ([]string, []s
 		args := []string{
 			"--print",
 			"--session-id", sessionID,
-			// --bare skips hooks, plugin sync, CLAUDE.md auto-
-			// discovery, auto-memory, keychain reads —
-			// minimising cold-start latency and avoiding the
-			// agent picking up unrelated project context.
-			"--bare",
+			// NOTE: --bare is tempting (it skips hooks / plugin
+			// sync / CLAUDE.md auto-discovery), but it forces
+			// auth via ANTHROPIC_API_KEY only — our multi-account
+			// OAuth tokens (CLAUDE_CODE_OAUTH_TOKEN) get ignored
+			// and the call fails with exit 1 "Not logged in".
+			// We rely on the scratch CWD to isolate from project
+			// CLAUDE.md, and --print already skips tool use so
+			// PostToolUse hooks won't fire.
 		}
 		sys := req.SystemPrompt
 		if req.ResponseFormatJSONSchema != "" {


### PR DESCRIPTION
## Summary

Every \`PUT /memory/workers/{task}\` → agent test or real call
was failing with \`claude --print: exit status 1\` and an empty
stderr. Root cause: the spawn passes \`--bare\`, which forces
auth via \`ANTHROPIC_API_KEY\` only and silently ignores our
\`CLAUDE_CODE_OAUTH_TOKEN\` env. M25 stores OAuth tokens (the
multi-account flow), not API keys, so every agent call hit
"Not logged in" → exit 1.

The features \`--bare\` gave us aren't load-bearing for the
worker spawn:

| --bare did this | We're fine because |
|---|---|
| Skip CLAUDE.md auto-discovery | Scratch CWD is empty |
| Skip hooks | --print without tool use never fires PostToolUse/Stop |
| Skip auto-memory | No project memory exists for /tmp/opd-memory-worker-* |
| Skip plugin sync | Minor latency we accept for OAuth auth |

Also widen the failure error message to include stdout
(Claude prints 401/429/auth errors to stdout, not stderr) so
operators get an actionable message instead of \`exit status 1
(stderr: )\`.

## Verified

Switched transcript to \`agent · claude · kev\`. Restarted server.

\`\`\`bash
POST /api/v1/memory/workers/transcript/test
→ {"ok": true, "duration_ms": 4515, "preview": "OK\\n",
   "worker_kind": "agent", "provider_id": "claude"}
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)