### PR TITLE
fix(mobile-android): grant INTERNET + permit cleartext for release APK

### DIFF
--- a/app/mobile/android/app/src/main/AndroidManifest.xml
+++ b/app/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Network access for release builds. The debug manifest already
+         grants INTERNET so dev builds work; without it on the main
+         manifest, the release APK installs cleanly but every HTTP /
+         WebSocket call to the gateway fails silently because the OS
+         denies socket creation at all. ACCESS_NETWORK_STATE is paired
+         so the app can detect offline / connectivity changes. -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <application
         android:label="opendray"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/mobile/android/app/src/main/res/xml/network_security_config.xml
+++ b/app/mobile/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Allow cleartext HTTP. opendray is typically self-hosted on a LAN
+  (Proxmox LXC, home server, etc.) and reached via a private IP like
+  192.168.x.x — but Android 9+ blocks cleartext globally by default,
+  so the release APK silently fails to connect.
+
+  Why not restrict by IP range: Android's network-security-config
+  <domain> matches literal hostnames only, no CIDR / no IP-range
+  syntax. Enumerating every possible private address is impractical;
+  the realistic options are "all cleartext" or "no cleartext".
+
+  Since this app's sole purpose is talking to a single self-hosted
+  gateway the operator already trusts (and points to via base URL
+  in settings), permitting cleartext globally is the right trade-off.
+
+  If you front opendray with a TLS reverse proxy and always reach
+  it via HTTPS, this file becomes a no-op.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system"/>
+            <certificates src="user"/>
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
## Summary

Release-built APKs install cleanly but can't reach the gateway —
because the main \`AndroidManifest.xml\` was missing two things
the debug manifest already provided:

1. **\`<uses-permission android:name=\"android.permission.INTERNET\"/>\`**
   Debug has it (the Flutter tool needs it for hot reload); release
   inherits no INTERNET permission at all, so every HTTP / WebSocket
   call to the gateway is denied by the OS at the socket layer
   before it ever leaves the process.

2. **Cleartext HTTP allowance.** opendray is typically reached at
   \`http://192.168.x.x:8770\` on a LAN. Android 9+ blocks cleartext
   globally by default — the release APK silently refused those
   requests even after INTERNET was granted.

## Changes

- \`AndroidManifest.xml\`: add \`INTERNET\` + \`ACCESS_NETWORK_STATE\`
  permissions, point \`android:networkSecurityConfig\` at the new
  XML resource. ACCESS_NETWORK_STATE lets the app distinguish "no
  network" from "wrong URL" in error messages — useful when
  operators troubleshoot LAN reachability.
- \`res/xml/network_security_config.xml\`: permit cleartext globally
  with both system and user trust anchors. We don't restrict by IP
  range because Android's \`<domain>\` matches literal hostnames
  only — no CIDR / no range syntax. Listing every private IP is
  impractical; the realistic choices are "all cleartext" or "no
  cleartext", and the latter breaks LAN deployments.

iOS already had \`NSAllowsArbitraryLoads=true\` in Info.plist, so no
changes needed there.

## Verified

- \`flutter analyze\` clean
- Manual: still need to build a fresh release APK on a tagged
  branch and install on a physical Android device pointing at a
  LAN gateway URL — operator-side verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)