### PR TITLE
fix(mobile): channel_kinds — 7 channel types fully bilingual

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -321,13 +321,68 @@
     "errorWithMessage": "{prefix}: {error}",
     "editor": {
       "nameHint": "my-mcp-server",
-      "jsonHint": "JSON config — name, transport: stdio, command, args…"
+      "jsonHint": "JSON config — name, transport: stdio, command, args…",
+      "descriptionPlaceholder": "Optional one-liner",
+      "validateJsonObject": "Body must be a JSON object",
+      "validateJsonInvalid": "Invalid JSON: {error}",
+      "appBarEdit": "Edit MCP server",
+      "appBarNew": "New MCP server",
+      "idLockedHint": "Locked in edit mode — delete + recreate to change.",
+      "jsonLabel": "Server JSON",
+      "jsonSchemaHelp": "Schema: transport must be stdio, http or sse. For stdio set command + args. For http/sse set url + headers. Use \\$secret:KEY to reference vault secrets.",
+      "idLabel": "id (URL segment, lowercase alphanumeric / dash / underscore)",
+      "idRequired": "id is required",
+      "saving": "Saving…",
+      "save": "Save",
+      "create": "Create"
     },
     "secret": {
       "keyLabel": "Key",
       "keyHint": "GITHUB_TOKEN, OPENAI_KEY, …",
-      "valueLabel": "Value"
-    }
+      "valueLabel": "Value",
+      "keyRequired": "Key is required.",
+      "keyInvalid": "Key must match [A-Za-z_][A-Za-z0-9_]* — same rules as a shell env var.",
+      "valueRequired": "Value is required.",
+      "replaceTitle": "Replace secret value",
+      "addTitle": "Add secret",
+      "saveButton": "Save",
+      "addButton": "Add",
+      "helpRules": "Shell-env-var rules: starts with a letter or _, then letters / digits / _ only.",
+      "replaceHint": "Paste new value (the previous one is wiped)",
+      "addHint": "Paste secret value",
+      "addedSnack": "Secret {key} added.",
+      "updatedSnack": "Secret {key} updated.",
+      "deletedSnack": "Deleted {key}.",
+      "deleteBody": "Removes the value from the encrypted vault. Any MCP server that references it will fail until restored."
+    },
+    "popup": {
+      "editConfigSubtitle": "Full JSON editor — vault-backed servers only",
+      "viewRawSubtitle": "Read-only inspector for the server JSON",
+      "deleteLabel": "Delete"
+    },
+    "kv": {
+      "transport": "Transport",
+      "description": "Description",
+      "command": "Command",
+      "args": "Args",
+      "headers": "Headers"
+    },
+    "deleteServerBody": "Removes the vault directory for {id}. Sessions that reference this server stop being able to spawn it.",
+    "deleteServerSnack": "Deleted {id}.",
+    "serversCount": "Servers ({count})",
+    "secretsCount": "Secrets ({count})",
+    "emptyServers": "No MCP servers registered. Tap \"New server\" to add one.",
+    "emptySecrets": "No secrets stored. Add one to feed sensitive env / headers into MCP servers without putting them in the JSON.",
+    "noVaultFileYet": "No vault file yet — added secrets create it.",
+    "tapToReplaceHint": "Tap to replace · long-press / trash to delete",
+    "failedToLoad": "Failed to load MCP state",
+    "serverCreatedSnack": "MCP server created.",
+    "serverUpdatedSnack": "MCP server updated.",
+    "envHeading": "Env",
+    "encryptionAes": "AES-GCM encrypted (key in OS keychain)",
+    "encryptionPlaintext": "PLAINTEXT — keychain unavailable",
+    "toggleEnabledSnack": "{name} enabled.",
+    "toggleDisabledSnack": "{name} disabled."
   },
   "providers": {
     "title": "Providers",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -656,7 +656,67 @@
       "update": "Update failed",
       "delete": "Delete failed"
     },
-    "failedToLoad": "Failed to load channels"
+    "failedToLoad": "Failed to load channels",
+    "kinds": {
+      "telegram": {
+        "description": "Bot via @BotFather. opendray long-polls getUpdates and sends via REST. Buttons + reply_to_message work natively.",
+        "botTokenLabel": "Bot token",
+        "botTokenHint": "From @BotFather. Stored in channel config; admin-only API.",
+        "chatIdLabel": "Default chat ID",
+        "chatIdPlaceholder": "42 (optional — used when no ReplyCtx)"
+      },
+      "slack": {
+        "description": "Socket Mode — no public webhook needed. Requires a bot OAuth token (xoxb-) and an app-level token (xapp-) with connections:write.",
+        "botTokenLabel": "Bot token (xoxb-…)",
+        "botTokenHint": "OAuth & Permissions → Bot User OAuth Token. Needs chat:write.",
+        "appTokenLabel": "App-level token (xapp-…)",
+        "appTokenHint": "Settings → Basic Information → App-Level Tokens. Scope: connections:write.",
+        "channelIdLabel": "Default channel ID",
+        "channelIdPlaceholder": "C0123ABC456 (optional)"
+      },
+      "discord": {
+        "description": "Bot via Discord Developer Portal with MESSAGE CONTENT INTENT enabled. Connects to Gateway WS — no public URL required.",
+        "botTokenLabel": "Bot token",
+        "botTokenPlaceholder": "Bot token from Discord Developer Portal",
+        "botTokenHint": "Application → Bot → Reset Token. Invite bot with send_messages + embed_links.",
+        "channelIdLabel": "Default channel ID",
+        "channelIdPlaceholder": "123456789012345678 (optional)"
+      },
+      "feishu": {
+        "description": "App-level credentials. Uses event subscription webhook for inbound. Public webhook URL is generated below — paste it into the Feishu dev console.",
+        "afterCreateHint": "Open the webhook URL from the channel card and paste it into Feishu Open Platform → Event Subscriptions → Request URL.",
+        "appIdLabel": "App ID",
+        "appSecretLabel": "App secret",
+        "appSecretPlaceholder": "Application credential secret",
+        "verificationTokenLabel": "Verification token",
+        "verificationTokenHint": "From Event Subscriptions → Verification Token. When set, opendray rejects webhooks with a different token.",
+        "chatIdLabel": "Default chat ID (oc_…)",
+        "chatIdPlaceholder": "oc_xxxxxxxxxx (optional)"
+      },
+      "dingtalk": {
+        "description": "Custom group robot. Outbound only. Group chat → Robots → Add → Sign mode → copy webhook + secret.",
+        "webhookUrlLabel": "Webhook URL",
+        "secretLabel": "Sign secret",
+        "secretHint": "When the robot is set to \"Sign\" security mode, copy the secret here. opendray adds the timestamp + sign params automatically."
+      },
+      "wecom": {
+        "description": "Group robot webhook. Outbound only (text + markdown). Group settings → Group robots → Add → copy webhook URL.",
+        "webhookKeyLabel": "Webhook key",
+        "webhookKeyPlaceholder": "The \"key=\" query value",
+        "webhookKeyHint": "Or paste the whole webhook URL into the field below — either is enough.",
+        "webhookUrlLabel": "Or full webhook URL"
+      },
+      "wechat": {
+        "description": "Push to personal WeChat via WxPusher. Outbound-only — push services do not relay user replies. Each recipient subscribes once via QR code.",
+        "appTokenLabel": "App token (AT_…)",
+        "appTokenHint": "WxPusher → 应用管理 → 创建应用 → 复制 App Token.",
+        "uidsLabel": "Recipient UIDs (one per line)",
+        "uidsHint": "Either UIDs or topic IDs is required.",
+        "topicIdsLabel": "Topic IDs (one per line)",
+        "urlLabel": "Tap-through URL",
+        "urlHint": "When set, tapping the WeChat notification opens this page."
+      }
+    }
   },
   "onboarding": {
     "gatewayLabel": "Gateway URL",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -607,8 +607,56 @@
       "repeatPolicy": "Repeat policy",
       "cooldownWindow": "Cooldown window",
       "includeSnippet": "Include terminal snippet",
-      "snippetLengthCap": "Snippet length cap"
-    }
+      "snippetLengthCap": "Snippet length cap",
+      "notifyOnAll": "All session events.",
+      "notifyOnEmpty": "No events selected — outbound notifications muted.",
+      "snippetHelper": "Embeds the recent terminal tail in each notification.",
+      "snippetNoCap": "no cap",
+      "snippetChars": "{n} chars",
+      "updatedSnack": "Notification preferences updated.",
+      "modes": {
+        "onceLabel": "Once per session",
+        "onceDescription": "Fire once when idle, stay silent until reply or end.",
+        "cooldownLabel": "Time-window cooldown",
+        "cooldownDescription": "Suppress repeats within the chosen window.",
+        "everyLabel": "Every event (noisy)",
+        "everyDescription": "No suppression — only for low-frequency channels."
+      }
+    },
+    "popup": {
+      "enable": "Enable",
+      "disable": "Disable",
+      "mute": "Mute",
+      "unmute": "Unmute",
+      "deleteLabel": "Delete"
+    },
+    "badges": {
+      "running": "running",
+      "starting": "starting…",
+      "disabled": "disabled",
+      "muted": "muted"
+    },
+    "capsLabel": "· caps: {list}",
+    "bridgeWebOnly": "Bridge channels stay web-only",
+    "bridgeEmptyAdd": "Add one from the web admin: Channels → New.",
+    "deleteBody": "Stops the channel and removes its configuration. In-flight notifications addressed to it will be dropped silently.",
+    "snacks": {
+      "testDispatched": "Test message dispatched.",
+      "channelEnabled": "Channel enabled.",
+      "channelDisabled": "Channel disabled.",
+      "channelMuted": "Channel muted.",
+      "channelUnmuted": "Channel unmuted.",
+      "configUpdated": "Channel config updated.",
+      "channelDeleted": "Channel deleted."
+    },
+    "errorPrefix": {
+      "test": "Test failed",
+      "toggle": "Toggle failed",
+      "muteToggle": "Mute toggle failed",
+      "update": "Update failed",
+      "delete": "Delete failed"
+    },
+    "failedToLoad": "Failed to load channels"
   },
   "onboarding": {
     "gatewayLabel": "Gateway URL",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -656,7 +656,67 @@
       "update": "更新失败",
       "delete": "删除失败"
     },
-    "failedToLoad": "加载通道失败"
+    "failedToLoad": "加载通道失败",
+    "kinds": {
+      "telegram": {
+        "description": "通过 @BotFather 创建机器人。opendray 长轮询 getUpdates 并通过 REST 发送。原生支持按钮和 reply_to_message。",
+        "botTokenLabel": "机器人 Token",
+        "botTokenHint": "从 @BotFather 获取。存储于通道配置；仅管理员 API 可见。",
+        "chatIdLabel": "默认 chat ID",
+        "chatIdPlaceholder": "42（可选 — 没有 ReplyCtx 时使用）"
+      },
+      "slack": {
+        "description": "Socket Mode — 无需公网 webhook。需要 bot OAuth token（xoxb-）和带 connections:write 的 app-level token（xapp-）。",
+        "botTokenLabel": "Bot token（xoxb-…）",
+        "botTokenHint": "OAuth & Permissions → Bot User OAuth Token。需要 chat:write。",
+        "appTokenLabel": "App-level token（xapp-…）",
+        "appTokenHint": "Settings → Basic Information → App-Level Tokens。范围：connections:write。",
+        "channelIdLabel": "默认 channel ID",
+        "channelIdPlaceholder": "C0123ABC456（可选）"
+      },
+      "discord": {
+        "description": "通过 Discord Developer Portal 创建机器人，启用 MESSAGE CONTENT INTENT。连接 Gateway WS — 无需公网 URL。",
+        "botTokenLabel": "Bot token",
+        "botTokenPlaceholder": "来自 Discord Developer Portal 的 Bot token",
+        "botTokenHint": "Application → Bot → Reset Token。邀请机器人时勾选 send_messages + embed_links。",
+        "channelIdLabel": "默认 channel ID",
+        "channelIdPlaceholder": "123456789012345678（可选）"
+      },
+      "feishu": {
+        "description": "应用级凭据。入站走事件订阅 webhook。下方生成公网 webhook URL — 粘贴到飞书开放平台控制台。",
+        "afterCreateHint": "在通道卡上打开 webhook URL，粘贴到飞书开放平台 → 事件订阅 → Request URL。",
+        "appIdLabel": "App ID",
+        "appSecretLabel": "App secret",
+        "appSecretPlaceholder": "应用凭据 secret",
+        "verificationTokenLabel": "Verification token",
+        "verificationTokenHint": "来自 事件订阅 → Verification Token。设置后，opendray 拒绝 token 不匹配的 webhook。",
+        "chatIdLabel": "默认 chat ID（oc_…）",
+        "chatIdPlaceholder": "oc_xxxxxxxxxx（可选）"
+      },
+      "dingtalk": {
+        "description": "自定义群机器人。仅外发。群聊 → 机器人 → 添加 → 加签模式 → 复制 webhook + secret。",
+        "webhookUrlLabel": "Webhook URL",
+        "secretLabel": "加签 secret",
+        "secretHint": "当机器人为「加签」安全模式时，将 secret 复制到这里。opendray 自动添加 timestamp + sign 参数。"
+      },
+      "wecom": {
+        "description": "群机器人 webhook。仅外发（文本 + markdown）。群设置 → 群机器人 → 添加 → 复制 webhook URL。",
+        "webhookKeyLabel": "Webhook key",
+        "webhookKeyPlaceholder": "「key=」查询参数值",
+        "webhookKeyHint": "或将整个 webhook URL 粘贴到下方字段 — 任一即可。",
+        "webhookUrlLabel": "或完整 webhook URL"
+      },
+      "wechat": {
+        "description": "通过 WxPusher 推送到个人微信。仅外发 — 推送服务不转发用户回复。每个接收方需通过二维码订阅一次。",
+        "appTokenLabel": "App token（AT_…）",
+        "appTokenHint": "WxPusher → 应用管理 → 创建应用 → 复制 App Token。",
+        "uidsLabel": "接收方 UID（每行一个）",
+        "uidsHint": "UID 或 topic ID 至少需要一个。",
+        "topicIdsLabel": "Topic ID（每行一个）",
+        "urlLabel": "点击跳转 URL",
+        "urlHint": "设置后，点击微信通知会打开此页面。"
+      }
+    }
   },
   "onboarding": {
     "gatewayLabel": "网关 URL",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -321,13 +321,68 @@
     "errorWithMessage": "{prefix}：{error}",
     "editor": {
       "nameHint": "my-mcp-server",
-      "jsonHint": "JSON 配置 — name、transport: stdio、command、args…"
+      "jsonHint": "JSON 配置 — name、transport: stdio、command、args…",
+      "descriptionPlaceholder": "可选的一行说明",
+      "validateJsonObject": "正文必须是 JSON 对象",
+      "validateJsonInvalid": "无效的 JSON：{error}",
+      "appBarEdit": "编辑 MCP 服务器",
+      "appBarNew": "新建 MCP 服务器",
+      "idLockedHint": "编辑模式下锁定 — 需删除后重建以更改。",
+      "jsonLabel": "服务器 JSON",
+      "jsonSchemaHelp": "Schema：transport 必须是 stdio、http 或 sse。stdio 需要 command + args。http/sse 需要 url + headers。用 \\$secret:KEY 引用密钥库的密钥。",
+      "idLabel": "id（URL 片段，小写字母数字 / 横线 / 下划线）",
+      "idRequired": "id 必填",
+      "saving": "保存中…",
+      "save": "保存",
+      "create": "创建"
     },
     "secret": {
       "keyLabel": "键",
       "keyHint": "GITHUB_TOKEN、OPENAI_KEY、…",
-      "valueLabel": "值"
-    }
+      "valueLabel": "值",
+      "keyRequired": "必须填写键。",
+      "keyInvalid": "键必须匹配 [A-Za-z_][A-Za-z0-9_]* — 与 shell 环境变量规则相同。",
+      "valueRequired": "必须填写值。",
+      "replaceTitle": "替换密钥值",
+      "addTitle": "添加密钥",
+      "saveButton": "保存",
+      "addButton": "添加",
+      "helpRules": "shell 环境变量规则：字母或 _ 开头，仅含字母 / 数字 / _。",
+      "replaceHint": "粘贴新值（旧值被擦除）",
+      "addHint": "粘贴密钥值",
+      "addedSnack": "已添加密钥 {key}。",
+      "updatedSnack": "已更新密钥 {key}。",
+      "deletedSnack": "已删除 {key}。",
+      "deleteBody": "从加密的密钥库中移除该值。引用此密钥的 MCP 服务器在恢复前将无法启动。"
+    },
+    "popup": {
+      "editConfigSubtitle": "完整 JSON 编辑器 — 仅限密钥库支持的服务器",
+      "viewRawSubtitle": "服务器 JSON 的只读查看器",
+      "deleteLabel": "删除"
+    },
+    "kv": {
+      "transport": "传输",
+      "description": "描述",
+      "command": "命令",
+      "args": "参数",
+      "headers": "Headers"
+    },
+    "deleteServerBody": "移除 {id} 的密钥库目录。引用此服务器的会话将无法启动。",
+    "deleteServerSnack": "已删除 {id}。",
+    "serversCount": "服务器（{count}）",
+    "secretsCount": "密钥（{count}）",
+    "emptyServers": "未注册任何 MCP 服务器。点击「新建服务器」添加一个。",
+    "emptySecrets": "暂无密钥。添加一个，将敏感的 env / headers 注入 MCP 服务器，无需放在 JSON 里。",
+    "noVaultFileYet": "尚无密钥库文件 — 添加密钥时会创建。",
+    "tapToReplaceHint": "点击替换 · 长按 / 垃圾桶 删除",
+    "failedToLoad": "加载 MCP 状态失败",
+    "serverCreatedSnack": "MCP 服务器已创建。",
+    "serverUpdatedSnack": "MCP 服务器已更新。",
+    "envHeading": "环境变量",
+    "encryptionAes": "AES-GCM 加密（密钥存于 OS keychain）",
+    "encryptionPlaintext": "明文 — keychain 不可用",
+    "toggleEnabledSnack": "{name} 已启用。",
+    "toggleDisabledSnack": "{name} 已停用。"
   },
   "providers": {
     "title": "提供商",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -607,8 +607,56 @@
       "repeatPolicy": "重复策略",
       "cooldownWindow": "冷却时间",
       "includeSnippet": "包含终端片段",
-      "snippetLengthCap": "片段长度上限"
-    }
+      "snippetLengthCap": "片段长度上限",
+      "notifyOnAll": "所有会话事件。",
+      "notifyOnEmpty": "未选择事件 — 已静音外发通知。",
+      "snippetHelper": "在每条通知中嵌入终端最近的内容。",
+      "snippetNoCap": "无上限",
+      "snippetChars": "{n} 字符",
+      "updatedSnack": "通知偏好已更新。",
+      "modes": {
+        "onceLabel": "每会话一次",
+        "onceDescription": "空闲时触发一次，回复或结束前不再触发。",
+        "cooldownLabel": "时间窗冷却",
+        "cooldownDescription": "在所选时间窗内抑制重复。",
+        "everyLabel": "每次事件（嘈杂）",
+        "everyDescription": "不抑制 — 仅适合低频通道。"
+      }
+    },
+    "popup": {
+      "enable": "启用",
+      "disable": "停用",
+      "mute": "静音",
+      "unmute": "取消静音",
+      "deleteLabel": "删除"
+    },
+    "badges": {
+      "running": "运行中",
+      "starting": "启动中…",
+      "disabled": "已停用",
+      "muted": "已静音"
+    },
+    "capsLabel": "· 能力：{list}",
+    "bridgeWebOnly": "Bridge 通道仅 Web 端",
+    "bridgeEmptyAdd": "在 Web 管理端添加：通道 → 新建。",
+    "deleteBody": "停止该通道并移除其配置。仍在传输中的通知会被静默丢弃。",
+    "snacks": {
+      "testDispatched": "测试消息已发送。",
+      "channelEnabled": "通道已启用。",
+      "channelDisabled": "通道已停用。",
+      "channelMuted": "通道已静音。",
+      "channelUnmuted": "通道已取消静音。",
+      "configUpdated": "通道配置已更新。",
+      "channelDeleted": "通道已删除。"
+    },
+    "errorPrefix": {
+      "test": "测试失败",
+      "toggle": "切换失败",
+      "muteToggle": "静音切换失败",
+      "update": "更新失败",
+      "delete": "删除失败"
+    },
+    "failedToLoad": "加载通道失败"
   },
   "onboarding": {
     "gatewayLabel": "网关 URL",

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 1278 (639 per locale)
+/// Strings: 1366 (683 per locale)
 ///
-/// Built on 2026-05-13 at 16:18 UTC
+/// Built on 2026-05-13 at 16:28 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 1202 (601 per locale)
+/// Strings: 1278 (639 per locale)
 ///
-/// Built on 2026-05-13 at 14:14 UTC
+/// Built on 2026-05-13 at 16:18 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 1100 (550 per locale)
+/// Strings: 1202 (601 per locale)
 ///
-/// Built on 2026-05-13 at 13:14 UTC
+/// Built on 2026-05-13 at 14:14 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -858,6 +858,8 @@ class TranslationsChannelsEn {
 
 	/// en: 'Failed to load channels'
 	String get failedToLoad => 'Failed to load channels';
+
+	late final TranslationsChannelsKindsEn kinds = TranslationsChannelsKindsEn.internal(_root);
 }
 
 // Path: onboarding
@@ -1927,6 +1929,22 @@ class TranslationsChannelsErrorPrefixEn {
 	String get delete => 'Delete failed';
 }
 
+// Path: channels.kinds
+class TranslationsChannelsKindsEn {
+	TranslationsChannelsKindsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsChannelsKindsTelegramEn telegram = TranslationsChannelsKindsTelegramEn.internal(_root);
+	late final TranslationsChannelsKindsSlackEn slack = TranslationsChannelsKindsSlackEn.internal(_root);
+	late final TranslationsChannelsKindsDiscordEn discord = TranslationsChannelsKindsDiscordEn.internal(_root);
+	late final TranslationsChannelsKindsFeishuEn feishu = TranslationsChannelsKindsFeishuEn.internal(_root);
+	late final TranslationsChannelsKindsDingtalkEn dingtalk = TranslationsChannelsKindsDingtalkEn.internal(_root);
+	late final TranslationsChannelsKindsWecomEn wecom = TranslationsChannelsKindsWecomEn.internal(_root);
+	late final TranslationsChannelsKindsWechatEn wechat = TranslationsChannelsKindsWechatEn.internal(_root);
+}
+
 // Path: notesPage.editor
 class TranslationsNotesPageEditorEn {
 	TranslationsNotesPageEditorEn.internal(this._root);
@@ -2968,6 +2986,201 @@ class TranslationsChannelsNotificationsModesEn {
 	String get everyDescription => 'No suppression — only for low-frequency channels.';
 }
 
+// Path: channels.kinds.telegram
+class TranslationsChannelsKindsTelegramEn {
+	TranslationsChannelsKindsTelegramEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Bot via @BotFather. opendray long-polls getUpdates and sends via REST. Buttons + reply_to_message work natively.'
+	String get description => 'Bot via @BotFather. opendray long-polls getUpdates and sends via REST. Buttons + reply_to_message work natively.';
+
+	/// en: 'Bot token'
+	String get botTokenLabel => 'Bot token';
+
+	/// en: 'From @BotFather. Stored in channel config; admin-only API.'
+	String get botTokenHint => 'From @BotFather. Stored in channel config; admin-only API.';
+
+	/// en: 'Default chat ID'
+	String get chatIdLabel => 'Default chat ID';
+
+	/// en: '42 (optional — used when no ReplyCtx)'
+	String get chatIdPlaceholder => '42 (optional — used when no ReplyCtx)';
+}
+
+// Path: channels.kinds.slack
+class TranslationsChannelsKindsSlackEn {
+	TranslationsChannelsKindsSlackEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Socket Mode — no public webhook needed. Requires a bot OAuth token (xoxb-) and an app-level token (xapp-) with connections:write.'
+	String get description => 'Socket Mode — no public webhook needed. Requires a bot OAuth token (xoxb-) and an app-level token (xapp-) with connections:write.';
+
+	/// en: 'Bot token (xoxb-…)'
+	String get botTokenLabel => 'Bot token (xoxb-…)';
+
+	/// en: 'OAuth & Permissions → Bot User OAuth Token. Needs chat:write.'
+	String get botTokenHint => 'OAuth & Permissions → Bot User OAuth Token. Needs chat:write.';
+
+	/// en: 'App-level token (xapp-…)'
+	String get appTokenLabel => 'App-level token (xapp-…)';
+
+	/// en: 'Settings → Basic Information → App-Level Tokens. Scope: connections:write.'
+	String get appTokenHint => 'Settings → Basic Information → App-Level Tokens. Scope: connections:write.';
+
+	/// en: 'Default channel ID'
+	String get channelIdLabel => 'Default channel ID';
+
+	/// en: 'C0123ABC456 (optional)'
+	String get channelIdPlaceholder => 'C0123ABC456 (optional)';
+}
+
+// Path: channels.kinds.discord
+class TranslationsChannelsKindsDiscordEn {
+	TranslationsChannelsKindsDiscordEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Bot via Discord Developer Portal with MESSAGE CONTENT INTENT enabled. Connects to Gateway WS — no public URL required.'
+	String get description => 'Bot via Discord Developer Portal with MESSAGE CONTENT INTENT enabled. Connects to Gateway WS — no public URL required.';
+
+	/// en: 'Bot token'
+	String get botTokenLabel => 'Bot token';
+
+	/// en: 'Bot token from Discord Developer Portal'
+	String get botTokenPlaceholder => 'Bot token from Discord Developer Portal';
+
+	/// en: 'Application → Bot → Reset Token. Invite bot with send_messages + embed_links.'
+	String get botTokenHint => 'Application → Bot → Reset Token. Invite bot with send_messages + embed_links.';
+
+	/// en: 'Default channel ID'
+	String get channelIdLabel => 'Default channel ID';
+
+	/// en: '123456789012345678 (optional)'
+	String get channelIdPlaceholder => '123456789012345678 (optional)';
+}
+
+// Path: channels.kinds.feishu
+class TranslationsChannelsKindsFeishuEn {
+	TranslationsChannelsKindsFeishuEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'App-level credentials. Uses event subscription webhook for inbound. Public webhook URL is generated below — paste it into the Feishu dev console.'
+	String get description => 'App-level credentials. Uses event subscription webhook for inbound. Public webhook URL is generated below — paste it into the Feishu dev console.';
+
+	/// en: 'Open the webhook URL from the channel card and paste it into Feishu Open Platform → Event Subscriptions → Request URL.'
+	String get afterCreateHint => 'Open the webhook URL from the channel card and paste it into Feishu Open Platform → Event Subscriptions → Request URL.';
+
+	/// en: 'App ID'
+	String get appIdLabel => 'App ID';
+
+	/// en: 'App secret'
+	String get appSecretLabel => 'App secret';
+
+	/// en: 'Application credential secret'
+	String get appSecretPlaceholder => 'Application credential secret';
+
+	/// en: 'Verification token'
+	String get verificationTokenLabel => 'Verification token';
+
+	/// en: 'From Event Subscriptions → Verification Token. When set, opendray rejects webhooks with a different token.'
+	String get verificationTokenHint => 'From Event Subscriptions → Verification Token. When set, opendray rejects webhooks with a different token.';
+
+	/// en: 'Default chat ID (oc_…)'
+	String get chatIdLabel => 'Default chat ID (oc_…)';
+
+	/// en: 'oc_xxxxxxxxxx (optional)'
+	String get chatIdPlaceholder => 'oc_xxxxxxxxxx (optional)';
+}
+
+// Path: channels.kinds.dingtalk
+class TranslationsChannelsKindsDingtalkEn {
+	TranslationsChannelsKindsDingtalkEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Custom group robot. Outbound only. Group chat → Robots → Add → Sign mode → copy webhook + secret.'
+	String get description => 'Custom group robot. Outbound only. Group chat → Robots → Add → Sign mode → copy webhook + secret.';
+
+	/// en: 'Webhook URL'
+	String get webhookUrlLabel => 'Webhook URL';
+
+	/// en: 'Sign secret'
+	String get secretLabel => 'Sign secret';
+
+	/// en: 'When the robot is set to "Sign" security mode, copy the secret here. opendray adds the timestamp + sign params automatically.'
+	String get secretHint => 'When the robot is set to "Sign" security mode, copy the secret here. opendray adds the timestamp + sign params automatically.';
+}
+
+// Path: channels.kinds.wecom
+class TranslationsChannelsKindsWecomEn {
+	TranslationsChannelsKindsWecomEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Group robot webhook. Outbound only (text + markdown). Group settings → Group robots → Add → copy webhook URL.'
+	String get description => 'Group robot webhook. Outbound only (text + markdown). Group settings → Group robots → Add → copy webhook URL.';
+
+	/// en: 'Webhook key'
+	String get webhookKeyLabel => 'Webhook key';
+
+	/// en: 'The "key=" query value'
+	String get webhookKeyPlaceholder => 'The "key=" query value';
+
+	/// en: 'Or paste the whole webhook URL into the field below — either is enough.'
+	String get webhookKeyHint => 'Or paste the whole webhook URL into the field below — either is enough.';
+
+	/// en: 'Or full webhook URL'
+	String get webhookUrlLabel => 'Or full webhook URL';
+}
+
+// Path: channels.kinds.wechat
+class TranslationsChannelsKindsWechatEn {
+	TranslationsChannelsKindsWechatEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Push to personal WeChat via WxPusher. Outbound-only — push services do not relay user replies. Each recipient subscribes once via QR code.'
+	String get description => 'Push to personal WeChat via WxPusher. Outbound-only — push services do not relay user replies. Each recipient subscribes once via QR code.';
+
+	/// en: 'App token (AT_…)'
+	String get appTokenLabel => 'App token (AT_…)';
+
+	/// en: 'WxPusher → 应用管理 → 创建应用 → 复制 App Token.'
+	String get appTokenHint => 'WxPusher → 应用管理 → 创建应用 → 复制 App Token.';
+
+	/// en: 'Recipient UIDs (one per line)'
+	String get uidsLabel => 'Recipient UIDs (one per line)';
+
+	/// en: 'Either UIDs or topic IDs is required.'
+	String get uidsHint => 'Either UIDs or topic IDs is required.';
+
+	/// en: 'Topic IDs (one per line)'
+	String get topicIdsLabel => 'Topic IDs (one per line)';
+
+	/// en: 'Tap-through URL'
+	String get urlLabel => 'Tap-through URL';
+
+	/// en: 'When set, tapping the WeChat notification opens this page.'
+	String get urlHint => 'When set, tapping the WeChat notification opens this page.';
+}
+
 // Path: settings.logViewer.levels
 class TranslationsSettingsLogViewerLevelsEn {
 	TranslationsSettingsLogViewerLevelsEn.internal(this._root);
@@ -3556,6 +3769,52 @@ extension on Translations {
 			'channels.errorPrefix.update' => 'Update failed',
 			'channels.errorPrefix.delete' => 'Delete failed',
 			'channels.failedToLoad' => 'Failed to load channels',
+			'channels.kinds.telegram.description' => 'Bot via @BotFather. opendray long-polls getUpdates and sends via REST. Buttons + reply_to_message work natively.',
+			'channels.kinds.telegram.botTokenLabel' => 'Bot token',
+			'channels.kinds.telegram.botTokenHint' => 'From @BotFather. Stored in channel config; admin-only API.',
+			'channels.kinds.telegram.chatIdLabel' => 'Default chat ID',
+			'channels.kinds.telegram.chatIdPlaceholder' => '42 (optional — used when no ReplyCtx)',
+			'channels.kinds.slack.description' => 'Socket Mode — no public webhook needed. Requires a bot OAuth token (xoxb-) and an app-level token (xapp-) with connections:write.',
+			'channels.kinds.slack.botTokenLabel' => 'Bot token (xoxb-…)',
+			'channels.kinds.slack.botTokenHint' => 'OAuth & Permissions → Bot User OAuth Token. Needs chat:write.',
+			'channels.kinds.slack.appTokenLabel' => 'App-level token (xapp-…)',
+			'channels.kinds.slack.appTokenHint' => 'Settings → Basic Information → App-Level Tokens. Scope: connections:write.',
+			'channels.kinds.slack.channelIdLabel' => 'Default channel ID',
+			'channels.kinds.slack.channelIdPlaceholder' => 'C0123ABC456 (optional)',
+			'channels.kinds.discord.description' => 'Bot via Discord Developer Portal with MESSAGE CONTENT INTENT enabled. Connects to Gateway WS — no public URL required.',
+			'channels.kinds.discord.botTokenLabel' => 'Bot token',
+			'channels.kinds.discord.botTokenPlaceholder' => 'Bot token from Discord Developer Portal',
+			'channels.kinds.discord.botTokenHint' => 'Application → Bot → Reset Token. Invite bot with send_messages + embed_links.',
+			'channels.kinds.discord.channelIdLabel' => 'Default channel ID',
+			'channels.kinds.discord.channelIdPlaceholder' => '123456789012345678 (optional)',
+			'channels.kinds.feishu.description' => 'App-level credentials. Uses event subscription webhook for inbound. Public webhook URL is generated below — paste it into the Feishu dev console.',
+			_ => null,
+		} ?? switch (path) {
+			'channels.kinds.feishu.afterCreateHint' => 'Open the webhook URL from the channel card and paste it into Feishu Open Platform → Event Subscriptions → Request URL.',
+			'channels.kinds.feishu.appIdLabel' => 'App ID',
+			'channels.kinds.feishu.appSecretLabel' => 'App secret',
+			'channels.kinds.feishu.appSecretPlaceholder' => 'Application credential secret',
+			'channels.kinds.feishu.verificationTokenLabel' => 'Verification token',
+			'channels.kinds.feishu.verificationTokenHint' => 'From Event Subscriptions → Verification Token. When set, opendray rejects webhooks with a different token.',
+			'channels.kinds.feishu.chatIdLabel' => 'Default chat ID (oc_…)',
+			'channels.kinds.feishu.chatIdPlaceholder' => 'oc_xxxxxxxxxx (optional)',
+			'channels.kinds.dingtalk.description' => 'Custom group robot. Outbound only. Group chat → Robots → Add → Sign mode → copy webhook + secret.',
+			'channels.kinds.dingtalk.webhookUrlLabel' => 'Webhook URL',
+			'channels.kinds.dingtalk.secretLabel' => 'Sign secret',
+			'channels.kinds.dingtalk.secretHint' => 'When the robot is set to "Sign" security mode, copy the secret here. opendray adds the timestamp + sign params automatically.',
+			'channels.kinds.wecom.description' => 'Group robot webhook. Outbound only (text + markdown). Group settings → Group robots → Add → copy webhook URL.',
+			'channels.kinds.wecom.webhookKeyLabel' => 'Webhook key',
+			'channels.kinds.wecom.webhookKeyPlaceholder' => 'The "key=" query value',
+			'channels.kinds.wecom.webhookKeyHint' => 'Or paste the whole webhook URL into the field below — either is enough.',
+			'channels.kinds.wecom.webhookUrlLabel' => 'Or full webhook URL',
+			'channels.kinds.wechat.description' => 'Push to personal WeChat via WxPusher. Outbound-only — push services do not relay user replies. Each recipient subscribes once via QR code.',
+			'channels.kinds.wechat.appTokenLabel' => 'App token (AT_…)',
+			'channels.kinds.wechat.appTokenHint' => 'WxPusher → 应用管理 → 创建应用 → 复制 App Token.',
+			'channels.kinds.wechat.uidsLabel' => 'Recipient UIDs (one per line)',
+			'channels.kinds.wechat.uidsHint' => 'Either UIDs or topic IDs is required.',
+			'channels.kinds.wechat.topicIdsLabel' => 'Topic IDs (one per line)',
+			'channels.kinds.wechat.urlLabel' => 'Tap-through URL',
+			'channels.kinds.wechat.urlHint' => 'When set, tapping the WeChat notification opens this page.',
 			'onboarding.gatewayLabel' => 'Gateway URL',
 			'onboarding.gatewayHint' => 'https://opendray.example.com',
 			'onboarding.kContinue' => 'Continue',
@@ -3575,8 +3834,6 @@ extension on Translations {
 			'customTasks.popupDelete' => 'Delete',
 			'customTasks.nameHint' => 'e.g. backend-tests',
 			'customTasks.commandHint' => '/run pnpm test --filter backend',
-			_ => null,
-		} ?? switch (path) {
 			'customTasks.descriptionHint' => 'One-liner shown under the task name.',
 			'customTasks.scopeGlobal' => 'Global',
 			'customTasks.scopeProject' => 'Project',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -259,6 +259,56 @@ class TranslationsMcpEn {
 
 	late final TranslationsMcpEditorEn editor = TranslationsMcpEditorEn.internal(_root);
 	late final TranslationsMcpSecretEn secret = TranslationsMcpSecretEn.internal(_root);
+	late final TranslationsMcpPopupEn popup = TranslationsMcpPopupEn.internal(_root);
+	late final TranslationsMcpKvEn kv = TranslationsMcpKvEn.internal(_root);
+
+	/// en: 'Removes the vault directory for {id}. Sessions that reference this server stop being able to spawn it.'
+	String deleteServerBody({required Object id}) => 'Removes the vault directory for ${id}. Sessions that reference this server stop being able to spawn it.';
+
+	/// en: 'Deleted {id}.'
+	String deleteServerSnack({required Object id}) => 'Deleted ${id}.';
+
+	/// en: 'Servers ({count})'
+	String serversCount({required Object count}) => 'Servers (${count})';
+
+	/// en: 'Secrets ({count})'
+	String secretsCount({required Object count}) => 'Secrets (${count})';
+
+	/// en: 'No MCP servers registered. Tap "New server" to add one.'
+	String get emptyServers => 'No MCP servers registered. Tap "New server" to add one.';
+
+	/// en: 'No secrets stored. Add one to feed sensitive env / headers into MCP servers without putting them in the JSON.'
+	String get emptySecrets => 'No secrets stored. Add one to feed sensitive env / headers into MCP servers without putting them in the JSON.';
+
+	/// en: 'No vault file yet — added secrets create it.'
+	String get noVaultFileYet => 'No vault file yet — added secrets create it.';
+
+	/// en: 'Tap to replace · long-press / trash to delete'
+	String get tapToReplaceHint => 'Tap to replace · long-press / trash to delete';
+
+	/// en: 'Failed to load MCP state'
+	String get failedToLoad => 'Failed to load MCP state';
+
+	/// en: 'MCP server created.'
+	String get serverCreatedSnack => 'MCP server created.';
+
+	/// en: 'MCP server updated.'
+	String get serverUpdatedSnack => 'MCP server updated.';
+
+	/// en: 'Env'
+	String get envHeading => 'Env';
+
+	/// en: 'AES-GCM encrypted (key in OS keychain)'
+	String get encryptionAes => 'AES-GCM encrypted (key in OS keychain)';
+
+	/// en: 'PLAINTEXT — keychain unavailable'
+	String get encryptionPlaintext => 'PLAINTEXT — keychain unavailable';
+
+	/// en: '{name} enabled.'
+	String toggleEnabledSnack({required Object name}) => '${name} enabled.';
+
+	/// en: '{name} disabled.'
+	String toggleDisabledSnack({required Object name}) => '${name} disabled.';
 }
 
 // Path: providers
@@ -1414,6 +1464,45 @@ class TranslationsMcpEditorEn {
 
 	/// en: 'JSON config — name, transport: stdio, command, args…'
 	String get jsonHint => 'JSON config — name, transport: stdio, command, args…';
+
+	/// en: 'Optional one-liner'
+	String get descriptionPlaceholder => 'Optional one-liner';
+
+	/// en: 'Body must be a JSON object'
+	String get validateJsonObject => 'Body must be a JSON object';
+
+	/// en: 'Invalid JSON: {error}'
+	String validateJsonInvalid({required Object error}) => 'Invalid JSON: ${error}';
+
+	/// en: 'Edit MCP server'
+	String get appBarEdit => 'Edit MCP server';
+
+	/// en: 'New MCP server'
+	String get appBarNew => 'New MCP server';
+
+	/// en: 'Locked in edit mode — delete + recreate to change.'
+	String get idLockedHint => 'Locked in edit mode — delete + recreate to change.';
+
+	/// en: 'Server JSON'
+	String get jsonLabel => 'Server JSON';
+
+	/// en: 'Schema: transport must be stdio, http or sse. For stdio set command + args. For http/sse set url + headers. Use \$secret:KEY to reference vault secrets.'
+	String get jsonSchemaHelp => 'Schema: transport must be stdio, http or sse. For stdio set command + args. For http/sse set url + headers. Use \$secret:KEY to reference vault secrets.';
+
+	/// en: 'id (URL segment, lowercase alphanumeric / dash / underscore)'
+	String get idLabel => 'id (URL segment, lowercase alphanumeric / dash / underscore)';
+
+	/// en: 'id is required'
+	String get idRequired => 'id is required';
+
+	/// en: 'Saving…'
+	String get saving => 'Saving…';
+
+	/// en: 'Save'
+	String get save => 'Save';
+
+	/// en: 'Create'
+	String get create => 'Create';
 }
 
 // Path: mcp.secret
@@ -1432,6 +1521,90 @@ class TranslationsMcpSecretEn {
 
 	/// en: 'Value'
 	String get valueLabel => 'Value';
+
+	/// en: 'Key is required.'
+	String get keyRequired => 'Key is required.';
+
+	/// en: 'Key must match [A-Za-z_][A-Za-z0-9_]* — same rules as a shell env var.'
+	String get keyInvalid => 'Key must match [A-Za-z_][A-Za-z0-9_]* — same rules as a shell env var.';
+
+	/// en: 'Value is required.'
+	String get valueRequired => 'Value is required.';
+
+	/// en: 'Replace secret value'
+	String get replaceTitle => 'Replace secret value';
+
+	/// en: 'Add secret'
+	String get addTitle => 'Add secret';
+
+	/// en: 'Save'
+	String get saveButton => 'Save';
+
+	/// en: 'Add'
+	String get addButton => 'Add';
+
+	/// en: 'Shell-env-var rules: starts with a letter or _, then letters / digits / _ only.'
+	String get helpRules => 'Shell-env-var rules: starts with a letter or _, then letters / digits / _ only.';
+
+	/// en: 'Paste new value (the previous one is wiped)'
+	String get replaceHint => 'Paste new value (the previous one is wiped)';
+
+	/// en: 'Paste secret value'
+	String get addHint => 'Paste secret value';
+
+	/// en: 'Secret {key} added.'
+	String addedSnack({required Object key}) => 'Secret ${key} added.';
+
+	/// en: 'Secret {key} updated.'
+	String updatedSnack({required Object key}) => 'Secret ${key} updated.';
+
+	/// en: 'Deleted {key}.'
+	String deletedSnack({required Object key}) => 'Deleted ${key}.';
+
+	/// en: 'Removes the value from the encrypted vault. Any MCP server that references it will fail until restored.'
+	String get deleteBody => 'Removes the value from the encrypted vault. Any MCP server that references it will fail until restored.';
+}
+
+// Path: mcp.popup
+class TranslationsMcpPopupEn {
+	TranslationsMcpPopupEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Full JSON editor — vault-backed servers only'
+	String get editConfigSubtitle => 'Full JSON editor — vault-backed servers only';
+
+	/// en: 'Read-only inspector for the server JSON'
+	String get viewRawSubtitle => 'Read-only inspector for the server JSON';
+
+	/// en: 'Delete'
+	String get deleteLabel => 'Delete';
+}
+
+// Path: mcp.kv
+class TranslationsMcpKvEn {
+	TranslationsMcpKvEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Transport'
+	String get transport => 'Transport';
+
+	/// en: 'Description'
+	String get description => 'Description';
+
+	/// en: 'Command'
+	String get command => 'Command';
+
+	/// en: 'Args'
+	String get args => 'Args';
+
+	/// en: 'Headers'
+	String get headers => 'Headers';
 }
 
 // Path: providers.errorPrefix
@@ -2947,9 +3120,60 @@ extension on Translations {
 			'mcp.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}: ${error}',
 			'mcp.editor.nameHint' => 'my-mcp-server',
 			'mcp.editor.jsonHint' => 'JSON config — name, transport: stdio, command, args…',
+			'mcp.editor.descriptionPlaceholder' => 'Optional one-liner',
+			'mcp.editor.validateJsonObject' => 'Body must be a JSON object',
+			'mcp.editor.validateJsonInvalid' => ({required Object error}) => 'Invalid JSON: ${error}',
+			'mcp.editor.appBarEdit' => 'Edit MCP server',
+			'mcp.editor.appBarNew' => 'New MCP server',
+			'mcp.editor.idLockedHint' => 'Locked in edit mode — delete + recreate to change.',
+			'mcp.editor.jsonLabel' => 'Server JSON',
+			'mcp.editor.jsonSchemaHelp' => 'Schema: transport must be stdio, http or sse. For stdio set command + args. For http/sse set url + headers. Use \$secret:KEY to reference vault secrets.',
+			'mcp.editor.idLabel' => 'id (URL segment, lowercase alphanumeric / dash / underscore)',
+			'mcp.editor.idRequired' => 'id is required',
+			'mcp.editor.saving' => 'Saving…',
+			'mcp.editor.save' => 'Save',
+			'mcp.editor.create' => 'Create',
 			'mcp.secret.keyLabel' => 'Key',
 			'mcp.secret.keyHint' => 'GITHUB_TOKEN, OPENAI_KEY, …',
 			'mcp.secret.valueLabel' => 'Value',
+			'mcp.secret.keyRequired' => 'Key is required.',
+			'mcp.secret.keyInvalid' => 'Key must match [A-Za-z_][A-Za-z0-9_]* — same rules as a shell env var.',
+			'mcp.secret.valueRequired' => 'Value is required.',
+			'mcp.secret.replaceTitle' => 'Replace secret value',
+			'mcp.secret.addTitle' => 'Add secret',
+			'mcp.secret.saveButton' => 'Save',
+			'mcp.secret.addButton' => 'Add',
+			'mcp.secret.helpRules' => 'Shell-env-var rules: starts with a letter or _, then letters / digits / _ only.',
+			'mcp.secret.replaceHint' => 'Paste new value (the previous one is wiped)',
+			'mcp.secret.addHint' => 'Paste secret value',
+			'mcp.secret.addedSnack' => ({required Object key}) => 'Secret ${key} added.',
+			'mcp.secret.updatedSnack' => ({required Object key}) => 'Secret ${key} updated.',
+			'mcp.secret.deletedSnack' => ({required Object key}) => 'Deleted ${key}.',
+			'mcp.secret.deleteBody' => 'Removes the value from the encrypted vault. Any MCP server that references it will fail until restored.',
+			'mcp.popup.editConfigSubtitle' => 'Full JSON editor — vault-backed servers only',
+			'mcp.popup.viewRawSubtitle' => 'Read-only inspector for the server JSON',
+			'mcp.popup.deleteLabel' => 'Delete',
+			'mcp.kv.transport' => 'Transport',
+			'mcp.kv.description' => 'Description',
+			'mcp.kv.command' => 'Command',
+			'mcp.kv.args' => 'Args',
+			'mcp.kv.headers' => 'Headers',
+			'mcp.deleteServerBody' => ({required Object id}) => 'Removes the vault directory for ${id}. Sessions that reference this server stop being able to spawn it.',
+			'mcp.deleteServerSnack' => ({required Object id}) => 'Deleted ${id}.',
+			'mcp.serversCount' => ({required Object count}) => 'Servers (${count})',
+			'mcp.secretsCount' => ({required Object count}) => 'Secrets (${count})',
+			'mcp.emptyServers' => 'No MCP servers registered. Tap "New server" to add one.',
+			'mcp.emptySecrets' => 'No secrets stored. Add one to feed sensitive env / headers into MCP servers without putting them in the JSON.',
+			'mcp.noVaultFileYet' => 'No vault file yet — added secrets create it.',
+			'mcp.tapToReplaceHint' => 'Tap to replace · long-press / trash to delete',
+			'mcp.failedToLoad' => 'Failed to load MCP state',
+			'mcp.serverCreatedSnack' => 'MCP server created.',
+			'mcp.serverUpdatedSnack' => 'MCP server updated.',
+			'mcp.envHeading' => 'Env',
+			'mcp.encryptionAes' => 'AES-GCM encrypted (key in OS keychain)',
+			'mcp.encryptionPlaintext' => 'PLAINTEXT — keychain unavailable',
+			'mcp.toggleEnabledSnack' => ({required Object name}) => '${name} enabled.',
+			'mcp.toggleDisabledSnack' => ({required Object name}) => '${name} disabled.',
 			'providers.title' => 'Providers',
 			'providers.configSaved' => 'Provider config updated.',
 			'providers.saveFailedApi' => ({required Object error}) => 'Save failed: ${error}',
@@ -3185,6 +3409,8 @@ extension on Translations {
 			'memory.deletedSnackOne' => ({required Object n}) => 'Deleted ${n} memory item',
 			'memory.deletedSnackOther' => ({required Object n}) => 'Deleted ${n} memory items',
 			'memory.bulkDeleteFailedApi' => ({required Object error}) => 'Bulk delete failed: ${error}',
+			_ => null,
+		} ?? switch (path) {
 			'memory.bulkDeleteFailedGeneric' => ({required Object error}) => 'Bulk delete failed: ${error}',
 			'memory.deleteOne.title' => 'Delete memory?',
 			'memory.deleteOne.body' => 'This cannot be undone.',
@@ -3236,8 +3462,6 @@ extension on Translations {
 			'settings.changeCredentials.currentPassword' => 'Current password',
 			'settings.changeCredentials.newUsername' => 'New username',
 			'settings.changeCredentials.newPassword' => 'New password',
-			_ => null,
-		} ?? switch (path) {
 			'settings.changeCredentials.confirmPassword' => 'Confirm new password',
 			'settings.changeCredentials.validatorRequired' => 'Required',
 			'settings.changeCredentials.passwordHelper' => 'At least 8 characters',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -838,6 +838,26 @@ class TranslationsChannelsEn {
 	String errorWithMessage({required Object prefix, required Object error}) => '${prefix}: ${error}';
 
 	late final TranslationsChannelsNotificationsEn notifications = TranslationsChannelsNotificationsEn.internal(_root);
+	late final TranslationsChannelsPopupEn popup = TranslationsChannelsPopupEn.internal(_root);
+	late final TranslationsChannelsBadgesEn badges = TranslationsChannelsBadgesEn.internal(_root);
+
+	/// en: '· caps: {list}'
+	String capsLabel({required Object list}) => '· caps: ${list}';
+
+	/// en: 'Bridge channels stay web-only'
+	String get bridgeWebOnly => 'Bridge channels stay web-only';
+
+	/// en: 'Add one from the web admin: Channels → New.'
+	String get bridgeEmptyAdd => 'Add one from the web admin: Channels → New.';
+
+	/// en: 'Stops the channel and removes its configuration. In-flight notifications addressed to it will be dropped silently.'
+	String get deleteBody => 'Stops the channel and removes its configuration. In-flight notifications addressed to it will be dropped silently.';
+
+	late final TranslationsChannelsSnacksEn snacks = TranslationsChannelsSnacksEn.internal(_root);
+	late final TranslationsChannelsErrorPrefixEn errorPrefix = TranslationsChannelsErrorPrefixEn.internal(_root);
+
+	/// en: 'Failed to load channels'
+	String get failedToLoad => 'Failed to load channels';
 }
 
 // Path: onboarding
@@ -1786,6 +1806,125 @@ class TranslationsChannelsNotificationsEn {
 
 	/// en: 'Snippet length cap'
 	String get snippetLengthCap => 'Snippet length cap';
+
+	/// en: 'All session events.'
+	String get notifyOnAll => 'All session events.';
+
+	/// en: 'No events selected — outbound notifications muted.'
+	String get notifyOnEmpty => 'No events selected — outbound notifications muted.';
+
+	/// en: 'Embeds the recent terminal tail in each notification.'
+	String get snippetHelper => 'Embeds the recent terminal tail in each notification.';
+
+	/// en: 'no cap'
+	String get snippetNoCap => 'no cap';
+
+	/// en: '{n} chars'
+	String snippetChars({required Object n}) => '${n} chars';
+
+	/// en: 'Notification preferences updated.'
+	String get updatedSnack => 'Notification preferences updated.';
+
+	late final TranslationsChannelsNotificationsModesEn modes = TranslationsChannelsNotificationsModesEn.internal(_root);
+}
+
+// Path: channels.popup
+class TranslationsChannelsPopupEn {
+	TranslationsChannelsPopupEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Enable'
+	String get enable => 'Enable';
+
+	/// en: 'Disable'
+	String get disable => 'Disable';
+
+	/// en: 'Mute'
+	String get mute => 'Mute';
+
+	/// en: 'Unmute'
+	String get unmute => 'Unmute';
+
+	/// en: 'Delete'
+	String get deleteLabel => 'Delete';
+}
+
+// Path: channels.badges
+class TranslationsChannelsBadgesEn {
+	TranslationsChannelsBadgesEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'running'
+	String get running => 'running';
+
+	/// en: 'starting…'
+	String get starting => 'starting…';
+
+	/// en: 'disabled'
+	String get disabled => 'disabled';
+
+	/// en: 'muted'
+	String get muted => 'muted';
+}
+
+// Path: channels.snacks
+class TranslationsChannelsSnacksEn {
+	TranslationsChannelsSnacksEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Test message dispatched.'
+	String get testDispatched => 'Test message dispatched.';
+
+	/// en: 'Channel enabled.'
+	String get channelEnabled => 'Channel enabled.';
+
+	/// en: 'Channel disabled.'
+	String get channelDisabled => 'Channel disabled.';
+
+	/// en: 'Channel muted.'
+	String get channelMuted => 'Channel muted.';
+
+	/// en: 'Channel unmuted.'
+	String get channelUnmuted => 'Channel unmuted.';
+
+	/// en: 'Channel config updated.'
+	String get configUpdated => 'Channel config updated.';
+
+	/// en: 'Channel deleted.'
+	String get channelDeleted => 'Channel deleted.';
+}
+
+// Path: channels.errorPrefix
+class TranslationsChannelsErrorPrefixEn {
+	TranslationsChannelsErrorPrefixEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Test failed'
+	String get test => 'Test failed';
+
+	/// en: 'Toggle failed'
+	String get toggle => 'Toggle failed';
+
+	/// en: 'Mute toggle failed'
+	String get muteToggle => 'Mute toggle failed';
+
+	/// en: 'Update failed'
+	String get update => 'Update failed';
+
+	/// en: 'Delete failed'
+	String get delete => 'Delete failed';
 }
 
 // Path: notesPage.editor
@@ -2802,6 +2941,33 @@ class TranslationsMemoryWorkersTasksTranscriptEn {
 	String get description => 'Session-end \'what did the agent do\' summary. Naturally fits an agent worker.';
 }
 
+// Path: channels.notifications.modes
+class TranslationsChannelsNotificationsModesEn {
+	TranslationsChannelsNotificationsModesEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Once per session'
+	String get onceLabel => 'Once per session';
+
+	/// en: 'Fire once when idle, stay silent until reply or end.'
+	String get onceDescription => 'Fire once when idle, stay silent until reply or end.';
+
+	/// en: 'Time-window cooldown'
+	String get cooldownLabel => 'Time-window cooldown';
+
+	/// en: 'Suppress repeats within the chosen window.'
+	String get cooldownDescription => 'Suppress repeats within the chosen window.';
+
+	/// en: 'Every event (noisy)'
+	String get everyLabel => 'Every event (noisy)';
+
+	/// en: 'No suppression — only for low-frequency channels.'
+	String get everyDescription => 'No suppression — only for low-frequency channels.';
+}
+
 // Path: settings.logViewer.levels
 class TranslationsSettingsLogViewerLevelsEn {
 	TranslationsSettingsLogViewerLevelsEn.internal(this._root);
@@ -3352,6 +3518,44 @@ extension on Translations {
 			'channels.notifications.cooldownWindow' => 'Cooldown window',
 			'channels.notifications.includeSnippet' => 'Include terminal snippet',
 			'channels.notifications.snippetLengthCap' => 'Snippet length cap',
+			'channels.notifications.notifyOnAll' => 'All session events.',
+			'channels.notifications.notifyOnEmpty' => 'No events selected — outbound notifications muted.',
+			'channels.notifications.snippetHelper' => 'Embeds the recent terminal tail in each notification.',
+			'channels.notifications.snippetNoCap' => 'no cap',
+			'channels.notifications.snippetChars' => ({required Object n}) => '${n} chars',
+			'channels.notifications.updatedSnack' => 'Notification preferences updated.',
+			'channels.notifications.modes.onceLabel' => 'Once per session',
+			'channels.notifications.modes.onceDescription' => 'Fire once when idle, stay silent until reply or end.',
+			'channels.notifications.modes.cooldownLabel' => 'Time-window cooldown',
+			'channels.notifications.modes.cooldownDescription' => 'Suppress repeats within the chosen window.',
+			'channels.notifications.modes.everyLabel' => 'Every event (noisy)',
+			'channels.notifications.modes.everyDescription' => 'No suppression — only for low-frequency channels.',
+			'channels.popup.enable' => 'Enable',
+			'channels.popup.disable' => 'Disable',
+			'channels.popup.mute' => 'Mute',
+			'channels.popup.unmute' => 'Unmute',
+			'channels.popup.deleteLabel' => 'Delete',
+			'channels.badges.running' => 'running',
+			'channels.badges.starting' => 'starting…',
+			'channels.badges.disabled' => 'disabled',
+			'channels.badges.muted' => 'muted',
+			'channels.capsLabel' => ({required Object list}) => '· caps: ${list}',
+			'channels.bridgeWebOnly' => 'Bridge channels stay web-only',
+			'channels.bridgeEmptyAdd' => 'Add one from the web admin: Channels → New.',
+			'channels.deleteBody' => 'Stops the channel and removes its configuration. In-flight notifications addressed to it will be dropped silently.',
+			'channels.snacks.testDispatched' => 'Test message dispatched.',
+			'channels.snacks.channelEnabled' => 'Channel enabled.',
+			'channels.snacks.channelDisabled' => 'Channel disabled.',
+			'channels.snacks.channelMuted' => 'Channel muted.',
+			'channels.snacks.channelUnmuted' => 'Channel unmuted.',
+			'channels.snacks.configUpdated' => 'Channel config updated.',
+			'channels.snacks.channelDeleted' => 'Channel deleted.',
+			'channels.errorPrefix.test' => 'Test failed',
+			'channels.errorPrefix.toggle' => 'Toggle failed',
+			'channels.errorPrefix.muteToggle' => 'Mute toggle failed',
+			'channels.errorPrefix.update' => 'Update failed',
+			'channels.errorPrefix.delete' => 'Delete failed',
+			'channels.failedToLoad' => 'Failed to load channels',
 			'onboarding.gatewayLabel' => 'Gateway URL',
 			'onboarding.gatewayHint' => 'https://opendray.example.com',
 			'onboarding.kContinue' => 'Continue',
@@ -3371,6 +3575,8 @@ extension on Translations {
 			'customTasks.popupDelete' => 'Delete',
 			'customTasks.nameHint' => 'e.g. backend-tests',
 			'customTasks.commandHint' => '/run pnpm test --filter backend',
+			_ => null,
+		} ?? switch (path) {
 			'customTasks.descriptionHint' => 'One-liner shown under the task name.',
 			'customTasks.scopeGlobal' => 'Global',
 			'customTasks.scopeProject' => 'Project',
@@ -3409,8 +3615,6 @@ extension on Translations {
 			'memory.deletedSnackOne' => ({required Object n}) => 'Deleted ${n} memory item',
 			'memory.deletedSnackOther' => ({required Object n}) => 'Deleted ${n} memory items',
 			'memory.bulkDeleteFailedApi' => ({required Object error}) => 'Bulk delete failed: ${error}',
-			_ => null,
-		} ?? switch (path) {
 			'memory.bulkDeleteFailedGeneric' => ({required Object error}) => 'Bulk delete failed: ${error}',
 			'memory.deleteOne.title' => 'Delete memory?',
 			'memory.deleteOne.body' => 'This cannot be undone.',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -437,6 +437,15 @@ class _TranslationsChannelsZh extends TranslationsChannelsEn {
 	@override late final _TranslationsChannelsWebhookDialogZh webhookDialog = _TranslationsChannelsWebhookDialogZh._(_root);
 	@override String errorWithMessage({required Object prefix, required Object error}) => '${prefix}：${error}';
 	@override late final _TranslationsChannelsNotificationsZh notifications = _TranslationsChannelsNotificationsZh._(_root);
+	@override late final _TranslationsChannelsPopupZh popup = _TranslationsChannelsPopupZh._(_root);
+	@override late final _TranslationsChannelsBadgesZh badges = _TranslationsChannelsBadgesZh._(_root);
+	@override String capsLabel({required Object list}) => '· 能力：${list}';
+	@override String get bridgeWebOnly => 'Bridge 通道仅 Web 端';
+	@override String get bridgeEmptyAdd => '在 Web 管理端添加：通道 → 新建。';
+	@override String get deleteBody => '停止该通道并移除其配置。仍在传输中的通知会被静默丢弃。';
+	@override late final _TranslationsChannelsSnacksZh snacks = _TranslationsChannelsSnacksZh._(_root);
+	@override late final _TranslationsChannelsErrorPrefixZh errorPrefix = _TranslationsChannelsErrorPrefixZh._(_root);
+	@override String get failedToLoad => '加载通道失败';
 }
 
 // Path: onboarding
@@ -986,6 +995,70 @@ class _TranslationsChannelsNotificationsZh extends TranslationsChannelsNotificat
 	@override String get cooldownWindow => '冷却时间';
 	@override String get includeSnippet => '包含终端片段';
 	@override String get snippetLengthCap => '片段长度上限';
+	@override String get notifyOnAll => '所有会话事件。';
+	@override String get notifyOnEmpty => '未选择事件 — 已静音外发通知。';
+	@override String get snippetHelper => '在每条通知中嵌入终端最近的内容。';
+	@override String get snippetNoCap => '无上限';
+	@override String snippetChars({required Object n}) => '${n} 字符';
+	@override String get updatedSnack => '通知偏好已更新。';
+	@override late final _TranslationsChannelsNotificationsModesZh modes = _TranslationsChannelsNotificationsModesZh._(_root);
+}
+
+// Path: channels.popup
+class _TranslationsChannelsPopupZh extends TranslationsChannelsPopupEn {
+	_TranslationsChannelsPopupZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get enable => '启用';
+	@override String get disable => '停用';
+	@override String get mute => '静音';
+	@override String get unmute => '取消静音';
+	@override String get deleteLabel => '删除';
+}
+
+// Path: channels.badges
+class _TranslationsChannelsBadgesZh extends TranslationsChannelsBadgesEn {
+	_TranslationsChannelsBadgesZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get running => '运行中';
+	@override String get starting => '启动中…';
+	@override String get disabled => '已停用';
+	@override String get muted => '已静音';
+}
+
+// Path: channels.snacks
+class _TranslationsChannelsSnacksZh extends TranslationsChannelsSnacksEn {
+	_TranslationsChannelsSnacksZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get testDispatched => '测试消息已发送。';
+	@override String get channelEnabled => '通道已启用。';
+	@override String get channelDisabled => '通道已停用。';
+	@override String get channelMuted => '通道已静音。';
+	@override String get channelUnmuted => '通道已取消静音。';
+	@override String get configUpdated => '通道配置已更新。';
+	@override String get channelDeleted => '通道已删除。';
+}
+
+// Path: channels.errorPrefix
+class _TranslationsChannelsErrorPrefixZh extends TranslationsChannelsErrorPrefixEn {
+	_TranslationsChannelsErrorPrefixZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get test => '测试失败';
+	@override String get toggle => '切换失败';
+	@override String get muteToggle => '静音切换失败';
+	@override String get update => '更新失败';
+	@override String get delete => '删除失败';
 }
 
 // Path: notesPage.editor
@@ -1615,6 +1688,21 @@ class _TranslationsMemoryWorkersTasksTranscriptZh extends TranslationsMemoryWork
 	@override String get description => '会话结束时的「agent 做了什么」摘要。天然适合 agent 工作器。';
 }
 
+// Path: channels.notifications.modes
+class _TranslationsChannelsNotificationsModesZh extends TranslationsChannelsNotificationsModesEn {
+	_TranslationsChannelsNotificationsModesZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get onceLabel => '每会话一次';
+	@override String get onceDescription => '空闲时触发一次，回复或结束前不再触发。';
+	@override String get cooldownLabel => '时间窗冷却';
+	@override String get cooldownDescription => '在所选时间窗内抑制重复。';
+	@override String get everyLabel => '每次事件（嘈杂）';
+	@override String get everyDescription => '不抑制 — 仅适合低频通道。';
+}
+
 // Path: settings.logViewer.levels
 class _TranslationsSettingsLogViewerLevelsZh extends TranslationsSettingsLogViewerLevelsEn {
 	_TranslationsSettingsLogViewerLevelsZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -2125,6 +2213,44 @@ extension on TranslationsZh {
 			'channels.notifications.cooldownWindow' => '冷却时间',
 			'channels.notifications.includeSnippet' => '包含终端片段',
 			'channels.notifications.snippetLengthCap' => '片段长度上限',
+			'channels.notifications.notifyOnAll' => '所有会话事件。',
+			'channels.notifications.notifyOnEmpty' => '未选择事件 — 已静音外发通知。',
+			'channels.notifications.snippetHelper' => '在每条通知中嵌入终端最近的内容。',
+			'channels.notifications.snippetNoCap' => '无上限',
+			'channels.notifications.snippetChars' => ({required Object n}) => '${n} 字符',
+			'channels.notifications.updatedSnack' => '通知偏好已更新。',
+			'channels.notifications.modes.onceLabel' => '每会话一次',
+			'channels.notifications.modes.onceDescription' => '空闲时触发一次，回复或结束前不再触发。',
+			'channels.notifications.modes.cooldownLabel' => '时间窗冷却',
+			'channels.notifications.modes.cooldownDescription' => '在所选时间窗内抑制重复。',
+			'channels.notifications.modes.everyLabel' => '每次事件（嘈杂）',
+			'channels.notifications.modes.everyDescription' => '不抑制 — 仅适合低频通道。',
+			'channels.popup.enable' => '启用',
+			'channels.popup.disable' => '停用',
+			'channels.popup.mute' => '静音',
+			'channels.popup.unmute' => '取消静音',
+			'channels.popup.deleteLabel' => '删除',
+			'channels.badges.running' => '运行中',
+			'channels.badges.starting' => '启动中…',
+			'channels.badges.disabled' => '已停用',
+			'channels.badges.muted' => '已静音',
+			'channels.capsLabel' => ({required Object list}) => '· 能力：${list}',
+			'channels.bridgeWebOnly' => 'Bridge 通道仅 Web 端',
+			'channels.bridgeEmptyAdd' => '在 Web 管理端添加：通道 → 新建。',
+			'channels.deleteBody' => '停止该通道并移除其配置。仍在传输中的通知会被静默丢弃。',
+			'channels.snacks.testDispatched' => '测试消息已发送。',
+			'channels.snacks.channelEnabled' => '通道已启用。',
+			'channels.snacks.channelDisabled' => '通道已停用。',
+			'channels.snacks.channelMuted' => '通道已静音。',
+			'channels.snacks.channelUnmuted' => '通道已取消静音。',
+			'channels.snacks.configUpdated' => '通道配置已更新。',
+			'channels.snacks.channelDeleted' => '通道已删除。',
+			'channels.errorPrefix.test' => '测试失败',
+			'channels.errorPrefix.toggle' => '切换失败',
+			'channels.errorPrefix.muteToggle' => '静音切换失败',
+			'channels.errorPrefix.update' => '更新失败',
+			'channels.errorPrefix.delete' => '删除失败',
+			'channels.failedToLoad' => '加载通道失败',
 			'onboarding.gatewayLabel' => '网关 URL',
 			'onboarding.gatewayHint' => 'https://opendray.example.com',
 			'onboarding.kContinue' => '继续',
@@ -2144,6 +2270,8 @@ extension on TranslationsZh {
 			'customTasks.popupDelete' => '删除',
 			'customTasks.nameHint' => '例如：backend-tests',
 			'customTasks.commandHint' => '/run pnpm test --filter backend',
+			_ => null,
+		} ?? switch (path) {
 			'customTasks.descriptionHint' => '在任务名下方显示的一行说明。',
 			'customTasks.scopeGlobal' => '全局',
 			'customTasks.scopeProject' => '项目',
@@ -2182,8 +2310,6 @@ extension on TranslationsZh {
 			'memory.deletedSnackOne' => ({required Object n}) => '已删除 ${n} 条记忆',
 			'memory.deletedSnackOther' => ({required Object n}) => '已删除 ${n} 条记忆',
 			'memory.bulkDeleteFailedApi' => ({required Object error}) => '批量删除失败：${error}',
-			_ => null,
-		} ?? switch (path) {
 			'memory.bulkDeleteFailedGeneric' => ({required Object error}) => '批量删除失败：${error}',
 			'memory.deleteOne.title' => '删除该记忆？',
 			'memory.deleteOne.body' => '此操作不可撤销。',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -446,6 +446,7 @@ class _TranslationsChannelsZh extends TranslationsChannelsEn {
 	@override late final _TranslationsChannelsSnacksZh snacks = _TranslationsChannelsSnacksZh._(_root);
 	@override late final _TranslationsChannelsErrorPrefixZh errorPrefix = _TranslationsChannelsErrorPrefixZh._(_root);
 	@override String get failedToLoad => '加载通道失败';
+	@override late final _TranslationsChannelsKindsZh kinds = _TranslationsChannelsKindsZh._(_root);
 }
 
 // Path: onboarding
@@ -1059,6 +1060,22 @@ class _TranslationsChannelsErrorPrefixZh extends TranslationsChannelsErrorPrefix
 	@override String get muteToggle => '静音切换失败';
 	@override String get update => '更新失败';
 	@override String get delete => '删除失败';
+}
+
+// Path: channels.kinds
+class _TranslationsChannelsKindsZh extends TranslationsChannelsKindsEn {
+	_TranslationsChannelsKindsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsChannelsKindsTelegramZh telegram = _TranslationsChannelsKindsTelegramZh._(_root);
+	@override late final _TranslationsChannelsKindsSlackZh slack = _TranslationsChannelsKindsSlackZh._(_root);
+	@override late final _TranslationsChannelsKindsDiscordZh discord = _TranslationsChannelsKindsDiscordZh._(_root);
+	@override late final _TranslationsChannelsKindsFeishuZh feishu = _TranslationsChannelsKindsFeishuZh._(_root);
+	@override late final _TranslationsChannelsKindsDingtalkZh dingtalk = _TranslationsChannelsKindsDingtalkZh._(_root);
+	@override late final _TranslationsChannelsKindsWecomZh wecom = _TranslationsChannelsKindsWecomZh._(_root);
+	@override late final _TranslationsChannelsKindsWechatZh wechat = _TranslationsChannelsKindsWechatZh._(_root);
 }
 
 // Path: notesPage.editor
@@ -1703,6 +1720,113 @@ class _TranslationsChannelsNotificationsModesZh extends TranslationsChannelsNoti
 	@override String get everyDescription => '不抑制 — 仅适合低频通道。';
 }
 
+// Path: channels.kinds.telegram
+class _TranslationsChannelsKindsTelegramZh extends TranslationsChannelsKindsTelegramEn {
+	_TranslationsChannelsKindsTelegramZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get description => '通过 @BotFather 创建机器人。opendray 长轮询 getUpdates 并通过 REST 发送。原生支持按钮和 reply_to_message。';
+	@override String get botTokenLabel => '机器人 Token';
+	@override String get botTokenHint => '从 @BotFather 获取。存储于通道配置；仅管理员 API 可见。';
+	@override String get chatIdLabel => '默认 chat ID';
+	@override String get chatIdPlaceholder => '42（可选 — 没有 ReplyCtx 时使用）';
+}
+
+// Path: channels.kinds.slack
+class _TranslationsChannelsKindsSlackZh extends TranslationsChannelsKindsSlackEn {
+	_TranslationsChannelsKindsSlackZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get description => 'Socket Mode — 无需公网 webhook。需要 bot OAuth token（xoxb-）和带 connections:write 的 app-level token（xapp-）。';
+	@override String get botTokenLabel => 'Bot token（xoxb-…）';
+	@override String get botTokenHint => 'OAuth & Permissions → Bot User OAuth Token。需要 chat:write。';
+	@override String get appTokenLabel => 'App-level token（xapp-…）';
+	@override String get appTokenHint => 'Settings → Basic Information → App-Level Tokens。范围：connections:write。';
+	@override String get channelIdLabel => '默认 channel ID';
+	@override String get channelIdPlaceholder => 'C0123ABC456（可选）';
+}
+
+// Path: channels.kinds.discord
+class _TranslationsChannelsKindsDiscordZh extends TranslationsChannelsKindsDiscordEn {
+	_TranslationsChannelsKindsDiscordZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get description => '通过 Discord Developer Portal 创建机器人，启用 MESSAGE CONTENT INTENT。连接 Gateway WS — 无需公网 URL。';
+	@override String get botTokenLabel => 'Bot token';
+	@override String get botTokenPlaceholder => '来自 Discord Developer Portal 的 Bot token';
+	@override String get botTokenHint => 'Application → Bot → Reset Token。邀请机器人时勾选 send_messages + embed_links。';
+	@override String get channelIdLabel => '默认 channel ID';
+	@override String get channelIdPlaceholder => '123456789012345678（可选）';
+}
+
+// Path: channels.kinds.feishu
+class _TranslationsChannelsKindsFeishuZh extends TranslationsChannelsKindsFeishuEn {
+	_TranslationsChannelsKindsFeishuZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get description => '应用级凭据。入站走事件订阅 webhook。下方生成公网 webhook URL — 粘贴到飞书开放平台控制台。';
+	@override String get afterCreateHint => '在通道卡上打开 webhook URL，粘贴到飞书开放平台 → 事件订阅 → Request URL。';
+	@override String get appIdLabel => 'App ID';
+	@override String get appSecretLabel => 'App secret';
+	@override String get appSecretPlaceholder => '应用凭据 secret';
+	@override String get verificationTokenLabel => 'Verification token';
+	@override String get verificationTokenHint => '来自 事件订阅 → Verification Token。设置后，opendray 拒绝 token 不匹配的 webhook。';
+	@override String get chatIdLabel => '默认 chat ID（oc_…）';
+	@override String get chatIdPlaceholder => 'oc_xxxxxxxxxx（可选）';
+}
+
+// Path: channels.kinds.dingtalk
+class _TranslationsChannelsKindsDingtalkZh extends TranslationsChannelsKindsDingtalkEn {
+	_TranslationsChannelsKindsDingtalkZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get description => '自定义群机器人。仅外发。群聊 → 机器人 → 添加 → 加签模式 → 复制 webhook + secret。';
+	@override String get webhookUrlLabel => 'Webhook URL';
+	@override String get secretLabel => '加签 secret';
+	@override String get secretHint => '当机器人为「加签」安全模式时，将 secret 复制到这里。opendray 自动添加 timestamp + sign 参数。';
+}
+
+// Path: channels.kinds.wecom
+class _TranslationsChannelsKindsWecomZh extends TranslationsChannelsKindsWecomEn {
+	_TranslationsChannelsKindsWecomZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get description => '群机器人 webhook。仅外发（文本 + markdown）。群设置 → 群机器人 → 添加 → 复制 webhook URL。';
+	@override String get webhookKeyLabel => 'Webhook key';
+	@override String get webhookKeyPlaceholder => '「key=」查询参数值';
+	@override String get webhookKeyHint => '或将整个 webhook URL 粘贴到下方字段 — 任一即可。';
+	@override String get webhookUrlLabel => '或完整 webhook URL';
+}
+
+// Path: channels.kinds.wechat
+class _TranslationsChannelsKindsWechatZh extends TranslationsChannelsKindsWechatEn {
+	_TranslationsChannelsKindsWechatZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get description => '通过 WxPusher 推送到个人微信。仅外发 — 推送服务不转发用户回复。每个接收方需通过二维码订阅一次。';
+	@override String get appTokenLabel => 'App token（AT_…）';
+	@override String get appTokenHint => 'WxPusher → 应用管理 → 创建应用 → 复制 App Token。';
+	@override String get uidsLabel => '接收方 UID（每行一个）';
+	@override String get uidsHint => 'UID 或 topic ID 至少需要一个。';
+	@override String get topicIdsLabel => 'Topic ID（每行一个）';
+	@override String get urlLabel => '点击跳转 URL';
+	@override String get urlHint => '设置后，点击微信通知会打开此页面。';
+}
+
 // Path: settings.logViewer.levels
 class _TranslationsSettingsLogViewerLevelsZh extends TranslationsSettingsLogViewerLevelsEn {
 	_TranslationsSettingsLogViewerLevelsZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -2251,6 +2375,52 @@ extension on TranslationsZh {
 			'channels.errorPrefix.update' => '更新失败',
 			'channels.errorPrefix.delete' => '删除失败',
 			'channels.failedToLoad' => '加载通道失败',
+			'channels.kinds.telegram.description' => '通过 @BotFather 创建机器人。opendray 长轮询 getUpdates 并通过 REST 发送。原生支持按钮和 reply_to_message。',
+			'channels.kinds.telegram.botTokenLabel' => '机器人 Token',
+			'channels.kinds.telegram.botTokenHint' => '从 @BotFather 获取。存储于通道配置；仅管理员 API 可见。',
+			'channels.kinds.telegram.chatIdLabel' => '默认 chat ID',
+			'channels.kinds.telegram.chatIdPlaceholder' => '42（可选 — 没有 ReplyCtx 时使用）',
+			'channels.kinds.slack.description' => 'Socket Mode — 无需公网 webhook。需要 bot OAuth token（xoxb-）和带 connections:write 的 app-level token（xapp-）。',
+			'channels.kinds.slack.botTokenLabel' => 'Bot token（xoxb-…）',
+			'channels.kinds.slack.botTokenHint' => 'OAuth & Permissions → Bot User OAuth Token。需要 chat:write。',
+			'channels.kinds.slack.appTokenLabel' => 'App-level token（xapp-…）',
+			'channels.kinds.slack.appTokenHint' => 'Settings → Basic Information → App-Level Tokens。范围：connections:write。',
+			'channels.kinds.slack.channelIdLabel' => '默认 channel ID',
+			'channels.kinds.slack.channelIdPlaceholder' => 'C0123ABC456（可选）',
+			'channels.kinds.discord.description' => '通过 Discord Developer Portal 创建机器人，启用 MESSAGE CONTENT INTENT。连接 Gateway WS — 无需公网 URL。',
+			'channels.kinds.discord.botTokenLabel' => 'Bot token',
+			'channels.kinds.discord.botTokenPlaceholder' => '来自 Discord Developer Portal 的 Bot token',
+			'channels.kinds.discord.botTokenHint' => 'Application → Bot → Reset Token。邀请机器人时勾选 send_messages + embed_links。',
+			'channels.kinds.discord.channelIdLabel' => '默认 channel ID',
+			'channels.kinds.discord.channelIdPlaceholder' => '123456789012345678（可选）',
+			'channels.kinds.feishu.description' => '应用级凭据。入站走事件订阅 webhook。下方生成公网 webhook URL — 粘贴到飞书开放平台控制台。',
+			_ => null,
+		} ?? switch (path) {
+			'channels.kinds.feishu.afterCreateHint' => '在通道卡上打开 webhook URL，粘贴到飞书开放平台 → 事件订阅 → Request URL。',
+			'channels.kinds.feishu.appIdLabel' => 'App ID',
+			'channels.kinds.feishu.appSecretLabel' => 'App secret',
+			'channels.kinds.feishu.appSecretPlaceholder' => '应用凭据 secret',
+			'channels.kinds.feishu.verificationTokenLabel' => 'Verification token',
+			'channels.kinds.feishu.verificationTokenHint' => '来自 事件订阅 → Verification Token。设置后，opendray 拒绝 token 不匹配的 webhook。',
+			'channels.kinds.feishu.chatIdLabel' => '默认 chat ID（oc_…）',
+			'channels.kinds.feishu.chatIdPlaceholder' => 'oc_xxxxxxxxxx（可选）',
+			'channels.kinds.dingtalk.description' => '自定义群机器人。仅外发。群聊 → 机器人 → 添加 → 加签模式 → 复制 webhook + secret。',
+			'channels.kinds.dingtalk.webhookUrlLabel' => 'Webhook URL',
+			'channels.kinds.dingtalk.secretLabel' => '加签 secret',
+			'channels.kinds.dingtalk.secretHint' => '当机器人为「加签」安全模式时，将 secret 复制到这里。opendray 自动添加 timestamp + sign 参数。',
+			'channels.kinds.wecom.description' => '群机器人 webhook。仅外发（文本 + markdown）。群设置 → 群机器人 → 添加 → 复制 webhook URL。',
+			'channels.kinds.wecom.webhookKeyLabel' => 'Webhook key',
+			'channels.kinds.wecom.webhookKeyPlaceholder' => '「key=」查询参数值',
+			'channels.kinds.wecom.webhookKeyHint' => '或将整个 webhook URL 粘贴到下方字段 — 任一即可。',
+			'channels.kinds.wecom.webhookUrlLabel' => '或完整 webhook URL',
+			'channels.kinds.wechat.description' => '通过 WxPusher 推送到个人微信。仅外发 — 推送服务不转发用户回复。每个接收方需通过二维码订阅一次。',
+			'channels.kinds.wechat.appTokenLabel' => 'App token（AT_…）',
+			'channels.kinds.wechat.appTokenHint' => 'WxPusher → 应用管理 → 创建应用 → 复制 App Token。',
+			'channels.kinds.wechat.uidsLabel' => '接收方 UID（每行一个）',
+			'channels.kinds.wechat.uidsHint' => 'UID 或 topic ID 至少需要一个。',
+			'channels.kinds.wechat.topicIdsLabel' => 'Topic ID（每行一个）',
+			'channels.kinds.wechat.urlLabel' => '点击跳转 URL',
+			'channels.kinds.wechat.urlHint' => '设置后，点击微信通知会打开此页面。',
 			'onboarding.gatewayLabel' => '网关 URL',
 			'onboarding.gatewayHint' => 'https://opendray.example.com',
 			'onboarding.kContinue' => '继续',
@@ -2270,8 +2440,6 @@ extension on TranslationsZh {
 			'customTasks.popupDelete' => '删除',
 			'customTasks.nameHint' => '例如：backend-tests',
 			'customTasks.commandHint' => '/run pnpm test --filter backend',
-			_ => null,
-		} ?? switch (path) {
 			'customTasks.descriptionHint' => '在任务名下方显示的一行说明。',
 			'customTasks.scopeGlobal' => '全局',
 			'customTasks.scopeProject' => '项目',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -173,6 +173,24 @@ class _TranslationsMcpZh extends TranslationsMcpEn {
 	@override String errorWithMessage({required Object prefix, required Object error}) => '${prefix}：${error}';
 	@override late final _TranslationsMcpEditorZh editor = _TranslationsMcpEditorZh._(_root);
 	@override late final _TranslationsMcpSecretZh secret = _TranslationsMcpSecretZh._(_root);
+	@override late final _TranslationsMcpPopupZh popup = _TranslationsMcpPopupZh._(_root);
+	@override late final _TranslationsMcpKvZh kv = _TranslationsMcpKvZh._(_root);
+	@override String deleteServerBody({required Object id}) => '移除 ${id} 的密钥库目录。引用此服务器的会话将无法启动。';
+	@override String deleteServerSnack({required Object id}) => '已删除 ${id}。';
+	@override String serversCount({required Object count}) => '服务器（${count}）';
+	@override String secretsCount({required Object count}) => '密钥（${count}）';
+	@override String get emptyServers => '未注册任何 MCP 服务器。点击「新建服务器」添加一个。';
+	@override String get emptySecrets => '暂无密钥。添加一个，将敏感的 env / headers 注入 MCP 服务器，无需放在 JSON 里。';
+	@override String get noVaultFileYet => '尚无密钥库文件 — 添加密钥时会创建。';
+	@override String get tapToReplaceHint => '点击替换 · 长按 / 垃圾桶 删除';
+	@override String get failedToLoad => '加载 MCP 状态失败';
+	@override String get serverCreatedSnack => 'MCP 服务器已创建。';
+	@override String get serverUpdatedSnack => 'MCP 服务器已更新。';
+	@override String get envHeading => '环境变量';
+	@override String get encryptionAes => 'AES-GCM 加密（密钥存于 OS keychain）';
+	@override String get encryptionPlaintext => '明文 — keychain 不可用';
+	@override String toggleEnabledSnack({required Object name}) => '${name} 已启用。';
+	@override String toggleDisabledSnack({required Object name}) => '${name} 已停用。';
 }
 
 // Path: providers
@@ -786,6 +804,19 @@ class _TranslationsMcpEditorZh extends TranslationsMcpEditorEn {
 	// Translations
 	@override String get nameHint => 'my-mcp-server';
 	@override String get jsonHint => 'JSON 配置 — name、transport: stdio、command、args…';
+	@override String get descriptionPlaceholder => '可选的一行说明';
+	@override String get validateJsonObject => '正文必须是 JSON 对象';
+	@override String validateJsonInvalid({required Object error}) => '无效的 JSON：${error}';
+	@override String get appBarEdit => '编辑 MCP 服务器';
+	@override String get appBarNew => '新建 MCP 服务器';
+	@override String get idLockedHint => '编辑模式下锁定 — 需删除后重建以更改。';
+	@override String get jsonLabel => '服务器 JSON';
+	@override String get jsonSchemaHelp => 'Schema：transport 必须是 stdio、http 或 sse。stdio 需要 command + args。http/sse 需要 url + headers。用 \$secret:KEY 引用密钥库的密钥。';
+	@override String get idLabel => 'id（URL 片段，小写字母数字 / 横线 / 下划线）';
+	@override String get idRequired => 'id 必填';
+	@override String get saving => '保存中…';
+	@override String get save => '保存';
+	@override String get create => '创建';
 }
 
 // Path: mcp.secret
@@ -798,6 +829,46 @@ class _TranslationsMcpSecretZh extends TranslationsMcpSecretEn {
 	@override String get keyLabel => '键';
 	@override String get keyHint => 'GITHUB_TOKEN、OPENAI_KEY、…';
 	@override String get valueLabel => '值';
+	@override String get keyRequired => '必须填写键。';
+	@override String get keyInvalid => '键必须匹配 [A-Za-z_][A-Za-z0-9_]* — 与 shell 环境变量规则相同。';
+	@override String get valueRequired => '必须填写值。';
+	@override String get replaceTitle => '替换密钥值';
+	@override String get addTitle => '添加密钥';
+	@override String get saveButton => '保存';
+	@override String get addButton => '添加';
+	@override String get helpRules => 'shell 环境变量规则：字母或 _ 开头，仅含字母 / 数字 / _。';
+	@override String get replaceHint => '粘贴新值（旧值被擦除）';
+	@override String get addHint => '粘贴密钥值';
+	@override String addedSnack({required Object key}) => '已添加密钥 ${key}。';
+	@override String updatedSnack({required Object key}) => '已更新密钥 ${key}。';
+	@override String deletedSnack({required Object key}) => '已删除 ${key}。';
+	@override String get deleteBody => '从加密的密钥库中移除该值。引用此密钥的 MCP 服务器在恢复前将无法启动。';
+}
+
+// Path: mcp.popup
+class _TranslationsMcpPopupZh extends TranslationsMcpPopupEn {
+	_TranslationsMcpPopupZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get editConfigSubtitle => '完整 JSON 编辑器 — 仅限密钥库支持的服务器';
+	@override String get viewRawSubtitle => '服务器 JSON 的只读查看器';
+	@override String get deleteLabel => '删除';
+}
+
+// Path: mcp.kv
+class _TranslationsMcpKvZh extends TranslationsMcpKvEn {
+	_TranslationsMcpKvZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get transport => '传输';
+	@override String get description => '描述';
+	@override String get command => '命令';
+	@override String get args => '参数';
+	@override String get headers => 'Headers';
 }
 
 // Path: providers.errorPrefix
@@ -1822,9 +1893,60 @@ extension on TranslationsZh {
 			'mcp.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}：${error}',
 			'mcp.editor.nameHint' => 'my-mcp-server',
 			'mcp.editor.jsonHint' => 'JSON 配置 — name、transport: stdio、command、args…',
+			'mcp.editor.descriptionPlaceholder' => '可选的一行说明',
+			'mcp.editor.validateJsonObject' => '正文必须是 JSON 对象',
+			'mcp.editor.validateJsonInvalid' => ({required Object error}) => '无效的 JSON：${error}',
+			'mcp.editor.appBarEdit' => '编辑 MCP 服务器',
+			'mcp.editor.appBarNew' => '新建 MCP 服务器',
+			'mcp.editor.idLockedHint' => '编辑模式下锁定 — 需删除后重建以更改。',
+			'mcp.editor.jsonLabel' => '服务器 JSON',
+			'mcp.editor.jsonSchemaHelp' => 'Schema：transport 必须是 stdio、http 或 sse。stdio 需要 command + args。http/sse 需要 url + headers。用 \$secret:KEY 引用密钥库的密钥。',
+			'mcp.editor.idLabel' => 'id（URL 片段，小写字母数字 / 横线 / 下划线）',
+			'mcp.editor.idRequired' => 'id 必填',
+			'mcp.editor.saving' => '保存中…',
+			'mcp.editor.save' => '保存',
+			'mcp.editor.create' => '创建',
 			'mcp.secret.keyLabel' => '键',
 			'mcp.secret.keyHint' => 'GITHUB_TOKEN、OPENAI_KEY、…',
 			'mcp.secret.valueLabel' => '值',
+			'mcp.secret.keyRequired' => '必须填写键。',
+			'mcp.secret.keyInvalid' => '键必须匹配 [A-Za-z_][A-Za-z0-9_]* — 与 shell 环境变量规则相同。',
+			'mcp.secret.valueRequired' => '必须填写值。',
+			'mcp.secret.replaceTitle' => '替换密钥值',
+			'mcp.secret.addTitle' => '添加密钥',
+			'mcp.secret.saveButton' => '保存',
+			'mcp.secret.addButton' => '添加',
+			'mcp.secret.helpRules' => 'shell 环境变量规则：字母或 _ 开头，仅含字母 / 数字 / _。',
+			'mcp.secret.replaceHint' => '粘贴新值（旧值被擦除）',
+			'mcp.secret.addHint' => '粘贴密钥值',
+			'mcp.secret.addedSnack' => ({required Object key}) => '已添加密钥 ${key}。',
+			'mcp.secret.updatedSnack' => ({required Object key}) => '已更新密钥 ${key}。',
+			'mcp.secret.deletedSnack' => ({required Object key}) => '已删除 ${key}。',
+			'mcp.secret.deleteBody' => '从加密的密钥库中移除该值。引用此密钥的 MCP 服务器在恢复前将无法启动。',
+			'mcp.popup.editConfigSubtitle' => '完整 JSON 编辑器 — 仅限密钥库支持的服务器',
+			'mcp.popup.viewRawSubtitle' => '服务器 JSON 的只读查看器',
+			'mcp.popup.deleteLabel' => '删除',
+			'mcp.kv.transport' => '传输',
+			'mcp.kv.description' => '描述',
+			'mcp.kv.command' => '命令',
+			'mcp.kv.args' => '参数',
+			'mcp.kv.headers' => 'Headers',
+			'mcp.deleteServerBody' => ({required Object id}) => '移除 ${id} 的密钥库目录。引用此服务器的会话将无法启动。',
+			'mcp.deleteServerSnack' => ({required Object id}) => '已删除 ${id}。',
+			'mcp.serversCount' => ({required Object count}) => '服务器（${count}）',
+			'mcp.secretsCount' => ({required Object count}) => '密钥（${count}）',
+			'mcp.emptyServers' => '未注册任何 MCP 服务器。点击「新建服务器」添加一个。',
+			'mcp.emptySecrets' => '暂无密钥。添加一个，将敏感的 env / headers 注入 MCP 服务器，无需放在 JSON 里。',
+			'mcp.noVaultFileYet' => '尚无密钥库文件 — 添加密钥时会创建。',
+			'mcp.tapToReplaceHint' => '点击替换 · 长按 / 垃圾桶 删除',
+			'mcp.failedToLoad' => '加载 MCP 状态失败',
+			'mcp.serverCreatedSnack' => 'MCP 服务器已创建。',
+			'mcp.serverUpdatedSnack' => 'MCP 服务器已更新。',
+			'mcp.envHeading' => '环境变量',
+			'mcp.encryptionAes' => 'AES-GCM 加密（密钥存于 OS keychain）',
+			'mcp.encryptionPlaintext' => '明文 — keychain 不可用',
+			'mcp.toggleEnabledSnack' => ({required Object name}) => '${name} 已启用。',
+			'mcp.toggleDisabledSnack' => ({required Object name}) => '${name} 已停用。',
 			'providers.title' => '提供商',
 			'providers.configSaved' => '提供商配置已更新。',
 			'providers.saveFailedApi' => ({required Object error}) => '保存失败：${error}',
@@ -2060,6 +2182,8 @@ extension on TranslationsZh {
 			'memory.deletedSnackOne' => ({required Object n}) => '已删除 ${n} 条记忆',
 			'memory.deletedSnackOther' => ({required Object n}) => '已删除 ${n} 条记忆',
 			'memory.bulkDeleteFailedApi' => ({required Object error}) => '批量删除失败：${error}',
+			_ => null,
+		} ?? switch (path) {
 			'memory.bulkDeleteFailedGeneric' => ({required Object error}) => '批量删除失败：${error}',
 			'memory.deleteOne.title' => '删除该记忆？',
 			'memory.deleteOne.body' => '此操作不可撤销。',
@@ -2111,8 +2235,6 @@ extension on TranslationsZh {
 			'settings.changeCredentials.currentPassword' => '当前密码',
 			'settings.changeCredentials.newUsername' => '新用户名',
 			'settings.changeCredentials.newPassword' => '新密码',
-			_ => null,
-		} ?? switch (path) {
 			'settings.changeCredentials.confirmPassword' => '确认新密码',
 			'settings.changeCredentials.validatorRequired' => '必填',
 			'settings.changeCredentials.passwordHelper' => '至少 8 个字符',

--- a/app/mobile/lib/features/backups/backup_schedules_screen.dart
+++ b/app/mobile/lib/features/backups/backup_schedules_screen.dart
@@ -203,6 +203,7 @@ class _BackupSchedulesScreenState
       ),
       floatingActionButton: _state.maybeWhen(
         data: (d) => FloatingActionButton.extended(
+          heroTag: 'backup_schedules_fab',
           onPressed: () => _onCreate(d.targets),
           icon: const Icon(Icons.add),
           label: const Text('New'),

--- a/app/mobile/lib/features/backups/backup_targets_screen.dart
+++ b/app/mobile/lib/features/backups/backup_targets_screen.dart
@@ -335,6 +335,7 @@ class _BackupTargetsScreenState
         error: (e, _) => _ErrorView(error: e.toString(), onRetry: _load),
       ),
       floatingActionButton: FloatingActionButton.extended(
+        heroTag: 'backup_targets_fab',
         onPressed: _openEditor,
         icon: const Icon(Icons.add),
         label: Text(i18n.t.backupTargets.newTarget),

--- a/app/mobile/lib/features/backups/backups_screen.dart
+++ b/app/mobile/lib/features/backups/backups_screen.dart
@@ -485,6 +485,7 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
       floatingActionButton: _state.valueOrNull?.featureOff ?? true
           ? null
           : FloatingActionButton.extended(
+              heroTag: 'backups_fab',
               // Greyed-out when pg_dump is broken or no targets are
               // configured — clicking would just produce a failed row.
               onPressed: _canRunNow() ? _runNow : null,

--- a/app/mobile/lib/features/channels/channel_form_dialog.dart
+++ b/app/mobile/lib/features/channels/channel_form_dialog.dart
@@ -246,15 +246,17 @@ class ChannelKindPickerSheet extends StatelessWidget {
           ),
           const Divider(height: 1),
           Flexible(
-            child: ListView.separated(
-              shrinkWrap: true,
-              itemCount: channelKinds.length,
-              separatorBuilder: (_, __) => Divider(
-                height: 1,
-                color: Theme.of(context).dividerColor,
-              ),
-              itemBuilder: (_, i) {
-                final k = channelKinds[i];
+            child: Builder(builder: (context) {
+              final kinds = channelKindsList();
+              return ListView.separated(
+                shrinkWrap: true,
+                itemCount: kinds.length,
+                separatorBuilder: (_, __) => Divider(
+                  height: 1,
+                  color: Theme.of(context).dividerColor,
+                ),
+                itemBuilder: (_, i) {
+                  final k = kinds[i];
                 return ListTile(
                   leading: Container(
                     width: 36,
@@ -285,7 +287,8 @@ class ChannelKindPickerSheet extends StatelessWidget {
                   onTap: () => Navigator.of(context).pop(k),
                 );
               },
-            ),
+              );
+            }),
           ),
           const SizedBox(height: 8),
         ],

--- a/app/mobile/lib/features/channels/channel_kinds.dart
+++ b/app/mobile/lib/features/channels/channel_kinds.dart
@@ -5,6 +5,8 @@
 // and capability multiselect that don't translate cleanly to the
 // mobile form pattern; bridge channels stay web-only on creation.
 
+import 'package:opendray/core/i18n/strings.g.dart';
+
 enum ChannelFieldType { text, password, textarea }
 
 class ChannelField {
@@ -56,242 +58,215 @@ class ChannelKind {
   final String? afterCreateHint;
 }
 
-const channelKinds = <ChannelKind>[
-  ChannelKind(
-    kind: 'telegram',
-    label: 'Telegram',
-    description:
-        'Bot via @BotFather. opendray long-polls getUpdates and sends '
-        'via REST. Buttons + reply_to_message work natively.',
-    tokenFields: ['bot_token'],
-    fields: [
-      ChannelField(
-        name: 'bot_token',
-        label: 'Bot token',
-        type: ChannelFieldType.password,
-        required: true,
-        placeholder: '123456:ABC-DEF...',
-        hint: 'From @BotFather. Stored in channel config; admin-only API.',
+// Runtime builder — i18n strings resolved against the active locale
+// each time it's called. Cheap (a few dozen string lookups) and the
+// callers already invoke it once per rebuild, so memoizing isn't
+// worth the staleness risk.
+List<ChannelKind> channelKindsList() => [
+      ChannelKind(
+        kind: 'telegram',
+        label: 'Telegram',
+        description: t.channels.kinds.telegram.description,
+        tokenFields: const ['bot_token'],
+        fields: [
+          ChannelField(
+            name: 'bot_token',
+            label: t.channels.kinds.telegram.botTokenLabel,
+            type: ChannelFieldType.password,
+            required: true,
+            placeholder: '123456:ABC-DEF...',
+            hint: t.channels.kinds.telegram.botTokenHint,
+          ),
+          ChannelField(
+            name: 'chat_id',
+            label: t.channels.kinds.telegram.chatIdLabel,
+            type: ChannelFieldType.text,
+            placeholder: t.channels.kinds.telegram.chatIdPlaceholder,
+            optional: true,
+          ),
+        ],
       ),
-      ChannelField(
-        name: 'chat_id',
-        label: 'Default chat ID',
-        type: ChannelFieldType.text,
-        placeholder: '42 (optional — used when no ReplyCtx)',
-        optional: true,
+      ChannelKind(
+        kind: 'slack',
+        label: 'Slack',
+        description: t.channels.kinds.slack.description,
+        tokenFields: const ['bot_token'],
+        fields: [
+          ChannelField(
+            name: 'bot_token',
+            label: t.channels.kinds.slack.botTokenLabel,
+            type: ChannelFieldType.password,
+            required: true,
+            placeholder: 'xoxb-...',
+            hint: t.channels.kinds.slack.botTokenHint,
+          ),
+          ChannelField(
+            name: 'app_token',
+            label: t.channels.kinds.slack.appTokenLabel,
+            type: ChannelFieldType.password,
+            required: true,
+            placeholder: 'xapp-...',
+            hint: t.channels.kinds.slack.appTokenHint,
+          ),
+          ChannelField(
+            name: 'channel_id',
+            label: t.channels.kinds.slack.channelIdLabel,
+            type: ChannelFieldType.text,
+            placeholder: t.channels.kinds.slack.channelIdPlaceholder,
+            optional: true,
+          ),
+        ],
       ),
-    ],
-  ),
-  ChannelKind(
-    kind: 'slack',
-    label: 'Slack',
-    description:
-        'Socket Mode — no public webhook needed. Requires a bot OAuth '
-        'token (xoxb-) and an app-level token (xapp-) with '
-        'connections:write.',
-    tokenFields: ['bot_token'],
-    fields: [
-      ChannelField(
-        name: 'bot_token',
-        label: 'Bot token (xoxb-…)',
-        type: ChannelFieldType.password,
-        required: true,
-        placeholder: 'xoxb-...',
-        hint:
-            'OAuth & Permissions → Bot User OAuth Token. Needs chat:write.',
+      ChannelKind(
+        kind: 'discord',
+        label: 'Discord',
+        description: t.channels.kinds.discord.description,
+        tokenFields: const ['bot_token'],
+        fields: [
+          ChannelField(
+            name: 'bot_token',
+            label: t.channels.kinds.discord.botTokenLabel,
+            type: ChannelFieldType.password,
+            required: true,
+            placeholder: t.channels.kinds.discord.botTokenPlaceholder,
+            hint: t.channels.kinds.discord.botTokenHint,
+          ),
+          ChannelField(
+            name: 'channel_id',
+            label: t.channels.kinds.discord.channelIdLabel,
+            type: ChannelFieldType.text,
+            placeholder: t.channels.kinds.discord.channelIdPlaceholder,
+            optional: true,
+          ),
+        ],
       ),
-      ChannelField(
-        name: 'app_token',
-        label: 'App-level token (xapp-…)',
-        type: ChannelFieldType.password,
-        required: true,
-        placeholder: 'xapp-...',
-        hint:
-            'Settings → Basic Information → App-Level Tokens. Scope: '
-            'connections:write.',
+      ChannelKind(
+        kind: 'feishu',
+        label: 'Feishu (飞书)',
+        description: t.channels.kinds.feishu.description,
+        tokenFields: const ['app_secret'],
+        webhookBased: true,
+        afterCreateHint: t.channels.kinds.feishu.afterCreateHint,
+        fields: [
+          ChannelField(
+            name: 'app_id',
+            label: t.channels.kinds.feishu.appIdLabel,
+            type: ChannelFieldType.text,
+            required: true,
+            placeholder: 'cli_a1b2c3d4...',
+          ),
+          ChannelField(
+            name: 'app_secret',
+            label: t.channels.kinds.feishu.appSecretLabel,
+            type: ChannelFieldType.password,
+            required: true,
+            placeholder: t.channels.kinds.feishu.appSecretPlaceholder,
+          ),
+          ChannelField(
+            name: 'verification_token',
+            label: t.channels.kinds.feishu.verificationTokenLabel,
+            type: ChannelFieldType.password,
+            optional: true,
+            hint: t.channels.kinds.feishu.verificationTokenHint,
+          ),
+          ChannelField(
+            name: 'chat_id',
+            label: t.channels.kinds.feishu.chatIdLabel,
+            type: ChannelFieldType.text,
+            placeholder: t.channels.kinds.feishu.chatIdPlaceholder,
+            optional: true,
+          ),
+        ],
       ),
-      ChannelField(
-        name: 'channel_id',
-        label: 'Default channel ID',
-        type: ChannelFieldType.text,
-        placeholder: 'C0123ABC456 (optional)',
-        optional: true,
+      ChannelKind(
+        kind: 'dingtalk',
+        label: 'DingTalk (钉钉)',
+        description: t.channels.kinds.dingtalk.description,
+        tokenFields: const ['secret', 'webhook_url'],
+        fields: [
+          ChannelField(
+            name: 'webhook_url',
+            label: t.channels.kinds.dingtalk.webhookUrlLabel,
+            type: ChannelFieldType.password,
+            required: true,
+            placeholder: 'https://oapi.dingtalk.com/robot/send?access_token=...',
+          ),
+          ChannelField(
+            name: 'secret',
+            label: t.channels.kinds.dingtalk.secretLabel,
+            type: ChannelFieldType.password,
+            optional: true,
+            placeholder: 'SEC...',
+            hint: t.channels.kinds.dingtalk.secretHint,
+          ),
+        ],
       ),
-    ],
-  ),
-  ChannelKind(
-    kind: 'discord',
-    label: 'Discord',
-    description:
-        'Bot via Discord Developer Portal with MESSAGE CONTENT INTENT '
-        'enabled. Connects to Gateway WS — no public URL required.',
-    tokenFields: ['bot_token'],
-    fields: [
-      ChannelField(
-        name: 'bot_token',
-        label: 'Bot token',
-        type: ChannelFieldType.password,
-        required: true,
-        placeholder: 'Bot token from Discord Developer Portal',
-        hint:
-            'Application → Bot → Reset Token. Invite bot with '
-            'send_messages + embed_links.',
+      ChannelKind(
+        kind: 'wecom',
+        label: 'WeCom (企业微信)',
+        description: t.channels.kinds.wecom.description,
+        tokenFields: const ['webhook_key', 'webhook_url'],
+        fields: [
+          ChannelField(
+            name: 'webhook_key',
+            label: t.channels.kinds.wecom.webhookKeyLabel,
+            type: ChannelFieldType.password,
+            required: true,
+            placeholder: t.channels.kinds.wecom.webhookKeyPlaceholder,
+            hint: t.channels.kinds.wecom.webhookKeyHint,
+          ),
+          ChannelField(
+            name: 'webhook_url',
+            label: t.channels.kinds.wecom.webhookUrlLabel,
+            type: ChannelFieldType.password,
+            optional: true,
+            placeholder: 'https://qyapi.weixin.qq.com/...',
+          ),
+        ],
       ),
-      ChannelField(
-        name: 'channel_id',
-        label: 'Default channel ID',
-        type: ChannelFieldType.text,
-        placeholder: '123456789012345678 (optional)',
-        optional: true,
+      ChannelKind(
+        kind: 'wechat',
+        label: 'WeChat (个人微信)',
+        description: t.channels.kinds.wechat.description,
+        tokenFields: const ['app_token'],
+        fields: [
+          ChannelField(
+            name: 'app_token',
+            label: t.channels.kinds.wechat.appTokenLabel,
+            type: ChannelFieldType.password,
+            required: true,
+            placeholder: 'AT_xxxxxxxxxxxxx',
+            hint: t.channels.kinds.wechat.appTokenHint,
+          ),
+          ChannelField(
+            name: 'uids',
+            label: t.channels.kinds.wechat.uidsLabel,
+            type: ChannelFieldType.textarea,
+            optional: true,
+            placeholder: 'UID_xxxxxxxxxxxx\nUID_yyyyyyyyyyyy',
+            hint: t.channels.kinds.wechat.uidsHint,
+          ),
+          ChannelField(
+            name: 'topic_ids',
+            label: t.channels.kinds.wechat.topicIdsLabel,
+            type: ChannelFieldType.textarea,
+            optional: true,
+            placeholder: '123\n456',
+          ),
+          ChannelField(
+            name: 'url',
+            label: t.channels.kinds.wechat.urlLabel,
+            type: ChannelFieldType.text,
+            optional: true,
+            placeholder: 'https://opendray.example/',
+            hint: t.channels.kinds.wechat.urlHint,
+          ),
+        ],
       ),
-    ],
-  ),
-  ChannelKind(
-    kind: 'feishu',
-    label: 'Feishu (飞书)',
-    description:
-        'App-level credentials. Uses event subscription webhook for '
-        'inbound. Public webhook URL is generated below — paste it '
-        'into the Feishu dev console.',
-    tokenFields: ['app_secret'],
-    webhookBased: true,
-    afterCreateHint:
-        'Open the webhook URL from the channel card and paste it into '
-        'Feishu Open Platform → Event Subscriptions → Request URL.',
-    fields: [
-      ChannelField(
-        name: 'app_id',
-        label: 'App ID',
-        type: ChannelFieldType.text,
-        required: true,
-        placeholder: 'cli_a1b2c3d4...',
-      ),
-      ChannelField(
-        name: 'app_secret',
-        label: 'App secret',
-        type: ChannelFieldType.password,
-        required: true,
-        placeholder: 'Application credential secret',
-      ),
-      ChannelField(
-        name: 'verification_token',
-        label: 'Verification token',
-        type: ChannelFieldType.password,
-        optional: true,
-        hint:
-            'From Event Subscriptions → Verification Token. When set, '
-            'opendray rejects webhooks with a different token.',
-      ),
-      ChannelField(
-        name: 'chat_id',
-        label: 'Default chat ID (oc_…)',
-        type: ChannelFieldType.text,
-        placeholder: 'oc_xxxxxxxxxx (optional)',
-        optional: true,
-      ),
-    ],
-  ),
-  ChannelKind(
-    kind: 'dingtalk',
-    label: 'DingTalk (钉钉)',
-    description:
-        'Custom group robot. Outbound only. Group chat → Robots → Add '
-        '→ Sign mode → copy webhook + secret.',
-    tokenFields: ['secret', 'webhook_url'],
-    fields: [
-      ChannelField(
-        name: 'webhook_url',
-        label: 'Webhook URL',
-        type: ChannelFieldType.password,
-        required: true,
-        placeholder: 'https://oapi.dingtalk.com/robot/send?access_token=...',
-      ),
-      ChannelField(
-        name: 'secret',
-        label: 'Sign secret',
-        type: ChannelFieldType.password,
-        optional: true,
-        placeholder: 'SEC...',
-        hint:
-            'When the robot is set to "Sign" security mode, copy the '
-            'secret here. opendray adds the timestamp + sign params '
-            'automatically.',
-      ),
-    ],
-  ),
-  ChannelKind(
-    kind: 'wecom',
-    label: 'WeCom (企业微信)',
-    description:
-        'Group robot webhook. Outbound only (text + markdown). Group '
-        'settings → Group robots → Add → copy webhook URL.',
-    tokenFields: ['webhook_key', 'webhook_url'],
-    fields: [
-      ChannelField(
-        name: 'webhook_key',
-        label: 'Webhook key',
-        type: ChannelFieldType.password,
-        required: true,
-        placeholder: 'The "key=" query value',
-        hint:
-            'Or paste the whole webhook URL into the field below — '
-            'either is enough.',
-      ),
-      ChannelField(
-        name: 'webhook_url',
-        label: 'Or full webhook URL',
-        type: ChannelFieldType.password,
-        optional: true,
-        placeholder: 'https://qyapi.weixin.qq.com/...',
-      ),
-    ],
-  ),
-  ChannelKind(
-    kind: 'wechat',
-    label: 'WeChat (个人微信)',
-    description:
-        'Push to personal WeChat via WxPusher. Outbound-only — push '
-        'services do not relay user replies. Each recipient '
-        'subscribes once via QR code.',
-    tokenFields: ['app_token'],
-    fields: [
-      ChannelField(
-        name: 'app_token',
-        label: 'App token (AT_…)',
-        type: ChannelFieldType.password,
-        required: true,
-        placeholder: 'AT_xxxxxxxxxxxxx',
-        hint: 'WxPusher → 应用管理 → 创建应用 → 复制 App Token.',
-      ),
-      ChannelField(
-        name: 'uids',
-        label: 'Recipient UIDs (one per line)',
-        type: ChannelFieldType.textarea,
-        optional: true,
-        placeholder: 'UID_xxxxxxxxxxxx\nUID_yyyyyyyyyyyy',
-        hint: 'Either UIDs or topic IDs is required.',
-      ),
-      ChannelField(
-        name: 'topic_ids',
-        label: 'Topic IDs (one per line)',
-        type: ChannelFieldType.textarea,
-        optional: true,
-        placeholder: '123\n456',
-      ),
-      ChannelField(
-        name: 'url',
-        label: 'Tap-through URL',
-        type: ChannelFieldType.text,
-        optional: true,
-        placeholder: 'https://opendray.example/',
-        hint: 'When set, tapping the WeChat notification opens this page.',
-      ),
-    ],
-  ),
-];
+    ];
 
 ChannelKind? findKind(String kind) {
-  for (final k in channelKinds) {
+  for (final k in channelKindsList()) {
     if (k.kind == kind) return k;
   }
   return null;

--- a/app/mobile/lib/features/channels/channels_screen.dart
+++ b/app/mobile/lib/features/channels/channels_screen.dart
@@ -150,7 +150,7 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
               leading: Icon(
                 ch.enabled ? Icons.pause_circle_outline : Icons.play_circle_outline,
               ),
-              title: Text(ch.enabled ? 'Disable' : 'Enable'),
+              title: Text(ch.enabled ? i18n.t.channels.popup.disable : i18n.t.channels.popup.enable),
               onTap: () => Navigator.of(sheetCtx).pop(_RowAction.toggleEnabled),
             ),
             ListTile(
@@ -158,7 +158,7 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
               leading: Icon(
                 ch.muted ? Icons.notifications_active_outlined : Icons.notifications_off_outlined,
               ),
-              title: Text(ch.muted ? 'Unmute' : 'Mute'),
+              title: Text(ch.muted ? i18n.t.channels.popup.unmute : i18n.t.channels.popup.mute),
               onTap: () => Navigator.of(sheetCtx).pop(_RowAction.toggleMuted),
             ),
             const Divider(height: 1),
@@ -167,9 +167,9 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
               leading: const Icon(Icons.edit_outlined),
               title: Text(i18n.t.channels.editConfig),
               subtitle: findKind(ch.kind) == null
-                  ? const Text(
-                      'Bridge channels stay web-only',
-                      style: TextStyle(fontSize: 11),
+                  ? Text(
+                      i18n.t.channels.bridgeWebOnly,
+                      style: const TextStyle(fontSize: 11),
                     )
                   : null,
               onTap: () =>
@@ -200,7 +200,7 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
                 color: Theme.of(sheetCtx).colorScheme.error,
               ),
               title: Text(
-                'Delete',
+                i18n.t.channels.popup.deleteLabel,
                 style: TextStyle(color: Theme.of(sheetCtx).colorScheme.error),
               ),
               onTap: () => Navigator.of(sheetCtx).pop(_RowAction.delete),
@@ -215,16 +215,16 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
       case _RowAction.test:
         await _runAction(
           id: ch.id,
-          okMessage: 'Test message dispatched.',
-          failPrefix: 'Test failed',
+          okMessage: i18n.t.channels.snacks.testDispatched,
+          failPrefix: i18n.t.channels.errorPrefix.test,
           op: () => ref.read(channelsApiProvider).test(ch.id),
         );
       case _RowAction.toggleEnabled:
         final next = !ch.enabled;
         await _runAction(
           id: ch.id,
-          okMessage: next ? 'Channel enabled.' : 'Channel disabled.',
-          failPrefix: 'Toggle failed',
+          okMessage: next ? i18n.t.channels.snacks.channelEnabled : i18n.t.channels.snacks.channelDisabled,
+          failPrefix: i18n.t.channels.errorPrefix.toggle,
           op: () => ref
               .read(channelsApiProvider)
               .setEnabled(ch.id, enabled: next)
@@ -234,8 +234,8 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
         final next = !ch.muted;
         await _runAction(
           id: ch.id,
-          okMessage: next ? 'Channel muted.' : 'Channel unmuted.',
-          failPrefix: 'Mute toggle failed',
+          okMessage: next ? i18n.t.channels.snacks.channelMuted : i18n.t.channels.snacks.channelUnmuted,
+          failPrefix: i18n.t.channels.errorPrefix.muteToggle,
           op: () => ref
               .read(channelsApiProvider)
               .setMuted(ch.id, muted: next)
@@ -342,8 +342,8 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
     }
     await _runAction(
       id: ch.id,
-      okMessage: 'Channel config updated.',
-      failPrefix: 'Update failed',
+      okMessage: i18n.t.channels.snacks.configUpdated,
+      failPrefix: i18n.t.channels.errorPrefix.update,
       op: () => ref
           .read(channelsApiProvider)
           .updateConfig(ch.id, patch)
@@ -361,8 +361,8 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
     if (patch == null || patch.isEmpty || !mounted) return;
     await _runAction(
       id: ch.id,
-      okMessage: 'Notification preferences updated.',
-      failPrefix: 'Update failed',
+      okMessage: i18n.t.channels.notifications.updatedSnack,
+      failPrefix: i18n.t.channels.errorPrefix.update,
       op: () => ref
           .read(channelsApiProvider)
           .updateConfig(ch.id, patch)
@@ -390,9 +390,7 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
             ),
             const SizedBox(height: 12),
             Text(
-              'Stops the channel and removes its configuration. '
-              'In-flight notifications addressed to it will be '
-              'dropped silently.',
+              i18n.t.channels.deleteBody,
               style: Theme.of(ctx).textTheme.bodySmall,
             ),
           ],
@@ -415,8 +413,8 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
     if (ok != true || !mounted) return;
     await _runAction(
       id: ch.id,
-      okMessage: 'Channel deleted.',
-      failPrefix: 'Delete failed',
+      okMessage: i18n.t.channels.snacks.channelDeleted,
+      failPrefix: i18n.t.channels.errorPrefix.delete,
       op: () => ref.read(channelsApiProvider).delete(ch.id),
     );
   }
@@ -481,6 +479,7 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
         error: (e, _) => _ErrorView(error: e.toString(), onRetry: _load),
       ),
       floatingActionButton: FloatingActionButton.extended(
+        heroTag: 'channels_fab',
         onPressed: _onCreate,
         icon: const Icon(Icons.add),
         label: Text(i18n.t.channels.kNew),
@@ -494,8 +493,7 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
         child: Padding(
           padding: const EdgeInsets.all(24),
           child: Text(
-            'No channels configured yet.\n\n'
-            'Add one from the web admin: Channels → New.',
+            i18n.t.channels.bridgeEmptyAdd,
             textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.bodyMedium,
           ),
@@ -593,7 +591,7 @@ class _ChannelTile extends StatelessWidget {
               style: const TextStyle(fontFamily: 'monospace'),
             ),
             if (channel.capabilities.isNotEmpty)
-              Text('· caps: ${channel.capabilities.join(", ")}'),
+              Text(i18n.t.channels.capsLabel(list: channel.capabilities.join(', '))),
           ],
         ),
       ),
@@ -616,17 +614,17 @@ class _StatusBadges extends StatelessWidget {
   Widget build(BuildContext context) {
     final badges = <Widget>[];
     if (channel.running) {
-      badges.add(const _Badge(label: 'running', color: Colors.greenAccent));
+      badges.add(_Badge(label: i18n.t.channels.badges.running, color: Colors.greenAccent));
     } else if (channel.enabled) {
-      badges.add(const _Badge(label: 'starting…', color: Colors.amberAccent));
+      badges.add(_Badge(label: i18n.t.channels.badges.starting, color: Colors.amberAccent));
     } else {
       badges.add(_Badge(
-        label: 'disabled',
+        label: i18n.t.channels.badges.disabled,
         color: Theme.of(context).colorScheme.error,
       ));
     }
     if (channel.muted) {
-      badges.add(const _Badge(label: 'muted', color: Colors.amberAccent));
+      badges.add(_Badge(label: i18n.t.channels.badges.muted, color: Colors.amberAccent));
     }
     return Wrap(spacing: 4, runSpacing: 2, children: badges);
   }
@@ -670,10 +668,22 @@ class _NotifyPrefsScreen extends StatefulWidget {
 
 class _NotifyPrefsScreenState extends State<_NotifyPrefsScreen> {
   static const _allTopics = ['session.started', 'session.idle', 'session.ended'];
-  static const _modes = [
-    ('once', 'Once per session', 'Fire once when idle, stay silent until reply or end.'),
-    ('cooldown', 'Time-window cooldown', 'Suppress repeats within the chosen window.'),
-    ('every', 'Every event (noisy)', 'No suppression — only for low-frequency channels.'),
+  static List<(String, String, String)> _modes() => [
+    (
+      'once',
+      i18n.t.channels.notifications.modes.onceLabel,
+      i18n.t.channels.notifications.modes.onceDescription,
+    ),
+    (
+      'cooldown',
+      i18n.t.channels.notifications.modes.cooldownLabel,
+      i18n.t.channels.notifications.modes.cooldownDescription,
+    ),
+    (
+      'every',
+      i18n.t.channels.notifications.modes.everyLabel,
+      i18n.t.channels.notifications.modes.everyDescription,
+    ),
   ];
   static const _cooldownPresets = [
     (60, '1m'),
@@ -786,9 +796,9 @@ class _NotifyPrefsScreenState extends State<_NotifyPrefsScreen> {
             padding: const EdgeInsets.only(top: 6),
             child: Text(
               _topics.length == _allTopics.length
-                  ? 'All session events.'
+                  ? i18n.t.channels.notifications.notifyOnAll
                   : _topics.isEmpty
-                      ? 'No events selected — outbound notifications muted.'
+                      ? i18n.t.channels.notifications.notifyOnEmpty
                       : '${_topics.length} of ${_allTopics.length} selected.',
               style: muted,
             ),
@@ -801,7 +811,7 @@ class _NotifyPrefsScreenState extends State<_NotifyPrefsScreen> {
             onChanged: (v) => setState(() => _mode = v ?? _mode),
             child: Column(
               children: [
-                for (final (val, label, hint) in _modes)
+                for (final (val, label, hint) in _modes())
                   RadioListTile<String>(
                     value: val,
                     title: Text(label),
@@ -833,7 +843,7 @@ class _NotifyPrefsScreenState extends State<_NotifyPrefsScreen> {
             contentPadding: EdgeInsets.zero,
             title: Text(i18n.t.channels.notifications.includeSnippet),
             subtitle: Text(
-              'Embeds the recent terminal tail in each notification.',
+              i18n.t.channels.notifications.snippetHelper,
               style: muted,
             ),
             value: _includeSnippet,
@@ -849,7 +859,7 @@ class _NotifyPrefsScreenState extends State<_NotifyPrefsScreen> {
               children: [
                 for (final n in const [0, 200, 500, 1000, 2000])
                   ChoiceChip(
-                    label: Text(n == 0 ? 'no cap' : '$n chars'),
+                    label: Text(n == 0 ? i18n.t.channels.notifications.snippetNoCap : i18n.t.channels.notifications.snippetChars(n: n.toString())),
                     selected: _snippetCap == n,
                     onSelected: (_) => setState(() => _snippetCap = n),
                   ),
@@ -882,7 +892,7 @@ class _ErrorView extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             Text(
-              'Failed to load channels',
+              i18n.t.channels.failedToLoad,
               style: Theme.of(context).textTheme.titleMedium,
             ),
             const SizedBox(height: 6),

--- a/app/mobile/lib/features/custom_tasks/custom_tasks_screen.dart
+++ b/app/mobile/lib/features/custom_tasks/custom_tasks_screen.dart
@@ -149,6 +149,7 @@ class _CustomTasksScreenState extends ConsumerState<CustomTasksScreen> {
         error: (e, _) => _ErrorView(error: e.toString(), onRetry: _load),
       ),
       floatingActionButton: FloatingActionButton.extended(
+        heroTag: 'custom_tasks_fab',
         onPressed: _openEditor,
         icon: const Icon(Icons.add),
         label: Text(i18n.t.customTasks.newTask),

--- a/app/mobile/lib/features/githosts/githosts_screen.dart
+++ b/app/mobile/lib/features/githosts/githosts_screen.dart
@@ -182,6 +182,7 @@ class _GitHostsScreenState extends ConsumerState<GitHostsScreen> {
         error: (e, _) => _ErrorView(error: e.toString(), onRetry: _load),
       ),
       floatingActionButton: FloatingActionButton.extended(
+        heroTag: 'githosts_fab',
         onPressed: _onCreate,
         icon: const Icon(Icons.add),
         label: Text(t.githosts.addHost),

--- a/app/mobile/lib/features/integrations/integrations_screen.dart
+++ b/app/mobile/lib/features/integrations/integrations_screen.dart
@@ -119,6 +119,7 @@ class _IntegrationsScreenState extends ConsumerState<IntegrationsScreen> {
         error: (e, _) => _ErrorView(error: e.toString(), onRetry: _load),
       ),
       floatingActionButton: FloatingActionButton.extended(
+        heroTag: 'integrations_fab',
         onPressed: _onRegister,
         icon: const Icon(Icons.add),
         label: Text(t.integrations.register),

--- a/app/mobile/lib/features/mcp/mcp_editor_screen.dart
+++ b/app/mobile/lib/features/mcp/mcp_editor_screen.dart
@@ -76,9 +76,9 @@ class _McpEditorScreenState extends ConsumerState<McpEditorScreen> {
   // Starter template for a new stdio MCP server — the operator
   // edits this into shape rather than facing a blank box.
   static String _scaffoldJson() {
-    const example = {
+    final example = {
       'name': 'my-mcp-server',
-      'description': 'Optional one-liner',
+      'description': t.mcp.editor.descriptionPlaceholder,
       'transport': 'stdio',
       'command': '/path/to/binary',
       'args': ['--arg1'],
@@ -91,19 +91,19 @@ class _McpEditorScreenState extends ConsumerState<McpEditorScreen> {
   Future<void> _submit() async {
     final id = _idCtrl.text.trim();
     if (id.isEmpty) {
-      setState(() => _error = 'id is required');
+      setState(() => _error = t.mcp.editor.idRequired);
       return;
     }
     Map<String, dynamic> parsed;
     try {
       final decoded = jsonDecode(_bodyCtrl.text);
       if (decoded is! Map<String, dynamic>) {
-        setState(() => _error = 'Body must be a JSON object');
+        setState(() => _error = t.mcp.editor.validateJsonObject);
         return;
       }
       parsed = decoded;
     } on FormatException catch (e) {
-      setState(() => _error = 'Invalid JSON: ${e.message}');
+      setState(() => _error = t.mcp.editor.validateJsonInvalid(error: e.message));
       return;
     }
     // Inject id into the server body; the server requires
@@ -147,7 +147,7 @@ class _McpEditorScreenState extends ConsumerState<McpEditorScreen> {
     final theme = Theme.of(context);
     return Scaffold(
       appBar: AppBar(
-        title: Text(_isEdit ? 'Edit MCP server' : 'New MCP server'),
+        title: Text(_isEdit ? t.mcp.editor.appBarEdit : t.mcp.editor.appBarNew),
       ),
       body: SafeArea(
         bottom: false,
@@ -155,7 +155,7 @@ class _McpEditorScreenState extends ConsumerState<McpEditorScreen> {
           padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
           children: [
             Text(
-              'id (URL segment, lowercase alphanumeric / dash / underscore)',
+              t.mcp.editor.idLabel,
               style: theme.textTheme.bodySmall,
             ),
             const SizedBox(height: 4),
@@ -166,15 +166,13 @@ class _McpEditorScreenState extends ConsumerState<McpEditorScreen> {
               textCapitalization: TextCapitalization.none,
               decoration: InputDecoration(
                 hintText: t.mcp.editor.nameHint,
-                helperText: _isEdit
-                    ? 'Locked in edit mode — delete + recreate to change.'
-                    : null,
+                helperText: _isEdit ? t.mcp.editor.idLockedHint : null,
               ),
               style: const TextStyle(fontFamily: 'monospace'),
             ),
             const SizedBox(height: 14),
             Text(
-              'Server JSON',
+              t.mcp.editor.jsonLabel,
               style: theme.textTheme.bodySmall,
             ),
             const SizedBox(height: 4),
@@ -197,9 +195,7 @@ class _McpEditorScreenState extends ConsumerState<McpEditorScreen> {
             ),
             const SizedBox(height: 6),
             Text(
-              'Schema: transport ∈ {stdio, http, sse}. For stdio set command + args. '
-              r'For http/sse set url + headers. Use $secret:KEY to reference '
-              'MCP secrets vault entries.',
+              t.mcp.editor.jsonSchemaHelp,
               style: theme.textTheme.bodySmall?.copyWith(fontSize: 11),
             ),
             if (_error != null) ...[
@@ -246,10 +242,10 @@ class _McpEditorScreenState extends ConsumerState<McpEditorScreen> {
                           )
                         : const Icon(Icons.check, size: 18),
                     label: Text(_submitting
-                        ? 'Saving…'
-                        : _isEdit
-                            ? 'Save'
-                            : 'Create'),
+                        ? t.mcp.editor.saving
+                        : (_isEdit
+                            ? t.mcp.editor.save
+                            : t.mcp.editor.create)),
                   ),
                 ),
               ],

--- a/app/mobile/lib/features/mcp/mcp_screen.dart
+++ b/app/mobile/lib/features/mcp/mcp_screen.dart
@@ -435,6 +435,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
         error: (e, _) => _ErrorView(error: e.toString(), onRetry: _load),
       ),
       floatingActionButton: FloatingActionButton.extended(
+        heroTag: 'mcp_fab',
         onPressed: _openEditor,
         icon: const Icon(Icons.add),
         label: Text(t.mcp.newServer),

--- a/app/mobile/lib/features/mcp/mcp_screen.dart
+++ b/app/mobile/lib/features/mcp/mcp_screen.dart
@@ -142,18 +142,18 @@ class _McpScreenState extends ConsumerState<McpScreen> {
             ListTile(
               leading: const Icon(Icons.edit_outlined),
               title: Text(t.mcp.editConfig),
-              subtitle: const Text(
-                'Full JSON editor — vault-backed servers only',
-                style: TextStyle(fontSize: 11),
+              subtitle: Text(
+                t.mcp.popup.editConfigSubtitle,
+                style: const TextStyle(fontSize: 11),
               ),
               onTap: () => Navigator.of(sheetCtx).pop(_ServerAction.edit),
             ),
             ListTile(
               leading: const Icon(Icons.code),
               title: Text(t.mcp.viewRawConfig),
-              subtitle: const Text(
-                'Read-only inspector for the server JSON',
-                style: TextStyle(fontSize: 11),
+              subtitle: Text(
+                t.mcp.popup.viewRawSubtitle,
+                style: const TextStyle(fontSize: 11),
               ),
               onTap: () =>
                   Navigator.of(sheetCtx).pop(_ServerAction.viewConfig),
@@ -170,7 +170,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
                 color: Theme.of(sheetCtx).colorScheme.error,
               ),
               title: Text(
-                'Delete',
+                t.mcp.popup.deleteLabel,
                 style: TextStyle(color: Theme.of(sheetCtx).colorScheme.error),
               ),
               onTap: () => Navigator.of(sheetCtx).pop(_ServerAction.delete),
@@ -211,8 +211,8 @@ class _McpScreenState extends ConsumerState<McpScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(existing == null
-              ? 'MCP server created.'
-              : 'MCP server updated.'),
+              ? t.mcp.serverCreatedSnack
+              : t.mcp.serverUpdatedSnack),
           duration: const Duration(seconds: 2),
           behavior: SnackBarBehavior.floating,
         ),
@@ -236,19 +236,19 @@ class _McpScreenState extends ConsumerState<McpScreen> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 _kv('ID', s.id, mono: true),
-                _kv('Transport', s.transport),
+                _kv(t.mcp.kv.transport, s.transport),
                 if ((s.description ?? '').isNotEmpty)
-                  _kv('Description', s.description!),
+                  _kv(t.mcp.kv.description, s.description!),
                 if ((s.command ?? '').isNotEmpty)
-                  _kv('Command', s.command!, mono: true),
+                  _kv(t.mcp.kv.command, s.command!, mono: true),
                 if (s.args != null && s.args!.isNotEmpty)
-                  _kv('Args', s.args!.join('  '), mono: true),
+                  _kv(t.mcp.kv.args, s.args!.join('  '), mono: true),
                 if ((s.url ?? '').isNotEmpty)
                   _kv('URL', s.url!, mono: true),
                 if (s.env != null && s.env!.isNotEmpty) ...[
                   const SizedBox(height: 6),
                   Text(
-                    'Env',
+                    t.mcp.envHeading,
                     style: Theme.of(ctx).textTheme.bodySmall,
                   ),
                   ...s.env!.entries.map(
@@ -267,7 +267,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
                 if (s.headers != null && s.headers!.isNotEmpty) ...[
                   const SizedBox(height: 6),
                   Text(
-                    'Headers',
+                    t.mcp.kv.headers,
                     style: Theme.of(ctx).textTheme.bodySmall,
                   ),
                   ...s.headers!.entries.map(
@@ -317,9 +317,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
             ),
             const SizedBox(height: 12),
             Text(
-              'Removes the vault directory for ${s.id}. Sessions that '
-              'inject this MCP at spawn will fail to load it on the '
-              'next launch.',
+              t.mcp.deleteServerBody(id: s.id),
               style: Theme.of(ctx).textTheme.bodySmall,
             ),
           ],
@@ -342,7 +340,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
     if (ok != true || !mounted) return;
     await _runOp(
       key: 's:${s.id}',
-      okMsg: 'Deleted ${s.id}.',
+      okMsg: t.mcp.deleteServerSnack(id: s.id),
       failPrefix: t.mcp.errorPrefix.delete,
       op: () => ref.read(mcpApiProvider).delete(s.id),
     );
@@ -359,8 +357,8 @@ class _McpScreenState extends ConsumerState<McpScreen> {
     await _runOp(
       key: 'k:${res.key}',
       okMsg: existingKey == null
-          ? 'Secret ${res.key} added.'
-          : 'Secret ${res.key} updated.',
+          ? t.mcp.secret.addedSnack(key: res.key)
+          : t.mcp.secret.updatedSnack(key: res.key),
       failPrefix: existingKey == null
           ? t.mcp.errorPrefix.add
           : t.mcp.errorPrefix.update,
@@ -389,9 +387,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
             ),
             const SizedBox(height: 8),
             Text(
-              'Removes the value from the encrypted vault. Any MCP '
-              'server referencing $key in its env or headers will '
-              'fail at next spawn.',
+              t.mcp.secret.deleteBody,
               style: Theme.of(ctx).textTheme.bodySmall,
             ),
           ],
@@ -414,7 +410,7 @@ class _McpScreenState extends ConsumerState<McpScreen> {
     if (ok != true || !mounted) return;
     await _runOp(
       key: 'k:$key',
-      okMsg: 'Deleted $key.',
+      okMsg: t.mcp.secret.deletedSnack(key: key),
       failPrefix: t.mcp.errorPrefix.delete,
       op: () => ref.read(mcpApiProvider).secretsDelete(key),
     );
@@ -451,13 +447,15 @@ class _McpScreenState extends ConsumerState<McpScreen> {
       onRefresh: _load,
       child: ListView(
         children: [
-          _SectionHeader(label: 'Servers (${data.servers.length})'),
+          _SectionHeader(
+            label: t.mcp.serversCount(count: data.servers.length.toString()),
+          ),
           if (data.servers.isEmpty)
-            const Padding(
-              padding: EdgeInsets.fromLTRB(20, 0, 16, 12),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 0, 16, 12),
               child: Text(
-                'No MCP servers registered. Tap "New server" to add one.',
-                style: TextStyle(fontSize: 12),
+                t.mcp.emptyServers,
+                style: const TextStyle(fontSize: 12),
               ),
             )
           else
@@ -467,7 +465,9 @@ class _McpScreenState extends ConsumerState<McpScreen> {
                 busy: _busy.contains('s:${s.id}'),
                 onToggle: (next) => _runOp(
                   key: 's:${s.id}',
-                  okMsg: next ? '${s.name} enabled.' : '${s.name} disabled.',
+                  okMsg: next
+                      ? t.mcp.toggleEnabledSnack(name: s.name)
+                      : t.mcp.toggleDisabledSnack(name: s.name),
                   failPrefix: t.mcp.errorPrefix.toggle,
                   op: () => ref
                       .read(mcpApiProvider)
@@ -476,16 +476,18 @@ class _McpScreenState extends ConsumerState<McpScreen> {
                 onTap: () => _onServerTap(s),
               ),
           const SizedBox(height: 8),
-          _SectionHeader(label: 'Secrets (${data.secrets.keys.length})'),
+          _SectionHeader(
+            label: t.mcp.secretsCount(
+              count: data.secrets.keys.length.toString(),
+            ),
+          ),
           _SecretsHeader(state: data.secrets),
           if (data.secrets.keys.isEmpty)
-            const Padding(
-              padding: EdgeInsets.fromLTRB(20, 6, 16, 12),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 6, 16, 12),
               child: Text(
-                'No secrets stored. Add one to feed sensitive env / '
-                'header values into MCP servers without committing them '
-                'to vault config.',
-                style: TextStyle(fontSize: 12),
+                t.mcp.emptySecrets,
+                style: const TextStyle(fontSize: 12),
               ),
             )
           else
@@ -672,10 +674,10 @@ class _SecretsHeader extends StatelessWidget {
           Expanded(
             child: Text(
               state.encrypted
-                  ? 'AES-GCM encrypted (key in OS keychain)'
+                  ? t.mcp.encryptionAes
                   : state.present
-                      ? 'PLAINTEXT — keychain unavailable'
-                      : 'No vault file yet — added secrets create it.',
+                      ? t.mcp.encryptionPlaintext
+                      : t.mcp.noVaultFileYet,
               style: muted,
             ),
           ),
@@ -711,7 +713,7 @@ class _SecretTile extends StatelessWidget {
         style: const TextStyle(fontFamily: 'monospace'),
       ),
       subtitle: Text(
-        'Tap to replace · long-press / trash to delete',
+        t.mcp.tapToReplaceHint,
         style: Theme.of(context).textTheme.bodySmall,
       ),
       onLongPress: busy ? null : onDelete,
@@ -778,7 +780,7 @@ class _ErrorView extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             Text(
-              'Failed to load MCP state',
+              t.mcp.failedToLoad,
               style: Theme.of(context).textTheme.titleMedium,
             ),
             const SizedBox(height: 6),
@@ -838,19 +840,16 @@ class _SecretFormScreenState extends State<_SecretFormScreen> {
     final key = _key.text.trim();
     final value = _value.text;
     if (key.isEmpty) {
-      setState(() => _error = 'Key is required.');
+      setState(() => _error = t.mcp.secret.keyRequired);
       return;
     }
     final keyOk = RegExp(r'^[A-Za-z_][A-Za-z0-9_]*$').hasMatch(key);
     if (!keyOk) {
-      setState(
-        () => _error =
-            'Key must match [A-Za-z_][A-Za-z0-9_]* — same rules as a shell env var.',
-      );
+      setState(() => _error = t.mcp.secret.keyInvalid);
       return;
     }
     if (value.isEmpty) {
-      setState(() => _error = 'Value is required.');
+      setState(() => _error = t.mcp.secret.valueRequired);
       return;
     }
     Navigator.of(context).pop(_SecretFormResult(key: key, value: value));
@@ -861,11 +860,15 @@ class _SecretFormScreenState extends State<_SecretFormScreen> {
     final isReplace = widget.existingKey != null;
     return Scaffold(
       appBar: AppBar(
-        title: Text(isReplace ? 'Replace secret value' : 'Add secret'),
+        title: Text(
+          isReplace ? t.mcp.secret.replaceTitle : t.mcp.secret.addTitle,
+        ),
         actions: [
           TextButton(
             onPressed: _submit,
-            child: Text(isReplace ? 'Save' : 'Add'),
+            child: Text(
+              isReplace ? t.mcp.secret.saveButton : t.mcp.secret.addButton,
+            ),
           ),
         ],
       ),
@@ -880,9 +883,7 @@ class _SecretFormScreenState extends State<_SecretFormScreen> {
             decoration: InputDecoration(
               labelText: t.mcp.secret.keyLabel,
               hintText: t.mcp.secret.keyHint,
-              helperText:
-                  'Shell-env-var rules: starts with a letter or _, '
-                  'rest letters/digits/_.',
+              helperText: t.mcp.secret.helpRules,
               helperMaxLines: 2,
               border: const OutlineInputBorder(),
             ),
@@ -899,8 +900,8 @@ class _SecretFormScreenState extends State<_SecretFormScreen> {
             decoration: InputDecoration(
               labelText: t.mcp.secret.valueLabel,
               hintText: isReplace
-                  ? 'Paste new value (the previous one is wiped)'
-                  : 'Paste secret value',
+                  ? t.mcp.secret.replaceHint
+                  : t.mcp.secret.addHint,
               border: const OutlineInputBorder(),
             ),
           ),

--- a/app/mobile/lib/features/memory/memory_screen.dart
+++ b/app/mobile/lib/features/memory/memory_screen.dart
@@ -406,6 +406,7 @@ class _MemoryScreenState extends ConsumerState<MemoryScreen>
         children: [_projectTab(), _globalTab()],
       ),
       floatingActionButton: FloatingActionButton.extended(
+        heroTag: 'memory_fab',
         onPressed: _newMemory,
         icon: const Icon(Icons.add),
         label: Text(t.memory.kNew),

--- a/app/mobile/lib/features/notes/notes_screen.dart
+++ b/app/mobile/lib/features/notes/notes_screen.dart
@@ -351,6 +351,7 @@ class _NotesScreenState extends ConsumerState<NotesScreen> {
         ],
       ),
       floatingActionButton: FloatingActionButton.extended(
+        heroTag: 'notes_fab',
         onPressed: _newNote,
         icon: const Icon(Icons.add),
         label: Text(t.notesPage.newButton),

--- a/app/mobile/lib/features/project/project_screen.dart
+++ b/app/mobile/lib/features/project/project_screen.dart
@@ -426,6 +426,7 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
                 right: 16,
                 bottom: 16,
                 child: FloatingActionButton.extended(
+                  heroTag: 'project_journal_fab',
                   onPressed: _openAppendJournal,
                   icon: const Icon(Icons.add),
                   label: Text(t.project.append),
@@ -670,6 +671,7 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
                 right: 16,
                 bottom: 16,
                 child: FloatingActionButton.extended(
+                  heroTag: 'project_cleanup_fab',
                   onPressed: _cleanupRunning ? null : _runCleanup,
                   icon: _cleanupRunning
                       ? const SizedBox(

--- a/app/mobile/lib/features/providers/provider_config_screen.dart
+++ b/app/mobile/lib/features/providers/provider_config_screen.dart
@@ -153,6 +153,7 @@ class _ProviderConfigScreenState
       ),
       floatingActionButton: _dirty
           ? FloatingActionButton.extended(
+              heroTag: 'provider_config_fab',
               onPressed: _saving ? null : _save,
               icon: _saving
                   ? const SizedBox(

--- a/app/mobile/lib/features/sessions/sessions_screen.dart
+++ b/app/mobile/lib/features/sessions/sessions_screen.dart
@@ -104,6 +104,7 @@ class _SessionsScreenState extends ConsumerState<SessionsScreen> {
         ),
       ),
       floatingActionButton: FloatingActionButton.extended(
+        heroTag: 'sessions_fab',
         onPressed: _onSpawn,
         icon: const Icon(Icons.add),
         label: Text(t.sessions.spawn),

--- a/app/mobile/lib/features/skills/skills_screen.dart
+++ b/app/mobile/lib/features/skills/skills_screen.dart
@@ -87,6 +87,7 @@ class _SkillsScreenState extends ConsumerState<SkillsScreen> {
         error: (e, _) => _ErrorView(error: e.toString(), onRetry: _load),
       ),
       floatingActionButton: FloatingActionButton.extended(
+        heroTag: 'skills_fab',
         // ignore: unnecessary_lambdas — _openEditor returns Future<void>
         onPressed: () => _openEditor(),
         icon: const Icon(Icons.add),


### PR DESCRIPTION
The 7-kind metadata table (Telegram / Slack / Discord / Feishu / DingTalk / WeCom / WeChat) was a top-level \`const channelKinds\` constant with hardcoded English description + per-field label/hint/placeholder. ~50 strings the kind-picker FAB sheet and the create/edit form rendered directly.

## Changes

### Translation source

\`channels.kinds.*\` — 7 sub-namespaces, one per kind:

- **telegram**: description + bot token (label, hint) + chat ID (label, placeholder).
- **slack**: description + bot token (label, hint) + app token (label, hint) + channel ID (label, placeholder).
- **discord**: description + bot token (label, placeholder, hint) + channel ID (label, placeholder).
- **feishu**: description + afterCreateHint + 4 fields (app ID, app secret, verification token, chat ID) with labels/hints/placeholders.
- **dingtalk**: description + webhook URL label + secret (label, hint).
- **wecom**: description + webhook key (label, placeholder, hint) + webhook URL label.
- **wechat**: description + app token (label, hint) + UIDs (label, hint) + topic IDs label + URL (label, hint).

Technical placeholders that are literal syntax (\`xoxb-...\`, \`AT_...\`, hostnames, full URLs) stay as English examples — translating them would obscure what to paste.

### Dart refactor

- \`const channelKinds\` → \`List<ChannelKind> channelKindsList()\` runtime builder. Each \`ChannelField\`'s \`label\` and translatable \`hint\` come from \`t.channels.kinds.<kind>.*\`. Cheap (a few dozen lookups, called once per rebuild) and doesn't need memoization.
- \`ChannelKind.label\` (the friendly kind name shown in the picker) stays a literal — "Telegram", "Feishu (飞书)", "DingTalk (钉钉)" — the original copy is already bilingual.
- \`ChannelKind.kind\` stays English (it's a wire identifier sent to the server).
- \`findKind(String)\` iterates the runtime list.
- \`channel_form_dialog.dart\`'s kind-picker wraps the \`ListView.separated\` in a \`Builder\` so \`channelKindsList()\` is evaluated once per list build, not once per tile.

## Verified

- [x] \`flutter analyze\` clean
- [ ] On-device: open Channels → tap FAB → confirm 7-kind picker descriptions render in target locale; pick one → confirm every field label/hint in the form is translated

🤖 Generated with [Claude Code](https://claude.com/claude-code)