### PR TITLE
feat(mobile): i18n foundation with Chinese + English (slang)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1,0 +1,44 @@
+{
+  "common": {
+    "ok": "OK",
+    "cancel": "Cancel",
+    "save": "Save",
+    "delete": "Delete",
+    "edit": "Edit",
+    "back": "Back",
+    "done": "Done",
+    "close": "Close",
+    "retry": "Retry"
+  },
+  "settings": {
+    "title": "Settings",
+    "language": {
+      "section": "Language",
+      "system": "System",
+      "systemSubtitle": "Follow your phone's language setting",
+      "english": "English",
+      "chinese": "中文"
+    },
+    "appearance": {
+      "section": "Appearance",
+      "system": "System",
+      "systemSubtitle": "Follow your phone's appearance setting",
+      "light": "Light",
+      "lightSubtitle": "Always use the light palette",
+      "dark": "Dark",
+      "darkSubtitle": "Always use the dark palette"
+    },
+    "account": {
+      "section": "Account",
+      "changeCredentials": "Change credentials",
+      "changeCredentialsSubtitle": "Username and password"
+    },
+    "gateway": {
+      "section": "Gateway",
+      "serverSettings": "Server settings",
+      "serverSettingsSubtitle": "Listen address, logging, vault, memory, storage paths…",
+      "liveLogs": "Live logs",
+      "liveLogsSubtitle": "Tail the gateway log buffer — same source as the web admin"
+    }
+  }
+}

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -1,0 +1,44 @@
+{
+  "common": {
+    "ok": "确定",
+    "cancel": "取消",
+    "save": "保存",
+    "delete": "删除",
+    "edit": "编辑",
+    "back": "返回",
+    "done": "完成",
+    "close": "关闭",
+    "retry": "重试"
+  },
+  "settings": {
+    "title": "设置",
+    "language": {
+      "section": "语言",
+      "system": "跟随系统",
+      "systemSubtitle": "跟随手机的语言设置",
+      "english": "English",
+      "chinese": "中文"
+    },
+    "appearance": {
+      "section": "外观",
+      "system": "跟随系统",
+      "systemSubtitle": "跟随手机的外观设置",
+      "light": "浅色",
+      "lightSubtitle": "始终使用浅色主题",
+      "dark": "深色",
+      "darkSubtitle": "始终使用深色主题"
+    },
+    "account": {
+      "section": "账户",
+      "changeCredentials": "修改凭据",
+      "changeCredentialsSubtitle": "用户名和密码"
+    },
+    "gateway": {
+      "section": "网关",
+      "serverSettings": "服务器设置",
+      "serverSettingsSubtitle": "监听地址、日志、凭据库、内存、存储路径…",
+      "liveLogs": "实时日志",
+      "liveLogsSubtitle": "查看网关实时日志 — 与 Web 管理端同源"
+    }
+  }
+}

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -1,0 +1,183 @@
+/// Generated file. Do not edit.
+///
+/// Source: ../i18n
+/// To regenerate, run: `dart run slang`
+///
+/// Locales: 2
+/// Strings: 60 (30 per locale)
+///
+/// Built on 2026-05-13 at 11:13 UTC
+
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
+import 'package:slang/generated.dart';
+import 'package:slang_flutter/slang_flutter.dart';
+export 'package:slang_flutter/slang_flutter.dart';
+
+import 'strings_zh.g.dart' deferred as l_zh;
+part 'strings_en.g.dart';
+
+/// Supported locales.
+///
+/// Usage:
+/// - LocaleSettings.setLocale(AppLocale.en) // set locale
+/// - Locale locale = AppLocale.en.flutterLocale // get flutter locale from enum
+/// - if (LocaleSettings.currentLocale == AppLocale.en) // locale check
+enum AppLocale with BaseAppLocale<AppLocale, Translations> {
+	en(languageCode: 'en'),
+	zh(languageCode: 'zh');
+
+	const AppLocale({
+		required this.languageCode,
+		this.scriptCode, // ignore: unused_element, unused_element_parameter
+		this.countryCode, // ignore: unused_element, unused_element_parameter
+	});
+
+	@override final String languageCode;
+	@override final String? scriptCode;
+	@override final String? countryCode;
+
+	@override
+	Future<Translations> build({
+		Map<String, Node>? overrides,
+		PluralResolver? cardinalResolver,
+		PluralResolver? ordinalResolver,
+	}) async {
+		switch (this) {
+			case AppLocale.en:
+				return TranslationsEn(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.zh:
+				await l_zh.loadLibrary();
+				return l_zh.TranslationsZh(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+		}
+	}
+
+	@override
+	Translations buildSync({
+		Map<String, Node>? overrides,
+		PluralResolver? cardinalResolver,
+		PluralResolver? ordinalResolver,
+	}) {
+		switch (this) {
+			case AppLocale.en:
+				return TranslationsEn(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.zh:
+				return l_zh.TranslationsZh(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+		}
+	}
+
+	/// Gets current instance managed by [LocaleSettings].
+	Translations get translations => LocaleSettings.instance.getTranslations(this);
+}
+
+/// Method A: Simple
+///
+/// No rebuild after locale change.
+/// Translation happens during initialization of the widget (call of t).
+/// Configurable via 'translate_var'.
+///
+/// Usage:
+/// String a = t.someKey.anotherKey;
+/// String b = t['someKey.anotherKey']; // Only for edge cases!
+Translations get t => LocaleSettings.instance.currentTranslations;
+
+/// Method B: Advanced
+///
+/// All widgets using this method will trigger a rebuild when locale changes.
+/// Use this if you have e.g. a settings page where the user can select the locale during runtime.
+///
+/// Step 1:
+/// wrap your App with
+/// TranslationProvider(
+/// 	child: MyApp()
+/// );
+///
+/// Step 2:
+/// final t = Translations.of(context); // Get t variable.
+/// String a = t.someKey.anotherKey; // Use t variable.
+/// String b = t['someKey.anotherKey']; // Only for edge cases!
+class TranslationProvider extends BaseTranslationProvider<AppLocale, Translations> {
+	TranslationProvider({required super.child}) : super(settings: LocaleSettings.instance);
+
+	static InheritedLocaleData<AppLocale, Translations> of(BuildContext context) => InheritedLocaleData.of<AppLocale, Translations>(context);
+}
+
+/// Method B shorthand via [BuildContext] extension method.
+/// Configurable via 'translate_var'.
+///
+/// Usage (e.g. in a widget's build method):
+/// context.t.someKey.anotherKey
+extension BuildContextTranslationsExtension on BuildContext {
+	Translations get t => TranslationProvider.of(this).translations;
+}
+
+/// Manages all translation instances and the current locale
+class LocaleSettings extends BaseFlutterLocaleSettings<AppLocale, Translations> {
+	LocaleSettings._() : super(
+		utils: AppLocaleUtils.instance,
+		lazy: true,
+	);
+
+	static final instance = LocaleSettings._();
+
+	// static aliases (checkout base methods for documentation)
+	static AppLocale get currentLocale => instance.currentLocale;
+	static Stream<AppLocale> getLocaleStream() => instance.getLocaleStream();
+	static Future<AppLocale> setLocale(AppLocale locale, {bool? listenToDeviceLocale = false}) => instance.setLocale(locale, listenToDeviceLocale: listenToDeviceLocale);
+	static Future<AppLocale> setLocaleRaw(String rawLocale, {bool? listenToDeviceLocale = false}) => instance.setLocaleRaw(rawLocale, listenToDeviceLocale: listenToDeviceLocale);
+	static Future<AppLocale> useDeviceLocale() => instance.useDeviceLocale();
+	static Future<void> setPluralResolver({String? language, AppLocale? locale, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver}) => instance.setPluralResolver(
+		language: language,
+		locale: locale,
+		cardinalResolver: cardinalResolver,
+		ordinalResolver: ordinalResolver,
+	);
+
+	// synchronous versions
+	static AppLocale setLocaleSync(AppLocale locale, {bool? listenToDeviceLocale = false}) => instance.setLocaleSync(locale, listenToDeviceLocale: listenToDeviceLocale);
+	static AppLocale setLocaleRawSync(String rawLocale, {bool? listenToDeviceLocale = false}) => instance.setLocaleRawSync(rawLocale, listenToDeviceLocale: listenToDeviceLocale);
+	static AppLocale useDeviceLocaleSync() => instance.useDeviceLocaleSync();
+	static void setPluralResolverSync({String? language, AppLocale? locale, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver}) => instance.setPluralResolverSync(
+		language: language,
+		locale: locale,
+		cardinalResolver: cardinalResolver,
+		ordinalResolver: ordinalResolver,
+	);
+}
+
+/// Provides utility functions without any side effects.
+class AppLocaleUtils extends BaseAppLocaleUtils<AppLocale, Translations> {
+	AppLocaleUtils._() : super(
+		baseLocale: AppLocale.en,
+		locales: AppLocale.values,
+	);
+
+	static final instance = AppLocaleUtils._();
+
+	// static aliases (checkout base methods for documentation)
+	static AppLocale parse(String rawLocale) => instance.parse(rawLocale);
+	static AppLocale parseLocaleParts({required String languageCode, String? scriptCode, String? countryCode}) => instance.parseLocaleParts(languageCode: languageCode, scriptCode: scriptCode, countryCode: countryCode);
+	static AppLocale findDeviceLocale() => instance.findDeviceLocale();
+	static List<Locale> get supportedLocales => instance.supportedLocales;
+	static List<String> get supportedLocalesRaw => instance.supportedLocalesRaw;
+}

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -1,0 +1,237 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+part of 'strings.g.dart';
+
+// Path: <root>
+typedef TranslationsEn = Translations; // ignore: unused_element
+class Translations with BaseTranslations<AppLocale, Translations> {
+	/// Returns the current translations of the given [context].
+	///
+	/// Usage:
+	/// final t = Translations.of(context);
+	static Translations of(BuildContext context) => InheritedLocaleData.of<AppLocale, Translations>(context).translations;
+
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	Translations({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = meta ?? TranslationMetadata(
+		    locale: AppLocale.en,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ) {
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
+
+	/// Metadata for the translations of <en>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
+
+	/// Access flat map
+	dynamic operator[](String key) => $meta.getTranslation(key);
+
+	late final Translations _root = this; // ignore: unused_field
+
+	Translations $copyWith({TranslationMetadata<AppLocale, Translations>? meta}) => Translations(meta: meta ?? this.$meta);
+
+	// Translations
+	late final TranslationsCommonEn common = TranslationsCommonEn.internal(_root);
+	late final TranslationsSettingsEn settings = TranslationsSettingsEn.internal(_root);
+}
+
+// Path: common
+class TranslationsCommonEn {
+	TranslationsCommonEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'OK'
+	String get ok => 'OK';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Save'
+	String get save => 'Save';
+
+	/// en: 'Delete'
+	String get delete => 'Delete';
+
+	/// en: 'Edit'
+	String get edit => 'Edit';
+
+	/// en: 'Back'
+	String get back => 'Back';
+
+	/// en: 'Done'
+	String get done => 'Done';
+
+	/// en: 'Close'
+	String get close => 'Close';
+
+	/// en: 'Retry'
+	String get retry => 'Retry';
+}
+
+// Path: settings
+class TranslationsSettingsEn {
+	TranslationsSettingsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Settings'
+	String get title => 'Settings';
+
+	late final TranslationsSettingsLanguageEn language = TranslationsSettingsLanguageEn.internal(_root);
+	late final TranslationsSettingsAppearanceEn appearance = TranslationsSettingsAppearanceEn.internal(_root);
+	late final TranslationsSettingsAccountEn account = TranslationsSettingsAccountEn.internal(_root);
+	late final TranslationsSettingsGatewayEn gateway = TranslationsSettingsGatewayEn.internal(_root);
+}
+
+// Path: settings.language
+class TranslationsSettingsLanguageEn {
+	TranslationsSettingsLanguageEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Language'
+	String get section => 'Language';
+
+	/// en: 'System'
+	String get system => 'System';
+
+	/// en: 'Follow your phone's language setting'
+	String get systemSubtitle => 'Follow your phone\'s language setting';
+
+	/// en: 'English'
+	String get english => 'English';
+
+	/// en: '中文'
+	String get chinese => '中文';
+}
+
+// Path: settings.appearance
+class TranslationsSettingsAppearanceEn {
+	TranslationsSettingsAppearanceEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Appearance'
+	String get section => 'Appearance';
+
+	/// en: 'System'
+	String get system => 'System';
+
+	/// en: 'Follow your phone's appearance setting'
+	String get systemSubtitle => 'Follow your phone\'s appearance setting';
+
+	/// en: 'Light'
+	String get light => 'Light';
+
+	/// en: 'Always use the light palette'
+	String get lightSubtitle => 'Always use the light palette';
+
+	/// en: 'Dark'
+	String get dark => 'Dark';
+
+	/// en: 'Always use the dark palette'
+	String get darkSubtitle => 'Always use the dark palette';
+}
+
+// Path: settings.account
+class TranslationsSettingsAccountEn {
+	TranslationsSettingsAccountEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Account'
+	String get section => 'Account';
+
+	/// en: 'Change credentials'
+	String get changeCredentials => 'Change credentials';
+
+	/// en: 'Username and password'
+	String get changeCredentialsSubtitle => 'Username and password';
+}
+
+// Path: settings.gateway
+class TranslationsSettingsGatewayEn {
+	TranslationsSettingsGatewayEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Gateway'
+	String get section => 'Gateway';
+
+	/// en: 'Server settings'
+	String get serverSettings => 'Server settings';
+
+	/// en: 'Listen address, logging, vault, memory, storage paths…'
+	String get serverSettingsSubtitle => 'Listen address, logging, vault, memory, storage paths…';
+
+	/// en: 'Live logs'
+	String get liveLogs => 'Live logs';
+
+	/// en: 'Tail the gateway log buffer — same source as the web admin'
+	String get liveLogsSubtitle => 'Tail the gateway log buffer — same source as the web admin';
+}
+
+/// The flat map containing all translations for locale <en>.
+/// Only for edge cases! For simple maps, use the map function of this library.
+///
+/// The Dart AOT compiler has issues with very large switch statements,
+/// so the map is split into smaller functions (512 entries each).
+extension on Translations {
+	dynamic _flatMapFunction(String path) {
+		return switch (path) {
+			'common.ok' => 'OK',
+			'common.cancel' => 'Cancel',
+			'common.save' => 'Save',
+			'common.delete' => 'Delete',
+			'common.edit' => 'Edit',
+			'common.back' => 'Back',
+			'common.done' => 'Done',
+			'common.close' => 'Close',
+			'common.retry' => 'Retry',
+			'settings.title' => 'Settings',
+			'settings.language.section' => 'Language',
+			'settings.language.system' => 'System',
+			'settings.language.systemSubtitle' => 'Follow your phone\'s language setting',
+			'settings.language.english' => 'English',
+			'settings.language.chinese' => '中文',
+			'settings.appearance.section' => 'Appearance',
+			'settings.appearance.system' => 'System',
+			'settings.appearance.systemSubtitle' => 'Follow your phone\'s appearance setting',
+			'settings.appearance.light' => 'Light',
+			'settings.appearance.lightSubtitle' => 'Always use the light palette',
+			'settings.appearance.dark' => 'Dark',
+			'settings.appearance.darkSubtitle' => 'Always use the dark palette',
+			'settings.account.section' => 'Account',
+			'settings.account.changeCredentials' => 'Change credentials',
+			'settings.account.changeCredentialsSubtitle' => 'Username and password',
+			'settings.gateway.section' => 'Gateway',
+			'settings.gateway.serverSettings' => 'Server settings',
+			'settings.gateway.serverSettingsSubtitle' => 'Listen address, logging, vault, memory, storage paths…',
+			'settings.gateway.liveLogs' => 'Live logs',
+			'settings.gateway.liveLogsSubtitle' => 'Tail the gateway log buffer — same source as the web admin',
+			_ => null,
+		};
+	}
+}

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -1,0 +1,175 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
+import 'package:slang/generated.dart';
+import 'strings.g.dart';
+
+// Path: <root>
+class TranslationsZh extends Translations with BaseTranslations<AppLocale, Translations> {
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	TranslationsZh({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = meta ?? TranslationMetadata(
+		    locale: AppLocale.zh,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ),
+		  super(cardinalResolver: cardinalResolver, ordinalResolver: ordinalResolver) {
+		super.$meta.setFlatMapFunction($meta.getTranslation); // copy base translations to super.$meta
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
+
+	/// Metadata for the translations of <zh>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
+
+	/// Access flat map
+	@override dynamic operator[](String key) => $meta.getTranslation(key) ?? super.$meta.getTranslation(key);
+
+	late final TranslationsZh _root = this; // ignore: unused_field
+
+	@override 
+	TranslationsZh $copyWith({TranslationMetadata<AppLocale, Translations>? meta}) => TranslationsZh(meta: meta ?? this.$meta);
+
+	// Translations
+	@override late final _TranslationsCommonZh common = _TranslationsCommonZh._(_root);
+	@override late final _TranslationsSettingsZh settings = _TranslationsSettingsZh._(_root);
+}
+
+// Path: common
+class _TranslationsCommonZh extends TranslationsCommonEn {
+	_TranslationsCommonZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get ok => '确定';
+	@override String get cancel => '取消';
+	@override String get save => '保存';
+	@override String get delete => '删除';
+	@override String get edit => '编辑';
+	@override String get back => '返回';
+	@override String get done => '完成';
+	@override String get close => '关闭';
+	@override String get retry => '重试';
+}
+
+// Path: settings
+class _TranslationsSettingsZh extends TranslationsSettingsEn {
+	_TranslationsSettingsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '设置';
+	@override late final _TranslationsSettingsLanguageZh language = _TranslationsSettingsLanguageZh._(_root);
+	@override late final _TranslationsSettingsAppearanceZh appearance = _TranslationsSettingsAppearanceZh._(_root);
+	@override late final _TranslationsSettingsAccountZh account = _TranslationsSettingsAccountZh._(_root);
+	@override late final _TranslationsSettingsGatewayZh gateway = _TranslationsSettingsGatewayZh._(_root);
+}
+
+// Path: settings.language
+class _TranslationsSettingsLanguageZh extends TranslationsSettingsLanguageEn {
+	_TranslationsSettingsLanguageZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get section => '语言';
+	@override String get system => '跟随系统';
+	@override String get systemSubtitle => '跟随手机的语言设置';
+	@override String get english => 'English';
+	@override String get chinese => '中文';
+}
+
+// Path: settings.appearance
+class _TranslationsSettingsAppearanceZh extends TranslationsSettingsAppearanceEn {
+	_TranslationsSettingsAppearanceZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get section => '外观';
+	@override String get system => '跟随系统';
+	@override String get systemSubtitle => '跟随手机的外观设置';
+	@override String get light => '浅色';
+	@override String get lightSubtitle => '始终使用浅色主题';
+	@override String get dark => '深色';
+	@override String get darkSubtitle => '始终使用深色主题';
+}
+
+// Path: settings.account
+class _TranslationsSettingsAccountZh extends TranslationsSettingsAccountEn {
+	_TranslationsSettingsAccountZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get section => '账户';
+	@override String get changeCredentials => '修改凭据';
+	@override String get changeCredentialsSubtitle => '用户名和密码';
+}
+
+// Path: settings.gateway
+class _TranslationsSettingsGatewayZh extends TranslationsSettingsGatewayEn {
+	_TranslationsSettingsGatewayZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get section => '网关';
+	@override String get serverSettings => '服务器设置';
+	@override String get serverSettingsSubtitle => '监听地址、日志、凭据库、内存、存储路径…';
+	@override String get liveLogs => '实时日志';
+	@override String get liveLogsSubtitle => '查看网关实时日志 — 与 Web 管理端同源';
+}
+
+/// The flat map containing all translations for locale <zh>.
+/// Only for edge cases! For simple maps, use the map function of this library.
+///
+/// The Dart AOT compiler has issues with very large switch statements,
+/// so the map is split into smaller functions (512 entries each).
+extension on TranslationsZh {
+	dynamic _flatMapFunction(String path) {
+		return switch (path) {
+			'common.ok' => '确定',
+			'common.cancel' => '取消',
+			'common.save' => '保存',
+			'common.delete' => '删除',
+			'common.edit' => '编辑',
+			'common.back' => '返回',
+			'common.done' => '完成',
+			'common.close' => '关闭',
+			'common.retry' => '重试',
+			'settings.title' => '设置',
+			'settings.language.section' => '语言',
+			'settings.language.system' => '跟随系统',
+			'settings.language.systemSubtitle' => '跟随手机的语言设置',
+			'settings.language.english' => 'English',
+			'settings.language.chinese' => '中文',
+			'settings.appearance.section' => '外观',
+			'settings.appearance.system' => '跟随系统',
+			'settings.appearance.systemSubtitle' => '跟随手机的外观设置',
+			'settings.appearance.light' => '浅色',
+			'settings.appearance.lightSubtitle' => '始终使用浅色主题',
+			'settings.appearance.dark' => '深色',
+			'settings.appearance.darkSubtitle' => '始终使用深色主题',
+			'settings.account.section' => '账户',
+			'settings.account.changeCredentials' => '修改凭据',
+			'settings.account.changeCredentialsSubtitle' => '用户名和密码',
+			'settings.gateway.section' => '网关',
+			'settings.gateway.serverSettings' => '服务器设置',
+			'settings.gateway.serverSettingsSubtitle' => '监听地址、日志、凭据库、内存、存储路径…',
+			'settings.gateway.liveLogs' => '实时日志',
+			'settings.gateway.liveLogsSubtitle' => '查看网关实时日志 — 与 Web 管理端同源',
+			_ => null,
+		};
+	}
+}

--- a/app/mobile/lib/core/locale/locale_controller.dart
+++ b/app/mobile/lib/core/locale/locale_controller.dart
@@ -1,0 +1,75 @@
+// LocaleController — single source of truth for the user's language
+// pick. Mirrors ThemeController: persists to shared_preferences so
+// the choice survives restarts, broadcasts via Riverpod so
+// MaterialApp.router rebuilds whenever the value flips.
+//
+// Three states (System / English / Chinese) decouple "what the user
+// asked for" from "what slang ended up using" — useful because the
+// system locale can be anything and slang resolves it via fallback.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+enum LocalePreference { system, english, chinese }
+
+const _prefsKey = 'opendray.locale.preference.v1';
+
+class LocaleController extends StateNotifier<LocalePreference> {
+  LocaleController() : super(LocalePreference.system) {
+    _restore();
+  }
+
+  Future<void> _restore() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final parsed = _parse(prefs.getString(_prefsKey));
+      if (parsed != null && parsed != state) {
+        state = parsed;
+      }
+      _apply(state);
+    } on Object {
+      _apply(state);
+    }
+  }
+
+  Future<void> setPreference(LocalePreference pref) async {
+    state = pref;
+    _apply(pref);
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_prefsKey, _serialise(pref));
+    } on Object {
+      // Best-effort persistence; in-memory pick still works.
+    }
+  }
+
+  static void _apply(LocalePreference pref) {
+    switch (pref) {
+      case LocalePreference.system:
+        LocaleSettings.useDeviceLocale();
+      case LocalePreference.english:
+        LocaleSettings.setLocale(AppLocale.en);
+      case LocalePreference.chinese:
+        LocaleSettings.setLocale(AppLocale.zh);
+    }
+  }
+
+  static String _serialise(LocalePreference pref) => switch (pref) {
+        LocalePreference.system => 'system',
+        LocalePreference.english => 'english',
+        LocalePreference.chinese => 'chinese',
+      };
+
+  static LocalePreference? _parse(String? raw) => switch (raw) {
+        'system' => LocalePreference.system,
+        'english' => LocalePreference.english,
+        'chinese' => LocalePreference.chinese,
+        _ => null,
+      };
+}
+
+final localeControllerProvider =
+    StateNotifierProvider<LocaleController, LocalePreference>(
+  (ref) => LocaleController(),
+);

--- a/app/mobile/lib/features/settings/settings_screen.dart
+++ b/app/mobile/lib/features/settings/settings_screen.dart
@@ -2,14 +2,15 @@
 // that aren't tied to a specific server resource. Reached via
 // More → Settings.
 //
-// PR #51 ships the Appearance section. The Account section
-// (change password / change username) lands in PR #52 — its
-// placeholder is included here so the layout doesn't shift when
-// it arrives.
+// All visible strings flow through slang (`t.settings.*`). The
+// Language section at the top lets the user override the system
+// locale; LocaleController persists the pick to shared_preferences.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/core/locale/locale_controller.dart';
 import 'package:opendray/core/theme/theme_controller.dart';
 import 'package:opendray/features/settings/change_credentials_screen.dart';
 import 'package:opendray/features/settings/log_viewer_screen.dart';
@@ -21,15 +22,49 @@ class SettingsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final mode = ref.watch(themeControllerProvider);
+    final locale = ref.watch(localeControllerProvider);
     final theme = Theme.of(context);
     return Scaffold(
-      appBar: AppBar(title: const Text('Settings')),
+      appBar: AppBar(title: Text(t.settings.title)),
       body: SafeArea(
         bottom: false,
         child: ListView(
           padding: const EdgeInsets.symmetric(vertical: 8),
           children: [
-            const _SectionHeader('Appearance'),
+            _SectionHeader(t.settings.language.section),
+            RadioGroup<LocalePreference>(
+              groupValue: locale,
+              onChanged: (pref) {
+                if (pref == null) return;
+                ref
+                    .read(localeControllerProvider.notifier)
+                    .setPreference(pref);
+              },
+              child: Column(
+                children: [
+                  _LocaleOption(
+                    title: t.settings.language.system,
+                    subtitle: t.settings.language.systemSubtitle,
+                    icon: Icons.language_outlined,
+                    value: LocalePreference.system,
+                  ),
+                  _LocaleOption(
+                    title: t.settings.language.english,
+                    subtitle: 'English',
+                    icon: Icons.translate_outlined,
+                    value: LocalePreference.english,
+                  ),
+                  _LocaleOption(
+                    title: t.settings.language.chinese,
+                    subtitle: '中文',
+                    icon: Icons.translate_outlined,
+                    value: LocalePreference.chinese,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            _SectionHeader(t.settings.appearance.section),
             // RadioGroup is the Flutter 3.32+ way to share group
             // state across Radio<T> descendants without each tile
             // duplicating groupValue/onChanged.
@@ -39,23 +74,23 @@ class SettingsScreen extends ConsumerWidget {
                 if (m == null) return;
                 ref.read(themeControllerProvider.notifier).setMode(m);
               },
-              child: const Column(
+              child: Column(
                 children: [
                   _ThemeOption(
-                    title: 'System',
-                    subtitle: "Follow your phone's appearance setting",
+                    title: t.settings.appearance.system,
+                    subtitle: t.settings.appearance.systemSubtitle,
                     icon: Icons.brightness_auto_outlined,
                     value: ThemeMode.system,
                   ),
                   _ThemeOption(
-                    title: 'Light',
-                    subtitle: 'Always use the light palette',
+                    title: t.settings.appearance.light,
+                    subtitle: t.settings.appearance.lightSubtitle,
                     icon: Icons.light_mode_outlined,
                     value: ThemeMode.light,
                   ),
                   _ThemeOption(
-                    title: 'Dark',
-                    subtitle: 'Always use the dark palette',
+                    title: t.settings.appearance.dark,
+                    subtitle: t.settings.appearance.darkSubtitle,
                     icon: Icons.dark_mode_outlined,
                     value: ThemeMode.dark,
                   ),
@@ -63,12 +98,12 @@ class SettingsScreen extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 16),
-            const _SectionHeader('Account'),
+            _SectionHeader(t.settings.account.section),
             ListTile(
               leading: const Icon(Icons.lock_outline),
-              title: const Text('Change credentials'),
+              title: Text(t.settings.account.changeCredentials),
               subtitle: Text(
-                'Username and password',
+                t.settings.account.changeCredentialsSubtitle,
                 style: theme.textTheme.bodySmall,
               ),
               trailing: const Icon(Icons.chevron_right, size: 18),
@@ -79,12 +114,12 @@ class SettingsScreen extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 16),
-            const _SectionHeader('Gateway'),
+            _SectionHeader(t.settings.gateway.section),
             ListTile(
               leading: const Icon(Icons.dns_outlined),
-              title: const Text('Server settings'),
+              title: Text(t.settings.gateway.serverSettings),
               subtitle: Text(
-                'Listen address, logging, vault, memory, storage paths…',
+                t.settings.gateway.serverSettingsSubtitle,
                 style: theme.textTheme.bodySmall,
               ),
               trailing: const Icon(Icons.chevron_right, size: 18),
@@ -96,9 +131,9 @@ class SettingsScreen extends ConsumerWidget {
             ),
             ListTile(
               leading: const Icon(Icons.subject_outlined),
-              title: const Text('Live logs'),
+              title: Text(t.settings.gateway.liveLogs),
               subtitle: Text(
-                'Tail the gateway log buffer — same source as the web admin',
+                t.settings.gateway.liveLogsSubtitle,
                 style: theme.textTheme.bodySmall,
               ),
               trailing: const Icon(Icons.chevron_right, size: 18),
@@ -162,14 +197,40 @@ class _ThemeOption extends StatelessWidget {
         style: theme.textTheme.bodySmall,
       ),
       trailing: Radio<ThemeMode>(value: value),
-      // ListTile.onTap forwards through RadioGroup's onChanged
-      // automatically via the Radio widget — no manual wiring
-      // needed.
       onTap: () {
-        // Find the ancestor RadioGroup and report this value as
-        // the new selection. Reaching through context keeps the
-        // option widget itself stateless.
         final group = RadioGroup.maybeOf<ThemeMode>(context);
+        group?.onChanged(value);
+      },
+    );
+  }
+}
+
+class _LocaleOption extends StatelessWidget {
+  const _LocaleOption({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.value,
+  });
+
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final LocalePreference value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListTile(
+      leading: Icon(icon),
+      title: Text(title),
+      subtitle: Text(
+        subtitle,
+        style: theme.textTheme.bodySmall,
+      ),
+      trailing: Radio<LocalePreference>(value: value),
+      onTap: () {
+        final group = RadioGroup.maybeOf<LocalePreference>(context);
         group?.onChanged(value);
       },
     );

--- a/app/mobile/lib/main.dart
+++ b/app/mobile/lib/main.dart
@@ -1,12 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/core/locale/locale_controller.dart';
 import 'package:opendray/core/routing/app_router.dart';
 import 'package:opendray/core/theme/app_theme.dart';
 import 'package:opendray/core/theme/theme_controller.dart';
 
 void main() {
-  runApp(const ProviderScope(child: OpendrayApp()));
+  WidgetsFlutterBinding.ensureInitialized();
+  LocaleSettings.useDeviceLocale();
+  runApp(
+    TranslationProvider(
+      child: const ProviderScope(child: OpendrayApp()),
+    ),
+  );
 }
 
 class OpendrayApp extends ConsumerWidget {
@@ -15,16 +24,21 @@ class OpendrayApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(routerProvider);
-    // Watch the controller so a picker change in Settings rebuilds
-    // MaterialApp with the new themeMode immediately — no app
-    // restart needed.
     final themeMode = ref.watch(themeControllerProvider);
+    // Watching the locale controller rebuilds MaterialApp so the
+    // Material/Cupertino delegates re-resolve and Flutter's own
+    // built-in widgets (DatePicker, dialog buttons, etc.) follow
+    // the user's pick.
+    ref.watch(localeControllerProvider);
     return MaterialApp.router(
       title: 'opendray',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.light(),
       darkTheme: AppTheme.dark(),
       themeMode: themeMode,
+      locale: TranslationProvider.of(context).flutterLocale,
+      supportedLocales: AppLocaleUtils.instance.supportedLocales,
+      localizationsDelegates: GlobalMaterialLocalizations.delegates,
       routerConfig: router,
     );
   }

--- a/app/mobile/pubspec.yaml
+++ b/app/mobile/pubspec.yaml
@@ -12,18 +12,22 @@ dependencies:
   dio: ^5.7.0
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   flutter_riverpod: ^2.6.1
   flutter_secure_storage: ^9.2.2
   freezed_annotation: ^2.4.4
   go_router: ^14.6.2
   image_picker: ^1.1.2
-  intl: ^0.19.0
+  intl: ^0.20.2
   json_annotation: ^4.9.0
   local_auth: ^2.3.0
   package_info_plus: ^8.1.1
   path: ^1.9.1
   pretty_dio_logger: ^1.4.0
   shared_preferences: ^2.3.4
+  slang: ^4.14.0
+  slang_flutter: ^4.14.0
   web_socket_channel: ^3.0.1
   xterm: ^4.0.0
   yaml: ^3.1.2
@@ -34,6 +38,7 @@ dev_dependencies:
     sdk: flutter
   freezed: ^2.5.7
   json_serializable: ^6.9.0
+  slang_build_runner: ^4.14.0
   very_good_analysis: ^7.0.0
 
 # Use the in-repo xterm fork (third_party/xterm) which enables IME features

--- a/app/mobile/slang.yaml
+++ b/app/mobile/slang.yaml
@@ -1,0 +1,13 @@
+base_locale: en
+fallback_strategy: base_locale
+input_directory: ../i18n
+input_file_pattern: .json
+output_directory: lib/core/i18n
+output_file_name: strings.g.dart
+locale_handling: true
+flutter_integration: true
+namespaces: false
+translate_var: t
+enum_name: AppLocale
+class_name: Translations
+translation_class_visibility: private


### PR DESCRIPTION
First slice of mobile internationalization. This PR sets up the translation pipeline, adds a Language picker in Settings, and migrates the Settings main screen as a worked example. Subsequent PRs migrate the remaining screens.

## What landed

- **Shared translation source**: `app/i18n/{en,zh}.json`. The directory sits at the repo root (outside `app/mobile`) so the web app can consume the same JSON files when it joins later.
- **slang + slang_flutter 4.14.0** for type-safe, compile-time translation classes. `slang_build_runner` as a dev dep. Configured via `app/mobile/slang.yaml`.
- **Generated `strings*.g.dart` is committed** under `app/mobile/lib/core/i18n/` so fresh clones / CI run without an extra codegen step.
- **`flutter_localizations`** added — Material / Cupertino built-ins (DatePicker, dialog buttons, etc.) now translate automatically. `intl` bumped `0.19.0 → 0.20.2` to satisfy the new constraint; no in-repo code touches intl directly.
- **`LocaleController`** (Riverpod `StateNotifier` + `shared_preferences`, mirrors `ThemeController`). States: `system / english / chinese`. Persists to `opendray.locale.preference.v1`.
- **`main.dart`** wraps the tree with `TranslationProvider`, watches `localeControllerProvider`, and feeds `MaterialApp.router` the `locale`, `supportedLocales`, and `localizationsDelegates`.
- **Settings screen migrated**: every visible string flows through `t.settings.*`. New Language section at the top with three radio options; switching is instant — no restart.

## Out of scope (follow-up PRs)

- Settings sub-screens (`change_credentials`, `server_settings`, `log_viewer`) untouched.
- Every other feature directory untouched (auth, sessions, memory, mcp, …).
- Web app: will pick up the same JSON in a later PR.
- Backend: stays English; per product decision we don't translate server-emitted messages.

## Architecture decisions captured

- **Keys use feature-namespaced nested style** (`settings.language.section`) — agreed in chat. Easier to organize than flat keys.
- **Generated files committed** — agreed in chat. Easier onboarding, no CI codegen requirement.
- **Placeholder syntax: `{name}` (ICU simplified)** — slang's default; same syntax works in `react-i18next` when web joins, so keys stay portable.

## Test plan

- [x] `flutter pub get` resolves with new deps
- [x] `flutter analyze` clean
- [x] `dart run slang` regenerates `strings.g.dart` from JSON
- [ ] **Manual on device**: open Settings → tap Language radio → flip between System / English / 中文. Verify: AppBar title, every section header (LANGUAGE / APPEARANCE / ACCOUNT / GATEWAY), every list item title + subtitle, and Appearance options all re-render in the new language without restart.
- [ ] **Regression**: confirm theme switching (Appearance section) still works.
- [ ] **Sub-screens** (Change credentials / Server settings / Live logs) still show their original English strings — expected, they migrate in follow-up PRs.

## Adding a new key (for the follow-up PR author)

1. Add the key under the right path in `app/i18n/en.json`, then add the matching translation in `app/i18n/zh.json`.
2. From `app/mobile/` run `dart run slang`.
3. Use `t.path.to.key` in your widget; `import 'package:opendray/core/i18n/strings.g.dart';`.
4. Commit the regenerated `strings*.g.dart` along with the JSON changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)