### PR TITLE
feat(web): i18n the Sessions page

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -60,6 +60,151 @@
       "signedInAs": "Signed in as",
       "tokenExpires": "Token expires",
       "signOut": "Sign out"
+    },
+    "sessions": {
+      "list": {
+        "title": "Sessions",
+        "countSeparator": "·",
+        "newAria": "Spawn new session",
+        "newTooltip": "New session",
+        "loading": "Loading…",
+        "emptyTitle": "No sessions yet.",
+        "emptyHint": "Press {kbd} to spawn.",
+        "endedHeader": "Ended ({count})",
+        "clearAll": "Clear all",
+        "confirmClearAll": "Remove all {count} ended sessions?",
+        "confirmTerminate": "Terminate and remove {name}?",
+        "childPromoted": " {count} child task session will be promoted to top-level.",
+        "childPromotedPlural": " {count} child task sessions will be promoted to top-level.",
+        "footer": "{live} live · {ended} ended",
+        "row": {
+          "deleteAria": "Delete session",
+          "titleRemoveHistory": "Remove from history",
+          "titleTerminate": "Terminate and remove",
+          "titleRemove": "Remove",
+          "claudeAccountTitle": "Claude account: {label}"
+        },
+        "deleteFailedToast": "Delete failed"
+      },
+      "tabs": {
+        "closeAria": "Close tab and remove session",
+        "closeTitle": "Close tab and remove session"
+      },
+      "page": {
+        "removedToast": "Session removed",
+        "removeFailedToast": "Remove failed",
+        "stoppedToast": "Session stopped",
+        "stopFailedToast": "Stop failed",
+        "restartedToast": "Session restarted",
+        "restartFailedToast": "Restart failed",
+        "confirmCloseTabTitle": "Stop and remove \"{name}\"?",
+        "confirmCloseTabDescription": "The CLI process will be terminated and the row deleted.",
+        "confirmCloseTabConfirm": "Stop and remove",
+        "confirmRemoveTitle": "Remove {name}?",
+        "confirmRemoveTitleFallback": "Remove session?",
+        "confirmRemoveDescription": "This deletes the row.",
+        "confirmRemoveConfirm": "Remove"
+      },
+      "empty": {
+        "title": "No session open",
+        "hint": "Pick a session from the list, or spawn a new one. Keyboard: {kbdN} new, {kbdW} close, {kbdRange} switch.",
+        "spawn": "Spawn session"
+      },
+      "header": {
+        "loadingSession": "Loading session…",
+        "showList": "Show session list",
+        "hideList": "Hide session list",
+        "showInspector": "Show inspector",
+        "hideInspector": "Hide inspector",
+        "showKeyboard": "Show on-screen keys",
+        "hideKeyboard": "Hide on-screen keys",
+        "showKeyboardTooltip": "Show on-screen keys (ESC, TAB, ↑↓, ⌃C…)",
+        "restart": "Restart",
+        "restarting": "Restarting…",
+        "remove": "Remove",
+        "removing": "Removing…",
+        "stop": "Stop",
+        "stopping": "Stopping…",
+        "pid": "pid {pid}"
+      },
+      "spawn": {
+        "title": "Spawn session",
+        "description": "Start a CLI session under a registered provider.",
+        "provider": "Provider",
+        "claudeAccount": "Claude account",
+        "loadingAccounts": "Loading accounts…",
+        "noAccounts": "No Claude accounts configured — the gateway will use the system ANTHROPIC_API_KEY.",
+        "default": "Default",
+        "defaultTooltip": "Use system keychain / env",
+        "tokenEmptyBadge": "·empty",
+        "tokenMissingTooltip": "No token set — set token in Providers panel first",
+        "multiAccountHint": "Multiple accounts configured — pick one for this session.",
+        "cwd": "Working directory",
+        "cwdPlaceholder": "/Users/you/projects/foo",
+        "browse": "Browse",
+        "nameLabel": "Name (optional)",
+        "namePlaceholder": "claude in pet-tracker",
+        "argsLabel": "CLI args (one per line)",
+        "bypassClaude": "Bypass permission prompts",
+        "bypassCodex": "Auto-approve (--ask-for-approval never)",
+        "bypassGemini": "YOLO mode (--yolo)",
+        "bypassOnHint": "This session will run with elevated autonomy.",
+        "bypassOffHint": "Off — confirmations and prompts behave normally.",
+        "errorPickProvider": "Pick a provider.",
+        "errorCwdRequired": "cwd is required.",
+        "cancel": "Cancel",
+        "submit": "Spawn",
+        "submitting": "Spawning…",
+        "spawnedToast": "Session spawned",
+        "spawnedDescription": "{provider} · pid {pid}",
+        "pidFallback": "—"
+      },
+      "accountSwitcher": {
+        "tooltip": "Switch Claude account (restarts the CLI process)",
+        "currentDefault": "default",
+        "menuTitle": "Switch Claude account",
+        "defaultName": "Default",
+        "defaultSubtitle": "CLI's system keychain / env",
+        "tokenEmpty": "·empty",
+        "confirmSwitch": "Switching account will restart the Claude CLI process. In-progress conversation state inside the CLI will be lost. Continue?",
+        "switchedToast": "Account switched",
+        "switchedDescription": "Now using @{account} · pid {pid}",
+        "switchedDefault": "default",
+        "switchFailedToast": "Switch failed"
+      },
+      "inspector": {
+        "tabs": {
+          "files": "Files",
+          "git": "Git",
+          "search": "Search",
+          "tasks": "Tasks",
+          "history": "History",
+          "notes": "Notes",
+          "memory": "Memory"
+        }
+      },
+      "ended": {
+        "bufferUnavailable": "[buffer unavailable]",
+        "readOnlyBanner": "[session ended — read-only buffer]"
+      },
+      "fileBrowser": {
+        "title": "Choose working directory",
+        "description": "Browse the gateway host's filesystem and pick a folder.",
+        "parent": "Parent directory",
+        "home": "Home directory",
+        "refresh": "Refresh",
+        "pathPlaceholder": "/Users/you/projects",
+        "loading": "Loading…",
+        "empty": "Empty directory.",
+        "newFolder": "New folder",
+        "newFolderPlaceholder": "new-folder-name",
+        "create": "Create",
+        "cancel": "Cancel",
+        "useThisFolder": "Use this folder",
+        "createdToast": "Directory created",
+        "mkdirFailedToast": "Mkdir failed",
+        "homeFailedToast": "Failed to read home"
+      }
     }
   },
   "more": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -60,6 +60,151 @@
       "signedInAs": "登录账号",
       "tokenExpires": "令牌到期",
       "signOut": "退出登录"
+    },
+    "sessions": {
+      "list": {
+        "title": "会话",
+        "countSeparator": "·",
+        "newAria": "创建新会话",
+        "newTooltip": "新建会话",
+        "loading": "加载中…",
+        "emptyTitle": "暂无会话。",
+        "emptyHint": "按 {kbd} 创建。",
+        "endedHeader": "已结束 ({count})",
+        "clearAll": "清空全部",
+        "confirmClearAll": "确定移除全部 {count} 个已结束的会话?",
+        "confirmTerminate": "终止并移除 {name}?",
+        "childPromoted": "其 {count} 个子任务会话将被提升为顶级。",
+        "childPromotedPlural": "其 {count} 个子任务会话将被提升为顶级。",
+        "footer": "{live} 运行中 · {ended} 已结束",
+        "row": {
+          "deleteAria": "删除会话",
+          "titleRemoveHistory": "从历史中移除",
+          "titleTerminate": "终止并移除",
+          "titleRemove": "移除",
+          "claudeAccountTitle": "Claude 账号：{label}"
+        },
+        "deleteFailedToast": "删除失败"
+      },
+      "tabs": {
+        "closeAria": "关闭标签并移除会话",
+        "closeTitle": "关闭标签并移除会话"
+      },
+      "page": {
+        "removedToast": "会话已移除",
+        "removeFailedToast": "移除失败",
+        "stoppedToast": "会话已停止",
+        "stopFailedToast": "停止失败",
+        "restartedToast": "会话已重启",
+        "restartFailedToast": "重启失败",
+        "confirmCloseTabTitle": "停止并移除 \"{name}\"?",
+        "confirmCloseTabDescription": "CLI 进程将被终止并删除该记录。",
+        "confirmCloseTabConfirm": "停止并移除",
+        "confirmRemoveTitle": "移除 {name}?",
+        "confirmRemoveTitleFallback": "移除会话?",
+        "confirmRemoveDescription": "这将删除该记录。",
+        "confirmRemoveConfirm": "移除"
+      },
+      "empty": {
+        "title": "未打开任何会话",
+        "hint": "从列表中挑选一个会话，或新建一个。快捷键：{kbdN} 新建，{kbdW} 关闭，{kbdRange} 切换。",
+        "spawn": "创建会话"
+      },
+      "header": {
+        "loadingSession": "正在加载会话…",
+        "showList": "显示会话列表",
+        "hideList": "隐藏会话列表",
+        "showInspector": "显示检查器",
+        "hideInspector": "隐藏检查器",
+        "showKeyboard": "显示屏幕键盘",
+        "hideKeyboard": "隐藏屏幕键盘",
+        "showKeyboardTooltip": "显示屏幕键盘 (ESC、TAB、↑↓、⌃C…)",
+        "restart": "重启",
+        "restarting": "重启中…",
+        "remove": "移除",
+        "removing": "移除中…",
+        "stop": "停止",
+        "stopping": "停止中…",
+        "pid": "pid {pid}"
+      },
+      "spawn": {
+        "title": "创建会话",
+        "description": "在已注册的 Provider 下启动一个 CLI 会话。",
+        "provider": "Provider",
+        "claudeAccount": "Claude 账号",
+        "loadingAccounts": "正在加载账号…",
+        "noAccounts": "尚未配置 Claude 账号 — 网关将使用系统的 ANTHROPIC_API_KEY。",
+        "default": "默认",
+        "defaultTooltip": "使用系统 keychain / 环境变量",
+        "tokenEmptyBadge": "·未填",
+        "tokenMissingTooltip": "未设置 token — 请先在 Providers 面板中填入",
+        "multiAccountHint": "已配置多个账号 — 请为本次会话挑选一个。",
+        "cwd": "工作目录",
+        "cwdPlaceholder": "/Users/you/projects/foo",
+        "browse": "浏览",
+        "nameLabel": "名称（可选）",
+        "namePlaceholder": "claude in pet-tracker",
+        "argsLabel": "CLI 参数（每行一个）",
+        "bypassClaude": "跳过权限提示",
+        "bypassCodex": "自动批准 (--ask-for-approval never)",
+        "bypassGemini": "YOLO 模式 (--yolo)",
+        "bypassOnHint": "本次会话将以更高的自主权运行。",
+        "bypassOffHint": "关闭 — 确认与提示按正常流程处理。",
+        "errorPickProvider": "请选择一个 Provider。",
+        "errorCwdRequired": "请填写工作目录。",
+        "cancel": "取消",
+        "submit": "创建",
+        "submitting": "创建中…",
+        "spawnedToast": "会话已创建",
+        "spawnedDescription": "{provider} · pid {pid}",
+        "pidFallback": "—"
+      },
+      "accountSwitcher": {
+        "tooltip": "切换 Claude 账号（将重启 CLI 进程）",
+        "currentDefault": "默认",
+        "menuTitle": "切换 Claude 账号",
+        "defaultName": "默认",
+        "defaultSubtitle": "CLI 的系统 keychain / 环境变量",
+        "tokenEmpty": "·未填",
+        "confirmSwitch": "切换账号将重启 Claude CLI 进程。CLI 内部进行中的对话状态将丢失。继续？",
+        "switchedToast": "账号已切换",
+        "switchedDescription": "当前使用 @{account} · pid {pid}",
+        "switchedDefault": "默认",
+        "switchFailedToast": "切换失败"
+      },
+      "inspector": {
+        "tabs": {
+          "files": "文件",
+          "git": "Git",
+          "search": "搜索",
+          "tasks": "任务",
+          "history": "历史",
+          "notes": "笔记",
+          "memory": "记忆"
+        }
+      },
+      "ended": {
+        "bufferUnavailable": "[缓冲区不可用]",
+        "readOnlyBanner": "[会话已结束 — 只读缓冲区]"
+      },
+      "fileBrowser": {
+        "title": "选择工作目录",
+        "description": "浏览网关主机的文件系统并选择一个文件夹。",
+        "parent": "上级目录",
+        "home": "家目录",
+        "refresh": "刷新",
+        "pathPlaceholder": "/Users/you/projects",
+        "loading": "加载中…",
+        "empty": "目录为空。",
+        "newFolder": "新建文件夹",
+        "newFolderPlaceholder": "new-folder-name",
+        "create": "创建",
+        "cancel": "取消",
+        "useThisFolder": "使用此文件夹",
+        "createdToast": "文件夹已创建",
+        "mkdirFailedToast": "创建失败",
+        "homeFailedToast": "读取家目录失败"
+      }
     }
   },
   "more": {

--- a/app/web/src/components/sessions/AccountSwitcher.tsx
+++ b/app/web/src/components/sessions/AccountSwitcher.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Check, ChevronDown, Loader2, UserRound } from 'lucide-react'
 import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -27,6 +28,7 @@ interface AccountSwitcherProps {
 // lost (the underlying process is replaced), so the dropdown shows a
 // confirm prompt before firing.
 export function AccountSwitcher({ session }: AccountSwitcherProps) {
+  const { t } = useTranslation()
   const qc = useQueryClient()
   const { data: accounts } = useQuery({
     queryKey: ['claude-accounts'],
@@ -37,34 +39,33 @@ export function AccountSwitcher({ session }: AccountSwitcherProps) {
   const current = (accounts ?? []).find((a) => a.id === session.claude_account_id)
   const currentLabel = session.claude_account_id
     ? current?.display_name || current?.name || session.claude_account_id
-    : 'default'
+    : t('web.sessions.accountSwitcher.currentDefault')
 
   const mutation = useMutation({
     mutationFn: (accountId: string) =>
       switchClaudeAccount(session.id, accountId),
     onSuccess: (next) => {
       qc.invalidateQueries({ queryKey: ['sessions'] })
-      toast.success('Account switched', {
-        description: `Now using @${
+      const account = next.claude_account_id
+        ? enabled.find((a) => a.id === next.claude_account_id)?.display_name ||
           next.claude_account_id
-            ? enabled.find((a) => a.id === next.claude_account_id)?.display_name
-              || next.claude_account_id
-            : 'default'
-        } · pid ${next.pid ?? '—'}`,
+        : t('web.sessions.accountSwitcher.switchedDefault')
+      toast.success(t('web.sessions.accountSwitcher.switchedToast'), {
+        description: t('web.sessions.accountSwitcher.switchedDescription', {
+          account,
+          pid: next.pid ?? '—',
+        }),
       })
     },
     onError: (err: Error) =>
-      toast.error('Switch failed', { description: err.message }),
+      toast.error(t('web.sessions.accountSwitcher.switchFailedToast'), {
+        description: err.message,
+      }),
   })
 
   const pick = (accountId: string) => {
     if (accountId === (session.claude_account_id ?? '')) return
-    if (
-      !confirm(
-        'Switching account will restart the Claude CLI process. ' +
-          'In-progress conversation state inside the CLI will be lost. Continue?',
-      )
-    ) {
+    if (!confirm(t('web.sessions.accountSwitcher.confirmSwitch'))) {
       return
     }
     mutation.mutate(accountId)
@@ -78,7 +79,7 @@ export function AccountSwitcher({ session }: AccountSwitcherProps) {
           size="sm"
           disabled={mutation.isPending}
           className="text-[11px] gap-1 hover:text-foreground"
-          title="Switch Claude account (restarts the CLI process)"
+          title={t('web.sessions.accountSwitcher.tooltip')}
         >
           {mutation.isPending ? (
             <Loader2 className="size-3 animate-spin" />
@@ -91,7 +92,7 @@ export function AccountSwitcher({ session }: AccountSwitcherProps) {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-[220px]">
         <DropdownMenuLabel className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
-          Switch Claude account
+          {t('web.sessions.accountSwitcher.menuTitle')}
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuItem
@@ -108,9 +109,11 @@ export function AccountSwitcher({ session }: AccountSwitcherProps) {
             )}
           />
           <div className="flex flex-col flex-1 min-w-0">
-            <span className="text-[12px]">Default</span>
+            <span className="text-[12px]">
+              {t('web.sessions.accountSwitcher.defaultName')}
+            </span>
             <span className="text-[10px] text-muted-foreground">
-              CLI's system keychain / env
+              {t('web.sessions.accountSwitcher.defaultSubtitle')}
             </span>
           </div>
         </DropdownMenuItem>
@@ -140,7 +143,9 @@ export function AccountSwitcher({ session }: AccountSwitcherProps) {
                 <span className="text-[10px] text-muted-foreground truncate">
                   {a.config_dir || a.name}
                   {!a.token_filled && (
-                    <span className="ml-1 text-amber-500/90">·empty</span>
+                    <span className="ml-1 text-amber-500/90">
+                      {t('web.sessions.accountSwitcher.tokenEmpty')}
+                    </span>
                   )}
                 </span>
               </div>

--- a/app/web/src/components/sessions/EndedSessionView.tsx
+++ b/app/web/src/components/sessions/EndedSessionView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react'
 import { Terminal as XTerm } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
+import { useTranslation } from 'react-i18next'
 
 import { api } from '@/lib/api'
 import { useTheme } from '@/stores/theme'
@@ -49,6 +50,7 @@ function buildTheme(applied: 'light' | 'dark') {
  * the workbench tries to stream a process that has already exited.
  */
 export function EndedSessionView({ sessionId }: EndedSessionViewProps) {
+  const { t } = useTranslation()
   const containerRef = useRef<HTMLDivElement>(null)
   const xtermRef = useRef<XTerm | null>(null)
   const fitRef = useRef<FitAddon | null>(null)
@@ -88,13 +90,13 @@ export function EndedSessionView({ sessionId }: EndedSessionViewProps) {
       })
       .catch(() => {
         if (!cancelled) {
-          term.writeln('\x1b[31m[buffer unavailable]\x1b[0m')
+          term.writeln(`\x1b[31m${t('web.sessions.ended.bufferUnavailable')}\x1b[0m`)
         }
       })
       .finally(() => {
         if (!cancelled) {
           term.writeln('')
-          term.writeln('\x1b[33m[session ended — read-only buffer]\x1b[0m')
+          term.writeln(`\x1b[33m${t('web.sessions.ended.readOnlyBanner')}\x1b[0m`)
         }
       })
 
@@ -114,7 +116,7 @@ export function EndedSessionView({ sessionId }: EndedSessionViewProps) {
       xtermRef.current = null
       fitRef.current = null
     }
-  }, [sessionId, themeApplied])
+  }, [sessionId, themeApplied, t])
 
   return (
     <div className="h-full w-full bg-background">

--- a/app/web/src/components/sessions/FileBrowserDialog.tsx
+++ b/app/web/src/components/sessions/FileBrowserDialog.tsx
@@ -10,6 +10,7 @@ import {
   RefreshCw,
 } from 'lucide-react'
 import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
 
 import {
   Dialog,
@@ -38,6 +39,7 @@ export function FileBrowserDialog({
   initialPath,
   onSelect,
 }: FileBrowserDialogProps) {
+  const { t } = useTranslation()
   const qc = useQueryClient()
   const [path, setPath] = useState<string>(initialPath ?? '')
   const [pathInput, setPathInput] = useState<string>(initialPath ?? '')
@@ -88,14 +90,16 @@ export function FileBrowserDialog({
     mutationFn: () => makeDir(path, newName.trim()),
     onSuccess: (created) => {
       qc.invalidateQueries({ queryKey: ['fs', path] })
-      toast.success('Directory created')
+      toast.success(t('web.sessions.fileBrowser.createdToast'))
       setNewName('')
       setShowMkdir(false)
       // Step into the new directory.
       setPath(created)
     },
     onError: (e: Error) =>
-      toast.error('Mkdir failed', { description: e.message }),
+      toast.error(t('web.sessions.fileBrowser.mkdirFailedToast'), {
+        description: e.message,
+      }),
   })
 
   const goHome = async () => {
@@ -103,7 +107,7 @@ export function FileBrowserDialog({
       const home = await getHomeDir()
       setPath(home)
     } catch (e) {
-      toast.error('Failed to read home', {
+      toast.error(t('web.sessions.fileBrowser.homeFailedToast'), {
         description: (e as Error).message,
       })
     }
@@ -120,9 +124,9 @@ export function FileBrowserDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-[640px]">
         <DialogHeader>
-          <DialogTitle>Choose working directory</DialogTitle>
+          <DialogTitle>{t('web.sessions.fileBrowser.title')}</DialogTitle>
           <DialogDescription>
-            Browse the gateway host's filesystem and pick a folder.
+            {t('web.sessions.fileBrowser.description')}
           </DialogDescription>
         </DialogHeader>
 
@@ -137,12 +141,14 @@ export function FileBrowserDialog({
                   if (list.data?.parent) setPath(list.data.parent)
                 }}
                 disabled={!list.data?.parent}
-                aria-label="Parent directory"
+                aria-label={t('web.sessions.fileBrowser.parent')}
               >
                 <ArrowUp className="size-3.5" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Parent directory</TooltipContent>
+            <TooltipContent>
+              {t('web.sessions.fileBrowser.parent')}
+            </TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -151,12 +157,14 @@ export function FileBrowserDialog({
                 size="icon"
                 className="size-7"
                 onClick={goHome}
-                aria-label="Home directory"
+                aria-label={t('web.sessions.fileBrowser.home')}
               >
                 <Home className="size-3.5" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Home directory</TooltipContent>
+            <TooltipContent>
+              {t('web.sessions.fileBrowser.home')}
+            </TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -167,12 +175,14 @@ export function FileBrowserDialog({
                 onClick={() =>
                   qc.invalidateQueries({ queryKey: ['fs', path] })
                 }
-                aria-label="Refresh"
+                aria-label={t('web.sessions.fileBrowser.refresh')}
               >
                 <RefreshCw className="size-3.5" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Refresh</TooltipContent>
+            <TooltipContent>
+              {t('web.sessions.fileBrowser.refresh')}
+            </TooltipContent>
           </Tooltip>
           <Input
             value={pathInput}
@@ -183,7 +193,7 @@ export function FileBrowserDialog({
                 setPath(pathInput.trim())
               }
             }}
-            placeholder="/Users/you/projects"
+            placeholder={t('web.sessions.fileBrowser.pathPlaceholder')}
             className="flex-1 font-mono text-[12px]"
           />
         </div>
@@ -193,7 +203,7 @@ export function FileBrowserDialog({
             {list.isLoading ? (
               <div className="flex items-center gap-2 p-3 text-[12px] text-muted-foreground">
                 <Loader2 className="size-3.5 animate-spin" />
-                Loading…
+                {t('web.sessions.fileBrowser.loading')}
               </div>
             ) : list.error ? (
               <div className="p-3 text-[12px] text-destructive">
@@ -201,7 +211,7 @@ export function FileBrowserDialog({
               </div>
             ) : (list.data?.entries ?? []).length === 0 ? (
               <div className="p-3 text-[12px] text-muted-foreground italic">
-                Empty directory.
+                {t('web.sessions.fileBrowser.empty')}
               </div>
             ) : (
               <ul className="py-1">
@@ -237,7 +247,7 @@ export function FileBrowserDialog({
                 }
                 if (e.key === 'Escape') setShowMkdir(false)
               }}
-              placeholder="new-folder-name"
+              placeholder={t('web.sessions.fileBrowser.newFolderPlaceholder')}
               className="flex-1 text-[12px]"
             />
             <Button
@@ -251,7 +261,7 @@ export function FileBrowserDialog({
               ) : (
                 <Check className="size-3.5" />
               )}
-              Create
+              {t('web.sessions.fileBrowser.create')}
             </Button>
             <Button
               variant="ghost"
@@ -259,7 +269,7 @@ export function FileBrowserDialog({
               onClick={() => setShowMkdir(false)}
               disabled={mkdir.isPending}
             >
-              Cancel
+              {t('web.sessions.fileBrowser.cancel')}
             </Button>
           </div>
         ) : (
@@ -270,7 +280,7 @@ export function FileBrowserDialog({
             className="self-start text-[11px] gap-1"
           >
             <FolderPlus className="size-3.5" />
-            New folder
+            {t('web.sessions.fileBrowser.newFolder')}
           </Button>
         )}
 
@@ -281,7 +291,7 @@ export function FileBrowserDialog({
             size="sm"
             onClick={() => onOpenChange(false)}
           >
-            Cancel
+            {t('web.sessions.fileBrowser.cancel')}
           </Button>
           <Button
             type="button"
@@ -290,7 +300,7 @@ export function FileBrowserDialog({
             onClick={handleSelect}
             disabled={!pathInput.trim()}
           >
-            Use this folder
+            {t('web.sessions.fileBrowser.useThisFolder')}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/app/web/src/components/sessions/InspectorPanel.tsx
+++ b/app/web/src/components/sessions/InspectorPanel.tsx
@@ -7,6 +7,7 @@ import {
   NotebookPen,
   History as HistoryIcon,
 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
@@ -27,6 +28,7 @@ interface InspectorPanelProps {
 // InspectorPanel — right-hand workbench sidebar. All four tabs are
 // scoped to the current session's working directory.
 export function InspectorPanel({ session }: InspectorPanelProps) {
+  const { t } = useTranslation()
   return (
     <aside className="w-80 shrink-0 border-l border-border bg-background flex flex-col">
       <Tabs defaultValue="files" className="flex-1 flex flex-col min-h-0">
@@ -41,49 +43,49 @@ export function InspectorPanel({ session }: InspectorPanelProps) {
               className="flex items-center justify-center gap-1.5 data-[state=active]:bg-card"
             >
               <Folder className="size-3" />
-              Files
+              {t('web.sessions.inspector.tabs.files')}
             </TabsTrigger>
             <TabsTrigger
               value="git"
               className="flex items-center justify-center gap-1.5 data-[state=active]:bg-card"
             >
               <GitBranch className="size-3" />
-              Git
+              {t('web.sessions.inspector.tabs.git')}
             </TabsTrigger>
             <TabsTrigger
               value="search"
               className="flex items-center justify-center gap-1.5 data-[state=active]:bg-card"
             >
               <Search className="size-3" />
-              Search
+              {t('web.sessions.inspector.tabs.search')}
             </TabsTrigger>
             <TabsTrigger
               value="tasks"
               className="flex items-center justify-center gap-1.5 data-[state=active]:bg-card"
             >
               <Play className="size-3" />
-              Tasks
+              {t('web.sessions.inspector.tabs.tasks')}
             </TabsTrigger>
             <TabsTrigger
               value="history"
               className="flex items-center justify-center gap-1.5 col-span-2 data-[state=active]:bg-card"
             >
               <HistoryIcon className="size-3" />
-              History
+              {t('web.sessions.inspector.tabs.history')}
             </TabsTrigger>
             <TabsTrigger
               value="notes"
               className="flex items-center justify-center gap-1.5 col-span-2 data-[state=active]:bg-card"
             >
               <NotebookPen className="size-3" />
-              Notes
+              {t('web.sessions.inspector.tabs.notes')}
             </TabsTrigger>
             <TabsTrigger
               value="memory"
               className="flex items-center justify-center gap-1.5 col-span-4 data-[state=active]:bg-card"
             >
               <Brain className="size-3" />
-              Memory
+              {t('web.sessions.inspector.tabs.memory')}
             </TabsTrigger>
           </TabsList>
         </div>

--- a/app/web/src/components/sessions/SessionList.tsx
+++ b/app/web/src/components/sessions/SessionList.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Plus, Loader2, X, CornerDownRight } from 'lucide-react'
 import { toast } from 'sonner'
+import { Trans, useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -56,6 +57,7 @@ function buildTree(sessions: Session[]) {
 }
 
 export function SessionList({ onSpawn, onOpen }: SessionListProps) {
+  const { t } = useTranslation()
   const qc = useQueryClient()
   const { data: sessions, isLoading } = useQuery({
     queryKey: ['sessions'],
@@ -72,7 +74,8 @@ export function SessionList({ onSpawn, onOpen }: SessionListProps) {
   )
   const labelFor = (s: Session): string | undefined => {
     if (s.provider_id !== 'claude') return undefined
-    if (!s.claude_account_id) return 'default'
+    if (!s.claude_account_id)
+      return t('web.sessions.accountSwitcher.currentDefault')
     return accountById.get(s.claude_account_id) ?? s.claude_account_id
   }
 
@@ -94,7 +97,9 @@ export function SessionList({ onSpawn, onOpen }: SessionListProps) {
       qc.invalidateQueries({ queryKey: ['sessions'] })
     },
     onError: (err: Error) =>
-      toast.error('Delete failed', { description: err.message }),
+      toast.error(t('web.sessions.list.deleteFailedToast'), {
+        description: err.message,
+      }),
   })
 
   const handleDelete = (s: Session) => {
@@ -102,11 +107,18 @@ export function SessionList({ onSpawn, onOpen }: SessionListProps) {
       const childCount = childrenOf.get(s.id)?.length ?? 0
       const childNote =
         childCount > 0
-          ? ` ${childCount} child task session${childCount === 1 ? '' : 's'} will be promoted to top-level.`
+          ? t(
+              childCount === 1
+                ? 'web.sessions.list.childPromoted'
+                : 'web.sessions.list.childPromotedPlural',
+              { count: childCount },
+            )
           : ''
       if (
         !confirm(
-          `Terminate and remove ${s.name || s.provider_id}?${childNote}`,
+          t('web.sessions.list.confirmTerminate', {
+            name: s.name || s.provider_id,
+          }) + childNote,
         )
       ) {
         return
@@ -144,7 +156,7 @@ export function SessionList({ onSpawn, onOpen }: SessionListProps) {
       <div className="h-14 px-3 flex items-center justify-between border-b border-border">
         <div className="flex items-baseline gap-1.5">
           <span className="text-[11px] font-semibold tracking-[0.12em] uppercase text-muted-foreground">
-            Sessions
+            {t('web.sessions.list.title')}
           </span>
           <span className="text-[11px] text-muted-foreground/60 font-mono">
             · {all.length}
@@ -156,14 +168,15 @@ export function SessionList({ onSpawn, onOpen }: SessionListProps) {
               variant="ghost"
               size="icon"
               onClick={onSpawn}
-              aria-label="Spawn new session"
+              aria-label={t('web.sessions.list.newAria')}
               className="size-6"
             >
               <Plus className="size-3.5" />
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            New session <kbd className="ml-1">⌘N</kbd>
+            {t('web.sessions.list.newTooltip')}{' '}
+            <kbd className="ml-1">⌘N</kbd>
           </TooltipContent>
         </Tooltip>
       </div>
@@ -173,14 +186,18 @@ export function SessionList({ onSpawn, onOpen }: SessionListProps) {
           {isLoading && (
             <div className="flex items-center gap-2 px-2 py-3 text-[12px] text-muted-foreground">
               <Loader2 className="size-3.5 animate-spin" />
-              Loading…
+              {t('web.sessions.list.loading')}
             </div>
           )}
           {!isLoading && all.length === 0 && (
             <div className="px-3 py-6 text-center text-[12px] text-muted-foreground">
-              No sessions yet.
+              {t('web.sessions.list.emptyTitle')}
               <br />
-              Press <kbd>⌘N</kbd> to spawn.
+              <Trans
+                i18nKey="web.sessions.list.emptyHint"
+                values={{ kbd: '⌘N' }}
+                components={{ 0: <kbd /> }}
+              />
             </div>
           )}
 
@@ -189,13 +206,19 @@ export function SessionList({ onSpawn, onOpen }: SessionListProps) {
           {endedTops.length > 0 && (
             <div className="px-2 py-1.5 mt-1 flex items-center justify-between gap-2">
               <span className="text-[10px] uppercase tracking-wider text-muted-foreground/60">
-                Ended ({endedCount})
+                {t('web.sessions.list.endedHeader', { count: endedCount })}
               </span>
               {endedCount > 1 && (
                 <button
                   type="button"
                   onClick={() => {
-                    if (!confirm(`Remove all ${endedCount} ended sessions?`))
+                    if (
+                      !confirm(
+                        t('web.sessions.list.confirmClearAll', {
+                          count: endedCount,
+                        }),
+                      )
+                    )
                       return
                     // Remove children first to keep parent_session_id
                     // FK happy, then parents.
@@ -209,7 +232,7 @@ export function SessionList({ onSpawn, onOpen }: SessionListProps) {
                   }}
                   className="text-[10px] text-muted-foreground/70 hover:text-destructive transition-colors"
                 >
-                  Clear all
+                  {t('web.sessions.list.clearAll')}
                 </button>
               )}
             </div>
@@ -219,7 +242,7 @@ export function SessionList({ onSpawn, onOpen }: SessionListProps) {
       </ScrollArea>
 
       <div className="px-3 py-2 border-t border-border text-[10px] text-muted-foreground/60 font-mono">
-        {liveCount} live · {endedCount} ended
+        {t('web.sessions.list.footer', { live: liveCount, ended: endedCount })}
       </div>
     </aside>
   )
@@ -237,6 +260,7 @@ interface ChildRowProps {
 // project's grouping visible without taking the full vertical real estate
 // of a top-level row.
 function ChildRow({ session, active, onClick, onDelete }: ChildRowProps) {
+  const { t } = useTranslation()
   const visual = providerVisual(session.provider_id)
   const dot =
     session.state === 'running'
@@ -246,6 +270,10 @@ function ChildRow({ session, active, onClick, onDelete }: ChildRowProps) {
         : session.exit_code != null && session.exit_code !== 0
           ? 'bg-state-failed'
           : 'bg-muted-foreground/60'
+  const deleteTitle =
+    session.state === 'ended' || session.state === 'stopped'
+      ? t('web.sessions.list.row.titleRemove')
+      : t('web.sessions.list.row.titleTerminate')
   return (
     <div
       role="button"
@@ -289,12 +317,8 @@ function ChildRow({ session, active, onClick, onDelete }: ChildRowProps) {
           e.stopPropagation()
           onDelete()
         }}
-        aria-label="Delete session"
-        title={
-          session.state === 'ended' || session.state === 'stopped'
-            ? 'Remove'
-            : 'Terminate and remove'
-        }
+        aria-label={t('web.sessions.list.row.deleteAria')}
+        title={deleteTitle}
         className={cn(
           'size-4 rounded-sm flex items-center justify-center shrink-0',
           'text-muted-foreground/40 hover:text-destructive hover:bg-destructive/10',

--- a/app/web/src/components/sessions/SessionRow.tsx
+++ b/app/web/src/components/sessions/SessionRow.tsx
@@ -1,5 +1,6 @@
 import { formatDistanceToNow } from 'date-fns'
 import { X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 import { cn } from '@/lib/utils'
 import { providerVisual, cwdTail } from '@/lib/providers'
@@ -48,10 +49,14 @@ export function SessionRow({
   onDelete,
   accountLabel,
 }: SessionRowProps) {
+  const { t } = useTranslation()
   const visual = providerVisual(session.provider_id)
   const isClaude = session.provider_id === 'claude'
   const acct = isClaude
-    ? accountLabel ?? (session.claude_account_id ? '…' : 'default')
+    ? accountLabel ??
+      (session.claude_account_id
+        ? '…'
+        : t('web.sessions.accountSwitcher.currentDefault'))
     : null
 
   return (
@@ -103,7 +108,9 @@ export function SessionRow({
           {acct && (
             <span
               className="ml-auto shrink-0 text-[10px] font-mono px-1.5 py-px rounded bg-card border border-border/60 text-muted-foreground/80"
-              title={`Claude account: ${acct}`}
+              title={t('web.sessions.list.row.claudeAccountTitle', {
+                label: acct,
+              })}
             >
               @{acct}
             </span>
@@ -118,11 +125,11 @@ export function SessionRow({
             e.stopPropagation()
             onDelete()
           }}
-          aria-label="Delete session"
+          aria-label={t('web.sessions.list.row.deleteAria')}
           title={
             session.state === 'ended' || session.state === 'stopped'
-              ? 'Remove from history'
-              : 'Terminate and remove'
+              ? t('web.sessions.list.row.titleRemoveHistory')
+              : t('web.sessions.list.row.titleTerminate')
           }
           className={cn(
             'absolute top-2 right-2 size-5 rounded-sm flex items-center justify-center',

--- a/app/web/src/components/sessions/SessionTabs.tsx
+++ b/app/web/src/components/sessions/SessionTabs.tsx
@@ -1,4 +1,5 @@
 import { X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 import { cn } from '@/lib/utils'
 import { useSessionTabs } from '@/stores/sessionTabs'
@@ -11,6 +12,7 @@ interface SessionTabsProps {
 }
 
 export function SessionTabs({ onCloseTab }: SessionTabsProps) {
+  const { t } = useTranslation()
   const tabs = useSessionTabs((s) => s.tabs)
   const currentId = useSessionTabs((s) => s.currentId)
   const setCurrent = useSessionTabs((s) => s.setCurrent)
@@ -51,8 +53,8 @@ export function SessionTabs({ onCloseTab }: SessionTabsProps) {
                 onCloseTab(tab.id)
               }}
               className="opacity-0 group-hover:opacity-100 hover:bg-border rounded-sm p-0.5 transition-opacity"
-              aria-label="Close tab and remove session"
-              title="Close tab and remove session"
+              aria-label={t('web.sessions.tabs.closeAria')}
+              title={t('web.sessions.tabs.closeTitle')}
             >
               <X className="size-3" />
             </button>

--- a/app/web/src/components/sessions/SpawnDialog.tsx
+++ b/app/web/src/components/sessions/SpawnDialog.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, type FormEvent } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { FolderOpen, Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
 
 import {
   Dialog,
@@ -40,13 +41,13 @@ const BYPASS_FLAGS: Record<string, string[]> = {
   gemini: ['--yolo'],
 }
 
-// Display label for the bypass toggle. Different CLIs use
-// different vocabulary; pretending they're all "Auto-approve"
+// i18n key suffix per provider for the bypass toggle label. Different
+// CLIs use different vocabulary; pretending they're all "Auto-approve"
 // would confuse operators who only know their tool's term.
-const BYPASS_LABEL: Record<string, string> = {
-  claude: 'Bypass permission prompts',
-  codex: 'Auto-approve (--ask-for-approval never)',
-  gemini: 'YOLO mode (--yolo)',
+const BYPASS_LABEL_KEY: Record<string, string> = {
+  claude: 'web.sessions.spawn.bypassClaude',
+  codex: 'web.sessions.spawn.bypassCodex',
+  gemini: 'web.sessions.spawn.bypassGemini',
 }
 
 export function SpawnDialog({
@@ -55,6 +56,7 @@ export function SpawnDialog({
   onSpawned,
   defaultCwd,
 }: SpawnDialogProps) {
+  const { t } = useTranslation()
   const qc = useQueryClient()
   const { data: providers } = useQuery({
     queryKey: ['providers'],
@@ -118,8 +120,11 @@ export function SpawnDialog({
     mutationFn: createSession,
     onSuccess: (session) => {
       qc.invalidateQueries({ queryKey: ['sessions'] })
-      toast.success('Session spawned', {
-        description: `${session.provider_id} · pid ${session.pid ?? '—'}`,
+      toast.success(t('web.sessions.spawn.spawnedToast'), {
+        description: t('web.sessions.spawn.spawnedDescription', {
+          provider: session.provider_id,
+          pid: session.pid ?? t('web.sessions.spawn.pidFallback'),
+        }),
       })
       onSpawned(session)
       onOpenChange(false)
@@ -139,11 +144,11 @@ export function SpawnDialog({
     e.preventDefault()
     setError(null)
     if (!providerId) {
-      setError('Pick a provider.')
+      setError(t('web.sessions.spawn.errorPickProvider'))
       return
     }
     if (!cwd.trim()) {
-      setError('cwd is required.')
+      setError(t('web.sessions.spawn.errorCwdRequired'))
       return
     }
     const userArgs = argsText
@@ -166,18 +171,20 @@ export function SpawnDialog({
     })
   }
 
+  const bypassLabelKey = BYPASS_LABEL_KEY[providerId]
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-[480px]">
         <DialogHeader>
-          <DialogTitle>Spawn session</DialogTitle>
+          <DialogTitle>{t('web.sessions.spawn.title')}</DialogTitle>
           <DialogDescription>
-            Start a CLI session under a registered provider.
+            {t('web.sessions.spawn.description')}
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={submit} className="flex flex-col gap-4 mt-2">
           <div className="space-y-1.5">
-            <Label htmlFor="provider">Provider</Label>
+            <Label htmlFor="provider">{t('web.sessions.spawn.provider')}</Label>
             <div className="grid grid-cols-2 gap-2">
               {(providers ?? []).map((p) => {
                 const active = providerId === p.manifest.id
@@ -215,15 +222,14 @@ export function SpawnDialog({
 
           {isClaude && (
             <div className="space-y-1.5">
-              <Label>Claude account</Label>
+              <Label>{t('web.sessions.spawn.claudeAccount')}</Label>
               {claudeAccountsLoading && accounts.length === 0 ? (
                 <div className="text-[11px] text-muted-foreground">
-                  Loading accounts…
+                  {t('web.sessions.spawn.loadingAccounts')}
                 </div>
               ) : accounts.length === 0 ? (
                 <div className="text-[11px] text-muted-foreground">
-                  No Claude accounts configured — the gateway will use the
-                  system ANTHROPIC_API_KEY.
+                  {t('web.sessions.spawn.noAccounts')}
                 </div>
               ) : (
                 <div className="flex flex-wrap gap-1.5">
@@ -236,9 +242,9 @@ export function SpawnDialog({
                           ? 'border-foreground/30 bg-card'
                           : 'border-border hover:bg-card hover:border-foreground/20'
                       }`}
-                      title="Use system keychain / env"
+                      title={t('web.sessions.spawn.defaultTooltip')}
                     >
-                      Default
+                      {t('web.sessions.spawn.default')}
                     </button>
                   )}
                   {accounts.map((a) => {
@@ -257,12 +263,14 @@ export function SpawnDialog({
                         title={
                           a.token_filled
                             ? `${a.config_dir || a.name}`
-                            : 'No token set — set token in Providers panel first'
+                            : t('web.sessions.spawn.tokenMissingTooltip')
                         }
                       >
                         {a.display_name || a.name}
                         {!a.token_filled && (
-                          <span className="ml-1 text-amber-500/90">·empty</span>
+                          <span className="ml-1 text-amber-500/90">
+                            {t('web.sessions.spawn.tokenEmptyBadge')}
+                          </span>
                         )}
                       </button>
                     )
@@ -271,20 +279,20 @@ export function SpawnDialog({
               )}
               {multiAccount && (
                 <div className="text-[11px] text-muted-foreground">
-                  Multiple accounts configured — pick one for this session.
+                  {t('web.sessions.spawn.multiAccountHint')}
                 </div>
               )}
             </div>
           )}
 
           <div className="space-y-1.5">
-            <Label htmlFor="cwd">Working directory</Label>
+            <Label htmlFor="cwd">{t('web.sessions.spawn.cwd')}</Label>
             <div className="flex gap-1.5">
               <Input
                 id="cwd"
                 value={cwd}
                 onChange={(e) => setCwd(e.target.value)}
-                placeholder="/Users/you/projects/foo"
+                placeholder={t('web.sessions.spawn.cwdPlaceholder')}
                 required
                 autoFocus
                 className="flex-1"
@@ -297,23 +305,23 @@ export function SpawnDialog({
                 className="shrink-0 gap-1"
               >
                 <FolderOpen className="size-3.5" />
-                Browse
+                {t('web.sessions.spawn.browse')}
               </Button>
             </div>
           </div>
 
           <div className="space-y-1.5">
-            <Label htmlFor="name">Name (optional)</Label>
+            <Label htmlFor="name">{t('web.sessions.spawn.nameLabel')}</Label>
             <Input
               id="name"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder="claude in pet-tracker"
+              placeholder={t('web.sessions.spawn.namePlaceholder')}
             />
           </div>
 
           <div className="space-y-1.5">
-            <Label htmlFor="args">CLI args (one per line)</Label>
+            <Label htmlFor="args">{t('web.sessions.spawn.argsLabel')}</Label>
             <textarea
               id="args"
               rows={3}
@@ -324,7 +332,7 @@ export function SpawnDialog({
             />
           </div>
 
-          {BYPASS_LABEL[providerId] && (
+          {bypassLabelKey && (
             <label className="flex items-start gap-2 text-[12px] cursor-pointer select-none">
               <input
                 type="checkbox"
@@ -333,11 +341,11 @@ export function SpawnDialog({
                 className="mt-0.5"
               />
               <span className="flex-1">
-                <span className="font-medium">{BYPASS_LABEL[providerId]}</span>
+                <span className="font-medium">{t(bypassLabelKey)}</span>
                 <span className="block text-muted-foreground mt-0.5 text-[11px]">
                   {bypassEnabled
-                    ? 'This session will run with elevated autonomy.'
-                    : 'Off — confirmations and prompts behave normally.'}
+                    ? t('web.sessions.spawn.bypassOnHint')
+                    : t('web.sessions.spawn.bypassOffHint')}
                 </span>
               </span>
             </label>
@@ -357,7 +365,7 @@ export function SpawnDialog({
               onClick={() => onOpenChange(false)}
               disabled={mutation.isPending}
             >
-              Cancel
+              {t('web.sessions.spawn.cancel')}
             </Button>
             <Button
               type="submit"
@@ -368,7 +376,9 @@ export function SpawnDialog({
               {mutation.isPending && (
                 <Loader2 className="size-3.5 animate-spin" />
               )}
-              {mutation.isPending ? 'Spawning…' : 'Spawn'}
+              {mutation.isPending
+                ? t('web.sessions.spawn.submitting')
+                : t('web.sessions.spawn.submit')}
             </Button>
           </DialogFooter>
         </form>

--- a/app/web/src/pages/Sessions.tsx
+++ b/app/web/src/pages/Sessions.tsx
@@ -14,6 +14,7 @@ import {
   Keyboard,
 } from 'lucide-react'
 import { toast } from 'sonner'
+import { Trans, useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -45,6 +46,7 @@ import { cn } from '@/lib/utils'
 import { isTerminalSessionState, type Session } from '@/lib/types'
 
 export function SessionsPage() {
+  const { t } = useTranslation()
   const [spawnOpen, setSpawnOpen] = useState(false)
   const tabs = useSessionTabs((s) => s.tabs)
   const currentId = useSessionTabs((s) => s.currentId)
@@ -66,30 +68,36 @@ export function SessionsPage() {
     onSuccess: (_, id) => {
       qc.invalidateQueries({ queryKey: ['sessions'] })
       close(id)
-      toast.success('Session removed')
+      toast.success(t('web.sessions.page.removedToast'))
     },
     onError: (err: Error) =>
-      toast.error('Remove failed', { description: err.message }),
+      toast.error(t('web.sessions.page.removeFailedToast'), {
+        description: err.message,
+      }),
   })
 
   const stop = useMutation({
     mutationFn: stopSession,
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['sessions'] })
-      toast.success('Session stopped')
+      toast.success(t('web.sessions.page.stoppedToast'))
     },
     onError: (err: Error) =>
-      toast.error('Stop failed', { description: err.message }),
+      toast.error(t('web.sessions.page.stopFailedToast'), {
+        description: err.message,
+      }),
   })
 
   const start = useMutation({
     mutationFn: startSession,
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['sessions'] })
-      toast.success('Session restarted')
+      toast.success(t('web.sessions.page.restartedToast'))
     },
     onError: (err: Error) =>
-      toast.error('Restart failed', { description: err.message }),
+      toast.error(t('web.sessions.page.restartFailedToast'), {
+        description: err.message,
+      }),
   })
 
   // Reconcile: if a tab's session is gone from server, drop it.
@@ -150,10 +158,11 @@ export function SessionsPage() {
     const target = sessions?.find((s) => s.id === id)
     if (target && !isTerminalSessionState(target.state)) {
       const ok = await confirmDialog({
-        title: `Stop and remove "${target.name || target.provider_id}"?`,
-        description:
-          'The CLI process will be terminated and the row deleted.',
-        confirmLabel: 'Stop and remove',
+        title: t('web.sessions.page.confirmCloseTabTitle', {
+          name: target.name || target.provider_id,
+        }),
+        description: t('web.sessions.page.confirmCloseTabDescription'),
+        confirmLabel: t('web.sessions.page.confirmCloseTabConfirm'),
         destructive: true,
       })
       if (!ok) return
@@ -199,9 +208,16 @@ export function SessionsPage() {
               onRemove={async () => {
                 if (!currentId) return
                 const ok = await confirmDialog({
-                  title: `Remove ${currentSession?.name || currentSession?.provider_id || 'session'}?`,
-                  description: 'This deletes the row.',
-                  confirmLabel: 'Remove',
+                  title: currentSession?.name || currentSession?.provider_id
+                    ? t('web.sessions.page.confirmRemoveTitle', {
+                        name:
+                          currentSession?.name ||
+                          currentSession?.provider_id ||
+                          '',
+                      })
+                    : t('web.sessions.page.confirmRemoveTitleFallback'),
+                  description: t('web.sessions.page.confirmRemoveDescription'),
+                  confirmLabel: t('web.sessions.page.confirmRemoveConfirm'),
                   destructive: true,
                 })
                 if (!ok) return
@@ -259,19 +275,28 @@ export function SessionsPage() {
 }
 
 function EmptyWorkbench({ onSpawn }: { onSpawn: () => void }) {
+  const { t } = useTranslation()
   return (
     <div className="flex-1 flex flex-col items-center justify-center gap-4 text-center p-6">
       <Layers className="size-10 text-muted-foreground/40" strokeWidth={1.5} />
       <div className="space-y-1">
-        <h2 className="text-[14px] font-semibold">No session open</h2>
+        <h2 className="text-[14px] font-semibold">
+          {t('web.sessions.empty.title')}
+        </h2>
         <p className="text-[12px] text-muted-foreground max-w-[320px]">
-          Pick a session from the list, or spawn a new one. Keyboard:{' '}
-          <kbd>⌘N</kbd> new, <kbd>⌘W</kbd> close,{' '}
-          <kbd>⌘1</kbd>–<kbd>⌘9</kbd> switch.
+          <Trans
+            i18nKey="web.sessions.empty.hint"
+            values={{
+              kbdN: '⌘N',
+              kbdW: '⌘W',
+              kbdRange: '⌘1–⌘9',
+            }}
+            components={{ 0: <kbd />, 1: <kbd />, 2: <kbd /> }}
+          />
         </p>
       </div>
       <Button onClick={onSpawn} variant="accent" size="sm">
-        <Plus className="size-3.5" /> Spawn session
+        <Plus className="size-3.5" /> {t('web.sessions.empty.spawn')}
       </Button>
     </div>
   )
@@ -306,15 +331,28 @@ function WorkbenchHeader({
   inspectorOpen: boolean
   onToggleInspector: () => void
 }) {
+  const { t } = useTranslation()
   if (!session) {
     return (
       <div className="h-14 border-b border-border flex items-center px-3 text-[12px] text-muted-foreground">
         <Loader2 className="size-3 animate-spin" />
-        <span className="ml-2">Loading session…</span>
+        <span className="ml-2">{t('web.sessions.header.loadingSession')}</span>
       </div>
     )
   }
   const visual = providerVisual(session.provider_id)
+  const listLabel = listCollapsed
+    ? t('web.sessions.header.showList')
+    : t('web.sessions.header.hideList')
+  const inspectorLabel = inspectorOpen
+    ? t('web.sessions.header.hideInspector')
+    : t('web.sessions.header.showInspector')
+  const keyboardAria = toolbarOpen
+    ? t('web.sessions.header.hideKeyboard')
+    : t('web.sessions.header.showKeyboard')
+  const keyboardTooltip = toolbarOpen
+    ? t('web.sessions.header.hideKeyboard')
+    : t('web.sessions.header.showKeyboardTooltip')
   return (
     <div className="h-14 border-b border-border flex items-center px-3 gap-3">
       <Tooltip>
@@ -323,7 +361,7 @@ function WorkbenchHeader({
             variant="ghost"
             size="icon"
             onClick={onToggleList}
-            aria-label={listCollapsed ? 'Show session list' : 'Hide session list'}
+            aria-label={listLabel}
             className="size-7 shrink-0"
           >
             {listCollapsed ? (
@@ -333,9 +371,7 @@ function WorkbenchHeader({
             )}
           </Button>
         </TooltipTrigger>
-        <TooltipContent>
-          {listCollapsed ? 'Show session list' : 'Hide session list'}
-        </TooltipContent>
+        <TooltipContent>{listLabel}</TooltipContent>
       </Tooltip>
       <BrandAvatar
         iconKey={providerIconKey(session.provider_id)}
@@ -351,7 +387,7 @@ function WorkbenchHeader({
           {visual.name} · {session.cwd}
           {session.pid != null && (
             <span className="ml-2 text-muted-foreground/60">
-              pid {session.pid}
+              {t('web.sessions.header.pid', { pid: session.pid })}
             </span>
           )}
         </div>
@@ -367,19 +403,13 @@ function WorkbenchHeader({
             variant="ghost"
             size="icon"
             onClick={onToggleToolbar}
-            aria-label={
-              toolbarOpen ? 'Hide on-screen keys' : 'Show on-screen keys'
-            }
+            aria-label={keyboardAria}
             className={cn('size-7 shrink-0', toolbarOpen && 'text-foreground')}
           >
             <Keyboard className="size-3.5" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent>
-          {toolbarOpen
-            ? 'Hide on-screen keys'
-            : 'Show on-screen keys (ESC, TAB, ↑↓, ⌃C…)'}
-        </TooltipContent>
+        <TooltipContent>{keyboardTooltip}</TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>
@@ -387,9 +417,7 @@ function WorkbenchHeader({
             variant="ghost"
             size="icon"
             onClick={onToggleInspector}
-            aria-label={
-              inspectorOpen ? 'Hide inspector' : 'Show inspector'
-            }
+            aria-label={inspectorLabel}
             className={cn(
               'size-7 shrink-0',
               inspectorOpen && 'text-foreground',
@@ -402,9 +430,7 @@ function WorkbenchHeader({
             )}
           </Button>
         </TooltipTrigger>
-        <TooltipContent>
-          {inspectorOpen ? 'Hide inspector' : 'Show inspector'}
-        </TooltipContent>
+        <TooltipContent>{inspectorLabel}</TooltipContent>
       </Tooltip>
       {isTerminalSessionState(session.state) ? (
         <>
@@ -420,7 +446,9 @@ function WorkbenchHeader({
             ) : (
               <RotateCcw className="size-3" />
             )}
-            {starting ? 'Restarting…' : 'Restart'}
+            {starting
+              ? t('web.sessions.header.restarting')
+              : t('web.sessions.header.restart')}
           </Button>
           <Button
             variant="ghost"
@@ -430,7 +458,9 @@ function WorkbenchHeader({
             className="text-[11px] gap-1 text-muted-foreground hover:text-destructive"
           >
             <Trash2 className="size-3" />
-            {removing ? 'Removing…' : 'Remove'}
+            {removing
+              ? t('web.sessions.header.removing')
+              : t('web.sessions.header.remove')}
           </Button>
         </>
       ) : (
@@ -443,11 +473,12 @@ function WorkbenchHeader({
             className="text-[11px] gap-1 text-muted-foreground hover:text-destructive"
           >
             <Power className="size-3" />
-            {stopping ? 'Stopping…' : 'Stop'}
+            {stopping
+              ? t('web.sessions.header.stopping')
+              : t('web.sessions.header.stop')}
           </Button>
         </>
       )}
     </div>
   )
 }
-


### PR DESCRIPTION
## Summary

Migrate every user-facing string in the Sessions surface to `useTranslation()`:

- **Sessions.tsx** — remove/stop/restart toasts; confirm dialogs for Stop+Remove and Remove; EmptyWorkbench hint with embedded ⌘N/⌘W/⌘1–⌘9 kbds via `<Trans>`; WorkbenchHeader sidebar/inspector/keyboard tooltips + aria; Restart/Stop/Remove buttons.
- **SessionList + ChildRow** — sidebar header, count footer, ended group header with `Clear all`, loading + empty states, native `confirm()` for terminate / clear-all.
- **SessionRow** — delete aria-label + remove/terminate title tooltips, Claude account tooltip.
- **SessionTabs** — close-tab aria-label and title.
- **SpawnDialog** — dialog title/description; provider grid; Claude account section (loading/empty/Default/multi-account hint); cwd + Browse; name; args; per-provider bypass toggle labels (`bypassClaude`/`bypassCodex`/`bypassGemini`) + on/off hints; validation errors; submit + spawned toast (`{provider} · pid {pid}`).
- **AccountSwitcher** — tooltip, menu title, default option name + subtitle, confirm prompt, switched/failed toasts.
- **InspectorPanel** — Files / Git / Search / Tasks / History / Notes / Memory tab labels.
- **EndedSessionView** — xterm banner strings (`[buffer unavailable]`, `[session ended — read-only buffer]`).
- **FileBrowserDialog** — dialog title/description, parent/home/refresh tooltips, loading/empty/error states, mkdir prompt + Create/Cancel, footer.

All keys live under a new `web.sessions.*` namespace in `app/i18n/{en,zh}.json` to avoid colliding with mobile's existing `sessions.*` Flutter slang keys.

## Stacking

Based on `feat/web-i18n-setup` (#105). **Merge #105 first**, then rebase this onto `main`.

## Out of scope (intentional)

- `StatePill` — short technical state labels (`running`/`idle`/`ended`) read as universal jargon.
- `TerminalToolbar` — labels are unicode glyphs (ESC/TAB/↑↓/⌃C…); language-neutral.
- `Terminal.tsx` in-canvas `[disconnected — reconnecting…]` line.
- `inspector/*Panel.tsx` (FilesPanel, GitPanel, etc.) — deferred to a follow-up PR.

## Test plan

- [x] `pnpm build` (web) succeeds.
- [x] `pnpm lint` — no new errors from changed files; 6 pre-existing errors in `Sessions.tsx`/`SpawnDialog.tsx`/`FileBrowserDialog.tsx` are unchanged (setState-in-effect + variable-access-before-declared).
- [ ] Manual: load `/sessions`, confirm sidebar + tabs + header swap between en/zh; spawn dialog form labels + bypass copy translate; AccountSwitcher dropdown translates; Inspector tabs translate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)