### PR TITLE
feat(web): add directory browser to Memory project picker

### DIFF
--- a/app/web/src/pages/Project.tsx
+++ b/app/web/src/pages/Project.tsx
@@ -10,17 +10,19 @@
 import { useState } from 'react'
 import { useSearch, useNavigate } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
-import { AlertCircle, Folder } from 'lucide-react'
+import { AlertCircle, Folder, FolderSearch } from 'lucide-react'
 
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { ProjectScreen } from '@/components/project/ProjectScreen'
+import { FileBrowserDialog } from '@/components/sessions/FileBrowserDialog'
 import { listScopeKeys } from '@/lib/memory'
 
 export function ProjectPage() {
   const search = useSearch({ strict: false }) as { cwd?: string }
   const navigate = useNavigate()
   const [picker, setPicker] = useState('')
+  const [browserOpen, setBrowserOpen] = useState(false)
 
   const projectsQuery = useQuery({
     queryKey: ['memory-project-scope-keys'],
@@ -44,6 +46,14 @@ export function ProjectPage() {
             className="font-mono"
           />
           <Button
+            variant="outline"
+            onClick={() => setBrowserOpen(true)}
+            title="Browse the gateway host's filesystem"
+          >
+            <FolderSearch className="mr-1 size-3.5" />
+            Browse
+          </Button>
+          <Button
             disabled={!picker.trim()}
             onClick={() =>
               navigate({
@@ -55,6 +65,18 @@ export function ProjectPage() {
             Open
           </Button>
         </div>
+        <FileBrowserDialog
+          open={browserOpen}
+          onOpenChange={setBrowserOpen}
+          initialPath={picker.trim() || undefined}
+          onSelect={(path) => {
+            setPicker(path)
+            navigate({
+              to: '/memory/project',
+              search: { cwd: path },
+            })
+          }}
+        />
         {projectsQuery.data && projectsQuery.data.length > 0 && (
           <div className="space-y-1">
             <p className="text-muted-foreground text-xs">


### PR DESCRIPTION
## Summary

Web's Memory → Project picker forced operators to either paste
the absolute path or pick from the "Recent projects" list seeded
by stored scope_keys. There was no way to discover a project that
doesn't yet have memory — exactly the case where you most want
project memory.

This patch adds a "Browse" button next to the path input that
opens the existing \`FileBrowserDialog\` (already used by the
spawn dialog), letting operators navigate the gateway host's
filesystem and pick a folder. Selecting a folder navigates
straight to the project view.

No backend change — \`/api/v1/fs/{list,home,mkdir}\` are already
mounted from \`internal/fs/handler.go\`.

## Verified

- \`pnpm tsc --noEmit\` clean
- \`pnpm build\` clean
- Manual: Browse → ~/Documents → click a folder → opens project
  view at that cwd. Existing paste + Recent list flows still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)