### PR TITLE
fix(mobile): finish session notes i18n — inspector tab + editor + top notes screen

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -252,7 +252,32 @@
         "filenameHint": "filename (e.g. spec or design.md)",
         "create": "Create",
         "filterHint": "Filter…",
-        "locationDialogTitle": "Project docs location"
+        "locationDialogTitle": "Project docs location",
+        "loadFailedApi": "Load failed: {error}",
+        "loadFailedGeneric": "Load failed: {error}",
+        "saveFailedApi": "Save failed: {error}",
+        "saveFailedGeneric": "Save failed: {error}",
+        "insertFailedApi": "Insert failed: {error}",
+        "insertFailedGeneric": "Insert failed: {error}",
+        "createFailedApi": "Create failed: {error}",
+        "createFailedGeneric": "Create failed: {error}",
+        "personalHint": "Personal scratchpad — auto-saves as you type. AI agents do not write here.",
+        "projectDocsHint": "Architecture / spec / decisions / plan / retros — typically authored or maintained by an agent.",
+        "mappingCleared": "Mapping cleared — using default",
+        "mappedTo": "Mapped to {path}",
+        "cancelTooltip": "Cancel",
+        "newDocTooltip": "New doc",
+        "noProjectMapping": "Could not resolve a project mapping for this session. Check that the gateway has a notes vault configured and that the session cwd is set.",
+        "emptyProjectDocs": "No project docs yet. Tap + to create one, or let an AI agent generate from a prompt.",
+        "emptyFilterMatch": "No matches for \"{query}\".",
+        "locationDialogHelp": "Pin this session's cwd to a specific folder under your notes vault. Leave blank to reset.",
+        "sessionCwd": "Session cwd",
+        "projectDocsPath": "Vault-relative project docs path",
+        "locationStoredHint": "Stored in <vault>/.opendray-projects.json — git-syncs with the rest of the vault.",
+        "pinnedHint": "Pinned to {path}/ (overrides {defaultPath}). AI agents author docs here too.",
+        "noProjectMapping2": "(no project mapping)",
+        "clearOverride": "Clear override",
+        "save": "Save"
       }
     },
     "spawnSheet": {
@@ -919,10 +944,23 @@
     "pathLabel": "Vault-relative path",
     "pathHint": "personal/scratch.md",
     "create": "Create",
+    "popupDelete": "Delete",
+    "deleteBody": "This is irreversible. Vault git sync will remove the file on the gateway host too.",
+    "emptyFilterMatch": "No notes match \"{query}\".",
+    "emptyVault": "Vault is empty. Tap + to create your first note.",
+    "emptyFolder": "Folder \"{path}\" is empty.",
+    "validatePath": "Path is required",
+    "validatePathDots": "Path cannot contain \"..\"",
+    "pathHelper": "Auto-appends .md if missing.",
     "editor": {
       "markdownHint": "Markdown…",
       "saving": "Saving…",
-      "autosave": "Auto-saves as you type"
+      "autosave": "Auto-saves as you type",
+      "loadFailedApi": "Load failed: {error}",
+      "loadFailedGeneric": "Load failed: {error}",
+      "saveFailedApi": "Save failed: {error}",
+      "saveFailedGeneric": "Save failed: {error}",
+      "savedAt": "Saved {time}"
     }
   },
   "memory": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -252,7 +252,32 @@
         "filenameHint": "文件名（例如：spec 或 design.md）",
         "create": "创建",
         "filterHint": "筛选…",
-        "locationDialogTitle": "项目文档位置"
+        "locationDialogTitle": "项目文档位置",
+        "loadFailedApi": "加载失败：{error}",
+        "loadFailedGeneric": "加载失败：{error}",
+        "saveFailedApi": "保存失败：{error}",
+        "saveFailedGeneric": "保存失败：{error}",
+        "insertFailedApi": "插入失败：{error}",
+        "insertFailedGeneric": "插入失败：{error}",
+        "createFailedApi": "创建失败：{error}",
+        "createFailedGeneric": "创建失败：{error}",
+        "personalHint": "个人草稿 — 随输入自动保存。AI agent 不会写入这里。",
+        "projectDocsHint": "架构 / 规范 / 决策 / 计划 / 回顾 — 通常由 agent 撰写或维护。",
+        "mappingCleared": "映射已清除 — 使用默认值",
+        "mappedTo": "已映射到 {path}",
+        "cancelTooltip": "取消",
+        "newDocTooltip": "新建文档",
+        "noProjectMapping": "无法为此会话解析项目映射。检查网关是否配置了笔记库，以及会话的 cwd 是否已设置。",
+        "emptyProjectDocs": "暂无项目文档。点击 + 创建一个，或让 AI agent 根据提示生成。",
+        "emptyFilterMatch": "未找到匹配「{query}」的内容。",
+        "locationDialogHelp": "将此会话的 cwd 固定到笔记库下的某个文件夹。留空 = 重置。",
+        "sessionCwd": "会话 cwd",
+        "projectDocsPath": "相对笔记库的项目文档路径",
+        "locationStoredHint": "存储于 <vault>/.opendray-projects.json — 与笔记库其余部分一起 git 同步。",
+        "pinnedHint": "已固定到 {path}/（覆盖 {defaultPath}）。AI agent 也会在此撰写文档。",
+        "noProjectMapping2": "（无项目映射）",
+        "clearOverride": "清除覆盖",
+        "save": "保存"
       }
     },
     "spawnSheet": {
@@ -919,10 +944,23 @@
     "pathLabel": "相对仓库的路径",
     "pathHint": "personal/scratch.md",
     "create": "创建",
+    "popupDelete": "删除",
+    "deleteBody": "此操作不可撤销。仓库的 git 同步会同时移除网关主机上的文件。",
+    "emptyFilterMatch": "未找到匹配「{query}」的笔记。",
+    "emptyVault": "仓库为空。点击 + 创建第一条笔记。",
+    "emptyFolder": "文件夹「{path}」为空。",
+    "validatePath": "必须填写路径",
+    "validatePathDots": "路径不能包含「..」",
+    "pathHelper": "缺失时自动追加 .md。",
     "editor": {
       "markdownHint": "Markdown…",
       "saving": "保存中…",
-      "autosave": "随输入自动保存"
+      "autosave": "随输入自动保存",
+      "loadFailedApi": "加载失败：{error}",
+      "loadFailedGeneric": "加载失败：{error}",
+      "saveFailedApi": "保存失败：{error}",
+      "saveFailedGeneric": "保存失败：{error}",
+      "savedAt": "{time} 已保存"
     }
   },
   "memory": {

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 1666 (833 per locale)
+/// Strings: 1742 (871 per locale)
 ///
-/// Built on 2026-05-13 at 16:44 UTC
+/// Built on 2026-05-14 at 00:00 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -1292,6 +1292,30 @@ class TranslationsNotesPageEn {
 	/// en: 'Create'
 	String get create => 'Create';
 
+	/// en: 'Delete'
+	String get popupDelete => 'Delete';
+
+	/// en: 'This is irreversible. Vault git sync will remove the file on the gateway host too.'
+	String get deleteBody => 'This is irreversible. Vault git sync will remove the file on the gateway host too.';
+
+	/// en: 'No notes match "{query}".'
+	String emptyFilterMatch({required Object query}) => 'No notes match "${query}".';
+
+	/// en: 'Vault is empty. Tap + to create your first note.'
+	String get emptyVault => 'Vault is empty. Tap + to create your first note.';
+
+	/// en: 'Folder "{path}" is empty.'
+	String emptyFolder({required Object path}) => 'Folder "${path}" is empty.';
+
+	/// en: 'Path is required'
+	String get validatePath => 'Path is required';
+
+	/// en: 'Path cannot contain ".."'
+	String get validatePathDots => 'Path cannot contain ".."';
+
+	/// en: 'Auto-appends .md if missing.'
+	String get pathHelper => 'Auto-appends .md if missing.';
+
 	late final TranslationsNotesPageEditorEn editor = TranslationsNotesPageEditorEn.internal(_root);
 }
 
@@ -2409,6 +2433,21 @@ class TranslationsNotesPageEditorEn {
 
 	/// en: 'Auto-saves as you type'
 	String get autosave => 'Auto-saves as you type';
+
+	/// en: 'Load failed: {error}'
+	String loadFailedApi({required Object error}) => 'Load failed: ${error}';
+
+	/// en: 'Load failed: {error}'
+	String loadFailedGeneric({required Object error}) => 'Load failed: ${error}';
+
+	/// en: 'Save failed: {error}'
+	String saveFailedApi({required Object error}) => 'Save failed: ${error}';
+
+	/// en: 'Save failed: {error}'
+	String saveFailedGeneric({required Object error}) => 'Save failed: ${error}';
+
+	/// en: 'Saved {time}'
+	String savedAt({required Object time}) => 'Saved ${time}';
 }
 
 // Path: memory.deleteAllConfirm
@@ -3249,6 +3288,81 @@ class TranslationsSessionsInspectorNotesEn {
 
 	/// en: 'Project docs location'
 	String get locationDialogTitle => 'Project docs location';
+
+	/// en: 'Load failed: {error}'
+	String loadFailedApi({required Object error}) => 'Load failed: ${error}';
+
+	/// en: 'Load failed: {error}'
+	String loadFailedGeneric({required Object error}) => 'Load failed: ${error}';
+
+	/// en: 'Save failed: {error}'
+	String saveFailedApi({required Object error}) => 'Save failed: ${error}';
+
+	/// en: 'Save failed: {error}'
+	String saveFailedGeneric({required Object error}) => 'Save failed: ${error}';
+
+	/// en: 'Insert failed: {error}'
+	String insertFailedApi({required Object error}) => 'Insert failed: ${error}';
+
+	/// en: 'Insert failed: {error}'
+	String insertFailedGeneric({required Object error}) => 'Insert failed: ${error}';
+
+	/// en: 'Create failed: {error}'
+	String createFailedApi({required Object error}) => 'Create failed: ${error}';
+
+	/// en: 'Create failed: {error}'
+	String createFailedGeneric({required Object error}) => 'Create failed: ${error}';
+
+	/// en: 'Personal scratchpad — auto-saves as you type. AI agents do not write here.'
+	String get personalHint => 'Personal scratchpad — auto-saves as you type. AI agents do not write here.';
+
+	/// en: 'Architecture / spec / decisions / plan / retros — typically authored or maintained by an agent.'
+	String get projectDocsHint => 'Architecture / spec / decisions / plan / retros — typically authored or maintained by an agent.';
+
+	/// en: 'Mapping cleared — using default'
+	String get mappingCleared => 'Mapping cleared — using default';
+
+	/// en: 'Mapped to {path}'
+	String mappedTo({required Object path}) => 'Mapped to ${path}';
+
+	/// en: 'Cancel'
+	String get cancelTooltip => 'Cancel';
+
+	/// en: 'New doc'
+	String get newDocTooltip => 'New doc';
+
+	/// en: 'Could not resolve a project mapping for this session. Check that the gateway has a notes vault configured and that the session cwd is set.'
+	String get noProjectMapping => 'Could not resolve a project mapping for this session. Check that the gateway has a notes vault configured and that the session cwd is set.';
+
+	/// en: 'No project docs yet. Tap + to create one, or let an AI agent generate from a prompt.'
+	String get emptyProjectDocs => 'No project docs yet. Tap + to create one, or let an AI agent generate from a prompt.';
+
+	/// en: 'No matches for "{query}".'
+	String emptyFilterMatch({required Object query}) => 'No matches for "${query}".';
+
+	/// en: 'Pin this session's cwd to a specific folder under your notes vault. Leave blank to reset.'
+	String get locationDialogHelp => 'Pin this session\'s cwd to a specific folder under your notes vault. Leave blank to reset.';
+
+	/// en: 'Session cwd'
+	String get sessionCwd => 'Session cwd';
+
+	/// en: 'Vault-relative project docs path'
+	String get projectDocsPath => 'Vault-relative project docs path';
+
+	/// en: 'Stored in <vault>/.opendray-projects.json — git-syncs with the rest of the vault.'
+	String get locationStoredHint => 'Stored in <vault>/.opendray-projects.json — git-syncs with the rest of the vault.';
+
+	/// en: 'Pinned to {path}/ (overrides {defaultPath}). AI agents author docs here too.'
+	String pinnedHint({required Object path, required Object defaultPath}) => 'Pinned to ${path}/ (overrides ${defaultPath}). AI agents author docs here too.';
+
+	/// en: '(no project mapping)'
+	String get noProjectMapping2 => '(no project mapping)';
+
+	/// en: 'Clear override'
+	String get clearOverride => 'Clear override';
+
+	/// en: 'Save'
+	String get save => 'Save';
 }
 
 // Path: sessions.spawnSheet.bypass
@@ -3919,6 +4033,31 @@ extension on Translations {
 			'sessions.inspector.notes.create' => 'Create',
 			'sessions.inspector.notes.filterHint' => 'Filter…',
 			'sessions.inspector.notes.locationDialogTitle' => 'Project docs location',
+			'sessions.inspector.notes.loadFailedApi' => ({required Object error}) => 'Load failed: ${error}',
+			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => 'Load failed: ${error}',
+			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => 'Save failed: ${error}',
+			'sessions.inspector.notes.saveFailedGeneric' => ({required Object error}) => 'Save failed: ${error}',
+			'sessions.inspector.notes.insertFailedApi' => ({required Object error}) => 'Insert failed: ${error}',
+			'sessions.inspector.notes.insertFailedGeneric' => ({required Object error}) => 'Insert failed: ${error}',
+			'sessions.inspector.notes.createFailedApi' => ({required Object error}) => 'Create failed: ${error}',
+			'sessions.inspector.notes.createFailedGeneric' => ({required Object error}) => 'Create failed: ${error}',
+			'sessions.inspector.notes.personalHint' => 'Personal scratchpad — auto-saves as you type. AI agents do not write here.',
+			'sessions.inspector.notes.projectDocsHint' => 'Architecture / spec / decisions / plan / retros — typically authored or maintained by an agent.',
+			'sessions.inspector.notes.mappingCleared' => 'Mapping cleared — using default',
+			'sessions.inspector.notes.mappedTo' => ({required Object path}) => 'Mapped to ${path}',
+			'sessions.inspector.notes.cancelTooltip' => 'Cancel',
+			'sessions.inspector.notes.newDocTooltip' => 'New doc',
+			'sessions.inspector.notes.noProjectMapping' => 'Could not resolve a project mapping for this session. Check that the gateway has a notes vault configured and that the session cwd is set.',
+			'sessions.inspector.notes.emptyProjectDocs' => 'No project docs yet. Tap + to create one, or let an AI agent generate from a prompt.',
+			'sessions.inspector.notes.emptyFilterMatch' => ({required Object query}) => 'No matches for "${query}".',
+			'sessions.inspector.notes.locationDialogHelp' => 'Pin this session\'s cwd to a specific folder under your notes vault. Leave blank to reset.',
+			'sessions.inspector.notes.sessionCwd' => 'Session cwd',
+			'sessions.inspector.notes.projectDocsPath' => 'Vault-relative project docs path',
+			'sessions.inspector.notes.locationStoredHint' => 'Stored in <vault>/.opendray-projects.json — git-syncs with the rest of the vault.',
+			'sessions.inspector.notes.pinnedHint' => ({required Object path, required Object defaultPath}) => 'Pinned to ${path}/ (overrides ${defaultPath}). AI agents author docs here too.',
+			'sessions.inspector.notes.noProjectMapping2' => '(no project mapping)',
+			'sessions.inspector.notes.clearOverride' => 'Clear override',
+			'sessions.inspector.notes.save' => 'Save',
 			'sessions.spawnSheet.title' => 'New session',
 			'sessions.spawnSheet.errorRequired' => 'Provider and working directory are required',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => 'Failed to spawn session: ${error}',
@@ -4235,6 +4374,8 @@ extension on Translations {
 			'backupSchedules.retentionLabel' => 'Retention (keep N most recent)',
 			'backupSchedules.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}: ${error}',
 			'backupTargetEditor.useHttps' => 'Use HTTPS',
+			_ => null,
+		} ?? switch (path) {
 			'backupTargetEditor.pathStyle' => 'Path-style addressing',
 			'backupTargetEditor.pathStyleSubtitle' => 'Legacy / MinIO',
 			'githosts.title' => 'Git hosts',
@@ -4260,8 +4401,6 @@ extension on Translations {
 			'githosts.form.saveFailedGeneric' => ({required Object error}) => 'Save failed: ${error}',
 			'githosts.form.saving' => 'Saving…',
 			'githosts.form.save' => 'Save',
-			_ => null,
-		} ?? switch (path) {
 			'githosts.form.add' => 'Add',
 			'githosts.form.nameHelper' => 'Display name shown in PR lists.',
 			'githosts.form.tokenLabelKeep' => 'Token (leave blank to keep existing)',
@@ -4477,9 +4616,22 @@ extension on Translations {
 			'notesPage.pathLabel' => 'Vault-relative path',
 			'notesPage.pathHint' => 'personal/scratch.md',
 			'notesPage.create' => 'Create',
+			'notesPage.popupDelete' => 'Delete',
+			'notesPage.deleteBody' => 'This is irreversible. Vault git sync will remove the file on the gateway host too.',
+			'notesPage.emptyFilterMatch' => ({required Object query}) => 'No notes match "${query}".',
+			'notesPage.emptyVault' => 'Vault is empty. Tap + to create your first note.',
+			'notesPage.emptyFolder' => ({required Object path}) => 'Folder "${path}" is empty.',
+			'notesPage.validatePath' => 'Path is required',
+			'notesPage.validatePathDots' => 'Path cannot contain ".."',
+			'notesPage.pathHelper' => 'Auto-appends .md if missing.',
 			'notesPage.editor.markdownHint' => 'Markdown…',
 			'notesPage.editor.saving' => 'Saving…',
 			'notesPage.editor.autosave' => 'Auto-saves as you type',
+			'notesPage.editor.loadFailedApi' => ({required Object error}) => 'Load failed: ${error}',
+			'notesPage.editor.loadFailedGeneric' => ({required Object error}) => 'Load failed: ${error}',
+			'notesPage.editor.saveFailedApi' => ({required Object error}) => 'Save failed: ${error}',
+			'notesPage.editor.saveFailedGeneric' => ({required Object error}) => 'Save failed: ${error}',
+			'notesPage.editor.savedAt' => ({required Object time}) => 'Saved ${time}',
 			'memory.title' => 'Memory',
 			'memory.more' => 'More',
 			'memory.workers' => 'Memory workers',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -615,6 +615,14 @@ class _TranslationsNotesPageZh extends TranslationsNotesPageEn {
 	@override String get pathLabel => '相对仓库的路径';
 	@override String get pathHint => 'personal/scratch.md';
 	@override String get create => '创建';
+	@override String get popupDelete => '删除';
+	@override String get deleteBody => '此操作不可撤销。仓库的 git 同步会同时移除网关主机上的文件。';
+	@override String emptyFilterMatch({required Object query}) => '未找到匹配「${query}」的笔记。';
+	@override String get emptyVault => '仓库为空。点击 + 创建第一条笔记。';
+	@override String emptyFolder({required Object path}) => '文件夹「${path}」为空。';
+	@override String get validatePath => '必须填写路径';
+	@override String get validatePathDots => '路径不能包含「..」';
+	@override String get pathHelper => '缺失时自动追加 .md。';
 	@override late final _TranslationsNotesPageEditorZh editor = _TranslationsNotesPageEditorZh._(_root);
 }
 
@@ -1244,6 +1252,11 @@ class _TranslationsNotesPageEditorZh extends TranslationsNotesPageEditorEn {
 	@override String get markdownHint => 'Markdown…';
 	@override String get saving => '保存中…';
 	@override String get autosave => '随输入自动保存';
+	@override String loadFailedApi({required Object error}) => '加载失败：${error}';
+	@override String loadFailedGeneric({required Object error}) => '加载失败：${error}';
+	@override String saveFailedApi({required Object error}) => '保存失败：${error}';
+	@override String saveFailedGeneric({required Object error}) => '保存失败：${error}';
+	@override String savedAt({required Object time}) => '${time} 已保存';
 }
 
 // Path: memory.deleteAllConfirm
@@ -1759,6 +1772,31 @@ class _TranslationsSessionsInspectorNotesZh extends TranslationsSessionsInspecto
 	@override String get create => '创建';
 	@override String get filterHint => '筛选…';
 	@override String get locationDialogTitle => '项目文档位置';
+	@override String loadFailedApi({required Object error}) => '加载失败：${error}';
+	@override String loadFailedGeneric({required Object error}) => '加载失败：${error}';
+	@override String saveFailedApi({required Object error}) => '保存失败：${error}';
+	@override String saveFailedGeneric({required Object error}) => '保存失败：${error}';
+	@override String insertFailedApi({required Object error}) => '插入失败：${error}';
+	@override String insertFailedGeneric({required Object error}) => '插入失败：${error}';
+	@override String createFailedApi({required Object error}) => '创建失败：${error}';
+	@override String createFailedGeneric({required Object error}) => '创建失败：${error}';
+	@override String get personalHint => '个人草稿 — 随输入自动保存。AI agent 不会写入这里。';
+	@override String get projectDocsHint => '架构 / 规范 / 决策 / 计划 / 回顾 — 通常由 agent 撰写或维护。';
+	@override String get mappingCleared => '映射已清除 — 使用默认值';
+	@override String mappedTo({required Object path}) => '已映射到 ${path}';
+	@override String get cancelTooltip => '取消';
+	@override String get newDocTooltip => '新建文档';
+	@override String get noProjectMapping => '无法为此会话解析项目映射。检查网关是否配置了笔记库，以及会话的 cwd 是否已设置。';
+	@override String get emptyProjectDocs => '暂无项目文档。点击 + 创建一个，或让 AI agent 根据提示生成。';
+	@override String emptyFilterMatch({required Object query}) => '未找到匹配「${query}」的内容。';
+	@override String get locationDialogHelp => '将此会话的 cwd 固定到笔记库下的某个文件夹。留空 = 重置。';
+	@override String get sessionCwd => '会话 cwd';
+	@override String get projectDocsPath => '相对笔记库的项目文档路径';
+	@override String get locationStoredHint => '存储于 <vault>/.opendray-projects.json — 与笔记库其余部分一起 git 同步。';
+	@override String pinnedHint({required Object path, required Object defaultPath}) => '已固定到 ${path}/（覆盖 ${defaultPath}）。AI agent 也会在此撰写文档。';
+	@override String get noProjectMapping2 => '（无项目映射）';
+	@override String get clearOverride => '清除覆盖';
+	@override String get save => '保存';
 }
 
 // Path: sessions.spawnSheet.bypass
@@ -2223,6 +2261,31 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.create' => '创建',
 			'sessions.inspector.notes.filterHint' => '筛选…',
 			'sessions.inspector.notes.locationDialogTitle' => '项目文档位置',
+			'sessions.inspector.notes.loadFailedApi' => ({required Object error}) => '加载失败：${error}',
+			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => '加载失败：${error}',
+			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => '保存失败：${error}',
+			'sessions.inspector.notes.saveFailedGeneric' => ({required Object error}) => '保存失败：${error}',
+			'sessions.inspector.notes.insertFailedApi' => ({required Object error}) => '插入失败：${error}',
+			'sessions.inspector.notes.insertFailedGeneric' => ({required Object error}) => '插入失败：${error}',
+			'sessions.inspector.notes.createFailedApi' => ({required Object error}) => '创建失败：${error}',
+			'sessions.inspector.notes.createFailedGeneric' => ({required Object error}) => '创建失败：${error}',
+			'sessions.inspector.notes.personalHint' => '个人草稿 — 随输入自动保存。AI agent 不会写入这里。',
+			'sessions.inspector.notes.projectDocsHint' => '架构 / 规范 / 决策 / 计划 / 回顾 — 通常由 agent 撰写或维护。',
+			'sessions.inspector.notes.mappingCleared' => '映射已清除 — 使用默认值',
+			'sessions.inspector.notes.mappedTo' => ({required Object path}) => '已映射到 ${path}',
+			'sessions.inspector.notes.cancelTooltip' => '取消',
+			'sessions.inspector.notes.newDocTooltip' => '新建文档',
+			'sessions.inspector.notes.noProjectMapping' => '无法为此会话解析项目映射。检查网关是否配置了笔记库，以及会话的 cwd 是否已设置。',
+			'sessions.inspector.notes.emptyProjectDocs' => '暂无项目文档。点击 + 创建一个，或让 AI agent 根据提示生成。',
+			'sessions.inspector.notes.emptyFilterMatch' => ({required Object query}) => '未找到匹配「${query}」的内容。',
+			'sessions.inspector.notes.locationDialogHelp' => '将此会话的 cwd 固定到笔记库下的某个文件夹。留空 = 重置。',
+			'sessions.inspector.notes.sessionCwd' => '会话 cwd',
+			'sessions.inspector.notes.projectDocsPath' => '相对笔记库的项目文档路径',
+			'sessions.inspector.notes.locationStoredHint' => '存储于 <vault>/.opendray-projects.json — 与笔记库其余部分一起 git 同步。',
+			'sessions.inspector.notes.pinnedHint' => ({required Object path, required Object defaultPath}) => '已固定到 ${path}/（覆盖 ${defaultPath}）。AI agent 也会在此撰写文档。',
+			'sessions.inspector.notes.noProjectMapping2' => '（无项目映射）',
+			'sessions.inspector.notes.clearOverride' => '清除覆盖',
+			'sessions.inspector.notes.save' => '保存',
 			'sessions.spawnSheet.title' => '新建会话',
 			'sessions.spawnSheet.errorRequired' => '需要指定提供商和工作目录',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => '创建会话失败：${error}',
@@ -2539,6 +2602,8 @@ extension on TranslationsZh {
 			'backupSchedules.retentionLabel' => '保留（最近 N 个）',
 			'backupSchedules.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}：${error}',
 			'backupTargetEditor.useHttps' => '使用 HTTPS',
+			_ => null,
+		} ?? switch (path) {
 			'backupTargetEditor.pathStyle' => '路径风格寻址',
 			'backupTargetEditor.pathStyleSubtitle' => '旧版 / MinIO',
 			'githosts.title' => 'Git 主机',
@@ -2564,8 +2629,6 @@ extension on TranslationsZh {
 			'githosts.form.saveFailedGeneric' => ({required Object error}) => '保存失败：${error}',
 			'githosts.form.saving' => '保存中…',
 			'githosts.form.save' => '保存',
-			_ => null,
-		} ?? switch (path) {
 			'githosts.form.add' => '添加',
 			'githosts.form.nameHelper' => '在 PR 列表中显示的名字。',
 			'githosts.form.tokenLabelKeep' => 'Token（留空 = 保留现有）',
@@ -2781,9 +2844,22 @@ extension on TranslationsZh {
 			'notesPage.pathLabel' => '相对仓库的路径',
 			'notesPage.pathHint' => 'personal/scratch.md',
 			'notesPage.create' => '创建',
+			'notesPage.popupDelete' => '删除',
+			'notesPage.deleteBody' => '此操作不可撤销。仓库的 git 同步会同时移除网关主机上的文件。',
+			'notesPage.emptyFilterMatch' => ({required Object query}) => '未找到匹配「${query}」的笔记。',
+			'notesPage.emptyVault' => '仓库为空。点击 + 创建第一条笔记。',
+			'notesPage.emptyFolder' => ({required Object path}) => '文件夹「${path}」为空。',
+			'notesPage.validatePath' => '必须填写路径',
+			'notesPage.validatePathDots' => '路径不能包含「..」',
+			'notesPage.pathHelper' => '缺失时自动追加 .md。',
 			'notesPage.editor.markdownHint' => 'Markdown…',
 			'notesPage.editor.saving' => '保存中…',
 			'notesPage.editor.autosave' => '随输入自动保存',
+			'notesPage.editor.loadFailedApi' => ({required Object error}) => '加载失败：${error}',
+			'notesPage.editor.loadFailedGeneric' => ({required Object error}) => '加载失败：${error}',
+			'notesPage.editor.saveFailedApi' => ({required Object error}) => '保存失败：${error}',
+			'notesPage.editor.saveFailedGeneric' => ({required Object error}) => '保存失败：${error}',
+			'notesPage.editor.savedAt' => ({required Object time}) => '${time} 已保存',
 			'memory.title' => '记忆',
 			'memory.more' => '更多',
 			'memory.workers' => '记忆工作器',

--- a/app/mobile/lib/features/channels/channels_screen.dart
+++ b/app/mobile/lib/features/channels/channels_screen.dart
@@ -110,103 +110,117 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
     final action = await showModalBottomSheet<_RowAction>(
       context: context,
       backgroundColor: Theme.of(context).colorScheme.surface,
+      isScrollControlled: true,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
       ),
       builder: (sheetCtx) => SafeArea(
         top: false,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 14, 16, 8),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    ch.kind,
-                    style: Theme.of(sheetCtx).textTheme.titleSmall,
-                  ),
-                  Text(
-                    ch.id,
-                    style: Theme.of(sheetCtx)
-                        .textTheme
-                        .bodySmall
-                        ?.copyWith(fontFamily: 'monospace'),
-                  ),
-                ],
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 14, 16, 8),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      ch.kind,
+                      style: Theme.of(sheetCtx).textTheme.titleSmall,
+                    ),
+                    Text(
+                      ch.id,
+                      style: Theme.of(
+                        sheetCtx,
+                      ).textTheme.bodySmall?.copyWith(fontFamily: 'monospace'),
+                    ),
+                  ],
+                ),
               ),
-            ),
-            const Divider(height: 1),
-            ListTile(
-              enabled: !isBusy,
-              leading: const Icon(Icons.send_outlined),
-              title: Text(i18n.t.channels.sendTest),
-              onTap: () => Navigator.of(sheetCtx).pop(_RowAction.test),
-            ),
-            ListTile(
-              enabled: !isBusy,
-              leading: Icon(
-                ch.enabled ? Icons.pause_circle_outline : Icons.play_circle_outline,
+              const Divider(height: 1),
+              ListTile(
+                enabled: !isBusy,
+                leading: const Icon(Icons.send_outlined),
+                title: Text(i18n.t.channels.sendTest),
+                onTap: () => Navigator.of(sheetCtx).pop(_RowAction.test),
               ),
-              title: Text(ch.enabled ? i18n.t.channels.popup.disable : i18n.t.channels.popup.enable),
-              onTap: () => Navigator.of(sheetCtx).pop(_RowAction.toggleEnabled),
-            ),
-            ListTile(
-              enabled: !isBusy,
-              leading: Icon(
-                ch.muted ? Icons.notifications_active_outlined : Icons.notifications_off_outlined,
+              ListTile(
+                enabled: !isBusy,
+                leading: Icon(
+                  ch.enabled
+                      ? Icons.pause_circle_outline
+                      : Icons.play_circle_outline,
+                ),
+                title: Text(
+                  ch.enabled
+                      ? i18n.t.channels.popup.disable
+                      : i18n.t.channels.popup.enable,
+                ),
+                onTap: () =>
+                    Navigator.of(sheetCtx).pop(_RowAction.toggleEnabled),
               ),
-              title: Text(ch.muted ? i18n.t.channels.popup.unmute : i18n.t.channels.popup.mute),
-              onTap: () => Navigator.of(sheetCtx).pop(_RowAction.toggleMuted),
-            ),
-            const Divider(height: 1),
-            ListTile(
-              enabled: !isBusy && findKind(ch.kind) != null,
-              leading: const Icon(Icons.edit_outlined),
-              title: Text(i18n.t.channels.editConfig),
-              subtitle: findKind(ch.kind) == null
-                  ? Text(
-                      i18n.t.channels.bridgeWebOnly,
-                      style: const TextStyle(fontSize: 11),
-                    )
-                  : null,
-              onTap: () =>
-                  Navigator.of(sheetCtx).pop(_RowAction.editKindConfig),
-            ),
-            ListTile(
-              enabled: !isBusy,
-              leading: const Icon(Icons.tune_outlined),
-              title: Text(i18n.t.channels.editNotifications),
-              onTap: () =>
-                  Navigator.of(sheetCtx).pop(_RowAction.editNotify),
-            ),
-            ListTile(
-              leading: const Icon(Icons.code),
-              title: Text(i18n.t.channels.viewRawConfig),
-              onTap: () => Navigator.of(sheetCtx).pop(_RowAction.viewConfig),
-            ),
-            ListTile(
-              leading: const Icon(Icons.copy_outlined),
-              title: Text(i18n.t.channels.copyChannelId),
-              onTap: () => Navigator.of(sheetCtx).pop(_RowAction.copyId),
-            ),
-            const Divider(height: 1),
-            ListTile(
-              enabled: !isBusy,
-              leading: Icon(
-                Icons.delete_outline,
-                color: Theme.of(sheetCtx).colorScheme.error,
+              ListTile(
+                enabled: !isBusy,
+                leading: Icon(
+                  ch.muted
+                      ? Icons.notifications_active_outlined
+                      : Icons.notifications_off_outlined,
+                ),
+                title: Text(
+                  ch.muted
+                      ? i18n.t.channels.popup.unmute
+                      : i18n.t.channels.popup.mute,
+                ),
+                onTap: () => Navigator.of(sheetCtx).pop(_RowAction.toggleMuted),
               ),
-              title: Text(
-                i18n.t.channels.popup.deleteLabel,
-                style: TextStyle(color: Theme.of(sheetCtx).colorScheme.error),
+              const Divider(height: 1),
+              ListTile(
+                enabled: !isBusy && findKind(ch.kind) != null,
+                leading: const Icon(Icons.edit_outlined),
+                title: Text(i18n.t.channels.editConfig),
+                subtitle: findKind(ch.kind) == null
+                    ? Text(
+                        i18n.t.channels.bridgeWebOnly,
+                        style: const TextStyle(fontSize: 11),
+                      )
+                    : null,
+                onTap: () =>
+                    Navigator.of(sheetCtx).pop(_RowAction.editKindConfig),
               ),
-              onTap: () => Navigator.of(sheetCtx).pop(_RowAction.delete),
-            ),
-            const SizedBox(height: 4),
-          ],
+              ListTile(
+                enabled: !isBusy,
+                leading: const Icon(Icons.tune_outlined),
+                title: Text(i18n.t.channels.editNotifications),
+                onTap: () => Navigator.of(sheetCtx).pop(_RowAction.editNotify),
+              ),
+              ListTile(
+                leading: const Icon(Icons.code),
+                title: Text(i18n.t.channels.viewRawConfig),
+                onTap: () => Navigator.of(sheetCtx).pop(_RowAction.viewConfig),
+              ),
+              ListTile(
+                leading: const Icon(Icons.copy_outlined),
+                title: Text(i18n.t.channels.copyChannelId),
+                onTap: () => Navigator.of(sheetCtx).pop(_RowAction.copyId),
+              ),
+              const Divider(height: 1),
+              ListTile(
+                enabled: !isBusy,
+                leading: Icon(
+                  Icons.delete_outline,
+                  color: Theme.of(sheetCtx).colorScheme.error,
+                ),
+                title: Text(
+                  i18n.t.channels.popup.deleteLabel,
+                  style: TextStyle(color: Theme.of(sheetCtx).colorScheme.error),
+                ),
+                onTap: () => Navigator.of(sheetCtx).pop(_RowAction.delete),
+              ),
+              const SizedBox(height: 4),
+            ],
+          ),
         ),
       ),
     );
@@ -223,7 +237,9 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
         final next = !ch.enabled;
         await _runAction(
           id: ch.id,
-          okMessage: next ? i18n.t.channels.snacks.channelEnabled : i18n.t.channels.snacks.channelDisabled,
+          okMessage: next
+              ? i18n.t.channels.snacks.channelEnabled
+              : i18n.t.channels.snacks.channelDisabled,
           failPrefix: i18n.t.channels.errorPrefix.toggle,
           op: () => ref
               .read(channelsApiProvider)
@@ -234,7 +250,9 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
         final next = !ch.muted;
         await _runAction(
           id: ch.id,
-          okMessage: next ? i18n.t.channels.snacks.channelMuted : i18n.t.channels.snacks.channelUnmuted,
+          okMessage: next
+              ? i18n.t.channels.snacks.channelMuted
+              : i18n.t.channels.snacks.channelUnmuted,
           failPrefix: i18n.t.channels.errorPrefix.muteToggle,
           op: () => ref
               .read(channelsApiProvider)
@@ -297,9 +315,7 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
       if (!mounted) return;
       messenger.showSnackBar(
         SnackBar(
-          content: Text(
-            i18n.t.channels.createFailedApi(error: e.message),
-          ),
+          content: Text(i18n.t.channels.createFailedApi(error: e.message)),
         ),
       );
     } on Object catch (e) {
@@ -344,10 +360,8 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
       id: ch.id,
       okMessage: i18n.t.channels.snacks.configUpdated,
       failPrefix: i18n.t.channels.errorPrefix.update,
-      op: () => ref
-          .read(channelsApiProvider)
-          .updateConfig(ch.id, patch)
-          .then((_) {}),
+      op: () =>
+          ref.read(channelsApiProvider).updateConfig(ch.id, patch).then((_) {}),
     );
   }
 
@@ -363,10 +377,8 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
       id: ch.id,
       okMessage: i18n.t.channels.notifications.updatedSnack,
       failPrefix: i18n.t.channels.errorPrefix.update,
-      op: () => ref
-          .read(channelsApiProvider)
-          .updateConfig(ch.id, patch)
-          .then((_) {}),
+      op: () =>
+          ref.read(channelsApiProvider).updateConfig(ch.id, patch).then((_) {}),
     );
   }
 
@@ -383,10 +395,9 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
             const SizedBox(height: 4),
             Text(
               ch.id,
-              style: Theme.of(ctx)
-                  .textTheme
-                  .bodySmall
-                  ?.copyWith(fontFamily: 'monospace'),
+              style: Theme.of(
+                ctx,
+              ).textTheme.bodySmall?.copyWith(fontFamily: 'monospace'),
             ),
             const SizedBox(height: 12),
             Text(
@@ -504,10 +515,8 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
       onRefresh: _load,
       child: ListView.separated(
         itemCount: list.length,
-        separatorBuilder: (_, __) => Divider(
-          height: 1,
-          color: Theme.of(context).dividerColor,
-        ),
+        separatorBuilder: (_, __) =>
+            Divider(height: 1, color: Theme.of(context).dividerColor),
         itemBuilder: (_, i) {
           final ch = list[i];
           return _ChannelTile(
@@ -553,10 +562,7 @@ class _ChannelTile extends StatelessWidget {
         height: 36,
         alignment: Alignment.center,
         decoration: BoxDecoration(
-          color: Theme.of(context)
-              .colorScheme
-              .primary
-              .withValues(alpha: 0.12),
+          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.12),
           borderRadius: BorderRadius.circular(8),
         ),
         child: Text(
@@ -586,12 +592,13 @@ class _ChannelTile extends StatelessWidget {
           spacing: 6,
           runSpacing: 2,
           children: [
-            Text(
-              channel.id,
-              style: const TextStyle(fontFamily: 'monospace'),
-            ),
+            Text(channel.id, style: const TextStyle(fontFamily: 'monospace')),
             if (channel.capabilities.isNotEmpty)
-              Text(i18n.t.channels.capsLabel(list: channel.capabilities.join(', '))),
+              Text(
+                i18n.t.channels.capsLabel(
+                  list: channel.capabilities.join(', '),
+                ),
+              ),
           ],
         ),
       ),
@@ -614,17 +621,31 @@ class _StatusBadges extends StatelessWidget {
   Widget build(BuildContext context) {
     final badges = <Widget>[];
     if (channel.running) {
-      badges.add(_Badge(label: i18n.t.channels.badges.running, color: Colors.greenAccent));
+      badges.add(
+        _Badge(
+          label: i18n.t.channels.badges.running,
+          color: Colors.greenAccent,
+        ),
+      );
     } else if (channel.enabled) {
-      badges.add(_Badge(label: i18n.t.channels.badges.starting, color: Colors.amberAccent));
+      badges.add(
+        _Badge(
+          label: i18n.t.channels.badges.starting,
+          color: Colors.amberAccent,
+        ),
+      );
     } else {
-      badges.add(_Badge(
-        label: i18n.t.channels.badges.disabled,
-        color: Theme.of(context).colorScheme.error,
-      ));
+      badges.add(
+        _Badge(
+          label: i18n.t.channels.badges.disabled,
+          color: Theme.of(context).colorScheme.error,
+        ),
+      );
     }
     if (channel.muted) {
-      badges.add(_Badge(label: i18n.t.channels.badges.muted, color: Colors.amberAccent));
+      badges.add(
+        _Badge(label: i18n.t.channels.badges.muted, color: Colors.amberAccent),
+      );
     }
     return Wrap(spacing: 4, runSpacing: 2, children: badges);
   }
@@ -644,10 +665,7 @@ class _Badge extends StatelessWidget {
         borderRadius: BorderRadius.circular(4),
         border: Border.all(color: color.withValues(alpha: 0.6), width: 0.5),
       ),
-      child: Text(
-        label,
-        style: TextStyle(color: color, fontSize: 10),
-      ),
+      child: Text(label, style: TextStyle(color: color, fontSize: 10)),
     );
   }
 }
@@ -667,7 +685,11 @@ class _NotifyPrefsScreen extends StatefulWidget {
 }
 
 class _NotifyPrefsScreenState extends State<_NotifyPrefsScreen> {
-  static const _allTopics = ['session.started', 'session.idle', 'session.ended'];
+  static const _allTopics = [
+    'session.started',
+    'session.idle',
+    'session.ended',
+  ];
   static List<(String, String, String)> _modes() => [
     (
       'once',
@@ -778,9 +800,13 @@ class _NotifyPrefsScreenState extends State<_NotifyPrefsScreen> {
             children: [
               for (final t in _allTopics)
                 FilterChip(
-                  label: Text(t,
-                      style: const TextStyle(
-                          fontFamily: 'monospace', fontSize: 12)),
+                  label: Text(
+                    t,
+                    style: const TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 12,
+                    ),
+                  ),
                   selected: _topics.contains(t),
                   onSelected: (v) => setState(() {
                     if (v) {
@@ -798,8 +824,8 @@ class _NotifyPrefsScreenState extends State<_NotifyPrefsScreen> {
               _topics.length == _allTopics.length
                   ? i18n.t.channels.notifications.notifyOnAll
                   : _topics.isEmpty
-                      ? i18n.t.channels.notifications.notifyOnEmpty
-                      : '${_topics.length} of ${_allTopics.length} selected.',
+                  ? i18n.t.channels.notifications.notifyOnEmpty
+                  : '${_topics.length} of ${_allTopics.length} selected.',
               style: muted,
             ),
           ),
@@ -859,7 +885,13 @@ class _NotifyPrefsScreenState extends State<_NotifyPrefsScreen> {
               children: [
                 for (final n in const [0, 200, 500, 1000, 2000])
                   ChoiceChip(
-                    label: Text(n == 0 ? i18n.t.channels.notifications.snippetNoCap : i18n.t.channels.notifications.snippetChars(n: n.toString())),
+                    label: Text(
+                      n == 0
+                          ? i18n.t.channels.notifications.snippetNoCap
+                          : i18n.t.channels.notifications.snippetChars(
+                              n: n.toString(),
+                            ),
+                    ),
                     selected: _snippetCap == n,
                     onSelected: (_) => setState(() => _snippetCap = n),
                   ),

--- a/app/mobile/lib/features/notes/note_editor_dialog.dart
+++ b/app/mobile/lib/features/notes/note_editor_dialog.dart
@@ -73,14 +73,14 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
       if (mounted) {
         setState(() {
           _loading = false;
-          _error = 'Load failed: ${e.message}';
+          _error = t.notesPage.editor.loadFailedApi(error: e.message);
         });
       }
     } on Object catch (e) {
       if (mounted) {
         setState(() {
           _loading = false;
-          _error = 'Load failed: $e';
+          _error = t.notesPage.editor.loadFailedGeneric(error: e.toString());
         });
       }
     }
@@ -110,14 +110,14 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
       if (mounted) {
         setState(() {
           _saving = false;
-          _error = 'Save failed: ${e.message}';
+          _error = t.notesPage.editor.saveFailedApi(error: e.message);
         });
       }
     } on Object catch (e) {
       if (mounted) {
         setState(() {
           _saving = false;
-          _error = 'Save failed: $e';
+          _error = t.notesPage.editor.saveFailedGeneric(error: e.toString());
         });
       }
     }
@@ -258,7 +258,7 @@ class NoteSaveStatus extends StatelessWidget {
     }
     if (lastSaved != null) {
       return Text(
-        'Saved ${DateFormat.Hm().format(lastSaved!.toLocal())}',
+        t.notesPage.editor.savedAt(time: DateFormat.Hm().format(lastSaved!.toLocal())),
         style: muted,
       );
     }

--- a/app/mobile/lib/features/notes/notes_screen.dart
+++ b/app/mobile/lib/features/notes/notes_screen.dart
@@ -124,7 +124,7 @@ class _NotesScreenState extends ConsumerState<NotesScreen> {
                 color: Theme.of(sheetCtx).colorScheme.error,
               ),
               title: Text(
-                'Delete',
+                t.notesPage.popupDelete,
                 style: TextStyle(color: Theme.of(sheetCtx).colorScheme.error),
               ),
               onTap: () => Navigator.of(sheetCtx).pop(_RowAction.delete),
@@ -173,8 +173,7 @@ class _NotesScreenState extends ConsumerState<NotesScreen> {
             ),
             const SizedBox(height: 8),
             Text(
-              'This is irreversible. Vault git sync will remove the file '
-              'from the next commit.',
+              t.notesPage.deleteBody,
               style: Theme.of(dialogCtx).textTheme.bodySmall,
             ),
           ],
@@ -365,7 +364,7 @@ class _NotesScreenState extends ConsumerState<NotesScreen> {
         if (_query.isNotEmpty) {
           final results = _searchAll(notes);
           if (results.isEmpty) {
-            return _Empty(text: 'No notes match "$_query".');
+            return _Empty(text: t.notesPage.emptyFilterMatch(query: _query));
           }
           return RefreshIndicator(
             onRefresh: _load,
@@ -388,8 +387,8 @@ class _NotesScreenState extends ConsumerState<NotesScreen> {
         if (level.folders.isEmpty && level.notes.isEmpty) {
           return _Empty(
             text: _currentPath.isEmpty
-                ? 'Vault is empty. Tap + to create your first note.'
-                : 'Folder "$_currentPath" is empty.',
+                ? t.notesPage.emptyVault
+                : t.notesPage.emptyFolder(path: _currentPath),
           );
         }
         return RefreshIndicator(
@@ -622,11 +621,11 @@ class _NewNoteDialogState extends State<_NewNoteDialog> {
   void _submit() {
     final raw = _ctrl.text.trim();
     if (raw.isEmpty) {
-      setState(() => _error = 'Path is required');
+      setState(() => _error = t.notesPage.validatePath);
       return;
     }
     if (raw.contains('..')) {
-      setState(() => _error = 'Path cannot contain ".."');
+      setState(() => _error = t.notesPage.validatePathDots);
       return;
     }
     final cleaned = raw.replaceAll(RegExp('^/+'), '');
@@ -652,7 +651,7 @@ class _NewNoteDialogState extends State<_NewNoteDialog> {
             decoration: InputDecoration(
               labelText: t.notesPage.pathLabel,
               hintText: t.notesPage.pathHint,
-              helperText: 'Auto-appends .md if missing.',
+              helperText: t.notesPage.pathHelper,
             ),
           ),
           if (_error != null) ...[

--- a/app/mobile/lib/features/sessions/inspector/notes_tab.dart
+++ b/app/mobile/lib/features/sessions/inspector/notes_tab.dart
@@ -265,14 +265,14 @@ class _PersonalSectionState extends ConsumerState<_PersonalSection> {
       if (mounted) {
         setState(() {
         _loading = false;
-        _saveError = 'Load failed: ${e.message}';
+        _saveError = t.sessions.inspector.notes.loadFailedApi(error: e.message);
       });
       }
     } on Object catch (e) {
       if (mounted) {
         setState(() {
         _loading = false;
-        _saveError = 'Load failed: $e';
+        _saveError = t.sessions.inspector.notes.loadFailedGeneric(error: e.toString());
       });
       }
     }
@@ -305,14 +305,14 @@ class _PersonalSectionState extends ConsumerState<_PersonalSection> {
       if (mounted) {
         setState(() {
         _saving = false;
-        _saveError = 'Save failed: ${e.message}';
+        _saveError = t.sessions.inspector.notes.saveFailedApi(error: e.message);
       });
       }
     } on Object catch (e) {
       if (mounted) {
         setState(() {
         _saving = false;
-        _saveError = 'Save failed: $e';
+        _saveError = t.sessions.inspector.notes.saveFailedGeneric(error: e.toString());
       });
       }
     }
@@ -334,12 +334,12 @@ class _PersonalSectionState extends ConsumerState<_PersonalSection> {
     } on ApiException catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Insert failed: ${e.message}')),
+        SnackBar(content: Text(t.sessions.inspector.notes.insertFailedApi(error: e.message))),
       );
     } on Object catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Insert failed: $e')),
+        SnackBar(content: Text(t.sessions.inspector.notes.insertFailedGeneric(error: e.toString()))),
       );
     }
   }
@@ -348,10 +348,9 @@ class _PersonalSectionState extends ConsumerState<_PersonalSection> {
   Widget build(BuildContext context) {
     return _SectionCard(
       icon: Icons.edit_note_outlined,
-      title: 'My notes',
+      title: t.sessions.inspector.notes.myNotes,
       subtitle: widget.personalPath,
-      hint: 'Personal scratchpad — auto-saves as you type. AI agents do '
-          'not write here.',
+      hint: t.sessions.inspector.notes.personalHint,
       action: IconButton(
         icon: const Icon(Icons.alternate_email, size: 18),
         tooltip: t.sessions.inspector.notes.insertAtRefTooltip,
@@ -459,10 +458,10 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
       await NoteEditorDialog.show(context: context, path: path);
     } on ApiException catch (e) {
       messenger.showSnackBar(
-        SnackBar(content: Text('Create failed: ${e.message}')),
+        SnackBar(content: Text(t.sessions.inspector.notes.createFailedApi(error: e.message))),
       );
     } on Object catch (e) {
-      messenger.showSnackBar(SnackBar(content: Text('Create failed: $e')));
+      messenger.showSnackBar(SnackBar(content: Text(t.sessions.inspector.notes.createFailedGeneric(error: e.toString()))));
     }
   }
 
@@ -487,18 +486,18 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
         SnackBar(
           content: Text(
             result.isEmpty
-                ? 'Mapping cleared — using default'
-                : 'Mapped to $result',
+                ? t.sessions.inspector.notes.mappingCleared
+                : t.sessions.inspector.notes.mappedTo(path: result),
           ),
         ),
       );
       await widget.onRefresh();
     } on ApiException catch (e) {
       messenger.showSnackBar(
-        SnackBar(content: Text('Save failed: ${e.message}')),
+        SnackBar(content: Text(t.sessions.inspector.notes.saveFailedApi(error: e.message))),
       );
     } on Object catch (e) {
-      messenger.showSnackBar(SnackBar(content: Text('Save failed: $e')));
+      messenger.showSnackBar(SnackBar(content: Text(t.sessions.inspector.notes.saveFailedGeneric(error: e.toString()))));
     }
   }
 
@@ -512,16 +511,16 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
                 d.title.toLowerCase().contains(_query))
             .toList();
     final hint = widget.mapping.custom
-        ? 'Pinned to ${widget.projectsRel}/ (overrides ${widget.mapping.defaultPath}). '
-            'AI agents author docs here too.'
-        : 'Architecture / spec / decisions / plan / retros — typically '
-            'authored by AI agents. Use the settings button to point at a '
-            'different vault folder.';
+        ? t.sessions.inspector.notes.pinnedHint(
+            path: widget.projectsRel,
+            defaultPath: widget.mapping.defaultPath,
+          )
+        : t.sessions.inspector.notes.projectDocsHint;
     return _SectionCard(
       icon: Icons.auto_awesome,
       title: t.sessions.inspector.notes.projectDocs,
       subtitle: widget.projectsRel.isEmpty
-          ? '(no project mapping)'
+          ? t.sessions.inspector.notes.noProjectMapping2
           : '${widget.projectsRel}/',
       hint: hint,
       action: Row(
@@ -534,7 +533,7 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
           ),
           IconButton(
             icon: Icon(_creating ? Icons.close : Icons.add, size: 18),
-            tooltip: _creating ? 'Cancel' : 'New doc',
+            tooltip: _creating ? t.sessions.inspector.notes.cancelTooltip : t.sessions.inspector.notes.newDocTooltip,
             onPressed: () => setState(() {
               _creating = !_creating;
               if (!_creating) _newNameCtrl.clear();
@@ -594,18 +593,15 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
           if (widget.projectsRel.isEmpty)
             _empty(
               context,
-              'Could not resolve a project mapping for this session. '
-              'Check that the gateway has a notes vault configured '
-              'and the session has a non-empty cwd.',
+              t.sessions.inspector.notes.noProjectMapping,
             )
           else if (widget.docs.isEmpty)
             _empty(
               context,
-              'No project docs yet. Tap + to create one, or let an AI '
-              'agent write to ${widget.projectsRel}/<file>.md.',
+              t.sessions.inspector.notes.emptyProjectDocs,
             )
           else if (filtered.isEmpty)
-            _empty(context, 'No matches for "$_query".')
+            _empty(context, t.sessions.inspector.notes.emptyFilterMatch(query: _query))
           else
             for (final d in filtered)
               _DocTile(
@@ -635,10 +631,10 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
       );
     } on ApiException catch (e) {
       messenger.showSnackBar(
-        SnackBar(content: Text('Insert failed: ${e.message}')),
+        SnackBar(content: Text(t.sessions.inspector.notes.insertFailedApi(error: e.message))),
       );
     } on Object catch (e) {
-      messenger.showSnackBar(SnackBar(content: Text('Insert failed: $e')));
+      messenger.showSnackBar(SnackBar(content: Text(t.sessions.inspector.notes.insertFailedGeneric(error: e.toString()))));
     }
   }
 
@@ -780,13 +776,12 @@ class _MappingDialogState extends State<_MappingDialog> {
           mainAxisSize: MainAxisSize.min,
           children: [
             Text(
-              "Pin this session's cwd to a specific folder under your "
-              'vault. Leave empty to revert to default.',
+              t.sessions.inspector.notes.locationDialogHelp,
               style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(height: 12),
             Text(
-              'Session cwd',
+              t.sessions.inspector.notes.sessionCwd,
               style: Theme.of(context).textTheme.labelSmall,
             ),
             const SizedBox(height: 4),
@@ -796,7 +791,7 @@ class _MappingDialogState extends State<_MappingDialog> {
             ),
             const SizedBox(height: 12),
             Text(
-              'Vault-relative project docs path',
+              t.sessions.inspector.notes.projectDocsPath,
               style: Theme.of(context).textTheme.labelSmall,
             ),
             const SizedBox(height: 4),
@@ -811,8 +806,7 @@ class _MappingDialogState extends State<_MappingDialog> {
             ),
             const SizedBox(height: 8),
             Text(
-              'Stored in <vault>/.opendray-projects.json — git-syncs with '
-              'your notes.',
+              t.sessions.inspector.notes.locationStoredHint,
               style: Theme.of(context).textTheme.bodySmall,
             ),
           ],
@@ -825,7 +819,9 @@ class _MappingDialogState extends State<_MappingDialog> {
         ),
         FilledButton(
           onPressed: () => Navigator.of(context).pop(_ctrl.text.trim()),
-          child: Text(_ctrl.text.trim().isEmpty ? 'Clear override' : 'Save'),
+          child: Text(_ctrl.text.trim().isEmpty
+              ? t.sessions.inspector.notes.clearOverride
+              : t.sessions.inspector.notes.save),
         ),
       ],
     );


### PR DESCRIPTION
Last post-merge i18n batch. Three notes-related files earlier PRs only partially migrated.

## Coverage (~35 strings)

- **\`sessions/inspector/notes_tab.dart\`** (~25 sites): all load/save/insert/create error templates (api + generic), personal scratchpad hint, project-docs hint default + pinned-custom variants, mapping-changed snackbars (cleared / mapped to {path}), new-doc Cancel/New tooltips, no-project-mapping fallback message, empty project docs state, search empty-state with {query}, project-mapping-override dialog (help text, two field labels, stored hint), Pinned-to header subtitle, Clear-override/Save button labels.
- **\`notes/notes_screen.dart\`** (~7 sites): popup Delete label, delete confirm body, search empty-state, vault/folder empty-states, two validators (path required / no \"..\"), helper text.
- **\`notes/note_editor_dialog.dart\`** (~5 sites): load/save error pairs, \"Saved {time}\" status line.

## New JSON

- \`sessions.inspector.notes.{loadFailedApi/Generic, saveFailedApi/Generic, insertFailedApi/Generic, createFailedApi/Generic, personalHint, projectDocsHint, mappingCleared, mappedTo({path}), cancelTooltip, newDocTooltip, noProjectMapping, emptyProjectDocs, emptyFilterMatch({query}), locationDialogHelp, sessionCwd, projectDocsPath, locationStoredHint, pinnedHint({path, defaultPath}), noProjectMapping2, clearOverride, save}\`
- \`notesPage.{popupDelete, deleteBody, emptyFilterMatch({query}), emptyVault, emptyFolder({path}), validatePath, validatePathDots, pathHelper, editor.{loadFailedApi/Generic, saveFailedApi/Generic, savedAt({time})}}\`

## Verified

- [x] \`flutter analyze\` clean
- [ ] On-device: open a session → Inspector → Notes tab → confirm personal + project-docs hints, dialog open/close, "Pinned to..." after pinning, new-doc create flow, all snackbars. Also top-level Notes tab → walk delete dialog + create-note validator paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)