### PR TITLE
feat(web): finish ServerSettings i18n — 9 form cases + helpers

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1589,6 +1589,262 @@
         "timedOutTitle": "Restart timed out",
         "timedOutDesc": "Health endpoint never came back. Check server logs.",
         "successToast": "Server restarted"
+      },
+      "formGroups": {
+        "network": "Network",
+        "operatorAccount": "Operator account",
+        "memoryConfiguration": "Configuration",
+        "memoryHttp": "HTTP backend (used when backend=http)",
+        "memoryLocal": "Local ONNX (used when backend=local)",
+        "backupStatus": "Status",
+        "backupWhere": "Where backups go",
+        "backupSchedules": "Schedules",
+        "backupWhatsInside": "What's in a backup?"
+      },
+      "fields": {
+        "listenAddress": {
+          "label": "Listen address",
+          "hint": "The host:port the HTTP server binds to. Example: 0.0.0.0:8770."
+        },
+        "username": {
+          "label": "Username",
+          "hint": "Login name used in the sign-in form. Changing this forces a re-login on the next request."
+        },
+        "password": {
+          "label": "Password",
+          "hint": "Leave blank to keep the current password. Sending a value overwrites it.",
+          "hideTitle": "Hide",
+          "revealTitle": "Reveal"
+        },
+        "tokenTTL": {
+          "label": "Token TTL",
+          "hint": "Bearer-token lifetime as a Go duration, e.g. \"24h\", \"30m\". Empty = never expire."
+        },
+        "logLevel": {
+          "label": "Log level",
+          "hint": "Lines below this level are dropped."
+        },
+        "logFormat": {
+          "label": "Format",
+          "hint": "\"text\" is human-readable; \"json\" is machine-parsable."
+        },
+        "logFile": {
+          "label": "Log file",
+          "hint": "Optional file path. Auto-rotates at 10 MB, keeps 5 backups. Empty = stderr only."
+        },
+        "idleThreshold": {
+          "label": "Idle threshold",
+          "hint": "A session is silent for this long before session.idle fires. Empty = 30s."
+        },
+        "idlePollInterval": {
+          "label": "Idle poll interval",
+          "hint": "How often the idle detector wakes up. Lower = lower latency, more wakeups. Empty = 5s."
+        },
+        "vaultRoot": {
+          "label": "Vault root",
+          "hint": "Top-level directory for notes, skills, and MCP registry."
+        },
+        "notesDirectory": {
+          "label": "Notes directory",
+          "hint": "Override notes location. Defaults to <vault root>/notes."
+        },
+        "skillsDirectory": {
+          "label": "Skills directory",
+          "hint": "Override skills location. Defaults to <vault root>/skills."
+        },
+        "gitRoot": {
+          "label": "Git root",
+          "hint": "Working tree the Vault Sync feature commits to."
+        },
+        "personalPrefix": {
+          "label": "Personal prefix",
+          "hint": "Folder name used for personal notes when auto-deriving paths. Default \"personal\"."
+        },
+        "projectsPrefix": {
+          "label": "Projects prefix",
+          "hint": "Folder name used for project notes. Default \"projects\"."
+        },
+        "registryRoot": {
+          "label": "Registry root",
+          "hint": "Directory holding MCP server JSON definitions. Defaults to <vault>/mcp."
+        },
+        "secretsFile": {
+          "label": "Secrets file",
+          "hint": "key=value file substituted into MCP server commands at spawn time."
+        },
+        "memoryBackend": {
+          "label": "Embedder backend",
+          "hint": "\"auto\" / \"bm25\" use the cgo-free pure-Go keyword path. \"http\" calls any OpenAI-compatible /v1/embeddings (ollama / OpenAI / LocalAI). \"local\" runs an ONNX sentence-transformer in-process — requires a binary built with `-tags local_onnx`."
+        },
+        "memoryStore": {
+          "label": "Store",
+          "hint": "\"pgvector\" reuses opendray's existing PG with the vector extension; only option in v1."
+        },
+        "memoryTopK": {
+          "label": "Default top-K",
+          "hint": "How many hits memory_search returns when the agent doesn't specify. Empty = 5."
+        },
+        "memoryThreshold": {
+          "label": "Similarity threshold",
+          "hint": "Hits below this score are dropped. Empty = 0.1 (permissive — BM25 sparse vectors rarely break 0.5)."
+        },
+        "memoryScope": {
+          "label": "Default scope",
+          "hint": "What memory_store uses when the agent doesn't specify. \"project\" (recommended) groups by cwd; \"session\" isolates per session; \"global\" shares across cwds."
+        },
+        "memoryBaseUrl": {
+          "label": "Base URL",
+          "hint": "e.g. \"http://localhost:11434/v1\" for ollama, \"https://api.openai.com/v1\" for OpenAI."
+        },
+        "memoryModel": {
+          "label": "Model",
+          "hint": "e.g. \"nomic-embed-text\" for ollama, \"text-embedding-3-small\" for OpenAI."
+        },
+        "memoryApiKey": {
+          "label": "API key",
+          "hint": "Empty for ollama / local servers. Required for OpenAI / Voyage / hosted services."
+        },
+        "memoryLocalModel": {
+          "label": "Model name",
+          "hint": "Cosmetic — appears in logs / Inspector. e.g. \"bge-m3\", \"bge-small-en-v1.5\"."
+        },
+        "memoryLibraryPath": {
+          "label": "Library path",
+          "hint": "Directory holding libonnxruntime.dylib (macOS) / libonnxruntime.so (Linux). After `brew install onnxruntime`, that's /opt/homebrew/opt/onnxruntime/lib."
+        },
+        "memoryModelPath": {
+          "label": "Model path",
+          "hint": "Absolute path to the .onnx weights. Download from HuggingFace, e.g. Xenova/bge-m3 or Xenova/bge-small-en-v1.5."
+        },
+        "memoryTokenizerPath": {
+          "label": "Tokenizer path",
+          "hint": "Absolute path to tokenizer.json (HuggingFace standard format) — usually right next to the model."
+        },
+        "memoryMaxSeqLen": {
+          "label": "Max sequence length",
+          "hint": "Tokens beyond this are truncated. bge-m3 default is 512. Empty = 512."
+        },
+        "claudeHistoryRoots": {
+          "label": "History roots",
+          "hint": "Directories scanned for Claude per-project JSONL transcripts. Empty = scan ~/.claude/projects + every ~/.claude-accounts/*/projects."
+        },
+        "claudeAccountsDir": {
+          "label": "Accounts directory",
+          "hint": "Root used for opendray-managed Claude account ConfigDirs. Default ~/.claude-accounts."
+        },
+        "codexSessionsRoot": {
+          "label": "Sessions root",
+          "hint": "Directory walked for Codex rollout JSONL files. Default ~/.codex/sessions."
+        },
+        "geminiTmpRoot": {
+          "label": "Tmp directory",
+          "hint": "Root holding Gemini per-project tmp folders. Default ~/.gemini/tmp."
+        },
+        "geminiProjectsFile": {
+          "label": "projects.json",
+          "hint": "Path to Gemini's cwd→short-name mapping file. Default ~/.gemini/projects.json."
+        },
+        "backupLocalDir": {
+          "label": "Local backup directory",
+          "hint": "Default root for the auto-created `local` target. Empty = ~/.opendray/backups. Restart required."
+        },
+        "backupExportDir": {
+          "label": "Export directory",
+          "hint": "Where one-shot export zips are staged on disk. Empty = ~/.opendray/exports. Bundles auto-expire after 24h. Restart required."
+        },
+        "backupPgDumpPath": {
+          "label": "pg_dump path",
+          "hint": "Absolute path to pg_dump. Major version must be ≥ the server's. Empty = first pg_dump on PATH."
+        },
+        "backupPgRestorePath": {
+          "label": "pg_restore path",
+          "hint": "Absolute path to pg_restore for the /backups/restore flow. Same major-version rule."
+        }
+      },
+      "liveTail": {
+        "heading": "Live tail",
+        "description": "In-memory ring buffer (last ~2,000 records). Resets on restart."
+      },
+      "memoryInspectorCard": {
+        "heading": "Inspector",
+        "description": "Browse, search and edit stored memories on the dedicated page.",
+        "openButton": "Open Memory →"
+      },
+      "localOnnxBanner": "Requires the binary to be compiled with <1>-tags local_onnx</1>. The standard build returns a clear stub error when this backend is selected. See <3>Memory → Local ONNX</3> tutorial for setup steps.",
+      "stringList": {
+        "noneDefault": "(none — using built-in defaults)",
+        "addPath": "Add path",
+        "removeTitle": "Remove"
+      },
+      "httpHelpers": {
+        "autoDetected": "Auto-detected at startup",
+        "modelCount": "{count} model(s) — click to use",
+        "presets": "Presets:",
+        "testConnection": "Test connection",
+        "presetTip": {
+          "ollama": "Local ollama daemon",
+          "lmStudio": "LM Studio local server",
+          "openai": "OpenAI cloud (needs API key)"
+        }
+      },
+      "probe": {
+        "unreachable": "✗ unreachable: {error}",
+        "connectionFailed": "connection failed",
+        "reachable": "✓ reachable {detected}· {total} model(s) total · {embedding} embedding",
+        "modelMissing": "⚠ Configured model {model} isn't in the list. Pick one of the embedding models below or fix the name.",
+        "embeddingModelsLabel": "embedding models:",
+        "moreModels": "+{count} more",
+        "noEmbeddingFound": "⚠ No model name contains \"embed\". The endpoint might not have an embedding model loaded — check your local server.",
+        "configuredTitle": "Currently configured",
+        "applyTitle": "Click to apply"
+      },
+      "backup": {
+        "featureDisabledTitle": "Feature disabled",
+        "featureDisabledHint": "Set <1>OPENDRAY_BACKUP_ENABLED=1</1> + <3>OPENDRAY_BACKUP_KEY=&lt;passphrase&gt;</3> in opendray's environment, then restart. The master passphrase is env-only — it never touches config.toml.",
+        "statusRowLabel": "Status",
+        "enabledHealthy": "enabled · healthy",
+        "enabledDegraded": "enabled · degraded",
+        "keyFingerprintLabel": "Key fingerprint",
+        "keyFingerprintHint": "record in Vaultwarden — losing it locks all prior backups",
+        "pgDumpLabel": "pg_dump",
+        "pgDumpUnavailable": "unavailable",
+        "pgRestoreLabel": "pg_restore",
+        "pgRestoreNotResolved": "(not resolved)",
+        "openBackups": "Open Backups page →",
+        "openExport": "Open Export / Import →",
+        "whereDesc": "Each target is one place a backup blob can be written. opendray supports <1>local disk</1>, <3>SMB/CIFS</3> (Windows / NAS), <5>S3-compatible</5> (AWS, R2, B2, MinIO, Alibaba Cloud OSS, Tencent Cloud COS, ...), <7>WebDAV</7> (Nextcloud, Synology, Jianguoyun), <9>SFTP</9>, plus an <11>rclone</11> passthrough that taps into 70+ extra backends (Google Drive, OneDrive, Dropbox, Baidu Pan, Aliyun Drive, ...).",
+        "loading": "Loading…",
+        "noTargets": "No targets yet. Add one to start backing up.",
+        "addTarget": "Add target",
+        "noSchedulesHint": "No recurring schedules. Add one on <1>/backups → Schedules</1> to take backups automatically.",
+        "scheduleHeaders": {
+          "schedule": "Schedule",
+          "target": "Target",
+          "cadence": "Cadence",
+          "keep": "Keep",
+          "state": "State"
+        },
+        "every": "every {interval}",
+        "backupsKeep": "{count} backups",
+        "stateEnabled": "enabled",
+        "statePaused": "paused",
+        "manageSchedules": "Manage on /backups → Schedules →",
+        "whatsInsideDesc": "Each backup is a <1>pg_dump --format=custom</1> of every opendray table (sessions, integrations, memories, audit_log, etc.) plus a <3>manifest.json</3> and (optionally) the live <5>config.toml</5>. Open the \"What's in a backup?\" panel on the <7>Backups page</7> to see the live inventory with row counts.",
+        "advancedToggle": "Advanced (paths & client binaries) — restart required"
+      },
+      "targetRow": {
+        "on": "on",
+        "off": "off",
+        "test": "Test",
+        "testing": "Testing…",
+        "delete": "Delete",
+        "connectionOk": "{id}: connection OK",
+        "connectionFailedTitle": "Connection failed",
+        "testFailedTitle": "Test failed",
+        "deleteConfirm": "Delete target \"{id}\"? Schedules referencing it will block the delete.",
+        "deleteSuccess": "Target deleted",
+        "deleteFailedTitle": "Delete failed",
+        "unknownError": "Unknown error"
       }
     },
     "settings": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -1589,6 +1589,262 @@
         "timedOutTitle": "重启超时",
         "timedOutDesc": "Health 接口未恢复。请查看服务器日志。",
         "successToast": "服务器已重启"
+      },
+      "formGroups": {
+        "network": "网络",
+        "operatorAccount": "操作员账号",
+        "memoryConfiguration": "配置",
+        "memoryHttp": "HTTP 后端（当 backend=http 时使用）",
+        "memoryLocal": "本地 ONNX（当 backend=local 时使用）",
+        "backupStatus": "状态",
+        "backupWhere": "备份目标位置",
+        "backupSchedules": "计划任务",
+        "backupWhatsInside": "备份里有什么？"
+      },
+      "fields": {
+        "listenAddress": {
+          "label": "监听地址",
+          "hint": "HTTP 服务绑定的 host:port，例如：0.0.0.0:8770。"
+        },
+        "username": {
+          "label": "用户名",
+          "hint": "登录表单使用的账号。修改后下次请求会强制重新登录。"
+        },
+        "password": {
+          "label": "密码",
+          "hint": "留空保持当前密码不变；填值则会覆盖。",
+          "hideTitle": "隐藏",
+          "revealTitle": "显示"
+        },
+        "tokenTTL": {
+          "label": "令牌 TTL",
+          "hint": "Bearer 令牌生命周期，使用 Go duration，如 \"24h\"、\"30m\"。留空 = 永不过期。"
+        },
+        "logLevel": {
+          "label": "日志级别",
+          "hint": "低于此级别的日志将被丢弃。"
+        },
+        "logFormat": {
+          "label": "格式",
+          "hint": "\"text\" 适合人读；\"json\" 便于机器解析。"
+        },
+        "logFile": {
+          "label": "日志文件",
+          "hint": "可选的文件路径。10MB 自动轮转，保留 5 个备份。留空 = 仅输出到 stderr。"
+        },
+        "idleThreshold": {
+          "label": "空闲阈值",
+          "hint": "会话静默这么久后触发 session.idle。留空 = 30s。"
+        },
+        "idlePollInterval": {
+          "label": "空闲轮询间隔",
+          "hint": "空闲检测器的唤醒频率。越低 = 延迟越低、唤醒越多。留空 = 5s。"
+        },
+        "vaultRoot": {
+          "label": "Vault 根目录",
+          "hint": "笔记、技能和 MCP 注册表的顶层目录。"
+        },
+        "notesDirectory": {
+          "label": "笔记目录",
+          "hint": "覆盖笔记位置。默认为 <vault root>/notes。"
+        },
+        "skillsDirectory": {
+          "label": "技能目录",
+          "hint": "覆盖技能位置。默认为 <vault root>/skills。"
+        },
+        "gitRoot": {
+          "label": "Git 根目录",
+          "hint": "Vault Sync 功能提交到的工作树。"
+        },
+        "personalPrefix": {
+          "label": "个人前缀",
+          "hint": "自动派生路径时用于个人笔记的文件夹名。默认 \"personal\"。"
+        },
+        "projectsPrefix": {
+          "label": "项目前缀",
+          "hint": "项目笔记的文件夹名。默认 \"projects\"。"
+        },
+        "registryRoot": {
+          "label": "注册表根目录",
+          "hint": "存放 MCP server JSON 定义的目录。默认为 <vault>/mcp。"
+        },
+        "secretsFile": {
+          "label": "密钥文件",
+          "hint": "spawn 时替换进 MCP server 命令的 key=value 文件。"
+        },
+        "memoryBackend": {
+          "label": "嵌入器后端",
+          "hint": "\"auto\" / \"bm25\" 使用纯 Go 关键词路径（无需 cgo）；\"http\" 调用任何兼容 OpenAI 的 /v1/embeddings（ollama / OpenAI / LocalAI）；\"local\" 进程内运行 ONNX sentence-transformer — 需要用 `-tags local_onnx` 编译的二进制。"
+        },
+        "memoryStore": {
+          "label": "存储",
+          "hint": "\"pgvector\" 复用 opendray 已有的 PG + vector 扩展；v1 唯一选项。"
+        },
+        "memoryTopK": {
+          "label": "默认 top-K",
+          "hint": "agent 未指定时 memory_search 返回多少条命中。留空 = 5。"
+        },
+        "memoryThreshold": {
+          "label": "相似度阈值",
+          "hint": "分数低于此值的命中将被丢弃。留空 = 0.1（宽松 — BM25 稀疏向量很少超过 0.5）。"
+        },
+        "memoryScope": {
+          "label": "默认作用域",
+          "hint": "agent 未指定时 memory_store 使用的作用域。\"project\"（推荐）按 cwd 分组；\"session\" 按会话隔离；\"global\" 跨 cwd 共享。"
+        },
+        "memoryBaseUrl": {
+          "label": "Base URL",
+          "hint": "如 ollama 用 \"http://localhost:11434/v1\"，OpenAI 用 \"https://api.openai.com/v1\"。"
+        },
+        "memoryModel": {
+          "label": "模型",
+          "hint": "如 ollama 用 \"nomic-embed-text\"，OpenAI 用 \"text-embedding-3-small\"。"
+        },
+        "memoryApiKey": {
+          "label": "API 密钥",
+          "hint": "ollama / 本地服务可留空；OpenAI / Voyage / 托管服务必填。"
+        },
+        "memoryLocalModel": {
+          "label": "模型名",
+          "hint": "仅作显示用 — 出现在日志 / Inspector 中。如 \"bge-m3\"、\"bge-small-en-v1.5\"。"
+        },
+        "memoryLibraryPath": {
+          "label": "库路径",
+          "hint": "存放 libonnxruntime.dylib (macOS) / libonnxruntime.so (Linux) 的目录。`brew install onnxruntime` 后即 /opt/homebrew/opt/onnxruntime/lib。"
+        },
+        "memoryModelPath": {
+          "label": "模型路径",
+          "hint": ".onnx 权重的绝对路径。从 HuggingFace 下载，如 Xenova/bge-m3 或 Xenova/bge-small-en-v1.5。"
+        },
+        "memoryTokenizerPath": {
+          "label": "Tokenizer 路径",
+          "hint": "tokenizer.json（HuggingFace 标准格式）的绝对路径 — 通常和模型放在一起。"
+        },
+        "memoryMaxSeqLen": {
+          "label": "最大序列长度",
+          "hint": "超过这个 token 数会被截断。bge-m3 默认 512。留空 = 512。"
+        },
+        "claudeHistoryRoots": {
+          "label": "历史根目录",
+          "hint": "扫描 Claude 每项目 JSONL 记录的目录。留空 = 扫描 ~/.claude/projects + 所有 ~/.claude-accounts/*/projects。"
+        },
+        "claudeAccountsDir": {
+          "label": "账号目录",
+          "hint": "opendray 管理的 Claude 账号 ConfigDir 根目录。默认 ~/.claude-accounts。"
+        },
+        "codexSessionsRoot": {
+          "label": "会话根目录",
+          "hint": "遍历 Codex rollout JSONL 文件的目录。默认 ~/.codex/sessions。"
+        },
+        "geminiTmpRoot": {
+          "label": "tmp 目录",
+          "hint": "存放 Gemini 每项目 tmp 文件夹的根目录。默认 ~/.gemini/tmp。"
+        },
+        "geminiProjectsFile": {
+          "label": "projects.json",
+          "hint": "Gemini cwd→短名映射文件的路径。默认 ~/.gemini/projects.json。"
+        },
+        "backupLocalDir": {
+          "label": "本地备份目录",
+          "hint": "自动创建的 `local` 目标的默认根目录。留空 = ~/.opendray/backups。需要重启。"
+        },
+        "backupExportDir": {
+          "label": "导出目录",
+          "hint": "一次性导出 zip 在磁盘上的暂存位置。留空 = ~/.opendray/exports。包将在 24 小时后自动过期。需要重启。"
+        },
+        "backupPgDumpPath": {
+          "label": "pg_dump 路径",
+          "hint": "pg_dump 的绝对路径。主版本号必须 ≥ 服务器的。留空 = PATH 上的第一个 pg_dump。"
+        },
+        "backupPgRestorePath": {
+          "label": "pg_restore 路径",
+          "hint": "/backups/restore 流程使用的 pg_restore 绝对路径。同样的主版本号规则。"
+        }
+      },
+      "liveTail": {
+        "heading": "实时日志",
+        "description": "内存中的环形缓冲区（最近约 2,000 条）。重启后清空。"
+      },
+      "memoryInspectorCard": {
+        "heading": "检查器",
+        "description": "在专门页面浏览、搜索、编辑已存储的记忆。",
+        "openButton": "打开记忆 →"
+      },
+      "localOnnxBanner": "需要使用 <1>-tags local_onnx</1> 编译二进制。标准构建在选择此后端时会返回明确的 stub 错误。设置步骤参见 <3>记忆 → 本地 ONNX</3> 教程。",
+      "stringList": {
+        "noneDefault": "（无 — 使用内置默认值）",
+        "addPath": "添加路径",
+        "removeTitle": "移除"
+      },
+      "httpHelpers": {
+        "autoDetected": "启动时自动检测到",
+        "modelCount": "{count} 个模型 — 点击使用",
+        "presets": "预设：",
+        "testConnection": "测试连接",
+        "presetTip": {
+          "ollama": "本地 ollama 守护进程",
+          "lmStudio": "LM Studio 本地服务",
+          "openai": "OpenAI 云端（需要 API key）"
+        }
+      },
+      "probe": {
+        "unreachable": "✗ 不可达：{error}",
+        "connectionFailed": "连接失败",
+        "reachable": "✓ 可达 {detected}· 共 {total} 个模型 · {embedding} 个嵌入",
+        "modelMissing": "⚠ 配置的模型 {model} 不在列表中。从下方嵌入模型中选一个，或修正名称。",
+        "embeddingModelsLabel": "嵌入模型：",
+        "moreModels": "还有 {count} 个",
+        "noEmbeddingFound": "⚠ 没有模型名包含 \"embed\"。该端点可能未加载嵌入模型 — 请检查本地服务。",
+        "configuredTitle": "当前已配置",
+        "applyTitle": "点击应用"
+      },
+      "backup": {
+        "featureDisabledTitle": "功能已禁用",
+        "featureDisabledHint": "在 opendray 的环境变量中设置 <1>OPENDRAY_BACKUP_ENABLED=1</1> + <3>OPENDRAY_BACKUP_KEY=&lt;passphrase&gt;</3>，然后重启。主密码仅来自环境变量 — 永不写入 config.toml。",
+        "statusRowLabel": "状态",
+        "enabledHealthy": "已启用 · 健康",
+        "enabledDegraded": "已启用 · 异常",
+        "keyFingerprintLabel": "密钥指纹",
+        "keyFingerprintHint": "记录到 Vaultwarden — 丢失会锁死所有先前的备份",
+        "pgDumpLabel": "pg_dump",
+        "pgDumpUnavailable": "不可用",
+        "pgRestoreLabel": "pg_restore",
+        "pgRestoreNotResolved": "（未解析）",
+        "openBackups": "打开备份页 →",
+        "openExport": "打开导出 / 导入 →",
+        "whereDesc": "每个目标都是备份块可写入的一个地方。opendray 支持 <1>本地磁盘</1>、<3>SMB/CIFS</3>（Windows / NAS）、<5>S3 兼容</5>（AWS、R2、B2、MinIO、阿里云 OSS、腾讯云 COS …）、<7>WebDAV</7>（Nextcloud、群晖、坚果云）、<9>SFTP</9>，外加 <11>rclone</11> 透传，接入另外 70+ 个后端（Google Drive、OneDrive、Dropbox、百度云、阿里云盘 …）。",
+        "loading": "加载中…",
+        "noTargets": "尚未添加目标。添加一个开始备份。",
+        "addTarget": "添加目标",
+        "noSchedulesHint": "没有循环计划。在 <1>/backups → 计划任务</1> 添加一个以自动执行备份。",
+        "scheduleHeaders": {
+          "schedule": "计划",
+          "target": "目标",
+          "cadence": "频率",
+          "keep": "保留",
+          "state": "状态"
+        },
+        "every": "每 {interval}",
+        "backupsKeep": "{count} 份备份",
+        "stateEnabled": "已启用",
+        "statePaused": "已暂停",
+        "manageSchedules": "在 /backups → 计划任务 管理 →",
+        "whatsInsideDesc": "每份备份都是所有 opendray 表（sessions、integrations、memories、audit_log 等）的 <1>pg_dump --format=custom</1>，加上一个 <3>manifest.json</3>，以及（可选）当前的 <5>config.toml</5>。在 <7>备份页</7> 打开「备份里有什么？」面板可以看到带行数的实时清单。",
+        "advancedToggle": "高级选项（路径与客户端二进制）— 需要重启"
+      },
+      "targetRow": {
+        "on": "开",
+        "off": "关",
+        "test": "测试",
+        "testing": "测试中…",
+        "delete": "删除",
+        "connectionOk": "{id}：连接正常",
+        "connectionFailedTitle": "连接失败",
+        "testFailedTitle": "测试失败",
+        "deleteConfirm": "删除目标 \"{id}\"？引用它的计划任务将阻止删除。",
+        "deleteSuccess": "目标已删除",
+        "deleteFailedTitle": "删除失败",
+        "unknownError": "未知错误"
       }
     },
     "settings": {

--- a/app/web/src/components/settings/ServerSettings.tsx
+++ b/app/web/src/components/settings/ServerSettings.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import {
   AlertTriangle,
   Archive,
@@ -310,6 +310,7 @@ function SectionForm({
   toggleShowPassword: () => void
   searchQuery: string
 }) {
+  const { t } = useTranslation()
   const c = draft
   // Filter rows by search; case-insensitive match against label or hint.
   const filter = searchQuery.trim().toLowerCase()
@@ -320,105 +321,109 @@ function SectionForm({
       (hint?.toLowerCase().includes(filter) ?? false)
     )
   }
+  // F wraps a control with the canonical FieldRow + visibility filter
+  // using i18n-keyed label/hint. `fieldKey` resolves to
+  // `web.serverSettings.fields.<fieldKey>.{label,hint}`.
+  const F = (
+    fieldKey: string,
+    tomlKey: string,
+    children: React.ReactNode,
+  ) => {
+    const label = t(`web.serverSettings.fields.${fieldKey}.label`)
+    const hint = t(`web.serverSettings.fields.${fieldKey}.hint`)
+    return visible(label, hint) ? (
+      <FieldRow label={label} hint={hint} tomlKey={tomlKey}>
+        {children}
+      </FieldRow>
+    ) : null
+  }
 
   switch (active) {
     case 'general':
       return (
         <div className="flex flex-col gap-8">
-          <FormGroup heading="Network">
-            {visible('Listen address', 'IP and port the gateway binds to') && (
-              <FieldRow
-                label="Listen address"
-                hint="The host:port the HTTP server binds to. Example: 0.0.0.0:8770."
-                tomlKey="listen"
-              >
-                <Input
-                  value={c.listen}
-                  onChange={(e) =>
-                    setDraft({ ...draft, listen: e.target.value })
-                  }
-                  placeholder="0.0.0.0:8770"
-                  className="h-9 font-mono"
-                />
-              </FieldRow>
+          <FormGroup heading={t('web.serverSettings.formGroups.network')}>
+            {F(
+              'listenAddress',
+              'listen',
+              <Input
+                value={c.listen}
+                onChange={(e) =>
+                  setDraft({ ...draft, listen: e.target.value })
+                }
+                placeholder="0.0.0.0:8770"
+                className="h-9 font-mono"
+              />,
             )}
           </FormGroup>
 
-          <FormGroup heading="Operator account">
-            {visible('Username', 'Login name for the admin') && (
-              <FieldRow
-                label="Username"
-                hint="Login name used in the sign-in form. Changing this forces a re-login on the next request."
-                tomlKey="admin.user"
-              >
+          <FormGroup heading={t('web.serverSettings.formGroups.operatorAccount')}>
+            {F(
+              'username',
+              'admin.user',
+              <Input
+                value={c.admin.user}
+                onChange={(e) =>
+                  setDraft({
+                    ...draft,
+                    admin: { ...c.admin, user: e.target.value },
+                  })
+                }
+                className="h-9 font-mono"
+                autoComplete="username"
+              />,
+            )}
+            {F(
+              'password',
+              'admin.password',
+              <div className="flex gap-1.5">
                 <Input
-                  value={c.admin.user}
+                  type={showPassword ? 'text' : 'password'}
+                  value={c.admin.password}
                   onChange={(e) =>
                     setDraft({
                       ...draft,
-                      admin: { ...c.admin, user: e.target.value },
+                      admin: { ...c.admin, password: e.target.value },
                     })
                   }
-                  className="h-9 font-mono"
-                  autoComplete="username"
+                  placeholder="••••••••"
+                  className="h-9 font-mono flex-1"
+                  autoComplete="new-password"
                 />
-              </FieldRow>
-            )}
-            {visible('Password', 'Login password') && (
-              <FieldRow
-                label="Password"
-                hint="Leave blank to keep the current password. Sending a value overwrites it."
-                tomlKey="admin.password"
-              >
-                <div className="flex gap-1.5">
-                  <Input
-                    type={showPassword ? 'text' : 'password'}
-                    value={c.admin.password}
-                    onChange={(e) =>
-                      setDraft({
-                        ...draft,
-                        admin: { ...c.admin, password: e.target.value },
-                      })
-                    }
-                    placeholder="••••••••"
-                    className="h-9 font-mono flex-1"
-                    autoComplete="new-password"
-                  />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    className="h-9 w-9 p-0"
-                    onClick={toggleShowPassword}
-                    title={showPassword ? 'Hide' : 'Reveal'}
-                  >
-                    {showPassword ? (
-                      <EyeOff className="size-3.5" />
-                    ) : (
-                      <Eye className="size-3.5" />
-                    )}
-                  </Button>
-                </div>
-              </FieldRow>
-            )}
-            {visible('Token TTL', 'Bearer token lifetime') && (
-              <FieldRow
-                label="Token TTL"
-                hint='Bearer-token lifetime as a Go duration, e.g. "24h", "30m". Empty = never expire.'
-                tomlKey="admin.token_ttl"
-              >
-                <Input
-                  value={c.admin.token_ttl}
-                  onChange={(e) =>
-                    setDraft({
-                      ...draft,
-                      admin: { ...c.admin, token_ttl: e.target.value },
-                    })
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-9 w-9 p-0"
+                  onClick={toggleShowPassword}
+                  title={
+                    showPassword
+                      ? t('web.serverSettings.fields.password.hideTitle')
+                      : t('web.serverSettings.fields.password.revealTitle')
                   }
-                  placeholder="24h"
-                  className="h-9 font-mono w-32"
-                />
-              </FieldRow>
+                >
+                  {showPassword ? (
+                    <EyeOff className="size-3.5" />
+                  ) : (
+                    <Eye className="size-3.5" />
+                  )}
+                </Button>
+              </div>,
+            )}
+            {F(
+              'tokenTTL',
+              'admin.token_ttl',
+              <Input
+                value={c.admin.token_ttl}
+                onChange={(e) =>
+                  setDraft({
+                    ...draft,
+                    admin: { ...c.admin, token_ttl: e.target.value },
+                  })
+                }
+                placeholder="24h"
+                className="h-9 font-mono w-32"
+              />,
             )}
           </FormGroup>
         </div>
@@ -428,66 +433,56 @@ function SectionForm({
       return (
         <div className="flex flex-col gap-8">
           <FormGrid>
-            {visible('Log level', 'Verbosity threshold') && (
-              <FieldRow
-                label="Log level"
-                hint="Lines below this level are dropped."
-                tomlKey="log.level"
-              >
-                <SegmentedSelect
-                  value={c.log.level || 'info'}
-                  options={[
-                    { value: 'debug', label: 'debug' },
-                    { value: 'info', label: 'info' },
-                    { value: 'warn', label: 'warn' },
-                    { value: 'error', label: 'error' },
-                  ]}
-                  onChange={(v) =>
-                    setDraft({ ...draft, log: { ...c.log, level: v } })
-                  }
-                />
-              </FieldRow>
+            {F(
+              'logLevel',
+              'log.level',
+              <SegmentedSelect
+                value={c.log.level || 'info'}
+                options={[
+                  { value: 'debug', label: 'debug' },
+                  { value: 'info', label: 'info' },
+                  { value: 'warn', label: 'warn' },
+                  { value: 'error', label: 'error' },
+                ]}
+                onChange={(v) =>
+                  setDraft({ ...draft, log: { ...c.log, level: v } })
+                }
+              />,
             )}
-            {visible('Format', 'Log encoding') && (
-              <FieldRow
-                label="Format"
-                hint='"text" is human-readable; "json" is machine-parsable.'
-                tomlKey="log.format"
-              >
-                <SegmentedSelect
-                  value={c.log.format || 'text'}
-                  options={[
-                    { value: 'text', label: 'text' },
-                    { value: 'json', label: 'json' },
-                  ]}
-                  onChange={(v) =>
-                    setDraft({ ...draft, log: { ...c.log, format: v } })
-                  }
-                />
-              </FieldRow>
+            {F(
+              'logFormat',
+              'log.format',
+              <SegmentedSelect
+                value={c.log.format || 'text'}
+                options={[
+                  { value: 'text', label: 'text' },
+                  { value: 'json', label: 'json' },
+                ]}
+                onChange={(v) =>
+                  setDraft({ ...draft, log: { ...c.log, format: v } })
+                }
+              />,
             )}
-            {visible('Log file', 'Persist log to disk') && (
-              <FieldRow
-                label="Log file"
-                hint="Optional file path. Auto-rotates at 10 MB, keeps 5 backups. Empty = stderr only."
-                tomlKey="log.file"
-              >
-                <PathInput
-                  value={c.log.file}
-                  onChange={(v) =>
-                    setDraft({ ...draft, log: { ...c.log, file: v } })
-                  }
-                  placeholder="~/.opendray/opendray.log"
-                />
-              </FieldRow>
+            {F(
+              'logFile',
+              'log.file',
+              <PathInput
+                value={c.log.file}
+                onChange={(v) =>
+                  setDraft({ ...draft, log: { ...c.log, file: v } })
+                }
+                placeholder="~/.opendray/opendray.log"
+              />,
             )}
           </FormGrid>
 
           <div>
             <div className="flex items-baseline justify-between mb-2">
-              <h3 className="text-[12.5px] font-medium">Live tail</h3>
+              <h3 className="text-[12.5px] font-medium">
+                {t('web.serverSettings.liveTail.heading')}
+              </h3>
               <p className="text-[10px] text-muted-foreground/70">
-                In-memory ring buffer (last ~2,000 records). Resets on restart.
+                {t('web.serverSettings.liveTail.description')}
               </p>
             </div>
             <LogViewer />
@@ -498,43 +493,35 @@ function SectionForm({
     case 'sessions':
       return (
         <FormGrid>
-          {visible('Idle threshold', 'How long before idle fires') && (
-            <FieldRow
-              label="Idle threshold"
-              hint="A session is silent for this long before session.idle fires. Empty = 30s."
-              tomlKey="session.idle_threshold"
-            >
-              <Input
-                value={c.session.idle_threshold}
-                onChange={(e) =>
-                  setDraft({
-                    ...draft,
-                    session: { ...c.session, idle_threshold: e.target.value },
-                  })
-                }
-                placeholder="30s"
-                className="h-9 font-mono w-32"
-              />
-            </FieldRow>
+          {F(
+            'idleThreshold',
+            'session.idle_threshold',
+            <Input
+              value={c.session.idle_threshold}
+              onChange={(e) =>
+                setDraft({
+                  ...draft,
+                  session: { ...c.session, idle_threshold: e.target.value },
+                })
+              }
+              placeholder="30s"
+              className="h-9 font-mono w-32"
+            />,
           )}
-          {visible('Idle poll interval', 'Idle detector cadence') && (
-            <FieldRow
-              label="Idle poll interval"
-              hint="How often the idle detector wakes up. Lower = lower latency, more wakeups. Empty = 5s."
-              tomlKey="session.idle_interval"
-            >
-              <Input
-                value={c.session.idle_interval}
-                onChange={(e) =>
-                  setDraft({
-                    ...draft,
-                    session: { ...c.session, idle_interval: e.target.value },
-                  })
-                }
-                placeholder="5s"
-                className="h-9 font-mono w-32"
-              />
-            </FieldRow>
+          {F(
+            'idlePollInterval',
+            'session.idle_interval',
+            <Input
+              value={c.session.idle_interval}
+              onChange={(e) =>
+                setDraft({
+                  ...draft,
+                  session: { ...c.session, idle_interval: e.target.value },
+                })
+              }
+              placeholder="5s"
+              className="h-9 font-mono w-32"
+            />,
           )}
         </FormGrid>
       )
@@ -542,107 +529,83 @@ function SectionForm({
     case 'vault':
       return (
         <FormGrid>
-          {visible('Vault root', 'Top-level directory') && (
-            <FieldRow
-              label="Vault root"
-              hint="Top-level directory for notes, skills, and MCP registry."
-              tomlKey="vault.root"
-            >
-              <PathInput
-                value={c.vault.root}
-                onChange={(v) =>
-                  setDraft({ ...draft, vault: { ...c.vault, root: v } })
-                }
-                placeholder="~/.opendray/vault"
-                expectDir
-              />
-            </FieldRow>
+          {F(
+            'vaultRoot',
+            'vault.root',
+            <PathInput
+              value={c.vault.root}
+              onChange={(v) =>
+                setDraft({ ...draft, vault: { ...c.vault, root: v } })
+              }
+              placeholder="~/.opendray/vault"
+              expectDir
+            />,
           )}
-          {visible('Notes directory', 'Where notes are written') && (
-            <FieldRow
-              label="Notes directory"
-              hint="Override notes location. Defaults to <vault root>/notes."
-              tomlKey="vault.notes"
-            >
-              <PathInput
-                value={c.vault.notes}
-                onChange={(v) =>
-                  setDraft({ ...draft, vault: { ...c.vault, notes: v } })
-                }
-                placeholder="<vault>/notes"
-                expectDir
-              />
-            </FieldRow>
+          {F(
+            'notesDirectory',
+            'vault.notes',
+            <PathInput
+              value={c.vault.notes}
+              onChange={(v) =>
+                setDraft({ ...draft, vault: { ...c.vault, notes: v } })
+              }
+              placeholder="<vault>/notes"
+              expectDir
+            />,
           )}
-          {visible('Skills directory', 'Where skill files live') && (
-            <FieldRow
-              label="Skills directory"
-              hint="Override skills location. Defaults to <vault root>/skills."
-              tomlKey="vault.skills"
-            >
-              <PathInput
-                value={c.vault.skills}
-                onChange={(v) =>
-                  setDraft({ ...draft, vault: { ...c.vault, skills: v } })
-                }
-                placeholder="<vault>/skills"
-                expectDir
-              />
-            </FieldRow>
+          {F(
+            'skillsDirectory',
+            'vault.skills',
+            <PathInput
+              value={c.vault.skills}
+              onChange={(v) =>
+                setDraft({ ...draft, vault: { ...c.vault, skills: v } })
+              }
+              placeholder="<vault>/skills"
+              expectDir
+            />,
           )}
-          {visible('Git root', 'Repo for vault sync') && (
-            <FieldRow
-              label="Git root"
-              hint="Working tree the Vault Sync feature commits to."
-              tomlKey="vault.git_root"
-            >
-              <PathInput
-                value={c.vault.git_root}
-                onChange={(v) =>
-                  setDraft({ ...draft, vault: { ...c.vault, git_root: v } })
-                }
-                placeholder="<vault root>"
-                expectDir
-              />
-            </FieldRow>
+          {F(
+            'gitRoot',
+            'vault.git_root',
+            <PathInput
+              value={c.vault.git_root}
+              onChange={(v) =>
+                setDraft({ ...draft, vault: { ...c.vault, git_root: v } })
+              }
+              placeholder="<vault root>"
+              expectDir
+            />,
           )}
-          {visible('Personal prefix', 'Default folder for personal notes') && (
-            <FieldRow
-              label="Personal prefix"
-              hint='Folder name used for personal notes when auto-deriving paths. Default "personal".'
-              tomlKey="vault.personal_prefix"
-            >
-              <Input
-                value={c.vault.personal_prefix}
-                onChange={(e) =>
-                  setDraft({
-                    ...draft,
-                    vault: { ...c.vault, personal_prefix: e.target.value },
-                  })
-                }
-                placeholder="personal"
-                className="h-9 font-mono w-48"
-              />
-            </FieldRow>
+          {F(
+            'personalPrefix',
+            'vault.personal_prefix',
+            <Input
+              value={c.vault.personal_prefix}
+              onChange={(e) =>
+                setDraft({
+                  ...draft,
+                  vault: { ...c.vault, personal_prefix: e.target.value },
+                })
+              }
+              placeholder="personal"
+              className="h-9 font-mono w-48"
+            />,
           )}
-          {visible('Projects prefix', 'Default folder for project notes') && (
-            <FieldRow
-              label="Projects prefix"
-              hint='Folder name used for project notes. Default "projects".'
-              tomlKey="vault.projects_prefix"
-            >
-              <Input
-                value={c.vault.projects_prefix}
-                onChange={(e) =>
-                  setDraft({
-                    ...draft,
-                    vault: { ...c.vault, projects_prefix: e.target.value },
-                  })
-                }
-                placeholder="projects"
-                className="h-9 font-mono w-48"
-              />
-            </FieldRow>
+          {F(
+            'projectsPrefix',
+            'vault.projects_prefix',
+            <Input
+              value={c.vault.projects_prefix}
+              onChange={(e) =>
+                setDraft({
+                  ...draft,
+                  vault: { ...c.vault, projects_prefix: e.target.value },
+                })
+              }
+              placeholder="projects"
+              className="h-9 font-mono w-48"
+            />,
           )}
         </FormGrid>
       )
@@ -650,39 +613,31 @@ function SectionForm({
     case 'mcp':
       return (
         <FormGrid>
-          {visible('Registry root', 'Where MCP server defs live') && (
-            <FieldRow
-              label="Registry root"
-              hint="Directory holding MCP server JSON definitions. Defaults to <vault>/mcp."
-              tomlKey="mcp.root"
-            >
-              <PathInput
-                value={c.mcp.root}
-                onChange={(v) =>
-                  setDraft({ ...draft, mcp: { ...c.mcp, root: v } })
-                }
-                placeholder="<vault>/mcp"
-                expectDir
-              />
-            </FieldRow>
+          {F(
+            'registryRoot',
+            'mcp.root',
+            <PathInput
+              value={c.mcp.root}
+              onChange={(v) =>
+                setDraft({ ...draft, mcp: { ...c.mcp, root: v } })
+              }
+              placeholder="<vault>/mcp"
+              expectDir
+            />,
           )}
-          {visible('Secrets file', 'Substitution source for ${KEY}') && (
-            <FieldRow
-              label="Secrets file"
-              hint="key=value file substituted into MCP server commands at spawn time."
-              tomlKey="mcp.secrets_file"
-            >
-              <PathInput
-                value={c.mcp.secrets_file}
-                onChange={(v) =>
-                  setDraft({
-                    ...draft,
-                    mcp: { ...c.mcp, secrets_file: v },
-                  })
-                }
-                placeholder="~/.opendray/secrets.env"
-              />
-            </FieldRow>
+          {F(
+            'secretsFile',
+            'mcp.secrets_file',
+            <PathInput
+              value={c.mcp.secrets_file}
+              onChange={(v) =>
+                setDraft({
+                  ...draft,
+                  mcp: { ...c.mcp, secrets_file: v },
+                })
+              }
+              placeholder="~/.opendray/secrets.env"
+            />,
           )}
         </FormGrid>
       )
@@ -690,119 +645,99 @@ function SectionForm({
     case 'memory':
       return (
         <div className="flex flex-col gap-8">
-          <FormGroup heading="Configuration">
-            {visible('Backend', 'Embedder choice') && (
-              <FieldRow
-                label="Embedder backend"
-                hint='"auto" / "bm25" use the cgo-free pure-Go keyword path. "http" calls any OpenAI-compatible /v1/embeddings (ollama / OpenAI / LocalAI). "local" runs an ONNX sentence-transformer in-process — requires a binary built with `-tags local_onnx`.'
-                tomlKey="memory.backend"
-              >
-                <SegmentedSelect
-                  value={c.memory.backend || 'auto'}
-                  options={[
-                    { value: 'auto', label: 'auto' },
-                    { value: 'bm25', label: 'bm25' },
-                    { value: 'http', label: 'http' },
-                    { value: 'local', label: 'local (onnx)' },
-                  ]}
-                  onChange={(v) =>
-                    setDraft({ ...draft, memory: { ...c.memory, backend: v } })
-                  }
-                />
-              </FieldRow>
+          <FormGroup heading={t('web.serverSettings.formGroups.memoryConfiguration')}>
+            {F(
+              'memoryBackend',
+              'memory.backend',
+              <SegmentedSelect
+                value={c.memory.backend || 'auto'}
+                options={[
+                  { value: 'auto', label: 'auto' },
+                  { value: 'bm25', label: 'bm25' },
+                  { value: 'http', label: 'http' },
+                  { value: 'local', label: 'local (onnx)' },
+                ]}
+                onChange={(v) =>
+                  setDraft({ ...draft, memory: { ...c.memory, backend: v } })
+                }
+              />,
             )}
-            {visible('Store', 'Vector store backend') && (
-              <FieldRow
-                label="Store"
-                hint={`"pgvector" reuses opendray's existing PG with the vector extension; only option in v1.`}
-                tomlKey="memory.store"
-              >
-                <SegmentedSelect
-                  value={c.memory.store || 'pgvector'}
-                  options={[{ value: 'pgvector', label: 'pgvector' }]}
-                  onChange={(v) =>
-                    setDraft({ ...draft, memory: { ...c.memory, store: v } })
-                  }
-                />
-              </FieldRow>
+            {F(
+              'memoryStore',
+              'memory.store',
+              <SegmentedSelect
+                value={c.memory.store || 'pgvector'}
+                options={[{ value: 'pgvector', label: 'pgvector' }]}
+                onChange={(v) =>
+                  setDraft({ ...draft, memory: { ...c.memory, store: v } })
+                }
+              />,
             )}
-            {visible('Top K', 'Default search result count') && (
-              <FieldRow
-                label="Default top-K"
-                hint="How many hits memory_search returns when the agent doesn't specify. Empty = 5."
-                tomlKey="memory.default_top_k"
-              >
-                <Input
-                  type="number"
-                  value={c.memory.default_top_k || ''}
-                  onChange={(e) =>
-                    setDraft({
-                      ...draft,
-                      memory: {
-                        ...c.memory,
-                        default_top_k: parseInt(e.target.value || '0', 10),
-                      },
-                    })
-                  }
-                  placeholder="5"
-                  className="h-9 font-mono w-24"
-                />
-              </FieldRow>
+            {F(
+              'memoryTopK',
+              'memory.default_top_k',
+              <Input
+                type="number"
+                value={c.memory.default_top_k || ''}
+                onChange={(e) =>
+                  setDraft({
+                    ...draft,
+                    memory: {
+                      ...c.memory,
+                      default_top_k: parseInt(e.target.value || '0', 10),
+                    },
+                  })
+                }
+                placeholder="5"
+                className="h-9 font-mono w-24"
+              />,
             )}
-            {visible('Threshold', 'Cosine similarity floor') && (
-              <FieldRow
-                label="Similarity threshold"
-                hint="Hits below this score are dropped. Empty = 0.1 (permissive — BM25 sparse vectors rarely break 0.5)."
-                tomlKey="memory.similarity_threshold"
-              >
-                <Input
-                  type="number"
-                  step="0.01"
-                  min="-1"
-                  max="1"
-                  value={c.memory.similarity_threshold || ''}
-                  onChange={(e) =>
-                    setDraft({
-                      ...draft,
-                      memory: {
-                        ...c.memory,
-                        similarity_threshold: parseFloat(e.target.value || '0'),
-                      },
-                    })
-                  }
-                  placeholder="0.1"
-                  className="h-9 font-mono w-28"
-                />
-              </FieldRow>
+            {F(
+              'memoryThreshold',
+              'memory.similarity_threshold',
+              <Input
+                type="number"
+                step="0.01"
+                min="-1"
+                max="1"
+                value={c.memory.similarity_threshold || ''}
+                onChange={(e) =>
+                  setDraft({
+                    ...draft,
+                    memory: {
+                      ...c.memory,
+                      similarity_threshold: parseFloat(e.target.value || '0'),
+                    },
+                  })
+                }
+                placeholder="0.1"
+                className="h-9 font-mono w-28"
+              />,
             )}
-            {visible('Default scope', 'Where new memories land') && (
-              <FieldRow
-                label="Default scope"
-                hint={`What memory_store uses when the agent doesn't specify. "project" (recommended) groups by cwd; "session" isolates per session; "global" shares across cwds.`}
-                tomlKey="memory.scope.default"
-              >
-                <SegmentedSelect
-                  value={c.memory.scope.default || 'project'}
-                  options={[
-                    { value: 'project', label: 'project' },
-                    { value: 'session', label: 'session' },
-                    { value: 'global', label: 'global' },
-                  ]}
-                  onChange={(v) =>
-                    setDraft({
-                      ...draft,
-                      memory: {
-                        ...c.memory,
-                        scope: { ...c.memory.scope, default: v },
-                      },
-                    })
-                  }
-                />
-              </FieldRow>
+            {F(
+              'memoryScope',
+              'memory.scope.default',
+              <SegmentedSelect
+                value={c.memory.scope.default || 'project'}
+                options={[
+                  { value: 'project', label: 'project' },
+                  { value: 'session', label: 'session' },
+                  { value: 'global', label: 'global' },
+                ]}
+                onChange={(v) =>
+                  setDraft({
+                    ...draft,
+                    memory: {
+                      ...c.memory,
+                      scope: { ...c.memory.scope, default: v },
+                    },
+                  })
+                }
+              />,
             )}
           </FormGroup>
 
-          <FormGroup heading="HTTP backend (used when backend=http)">
+          <FormGroup heading={t('web.serverSettings.formGroups.memoryHttp')}>
             <HttpBackendHelpers
               draft={c}
               onApply={(patch) =>
@@ -815,208 +750,182 @@ function SectionForm({
                 })
               }
             />
-            {visible('Base URL', 'OpenAI-compatible /v1/embeddings') && (
-              <FieldRow
-                label="Base URL"
-                hint='e.g. "http://localhost:11434/v1" for ollama, "https://api.openai.com/v1" for OpenAI.'
-                tomlKey="memory.http.base_url"
-              >
-                <Input
-                  value={c.memory.http.base_url}
-                  onChange={(e) =>
-                    setDraft({
-                      ...draft,
-                      memory: {
-                        ...c.memory,
-                        http: { ...c.memory.http, base_url: e.target.value },
-                      },
-                    })
-                  }
-                  placeholder="http://localhost:11434/v1"
-                  className="h-9 font-mono"
-                />
-              </FieldRow>
+            {F(
+              'memoryBaseUrl',
+              'memory.http.base_url',
+              <Input
+                value={c.memory.http.base_url}
+                onChange={(e) =>
+                  setDraft({
+                    ...draft,
+                    memory: {
+                      ...c.memory,
+                      http: { ...c.memory.http, base_url: e.target.value },
+                    },
+                  })
+                }
+                placeholder="http://localhost:11434/v1"
+                className="h-9 font-mono"
+              />,
             )}
-            {visible('Model', 'Embedding model name') && (
-              <FieldRow
-                label="Model"
-                hint='e.g. "nomic-embed-text" for ollama, "text-embedding-3-small" for OpenAI.'
-                tomlKey="memory.http.model"
-              >
-                <Input
-                  value={c.memory.http.model}
-                  onChange={(e) =>
-                    setDraft({
-                      ...draft,
-                      memory: {
-                        ...c.memory,
-                        http: { ...c.memory.http, model: e.target.value },
-                      },
-                    })
-                  }
-                  placeholder="nomic-embed-text"
-                  className="h-9 font-mono"
-                />
-              </FieldRow>
+            {F(
+              'memoryModel',
+              'memory.http.model',
+              <Input
+                value={c.memory.http.model}
+                onChange={(e) =>
+                  setDraft({
+                    ...draft,
+                    memory: {
+                      ...c.memory,
+                      http: { ...c.memory.http, model: e.target.value },
+                    },
+                  })
+                }
+                placeholder="nomic-embed-text"
+                className="h-9 font-mono"
+              />,
             )}
-            {visible('API key', 'Bearer for the HTTP backend') && (
-              <FieldRow
-                label="API key"
-                hint="Empty for ollama / local servers. Required for OpenAI / Voyage / hosted services."
-                tomlKey="memory.http.api_key"
-              >
-                <Input
-                  type="password"
-                  value={c.memory.http.api_key}
-                  onChange={(e) =>
-                    setDraft({
-                      ...draft,
-                      memory: {
-                        ...c.memory,
-                        http: { ...c.memory.http, api_key: e.target.value },
-                      },
-                    })
-                  }
-                  placeholder="sk-…"
-                  className="h-9 font-mono"
-                />
-              </FieldRow>
+            {F(
+              'memoryApiKey',
+              'memory.http.api_key',
+              <Input
+                type="password"
+                value={c.memory.http.api_key}
+                onChange={(e) =>
+                  setDraft({
+                    ...draft,
+                    memory: {
+                      ...c.memory,
+                      http: { ...c.memory.http, api_key: e.target.value },
+                    },
+                  })
+                }
+                placeholder="sk-…"
+                className="h-9 font-mono"
+              />,
             )}
           </FormGroup>
 
-          <FormGroup heading="Local ONNX (used when backend=local)">
+          <FormGroup heading={t('web.serverSettings.formGroups.memoryLocal')}>
             <div className="rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-[11px] text-amber-200/80 leading-snug">
-              Requires the binary to be compiled with{' '}
-              <code className="font-mono">-tags local_onnx</code>. The
-              standard build returns a clear stub error when this backend is
-              selected. See <strong>Memory → Local ONNX</strong> tutorial for
-              setup steps.
+              <Trans
+                i18nKey="web.serverSettings.localOnnxBanner"
+                components={{
+                  1: <code className="font-mono" />,
+                  3: <strong />,
+                }}
+              />
             </div>
-            {visible('Model name', 'Cosmetic label') && (
-              <FieldRow
-                label="Model name"
-                hint='Cosmetic — appears in logs / Inspector. e.g. "bge-m3", "bge-small-en-v1.5".'
-                tomlKey="memory.local.model"
-              >
-                <Input
-                  value={c.memory.local.model}
-                  onChange={(e) =>
-                    setDraft({
-                      ...draft,
-                      memory: {
-                        ...c.memory,
-                        local: { ...c.memory.local, model: e.target.value },
-                      },
-                    })
-                  }
-                  placeholder="bge-m3"
-                  className="h-9 font-mono w-48"
-                />
-              </FieldRow>
+            {F(
+              'memoryLocalModel',
+              'memory.local.model',
+              <Input
+                value={c.memory.local.model}
+                onChange={(e) =>
+                  setDraft({
+                    ...draft,
+                    memory: {
+                      ...c.memory,
+                      local: { ...c.memory.local, model: e.target.value },
+                    },
+                  })
+                }
+                placeholder="bge-m3"
+                className="h-9 font-mono w-48"
+              />,
             )}
-            {visible('Library path', 'Where libonnxruntime lives') && (
-              <FieldRow
-                label="Library path"
-                hint="Directory holding libonnxruntime.dylib (macOS) / libonnxruntime.so (Linux). After `brew install onnxruntime`, that's /opt/homebrew/opt/onnxruntime/lib."
-                tomlKey="memory.local.library_path"
-              >
-                <PathInput
-                  value={c.memory.local.library_path}
-                  onChange={(v) =>
-                    setDraft({
-                      ...draft,
-                      memory: {
-                        ...c.memory,
-                        local: { ...c.memory.local, library_path: v },
-                      },
-                    })
-                  }
-                  placeholder="/opt/homebrew/opt/onnxruntime/lib"
-                  expectDir
-                />
-              </FieldRow>
+            {F(
+              'memoryLibraryPath',
+              'memory.local.library_path',
+              <PathInput
+                value={c.memory.local.library_path}
+                onChange={(v) =>
+                  setDraft({
+                    ...draft,
+                    memory: {
+                      ...c.memory,
+                      local: { ...c.memory.local, library_path: v },
+                    },
+                  })
+                }
+                placeholder="/opt/homebrew/opt/onnxruntime/lib"
+                expectDir
+              />,
             )}
-            {visible('Model path', 'Path to model.onnx') && (
-              <FieldRow
-                label="Model path"
-                hint="Absolute path to the .onnx weights. Download from HuggingFace, e.g. Xenova/bge-m3 or Xenova/bge-small-en-v1.5."
-                tomlKey="memory.local.model_path"
-              >
-                <PathInput
-                  value={c.memory.local.model_path}
-                  onChange={(v) =>
-                    setDraft({
-                      ...draft,
-                      memory: {
-                        ...c.memory,
-                        local: { ...c.memory.local, model_path: v },
-                      },
-                    })
-                  }
-                  placeholder="~/.opendray/models/bge-m3/model.onnx"
-                />
-              </FieldRow>
+            {F(
+              'memoryModelPath',
+              'memory.local.model_path',
+              <PathInput
+                value={c.memory.local.model_path}
+                onChange={(v) =>
+                  setDraft({
+                    ...draft,
+                    memory: {
+                      ...c.memory,
+                      local: { ...c.memory.local, model_path: v },
+                    },
+                  })
+                }
+                placeholder="~/.opendray/models/bge-m3/model.onnx"
+              />,
             )}
-            {visible('Tokenizer path', 'Path to tokenizer.json') && (
-              <FieldRow
-                label="Tokenizer path"
-                hint="Absolute path to tokenizer.json (HuggingFace standard format) — usually right next to the model."
-                tomlKey="memory.local.tokenizer_path"
-              >
-                <PathInput
-                  value={c.memory.local.tokenizer_path}
-                  onChange={(v) =>
-                    setDraft({
-                      ...draft,
-                      memory: {
-                        ...c.memory,
-                        local: { ...c.memory.local, tokenizer_path: v },
-                      },
-                    })
-                  }
-                  placeholder="~/.opendray/models/bge-m3/tokenizer.json"
-                />
-              </FieldRow>
+            {F(
+              'memoryTokenizerPath',
+              'memory.local.tokenizer_path',
+              <PathInput
+                value={c.memory.local.tokenizer_path}
+                onChange={(v) =>
+                  setDraft({
+                    ...draft,
+                    memory: {
+                      ...c.memory,
+                      local: { ...c.memory.local, tokenizer_path: v },
+                    },
+                  })
+                }
+                placeholder="~/.opendray/models/bge-m3/tokenizer.json"
+              />,
             )}
-            {visible('Max sequence length', 'Token cap per text') && (
-              <FieldRow
-                label="Max sequence length"
-                hint="Tokens beyond this are truncated. bge-m3 default is 512. Empty = 512."
-                tomlKey="memory.local.max_seq_len"
-              >
-                <Input
-                  type="number"
-                  min="32"
-                  max="8192"
-                  value={c.memory.local.max_seq_len || ''}
-                  onChange={(e) =>
-                    setDraft({
-                      ...draft,
-                      memory: {
-                        ...c.memory,
-                        local: {
-                          ...c.memory.local,
-                          max_seq_len: parseInt(e.target.value || '0', 10),
-                        },
+            {F(
+              'memoryMaxSeqLen',
+              'memory.local.max_seq_len',
+              <Input
+                type="number"
+                min="32"
+                max="8192"
+                value={c.memory.local.max_seq_len || ''}
+                onChange={(e) =>
+                  setDraft({
+                    ...draft,
+                    memory: {
+                      ...c.memory,
+                      local: {
+                        ...c.memory.local,
+                        max_seq_len: parseInt(e.target.value || '0', 10),
                       },
-                    })
-                  }
-                  placeholder="512"
-                  className="h-9 font-mono w-24"
-                />
-              </FieldRow>
+                    },
+                  })
+                }
+                placeholder="512"
+                className="h-9 font-mono w-24"
+              />,
             )}
           </FormGroup>
 
           <div className="rounded-md border border-border bg-card/30 px-3 py-2.5 flex items-center justify-between gap-3">
             <div>
-              <h3 className="text-[12.5px] font-medium">Inspector</h3>
+              <h3 className="text-[12.5px] font-medium">
+                {t('web.serverSettings.memoryInspectorCard.heading')}
+              </h3>
               <p className="text-[11px] text-muted-foreground/70 mt-0.5">
-                Browse, search and edit stored memories on the dedicated page.
+                {t('web.serverSettings.memoryInspectorCard.description')}
               </p>
             </div>
             <Button asChild variant="outline" size="sm" className="h-8 text-[11px]">
-              <Link to="/memory">Open Memory →</Link>
+              <Link to="/memory">
+                {t('web.serverSettings.memoryInspectorCard.openButton')}
+              </Link>
             </Button>
           </div>
         </div>
@@ -1031,48 +940,40 @@ function SectionForm({
     case 'claude':
       return (
         <FormGrid>
-          {visible('History roots', 'Where Claude transcripts live') && (
-            <FieldRow
-              label="History roots"
-              hint="Directories scanned for Claude per-project JSONL transcripts. Empty = scan ~/.claude/projects + every ~/.claude-accounts/*/projects."
-              tomlKey="providers.claude.history_roots"
-            >
-              <StringList
-                value={c.providers.claude.history_roots ?? []}
-                onChange={(arr) =>
-                  setDraft({
-                    ...draft,
-                    providers: {
-                      ...c.providers,
-                      claude: { ...c.providers.claude, history_roots: arr },
-                    },
-                  })
-                }
-                placeholder="~/.claude/projects"
-              />
-            </FieldRow>
+          {F(
+            'claudeHistoryRoots',
+            'providers.claude.history_roots',
+            <StringList
+              value={c.providers.claude.history_roots ?? []}
+              onChange={(arr) =>
+                setDraft({
+                  ...draft,
+                  providers: {
+                    ...c.providers,
+                    claude: { ...c.providers.claude, history_roots: arr },
+                  },
+                })
+              }
+              placeholder="~/.claude/projects"
+            />,
           )}
-          {visible('Accounts directory', 'Multi-account root') && (
-            <FieldRow
-              label="Accounts directory"
-              hint="Root used for opendray-managed Claude account ConfigDirs. Default ~/.claude-accounts."
-              tomlKey="providers.claude.accounts_dir"
-            >
-              <PathInput
-                value={c.providers.claude.accounts_dir}
-                onChange={(v) =>
-                  setDraft({
-                    ...draft,
-                    providers: {
-                      ...c.providers,
-                      claude: { ...c.providers.claude, accounts_dir: v },
-                    },
-                  })
-                }
-                placeholder="~/.claude-accounts"
-                expectDir
-              />
-            </FieldRow>
+          {F(
+            'claudeAccountsDir',
+            'providers.claude.accounts_dir',
+            <PathInput
+              value={c.providers.claude.accounts_dir}
+              onChange={(v) =>
+                setDraft({
+                  ...draft,
+                  providers: {
+                    ...c.providers,
+                    claude: { ...c.providers.claude, accounts_dir: v },
+                  },
+                })
+              }
+              placeholder="~/.claude-accounts"
+              expectDir
+            />,
           )}
         </FormGrid>
       )
@@ -1080,27 +981,23 @@ function SectionForm({
     case 'codex':
       return (
         <FormGrid>
-          {visible('Sessions root', 'Codex rollouts directory') && (
-            <FieldRow
-              label="Sessions root"
-              hint="Directory walked for Codex rollout JSONL files. Default ~/.codex/sessions."
-              tomlKey="providers.codex.sessions_root"
-            >
-              <PathInput
-                value={c.providers.codex.sessions_root}
-                onChange={(v) =>
-                  setDraft({
-                    ...draft,
-                    providers: {
-                      ...c.providers,
-                      codex: { sessions_root: v },
-                    },
-                  })
-                }
-                placeholder="~/.codex/sessions"
-                expectDir
-              />
-            </FieldRow>
+          {F(
+            'codexSessionsRoot',
+            'providers.codex.sessions_root',
+            <PathInput
+              value={c.providers.codex.sessions_root}
+              onChange={(v) =>
+                setDraft({
+                  ...draft,
+                  providers: {
+                    ...c.providers,
+                    codex: { sessions_root: v },
+                  },
+                })
+              }
+              placeholder="~/.codex/sessions"
+              expectDir
+            />,
           )}
         </FormGrid>
       )
@@ -1108,48 +1005,40 @@ function SectionForm({
     case 'gemini':
       return (
         <FormGrid>
-          {visible('tmp directory', 'Per-project Gemini logs') && (
-            <FieldRow
-              label="Tmp directory"
-              hint="Root holding Gemini per-project tmp folders. Default ~/.gemini/tmp."
-              tomlKey="providers.gemini.tmp_root"
-            >
-              <PathInput
-                value={c.providers.gemini.tmp_root}
-                onChange={(v) =>
-                  setDraft({
-                    ...draft,
-                    providers: {
-                      ...c.providers,
-                      gemini: { ...c.providers.gemini, tmp_root: v },
-                    },
-                  })
-                }
-                placeholder="~/.gemini/tmp"
-                expectDir
-              />
-            </FieldRow>
+          {F(
+            'geminiTmpRoot',
+            'providers.gemini.tmp_root',
+            <PathInput
+              value={c.providers.gemini.tmp_root}
+              onChange={(v) =>
+                setDraft({
+                  ...draft,
+                  providers: {
+                    ...c.providers,
+                    gemini: { ...c.providers.gemini, tmp_root: v },
+                  },
+                })
+              }
+              placeholder="~/.gemini/tmp"
+              expectDir
+            />,
           )}
-          {visible('projects.json', 'cwd → short-name map') && (
-            <FieldRow
-              label="projects.json"
-              hint="Path to Gemini's cwd→short-name mapping file. Default ~/.gemini/projects.json."
-              tomlKey="providers.gemini.projects_file"
-            >
-              <PathInput
-                value={c.providers.gemini.projects_file}
-                onChange={(v) =>
-                  setDraft({
-                    ...draft,
-                    providers: {
-                      ...c.providers,
-                      gemini: { ...c.providers.gemini, projects_file: v },
-                    },
-                  })
-                }
-                placeholder="~/.gemini/projects.json"
-              />
-            </FieldRow>
+          {F(
+            'geminiProjectsFile',
+            'providers.gemini.projects_file',
+            <PathInput
+              value={c.providers.gemini.projects_file}
+              onChange={(v) =>
+                setDraft({
+                  ...draft,
+                  providers: {
+                    ...c.providers,
+                    gemini: { ...c.providers.gemini, projects_file: v },
+                  },
+                })
+              }
+              placeholder="~/.gemini/projects.json"
+            />,
           )}
         </FormGrid>
       )
@@ -1259,12 +1148,13 @@ function StringList({
   onChange: (next: string[]) => void
   placeholder?: string
 }) {
+  const { t } = useTranslation()
   const list = value ?? []
   return (
     <div className="flex flex-col gap-2">
       {list.length === 0 && (
         <p className="text-[11px] text-muted-foreground/70 italic">
-          (none — using built-in defaults)
+          {t('web.serverSettings.stringList.noneDefault')}
         </p>
       )}
       {list.map((v, i) => (
@@ -1288,7 +1178,7 @@ function StringList({
             size="sm"
             className="h-9 w-9 p-0 text-muted-foreground hover:text-destructive"
             onClick={() => onChange(list.filter((_, j) => j !== i))}
-            title="Remove"
+            title={t('web.serverSettings.stringList.removeTitle')}
           >
             <X className="size-3.5" />
           </Button>
@@ -1302,7 +1192,7 @@ function StringList({
         onClick={() => onChange([...list, ''])}
       >
         <Plus className="size-3 mr-1" />
-        Add path
+        {t('web.serverSettings.stringList.addPath')}
       </Button>
     </div>
   )
@@ -1456,6 +1346,7 @@ function HttpBackendHelpers({
   draft: ServerConfig
   onApply: (patch: { base_url?: string; model?: string; api_key?: string }) => void
 }) {
+  const { t } = useTranslation()
   const { data: status } = useQuery({
     queryKey: ['memory-status-presets'],
     queryFn: fetchMemoryStatus,
@@ -1479,9 +1370,24 @@ function HttpBackendHelpers({
   }
 
   const presets = [
-    { label: 'ollama', url: 'http://localhost:11434/v1', model: 'nomic-embed-text', tip: 'Local ollama daemon' },
-    { label: 'LM Studio', url: 'http://localhost:1234/v1', model: '', tip: 'LM Studio local server' },
-    { label: 'OpenAI', url: 'https://api.openai.com/v1', model: 'text-embedding-3-small', tip: 'OpenAI cloud (needs API key)' },
+    {
+      label: 'ollama',
+      url: 'http://localhost:11434/v1',
+      model: 'nomic-embed-text',
+      tip: t('web.serverSettings.httpHelpers.presetTip.ollama'),
+    },
+    {
+      label: 'LM Studio',
+      url: 'http://localhost:1234/v1',
+      model: '',
+      tip: t('web.serverSettings.httpHelpers.presetTip.lmStudio'),
+    },
+    {
+      label: 'OpenAI',
+      url: 'https://api.openai.com/v1',
+      model: 'text-embedding-3-small',
+      tip: t('web.serverSettings.httpHelpers.presetTip.openai'),
+    },
   ]
 
   const test = async () => {
@@ -1521,7 +1427,7 @@ function HttpBackendHelpers({
       {detected.length > 0 && (
         <div className="rounded-md border border-emerald-500/30 bg-emerald-500/5 p-2.5 text-[11px]">
           <p className="font-medium text-emerald-300/90 mb-1">
-            Auto-detected at startup
+            {t('web.serverSettings.httpHelpers.autoDetected')}
           </p>
           <div className="flex flex-wrap gap-1.5">
             {detected.map((d) => (
@@ -1535,7 +1441,9 @@ function HttpBackendHelpers({
                   onApply({ base_url: d.base_url, model: embedModel })
                 }}
                 className="px-2 py-0.5 rounded border border-emerald-500/40 bg-emerald-500/10 text-emerald-200 hover:bg-emerald-500/20 transition-colors font-mono text-[10.5px]"
-                title={`${d.models?.length ?? 0} model(s) — click to use`}
+                title={t('web.serverSettings.httpHelpers.modelCount', {
+                  count: d.models?.length ?? 0,
+                })}
               >
                 {d.detected} · {d.base_url} ({d.models?.length ?? 0} models)
               </button>
@@ -1545,7 +1453,9 @@ function HttpBackendHelpers({
       )}
 
       <div className="flex flex-wrap items-center gap-1.5">
-        <span className="text-[10px] text-muted-foreground/70 mr-1">Presets:</span>
+        <span className="text-[10px] text-muted-foreground/70 mr-1">
+          {t('web.serverSettings.httpHelpers.presets')}
+        </span>
         {presets.map((p) => (
           <Button
             key={p.label}
@@ -1566,7 +1476,11 @@ function HttpBackendHelpers({
           disabled={!draft.memory.http.base_url || busy}
           onClick={test}
         >
-          {busy ? <Loader2 className="size-3 animate-spin" /> : 'Test connection'}
+          {busy ? (
+            <Loader2 className="size-3 animate-spin" />
+          ) : (
+            t('web.serverSettings.httpHelpers.testConnection')
+          )}
         </Button>
       </div>
 
@@ -1590,10 +1504,13 @@ function ProbeResultLine({
   configuredModel: string
   onApplyModel: (m: string) => void
 }) {
+  const { t } = useTranslation()
   if (!res.reachable) {
     return (
       <p className="text-[10.5px] text-destructive bg-destructive/10 border border-destructive/30 rounded px-2 py-1">
-        ✗ unreachable: {res.error ?? 'connection failed'}
+        {t('web.serverSettings.probe.unreachable', {
+          error: res.error ?? t('web.serverSettings.probe.connectionFailed'),
+        })}
       </p>
     )
   }
@@ -1606,19 +1523,26 @@ function ProbeResultLine({
   return (
     <div className="text-[10.5px] bg-emerald-500/10 border border-emerald-500/30 rounded px-2 py-1.5 flex flex-col gap-1">
       <p className="text-emerald-300">
-        ✓ reachable {res.detected ? `(${res.detected})` : ''} ·{' '}
-        {allModels.length} model(s) total · {embedModels.length} embedding
+        {t('web.serverSettings.probe.reachable', {
+          detected: res.detected ? `(${res.detected}) ` : '',
+          total: allModels.length,
+          embedding: embedModels.length,
+        })}
       </p>
       {configuredModel && !hasConfigured && (
         <p className="text-amber-300">
-          ⚠ Configured model{' '}
-          <code className="font-mono">{configuredModel}</code> isn't in the
-          list. Pick one of the embedding models below or fix the name.
+          <Trans
+            i18nKey="web.serverSettings.probe.modelMissing"
+            values={{ model: configuredModel }}
+            components={{ 1: <code className="font-mono" /> }}
+          />
         </p>
       )}
       {embedModels.length > 0 && (
         <div className="flex flex-wrap gap-1 mt-0.5">
-          <span className="text-emerald-300/70">embedding models:</span>
+          <span className="text-emerald-300/70">
+            {t('web.serverSettings.probe.embeddingModelsLabel')}
+          </span>
           {embedModels.slice(0, 6).map((m) => {
             const active = m === configuredModel
             return (
@@ -1631,7 +1555,11 @@ function ProbeResultLine({
                     ? 'border-emerald-400 bg-emerald-500/30 text-emerald-100'
                     : 'border-emerald-500/30 hover:bg-emerald-500/20 text-emerald-200'
                 }`}
-                title={active ? 'Currently configured' : 'Click to apply'}
+                title={
+                  active
+                    ? t('web.serverSettings.probe.configuredTitle')
+                    : t('web.serverSettings.probe.applyTitle')
+                }
               >
                 {active ? '✓ ' : ''}
                 {m}
@@ -1640,15 +1568,16 @@ function ProbeResultLine({
           })}
           {embedModels.length > 6 && (
             <span className="text-emerald-300/60">
-              +{embedModels.length - 6} more
+              {t('web.serverSettings.probe.moreModels', {
+                count: embedModels.length - 6,
+              })}
             </span>
           )}
         </div>
       )}
       {embedModels.length === 0 && allModels.length > 0 && (
         <p className="text-amber-300">
-          ⚠ No model name contains "embed". The endpoint might not have
-          an embedding model loaded — check your local server.
+          {t('web.serverSettings.probe.noEmbeddingFound')}
         </p>
       )}
     </div>
@@ -1668,6 +1597,7 @@ function BackupSection({
   setDraft: React.Dispatch<React.SetStateAction<ServerConfig>>
   visible: (label: string, hint?: string) => boolean
 }) {
+  const { t } = useTranslation()
   const c = draft
   const qc = useQueryClient()
   const [advancedOpen, setAdvancedOpen] = useState(false)
@@ -1694,10 +1624,25 @@ function BackupSection({
   const featureOff = status === null
   const showFilter = !visible || true // search filter not applied to control-center widgets
 
+  // Field helper for the Advanced sub-section. Mirrors the SectionForm F().
+  const FB = (
+    fieldKey: string,
+    tomlKey: string,
+    children: React.ReactNode,
+  ) => {
+    const label = t(`web.serverSettings.fields.${fieldKey}.label`)
+    const hint = t(`web.serverSettings.fields.${fieldKey}.hint`)
+    return visible(label, hint) ? (
+      <FieldRow label={label} hint={hint} tomlKey={tomlKey}>
+        {children}
+      </FieldRow>
+    ) : null
+  }
+
   return (
     <div className="flex flex-col gap-8">
       {/* ── Status ─────────────────────────────────────────────── */}
-      <FormGroup heading="Status">
+      <FormGroup heading={t('web.serverSettings.formGroups.backupStatus')}>
         <div
           className={cn(
             'rounded-md border p-3 text-[12px] flex flex-col gap-2',
@@ -1710,53 +1655,58 @@ function BackupSection({
             <div className="flex items-start gap-2">
               <Archive className="size-3.5 mt-0.5 text-state-idle" />
               <div>
-                <div className="font-medium">Feature disabled</div>
+                <div className="font-medium">
+                  {t('web.serverSettings.backup.featureDisabledTitle')}
+                </div>
                 <div className="text-muted-foreground mt-0.5">
-                  Set{' '}
-                  <code className="text-foreground">OPENDRAY_BACKUP_ENABLED=1</code>{' '}
-                  +{' '}
-                  <code className="text-foreground">
-                    OPENDRAY_BACKUP_KEY=&lt;passphrase&gt;
-                  </code>{' '}
-                  in opendray's environment, then restart. The master
-                  passphrase is env-only — it never touches config.toml.
+                  <Trans
+                    i18nKey="web.serverSettings.backup.featureDisabledHint"
+                    components={{
+                      1: <code className="text-foreground" />,
+                      3: <code className="text-foreground" />,
+                    }}
+                  />
                 </div>
               </div>
             </div>
           )}
           {status && (
             <>
-              <Row label="Status">
+              <Row label={t('web.serverSettings.backup.statusRowLabel')}>
                 <span className={status.ok ? 'text-state-running' : 'text-state-failed'}>
-                  {status.ok ? 'enabled · healthy' : 'enabled · degraded'}
+                  {status.ok
+                    ? t('web.serverSettings.backup.enabledHealthy')
+                    : t('web.serverSettings.backup.enabledDegraded')}
                 </span>
               </Row>
-              <Row label="Key fingerprint">
+              <Row label={t('web.serverSettings.backup.keyFingerprintLabel')}>
                 <code className="text-foreground">{status.key_fingerprint}</code>
                 <span className="ml-2 text-[10.5px] text-muted-foreground">
-                  record in Vaultwarden — losing it locks all prior backups
+                  {t('web.serverSettings.backup.keyFingerprintHint')}
                 </span>
               </Row>
-              <Row label="pg_dump">
+              <Row label={t('web.serverSettings.backup.pgDumpLabel')}>
                 {status.ok ? (
                   <code className="text-foreground">{status.pg_dump_version}</code>
                 ) : (
                   <span className="text-state-failed">
-                    {status.pg_dump_error || 'unavailable'}
+                    {status.pg_dump_error ||
+                      t('web.serverSettings.backup.pgDumpUnavailable')}
                   </span>
                 )}
               </Row>
-              <Row label="pg_restore">
+              <Row label={t('web.serverSettings.backup.pgRestoreLabel')}>
                 <code className="text-foreground">
-                  {status.pg_restore_version || '(not resolved)'}
+                  {status.pg_restore_version ||
+                    t('web.serverSettings.backup.pgRestoreNotResolved')}
                 </code>
               </Row>
               <div className="pt-1 border-t border-border/50 flex items-center justify-between">
                 <Link to="/backups" className="text-[11.5px] underline text-accent">
-                  Open Backups page →
+                  {t('web.serverSettings.backup.openBackups')}
                 </Link>
                 <Link to="/export" className="text-[11.5px] underline text-accent">
-                  Open Export / Import →
+                  {t('web.serverSettings.backup.openExport')}
                 </Link>
               </div>
             </>
@@ -1766,31 +1716,35 @@ function BackupSection({
 
       {/* ── Where backups go (targets) ─────────────────────────── */}
       {!featureOff && showFilter && (
-        <FormGroup heading="Where backups go">
+        <FormGroup heading={t('web.serverSettings.formGroups.backupWhere')}>
           <p className="text-[12px] text-muted-foreground mb-1">
-            Each target is one place a backup blob can be written.
-            opendray supports <strong>local disk</strong>,{' '}
-            <strong>SMB/CIFS</strong> (Windows / NAS),{' '}
-            <strong>S3-compatible</strong> (AWS, R2, B2, MinIO,
-            Alibaba Cloud OSS, Tencent Cloud COS, ...),{' '}
-            <strong>WebDAV</strong> (Nextcloud, Synology, Jianguoyun),{' '}
-            <strong>SFTP</strong>, plus an <strong>rclone</strong>{' '}
-            passthrough that taps into 70+ extra backends (Google
-            Drive, OneDrive, Dropbox, Baidu Pan, Aliyun Drive, ...).
+            <Trans
+              i18nKey="web.serverSettings.backup.whereDesc"
+              components={{
+                1: <strong />,
+                3: <strong />,
+                5: <strong />,
+                7: <strong />,
+                9: <strong />,
+                11: <strong />,
+              }}
+            />
           </p>
 
           <div className="flex flex-col gap-1.5">
             {targets === undefined ? (
-              <div className="text-muted-foreground text-[12px]">Loading…</div>
+              <div className="text-muted-foreground text-[12px]">
+                {t('web.serverSettings.backup.loading')}
+              </div>
             ) : targets.length === 0 ? (
               <div className="rounded-md border border-dashed border-border p-4 text-center text-[12px] text-muted-foreground">
-                No targets yet. Add one to start backing up.
+                {t('web.serverSettings.backup.noTargets')}
               </div>
             ) : (
-              targets.map((t) => (
+              targets.map((target) => (
                 <TargetRow
-                  key={t.id}
-                  target={t}
+                  key={target.id}
+                  target={target}
                   onChanged={() => qc.invalidateQueries({ queryKey: ['backup-targets'] })}
                 />
               ))
@@ -1801,7 +1755,7 @@ function BackupSection({
             <DialogTrigger asChild>
               <Button size="sm" className="mt-2 self-start">
                 <Plus className="size-3.5 mr-1.5" />
-                Add target
+                {t('web.serverSettings.backup.addTarget')}
               </Button>
             </DialogTrigger>
             <TargetEditor
@@ -1816,27 +1770,40 @@ function BackupSection({
 
       {/* ── Schedules ──────────────────────────────────────────── */}
       {!featureOff && (
-        <FormGroup heading="Schedules">
+        <FormGroup heading={t('web.serverSettings.formGroups.backupSchedules')}>
           {schedules === undefined ? (
-            <div className="text-muted-foreground text-[12px]">Loading…</div>
+            <div className="text-muted-foreground text-[12px]">
+              {t('web.serverSettings.backup.loading')}
+            </div>
           ) : schedules.length === 0 ? (
             <div className="text-[12px] text-muted-foreground">
-              No recurring schedules. Add one on{' '}
-              <Link to="/backups" className="underline text-accent">
-                /backups → Schedules
-              </Link>{' '}
-              to take backups automatically.
+              <Trans
+                i18nKey="web.serverSettings.backup.noSchedulesHint"
+                components={{
+                  1: <Link to="/backups" className="underline text-accent" />,
+                }}
+              />
             </div>
           ) : (
             <div className="rounded-md border border-border bg-card/30 overflow-hidden">
               <table className="w-full text-[12px]">
                 <thead className="bg-card/50 text-muted-foreground">
                   <tr className="text-left">
-                    <th className="px-3 py-2 font-medium">Schedule</th>
-                    <th className="px-3 py-2 font-medium">Target</th>
-                    <th className="px-3 py-2 font-medium">Cadence</th>
-                    <th className="px-3 py-2 font-medium">Keep</th>
-                    <th className="px-3 py-2 font-medium">State</th>
+                    <th className="px-3 py-2 font-medium">
+                      {t('web.serverSettings.backup.scheduleHeaders.schedule')}
+                    </th>
+                    <th className="px-3 py-2 font-medium">
+                      {t('web.serverSettings.backup.scheduleHeaders.target')}
+                    </th>
+                    <th className="px-3 py-2 font-medium">
+                      {t('web.serverSettings.backup.scheduleHeaders.cadence')}
+                    </th>
+                    <th className="px-3 py-2 font-medium">
+                      {t('web.serverSettings.backup.scheduleHeaders.keep')}
+                    </th>
+                    <th className="px-3 py-2 font-medium">
+                      {t('web.serverSettings.backup.scheduleHeaders.state')}
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
@@ -1847,16 +1814,24 @@ function BackupSection({
                         {s.target_id}
                       </td>
                       <td className="px-3 py-2 text-muted-foreground">
-                        every {formatInterval(s.interval_sec)}
+                        {t('web.serverSettings.backup.every', {
+                          interval: formatInterval(s.interval_sec),
+                        })}
                       </td>
                       <td className="px-3 py-2 text-muted-foreground">
-                        {s.retention} backups
+                        {t('web.serverSettings.backup.backupsKeep', {
+                          count: s.retention,
+                        })}
                       </td>
                       <td className="px-3 py-2">
                         {s.enabled ? (
-                          <span className="text-state-running">enabled</span>
+                          <span className="text-state-running">
+                            {t('web.serverSettings.backup.stateEnabled')}
+                          </span>
                         ) : (
-                          <span className="text-muted-foreground">paused</span>
+                          <span className="text-muted-foreground">
+                            {t('web.serverSettings.backup.statePaused')}
+                          </span>
                         )}
                       </td>
                     </tr>
@@ -1865,7 +1840,7 @@ function BackupSection({
               </table>
               <div className="px-3 py-2 border-t border-border/60 text-right">
                 <Link to="/backups" className="text-[11px] underline text-accent">
-                  Manage on /backups → Schedules →
+                  {t('web.serverSettings.backup.manageSchedules')}
                 </Link>
               </div>
             </div>
@@ -1875,17 +1850,17 @@ function BackupSection({
 
       {/* ── What's in a backup? ───────────────────────────────── */}
       {!featureOff && (
-        <FormGroup heading="What's in a backup?">
+        <FormGroup heading={t('web.serverSettings.formGroups.backupWhatsInside')}>
           <div className="text-[12px] text-muted-foreground">
-            Each backup is a <code>pg_dump --format=custom</code> of every
-            opendray table (sessions, integrations, memories,
-            audit_log, etc.) plus a <code>manifest.json</code> and
-            (optionally) the live <code>config.toml</code>. Open the
-            "What's in a backup?" panel on the{' '}
-            <Link to="/backups" className="underline text-accent">
-              Backups page
-            </Link>{' '}
-            to see the live inventory with row counts.
+            <Trans
+              i18nKey="web.serverSettings.backup.whatsInsideDesc"
+              components={{
+                1: <code />,
+                3: <code />,
+                5: <code />,
+                7: <Link to="/backups" className="underline text-accent" />,
+              }}
+            />
           </div>
         </FormGroup>
       )}
@@ -1897,69 +1872,53 @@ function BackupSection({
           onClick={() => setAdvancedOpen((v) => !v)}
           className="w-full flex items-center gap-2 px-4 py-2.5 hover:bg-card/40 text-left text-[12px] font-medium"
         >
-          {advancedOpen ? '▾' : '▸'} Advanced (paths & client binaries) — restart required
+          {advancedOpen ? '▾' : '▸'} {t('web.serverSettings.backup.advancedToggle')}
         </button>
         {advancedOpen && (
           <div className="px-4 pb-4 pt-2 border-t border-border/50 flex flex-col gap-5">
-            {visible('Local backup directory', 'Where local-target bundles are written') && (
-              <FieldRow
-                label="Local backup directory"
-                hint="Default root for the auto-created `local` target. Empty = ~/.opendray/backups. Restart required."
-                tomlKey="backup.local_dir"
-              >
-                <PathInput
-                  value={c.backup.local_dir}
-                  onChange={(v) =>
-                    setDraft({ ...draft, backup: { ...c.backup, local_dir: v } })
-                  }
-                  placeholder="~/.opendray/backups"
-                />
-              </FieldRow>
+            {FB(
+              'backupLocalDir',
+              'backup.local_dir',
+              <PathInput
+                value={c.backup.local_dir}
+                onChange={(v) =>
+                  setDraft({ ...draft, backup: { ...c.backup, local_dir: v } })
+                }
+                placeholder="~/.opendray/backups"
+              />,
             )}
-            {visible('Export directory', 'Where /export bundles are staged') && (
-              <FieldRow
-                label="Export directory"
-                hint="Where one-shot export zips are staged on disk. Empty = ~/.opendray/exports. Bundles auto-expire after 24h. Restart required."
-                tomlKey="backup.export_dir"
-              >
-                <PathInput
-                  value={c.backup.export_dir}
-                  onChange={(v) =>
-                    setDraft({ ...draft, backup: { ...c.backup, export_dir: v } })
-                  }
-                  placeholder="~/.opendray/exports"
-                />
-              </FieldRow>
+            {FB(
+              'backupExportDir',
+              'backup.export_dir',
+              <PathInput
+                value={c.backup.export_dir}
+                onChange={(v) =>
+                  setDraft({ ...draft, backup: { ...c.backup, export_dir: v } })
+                }
+                placeholder="~/.opendray/exports"
+              />,
             )}
-            {visible('pg_dump path', 'Override the resolved pg_dump binary') && (
-              <FieldRow
-                label="pg_dump path"
-                hint="Absolute path to pg_dump. Major version must be ≥ the server's. Empty = first pg_dump on PATH."
-                tomlKey="backup.pg_dump_path"
-              >
-                <PathInput
-                  value={c.backup.pg_dump_path}
-                  onChange={(v) =>
-                    setDraft({ ...draft, backup: { ...c.backup, pg_dump_path: v } })
-                  }
-                  placeholder="/opt/homebrew/opt/postgresql@17/bin/pg_dump"
-                />
-              </FieldRow>
+            {FB(
+              'backupPgDumpPath',
+              'backup.pg_dump_path',
+              <PathInput
+                value={c.backup.pg_dump_path}
+                onChange={(v) =>
+                  setDraft({ ...draft, backup: { ...c.backup, pg_dump_path: v } })
+                }
+                placeholder="/opt/homebrew/opt/postgresql@17/bin/pg_dump"
+              />,
             )}
-            {visible('pg_restore path', 'Override the resolved pg_restore binary') && (
-              <FieldRow
-                label="pg_restore path"
-                hint="Absolute path to pg_restore for the /backups/restore flow. Same major-version rule."
-                tomlKey="backup.pg_restore_path"
-              >
-                <PathInput
-                  value={c.backup.pg_restore_path}
-                  onChange={(v) =>
-                    setDraft({ ...draft, backup: { ...c.backup, pg_restore_path: v } })
-                  }
-                  placeholder="/opt/homebrew/opt/postgresql@17/bin/pg_restore"
-                />
-              </FieldRow>
+            {FB(
+              'backupPgRestorePath',
+              'backup.pg_restore_path',
+              <PathInput
+                value={c.backup.pg_restore_path}
+                onChange={(v) =>
+                  setDraft({ ...draft, backup: { ...c.backup, pg_restore_path: v } })
+                }
+                placeholder="/opt/homebrew/opt/postgresql@17/bin/pg_restore"
+              />,
             )}
           </div>
         )}
@@ -1975,31 +1934,54 @@ function TargetRow({
   target: TargetSpec
   onChanged: () => void
 }) {
+  const { t } = useTranslation()
   const [testing, setTesting] = useState(false)
 
   async function onTest() {
     setTesting(true)
     try {
       const res = await testTarget(target.id)
-      if (res.ok) toast.success(`${target.id}: connection OK`)
-      else toast.error('Connection failed', { description: res.error })
+      if (res.ok) {
+        toast.success(
+          t('web.serverSettings.targetRow.connectionOk', { id: target.id }),
+        )
+      } else {
+        toast.error(t('web.serverSettings.targetRow.connectionFailedTitle'), {
+          description: res.error,
+        })
+      }
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Unknown error'
-      toast.error('Test failed', { description: msg })
+      const msg =
+        err instanceof Error
+          ? err.message
+          : t('web.serverSettings.targetRow.unknownError')
+      toast.error(t('web.serverSettings.targetRow.testFailedTitle'), {
+        description: msg,
+      })
     } finally {
       setTesting(false)
     }
   }
 
   async function onDelete() {
-    if (!window.confirm(`Delete target "${target.id}"? Schedules referencing it will block the delete.`)) return
+    if (
+      !window.confirm(
+        t('web.serverSettings.targetRow.deleteConfirm', { id: target.id }),
+      )
+    )
+      return
     try {
       await deleteTarget(target.id)
-      toast.success('Target deleted')
+      toast.success(t('web.serverSettings.targetRow.deleteSuccess'))
       onChanged()
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Unknown error'
-      toast.error('Delete failed', { description: msg })
+      const msg =
+        err instanceof Error
+          ? err.message
+          : t('web.serverSettings.targetRow.unknownError')
+      toast.error(t('web.serverSettings.targetRow.deleteFailedTitle'), {
+        description: msg,
+      })
     }
   }
 
@@ -2020,7 +2002,9 @@ function TargetRow({
           target.enabled ? 'text-state-running' : 'text-muted-foreground',
         )}
       >
-        {target.enabled ? 'on' : 'off'}
+        {target.enabled
+          ? t('web.serverSettings.targetRow.on')
+          : t('web.serverSettings.targetRow.off')}
       </span>
       <Button
         onClick={onTest}
@@ -2029,7 +2013,9 @@ function TargetRow({
         className="h-7 text-[11px]"
         disabled={testing}
       >
-        {testing ? 'Testing…' : 'Test'}
+        {testing
+          ? t('web.serverSettings.targetRow.testing')
+          : t('web.serverSettings.targetRow.test')}
       </Button>
       <Button
         onClick={onDelete}
@@ -2037,7 +2023,7 @@ function TargetRow({
         size="sm"
         className="h-7 px-2 text-[11px]"
       >
-        Delete
+        {t('web.serverSettings.targetRow.delete')}
       </Button>
     </div>
   )


### PR DESCRIPTION
## Summary

Completes the i18n migration deferred from #121. Every English string in the Server settings page's body forms is now translated.

### Translated
- **9 SectionForm switch cases** (~40 FieldRow label+hint pairs) — general / logging / sessions / vault / mcp / memory / claude / codex / gemini. Refactored each FieldRow through a small \`F(fieldKey, tomlKey, control)\` helper that pulls label/hint from a single i18n key and folds in the visibility-filter check.
- **FormGroup sub-headings**: Network, Operator account, Configuration, HTTP backend (used when backend=http), Local ONNX (used when backend=local), Status, Where backups go, Schedules, What's in a backup?
- **Logging Live tail** card heading + description.
- **Memory Inspector card** (heading + description + Open Memory link).
- **Local ONNX amber banner** via \`<Trans>\` for the embedded \`<code>\` and \`<strong>\`.
- **StringList**: \"(none — using built-in defaults)\", Add path, Remove tooltip.
- **HttpBackendHelpers**: Auto-detected banner, model-count tooltip, Presets label, 3 preset tooltips (ollama / LM Studio / OpenAI), Test connection button.
- **ProbeResultLine**: reachable / unreachable summaries, missing-model warning (Trans), embedding-models label, +N more, Currently configured / Click to apply tooltips, no-embed warning.
- **BackupSection**: Status rows (Status / Key fingerprint / pg_dump / pg_restore + their values), Feature-disabled banner (Trans for two embedded \`<code>\` spans), Open Backups / Open Export links, \"Where backups go\" intro paragraph (Trans with 6 strong placeholders covering all storage kinds), Loading…, No targets yet, Add target, no-schedules Trans with a link, schedule table headers + cells (every N, N backups, enabled / paused, Manage), \"What's in a backup?\" description (Trans), Advanced toggle. 4 advanced backup-paths fields via a section-local FB() helper.
- **TargetRow**: on / off, Test / Testing…, Delete, connection-OK toast, Connection failed / Test failed / Delete failed titles, delete confirm with target id interpolation, unknown-error fallback.

### Filter behavior
Search filter now matches against the **translated** label/hint, so filtering works in both en and zh — the \`visible()\` check inside \`F()\` / \`FB()\` consumes the same translated text the user sees.

## Test plan
- [x] \`pnpm --filter web build\` clean
- [x] Lint count unchanged (91 → 91)
- [ ] Manually verify all 9 server sections render translated labels/hints in zh and en
- [ ] Verify search filter matches translated text
- [ ] Verify BackupSection status / where / schedules / advanced render in zh
- [ ] Verify HttpBackendHelpers / ProbeResultLine ollama probe flow in zh

🤖 Generated with [Claude Code](https://claude.com/claude-code)