### PR TITLE
fix(codex): preserve trust and auto-approve in spawned sessions

### DIFF
--- a/app/mobile/lib/features/sessions/spawn_session_sheet.dart
+++ b/app/mobile/lib/features/sessions/spawn_session_sheet.dart
@@ -26,7 +26,7 @@ const _claudeProviderId = 'claude';
 // (later wins in cobra parse).
 const Map<String, List<String>> _bypassFlagsByProvider = {
   'claude': ['--dangerously-skip-permissions'],
-  'codex': ['--ask-for-approval', 'never'],
+  'codex': ['--ask-for-approval', 'never', '-c', 'approval_policy="never"'],
   'gemini': ['--yolo'],
 };
 

--- a/app/web/src/components/sessions/SpawnDialog.tsx
+++ b/app/web/src/components/sessions/SpawnDialog.tsx
@@ -36,7 +36,7 @@ const HOME_HINT = '/Users/' // macOS-friendly default; user can edit.
 // table avoids importing config logic from the gateway side.
 const BYPASS_FLAGS: Record<string, string[]> = {
   claude: ['--dangerously-skip-permissions'],
-  codex: ['--ask-for-approval', 'never'],
+  codex: ['--ask-for-approval', 'never', '-c', 'approval_policy="never"'],
   gemini: ['--yolo'],
 }
 

--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -269,6 +270,11 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 	// manifest, which keeps spawn args reproducible across restarts.
 	configArgs, configEnv := applyConfigSchema(p.Manifest.ConfigSchema, p.Config)
 	args = append(args, configArgs...)
+	if p.Manifest.ID == "codex" {
+		if approval, ok := p.Config["approval"].(string); ok && approval != "" {
+			args = append(args, "-c", "approval_policy="+tomlString(approval))
+		}
+	}
 
 	info := session.ProviderInfo{
 		ID:         p.Manifest.ID,
@@ -527,6 +533,12 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 			}
 		}
 
+		if providerID == "codex" && out.Env["CODEX_HOME"] != "" {
+			if err := ensureCodexScratchTrust(out.Env["CODEX_HOME"], session.Cwd(prepareCtx)); err != nil {
+				return session.PrepareOutput{}, fmt.Errorf("prepare codex config: %w", err)
+			}
+		}
+
 		if len(out.Env) == 0 {
 			out.Env = nil
 		}
@@ -780,6 +792,33 @@ func mirrorCodexHome(src, dest string) error {
 		}
 	}
 	return nil
+}
+
+func ensureCodexScratchTrust(home, cwd string) error {
+	if home == "" || cwd == "" {
+		return nil
+	}
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		return err
+	}
+	path := filepath.Join(home, "config.toml")
+	bodyBytes, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		bodyBytes = []byte(codexBaseConfigForScratch())
+	}
+	body := string(bodyBytes)
+	projectHeader := "[projects." + tomlString(cwd) + "]"
+	if strings.Contains(body, projectHeader) {
+		return nil
+	}
+	if strings.TrimSpace(body) != "" {
+		body = strings.TrimRight(body, "\n") + "\n\n"
+	}
+	body += projectHeader + "\ntrust_level = \"trusted\"\n"
+	return os.WriteFile(path, []byte(body), 0o600)
 }
 
 // defaultStr returns def when s is empty after trimming, otherwise s.

--- a/internal/catalog/inject_test.go
+++ b/internal/catalog/inject_test.go
@@ -172,3 +172,30 @@ func TestInjectSessionID_FreshUUIDsAcrossSpawns(t *testing.T) {
 		t.Errorf("expected distinct UUIDs across spawns, got %q twice", out1.ClaudeSessionID)
 	}
 }
+
+func TestEnsureCodexScratchTrust_AppendsCurrentCwd(t *testing.T) {
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte(`model = "gpt-5.4"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd := "/Users/test/work with spaces"
+	if err := ensureCodexScratchTrust(home, cwd); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(home, "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	str := string(body)
+	if !strings.Contains(str, `model = "gpt-5.4"`) {
+		t.Errorf("base config missing: %s", str)
+	}
+	if !strings.Contains(str, `[projects."/Users/test/work with spaces"]`) {
+		t.Errorf("project trust header missing: %s", str)
+	}
+	if !strings.Contains(str, `trust_level = "trusted"`) {
+		t.Errorf("trust level missing: %s", str)
+	}
+}

--- a/internal/catalog/mcp.go
+++ b/internal/catalog/mcp.go
@@ -175,11 +175,32 @@ func renderCodexMCP(baseDir string, servers []MCPServer) ([]string, map[string]s
 		return nil, nil, fmt.Errorf("mkdir codex home: %w", err)
 	}
 	path := filepath.Join(home, "config.toml")
-	body := strings.Join(blocks, "\n\n") + "\n"
+	body := codexBaseConfigForScratch()
+	if strings.TrimSpace(body) != "" {
+		body = strings.TrimRight(body, "\n") + "\n\n"
+	}
+	body += strings.Join(blocks, "\n\n") + "\n"
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		return nil, nil, fmt.Errorf("write codex config: %w", err)
 	}
 	return nil, map[string]string{"CODEX_HOME": home}, nil
+}
+
+func codexBaseConfigForScratch() string {
+	home := os.Getenv("CODEX_HOME")
+	if home == "" {
+		if h, err := os.UserHomeDir(); err == nil {
+			home = filepath.Join(h, ".codex")
+		}
+	}
+	if home == "" {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(home, "config.toml"))
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }
 
 func codexServerBlock(s MCPServer) string {

--- a/internal/catalog/mcp_test.go
+++ b/internal/catalog/mcp_test.go
@@ -75,6 +75,7 @@ func TestRenderClaudeMCP_DropsInvalid(t *testing.T) {
 }
 
 func TestRenderCodexMCP_TomlOutput(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
 	dir := t.TempDir()
 	servers := []MCPServer{
 		{Name: "fs", Command: "npx", Args: []string{"-y", "server-fs"},
@@ -110,7 +111,41 @@ func TestRenderCodexMCP_TomlOutput(t *testing.T) {
 	}
 }
 
+func TestRenderCodexMCP_PreservesUserConfig(t *testing.T) {
+	userHome := t.TempDir()
+	t.Setenv("CODEX_HOME", userHome)
+	if err := os.WriteFile(filepath.Join(userHome, "config.toml"), []byte(`model = "gpt-5.4"
+
+[projects."/repo"]
+trust_level = "trusted"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, env, err := renderMCP("codex", t.TempDir(), []MCPServer{
+		{Name: "fs", Command: "npx"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(env["CODEX_HOME"], "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	str := string(body)
+	if !strings.Contains(str, `model = "gpt-5.4"`) {
+		t.Errorf("user model config missing: %s", str)
+	}
+	if !strings.Contains(str, `[projects."/repo"]`) {
+		t.Errorf("user project trust missing: %s", str)
+	}
+	if !strings.Contains(str, `[mcp_servers.fs]`) {
+		t.Errorf("mcp server missing: %s", str)
+	}
+}
+
 func TestRenderCodexMCP_SkipsNonStdio(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
 	dir := t.TempDir()
 	servers := []MCPServer{
 		{Name: "remote", Transport: "http", URL: "https://x"},


### PR DESCRIPTION
## Summary

Redirecting `CODEX_HOME` to a per-session scratch dir (MCP injection from #102) hides `~/.codex/config.toml` from the spawned codex process, so the user's `[projects.<cwd>]` trust entries vanish — codex re-prompts as if the project is untrusted. Spawn-time approval choices were also not being passed through to the CLI.

## Changes

- `internal/catalog/adapter.go` — `ensureCodexScratchTrust` seeds the scratch `config.toml` with the user's existing config and writes a `[projects.<cwd>]` trust block when missing; propagate the spawn config's `approval` value as `-c approval_policy=...`.
- `internal/catalog/mcp.go` — `codexBaseConfigForScratch` reads `~/.codex/config.toml` so `renderCodexMCP` can prepend it before the generated `[mcp_servers.*]` blocks.
- `internal/catalog/mcp_test.go` — hermetic `CODEX_HOME` via `t.Setenv`; add `TestRenderCodexMCP_PreservesUserConfig`.
- `internal/catalog/inject_test.go` — trust block coverage.
- `app/mobile/.../spawn_session_sheet.dart`, `app/web/.../SpawnDialog.tsx` — propagate approval choice via spawn UI.

## Test plan

- [x] `go test -race ./internal/catalog/... ./internal/session/...` — PASS locally
- [ ] CI green (Backend Go / Lint Go / Frontend web)
- [ ] Spawn a codex session in a trusted project; verify no untrusted-prompt re-appears
- [ ] Spawn with auto-approve selected; verify `approval_policy` flows through to the CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)