### PR TITLE
feat(mobile): i18n migrate sessions list screen

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1,0 +1,44 @@
+{
+  "common": {
+    "ok": "OK",
+    "cancel": "Cancel",
+    "save": "Save",
+    "delete": "Delete",
+    "edit": "Edit",
+    "back": "Back",
+    "done": "Done",
+    "close": "Close",
+    "retry": "Retry"
+  },
+  "settings": {
+    "title": "Settings",
+    "language": {
+      "section": "Language",
+      "system": "System",
+      "systemSubtitle": "Follow your phone's language setting",
+      "english": "English",
+      "chinese": "中文"
+    },
+    "appearance": {
+      "section": "Appearance",
+      "system": "System",
+      "systemSubtitle": "Follow your phone's appearance setting",
+      "light": "Light",
+      "lightSubtitle": "Always use the light palette",
+      "dark": "Dark",
+      "darkSubtitle": "Always use the dark palette"
+    },
+    "account": {
+      "section": "Account",
+      "changeCredentials": "Change credentials",
+      "changeCredentialsSubtitle": "Username and password"
+    },
+    "gateway": {
+      "section": "Gateway",
+      "serverSettings": "Server settings",
+      "serverSettingsSubtitle": "Listen address, logging, vault, memory, storage paths…",
+      "liveLogs": "Live logs",
+      "liveLogsSubtitle": "Tail the gateway log buffer — same source as the web admin"
+    }
+  }
+}

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -19,6 +19,100 @@
     "errorRequired": "Username and password are required",
     "errorGeneric": "Login failed: {error}"
   },
+  "nav": {
+    "sessions": "Sessions",
+    "memory": "Memory",
+    "notes": "Notes",
+    "more": "More"
+  },
+  "more": {
+    "title": "More",
+    "identity": {
+      "signedInAs": "Signed in as",
+      "server": "Server",
+      "tokenExpires": "Token expires"
+    },
+    "sections": {
+      "gateway": "Gateway",
+      "memory": "Memory",
+      "system": "System"
+    },
+    "items": {
+      "integrations": {
+        "title": "Integrations",
+        "subtitle": "API callers — recent activity & error rates"
+      },
+      "channels": {
+        "title": "Channels",
+        "subtitle": "Notification destinations"
+      },
+      "providers": {
+        "title": "Providers",
+        "subtitle": "Claude / Codex / Gemini CLI status"
+      },
+      "mcp": {
+        "title": "MCP",
+        "subtitle": "Model Context Protocol servers & secrets"
+      },
+      "skills": {
+        "title": "Skills",
+        "subtitle": "Agent SKILL.md library (built-in + vault)"
+      },
+      "gitHosts": {
+        "title": "Git hosts",
+        "subtitle": "PAT credentials for GitHub / GitLab / etc."
+      },
+      "customTasks": {
+        "title": "Custom tasks",
+        "subtitle": "Slash commands shown in the session task picker"
+      },
+      "projectMemory": {
+        "title": "Project goal / plan / journal",
+        "subtitle": "Per-cwd memory layers 2-4 + agent proposals"
+      },
+      "cleanupInbox": {
+        "title": "Cleanup inbox",
+        "subtitle": "LLM-proposed deletions / merges across all projects"
+      },
+      "backups": {
+        "title": "Backups",
+        "subtitle": "Latest backup status & run-now"
+      },
+      "settings": {
+        "title": "Settings",
+        "subtitle": "Language, appearance, account"
+      },
+      "about": {
+        "title": "About",
+        "subtitle": "Build version & server info"
+      }
+    },
+    "signOut": "Sign out"
+  },
+  "about": {
+    "title": "About",
+    "loading": "Loading…",
+    "sections": {
+      "app": "App",
+      "server": "Server"
+    },
+    "fields": {
+      "app": "App",
+      "version": "Version",
+      "versionFormat": "{version} (build {build})",
+      "package": "Package",
+      "url": "URL",
+      "signedInAs": "Signed in as",
+      "tokenExpires": "Token expires"
+    },
+    "copied": "Copied {label}",
+    "copyTooltip": "Copy",
+    "copyLabels": {
+      "version": "version",
+      "serverUrl": "server URL"
+    },
+    "tagline": "opendray mobile — multi-CLI gateway control.\nSource: github.com/Opendray/opendray_v2"
+  },
   "settings": {
     "title": "Settings",
     "language": {

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -10,6 +10,15 @@
     "close": "Close",
     "retry": "Retry"
   },
+  "auth": {
+    "signInTitle": "Sign in",
+    "changeServer": "Change",
+    "username": "Username",
+    "password": "Password",
+    "signIn": "Sign in",
+    "errorRequired": "Username and password are required",
+    "errorGeneric": "Login failed: {error}"
+  },
   "settings": {
     "title": "Settings",
     "language": {

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -89,6 +89,34 @@
     },
     "signOut": "Sign out"
   },
+  "sessions": {
+    "title": "Sessions",
+    "refresh": "Refresh",
+    "actions": "Actions",
+    "spawn": "Spawn",
+    "filters": {
+      "all": "All",
+      "running": "Running",
+      "idle": "Idle",
+      "ended": "Ended"
+    },
+    "card": {
+      "startedRelative": "{provider} · started {when}"
+    },
+    "empty": {
+      "titleAll": "No sessions yet",
+      "titleFiltered": "No sessions match the \"{filter}\" filter.",
+      "subtitleAll": "Tap the Spawn button to create one.",
+      "subtitleFiltered": "Try a different filter or pull to refresh."
+    },
+    "errorTitle": "Failed to load sessions",
+    "relative": {
+      "secondsAgo": "{n}s ago",
+      "minutesAgo": "{n}m ago",
+      "hoursAgo": "{n}h ago",
+      "daysAgo": "{n}d ago"
+    }
+  },
   "about": {
     "title": "About",
     "loading": "Loading…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -1,0 +1,44 @@
+{
+  "common": {
+    "ok": "确定",
+    "cancel": "取消",
+    "save": "保存",
+    "delete": "删除",
+    "edit": "编辑",
+    "back": "返回",
+    "done": "完成",
+    "close": "关闭",
+    "retry": "重试"
+  },
+  "settings": {
+    "title": "设置",
+    "language": {
+      "section": "语言",
+      "system": "跟随系统",
+      "systemSubtitle": "跟随手机的语言设置",
+      "english": "English",
+      "chinese": "中文"
+    },
+    "appearance": {
+      "section": "外观",
+      "system": "跟随系统",
+      "systemSubtitle": "跟随手机的外观设置",
+      "light": "浅色",
+      "lightSubtitle": "始终使用浅色主题",
+      "dark": "深色",
+      "darkSubtitle": "始终使用深色主题"
+    },
+    "account": {
+      "section": "账户",
+      "changeCredentials": "修改凭据",
+      "changeCredentialsSubtitle": "用户名和密码"
+    },
+    "gateway": {
+      "section": "网关",
+      "serverSettings": "服务器设置",
+      "serverSettingsSubtitle": "监听地址、日志、凭据库、内存、存储路径…",
+      "liveLogs": "实时日志",
+      "liveLogsSubtitle": "查看网关实时日志 — 与 Web 管理端同源"
+    }
+  }
+}

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -89,6 +89,34 @@
     },
     "signOut": "退出登录"
   },
+  "sessions": {
+    "title": "会话",
+    "refresh": "刷新",
+    "actions": "操作",
+    "spawn": "创建",
+    "filters": {
+      "all": "全部",
+      "running": "运行中",
+      "idle": "空闲",
+      "ended": "已结束"
+    },
+    "card": {
+      "startedRelative": "{provider} · {when}启动"
+    },
+    "empty": {
+      "titleAll": "暂无会话",
+      "titleFiltered": "没有匹配「{filter}」筛选的会话。",
+      "subtitleAll": "点击「创建」按钮新建一个。",
+      "subtitleFiltered": "试试其他筛选条件或下拉刷新。"
+    },
+    "errorTitle": "加载会话失败",
+    "relative": {
+      "secondsAgo": "{n} 秒前",
+      "minutesAgo": "{n} 分钟前",
+      "hoursAgo": "{n} 小时前",
+      "daysAgo": "{n} 天前"
+    }
+  },
   "about": {
     "title": "关于",
     "loading": "加载中…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -19,6 +19,100 @@
     "errorRequired": "请输入用户名和密码",
     "errorGeneric": "登录失败：{error}"
   },
+  "nav": {
+    "sessions": "会话",
+    "memory": "记忆",
+    "notes": "笔记",
+    "more": "更多"
+  },
+  "more": {
+    "title": "更多",
+    "identity": {
+      "signedInAs": "登录账号",
+      "server": "服务器",
+      "tokenExpires": "令牌到期"
+    },
+    "sections": {
+      "gateway": "网关",
+      "memory": "记忆",
+      "system": "系统"
+    },
+    "items": {
+      "integrations": {
+        "title": "集成",
+        "subtitle": "API 调用方 — 近期活动与错误率"
+      },
+      "channels": {
+        "title": "通道",
+        "subtitle": "通知目的地"
+      },
+      "providers": {
+        "title": "提供商",
+        "subtitle": "Claude / Codex / Gemini CLI 状态"
+      },
+      "mcp": {
+        "title": "MCP",
+        "subtitle": "Model Context Protocol 服务与密钥"
+      },
+      "skills": {
+        "title": "技能",
+        "subtitle": "Agent SKILL.md 库（内置 + 库）"
+      },
+      "gitHosts": {
+        "title": "Git 主机",
+        "subtitle": "GitHub / GitLab 等的 PAT 凭据"
+      },
+      "customTasks": {
+        "title": "自定义任务",
+        "subtitle": "会话任务选择器中显示的斜杠命令"
+      },
+      "projectMemory": {
+        "title": "项目目标 / 计划 / 日志",
+        "subtitle": "按 cwd 的记忆层 2-4 + 代理提案"
+      },
+      "cleanupInbox": {
+        "title": "清理收件箱",
+        "subtitle": "跨项目的 LLM 提议删除 / 合并"
+      },
+      "backups": {
+        "title": "备份",
+        "subtitle": "最新备份状态与立即运行"
+      },
+      "settings": {
+        "title": "设置",
+        "subtitle": "语言、外观、账户"
+      },
+      "about": {
+        "title": "关于",
+        "subtitle": "构建版本与服务器信息"
+      }
+    },
+    "signOut": "退出登录"
+  },
+  "about": {
+    "title": "关于",
+    "loading": "加载中…",
+    "sections": {
+      "app": "应用",
+      "server": "服务器"
+    },
+    "fields": {
+      "app": "应用",
+      "version": "版本",
+      "versionFormat": "{version}（build {build}）",
+      "package": "包名",
+      "url": "URL",
+      "signedInAs": "登录账号",
+      "tokenExpires": "令牌到期"
+    },
+    "copied": "已复制 {label}",
+    "copyTooltip": "复制",
+    "copyLabels": {
+      "version": "版本",
+      "serverUrl": "服务器 URL"
+    },
+    "tagline": "opendray mobile — 多 CLI 网关控制。\n源码：github.com/Opendray/opendray_v2"
+  },
   "settings": {
     "title": "设置",
     "language": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -10,6 +10,15 @@
     "close": "关闭",
     "retry": "重试"
   },
+  "auth": {
+    "signInTitle": "登录",
+    "changeServer": "更换",
+    "username": "用户名",
+    "password": "密码",
+    "signIn": "登录",
+    "errorRequired": "请输入用户名和密码",
+    "errorGeneric": "登录失败：{error}"
+  },
   "settings": {
     "title": "设置",
     "language": {

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -1,0 +1,183 @@
+/// Generated file. Do not edit.
+///
+/// Source: ../i18n
+/// To regenerate, run: `dart run slang`
+///
+/// Locales: 2
+/// Strings: 60 (30 per locale)
+///
+/// Built on 2026-05-13 at 11:13 UTC
+
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
+import 'package:slang/generated.dart';
+import 'package:slang_flutter/slang_flutter.dart';
+export 'package:slang_flutter/slang_flutter.dart';
+
+import 'strings_zh.g.dart' deferred as l_zh;
+part 'strings_en.g.dart';
+
+/// Supported locales.
+///
+/// Usage:
+/// - LocaleSettings.setLocale(AppLocale.en) // set locale
+/// - Locale locale = AppLocale.en.flutterLocale // get flutter locale from enum
+/// - if (LocaleSettings.currentLocale == AppLocale.en) // locale check
+enum AppLocale with BaseAppLocale<AppLocale, Translations> {
+	en(languageCode: 'en'),
+	zh(languageCode: 'zh');
+
+	const AppLocale({
+		required this.languageCode,
+		this.scriptCode, // ignore: unused_element, unused_element_parameter
+		this.countryCode, // ignore: unused_element, unused_element_parameter
+	});
+
+	@override final String languageCode;
+	@override final String? scriptCode;
+	@override final String? countryCode;
+
+	@override
+	Future<Translations> build({
+		Map<String, Node>? overrides,
+		PluralResolver? cardinalResolver,
+		PluralResolver? ordinalResolver,
+	}) async {
+		switch (this) {
+			case AppLocale.en:
+				return TranslationsEn(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.zh:
+				await l_zh.loadLibrary();
+				return l_zh.TranslationsZh(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+		}
+	}
+
+	@override
+	Translations buildSync({
+		Map<String, Node>? overrides,
+		PluralResolver? cardinalResolver,
+		PluralResolver? ordinalResolver,
+	}) {
+		switch (this) {
+			case AppLocale.en:
+				return TranslationsEn(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.zh:
+				return l_zh.TranslationsZh(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+		}
+	}
+
+	/// Gets current instance managed by [LocaleSettings].
+	Translations get translations => LocaleSettings.instance.getTranslations(this);
+}
+
+/// Method A: Simple
+///
+/// No rebuild after locale change.
+/// Translation happens during initialization of the widget (call of t).
+/// Configurable via 'translate_var'.
+///
+/// Usage:
+/// String a = t.someKey.anotherKey;
+/// String b = t['someKey.anotherKey']; // Only for edge cases!
+Translations get t => LocaleSettings.instance.currentTranslations;
+
+/// Method B: Advanced
+///
+/// All widgets using this method will trigger a rebuild when locale changes.
+/// Use this if you have e.g. a settings page where the user can select the locale during runtime.
+///
+/// Step 1:
+/// wrap your App with
+/// TranslationProvider(
+/// 	child: MyApp()
+/// );
+///
+/// Step 2:
+/// final t = Translations.of(context); // Get t variable.
+/// String a = t.someKey.anotherKey; // Use t variable.
+/// String b = t['someKey.anotherKey']; // Only for edge cases!
+class TranslationProvider extends BaseTranslationProvider<AppLocale, Translations> {
+	TranslationProvider({required super.child}) : super(settings: LocaleSettings.instance);
+
+	static InheritedLocaleData<AppLocale, Translations> of(BuildContext context) => InheritedLocaleData.of<AppLocale, Translations>(context);
+}
+
+/// Method B shorthand via [BuildContext] extension method.
+/// Configurable via 'translate_var'.
+///
+/// Usage (e.g. in a widget's build method):
+/// context.t.someKey.anotherKey
+extension BuildContextTranslationsExtension on BuildContext {
+	Translations get t => TranslationProvider.of(this).translations;
+}
+
+/// Manages all translation instances and the current locale
+class LocaleSettings extends BaseFlutterLocaleSettings<AppLocale, Translations> {
+	LocaleSettings._() : super(
+		utils: AppLocaleUtils.instance,
+		lazy: true,
+	);
+
+	static final instance = LocaleSettings._();
+
+	// static aliases (checkout base methods for documentation)
+	static AppLocale get currentLocale => instance.currentLocale;
+	static Stream<AppLocale> getLocaleStream() => instance.getLocaleStream();
+	static Future<AppLocale> setLocale(AppLocale locale, {bool? listenToDeviceLocale = false}) => instance.setLocale(locale, listenToDeviceLocale: listenToDeviceLocale);
+	static Future<AppLocale> setLocaleRaw(String rawLocale, {bool? listenToDeviceLocale = false}) => instance.setLocaleRaw(rawLocale, listenToDeviceLocale: listenToDeviceLocale);
+	static Future<AppLocale> useDeviceLocale() => instance.useDeviceLocale();
+	static Future<void> setPluralResolver({String? language, AppLocale? locale, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver}) => instance.setPluralResolver(
+		language: language,
+		locale: locale,
+		cardinalResolver: cardinalResolver,
+		ordinalResolver: ordinalResolver,
+	);
+
+	// synchronous versions
+	static AppLocale setLocaleSync(AppLocale locale, {bool? listenToDeviceLocale = false}) => instance.setLocaleSync(locale, listenToDeviceLocale: listenToDeviceLocale);
+	static AppLocale setLocaleRawSync(String rawLocale, {bool? listenToDeviceLocale = false}) => instance.setLocaleRawSync(rawLocale, listenToDeviceLocale: listenToDeviceLocale);
+	static AppLocale useDeviceLocaleSync() => instance.useDeviceLocaleSync();
+	static void setPluralResolverSync({String? language, AppLocale? locale, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver}) => instance.setPluralResolverSync(
+		language: language,
+		locale: locale,
+		cardinalResolver: cardinalResolver,
+		ordinalResolver: ordinalResolver,
+	);
+}
+
+/// Provides utility functions without any side effects.
+class AppLocaleUtils extends BaseAppLocaleUtils<AppLocale, Translations> {
+	AppLocaleUtils._() : super(
+		baseLocale: AppLocale.en,
+		locales: AppLocale.values,
+	);
+
+	static final instance = AppLocaleUtils._();
+
+	// static aliases (checkout base methods for documentation)
+	static AppLocale parse(String rawLocale) => instance.parse(rawLocale);
+	static AppLocale parseLocaleParts({required String languageCode, String? scriptCode, String? countryCode}) => instance.parseLocaleParts(languageCode: languageCode, scriptCode: scriptCode, countryCode: countryCode);
+	static AppLocale findDeviceLocale() => instance.findDeviceLocale();
+	static List<Locale> get supportedLocales => instance.supportedLocales;
+	static List<String> get supportedLocalesRaw => instance.supportedLocalesRaw;
+}

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 74 (37 per locale)
+/// Strings: 178 (89 per locale)
 ///
-/// Built on 2026-05-13 at 11:21 UTC
+/// Built on 2026-05-13 at 11:24 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 60 (30 per locale)
+/// Strings: 74 (37 per locale)
 ///
-/// Built on 2026-05-13 at 11:13 UTC
+/// Built on 2026-05-13 at 11:21 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 178 (89 per locale)
+/// Strings: 214 (107 per locale)
 ///
-/// Built on 2026-05-13 at 11:24 UTC
+/// Built on 2026-05-13 at 11:27 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -1,0 +1,237 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+part of 'strings.g.dart';
+
+// Path: <root>
+typedef TranslationsEn = Translations; // ignore: unused_element
+class Translations with BaseTranslations<AppLocale, Translations> {
+	/// Returns the current translations of the given [context].
+	///
+	/// Usage:
+	/// final t = Translations.of(context);
+	static Translations of(BuildContext context) => InheritedLocaleData.of<AppLocale, Translations>(context).translations;
+
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	Translations({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = meta ?? TranslationMetadata(
+		    locale: AppLocale.en,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ) {
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
+
+	/// Metadata for the translations of <en>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
+
+	/// Access flat map
+	dynamic operator[](String key) => $meta.getTranslation(key);
+
+	late final Translations _root = this; // ignore: unused_field
+
+	Translations $copyWith({TranslationMetadata<AppLocale, Translations>? meta}) => Translations(meta: meta ?? this.$meta);
+
+	// Translations
+	late final TranslationsCommonEn common = TranslationsCommonEn.internal(_root);
+	late final TranslationsSettingsEn settings = TranslationsSettingsEn.internal(_root);
+}
+
+// Path: common
+class TranslationsCommonEn {
+	TranslationsCommonEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'OK'
+	String get ok => 'OK';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Save'
+	String get save => 'Save';
+
+	/// en: 'Delete'
+	String get delete => 'Delete';
+
+	/// en: 'Edit'
+	String get edit => 'Edit';
+
+	/// en: 'Back'
+	String get back => 'Back';
+
+	/// en: 'Done'
+	String get done => 'Done';
+
+	/// en: 'Close'
+	String get close => 'Close';
+
+	/// en: 'Retry'
+	String get retry => 'Retry';
+}
+
+// Path: settings
+class TranslationsSettingsEn {
+	TranslationsSettingsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Settings'
+	String get title => 'Settings';
+
+	late final TranslationsSettingsLanguageEn language = TranslationsSettingsLanguageEn.internal(_root);
+	late final TranslationsSettingsAppearanceEn appearance = TranslationsSettingsAppearanceEn.internal(_root);
+	late final TranslationsSettingsAccountEn account = TranslationsSettingsAccountEn.internal(_root);
+	late final TranslationsSettingsGatewayEn gateway = TranslationsSettingsGatewayEn.internal(_root);
+}
+
+// Path: settings.language
+class TranslationsSettingsLanguageEn {
+	TranslationsSettingsLanguageEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Language'
+	String get section => 'Language';
+
+	/// en: 'System'
+	String get system => 'System';
+
+	/// en: 'Follow your phone's language setting'
+	String get systemSubtitle => 'Follow your phone\'s language setting';
+
+	/// en: 'English'
+	String get english => 'English';
+
+	/// en: '中文'
+	String get chinese => '中文';
+}
+
+// Path: settings.appearance
+class TranslationsSettingsAppearanceEn {
+	TranslationsSettingsAppearanceEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Appearance'
+	String get section => 'Appearance';
+
+	/// en: 'System'
+	String get system => 'System';
+
+	/// en: 'Follow your phone's appearance setting'
+	String get systemSubtitle => 'Follow your phone\'s appearance setting';
+
+	/// en: 'Light'
+	String get light => 'Light';
+
+	/// en: 'Always use the light palette'
+	String get lightSubtitle => 'Always use the light palette';
+
+	/// en: 'Dark'
+	String get dark => 'Dark';
+
+	/// en: 'Always use the dark palette'
+	String get darkSubtitle => 'Always use the dark palette';
+}
+
+// Path: settings.account
+class TranslationsSettingsAccountEn {
+	TranslationsSettingsAccountEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Account'
+	String get section => 'Account';
+
+	/// en: 'Change credentials'
+	String get changeCredentials => 'Change credentials';
+
+	/// en: 'Username and password'
+	String get changeCredentialsSubtitle => 'Username and password';
+}
+
+// Path: settings.gateway
+class TranslationsSettingsGatewayEn {
+	TranslationsSettingsGatewayEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Gateway'
+	String get section => 'Gateway';
+
+	/// en: 'Server settings'
+	String get serverSettings => 'Server settings';
+
+	/// en: 'Listen address, logging, vault, memory, storage paths…'
+	String get serverSettingsSubtitle => 'Listen address, logging, vault, memory, storage paths…';
+
+	/// en: 'Live logs'
+	String get liveLogs => 'Live logs';
+
+	/// en: 'Tail the gateway log buffer — same source as the web admin'
+	String get liveLogsSubtitle => 'Tail the gateway log buffer — same source as the web admin';
+}
+
+/// The flat map containing all translations for locale <en>.
+/// Only for edge cases! For simple maps, use the map function of this library.
+///
+/// The Dart AOT compiler has issues with very large switch statements,
+/// so the map is split into smaller functions (512 entries each).
+extension on Translations {
+	dynamic _flatMapFunction(String path) {
+		return switch (path) {
+			'common.ok' => 'OK',
+			'common.cancel' => 'Cancel',
+			'common.save' => 'Save',
+			'common.delete' => 'Delete',
+			'common.edit' => 'Edit',
+			'common.back' => 'Back',
+			'common.done' => 'Done',
+			'common.close' => 'Close',
+			'common.retry' => 'Retry',
+			'settings.title' => 'Settings',
+			'settings.language.section' => 'Language',
+			'settings.language.system' => 'System',
+			'settings.language.systemSubtitle' => 'Follow your phone\'s language setting',
+			'settings.language.english' => 'English',
+			'settings.language.chinese' => '中文',
+			'settings.appearance.section' => 'Appearance',
+			'settings.appearance.system' => 'System',
+			'settings.appearance.systemSubtitle' => 'Follow your phone\'s appearance setting',
+			'settings.appearance.light' => 'Light',
+			'settings.appearance.lightSubtitle' => 'Always use the light palette',
+			'settings.appearance.dark' => 'Dark',
+			'settings.appearance.darkSubtitle' => 'Always use the dark palette',
+			'settings.account.section' => 'Account',
+			'settings.account.changeCredentials' => 'Change credentials',
+			'settings.account.changeCredentialsSubtitle' => 'Username and password',
+			'settings.gateway.section' => 'Gateway',
+			'settings.gateway.serverSettings' => 'Server settings',
+			'settings.gateway.serverSettingsSubtitle' => 'Listen address, logging, vault, memory, storage paths…',
+			'settings.gateway.liveLogs' => 'Live logs',
+			'settings.gateway.liveLogsSubtitle' => 'Tail the gateway log buffer — same source as the web admin',
+			_ => null,
+		};
+	}
+}

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -41,6 +41,7 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 
 	// Translations
 	late final TranslationsCommonEn common = TranslationsCommonEn.internal(_root);
+	late final TranslationsAuthEn auth = TranslationsAuthEn.internal(_root);
 	late final TranslationsSettingsEn settings = TranslationsSettingsEn.internal(_root);
 }
 
@@ -78,6 +79,36 @@ class TranslationsCommonEn {
 
 	/// en: 'Retry'
 	String get retry => 'Retry';
+}
+
+// Path: auth
+class TranslationsAuthEn {
+	TranslationsAuthEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Sign in'
+	String get signInTitle => 'Sign in';
+
+	/// en: 'Change'
+	String get changeServer => 'Change';
+
+	/// en: 'Username'
+	String get username => 'Username';
+
+	/// en: 'Password'
+	String get password => 'Password';
+
+	/// en: 'Sign in'
+	String get signIn => 'Sign in';
+
+	/// en: 'Username and password are required'
+	String get errorRequired => 'Username and password are required';
+
+	/// en: 'Login failed: {error}'
+	String errorGeneric({required Object error}) => 'Login failed: ${error}';
 }
 
 // Path: settings
@@ -210,6 +241,13 @@ extension on Translations {
 			'common.done' => 'Done',
 			'common.close' => 'Close',
 			'common.retry' => 'Retry',
+			'auth.signInTitle' => 'Sign in',
+			'auth.changeServer' => 'Change',
+			'auth.username' => 'Username',
+			'auth.password' => 'Password',
+			'auth.signIn' => 'Sign in',
+			'auth.errorRequired' => 'Username and password are required',
+			'auth.errorGeneric' => ({required Object error}) => 'Login failed: ${error}',
 			'settings.title' => 'Settings',
 			'settings.language.section' => 'Language',
 			'settings.language.system' => 'System',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -42,6 +42,9 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	// Translations
 	late final TranslationsCommonEn common = TranslationsCommonEn.internal(_root);
 	late final TranslationsAuthEn auth = TranslationsAuthEn.internal(_root);
+	late final TranslationsNavEn nav = TranslationsNavEn.internal(_root);
+	late final TranslationsMoreEn more = TranslationsMoreEn.internal(_root);
+	late final TranslationsAboutEn about = TranslationsAboutEn.internal(_root);
 	late final TranslationsSettingsEn settings = TranslationsSettingsEn.internal(_root);
 }
 
@@ -111,6 +114,75 @@ class TranslationsAuthEn {
 	String errorGeneric({required Object error}) => 'Login failed: ${error}';
 }
 
+// Path: nav
+class TranslationsNavEn {
+	TranslationsNavEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Sessions'
+	String get sessions => 'Sessions';
+
+	/// en: 'Memory'
+	String get memory => 'Memory';
+
+	/// en: 'Notes'
+	String get notes => 'Notes';
+
+	/// en: 'More'
+	String get more => 'More';
+}
+
+// Path: more
+class TranslationsMoreEn {
+	TranslationsMoreEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'More'
+	String get title => 'More';
+
+	late final TranslationsMoreIdentityEn identity = TranslationsMoreIdentityEn.internal(_root);
+	late final TranslationsMoreSectionsEn sections = TranslationsMoreSectionsEn.internal(_root);
+	late final TranslationsMoreItemsEn items = TranslationsMoreItemsEn.internal(_root);
+
+	/// en: 'Sign out'
+	String get signOut => 'Sign out';
+}
+
+// Path: about
+class TranslationsAboutEn {
+	TranslationsAboutEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'About'
+	String get title => 'About';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	late final TranslationsAboutSectionsEn sections = TranslationsAboutSectionsEn.internal(_root);
+	late final TranslationsAboutFieldsEn fields = TranslationsAboutFieldsEn.internal(_root);
+
+	/// en: 'Copied {label}'
+	String copied({required Object label}) => 'Copied ${label}';
+
+	/// en: 'Copy'
+	String get copyTooltip => 'Copy';
+
+	late final TranslationsAboutCopyLabelsEn copyLabels = TranslationsAboutCopyLabelsEn.internal(_root);
+
+	/// en: 'opendray mobile — multi-CLI gateway control. Source: github.com/Opendray/opendray_v2'
+	String get tagline => 'opendray mobile — multi-CLI gateway control.\nSource: github.com/Opendray/opendray_v2';
+}
+
 // Path: settings
 class TranslationsSettingsEn {
 	TranslationsSettingsEn.internal(this._root);
@@ -126,6 +198,123 @@ class TranslationsSettingsEn {
 	late final TranslationsSettingsAppearanceEn appearance = TranslationsSettingsAppearanceEn.internal(_root);
 	late final TranslationsSettingsAccountEn account = TranslationsSettingsAccountEn.internal(_root);
 	late final TranslationsSettingsGatewayEn gateway = TranslationsSettingsGatewayEn.internal(_root);
+}
+
+// Path: more.identity
+class TranslationsMoreIdentityEn {
+	TranslationsMoreIdentityEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Signed in as'
+	String get signedInAs => 'Signed in as';
+
+	/// en: 'Server'
+	String get server => 'Server';
+
+	/// en: 'Token expires'
+	String get tokenExpires => 'Token expires';
+}
+
+// Path: more.sections
+class TranslationsMoreSectionsEn {
+	TranslationsMoreSectionsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Gateway'
+	String get gateway => 'Gateway';
+
+	/// en: 'Memory'
+	String get memory => 'Memory';
+
+	/// en: 'System'
+	String get system => 'System';
+}
+
+// Path: more.items
+class TranslationsMoreItemsEn {
+	TranslationsMoreItemsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsMoreItemsIntegrationsEn integrations = TranslationsMoreItemsIntegrationsEn.internal(_root);
+	late final TranslationsMoreItemsChannelsEn channels = TranslationsMoreItemsChannelsEn.internal(_root);
+	late final TranslationsMoreItemsProvidersEn providers = TranslationsMoreItemsProvidersEn.internal(_root);
+	late final TranslationsMoreItemsMcpEn mcp = TranslationsMoreItemsMcpEn.internal(_root);
+	late final TranslationsMoreItemsSkillsEn skills = TranslationsMoreItemsSkillsEn.internal(_root);
+	late final TranslationsMoreItemsGitHostsEn gitHosts = TranslationsMoreItemsGitHostsEn.internal(_root);
+	late final TranslationsMoreItemsCustomTasksEn customTasks = TranslationsMoreItemsCustomTasksEn.internal(_root);
+	late final TranslationsMoreItemsProjectMemoryEn projectMemory = TranslationsMoreItemsProjectMemoryEn.internal(_root);
+	late final TranslationsMoreItemsCleanupInboxEn cleanupInbox = TranslationsMoreItemsCleanupInboxEn.internal(_root);
+	late final TranslationsMoreItemsBackupsEn backups = TranslationsMoreItemsBackupsEn.internal(_root);
+	late final TranslationsMoreItemsSettingsEn settings = TranslationsMoreItemsSettingsEn.internal(_root);
+	late final TranslationsMoreItemsAboutEn about = TranslationsMoreItemsAboutEn.internal(_root);
+}
+
+// Path: about.sections
+class TranslationsAboutSectionsEn {
+	TranslationsAboutSectionsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'App'
+	String get app => 'App';
+
+	/// en: 'Server'
+	String get server => 'Server';
+}
+
+// Path: about.fields
+class TranslationsAboutFieldsEn {
+	TranslationsAboutFieldsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'App'
+	String get app => 'App';
+
+	/// en: 'Version'
+	String get version => 'Version';
+
+	/// en: '{version} (build {build})'
+	String versionFormat({required Object version, required Object build}) => '${version} (build ${build})';
+
+	/// en: 'Package'
+	String get package => 'Package';
+
+	/// en: 'URL'
+	String get url => 'URL';
+
+	/// en: 'Signed in as'
+	String get signedInAs => 'Signed in as';
+
+	/// en: 'Token expires'
+	String get tokenExpires => 'Token expires';
+}
+
+// Path: about.copyLabels
+class TranslationsAboutCopyLabelsEn {
+	TranslationsAboutCopyLabelsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'version'
+	String get version => 'version';
+
+	/// en: 'server URL'
+	String get serverUrl => 'server URL';
 }
 
 // Path: settings.language
@@ -224,6 +413,186 @@ class TranslationsSettingsGatewayEn {
 	String get liveLogsSubtitle => 'Tail the gateway log buffer — same source as the web admin';
 }
 
+// Path: more.items.integrations
+class TranslationsMoreItemsIntegrationsEn {
+	TranslationsMoreItemsIntegrationsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Integrations'
+	String get title => 'Integrations';
+
+	/// en: 'API callers — recent activity & error rates'
+	String get subtitle => 'API callers — recent activity & error rates';
+}
+
+// Path: more.items.channels
+class TranslationsMoreItemsChannelsEn {
+	TranslationsMoreItemsChannelsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Channels'
+	String get title => 'Channels';
+
+	/// en: 'Notification destinations'
+	String get subtitle => 'Notification destinations';
+}
+
+// Path: more.items.providers
+class TranslationsMoreItemsProvidersEn {
+	TranslationsMoreItemsProvidersEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Providers'
+	String get title => 'Providers';
+
+	/// en: 'Claude / Codex / Gemini CLI status'
+	String get subtitle => 'Claude / Codex / Gemini CLI status';
+}
+
+// Path: more.items.mcp
+class TranslationsMoreItemsMcpEn {
+	TranslationsMoreItemsMcpEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'MCP'
+	String get title => 'MCP';
+
+	/// en: 'Model Context Protocol servers & secrets'
+	String get subtitle => 'Model Context Protocol servers & secrets';
+}
+
+// Path: more.items.skills
+class TranslationsMoreItemsSkillsEn {
+	TranslationsMoreItemsSkillsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Skills'
+	String get title => 'Skills';
+
+	/// en: 'Agent SKILL.md library (built-in + vault)'
+	String get subtitle => 'Agent SKILL.md library (built-in + vault)';
+}
+
+// Path: more.items.gitHosts
+class TranslationsMoreItemsGitHostsEn {
+	TranslationsMoreItemsGitHostsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Git hosts'
+	String get title => 'Git hosts';
+
+	/// en: 'PAT credentials for GitHub / GitLab / etc.'
+	String get subtitle => 'PAT credentials for GitHub / GitLab / etc.';
+}
+
+// Path: more.items.customTasks
+class TranslationsMoreItemsCustomTasksEn {
+	TranslationsMoreItemsCustomTasksEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Custom tasks'
+	String get title => 'Custom tasks';
+
+	/// en: 'Slash commands shown in the session task picker'
+	String get subtitle => 'Slash commands shown in the session task picker';
+}
+
+// Path: more.items.projectMemory
+class TranslationsMoreItemsProjectMemoryEn {
+	TranslationsMoreItemsProjectMemoryEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Project goal / plan / journal'
+	String get title => 'Project goal / plan / journal';
+
+	/// en: 'Per-cwd memory layers 2-4 + agent proposals'
+	String get subtitle => 'Per-cwd memory layers 2-4 + agent proposals';
+}
+
+// Path: more.items.cleanupInbox
+class TranslationsMoreItemsCleanupInboxEn {
+	TranslationsMoreItemsCleanupInboxEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Cleanup inbox'
+	String get title => 'Cleanup inbox';
+
+	/// en: 'LLM-proposed deletions / merges across all projects'
+	String get subtitle => 'LLM-proposed deletions / merges across all projects';
+}
+
+// Path: more.items.backups
+class TranslationsMoreItemsBackupsEn {
+	TranslationsMoreItemsBackupsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Backups'
+	String get title => 'Backups';
+
+	/// en: 'Latest backup status & run-now'
+	String get subtitle => 'Latest backup status & run-now';
+}
+
+// Path: more.items.settings
+class TranslationsMoreItemsSettingsEn {
+	TranslationsMoreItemsSettingsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Settings'
+	String get title => 'Settings';
+
+	/// en: 'Language, appearance, account'
+	String get subtitle => 'Language, appearance, account';
+}
+
+// Path: more.items.about
+class TranslationsMoreItemsAboutEn {
+	TranslationsMoreItemsAboutEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'About'
+	String get title => 'About';
+
+	/// en: 'Build version & server info'
+	String get subtitle => 'Build version & server info';
+}
+
 /// The flat map containing all translations for locale <en>.
 /// Only for edge cases! For simple maps, use the map function of this library.
 ///
@@ -248,6 +617,58 @@ extension on Translations {
 			'auth.signIn' => 'Sign in',
 			'auth.errorRequired' => 'Username and password are required',
 			'auth.errorGeneric' => ({required Object error}) => 'Login failed: ${error}',
+			'nav.sessions' => 'Sessions',
+			'nav.memory' => 'Memory',
+			'nav.notes' => 'Notes',
+			'nav.more' => 'More',
+			'more.title' => 'More',
+			'more.identity.signedInAs' => 'Signed in as',
+			'more.identity.server' => 'Server',
+			'more.identity.tokenExpires' => 'Token expires',
+			'more.sections.gateway' => 'Gateway',
+			'more.sections.memory' => 'Memory',
+			'more.sections.system' => 'System',
+			'more.items.integrations.title' => 'Integrations',
+			'more.items.integrations.subtitle' => 'API callers — recent activity & error rates',
+			'more.items.channels.title' => 'Channels',
+			'more.items.channels.subtitle' => 'Notification destinations',
+			'more.items.providers.title' => 'Providers',
+			'more.items.providers.subtitle' => 'Claude / Codex / Gemini CLI status',
+			'more.items.mcp.title' => 'MCP',
+			'more.items.mcp.subtitle' => 'Model Context Protocol servers & secrets',
+			'more.items.skills.title' => 'Skills',
+			'more.items.skills.subtitle' => 'Agent SKILL.md library (built-in + vault)',
+			'more.items.gitHosts.title' => 'Git hosts',
+			'more.items.gitHosts.subtitle' => 'PAT credentials for GitHub / GitLab / etc.',
+			'more.items.customTasks.title' => 'Custom tasks',
+			'more.items.customTasks.subtitle' => 'Slash commands shown in the session task picker',
+			'more.items.projectMemory.title' => 'Project goal / plan / journal',
+			'more.items.projectMemory.subtitle' => 'Per-cwd memory layers 2-4 + agent proposals',
+			'more.items.cleanupInbox.title' => 'Cleanup inbox',
+			'more.items.cleanupInbox.subtitle' => 'LLM-proposed deletions / merges across all projects',
+			'more.items.backups.title' => 'Backups',
+			'more.items.backups.subtitle' => 'Latest backup status & run-now',
+			'more.items.settings.title' => 'Settings',
+			'more.items.settings.subtitle' => 'Language, appearance, account',
+			'more.items.about.title' => 'About',
+			'more.items.about.subtitle' => 'Build version & server info',
+			'more.signOut' => 'Sign out',
+			'about.title' => 'About',
+			'about.loading' => 'Loading…',
+			'about.sections.app' => 'App',
+			'about.sections.server' => 'Server',
+			'about.fields.app' => 'App',
+			'about.fields.version' => 'Version',
+			'about.fields.versionFormat' => ({required Object version, required Object build}) => '${version} (build ${build})',
+			'about.fields.package' => 'Package',
+			'about.fields.url' => 'URL',
+			'about.fields.signedInAs' => 'Signed in as',
+			'about.fields.tokenExpires' => 'Token expires',
+			'about.copied' => ({required Object label}) => 'Copied ${label}',
+			'about.copyTooltip' => 'Copy',
+			'about.copyLabels.version' => 'version',
+			'about.copyLabels.serverUrl' => 'server URL',
+			'about.tagline' => 'opendray mobile — multi-CLI gateway control.\nSource: github.com/Opendray/opendray_v2',
 			'settings.title' => 'Settings',
 			'settings.language.section' => 'Language',
 			'settings.language.system' => 'System',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -44,6 +44,7 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	late final TranslationsAuthEn auth = TranslationsAuthEn.internal(_root);
 	late final TranslationsNavEn nav = TranslationsNavEn.internal(_root);
 	late final TranslationsMoreEn more = TranslationsMoreEn.internal(_root);
+	late final TranslationsSessionsEn sessions = TranslationsSessionsEn.internal(_root);
 	late final TranslationsAboutEn about = TranslationsAboutEn.internal(_root);
 	late final TranslationsSettingsEn settings = TranslationsSettingsEn.internal(_root);
 }
@@ -154,6 +155,36 @@ class TranslationsMoreEn {
 	String get signOut => 'Sign out';
 }
 
+// Path: sessions
+class TranslationsSessionsEn {
+	TranslationsSessionsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Sessions'
+	String get title => 'Sessions';
+
+	/// en: 'Refresh'
+	String get refresh => 'Refresh';
+
+	/// en: 'Actions'
+	String get actions => 'Actions';
+
+	/// en: 'Spawn'
+	String get spawn => 'Spawn';
+
+	late final TranslationsSessionsFiltersEn filters = TranslationsSessionsFiltersEn.internal(_root);
+	late final TranslationsSessionsCardEn card = TranslationsSessionsCardEn.internal(_root);
+	late final TranslationsSessionsEmptyEn empty = TranslationsSessionsEmptyEn.internal(_root);
+
+	/// en: 'Failed to load sessions'
+	String get errorTitle => 'Failed to load sessions';
+
+	late final TranslationsSessionsRelativeEn relative = TranslationsSessionsRelativeEn.internal(_root);
+}
+
 // Path: about
 class TranslationsAboutEn {
 	TranslationsAboutEn.internal(this._root);
@@ -255,6 +286,81 @@ class TranslationsMoreItemsEn {
 	late final TranslationsMoreItemsBackupsEn backups = TranslationsMoreItemsBackupsEn.internal(_root);
 	late final TranslationsMoreItemsSettingsEn settings = TranslationsMoreItemsSettingsEn.internal(_root);
 	late final TranslationsMoreItemsAboutEn about = TranslationsMoreItemsAboutEn.internal(_root);
+}
+
+// Path: sessions.filters
+class TranslationsSessionsFiltersEn {
+	TranslationsSessionsFiltersEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'All'
+	String get all => 'All';
+
+	/// en: 'Running'
+	String get running => 'Running';
+
+	/// en: 'Idle'
+	String get idle => 'Idle';
+
+	/// en: 'Ended'
+	String get ended => 'Ended';
+}
+
+// Path: sessions.card
+class TranslationsSessionsCardEn {
+	TranslationsSessionsCardEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: '{provider} · started {when}'
+	String startedRelative({required Object provider, required Object when}) => '${provider} · started ${when}';
+}
+
+// Path: sessions.empty
+class TranslationsSessionsEmptyEn {
+	TranslationsSessionsEmptyEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'No sessions yet'
+	String get titleAll => 'No sessions yet';
+
+	/// en: 'No sessions match the "{filter}" filter.'
+	String titleFiltered({required Object filter}) => 'No sessions match the "${filter}" filter.';
+
+	/// en: 'Tap the Spawn button to create one.'
+	String get subtitleAll => 'Tap the Spawn button to create one.';
+
+	/// en: 'Try a different filter or pull to refresh.'
+	String get subtitleFiltered => 'Try a different filter or pull to refresh.';
+}
+
+// Path: sessions.relative
+class TranslationsSessionsRelativeEn {
+	TranslationsSessionsRelativeEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: '{n}s ago'
+	String secondsAgo({required Object n}) => '${n}s ago';
+
+	/// en: '{n}m ago'
+	String minutesAgo({required Object n}) => '${n}m ago';
+
+	/// en: '{n}h ago'
+	String hoursAgo({required Object n}) => '${n}h ago';
+
+	/// en: '{n}d ago'
+	String daysAgo({required Object n}) => '${n}d ago';
 }
 
 // Path: about.sections
@@ -653,6 +759,24 @@ extension on Translations {
 			'more.items.about.title' => 'About',
 			'more.items.about.subtitle' => 'Build version & server info',
 			'more.signOut' => 'Sign out',
+			'sessions.title' => 'Sessions',
+			'sessions.refresh' => 'Refresh',
+			'sessions.actions' => 'Actions',
+			'sessions.spawn' => 'Spawn',
+			'sessions.filters.all' => 'All',
+			'sessions.filters.running' => 'Running',
+			'sessions.filters.idle' => 'Idle',
+			'sessions.filters.ended' => 'Ended',
+			'sessions.card.startedRelative' => ({required Object provider, required Object when}) => '${provider} · started ${when}',
+			'sessions.empty.titleAll' => 'No sessions yet',
+			'sessions.empty.titleFiltered' => ({required Object filter}) => 'No sessions match the "${filter}" filter.',
+			'sessions.empty.subtitleAll' => 'Tap the Spawn button to create one.',
+			'sessions.empty.subtitleFiltered' => 'Try a different filter or pull to refresh.',
+			'sessions.errorTitle' => 'Failed to load sessions',
+			'sessions.relative.secondsAgo' => ({required Object n}) => '${n}s ago',
+			'sessions.relative.minutesAgo' => ({required Object n}) => '${n}m ago',
+			'sessions.relative.hoursAgo' => ({required Object n}) => '${n}h ago',
+			'sessions.relative.daysAgo' => ({required Object n}) => '${n}d ago',
 			'about.title' => 'About',
 			'about.loading' => 'Loading…',
 			'about.sections.app' => 'App',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -1,0 +1,175 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
+import 'package:slang/generated.dart';
+import 'strings.g.dart';
+
+// Path: <root>
+class TranslationsZh extends Translations with BaseTranslations<AppLocale, Translations> {
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	TranslationsZh({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = meta ?? TranslationMetadata(
+		    locale: AppLocale.zh,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ),
+		  super(cardinalResolver: cardinalResolver, ordinalResolver: ordinalResolver) {
+		super.$meta.setFlatMapFunction($meta.getTranslation); // copy base translations to super.$meta
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
+
+	/// Metadata for the translations of <zh>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
+
+	/// Access flat map
+	@override dynamic operator[](String key) => $meta.getTranslation(key) ?? super.$meta.getTranslation(key);
+
+	late final TranslationsZh _root = this; // ignore: unused_field
+
+	@override 
+	TranslationsZh $copyWith({TranslationMetadata<AppLocale, Translations>? meta}) => TranslationsZh(meta: meta ?? this.$meta);
+
+	// Translations
+	@override late final _TranslationsCommonZh common = _TranslationsCommonZh._(_root);
+	@override late final _TranslationsSettingsZh settings = _TranslationsSettingsZh._(_root);
+}
+
+// Path: common
+class _TranslationsCommonZh extends TranslationsCommonEn {
+	_TranslationsCommonZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get ok => '确定';
+	@override String get cancel => '取消';
+	@override String get save => '保存';
+	@override String get delete => '删除';
+	@override String get edit => '编辑';
+	@override String get back => '返回';
+	@override String get done => '完成';
+	@override String get close => '关闭';
+	@override String get retry => '重试';
+}
+
+// Path: settings
+class _TranslationsSettingsZh extends TranslationsSettingsEn {
+	_TranslationsSettingsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '设置';
+	@override late final _TranslationsSettingsLanguageZh language = _TranslationsSettingsLanguageZh._(_root);
+	@override late final _TranslationsSettingsAppearanceZh appearance = _TranslationsSettingsAppearanceZh._(_root);
+	@override late final _TranslationsSettingsAccountZh account = _TranslationsSettingsAccountZh._(_root);
+	@override late final _TranslationsSettingsGatewayZh gateway = _TranslationsSettingsGatewayZh._(_root);
+}
+
+// Path: settings.language
+class _TranslationsSettingsLanguageZh extends TranslationsSettingsLanguageEn {
+	_TranslationsSettingsLanguageZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get section => '语言';
+	@override String get system => '跟随系统';
+	@override String get systemSubtitle => '跟随手机的语言设置';
+	@override String get english => 'English';
+	@override String get chinese => '中文';
+}
+
+// Path: settings.appearance
+class _TranslationsSettingsAppearanceZh extends TranslationsSettingsAppearanceEn {
+	_TranslationsSettingsAppearanceZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get section => '外观';
+	@override String get system => '跟随系统';
+	@override String get systemSubtitle => '跟随手机的外观设置';
+	@override String get light => '浅色';
+	@override String get lightSubtitle => '始终使用浅色主题';
+	@override String get dark => '深色';
+	@override String get darkSubtitle => '始终使用深色主题';
+}
+
+// Path: settings.account
+class _TranslationsSettingsAccountZh extends TranslationsSettingsAccountEn {
+	_TranslationsSettingsAccountZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get section => '账户';
+	@override String get changeCredentials => '修改凭据';
+	@override String get changeCredentialsSubtitle => '用户名和密码';
+}
+
+// Path: settings.gateway
+class _TranslationsSettingsGatewayZh extends TranslationsSettingsGatewayEn {
+	_TranslationsSettingsGatewayZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get section => '网关';
+	@override String get serverSettings => '服务器设置';
+	@override String get serverSettingsSubtitle => '监听地址、日志、凭据库、内存、存储路径…';
+	@override String get liveLogs => '实时日志';
+	@override String get liveLogsSubtitle => '查看网关实时日志 — 与 Web 管理端同源';
+}
+
+/// The flat map containing all translations for locale <zh>.
+/// Only for edge cases! For simple maps, use the map function of this library.
+///
+/// The Dart AOT compiler has issues with very large switch statements,
+/// so the map is split into smaller functions (512 entries each).
+extension on TranslationsZh {
+	dynamic _flatMapFunction(String path) {
+		return switch (path) {
+			'common.ok' => '确定',
+			'common.cancel' => '取消',
+			'common.save' => '保存',
+			'common.delete' => '删除',
+			'common.edit' => '编辑',
+			'common.back' => '返回',
+			'common.done' => '完成',
+			'common.close' => '关闭',
+			'common.retry' => '重试',
+			'settings.title' => '设置',
+			'settings.language.section' => '语言',
+			'settings.language.system' => '跟随系统',
+			'settings.language.systemSubtitle' => '跟随手机的语言设置',
+			'settings.language.english' => 'English',
+			'settings.language.chinese' => '中文',
+			'settings.appearance.section' => '外观',
+			'settings.appearance.system' => '跟随系统',
+			'settings.appearance.systemSubtitle' => '跟随手机的外观设置',
+			'settings.appearance.light' => '浅色',
+			'settings.appearance.lightSubtitle' => '始终使用浅色主题',
+			'settings.appearance.dark' => '深色',
+			'settings.appearance.darkSubtitle' => '始终使用深色主题',
+			'settings.account.section' => '账户',
+			'settings.account.changeCredentials' => '修改凭据',
+			'settings.account.changeCredentialsSubtitle' => '用户名和密码',
+			'settings.gateway.section' => '网关',
+			'settings.gateway.serverSettings' => '服务器设置',
+			'settings.gateway.serverSettingsSubtitle' => '监听地址、日志、凭据库、内存、存储路径…',
+			'settings.gateway.liveLogs' => '实时日志',
+			'settings.gateway.liveLogsSubtitle' => '查看网关实时日志 — 与 Web 管理端同源',
+			_ => null,
+		};
+	}
+}

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -40,6 +40,7 @@ class TranslationsZh extends Translations with BaseTranslations<AppLocale, Trans
 
 	// Translations
 	@override late final _TranslationsCommonZh common = _TranslationsCommonZh._(_root);
+	@override late final _TranslationsAuthZh auth = _TranslationsAuthZh._(_root);
 	@override late final _TranslationsSettingsZh settings = _TranslationsSettingsZh._(_root);
 }
 
@@ -59,6 +60,22 @@ class _TranslationsCommonZh extends TranslationsCommonEn {
 	@override String get done => '完成';
 	@override String get close => '关闭';
 	@override String get retry => '重试';
+}
+
+// Path: auth
+class _TranslationsAuthZh extends TranslationsAuthEn {
+	_TranslationsAuthZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get signInTitle => '登录';
+	@override String get changeServer => '更换';
+	@override String get username => '用户名';
+	@override String get password => '密码';
+	@override String get signIn => '登录';
+	@override String get errorRequired => '请输入用户名和密码';
+	@override String errorGeneric({required Object error}) => '登录失败：${error}';
 }
 
 // Path: settings
@@ -148,6 +165,13 @@ extension on TranslationsZh {
 			'common.done' => '完成',
 			'common.close' => '关闭',
 			'common.retry' => '重试',
+			'auth.signInTitle' => '登录',
+			'auth.changeServer' => '更换',
+			'auth.username' => '用户名',
+			'auth.password' => '密码',
+			'auth.signIn' => '登录',
+			'auth.errorRequired' => '请输入用户名和密码',
+			'auth.errorGeneric' => ({required Object error}) => '登录失败：${error}',
 			'settings.title' => '设置',
 			'settings.language.section' => '语言',
 			'settings.language.system' => '跟随系统',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -41,6 +41,9 @@ class TranslationsZh extends Translations with BaseTranslations<AppLocale, Trans
 	// Translations
 	@override late final _TranslationsCommonZh common = _TranslationsCommonZh._(_root);
 	@override late final _TranslationsAuthZh auth = _TranslationsAuthZh._(_root);
+	@override late final _TranslationsNavZh nav = _TranslationsNavZh._(_root);
+	@override late final _TranslationsMoreZh more = _TranslationsMoreZh._(_root);
+	@override late final _TranslationsAboutZh about = _TranslationsAboutZh._(_root);
 	@override late final _TranslationsSettingsZh settings = _TranslationsSettingsZh._(_root);
 }
 
@@ -78,6 +81,50 @@ class _TranslationsAuthZh extends TranslationsAuthEn {
 	@override String errorGeneric({required Object error}) => '登录失败：${error}';
 }
 
+// Path: nav
+class _TranslationsNavZh extends TranslationsNavEn {
+	_TranslationsNavZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get sessions => '会话';
+	@override String get memory => '记忆';
+	@override String get notes => '笔记';
+	@override String get more => '更多';
+}
+
+// Path: more
+class _TranslationsMoreZh extends TranslationsMoreEn {
+	_TranslationsMoreZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '更多';
+	@override late final _TranslationsMoreIdentityZh identity = _TranslationsMoreIdentityZh._(_root);
+	@override late final _TranslationsMoreSectionsZh sections = _TranslationsMoreSectionsZh._(_root);
+	@override late final _TranslationsMoreItemsZh items = _TranslationsMoreItemsZh._(_root);
+	@override String get signOut => '退出登录';
+}
+
+// Path: about
+class _TranslationsAboutZh extends TranslationsAboutEn {
+	_TranslationsAboutZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '关于';
+	@override String get loading => '加载中…';
+	@override late final _TranslationsAboutSectionsZh sections = _TranslationsAboutSectionsZh._(_root);
+	@override late final _TranslationsAboutFieldsZh fields = _TranslationsAboutFieldsZh._(_root);
+	@override String copied({required Object label}) => '已复制 ${label}';
+	@override String get copyTooltip => '复制';
+	@override late final _TranslationsAboutCopyLabelsZh copyLabels = _TranslationsAboutCopyLabelsZh._(_root);
+	@override String get tagline => 'opendray mobile — 多 CLI 网关控制。\n源码：github.com/Opendray/opendray_v2';
+}
+
 // Path: settings
 class _TranslationsSettingsZh extends TranslationsSettingsEn {
 	_TranslationsSettingsZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -90,6 +137,89 @@ class _TranslationsSettingsZh extends TranslationsSettingsEn {
 	@override late final _TranslationsSettingsAppearanceZh appearance = _TranslationsSettingsAppearanceZh._(_root);
 	@override late final _TranslationsSettingsAccountZh account = _TranslationsSettingsAccountZh._(_root);
 	@override late final _TranslationsSettingsGatewayZh gateway = _TranslationsSettingsGatewayZh._(_root);
+}
+
+// Path: more.identity
+class _TranslationsMoreIdentityZh extends TranslationsMoreIdentityEn {
+	_TranslationsMoreIdentityZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get signedInAs => '登录账号';
+	@override String get server => '服务器';
+	@override String get tokenExpires => '令牌到期';
+}
+
+// Path: more.sections
+class _TranslationsMoreSectionsZh extends TranslationsMoreSectionsEn {
+	_TranslationsMoreSectionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get gateway => '网关';
+	@override String get memory => '记忆';
+	@override String get system => '系统';
+}
+
+// Path: more.items
+class _TranslationsMoreItemsZh extends TranslationsMoreItemsEn {
+	_TranslationsMoreItemsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsMoreItemsIntegrationsZh integrations = _TranslationsMoreItemsIntegrationsZh._(_root);
+	@override late final _TranslationsMoreItemsChannelsZh channels = _TranslationsMoreItemsChannelsZh._(_root);
+	@override late final _TranslationsMoreItemsProvidersZh providers = _TranslationsMoreItemsProvidersZh._(_root);
+	@override late final _TranslationsMoreItemsMcpZh mcp = _TranslationsMoreItemsMcpZh._(_root);
+	@override late final _TranslationsMoreItemsSkillsZh skills = _TranslationsMoreItemsSkillsZh._(_root);
+	@override late final _TranslationsMoreItemsGitHostsZh gitHosts = _TranslationsMoreItemsGitHostsZh._(_root);
+	@override late final _TranslationsMoreItemsCustomTasksZh customTasks = _TranslationsMoreItemsCustomTasksZh._(_root);
+	@override late final _TranslationsMoreItemsProjectMemoryZh projectMemory = _TranslationsMoreItemsProjectMemoryZh._(_root);
+	@override late final _TranslationsMoreItemsCleanupInboxZh cleanupInbox = _TranslationsMoreItemsCleanupInboxZh._(_root);
+	@override late final _TranslationsMoreItemsBackupsZh backups = _TranslationsMoreItemsBackupsZh._(_root);
+	@override late final _TranslationsMoreItemsSettingsZh settings = _TranslationsMoreItemsSettingsZh._(_root);
+	@override late final _TranslationsMoreItemsAboutZh about = _TranslationsMoreItemsAboutZh._(_root);
+}
+
+// Path: about.sections
+class _TranslationsAboutSectionsZh extends TranslationsAboutSectionsEn {
+	_TranslationsAboutSectionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get app => '应用';
+	@override String get server => '服务器';
+}
+
+// Path: about.fields
+class _TranslationsAboutFieldsZh extends TranslationsAboutFieldsEn {
+	_TranslationsAboutFieldsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get app => '应用';
+	@override String get version => '版本';
+	@override String versionFormat({required Object version, required Object build}) => '${version}（build ${build}）';
+	@override String get package => '包名';
+	@override String get url => 'URL';
+	@override String get signedInAs => '登录账号';
+	@override String get tokenExpires => '令牌到期';
+}
+
+// Path: about.copyLabels
+class _TranslationsAboutCopyLabelsZh extends TranslationsAboutCopyLabelsEn {
+	_TranslationsAboutCopyLabelsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get version => '版本';
+	@override String get serverUrl => '服务器 URL';
 }
 
 // Path: settings.language
@@ -148,6 +278,138 @@ class _TranslationsSettingsGatewayZh extends TranslationsSettingsGatewayEn {
 	@override String get liveLogsSubtitle => '查看网关实时日志 — 与 Web 管理端同源';
 }
 
+// Path: more.items.integrations
+class _TranslationsMoreItemsIntegrationsZh extends TranslationsMoreItemsIntegrationsEn {
+	_TranslationsMoreItemsIntegrationsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '集成';
+	@override String get subtitle => 'API 调用方 — 近期活动与错误率';
+}
+
+// Path: more.items.channels
+class _TranslationsMoreItemsChannelsZh extends TranslationsMoreItemsChannelsEn {
+	_TranslationsMoreItemsChannelsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '通道';
+	@override String get subtitle => '通知目的地';
+}
+
+// Path: more.items.providers
+class _TranslationsMoreItemsProvidersZh extends TranslationsMoreItemsProvidersEn {
+	_TranslationsMoreItemsProvidersZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '提供商';
+	@override String get subtitle => 'Claude / Codex / Gemini CLI 状态';
+}
+
+// Path: more.items.mcp
+class _TranslationsMoreItemsMcpZh extends TranslationsMoreItemsMcpEn {
+	_TranslationsMoreItemsMcpZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'MCP';
+	@override String get subtitle => 'Model Context Protocol 服务与密钥';
+}
+
+// Path: more.items.skills
+class _TranslationsMoreItemsSkillsZh extends TranslationsMoreItemsSkillsEn {
+	_TranslationsMoreItemsSkillsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '技能';
+	@override String get subtitle => 'Agent SKILL.md 库（内置 + 库）';
+}
+
+// Path: more.items.gitHosts
+class _TranslationsMoreItemsGitHostsZh extends TranslationsMoreItemsGitHostsEn {
+	_TranslationsMoreItemsGitHostsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Git 主机';
+	@override String get subtitle => 'GitHub / GitLab 等的 PAT 凭据';
+}
+
+// Path: more.items.customTasks
+class _TranslationsMoreItemsCustomTasksZh extends TranslationsMoreItemsCustomTasksEn {
+	_TranslationsMoreItemsCustomTasksZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '自定义任务';
+	@override String get subtitle => '会话任务选择器中显示的斜杠命令';
+}
+
+// Path: more.items.projectMemory
+class _TranslationsMoreItemsProjectMemoryZh extends TranslationsMoreItemsProjectMemoryEn {
+	_TranslationsMoreItemsProjectMemoryZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '项目目标 / 计划 / 日志';
+	@override String get subtitle => '按 cwd 的记忆层 2-4 + 代理提案';
+}
+
+// Path: more.items.cleanupInbox
+class _TranslationsMoreItemsCleanupInboxZh extends TranslationsMoreItemsCleanupInboxEn {
+	_TranslationsMoreItemsCleanupInboxZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '清理收件箱';
+	@override String get subtitle => '跨项目的 LLM 提议删除 / 合并';
+}
+
+// Path: more.items.backups
+class _TranslationsMoreItemsBackupsZh extends TranslationsMoreItemsBackupsEn {
+	_TranslationsMoreItemsBackupsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '备份';
+	@override String get subtitle => '最新备份状态与立即运行';
+}
+
+// Path: more.items.settings
+class _TranslationsMoreItemsSettingsZh extends TranslationsMoreItemsSettingsEn {
+	_TranslationsMoreItemsSettingsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '设置';
+	@override String get subtitle => '语言、外观、账户';
+}
+
+// Path: more.items.about
+class _TranslationsMoreItemsAboutZh extends TranslationsMoreItemsAboutEn {
+	_TranslationsMoreItemsAboutZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '关于';
+	@override String get subtitle => '构建版本与服务器信息';
+}
+
 /// The flat map containing all translations for locale <zh>.
 /// Only for edge cases! For simple maps, use the map function of this library.
 ///
@@ -172,6 +434,58 @@ extension on TranslationsZh {
 			'auth.signIn' => '登录',
 			'auth.errorRequired' => '请输入用户名和密码',
 			'auth.errorGeneric' => ({required Object error}) => '登录失败：${error}',
+			'nav.sessions' => '会话',
+			'nav.memory' => '记忆',
+			'nav.notes' => '笔记',
+			'nav.more' => '更多',
+			'more.title' => '更多',
+			'more.identity.signedInAs' => '登录账号',
+			'more.identity.server' => '服务器',
+			'more.identity.tokenExpires' => '令牌到期',
+			'more.sections.gateway' => '网关',
+			'more.sections.memory' => '记忆',
+			'more.sections.system' => '系统',
+			'more.items.integrations.title' => '集成',
+			'more.items.integrations.subtitle' => 'API 调用方 — 近期活动与错误率',
+			'more.items.channels.title' => '通道',
+			'more.items.channels.subtitle' => '通知目的地',
+			'more.items.providers.title' => '提供商',
+			'more.items.providers.subtitle' => 'Claude / Codex / Gemini CLI 状态',
+			'more.items.mcp.title' => 'MCP',
+			'more.items.mcp.subtitle' => 'Model Context Protocol 服务与密钥',
+			'more.items.skills.title' => '技能',
+			'more.items.skills.subtitle' => 'Agent SKILL.md 库（内置 + 库）',
+			'more.items.gitHosts.title' => 'Git 主机',
+			'more.items.gitHosts.subtitle' => 'GitHub / GitLab 等的 PAT 凭据',
+			'more.items.customTasks.title' => '自定义任务',
+			'more.items.customTasks.subtitle' => '会话任务选择器中显示的斜杠命令',
+			'more.items.projectMemory.title' => '项目目标 / 计划 / 日志',
+			'more.items.projectMemory.subtitle' => '按 cwd 的记忆层 2-4 + 代理提案',
+			'more.items.cleanupInbox.title' => '清理收件箱',
+			'more.items.cleanupInbox.subtitle' => '跨项目的 LLM 提议删除 / 合并',
+			'more.items.backups.title' => '备份',
+			'more.items.backups.subtitle' => '最新备份状态与立即运行',
+			'more.items.settings.title' => '设置',
+			'more.items.settings.subtitle' => '语言、外观、账户',
+			'more.items.about.title' => '关于',
+			'more.items.about.subtitle' => '构建版本与服务器信息',
+			'more.signOut' => '退出登录',
+			'about.title' => '关于',
+			'about.loading' => '加载中…',
+			'about.sections.app' => '应用',
+			'about.sections.server' => '服务器',
+			'about.fields.app' => '应用',
+			'about.fields.version' => '版本',
+			'about.fields.versionFormat' => ({required Object version, required Object build}) => '${version}（build ${build}）',
+			'about.fields.package' => '包名',
+			'about.fields.url' => 'URL',
+			'about.fields.signedInAs' => '登录账号',
+			'about.fields.tokenExpires' => '令牌到期',
+			'about.copied' => ({required Object label}) => '已复制 ${label}',
+			'about.copyTooltip' => '复制',
+			'about.copyLabels.version' => '版本',
+			'about.copyLabels.serverUrl' => '服务器 URL',
+			'about.tagline' => 'opendray mobile — 多 CLI 网关控制。\n源码：github.com/Opendray/opendray_v2',
 			'settings.title' => '设置',
 			'settings.language.section' => '语言',
 			'settings.language.system' => '跟随系统',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -43,6 +43,7 @@ class TranslationsZh extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsAuthZh auth = _TranslationsAuthZh._(_root);
 	@override late final _TranslationsNavZh nav = _TranslationsNavZh._(_root);
 	@override late final _TranslationsMoreZh more = _TranslationsMoreZh._(_root);
+	@override late final _TranslationsSessionsZh sessions = _TranslationsSessionsZh._(_root);
 	@override late final _TranslationsAboutZh about = _TranslationsAboutZh._(_root);
 	@override late final _TranslationsSettingsZh settings = _TranslationsSettingsZh._(_root);
 }
@@ -106,6 +107,24 @@ class _TranslationsMoreZh extends TranslationsMoreEn {
 	@override late final _TranslationsMoreSectionsZh sections = _TranslationsMoreSectionsZh._(_root);
 	@override late final _TranslationsMoreItemsZh items = _TranslationsMoreItemsZh._(_root);
 	@override String get signOut => '退出登录';
+}
+
+// Path: sessions
+class _TranslationsSessionsZh extends TranslationsSessionsEn {
+	_TranslationsSessionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '会话';
+	@override String get refresh => '刷新';
+	@override String get actions => '操作';
+	@override String get spawn => '创建';
+	@override late final _TranslationsSessionsFiltersZh filters = _TranslationsSessionsFiltersZh._(_root);
+	@override late final _TranslationsSessionsCardZh card = _TranslationsSessionsCardZh._(_root);
+	@override late final _TranslationsSessionsEmptyZh empty = _TranslationsSessionsEmptyZh._(_root);
+	@override String get errorTitle => '加载会话失败';
+	@override late final _TranslationsSessionsRelativeZh relative = _TranslationsSessionsRelativeZh._(_root);
 }
 
 // Path: about
@@ -182,6 +201,55 @@ class _TranslationsMoreItemsZh extends TranslationsMoreItemsEn {
 	@override late final _TranslationsMoreItemsBackupsZh backups = _TranslationsMoreItemsBackupsZh._(_root);
 	@override late final _TranslationsMoreItemsSettingsZh settings = _TranslationsMoreItemsSettingsZh._(_root);
 	@override late final _TranslationsMoreItemsAboutZh about = _TranslationsMoreItemsAboutZh._(_root);
+}
+
+// Path: sessions.filters
+class _TranslationsSessionsFiltersZh extends TranslationsSessionsFiltersEn {
+	_TranslationsSessionsFiltersZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get all => '全部';
+	@override String get running => '运行中';
+	@override String get idle => '空闲';
+	@override String get ended => '已结束';
+}
+
+// Path: sessions.card
+class _TranslationsSessionsCardZh extends TranslationsSessionsCardEn {
+	_TranslationsSessionsCardZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String startedRelative({required Object provider, required Object when}) => '${provider} · ${when}启动';
+}
+
+// Path: sessions.empty
+class _TranslationsSessionsEmptyZh extends TranslationsSessionsEmptyEn {
+	_TranslationsSessionsEmptyZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get titleAll => '暂无会话';
+	@override String titleFiltered({required Object filter}) => '没有匹配「${filter}」筛选的会话。';
+	@override String get subtitleAll => '点击「创建」按钮新建一个。';
+	@override String get subtitleFiltered => '试试其他筛选条件或下拉刷新。';
+}
+
+// Path: sessions.relative
+class _TranslationsSessionsRelativeZh extends TranslationsSessionsRelativeEn {
+	_TranslationsSessionsRelativeZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String secondsAgo({required Object n}) => '${n} 秒前';
+	@override String minutesAgo({required Object n}) => '${n} 分钟前';
+	@override String hoursAgo({required Object n}) => '${n} 小时前';
+	@override String daysAgo({required Object n}) => '${n} 天前';
 }
 
 // Path: about.sections
@@ -470,6 +538,24 @@ extension on TranslationsZh {
 			'more.items.about.title' => '关于',
 			'more.items.about.subtitle' => '构建版本与服务器信息',
 			'more.signOut' => '退出登录',
+			'sessions.title' => '会话',
+			'sessions.refresh' => '刷新',
+			'sessions.actions' => '操作',
+			'sessions.spawn' => '创建',
+			'sessions.filters.all' => '全部',
+			'sessions.filters.running' => '运行中',
+			'sessions.filters.idle' => '空闲',
+			'sessions.filters.ended' => '已结束',
+			'sessions.card.startedRelative' => ({required Object provider, required Object when}) => '${provider} · ${when}启动',
+			'sessions.empty.titleAll' => '暂无会话',
+			'sessions.empty.titleFiltered' => ({required Object filter}) => '没有匹配「${filter}」筛选的会话。',
+			'sessions.empty.subtitleAll' => '点击「创建」按钮新建一个。',
+			'sessions.empty.subtitleFiltered' => '试试其他筛选条件或下拉刷新。',
+			'sessions.errorTitle' => '加载会话失败',
+			'sessions.relative.secondsAgo' => ({required Object n}) => '${n} 秒前',
+			'sessions.relative.minutesAgo' => ({required Object n}) => '${n} 分钟前',
+			'sessions.relative.hoursAgo' => ({required Object n}) => '${n} 小时前',
+			'sessions.relative.daysAgo' => ({required Object n}) => '${n} 天前',
 			'about.title' => '关于',
 			'about.loading' => '加载中…',
 			'about.sections.app' => '应用',

--- a/app/mobile/lib/core/locale/locale_controller.dart
+++ b/app/mobile/lib/core/locale/locale_controller.dart
@@ -1,0 +1,75 @@
+// LocaleController — single source of truth for the user's language
+// pick. Mirrors ThemeController: persists to shared_preferences so
+// the choice survives restarts, broadcasts via Riverpod so
+// MaterialApp.router rebuilds whenever the value flips.
+//
+// Three states (System / English / Chinese) decouple "what the user
+// asked for" from "what slang ended up using" — useful because the
+// system locale can be anything and slang resolves it via fallback.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+enum LocalePreference { system, english, chinese }
+
+const _prefsKey = 'opendray.locale.preference.v1';
+
+class LocaleController extends StateNotifier<LocalePreference> {
+  LocaleController() : super(LocalePreference.system) {
+    _restore();
+  }
+
+  Future<void> _restore() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final parsed = _parse(prefs.getString(_prefsKey));
+      if (parsed != null && parsed != state) {
+        state = parsed;
+      }
+      _apply(state);
+    } on Object {
+      _apply(state);
+    }
+  }
+
+  Future<void> setPreference(LocalePreference pref) async {
+    state = pref;
+    _apply(pref);
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_prefsKey, _serialise(pref));
+    } on Object {
+      // Best-effort persistence; in-memory pick still works.
+    }
+  }
+
+  static void _apply(LocalePreference pref) {
+    switch (pref) {
+      case LocalePreference.system:
+        LocaleSettings.useDeviceLocale();
+      case LocalePreference.english:
+        LocaleSettings.setLocale(AppLocale.en);
+      case LocalePreference.chinese:
+        LocaleSettings.setLocale(AppLocale.zh);
+    }
+  }
+
+  static String _serialise(LocalePreference pref) => switch (pref) {
+        LocalePreference.system => 'system',
+        LocalePreference.english => 'english',
+        LocalePreference.chinese => 'chinese',
+      };
+
+  static LocalePreference? _parse(String? raw) => switch (raw) {
+        'system' => LocalePreference.system,
+        'english' => LocalePreference.english,
+        'chinese' => LocalePreference.chinese,
+        _ => null,
+      };
+}
+
+final localeControllerProvider =
+    StateNotifierProvider<LocaleController, LocalePreference>(
+  (ref) => LocaleController(),
+);

--- a/app/mobile/lib/features/auth/login_screen.dart
+++ b/app/mobile/lib/features/auth/login_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/auth_api.dart';
 import 'package:opendray/core/auth/auth_state.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 
 // Username + password login. Calls /api/v1/auth/mobile-login which
 // returns a token with mobile_token_ttl (default 30 days, vs the
@@ -34,7 +35,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     final username = _userCtrl.text.trim();
     final password = _passCtrl.text;
     if (username.isEmpty || password.isEmpty) {
-      setState(() => _error = 'Username and password are required');
+      setState(() => _error = t.auth.errorRequired);
       return;
     }
     setState(() {
@@ -56,7 +57,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     } on ApiException catch (e) {
       setState(() => _error = e.message);
     } on Object catch (e) {
-      setState(() => _error = 'Login failed: $e');
+      setState(() => _error = t.auth.errorGeneric(error: e.toString()));
     } finally {
       if (mounted) setState(() => _busy = false);
     }
@@ -81,7 +82,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               Text(
-                'Sign in',
+                t.auth.signInTitle,
                 style: Theme.of(context).textTheme.headlineMedium?.copyWith(
                       fontWeight: FontWeight.w700,
                     ),
@@ -98,7 +99,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                   ),
                   TextButton(
                     onPressed: _busy ? null : _changeServer,
-                    child: const Text('Change'),
+                    child: Text(t.auth.changeServer),
                   ),
                 ],
               ),
@@ -108,7 +109,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                 autocorrect: false,
                 textCapitalization: TextCapitalization.none,
                 textInputAction: TextInputAction.next,
-                decoration: const InputDecoration(labelText: 'Username'),
+                decoration: InputDecoration(labelText: t.auth.username),
               ),
               const SizedBox(height: 16),
               TextField(
@@ -118,7 +119,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                 textInputAction: TextInputAction.go,
                 onSubmitted: (_) => _submit(),
                 decoration: InputDecoration(
-                  labelText: 'Password',
+                  labelText: t.auth.password,
                   suffixIcon: IconButton(
                     icon: Icon(
                       _obscurePass
@@ -164,7 +165,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                         width: 18,
                         child: CircularProgressIndicator(strokeWidth: 2),
                       )
-                    : const Text('Sign in'),
+                    : Text(t.auth.signIn),
               ),
             ],
           ),

--- a/app/mobile/lib/features/home/home_shell.dart
+++ b/app/mobile/lib/features/home/home_shell.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/memory/memory_screen.dart';
 import 'package:opendray/features/more/more_screen.dart';
 import 'package:opendray/features/notes/notes_screen.dart';
@@ -27,13 +28,6 @@ class HomeShell extends ConsumerStatefulWidget {
 class _HomeShellState extends ConsumerState<HomeShell> {
   int _index = 0;
 
-  static const _tabs = <_TabSpec>[
-    _TabSpec(icon: Icons.terminal_outlined, label: 'Sessions'),
-    _TabSpec(icon: Icons.psychology_outlined, label: 'Memory'),
-    _TabSpec(icon: Icons.description_outlined, label: 'Notes'),
-    _TabSpec(icon: Icons.more_horiz, label: 'More'),
-  ];
-
   @override
   Widget build(BuildContext context) {
     const pages = [
@@ -42,6 +36,12 @@ class _HomeShellState extends ConsumerState<HomeShell> {
       NotesScreen(),
       MoreScreen(),
     ];
+    final tabs = <_TabSpec>[
+      _TabSpec(icon: Icons.terminal_outlined, label: t.nav.sessions),
+      _TabSpec(icon: Icons.psychology_outlined, label: t.nav.memory),
+      _TabSpec(icon: Icons.description_outlined, label: t.nav.notes),
+      _TabSpec(icon: Icons.more_horiz, label: t.nav.more),
+    ];
 
     return Scaffold(
       body: IndexedStack(index: _index, children: pages),
@@ -49,8 +49,8 @@ class _HomeShellState extends ConsumerState<HomeShell> {
         currentIndex: _index,
         onTap: (i) => setState(() => _index = i),
         items: [
-          for (final t in _tabs)
-            BottomNavigationBarItem(icon: Icon(t.icon), label: t.label),
+          for (final tab in tabs)
+            BottomNavigationBarItem(icon: Icon(tab.icon), label: tab.label),
         ],
       ),
     );

--- a/app/mobile/lib/features/more/about_screen.dart
+++ b/app/mobile/lib/features/more/about_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:opendray/core/auth/auth_state.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 // Diagnostics screen for "what version is this and which server am
@@ -37,7 +38,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text('Copied $label'),
+        content: Text(t.about.copied(label: label)),
         duration: const Duration(seconds: 2),
         behavior: SnackBarBehavior.floating,
       ),
@@ -50,61 +51,64 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
     final loggedIn = auth is AuthLoggedIn ? auth : null;
     final info = _info;
     return Scaffold(
-      appBar: AppBar(title: const Text('About')),
+      appBar: AppBar(title: Text(t.about.title)),
       body: ListView(
         padding: const EdgeInsets.symmetric(vertical: 8),
         children: [
-          const _SectionHeader(label: 'App'),
+          _SectionHeader(label: t.about.sections.app),
           if (info == null)
-            const ListTile(
-              leading: SizedBox(
+            ListTile(
+              leading: const SizedBox(
                 width: 24,
                 height: 24,
                 child: CircularProgressIndicator(strokeWidth: 2),
               ),
-              title: Text('Loading…'),
+              title: Text(t.about.loading),
             )
           else ...[
             _kv(
               context,
-              label: 'App',
+              label: t.about.fields.app,
               value: info.appName,
             ),
             _kv(
               context,
-              label: 'Version',
-              value: '${info.version} (build ${info.buildNumber})',
+              label: t.about.fields.version,
+              value: t.about.fields.versionFormat(
+                version: info.version,
+                build: info.buildNumber,
+              ),
               mono: true,
               onCopy: () => _copy(
-                'version',
+                t.about.copyLabels.version,
                 '${info.version}+${info.buildNumber}',
               ),
             ),
             _kv(
               context,
-              label: 'Package',
+              label: t.about.fields.package,
               value: info.packageName,
               mono: true,
             ),
           ],
           const SizedBox(height: 8),
           if (loggedIn != null) ...[
-            const _SectionHeader(label: 'Server'),
+            _SectionHeader(label: t.about.sections.server),
             _kv(
               context,
-              label: 'URL',
+              label: t.about.fields.url,
               value: loggedIn.serverUrl,
               mono: true,
-              onCopy: () => _copy('server URL', loggedIn.serverUrl),
+              onCopy: () => _copy(t.about.copyLabels.serverUrl, loggedIn.serverUrl),
             ),
             _kv(
               context,
-              label: 'Signed in as',
+              label: t.about.fields.signedInAs,
               value: loggedIn.username,
             ),
             _kv(
               context,
-              label: 'Token expires',
+              label: t.about.fields.tokenExpires,
               value: DateFormat.yMMMd()
                   .add_Hms()
                   .format(loggedIn.expiresAt.toLocal()),
@@ -115,8 +119,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 24),
               child: Text(
-                'opendray mobile — multi-CLI gateway control.\n'
-                'Source: github.com/Opendray/opendray_v2',
+                t.about.tagline,
                 textAlign: TextAlign.center,
                 style: Theme.of(context).textTheme.bodySmall,
               ),
@@ -151,7 +154,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
           ? null
           : IconButton(
               icon: const Icon(Icons.copy_outlined, size: 18),
-              tooltip: 'Copy',
+              tooltip: t.about.copyTooltip,
               onPressed: onCopy,
             ),
       dense: true,

--- a/app/mobile/lib/features/more/more_screen.dart
+++ b/app/mobile/lib/features/more/more_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
 import 'package:opendray/core/auth/auth_state.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/backups/backups_screen.dart';
 import 'package:opendray/features/channels/channels_screen.dart';
 import 'package:opendray/features/custom_tasks/custom_tasks_screen.dart';
@@ -36,87 +37,86 @@ class MoreScreen extends ConsumerWidget {
       return const Scaffold(body: SizedBox.shrink());
     }
     return Scaffold(
-      appBar: AppBar(title: const Text('More')),
+      appBar: AppBar(title: Text(t.more.title)),
       body: ListView(
         children: [
           _IdentityCard(auth: auth),
           const SizedBox(height: 8),
-          const _SectionHeader(label: 'Gateway'),
+          _SectionHeader(label: t.more.sections.gateway),
           _MenuTile(
             icon: Icons.api_outlined,
-            title: 'Integrations',
-            subtitle: 'API callers — recent activity & error rates',
+            title: t.more.items.integrations.title,
+            subtitle: t.more.items.integrations.subtitle,
             onTap: () => _push(context, const IntegrationsScreen()),
           ),
           _MenuTile(
             icon: Icons.notifications_outlined,
-            title: 'Channels',
-            subtitle: 'Notification destinations',
+            title: t.more.items.channels.title,
+            subtitle: t.more.items.channels.subtitle,
             onTap: () => _push(context, const ChannelsScreen()),
           ),
           _MenuTile(
             icon: Icons.psychology_outlined,
-            title: 'Providers',
-            subtitle: 'Claude / Codex / Gemini CLI status',
+            title: t.more.items.providers.title,
+            subtitle: t.more.items.providers.subtitle,
             onTap: () => _push(context, const ProvidersScreen()),
           ),
           _MenuTile(
             icon: Icons.extension_outlined,
-            title: 'MCP',
-            subtitle: 'Model Context Protocol servers & secrets',
+            title: t.more.items.mcp.title,
+            subtitle: t.more.items.mcp.subtitle,
             onTap: () => _push(context, const McpScreen()),
           ),
           _MenuTile(
             icon: Icons.auto_awesome_outlined,
-            title: 'Skills',
-            subtitle: 'Agent SKILL.md library (built-in + vault)',
+            title: t.more.items.skills.title,
+            subtitle: t.more.items.skills.subtitle,
             onTap: () => _push(context, const SkillsScreen()),
           ),
           _MenuTile(
             icon: Icons.account_tree_outlined,
-            title: 'Git hosts',
-            subtitle: 'PAT credentials for GitHub / GitLab / etc.',
+            title: t.more.items.gitHosts.title,
+            subtitle: t.more.items.gitHosts.subtitle,
             onTap: () => _push(context, const GitHostsScreen()),
           ),
           _MenuTile(
             icon: Icons.terminal_outlined,
-            title: 'Custom tasks',
-            subtitle: 'Slash commands shown in the session task picker',
+            title: t.more.items.customTasks.title,
+            subtitle: t.more.items.customTasks.subtitle,
             onTap: () => _push(context, const CustomTasksScreen()),
           ),
           const SizedBox(height: 8),
-          const _SectionHeader(label: 'Memory'),
+          _SectionHeader(label: t.more.sections.memory),
           _MenuTile(
             icon: Icons.flag_outlined,
-            title: 'Project goal / plan / journal',
-            subtitle: 'Per-cwd memory layers 2-4 + agent proposals',
+            title: t.more.items.projectMemory.title,
+            subtitle: t.more.items.projectMemory.subtitle,
             onTap: () => _push(context, const ProjectScreen()),
           ),
           _MenuTile(
             icon: Icons.cleaning_services_outlined,
-            title: 'Cleanup inbox',
-            subtitle:
-                'LLM-proposed deletions / merges across all projects',
+            title: t.more.items.cleanupInbox.title,
+            subtitle: t.more.items.cleanupInbox.subtitle,
             onTap: () => _push(context, const CleanupInboxScreen()),
           ),
           const SizedBox(height: 8),
-          const _SectionHeader(label: 'System'),
+          _SectionHeader(label: t.more.sections.system),
           _MenuTile(
             icon: Icons.backup_outlined,
-            title: 'Backups',
-            subtitle: 'Latest backup status & run-now',
+            title: t.more.items.backups.title,
+            subtitle: t.more.items.backups.subtitle,
             onTap: () => _push(context, const BackupsScreen()),
           ),
           _MenuTile(
             icon: Icons.tune_outlined,
-            title: 'Settings',
-            subtitle: 'Appearance, account',
+            title: t.more.items.settings.title,
+            subtitle: t.more.items.settings.subtitle,
             onTap: () => _push(context, const SettingsScreen()),
           ),
           _MenuTile(
             icon: Icons.info_outline,
-            title: 'About',
-            subtitle: 'Build version & server info',
+            title: t.more.items.about.title,
+            subtitle: t.more.items.about.subtitle,
             onTap: () => _push(context, const AboutScreen()),
           ),
           const Divider(height: 32),
@@ -135,7 +135,7 @@ class MoreScreen extends ConsumerWidget {
               ),
               onPressed: () =>
                   ref.read(authControllerProvider.notifier).logout(),
-              child: const Text('Sign out'),
+              child: Text(t.more.signOut),
             ),
           ),
         ],
@@ -165,19 +165,19 @@ class _IdentityCard extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text('Signed in as', style: muted),
+              Text(t.more.identity.signedInAs, style: muted),
               Text(
                 auth.username,
                 style: Theme.of(context).textTheme.titleMedium,
               ),
               const SizedBox(height: 12),
-              Text('Server', style: muted),
+              Text(t.more.identity.server, style: muted),
               Text(
                 auth.serverUrl,
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
               const SizedBox(height: 12),
-              Text('Token expires', style: muted),
+              Text(t.more.identity.tokenExpires, style: muted),
               Text(
                 DateFormat.yMMMd().add_jm().format(auth.expiresAt.toLocal()),
                 style: Theme.of(context).textTheme.bodyMedium,

--- a/app/mobile/lib/features/sessions/sessions_screen.dart
+++ b/app/mobile/lib/features/sessions/sessions_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/sessions_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/sessions/session_action_sheet.dart';
 import 'package:opendray/features/sessions/spawn_session_sheet.dart';
 import 'package:path/path.dart' as p;
@@ -50,11 +51,11 @@ class _SessionsScreenState extends ConsumerState<SessionsScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Sessions'),
+        title: Text(t.sessions.title),
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),
-            tooltip: 'Refresh',
+            tooltip: t.sessions.refresh,
             onPressed: async.isLoading
                 ? null
                 : () => ref.invalidate(sessionsListProvider),
@@ -105,20 +106,24 @@ class _SessionsScreenState extends ConsumerState<SessionsScreen> {
       floatingActionButton: FloatingActionButton.extended(
         onPressed: _onSpawn,
         icon: const Icon(Icons.add),
-        label: const Text('Spawn'),
+        label: Text(t.sessions.spawn),
       ),
     );
   }
 }
 
 enum _Filter {
-  all('All'),
-  running('Running'),
-  idle('Idle'),
-  ended('Ended');
+  all,
+  running,
+  idle,
+  ended;
 
-  const _Filter(this.label);
-  final String label;
+  String label() => switch (this) {
+        _Filter.all => t.sessions.filters.all,
+        _Filter.running => t.sessions.filters.running,
+        _Filter.idle => t.sessions.filters.idle,
+        _Filter.ended => t.sessions.filters.ended,
+      };
 
   bool matches(SessionSummary s) => switch (this) {
         _Filter.all => true,
@@ -148,7 +153,7 @@ class _FilterBar extends StatelessWidget {
           final f = _Filter.values[i];
           final selected = f == value;
           return ChoiceChip(
-            label: Text(f.label),
+            label: Text(f.label()),
             selected: selected,
             onSelected: (_) => onChanged(f),
           );
@@ -213,7 +218,10 @@ class _SessionCard extends StatelessWidget {
                     ),
                     const SizedBox(height: 2),
                     Text(
-                      '${session.providerId} · started ${_formatRelative(session.startedAt)}',
+                      t.sessions.card.startedRelative(
+                        provider: session.providerId,
+                        when: _formatRelative(session.startedAt),
+                      ),
                       style: Theme.of(context).textTheme.bodySmall,
                       overflow: TextOverflow.ellipsis,
                     ),
@@ -222,7 +230,7 @@ class _SessionCard extends StatelessWidget {
               ),
               IconButton(
                 icon: const Icon(Icons.more_vert),
-                tooltip: 'Actions',
+                tooltip: t.sessions.actions,
                 onPressed: onMore,
               ),
             ],
@@ -284,8 +292,8 @@ class _EmptyState extends StatelessWidget {
         Center(
           child: Text(
             hasAny
-                ? 'No sessions match the "${filter.label}" filter.'
-                : 'No sessions yet',
+                ? t.sessions.empty.titleFiltered(filter: filter.label())
+                : t.sessions.empty.titleAll,
             style: Theme.of(context).textTheme.titleMedium,
           ),
         ),
@@ -293,8 +301,8 @@ class _EmptyState extends StatelessWidget {
         Center(
           child: Text(
             hasAny
-                ? 'Try a different filter or pull to refresh.'
-                : 'Tap the Spawn button to create one.',
+                ? t.sessions.empty.subtitleFiltered
+                : t.sessions.empty.subtitleAll,
             textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.bodySmall,
           ),
@@ -322,7 +330,7 @@ class _ErrorView extends StatelessWidget {
         const SizedBox(height: 12),
         Center(
           child: Text(
-            'Failed to load sessions',
+            t.sessions.errorTitle,
             style: Theme.of(context).textTheme.titleMedium,
           ),
         ),
@@ -336,7 +344,7 @@ class _ErrorView extends StatelessWidget {
         ),
         const SizedBox(height: 16),
         Center(
-          child: FilledButton(onPressed: onRetry, child: const Text('Retry')),
+          child: FilledButton(onPressed: onRetry, child: Text(t.common.retry)),
         ),
       ],
     );
@@ -345,10 +353,10 @@ class _ErrorView extends StatelessWidget {
 
 String _formatRelative(DateTime ts) {
   final diff = DateTime.now().toUtc().difference(ts.toUtc());
-  if (diff.inSeconds < 60) return '${diff.inSeconds}s ago';
-  if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
-  if (diff.inHours < 24) return '${diff.inHours}h ago';
-  if (diff.inDays < 7) return '${diff.inDays}d ago';
+  if (diff.inSeconds < 60) return t.sessions.relative.secondsAgo(n: diff.inSeconds);
+  if (diff.inMinutes < 60) return t.sessions.relative.minutesAgo(n: diff.inMinutes);
+  if (diff.inHours < 24) return t.sessions.relative.hoursAgo(n: diff.inHours);
+  if (diff.inDays < 7) return t.sessions.relative.daysAgo(n: diff.inDays);
   return DateFormat.yMMMd().format(ts.toLocal());
 }
 

--- a/app/mobile/lib/features/settings/settings_screen.dart
+++ b/app/mobile/lib/features/settings/settings_screen.dart
@@ -2,14 +2,15 @@
 // that aren't tied to a specific server resource. Reached via
 // More → Settings.
 //
-// PR #51 ships the Appearance section. The Account section
-// (change password / change username) lands in PR #52 — its
-// placeholder is included here so the layout doesn't shift when
-// it arrives.
+// All visible strings flow through slang (`t.settings.*`). The
+// Language section at the top lets the user override the system
+// locale; LocaleController persists the pick to shared_preferences.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/core/locale/locale_controller.dart';
 import 'package:opendray/core/theme/theme_controller.dart';
 import 'package:opendray/features/settings/change_credentials_screen.dart';
 import 'package:opendray/features/settings/log_viewer_screen.dart';
@@ -21,15 +22,49 @@ class SettingsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final mode = ref.watch(themeControllerProvider);
+    final locale = ref.watch(localeControllerProvider);
     final theme = Theme.of(context);
     return Scaffold(
-      appBar: AppBar(title: const Text('Settings')),
+      appBar: AppBar(title: Text(t.settings.title)),
       body: SafeArea(
         bottom: false,
         child: ListView(
           padding: const EdgeInsets.symmetric(vertical: 8),
           children: [
-            const _SectionHeader('Appearance'),
+            _SectionHeader(t.settings.language.section),
+            RadioGroup<LocalePreference>(
+              groupValue: locale,
+              onChanged: (pref) {
+                if (pref == null) return;
+                ref
+                    .read(localeControllerProvider.notifier)
+                    .setPreference(pref);
+              },
+              child: Column(
+                children: [
+                  _LocaleOption(
+                    title: t.settings.language.system,
+                    subtitle: t.settings.language.systemSubtitle,
+                    icon: Icons.language_outlined,
+                    value: LocalePreference.system,
+                  ),
+                  _LocaleOption(
+                    title: t.settings.language.english,
+                    subtitle: 'English',
+                    icon: Icons.translate_outlined,
+                    value: LocalePreference.english,
+                  ),
+                  _LocaleOption(
+                    title: t.settings.language.chinese,
+                    subtitle: '中文',
+                    icon: Icons.translate_outlined,
+                    value: LocalePreference.chinese,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            _SectionHeader(t.settings.appearance.section),
             // RadioGroup is the Flutter 3.32+ way to share group
             // state across Radio<T> descendants without each tile
             // duplicating groupValue/onChanged.
@@ -39,23 +74,23 @@ class SettingsScreen extends ConsumerWidget {
                 if (m == null) return;
                 ref.read(themeControllerProvider.notifier).setMode(m);
               },
-              child: const Column(
+              child: Column(
                 children: [
                   _ThemeOption(
-                    title: 'System',
-                    subtitle: "Follow your phone's appearance setting",
+                    title: t.settings.appearance.system,
+                    subtitle: t.settings.appearance.systemSubtitle,
                     icon: Icons.brightness_auto_outlined,
                     value: ThemeMode.system,
                   ),
                   _ThemeOption(
-                    title: 'Light',
-                    subtitle: 'Always use the light palette',
+                    title: t.settings.appearance.light,
+                    subtitle: t.settings.appearance.lightSubtitle,
                     icon: Icons.light_mode_outlined,
                     value: ThemeMode.light,
                   ),
                   _ThemeOption(
-                    title: 'Dark',
-                    subtitle: 'Always use the dark palette',
+                    title: t.settings.appearance.dark,
+                    subtitle: t.settings.appearance.darkSubtitle,
                     icon: Icons.dark_mode_outlined,
                     value: ThemeMode.dark,
                   ),
@@ -63,12 +98,12 @@ class SettingsScreen extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 16),
-            const _SectionHeader('Account'),
+            _SectionHeader(t.settings.account.section),
             ListTile(
               leading: const Icon(Icons.lock_outline),
-              title: const Text('Change credentials'),
+              title: Text(t.settings.account.changeCredentials),
               subtitle: Text(
-                'Username and password',
+                t.settings.account.changeCredentialsSubtitle,
                 style: theme.textTheme.bodySmall,
               ),
               trailing: const Icon(Icons.chevron_right, size: 18),
@@ -79,12 +114,12 @@ class SettingsScreen extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 16),
-            const _SectionHeader('Gateway'),
+            _SectionHeader(t.settings.gateway.section),
             ListTile(
               leading: const Icon(Icons.dns_outlined),
-              title: const Text('Server settings'),
+              title: Text(t.settings.gateway.serverSettings),
               subtitle: Text(
-                'Listen address, logging, vault, memory, storage paths…',
+                t.settings.gateway.serverSettingsSubtitle,
                 style: theme.textTheme.bodySmall,
               ),
               trailing: const Icon(Icons.chevron_right, size: 18),
@@ -96,9 +131,9 @@ class SettingsScreen extends ConsumerWidget {
             ),
             ListTile(
               leading: const Icon(Icons.subject_outlined),
-              title: const Text('Live logs'),
+              title: Text(t.settings.gateway.liveLogs),
               subtitle: Text(
-                'Tail the gateway log buffer — same source as the web admin',
+                t.settings.gateway.liveLogsSubtitle,
                 style: theme.textTheme.bodySmall,
               ),
               trailing: const Icon(Icons.chevron_right, size: 18),
@@ -162,14 +197,40 @@ class _ThemeOption extends StatelessWidget {
         style: theme.textTheme.bodySmall,
       ),
       trailing: Radio<ThemeMode>(value: value),
-      // ListTile.onTap forwards through RadioGroup's onChanged
-      // automatically via the Radio widget — no manual wiring
-      // needed.
       onTap: () {
-        // Find the ancestor RadioGroup and report this value as
-        // the new selection. Reaching through context keeps the
-        // option widget itself stateless.
         final group = RadioGroup.maybeOf<ThemeMode>(context);
+        group?.onChanged(value);
+      },
+    );
+  }
+}
+
+class _LocaleOption extends StatelessWidget {
+  const _LocaleOption({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.value,
+  });
+
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final LocalePreference value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListTile(
+      leading: Icon(icon),
+      title: Text(title),
+      subtitle: Text(
+        subtitle,
+        style: theme.textTheme.bodySmall,
+      ),
+      trailing: Radio<LocalePreference>(value: value),
+      onTap: () {
+        final group = RadioGroup.maybeOf<LocalePreference>(context);
         group?.onChanged(value);
       },
     );

--- a/app/mobile/lib/main.dart
+++ b/app/mobile/lib/main.dart
@@ -1,12 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/core/locale/locale_controller.dart';
 import 'package:opendray/core/routing/app_router.dart';
 import 'package:opendray/core/theme/app_theme.dart';
 import 'package:opendray/core/theme/theme_controller.dart';
 
 void main() {
-  runApp(const ProviderScope(child: OpendrayApp()));
+  WidgetsFlutterBinding.ensureInitialized();
+  LocaleSettings.useDeviceLocale();
+  runApp(
+    TranslationProvider(
+      child: const ProviderScope(child: OpendrayApp()),
+    ),
+  );
 }
 
 class OpendrayApp extends ConsumerWidget {
@@ -15,16 +24,21 @@ class OpendrayApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(routerProvider);
-    // Watch the controller so a picker change in Settings rebuilds
-    // MaterialApp with the new themeMode immediately — no app
-    // restart needed.
     final themeMode = ref.watch(themeControllerProvider);
+    // Watching the locale controller rebuilds MaterialApp so the
+    // Material/Cupertino delegates re-resolve and Flutter's own
+    // built-in widgets (DatePicker, dialog buttons, etc.) follow
+    // the user's pick.
+    ref.watch(localeControllerProvider);
     return MaterialApp.router(
       title: 'opendray',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.light(),
       darkTheme: AppTheme.dark(),
       themeMode: themeMode,
+      locale: TranslationProvider.of(context).flutterLocale,
+      supportedLocales: AppLocaleUtils.instance.supportedLocales,
+      localizationsDelegates: GlobalMaterialLocalizations.delegates,
       routerConfig: router,
     );
   }

--- a/app/mobile/pubspec.yaml
+++ b/app/mobile/pubspec.yaml
@@ -12,18 +12,22 @@ dependencies:
   dio: ^5.7.0
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   flutter_riverpod: ^2.6.1
   flutter_secure_storage: ^9.2.2
   freezed_annotation: ^2.4.4
   go_router: ^14.6.2
   image_picker: ^1.1.2
-  intl: ^0.19.0
+  intl: ^0.20.2
   json_annotation: ^4.9.0
   local_auth: ^2.3.0
   package_info_plus: ^8.1.1
   path: ^1.9.1
   pretty_dio_logger: ^1.4.0
   shared_preferences: ^2.3.4
+  slang: ^4.14.0
+  slang_flutter: ^4.14.0
   web_socket_channel: ^3.0.1
   xterm: ^4.0.0
   yaml: ^3.1.2
@@ -34,6 +38,7 @@ dev_dependencies:
     sdk: flutter
   freezed: ^2.5.7
   json_serializable: ^6.9.0
+  slang_build_runner: ^4.14.0
   very_good_analysis: ^7.0.0
 
 # Use the in-repo xterm fork (third_party/xterm) which enables IME features

--- a/app/mobile/slang.yaml
+++ b/app/mobile/slang.yaml
@@ -1,0 +1,13 @@
+base_locale: en
+fallback_strategy: base_locale
+input_directory: ../i18n
+input_file_pattern: .json
+output_directory: lib/core/i18n
+output_file_name: strings.g.dart
+locale_handling: true
+flutter_integration: true
+namespaces: false
+translate_var: t
+enum_name: AppLocale
+class_name: Translations
+translation_class_visibility: private

--- a/app/mobile/slang.yaml
+++ b/app/mobile/slang.yaml
@@ -11,3 +11,6 @@ translate_var: t
 enum_name: AppLocale
 class_name: Translations
 translation_class_visibility: private
+# {name} placeholder syntax — matches react-i18next default, keeps
+# the JSON keys portable when web joins the same translation source.
+string_interpolation: braces


### PR DESCRIPTION
Stacked on #69. Migrates the Sessions list — the highest-traffic surface in the app. Sub-screens (detail, terminal, spawn sheet, action sheet, directory picker, inspector tabs) ship separately to keep diffs reviewable.

## Changes

- **`app/i18n/{en,zh}.json`**: new `sessions.*` namespace.
  - `title`, `refresh`, `actions`, `spawn`
  - `filters.{all,running,idle,ended}`
  - `card.startedRelative`: `{provider} · started {when}` (two placeholders)
  - `empty.titleAll` / `empty.titleFiltered` (with `{filter}`) / `empty.subtitleAll` / `empty.subtitleFiltered`
  - `errorTitle`
  - `relative.{secondsAgo,minutesAgo,hoursAgo,daysAgo}` — each takes `{n}`
- **`sessions_screen.dart`**: AppBar title, refresh tooltip, FAB label, IconButton "Actions" tooltip, filter chip labels, empty/error views, and `_formatRelative` all flow through `t.sessions.*`. `common.retry` reused for the retry button.
- **`_Filter` enum**: dropped the const `label` field (slang lookups are runtime). Now exposes a `label()` method that resolves against `t.sessions.filters.*`. No behavioral change.

## Out of scope

- All other sessions files (terminal view, spawn sheet, action sheet, directory picker, detail screen, inspector tabs) — separate PRs.

## Verified

- [x] `flutter analyze` clean
- [ ] Manual on-device test together with the rest of the stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)