### PR TITLE
fix(mobile): finish Memory workers i18n — intro card, errors, task labels

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -392,7 +392,35 @@
     "cliGemini": "Gemini",
     "claudeAccountLabel": "Claude account",
     "claudeAccountDefault": "Default",
-    "test": "Test"
+    "test": "Test",
+    "intro": "Each memory-system LLM touchpoint can be served independently by the local summarizer endpoint (LM Studio / OpenAI-compat) or by spawning a headless Claude / Gemini agent in --print mode. High-quality narrative tasks (gitactivity, transcript) benefit from agent workers; high-frequency tasks (gatekeeper) stay on the local endpoint by design.",
+    "errorTitle": "Endpoint not reachable",
+    "errorDetail": "The /api/v1/memory/workers routes are new in M25 — the opendray binary may need a restart to mount them and run migration 0029.",
+    "summarizerOnlyBadge": "summarizer-only",
+    "summarizerInfo": "Uses the registry default summarizer provider. Pick a specific row on the web admin.",
+    "agentWarning": "Agent mode spawns a headless CLI per call. Latency ~5-15s (vs ~1s summarizer); cost shifts from CPU to your Claude/Gemini quota.",
+    "noCalls24h": "No calls in last 24h.",
+    "testOkSnack": "{label} OK — {duration}ms",
+    "testFailedReturnedSnack": "{label} failed: {error}",
+    "unknownError": "unknown",
+    "tasks": {
+      "gatekeeper": {
+        "label": "Gatekeeper",
+        "description": "Pre-write filter on every memory_store. High frequency (<500ms target) — summarizer-only."
+      },
+      "cleaner": {
+        "label": "Cleaner librarian",
+        "description": "Periodic LLM librarian. Judges aged memories as keep / stale / duplicate."
+      },
+      "gitactivity": {
+        "label": "Git activity summariser",
+        "description": "git log → 2-3 paragraph narrative every 24h. Naturally fits an agent worker."
+      },
+      "transcript": {
+        "label": "Session transcript summariser",
+        "description": "Session-end 'what did the agent do' summary. Naturally fits an agent worker."
+      }
+    }
   },
   "memoryCleanup": {
     "title": "Memory cleanup",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -392,7 +392,35 @@
     "cliGemini": "Gemini",
     "claudeAccountLabel": "Claude 账号",
     "claudeAccountDefault": "默认",
-    "test": "测试"
+    "test": "测试",
+    "intro": "每个记忆系统的 LLM 触点都可以独立服务 — 由本地 summarizer 端点（LM Studio / OpenAI 兼容）或在 --print 模式下生成无头 Claude / Gemini agent 来处理。高质量叙事任务（gitactivity、transcript）适合 agent 工作器；高频任务（gatekeeper）按设计保留在本地端点上。",
+    "errorTitle": "端点不可达",
+    "errorDetail": "/api/v1/memory/workers 路由在 M25 中是新增的 — opendray 二进制可能需要重启以挂载这些路由并运行迁移 0029。",
+    "summarizerOnlyBadge": "仅 summarizer",
+    "summarizerInfo": "使用注册表默认 summarizer 提供商。在 Web 管理端选择具体行。",
+    "agentWarning": "Agent 模式每次调用都会生成无头 CLI。延迟约 5-15 秒（相比 summarizer 约 1 秒）；成本从 CPU 转移到你的 Claude / Gemini 配额。",
+    "noCalls24h": "过去 24 小时没有调用。",
+    "testOkSnack": "{label} OK — {duration}ms",
+    "testFailedReturnedSnack": "{label} 失败：{error}",
+    "unknownError": "未知",
+    "tasks": {
+      "gatekeeper": {
+        "label": "守门员",
+        "description": "每次 memory_store 写入前的过滤器。高频（目标 <500ms） — 仅 summarizer。"
+      },
+      "cleaner": {
+        "label": "清理馆员",
+        "description": "定期 LLM 馆员。判断旧记忆为保留 / 过期 / 重复。"
+      },
+      "gitactivity": {
+        "label": "Git 活动摘要器",
+        "description": "git log → 每 24 小时的 2-3 段叙事。天然适合 agent 工作器。"
+      },
+      "transcript": {
+        "label": "会话记录摘要器",
+        "description": "会话结束时的「agent 做了什么」摘要。天然适合 agent 工作器。"
+      }
+    }
   },
   "memoryCleanup": {
     "title": "记忆清理",

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 1064 (532 per locale)
+/// Strings: 1100 (550 per locale)
 ///
-/// Built on 2026-05-13 at 12:40 UTC
+/// Built on 2026-05-13 at 13:14 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -425,6 +425,38 @@ class TranslationsMemoryWorkersEn {
 
 	/// en: 'Test'
 	String get test => 'Test';
+
+	/// en: 'Each memory-system LLM touchpoint can be served independently by the local summarizer endpoint (LM Studio / OpenAI-compat) or by spawning a headless Claude / Gemini agent in --print mode. High-quality narrative tasks (gitactivity, transcript) benefit from agent workers; high-frequency tasks (gatekeeper) stay on the local endpoint by design.'
+	String get intro => 'Each memory-system LLM touchpoint can be served independently by the local summarizer endpoint (LM Studio / OpenAI-compat) or by spawning a headless Claude / Gemini agent in --print mode. High-quality narrative tasks (gitactivity, transcript) benefit from agent workers; high-frequency tasks (gatekeeper) stay on the local endpoint by design.';
+
+	/// en: 'Endpoint not reachable'
+	String get errorTitle => 'Endpoint not reachable';
+
+	/// en: 'The /api/v1/memory/workers routes are new in M25 — the opendray binary may need a restart to mount them and run migration 0029.'
+	String get errorDetail => 'The /api/v1/memory/workers routes are new in M25 — the opendray binary may need a restart to mount them and run migration 0029.';
+
+	/// en: 'summarizer-only'
+	String get summarizerOnlyBadge => 'summarizer-only';
+
+	/// en: 'Uses the registry default summarizer provider. Pick a specific row on the web admin.'
+	String get summarizerInfo => 'Uses the registry default summarizer provider. Pick a specific row on the web admin.';
+
+	/// en: 'Agent mode spawns a headless CLI per call. Latency ~5-15s (vs ~1s summarizer); cost shifts from CPU to your Claude/Gemini quota.'
+	String get agentWarning => 'Agent mode spawns a headless CLI per call. Latency ~5-15s (vs ~1s summarizer); cost shifts from CPU to your Claude/Gemini quota.';
+
+	/// en: 'No calls in last 24h.'
+	String get noCalls24h => 'No calls in last 24h.';
+
+	/// en: '{label} OK — {duration}ms'
+	String testOkSnack({required Object label, required Object duration}) => '${label} OK — ${duration}ms';
+
+	/// en: '{label} failed: {error}'
+	String testFailedReturnedSnack({required Object label, required Object error}) => '${label} failed: ${error}';
+
+	/// en: 'unknown'
+	String get unknownError => 'unknown';
+
+	late final TranslationsMemoryWorkersTasksEn tasks = TranslationsMemoryWorkersTasksEn.internal(_root);
 }
 
 // Path: memoryCleanup
@@ -1448,6 +1480,19 @@ class TranslationsProvidersAccountsEn {
 
 	/// en: 'Import failed: {error}'
 	String importFailedGeneric({required Object error}) => 'Import failed: ${error}';
+}
+
+// Path: memoryWorkers.tasks
+class TranslationsMemoryWorkersTasksEn {
+	TranslationsMemoryWorkersTasksEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsMemoryWorkersTasksGatekeeperEn gatekeeper = TranslationsMemoryWorkersTasksGatekeeperEn.internal(_root);
+	late final TranslationsMemoryWorkersTasksCleanerEn cleaner = TranslationsMemoryWorkersTasksCleanerEn.internal(_root);
+	late final TranslationsMemoryWorkersTasksGitactivityEn gitactivity = TranslationsMemoryWorkersTasksGitactivityEn.internal(_root);
+	late final TranslationsMemoryWorkersTasksTranscriptEn transcript = TranslationsMemoryWorkersTasksTranscriptEn.internal(_root);
 }
 
 // Path: backups.encryption
@@ -2524,6 +2569,66 @@ class TranslationsSessionsSpawnSheetClaudeAccountEn {
 	String errorHint({required Object error}) => 'Could not load Claude accounts (${error}). The session will spawn with the gateway default.';
 }
 
+// Path: memoryWorkers.tasks.gatekeeper
+class TranslationsMemoryWorkersTasksGatekeeperEn {
+	TranslationsMemoryWorkersTasksGatekeeperEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Gatekeeper'
+	String get label => 'Gatekeeper';
+
+	/// en: 'Pre-write filter on every memory_store. High frequency (<500ms target) — summarizer-only.'
+	String get description => 'Pre-write filter on every memory_store. High frequency (<500ms target) — summarizer-only.';
+}
+
+// Path: memoryWorkers.tasks.cleaner
+class TranslationsMemoryWorkersTasksCleanerEn {
+	TranslationsMemoryWorkersTasksCleanerEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Cleaner librarian'
+	String get label => 'Cleaner librarian';
+
+	/// en: 'Periodic LLM librarian. Judges aged memories as keep / stale / duplicate.'
+	String get description => 'Periodic LLM librarian. Judges aged memories as keep / stale / duplicate.';
+}
+
+// Path: memoryWorkers.tasks.gitactivity
+class TranslationsMemoryWorkersTasksGitactivityEn {
+	TranslationsMemoryWorkersTasksGitactivityEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Git activity summariser'
+	String get label => 'Git activity summariser';
+
+	/// en: 'git log → 2-3 paragraph narrative every 24h. Naturally fits an agent worker.'
+	String get description => 'git log → 2-3 paragraph narrative every 24h. Naturally fits an agent worker.';
+}
+
+// Path: memoryWorkers.tasks.transcript
+class TranslationsMemoryWorkersTasksTranscriptEn {
+	TranslationsMemoryWorkersTasksTranscriptEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Session transcript summariser'
+	String get label => 'Session transcript summariser';
+
+	/// en: 'Session-end 'what did the agent do' summary. Naturally fits an agent worker.'
+	String get description => 'Session-end \'what did the agent do\' summary. Naturally fits an agent worker.';
+}
+
 // Path: settings.logViewer.levels
 class TranslationsSettingsLogViewerLevelsEn {
 	TranslationsSettingsLogViewerLevelsEn.internal(this._root);
@@ -2900,6 +3005,24 @@ extension on Translations {
 			'memoryWorkers.claudeAccountLabel' => 'Claude account',
 			'memoryWorkers.claudeAccountDefault' => 'Default',
 			'memoryWorkers.test' => 'Test',
+			'memoryWorkers.intro' => 'Each memory-system LLM touchpoint can be served independently by the local summarizer endpoint (LM Studio / OpenAI-compat) or by spawning a headless Claude / Gemini agent in --print mode. High-quality narrative tasks (gitactivity, transcript) benefit from agent workers; high-frequency tasks (gatekeeper) stay on the local endpoint by design.',
+			'memoryWorkers.errorTitle' => 'Endpoint not reachable',
+			'memoryWorkers.errorDetail' => 'The /api/v1/memory/workers routes are new in M25 — the opendray binary may need a restart to mount them and run migration 0029.',
+			'memoryWorkers.summarizerOnlyBadge' => 'summarizer-only',
+			'memoryWorkers.summarizerInfo' => 'Uses the registry default summarizer provider. Pick a specific row on the web admin.',
+			'memoryWorkers.agentWarning' => 'Agent mode spawns a headless CLI per call. Latency ~5-15s (vs ~1s summarizer); cost shifts from CPU to your Claude/Gemini quota.',
+			'memoryWorkers.noCalls24h' => 'No calls in last 24h.',
+			'memoryWorkers.testOkSnack' => ({required Object label, required Object duration}) => '${label} OK — ${duration}ms',
+			'memoryWorkers.testFailedReturnedSnack' => ({required Object label, required Object error}) => '${label} failed: ${error}',
+			'memoryWorkers.unknownError' => 'unknown',
+			'memoryWorkers.tasks.gatekeeper.label' => 'Gatekeeper',
+			'memoryWorkers.tasks.gatekeeper.description' => 'Pre-write filter on every memory_store. High frequency (<500ms target) — summarizer-only.',
+			'memoryWorkers.tasks.cleaner.label' => 'Cleaner librarian',
+			'memoryWorkers.tasks.cleaner.description' => 'Periodic LLM librarian. Judges aged memories as keep / stale / duplicate.',
+			'memoryWorkers.tasks.gitactivity.label' => 'Git activity summariser',
+			'memoryWorkers.tasks.gitactivity.description' => 'git log → 2-3 paragraph narrative every 24h. Naturally fits an agent worker.',
+			'memoryWorkers.tasks.transcript.label' => 'Session transcript summariser',
+			'memoryWorkers.tasks.transcript.description' => 'Session-end \'what did the agent do\' summary. Naturally fits an agent worker.',
 			'memoryCleanup.title' => 'Memory cleanup',
 			'memoryCleanup.approveFailed' => ({required Object error}) => 'Approve failed: ${error}',
 			'memoryCleanup.rejectFailed' => ({required Object error}) => 'Reject failed: ${error}',
@@ -3113,6 +3236,8 @@ extension on Translations {
 			'settings.changeCredentials.currentPassword' => 'Current password',
 			'settings.changeCredentials.newUsername' => 'New username',
 			'settings.changeCredentials.newPassword' => 'New password',
+			_ => null,
+		} ?? switch (path) {
 			'settings.changeCredentials.confirmPassword' => 'Confirm new password',
 			'settings.changeCredentials.validatorRequired' => 'Required',
 			'settings.changeCredentials.passwordHelper' => 'At least 8 characters',
@@ -3131,8 +3256,6 @@ extension on Translations {
 			'settings.logViewer.levels.all' => 'All',
 			'settings.logViewer.levels.debug' => 'Debug',
 			'settings.logViewer.levels.info' => 'Info',
-			_ => null,
-		} ?? switch (path) {
 			'settings.logViewer.levels.warn' => 'Warn',
 			'settings.logViewer.levels.error' => 'Error',
 			'settings.serverSettings.title' => 'Server settings',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -247,6 +247,17 @@ class _TranslationsMemoryWorkersZh extends TranslationsMemoryWorkersEn {
 	@override String get claudeAccountLabel => 'Claude 账号';
 	@override String get claudeAccountDefault => '默认';
 	@override String get test => '测试';
+	@override String get intro => '每个记忆系统的 LLM 触点都可以独立服务 — 由本地 summarizer 端点（LM Studio / OpenAI 兼容）或在 --print 模式下生成无头 Claude / Gemini agent 来处理。高质量叙事任务（gitactivity、transcript）适合 agent 工作器；高频任务（gatekeeper）按设计保留在本地端点上。';
+	@override String get errorTitle => '端点不可达';
+	@override String get errorDetail => '/api/v1/memory/workers 路由在 M25 中是新增的 — opendray 二进制可能需要重启以挂载这些路由并运行迁移 0029。';
+	@override String get summarizerOnlyBadge => '仅 summarizer';
+	@override String get summarizerInfo => '使用注册表默认 summarizer 提供商。在 Web 管理端选择具体行。';
+	@override String get agentWarning => 'Agent 模式每次调用都会生成无头 CLI。延迟约 5-15 秒（相比 summarizer 约 1 秒）；成本从 CPU 转移到你的 Claude / Gemini 配额。';
+	@override String get noCalls24h => '过去 24 小时没有调用。';
+	@override String testOkSnack({required Object label, required Object duration}) => '${label} OK — ${duration}ms';
+	@override String testFailedReturnedSnack({required Object label, required Object error}) => '${label} 失败：${error}';
+	@override String get unknownError => '未知';
+	@override late final _TranslationsMemoryWorkersTasksZh tasks = _TranslationsMemoryWorkersTasksZh._(_root);
 }
 
 // Path: memoryCleanup
@@ -815,6 +826,19 @@ class _TranslationsProvidersAccountsZh extends TranslationsProvidersAccountsEn {
 	@override String get deleteTitle => '删除账号？';
 	@override String importFailedApi({required Object error}) => '导入失败：${error}';
 	@override String importFailedGeneric({required Object error}) => '导入失败：${error}';
+}
+
+// Path: memoryWorkers.tasks
+class _TranslationsMemoryWorkersTasksZh extends TranslationsMemoryWorkersTasksEn {
+	_TranslationsMemoryWorkersTasksZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsMemoryWorkersTasksGatekeeperZh gatekeeper = _TranslationsMemoryWorkersTasksGatekeeperZh._(_root);
+	@override late final _TranslationsMemoryWorkersTasksCleanerZh cleaner = _TranslationsMemoryWorkersTasksCleanerZh._(_root);
+	@override late final _TranslationsMemoryWorkersTasksGitactivityZh gitactivity = _TranslationsMemoryWorkersTasksGitactivityZh._(_root);
+	@override late final _TranslationsMemoryWorkersTasksTranscriptZh transcript = _TranslationsMemoryWorkersTasksTranscriptZh._(_root);
 }
 
 // Path: backups.encryption
@@ -1476,6 +1500,50 @@ class _TranslationsSessionsSpawnSheetClaudeAccountZh extends TranslationsSession
 	@override String errorHint({required Object error}) => '无法加载 Claude 账号（${error}）。会话将以网关默认配置启动。';
 }
 
+// Path: memoryWorkers.tasks.gatekeeper
+class _TranslationsMemoryWorkersTasksGatekeeperZh extends TranslationsMemoryWorkersTasksGatekeeperEn {
+	_TranslationsMemoryWorkersTasksGatekeeperZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '守门员';
+	@override String get description => '每次 memory_store 写入前的过滤器。高频（目标 <500ms） — 仅 summarizer。';
+}
+
+// Path: memoryWorkers.tasks.cleaner
+class _TranslationsMemoryWorkersTasksCleanerZh extends TranslationsMemoryWorkersTasksCleanerEn {
+	_TranslationsMemoryWorkersTasksCleanerZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '清理馆员';
+	@override String get description => '定期 LLM 馆员。判断旧记忆为保留 / 过期 / 重复。';
+}
+
+// Path: memoryWorkers.tasks.gitactivity
+class _TranslationsMemoryWorkersTasksGitactivityZh extends TranslationsMemoryWorkersTasksGitactivityEn {
+	_TranslationsMemoryWorkersTasksGitactivityZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'Git 活动摘要器';
+	@override String get description => 'git log → 每 24 小时的 2-3 段叙事。天然适合 agent 工作器。';
+}
+
+// Path: memoryWorkers.tasks.transcript
+class _TranslationsMemoryWorkersTasksTranscriptZh extends TranslationsMemoryWorkersTasksTranscriptEn {
+	_TranslationsMemoryWorkersTasksTranscriptZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '会话记录摘要器';
+	@override String get description => '会话结束时的「agent 做了什么」摘要。天然适合 agent 工作器。';
+}
+
 // Path: settings.logViewer.levels
 class _TranslationsSettingsLogViewerLevelsZh extends TranslationsSettingsLogViewerLevelsEn {
 	_TranslationsSettingsLogViewerLevelsZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -1812,6 +1880,24 @@ extension on TranslationsZh {
 			'memoryWorkers.claudeAccountLabel' => 'Claude 账号',
 			'memoryWorkers.claudeAccountDefault' => '默认',
 			'memoryWorkers.test' => '测试',
+			'memoryWorkers.intro' => '每个记忆系统的 LLM 触点都可以独立服务 — 由本地 summarizer 端点（LM Studio / OpenAI 兼容）或在 --print 模式下生成无头 Claude / Gemini agent 来处理。高质量叙事任务（gitactivity、transcript）适合 agent 工作器；高频任务（gatekeeper）按设计保留在本地端点上。',
+			'memoryWorkers.errorTitle' => '端点不可达',
+			'memoryWorkers.errorDetail' => '/api/v1/memory/workers 路由在 M25 中是新增的 — opendray 二进制可能需要重启以挂载这些路由并运行迁移 0029。',
+			'memoryWorkers.summarizerOnlyBadge' => '仅 summarizer',
+			'memoryWorkers.summarizerInfo' => '使用注册表默认 summarizer 提供商。在 Web 管理端选择具体行。',
+			'memoryWorkers.agentWarning' => 'Agent 模式每次调用都会生成无头 CLI。延迟约 5-15 秒（相比 summarizer 约 1 秒）；成本从 CPU 转移到你的 Claude / Gemini 配额。',
+			'memoryWorkers.noCalls24h' => '过去 24 小时没有调用。',
+			'memoryWorkers.testOkSnack' => ({required Object label, required Object duration}) => '${label} OK — ${duration}ms',
+			'memoryWorkers.testFailedReturnedSnack' => ({required Object label, required Object error}) => '${label} 失败：${error}',
+			'memoryWorkers.unknownError' => '未知',
+			'memoryWorkers.tasks.gatekeeper.label' => '守门员',
+			'memoryWorkers.tasks.gatekeeper.description' => '每次 memory_store 写入前的过滤器。高频（目标 <500ms） — 仅 summarizer。',
+			'memoryWorkers.tasks.cleaner.label' => '清理馆员',
+			'memoryWorkers.tasks.cleaner.description' => '定期 LLM 馆员。判断旧记忆为保留 / 过期 / 重复。',
+			'memoryWorkers.tasks.gitactivity.label' => 'Git 活动摘要器',
+			'memoryWorkers.tasks.gitactivity.description' => 'git log → 每 24 小时的 2-3 段叙事。天然适合 agent 工作器。',
+			'memoryWorkers.tasks.transcript.label' => '会话记录摘要器',
+			'memoryWorkers.tasks.transcript.description' => '会话结束时的「agent 做了什么」摘要。天然适合 agent 工作器。',
 			'memoryCleanup.title' => '记忆清理',
 			'memoryCleanup.approveFailed' => ({required Object error}) => '批准失败：${error}',
 			'memoryCleanup.rejectFailed' => ({required Object error}) => '拒绝失败：${error}',
@@ -2025,6 +2111,8 @@ extension on TranslationsZh {
 			'settings.changeCredentials.currentPassword' => '当前密码',
 			'settings.changeCredentials.newUsername' => '新用户名',
 			'settings.changeCredentials.newPassword' => '新密码',
+			_ => null,
+		} ?? switch (path) {
 			'settings.changeCredentials.confirmPassword' => '确认新密码',
 			'settings.changeCredentials.validatorRequired' => '必填',
 			'settings.changeCredentials.passwordHelper' => '至少 8 个字符',
@@ -2043,8 +2131,6 @@ extension on TranslationsZh {
 			'settings.logViewer.levels.all' => '全部',
 			'settings.logViewer.levels.debug' => '调试',
 			'settings.logViewer.levels.info' => '信息',
-			_ => null,
-		} ?? switch (path) {
 			'settings.logViewer.levels.warn' => '警告',
 			'settings.logViewer.levels.error' => '错误',
 			'settings.serverSettings.title' => '服务器设置',

--- a/app/mobile/lib/features/memory_workers/memory_workers_screen.dart
+++ b/app/mobile/lib/features/memory_workers/memory_workers_screen.dart
@@ -70,16 +70,14 @@ class _MemoryWorkersScreenState extends ConsumerState<MemoryWorkersScreen> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      const Text(
-                        'Endpoint not reachable',
-                        style: TextStyle(fontWeight: FontWeight.bold),
+                      Text(
+                        t.memoryWorkers.errorTitle,
+                        style: const TextStyle(fontWeight: FontWeight.bold),
                       ),
                       const SizedBox(height: 8),
-                      const Text(
-                        'The /api/v1/memory/workers routes are new in M25 — '
-                        'the opendray binary may need a restart to mount '
-                        'them and run migration 0029.',
-                        style: TextStyle(fontSize: 12),
+                      Text(
+                        t.memoryWorkers.errorDetail,
+                        style: const TextStyle(fontSize: 12),
                       ),
                       const SizedBox(height: 8),
                       Text(
@@ -101,18 +99,11 @@ class _MemoryWorkersScreenState extends ConsumerState<MemoryWorkersScreen> {
             children: [
               Card(
                 color: Theme.of(context).colorScheme.surfaceContainerHighest,
-                child: const Padding(
-                  padding: EdgeInsets.all(12),
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
                   child: Text(
-                    'Each memory-system LLM touchpoint can be served '
-                    'independently by the local summarizer endpoint '
-                    '(LM Studio / OpenAI-compat) or by spawning a '
-                    'headless Claude / Gemini agent in --print mode. '
-                    'High-quality narrative tasks (gitactivity, '
-                    'transcript) benefit from agent workers; '
-                    'high-frequency tasks (gatekeeper) stay on the '
-                    'local endpoint by design.',
-                    style: TextStyle(fontSize: 12),
+                    t.memoryWorkers.intro,
+                    style: const TextStyle(fontSize: 12),
                   ),
                 ),
               ),
@@ -191,7 +182,7 @@ class _WorkerCardState extends ConsumerState<_WorkerCard> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(t.memoryWorkers
-              .savedSnack(label: widget.config.task.label)),
+              .savedSnack(label: _taskLabel(widget.config.task))),
         ),
       );
       widget.onChanged();
@@ -217,12 +208,16 @@ class _WorkerCardState extends ConsumerState<_WorkerCard> {
           await ref.read(memoryWorkersApiProvider).test(widget.config.task);
       if (!mounted) return;
       if (res.ok) {
+        final base = t.memoryWorkers.testOkSnack(
+          label: _taskLabel(widget.config.task),
+          duration: res.durationMs.toString(),
+        );
+        final preview = (res.preview != null && res.preview!.isNotEmpty)
+            ? '\n${_truncate(res.preview!, 200)}'
+            : '';
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(
-              '${widget.config.task.label} OK — ${res.durationMs}ms'
-              '${res.preview != null && res.preview!.isNotEmpty ? "\n${_truncate(res.preview!, 200)}" : ""}',
-            ),
+            content: Text('$base$preview'),
             duration: const Duration(seconds: 6),
           ),
         );
@@ -230,7 +225,10 @@ class _WorkerCardState extends ConsumerState<_WorkerCard> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
-              '${widget.config.task.label} failed: ${res.error ?? "unknown"}',
+              t.memoryWorkers.testFailedReturnedSnack(
+                label: _taskLabel(widget.config.task),
+                error: res.error ?? t.memoryWorkers.unknownError,
+              ),
             ),
           ),
         );
@@ -250,6 +248,20 @@ class _WorkerCardState extends ConsumerState<_WorkerCard> {
     }
   }
 
+  String _taskLabel(WorkerTaskKind k) => switch (k) {
+        WorkerTaskKind.gatekeeper => t.memoryWorkers.tasks.gatekeeper.label,
+        WorkerTaskKind.cleaner => t.memoryWorkers.tasks.cleaner.label,
+        WorkerTaskKind.gitactivity => t.memoryWorkers.tasks.gitactivity.label,
+        WorkerTaskKind.transcript => t.memoryWorkers.tasks.transcript.label,
+      };
+
+  String _taskDescription(WorkerTaskKind k) => switch (k) {
+        WorkerTaskKind.gatekeeper => t.memoryWorkers.tasks.gatekeeper.description,
+        WorkerTaskKind.cleaner => t.memoryWorkers.tasks.cleaner.description,
+        WorkerTaskKind.gitactivity => t.memoryWorkers.tasks.gitactivity.description,
+        WorkerTaskKind.transcript => t.memoryWorkers.tasks.transcript.description,
+      };
+
   @override
   Widget build(BuildContext context) {
     final agentAllowed = widget.config.task.agentSupported;
@@ -264,7 +276,7 @@ class _WorkerCardState extends ConsumerState<_WorkerCard> {
               children: [
                 Expanded(
                   child: Text(
-                    widget.config.task.label,
+                    _taskLabel(widget.config.task),
                     style: Theme.of(context).textTheme.titleMedium?.copyWith(
                           fontWeight: FontWeight.w600,
                         ),
@@ -279,7 +291,7 @@ class _WorkerCardState extends ConsumerState<_WorkerCard> {
                       borderRadius: BorderRadius.circular(8),
                     ),
                     child: Text(
-                      'summarizer-only',
+                      t.memoryWorkers.summarizerOnlyBadge,
                       style: TextStyle(
                         fontSize: 9,
                         color:
@@ -292,7 +304,7 @@ class _WorkerCardState extends ConsumerState<_WorkerCard> {
             ),
             const SizedBox(height: 4),
             Text(
-              widget.config.task.description,
+              _taskDescription(widget.config.task),
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: Theme.of(context).hintColor,
                   ),
@@ -385,8 +397,7 @@ class _WorkerCardState extends ConsumerState<_WorkerCard> {
           const SizedBox(width: 6),
           Expanded(
             child: Text(
-              'Uses the registry default summarizer provider. '
-              'Pick a specific row on the web admin.',
+              t.memoryWorkers.summarizerInfo,
               style: Theme.of(context).textTheme.bodySmall,
             ),
           ),
@@ -461,9 +472,7 @@ class _WorkerCardState extends ConsumerState<_WorkerCard> {
           const SizedBox(width: 6),
           Expanded(
             child: Text(
-              'Agent mode spawns a headless CLI per call. Latency ~5-15s '
-              '(vs ~1s summarizer); cost shifts from CPU to your '
-              'Claude/Gemini quota.',
+              t.memoryWorkers.agentWarning,
               style: Theme.of(context).textTheme.bodySmall,
             ),
           ),
@@ -486,7 +495,7 @@ class _WorkerCardState extends ConsumerState<_WorkerCard> {
             .toList();
         if (recent.isEmpty) {
           return Text(
-            'No calls in last 24h.',
+            t.memoryWorkers.noCalls24h,
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
                   color: Theme.of(context).hintColor,
                   fontSize: 11,


### PR DESCRIPTION
Follow-up to #92 (Memory sub-system). On-device verification surfaced that the Memory workers configuration screen has **several large blocks** of explanatory English text the original PR missed.

## What was still English

- Top intro card describing what the four worker tasks do (~8 lines of prose)
- The **per-task label and description** of Gatekeeper / Cleaner / Git activity / Session transcript — these came from a `WorkerTaskKindX` enum extension in `memory_workers_api.dart` and were not visible to a string grep
- "Endpoint not reachable" error card + the migration-0029 hint underneath
- "summarizer-only" badge
- The provider-info card under summarizer mode
- The agent-mode latency / cost warning
- "No calls in last 24h." empty state
- Two test-button snackbars (success with preview / explicit failure return)

## Approach

- Extended `memoryWorkers.*` namespace with all the missing strings + a `tasks.{gatekeeper, cleaner, gitactivity, transcript}.{label, description}` sub-tree.
- Added local `_taskLabel` / `_taskDescription` switch helpers in `memory_workers_screen.dart` that resolve to the new keys. The original `WorkerTaskKindX` extension in `memory_workers_api.dart` is **left untouched** — the API layer shouldn't depend on UI translation. Call sites use the helpers.

## Verified

- [x] `flutter analyze` clean
- [ ] On-device: open Memory → Memory workers → confirm every visible string (intro card, task names, descriptions, badges, warnings, test snackbar) renders in the selected locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)