### PR TITLE
feat(mobile): i18n migrate MCP + Providers + Integrations

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -115,6 +115,82 @@
       "minutesAgo": "{n}m ago",
       "hoursAgo": "{n}h ago",
       "daysAgo": "{n}d ago"
+    },
+    "action": {
+      "stop": "Stop",
+      "stopping": "Stopping…",
+      "stopDescription": "Send SIGTERM, retain history",
+      "restart": "Restart",
+      "restarting": "Restarting…",
+      "restartDescription": "Re-spawn the CLI process",
+      "delete": "Delete",
+      "deleteDescription": "Remove the session and its history",
+      "deleteConfirm": "Delete this session permanently? Its ring buffer and history will be gone.",
+      "errors": {
+        "stop": "Stop failed: {error}",
+        "start": "Restart failed: {error}",
+        "delete": "Delete failed: {error}"
+      }
+    },
+    "dirPicker": {
+      "parent": "Parent",
+      "newFolder": "New folder",
+      "useThisFolder": "Use this folder",
+      "loading": "Loading…",
+      "empty": "No subfolders here.\nPick this folder, or create a new one.",
+      "createdSnack": "Created {path}",
+      "mkdirFailedSnack": "mkdir failed: {error}",
+      "dialog": {
+        "title": "New folder",
+        "hint": "Folder name",
+        "create": "Create"
+      }
+    },
+    "spawnSheet": {
+      "title": "New session",
+      "errorRequired": "Provider and working directory are required",
+      "errorGeneric": "Failed to spawn session: {error}",
+      "cancel": "Cancel",
+      "spawn": "Spawn",
+      "providerLabel": "Provider",
+      "disabledSuffix": " (disabled)",
+      "cwdLabel": "Working directory",
+      "cwdHint": "/Users/you/projects/foo",
+      "cwdHelper": "Absolute path on the gateway host.",
+      "browse": "Browse",
+      "nameLabel": "Name (optional)",
+      "nameHint": "e.g. backend-refactor",
+      "argsLabel": "Extra args (optional)",
+      "argsHint": "--continue --verbose",
+      "argsHelper": "Whitespace-separated; blank uses the provider's defaults.",
+      "bypass": {
+        "labelClaude": "Bypass permissions",
+        "labelCodex": "Auto-approve (never ask)",
+        "labelGemini": "YOLO mode",
+        "subtitleOn": "This session will run with elevated autonomy.",
+        "subtitleOff": "Off — confirmations and prompts behave normally."
+      },
+      "noProviders": {
+        "title": "No providers configured",
+        "message": "The gateway has no CLI providers enabled. Configure one under Providers (web admin) or [providers] in config.toml, then tap Reload.",
+        "reload": "Reload"
+      },
+      "providerLoadError": {
+        "title": "Could not load providers",
+        "networkError": "Network error",
+        "serverPrefix": "Server {code}",
+        "format": "{prefix}: {message}"
+      },
+      "claudeAccount": {
+        "label": "Claude account",
+        "helperMulti": "Multiple accounts configured — pick one for this session.",
+        "helperSingle": "Pick a configured account or use the default (env / system).",
+        "default": "Default (env / system)",
+        "disabledSuffix": " (disabled)",
+        "noTokenSuffix": " (no token)",
+        "noneHint": "No Claude accounts configured — the gateway will use the system ANTHROPIC_API_KEY. Add accounts under Settings → Accounts on the web admin.",
+        "errorHint": "Could not load Claude accounts ({error}). The session will spawn with the gateway default."
+      }
     }
   },
   "about": {

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -184,6 +184,74 @@
         "create": "Create"
       }
     },
+    "inspector": {
+      "shell": {
+        "title": "Inspector",
+        "loadError": "Failed to load session: {error}",
+        "tabs": {
+          "files": "Files",
+          "git": "Git",
+          "tasks": "Tasks",
+          "history": "History",
+          "notes": "Notes"
+        }
+      },
+      "shared": {
+        "refresh": "Refresh",
+        "inserted": "Inserted: {text}",
+        "insertFailedApi": "Insert failed ({status}): {message}",
+        "insertFailedGeneric": "Insert failed: {error}",
+        "insertFailedShort": "Insert failed: {error}"
+      },
+      "history": {
+        "insertIntoTerminal": "Insert into terminal",
+        "searchHint": "Search prompts…"
+      },
+      "files": {
+        "insertAtRef": "Insert as @reference",
+        "insertPath": "Insert path",
+        "insertPathSubtitle": "Pastes the absolute path verbatim",
+        "readContent": "Read content",
+        "readContentSubtitle": "Up to 256 KiB plain text",
+        "readFailedApi": "Read failed ({status}): {message}",
+        "readFailedGeneric": "Read failed: {error}",
+        "parent": "Parent",
+        "backToCwd": "Back to session cwd"
+      },
+      "git": {
+        "insertAtRef": "Insert as @reference",
+        "insertPath": "Insert path",
+        "showDiff": "Show diff",
+        "diffFailedApi": "Diff failed ({status}): {message}",
+        "diffFailedGeneric": "Diff failed: {error}",
+        "insertHash": "Insert hash",
+        "showFullPatch": "Show full patch",
+        "showFailedApi": "Show failed ({status}): {message}",
+        "showFailedGeneric": "Show failed: {error}",
+        "tabStatus": "Status",
+        "tabLog": "Log"
+      },
+      "tasks": {
+        "runCommand": "Run command",
+        "insertCommand": "Insert command",
+        "insertCommandSubtitle": "Pastes without return so you can edit"
+      },
+      "notes": {
+        "insertedAt": "Inserted: @{path}",
+        "myNotes": "My notes",
+        "projectDocs": "Project docs",
+        "insertAtRefTooltip": "Insert as @reference",
+        "insertAtRefShort": "Insert @reference",
+        "draftHint": "# {project}\n\nThoughts, todos, context for the agent…",
+        "createFailed": "Create failed: {error}",
+        "saveFailed": "Save failed: {error}",
+        "changeLocationTooltip": "Change project docs location",
+        "filenameHint": "filename (e.g. spec or design.md)",
+        "create": "Create",
+        "filterHint": "Filter…",
+        "locationDialogTitle": "Project docs location"
+      }
+    },
     "spawnSheet": {
       "title": "New session",
       "errorRequired": "Provider and working directory are required",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1,0 +1,44 @@
+{
+  "common": {
+    "ok": "OK",
+    "cancel": "Cancel",
+    "save": "Save",
+    "delete": "Delete",
+    "edit": "Edit",
+    "back": "Back",
+    "done": "Done",
+    "close": "Close",
+    "retry": "Retry"
+  },
+  "settings": {
+    "title": "Settings",
+    "language": {
+      "section": "Language",
+      "system": "System",
+      "systemSubtitle": "Follow your phone's language setting",
+      "english": "English",
+      "chinese": "中文"
+    },
+    "appearance": {
+      "section": "Appearance",
+      "system": "System",
+      "systemSubtitle": "Follow your phone's appearance setting",
+      "light": "Light",
+      "lightSubtitle": "Always use the light palette",
+      "dark": "Dark",
+      "darkSubtitle": "Always use the dark palette"
+    },
+    "account": {
+      "section": "Account",
+      "changeCredentials": "Change credentials",
+      "changeCredentialsSubtitle": "Username and password"
+    },
+    "gateway": {
+      "section": "Gateway",
+      "serverSettings": "Server settings",
+      "serverSettingsSubtitle": "Listen address, logging, vault, memory, storage paths…",
+      "liveLogs": "Live logs",
+      "liveLogsSubtitle": "Tail the gateway log buffer — same source as the web admin"
+    }
+  }
+}

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -299,6 +299,39 @@
       }
     }
   },
+  "memory": {
+    "title": "Memory",
+    "more": "More",
+    "workers": "Memory workers",
+    "new": "New",
+    "searchHint": "Search…",
+    "projectLabel": "Project",
+    "filterHint": "Filter by name or path…",
+    "copied": "Copied",
+    "copyTooltip": "Copy text",
+    "deleteAllConfirm": {
+      "title": "Delete every memory in this scope?",
+      "deleteAll": "Delete all"
+    },
+    "deletedSnackOne": "Deleted {n} memory item",
+    "deletedSnackOther": "Deleted {n} memory items",
+    "bulkDeleteFailedApi": "Bulk delete failed: {error}",
+    "bulkDeleteFailedGeneric": "Bulk delete failed: {error}",
+    "deleteOne": {
+      "title": "Delete memory?",
+      "body": "This cannot be undone."
+    },
+    "scope": {
+      "project": "Project",
+      "global": "Global"
+    },
+    "create": {
+      "textLabel": "Text",
+      "scopeKeyLabel": "Scope key (project cwd)",
+      "scopeKeyHint": "/Users/you/projects/foo",
+      "submit": "Create"
+    }
+  },
   "about": {
     "title": "About",
     "loading": "Loading…",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -116,6 +116,44 @@
       "hoursAgo": "{n}h ago",
       "daysAgo": "{n}d ago"
     },
+    "detail": {
+      "fallbackTitle": "Session",
+      "refreshMetadata": "Refresh metadata",
+      "inspector": "Inspector (Files / Git / Tasks / History / Notes)",
+      "projectMemory": "Project memory (goal / plan / journal / inbox)",
+      "actions": "Actions",
+      "started": "started {when}",
+      "startedEnded": "started {started}  ·  ended {ended}",
+      "idPrefix": "id: {id}",
+      "errorTitle": "Failed to load session"
+    },
+    "terminal": {
+      "snackbar": {
+        "imagePickerFailed": "Image picker failed: {error}",
+        "uploadingImage": "Uploading image…",
+        "imageAttached": "Image attached: {path}",
+        "uploadFailed": "Upload failed ({status}): {message}",
+        "uploadFailedGeneric": "Upload failed: {error}"
+      },
+      "imageSource": {
+        "photoLibrary": "Photo library",
+        "takePhoto": "Take a photo"
+      },
+      "keyboard": {
+        "copyBuffer": "Copy buffer",
+        "paste": "Paste",
+        "attachImage": "Attach image"
+      },
+      "connection": {
+        "connecting": "Connecting…",
+        "connected": "Connected",
+        "reconnecting": "Reconnecting…",
+        "reconnectingWithError": "Reconnecting ({error})…",
+        "disconnected": "Disconnected",
+        "disconnectedWithError": "Disconnected ({error})",
+        "ended": "Session ended"
+      }
+    },
     "action": {
       "stop": "Stop",
       "stopping": "Stopping…",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -19,6 +19,100 @@
     "errorRequired": "Username and password are required",
     "errorGeneric": "Login failed: {error}"
   },
+  "nav": {
+    "sessions": "Sessions",
+    "memory": "Memory",
+    "notes": "Notes",
+    "more": "More"
+  },
+  "more": {
+    "title": "More",
+    "identity": {
+      "signedInAs": "Signed in as",
+      "server": "Server",
+      "tokenExpires": "Token expires"
+    },
+    "sections": {
+      "gateway": "Gateway",
+      "memory": "Memory",
+      "system": "System"
+    },
+    "items": {
+      "integrations": {
+        "title": "Integrations",
+        "subtitle": "API callers — recent activity & error rates"
+      },
+      "channels": {
+        "title": "Channels",
+        "subtitle": "Notification destinations"
+      },
+      "providers": {
+        "title": "Providers",
+        "subtitle": "Claude / Codex / Gemini CLI status"
+      },
+      "mcp": {
+        "title": "MCP",
+        "subtitle": "Model Context Protocol servers & secrets"
+      },
+      "skills": {
+        "title": "Skills",
+        "subtitle": "Agent SKILL.md library (built-in + vault)"
+      },
+      "gitHosts": {
+        "title": "Git hosts",
+        "subtitle": "PAT credentials for GitHub / GitLab / etc."
+      },
+      "customTasks": {
+        "title": "Custom tasks",
+        "subtitle": "Slash commands shown in the session task picker"
+      },
+      "projectMemory": {
+        "title": "Project goal / plan / journal",
+        "subtitle": "Per-cwd memory layers 2-4 + agent proposals"
+      },
+      "cleanupInbox": {
+        "title": "Cleanup inbox",
+        "subtitle": "LLM-proposed deletions / merges across all projects"
+      },
+      "backups": {
+        "title": "Backups",
+        "subtitle": "Latest backup status & run-now"
+      },
+      "settings": {
+        "title": "Settings",
+        "subtitle": "Language, appearance, account"
+      },
+      "about": {
+        "title": "About",
+        "subtitle": "Build version & server info"
+      }
+    },
+    "signOut": "Sign out"
+  },
+  "about": {
+    "title": "About",
+    "loading": "Loading…",
+    "sections": {
+      "app": "App",
+      "server": "Server"
+    },
+    "fields": {
+      "app": "App",
+      "version": "Version",
+      "versionFormat": "{version} (build {build})",
+      "package": "Package",
+      "url": "URL",
+      "signedInAs": "Signed in as",
+      "tokenExpires": "Token expires"
+    },
+    "copied": "Copied {label}",
+    "copyTooltip": "Copy",
+    "copyLabels": {
+      "version": "version",
+      "serverUrl": "server URL"
+    },
+    "tagline": "opendray mobile — multi-CLI gateway control.\nSource: github.com/Opendray/opendray_v2"
+  },
   "settings": {
     "title": "Settings",
     "language": {

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -10,6 +10,15 @@
     "close": "Close",
     "retry": "Retry"
   },
+  "auth": {
+    "signInTitle": "Sign in",
+    "changeServer": "Change",
+    "username": "Username",
+    "password": "Password",
+    "signIn": "Sign in",
+    "errorRequired": "Username and password are required",
+    "errorGeneric": "Login failed: {error}"
+  },
   "settings": {
     "title": "Settings",
     "language": {

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -299,6 +299,83 @@
       }
     }
   },
+  "mcp": {
+    "title": "MCP",
+    "newServer": "New server",
+    "addSecret": "Add secret",
+    "editConfig": "Edit config",
+    "viewRawConfig": "View raw config",
+    "copyId": "Copy id",
+    "copiedSnack": "Copied {id}",
+    "deleteServerTitle": "Delete MCP server?",
+    "deleteSecretTitle": "Delete secret?",
+    "errorPrefix": {
+      "delete": "Delete failed",
+      "add": "Add failed",
+      "update": "Update failed",
+      "toggle": "Toggle failed"
+    },
+    "errorWithMessage": "{prefix}: {error}",
+    "editor": {
+      "nameHint": "my-mcp-server",
+      "jsonHint": "JSON config — name, transport: stdio, command, args…"
+    },
+    "secret": {
+      "keyLabel": "Key",
+      "keyHint": "GITHUB_TOKEN, OPENAI_KEY, …",
+      "valueLabel": "Value"
+    }
+  },
+  "providers": {
+    "title": "Providers",
+    "configSaved": "Provider config updated.",
+    "saveFailedApi": "Save failed: {error}",
+    "saveFailedGeneric": "Save failed: {error}",
+    "reload": "Reload",
+    "errorPrefix": {
+      "toggle": "Toggle failed",
+      "rename": "Rename failed",
+      "delete": "Delete failed"
+    },
+    "errorWithMessage": "{prefix}: {error}",
+    "accounts": {
+      "rename": "Rename",
+      "renameTitle": "Rename {name}",
+      "displayNameLabel": "Display name",
+      "displayNameHint": "Work account",
+      "deleteTitle": "Delete account?",
+      "importFailedApi": "Import failed: {error}",
+      "importFailedGeneric": "Import failed: {error}"
+    }
+  },
+  "integrations": {
+    "title": "Integrations",
+    "register": "Register",
+    "registerDialogTitle": "Register integration",
+    "edit": "Edit",
+    "editTitle": "Edit {name}",
+    "enabledLabel": "Enabled",
+    "iSavedIt": "I've saved it",
+    "apiKeyForName": "API key for {name}",
+    "apiKeySubtitleRegister": "Hand this to the integration so it can authenticate against /api/v1/{routePrefix}/…",
+    "copiedRequestId": "Copied request_id {id}",
+    "updateOk": "Integration updated.",
+    "registerFailedApi": "Register failed: {error}",
+    "registerFailedGeneric": "Register failed: {error}",
+    "updateFailedApi": "Update failed: {error}",
+    "updateFailedGeneric": "Update failed: {error}",
+    "deleteTitle": "Delete integration?",
+    "deletedSnack": "Deleted {name}.",
+    "deleteFailedApi": "Delete failed: {error}",
+    "deleteFailedGeneric": "Delete failed: {error}",
+    "rotateKey": "Rotate key",
+    "rotateConfirmTitle": "Rotate API key?",
+    "rotate": "Rotate",
+    "newApiKeyTitle": "New API key for {name}",
+    "newApiKeySubtitle": "Hand this to the integration. The previous key has just been invalidated.",
+    "rotateFailedApi": "Rotate failed: {error}",
+    "rotateFailedGeneric": "Rotate failed: {error}"
+  },
   "memory": {
     "title": "Memory",
     "more": "More",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -89,6 +89,34 @@
     },
     "signOut": "Sign out"
   },
+  "sessions": {
+    "title": "Sessions",
+    "refresh": "Refresh",
+    "actions": "Actions",
+    "spawn": "Spawn",
+    "filters": {
+      "all": "All",
+      "running": "Running",
+      "idle": "Idle",
+      "ended": "Ended"
+    },
+    "card": {
+      "startedRelative": "{provider} · started {when}"
+    },
+    "empty": {
+      "titleAll": "No sessions yet",
+      "titleFiltered": "No sessions match the \"{filter}\" filter.",
+      "subtitleAll": "Tap the Spawn button to create one.",
+      "subtitleFiltered": "Try a different filter or pull to refresh."
+    },
+    "errorTitle": "Failed to load sessions",
+    "relative": {
+      "secondsAgo": "{n}s ago",
+      "minutesAgo": "{n}m ago",
+      "hoursAgo": "{n}h ago",
+      "daysAgo": "{n}d ago"
+    }
+  },
   "about": {
     "title": "About",
     "loading": "Loading…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -184,6 +184,74 @@
         "create": "创建"
       }
     },
+    "inspector": {
+      "shell": {
+        "title": "检查器",
+        "loadError": "加载会话失败：{error}",
+        "tabs": {
+          "files": "文件",
+          "git": "Git",
+          "tasks": "任务",
+          "history": "历史",
+          "notes": "笔记"
+        }
+      },
+      "shared": {
+        "refresh": "刷新",
+        "inserted": "已插入：{text}",
+        "insertFailedApi": "插入失败（{status}）：{message}",
+        "insertFailedGeneric": "插入失败：{error}",
+        "insertFailedShort": "插入失败：{error}"
+      },
+      "history": {
+        "insertIntoTerminal": "插入到终端",
+        "searchHint": "搜索提示…"
+      },
+      "files": {
+        "insertAtRef": "作为 @引用 插入",
+        "insertPath": "插入路径",
+        "insertPathSubtitle": "原样粘贴绝对路径",
+        "readContent": "读取内容",
+        "readContentSubtitle": "最多 256 KiB 纯文本",
+        "readFailedApi": "读取失败（{status}）：{message}",
+        "readFailedGeneric": "读取失败：{error}",
+        "parent": "上级",
+        "backToCwd": "返回会话目录"
+      },
+      "git": {
+        "insertAtRef": "作为 @引用 插入",
+        "insertPath": "插入路径",
+        "showDiff": "查看 diff",
+        "diffFailedApi": "Diff 失败（{status}）：{message}",
+        "diffFailedGeneric": "Diff 失败：{error}",
+        "insertHash": "插入哈希",
+        "showFullPatch": "查看完整 patch",
+        "showFailedApi": "查看失败（{status}）：{message}",
+        "showFailedGeneric": "查看失败：{error}",
+        "tabStatus": "状态",
+        "tabLog": "日志"
+      },
+      "tasks": {
+        "runCommand": "运行命令",
+        "insertCommand": "插入命令",
+        "insertCommandSubtitle": "粘贴但不回车，方便编辑"
+      },
+      "notes": {
+        "insertedAt": "已插入：@{path}",
+        "myNotes": "我的笔记",
+        "projectDocs": "项目文档",
+        "insertAtRefTooltip": "作为 @引用 插入",
+        "insertAtRefShort": "插入 @引用",
+        "draftHint": "# {project}\n\n想法、待办、为 agent 提供的上下文…",
+        "createFailed": "创建失败：{error}",
+        "saveFailed": "保存失败：{error}",
+        "changeLocationTooltip": "更改项目文档位置",
+        "filenameHint": "文件名（例如：spec 或 design.md）",
+        "create": "创建",
+        "filterHint": "筛选…",
+        "locationDialogTitle": "项目文档位置"
+      }
+    },
     "spawnSheet": {
       "title": "新建会话",
       "errorRequired": "需要指定提供商和工作目录",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -115,6 +115,82 @@
       "minutesAgo": "{n} 分钟前",
       "hoursAgo": "{n} 小时前",
       "daysAgo": "{n} 天前"
+    },
+    "action": {
+      "stop": "停止",
+      "stopping": "停止中…",
+      "stopDescription": "发送 SIGTERM，保留历史",
+      "restart": "重启",
+      "restarting": "重启中…",
+      "restartDescription": "重新启动 CLI 进程",
+      "delete": "删除",
+      "deleteDescription": "移除会话及其历史",
+      "deleteConfirm": "确定永久删除此会话吗？其环形缓冲区和历史将全部丢失。",
+      "errors": {
+        "stop": "停止失败：{error}",
+        "start": "重启失败：{error}",
+        "delete": "删除失败：{error}"
+      }
+    },
+    "dirPicker": {
+      "parent": "上级",
+      "newFolder": "新建文件夹",
+      "useThisFolder": "使用此文件夹",
+      "loading": "加载中…",
+      "empty": "此处没有子文件夹。\n选择此文件夹，或新建一个。",
+      "createdSnack": "已创建 {path}",
+      "mkdirFailedSnack": "创建文件夹失败：{error}",
+      "dialog": {
+        "title": "新建文件夹",
+        "hint": "文件夹名",
+        "create": "创建"
+      }
+    },
+    "spawnSheet": {
+      "title": "新建会话",
+      "errorRequired": "需要指定提供商和工作目录",
+      "errorGeneric": "创建会话失败：{error}",
+      "cancel": "取消",
+      "spawn": "创建",
+      "providerLabel": "提供商",
+      "disabledSuffix": "（已停用）",
+      "cwdLabel": "工作目录",
+      "cwdHint": "/Users/you/projects/foo",
+      "cwdHelper": "网关主机上的绝对路径。",
+      "browse": "浏览",
+      "nameLabel": "名称（可选）",
+      "nameHint": "例如：backend-refactor",
+      "argsLabel": "额外参数（可选）",
+      "argsHint": "--continue --verbose",
+      "argsHelper": "以空格分隔；留空使用提供商默认值。",
+      "bypass": {
+        "labelClaude": "绕过权限",
+        "labelCodex": "自动批准（从不询问）",
+        "labelGemini": "YOLO 模式",
+        "subtitleOn": "此会话将以提升的自主权运行。",
+        "subtitleOff": "关闭 — 确认和提示按正常方式处理。"
+      },
+      "noProviders": {
+        "title": "未配置任何提供商",
+        "message": "网关没有启用任何 CLI 提供商。在 Web 管理端的「提供商」中配置，或编辑 config.toml 的 [providers] 段，然后点击重新加载。",
+        "reload": "重新加载"
+      },
+      "providerLoadError": {
+        "title": "无法加载提供商",
+        "networkError": "网络错误",
+        "serverPrefix": "服务器 {code}",
+        "format": "{prefix}：{message}"
+      },
+      "claudeAccount": {
+        "label": "Claude 账号",
+        "helperMulti": "已配置多个账号 — 为此会话选择一个。",
+        "helperSingle": "选择已配置的账号，或使用默认（环境变量 / 系统）。",
+        "default": "默认（环境变量 / 系统）",
+        "disabledSuffix": "（已停用）",
+        "noTokenSuffix": "（无令牌）",
+        "noneHint": "未配置 Claude 账号 — 网关将使用系统的 ANTHROPIC_API_KEY。在 Web 管理端的「设置 → 账号」中添加账号。",
+        "errorHint": "无法加载 Claude 账号（{error}）。会话将以网关默认配置启动。"
+      }
     }
   },
   "about": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -1,0 +1,44 @@
+{
+  "common": {
+    "ok": "确定",
+    "cancel": "取消",
+    "save": "保存",
+    "delete": "删除",
+    "edit": "编辑",
+    "back": "返回",
+    "done": "完成",
+    "close": "关闭",
+    "retry": "重试"
+  },
+  "settings": {
+    "title": "设置",
+    "language": {
+      "section": "语言",
+      "system": "跟随系统",
+      "systemSubtitle": "跟随手机的语言设置",
+      "english": "English",
+      "chinese": "中文"
+    },
+    "appearance": {
+      "section": "外观",
+      "system": "跟随系统",
+      "systemSubtitle": "跟随手机的外观设置",
+      "light": "浅色",
+      "lightSubtitle": "始终使用浅色主题",
+      "dark": "深色",
+      "darkSubtitle": "始终使用深色主题"
+    },
+    "account": {
+      "section": "账户",
+      "changeCredentials": "修改凭据",
+      "changeCredentialsSubtitle": "用户名和密码"
+    },
+    "gateway": {
+      "section": "网关",
+      "serverSettings": "服务器设置",
+      "serverSettingsSubtitle": "监听地址、日志、凭据库、内存、存储路径…",
+      "liveLogs": "实时日志",
+      "liveLogsSubtitle": "查看网关实时日志 — 与 Web 管理端同源"
+    }
+  }
+}

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -299,6 +299,39 @@
       }
     }
   },
+  "memory": {
+    "title": "记忆",
+    "more": "更多",
+    "workers": "记忆工作器",
+    "new": "新建",
+    "searchHint": "搜索…",
+    "projectLabel": "项目",
+    "filterHint": "按名称或路径筛选…",
+    "copied": "已复制",
+    "copyTooltip": "复制文本",
+    "deleteAllConfirm": {
+      "title": "删除此范围内所有记忆？",
+      "deleteAll": "全部删除"
+    },
+    "deletedSnackOne": "已删除 {n} 条记忆",
+    "deletedSnackOther": "已删除 {n} 条记忆",
+    "bulkDeleteFailedApi": "批量删除失败：{error}",
+    "bulkDeleteFailedGeneric": "批量删除失败：{error}",
+    "deleteOne": {
+      "title": "删除该记忆？",
+      "body": "此操作不可撤销。"
+    },
+    "scope": {
+      "project": "项目",
+      "global": "全局"
+    },
+    "create": {
+      "textLabel": "文本",
+      "scopeKeyLabel": "范围键（项目 cwd）",
+      "scopeKeyHint": "/Users/you/projects/foo",
+      "submit": "创建"
+    }
+  },
   "about": {
     "title": "关于",
     "loading": "加载中…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -89,6 +89,34 @@
     },
     "signOut": "退出登录"
   },
+  "sessions": {
+    "title": "会话",
+    "refresh": "刷新",
+    "actions": "操作",
+    "spawn": "创建",
+    "filters": {
+      "all": "全部",
+      "running": "运行中",
+      "idle": "空闲",
+      "ended": "已结束"
+    },
+    "card": {
+      "startedRelative": "{provider} · {when}启动"
+    },
+    "empty": {
+      "titleAll": "暂无会话",
+      "titleFiltered": "没有匹配「{filter}」筛选的会话。",
+      "subtitleAll": "点击「创建」按钮新建一个。",
+      "subtitleFiltered": "试试其他筛选条件或下拉刷新。"
+    },
+    "errorTitle": "加载会话失败",
+    "relative": {
+      "secondsAgo": "{n} 秒前",
+      "minutesAgo": "{n} 分钟前",
+      "hoursAgo": "{n} 小时前",
+      "daysAgo": "{n} 天前"
+    }
+  },
   "about": {
     "title": "关于",
     "loading": "加载中…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -299,6 +299,83 @@
       }
     }
   },
+  "mcp": {
+    "title": "MCP",
+    "newServer": "新建服务器",
+    "addSecret": "添加密钥",
+    "editConfig": "编辑配置",
+    "viewRawConfig": "查看原始配置",
+    "copyId": "复制 ID",
+    "copiedSnack": "已复制 {id}",
+    "deleteServerTitle": "删除 MCP 服务器？",
+    "deleteSecretTitle": "删除密钥？",
+    "errorPrefix": {
+      "delete": "删除失败",
+      "add": "添加失败",
+      "update": "更新失败",
+      "toggle": "切换失败"
+    },
+    "errorWithMessage": "{prefix}：{error}",
+    "editor": {
+      "nameHint": "my-mcp-server",
+      "jsonHint": "JSON 配置 — name、transport: stdio、command、args…"
+    },
+    "secret": {
+      "keyLabel": "键",
+      "keyHint": "GITHUB_TOKEN、OPENAI_KEY、…",
+      "valueLabel": "值"
+    }
+  },
+  "providers": {
+    "title": "提供商",
+    "configSaved": "提供商配置已更新。",
+    "saveFailedApi": "保存失败：{error}",
+    "saveFailedGeneric": "保存失败：{error}",
+    "reload": "重新加载",
+    "errorPrefix": {
+      "toggle": "切换失败",
+      "rename": "重命名失败",
+      "delete": "删除失败"
+    },
+    "errorWithMessage": "{prefix}：{error}",
+    "accounts": {
+      "rename": "重命名",
+      "renameTitle": "重命名 {name}",
+      "displayNameLabel": "显示名",
+      "displayNameHint": "工作账号",
+      "deleteTitle": "删除账号？",
+      "importFailedApi": "导入失败：{error}",
+      "importFailedGeneric": "导入失败：{error}"
+    }
+  },
+  "integrations": {
+    "title": "集成",
+    "register": "注册",
+    "registerDialogTitle": "注册集成",
+    "edit": "编辑",
+    "editTitle": "编辑 {name}",
+    "enabledLabel": "已启用",
+    "iSavedIt": "我已保存",
+    "apiKeyForName": "{name} 的 API key",
+    "apiKeySubtitleRegister": "将其交给集成方，使其能够通过 /api/v1/{routePrefix}/… 进行认证。",
+    "copiedRequestId": "已复制 request_id {id}",
+    "updateOk": "集成已更新。",
+    "registerFailedApi": "注册失败：{error}",
+    "registerFailedGeneric": "注册失败：{error}",
+    "updateFailedApi": "更新失败：{error}",
+    "updateFailedGeneric": "更新失败：{error}",
+    "deleteTitle": "删除集成？",
+    "deletedSnack": "已删除 {name}。",
+    "deleteFailedApi": "删除失败：{error}",
+    "deleteFailedGeneric": "删除失败：{error}",
+    "rotateKey": "轮换密钥",
+    "rotateConfirmTitle": "轮换 API key？",
+    "rotate": "轮换",
+    "newApiKeyTitle": "{name} 的新 API key",
+    "newApiKeySubtitle": "将其交给集成方。旧密钥已失效。",
+    "rotateFailedApi": "轮换失败：{error}",
+    "rotateFailedGeneric": "轮换失败：{error}"
+  },
   "memory": {
     "title": "记忆",
     "more": "更多",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -19,6 +19,100 @@
     "errorRequired": "请输入用户名和密码",
     "errorGeneric": "登录失败：{error}"
   },
+  "nav": {
+    "sessions": "会话",
+    "memory": "记忆",
+    "notes": "笔记",
+    "more": "更多"
+  },
+  "more": {
+    "title": "更多",
+    "identity": {
+      "signedInAs": "登录账号",
+      "server": "服务器",
+      "tokenExpires": "令牌到期"
+    },
+    "sections": {
+      "gateway": "网关",
+      "memory": "记忆",
+      "system": "系统"
+    },
+    "items": {
+      "integrations": {
+        "title": "集成",
+        "subtitle": "API 调用方 — 近期活动与错误率"
+      },
+      "channels": {
+        "title": "通道",
+        "subtitle": "通知目的地"
+      },
+      "providers": {
+        "title": "提供商",
+        "subtitle": "Claude / Codex / Gemini CLI 状态"
+      },
+      "mcp": {
+        "title": "MCP",
+        "subtitle": "Model Context Protocol 服务与密钥"
+      },
+      "skills": {
+        "title": "技能",
+        "subtitle": "Agent SKILL.md 库（内置 + 库）"
+      },
+      "gitHosts": {
+        "title": "Git 主机",
+        "subtitle": "GitHub / GitLab 等的 PAT 凭据"
+      },
+      "customTasks": {
+        "title": "自定义任务",
+        "subtitle": "会话任务选择器中显示的斜杠命令"
+      },
+      "projectMemory": {
+        "title": "项目目标 / 计划 / 日志",
+        "subtitle": "按 cwd 的记忆层 2-4 + 代理提案"
+      },
+      "cleanupInbox": {
+        "title": "清理收件箱",
+        "subtitle": "跨项目的 LLM 提议删除 / 合并"
+      },
+      "backups": {
+        "title": "备份",
+        "subtitle": "最新备份状态与立即运行"
+      },
+      "settings": {
+        "title": "设置",
+        "subtitle": "语言、外观、账户"
+      },
+      "about": {
+        "title": "关于",
+        "subtitle": "构建版本与服务器信息"
+      }
+    },
+    "signOut": "退出登录"
+  },
+  "about": {
+    "title": "关于",
+    "loading": "加载中…",
+    "sections": {
+      "app": "应用",
+      "server": "服务器"
+    },
+    "fields": {
+      "app": "应用",
+      "version": "版本",
+      "versionFormat": "{version}（build {build}）",
+      "package": "包名",
+      "url": "URL",
+      "signedInAs": "登录账号",
+      "tokenExpires": "令牌到期"
+    },
+    "copied": "已复制 {label}",
+    "copyTooltip": "复制",
+    "copyLabels": {
+      "version": "版本",
+      "serverUrl": "服务器 URL"
+    },
+    "tagline": "opendray mobile — 多 CLI 网关控制。\n源码：github.com/Opendray/opendray_v2"
+  },
   "settings": {
     "title": "设置",
     "language": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -10,6 +10,15 @@
     "close": "关闭",
     "retry": "重试"
   },
+  "auth": {
+    "signInTitle": "登录",
+    "changeServer": "更换",
+    "username": "用户名",
+    "password": "密码",
+    "signIn": "登录",
+    "errorRequired": "请输入用户名和密码",
+    "errorGeneric": "登录失败：{error}"
+  },
   "settings": {
     "title": "设置",
     "language": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -116,6 +116,44 @@
       "hoursAgo": "{n} 小时前",
       "daysAgo": "{n} 天前"
     },
+    "detail": {
+      "fallbackTitle": "会话",
+      "refreshMetadata": "刷新元数据",
+      "inspector": "检查器（文件 / Git / 任务 / 历史 / 笔记）",
+      "projectMemory": "项目记忆（目标 / 计划 / 日志 / 收件箱）",
+      "actions": "操作",
+      "started": "{when} 启动",
+      "startedEnded": "{started} 启动  ·  {ended} 结束",
+      "idPrefix": "id: {id}",
+      "errorTitle": "加载会话失败"
+    },
+    "terminal": {
+      "snackbar": {
+        "imagePickerFailed": "图片选择失败：{error}",
+        "uploadingImage": "正在上传图片…",
+        "imageAttached": "已附加图片：{path}",
+        "uploadFailed": "上传失败（{status}）：{message}",
+        "uploadFailedGeneric": "上传失败：{error}"
+      },
+      "imageSource": {
+        "photoLibrary": "相册",
+        "takePhoto": "拍照"
+      },
+      "keyboard": {
+        "copyBuffer": "复制缓冲",
+        "paste": "粘贴",
+        "attachImage": "附加图片"
+      },
+      "connection": {
+        "connecting": "连接中…",
+        "connected": "已连接",
+        "reconnecting": "重连中…",
+        "reconnectingWithError": "重连中（{error}）…",
+        "disconnected": "已断开",
+        "disconnectedWithError": "已断开（{error}）",
+        "ended": "会话已结束"
+      }
+    },
     "action": {
       "stop": "停止",
       "stopping": "停止中…",

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -1,0 +1,183 @@
+/// Generated file. Do not edit.
+///
+/// Source: ../i18n
+/// To regenerate, run: `dart run slang`
+///
+/// Locales: 2
+/// Strings: 60 (30 per locale)
+///
+/// Built on 2026-05-13 at 11:13 UTC
+
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
+import 'package:slang/generated.dart';
+import 'package:slang_flutter/slang_flutter.dart';
+export 'package:slang_flutter/slang_flutter.dart';
+
+import 'strings_zh.g.dart' deferred as l_zh;
+part 'strings_en.g.dart';
+
+/// Supported locales.
+///
+/// Usage:
+/// - LocaleSettings.setLocale(AppLocale.en) // set locale
+/// - Locale locale = AppLocale.en.flutterLocale // get flutter locale from enum
+/// - if (LocaleSettings.currentLocale == AppLocale.en) // locale check
+enum AppLocale with BaseAppLocale<AppLocale, Translations> {
+	en(languageCode: 'en'),
+	zh(languageCode: 'zh');
+
+	const AppLocale({
+		required this.languageCode,
+		this.scriptCode, // ignore: unused_element, unused_element_parameter
+		this.countryCode, // ignore: unused_element, unused_element_parameter
+	});
+
+	@override final String languageCode;
+	@override final String? scriptCode;
+	@override final String? countryCode;
+
+	@override
+	Future<Translations> build({
+		Map<String, Node>? overrides,
+		PluralResolver? cardinalResolver,
+		PluralResolver? ordinalResolver,
+	}) async {
+		switch (this) {
+			case AppLocale.en:
+				return TranslationsEn(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.zh:
+				await l_zh.loadLibrary();
+				return l_zh.TranslationsZh(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+		}
+	}
+
+	@override
+	Translations buildSync({
+		Map<String, Node>? overrides,
+		PluralResolver? cardinalResolver,
+		PluralResolver? ordinalResolver,
+	}) {
+		switch (this) {
+			case AppLocale.en:
+				return TranslationsEn(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.zh:
+				return l_zh.TranslationsZh(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+		}
+	}
+
+	/// Gets current instance managed by [LocaleSettings].
+	Translations get translations => LocaleSettings.instance.getTranslations(this);
+}
+
+/// Method A: Simple
+///
+/// No rebuild after locale change.
+/// Translation happens during initialization of the widget (call of t).
+/// Configurable via 'translate_var'.
+///
+/// Usage:
+/// String a = t.someKey.anotherKey;
+/// String b = t['someKey.anotherKey']; // Only for edge cases!
+Translations get t => LocaleSettings.instance.currentTranslations;
+
+/// Method B: Advanced
+///
+/// All widgets using this method will trigger a rebuild when locale changes.
+/// Use this if you have e.g. a settings page where the user can select the locale during runtime.
+///
+/// Step 1:
+/// wrap your App with
+/// TranslationProvider(
+/// 	child: MyApp()
+/// );
+///
+/// Step 2:
+/// final t = Translations.of(context); // Get t variable.
+/// String a = t.someKey.anotherKey; // Use t variable.
+/// String b = t['someKey.anotherKey']; // Only for edge cases!
+class TranslationProvider extends BaseTranslationProvider<AppLocale, Translations> {
+	TranslationProvider({required super.child}) : super(settings: LocaleSettings.instance);
+
+	static InheritedLocaleData<AppLocale, Translations> of(BuildContext context) => InheritedLocaleData.of<AppLocale, Translations>(context);
+}
+
+/// Method B shorthand via [BuildContext] extension method.
+/// Configurable via 'translate_var'.
+///
+/// Usage (e.g. in a widget's build method):
+/// context.t.someKey.anotherKey
+extension BuildContextTranslationsExtension on BuildContext {
+	Translations get t => TranslationProvider.of(this).translations;
+}
+
+/// Manages all translation instances and the current locale
+class LocaleSettings extends BaseFlutterLocaleSettings<AppLocale, Translations> {
+	LocaleSettings._() : super(
+		utils: AppLocaleUtils.instance,
+		lazy: true,
+	);
+
+	static final instance = LocaleSettings._();
+
+	// static aliases (checkout base methods for documentation)
+	static AppLocale get currentLocale => instance.currentLocale;
+	static Stream<AppLocale> getLocaleStream() => instance.getLocaleStream();
+	static Future<AppLocale> setLocale(AppLocale locale, {bool? listenToDeviceLocale = false}) => instance.setLocale(locale, listenToDeviceLocale: listenToDeviceLocale);
+	static Future<AppLocale> setLocaleRaw(String rawLocale, {bool? listenToDeviceLocale = false}) => instance.setLocaleRaw(rawLocale, listenToDeviceLocale: listenToDeviceLocale);
+	static Future<AppLocale> useDeviceLocale() => instance.useDeviceLocale();
+	static Future<void> setPluralResolver({String? language, AppLocale? locale, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver}) => instance.setPluralResolver(
+		language: language,
+		locale: locale,
+		cardinalResolver: cardinalResolver,
+		ordinalResolver: ordinalResolver,
+	);
+
+	// synchronous versions
+	static AppLocale setLocaleSync(AppLocale locale, {bool? listenToDeviceLocale = false}) => instance.setLocaleSync(locale, listenToDeviceLocale: listenToDeviceLocale);
+	static AppLocale setLocaleRawSync(String rawLocale, {bool? listenToDeviceLocale = false}) => instance.setLocaleRawSync(rawLocale, listenToDeviceLocale: listenToDeviceLocale);
+	static AppLocale useDeviceLocaleSync() => instance.useDeviceLocaleSync();
+	static void setPluralResolverSync({String? language, AppLocale? locale, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver}) => instance.setPluralResolverSync(
+		language: language,
+		locale: locale,
+		cardinalResolver: cardinalResolver,
+		ordinalResolver: ordinalResolver,
+	);
+}
+
+/// Provides utility functions without any side effects.
+class AppLocaleUtils extends BaseAppLocaleUtils<AppLocale, Translations> {
+	AppLocaleUtils._() : super(
+		baseLocale: AppLocale.en,
+		locales: AppLocale.values,
+	);
+
+	static final instance = AppLocaleUtils._();
+
+	// static aliases (checkout base methods for documentation)
+	static AppLocale parse(String rawLocale) => instance.parse(rawLocale);
+	static AppLocale parseLocaleParts({required String languageCode, String? scriptCode, String? countryCode}) => instance.parseLocaleParts(languageCode: languageCode, scriptCode: scriptCode, countryCode: countryCode);
+	static AppLocale findDeviceLocale() => instance.findDeviceLocale();
+	static List<Locale> get supportedLocales => instance.supportedLocales;
+	static List<String> get supportedLocalesRaw => instance.supportedLocalesRaw;
+}

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 214 (107 per locale)
+/// Strings: 330 (165 per locale)
 ///
-/// Built on 2026-05-13 at 11:27 UTC
+/// Built on 2026-05-13 at 11:33 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 382 (191 per locale)
+/// Strings: 482 (241 per locale)
 ///
-/// Built on 2026-05-13 at 11:36 UTC
+/// Built on 2026-05-13 at 11:43 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 482 (241 per locale)
+/// Strings: 528 (264 per locale)
 ///
-/// Built on 2026-05-13 at 11:43 UTC
+/// Built on 2026-05-13 at 11:45 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 74 (37 per locale)
+/// Strings: 178 (89 per locale)
 ///
-/// Built on 2026-05-13 at 11:21 UTC
+/// Built on 2026-05-13 at 11:24 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 60 (30 per locale)
+/// Strings: 74 (37 per locale)
 ///
-/// Built on 2026-05-13 at 11:13 UTC
+/// Built on 2026-05-13 at 11:21 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 528 (264 per locale)
+/// Strings: 650 (325 per locale)
 ///
-/// Built on 2026-05-13 at 11:45 UTC
+/// Built on 2026-05-13 at 12:04 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 330 (165 per locale)
+/// Strings: 382 (191 per locale)
 ///
-/// Built on 2026-05-13 at 11:33 UTC
+/// Built on 2026-05-13 at 11:36 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 178 (89 per locale)
+/// Strings: 214 (107 per locale)
 ///
-/// Built on 2026-05-13 at 11:24 UTC
+/// Built on 2026-05-13 at 11:27 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -1,0 +1,237 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+part of 'strings.g.dart';
+
+// Path: <root>
+typedef TranslationsEn = Translations; // ignore: unused_element
+class Translations with BaseTranslations<AppLocale, Translations> {
+	/// Returns the current translations of the given [context].
+	///
+	/// Usage:
+	/// final t = Translations.of(context);
+	static Translations of(BuildContext context) => InheritedLocaleData.of<AppLocale, Translations>(context).translations;
+
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	Translations({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = meta ?? TranslationMetadata(
+		    locale: AppLocale.en,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ) {
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
+
+	/// Metadata for the translations of <en>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
+
+	/// Access flat map
+	dynamic operator[](String key) => $meta.getTranslation(key);
+
+	late final Translations _root = this; // ignore: unused_field
+
+	Translations $copyWith({TranslationMetadata<AppLocale, Translations>? meta}) => Translations(meta: meta ?? this.$meta);
+
+	// Translations
+	late final TranslationsCommonEn common = TranslationsCommonEn.internal(_root);
+	late final TranslationsSettingsEn settings = TranslationsSettingsEn.internal(_root);
+}
+
+// Path: common
+class TranslationsCommonEn {
+	TranslationsCommonEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'OK'
+	String get ok => 'OK';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Save'
+	String get save => 'Save';
+
+	/// en: 'Delete'
+	String get delete => 'Delete';
+
+	/// en: 'Edit'
+	String get edit => 'Edit';
+
+	/// en: 'Back'
+	String get back => 'Back';
+
+	/// en: 'Done'
+	String get done => 'Done';
+
+	/// en: 'Close'
+	String get close => 'Close';
+
+	/// en: 'Retry'
+	String get retry => 'Retry';
+}
+
+// Path: settings
+class TranslationsSettingsEn {
+	TranslationsSettingsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Settings'
+	String get title => 'Settings';
+
+	late final TranslationsSettingsLanguageEn language = TranslationsSettingsLanguageEn.internal(_root);
+	late final TranslationsSettingsAppearanceEn appearance = TranslationsSettingsAppearanceEn.internal(_root);
+	late final TranslationsSettingsAccountEn account = TranslationsSettingsAccountEn.internal(_root);
+	late final TranslationsSettingsGatewayEn gateway = TranslationsSettingsGatewayEn.internal(_root);
+}
+
+// Path: settings.language
+class TranslationsSettingsLanguageEn {
+	TranslationsSettingsLanguageEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Language'
+	String get section => 'Language';
+
+	/// en: 'System'
+	String get system => 'System';
+
+	/// en: 'Follow your phone's language setting'
+	String get systemSubtitle => 'Follow your phone\'s language setting';
+
+	/// en: 'English'
+	String get english => 'English';
+
+	/// en: '中文'
+	String get chinese => '中文';
+}
+
+// Path: settings.appearance
+class TranslationsSettingsAppearanceEn {
+	TranslationsSettingsAppearanceEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Appearance'
+	String get section => 'Appearance';
+
+	/// en: 'System'
+	String get system => 'System';
+
+	/// en: 'Follow your phone's appearance setting'
+	String get systemSubtitle => 'Follow your phone\'s appearance setting';
+
+	/// en: 'Light'
+	String get light => 'Light';
+
+	/// en: 'Always use the light palette'
+	String get lightSubtitle => 'Always use the light palette';
+
+	/// en: 'Dark'
+	String get dark => 'Dark';
+
+	/// en: 'Always use the dark palette'
+	String get darkSubtitle => 'Always use the dark palette';
+}
+
+// Path: settings.account
+class TranslationsSettingsAccountEn {
+	TranslationsSettingsAccountEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Account'
+	String get section => 'Account';
+
+	/// en: 'Change credentials'
+	String get changeCredentials => 'Change credentials';
+
+	/// en: 'Username and password'
+	String get changeCredentialsSubtitle => 'Username and password';
+}
+
+// Path: settings.gateway
+class TranslationsSettingsGatewayEn {
+	TranslationsSettingsGatewayEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Gateway'
+	String get section => 'Gateway';
+
+	/// en: 'Server settings'
+	String get serverSettings => 'Server settings';
+
+	/// en: 'Listen address, logging, vault, memory, storage paths…'
+	String get serverSettingsSubtitle => 'Listen address, logging, vault, memory, storage paths…';
+
+	/// en: 'Live logs'
+	String get liveLogs => 'Live logs';
+
+	/// en: 'Tail the gateway log buffer — same source as the web admin'
+	String get liveLogsSubtitle => 'Tail the gateway log buffer — same source as the web admin';
+}
+
+/// The flat map containing all translations for locale <en>.
+/// Only for edge cases! For simple maps, use the map function of this library.
+///
+/// The Dart AOT compiler has issues with very large switch statements,
+/// so the map is split into smaller functions (512 entries each).
+extension on Translations {
+	dynamic _flatMapFunction(String path) {
+		return switch (path) {
+			'common.ok' => 'OK',
+			'common.cancel' => 'Cancel',
+			'common.save' => 'Save',
+			'common.delete' => 'Delete',
+			'common.edit' => 'Edit',
+			'common.back' => 'Back',
+			'common.done' => 'Done',
+			'common.close' => 'Close',
+			'common.retry' => 'Retry',
+			'settings.title' => 'Settings',
+			'settings.language.section' => 'Language',
+			'settings.language.system' => 'System',
+			'settings.language.systemSubtitle' => 'Follow your phone\'s language setting',
+			'settings.language.english' => 'English',
+			'settings.language.chinese' => '中文',
+			'settings.appearance.section' => 'Appearance',
+			'settings.appearance.system' => 'System',
+			'settings.appearance.systemSubtitle' => 'Follow your phone\'s appearance setting',
+			'settings.appearance.light' => 'Light',
+			'settings.appearance.lightSubtitle' => 'Always use the light palette',
+			'settings.appearance.dark' => 'Dark',
+			'settings.appearance.darkSubtitle' => 'Always use the dark palette',
+			'settings.account.section' => 'Account',
+			'settings.account.changeCredentials' => 'Change credentials',
+			'settings.account.changeCredentialsSubtitle' => 'Username and password',
+			'settings.gateway.section' => 'Gateway',
+			'settings.gateway.serverSettings' => 'Server settings',
+			'settings.gateway.serverSettingsSubtitle' => 'Listen address, logging, vault, memory, storage paths…',
+			'settings.gateway.liveLogs' => 'Live logs',
+			'settings.gateway.liveLogsSubtitle' => 'Tail the gateway log buffer — same source as the web admin',
+			_ => null,
+		};
+	}
+}

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -187,6 +187,7 @@ class TranslationsSessionsEn {
 	late final TranslationsSessionsTerminalEn terminal = TranslationsSessionsTerminalEn.internal(_root);
 	late final TranslationsSessionsActionEn action = TranslationsSessionsActionEn.internal(_root);
 	late final TranslationsSessionsDirPickerEn dirPicker = TranslationsSessionsDirPickerEn.internal(_root);
+	late final TranslationsSessionsInspectorEn inspector = TranslationsSessionsInspectorEn.internal(_root);
 	late final TranslationsSessionsSpawnSheetEn spawnSheet = TranslationsSessionsSpawnSheetEn.internal(_root);
 }
 
@@ -485,6 +486,22 @@ class TranslationsSessionsDirPickerEn {
 	String mkdirFailedSnack({required Object error}) => 'mkdir failed: ${error}';
 
 	late final TranslationsSessionsDirPickerDialogEn dialog = TranslationsSessionsDirPickerDialogEn.internal(_root);
+}
+
+// Path: sessions.inspector
+class TranslationsSessionsInspectorEn {
+	TranslationsSessionsInspectorEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsSessionsInspectorShellEn shell = TranslationsSessionsInspectorShellEn.internal(_root);
+	late final TranslationsSessionsInspectorSharedEn shared = TranslationsSessionsInspectorSharedEn.internal(_root);
+	late final TranslationsSessionsInspectorHistoryEn history = TranslationsSessionsInspectorHistoryEn.internal(_root);
+	late final TranslationsSessionsInspectorFilesEn files = TranslationsSessionsInspectorFilesEn.internal(_root);
+	late final TranslationsSessionsInspectorGitEn git = TranslationsSessionsInspectorGitEn.internal(_root);
+	late final TranslationsSessionsInspectorTasksEn tasks = TranslationsSessionsInspectorTasksEn.internal(_root);
+	late final TranslationsSessionsInspectorNotesEn notes = TranslationsSessionsInspectorNotesEn.internal(_root);
 }
 
 // Path: sessions.spawnSheet
@@ -1008,6 +1025,206 @@ class TranslationsSessionsDirPickerDialogEn {
 	String get create => 'Create';
 }
 
+// Path: sessions.inspector.shell
+class TranslationsSessionsInspectorShellEn {
+	TranslationsSessionsInspectorShellEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Inspector'
+	String get title => 'Inspector';
+
+	/// en: 'Failed to load session: {error}'
+	String loadError({required Object error}) => 'Failed to load session: ${error}';
+
+	late final TranslationsSessionsInspectorShellTabsEn tabs = TranslationsSessionsInspectorShellTabsEn.internal(_root);
+}
+
+// Path: sessions.inspector.shared
+class TranslationsSessionsInspectorSharedEn {
+	TranslationsSessionsInspectorSharedEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Refresh'
+	String get refresh => 'Refresh';
+
+	/// en: 'Inserted: {text}'
+	String inserted({required Object text}) => 'Inserted: ${text}';
+
+	/// en: 'Insert failed ({status}): {message}'
+	String insertFailedApi({required Object status, required Object message}) => 'Insert failed (${status}): ${message}';
+
+	/// en: 'Insert failed: {error}'
+	String insertFailedGeneric({required Object error}) => 'Insert failed: ${error}';
+
+	/// en: 'Insert failed: {error}'
+	String insertFailedShort({required Object error}) => 'Insert failed: ${error}';
+}
+
+// Path: sessions.inspector.history
+class TranslationsSessionsInspectorHistoryEn {
+	TranslationsSessionsInspectorHistoryEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Insert into terminal'
+	String get insertIntoTerminal => 'Insert into terminal';
+
+	/// en: 'Search prompts…'
+	String get searchHint => 'Search prompts…';
+}
+
+// Path: sessions.inspector.files
+class TranslationsSessionsInspectorFilesEn {
+	TranslationsSessionsInspectorFilesEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Insert as @reference'
+	String get insertAtRef => 'Insert as @reference';
+
+	/// en: 'Insert path'
+	String get insertPath => 'Insert path';
+
+	/// en: 'Pastes the absolute path verbatim'
+	String get insertPathSubtitle => 'Pastes the absolute path verbatim';
+
+	/// en: 'Read content'
+	String get readContent => 'Read content';
+
+	/// en: 'Up to 256 KiB plain text'
+	String get readContentSubtitle => 'Up to 256 KiB plain text';
+
+	/// en: 'Read failed ({status}): {message}'
+	String readFailedApi({required Object status, required Object message}) => 'Read failed (${status}): ${message}';
+
+	/// en: 'Read failed: {error}'
+	String readFailedGeneric({required Object error}) => 'Read failed: ${error}';
+
+	/// en: 'Parent'
+	String get parent => 'Parent';
+
+	/// en: 'Back to session cwd'
+	String get backToCwd => 'Back to session cwd';
+}
+
+// Path: sessions.inspector.git
+class TranslationsSessionsInspectorGitEn {
+	TranslationsSessionsInspectorGitEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Insert as @reference'
+	String get insertAtRef => 'Insert as @reference';
+
+	/// en: 'Insert path'
+	String get insertPath => 'Insert path';
+
+	/// en: 'Show diff'
+	String get showDiff => 'Show diff';
+
+	/// en: 'Diff failed ({status}): {message}'
+	String diffFailedApi({required Object status, required Object message}) => 'Diff failed (${status}): ${message}';
+
+	/// en: 'Diff failed: {error}'
+	String diffFailedGeneric({required Object error}) => 'Diff failed: ${error}';
+
+	/// en: 'Insert hash'
+	String get insertHash => 'Insert hash';
+
+	/// en: 'Show full patch'
+	String get showFullPatch => 'Show full patch';
+
+	/// en: 'Show failed ({status}): {message}'
+	String showFailedApi({required Object status, required Object message}) => 'Show failed (${status}): ${message}';
+
+	/// en: 'Show failed: {error}'
+	String showFailedGeneric({required Object error}) => 'Show failed: ${error}';
+
+	/// en: 'Status'
+	String get tabStatus => 'Status';
+
+	/// en: 'Log'
+	String get tabLog => 'Log';
+}
+
+// Path: sessions.inspector.tasks
+class TranslationsSessionsInspectorTasksEn {
+	TranslationsSessionsInspectorTasksEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Run command'
+	String get runCommand => 'Run command';
+
+	/// en: 'Insert command'
+	String get insertCommand => 'Insert command';
+
+	/// en: 'Pastes without return so you can edit'
+	String get insertCommandSubtitle => 'Pastes without return so you can edit';
+}
+
+// Path: sessions.inspector.notes
+class TranslationsSessionsInspectorNotesEn {
+	TranslationsSessionsInspectorNotesEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Inserted: @{path}'
+	String insertedAt({required Object path}) => 'Inserted: @${path}';
+
+	/// en: 'My notes'
+	String get myNotes => 'My notes';
+
+	/// en: 'Project docs'
+	String get projectDocs => 'Project docs';
+
+	/// en: 'Insert as @reference'
+	String get insertAtRefTooltip => 'Insert as @reference';
+
+	/// en: 'Insert @reference'
+	String get insertAtRefShort => 'Insert @reference';
+
+	/// en: '# {project} Thoughts, todos, context for the agent…'
+	String draftHint({required Object project}) => '# ${project}\n\nThoughts, todos, context for the agent…';
+
+	/// en: 'Create failed: {error}'
+	String createFailed({required Object error}) => 'Create failed: ${error}';
+
+	/// en: 'Save failed: {error}'
+	String saveFailed({required Object error}) => 'Save failed: ${error}';
+
+	/// en: 'Change project docs location'
+	String get changeLocationTooltip => 'Change project docs location';
+
+	/// en: 'filename (e.g. spec or design.md)'
+	String get filenameHint => 'filename (e.g. spec or design.md)';
+
+	/// en: 'Create'
+	String get create => 'Create';
+
+	/// en: 'Filter…'
+	String get filterHint => 'Filter…';
+
+	/// en: 'Project docs location'
+	String get locationDialogTitle => 'Project docs location';
+}
+
 // Path: sessions.spawnSheet.bypass
 class TranslationsSessionsSpawnSheetBypassEn {
 	TranslationsSessionsSpawnSheetBypassEn.internal(this._root);
@@ -1102,6 +1319,30 @@ class TranslationsSessionsSpawnSheetClaudeAccountEn {
 
 	/// en: 'Could not load Claude accounts ({error}). The session will spawn with the gateway default.'
 	String errorHint({required Object error}) => 'Could not load Claude accounts (${error}). The session will spawn with the gateway default.';
+}
+
+// Path: sessions.inspector.shell.tabs
+class TranslationsSessionsInspectorShellTabsEn {
+	TranslationsSessionsInspectorShellTabsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Files'
+	String get files => 'Files';
+
+	/// en: 'Git'
+	String get git => 'Git';
+
+	/// en: 'Tasks'
+	String get tasks => 'Tasks';
+
+	/// en: 'History'
+	String get history => 'History';
+
+	/// en: 'Notes'
+	String get notes => 'Notes';
 }
 
 /// The flat map containing all translations for locale <en>.
@@ -1230,6 +1471,56 @@ extension on Translations {
 			'sessions.dirPicker.dialog.title' => 'New folder',
 			'sessions.dirPicker.dialog.hint' => 'Folder name',
 			'sessions.dirPicker.dialog.create' => 'Create',
+			'sessions.inspector.shell.title' => 'Inspector',
+			'sessions.inspector.shell.loadError' => ({required Object error}) => 'Failed to load session: ${error}',
+			'sessions.inspector.shell.tabs.files' => 'Files',
+			'sessions.inspector.shell.tabs.git' => 'Git',
+			'sessions.inspector.shell.tabs.tasks' => 'Tasks',
+			'sessions.inspector.shell.tabs.history' => 'History',
+			'sessions.inspector.shell.tabs.notes' => 'Notes',
+			'sessions.inspector.shared.refresh' => 'Refresh',
+			'sessions.inspector.shared.inserted' => ({required Object text}) => 'Inserted: ${text}',
+			'sessions.inspector.shared.insertFailedApi' => ({required Object status, required Object message}) => 'Insert failed (${status}): ${message}',
+			'sessions.inspector.shared.insertFailedGeneric' => ({required Object error}) => 'Insert failed: ${error}',
+			'sessions.inspector.shared.insertFailedShort' => ({required Object error}) => 'Insert failed: ${error}',
+			'sessions.inspector.history.insertIntoTerminal' => 'Insert into terminal',
+			'sessions.inspector.history.searchHint' => 'Search prompts…',
+			'sessions.inspector.files.insertAtRef' => 'Insert as @reference',
+			'sessions.inspector.files.insertPath' => 'Insert path',
+			'sessions.inspector.files.insertPathSubtitle' => 'Pastes the absolute path verbatim',
+			'sessions.inspector.files.readContent' => 'Read content',
+			'sessions.inspector.files.readContentSubtitle' => 'Up to 256 KiB plain text',
+			'sessions.inspector.files.readFailedApi' => ({required Object status, required Object message}) => 'Read failed (${status}): ${message}',
+			'sessions.inspector.files.readFailedGeneric' => ({required Object error}) => 'Read failed: ${error}',
+			'sessions.inspector.files.parent' => 'Parent',
+			'sessions.inspector.files.backToCwd' => 'Back to session cwd',
+			'sessions.inspector.git.insertAtRef' => 'Insert as @reference',
+			'sessions.inspector.git.insertPath' => 'Insert path',
+			'sessions.inspector.git.showDiff' => 'Show diff',
+			'sessions.inspector.git.diffFailedApi' => ({required Object status, required Object message}) => 'Diff failed (${status}): ${message}',
+			'sessions.inspector.git.diffFailedGeneric' => ({required Object error}) => 'Diff failed: ${error}',
+			'sessions.inspector.git.insertHash' => 'Insert hash',
+			'sessions.inspector.git.showFullPatch' => 'Show full patch',
+			'sessions.inspector.git.showFailedApi' => ({required Object status, required Object message}) => 'Show failed (${status}): ${message}',
+			'sessions.inspector.git.showFailedGeneric' => ({required Object error}) => 'Show failed: ${error}',
+			'sessions.inspector.git.tabStatus' => 'Status',
+			'sessions.inspector.git.tabLog' => 'Log',
+			'sessions.inspector.tasks.runCommand' => 'Run command',
+			'sessions.inspector.tasks.insertCommand' => 'Insert command',
+			'sessions.inspector.tasks.insertCommandSubtitle' => 'Pastes without return so you can edit',
+			'sessions.inspector.notes.insertedAt' => ({required Object path}) => 'Inserted: @${path}',
+			'sessions.inspector.notes.myNotes' => 'My notes',
+			'sessions.inspector.notes.projectDocs' => 'Project docs',
+			'sessions.inspector.notes.insertAtRefTooltip' => 'Insert as @reference',
+			'sessions.inspector.notes.insertAtRefShort' => 'Insert @reference',
+			'sessions.inspector.notes.draftHint' => ({required Object project}) => '# ${project}\n\nThoughts, todos, context for the agent…',
+			'sessions.inspector.notes.createFailed' => ({required Object error}) => 'Create failed: ${error}',
+			'sessions.inspector.notes.saveFailed' => ({required Object error}) => 'Save failed: ${error}',
+			'sessions.inspector.notes.changeLocationTooltip' => 'Change project docs location',
+			'sessions.inspector.notes.filenameHint' => 'filename (e.g. spec or design.md)',
+			'sessions.inspector.notes.create' => 'Create',
+			'sessions.inspector.notes.filterHint' => 'Filter…',
+			'sessions.inspector.notes.locationDialogTitle' => 'Project docs location',
 			'sessions.spawnSheet.title' => 'New session',
 			'sessions.spawnSheet.errorRequired' => 'Provider and working directory are required',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => 'Failed to spawn session: ${error}',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -45,6 +45,7 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	late final TranslationsNavEn nav = TranslationsNavEn.internal(_root);
 	late final TranslationsMoreEn more = TranslationsMoreEn.internal(_root);
 	late final TranslationsSessionsEn sessions = TranslationsSessionsEn.internal(_root);
+	late final TranslationsMemoryEn memory = TranslationsMemoryEn.internal(_root);
 	late final TranslationsAboutEn about = TranslationsAboutEn.internal(_root);
 	late final TranslationsSettingsEn settings = TranslationsSettingsEn.internal(_root);
 }
@@ -189,6 +190,60 @@ class TranslationsSessionsEn {
 	late final TranslationsSessionsDirPickerEn dirPicker = TranslationsSessionsDirPickerEn.internal(_root);
 	late final TranslationsSessionsInspectorEn inspector = TranslationsSessionsInspectorEn.internal(_root);
 	late final TranslationsSessionsSpawnSheetEn spawnSheet = TranslationsSessionsSpawnSheetEn.internal(_root);
+}
+
+// Path: memory
+class TranslationsMemoryEn {
+	TranslationsMemoryEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Memory'
+	String get title => 'Memory';
+
+	/// en: 'More'
+	String get more => 'More';
+
+	/// en: 'Memory workers'
+	String get workers => 'Memory workers';
+
+	/// en: 'New'
+	String get kNew => 'New';
+
+	/// en: 'Search…'
+	String get searchHint => 'Search…';
+
+	/// en: 'Project'
+	String get projectLabel => 'Project';
+
+	/// en: 'Filter by name or path…'
+	String get filterHint => 'Filter by name or path…';
+
+	/// en: 'Copied'
+	String get copied => 'Copied';
+
+	/// en: 'Copy text'
+	String get copyTooltip => 'Copy text';
+
+	late final TranslationsMemoryDeleteAllConfirmEn deleteAllConfirm = TranslationsMemoryDeleteAllConfirmEn.internal(_root);
+
+	/// en: 'Deleted {n} memory item'
+	String deletedSnackOne({required Object n}) => 'Deleted ${n} memory item';
+
+	/// en: 'Deleted {n} memory items'
+	String deletedSnackOther({required Object n}) => 'Deleted ${n} memory items';
+
+	/// en: 'Bulk delete failed: {error}'
+	String bulkDeleteFailedApi({required Object error}) => 'Bulk delete failed: ${error}';
+
+	/// en: 'Bulk delete failed: {error}'
+	String bulkDeleteFailedGeneric({required Object error}) => 'Bulk delete failed: ${error}';
+
+	late final TranslationsMemoryDeleteOneEn deleteOne = TranslationsMemoryDeleteOneEn.internal(_root);
+	late final TranslationsMemoryScopeEn scope = TranslationsMemoryScopeEn.internal(_root);
+	late final TranslationsMemoryCreateEn create = TranslationsMemoryCreateEn.internal(_root);
 }
 
 // Path: about
@@ -564,6 +619,72 @@ class TranslationsSessionsSpawnSheetEn {
 	late final TranslationsSessionsSpawnSheetNoProvidersEn noProviders = TranslationsSessionsSpawnSheetNoProvidersEn.internal(_root);
 	late final TranslationsSessionsSpawnSheetProviderLoadErrorEn providerLoadError = TranslationsSessionsSpawnSheetProviderLoadErrorEn.internal(_root);
 	late final TranslationsSessionsSpawnSheetClaudeAccountEn claudeAccount = TranslationsSessionsSpawnSheetClaudeAccountEn.internal(_root);
+}
+
+// Path: memory.deleteAllConfirm
+class TranslationsMemoryDeleteAllConfirmEn {
+	TranslationsMemoryDeleteAllConfirmEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Delete every memory in this scope?'
+	String get title => 'Delete every memory in this scope?';
+
+	/// en: 'Delete all'
+	String get deleteAll => 'Delete all';
+}
+
+// Path: memory.deleteOne
+class TranslationsMemoryDeleteOneEn {
+	TranslationsMemoryDeleteOneEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Delete memory?'
+	String get title => 'Delete memory?';
+
+	/// en: 'This cannot be undone.'
+	String get body => 'This cannot be undone.';
+}
+
+// Path: memory.scope
+class TranslationsMemoryScopeEn {
+	TranslationsMemoryScopeEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Project'
+	String get project => 'Project';
+
+	/// en: 'Global'
+	String get global => 'Global';
+}
+
+// Path: memory.create
+class TranslationsMemoryCreateEn {
+	TranslationsMemoryCreateEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Text'
+	String get textLabel => 'Text';
+
+	/// en: 'Scope key (project cwd)'
+	String get scopeKeyLabel => 'Scope key (project cwd)';
+
+	/// en: '/Users/you/projects/foo'
+	String get scopeKeyHint => '/Users/you/projects/foo';
+
+	/// en: 'Create'
+	String get submit => 'Create';
 }
 
 // Path: about.sections
@@ -1557,6 +1678,29 @@ extension on Translations {
 			'sessions.spawnSheet.claudeAccount.noTokenSuffix' => ' (no token)',
 			'sessions.spawnSheet.claudeAccount.noneHint' => 'No Claude accounts configured — the gateway will use the system ANTHROPIC_API_KEY. Add accounts under Settings → Accounts on the web admin.',
 			'sessions.spawnSheet.claudeAccount.errorHint' => ({required Object error}) => 'Could not load Claude accounts (${error}). The session will spawn with the gateway default.',
+			'memory.title' => 'Memory',
+			'memory.more' => 'More',
+			'memory.workers' => 'Memory workers',
+			'memory.kNew' => 'New',
+			'memory.searchHint' => 'Search…',
+			'memory.projectLabel' => 'Project',
+			'memory.filterHint' => 'Filter by name or path…',
+			'memory.copied' => 'Copied',
+			'memory.copyTooltip' => 'Copy text',
+			'memory.deleteAllConfirm.title' => 'Delete every memory in this scope?',
+			'memory.deleteAllConfirm.deleteAll' => 'Delete all',
+			'memory.deletedSnackOne' => ({required Object n}) => 'Deleted ${n} memory item',
+			'memory.deletedSnackOther' => ({required Object n}) => 'Deleted ${n} memory items',
+			'memory.bulkDeleteFailedApi' => ({required Object error}) => 'Bulk delete failed: ${error}',
+			'memory.bulkDeleteFailedGeneric' => ({required Object error}) => 'Bulk delete failed: ${error}',
+			'memory.deleteOne.title' => 'Delete memory?',
+			'memory.deleteOne.body' => 'This cannot be undone.',
+			'memory.scope.project' => 'Project',
+			'memory.scope.global' => 'Global',
+			'memory.create.textLabel' => 'Text',
+			'memory.create.scopeKeyLabel' => 'Scope key (project cwd)',
+			'memory.create.scopeKeyHint' => '/Users/you/projects/foo',
+			'memory.create.submit' => 'Create',
 			'about.title' => 'About',
 			'about.loading' => 'Loading…',
 			'about.sections.app' => 'App',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -183,6 +183,9 @@ class TranslationsSessionsEn {
 	String get errorTitle => 'Failed to load sessions';
 
 	late final TranslationsSessionsRelativeEn relative = TranslationsSessionsRelativeEn.internal(_root);
+	late final TranslationsSessionsActionEn action = TranslationsSessionsActionEn.internal(_root);
+	late final TranslationsSessionsDirPickerEn dirPicker = TranslationsSessionsDirPickerEn.internal(_root);
+	late final TranslationsSessionsSpawnSheetEn spawnSheet = TranslationsSessionsSpawnSheetEn.internal(_root);
 }
 
 // Path: about
@@ -361,6 +364,138 @@ class TranslationsSessionsRelativeEn {
 
 	/// en: '{n}d ago'
 	String daysAgo({required Object n}) => '${n}d ago';
+}
+
+// Path: sessions.action
+class TranslationsSessionsActionEn {
+	TranslationsSessionsActionEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Stop'
+	String get stop => 'Stop';
+
+	/// en: 'Stopping…'
+	String get stopping => 'Stopping…';
+
+	/// en: 'Send SIGTERM, retain history'
+	String get stopDescription => 'Send SIGTERM, retain history';
+
+	/// en: 'Restart'
+	String get restart => 'Restart';
+
+	/// en: 'Restarting…'
+	String get restarting => 'Restarting…';
+
+	/// en: 'Re-spawn the CLI process'
+	String get restartDescription => 'Re-spawn the CLI process';
+
+	/// en: 'Delete'
+	String get delete => 'Delete';
+
+	/// en: 'Remove the session and its history'
+	String get deleteDescription => 'Remove the session and its history';
+
+	/// en: 'Delete this session permanently? Its ring buffer and history will be gone.'
+	String get deleteConfirm => 'Delete this session permanently? Its ring buffer and history will be gone.';
+
+	late final TranslationsSessionsActionErrorsEn errors = TranslationsSessionsActionErrorsEn.internal(_root);
+}
+
+// Path: sessions.dirPicker
+class TranslationsSessionsDirPickerEn {
+	TranslationsSessionsDirPickerEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Parent'
+	String get parent => 'Parent';
+
+	/// en: 'New folder'
+	String get newFolder => 'New folder';
+
+	/// en: 'Use this folder'
+	String get useThisFolder => 'Use this folder';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'No subfolders here. Pick this folder, or create a new one.'
+	String get empty => 'No subfolders here.\nPick this folder, or create a new one.';
+
+	/// en: 'Created {path}'
+	String createdSnack({required Object path}) => 'Created ${path}';
+
+	/// en: 'mkdir failed: {error}'
+	String mkdirFailedSnack({required Object error}) => 'mkdir failed: ${error}';
+
+	late final TranslationsSessionsDirPickerDialogEn dialog = TranslationsSessionsDirPickerDialogEn.internal(_root);
+}
+
+// Path: sessions.spawnSheet
+class TranslationsSessionsSpawnSheetEn {
+	TranslationsSessionsSpawnSheetEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'New session'
+	String get title => 'New session';
+
+	/// en: 'Provider and working directory are required'
+	String get errorRequired => 'Provider and working directory are required';
+
+	/// en: 'Failed to spawn session: {error}'
+	String errorGeneric({required Object error}) => 'Failed to spawn session: ${error}';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Spawn'
+	String get spawn => 'Spawn';
+
+	/// en: 'Provider'
+	String get providerLabel => 'Provider';
+
+	/// en: ' (disabled)'
+	String get disabledSuffix => ' (disabled)';
+
+	/// en: 'Working directory'
+	String get cwdLabel => 'Working directory';
+
+	/// en: '/Users/you/projects/foo'
+	String get cwdHint => '/Users/you/projects/foo';
+
+	/// en: 'Absolute path on the gateway host.'
+	String get cwdHelper => 'Absolute path on the gateway host.';
+
+	/// en: 'Browse'
+	String get browse => 'Browse';
+
+	/// en: 'Name (optional)'
+	String get nameLabel => 'Name (optional)';
+
+	/// en: 'e.g. backend-refactor'
+	String get nameHint => 'e.g. backend-refactor';
+
+	/// en: 'Extra args (optional)'
+	String get argsLabel => 'Extra args (optional)';
+
+	/// en: '--continue --verbose'
+	String get argsHint => '--continue --verbose';
+
+	/// en: 'Whitespace-separated; blank uses the provider's defaults.'
+	String get argsHelper => 'Whitespace-separated; blank uses the provider\'s defaults.';
+
+	late final TranslationsSessionsSpawnSheetBypassEn bypass = TranslationsSessionsSpawnSheetBypassEn.internal(_root);
+	late final TranslationsSessionsSpawnSheetNoProvidersEn noProviders = TranslationsSessionsSpawnSheetNoProvidersEn.internal(_root);
+	late final TranslationsSessionsSpawnSheetProviderLoadErrorEn providerLoadError = TranslationsSessionsSpawnSheetProviderLoadErrorEn.internal(_root);
+	late final TranslationsSessionsSpawnSheetClaudeAccountEn claudeAccount = TranslationsSessionsSpawnSheetClaudeAccountEn.internal(_root);
 }
 
 // Path: about.sections
@@ -699,6 +834,138 @@ class TranslationsMoreItemsAboutEn {
 	String get subtitle => 'Build version & server info';
 }
 
+// Path: sessions.action.errors
+class TranslationsSessionsActionErrorsEn {
+	TranslationsSessionsActionErrorsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Stop failed: {error}'
+	String stop({required Object error}) => 'Stop failed: ${error}';
+
+	/// en: 'Restart failed: {error}'
+	String start({required Object error}) => 'Restart failed: ${error}';
+
+	/// en: 'Delete failed: {error}'
+	String delete({required Object error}) => 'Delete failed: ${error}';
+}
+
+// Path: sessions.dirPicker.dialog
+class TranslationsSessionsDirPickerDialogEn {
+	TranslationsSessionsDirPickerDialogEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'New folder'
+	String get title => 'New folder';
+
+	/// en: 'Folder name'
+	String get hint => 'Folder name';
+
+	/// en: 'Create'
+	String get create => 'Create';
+}
+
+// Path: sessions.spawnSheet.bypass
+class TranslationsSessionsSpawnSheetBypassEn {
+	TranslationsSessionsSpawnSheetBypassEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Bypass permissions'
+	String get labelClaude => 'Bypass permissions';
+
+	/// en: 'Auto-approve (never ask)'
+	String get labelCodex => 'Auto-approve (never ask)';
+
+	/// en: 'YOLO mode'
+	String get labelGemini => 'YOLO mode';
+
+	/// en: 'This session will run with elevated autonomy.'
+	String get subtitleOn => 'This session will run with elevated autonomy.';
+
+	/// en: 'Off — confirmations and prompts behave normally.'
+	String get subtitleOff => 'Off — confirmations and prompts behave normally.';
+}
+
+// Path: sessions.spawnSheet.noProviders
+class TranslationsSessionsSpawnSheetNoProvidersEn {
+	TranslationsSessionsSpawnSheetNoProvidersEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'No providers configured'
+	String get title => 'No providers configured';
+
+	/// en: 'The gateway has no CLI providers enabled. Configure one under Providers (web admin) or [providers] in config.toml, then tap Reload.'
+	String get message => 'The gateway has no CLI providers enabled. Configure one under Providers (web admin) or [providers] in config.toml, then tap Reload.';
+
+	/// en: 'Reload'
+	String get reload => 'Reload';
+}
+
+// Path: sessions.spawnSheet.providerLoadError
+class TranslationsSessionsSpawnSheetProviderLoadErrorEn {
+	TranslationsSessionsSpawnSheetProviderLoadErrorEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Could not load providers'
+	String get title => 'Could not load providers';
+
+	/// en: 'Network error'
+	String get networkError => 'Network error';
+
+	/// en: 'Server {code}'
+	String serverPrefix({required Object code}) => 'Server ${code}';
+
+	/// en: '{prefix}: {message}'
+	String format({required Object prefix, required Object message}) => '${prefix}: ${message}';
+}
+
+// Path: sessions.spawnSheet.claudeAccount
+class TranslationsSessionsSpawnSheetClaudeAccountEn {
+	TranslationsSessionsSpawnSheetClaudeAccountEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Claude account'
+	String get label => 'Claude account';
+
+	/// en: 'Multiple accounts configured — pick one for this session.'
+	String get helperMulti => 'Multiple accounts configured — pick one for this session.';
+
+	/// en: 'Pick a configured account or use the default (env / system).'
+	String get helperSingle => 'Pick a configured account or use the default (env / system).';
+
+	/// en: 'Default (env / system)'
+	String get kDefault => 'Default (env / system)';
+
+	/// en: ' (disabled)'
+	String get disabledSuffix => ' (disabled)';
+
+	/// en: ' (no token)'
+	String get noTokenSuffix => ' (no token)';
+
+	/// en: 'No Claude accounts configured — the gateway will use the system ANTHROPIC_API_KEY. Add accounts under Settings → Accounts on the web admin.'
+	String get noneHint => 'No Claude accounts configured — the gateway will use the system ANTHROPIC_API_KEY. Add accounts under Settings → Accounts on the web admin.';
+
+	/// en: 'Could not load Claude accounts ({error}). The session will spawn with the gateway default.'
+	String errorHint({required Object error}) => 'Could not load Claude accounts (${error}). The session will spawn with the gateway default.';
+}
+
 /// The flat map containing all translations for locale <en>.
 /// Only for edge cases! For simple maps, use the map function of this library.
 ///
@@ -777,6 +1044,64 @@ extension on Translations {
 			'sessions.relative.minutesAgo' => ({required Object n}) => '${n}m ago',
 			'sessions.relative.hoursAgo' => ({required Object n}) => '${n}h ago',
 			'sessions.relative.daysAgo' => ({required Object n}) => '${n}d ago',
+			'sessions.action.stop' => 'Stop',
+			'sessions.action.stopping' => 'Stopping…',
+			'sessions.action.stopDescription' => 'Send SIGTERM, retain history',
+			'sessions.action.restart' => 'Restart',
+			'sessions.action.restarting' => 'Restarting…',
+			'sessions.action.restartDescription' => 'Re-spawn the CLI process',
+			'sessions.action.delete' => 'Delete',
+			'sessions.action.deleteDescription' => 'Remove the session and its history',
+			'sessions.action.deleteConfirm' => 'Delete this session permanently? Its ring buffer and history will be gone.',
+			'sessions.action.errors.stop' => ({required Object error}) => 'Stop failed: ${error}',
+			'sessions.action.errors.start' => ({required Object error}) => 'Restart failed: ${error}',
+			'sessions.action.errors.delete' => ({required Object error}) => 'Delete failed: ${error}',
+			'sessions.dirPicker.parent' => 'Parent',
+			'sessions.dirPicker.newFolder' => 'New folder',
+			'sessions.dirPicker.useThisFolder' => 'Use this folder',
+			'sessions.dirPicker.loading' => 'Loading…',
+			'sessions.dirPicker.empty' => 'No subfolders here.\nPick this folder, or create a new one.',
+			'sessions.dirPicker.createdSnack' => ({required Object path}) => 'Created ${path}',
+			'sessions.dirPicker.mkdirFailedSnack' => ({required Object error}) => 'mkdir failed: ${error}',
+			'sessions.dirPicker.dialog.title' => 'New folder',
+			'sessions.dirPicker.dialog.hint' => 'Folder name',
+			'sessions.dirPicker.dialog.create' => 'Create',
+			'sessions.spawnSheet.title' => 'New session',
+			'sessions.spawnSheet.errorRequired' => 'Provider and working directory are required',
+			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => 'Failed to spawn session: ${error}',
+			'sessions.spawnSheet.cancel' => 'Cancel',
+			'sessions.spawnSheet.spawn' => 'Spawn',
+			'sessions.spawnSheet.providerLabel' => 'Provider',
+			'sessions.spawnSheet.disabledSuffix' => ' (disabled)',
+			'sessions.spawnSheet.cwdLabel' => 'Working directory',
+			'sessions.spawnSheet.cwdHint' => '/Users/you/projects/foo',
+			'sessions.spawnSheet.cwdHelper' => 'Absolute path on the gateway host.',
+			'sessions.spawnSheet.browse' => 'Browse',
+			'sessions.spawnSheet.nameLabel' => 'Name (optional)',
+			'sessions.spawnSheet.nameHint' => 'e.g. backend-refactor',
+			'sessions.spawnSheet.argsLabel' => 'Extra args (optional)',
+			'sessions.spawnSheet.argsHint' => '--continue --verbose',
+			'sessions.spawnSheet.argsHelper' => 'Whitespace-separated; blank uses the provider\'s defaults.',
+			'sessions.spawnSheet.bypass.labelClaude' => 'Bypass permissions',
+			'sessions.spawnSheet.bypass.labelCodex' => 'Auto-approve (never ask)',
+			'sessions.spawnSheet.bypass.labelGemini' => 'YOLO mode',
+			'sessions.spawnSheet.bypass.subtitleOn' => 'This session will run with elevated autonomy.',
+			'sessions.spawnSheet.bypass.subtitleOff' => 'Off — confirmations and prompts behave normally.',
+			'sessions.spawnSheet.noProviders.title' => 'No providers configured',
+			'sessions.spawnSheet.noProviders.message' => 'The gateway has no CLI providers enabled. Configure one under Providers (web admin) or [providers] in config.toml, then tap Reload.',
+			'sessions.spawnSheet.noProviders.reload' => 'Reload',
+			'sessions.spawnSheet.providerLoadError.title' => 'Could not load providers',
+			'sessions.spawnSheet.providerLoadError.networkError' => 'Network error',
+			'sessions.spawnSheet.providerLoadError.serverPrefix' => ({required Object code}) => 'Server ${code}',
+			'sessions.spawnSheet.providerLoadError.format' => ({required Object prefix, required Object message}) => '${prefix}: ${message}',
+			'sessions.spawnSheet.claudeAccount.label' => 'Claude account',
+			'sessions.spawnSheet.claudeAccount.helperMulti' => 'Multiple accounts configured — pick one for this session.',
+			'sessions.spawnSheet.claudeAccount.helperSingle' => 'Pick a configured account or use the default (env / system).',
+			'sessions.spawnSheet.claudeAccount.kDefault' => 'Default (env / system)',
+			'sessions.spawnSheet.claudeAccount.disabledSuffix' => ' (disabled)',
+			'sessions.spawnSheet.claudeAccount.noTokenSuffix' => ' (no token)',
+			'sessions.spawnSheet.claudeAccount.noneHint' => 'No Claude accounts configured — the gateway will use the system ANTHROPIC_API_KEY. Add accounts under Settings → Accounts on the web admin.',
+			'sessions.spawnSheet.claudeAccount.errorHint' => ({required Object error}) => 'Could not load Claude accounts (${error}). The session will spawn with the gateway default.',
 			'about.title' => 'About',
 			'about.loading' => 'Loading…',
 			'about.sections.app' => 'App',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -183,6 +183,8 @@ class TranslationsSessionsEn {
 	String get errorTitle => 'Failed to load sessions';
 
 	late final TranslationsSessionsRelativeEn relative = TranslationsSessionsRelativeEn.internal(_root);
+	late final TranslationsSessionsDetailEn detail = TranslationsSessionsDetailEn.internal(_root);
+	late final TranslationsSessionsTerminalEn terminal = TranslationsSessionsTerminalEn.internal(_root);
 	late final TranslationsSessionsActionEn action = TranslationsSessionsActionEn.internal(_root);
 	late final TranslationsSessionsDirPickerEn dirPicker = TranslationsSessionsDirPickerEn.internal(_root);
 	late final TranslationsSessionsSpawnSheetEn spawnSheet = TranslationsSessionsSpawnSheetEn.internal(_root);
@@ -364,6 +366,55 @@ class TranslationsSessionsRelativeEn {
 
 	/// en: '{n}d ago'
 	String daysAgo({required Object n}) => '${n}d ago';
+}
+
+// Path: sessions.detail
+class TranslationsSessionsDetailEn {
+	TranslationsSessionsDetailEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Session'
+	String get fallbackTitle => 'Session';
+
+	/// en: 'Refresh metadata'
+	String get refreshMetadata => 'Refresh metadata';
+
+	/// en: 'Inspector (Files / Git / Tasks / History / Notes)'
+	String get inspector => 'Inspector (Files / Git / Tasks / History / Notes)';
+
+	/// en: 'Project memory (goal / plan / journal / inbox)'
+	String get projectMemory => 'Project memory (goal / plan / journal / inbox)';
+
+	/// en: 'Actions'
+	String get actions => 'Actions';
+
+	/// en: 'started {when}'
+	String started({required Object when}) => 'started ${when}';
+
+	/// en: 'started {started} · ended {ended}'
+	String startedEnded({required Object started, required Object ended}) => 'started ${started}  ·  ended ${ended}';
+
+	/// en: 'id: {id}'
+	String idPrefix({required Object id}) => 'id: ${id}';
+
+	/// en: 'Failed to load session'
+	String get errorTitle => 'Failed to load session';
+}
+
+// Path: sessions.terminal
+class TranslationsSessionsTerminalEn {
+	TranslationsSessionsTerminalEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsSessionsTerminalSnackbarEn snackbar = TranslationsSessionsTerminalSnackbarEn.internal(_root);
+	late final TranslationsSessionsTerminalImageSourceEn imageSource = TranslationsSessionsTerminalImageSourceEn.internal(_root);
+	late final TranslationsSessionsTerminalKeyboardEn keyboard = TranslationsSessionsTerminalKeyboardEn.internal(_root);
+	late final TranslationsSessionsTerminalConnectionEn connection = TranslationsSessionsTerminalConnectionEn.internal(_root);
 }
 
 // Path: sessions.action
@@ -834,6 +885,93 @@ class TranslationsMoreItemsAboutEn {
 	String get subtitle => 'Build version & server info';
 }
 
+// Path: sessions.terminal.snackbar
+class TranslationsSessionsTerminalSnackbarEn {
+	TranslationsSessionsTerminalSnackbarEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Image picker failed: {error}'
+	String imagePickerFailed({required Object error}) => 'Image picker failed: ${error}';
+
+	/// en: 'Uploading image…'
+	String get uploadingImage => 'Uploading image…';
+
+	/// en: 'Image attached: {path}'
+	String imageAttached({required Object path}) => 'Image attached: ${path}';
+
+	/// en: 'Upload failed ({status}): {message}'
+	String uploadFailed({required Object status, required Object message}) => 'Upload failed (${status}): ${message}';
+
+	/// en: 'Upload failed: {error}'
+	String uploadFailedGeneric({required Object error}) => 'Upload failed: ${error}';
+}
+
+// Path: sessions.terminal.imageSource
+class TranslationsSessionsTerminalImageSourceEn {
+	TranslationsSessionsTerminalImageSourceEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Photo library'
+	String get photoLibrary => 'Photo library';
+
+	/// en: 'Take a photo'
+	String get takePhoto => 'Take a photo';
+}
+
+// Path: sessions.terminal.keyboard
+class TranslationsSessionsTerminalKeyboardEn {
+	TranslationsSessionsTerminalKeyboardEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Copy buffer'
+	String get copyBuffer => 'Copy buffer';
+
+	/// en: 'Paste'
+	String get paste => 'Paste';
+
+	/// en: 'Attach image'
+	String get attachImage => 'Attach image';
+}
+
+// Path: sessions.terminal.connection
+class TranslationsSessionsTerminalConnectionEn {
+	TranslationsSessionsTerminalConnectionEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Connecting…'
+	String get connecting => 'Connecting…';
+
+	/// en: 'Connected'
+	String get connected => 'Connected';
+
+	/// en: 'Reconnecting…'
+	String get reconnecting => 'Reconnecting…';
+
+	/// en: 'Reconnecting ({error})…'
+	String reconnectingWithError({required Object error}) => 'Reconnecting (${error})…';
+
+	/// en: 'Disconnected'
+	String get disconnected => 'Disconnected';
+
+	/// en: 'Disconnected ({error})'
+	String disconnectedWithError({required Object error}) => 'Disconnected (${error})';
+
+	/// en: 'Session ended'
+	String get ended => 'Session ended';
+}
+
 // Path: sessions.action.errors
 class TranslationsSessionsActionErrorsEn {
 	TranslationsSessionsActionErrorsEn.internal(this._root);
@@ -1044,6 +1182,32 @@ extension on Translations {
 			'sessions.relative.minutesAgo' => ({required Object n}) => '${n}m ago',
 			'sessions.relative.hoursAgo' => ({required Object n}) => '${n}h ago',
 			'sessions.relative.daysAgo' => ({required Object n}) => '${n}d ago',
+			'sessions.detail.fallbackTitle' => 'Session',
+			'sessions.detail.refreshMetadata' => 'Refresh metadata',
+			'sessions.detail.inspector' => 'Inspector (Files / Git / Tasks / History / Notes)',
+			'sessions.detail.projectMemory' => 'Project memory (goal / plan / journal / inbox)',
+			'sessions.detail.actions' => 'Actions',
+			'sessions.detail.started' => ({required Object when}) => 'started ${when}',
+			'sessions.detail.startedEnded' => ({required Object started, required Object ended}) => 'started ${started}  ·  ended ${ended}',
+			'sessions.detail.idPrefix' => ({required Object id}) => 'id: ${id}',
+			'sessions.detail.errorTitle' => 'Failed to load session',
+			'sessions.terminal.snackbar.imagePickerFailed' => ({required Object error}) => 'Image picker failed: ${error}',
+			'sessions.terminal.snackbar.uploadingImage' => 'Uploading image…',
+			'sessions.terminal.snackbar.imageAttached' => ({required Object path}) => 'Image attached: ${path}',
+			'sessions.terminal.snackbar.uploadFailed' => ({required Object status, required Object message}) => 'Upload failed (${status}): ${message}',
+			'sessions.terminal.snackbar.uploadFailedGeneric' => ({required Object error}) => 'Upload failed: ${error}',
+			'sessions.terminal.imageSource.photoLibrary' => 'Photo library',
+			'sessions.terminal.imageSource.takePhoto' => 'Take a photo',
+			'sessions.terminal.keyboard.copyBuffer' => 'Copy buffer',
+			'sessions.terminal.keyboard.paste' => 'Paste',
+			'sessions.terminal.keyboard.attachImage' => 'Attach image',
+			'sessions.terminal.connection.connecting' => 'Connecting…',
+			'sessions.terminal.connection.connected' => 'Connected',
+			'sessions.terminal.connection.reconnecting' => 'Reconnecting…',
+			'sessions.terminal.connection.reconnectingWithError' => ({required Object error}) => 'Reconnecting (${error})…',
+			'sessions.terminal.connection.disconnected' => 'Disconnected',
+			'sessions.terminal.connection.disconnectedWithError' => ({required Object error}) => 'Disconnected (${error})',
+			'sessions.terminal.connection.ended' => 'Session ended',
 			'sessions.action.stop' => 'Stop',
 			'sessions.action.stopping' => 'Stopping…',
 			'sessions.action.stopDescription' => 'Send SIGTERM, retain history',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -41,6 +41,7 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 
 	// Translations
 	late final TranslationsCommonEn common = TranslationsCommonEn.internal(_root);
+	late final TranslationsAuthEn auth = TranslationsAuthEn.internal(_root);
 	late final TranslationsSettingsEn settings = TranslationsSettingsEn.internal(_root);
 }
 
@@ -78,6 +79,36 @@ class TranslationsCommonEn {
 
 	/// en: 'Retry'
 	String get retry => 'Retry';
+}
+
+// Path: auth
+class TranslationsAuthEn {
+	TranslationsAuthEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Sign in'
+	String get signInTitle => 'Sign in';
+
+	/// en: 'Change'
+	String get changeServer => 'Change';
+
+	/// en: 'Username'
+	String get username => 'Username';
+
+	/// en: 'Password'
+	String get password => 'Password';
+
+	/// en: 'Sign in'
+	String get signIn => 'Sign in';
+
+	/// en: 'Username and password are required'
+	String get errorRequired => 'Username and password are required';
+
+	/// en: 'Login failed: {error}'
+	String errorGeneric({required Object error}) => 'Login failed: ${error}';
 }
 
 // Path: settings
@@ -210,6 +241,13 @@ extension on Translations {
 			'common.done' => 'Done',
 			'common.close' => 'Close',
 			'common.retry' => 'Retry',
+			'auth.signInTitle' => 'Sign in',
+			'auth.changeServer' => 'Change',
+			'auth.username' => 'Username',
+			'auth.password' => 'Password',
+			'auth.signIn' => 'Sign in',
+			'auth.errorRequired' => 'Username and password are required',
+			'auth.errorGeneric' => ({required Object error}) => 'Login failed: ${error}',
 			'settings.title' => 'Settings',
 			'settings.language.section' => 'Language',
 			'settings.language.system' => 'System',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -45,6 +45,9 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	late final TranslationsNavEn nav = TranslationsNavEn.internal(_root);
 	late final TranslationsMoreEn more = TranslationsMoreEn.internal(_root);
 	late final TranslationsSessionsEn sessions = TranslationsSessionsEn.internal(_root);
+	late final TranslationsMcpEn mcp = TranslationsMcpEn.internal(_root);
+	late final TranslationsProvidersEn providers = TranslationsProvidersEn.internal(_root);
+	late final TranslationsIntegrationsEn integrations = TranslationsIntegrationsEn.internal(_root);
 	late final TranslationsMemoryEn memory = TranslationsMemoryEn.internal(_root);
 	late final TranslationsAboutEn about = TranslationsAboutEn.internal(_root);
 	late final TranslationsSettingsEn settings = TranslationsSettingsEn.internal(_root);
@@ -190,6 +193,168 @@ class TranslationsSessionsEn {
 	late final TranslationsSessionsDirPickerEn dirPicker = TranslationsSessionsDirPickerEn.internal(_root);
 	late final TranslationsSessionsInspectorEn inspector = TranslationsSessionsInspectorEn.internal(_root);
 	late final TranslationsSessionsSpawnSheetEn spawnSheet = TranslationsSessionsSpawnSheetEn.internal(_root);
+}
+
+// Path: mcp
+class TranslationsMcpEn {
+	TranslationsMcpEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'MCP'
+	String get title => 'MCP';
+
+	/// en: 'New server'
+	String get newServer => 'New server';
+
+	/// en: 'Add secret'
+	String get addSecret => 'Add secret';
+
+	/// en: 'Edit config'
+	String get editConfig => 'Edit config';
+
+	/// en: 'View raw config'
+	String get viewRawConfig => 'View raw config';
+
+	/// en: 'Copy id'
+	String get copyId => 'Copy id';
+
+	/// en: 'Copied {id}'
+	String copiedSnack({required Object id}) => 'Copied ${id}';
+
+	/// en: 'Delete MCP server?'
+	String get deleteServerTitle => 'Delete MCP server?';
+
+	/// en: 'Delete secret?'
+	String get deleteSecretTitle => 'Delete secret?';
+
+	late final TranslationsMcpErrorPrefixEn errorPrefix = TranslationsMcpErrorPrefixEn.internal(_root);
+
+	/// en: '{prefix}: {error}'
+	String errorWithMessage({required Object prefix, required Object error}) => '${prefix}: ${error}';
+
+	late final TranslationsMcpEditorEn editor = TranslationsMcpEditorEn.internal(_root);
+	late final TranslationsMcpSecretEn secret = TranslationsMcpSecretEn.internal(_root);
+}
+
+// Path: providers
+class TranslationsProvidersEn {
+	TranslationsProvidersEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Providers'
+	String get title => 'Providers';
+
+	/// en: 'Provider config updated.'
+	String get configSaved => 'Provider config updated.';
+
+	/// en: 'Save failed: {error}'
+	String saveFailedApi({required Object error}) => 'Save failed: ${error}';
+
+	/// en: 'Save failed: {error}'
+	String saveFailedGeneric({required Object error}) => 'Save failed: ${error}';
+
+	/// en: 'Reload'
+	String get reload => 'Reload';
+
+	late final TranslationsProvidersErrorPrefixEn errorPrefix = TranslationsProvidersErrorPrefixEn.internal(_root);
+
+	/// en: '{prefix}: {error}'
+	String errorWithMessage({required Object prefix, required Object error}) => '${prefix}: ${error}';
+
+	late final TranslationsProvidersAccountsEn accounts = TranslationsProvidersAccountsEn.internal(_root);
+}
+
+// Path: integrations
+class TranslationsIntegrationsEn {
+	TranslationsIntegrationsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Integrations'
+	String get title => 'Integrations';
+
+	/// en: 'Register'
+	String get register => 'Register';
+
+	/// en: 'Register integration'
+	String get registerDialogTitle => 'Register integration';
+
+	/// en: 'Edit'
+	String get edit => 'Edit';
+
+	/// en: 'Edit {name}'
+	String editTitle({required Object name}) => 'Edit ${name}';
+
+	/// en: 'Enabled'
+	String get enabledLabel => 'Enabled';
+
+	/// en: 'I've saved it'
+	String get iSavedIt => 'I\'ve saved it';
+
+	/// en: 'API key for {name}'
+	String apiKeyForName({required Object name}) => 'API key for ${name}';
+
+	/// en: 'Hand this to the integration so it can authenticate against /api/v1/{routePrefix}/…'
+	String apiKeySubtitleRegister({required Object routePrefix}) => 'Hand this to the integration so it can authenticate against /api/v1/${routePrefix}/…';
+
+	/// en: 'Copied request_id {id}'
+	String copiedRequestId({required Object id}) => 'Copied request_id ${id}';
+
+	/// en: 'Integration updated.'
+	String get updateOk => 'Integration updated.';
+
+	/// en: 'Register failed: {error}'
+	String registerFailedApi({required Object error}) => 'Register failed: ${error}';
+
+	/// en: 'Register failed: {error}'
+	String registerFailedGeneric({required Object error}) => 'Register failed: ${error}';
+
+	/// en: 'Update failed: {error}'
+	String updateFailedApi({required Object error}) => 'Update failed: ${error}';
+
+	/// en: 'Update failed: {error}'
+	String updateFailedGeneric({required Object error}) => 'Update failed: ${error}';
+
+	/// en: 'Delete integration?'
+	String get deleteTitle => 'Delete integration?';
+
+	/// en: 'Deleted {name}.'
+	String deletedSnack({required Object name}) => 'Deleted ${name}.';
+
+	/// en: 'Delete failed: {error}'
+	String deleteFailedApi({required Object error}) => 'Delete failed: ${error}';
+
+	/// en: 'Delete failed: {error}'
+	String deleteFailedGeneric({required Object error}) => 'Delete failed: ${error}';
+
+	/// en: 'Rotate key'
+	String get rotateKey => 'Rotate key';
+
+	/// en: 'Rotate API key?'
+	String get rotateConfirmTitle => 'Rotate API key?';
+
+	/// en: 'Rotate'
+	String get rotate => 'Rotate';
+
+	/// en: 'New API key for {name}'
+	String newApiKeyTitle({required Object name}) => 'New API key for ${name}';
+
+	/// en: 'Hand this to the integration. The previous key has just been invalidated.'
+	String get newApiKeySubtitle => 'Hand this to the integration. The previous key has just been invalidated.';
+
+	/// en: 'Rotate failed: {error}'
+	String rotateFailedApi({required Object error}) => 'Rotate failed: ${error}';
+
+	/// en: 'Rotate failed: {error}'
+	String rotateFailedGeneric({required Object error}) => 'Rotate failed: ${error}';
 }
 
 // Path: memory
@@ -619,6 +784,108 @@ class TranslationsSessionsSpawnSheetEn {
 	late final TranslationsSessionsSpawnSheetNoProvidersEn noProviders = TranslationsSessionsSpawnSheetNoProvidersEn.internal(_root);
 	late final TranslationsSessionsSpawnSheetProviderLoadErrorEn providerLoadError = TranslationsSessionsSpawnSheetProviderLoadErrorEn.internal(_root);
 	late final TranslationsSessionsSpawnSheetClaudeAccountEn claudeAccount = TranslationsSessionsSpawnSheetClaudeAccountEn.internal(_root);
+}
+
+// Path: mcp.errorPrefix
+class TranslationsMcpErrorPrefixEn {
+	TranslationsMcpErrorPrefixEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Delete failed'
+	String get delete => 'Delete failed';
+
+	/// en: 'Add failed'
+	String get add => 'Add failed';
+
+	/// en: 'Update failed'
+	String get update => 'Update failed';
+
+	/// en: 'Toggle failed'
+	String get toggle => 'Toggle failed';
+}
+
+// Path: mcp.editor
+class TranslationsMcpEditorEn {
+	TranslationsMcpEditorEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'my-mcp-server'
+	String get nameHint => 'my-mcp-server';
+
+	/// en: 'JSON config — name, transport: stdio, command, args…'
+	String get jsonHint => 'JSON config — name, transport: stdio, command, args…';
+}
+
+// Path: mcp.secret
+class TranslationsMcpSecretEn {
+	TranslationsMcpSecretEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Key'
+	String get keyLabel => 'Key';
+
+	/// en: 'GITHUB_TOKEN, OPENAI_KEY, …'
+	String get keyHint => 'GITHUB_TOKEN, OPENAI_KEY, …';
+
+	/// en: 'Value'
+	String get valueLabel => 'Value';
+}
+
+// Path: providers.errorPrefix
+class TranslationsProvidersErrorPrefixEn {
+	TranslationsProvidersErrorPrefixEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Toggle failed'
+	String get toggle => 'Toggle failed';
+
+	/// en: 'Rename failed'
+	String get rename => 'Rename failed';
+
+	/// en: 'Delete failed'
+	String get delete => 'Delete failed';
+}
+
+// Path: providers.accounts
+class TranslationsProvidersAccountsEn {
+	TranslationsProvidersAccountsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Rename'
+	String get rename => 'Rename';
+
+	/// en: 'Rename {name}'
+	String renameTitle({required Object name}) => 'Rename ${name}';
+
+	/// en: 'Display name'
+	String get displayNameLabel => 'Display name';
+
+	/// en: 'Work account'
+	String get displayNameHint => 'Work account';
+
+	/// en: 'Delete account?'
+	String get deleteTitle => 'Delete account?';
+
+	/// en: 'Import failed: {error}'
+	String importFailedApi({required Object error}) => 'Import failed: ${error}';
+
+	/// en: 'Import failed: {error}'
+	String importFailedGeneric({required Object error}) => 'Import failed: ${error}';
 }
 
 // Path: memory.deleteAllConfirm
@@ -1678,6 +1945,67 @@ extension on Translations {
 			'sessions.spawnSheet.claudeAccount.noTokenSuffix' => ' (no token)',
 			'sessions.spawnSheet.claudeAccount.noneHint' => 'No Claude accounts configured — the gateway will use the system ANTHROPIC_API_KEY. Add accounts under Settings → Accounts on the web admin.',
 			'sessions.spawnSheet.claudeAccount.errorHint' => ({required Object error}) => 'Could not load Claude accounts (${error}). The session will spawn with the gateway default.',
+			'mcp.title' => 'MCP',
+			'mcp.newServer' => 'New server',
+			'mcp.addSecret' => 'Add secret',
+			'mcp.editConfig' => 'Edit config',
+			'mcp.viewRawConfig' => 'View raw config',
+			'mcp.copyId' => 'Copy id',
+			'mcp.copiedSnack' => ({required Object id}) => 'Copied ${id}',
+			'mcp.deleteServerTitle' => 'Delete MCP server?',
+			'mcp.deleteSecretTitle' => 'Delete secret?',
+			'mcp.errorPrefix.delete' => 'Delete failed',
+			'mcp.errorPrefix.add' => 'Add failed',
+			'mcp.errorPrefix.update' => 'Update failed',
+			'mcp.errorPrefix.toggle' => 'Toggle failed',
+			'mcp.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}: ${error}',
+			'mcp.editor.nameHint' => 'my-mcp-server',
+			'mcp.editor.jsonHint' => 'JSON config — name, transport: stdio, command, args…',
+			'mcp.secret.keyLabel' => 'Key',
+			'mcp.secret.keyHint' => 'GITHUB_TOKEN, OPENAI_KEY, …',
+			'mcp.secret.valueLabel' => 'Value',
+			'providers.title' => 'Providers',
+			'providers.configSaved' => 'Provider config updated.',
+			'providers.saveFailedApi' => ({required Object error}) => 'Save failed: ${error}',
+			'providers.saveFailedGeneric' => ({required Object error}) => 'Save failed: ${error}',
+			'providers.reload' => 'Reload',
+			'providers.errorPrefix.toggle' => 'Toggle failed',
+			'providers.errorPrefix.rename' => 'Rename failed',
+			'providers.errorPrefix.delete' => 'Delete failed',
+			'providers.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}: ${error}',
+			'providers.accounts.rename' => 'Rename',
+			'providers.accounts.renameTitle' => ({required Object name}) => 'Rename ${name}',
+			'providers.accounts.displayNameLabel' => 'Display name',
+			'providers.accounts.displayNameHint' => 'Work account',
+			'providers.accounts.deleteTitle' => 'Delete account?',
+			'providers.accounts.importFailedApi' => ({required Object error}) => 'Import failed: ${error}',
+			'providers.accounts.importFailedGeneric' => ({required Object error}) => 'Import failed: ${error}',
+			'integrations.title' => 'Integrations',
+			'integrations.register' => 'Register',
+			'integrations.registerDialogTitle' => 'Register integration',
+			'integrations.edit' => 'Edit',
+			'integrations.editTitle' => ({required Object name}) => 'Edit ${name}',
+			'integrations.enabledLabel' => 'Enabled',
+			'integrations.iSavedIt' => 'I\'ve saved it',
+			'integrations.apiKeyForName' => ({required Object name}) => 'API key for ${name}',
+			'integrations.apiKeySubtitleRegister' => ({required Object routePrefix}) => 'Hand this to the integration so it can authenticate against /api/v1/${routePrefix}/…',
+			'integrations.copiedRequestId' => ({required Object id}) => 'Copied request_id ${id}',
+			'integrations.updateOk' => 'Integration updated.',
+			'integrations.registerFailedApi' => ({required Object error}) => 'Register failed: ${error}',
+			'integrations.registerFailedGeneric' => ({required Object error}) => 'Register failed: ${error}',
+			'integrations.updateFailedApi' => ({required Object error}) => 'Update failed: ${error}',
+			'integrations.updateFailedGeneric' => ({required Object error}) => 'Update failed: ${error}',
+			'integrations.deleteTitle' => 'Delete integration?',
+			'integrations.deletedSnack' => ({required Object name}) => 'Deleted ${name}.',
+			'integrations.deleteFailedApi' => ({required Object error}) => 'Delete failed: ${error}',
+			'integrations.deleteFailedGeneric' => ({required Object error}) => 'Delete failed: ${error}',
+			'integrations.rotateKey' => 'Rotate key',
+			'integrations.rotateConfirmTitle' => 'Rotate API key?',
+			'integrations.rotate' => 'Rotate',
+			'integrations.newApiKeyTitle' => ({required Object name}) => 'New API key for ${name}',
+			'integrations.newApiKeySubtitle' => 'Hand this to the integration. The previous key has just been invalidated.',
+			'integrations.rotateFailedApi' => ({required Object error}) => 'Rotate failed: ${error}',
+			'integrations.rotateFailedGeneric' => ({required Object error}) => 'Rotate failed: ${error}',
 			'memory.title' => 'Memory',
 			'memory.more' => 'More',
 			'memory.workers' => 'Memory workers',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -42,6 +42,9 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	// Translations
 	late final TranslationsCommonEn common = TranslationsCommonEn.internal(_root);
 	late final TranslationsAuthEn auth = TranslationsAuthEn.internal(_root);
+	late final TranslationsNavEn nav = TranslationsNavEn.internal(_root);
+	late final TranslationsMoreEn more = TranslationsMoreEn.internal(_root);
+	late final TranslationsAboutEn about = TranslationsAboutEn.internal(_root);
 	late final TranslationsSettingsEn settings = TranslationsSettingsEn.internal(_root);
 }
 
@@ -111,6 +114,75 @@ class TranslationsAuthEn {
 	String errorGeneric({required Object error}) => 'Login failed: ${error}';
 }
 
+// Path: nav
+class TranslationsNavEn {
+	TranslationsNavEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Sessions'
+	String get sessions => 'Sessions';
+
+	/// en: 'Memory'
+	String get memory => 'Memory';
+
+	/// en: 'Notes'
+	String get notes => 'Notes';
+
+	/// en: 'More'
+	String get more => 'More';
+}
+
+// Path: more
+class TranslationsMoreEn {
+	TranslationsMoreEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'More'
+	String get title => 'More';
+
+	late final TranslationsMoreIdentityEn identity = TranslationsMoreIdentityEn.internal(_root);
+	late final TranslationsMoreSectionsEn sections = TranslationsMoreSectionsEn.internal(_root);
+	late final TranslationsMoreItemsEn items = TranslationsMoreItemsEn.internal(_root);
+
+	/// en: 'Sign out'
+	String get signOut => 'Sign out';
+}
+
+// Path: about
+class TranslationsAboutEn {
+	TranslationsAboutEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'About'
+	String get title => 'About';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	late final TranslationsAboutSectionsEn sections = TranslationsAboutSectionsEn.internal(_root);
+	late final TranslationsAboutFieldsEn fields = TranslationsAboutFieldsEn.internal(_root);
+
+	/// en: 'Copied {label}'
+	String copied({required Object label}) => 'Copied ${label}';
+
+	/// en: 'Copy'
+	String get copyTooltip => 'Copy';
+
+	late final TranslationsAboutCopyLabelsEn copyLabels = TranslationsAboutCopyLabelsEn.internal(_root);
+
+	/// en: 'opendray mobile — multi-CLI gateway control. Source: github.com/Opendray/opendray_v2'
+	String get tagline => 'opendray mobile — multi-CLI gateway control.\nSource: github.com/Opendray/opendray_v2';
+}
+
 // Path: settings
 class TranslationsSettingsEn {
 	TranslationsSettingsEn.internal(this._root);
@@ -126,6 +198,123 @@ class TranslationsSettingsEn {
 	late final TranslationsSettingsAppearanceEn appearance = TranslationsSettingsAppearanceEn.internal(_root);
 	late final TranslationsSettingsAccountEn account = TranslationsSettingsAccountEn.internal(_root);
 	late final TranslationsSettingsGatewayEn gateway = TranslationsSettingsGatewayEn.internal(_root);
+}
+
+// Path: more.identity
+class TranslationsMoreIdentityEn {
+	TranslationsMoreIdentityEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Signed in as'
+	String get signedInAs => 'Signed in as';
+
+	/// en: 'Server'
+	String get server => 'Server';
+
+	/// en: 'Token expires'
+	String get tokenExpires => 'Token expires';
+}
+
+// Path: more.sections
+class TranslationsMoreSectionsEn {
+	TranslationsMoreSectionsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Gateway'
+	String get gateway => 'Gateway';
+
+	/// en: 'Memory'
+	String get memory => 'Memory';
+
+	/// en: 'System'
+	String get system => 'System';
+}
+
+// Path: more.items
+class TranslationsMoreItemsEn {
+	TranslationsMoreItemsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsMoreItemsIntegrationsEn integrations = TranslationsMoreItemsIntegrationsEn.internal(_root);
+	late final TranslationsMoreItemsChannelsEn channels = TranslationsMoreItemsChannelsEn.internal(_root);
+	late final TranslationsMoreItemsProvidersEn providers = TranslationsMoreItemsProvidersEn.internal(_root);
+	late final TranslationsMoreItemsMcpEn mcp = TranslationsMoreItemsMcpEn.internal(_root);
+	late final TranslationsMoreItemsSkillsEn skills = TranslationsMoreItemsSkillsEn.internal(_root);
+	late final TranslationsMoreItemsGitHostsEn gitHosts = TranslationsMoreItemsGitHostsEn.internal(_root);
+	late final TranslationsMoreItemsCustomTasksEn customTasks = TranslationsMoreItemsCustomTasksEn.internal(_root);
+	late final TranslationsMoreItemsProjectMemoryEn projectMemory = TranslationsMoreItemsProjectMemoryEn.internal(_root);
+	late final TranslationsMoreItemsCleanupInboxEn cleanupInbox = TranslationsMoreItemsCleanupInboxEn.internal(_root);
+	late final TranslationsMoreItemsBackupsEn backups = TranslationsMoreItemsBackupsEn.internal(_root);
+	late final TranslationsMoreItemsSettingsEn settings = TranslationsMoreItemsSettingsEn.internal(_root);
+	late final TranslationsMoreItemsAboutEn about = TranslationsMoreItemsAboutEn.internal(_root);
+}
+
+// Path: about.sections
+class TranslationsAboutSectionsEn {
+	TranslationsAboutSectionsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'App'
+	String get app => 'App';
+
+	/// en: 'Server'
+	String get server => 'Server';
+}
+
+// Path: about.fields
+class TranslationsAboutFieldsEn {
+	TranslationsAboutFieldsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'App'
+	String get app => 'App';
+
+	/// en: 'Version'
+	String get version => 'Version';
+
+	/// en: '{version} (build {build})'
+	String versionFormat({required Object version, required Object build}) => '${version} (build ${build})';
+
+	/// en: 'Package'
+	String get package => 'Package';
+
+	/// en: 'URL'
+	String get url => 'URL';
+
+	/// en: 'Signed in as'
+	String get signedInAs => 'Signed in as';
+
+	/// en: 'Token expires'
+	String get tokenExpires => 'Token expires';
+}
+
+// Path: about.copyLabels
+class TranslationsAboutCopyLabelsEn {
+	TranslationsAboutCopyLabelsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'version'
+	String get version => 'version';
+
+	/// en: 'server URL'
+	String get serverUrl => 'server URL';
 }
 
 // Path: settings.language
@@ -224,6 +413,186 @@ class TranslationsSettingsGatewayEn {
 	String get liveLogsSubtitle => 'Tail the gateway log buffer — same source as the web admin';
 }
 
+// Path: more.items.integrations
+class TranslationsMoreItemsIntegrationsEn {
+	TranslationsMoreItemsIntegrationsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Integrations'
+	String get title => 'Integrations';
+
+	/// en: 'API callers — recent activity & error rates'
+	String get subtitle => 'API callers — recent activity & error rates';
+}
+
+// Path: more.items.channels
+class TranslationsMoreItemsChannelsEn {
+	TranslationsMoreItemsChannelsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Channels'
+	String get title => 'Channels';
+
+	/// en: 'Notification destinations'
+	String get subtitle => 'Notification destinations';
+}
+
+// Path: more.items.providers
+class TranslationsMoreItemsProvidersEn {
+	TranslationsMoreItemsProvidersEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Providers'
+	String get title => 'Providers';
+
+	/// en: 'Claude / Codex / Gemini CLI status'
+	String get subtitle => 'Claude / Codex / Gemini CLI status';
+}
+
+// Path: more.items.mcp
+class TranslationsMoreItemsMcpEn {
+	TranslationsMoreItemsMcpEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'MCP'
+	String get title => 'MCP';
+
+	/// en: 'Model Context Protocol servers & secrets'
+	String get subtitle => 'Model Context Protocol servers & secrets';
+}
+
+// Path: more.items.skills
+class TranslationsMoreItemsSkillsEn {
+	TranslationsMoreItemsSkillsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Skills'
+	String get title => 'Skills';
+
+	/// en: 'Agent SKILL.md library (built-in + vault)'
+	String get subtitle => 'Agent SKILL.md library (built-in + vault)';
+}
+
+// Path: more.items.gitHosts
+class TranslationsMoreItemsGitHostsEn {
+	TranslationsMoreItemsGitHostsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Git hosts'
+	String get title => 'Git hosts';
+
+	/// en: 'PAT credentials for GitHub / GitLab / etc.'
+	String get subtitle => 'PAT credentials for GitHub / GitLab / etc.';
+}
+
+// Path: more.items.customTasks
+class TranslationsMoreItemsCustomTasksEn {
+	TranslationsMoreItemsCustomTasksEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Custom tasks'
+	String get title => 'Custom tasks';
+
+	/// en: 'Slash commands shown in the session task picker'
+	String get subtitle => 'Slash commands shown in the session task picker';
+}
+
+// Path: more.items.projectMemory
+class TranslationsMoreItemsProjectMemoryEn {
+	TranslationsMoreItemsProjectMemoryEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Project goal / plan / journal'
+	String get title => 'Project goal / plan / journal';
+
+	/// en: 'Per-cwd memory layers 2-4 + agent proposals'
+	String get subtitle => 'Per-cwd memory layers 2-4 + agent proposals';
+}
+
+// Path: more.items.cleanupInbox
+class TranslationsMoreItemsCleanupInboxEn {
+	TranslationsMoreItemsCleanupInboxEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Cleanup inbox'
+	String get title => 'Cleanup inbox';
+
+	/// en: 'LLM-proposed deletions / merges across all projects'
+	String get subtitle => 'LLM-proposed deletions / merges across all projects';
+}
+
+// Path: more.items.backups
+class TranslationsMoreItemsBackupsEn {
+	TranslationsMoreItemsBackupsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Backups'
+	String get title => 'Backups';
+
+	/// en: 'Latest backup status & run-now'
+	String get subtitle => 'Latest backup status & run-now';
+}
+
+// Path: more.items.settings
+class TranslationsMoreItemsSettingsEn {
+	TranslationsMoreItemsSettingsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Settings'
+	String get title => 'Settings';
+
+	/// en: 'Language, appearance, account'
+	String get subtitle => 'Language, appearance, account';
+}
+
+// Path: more.items.about
+class TranslationsMoreItemsAboutEn {
+	TranslationsMoreItemsAboutEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'About'
+	String get title => 'About';
+
+	/// en: 'Build version & server info'
+	String get subtitle => 'Build version & server info';
+}
+
 /// The flat map containing all translations for locale <en>.
 /// Only for edge cases! For simple maps, use the map function of this library.
 ///
@@ -248,6 +617,58 @@ extension on Translations {
 			'auth.signIn' => 'Sign in',
 			'auth.errorRequired' => 'Username and password are required',
 			'auth.errorGeneric' => ({required Object error}) => 'Login failed: ${error}',
+			'nav.sessions' => 'Sessions',
+			'nav.memory' => 'Memory',
+			'nav.notes' => 'Notes',
+			'nav.more' => 'More',
+			'more.title' => 'More',
+			'more.identity.signedInAs' => 'Signed in as',
+			'more.identity.server' => 'Server',
+			'more.identity.tokenExpires' => 'Token expires',
+			'more.sections.gateway' => 'Gateway',
+			'more.sections.memory' => 'Memory',
+			'more.sections.system' => 'System',
+			'more.items.integrations.title' => 'Integrations',
+			'more.items.integrations.subtitle' => 'API callers — recent activity & error rates',
+			'more.items.channels.title' => 'Channels',
+			'more.items.channels.subtitle' => 'Notification destinations',
+			'more.items.providers.title' => 'Providers',
+			'more.items.providers.subtitle' => 'Claude / Codex / Gemini CLI status',
+			'more.items.mcp.title' => 'MCP',
+			'more.items.mcp.subtitle' => 'Model Context Protocol servers & secrets',
+			'more.items.skills.title' => 'Skills',
+			'more.items.skills.subtitle' => 'Agent SKILL.md library (built-in + vault)',
+			'more.items.gitHosts.title' => 'Git hosts',
+			'more.items.gitHosts.subtitle' => 'PAT credentials for GitHub / GitLab / etc.',
+			'more.items.customTasks.title' => 'Custom tasks',
+			'more.items.customTasks.subtitle' => 'Slash commands shown in the session task picker',
+			'more.items.projectMemory.title' => 'Project goal / plan / journal',
+			'more.items.projectMemory.subtitle' => 'Per-cwd memory layers 2-4 + agent proposals',
+			'more.items.cleanupInbox.title' => 'Cleanup inbox',
+			'more.items.cleanupInbox.subtitle' => 'LLM-proposed deletions / merges across all projects',
+			'more.items.backups.title' => 'Backups',
+			'more.items.backups.subtitle' => 'Latest backup status & run-now',
+			'more.items.settings.title' => 'Settings',
+			'more.items.settings.subtitle' => 'Language, appearance, account',
+			'more.items.about.title' => 'About',
+			'more.items.about.subtitle' => 'Build version & server info',
+			'more.signOut' => 'Sign out',
+			'about.title' => 'About',
+			'about.loading' => 'Loading…',
+			'about.sections.app' => 'App',
+			'about.sections.server' => 'Server',
+			'about.fields.app' => 'App',
+			'about.fields.version' => 'Version',
+			'about.fields.versionFormat' => ({required Object version, required Object build}) => '${version} (build ${build})',
+			'about.fields.package' => 'Package',
+			'about.fields.url' => 'URL',
+			'about.fields.signedInAs' => 'Signed in as',
+			'about.fields.tokenExpires' => 'Token expires',
+			'about.copied' => ({required Object label}) => 'Copied ${label}',
+			'about.copyTooltip' => 'Copy',
+			'about.copyLabels.version' => 'version',
+			'about.copyLabels.serverUrl' => 'server URL',
+			'about.tagline' => 'opendray mobile — multi-CLI gateway control.\nSource: github.com/Opendray/opendray_v2',
 			'settings.title' => 'Settings',
 			'settings.language.section' => 'Language',
 			'settings.language.system' => 'System',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -44,6 +44,7 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	late final TranslationsAuthEn auth = TranslationsAuthEn.internal(_root);
 	late final TranslationsNavEn nav = TranslationsNavEn.internal(_root);
 	late final TranslationsMoreEn more = TranslationsMoreEn.internal(_root);
+	late final TranslationsSessionsEn sessions = TranslationsSessionsEn.internal(_root);
 	late final TranslationsAboutEn about = TranslationsAboutEn.internal(_root);
 	late final TranslationsSettingsEn settings = TranslationsSettingsEn.internal(_root);
 }
@@ -154,6 +155,36 @@ class TranslationsMoreEn {
 	String get signOut => 'Sign out';
 }
 
+// Path: sessions
+class TranslationsSessionsEn {
+	TranslationsSessionsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Sessions'
+	String get title => 'Sessions';
+
+	/// en: 'Refresh'
+	String get refresh => 'Refresh';
+
+	/// en: 'Actions'
+	String get actions => 'Actions';
+
+	/// en: 'Spawn'
+	String get spawn => 'Spawn';
+
+	late final TranslationsSessionsFiltersEn filters = TranslationsSessionsFiltersEn.internal(_root);
+	late final TranslationsSessionsCardEn card = TranslationsSessionsCardEn.internal(_root);
+	late final TranslationsSessionsEmptyEn empty = TranslationsSessionsEmptyEn.internal(_root);
+
+	/// en: 'Failed to load sessions'
+	String get errorTitle => 'Failed to load sessions';
+
+	late final TranslationsSessionsRelativeEn relative = TranslationsSessionsRelativeEn.internal(_root);
+}
+
 // Path: about
 class TranslationsAboutEn {
 	TranslationsAboutEn.internal(this._root);
@@ -255,6 +286,81 @@ class TranslationsMoreItemsEn {
 	late final TranslationsMoreItemsBackupsEn backups = TranslationsMoreItemsBackupsEn.internal(_root);
 	late final TranslationsMoreItemsSettingsEn settings = TranslationsMoreItemsSettingsEn.internal(_root);
 	late final TranslationsMoreItemsAboutEn about = TranslationsMoreItemsAboutEn.internal(_root);
+}
+
+// Path: sessions.filters
+class TranslationsSessionsFiltersEn {
+	TranslationsSessionsFiltersEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'All'
+	String get all => 'All';
+
+	/// en: 'Running'
+	String get running => 'Running';
+
+	/// en: 'Idle'
+	String get idle => 'Idle';
+
+	/// en: 'Ended'
+	String get ended => 'Ended';
+}
+
+// Path: sessions.card
+class TranslationsSessionsCardEn {
+	TranslationsSessionsCardEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: '{provider} · started {when}'
+	String startedRelative({required Object provider, required Object when}) => '${provider} · started ${when}';
+}
+
+// Path: sessions.empty
+class TranslationsSessionsEmptyEn {
+	TranslationsSessionsEmptyEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'No sessions yet'
+	String get titleAll => 'No sessions yet';
+
+	/// en: 'No sessions match the "{filter}" filter.'
+	String titleFiltered({required Object filter}) => 'No sessions match the "${filter}" filter.';
+
+	/// en: 'Tap the Spawn button to create one.'
+	String get subtitleAll => 'Tap the Spawn button to create one.';
+
+	/// en: 'Try a different filter or pull to refresh.'
+	String get subtitleFiltered => 'Try a different filter or pull to refresh.';
+}
+
+// Path: sessions.relative
+class TranslationsSessionsRelativeEn {
+	TranslationsSessionsRelativeEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: '{n}s ago'
+	String secondsAgo({required Object n}) => '${n}s ago';
+
+	/// en: '{n}m ago'
+	String minutesAgo({required Object n}) => '${n}m ago';
+
+	/// en: '{n}h ago'
+	String hoursAgo({required Object n}) => '${n}h ago';
+
+	/// en: '{n}d ago'
+	String daysAgo({required Object n}) => '${n}d ago';
 }
 
 // Path: about.sections
@@ -653,6 +759,24 @@ extension on Translations {
 			'more.items.about.title' => 'About',
 			'more.items.about.subtitle' => 'Build version & server info',
 			'more.signOut' => 'Sign out',
+			'sessions.title' => 'Sessions',
+			'sessions.refresh' => 'Refresh',
+			'sessions.actions' => 'Actions',
+			'sessions.spawn' => 'Spawn',
+			'sessions.filters.all' => 'All',
+			'sessions.filters.running' => 'Running',
+			'sessions.filters.idle' => 'Idle',
+			'sessions.filters.ended' => 'Ended',
+			'sessions.card.startedRelative' => ({required Object provider, required Object when}) => '${provider} · started ${when}',
+			'sessions.empty.titleAll' => 'No sessions yet',
+			'sessions.empty.titleFiltered' => ({required Object filter}) => 'No sessions match the "${filter}" filter.',
+			'sessions.empty.subtitleAll' => 'Tap the Spawn button to create one.',
+			'sessions.empty.subtitleFiltered' => 'Try a different filter or pull to refresh.',
+			'sessions.errorTitle' => 'Failed to load sessions',
+			'sessions.relative.secondsAgo' => ({required Object n}) => '${n}s ago',
+			'sessions.relative.minutesAgo' => ({required Object n}) => '${n}m ago',
+			'sessions.relative.hoursAgo' => ({required Object n}) => '${n}h ago',
+			'sessions.relative.daysAgo' => ({required Object n}) => '${n}d ago',
 			'about.title' => 'About',
 			'about.loading' => 'Loading…',
 			'about.sections.app' => 'App',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -1,0 +1,175 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
+import 'package:slang/generated.dart';
+import 'strings.g.dart';
+
+// Path: <root>
+class TranslationsZh extends Translations with BaseTranslations<AppLocale, Translations> {
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	TranslationsZh({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = meta ?? TranslationMetadata(
+		    locale: AppLocale.zh,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ),
+		  super(cardinalResolver: cardinalResolver, ordinalResolver: ordinalResolver) {
+		super.$meta.setFlatMapFunction($meta.getTranslation); // copy base translations to super.$meta
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
+
+	/// Metadata for the translations of <zh>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
+
+	/// Access flat map
+	@override dynamic operator[](String key) => $meta.getTranslation(key) ?? super.$meta.getTranslation(key);
+
+	late final TranslationsZh _root = this; // ignore: unused_field
+
+	@override 
+	TranslationsZh $copyWith({TranslationMetadata<AppLocale, Translations>? meta}) => TranslationsZh(meta: meta ?? this.$meta);
+
+	// Translations
+	@override late final _TranslationsCommonZh common = _TranslationsCommonZh._(_root);
+	@override late final _TranslationsSettingsZh settings = _TranslationsSettingsZh._(_root);
+}
+
+// Path: common
+class _TranslationsCommonZh extends TranslationsCommonEn {
+	_TranslationsCommonZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get ok => '确定';
+	@override String get cancel => '取消';
+	@override String get save => '保存';
+	@override String get delete => '删除';
+	@override String get edit => '编辑';
+	@override String get back => '返回';
+	@override String get done => '完成';
+	@override String get close => '关闭';
+	@override String get retry => '重试';
+}
+
+// Path: settings
+class _TranslationsSettingsZh extends TranslationsSettingsEn {
+	_TranslationsSettingsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '设置';
+	@override late final _TranslationsSettingsLanguageZh language = _TranslationsSettingsLanguageZh._(_root);
+	@override late final _TranslationsSettingsAppearanceZh appearance = _TranslationsSettingsAppearanceZh._(_root);
+	@override late final _TranslationsSettingsAccountZh account = _TranslationsSettingsAccountZh._(_root);
+	@override late final _TranslationsSettingsGatewayZh gateway = _TranslationsSettingsGatewayZh._(_root);
+}
+
+// Path: settings.language
+class _TranslationsSettingsLanguageZh extends TranslationsSettingsLanguageEn {
+	_TranslationsSettingsLanguageZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get section => '语言';
+	@override String get system => '跟随系统';
+	@override String get systemSubtitle => '跟随手机的语言设置';
+	@override String get english => 'English';
+	@override String get chinese => '中文';
+}
+
+// Path: settings.appearance
+class _TranslationsSettingsAppearanceZh extends TranslationsSettingsAppearanceEn {
+	_TranslationsSettingsAppearanceZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get section => '外观';
+	@override String get system => '跟随系统';
+	@override String get systemSubtitle => '跟随手机的外观设置';
+	@override String get light => '浅色';
+	@override String get lightSubtitle => '始终使用浅色主题';
+	@override String get dark => '深色';
+	@override String get darkSubtitle => '始终使用深色主题';
+}
+
+// Path: settings.account
+class _TranslationsSettingsAccountZh extends TranslationsSettingsAccountEn {
+	_TranslationsSettingsAccountZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get section => '账户';
+	@override String get changeCredentials => '修改凭据';
+	@override String get changeCredentialsSubtitle => '用户名和密码';
+}
+
+// Path: settings.gateway
+class _TranslationsSettingsGatewayZh extends TranslationsSettingsGatewayEn {
+	_TranslationsSettingsGatewayZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get section => '网关';
+	@override String get serverSettings => '服务器设置';
+	@override String get serverSettingsSubtitle => '监听地址、日志、凭据库、内存、存储路径…';
+	@override String get liveLogs => '实时日志';
+	@override String get liveLogsSubtitle => '查看网关实时日志 — 与 Web 管理端同源';
+}
+
+/// The flat map containing all translations for locale <zh>.
+/// Only for edge cases! For simple maps, use the map function of this library.
+///
+/// The Dart AOT compiler has issues with very large switch statements,
+/// so the map is split into smaller functions (512 entries each).
+extension on TranslationsZh {
+	dynamic _flatMapFunction(String path) {
+		return switch (path) {
+			'common.ok' => '确定',
+			'common.cancel' => '取消',
+			'common.save' => '保存',
+			'common.delete' => '删除',
+			'common.edit' => '编辑',
+			'common.back' => '返回',
+			'common.done' => '完成',
+			'common.close' => '关闭',
+			'common.retry' => '重试',
+			'settings.title' => '设置',
+			'settings.language.section' => '语言',
+			'settings.language.system' => '跟随系统',
+			'settings.language.systemSubtitle' => '跟随手机的语言设置',
+			'settings.language.english' => 'English',
+			'settings.language.chinese' => '中文',
+			'settings.appearance.section' => '外观',
+			'settings.appearance.system' => '跟随系统',
+			'settings.appearance.systemSubtitle' => '跟随手机的外观设置',
+			'settings.appearance.light' => '浅色',
+			'settings.appearance.lightSubtitle' => '始终使用浅色主题',
+			'settings.appearance.dark' => '深色',
+			'settings.appearance.darkSubtitle' => '始终使用深色主题',
+			'settings.account.section' => '账户',
+			'settings.account.changeCredentials' => '修改凭据',
+			'settings.account.changeCredentialsSubtitle' => '用户名和密码',
+			'settings.gateway.section' => '网关',
+			'settings.gateway.serverSettings' => '服务器设置',
+			'settings.gateway.serverSettingsSubtitle' => '监听地址、日志、凭据库、内存、存储路径…',
+			'settings.gateway.liveLogs' => '实时日志',
+			'settings.gateway.liveLogsSubtitle' => '查看网关实时日志 — 与 Web 管理端同源',
+			_ => null,
+		};
+	}
+}

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -44,6 +44,7 @@ class TranslationsZh extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsNavZh nav = _TranslationsNavZh._(_root);
 	@override late final _TranslationsMoreZh more = _TranslationsMoreZh._(_root);
 	@override late final _TranslationsSessionsZh sessions = _TranslationsSessionsZh._(_root);
+	@override late final _TranslationsMemoryZh memory = _TranslationsMemoryZh._(_root);
 	@override late final _TranslationsAboutZh about = _TranslationsAboutZh._(_root);
 	@override late final _TranslationsSettingsZh settings = _TranslationsSettingsZh._(_root);
 }
@@ -131,6 +132,32 @@ class _TranslationsSessionsZh extends TranslationsSessionsEn {
 	@override late final _TranslationsSessionsDirPickerZh dirPicker = _TranslationsSessionsDirPickerZh._(_root);
 	@override late final _TranslationsSessionsInspectorZh inspector = _TranslationsSessionsInspectorZh._(_root);
 	@override late final _TranslationsSessionsSpawnSheetZh spawnSheet = _TranslationsSessionsSpawnSheetZh._(_root);
+}
+
+// Path: memory
+class _TranslationsMemoryZh extends TranslationsMemoryEn {
+	_TranslationsMemoryZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '记忆';
+	@override String get more => '更多';
+	@override String get workers => '记忆工作器';
+	@override String get kNew => '新建';
+	@override String get searchHint => '搜索…';
+	@override String get projectLabel => '项目';
+	@override String get filterHint => '按名称或路径筛选…';
+	@override String get copied => '已复制';
+	@override String get copyTooltip => '复制文本';
+	@override late final _TranslationsMemoryDeleteAllConfirmZh deleteAllConfirm = _TranslationsMemoryDeleteAllConfirmZh._(_root);
+	@override String deletedSnackOne({required Object n}) => '已删除 ${n} 条记忆';
+	@override String deletedSnackOther({required Object n}) => '已删除 ${n} 条记忆';
+	@override String bulkDeleteFailedApi({required Object error}) => '批量删除失败：${error}';
+	@override String bulkDeleteFailedGeneric({required Object error}) => '批量删除失败：${error}';
+	@override late final _TranslationsMemoryDeleteOneZh deleteOne = _TranslationsMemoryDeleteOneZh._(_root);
+	@override late final _TranslationsMemoryScopeZh scope = _TranslationsMemoryScopeZh._(_root);
+	@override late final _TranslationsMemoryCreateZh create = _TranslationsMemoryCreateZh._(_root);
 }
 
 // Path: about
@@ -368,6 +395,52 @@ class _TranslationsSessionsSpawnSheetZh extends TranslationsSessionsSpawnSheetEn
 	@override late final _TranslationsSessionsSpawnSheetNoProvidersZh noProviders = _TranslationsSessionsSpawnSheetNoProvidersZh._(_root);
 	@override late final _TranslationsSessionsSpawnSheetProviderLoadErrorZh providerLoadError = _TranslationsSessionsSpawnSheetProviderLoadErrorZh._(_root);
 	@override late final _TranslationsSessionsSpawnSheetClaudeAccountZh claudeAccount = _TranslationsSessionsSpawnSheetClaudeAccountZh._(_root);
+}
+
+// Path: memory.deleteAllConfirm
+class _TranslationsMemoryDeleteAllConfirmZh extends TranslationsMemoryDeleteAllConfirmEn {
+	_TranslationsMemoryDeleteAllConfirmZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '删除此范围内所有记忆？';
+	@override String get deleteAll => '全部删除';
+}
+
+// Path: memory.deleteOne
+class _TranslationsMemoryDeleteOneZh extends TranslationsMemoryDeleteOneEn {
+	_TranslationsMemoryDeleteOneZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '删除该记忆？';
+	@override String get body => '此操作不可撤销。';
+}
+
+// Path: memory.scope
+class _TranslationsMemoryScopeZh extends TranslationsMemoryScopeEn {
+	_TranslationsMemoryScopeZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get project => '项目';
+	@override String get global => '全局';
+}
+
+// Path: memory.create
+class _TranslationsMemoryCreateZh extends TranslationsMemoryCreateEn {
+	_TranslationsMemoryCreateZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get textLabel => '文本';
+	@override String get scopeKeyLabel => '范围键（项目 cwd）';
+	@override String get scopeKeyHint => '/Users/you/projects/foo';
+	@override String get submit => '创建';
 }
 
 // Path: about.sections
@@ -1064,6 +1137,29 @@ extension on TranslationsZh {
 			'sessions.spawnSheet.claudeAccount.noTokenSuffix' => '（无令牌）',
 			'sessions.spawnSheet.claudeAccount.noneHint' => '未配置 Claude 账号 — 网关将使用系统的 ANTHROPIC_API_KEY。在 Web 管理端的「设置 → 账号」中添加账号。',
 			'sessions.spawnSheet.claudeAccount.errorHint' => ({required Object error}) => '无法加载 Claude 账号（${error}）。会话将以网关默认配置启动。',
+			'memory.title' => '记忆',
+			'memory.more' => '更多',
+			'memory.workers' => '记忆工作器',
+			'memory.kNew' => '新建',
+			'memory.searchHint' => '搜索…',
+			'memory.projectLabel' => '项目',
+			'memory.filterHint' => '按名称或路径筛选…',
+			'memory.copied' => '已复制',
+			'memory.copyTooltip' => '复制文本',
+			'memory.deleteAllConfirm.title' => '删除此范围内所有记忆？',
+			'memory.deleteAllConfirm.deleteAll' => '全部删除',
+			'memory.deletedSnackOne' => ({required Object n}) => '已删除 ${n} 条记忆',
+			'memory.deletedSnackOther' => ({required Object n}) => '已删除 ${n} 条记忆',
+			'memory.bulkDeleteFailedApi' => ({required Object error}) => '批量删除失败：${error}',
+			'memory.bulkDeleteFailedGeneric' => ({required Object error}) => '批量删除失败：${error}',
+			'memory.deleteOne.title' => '删除该记忆？',
+			'memory.deleteOne.body' => '此操作不可撤销。',
+			'memory.scope.project' => '项目',
+			'memory.scope.global' => '全局',
+			'memory.create.textLabel' => '文本',
+			'memory.create.scopeKeyLabel' => '范围键（项目 cwd）',
+			'memory.create.scopeKeyHint' => '/Users/you/projects/foo',
+			'memory.create.submit' => '创建',
 			'about.title' => '关于',
 			'about.loading' => '加载中…',
 			'about.sections.app' => '应用',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -125,6 +125,9 @@ class _TranslationsSessionsZh extends TranslationsSessionsEn {
 	@override late final _TranslationsSessionsEmptyZh empty = _TranslationsSessionsEmptyZh._(_root);
 	@override String get errorTitle => '加载会话失败';
 	@override late final _TranslationsSessionsRelativeZh relative = _TranslationsSessionsRelativeZh._(_root);
+	@override late final _TranslationsSessionsActionZh action = _TranslationsSessionsActionZh._(_root);
+	@override late final _TranslationsSessionsDirPickerZh dirPicker = _TranslationsSessionsDirPickerZh._(_root);
+	@override late final _TranslationsSessionsSpawnSheetZh spawnSheet = _TranslationsSessionsSpawnSheetZh._(_root);
 }
 
 // Path: about
@@ -250,6 +253,71 @@ class _TranslationsSessionsRelativeZh extends TranslationsSessionsRelativeEn {
 	@override String minutesAgo({required Object n}) => '${n} 分钟前';
 	@override String hoursAgo({required Object n}) => '${n} 小时前';
 	@override String daysAgo({required Object n}) => '${n} 天前';
+}
+
+// Path: sessions.action
+class _TranslationsSessionsActionZh extends TranslationsSessionsActionEn {
+	_TranslationsSessionsActionZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get stop => '停止';
+	@override String get stopping => '停止中…';
+	@override String get stopDescription => '发送 SIGTERM，保留历史';
+	@override String get restart => '重启';
+	@override String get restarting => '重启中…';
+	@override String get restartDescription => '重新启动 CLI 进程';
+	@override String get delete => '删除';
+	@override String get deleteDescription => '移除会话及其历史';
+	@override String get deleteConfirm => '确定永久删除此会话吗？其环形缓冲区和历史将全部丢失。';
+	@override late final _TranslationsSessionsActionErrorsZh errors = _TranslationsSessionsActionErrorsZh._(_root);
+}
+
+// Path: sessions.dirPicker
+class _TranslationsSessionsDirPickerZh extends TranslationsSessionsDirPickerEn {
+	_TranslationsSessionsDirPickerZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get parent => '上级';
+	@override String get newFolder => '新建文件夹';
+	@override String get useThisFolder => '使用此文件夹';
+	@override String get loading => '加载中…';
+	@override String get empty => '此处没有子文件夹。\n选择此文件夹，或新建一个。';
+	@override String createdSnack({required Object path}) => '已创建 ${path}';
+	@override String mkdirFailedSnack({required Object error}) => '创建文件夹失败：${error}';
+	@override late final _TranslationsSessionsDirPickerDialogZh dialog = _TranslationsSessionsDirPickerDialogZh._(_root);
+}
+
+// Path: sessions.spawnSheet
+class _TranslationsSessionsSpawnSheetZh extends TranslationsSessionsSpawnSheetEn {
+	_TranslationsSessionsSpawnSheetZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '新建会话';
+	@override String get errorRequired => '需要指定提供商和工作目录';
+	@override String errorGeneric({required Object error}) => '创建会话失败：${error}';
+	@override String get cancel => '取消';
+	@override String get spawn => '创建';
+	@override String get providerLabel => '提供商';
+	@override String get disabledSuffix => '（已停用）';
+	@override String get cwdLabel => '工作目录';
+	@override String get cwdHint => '/Users/you/projects/foo';
+	@override String get cwdHelper => '网关主机上的绝对路径。';
+	@override String get browse => '浏览';
+	@override String get nameLabel => '名称（可选）';
+	@override String get nameHint => '例如：backend-refactor';
+	@override String get argsLabel => '额外参数（可选）';
+	@override String get argsHint => '--continue --verbose';
+	@override String get argsHelper => '以空格分隔；留空使用提供商默认值。';
+	@override late final _TranslationsSessionsSpawnSheetBypassZh bypass = _TranslationsSessionsSpawnSheetBypassZh._(_root);
+	@override late final _TranslationsSessionsSpawnSheetNoProvidersZh noProviders = _TranslationsSessionsSpawnSheetNoProvidersZh._(_root);
+	@override late final _TranslationsSessionsSpawnSheetProviderLoadErrorZh providerLoadError = _TranslationsSessionsSpawnSheetProviderLoadErrorZh._(_root);
+	@override late final _TranslationsSessionsSpawnSheetClaudeAccountZh claudeAccount = _TranslationsSessionsSpawnSheetClaudeAccountZh._(_root);
 }
 
 // Path: about.sections
@@ -478,6 +546,86 @@ class _TranslationsMoreItemsAboutZh extends TranslationsMoreItemsAboutEn {
 	@override String get subtitle => '构建版本与服务器信息';
 }
 
+// Path: sessions.action.errors
+class _TranslationsSessionsActionErrorsZh extends TranslationsSessionsActionErrorsEn {
+	_TranslationsSessionsActionErrorsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String stop({required Object error}) => '停止失败：${error}';
+	@override String start({required Object error}) => '重启失败：${error}';
+	@override String delete({required Object error}) => '删除失败：${error}';
+}
+
+// Path: sessions.dirPicker.dialog
+class _TranslationsSessionsDirPickerDialogZh extends TranslationsSessionsDirPickerDialogEn {
+	_TranslationsSessionsDirPickerDialogZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '新建文件夹';
+	@override String get hint => '文件夹名';
+	@override String get create => '创建';
+}
+
+// Path: sessions.spawnSheet.bypass
+class _TranslationsSessionsSpawnSheetBypassZh extends TranslationsSessionsSpawnSheetBypassEn {
+	_TranslationsSessionsSpawnSheetBypassZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get labelClaude => '绕过权限';
+	@override String get labelCodex => '自动批准（从不询问）';
+	@override String get labelGemini => 'YOLO 模式';
+	@override String get subtitleOn => '此会话将以提升的自主权运行。';
+	@override String get subtitleOff => '关闭 — 确认和提示按正常方式处理。';
+}
+
+// Path: sessions.spawnSheet.noProviders
+class _TranslationsSessionsSpawnSheetNoProvidersZh extends TranslationsSessionsSpawnSheetNoProvidersEn {
+	_TranslationsSessionsSpawnSheetNoProvidersZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '未配置任何提供商';
+	@override String get message => '网关没有启用任何 CLI 提供商。在 Web 管理端的「提供商」中配置，或编辑 config.toml 的 [providers] 段，然后点击重新加载。';
+	@override String get reload => '重新加载';
+}
+
+// Path: sessions.spawnSheet.providerLoadError
+class _TranslationsSessionsSpawnSheetProviderLoadErrorZh extends TranslationsSessionsSpawnSheetProviderLoadErrorEn {
+	_TranslationsSessionsSpawnSheetProviderLoadErrorZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '无法加载提供商';
+	@override String get networkError => '网络错误';
+	@override String serverPrefix({required Object code}) => '服务器 ${code}';
+	@override String format({required Object prefix, required Object message}) => '${prefix}：${message}';
+}
+
+// Path: sessions.spawnSheet.claudeAccount
+class _TranslationsSessionsSpawnSheetClaudeAccountZh extends TranslationsSessionsSpawnSheetClaudeAccountEn {
+	_TranslationsSessionsSpawnSheetClaudeAccountZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'Claude 账号';
+	@override String get helperMulti => '已配置多个账号 — 为此会话选择一个。';
+	@override String get helperSingle => '选择已配置的账号，或使用默认（环境变量 / 系统）。';
+	@override String get kDefault => '默认（环境变量 / 系统）';
+	@override String get disabledSuffix => '（已停用）';
+	@override String get noTokenSuffix => '（无令牌）';
+	@override String get noneHint => '未配置 Claude 账号 — 网关将使用系统的 ANTHROPIC_API_KEY。在 Web 管理端的「设置 → 账号」中添加账号。';
+	@override String errorHint({required Object error}) => '无法加载 Claude 账号（${error}）。会话将以网关默认配置启动。';
+}
+
 /// The flat map containing all translations for locale <zh>.
 /// Only for edge cases! For simple maps, use the map function of this library.
 ///
@@ -556,6 +704,64 @@ extension on TranslationsZh {
 			'sessions.relative.minutesAgo' => ({required Object n}) => '${n} 分钟前',
 			'sessions.relative.hoursAgo' => ({required Object n}) => '${n} 小时前',
 			'sessions.relative.daysAgo' => ({required Object n}) => '${n} 天前',
+			'sessions.action.stop' => '停止',
+			'sessions.action.stopping' => '停止中…',
+			'sessions.action.stopDescription' => '发送 SIGTERM，保留历史',
+			'sessions.action.restart' => '重启',
+			'sessions.action.restarting' => '重启中…',
+			'sessions.action.restartDescription' => '重新启动 CLI 进程',
+			'sessions.action.delete' => '删除',
+			'sessions.action.deleteDescription' => '移除会话及其历史',
+			'sessions.action.deleteConfirm' => '确定永久删除此会话吗？其环形缓冲区和历史将全部丢失。',
+			'sessions.action.errors.stop' => ({required Object error}) => '停止失败：${error}',
+			'sessions.action.errors.start' => ({required Object error}) => '重启失败：${error}',
+			'sessions.action.errors.delete' => ({required Object error}) => '删除失败：${error}',
+			'sessions.dirPicker.parent' => '上级',
+			'sessions.dirPicker.newFolder' => '新建文件夹',
+			'sessions.dirPicker.useThisFolder' => '使用此文件夹',
+			'sessions.dirPicker.loading' => '加载中…',
+			'sessions.dirPicker.empty' => '此处没有子文件夹。\n选择此文件夹，或新建一个。',
+			'sessions.dirPicker.createdSnack' => ({required Object path}) => '已创建 ${path}',
+			'sessions.dirPicker.mkdirFailedSnack' => ({required Object error}) => '创建文件夹失败：${error}',
+			'sessions.dirPicker.dialog.title' => '新建文件夹',
+			'sessions.dirPicker.dialog.hint' => '文件夹名',
+			'sessions.dirPicker.dialog.create' => '创建',
+			'sessions.spawnSheet.title' => '新建会话',
+			'sessions.spawnSheet.errorRequired' => '需要指定提供商和工作目录',
+			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => '创建会话失败：${error}',
+			'sessions.spawnSheet.cancel' => '取消',
+			'sessions.spawnSheet.spawn' => '创建',
+			'sessions.spawnSheet.providerLabel' => '提供商',
+			'sessions.spawnSheet.disabledSuffix' => '（已停用）',
+			'sessions.spawnSheet.cwdLabel' => '工作目录',
+			'sessions.spawnSheet.cwdHint' => '/Users/you/projects/foo',
+			'sessions.spawnSheet.cwdHelper' => '网关主机上的绝对路径。',
+			'sessions.spawnSheet.browse' => '浏览',
+			'sessions.spawnSheet.nameLabel' => '名称（可选）',
+			'sessions.spawnSheet.nameHint' => '例如：backend-refactor',
+			'sessions.spawnSheet.argsLabel' => '额外参数（可选）',
+			'sessions.spawnSheet.argsHint' => '--continue --verbose',
+			'sessions.spawnSheet.argsHelper' => '以空格分隔；留空使用提供商默认值。',
+			'sessions.spawnSheet.bypass.labelClaude' => '绕过权限',
+			'sessions.spawnSheet.bypass.labelCodex' => '自动批准（从不询问）',
+			'sessions.spawnSheet.bypass.labelGemini' => 'YOLO 模式',
+			'sessions.spawnSheet.bypass.subtitleOn' => '此会话将以提升的自主权运行。',
+			'sessions.spawnSheet.bypass.subtitleOff' => '关闭 — 确认和提示按正常方式处理。',
+			'sessions.spawnSheet.noProviders.title' => '未配置任何提供商',
+			'sessions.spawnSheet.noProviders.message' => '网关没有启用任何 CLI 提供商。在 Web 管理端的「提供商」中配置，或编辑 config.toml 的 [providers] 段，然后点击重新加载。',
+			'sessions.spawnSheet.noProviders.reload' => '重新加载',
+			'sessions.spawnSheet.providerLoadError.title' => '无法加载提供商',
+			'sessions.spawnSheet.providerLoadError.networkError' => '网络错误',
+			'sessions.spawnSheet.providerLoadError.serverPrefix' => ({required Object code}) => '服务器 ${code}',
+			'sessions.spawnSheet.providerLoadError.format' => ({required Object prefix, required Object message}) => '${prefix}：${message}',
+			'sessions.spawnSheet.claudeAccount.label' => 'Claude 账号',
+			'sessions.spawnSheet.claudeAccount.helperMulti' => '已配置多个账号 — 为此会话选择一个。',
+			'sessions.spawnSheet.claudeAccount.helperSingle' => '选择已配置的账号，或使用默认（环境变量 / 系统）。',
+			'sessions.spawnSheet.claudeAccount.kDefault' => '默认（环境变量 / 系统）',
+			'sessions.spawnSheet.claudeAccount.disabledSuffix' => '（已停用）',
+			'sessions.spawnSheet.claudeAccount.noTokenSuffix' => '（无令牌）',
+			'sessions.spawnSheet.claudeAccount.noneHint' => '未配置 Claude 账号 — 网关将使用系统的 ANTHROPIC_API_KEY。在 Web 管理端的「设置 → 账号」中添加账号。',
+			'sessions.spawnSheet.claudeAccount.errorHint' => ({required Object error}) => '无法加载 Claude 账号（${error}）。会话将以网关默认配置启动。',
 			'about.title' => '关于',
 			'about.loading' => '加载中…',
 			'about.sections.app' => '应用',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -129,6 +129,7 @@ class _TranslationsSessionsZh extends TranslationsSessionsEn {
 	@override late final _TranslationsSessionsTerminalZh terminal = _TranslationsSessionsTerminalZh._(_root);
 	@override late final _TranslationsSessionsActionZh action = _TranslationsSessionsActionZh._(_root);
 	@override late final _TranslationsSessionsDirPickerZh dirPicker = _TranslationsSessionsDirPickerZh._(_root);
+	@override late final _TranslationsSessionsInspectorZh inspector = _TranslationsSessionsInspectorZh._(_root);
 	@override late final _TranslationsSessionsSpawnSheetZh spawnSheet = _TranslationsSessionsSpawnSheetZh._(_root);
 }
 
@@ -322,6 +323,22 @@ class _TranslationsSessionsDirPickerZh extends TranslationsSessionsDirPickerEn {
 	@override String createdSnack({required Object path}) => '已创建 ${path}';
 	@override String mkdirFailedSnack({required Object error}) => '创建文件夹失败：${error}';
 	@override late final _TranslationsSessionsDirPickerDialogZh dialog = _TranslationsSessionsDirPickerDialogZh._(_root);
+}
+
+// Path: sessions.inspector
+class _TranslationsSessionsInspectorZh extends TranslationsSessionsInspectorEn {
+	_TranslationsSessionsInspectorZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsSessionsInspectorShellZh shell = _TranslationsSessionsInspectorShellZh._(_root);
+	@override late final _TranslationsSessionsInspectorSharedZh shared = _TranslationsSessionsInspectorSharedZh._(_root);
+	@override late final _TranslationsSessionsInspectorHistoryZh history = _TranslationsSessionsInspectorHistoryZh._(_root);
+	@override late final _TranslationsSessionsInspectorFilesZh files = _TranslationsSessionsInspectorFilesZh._(_root);
+	@override late final _TranslationsSessionsInspectorGitZh git = _TranslationsSessionsInspectorGitZh._(_root);
+	@override late final _TranslationsSessionsInspectorTasksZh tasks = _TranslationsSessionsInspectorTasksZh._(_root);
+	@override late final _TranslationsSessionsInspectorNotesZh notes = _TranslationsSessionsInspectorNotesZh._(_root);
 }
 
 // Path: sessions.spawnSheet
@@ -656,6 +673,115 @@ class _TranslationsSessionsDirPickerDialogZh extends TranslationsSessionsDirPick
 	@override String get create => '创建';
 }
 
+// Path: sessions.inspector.shell
+class _TranslationsSessionsInspectorShellZh extends TranslationsSessionsInspectorShellEn {
+	_TranslationsSessionsInspectorShellZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '检查器';
+	@override String loadError({required Object error}) => '加载会话失败：${error}';
+	@override late final _TranslationsSessionsInspectorShellTabsZh tabs = _TranslationsSessionsInspectorShellTabsZh._(_root);
+}
+
+// Path: sessions.inspector.shared
+class _TranslationsSessionsInspectorSharedZh extends TranslationsSessionsInspectorSharedEn {
+	_TranslationsSessionsInspectorSharedZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get refresh => '刷新';
+	@override String inserted({required Object text}) => '已插入：${text}';
+	@override String insertFailedApi({required Object status, required Object message}) => '插入失败（${status}）：${message}';
+	@override String insertFailedGeneric({required Object error}) => '插入失败：${error}';
+	@override String insertFailedShort({required Object error}) => '插入失败：${error}';
+}
+
+// Path: sessions.inspector.history
+class _TranslationsSessionsInspectorHistoryZh extends TranslationsSessionsInspectorHistoryEn {
+	_TranslationsSessionsInspectorHistoryZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get insertIntoTerminal => '插入到终端';
+	@override String get searchHint => '搜索提示…';
+}
+
+// Path: sessions.inspector.files
+class _TranslationsSessionsInspectorFilesZh extends TranslationsSessionsInspectorFilesEn {
+	_TranslationsSessionsInspectorFilesZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get insertAtRef => '作为 @引用 插入';
+	@override String get insertPath => '插入路径';
+	@override String get insertPathSubtitle => '原样粘贴绝对路径';
+	@override String get readContent => '读取内容';
+	@override String get readContentSubtitle => '最多 256 KiB 纯文本';
+	@override String readFailedApi({required Object status, required Object message}) => '读取失败（${status}）：${message}';
+	@override String readFailedGeneric({required Object error}) => '读取失败：${error}';
+	@override String get parent => '上级';
+	@override String get backToCwd => '返回会话目录';
+}
+
+// Path: sessions.inspector.git
+class _TranslationsSessionsInspectorGitZh extends TranslationsSessionsInspectorGitEn {
+	_TranslationsSessionsInspectorGitZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get insertAtRef => '作为 @引用 插入';
+	@override String get insertPath => '插入路径';
+	@override String get showDiff => '查看 diff';
+	@override String diffFailedApi({required Object status, required Object message}) => 'Diff 失败（${status}）：${message}';
+	@override String diffFailedGeneric({required Object error}) => 'Diff 失败：${error}';
+	@override String get insertHash => '插入哈希';
+	@override String get showFullPatch => '查看完整 patch';
+	@override String showFailedApi({required Object status, required Object message}) => '查看失败（${status}）：${message}';
+	@override String showFailedGeneric({required Object error}) => '查看失败：${error}';
+	@override String get tabStatus => '状态';
+	@override String get tabLog => '日志';
+}
+
+// Path: sessions.inspector.tasks
+class _TranslationsSessionsInspectorTasksZh extends TranslationsSessionsInspectorTasksEn {
+	_TranslationsSessionsInspectorTasksZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get runCommand => '运行命令';
+	@override String get insertCommand => '插入命令';
+	@override String get insertCommandSubtitle => '粘贴但不回车，方便编辑';
+}
+
+// Path: sessions.inspector.notes
+class _TranslationsSessionsInspectorNotesZh extends TranslationsSessionsInspectorNotesEn {
+	_TranslationsSessionsInspectorNotesZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String insertedAt({required Object path}) => '已插入：@${path}';
+	@override String get myNotes => '我的笔记';
+	@override String get projectDocs => '项目文档';
+	@override String get insertAtRefTooltip => '作为 @引用 插入';
+	@override String get insertAtRefShort => '插入 @引用';
+	@override String draftHint({required Object project}) => '# ${project}\n\n想法、待办、为 agent 提供的上下文…';
+	@override String createFailed({required Object error}) => '创建失败：${error}';
+	@override String saveFailed({required Object error}) => '保存失败：${error}';
+	@override String get changeLocationTooltip => '更改项目文档位置';
+	@override String get filenameHint => '文件名（例如：spec 或 design.md）';
+	@override String get create => '创建';
+	@override String get filterHint => '筛选…';
+	@override String get locationDialogTitle => '项目文档位置';
+}
+
 // Path: sessions.spawnSheet.bypass
 class _TranslationsSessionsSpawnSheetBypassZh extends TranslationsSessionsSpawnSheetBypassEn {
 	_TranslationsSessionsSpawnSheetBypassZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -710,6 +836,20 @@ class _TranslationsSessionsSpawnSheetClaudeAccountZh extends TranslationsSession
 	@override String get noTokenSuffix => '（无令牌）';
 	@override String get noneHint => '未配置 Claude 账号 — 网关将使用系统的 ANTHROPIC_API_KEY。在 Web 管理端的「设置 → 账号」中添加账号。';
 	@override String errorHint({required Object error}) => '无法加载 Claude 账号（${error}）。会话将以网关默认配置启动。';
+}
+
+// Path: sessions.inspector.shell.tabs
+class _TranslationsSessionsInspectorShellTabsZh extends TranslationsSessionsInspectorShellTabsEn {
+	_TranslationsSessionsInspectorShellTabsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get files => '文件';
+	@override String get git => 'Git';
+	@override String get tasks => '任务';
+	@override String get history => '历史';
+	@override String get notes => '笔记';
 }
 
 /// The flat map containing all translations for locale <zh>.
@@ -838,6 +978,56 @@ extension on TranslationsZh {
 			'sessions.dirPicker.dialog.title' => '新建文件夹',
 			'sessions.dirPicker.dialog.hint' => '文件夹名',
 			'sessions.dirPicker.dialog.create' => '创建',
+			'sessions.inspector.shell.title' => '检查器',
+			'sessions.inspector.shell.loadError' => ({required Object error}) => '加载会话失败：${error}',
+			'sessions.inspector.shell.tabs.files' => '文件',
+			'sessions.inspector.shell.tabs.git' => 'Git',
+			'sessions.inspector.shell.tabs.tasks' => '任务',
+			'sessions.inspector.shell.tabs.history' => '历史',
+			'sessions.inspector.shell.tabs.notes' => '笔记',
+			'sessions.inspector.shared.refresh' => '刷新',
+			'sessions.inspector.shared.inserted' => ({required Object text}) => '已插入：${text}',
+			'sessions.inspector.shared.insertFailedApi' => ({required Object status, required Object message}) => '插入失败（${status}）：${message}',
+			'sessions.inspector.shared.insertFailedGeneric' => ({required Object error}) => '插入失败：${error}',
+			'sessions.inspector.shared.insertFailedShort' => ({required Object error}) => '插入失败：${error}',
+			'sessions.inspector.history.insertIntoTerminal' => '插入到终端',
+			'sessions.inspector.history.searchHint' => '搜索提示…',
+			'sessions.inspector.files.insertAtRef' => '作为 @引用 插入',
+			'sessions.inspector.files.insertPath' => '插入路径',
+			'sessions.inspector.files.insertPathSubtitle' => '原样粘贴绝对路径',
+			'sessions.inspector.files.readContent' => '读取内容',
+			'sessions.inspector.files.readContentSubtitle' => '最多 256 KiB 纯文本',
+			'sessions.inspector.files.readFailedApi' => ({required Object status, required Object message}) => '读取失败（${status}）：${message}',
+			'sessions.inspector.files.readFailedGeneric' => ({required Object error}) => '读取失败：${error}',
+			'sessions.inspector.files.parent' => '上级',
+			'sessions.inspector.files.backToCwd' => '返回会话目录',
+			'sessions.inspector.git.insertAtRef' => '作为 @引用 插入',
+			'sessions.inspector.git.insertPath' => '插入路径',
+			'sessions.inspector.git.showDiff' => '查看 diff',
+			'sessions.inspector.git.diffFailedApi' => ({required Object status, required Object message}) => 'Diff 失败（${status}）：${message}',
+			'sessions.inspector.git.diffFailedGeneric' => ({required Object error}) => 'Diff 失败：${error}',
+			'sessions.inspector.git.insertHash' => '插入哈希',
+			'sessions.inspector.git.showFullPatch' => '查看完整 patch',
+			'sessions.inspector.git.showFailedApi' => ({required Object status, required Object message}) => '查看失败（${status}）：${message}',
+			'sessions.inspector.git.showFailedGeneric' => ({required Object error}) => '查看失败：${error}',
+			'sessions.inspector.git.tabStatus' => '状态',
+			'sessions.inspector.git.tabLog' => '日志',
+			'sessions.inspector.tasks.runCommand' => '运行命令',
+			'sessions.inspector.tasks.insertCommand' => '插入命令',
+			'sessions.inspector.tasks.insertCommandSubtitle' => '粘贴但不回车，方便编辑',
+			'sessions.inspector.notes.insertedAt' => ({required Object path}) => '已插入：@${path}',
+			'sessions.inspector.notes.myNotes' => '我的笔记',
+			'sessions.inspector.notes.projectDocs' => '项目文档',
+			'sessions.inspector.notes.insertAtRefTooltip' => '作为 @引用 插入',
+			'sessions.inspector.notes.insertAtRefShort' => '插入 @引用',
+			'sessions.inspector.notes.draftHint' => ({required Object project}) => '# ${project}\n\n想法、待办、为 agent 提供的上下文…',
+			'sessions.inspector.notes.createFailed' => ({required Object error}) => '创建失败：${error}',
+			'sessions.inspector.notes.saveFailed' => ({required Object error}) => '保存失败：${error}',
+			'sessions.inspector.notes.changeLocationTooltip' => '更改项目文档位置',
+			'sessions.inspector.notes.filenameHint' => '文件名（例如：spec 或 design.md）',
+			'sessions.inspector.notes.create' => '创建',
+			'sessions.inspector.notes.filterHint' => '筛选…',
+			'sessions.inspector.notes.locationDialogTitle' => '项目文档位置',
 			'sessions.spawnSheet.title' => '新建会话',
 			'sessions.spawnSheet.errorRequired' => '需要指定提供商和工作目录',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => '创建会话失败：${error}',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -44,6 +44,9 @@ class TranslationsZh extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsNavZh nav = _TranslationsNavZh._(_root);
 	@override late final _TranslationsMoreZh more = _TranslationsMoreZh._(_root);
 	@override late final _TranslationsSessionsZh sessions = _TranslationsSessionsZh._(_root);
+	@override late final _TranslationsMcpZh mcp = _TranslationsMcpZh._(_root);
+	@override late final _TranslationsProvidersZh providers = _TranslationsProvidersZh._(_root);
+	@override late final _TranslationsIntegrationsZh integrations = _TranslationsIntegrationsZh._(_root);
 	@override late final _TranslationsMemoryZh memory = _TranslationsMemoryZh._(_root);
 	@override late final _TranslationsAboutZh about = _TranslationsAboutZh._(_root);
 	@override late final _TranslationsSettingsZh settings = _TranslationsSettingsZh._(_root);
@@ -132,6 +135,80 @@ class _TranslationsSessionsZh extends TranslationsSessionsEn {
 	@override late final _TranslationsSessionsDirPickerZh dirPicker = _TranslationsSessionsDirPickerZh._(_root);
 	@override late final _TranslationsSessionsInspectorZh inspector = _TranslationsSessionsInspectorZh._(_root);
 	@override late final _TranslationsSessionsSpawnSheetZh spawnSheet = _TranslationsSessionsSpawnSheetZh._(_root);
+}
+
+// Path: mcp
+class _TranslationsMcpZh extends TranslationsMcpEn {
+	_TranslationsMcpZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'MCP';
+	@override String get newServer => '新建服务器';
+	@override String get addSecret => '添加密钥';
+	@override String get editConfig => '编辑配置';
+	@override String get viewRawConfig => '查看原始配置';
+	@override String get copyId => '复制 ID';
+	@override String copiedSnack({required Object id}) => '已复制 ${id}';
+	@override String get deleteServerTitle => '删除 MCP 服务器？';
+	@override String get deleteSecretTitle => '删除密钥？';
+	@override late final _TranslationsMcpErrorPrefixZh errorPrefix = _TranslationsMcpErrorPrefixZh._(_root);
+	@override String errorWithMessage({required Object prefix, required Object error}) => '${prefix}：${error}';
+	@override late final _TranslationsMcpEditorZh editor = _TranslationsMcpEditorZh._(_root);
+	@override late final _TranslationsMcpSecretZh secret = _TranslationsMcpSecretZh._(_root);
+}
+
+// Path: providers
+class _TranslationsProvidersZh extends TranslationsProvidersEn {
+	_TranslationsProvidersZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '提供商';
+	@override String get configSaved => '提供商配置已更新。';
+	@override String saveFailedApi({required Object error}) => '保存失败：${error}';
+	@override String saveFailedGeneric({required Object error}) => '保存失败：${error}';
+	@override String get reload => '重新加载';
+	@override late final _TranslationsProvidersErrorPrefixZh errorPrefix = _TranslationsProvidersErrorPrefixZh._(_root);
+	@override String errorWithMessage({required Object prefix, required Object error}) => '${prefix}：${error}';
+	@override late final _TranslationsProvidersAccountsZh accounts = _TranslationsProvidersAccountsZh._(_root);
+}
+
+// Path: integrations
+class _TranslationsIntegrationsZh extends TranslationsIntegrationsEn {
+	_TranslationsIntegrationsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '集成';
+	@override String get register => '注册';
+	@override String get registerDialogTitle => '注册集成';
+	@override String get edit => '编辑';
+	@override String editTitle({required Object name}) => '编辑 ${name}';
+	@override String get enabledLabel => '已启用';
+	@override String get iSavedIt => '我已保存';
+	@override String apiKeyForName({required Object name}) => '${name} 的 API key';
+	@override String apiKeySubtitleRegister({required Object routePrefix}) => '将其交给集成方，使其能够通过 /api/v1/${routePrefix}/… 进行认证。';
+	@override String copiedRequestId({required Object id}) => '已复制 request_id ${id}';
+	@override String get updateOk => '集成已更新。';
+	@override String registerFailedApi({required Object error}) => '注册失败：${error}';
+	@override String registerFailedGeneric({required Object error}) => '注册失败：${error}';
+	@override String updateFailedApi({required Object error}) => '更新失败：${error}';
+	@override String updateFailedGeneric({required Object error}) => '更新失败：${error}';
+	@override String get deleteTitle => '删除集成？';
+	@override String deletedSnack({required Object name}) => '已删除 ${name}。';
+	@override String deleteFailedApi({required Object error}) => '删除失败：${error}';
+	@override String deleteFailedGeneric({required Object error}) => '删除失败：${error}';
+	@override String get rotateKey => '轮换密钥';
+	@override String get rotateConfirmTitle => '轮换 API key？';
+	@override String get rotate => '轮换';
+	@override String newApiKeyTitle({required Object name}) => '${name} 的新 API key';
+	@override String get newApiKeySubtitle => '将其交给集成方。旧密钥已失效。';
+	@override String rotateFailedApi({required Object error}) => '轮换失败：${error}';
+	@override String rotateFailedGeneric({required Object error}) => '轮换失败：${error}';
 }
 
 // Path: memory
@@ -395,6 +472,70 @@ class _TranslationsSessionsSpawnSheetZh extends TranslationsSessionsSpawnSheetEn
 	@override late final _TranslationsSessionsSpawnSheetNoProvidersZh noProviders = _TranslationsSessionsSpawnSheetNoProvidersZh._(_root);
 	@override late final _TranslationsSessionsSpawnSheetProviderLoadErrorZh providerLoadError = _TranslationsSessionsSpawnSheetProviderLoadErrorZh._(_root);
 	@override late final _TranslationsSessionsSpawnSheetClaudeAccountZh claudeAccount = _TranslationsSessionsSpawnSheetClaudeAccountZh._(_root);
+}
+
+// Path: mcp.errorPrefix
+class _TranslationsMcpErrorPrefixZh extends TranslationsMcpErrorPrefixEn {
+	_TranslationsMcpErrorPrefixZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get delete => '删除失败';
+	@override String get add => '添加失败';
+	@override String get update => '更新失败';
+	@override String get toggle => '切换失败';
+}
+
+// Path: mcp.editor
+class _TranslationsMcpEditorZh extends TranslationsMcpEditorEn {
+	_TranslationsMcpEditorZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get nameHint => 'my-mcp-server';
+	@override String get jsonHint => 'JSON 配置 — name、transport: stdio、command、args…';
+}
+
+// Path: mcp.secret
+class _TranslationsMcpSecretZh extends TranslationsMcpSecretEn {
+	_TranslationsMcpSecretZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get keyLabel => '键';
+	@override String get keyHint => 'GITHUB_TOKEN、OPENAI_KEY、…';
+	@override String get valueLabel => '值';
+}
+
+// Path: providers.errorPrefix
+class _TranslationsProvidersErrorPrefixZh extends TranslationsProvidersErrorPrefixEn {
+	_TranslationsProvidersErrorPrefixZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get toggle => '切换失败';
+	@override String get rename => '重命名失败';
+	@override String get delete => '删除失败';
+}
+
+// Path: providers.accounts
+class _TranslationsProvidersAccountsZh extends TranslationsProvidersAccountsEn {
+	_TranslationsProvidersAccountsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get rename => '重命名';
+	@override String renameTitle({required Object name}) => '重命名 ${name}';
+	@override String get displayNameLabel => '显示名';
+	@override String get displayNameHint => '工作账号';
+	@override String get deleteTitle => '删除账号？';
+	@override String importFailedApi({required Object error}) => '导入失败：${error}';
+	@override String importFailedGeneric({required Object error}) => '导入失败：${error}';
 }
 
 // Path: memory.deleteAllConfirm
@@ -1137,6 +1278,67 @@ extension on TranslationsZh {
 			'sessions.spawnSheet.claudeAccount.noTokenSuffix' => '（无令牌）',
 			'sessions.spawnSheet.claudeAccount.noneHint' => '未配置 Claude 账号 — 网关将使用系统的 ANTHROPIC_API_KEY。在 Web 管理端的「设置 → 账号」中添加账号。',
 			'sessions.spawnSheet.claudeAccount.errorHint' => ({required Object error}) => '无法加载 Claude 账号（${error}）。会话将以网关默认配置启动。',
+			'mcp.title' => 'MCP',
+			'mcp.newServer' => '新建服务器',
+			'mcp.addSecret' => '添加密钥',
+			'mcp.editConfig' => '编辑配置',
+			'mcp.viewRawConfig' => '查看原始配置',
+			'mcp.copyId' => '复制 ID',
+			'mcp.copiedSnack' => ({required Object id}) => '已复制 ${id}',
+			'mcp.deleteServerTitle' => '删除 MCP 服务器？',
+			'mcp.deleteSecretTitle' => '删除密钥？',
+			'mcp.errorPrefix.delete' => '删除失败',
+			'mcp.errorPrefix.add' => '添加失败',
+			'mcp.errorPrefix.update' => '更新失败',
+			'mcp.errorPrefix.toggle' => '切换失败',
+			'mcp.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}：${error}',
+			'mcp.editor.nameHint' => 'my-mcp-server',
+			'mcp.editor.jsonHint' => 'JSON 配置 — name、transport: stdio、command、args…',
+			'mcp.secret.keyLabel' => '键',
+			'mcp.secret.keyHint' => 'GITHUB_TOKEN、OPENAI_KEY、…',
+			'mcp.secret.valueLabel' => '值',
+			'providers.title' => '提供商',
+			'providers.configSaved' => '提供商配置已更新。',
+			'providers.saveFailedApi' => ({required Object error}) => '保存失败：${error}',
+			'providers.saveFailedGeneric' => ({required Object error}) => '保存失败：${error}',
+			'providers.reload' => '重新加载',
+			'providers.errorPrefix.toggle' => '切换失败',
+			'providers.errorPrefix.rename' => '重命名失败',
+			'providers.errorPrefix.delete' => '删除失败',
+			'providers.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}：${error}',
+			'providers.accounts.rename' => '重命名',
+			'providers.accounts.renameTitle' => ({required Object name}) => '重命名 ${name}',
+			'providers.accounts.displayNameLabel' => '显示名',
+			'providers.accounts.displayNameHint' => '工作账号',
+			'providers.accounts.deleteTitle' => '删除账号？',
+			'providers.accounts.importFailedApi' => ({required Object error}) => '导入失败：${error}',
+			'providers.accounts.importFailedGeneric' => ({required Object error}) => '导入失败：${error}',
+			'integrations.title' => '集成',
+			'integrations.register' => '注册',
+			'integrations.registerDialogTitle' => '注册集成',
+			'integrations.edit' => '编辑',
+			'integrations.editTitle' => ({required Object name}) => '编辑 ${name}',
+			'integrations.enabledLabel' => '已启用',
+			'integrations.iSavedIt' => '我已保存',
+			'integrations.apiKeyForName' => ({required Object name}) => '${name} 的 API key',
+			'integrations.apiKeySubtitleRegister' => ({required Object routePrefix}) => '将其交给集成方，使其能够通过 /api/v1/${routePrefix}/… 进行认证。',
+			'integrations.copiedRequestId' => ({required Object id}) => '已复制 request_id ${id}',
+			'integrations.updateOk' => '集成已更新。',
+			'integrations.registerFailedApi' => ({required Object error}) => '注册失败：${error}',
+			'integrations.registerFailedGeneric' => ({required Object error}) => '注册失败：${error}',
+			'integrations.updateFailedApi' => ({required Object error}) => '更新失败：${error}',
+			'integrations.updateFailedGeneric' => ({required Object error}) => '更新失败：${error}',
+			'integrations.deleteTitle' => '删除集成？',
+			'integrations.deletedSnack' => ({required Object name}) => '已删除 ${name}。',
+			'integrations.deleteFailedApi' => ({required Object error}) => '删除失败：${error}',
+			'integrations.deleteFailedGeneric' => ({required Object error}) => '删除失败：${error}',
+			'integrations.rotateKey' => '轮换密钥',
+			'integrations.rotateConfirmTitle' => '轮换 API key？',
+			'integrations.rotate' => '轮换',
+			'integrations.newApiKeyTitle' => ({required Object name}) => '${name} 的新 API key',
+			'integrations.newApiKeySubtitle' => '将其交给集成方。旧密钥已失效。',
+			'integrations.rotateFailedApi' => ({required Object error}) => '轮换失败：${error}',
+			'integrations.rotateFailedGeneric' => ({required Object error}) => '轮换失败：${error}',
 			'memory.title' => '记忆',
 			'memory.more' => '更多',
 			'memory.workers' => '记忆工作器',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -40,6 +40,7 @@ class TranslationsZh extends Translations with BaseTranslations<AppLocale, Trans
 
 	// Translations
 	@override late final _TranslationsCommonZh common = _TranslationsCommonZh._(_root);
+	@override late final _TranslationsAuthZh auth = _TranslationsAuthZh._(_root);
 	@override late final _TranslationsSettingsZh settings = _TranslationsSettingsZh._(_root);
 }
 
@@ -59,6 +60,22 @@ class _TranslationsCommonZh extends TranslationsCommonEn {
 	@override String get done => '完成';
 	@override String get close => '关闭';
 	@override String get retry => '重试';
+}
+
+// Path: auth
+class _TranslationsAuthZh extends TranslationsAuthEn {
+	_TranslationsAuthZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get signInTitle => '登录';
+	@override String get changeServer => '更换';
+	@override String get username => '用户名';
+	@override String get password => '密码';
+	@override String get signIn => '登录';
+	@override String get errorRequired => '请输入用户名和密码';
+	@override String errorGeneric({required Object error}) => '登录失败：${error}';
 }
 
 // Path: settings
@@ -148,6 +165,13 @@ extension on TranslationsZh {
 			'common.done' => '完成',
 			'common.close' => '关闭',
 			'common.retry' => '重试',
+			'auth.signInTitle' => '登录',
+			'auth.changeServer' => '更换',
+			'auth.username' => '用户名',
+			'auth.password' => '密码',
+			'auth.signIn' => '登录',
+			'auth.errorRequired' => '请输入用户名和密码',
+			'auth.errorGeneric' => ({required Object error}) => '登录失败：${error}',
 			'settings.title' => '设置',
 			'settings.language.section' => '语言',
 			'settings.language.system' => '跟随系统',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -41,6 +41,9 @@ class TranslationsZh extends Translations with BaseTranslations<AppLocale, Trans
 	// Translations
 	@override late final _TranslationsCommonZh common = _TranslationsCommonZh._(_root);
 	@override late final _TranslationsAuthZh auth = _TranslationsAuthZh._(_root);
+	@override late final _TranslationsNavZh nav = _TranslationsNavZh._(_root);
+	@override late final _TranslationsMoreZh more = _TranslationsMoreZh._(_root);
+	@override late final _TranslationsAboutZh about = _TranslationsAboutZh._(_root);
 	@override late final _TranslationsSettingsZh settings = _TranslationsSettingsZh._(_root);
 }
 
@@ -78,6 +81,50 @@ class _TranslationsAuthZh extends TranslationsAuthEn {
 	@override String errorGeneric({required Object error}) => '登录失败：${error}';
 }
 
+// Path: nav
+class _TranslationsNavZh extends TranslationsNavEn {
+	_TranslationsNavZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get sessions => '会话';
+	@override String get memory => '记忆';
+	@override String get notes => '笔记';
+	@override String get more => '更多';
+}
+
+// Path: more
+class _TranslationsMoreZh extends TranslationsMoreEn {
+	_TranslationsMoreZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '更多';
+	@override late final _TranslationsMoreIdentityZh identity = _TranslationsMoreIdentityZh._(_root);
+	@override late final _TranslationsMoreSectionsZh sections = _TranslationsMoreSectionsZh._(_root);
+	@override late final _TranslationsMoreItemsZh items = _TranslationsMoreItemsZh._(_root);
+	@override String get signOut => '退出登录';
+}
+
+// Path: about
+class _TranslationsAboutZh extends TranslationsAboutEn {
+	_TranslationsAboutZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '关于';
+	@override String get loading => '加载中…';
+	@override late final _TranslationsAboutSectionsZh sections = _TranslationsAboutSectionsZh._(_root);
+	@override late final _TranslationsAboutFieldsZh fields = _TranslationsAboutFieldsZh._(_root);
+	@override String copied({required Object label}) => '已复制 ${label}';
+	@override String get copyTooltip => '复制';
+	@override late final _TranslationsAboutCopyLabelsZh copyLabels = _TranslationsAboutCopyLabelsZh._(_root);
+	@override String get tagline => 'opendray mobile — 多 CLI 网关控制。\n源码：github.com/Opendray/opendray_v2';
+}
+
 // Path: settings
 class _TranslationsSettingsZh extends TranslationsSettingsEn {
 	_TranslationsSettingsZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -90,6 +137,89 @@ class _TranslationsSettingsZh extends TranslationsSettingsEn {
 	@override late final _TranslationsSettingsAppearanceZh appearance = _TranslationsSettingsAppearanceZh._(_root);
 	@override late final _TranslationsSettingsAccountZh account = _TranslationsSettingsAccountZh._(_root);
 	@override late final _TranslationsSettingsGatewayZh gateway = _TranslationsSettingsGatewayZh._(_root);
+}
+
+// Path: more.identity
+class _TranslationsMoreIdentityZh extends TranslationsMoreIdentityEn {
+	_TranslationsMoreIdentityZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get signedInAs => '登录账号';
+	@override String get server => '服务器';
+	@override String get tokenExpires => '令牌到期';
+}
+
+// Path: more.sections
+class _TranslationsMoreSectionsZh extends TranslationsMoreSectionsEn {
+	_TranslationsMoreSectionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get gateway => '网关';
+	@override String get memory => '记忆';
+	@override String get system => '系统';
+}
+
+// Path: more.items
+class _TranslationsMoreItemsZh extends TranslationsMoreItemsEn {
+	_TranslationsMoreItemsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsMoreItemsIntegrationsZh integrations = _TranslationsMoreItemsIntegrationsZh._(_root);
+	@override late final _TranslationsMoreItemsChannelsZh channels = _TranslationsMoreItemsChannelsZh._(_root);
+	@override late final _TranslationsMoreItemsProvidersZh providers = _TranslationsMoreItemsProvidersZh._(_root);
+	@override late final _TranslationsMoreItemsMcpZh mcp = _TranslationsMoreItemsMcpZh._(_root);
+	@override late final _TranslationsMoreItemsSkillsZh skills = _TranslationsMoreItemsSkillsZh._(_root);
+	@override late final _TranslationsMoreItemsGitHostsZh gitHosts = _TranslationsMoreItemsGitHostsZh._(_root);
+	@override late final _TranslationsMoreItemsCustomTasksZh customTasks = _TranslationsMoreItemsCustomTasksZh._(_root);
+	@override late final _TranslationsMoreItemsProjectMemoryZh projectMemory = _TranslationsMoreItemsProjectMemoryZh._(_root);
+	@override late final _TranslationsMoreItemsCleanupInboxZh cleanupInbox = _TranslationsMoreItemsCleanupInboxZh._(_root);
+	@override late final _TranslationsMoreItemsBackupsZh backups = _TranslationsMoreItemsBackupsZh._(_root);
+	@override late final _TranslationsMoreItemsSettingsZh settings = _TranslationsMoreItemsSettingsZh._(_root);
+	@override late final _TranslationsMoreItemsAboutZh about = _TranslationsMoreItemsAboutZh._(_root);
+}
+
+// Path: about.sections
+class _TranslationsAboutSectionsZh extends TranslationsAboutSectionsEn {
+	_TranslationsAboutSectionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get app => '应用';
+	@override String get server => '服务器';
+}
+
+// Path: about.fields
+class _TranslationsAboutFieldsZh extends TranslationsAboutFieldsEn {
+	_TranslationsAboutFieldsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get app => '应用';
+	@override String get version => '版本';
+	@override String versionFormat({required Object version, required Object build}) => '${version}（build ${build}）';
+	@override String get package => '包名';
+	@override String get url => 'URL';
+	@override String get signedInAs => '登录账号';
+	@override String get tokenExpires => '令牌到期';
+}
+
+// Path: about.copyLabels
+class _TranslationsAboutCopyLabelsZh extends TranslationsAboutCopyLabelsEn {
+	_TranslationsAboutCopyLabelsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get version => '版本';
+	@override String get serverUrl => '服务器 URL';
 }
 
 // Path: settings.language
@@ -148,6 +278,138 @@ class _TranslationsSettingsGatewayZh extends TranslationsSettingsGatewayEn {
 	@override String get liveLogsSubtitle => '查看网关实时日志 — 与 Web 管理端同源';
 }
 
+// Path: more.items.integrations
+class _TranslationsMoreItemsIntegrationsZh extends TranslationsMoreItemsIntegrationsEn {
+	_TranslationsMoreItemsIntegrationsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '集成';
+	@override String get subtitle => 'API 调用方 — 近期活动与错误率';
+}
+
+// Path: more.items.channels
+class _TranslationsMoreItemsChannelsZh extends TranslationsMoreItemsChannelsEn {
+	_TranslationsMoreItemsChannelsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '通道';
+	@override String get subtitle => '通知目的地';
+}
+
+// Path: more.items.providers
+class _TranslationsMoreItemsProvidersZh extends TranslationsMoreItemsProvidersEn {
+	_TranslationsMoreItemsProvidersZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '提供商';
+	@override String get subtitle => 'Claude / Codex / Gemini CLI 状态';
+}
+
+// Path: more.items.mcp
+class _TranslationsMoreItemsMcpZh extends TranslationsMoreItemsMcpEn {
+	_TranslationsMoreItemsMcpZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'MCP';
+	@override String get subtitle => 'Model Context Protocol 服务与密钥';
+}
+
+// Path: more.items.skills
+class _TranslationsMoreItemsSkillsZh extends TranslationsMoreItemsSkillsEn {
+	_TranslationsMoreItemsSkillsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '技能';
+	@override String get subtitle => 'Agent SKILL.md 库（内置 + 库）';
+}
+
+// Path: more.items.gitHosts
+class _TranslationsMoreItemsGitHostsZh extends TranslationsMoreItemsGitHostsEn {
+	_TranslationsMoreItemsGitHostsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Git 主机';
+	@override String get subtitle => 'GitHub / GitLab 等的 PAT 凭据';
+}
+
+// Path: more.items.customTasks
+class _TranslationsMoreItemsCustomTasksZh extends TranslationsMoreItemsCustomTasksEn {
+	_TranslationsMoreItemsCustomTasksZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '自定义任务';
+	@override String get subtitle => '会话任务选择器中显示的斜杠命令';
+}
+
+// Path: more.items.projectMemory
+class _TranslationsMoreItemsProjectMemoryZh extends TranslationsMoreItemsProjectMemoryEn {
+	_TranslationsMoreItemsProjectMemoryZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '项目目标 / 计划 / 日志';
+	@override String get subtitle => '按 cwd 的记忆层 2-4 + 代理提案';
+}
+
+// Path: more.items.cleanupInbox
+class _TranslationsMoreItemsCleanupInboxZh extends TranslationsMoreItemsCleanupInboxEn {
+	_TranslationsMoreItemsCleanupInboxZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '清理收件箱';
+	@override String get subtitle => '跨项目的 LLM 提议删除 / 合并';
+}
+
+// Path: more.items.backups
+class _TranslationsMoreItemsBackupsZh extends TranslationsMoreItemsBackupsEn {
+	_TranslationsMoreItemsBackupsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '备份';
+	@override String get subtitle => '最新备份状态与立即运行';
+}
+
+// Path: more.items.settings
+class _TranslationsMoreItemsSettingsZh extends TranslationsMoreItemsSettingsEn {
+	_TranslationsMoreItemsSettingsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '设置';
+	@override String get subtitle => '语言、外观、账户';
+}
+
+// Path: more.items.about
+class _TranslationsMoreItemsAboutZh extends TranslationsMoreItemsAboutEn {
+	_TranslationsMoreItemsAboutZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '关于';
+	@override String get subtitle => '构建版本与服务器信息';
+}
+
 /// The flat map containing all translations for locale <zh>.
 /// Only for edge cases! For simple maps, use the map function of this library.
 ///
@@ -172,6 +434,58 @@ extension on TranslationsZh {
 			'auth.signIn' => '登录',
 			'auth.errorRequired' => '请输入用户名和密码',
 			'auth.errorGeneric' => ({required Object error}) => '登录失败：${error}',
+			'nav.sessions' => '会话',
+			'nav.memory' => '记忆',
+			'nav.notes' => '笔记',
+			'nav.more' => '更多',
+			'more.title' => '更多',
+			'more.identity.signedInAs' => '登录账号',
+			'more.identity.server' => '服务器',
+			'more.identity.tokenExpires' => '令牌到期',
+			'more.sections.gateway' => '网关',
+			'more.sections.memory' => '记忆',
+			'more.sections.system' => '系统',
+			'more.items.integrations.title' => '集成',
+			'more.items.integrations.subtitle' => 'API 调用方 — 近期活动与错误率',
+			'more.items.channels.title' => '通道',
+			'more.items.channels.subtitle' => '通知目的地',
+			'more.items.providers.title' => '提供商',
+			'more.items.providers.subtitle' => 'Claude / Codex / Gemini CLI 状态',
+			'more.items.mcp.title' => 'MCP',
+			'more.items.mcp.subtitle' => 'Model Context Protocol 服务与密钥',
+			'more.items.skills.title' => '技能',
+			'more.items.skills.subtitle' => 'Agent SKILL.md 库（内置 + 库）',
+			'more.items.gitHosts.title' => 'Git 主机',
+			'more.items.gitHosts.subtitle' => 'GitHub / GitLab 等的 PAT 凭据',
+			'more.items.customTasks.title' => '自定义任务',
+			'more.items.customTasks.subtitle' => '会话任务选择器中显示的斜杠命令',
+			'more.items.projectMemory.title' => '项目目标 / 计划 / 日志',
+			'more.items.projectMemory.subtitle' => '按 cwd 的记忆层 2-4 + 代理提案',
+			'more.items.cleanupInbox.title' => '清理收件箱',
+			'more.items.cleanupInbox.subtitle' => '跨项目的 LLM 提议删除 / 合并',
+			'more.items.backups.title' => '备份',
+			'more.items.backups.subtitle' => '最新备份状态与立即运行',
+			'more.items.settings.title' => '设置',
+			'more.items.settings.subtitle' => '语言、外观、账户',
+			'more.items.about.title' => '关于',
+			'more.items.about.subtitle' => '构建版本与服务器信息',
+			'more.signOut' => '退出登录',
+			'about.title' => '关于',
+			'about.loading' => '加载中…',
+			'about.sections.app' => '应用',
+			'about.sections.server' => '服务器',
+			'about.fields.app' => '应用',
+			'about.fields.version' => '版本',
+			'about.fields.versionFormat' => ({required Object version, required Object build}) => '${version}（build ${build}）',
+			'about.fields.package' => '包名',
+			'about.fields.url' => 'URL',
+			'about.fields.signedInAs' => '登录账号',
+			'about.fields.tokenExpires' => '令牌到期',
+			'about.copied' => ({required Object label}) => '已复制 ${label}',
+			'about.copyTooltip' => '复制',
+			'about.copyLabels.version' => '版本',
+			'about.copyLabels.serverUrl' => '服务器 URL',
+			'about.tagline' => 'opendray mobile — 多 CLI 网关控制。\n源码：github.com/Opendray/opendray_v2',
 			'settings.title' => '设置',
 			'settings.language.section' => '语言',
 			'settings.language.system' => '跟随系统',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -125,6 +125,8 @@ class _TranslationsSessionsZh extends TranslationsSessionsEn {
 	@override late final _TranslationsSessionsEmptyZh empty = _TranslationsSessionsEmptyZh._(_root);
 	@override String get errorTitle => '加载会话失败';
 	@override late final _TranslationsSessionsRelativeZh relative = _TranslationsSessionsRelativeZh._(_root);
+	@override late final _TranslationsSessionsDetailZh detail = _TranslationsSessionsDetailZh._(_root);
+	@override late final _TranslationsSessionsTerminalZh terminal = _TranslationsSessionsTerminalZh._(_root);
 	@override late final _TranslationsSessionsActionZh action = _TranslationsSessionsActionZh._(_root);
 	@override late final _TranslationsSessionsDirPickerZh dirPicker = _TranslationsSessionsDirPickerZh._(_root);
 	@override late final _TranslationsSessionsSpawnSheetZh spawnSheet = _TranslationsSessionsSpawnSheetZh._(_root);
@@ -253,6 +255,37 @@ class _TranslationsSessionsRelativeZh extends TranslationsSessionsRelativeEn {
 	@override String minutesAgo({required Object n}) => '${n} 分钟前';
 	@override String hoursAgo({required Object n}) => '${n} 小时前';
 	@override String daysAgo({required Object n}) => '${n} 天前';
+}
+
+// Path: sessions.detail
+class _TranslationsSessionsDetailZh extends TranslationsSessionsDetailEn {
+	_TranslationsSessionsDetailZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get fallbackTitle => '会话';
+	@override String get refreshMetadata => '刷新元数据';
+	@override String get inspector => '检查器（文件 / Git / 任务 / 历史 / 笔记）';
+	@override String get projectMemory => '项目记忆（目标 / 计划 / 日志 / 收件箱）';
+	@override String get actions => '操作';
+	@override String started({required Object when}) => '${when} 启动';
+	@override String startedEnded({required Object started, required Object ended}) => '${started} 启动  ·  ${ended} 结束';
+	@override String idPrefix({required Object id}) => 'id: ${id}';
+	@override String get errorTitle => '加载会话失败';
+}
+
+// Path: sessions.terminal
+class _TranslationsSessionsTerminalZh extends TranslationsSessionsTerminalEn {
+	_TranslationsSessionsTerminalZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsSessionsTerminalSnackbarZh snackbar = _TranslationsSessionsTerminalSnackbarZh._(_root);
+	@override late final _TranslationsSessionsTerminalImageSourceZh imageSource = _TranslationsSessionsTerminalImageSourceZh._(_root);
+	@override late final _TranslationsSessionsTerminalKeyboardZh keyboard = _TranslationsSessionsTerminalKeyboardZh._(_root);
+	@override late final _TranslationsSessionsTerminalConnectionZh connection = _TranslationsSessionsTerminalConnectionZh._(_root);
 }
 
 // Path: sessions.action
@@ -546,6 +579,59 @@ class _TranslationsMoreItemsAboutZh extends TranslationsMoreItemsAboutEn {
 	@override String get subtitle => '构建版本与服务器信息';
 }
 
+// Path: sessions.terminal.snackbar
+class _TranslationsSessionsTerminalSnackbarZh extends TranslationsSessionsTerminalSnackbarEn {
+	_TranslationsSessionsTerminalSnackbarZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String imagePickerFailed({required Object error}) => '图片选择失败：${error}';
+	@override String get uploadingImage => '正在上传图片…';
+	@override String imageAttached({required Object path}) => '已附加图片：${path}';
+	@override String uploadFailed({required Object status, required Object message}) => '上传失败（${status}）：${message}';
+	@override String uploadFailedGeneric({required Object error}) => '上传失败：${error}';
+}
+
+// Path: sessions.terminal.imageSource
+class _TranslationsSessionsTerminalImageSourceZh extends TranslationsSessionsTerminalImageSourceEn {
+	_TranslationsSessionsTerminalImageSourceZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get photoLibrary => '相册';
+	@override String get takePhoto => '拍照';
+}
+
+// Path: sessions.terminal.keyboard
+class _TranslationsSessionsTerminalKeyboardZh extends TranslationsSessionsTerminalKeyboardEn {
+	_TranslationsSessionsTerminalKeyboardZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get copyBuffer => '复制缓冲';
+	@override String get paste => '粘贴';
+	@override String get attachImage => '附加图片';
+}
+
+// Path: sessions.terminal.connection
+class _TranslationsSessionsTerminalConnectionZh extends TranslationsSessionsTerminalConnectionEn {
+	_TranslationsSessionsTerminalConnectionZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get connecting => '连接中…';
+	@override String get connected => '已连接';
+	@override String get reconnecting => '重连中…';
+	@override String reconnectingWithError({required Object error}) => '重连中（${error}）…';
+	@override String get disconnected => '已断开';
+	@override String disconnectedWithError({required Object error}) => '已断开（${error}）';
+	@override String get ended => '会话已结束';
+}
+
 // Path: sessions.action.errors
 class _TranslationsSessionsActionErrorsZh extends TranslationsSessionsActionErrorsEn {
 	_TranslationsSessionsActionErrorsZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -704,6 +790,32 @@ extension on TranslationsZh {
 			'sessions.relative.minutesAgo' => ({required Object n}) => '${n} 分钟前',
 			'sessions.relative.hoursAgo' => ({required Object n}) => '${n} 小时前',
 			'sessions.relative.daysAgo' => ({required Object n}) => '${n} 天前',
+			'sessions.detail.fallbackTitle' => '会话',
+			'sessions.detail.refreshMetadata' => '刷新元数据',
+			'sessions.detail.inspector' => '检查器（文件 / Git / 任务 / 历史 / 笔记）',
+			'sessions.detail.projectMemory' => '项目记忆（目标 / 计划 / 日志 / 收件箱）',
+			'sessions.detail.actions' => '操作',
+			'sessions.detail.started' => ({required Object when}) => '${when} 启动',
+			'sessions.detail.startedEnded' => ({required Object started, required Object ended}) => '${started} 启动  ·  ${ended} 结束',
+			'sessions.detail.idPrefix' => ({required Object id}) => 'id: ${id}',
+			'sessions.detail.errorTitle' => '加载会话失败',
+			'sessions.terminal.snackbar.imagePickerFailed' => ({required Object error}) => '图片选择失败：${error}',
+			'sessions.terminal.snackbar.uploadingImage' => '正在上传图片…',
+			'sessions.terminal.snackbar.imageAttached' => ({required Object path}) => '已附加图片：${path}',
+			'sessions.terminal.snackbar.uploadFailed' => ({required Object status, required Object message}) => '上传失败（${status}）：${message}',
+			'sessions.terminal.snackbar.uploadFailedGeneric' => ({required Object error}) => '上传失败：${error}',
+			'sessions.terminal.imageSource.photoLibrary' => '相册',
+			'sessions.terminal.imageSource.takePhoto' => '拍照',
+			'sessions.terminal.keyboard.copyBuffer' => '复制缓冲',
+			'sessions.terminal.keyboard.paste' => '粘贴',
+			'sessions.terminal.keyboard.attachImage' => '附加图片',
+			'sessions.terminal.connection.connecting' => '连接中…',
+			'sessions.terminal.connection.connected' => '已连接',
+			'sessions.terminal.connection.reconnecting' => '重连中…',
+			'sessions.terminal.connection.reconnectingWithError' => ({required Object error}) => '重连中（${error}）…',
+			'sessions.terminal.connection.disconnected' => '已断开',
+			'sessions.terminal.connection.disconnectedWithError' => ({required Object error}) => '已断开（${error}）',
+			'sessions.terminal.connection.ended' => '会话已结束',
 			'sessions.action.stop' => '停止',
 			'sessions.action.stopping' => '停止中…',
 			'sessions.action.stopDescription' => '发送 SIGTERM，保留历史',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -43,6 +43,7 @@ class TranslationsZh extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsAuthZh auth = _TranslationsAuthZh._(_root);
 	@override late final _TranslationsNavZh nav = _TranslationsNavZh._(_root);
 	@override late final _TranslationsMoreZh more = _TranslationsMoreZh._(_root);
+	@override late final _TranslationsSessionsZh sessions = _TranslationsSessionsZh._(_root);
 	@override late final _TranslationsAboutZh about = _TranslationsAboutZh._(_root);
 	@override late final _TranslationsSettingsZh settings = _TranslationsSettingsZh._(_root);
 }
@@ -106,6 +107,24 @@ class _TranslationsMoreZh extends TranslationsMoreEn {
 	@override late final _TranslationsMoreSectionsZh sections = _TranslationsMoreSectionsZh._(_root);
 	@override late final _TranslationsMoreItemsZh items = _TranslationsMoreItemsZh._(_root);
 	@override String get signOut => '退出登录';
+}
+
+// Path: sessions
+class _TranslationsSessionsZh extends TranslationsSessionsEn {
+	_TranslationsSessionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '会话';
+	@override String get refresh => '刷新';
+	@override String get actions => '操作';
+	@override String get spawn => '创建';
+	@override late final _TranslationsSessionsFiltersZh filters = _TranslationsSessionsFiltersZh._(_root);
+	@override late final _TranslationsSessionsCardZh card = _TranslationsSessionsCardZh._(_root);
+	@override late final _TranslationsSessionsEmptyZh empty = _TranslationsSessionsEmptyZh._(_root);
+	@override String get errorTitle => '加载会话失败';
+	@override late final _TranslationsSessionsRelativeZh relative = _TranslationsSessionsRelativeZh._(_root);
 }
 
 // Path: about
@@ -182,6 +201,55 @@ class _TranslationsMoreItemsZh extends TranslationsMoreItemsEn {
 	@override late final _TranslationsMoreItemsBackupsZh backups = _TranslationsMoreItemsBackupsZh._(_root);
 	@override late final _TranslationsMoreItemsSettingsZh settings = _TranslationsMoreItemsSettingsZh._(_root);
 	@override late final _TranslationsMoreItemsAboutZh about = _TranslationsMoreItemsAboutZh._(_root);
+}
+
+// Path: sessions.filters
+class _TranslationsSessionsFiltersZh extends TranslationsSessionsFiltersEn {
+	_TranslationsSessionsFiltersZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get all => '全部';
+	@override String get running => '运行中';
+	@override String get idle => '空闲';
+	@override String get ended => '已结束';
+}
+
+// Path: sessions.card
+class _TranslationsSessionsCardZh extends TranslationsSessionsCardEn {
+	_TranslationsSessionsCardZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String startedRelative({required Object provider, required Object when}) => '${provider} · ${when}启动';
+}
+
+// Path: sessions.empty
+class _TranslationsSessionsEmptyZh extends TranslationsSessionsEmptyEn {
+	_TranslationsSessionsEmptyZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get titleAll => '暂无会话';
+	@override String titleFiltered({required Object filter}) => '没有匹配「${filter}」筛选的会话。';
+	@override String get subtitleAll => '点击「创建」按钮新建一个。';
+	@override String get subtitleFiltered => '试试其他筛选条件或下拉刷新。';
+}
+
+// Path: sessions.relative
+class _TranslationsSessionsRelativeZh extends TranslationsSessionsRelativeEn {
+	_TranslationsSessionsRelativeZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String secondsAgo({required Object n}) => '${n} 秒前';
+	@override String minutesAgo({required Object n}) => '${n} 分钟前';
+	@override String hoursAgo({required Object n}) => '${n} 小时前';
+	@override String daysAgo({required Object n}) => '${n} 天前';
 }
 
 // Path: about.sections
@@ -470,6 +538,24 @@ extension on TranslationsZh {
 			'more.items.about.title' => '关于',
 			'more.items.about.subtitle' => '构建版本与服务器信息',
 			'more.signOut' => '退出登录',
+			'sessions.title' => '会话',
+			'sessions.refresh' => '刷新',
+			'sessions.actions' => '操作',
+			'sessions.spawn' => '创建',
+			'sessions.filters.all' => '全部',
+			'sessions.filters.running' => '运行中',
+			'sessions.filters.idle' => '空闲',
+			'sessions.filters.ended' => '已结束',
+			'sessions.card.startedRelative' => ({required Object provider, required Object when}) => '${provider} · ${when}启动',
+			'sessions.empty.titleAll' => '暂无会话',
+			'sessions.empty.titleFiltered' => ({required Object filter}) => '没有匹配「${filter}」筛选的会话。',
+			'sessions.empty.subtitleAll' => '点击「创建」按钮新建一个。',
+			'sessions.empty.subtitleFiltered' => '试试其他筛选条件或下拉刷新。',
+			'sessions.errorTitle' => '加载会话失败',
+			'sessions.relative.secondsAgo' => ({required Object n}) => '${n} 秒前',
+			'sessions.relative.minutesAgo' => ({required Object n}) => '${n} 分钟前',
+			'sessions.relative.hoursAgo' => ({required Object n}) => '${n} 小时前',
+			'sessions.relative.daysAgo' => ({required Object n}) => '${n} 天前',
 			'about.title' => '关于',
 			'about.loading' => '加载中…',
 			'about.sections.app' => '应用',

--- a/app/mobile/lib/core/locale/locale_controller.dart
+++ b/app/mobile/lib/core/locale/locale_controller.dart
@@ -1,0 +1,75 @@
+// LocaleController — single source of truth for the user's language
+// pick. Mirrors ThemeController: persists to shared_preferences so
+// the choice survives restarts, broadcasts via Riverpod so
+// MaterialApp.router rebuilds whenever the value flips.
+//
+// Three states (System / English / Chinese) decouple "what the user
+// asked for" from "what slang ended up using" — useful because the
+// system locale can be anything and slang resolves it via fallback.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+enum LocalePreference { system, english, chinese }
+
+const _prefsKey = 'opendray.locale.preference.v1';
+
+class LocaleController extends StateNotifier<LocalePreference> {
+  LocaleController() : super(LocalePreference.system) {
+    _restore();
+  }
+
+  Future<void> _restore() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final parsed = _parse(prefs.getString(_prefsKey));
+      if (parsed != null && parsed != state) {
+        state = parsed;
+      }
+      _apply(state);
+    } on Object {
+      _apply(state);
+    }
+  }
+
+  Future<void> setPreference(LocalePreference pref) async {
+    state = pref;
+    _apply(pref);
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_prefsKey, _serialise(pref));
+    } on Object {
+      // Best-effort persistence; in-memory pick still works.
+    }
+  }
+
+  static void _apply(LocalePreference pref) {
+    switch (pref) {
+      case LocalePreference.system:
+        LocaleSettings.useDeviceLocale();
+      case LocalePreference.english:
+        LocaleSettings.setLocale(AppLocale.en);
+      case LocalePreference.chinese:
+        LocaleSettings.setLocale(AppLocale.zh);
+    }
+  }
+
+  static String _serialise(LocalePreference pref) => switch (pref) {
+        LocalePreference.system => 'system',
+        LocalePreference.english => 'english',
+        LocalePreference.chinese => 'chinese',
+      };
+
+  static LocalePreference? _parse(String? raw) => switch (raw) {
+        'system' => LocalePreference.system,
+        'english' => LocalePreference.english,
+        'chinese' => LocalePreference.chinese,
+        _ => null,
+      };
+}
+
+final localeControllerProvider =
+    StateNotifierProvider<LocaleController, LocalePreference>(
+  (ref) => LocaleController(),
+);

--- a/app/mobile/lib/features/auth/login_screen.dart
+++ b/app/mobile/lib/features/auth/login_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/auth_api.dart';
 import 'package:opendray/core/auth/auth_state.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 
 // Username + password login. Calls /api/v1/auth/mobile-login which
 // returns a token with mobile_token_ttl (default 30 days, vs the
@@ -34,7 +35,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     final username = _userCtrl.text.trim();
     final password = _passCtrl.text;
     if (username.isEmpty || password.isEmpty) {
-      setState(() => _error = 'Username and password are required');
+      setState(() => _error = t.auth.errorRequired);
       return;
     }
     setState(() {
@@ -56,7 +57,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     } on ApiException catch (e) {
       setState(() => _error = e.message);
     } on Object catch (e) {
-      setState(() => _error = 'Login failed: $e');
+      setState(() => _error = t.auth.errorGeneric(error: e.toString()));
     } finally {
       if (mounted) setState(() => _busy = false);
     }
@@ -81,7 +82,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               Text(
-                'Sign in',
+                t.auth.signInTitle,
                 style: Theme.of(context).textTheme.headlineMedium?.copyWith(
                       fontWeight: FontWeight.w700,
                     ),
@@ -98,7 +99,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                   ),
                   TextButton(
                     onPressed: _busy ? null : _changeServer,
-                    child: const Text('Change'),
+                    child: Text(t.auth.changeServer),
                   ),
                 ],
               ),
@@ -108,7 +109,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                 autocorrect: false,
                 textCapitalization: TextCapitalization.none,
                 textInputAction: TextInputAction.next,
-                decoration: const InputDecoration(labelText: 'Username'),
+                decoration: InputDecoration(labelText: t.auth.username),
               ),
               const SizedBox(height: 16),
               TextField(
@@ -118,7 +119,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                 textInputAction: TextInputAction.go,
                 onSubmitted: (_) => _submit(),
                 decoration: InputDecoration(
-                  labelText: 'Password',
+                  labelText: t.auth.password,
                   suffixIcon: IconButton(
                     icon: Icon(
                       _obscurePass
@@ -164,7 +165,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                         width: 18,
                         child: CircularProgressIndicator(strokeWidth: 2),
                       )
-                    : const Text('Sign in'),
+                    : Text(t.auth.signIn),
               ),
             ],
           ),

--- a/app/mobile/lib/features/home/home_shell.dart
+++ b/app/mobile/lib/features/home/home_shell.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/memory/memory_screen.dart';
 import 'package:opendray/features/more/more_screen.dart';
 import 'package:opendray/features/notes/notes_screen.dart';
@@ -27,13 +28,6 @@ class HomeShell extends ConsumerStatefulWidget {
 class _HomeShellState extends ConsumerState<HomeShell> {
   int _index = 0;
 
-  static const _tabs = <_TabSpec>[
-    _TabSpec(icon: Icons.terminal_outlined, label: 'Sessions'),
-    _TabSpec(icon: Icons.psychology_outlined, label: 'Memory'),
-    _TabSpec(icon: Icons.description_outlined, label: 'Notes'),
-    _TabSpec(icon: Icons.more_horiz, label: 'More'),
-  ];
-
   @override
   Widget build(BuildContext context) {
     const pages = [
@@ -42,6 +36,12 @@ class _HomeShellState extends ConsumerState<HomeShell> {
       NotesScreen(),
       MoreScreen(),
     ];
+    final tabs = <_TabSpec>[
+      _TabSpec(icon: Icons.terminal_outlined, label: t.nav.sessions),
+      _TabSpec(icon: Icons.psychology_outlined, label: t.nav.memory),
+      _TabSpec(icon: Icons.description_outlined, label: t.nav.notes),
+      _TabSpec(icon: Icons.more_horiz, label: t.nav.more),
+    ];
 
     return Scaffold(
       body: IndexedStack(index: _index, children: pages),
@@ -49,8 +49,8 @@ class _HomeShellState extends ConsumerState<HomeShell> {
         currentIndex: _index,
         onTap: (i) => setState(() => _index = i),
         items: [
-          for (final t in _tabs)
-            BottomNavigationBarItem(icon: Icon(t.icon), label: t.label),
+          for (final tab in tabs)
+            BottomNavigationBarItem(icon: Icon(tab.icon), label: tab.label),
         ],
       ),
     );

--- a/app/mobile/lib/features/integrations/integration_detail_screen.dart
+++ b/app/mobile/lib/features/integrations/integration_detail_screen.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart';
 
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/integrations_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/integrations/integration_forms.dart';
 
 // Per-integration detail: header card with the registration metadata
@@ -129,7 +130,7 @@ class _IntegrationDetailScreenState
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text('Copied request_id $id'),
+        content: Text(t.integrations.copiedRequestId(id: id)),
         duration: const Duration(seconds: 2),
         behavior: SnackBarBehavior.floating,
       ),
@@ -152,9 +153,9 @@ class _IntegrationDetailScreenState
           );
       if (!mounted) return;
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Integration updated.'),
-          duration: Duration(seconds: 2),
+        SnackBar(
+          content: Text(t.integrations.updateOk),
+          duration: const Duration(seconds: 2),
           behavior: SnackBarBehavior.floating,
         ),
       );
@@ -162,11 +163,19 @@ class _IntegrationDetailScreenState
     } on ApiException catch (e) {
       if (!mounted) return;
       messenger.showSnackBar(
-        SnackBar(content: Text('Update failed: ${e.message}')),
+        SnackBar(
+          content: Text(t.integrations.updateFailedApi(error: e.message)),
+        ),
       );
     } on Object catch (e) {
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text('Update failed: $e')));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.integrations.updateFailedGeneric(error: e.toString()),
+          ),
+        ),
+      );
     }
   }
 
@@ -176,7 +185,7 @@ class _IntegrationDetailScreenState
     final ok = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: const Text('Delete integration?'),
+        title: Text(t.integrations.deleteTitle),
         content: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -202,14 +211,14 @@ class _IntegrationDetailScreenState
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('Cancel'),
+            child: Text(t.common.cancel),
           ),
           FilledButton(
             style: FilledButton.styleFrom(
               backgroundColor: Theme.of(ctx).colorScheme.error,
             ),
             onPressed: () => Navigator.of(ctx).pop(true),
-            child: const Text('Delete'),
+            child: Text(t.common.delete),
           ),
         ],
       ),
@@ -222,7 +231,7 @@ class _IntegrationDetailScreenState
       if (!mounted) return;
       messenger.showSnackBar(
         SnackBar(
-          content: Text('Deleted ${i.name}.'),
+          content: Text(t.integrations.deletedSnack(name: i.name)),
           duration: const Duration(seconds: 2),
           behavior: SnackBarBehavior.floating,
         ),
@@ -231,11 +240,19 @@ class _IntegrationDetailScreenState
     } on ApiException catch (e) {
       if (!mounted) return;
       messenger.showSnackBar(
-        SnackBar(content: Text('Delete failed: ${e.message}')),
+        SnackBar(
+          content: Text(t.integrations.deleteFailedApi(error: e.message)),
+        ),
       );
     } on Object catch (e) {
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text('Delete failed: $e')));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.integrations.deleteFailedGeneric(error: e.toString()),
+          ),
+        ),
+      );
     }
   }
 
@@ -245,7 +262,7 @@ class _IntegrationDetailScreenState
     final ok = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: const Text('Rotate API key?'),
+        title: Text(t.integrations.rotateConfirmTitle),
         content: Text(
           'Generates a new API key for ${i.name} and immediately '
           'invalidates the previous one. Any caller still holding '
@@ -256,11 +273,11 @@ class _IntegrationDetailScreenState
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('Cancel'),
+            child: Text(t.common.cancel),
           ),
           FilledButton(
             onPressed: () => Navigator.of(ctx).pop(true),
-            child: const Text('Rotate'),
+            child: Text(t.integrations.rotate),
           ),
         ],
       ),
@@ -273,20 +290,27 @@ class _IntegrationDetailScreenState
       await RevealApiKeyDialog.show(
         context: context,
         apiKey: result.apiKey,
-        title: 'New API key for ${i.name}',
-        subtitle: 'Hand this to the integration. The previous key '
-            'has just been invalidated.',
+        title: t.integrations.newApiKeyTitle(name: i.name),
+        subtitle: t.integrations.newApiKeySubtitle,
       );
       if (!mounted) return;
       await _loadDetail();
     } on ApiException catch (e) {
       if (!mounted) return;
       messenger.showSnackBar(
-        SnackBar(content: Text('Rotate failed: ${e.message}')),
+        SnackBar(
+          content: Text(t.integrations.rotateFailedApi(error: e.message)),
+        ),
       );
     } on Object catch (e) {
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text('Rotate failed: $e')));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.integrations.rotateFailedGeneric(error: e.toString()),
+          ),
+        ),
+      );
     }
   }
 
@@ -300,7 +324,7 @@ class _IntegrationDetailScreenState
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),
-            tooltip: 'Refresh',
+            tooltip: t.sessions.inspector.shared.refresh,
             onPressed: _loadingCalls ? null : _loadAll,
           ),
           PopupMenuButton<_DetailAction>(
@@ -317,27 +341,28 @@ class _IntegrationDetailScreenState
               }
             },
             itemBuilder: (_) => [
-              const PopupMenuItem(
+              PopupMenuItem(
                 value: _DetailAction.edit,
                 child: ListTile(
-                  leading: Icon(Icons.edit_outlined),
-                  title: Text('Edit'),
+                  leading: const Icon(Icons.edit_outlined),
+                  title: Text(t.integrations.edit),
                 ),
               ),
-              const PopupMenuItem(
+              PopupMenuItem(
                 value: _DetailAction.rotateKey,
                 child: ListTile(
-                  leading: Icon(Icons.vpn_key_outlined),
-                  title: Text('Rotate key'),
+                  leading: const Icon(Icons.vpn_key_outlined),
+                  title: Text(t.integrations.rotateKey),
                 ),
               ),
-              const PopupMenuItem(
+              PopupMenuItem(
                 value: _DetailAction.delete,
                 child: ListTile(
-                  leading: Icon(Icons.delete_outline, color: Colors.redAccent),
+                  leading: const Icon(Icons.delete_outline,
+                      color: Colors.redAccent),
                   title: Text(
-                    'Delete',
-                    style: TextStyle(color: Colors.redAccent),
+                    t.common.delete,
+                    style: const TextStyle(color: Colors.redAccent),
                   ),
                 ),
               ),
@@ -803,7 +828,7 @@ class _InlineError extends StatelessWidget {
               style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(height: 12),
-            FilledButton(onPressed: onRetry, child: const Text('Retry')),
+            FilledButton(onPressed: onRetry, child: Text(t.common.retry)),
           ],
         ),
       ),

--- a/app/mobile/lib/features/integrations/integration_forms.dart
+++ b/app/mobile/lib/features/integrations/integration_forms.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:opendray/core/api/integrations_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 
 // Form pages and small read-only dialogs shared by the Integrations
 // screens. Multi-field forms (register / edit) are full-screen pages
@@ -79,11 +80,11 @@ class _RegisterIntegrationScreenState
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Register integration'),
+        title: Text(t.integrations.registerDialogTitle),
         actions: [
           TextButton(
             onPressed: _submit,
-            child: const Text('Register'),
+            child: Text(t.integrations.register),
           ),
         ],
       ),
@@ -226,11 +227,11 @@ class _EditIntegrationScreenState extends State<EditIntegrationScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Edit ${widget.current.name}'),
+        title: Text(t.integrations.editTitle(name: widget.current.name)),
         actions: [
           TextButton(
             onPressed: _submit,
-            child: const Text('Save'),
+            child: Text(t.common.save),
           ),
         ],
       ),
@@ -254,7 +255,7 @@ class _EditIntegrationScreenState extends State<EditIntegrationScreen> {
           const SizedBox(height: 8),
           SwitchListTile(
             contentPadding: EdgeInsets.zero,
-            title: const Text('Enabled'),
+            title: Text(t.integrations.enabledLabel),
             value: _enabled,
             onChanged: (v) => setState(() => _enabled = v),
           ),
@@ -396,7 +397,7 @@ class _RevealApiKeyDialogState extends State<RevealApiKeyDialog> {
         ),
         FilledButton(
           onPressed: _copied ? () => Navigator.of(context).pop() : null,
-          child: const Text("I've saved it"),
+          child: Text(t.integrations.iSavedIt),
         ),
       ],
     );

--- a/app/mobile/lib/features/integrations/integrations_screen.dart
+++ b/app/mobile/lib/features/integrations/integrations_screen.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/integrations_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/integrations/integration_detail_screen.dart';
 import 'package:opendray/features/integrations/integration_forms.dart';
 
@@ -73,20 +74,29 @@ class _IntegrationsScreenState extends ConsumerState<IntegrationsScreen> {
       await RevealApiKeyDialog.show(
         context: context,
         apiKey: result.apiKey,
-        title: 'API key for ${result.integration.name}',
-        subtitle: 'Hand this to the integration so it can authenticate '
-            'against /api/v1/${result.integration.routePrefix}/...',
+        title: t.integrations.apiKeyForName(name: result.integration.name),
+        subtitle: t.integrations.apiKeySubtitleRegister(
+          routePrefix: result.integration.routePrefix,
+        ),
       );
       if (!mounted) return;
       await _load();
     } on ApiException catch (e) {
       if (!mounted) return;
       messenger.showSnackBar(
-        SnackBar(content: Text('Register failed: ${e.message}')),
+        SnackBar(
+          content: Text(t.integrations.registerFailedApi(error: e.message)),
+        ),
       );
     } on Object catch (e) {
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text('Register failed: $e')));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.integrations.registerFailedGeneric(error: e.toString()),
+          ),
+        ),
+      );
     }
   }
 
@@ -94,11 +104,11 @@ class _IntegrationsScreenState extends ConsumerState<IntegrationsScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Integrations'),
+        title: Text(t.integrations.title),
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),
-            tooltip: 'Refresh',
+            tooltip: t.sessions.inspector.shared.refresh,
             onPressed: _state is AsyncLoading ? null : _load,
           ),
         ],
@@ -111,7 +121,7 @@ class _IntegrationsScreenState extends ConsumerState<IntegrationsScreen> {
       floatingActionButton: FloatingActionButton.extended(
         onPressed: _onRegister,
         icon: const Icon(Icons.add),
-        label: const Text('Register'),
+        label: Text(t.integrations.register),
       ),
     );
   }
@@ -330,7 +340,7 @@ class _ErrorView extends StatelessWidget {
               style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(height: 16),
-            FilledButton(onPressed: onRetry, child: const Text('Retry')),
+            FilledButton(onPressed: onRetry, child: Text(t.common.retry)),
           ],
         ),
       ),

--- a/app/mobile/lib/features/mcp/mcp_editor_screen.dart
+++ b/app/mobile/lib/features/mcp/mcp_editor_screen.dart
@@ -16,6 +16,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/mcp_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 
 class McpEditorScreen extends ConsumerStatefulWidget {
   const McpEditorScreen({super.key, this.existing});
@@ -164,7 +165,7 @@ class _McpEditorScreenState extends ConsumerState<McpEditorScreen> {
               autocorrect: false,
               textCapitalization: TextCapitalization.none,
               decoration: InputDecoration(
-                hintText: 'my-mcp-server',
+                hintText: t.mcp.editor.nameHint,
                 helperText: _isEdit
                     ? 'Locked in edit mode — delete + recreate to change.'
                     : null,
@@ -184,8 +185,8 @@ class _McpEditorScreenState extends ConsumerState<McpEditorScreen> {
               maxLines: 18,
               minLines: 10,
               keyboardType: TextInputType.multiline,
-              decoration: const InputDecoration(
-                hintText: '{ "name": ..., "transport": "stdio", ... }',
+              decoration: InputDecoration(
+                hintText: t.mcp.editor.jsonHint,
               ),
               style: const TextStyle(
                 fontFamily: 'monospace',
@@ -230,7 +231,7 @@ class _McpEditorScreenState extends ConsumerState<McpEditorScreen> {
                     onPressed: _submitting
                         ? null
                         : () => Navigator.of(context).pop(false),
-                    child: const Text('Cancel'),
+                    child: Text(t.common.cancel),
                   ),
                 ),
                 const SizedBox(width: 12),

--- a/app/mobile/lib/features/mcp/mcp_screen.dart
+++ b/app/mobile/lib/features/mcp/mcp_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/mcp_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/mcp/mcp_editor_screen.dart';
 
 // Two-section MCP control surface for mobile.
@@ -85,11 +86,21 @@ class _McpScreenState extends ConsumerState<McpScreen> {
     } on ApiException catch (e) {
       if (!mounted) return;
       messenger.showSnackBar(
-        SnackBar(content: Text('$failPrefix: ${e.message}')),
+        SnackBar(
+          content: Text(
+            t.mcp.errorWithMessage(prefix: failPrefix, error: e.message),
+          ),
+        ),
       );
     } on Object catch (e) {
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text('$failPrefix: $e')));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.mcp.errorWithMessage(prefix: failPrefix, error: e.toString()),
+          ),
+        ),
+      );
     } finally {
       if (mounted) setState(() => _busy.remove(key));
     }
@@ -130,7 +141,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
             const Divider(height: 1),
             ListTile(
               leading: const Icon(Icons.edit_outlined),
-              title: const Text('Edit config'),
+              title: Text(t.mcp.editConfig),
               subtitle: const Text(
                 'Full JSON editor — vault-backed servers only',
                 style: TextStyle(fontSize: 11),
@@ -139,7 +150,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
             ),
             ListTile(
               leading: const Icon(Icons.code),
-              title: const Text('View raw config'),
+              title: Text(t.mcp.viewRawConfig),
               subtitle: const Text(
                 'Read-only inspector for the server JSON',
                 style: TextStyle(fontSize: 11),
@@ -149,7 +160,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
             ),
             ListTile(
               leading: const Icon(Icons.copy_outlined),
-              title: const Text('Copy id'),
+              title: Text(t.mcp.copyId),
               onTap: () => Navigator.of(sheetCtx).pop(_ServerAction.copyId),
             ),
             const Divider(height: 1),
@@ -180,7 +191,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('Copied ${s.id}'),
+            content: Text(t.mcp.copiedSnack(id: s.id)),
             duration: const Duration(seconds: 2),
             behavior: SnackBarBehavior.floating,
           ),
@@ -279,7 +290,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
         actions: [
           FilledButton(
             onPressed: () => Navigator.of(ctx).pop(),
-            child: const Text('Close'),
+            child: Text(t.common.close),
           ),
         ],
       ),
@@ -290,7 +301,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
     final ok = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: const Text('Delete MCP server?'),
+        title: Text(t.mcp.deleteServerTitle),
         content: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -316,14 +327,14 @@ class _McpScreenState extends ConsumerState<McpScreen> {
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('Cancel'),
+            child: Text(t.common.cancel),
           ),
           FilledButton(
             style: FilledButton.styleFrom(
               backgroundColor: Theme.of(ctx).colorScheme.error,
             ),
             onPressed: () => Navigator.of(ctx).pop(true),
-            child: const Text('Delete'),
+            child: Text(t.common.delete),
           ),
         ],
       ),
@@ -332,7 +343,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
     await _runOp(
       key: 's:${s.id}',
       okMsg: 'Deleted ${s.id}.',
-      failPrefix: 'Delete failed',
+      failPrefix: t.mcp.errorPrefix.delete,
       op: () => ref.read(mcpApiProvider).delete(s.id),
     );
   }
@@ -350,7 +361,9 @@ class _McpScreenState extends ConsumerState<McpScreen> {
       okMsg: existingKey == null
           ? 'Secret ${res.key} added.'
           : 'Secret ${res.key} updated.',
-      failPrefix: existingKey == null ? 'Add failed' : 'Update failed',
+      failPrefix: existingKey == null
+          ? t.mcp.errorPrefix.add
+          : t.mcp.errorPrefix.update,
       op: () => ref
           .read(mcpApiProvider)
           .secretsSet(res.key, res.value)
@@ -362,7 +375,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
     final ok = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: const Text('Delete secret?'),
+        title: Text(t.mcp.deleteSecretTitle),
         content: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -386,14 +399,14 @@ class _McpScreenState extends ConsumerState<McpScreen> {
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('Cancel'),
+            child: Text(t.common.cancel),
           ),
           FilledButton(
             style: FilledButton.styleFrom(
               backgroundColor: Theme.of(ctx).colorScheme.error,
             ),
             onPressed: () => Navigator.of(ctx).pop(true),
-            child: const Text('Delete'),
+            child: Text(t.common.delete),
           ),
         ],
       ),
@@ -402,7 +415,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
     await _runOp(
       key: 'k:$key',
       okMsg: 'Deleted $key.',
-      failPrefix: 'Delete failed',
+      failPrefix: t.mcp.errorPrefix.delete,
       op: () => ref.read(mcpApiProvider).secretsDelete(key),
     );
   }
@@ -411,11 +424,11 @@ class _McpScreenState extends ConsumerState<McpScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('MCP'),
+        title: Text(t.mcp.title),
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),
-            tooltip: 'Refresh',
+            tooltip: t.sessions.inspector.shared.refresh,
             onPressed: _state is AsyncLoading ? null : _load,
           ),
         ],
@@ -428,7 +441,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
       floatingActionButton: FloatingActionButton.extended(
         onPressed: _openEditor,
         icon: const Icon(Icons.add),
-        label: const Text('New server'),
+        label: Text(t.mcp.newServer),
       ),
     );
   }
@@ -455,7 +468,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
                 onToggle: (next) => _runOp(
                   key: 's:${s.id}',
                   okMsg: next ? '${s.name} enabled.' : '${s.name} disabled.',
-                  failPrefix: 'Toggle failed',
+                  failPrefix: t.mcp.errorPrefix.toggle,
                   op: () => ref
                       .read(mcpApiProvider)
                       .setEnabled(s.id, enabled: next),
@@ -487,7 +500,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
             padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
             child: OutlinedButton.icon(
               icon: const Icon(Icons.add, size: 16),
-              label: const Text('Add secret'),
+              label: Text(t.mcp.addSecret),
               // Lambda needed because _setSecret returns Future<void>
               // — VoidCallback expects () -> void.
               // ignore: unnecessary_lambdas
@@ -716,7 +729,7 @@ class _SecretTile extends StatelessWidget {
                 Icons.delete_outline,
                 color: Theme.of(context).colorScheme.error,
               ),
-              tooltip: 'Delete',
+              tooltip: t.common.delete,
               onPressed: onDelete,
             ),
     );
@@ -775,7 +788,7 @@ class _ErrorView extends StatelessWidget {
               style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(height: 16),
-            FilledButton(onPressed: onRetry, child: const Text('Retry')),
+            FilledButton(onPressed: onRetry, child: Text(t.common.retry)),
           ],
         ),
       ),
@@ -864,14 +877,14 @@ class _SecretFormScreenState extends State<_SecretFormScreen> {
             autofocus: !isReplace,
             autocorrect: false,
             enabled: !isReplace,
-            decoration: const InputDecoration(
-              labelText: 'Key',
-              hintText: 'GITHUB_TOKEN, OPENAI_KEY, …',
+            decoration: InputDecoration(
+              labelText: t.mcp.secret.keyLabel,
+              hintText: t.mcp.secret.keyHint,
               helperText:
                   'Shell-env-var rules: starts with a letter or _, '
                   'rest letters/digits/_.',
               helperMaxLines: 2,
-              border: OutlineInputBorder(),
+              border: const OutlineInputBorder(),
             ),
           ),
           const SizedBox(height: 12),
@@ -884,7 +897,7 @@ class _SecretFormScreenState extends State<_SecretFormScreen> {
             // multiline is forbidden by Flutter, and a single-line
             // capped field would truncate certificate blobs.
             decoration: InputDecoration(
-              labelText: 'Value',
+              labelText: t.mcp.secret.valueLabel,
               hintText: isReplace
                   ? 'Paste new value (the previous one is wiped)'
                   : 'Paste secret value',

--- a/app/mobile/lib/features/memory/memory_screen.dart
+++ b/app/mobile/lib/features/memory/memory_screen.dart
@@ -8,6 +8,7 @@ import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/memory_api.dart';
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/project_docs_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/memory_workers/memory_workers_screen.dart';
 import 'package:opendray/features/project/project_screen.dart';
 import 'package:path/path.dart' as p;
@@ -238,7 +239,7 @@ class _MemoryScreenState extends ConsumerState<MemoryScreen>
     }
     return PopupMenuButton<String>(
       icon: const Icon(Icons.more_vert),
-      tooltip: 'More',
+      tooltip: t.memory.more,
       onSelected: (v) {
         if (v == 'wipe') _confirmAndWipe();
       },
@@ -276,7 +277,7 @@ class _MemoryScreenState extends ConsumerState<MemoryScreen>
     final ok = await showDialog<bool>(
       context: context,
       builder: (dialogCtx) => AlertDialog(
-        title: const Text('Delete every memory in this scope?'),
+        title: Text(t.memory.deleteAllConfirm.title),
         content: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -306,14 +307,14 @@ class _MemoryScreenState extends ConsumerState<MemoryScreen>
         actions: [
           TextButton(
             onPressed: () => Navigator.of(dialogCtx).pop(false),
-            child: const Text('Cancel'),
+            child: Text(t.common.cancel),
           ),
           FilledButton(
             style: FilledButton.styleFrom(
               backgroundColor: Theme.of(dialogCtx).colorScheme.error,
             ),
             onPressed: () => Navigator.of(dialogCtx).pop(true),
-            child: const Text('Delete all'),
+            child: Text(t.memory.deleteAllConfirm.deleteAll),
           ),
         ],
       ),
@@ -328,7 +329,11 @@ class _MemoryScreenState extends ConsumerState<MemoryScreen>
       if (!mounted) return;
       messenger.showSnackBar(
         SnackBar(
-          content: Text('Deleted $deleted memory ${deleted == 1 ? 'item' : 'items'}'),
+          content: Text(
+            deleted == 1
+                ? t.memory.deletedSnackOne(n: deleted.toString())
+                : t.memory.deletedSnackOther(n: deleted.toString()),
+          ),
           behavior: SnackBarBehavior.floating,
         ),
       );
@@ -341,11 +346,11 @@ class _MemoryScreenState extends ConsumerState<MemoryScreen>
       }
     } on ApiException catch (e) {
       messenger.showSnackBar(
-        SnackBar(content: Text('Bulk delete failed: ${e.message}')),
+        SnackBar(content: Text(t.memory.bulkDeleteFailedApi(error: e.message))),
       );
     } on Object catch (e) {
       messenger.showSnackBar(
-        SnackBar(content: Text('Bulk delete failed: $e')),
+        SnackBar(content: Text(t.memory.bulkDeleteFailedGeneric(error: e.toString()))),
       );
     }
   }
@@ -373,11 +378,11 @@ class _MemoryScreenState extends ConsumerState<MemoryScreen>
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Memory'),
+        title: Text(t.memory.title),
         actions: [
           IconButton(
             icon: const Icon(Icons.tune),
-            tooltip: 'Memory workers',
+            tooltip: t.memory.workers,
             onPressed: () {
               Navigator.of(context).push(
                 MaterialPageRoute<void>(
@@ -403,7 +408,7 @@ class _MemoryScreenState extends ConsumerState<MemoryScreen>
       floatingActionButton: FloatingActionButton.extended(
         onPressed: _newMemory,
         icon: const Icon(Icons.add),
-        label: const Text('New'),
+        label: Text(t.memory.kNew),
       ),
     );
   }
@@ -444,7 +449,7 @@ class _MemoryScreenState extends ConsumerState<MemoryScreen>
             controller: _projectSearch,
             onChanged: _onProjectQueryChanged,
             decoration: InputDecoration(
-              hintText: 'Search…',
+              hintText: t.memory.searchHint,
               prefixIcon: const Icon(Icons.search, size: 18),
               isDense: true,
               suffixIcon: _projectQuery.isEmpty
@@ -483,7 +488,7 @@ class _MemoryScreenState extends ConsumerState<MemoryScreen>
             controller: _globalSearch,
             onChanged: _onGlobalQueryChanged,
             decoration: InputDecoration(
-              hintText: 'Search…',
+              hintText: t.memory.searchHint,
               prefixIcon: const Icon(Icons.search, size: 18),
               isDense: true,
               suffixIcon: _globalQuery.isEmpty
@@ -558,7 +563,7 @@ class _ProjectSelector extends StatelessWidget {
         borderRadius: BorderRadius.circular(10),
         child: InputDecorator(
           decoration: InputDecoration(
-            labelText: 'Project',
+            labelText: t.memory.projectLabel,
             // The picker is always pre-selected at first project, so
             // there is always a value below the label — no need to
             // suppress hintText. Adding an explicit suffixIcon makes
@@ -735,9 +740,9 @@ class _ProjectPickerSheetState extends State<_ProjectPickerSheet> {
                   controller: _searchCtrl,
                   autofocus: true,
                   onChanged: (v) => setState(() => _query = v),
-                  decoration: const InputDecoration(
-                    hintText: 'Filter by name or path…',
-                    prefixIcon: Icon(Icons.search, size: 18),
+                  decoration: InputDecoration(
+                    hintText: t.memory.filterHint,
+                    prefixIcon: const Icon(Icons.search, size: 18),
                     isDense: true,
                   ),
                 ),
@@ -1053,7 +1058,7 @@ class _ErrorStrip extends StatelessWidget {
               style: Theme.of(context).textTheme.bodySmall,
             ),
           ),
-          TextButton(onPressed: onRetry, child: const Text('Retry')),
+          TextButton(onPressed: onRetry, child: Text(t.common.retry)),
         ],
       ),
     );
@@ -1119,7 +1124,7 @@ class _ErrorView extends StatelessWidget {
             const SizedBox(height: 16),
             FilledButton(
               onPressed: onRetry,
-              child: const Text('Retry'),
+              child: Text(t.common.retry),
             ),
           ],
         ),
@@ -1218,8 +1223,8 @@ class _MemoryDetailSheetState extends ConsumerState<_MemoryDetailSheet> {
     final ok = await showDialog<bool>(
       context: context,
       builder: (dialogCtx) => AlertDialog(
-        title: const Text('Delete memory?'),
-        content: const Text('This cannot be undone.'),
+        title: Text(t.memory.deleteOne.title),
+        content: Text(t.memory.deleteOne.body),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(dialogCtx).pop(false),
@@ -1265,9 +1270,9 @@ class _MemoryDetailSheetState extends ConsumerState<_MemoryDetailSheet> {
     await Clipboard.setData(ClipboardData(text: widget.memory.text));
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text('Copied'),
-        duration: Duration(seconds: 2),
+      SnackBar(
+        content: Text(t.memory.copied),
+        duration: const Duration(seconds: 2),
         behavior: SnackBarBehavior.floating,
       ),
     );
@@ -1311,7 +1316,7 @@ class _MemoryDetailSheetState extends ConsumerState<_MemoryDetailSheet> {
                     ),
                   IconButton(
                     icon: const Icon(Icons.copy, size: 18),
-                    tooltip: 'Copy text',
+                    tooltip: t.memory.copyTooltip,
                     onPressed: _busy ? null : _copyText,
                   ),
                   IconButton(
@@ -1376,7 +1381,7 @@ class _MemoryDetailSheetState extends ConsumerState<_MemoryDetailSheet> {
                                 width: 16,
                                 child: CircularProgressIndicator(strokeWidth: 2),
                               )
-                            : const Text('Save'),
+                            : Text(t.common.save),
                       ),
                     )
                   else
@@ -1393,7 +1398,7 @@ class _MemoryDetailSheetState extends ConsumerState<_MemoryDetailSheet> {
                           ),
                         ),
                         icon: const Icon(Icons.delete_outline, size: 18),
-                        label: const Text('Delete'),
+                        label: Text(t.common.delete),
                       ),
                     ),
                 ],
@@ -1611,14 +1616,14 @@ class _NewMemorySheetState extends ConsumerState<_NewMemorySheet> {
               ),
               const SizedBox(height: 16),
               SegmentedButton<MemoryScope>(
-                segments: const [
+                segments: [
                   ButtonSegment(
                     value: MemoryScope.project,
-                    label: Text('Project'),
+                    label: Text(t.memory.scope.project),
                   ),
                   ButtonSegment(
                     value: MemoryScope.global,
-                    label: Text('Global'),
+                    label: Text(t.memory.scope.global),
                   ),
                 ],
                 selected: {_scope},
@@ -1642,7 +1647,7 @@ class _NewMemorySheetState extends ConsumerState<_NewMemorySheet> {
                 minLines: 5,
                 autofocus: true,
                 decoration: InputDecoration(
-                  labelText: 'Text',
+                  labelText: t.memory.create.textLabel,
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(8),
                   ),
@@ -1717,8 +1722,8 @@ class _ScopeKeyField extends StatelessWidget {
           focusNode: focusNode,
           autocorrect: false,
           decoration: InputDecoration(
-            labelText: 'Scope key (project cwd)',
-            hintText: '/Users/you/projects/foo',
+            labelText: t.memory.create.scopeKeyLabel,
+            hintText: t.memory.create.scopeKeyHint,
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(8),
             ),

--- a/app/mobile/lib/features/more/about_screen.dart
+++ b/app/mobile/lib/features/more/about_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:opendray/core/auth/auth_state.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 // Diagnostics screen for "what version is this and which server am
@@ -37,7 +38,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text('Copied $label'),
+        content: Text(t.about.copied(label: label)),
         duration: const Duration(seconds: 2),
         behavior: SnackBarBehavior.floating,
       ),
@@ -50,61 +51,64 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
     final loggedIn = auth is AuthLoggedIn ? auth : null;
     final info = _info;
     return Scaffold(
-      appBar: AppBar(title: const Text('About')),
+      appBar: AppBar(title: Text(t.about.title)),
       body: ListView(
         padding: const EdgeInsets.symmetric(vertical: 8),
         children: [
-          const _SectionHeader(label: 'App'),
+          _SectionHeader(label: t.about.sections.app),
           if (info == null)
-            const ListTile(
-              leading: SizedBox(
+            ListTile(
+              leading: const SizedBox(
                 width: 24,
                 height: 24,
                 child: CircularProgressIndicator(strokeWidth: 2),
               ),
-              title: Text('Loading…'),
+              title: Text(t.about.loading),
             )
           else ...[
             _kv(
               context,
-              label: 'App',
+              label: t.about.fields.app,
               value: info.appName,
             ),
             _kv(
               context,
-              label: 'Version',
-              value: '${info.version} (build ${info.buildNumber})',
+              label: t.about.fields.version,
+              value: t.about.fields.versionFormat(
+                version: info.version,
+                build: info.buildNumber,
+              ),
               mono: true,
               onCopy: () => _copy(
-                'version',
+                t.about.copyLabels.version,
                 '${info.version}+${info.buildNumber}',
               ),
             ),
             _kv(
               context,
-              label: 'Package',
+              label: t.about.fields.package,
               value: info.packageName,
               mono: true,
             ),
           ],
           const SizedBox(height: 8),
           if (loggedIn != null) ...[
-            const _SectionHeader(label: 'Server'),
+            _SectionHeader(label: t.about.sections.server),
             _kv(
               context,
-              label: 'URL',
+              label: t.about.fields.url,
               value: loggedIn.serverUrl,
               mono: true,
-              onCopy: () => _copy('server URL', loggedIn.serverUrl),
+              onCopy: () => _copy(t.about.copyLabels.serverUrl, loggedIn.serverUrl),
             ),
             _kv(
               context,
-              label: 'Signed in as',
+              label: t.about.fields.signedInAs,
               value: loggedIn.username,
             ),
             _kv(
               context,
-              label: 'Token expires',
+              label: t.about.fields.tokenExpires,
               value: DateFormat.yMMMd()
                   .add_Hms()
                   .format(loggedIn.expiresAt.toLocal()),
@@ -115,8 +119,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 24),
               child: Text(
-                'opendray mobile — multi-CLI gateway control.\n'
-                'Source: github.com/Opendray/opendray_v2',
+                t.about.tagline,
                 textAlign: TextAlign.center,
                 style: Theme.of(context).textTheme.bodySmall,
               ),
@@ -151,7 +154,7 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
           ? null
           : IconButton(
               icon: const Icon(Icons.copy_outlined, size: 18),
-              tooltip: 'Copy',
+              tooltip: t.about.copyTooltip,
               onPressed: onCopy,
             ),
       dense: true,

--- a/app/mobile/lib/features/more/more_screen.dart
+++ b/app/mobile/lib/features/more/more_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
 import 'package:opendray/core/auth/auth_state.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/backups/backups_screen.dart';
 import 'package:opendray/features/channels/channels_screen.dart';
 import 'package:opendray/features/custom_tasks/custom_tasks_screen.dart';
@@ -36,87 +37,86 @@ class MoreScreen extends ConsumerWidget {
       return const Scaffold(body: SizedBox.shrink());
     }
     return Scaffold(
-      appBar: AppBar(title: const Text('More')),
+      appBar: AppBar(title: Text(t.more.title)),
       body: ListView(
         children: [
           _IdentityCard(auth: auth),
           const SizedBox(height: 8),
-          const _SectionHeader(label: 'Gateway'),
+          _SectionHeader(label: t.more.sections.gateway),
           _MenuTile(
             icon: Icons.api_outlined,
-            title: 'Integrations',
-            subtitle: 'API callers — recent activity & error rates',
+            title: t.more.items.integrations.title,
+            subtitle: t.more.items.integrations.subtitle,
             onTap: () => _push(context, const IntegrationsScreen()),
           ),
           _MenuTile(
             icon: Icons.notifications_outlined,
-            title: 'Channels',
-            subtitle: 'Notification destinations',
+            title: t.more.items.channels.title,
+            subtitle: t.more.items.channels.subtitle,
             onTap: () => _push(context, const ChannelsScreen()),
           ),
           _MenuTile(
             icon: Icons.psychology_outlined,
-            title: 'Providers',
-            subtitle: 'Claude / Codex / Gemini CLI status',
+            title: t.more.items.providers.title,
+            subtitle: t.more.items.providers.subtitle,
             onTap: () => _push(context, const ProvidersScreen()),
           ),
           _MenuTile(
             icon: Icons.extension_outlined,
-            title: 'MCP',
-            subtitle: 'Model Context Protocol servers & secrets',
+            title: t.more.items.mcp.title,
+            subtitle: t.more.items.mcp.subtitle,
             onTap: () => _push(context, const McpScreen()),
           ),
           _MenuTile(
             icon: Icons.auto_awesome_outlined,
-            title: 'Skills',
-            subtitle: 'Agent SKILL.md library (built-in + vault)',
+            title: t.more.items.skills.title,
+            subtitle: t.more.items.skills.subtitle,
             onTap: () => _push(context, const SkillsScreen()),
           ),
           _MenuTile(
             icon: Icons.account_tree_outlined,
-            title: 'Git hosts',
-            subtitle: 'PAT credentials for GitHub / GitLab / etc.',
+            title: t.more.items.gitHosts.title,
+            subtitle: t.more.items.gitHosts.subtitle,
             onTap: () => _push(context, const GitHostsScreen()),
           ),
           _MenuTile(
             icon: Icons.terminal_outlined,
-            title: 'Custom tasks',
-            subtitle: 'Slash commands shown in the session task picker',
+            title: t.more.items.customTasks.title,
+            subtitle: t.more.items.customTasks.subtitle,
             onTap: () => _push(context, const CustomTasksScreen()),
           ),
           const SizedBox(height: 8),
-          const _SectionHeader(label: 'Memory'),
+          _SectionHeader(label: t.more.sections.memory),
           _MenuTile(
             icon: Icons.flag_outlined,
-            title: 'Project goal / plan / journal',
-            subtitle: 'Per-cwd memory layers 2-4 + agent proposals',
+            title: t.more.items.projectMemory.title,
+            subtitle: t.more.items.projectMemory.subtitle,
             onTap: () => _push(context, const ProjectScreen()),
           ),
           _MenuTile(
             icon: Icons.cleaning_services_outlined,
-            title: 'Cleanup inbox',
-            subtitle:
-                'LLM-proposed deletions / merges across all projects',
+            title: t.more.items.cleanupInbox.title,
+            subtitle: t.more.items.cleanupInbox.subtitle,
             onTap: () => _push(context, const CleanupInboxScreen()),
           ),
           const SizedBox(height: 8),
-          const _SectionHeader(label: 'System'),
+          _SectionHeader(label: t.more.sections.system),
           _MenuTile(
             icon: Icons.backup_outlined,
-            title: 'Backups',
-            subtitle: 'Latest backup status & run-now',
+            title: t.more.items.backups.title,
+            subtitle: t.more.items.backups.subtitle,
             onTap: () => _push(context, const BackupsScreen()),
           ),
           _MenuTile(
             icon: Icons.tune_outlined,
-            title: 'Settings',
-            subtitle: 'Appearance, account',
+            title: t.more.items.settings.title,
+            subtitle: t.more.items.settings.subtitle,
             onTap: () => _push(context, const SettingsScreen()),
           ),
           _MenuTile(
             icon: Icons.info_outline,
-            title: 'About',
-            subtitle: 'Build version & server info',
+            title: t.more.items.about.title,
+            subtitle: t.more.items.about.subtitle,
             onTap: () => _push(context, const AboutScreen()),
           ),
           const Divider(height: 32),
@@ -135,7 +135,7 @@ class MoreScreen extends ConsumerWidget {
               ),
               onPressed: () =>
                   ref.read(authControllerProvider.notifier).logout(),
-              child: const Text('Sign out'),
+              child: Text(t.more.signOut),
             ),
           ),
         ],
@@ -165,19 +165,19 @@ class _IdentityCard extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text('Signed in as', style: muted),
+              Text(t.more.identity.signedInAs, style: muted),
               Text(
                 auth.username,
                 style: Theme.of(context).textTheme.titleMedium,
               ),
               const SizedBox(height: 12),
-              Text('Server', style: muted),
+              Text(t.more.identity.server, style: muted),
               Text(
                 auth.serverUrl,
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
               const SizedBox(height: 12),
-              Text('Token expires', style: muted),
+              Text(t.more.identity.tokenExpires, style: muted),
               Text(
                 DateFormat.yMMMd().add_jm().format(auth.expiresAt.toLocal()),
                 style: Theme.of(context).textTheme.bodyMedium,

--- a/app/mobile/lib/features/providers/claude_account_dialogs.dart
+++ b/app/mobile/lib/features/providers/claude_account_dialogs.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:opendray/core/api/models.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 
 // Claude account UI dialogs. Account creation is gateway-host only
 // (run `claude login` with CLAUDE_CONFIG_DIR), so the only dialog
@@ -44,27 +45,29 @@ class _RenameClaudeAccountDialogState
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: Text('Rename ${widget.account.name}'),
+      title: Text(
+        t.providers.accounts.renameTitle(name: widget.account.name),
+      ),
       content: TextField(
         controller: _ctrl,
         autofocus: true,
         autocorrect: false,
         textInputAction: TextInputAction.done,
         onSubmitted: (v) => Navigator.of(context).pop(v.trim()),
-        decoration: const InputDecoration(
-          labelText: 'Display name',
-          hintText: 'Work account',
+        decoration: InputDecoration(
+          labelText: t.providers.accounts.displayNameLabel,
+          hintText: t.providers.accounts.displayNameHint,
           isDense: true,
         ),
       ),
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
-          child: const Text('Cancel'),
+          child: Text(t.common.cancel),
         ),
         FilledButton(
           onPressed: () => Navigator.of(context).pop(_ctrl.text.trim()),
-          child: const Text('Save'),
+          child: Text(t.common.save),
         ),
       ],
     );

--- a/app/mobile/lib/features/providers/claude_accounts_section.dart
+++ b/app/mobile/lib/features/providers/claude_accounts_section.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/claude_accounts_api.dart';
 import 'package:opendray/core/api/models.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/providers/claude_account_dialogs.dart'
     show RenameClaudeAccountDialog;
 
@@ -75,11 +76,22 @@ class _ClaudeAccountsSectionState
     } on ApiException catch (e) {
       if (!mounted) return;
       messenger.showSnackBar(
-        SnackBar(content: Text('$failPrefix: ${e.message}')),
+        SnackBar(
+          content: Text(
+            t.providers.errorWithMessage(prefix: failPrefix, error: e.message),
+          ),
+        ),
       );
     } on Object catch (e) {
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text('$failPrefix: $e')));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.providers
+                .errorWithMessage(prefix: failPrefix, error: e.toString()),
+          ),
+        ),
+      );
     } finally {
       if (mounted) setState(() => _busy.remove(key));
     }
@@ -126,7 +138,7 @@ class _ClaudeAccountsSectionState
             ),
             ListTile(
               leading: const Icon(Icons.drive_file_rename_outline),
-              title: const Text('Rename'),
+              title: Text(t.providers.accounts.rename),
               onTap: () => Navigator.of(sheetCtx).pop(_AccountAction.rename),
             ),
             const Divider(height: 1),
@@ -153,7 +165,7 @@ class _ClaudeAccountsSectionState
         await _runOp(
           key: 'a:${a.id}',
           okMsg: next ? '${a.displayName} enabled.' : '${a.displayName} disabled.',
-          failPrefix: 'Toggle failed',
+          failPrefix: t.providers.errorPrefix.toggle,
           op: () => ref
               .read(claudeAccountsApiProvider)
               .setEnabled(a.id, enabled: next),
@@ -164,7 +176,7 @@ class _ClaudeAccountsSectionState
         await _runOp(
           key: 'a:${a.id}',
           okMsg: 'Renamed to $next.',
-          failPrefix: 'Rename failed',
+          failPrefix: t.providers.errorPrefix.rename,
           op: () => ref
               .read(claudeAccountsApiProvider)
               .update(a.id, displayName: next),
@@ -173,7 +185,7 @@ class _ClaudeAccountsSectionState
         final ok = await showDialog<bool>(
           context: context,
           builder: (ctx) => AlertDialog(
-            title: const Text('Delete account?'),
+            title: Text(t.providers.accounts.deleteTitle),
             content: Column(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -194,14 +206,14 @@ class _ClaudeAccountsSectionState
             actions: [
               TextButton(
                 onPressed: () => Navigator.of(ctx).pop(false),
-                child: const Text('Cancel'),
+                child: Text(t.common.cancel),
               ),
               FilledButton(
                 style: FilledButton.styleFrom(
                   backgroundColor: Theme.of(ctx).colorScheme.error,
                 ),
                 onPressed: () => Navigator.of(ctx).pop(true),
-                child: const Text('Delete'),
+                child: Text(t.common.delete),
               ),
             ],
           ),
@@ -210,7 +222,7 @@ class _ClaudeAccountsSectionState
         await _runOp(
           key: 'a:${a.id}',
           okMsg: 'Deleted ${a.name}.',
-          failPrefix: 'Delete failed',
+          failPrefix: t.providers.errorPrefix.delete,
           op: () => ref.read(claudeAccountsApiProvider).delete(a.id),
         );
     }
@@ -237,11 +249,21 @@ class _ClaudeAccountsSectionState
     } on ApiException catch (e) {
       if (!mounted) return;
       messenger.showSnackBar(
-        SnackBar(content: Text('Import failed: ${e.message}')),
+        SnackBar(
+          content: Text(
+            t.providers.accounts.importFailedApi(error: e.message),
+          ),
+        ),
       );
     } on Object catch (e) {
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text('Import failed: $e')));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.providers.accounts.importFailedGeneric(error: e.toString()),
+          ),
+        ),
+      );
     } finally {
       if (mounted) setState(() => _busy.remove('import'));
     }
@@ -351,7 +373,7 @@ class _ClaudeAccountsSectionState
                 const SizedBox(height: 6),
                 OutlinedButton(
                   onPressed: _load,
-                  child: const Text('Retry'),
+                  child: Text(t.common.retry),
                 ),
               ],
             ),

--- a/app/mobile/lib/features/providers/provider_config_screen.dart
+++ b/app/mobile/lib/features/providers/provider_config_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/providers_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/providers/claude_accounts_section.dart';
 
 // Provider config editor — schema-driven so we don't carry per-
@@ -80,9 +81,9 @@ class _ProviderConfigScreenState
           .updateConfig(widget.providerId, _values);
       if (!mounted) return;
       messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Provider config updated.'),
-          duration: Duration(seconds: 2),
+        SnackBar(
+          content: Text(t.providers.configSaved),
+          duration: const Duration(seconds: 2),
           behavior: SnackBarBehavior.floating,
         ),
       );
@@ -90,11 +91,15 @@ class _ProviderConfigScreenState
     } on ApiException catch (e) {
       if (!mounted) return;
       messenger.showSnackBar(
-        SnackBar(content: Text('Save failed: ${e.message}')),
+        SnackBar(content: Text(t.providers.saveFailedApi(error: e.message))),
       );
     } on Object catch (e) {
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text('Save failed: $e')));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(t.providers.saveFailedGeneric(error: e.toString())),
+        ),
+      );
     } finally {
       if (mounted) setState(() => _saving = false);
     }
@@ -136,7 +141,7 @@ class _ProviderConfigScreenState
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),
-            tooltip: 'Reload',
+            tooltip: t.providers.reload,
             onPressed: _saving ? null : _load,
           ),
         ],
@@ -497,7 +502,7 @@ class _ErrorView extends StatelessWidget {
               style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(height: 16),
-            FilledButton(onPressed: onRetry, child: const Text('Retry')),
+            FilledButton(onPressed: onRetry, child: Text(t.common.retry)),
           ],
         ),
       ),

--- a/app/mobile/lib/features/providers/providers_screen.dart
+++ b/app/mobile/lib/features/providers/providers_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/providers_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/providers/provider_config_screen.dart';
 
 // Providers — list of CLI providers (Claude / Codex / Gemini / Shell).
@@ -73,12 +74,21 @@ class _ProvidersScreenState extends ConsumerState<ProvidersScreen> {
     } on ApiException catch (e) {
       if (!mounted) return;
       messenger.showSnackBar(
-        SnackBar(content: Text('$failPrefix: ${e.message}')),
+        SnackBar(
+          content: Text(
+            t.providers.errorWithMessage(prefix: failPrefix, error: e.message),
+          ),
+        ),
       );
     } on Object catch (e) {
       if (!mounted) return;
       messenger.showSnackBar(
-        SnackBar(content: Text('$failPrefix: $e')),
+        SnackBar(
+          content: Text(
+            t.providers
+                .errorWithMessage(prefix: failPrefix, error: e.toString()),
+          ),
+        ),
       );
     } finally {
       if (mounted) setState(() => _busy.remove(key));
@@ -89,11 +99,11 @@ class _ProvidersScreenState extends ConsumerState<ProvidersScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Providers'),
+        title: Text(t.providers.title),
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),
-            tooltip: 'Refresh',
+            tooltip: t.sessions.inspector.shared.refresh,
             onPressed: _state is AsyncLoading ? null : _load,
           ),
         ],
@@ -133,7 +143,7 @@ class _ProvidersScreenState extends ConsumerState<ProvidersScreen> {
               onToggle: (next) => _runToggle(
                 key: 'p:${p.id}',
                 okMsg: next ? '${p.name} enabled.' : '${p.name} disabled.',
-                failPrefix: 'Toggle failed',
+                failPrefix: t.providers.errorPrefix.toggle,
                 op: () => ref
                     .read(providersApiProvider)
                     .setEnabled(p.id, enabled: next),
@@ -268,7 +278,7 @@ class _ErrorView extends StatelessWidget {
               style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(height: 16),
-            FilledButton(onPressed: onRetry, child: const Text('Retry')),
+            FilledButton(onPressed: onRetry, child: Text(t.common.retry)),
           ],
         ),
       ),

--- a/app/mobile/lib/features/sessions/directory_picker_sheet.dart
+++ b/app/mobile/lib/features/sessions/directory_picker_sheet.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/fs_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 
 // Server-side directory picker. Renders a full-height bottom sheet
 // (90% screen) with a path bar, breadcrumb-style "up" affordance,
@@ -104,12 +105,16 @@ class _DirectoryPickerSheetState extends ConsumerState<DirectoryPickerSheet> {
       // Surface a confirm.
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Created $created')),
+        SnackBar(content: Text(t.sessions.dirPicker.createdSnack(path: created))),
       );
     } on ApiException catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('mkdir failed: ${e.message}')),
+        SnackBar(
+          content: Text(
+            t.sessions.dirPicker.mkdirFailedSnack(error: e.message),
+          ),
+        ),
       );
     }
   }
@@ -172,7 +177,7 @@ class _Body extends ConsumerWidget {
         child: Padding(
           padding: const EdgeInsets.all(32),
           child: Text(
-            'No subfolders here.\nPick this folder, or create a new one.',
+            t.sessions.dirPicker.empty,
             textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.bodyMedium,
           ),
@@ -224,7 +229,7 @@ class _Header extends StatelessWidget {
         children: [
           IconButton(
             icon: const Icon(Icons.arrow_upward),
-            tooltip: 'Parent',
+            tooltip: t.sessions.dirPicker.parent,
             onPressed: canGoUp ? onUp : null,
           ),
           Expanded(
@@ -240,12 +245,12 @@ class _Header extends StatelessWidget {
           ),
           IconButton(
             icon: const Icon(Icons.create_new_folder_outlined),
-            tooltip: 'New folder',
+            tooltip: t.sessions.dirPicker.newFolder,
             onPressed: onNewFolder,
           ),
           IconButton(
             icon: const Icon(Icons.close),
-            tooltip: 'Close',
+            tooltip: t.common.close,
             onPressed: onClose,
           ),
         ],
@@ -279,7 +284,9 @@ class _Footer extends StatelessWidget {
                 onPressed: onUse,
                 icon: const Icon(Icons.check),
                 label: Text(
-                  path != null ? 'Use this folder' : 'Loading…',
+                  path != null
+                      ? t.sessions.dirPicker.useThisFolder
+                      : t.sessions.dirPicker.loading,
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
@@ -310,24 +317,24 @@ class _NewFolderDialogState extends State<_NewFolderDialog> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: const Text('New folder'),
+      title: Text(t.sessions.dirPicker.dialog.title),
       content: TextField(
         controller: _ctrl,
         autofocus: true,
         autocorrect: false,
-        decoration: const InputDecoration(
-          hintText: 'Folder name',
+        decoration: InputDecoration(
+          hintText: t.sessions.dirPicker.dialog.hint,
         ),
         onSubmitted: (v) => Navigator.of(context).pop(v),
       ),
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
-          child: const Text('Cancel'),
+          child: Text(t.common.cancel),
         ),
         FilledButton(
           onPressed: () => Navigator.of(context).pop(_ctrl.text),
-          child: const Text('Create'),
+          child: Text(t.sessions.dirPicker.dialog.create),
         ),
       ],
     );
@@ -375,7 +382,7 @@ class _ErrorView extends StatelessWidget {
               style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(height: 16),
-            FilledButton(onPressed: onRetry, child: const Text('Retry')),
+            FilledButton(onPressed: onRetry, child: Text(t.common.retry)),
           ],
         ),
       ),

--- a/app/mobile/lib/features/sessions/inspector/files_tab.dart
+++ b/app/mobile/lib/features/sessions/inspector/files_tab.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/fs_api.dart';
 import 'package:opendray/core/api/sessions_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:path/path.dart' as p;
 
 // Files surface inside the session inspector. Browses the gateway-
@@ -94,7 +95,7 @@ class _FilesTabState extends ConsumerState<FilesTab>
             const Divider(height: 1),
             ListTile(
               leading: const Icon(Icons.alternate_email),
-              title: const Text('Insert as @reference'),
+              title: Text(t.sessions.inspector.files.insertAtRef),
               subtitle: const Text(
                 'Pastes "@<path>" into the running prompt',
               ),
@@ -102,14 +103,14 @@ class _FilesTabState extends ConsumerState<FilesTab>
             ),
             ListTile(
               leading: const Icon(Icons.content_paste_go),
-              title: const Text('Insert path'),
-              subtitle: const Text('Pastes the absolute path verbatim'),
+              title: Text(t.sessions.inspector.files.insertPath),
+              subtitle: Text(t.sessions.inspector.files.insertPathSubtitle),
               onTap: () => Navigator.of(sheetCtx).pop(_FileAction.insertPath),
             ),
             ListTile(
               leading: const Icon(Icons.text_snippet_outlined),
-              title: const Text('Read content'),
-              subtitle: const Text('Up to 256 KiB plain text'),
+              title: Text(t.sessions.inspector.files.readContent),
+              subtitle: Text(t.sessions.inspector.files.readContentSubtitle),
               onTap: () => Navigator.of(sheetCtx).pop(_FileAction.read),
             ),
             const SizedBox(height: 4),
@@ -134,18 +135,29 @@ class _FilesTabState extends ConsumerState<FilesTab>
       await ref.read(sessionsApiProvider).input(widget.sessionId, text);
       messenger.showSnackBar(
         SnackBar(
-          content: Text('Inserted: $text'),
+          content: Text(t.sessions.inspector.shared.inserted(text: text)),
           duration: const Duration(seconds: 2),
           behavior: SnackBarBehavior.floating,
         ),
       );
     } on ApiException catch (e) {
       messenger.showSnackBar(
-        SnackBar(content: Text('Insert failed (${e.statusCode}): ${e.message}')),
+        SnackBar(
+          content: Text(
+            t.sessions.inspector.shared.insertFailedApi(
+              status: e.statusCode.toString(),
+              message: e.message,
+            ),
+          ),
+        ),
       );
     } on Object catch (e) {
       messenger.showSnackBar(
-        SnackBar(content: Text('Insert failed: $e')),
+        SnackBar(
+          content: Text(
+            t.sessions.inspector.shared.insertFailedGeneric(error: e.toString()),
+          ),
+        ),
       );
     }
   }
@@ -205,11 +217,22 @@ class _FilesTabState extends ConsumerState<FilesTab>
       );
     } on ApiException catch (e) {
       messenger.showSnackBar(
-        SnackBar(content: Text('Read failed (${e.statusCode}): ${e.message}')),
+        SnackBar(
+          content: Text(
+            t.sessions.inspector.files.readFailedApi(
+              status: e.statusCode.toString(),
+              message: e.message,
+            ),
+          ),
+        ),
       );
     } on Object catch (e) {
       messenger.showSnackBar(
-        SnackBar(content: Text('Read failed: $e')),
+        SnackBar(
+          content: Text(
+            t.sessions.inspector.files.readFailedGeneric(error: e.toString()),
+          ),
+        ),
       );
     }
   }
@@ -314,13 +337,13 @@ class _PathBar extends StatelessWidget {
         children: [
           IconButton(
             icon: const Icon(Icons.arrow_upward),
-            tooltip: 'Parent',
+            tooltip: t.sessions.inspector.files.parent,
             onPressed: canGoUp ? onUp : null,
             visualDensity: VisualDensity.compact,
           ),
           IconButton(
             icon: const Icon(Icons.home_outlined),
-            tooltip: 'Back to session cwd',
+            tooltip: t.sessions.inspector.files.backToCwd,
             onPressed: onGoToCwd,
             visualDensity: VisualDensity.compact,
           ),
@@ -336,7 +359,7 @@ class _PathBar extends StatelessWidget {
           ),
           IconButton(
             icon: const Icon(Icons.refresh),
-            tooltip: 'Refresh',
+            tooltip: t.sessions.inspector.shared.refresh,
             onPressed: onRefresh,
             visualDensity: VisualDensity.compact,
           ),
@@ -371,7 +394,7 @@ class _ErrorView extends StatelessWidget {
               style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(height: 16),
-            FilledButton(onPressed: onRetry, child: const Text('Retry')),
+            FilledButton(onPressed: onRetry, child: Text(t.common.retry)),
           ],
         ),
       ),

--- a/app/mobile/lib/features/sessions/inspector/git_tab.dart
+++ b/app/mobile/lib/features/sessions/inspector/git_tab.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/git_api.dart';
 import 'package:opendray/core/api/sessions_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 
 // Git surface inside the session inspector. Two views toggle via a
 // segmented control:
@@ -72,17 +73,30 @@ class _GitTabState extends ConsumerState<GitTab>
       await ref.read(sessionsApiProvider).input(widget.sessionId, text);
       messenger.showSnackBar(
         SnackBar(
-          content: Text('Inserted: $text'),
+          content: Text(t.sessions.inspector.shared.inserted(text: text)),
           duration: const Duration(seconds: 2),
           behavior: SnackBarBehavior.floating,
         ),
       );
     } on ApiException catch (e) {
       messenger.showSnackBar(
-        SnackBar(content: Text('Insert failed (${e.statusCode}): ${e.message}')),
+        SnackBar(
+          content: Text(
+            t.sessions.inspector.shared.insertFailedApi(
+              status: e.statusCode.toString(),
+              message: e.message,
+            ),
+          ),
+        ),
       );
     } on Object catch (e) {
-      messenger.showSnackBar(SnackBar(content: Text('Insert failed: $e')));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.sessions.inspector.shared.insertFailedGeneric(error: e.toString()),
+          ),
+        ),
+      );
     }
   }
 
@@ -122,18 +136,18 @@ class _GitTabState extends ConsumerState<GitTab>
             const Divider(height: 1),
             ListTile(
               leading: const Icon(Icons.alternate_email),
-              title: const Text('Insert as @reference'),
+              title: Text(t.sessions.inspector.git.insertAtRef),
               onTap: () => Navigator.of(sheetCtx).pop(_FileAction.insertAt),
             ),
             ListTile(
               leading: const Icon(Icons.content_paste_go),
-              title: const Text('Insert path'),
+              title: Text(t.sessions.inspector.git.insertPath),
               onTap: () => Navigator.of(sheetCtx).pop(_FileAction.insertPath),
             ),
             if (!file.isUntracked)
               ListTile(
                 leading: const Icon(Icons.compare_arrows),
-                title: const Text('Show diff'),
+                title: Text(t.sessions.inspector.git.showDiff),
                 subtitle: Text(
                   file.isStaged ? 'staged changes' : 'unstaged changes',
                 ),
@@ -167,10 +181,23 @@ class _GitTabState extends ConsumerState<GitTab>
       await _showTextDialog(title: file.path, body: body);
     } on ApiException catch (e) {
       messenger.showSnackBar(
-        SnackBar(content: Text('Diff failed (${e.statusCode}): ${e.message}')),
+        SnackBar(
+          content: Text(
+            t.sessions.inspector.git.diffFailedApi(
+              status: e.statusCode.toString(),
+              message: e.message,
+            ),
+          ),
+        ),
       );
     } on Object catch (e) {
-      messenger.showSnackBar(SnackBar(content: Text('Diff failed: $e')));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.sessions.inspector.git.diffFailedGeneric(error: e.toString()),
+          ),
+        ),
+      );
     }
   }
 
@@ -215,13 +242,13 @@ class _GitTabState extends ConsumerState<GitTab>
             const Divider(height: 1),
             ListTile(
               leading: const Icon(Icons.tag_outlined),
-              title: const Text('Insert hash'),
+              title: Text(t.sessions.inspector.git.insertHash),
               subtitle: Text(commit.shortHash),
               onTap: () => Navigator.of(sheetCtx).pop(_CommitAction.insertHash),
             ),
             ListTile(
               leading: const Icon(Icons.description_outlined),
-              title: const Text('Show full patch'),
+              title: Text(t.sessions.inspector.git.showFullPatch),
               onTap: () => Navigator.of(sheetCtx).pop(_CommitAction.show),
             ),
             const SizedBox(height: 4),
@@ -249,10 +276,23 @@ class _GitTabState extends ConsumerState<GitTab>
       await _showTextDialog(title: commit.shortHash, body: body);
     } on ApiException catch (e) {
       messenger.showSnackBar(
-        SnackBar(content: Text('Show failed (${e.statusCode}): ${e.message}')),
+        SnackBar(
+          content: Text(
+            t.sessions.inspector.git.showFailedApi(
+              status: e.statusCode.toString(),
+              message: e.message,
+            ),
+          ),
+        ),
       );
     } on Object catch (e) {
-      messenger.showSnackBar(SnackBar(content: Text('Show failed: $e')));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.sessions.inspector.git.showFailedGeneric(error: e.toString()),
+          ),
+        ),
+      );
     }
   }
 
@@ -459,16 +499,16 @@ class _PaneSwitch extends StatelessWidget {
         children: [
           Expanded(
             child: SegmentedButton<_Pane>(
-              segments: const [
+              segments: [
                 ButtonSegment<_Pane>(
                   value: _Pane.status,
-                  icon: Icon(Icons.list_alt, size: 18),
-                  label: Text('Status'),
+                  icon: const Icon(Icons.list_alt, size: 18),
+                  label: Text(t.sessions.inspector.git.tabStatus),
                 ),
                 ButtonSegment<_Pane>(
                   value: _Pane.log,
-                  icon: Icon(Icons.history, size: 18),
-                  label: Text('Log'),
+                  icon: const Icon(Icons.history, size: 18),
+                  label: Text(t.sessions.inspector.git.tabLog),
                 ),
               ],
               selected: {pane},
@@ -477,7 +517,7 @@ class _PaneSwitch extends StatelessWidget {
           ),
           IconButton(
             icon: const Icon(Icons.refresh),
-            tooltip: 'Refresh',
+            tooltip: t.sessions.inspector.shared.refresh,
             onPressed: onRefresh,
           ),
         ],
@@ -632,7 +672,7 @@ class _ErrorView extends StatelessWidget {
               style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(height: 16),
-            FilledButton(onPressed: onRetry, child: const Text('Retry')),
+            FilledButton(onPressed: onRetry, child: Text(t.common.retry)),
           ],
         ),
       ),

--- a/app/mobile/lib/features/sessions/inspector/history_tab.dart
+++ b/app/mobile/lib/features/sessions/inspector/history_tab.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/sessions_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 
 // History surface inside the session inspector. Shows the user's
 // past prompts in this project (cwd) across every session that
@@ -95,7 +96,7 @@ class _HistoryTabState extends ConsumerState<HistoryTab>
             const Divider(height: 1),
             ListTile(
               leading: const Icon(Icons.send_outlined),
-              title: const Text('Insert into terminal'),
+              title: Text(t.sessions.inspector.history.insertIntoTerminal),
               subtitle: const Text(
                 'Pastes the prompt as keystrokes; press Return to send',
               ),
@@ -126,10 +127,23 @@ class _HistoryTabState extends ConsumerState<HistoryTab>
       );
     } on ApiException catch (e) {
       messenger.showSnackBar(
-        SnackBar(content: Text('Insert failed (${e.statusCode}): ${e.message}')),
+        SnackBar(
+          content: Text(
+            t.sessions.inspector.shared.insertFailedApi(
+              status: e.statusCode.toString(),
+              message: e.message,
+            ),
+          ),
+        ),
       );
     } on Object catch (e) {
-      messenger.showSnackBar(SnackBar(content: Text('Insert failed: $e')));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.sessions.inspector.shared.insertFailedGeneric(error: e.toString()),
+          ),
+        ),
+      );
     }
   }
 
@@ -211,7 +225,7 @@ class _SearchBar extends StatelessWidget {
               textInputAction: TextInputAction.search,
               onChanged: onChanged,
               decoration: InputDecoration(
-                hintText: 'Search prompts…',
+                hintText: t.sessions.inspector.history.searchHint,
                 prefixIcon: const Icon(Icons.search, size: 20),
                 suffixIcon: controller.text.isEmpty
                     ? null
@@ -229,7 +243,7 @@ class _SearchBar extends StatelessWidget {
           ),
           IconButton(
             icon: const Icon(Icons.refresh),
-            tooltip: 'Refresh',
+            tooltip: t.sessions.inspector.shared.refresh,
             onPressed: onRefresh,
           ),
         ],
@@ -370,7 +384,7 @@ class _ErrorView extends StatelessWidget {
               style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(height: 16),
-            FilledButton(onPressed: onRetry, child: const Text('Retry')),
+            FilledButton(onPressed: onRetry, child: Text(t.common.retry)),
           ],
         ),
       ),

--- a/app/mobile/lib/features/sessions/inspector/notes_tab.dart
+++ b/app/mobile/lib/features/sessions/inspector/notes_tab.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/notes_api.dart';
 import 'package:opendray/core/api/sessions_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/notes/note_editor_dialog.dart';
 
 // Notes surface inside the session inspector. Mirrors the web admin
@@ -325,7 +326,7 @@ class _PersonalSectionState extends ConsumerState<_PersonalSection> {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Inserted: @${widget.personalPath}'),
+          content: Text(t.sessions.inspector.notes.insertedAt(path: widget.personalPath)),
           duration: const Duration(seconds: 2),
           behavior: SnackBarBehavior.floating,
         ),
@@ -353,7 +354,7 @@ class _PersonalSectionState extends ConsumerState<_PersonalSection> {
           'not write here.',
       action: IconButton(
         icon: const Icon(Icons.alternate_email, size: 18),
-        tooltip: 'Insert as @reference',
+        tooltip: t.sessions.inspector.notes.insertAtRefTooltip,
         onPressed: _insertReference,
       ),
       child: _loading
@@ -373,8 +374,7 @@ class _PersonalSectionState extends ConsumerState<_PersonalSection> {
                   keyboardType: TextInputType.multiline,
                   style: const TextStyle(fontSize: 13, height: 1.5),
                   decoration: InputDecoration(
-                    hintText: '# ${widget.cwdBase}\n\nThoughts, todos, '
-                        'context for the agent…',
+                    hintText: t.sessions.inspector.notes.draftHint(project: widget.cwdBase),
                     border: OutlineInputBorder(
                       borderSide: BorderSide(
                         color: Theme.of(context).dividerColor,
@@ -519,7 +519,7 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
             'different vault folder.';
     return _SectionCard(
       icon: Icons.auto_awesome,
-      title: 'Project docs',
+      title: t.sessions.inspector.notes.projectDocs,
       subtitle: widget.projectsRel.isEmpty
           ? '(no project mapping)'
           : '${widget.projectsRel}/',
@@ -529,7 +529,7 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
         children: [
           IconButton(
             icon: const Icon(Icons.tune, size: 18),
-            tooltip: 'Change project docs location',
+            tooltip: t.sessions.inspector.notes.changeLocationTooltip,
             onPressed: _editMapping,
           ),
           IconButton(
@@ -555,10 +555,10 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
                     autocorrect: false,
                     textInputAction: TextInputAction.done,
                     onSubmitted: (_) => _create(),
-                    decoration: const InputDecoration(
+                    decoration: InputDecoration(
                       isDense: true,
-                      hintText: 'filename (e.g. spec or design.md)',
-                      contentPadding: EdgeInsets.symmetric(
+                      hintText: t.sessions.inspector.notes.filenameHint,
+                      contentPadding: const EdgeInsets.symmetric(
                         horizontal: 10,
                         vertical: 10,
                       ),
@@ -568,7 +568,7 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
                 const SizedBox(width: 6),
                 FilledButton(
                   onPressed: _create,
-                  child: const Text('Create'),
+                  child: Text(t.sessions.inspector.notes.create),
                 ),
               ],
             ),
@@ -579,11 +579,11 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
               controller: _searchCtrl,
               onChanged: (v) =>
                   setState(() => _query = v.trim().toLowerCase()),
-              decoration: const InputDecoration(
+              decoration: InputDecoration(
                 isDense: true,
-                hintText: 'Filter…',
-                prefixIcon: Icon(Icons.search, size: 18),
-                contentPadding: EdgeInsets.symmetric(
+                hintText: t.sessions.inspector.notes.filterHint,
+                prefixIcon: const Icon(Icons.search, size: 18),
+                contentPadding: const EdgeInsets.symmetric(
                   horizontal: 8,
                   vertical: 8,
                 ),
@@ -628,7 +628,7 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
       await ref.read(sessionsApiProvider).input(sid, text);
       messenger.showSnackBar(
         SnackBar(
-          content: Text('Inserted: $text'),
+          content: Text(t.sessions.inspector.shared.inserted(text: text)),
           duration: const Duration(seconds: 2),
           behavior: SnackBarBehavior.floating,
         ),
@@ -711,7 +711,7 @@ class _DocTile extends StatelessWidget {
             ),
             IconButton(
               icon: const Icon(Icons.alternate_email, size: 16),
-              tooltip: 'Insert @reference',
+              tooltip: t.sessions.inspector.notes.insertAtRefShort,
               visualDensity: VisualDensity.compact,
               onPressed: onInsertRef,
             ),
@@ -773,7 +773,7 @@ class _MappingDialogState extends State<_MappingDialog> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: const Text('Project docs location'),
+      title: Text(t.sessions.inspector.notes.locationDialogTitle),
       content: SingleChildScrollView(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -821,7 +821,7 @@ class _MappingDialogState extends State<_MappingDialog> {
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(null),
-          child: const Text('Cancel'),
+          child: Text(t.common.cancel),
         ),
         FilledButton(
           onPressed: () => Navigator.of(context).pop(_ctrl.text.trim()),
@@ -936,7 +936,7 @@ class _ErrorView extends StatelessWidget {
               style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(height: 16),
-            FilledButton(onPressed: onRetry, child: const Text('Retry')),
+            FilledButton(onPressed: onRetry, child: Text(t.common.retry)),
           ],
         ),
       ),

--- a/app/mobile/lib/features/sessions/inspector/session_inspector_screen.dart
+++ b/app/mobile/lib/features/sessions/inspector/session_inspector_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/sessions_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/sessions/inspector/files_tab.dart';
 import 'package:opendray/features/sessions/inspector/git_tab.dart';
 import 'package:opendray/features/sessions/inspector/history_tab.dart';
@@ -47,7 +48,7 @@ class _Body extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               Text(
-                'Inspector',
+                t.sessions.inspector.shell.title,
                 style: Theme.of(context).textTheme.titleSmall,
               ),
               Text(
@@ -57,15 +58,30 @@ class _Body extends StatelessWidget {
               ),
             ],
           ),
-          bottom: const TabBar(
+          bottom: TabBar(
             isScrollable: true,
             tabAlignment: TabAlignment.start,
             tabs: [
-              Tab(icon: Icon(Icons.folder_outlined), text: 'Files'),
-              Tab(icon: Icon(Icons.account_tree_outlined), text: 'Git'),
-              Tab(icon: Icon(Icons.play_circle_outline), text: 'Tasks'),
-              Tab(icon: Icon(Icons.history), text: 'History'),
-              Tab(icon: Icon(Icons.description_outlined), text: 'Notes'),
+              Tab(
+                icon: const Icon(Icons.folder_outlined),
+                text: t.sessions.inspector.shell.tabs.files,
+              ),
+              Tab(
+                icon: const Icon(Icons.account_tree_outlined),
+                text: t.sessions.inspector.shell.tabs.git,
+              ),
+              Tab(
+                icon: const Icon(Icons.play_circle_outline),
+                text: t.sessions.inspector.shell.tabs.tasks,
+              ),
+              Tab(
+                icon: const Icon(Icons.history),
+                text: t.sessions.inspector.shell.tabs.history,
+              ),
+              Tab(
+                icon: const Icon(Icons.description_outlined),
+                text: t.sessions.inspector.shell.tabs.notes,
+              ),
             ],
           ),
         ),
@@ -89,7 +105,7 @@ class _LoadingScaffold extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Inspector')),
+      appBar: AppBar(title: Text(t.sessions.inspector.shell.title)),
       body: const Center(child: CircularProgressIndicator()),
     );
   }
@@ -102,12 +118,12 @@ class _ErrorScaffold extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Inspector')),
+      appBar: AppBar(title: Text(t.sessions.inspector.shell.title)),
       body: Center(
         child: Padding(
           padding: const EdgeInsets.all(24),
           child: Text(
-            'Failed to load session: $error',
+            t.sessions.inspector.shell.loadError(error: error.toString()),
             textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.bodySmall,
           ),

--- a/app/mobile/lib/features/sessions/inspector/tasks_tab.dart
+++ b/app/mobile/lib/features/sessions/inspector/tasks_tab.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/fs_api.dart';
 import 'package:opendray/core/api/sessions_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
@@ -134,7 +135,7 @@ class _TasksTabState extends ConsumerState<TasksTab>
             const Divider(height: 1),
             ListTile(
               leading: const Icon(Icons.play_arrow),
-              title: const Text('Run command'),
+              title: Text(t.sessions.inspector.tasks.runCommand),
               subtitle: const Text(
                 'Pastes the command and presses return — runs immediately',
               ),
@@ -142,8 +143,8 @@ class _TasksTabState extends ConsumerState<TasksTab>
             ),
             ListTile(
               leading: const Icon(Icons.content_paste_go),
-              title: const Text('Insert command'),
-              subtitle: const Text('Pastes without return so you can edit'),
+              title: Text(t.sessions.inspector.tasks.insertCommand),
+              subtitle: Text(t.sessions.inspector.tasks.insertCommandSubtitle),
               onTap: () => Navigator.of(sheetCtx).pop(_TaskAction.insert),
             ),
             const SizedBox(height: 4),
@@ -170,10 +171,23 @@ class _TasksTabState extends ConsumerState<TasksTab>
       );
     } on ApiException catch (e) {
       messenger.showSnackBar(
-        SnackBar(content: Text('Insert failed (${e.statusCode}): ${e.message}')),
+        SnackBar(
+          content: Text(
+            t.sessions.inspector.shared.insertFailedApi(
+              status: e.statusCode.toString(),
+              message: e.message,
+            ),
+          ),
+        ),
       );
     } on Object catch (e) {
-      messenger.showSnackBar(SnackBar(content: Text('Insert failed: $e')));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.sessions.inspector.shared.insertFailedGeneric(error: e.toString()),
+          ),
+        ),
+      );
     }
   }
 
@@ -235,7 +249,7 @@ class _Header extends StatelessWidget {
           ),
           IconButton(
             icon: const Icon(Icons.refresh),
-            tooltip: 'Refresh',
+            tooltip: t.sessions.inspector.shared.refresh,
             onPressed: onRefresh,
           ),
         ],
@@ -400,7 +414,7 @@ class _ErrorView extends StatelessWidget {
               style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(height: 16),
-            FilledButton(onPressed: onRetry, child: const Text('Retry')),
+            FilledButton(onPressed: onRetry, child: Text(t.common.retry)),
           ],
         ),
       ),

--- a/app/mobile/lib/features/sessions/session_action_sheet.dart
+++ b/app/mobile/lib/features/sessions/session_action_sheet.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/sessions_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 
 // Result returned to the caller so it knows what happened (and
 // can choose to refresh the list, navigate away, etc.).
@@ -61,7 +62,13 @@ class _SessionActionSheetState extends ConsumerState<SessionActionSheet> {
     } on ApiException catch (e) {
       setState(() => _error = e.message);
     } on Object catch (e) {
-      setState(() => _error = 'Failed to $verb: $e');
+      final errStr = e.toString();
+      setState(() => _error = switch (verb) {
+            'stop' => t.sessions.action.errors.stop(error: errStr),
+            'start' => t.sessions.action.errors.start(error: errStr),
+            'delete' => t.sessions.action.errors.delete(error: errStr),
+            _ => errStr,
+          });
     } finally {
       if (mounted) setState(() => _busy = false);
     }
@@ -165,21 +172,25 @@ class _Actions extends StatelessWidget {
         if (session.isLive)
           _ActionTile(
             icon: Icons.stop_circle_outlined,
-            label: busyVerb == 'stop' ? 'Stopping…' : 'Stop',
-            description: 'Send SIGTERM, retain history',
+            label: busyVerb == 'stop'
+                ? t.sessions.action.stopping
+                : t.sessions.action.stop,
+            description: t.sessions.action.stopDescription,
             onTap: busy ? null : onStop,
           ),
         if (session.isFinished)
           _ActionTile(
             icon: Icons.play_circle_outline,
-            label: busyVerb == 'start' ? 'Restarting…' : 'Restart',
-            description: 'Re-spawn the CLI process',
+            label: busyVerb == 'start'
+                ? t.sessions.action.restarting
+                : t.sessions.action.restart,
+            description: t.sessions.action.restartDescription,
             onTap: busy ? null : onStart,
           ),
         _ActionTile(
           icon: Icons.delete_outline,
-          label: 'Delete',
-          description: 'Remove the session and its history',
+          label: t.sessions.action.delete,
+          description: t.sessions.action.deleteDescription,
           destructive: true,
           onTap: busy ? null : onDelete,
         ),
@@ -274,8 +285,7 @@ class _DeleteConfirm extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Text(
-          'Delete this session permanently? Its ring buffer and '
-          'history will be gone.',
+          t.sessions.action.deleteConfirm,
           style: Theme.of(context).textTheme.bodyMedium,
         ),
         const SizedBox(height: 16),
@@ -284,7 +294,7 @@ class _DeleteConfirm extends StatelessWidget {
             Expanded(
               child: OutlinedButton(
                 onPressed: busy ? null : onCancel,
-                child: const Text('Cancel'),
+                child: Text(t.common.cancel),
               ),
             ),
             const SizedBox(width: 12),
@@ -301,7 +311,7 @@ class _DeleteConfirm extends StatelessWidget {
                         width: 18,
                         child: CircularProgressIndicator(strokeWidth: 2),
                       )
-                    : const Text('Delete'),
+                    : Text(t.common.delete),
               ),
             ),
           ],

--- a/app/mobile/lib/features/sessions/session_detail_screen.dart
+++ b/app/mobile/lib/features/sessions/session_detail_screen.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart';
 
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/sessions_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/project/project_screen.dart';
 import 'package:opendray/features/sessions/session_action_sheet.dart';
 import 'package:opendray/features/sessions/session_terminal_view.dart';
@@ -40,19 +41,19 @@ class _SessionDetailScreenState extends ConsumerState<SessionDetailScreen> {
             s.displayName,
             overflow: TextOverflow.ellipsis,
           ),
-          loading: () => const Text('Session'),
-          error: (_, __) => const Text('Session'),
+          loading: () => Text(t.sessions.detail.fallbackTitle),
+          error: (_, __) => Text(t.sessions.detail.fallbackTitle),
         ),
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),
-            tooltip: 'Refresh metadata',
+            tooltip: t.sessions.detail.refreshMetadata,
             onPressed: () =>
                 ref.invalidate(sessionByIdProvider(widget.sessionId)),
           ),
           IconButton(
             icon: const Icon(Icons.dashboard_customize_outlined),
-            tooltip: 'Inspector (Files / Git / Tasks / History / Notes)',
+            tooltip: t.sessions.detail.inspector,
             onPressed: () =>
                 context.push('/session/${widget.sessionId}/inspector'),
           ),
@@ -63,7 +64,7 @@ class _SessionDetailScreenState extends ConsumerState<SessionDetailScreen> {
           async.maybeWhen(
             data: (s) => IconButton(
               icon: const Icon(Icons.flag_outlined),
-              tooltip: 'Project memory (goal / plan / journal / inbox)',
+              tooltip: t.sessions.detail.projectMemory,
               onPressed: () {
                 Navigator.of(context).push(
                   MaterialPageRoute<void>(
@@ -77,7 +78,7 @@ class _SessionDetailScreenState extends ConsumerState<SessionDetailScreen> {
           async.maybeWhen(
             data: (s) => IconButton(
               icon: const Icon(Icons.tune),
-              tooltip: 'Actions',
+              tooltip: t.sessions.detail.actions,
               onPressed: () async {
                 final result = await SessionActionSheet.show(
                   context,
@@ -206,13 +207,16 @@ class _ExpandedDetail extends StatelessWidget {
           const SizedBox(height: 2),
           Text(
             ended == null
-                ? 'started $started'
-                : 'started $started  ·  ended $ended',
+                ? t.sessions.detail.started(when: started)
+                : t.sessions.detail.startedEnded(
+                    started: started,
+                    ended: ended,
+                  ),
             style: muted,
           ),
           const SizedBox(height: 2),
           SelectableText(
-            'id: ${session.id}',
+            t.sessions.detail.idPrefix(id: session.id),
             style: muted,
           ),
         ],
@@ -276,7 +280,7 @@ class _ErrorView extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             Text(
-              'Failed to load session',
+              t.sessions.detail.errorTitle,
               style: Theme.of(context).textTheme.titleMedium,
             ),
             const SizedBox(height: 8),
@@ -286,7 +290,7 @@ class _ErrorView extends StatelessWidget {
               style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(height: 16),
-            FilledButton(onPressed: onRetry, child: const Text('Retry')),
+            FilledButton(onPressed: onRetry, child: Text(t.common.retry)),
           ],
         ),
       ),

--- a/app/mobile/lib/features/sessions/session_terminal_view.dart
+++ b/app/mobile/lib/features/sessions/session_terminal_view.dart
@@ -10,6 +10,7 @@ import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/sessions_api.dart';
 import 'package:opendray/core/auth/auth_state.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:xterm/xterm.dart';
 
@@ -334,15 +335,19 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
       );
     } on Object catch (e) {
       messenger.showSnackBar(
-        SnackBar(content: Text('Image picker failed: $e')),
+        SnackBar(
+          content: Text(
+            t.sessions.terminal.snackbar.imagePickerFailed(error: e.toString()),
+          ),
+        ),
       );
       return;
     }
     if (file == null) return; // user cancelled
     messenger.showSnackBar(
-      const SnackBar(
-        content: Text('Uploading image…'),
-        duration: Duration(seconds: 1),
+      SnackBar(
+        content: Text(t.sessions.terminal.snackbar.uploadingImage),
+        duration: const Duration(seconds: 1),
       ),
     );
     try {
@@ -355,7 +360,9 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Image attached: $remotePath'),
+          content: Text(
+            t.sessions.terminal.snackbar.imageAttached(path: remotePath),
+          ),
           behavior: SnackBarBehavior.floating,
           duration: const Duration(seconds: 3),
         ),
@@ -363,12 +370,23 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
     } on ApiException catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Upload failed (${e.statusCode}): ${e.message}')),
+        SnackBar(
+          content: Text(
+            t.sessions.terminal.snackbar.uploadFailed(
+              status: e.statusCode.toString(),
+              message: e.message,
+            ),
+          ),
+        ),
       );
     } on Object catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Upload failed: $e')),
+        SnackBar(
+          content: Text(
+            t.sessions.terminal.snackbar.uploadFailedGeneric(error: e.toString()),
+          ),
+        ),
       );
     }
   }
@@ -397,12 +415,12 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
             const SizedBox(height: 8),
             ListTile(
               leading: const Icon(Icons.photo_library_outlined),
-              title: const Text('Photo library'),
+              title: Text(t.sessions.terminal.imageSource.photoLibrary),
               onTap: () => Navigator.of(sheetCtx).pop(ImageSource.gallery),
             ),
             ListTile(
               leading: const Icon(Icons.camera_alt_outlined),
-              title: const Text('Take a photo'),
+              title: Text(t.sessions.terminal.imageSource.takePhoto),
               onTap: () => Navigator.of(sheetCtx).pop(ImageSource.camera),
             ),
             const SizedBox(height: 4),
@@ -510,13 +528,21 @@ class _StatusStrip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final (label, color) = switch (state) {
-      _ConnState.connecting => ('Connecting…', Colors.amber),
-      _ConnState.connected => ('Connected', Colors.green),
-      _ConnState.reconnecting =>
-        (error != null ? 'Reconnecting (${_short(error!)})…' : 'Reconnecting…', Colors.amber),
-      _ConnState.error =>
-        (error != null ? 'Disconnected (${_short(error!)})' : 'Disconnected', Colors.red),
-      _ConnState.ended => ('Session ended', Colors.grey),
+      _ConnState.connecting => (t.sessions.terminal.connection.connecting, Colors.amber),
+      _ConnState.connected => (t.sessions.terminal.connection.connected, Colors.green),
+      _ConnState.reconnecting => (
+          error != null
+              ? t.sessions.terminal.connection.reconnectingWithError(error: _short(error!))
+              : t.sessions.terminal.connection.reconnecting,
+          Colors.amber,
+        ),
+      _ConnState.error => (
+          error != null
+              ? t.sessions.terminal.connection.disconnectedWithError(error: _short(error!))
+              : t.sessions.terminal.connection.disconnected,
+          Colors.red,
+        ),
+      _ConnState.ended => (t.sessions.terminal.connection.ended, Colors.grey),
     };
     return Container(
       width: double.infinity,
@@ -546,7 +572,7 @@ class _StatusStrip extends StatelessWidget {
                 minimumSize: const Size(0, 28),
                 padding: const EdgeInsets.symmetric(horizontal: 8),
               ),
-              child: const Text('Retry'),
+              child: Text(t.common.retry),
             ),
         ],
       ),
@@ -671,7 +697,7 @@ class _MobileKeyboardBarState extends State<_MobileKeyboardBar> {
             ),
             _Key(
               icon: Icons.content_copy,
-              tooltip: 'Copy buffer',
+              tooltip: t.sessions.terminal.keyboard.copyBuffer,
               onTap: () {
                 _haptic();
                 unawaited(widget.onCopy());
@@ -679,7 +705,7 @@ class _MobileKeyboardBarState extends State<_MobileKeyboardBar> {
             ),
             _Key(
               icon: Icons.content_paste,
-              tooltip: 'Paste',
+              tooltip: t.sessions.terminal.keyboard.paste,
               onTap: () {
                 _haptic();
                 unawaited(widget.onPaste());
@@ -687,7 +713,7 @@ class _MobileKeyboardBarState extends State<_MobileKeyboardBar> {
             ),
             _Key(
               icon: Icons.add_photo_alternate_outlined,
-              tooltip: 'Attach image',
+              tooltip: t.sessions.terminal.keyboard.attachImage,
               onTap: () {
                 _haptic();
                 unawaited(widget.onAttachImage());

--- a/app/mobile/lib/features/sessions/sessions_screen.dart
+++ b/app/mobile/lib/features/sessions/sessions_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/sessions_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/sessions/session_action_sheet.dart';
 import 'package:opendray/features/sessions/spawn_session_sheet.dart';
 import 'package:path/path.dart' as p;
@@ -50,11 +51,11 @@ class _SessionsScreenState extends ConsumerState<SessionsScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Sessions'),
+        title: Text(t.sessions.title),
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),
-            tooltip: 'Refresh',
+            tooltip: t.sessions.refresh,
             onPressed: async.isLoading
                 ? null
                 : () => ref.invalidate(sessionsListProvider),
@@ -105,20 +106,24 @@ class _SessionsScreenState extends ConsumerState<SessionsScreen> {
       floatingActionButton: FloatingActionButton.extended(
         onPressed: _onSpawn,
         icon: const Icon(Icons.add),
-        label: const Text('Spawn'),
+        label: Text(t.sessions.spawn),
       ),
     );
   }
 }
 
 enum _Filter {
-  all('All'),
-  running('Running'),
-  idle('Idle'),
-  ended('Ended');
+  all,
+  running,
+  idle,
+  ended;
 
-  const _Filter(this.label);
-  final String label;
+  String label() => switch (this) {
+        _Filter.all => t.sessions.filters.all,
+        _Filter.running => t.sessions.filters.running,
+        _Filter.idle => t.sessions.filters.idle,
+        _Filter.ended => t.sessions.filters.ended,
+      };
 
   bool matches(SessionSummary s) => switch (this) {
         _Filter.all => true,
@@ -148,7 +153,7 @@ class _FilterBar extends StatelessWidget {
           final f = _Filter.values[i];
           final selected = f == value;
           return ChoiceChip(
-            label: Text(f.label),
+            label: Text(f.label()),
             selected: selected,
             onSelected: (_) => onChanged(f),
           );
@@ -213,7 +218,10 @@ class _SessionCard extends StatelessWidget {
                     ),
                     const SizedBox(height: 2),
                     Text(
-                      '${session.providerId} · started ${_formatRelative(session.startedAt)}',
+                      t.sessions.card.startedRelative(
+                        provider: session.providerId,
+                        when: _formatRelative(session.startedAt),
+                      ),
                       style: Theme.of(context).textTheme.bodySmall,
                       overflow: TextOverflow.ellipsis,
                     ),
@@ -222,7 +230,7 @@ class _SessionCard extends StatelessWidget {
               ),
               IconButton(
                 icon: const Icon(Icons.more_vert),
-                tooltip: 'Actions',
+                tooltip: t.sessions.actions,
                 onPressed: onMore,
               ),
             ],
@@ -284,8 +292,8 @@ class _EmptyState extends StatelessWidget {
         Center(
           child: Text(
             hasAny
-                ? 'No sessions match the "${filter.label}" filter.'
-                : 'No sessions yet',
+                ? t.sessions.empty.titleFiltered(filter: filter.label())
+                : t.sessions.empty.titleAll,
             style: Theme.of(context).textTheme.titleMedium,
           ),
         ),
@@ -293,8 +301,8 @@ class _EmptyState extends StatelessWidget {
         Center(
           child: Text(
             hasAny
-                ? 'Try a different filter or pull to refresh.'
-                : 'Tap the Spawn button to create one.',
+                ? t.sessions.empty.subtitleFiltered
+                : t.sessions.empty.subtitleAll,
             textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.bodySmall,
           ),
@@ -322,7 +330,7 @@ class _ErrorView extends StatelessWidget {
         const SizedBox(height: 12),
         Center(
           child: Text(
-            'Failed to load sessions',
+            t.sessions.errorTitle,
             style: Theme.of(context).textTheme.titleMedium,
           ),
         ),
@@ -336,7 +344,7 @@ class _ErrorView extends StatelessWidget {
         ),
         const SizedBox(height: 16),
         Center(
-          child: FilledButton(onPressed: onRetry, child: const Text('Retry')),
+          child: FilledButton(onPressed: onRetry, child: Text(t.common.retry)),
         ),
       ],
     );
@@ -345,10 +353,10 @@ class _ErrorView extends StatelessWidget {
 
 String _formatRelative(DateTime ts) {
   final diff = DateTime.now().toUtc().difference(ts.toUtc());
-  if (diff.inSeconds < 60) return '${diff.inSeconds}s ago';
-  if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
-  if (diff.inHours < 24) return '${diff.inHours}h ago';
-  if (diff.inDays < 7) return '${diff.inDays}d ago';
+  if (diff.inSeconds < 60) return t.sessions.relative.secondsAgo(n: diff.inSeconds);
+  if (diff.inMinutes < 60) return t.sessions.relative.minutesAgo(n: diff.inMinutes);
+  if (diff.inHours < 24) return t.sessions.relative.hoursAgo(n: diff.inHours);
+  if (diff.inDays < 7) return t.sessions.relative.daysAgo(n: diff.inDays);
   return DateFormat.yMMMd().format(ts.toLocal());
 }
 

--- a/app/mobile/lib/features/sessions/spawn_session_sheet.dart
+++ b/app/mobile/lib/features/sessions/spawn_session_sheet.dart
@@ -6,6 +6,7 @@ import 'package:opendray/core/api/claude_accounts_api.dart';
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/providers_api.dart';
 import 'package:opendray/core/api/sessions_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/sessions/directory_picker_sheet.dart';
 
 // Provider id that triggers the Claude-account picker. Multi-account
@@ -34,9 +35,9 @@ const Map<String, List<String>> _bypassFlagsByProvider = {
 // term; pretending it's all "Auto-approve" would be confusing.
 String? _bypassLabelFor(String providerId) {
   return switch (providerId) {
-    'claude' => 'Bypass permissions',
-    'codex' => 'Auto-approve (never ask)',
-    'gemini' => 'YOLO mode',
+    'claude' => t.sessions.spawnSheet.bypass.labelClaude,
+    'codex' => t.sessions.spawnSheet.bypass.labelCodex,
+    'gemini' => t.sessions.spawnSheet.bypass.labelGemini,
     _ => null,
   };
 }
@@ -107,7 +108,7 @@ class _SpawnSessionSheetState extends ConsumerState<SpawnSessionSheet> {
   Future<void> _submit() async {
     final cwd = _cwdCtrl.text.trim();
     if (_providerId == null || _providerId!.isEmpty || cwd.isEmpty) {
-      setState(() => _error = 'Provider and working directory are required');
+      setState(() => _error = t.sessions.spawnSheet.errorRequired);
       return;
     }
     setState(() {
@@ -152,7 +153,7 @@ class _SpawnSessionSheetState extends ConsumerState<SpawnSessionSheet> {
     } on ApiException catch (e) {
       setState(() => _error = e.message);
     } on Object catch (e) {
-      setState(() => _error = 'Failed to spawn session: $e');
+      setState(() => _error = t.sessions.spawnSheet.errorGeneric(error: e.toString()));
     } finally {
       if (mounted) setState(() => _submitting = false);
     }
@@ -203,7 +204,7 @@ class _SpawnSessionSheetState extends ConsumerState<SpawnSessionSheet> {
                 children: [
                   Expanded(
                     child: Text(
-                      'New session',
+                      t.sessions.spawnSheet.title,
                       style: Theme.of(context).textTheme.titleLarge,
                     ),
                   ),
@@ -248,12 +249,12 @@ class _SpawnSessionSheetState extends ConsumerState<SpawnSessionSheet> {
                 autocorrect: false,
                 keyboardType: TextInputType.url,
                 decoration: InputDecoration(
-                  labelText: 'Working directory',
-                  hintText: '/Users/you/projects/foo',
-                  helperText: 'Absolute path on the gateway host.',
+                  labelText: t.sessions.spawnSheet.cwdLabel,
+                  hintText: t.sessions.spawnSheet.cwdHint,
+                  helperText: t.sessions.spawnSheet.cwdHelper,
                   suffixIcon: IconButton(
                     icon: const Icon(Icons.folder_open_outlined),
-                    tooltip: 'Browse',
+                    tooltip: t.sessions.spawnSheet.browse,
                     onPressed: _submitting ? null : _browseCwd,
                   ),
                 ),
@@ -262,9 +263,9 @@ class _SpawnSessionSheetState extends ConsumerState<SpawnSessionSheet> {
               TextField(
                 controller: _nameCtrl,
                 enabled: !_submitting,
-                decoration: const InputDecoration(
-                  labelText: 'Name (optional)',
-                  hintText: 'e.g. backend-refactor',
+                decoration: InputDecoration(
+                  labelText: t.sessions.spawnSheet.nameLabel,
+                  hintText: t.sessions.spawnSheet.nameHint,
                 ),
               ),
               const SizedBox(height: 14),
@@ -272,11 +273,10 @@ class _SpawnSessionSheetState extends ConsumerState<SpawnSessionSheet> {
                 controller: _argsCtrl,
                 enabled: !_submitting,
                 autocorrect: false,
-                decoration: const InputDecoration(
-                  labelText: 'Extra args (optional)',
-                  hintText: '--continue --verbose',
-                  helperText:
-                      "Whitespace-separated; blank uses the provider's defaults.",
+                decoration: InputDecoration(
+                  labelText: t.sessions.spawnSheet.argsLabel,
+                  hintText: t.sessions.spawnSheet.argsHint,
+                  helperText: t.sessions.spawnSheet.argsHelper,
                 ),
               ),
               if (bypassLabel != null) ...[
@@ -289,8 +289,8 @@ class _SpawnSessionSheetState extends ConsumerState<SpawnSessionSheet> {
                   title: Text(bypassLabel),
                   subtitle: Text(
                     _bypassEnabled
-                        ? 'This session will run with elevated autonomy.'
-                        : 'Off — confirmations and prompts behave normally.',
+                        ? t.sessions.spawnSheet.bypass.subtitleOn
+                        : t.sessions.spawnSheet.bypass.subtitleOff,
                     style: Theme.of(context).textTheme.bodySmall,
                   ),
                   contentPadding: EdgeInsets.zero,
@@ -309,7 +309,7 @@ class _SpawnSessionSheetState extends ConsumerState<SpawnSessionSheet> {
                       onPressed: _submitting
                           ? null
                           : () => Navigator.of(context).pop(),
-                      child: const Text('Cancel'),
+                      child: Text(t.common.cancel),
                     ),
                   ),
                   const SizedBox(width: 12),
@@ -322,7 +322,7 @@ class _SpawnSessionSheetState extends ConsumerState<SpawnSessionSheet> {
                               width: 18,
                               child: CircularProgressIndicator(strokeWidth: 2),
                             )
-                          : const Text('Spawn'),
+                          : Text(t.sessions.spawnSheet.spawn),
                     ),
                   ),
                 ],
@@ -353,10 +353,8 @@ class _ProviderField extends ConsumerWidget {
         if (providers.isEmpty) {
           return _ProviderProblem(
             icon: Icons.inventory_2_outlined,
-            title: 'No providers configured',
-            message: 'The gateway has no CLI providers enabled. Configure '
-                'one under Providers (web admin) or [providers] in '
-                'config.toml, then tap Reload.',
+            title: t.sessions.spawnSheet.noProviders.title,
+            message: t.sessions.spawnSheet.noProviders.message,
             onReload: () => ref.invalidate(providersListProvider),
           );
         }
@@ -370,13 +368,19 @@ class _ProviderField extends ConsumerWidget {
                 .id;
         return DropdownButtonFormField<String>(
           initialValue: effectiveValue,
-          decoration: const InputDecoration(labelText: 'Provider'),
+          decoration: InputDecoration(
+            labelText: t.sessions.spawnSheet.providerLabel,
+          ),
           onChanged: onChanged,
           items: [
             for (final p in providers)
               DropdownMenuItem<String>(
                 value: p.id,
-                child: Text(p.enabled ? p.name : '${p.name} (disabled)'),
+                child: Text(
+                  p.enabled
+                      ? p.name
+                      : '${p.name}${t.sessions.spawnSheet.disabledSuffix}',
+                ),
               ),
           ],
         );
@@ -387,9 +391,15 @@ class _ProviderField extends ConsumerWidget {
       ),
       error: (e, _) => _ProviderProblem(
         icon: Icons.cloud_off_outlined,
-        title: 'Could not load providers',
+        title: t.sessions.spawnSheet.providerLoadError.title,
         message: e is ApiException
-            ? '${e.statusCode == 0 ? "Network error" : "Server ${e.statusCode}"}: ${e.message}'
+            ? t.sessions.spawnSheet.providerLoadError.format(
+                prefix: e.statusCode == 0
+                    ? t.sessions.spawnSheet.providerLoadError.networkError
+                    : t.sessions.spawnSheet.providerLoadError
+                        .serverPrefix(code: e.statusCode.toString()),
+                message: e.message,
+              )
             : e.toString(),
         onReload: () => ref.invalidate(providersListProvider),
       ),
@@ -413,9 +423,8 @@ class _ClaudeAccountField extends ConsumerWidget {
         // single-account setups. Operators who want multi-account
         // configure them in web admin → Settings → Accounts.
         if (accounts.isEmpty) {
-          return const _AccountHint(
-            text:
-                'No Claude accounts configured — the gateway will use the system ANTHROPIC_API_KEY. Add accounts under Settings → Accounts on the web admin.',
+          return _AccountHint(
+            text: t.sessions.spawnSheet.claudeAccount.noneHint,
           );
         }
         // Multi-account (2+ enabled): drop the Default option and
@@ -449,17 +458,17 @@ class _ClaudeAccountField extends ConsumerWidget {
         return DropdownButtonFormField<String?>(
           initialValue: effectiveValue,
           decoration: InputDecoration(
-            labelText: 'Claude account',
+            labelText: t.sessions.spawnSheet.claudeAccount.label,
             helperText: multiAccount
-                ? 'Multiple accounts configured — pick one for this session.'
-                : 'Pick a configured account or use the default (env / system).',
+                ? t.sessions.spawnSheet.claudeAccount.helperMulti
+                : t.sessions.spawnSheet.claudeAccount.helperSingle,
           ),
           onChanged: onChanged,
           items: [
             if (!multiAccount)
-              const DropdownMenuItem<String?>(
+              DropdownMenuItem<String?>(
                 value: null,
-                child: Text('Default (env / system)'),
+                child: Text(t.sessions.spawnSheet.claudeAccount.kDefault),
               ),
             for (final a in accounts)
               DropdownMenuItem<String?>(
@@ -476,16 +485,21 @@ class _ClaudeAccountField extends ConsumerWidget {
       // Error here is not fatal — fall back to "Default" silently with
       // a small inline note so the user can still spawn the session.
       error: (e, _) => _AccountHint(
-        text:
-            'Could not load Claude accounts (${e is ApiException ? e.message : e}). The session will spawn with the gateway default.',
+        text: t.sessions.spawnSheet.claudeAccount.errorHint(
+          error: e is ApiException ? e.message : e.toString(),
+        ),
       ),
     );
   }
 
   static String _accountLabel(ClaudeAccountSummary a) {
     final base = a.displayName;
-    if (!a.enabled) return '$base (disabled)';
-    if (!a.tokenFilled) return '$base (no token)';
+    if (!a.enabled) {
+      return '$base${t.sessions.spawnSheet.claudeAccount.disabledSuffix}';
+    }
+    if (!a.tokenFilled) {
+      return '$base${t.sessions.spawnSheet.claudeAccount.noTokenSuffix}';
+    }
     return base;
   }
 }
@@ -555,7 +569,7 @@ class _ProviderProblem extends StatelessWidget {
                 OutlinedButton.icon(
                   onPressed: onReload,
                   icon: const Icon(Icons.refresh, size: 16),
-                  label: const Text('Reload'),
+                  label: Text(t.sessions.spawnSheet.noProviders.reload),
                   style: OutlinedButton.styleFrom(
                     visualDensity: VisualDensity.compact,
                     foregroundColor: scheme.error,

--- a/app/mobile/lib/features/settings/settings_screen.dart
+++ b/app/mobile/lib/features/settings/settings_screen.dart
@@ -2,14 +2,15 @@
 // that aren't tied to a specific server resource. Reached via
 // More → Settings.
 //
-// PR #51 ships the Appearance section. The Account section
-// (change password / change username) lands in PR #52 — its
-// placeholder is included here so the layout doesn't shift when
-// it arrives.
+// All visible strings flow through slang (`t.settings.*`). The
+// Language section at the top lets the user override the system
+// locale; LocaleController persists the pick to shared_preferences.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/core/locale/locale_controller.dart';
 import 'package:opendray/core/theme/theme_controller.dart';
 import 'package:opendray/features/settings/change_credentials_screen.dart';
 import 'package:opendray/features/settings/log_viewer_screen.dart';
@@ -21,15 +22,49 @@ class SettingsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final mode = ref.watch(themeControllerProvider);
+    final locale = ref.watch(localeControllerProvider);
     final theme = Theme.of(context);
     return Scaffold(
-      appBar: AppBar(title: const Text('Settings')),
+      appBar: AppBar(title: Text(t.settings.title)),
       body: SafeArea(
         bottom: false,
         child: ListView(
           padding: const EdgeInsets.symmetric(vertical: 8),
           children: [
-            const _SectionHeader('Appearance'),
+            _SectionHeader(t.settings.language.section),
+            RadioGroup<LocalePreference>(
+              groupValue: locale,
+              onChanged: (pref) {
+                if (pref == null) return;
+                ref
+                    .read(localeControllerProvider.notifier)
+                    .setPreference(pref);
+              },
+              child: Column(
+                children: [
+                  _LocaleOption(
+                    title: t.settings.language.system,
+                    subtitle: t.settings.language.systemSubtitle,
+                    icon: Icons.language_outlined,
+                    value: LocalePreference.system,
+                  ),
+                  _LocaleOption(
+                    title: t.settings.language.english,
+                    subtitle: 'English',
+                    icon: Icons.translate_outlined,
+                    value: LocalePreference.english,
+                  ),
+                  _LocaleOption(
+                    title: t.settings.language.chinese,
+                    subtitle: '中文',
+                    icon: Icons.translate_outlined,
+                    value: LocalePreference.chinese,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            _SectionHeader(t.settings.appearance.section),
             // RadioGroup is the Flutter 3.32+ way to share group
             // state across Radio<T> descendants without each tile
             // duplicating groupValue/onChanged.
@@ -39,23 +74,23 @@ class SettingsScreen extends ConsumerWidget {
                 if (m == null) return;
                 ref.read(themeControllerProvider.notifier).setMode(m);
               },
-              child: const Column(
+              child: Column(
                 children: [
                   _ThemeOption(
-                    title: 'System',
-                    subtitle: "Follow your phone's appearance setting",
+                    title: t.settings.appearance.system,
+                    subtitle: t.settings.appearance.systemSubtitle,
                     icon: Icons.brightness_auto_outlined,
                     value: ThemeMode.system,
                   ),
                   _ThemeOption(
-                    title: 'Light',
-                    subtitle: 'Always use the light palette',
+                    title: t.settings.appearance.light,
+                    subtitle: t.settings.appearance.lightSubtitle,
                     icon: Icons.light_mode_outlined,
                     value: ThemeMode.light,
                   ),
                   _ThemeOption(
-                    title: 'Dark',
-                    subtitle: 'Always use the dark palette',
+                    title: t.settings.appearance.dark,
+                    subtitle: t.settings.appearance.darkSubtitle,
                     icon: Icons.dark_mode_outlined,
                     value: ThemeMode.dark,
                   ),
@@ -63,12 +98,12 @@ class SettingsScreen extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 16),
-            const _SectionHeader('Account'),
+            _SectionHeader(t.settings.account.section),
             ListTile(
               leading: const Icon(Icons.lock_outline),
-              title: const Text('Change credentials'),
+              title: Text(t.settings.account.changeCredentials),
               subtitle: Text(
-                'Username and password',
+                t.settings.account.changeCredentialsSubtitle,
                 style: theme.textTheme.bodySmall,
               ),
               trailing: const Icon(Icons.chevron_right, size: 18),
@@ -79,12 +114,12 @@ class SettingsScreen extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 16),
-            const _SectionHeader('Gateway'),
+            _SectionHeader(t.settings.gateway.section),
             ListTile(
               leading: const Icon(Icons.dns_outlined),
-              title: const Text('Server settings'),
+              title: Text(t.settings.gateway.serverSettings),
               subtitle: Text(
-                'Listen address, logging, vault, memory, storage paths…',
+                t.settings.gateway.serverSettingsSubtitle,
                 style: theme.textTheme.bodySmall,
               ),
               trailing: const Icon(Icons.chevron_right, size: 18),
@@ -96,9 +131,9 @@ class SettingsScreen extends ConsumerWidget {
             ),
             ListTile(
               leading: const Icon(Icons.subject_outlined),
-              title: const Text('Live logs'),
+              title: Text(t.settings.gateway.liveLogs),
               subtitle: Text(
-                'Tail the gateway log buffer — same source as the web admin',
+                t.settings.gateway.liveLogsSubtitle,
                 style: theme.textTheme.bodySmall,
               ),
               trailing: const Icon(Icons.chevron_right, size: 18),
@@ -162,14 +197,40 @@ class _ThemeOption extends StatelessWidget {
         style: theme.textTheme.bodySmall,
       ),
       trailing: Radio<ThemeMode>(value: value),
-      // ListTile.onTap forwards through RadioGroup's onChanged
-      // automatically via the Radio widget — no manual wiring
-      // needed.
       onTap: () {
-        // Find the ancestor RadioGroup and report this value as
-        // the new selection. Reaching through context keeps the
-        // option widget itself stateless.
         final group = RadioGroup.maybeOf<ThemeMode>(context);
+        group?.onChanged(value);
+      },
+    );
+  }
+}
+
+class _LocaleOption extends StatelessWidget {
+  const _LocaleOption({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.value,
+  });
+
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final LocalePreference value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListTile(
+      leading: Icon(icon),
+      title: Text(title),
+      subtitle: Text(
+        subtitle,
+        style: theme.textTheme.bodySmall,
+      ),
+      trailing: Radio<LocalePreference>(value: value),
+      onTap: () {
+        final group = RadioGroup.maybeOf<LocalePreference>(context);
         group?.onChanged(value);
       },
     );

--- a/app/mobile/lib/main.dart
+++ b/app/mobile/lib/main.dart
@@ -1,12 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/core/locale/locale_controller.dart';
 import 'package:opendray/core/routing/app_router.dart';
 import 'package:opendray/core/theme/app_theme.dart';
 import 'package:opendray/core/theme/theme_controller.dart';
 
 void main() {
-  runApp(const ProviderScope(child: OpendrayApp()));
+  WidgetsFlutterBinding.ensureInitialized();
+  LocaleSettings.useDeviceLocale();
+  runApp(
+    TranslationProvider(
+      child: const ProviderScope(child: OpendrayApp()),
+    ),
+  );
 }
 
 class OpendrayApp extends ConsumerWidget {
@@ -15,16 +24,21 @@ class OpendrayApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(routerProvider);
-    // Watch the controller so a picker change in Settings rebuilds
-    // MaterialApp with the new themeMode immediately — no app
-    // restart needed.
     final themeMode = ref.watch(themeControllerProvider);
+    // Watching the locale controller rebuilds MaterialApp so the
+    // Material/Cupertino delegates re-resolve and Flutter's own
+    // built-in widgets (DatePicker, dialog buttons, etc.) follow
+    // the user's pick.
+    ref.watch(localeControllerProvider);
     return MaterialApp.router(
       title: 'opendray',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.light(),
       darkTheme: AppTheme.dark(),
       themeMode: themeMode,
+      locale: TranslationProvider.of(context).flutterLocale,
+      supportedLocales: AppLocaleUtils.instance.supportedLocales,
+      localizationsDelegates: GlobalMaterialLocalizations.delegates,
       routerConfig: router,
     );
   }

--- a/app/mobile/pubspec.yaml
+++ b/app/mobile/pubspec.yaml
@@ -12,18 +12,22 @@ dependencies:
   dio: ^5.7.0
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   flutter_riverpod: ^2.6.1
   flutter_secure_storage: ^9.2.2
   freezed_annotation: ^2.4.4
   go_router: ^14.6.2
   image_picker: ^1.1.2
-  intl: ^0.19.0
+  intl: ^0.20.2
   json_annotation: ^4.9.0
   local_auth: ^2.3.0
   package_info_plus: ^8.1.1
   path: ^1.9.1
   pretty_dio_logger: ^1.4.0
   shared_preferences: ^2.3.4
+  slang: ^4.14.0
+  slang_flutter: ^4.14.0
   web_socket_channel: ^3.0.1
   xterm: ^4.0.0
   yaml: ^3.1.2
@@ -34,6 +38,7 @@ dev_dependencies:
     sdk: flutter
   freezed: ^2.5.7
   json_serializable: ^6.9.0
+  slang_build_runner: ^4.14.0
   very_good_analysis: ^7.0.0
 
 # Use the in-repo xterm fork (third_party/xterm) which enables IME features

--- a/app/mobile/slang.yaml
+++ b/app/mobile/slang.yaml
@@ -1,0 +1,13 @@
+base_locale: en
+fallback_strategy: base_locale
+input_directory: ../i18n
+input_file_pattern: .json
+output_directory: lib/core/i18n
+output_file_name: strings.g.dart
+locale_handling: true
+flutter_integration: true
+namespaces: false
+translate_var: t
+enum_name: AppLocale
+class_name: Translations
+translation_class_visibility: private

--- a/app/mobile/slang.yaml
+++ b/app/mobile/slang.yaml
@@ -11,3 +11,6 @@ translate_var: t
 enum_name: AppLocale
 class_name: Translations
 translation_class_visibility: private
+# {name} placeholder syntax — matches react-i18next default, keeps
+# the JSON keys portable when web joins the same translation source.
+string_interpolation: braces


### PR DESCRIPTION
Stacked on #74. Migrates the three configuration screens reached from the More tab — MCP servers/secrets, providers + Claude account list, and the integrations register/edit/rotate flow.

## Changes

### Translation source

- **`app/i18n/{en,zh}.json`** — three new namespaces:
  - **`mcp.*`**: title, newServer, addSecret, editConfig, viewRawConfig, copyId, copiedSnack(`{id}`), deleteServerTitle, deleteSecretTitle, errorPrefix.{delete,add,update,toggle}, errorWithMessage(`{prefix,error}`), editor.{nameHint, jsonHint}, secret.{keyLabel,keyHint,valueLabel}.
  - **`providers.*`**: title, configSaved, saveFailedApi/Generic(`{error}`), reload, errorPrefix.{toggle,rename,delete}, errorWithMessage(`{prefix,error}`), accounts.{rename, renameTitle(`{name}`), displayNameLabel, displayNameHint, deleteTitle, importFailedApi/Generic}.
  - **`integrations.*`**: title, register, registerDialogTitle, edit, editTitle(`{name}`), enabledLabel, iSavedIt, apiKeyForName(`{name}`), apiKeySubtitleRegister(`{routePrefix}`), copiedRequestId(`{id}`), updateOk, deleteTitle, deletedSnack(`{name}`), rotateKey, rotateConfirmTitle, rotate, newApiKeyTitle(`{name}`), newApiKeySubtitle, and 4× failed-action templates (register / update / delete / rotate × api/generic variants).

### Dart files (9)

- `mcp_screen.dart`, `mcp_editor_screen.dart`
- `providers_screen.dart`, `provider_config_screen.dart`, `claude_account_dialogs.dart`, `claude_accounts_section.dart`
- `integrations_screen.dart`, `integration_forms.dart`, `integration_detail_screen.dart`

All visible strings flow through `t.*`. The shared `_run` error-helper pattern (with a `failPrefix` parameter) now receives an i18n value via `t.{mcp,providers}.errorPrefix.*`, and the snackbar template `'$failPrefix: $error'` is centralized as `t.{ns}.errorWithMessage({prefix, error})`.

## Edge case worth knowing

The MCP editor's JSON-shaped hintText `{ "name": ..., "transport": "stdio", ... }` tripped slang's brace-placeholder parser — the `{name}` and `{transport}` substrings were interpreted as placeholder names, generating broken Dart. **Rewrote** the hint as natural-language guidance: `"JSON config — name, transport: stdio, command, args…"`. The original was an example, not a copy-paste template, so this loses nothing.

Alternative considered: escape `\{` in the JSON source. Slang's brace-mode escape semantics aren't well-documented and would be a maintenance footgun; the rewrite is clearer.

## Out of scope

- Skills / custom_tasks / top-level Notes
- Backups / Git hosts / Channels / Onboarding
- Settings sub-screens (change_credentials / server_settings / log_viewer)
- memory_workers / memory_cleanup / project (memory sub-screens)

## Verified

- [x] `flutter analyze` clean
- [ ] Manual on-device verification together with the rest of the stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)