### PR TITLE
feat(catalog): implement MCP injection for Gemini CLI

### DIFF
--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -507,6 +507,24 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 			for k, v := range mcpEnv {
 				out.Env[k] = v
 			}
+
+			// Gemini mirroring: if renderMCP set GEMINI_CONFIG_DIR,
+			// symlink the user's real ~/.gemini into the scratch dir
+			// so they stay logged in.
+			if providerID == "gemini" && out.Env["GEMINI_CONFIG_DIR"] != "" {
+				home := out.Env["GEMINI_CONFIG_DIR"]
+				userHome := os.Getenv("GEMINI_CONFIG_DIR")
+				if userHome == "" {
+					if h, err := os.UserHomeDir(); err == nil {
+						userHome = filepath.Join(h, ".gemini")
+					}
+				}
+				if userHome != "" && userHome != home {
+					if err := mirrorGeminiHome(userHome, home); err != nil {
+						return session.PrepareOutput{}, fmt.Errorf("mirror gemini home: %w", err)
+					}
+				}
+			}
 		}
 
 		if len(out.Env) == 0 {
@@ -1020,6 +1038,36 @@ func appendToFile(path, content string) error {
 	defer f.Close()
 	if _, err := f.WriteString(content); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func mirrorGeminiHome(src, dest string) error {
+	if err := os.MkdirAll(dest, 0o700); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	skip := map[string]bool{
+		"settings.json": true,
+	}
+	for _, e := range entries {
+		if skip[e.Name()] {
+			continue
+		}
+		srcPath := filepath.Join(src, e.Name())
+		dstPath := filepath.Join(dest, e.Name())
+		if err := os.Symlink(srcPath, dstPath); err != nil {
+			if os.IsExist(err) {
+				continue
+			}
+			return fmt.Errorf("symlink %s: %w", e.Name(), err)
+		}
 	}
 	return nil
 }

--- a/internal/catalog/mcp.go
+++ b/internal/catalog/mcp.go
@@ -53,6 +53,8 @@ func renderMCP(providerID, baseDir string, servers []MCPServer) ([]string, map[s
 		return renderClaudeMCP(baseDir, servers)
 	case "codex":
 		return renderCodexMCP(baseDir, servers)
+	case "gemini":
+		return renderGeminiMCP(baseDir, servers)
 	default:
 		// Provider declared supportsMcp=true but we have no renderer
 		// for it; surface as a no-op rather than failing the spawn.
@@ -63,7 +65,7 @@ func renderMCP(providerID, baseDir string, servers []MCPServer) ([]string, map[s
 func renderClaudeMCP(baseDir string, servers []MCPServer) ([]string, map[string]string, error) {
 	entries := map[string]map[string]any{}
 	for _, s := range servers {
-		spec := claudeServerSpec(s)
+		spec := stdioMCPServerSpec(s)
 		if spec == nil {
 			continue
 		}
@@ -86,7 +88,38 @@ func renderClaudeMCP(baseDir string, servers []MCPServer) ([]string, map[string]
 	return []string{"--mcp-config", path}, nil, nil
 }
 
-func claudeServerSpec(s MCPServer) map[string]any {
+func renderGeminiMCP(baseDir string, servers []MCPServer) ([]string, map[string]string, error) {
+	entries := map[string]map[string]any{}
+	for _, s := range servers {
+		spec := stdioMCPServerSpec(s)
+		if spec == nil {
+			continue
+		}
+		entries[s.Name] = spec
+	}
+	if len(entries) == 0 {
+		return nil, nil, nil
+	}
+
+	home := filepath.Join(baseDir, "gemini-home")
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		return nil, nil, fmt.Errorf("mkdir gemini home: %w", err)
+	}
+
+	payload := map[string]any{"mcpServers": entries}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal gemini settings: %w", err)
+	}
+
+	path := filepath.Join(home, "settings.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return nil, nil, fmt.Errorf("write gemini settings: %w", err)
+	}
+	return nil, map[string]string{"GEMINI_CONFIG_DIR": home}, nil
+}
+
+func stdioMCPServerSpec(s MCPServer) map[string]any {
 	switch s.Transport {
 	case "sse":
 		if s.URL == "" {

--- a/internal/catalog/mcp_test.go
+++ b/internal/catalog/mcp_test.go
@@ -129,12 +129,42 @@ func TestRenderCodexMCP_SkipsNonStdio(t *testing.T) {
 	}
 }
 
+func TestRenderGeminiMCP_SettingsOutput(t *testing.T) {
+	dir := t.TempDir()
+	servers := []MCPServer{
+		{Name: "fs", Command: "npx", Args: []string{"-y", "server-fs"}},
+	}
+	args, env, err := renderMCP("gemini", dir, servers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(args) != 0 {
+		t.Errorf("args=%v, want none", args)
+	}
+	home, ok := env["GEMINI_CONFIG_DIR"]
+	if !ok {
+		t.Fatalf("GEMINI_CONFIG_DIR missing from env=%v", env)
+	}
+	body, err := os.ReadFile(filepath.Join(home, "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	servers0 := got["mcpServers"].(map[string]any)["fs"].(map[string]any)
+	if servers0["command"].(string) != "npx" {
+		t.Errorf("command=%v", servers0["command"])
+	}
+}
+
 func TestRenderMCP_UnknownProviderNoOp(t *testing.T) {
-	args, env, err := renderMCP("gemini", t.TempDir(), []MCPServer{
+	args, env, err := renderMCP("unknown-provider", t.TempDir(), []MCPServer{
 		{Name: "x", Command: "y"},
 	})
 	if err != nil || args != nil || env != nil {
-		t.Errorf("expected no-op for gemini, got args=%v env=%v err=%v", args, env, err)
+		t.Errorf("expected no-op for unknown-provider, got args=%v env=%v err=%v", args, env, err)
 	}
 }
 


### PR DESCRIPTION
Gemini CLI lacks a specific --mcp-config flag or CODEX_HOME equivalent for dynamic tool injection. It follows a hierarchical settings.json system where local ./.gemini/settings.json overrides global config.

This PR implements renderGeminiMCP to generate a session-specific settings.json in a scratch directory, and updates the catalog adapter to mirror the user's ~/.gemini (auth, history) into that scratch dir using the GEMINI_CONFIG_DIR environment variable.

- internal/catalog/mcp.go: implement renderGeminiMCP + stdioMCPServerSpec.
- internal/catalog/adapter.go: call renderGeminiMCP + implement mirrorGeminiHome.
- internal/catalog/mcp_test.go: add verification for Gemini settings output.

Verified: internal/catalog tests PASS.