### PR TITLE
fix(codex): bypass MCP tool approvals + tolerate stale skill symlinks

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -152,7 +152,7 @@
         "namePlaceholder": "claude in pet-tracker",
         "argsLabel": "CLI args (one per line)",
         "bypassClaude": "Bypass permission prompts",
-        "bypassCodex": "Auto-approve (--ask-for-approval never)",
+        "bypassCodex": "Bypass approvals & sandbox (--dangerously-bypass-approvals-and-sandbox)",
         "bypassGemini": "YOLO mode (--yolo)",
         "bypassOnHint": "This session will run with elevated autonomy.",
         "bypassOffHint": "Off — confirmations and prompts behave normally.",
@@ -2458,7 +2458,7 @@
       "argsHelper": "Whitespace-separated; blank uses the provider's defaults.",
       "bypass": {
         "labelClaude": "Bypass permissions",
-        "labelCodex": "Auto-approve (never ask)",
+        "labelCodex": "Bypass approvals & sandbox",
         "labelGemini": "YOLO mode",
         "subtitleOn": "This session will run with elevated autonomy.",
         "subtitleOff": "Off — confirmations and prompts behave normally."

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -152,7 +152,7 @@
         "namePlaceholder": "claude in pet-tracker",
         "argsLabel": "CLI 参数（每行一个）",
         "bypassClaude": "跳过权限提示",
-        "bypassCodex": "自动批准 (--ask-for-approval never)",
+        "bypassCodex": "跳过所有批准与沙盒 (--dangerously-bypass-approvals-and-sandbox)",
         "bypassGemini": "YOLO 模式 (--yolo)",
         "bypassOnHint": "本次会话将以更高的自主权运行。",
         "bypassOffHint": "关闭 — 确认与提示按正常流程处理。",
@@ -2458,7 +2458,7 @@
       "argsHelper": "以空格分隔；留空使用提供商默认值。",
       "bypass": {
         "labelClaude": "绕过权限",
-        "labelCodex": "自动批准（从不询问）",
+        "labelCodex": "跳过批准与沙盒",
         "labelGemini": "YOLO 模式",
         "subtitleOn": "此会话将以提升的自主权运行。",
         "subtitleOff": "关闭 — 确认和提示按正常方式处理。"

--- a/app/mobile/ios/Podfile.lock
+++ b/app/mobile/ios/Podfile.lock
@@ -9,6 +9,9 @@ PODS:
     - FlutterMacOS
   - package_info_plus (0.4.5):
     - Flutter
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -16,6 +19,7 @@ DEPENDENCIES:
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
 
 EXTERNAL SOURCES:
   Flutter:
@@ -28,6 +32,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/local_auth_darwin/darwin"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
@@ -35,6 +41,7 @@ SPEC CHECKSUMS:
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
 
 PODFILE CHECKSUM: f8c2dcdfb50bb67645580d28a6bf814fca30bdec
 

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 2158 (1079 per locale)
+/// Strings: 5550 (2775 per locale)
 ///
-/// Built on 2026-05-14 at 00:12 UTC
+/// Built on 2026-05-14 at 13:10 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -43,6 +43,7 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	late final TranslationsCommonEn common = TranslationsCommonEn.internal(_root);
 	late final TranslationsAuthEn auth = TranslationsAuthEn.internal(_root);
 	late final TranslationsNavEn nav = TranslationsNavEn.internal(_root);
+	late final TranslationsWebEn web = TranslationsWebEn.internal(_root);
 	late final TranslationsMoreEn more = TranslationsMoreEn.internal(_root);
 	late final TranslationsSessionsEn sessions = TranslationsSessionsEn.internal(_root);
 	late final TranslationsMcpEn mcp = TranslationsMcpEn.internal(_root);
@@ -134,11 +135,20 @@ class TranslationsAuthEn {
 	/// en: 'Sign in'
 	String get signIn => 'Sign in';
 
+	/// en: 'Signing in…'
+	String get signingIn => 'Signing in…';
+
+	/// en: 'Use your operator credentials.'
+	String get subtitle => 'Use your operator credentials.';
+
 	/// en: 'Username and password are required'
 	String get errorRequired => 'Username and password are required';
 
 	/// en: 'Login failed: {error}'
 	String errorGeneric({required Object error}) => 'Login failed: ${error}';
+
+	/// en: 'Login failed'
+	String get errorFallback => 'Login failed';
 }
 
 // Path: nav
@@ -160,6 +170,70 @@ class TranslationsNavEn {
 
 	/// en: 'More'
 	String get more => 'More';
+
+	/// en: 'Activity'
+	String get activity => 'Activity';
+
+	/// en: 'Providers'
+	String get providers => 'Providers';
+
+	/// en: 'Channels'
+	String get channels => 'Channels';
+
+	/// en: 'Integrations'
+	String get integrations => 'Integrations';
+
+	/// en: 'Plugins'
+	String get plugins => 'Plugins';
+
+	/// en: 'Backups'
+	String get backups => 'Backups';
+
+	/// en: 'Settings'
+	String get settings => 'Settings';
+
+	/// en: 'Tutorial'
+	String get tutorial => 'Tutorial';
+
+	/// en: 'Workspace'
+	String get workspace => 'Workspace';
+}
+
+// Path: web
+class TranslationsWebEn {
+	TranslationsWebEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'opendray'
+	String get brand => 'opendray';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	late final TranslationsWebTopbarEn topbar = TranslationsWebTopbarEn.internal(_root);
+	late final TranslationsWebSessionsEn sessions = TranslationsWebSessionsEn.internal(_root);
+	late final TranslationsWebMemoryEn memory = TranslationsWebMemoryEn.internal(_root);
+	late final TranslationsWebMemoryWorkersEn memoryWorkers = TranslationsWebMemoryWorkersEn.internal(_root);
+	late final TranslationsWebCleanupInboxEn cleanupInbox = TranslationsWebCleanupInboxEn.internal(_root);
+	late final TranslationsWebProjectEn project = TranslationsWebProjectEn.internal(_root);
+	late final TranslationsWebMemoryInspectorEn memoryInspector = TranslationsWebMemoryInspectorEn.internal(_root);
+	late final TranslationsWebNotesEn notes = TranslationsWebNotesEn.internal(_root);
+	late final TranslationsWebActivityEn activity = TranslationsWebActivityEn.internal(_root);
+	late final TranslationsWebProvidersEn providers = TranslationsWebProvidersEn.internal(_root);
+	late final TranslationsWebChannelsEn channels = TranslationsWebChannelsEn.internal(_root);
+	late final TranslationsWebIntegrationsEn integrations = TranslationsWebIntegrationsEn.internal(_root);
+	late final TranslationsWebPluginsEn plugins = TranslationsWebPluginsEn.internal(_root);
+	late final TranslationsWebBackupsEn backups = TranslationsWebBackupsEn.internal(_root);
+	late final TranslationsWebServerSettingsEn serverSettings = TranslationsWebServerSettingsEn.internal(_root);
+	late final TranslationsWebSettingsEn settings = TranslationsWebSettingsEn.internal(_root);
+	late final TranslationsWebLogViewerEn logViewer = TranslationsWebLogViewerEn.internal(_root);
+	late final TranslationsWebPathInputEn pathInput = TranslationsWebPathInputEn.internal(_root);
+	late final TranslationsWebMemoryAmbientEn memoryAmbient = TranslationsWebMemoryAmbientEn.internal(_root);
+	late final TranslationsWebNoteEditorEn noteEditor = TranslationsWebNoteEditorEn.internal(_root);
+	late final TranslationsWebExportEn export = TranslationsWebExportEn.internal(_root);
 }
 
 // Path: more
@@ -1710,6 +1784,790 @@ class TranslationsSettingsEn {
 	late final TranslationsSettingsServerSettingsEn serverSettings = TranslationsSettingsServerSettingsEn.internal(_root);
 }
 
+// Path: web.topbar
+class TranslationsWebTopbarEn {
+	TranslationsWebTopbarEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Expand sidebar'
+	String get expandSidebar => 'Expand sidebar';
+
+	/// en: 'Collapse sidebar'
+	String get collapseSidebar => 'Collapse sidebar';
+
+	/// en: 'Search'
+	String get search => 'Search';
+
+	/// en: 'Open command palette'
+	String get openPalette => 'Open command palette';
+
+	/// en: 'Theme'
+	String get theme => 'Theme';
+
+	/// en: 'Theme: {mode}'
+	String themeLabel({required Object mode}) => 'Theme: ${mode}';
+
+	/// en: 'Appearance'
+	String get appearance => 'Appearance';
+
+	/// en: 'Light'
+	String get themeLight => 'Light';
+
+	/// en: 'Dark'
+	String get themeDark => 'Dark';
+
+	/// en: 'System'
+	String get themeSystem => 'System';
+
+	/// en: 'Language'
+	String get language => 'Language';
+
+	/// en: 'English'
+	String get languageEnglish => 'English';
+
+	/// en: '中文'
+	String get languageChinese => '中文';
+
+	/// en: 'Signed in as'
+	String get signedInAs => 'Signed in as';
+
+	/// en: 'Token expires'
+	String get tokenExpires => 'Token expires';
+
+	/// en: 'Sign out'
+	String get signOut => 'Sign out';
+}
+
+// Path: web.sessions
+class TranslationsWebSessionsEn {
+	TranslationsWebSessionsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsWebSessionsListEn list = TranslationsWebSessionsListEn.internal(_root);
+	late final TranslationsWebSessionsTabsEn tabs = TranslationsWebSessionsTabsEn.internal(_root);
+	late final TranslationsWebSessionsPageEn page = TranslationsWebSessionsPageEn.internal(_root);
+	late final TranslationsWebSessionsEmptyEn empty = TranslationsWebSessionsEmptyEn.internal(_root);
+	late final TranslationsWebSessionsHeaderEn header = TranslationsWebSessionsHeaderEn.internal(_root);
+	late final TranslationsWebSessionsTerminalEn terminal = TranslationsWebSessionsTerminalEn.internal(_root);
+	late final TranslationsWebSessionsSpawnEn spawn = TranslationsWebSessionsSpawnEn.internal(_root);
+	late final TranslationsWebSessionsAccountSwitcherEn accountSwitcher = TranslationsWebSessionsAccountSwitcherEn.internal(_root);
+	late final TranslationsWebSessionsInspectorEn inspector = TranslationsWebSessionsInspectorEn.internal(_root);
+	late final TranslationsWebSessionsEndedEn ended = TranslationsWebSessionsEndedEn.internal(_root);
+	late final TranslationsWebSessionsFileBrowserEn fileBrowser = TranslationsWebSessionsFileBrowserEn.internal(_root);
+}
+
+// Path: web.memory
+class TranslationsWebMemoryEn {
+	TranslationsWebMemoryEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Memory'
+	String get title => 'Memory';
+
+	/// en: 'Browse, search and edit memories agents have stored via the opendray-memory MCP server.'
+	String get subtitle => 'Browse, search and edit memories agents have stored via the opendray-memory MCP server.';
+
+	/// en: 'Project'
+	String get navProject => 'Project';
+
+	/// en: 'Cleanup inbox'
+	String get navCleanupInbox => 'Cleanup inbox';
+
+	/// en: 'Workers'
+	String get navWorkers => 'Workers';
+
+	/// en: 'Configuration →'
+	String get navConfiguration => 'Configuration →';
+}
+
+// Path: web.memoryWorkers
+class TranslationsWebMemoryWorkersEn {
+	TranslationsWebMemoryWorkersEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Memory workers'
+	String get title => 'Memory workers';
+
+	/// en: 'Loading worker config…'
+	String get loading => 'Loading worker config…';
+
+	/// en: 'Endpoint not reachable.'
+	String get errorTitle => 'Endpoint not reachable.';
+
+	/// en: 'The /api/v1/memory/workers routes are new in M25 — the opendray binary may need a restart to mount them and run migration 0029.'
+	String get errorDescription => 'The /api/v1/memory/workers routes are new in M25 — the opendray binary may need a restart to mount them and run migration 0029.';
+
+	/// en: 'Each memory-system LLM touchpoint can be served independently by the local <1>summarizer</1> endpoint (LM Studio / OpenAI-compat) or by spawning a headless <3>Claude / Gemini agent</3> in <5>--print</5> mode. High-quality narrative tasks (gitactivity, transcript) benefit from agent workers; high-frequency tasks (gatekeeper) stay on the local endpoint by design.'
+	String get intro => 'Each memory-system LLM touchpoint can be served independently by the local <1>summarizer</1> endpoint (LM Studio / OpenAI-compat) or by spawning a headless <3>Claude / Gemini agent</3> in <5>--print</5> mode. High-quality narrative tasks (gitactivity, transcript) benefit from agent workers; high-frequency tasks (gatekeeper) stay on the local endpoint by design.';
+
+	/// en: 'enabled'
+	String get enabledBadge => 'enabled';
+
+	/// en: 'disabled'
+	String get disabledBadge => 'disabled';
+
+	/// en: 'summarizer-only'
+	String get summarizerOnlyBadge => 'summarizer-only';
+
+	/// en: '{count} calls · 24h'
+	String callsCount({required Object count}) => '${count} calls · 24h';
+
+	/// en: 'avg {ms}ms'
+	String avgMs({required Object ms}) => 'avg ${ms}ms';
+
+	/// en: '{count} errors'
+	String errorsCount({required Object count}) => '${count} errors';
+
+	/// en: 'Worker'
+	String get workerLabel => 'Worker';
+
+	/// en: 'Summarizer (HTTP)'
+	String get summarizerHttp => 'Summarizer (HTTP)';
+
+	/// en: 'Agent (CLI --print)'
+	String get agentCliPrint => 'Agent (CLI --print)';
+
+	/// en: 'Summarizer provider'
+	String get summarizerProviderLabel => 'Summarizer provider';
+
+	/// en: 'Registry default'
+	String get registryDefault => 'Registry default';
+
+	/// en: 'CLI'
+	String get cliLabel => 'CLI';
+
+	/// en: 'Select'
+	String get selectPlaceholder => 'Select';
+
+	/// en: 'Claude'
+	String get cliClaude => 'Claude';
+
+	/// en: 'Gemini'
+	String get cliGemini => 'Gemini';
+
+	/// en: 'Claude account'
+	String get claudeAccountLabel => 'Claude account';
+
+	/// en: 'Default'
+	String get claudeAccountDefault => 'Default';
+
+	/// en: 'Agent mode spawns a headless CLI per call. Latency rises from <1>~1s</1> (summarizer) to <3>~5-15s</3>; cost shifts from CPU to your Claude/Gemini quota.'
+	String get agentWarning => 'Agent mode spawns a headless CLI per call. Latency rises from <1>~1s</1> (summarizer) to <3>~5-15s</3>; cost shifts from CPU to your Claude/Gemini quota.';
+
+	/// en: 'Enabled'
+	String get enabledCheckbox => 'Enabled';
+
+	/// en: 'Test'
+	String get testButton => 'Test';
+
+	/// en: 'Save'
+	String get saveButton => 'Save';
+
+	/// en: 'Recent calls ({count})'
+	String recentCalls({required Object count}) => 'Recent calls (${count})';
+
+	/// en: 'when'
+	String get tableWhen => 'when';
+
+	/// en: 'worker'
+	String get tableWorker => 'worker';
+
+	/// en: 'ms'
+	String get tableMs => 'ms';
+
+	/// en: 'ok'
+	String get tableOk => 'ok';
+
+	/// en: '{label} updated'
+	String savedToast({required Object label}) => '${label} updated';
+
+	/// en: 'Save failed'
+	String get saveFailedToast => 'Save failed';
+
+	/// en: '{label} OK — {ms}ms'
+	String testOkToast({required Object label, required Object ms}) => '${label} OK — ${ms}ms';
+
+	/// en: '{label} failed'
+	String testFailedToast({required Object label}) => '${label} failed';
+
+	/// en: 'Test call failed'
+	String get testCallFailedToast => 'Test call failed';
+
+	/// en: 'unknown error'
+	String get unknownError => 'unknown error';
+
+	late final TranslationsWebMemoryWorkersTasksEn tasks = TranslationsWebMemoryWorkersTasksEn.internal(_root);
+}
+
+// Path: web.cleanupInbox
+class TranslationsWebCleanupInboxEn {
+	TranslationsWebCleanupInboxEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'Cleanup inbox empty'
+	String get emptyTitle => 'Cleanup inbox empty';
+
+	/// en: 'No pending cleanup decisions across any project. The LLM librarian either hasn't run yet for the eligible memories, or it found everything load-bearing.'
+	String get emptyDescription => 'No pending cleanup decisions across any project. The LLM librarian either hasn\'t run yet for the eligible memories, or it found everything load-bearing.';
+
+	/// en: 'Cleanup inbox'
+	String get title => 'Cleanup inbox';
+
+	/// en: 'Cross-project pending decisions from the LLM memory librarian. Approving stale → deletes, approving duplicate → merges, approving keep → freezes the entry from being re-judged for a while.'
+	String get subtitle => 'Cross-project pending decisions from the LLM memory librarian. Approving stale → deletes, approving duplicate → merges, approving keep → freezes the entry from being re-judged for a while.';
+
+	/// en: '(global)'
+	String get globalScope => '(global)';
+
+	/// en: 'orphan'
+	String get orphanBadge => 'orphan';
+
+	/// en: 'Truncated scope_key (old mirror import). Not a navigable project.'
+	String get orphanTitle => 'Truncated scope_key (old mirror import). Not a navigable project.';
+
+	/// en: 'Open project'
+	String get openProject => 'Open project';
+
+	/// en: '→ merge into'
+	String get mergeIntoPrefix => '→ merge into';
+
+	/// en: 'Reason:'
+	String get reasonPrefix => 'Reason:';
+
+	/// en: 'Execute'
+	String get executeButton => 'Execute';
+
+	/// en: 'Confirm keep'
+	String get confirmKeepButton => 'Confirm keep';
+
+	/// en: 'Reject'
+	String get rejectButton => 'Reject';
+
+	/// en: 'Kept'
+	String get approvedKeptToast => 'Kept';
+
+	/// en: '{verdict} executed'
+	String approvedExecutedToast({required Object verdict}) => '${verdict} executed';
+
+	/// en: 'Approve failed'
+	String get approveFailedToast => 'Approve failed';
+
+	/// en: 'Rejected — memory kept'
+	String get rejectedToast => 'Rejected — memory kept';
+
+	/// en: 'Reject failed'
+	String get rejectFailedToast => 'Reject failed';
+}
+
+// Path: web.project
+class TranslationsWebProjectEn {
+	TranslationsWebProjectEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsWebProjectPickerEn picker = TranslationsWebProjectPickerEn.internal(_root);
+
+	/// en: 'Pick a project to manage its memory.'
+	String get noCwd => 'Pick a project to manage its memory.';
+
+	late final TranslationsWebProjectHeaderEn header = TranslationsWebProjectHeaderEn.internal(_root);
+	late final TranslationsWebProjectTabsEn tabs = TranslationsWebProjectTabsEn.internal(_root);
+	late final TranslationsWebProjectDocLabelEn docLabel = TranslationsWebProjectDocLabelEn.internal(_root);
+	late final TranslationsWebProjectVerdictLabelEn verdictLabel = TranslationsWebProjectVerdictLabelEn.internal(_root);
+	late final TranslationsWebProjectEditorEn editor = TranslationsWebProjectEditorEn.internal(_root);
+	late final TranslationsWebProjectReadonlyEn readonly = TranslationsWebProjectReadonlyEn.internal(_root);
+	late final TranslationsWebProjectJournalEn journal = TranslationsWebProjectJournalEn.internal(_root);
+	late final TranslationsWebProjectInboxEn inbox = TranslationsWebProjectInboxEn.internal(_root);
+	late final TranslationsWebProjectCleanupEn cleanup = TranslationsWebProjectCleanupEn.internal(_root);
+	late final TranslationsWebProjectResetEn reset = TranslationsWebProjectResetEn.internal(_root);
+}
+
+// Path: web.memoryInspector
+class TranslationsWebMemoryInspectorEn {
+	TranslationsWebMemoryInspectorEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsWebMemoryInspectorStatusEn status = TranslationsWebMemoryInspectorStatusEn.internal(_root);
+
+	/// en: 'This is the embedder the gateway is currently using for every <1>memory_search</1> / <3>memory_store</3> call. If this doesn't match the configuration above, you have unsaved changes — click Save then Restart server to apply.'
+	String get statusBody => 'This is the embedder the gateway is currently using for every <1>memory_search</1> / <3>memory_store</3> call. If this doesn\'t match the configuration above, you have unsaved changes — click Save then Restart server to apply.';
+
+	late final TranslationsWebMemoryInspectorScopeEn scope = TranslationsWebMemoryInspectorScopeEn.internal(_root);
+	late final TranslationsWebMemoryInspectorSearchEn search = TranslationsWebMemoryInspectorSearchEn.internal(_root);
+	late final TranslationsWebMemoryInspectorRecordsEn records = TranslationsWebMemoryInspectorRecordsEn.internal(_root);
+	late final TranslationsWebMemoryInspectorRowEn row = TranslationsWebMemoryInspectorRowEn.internal(_root);
+	late final TranslationsWebMemoryInspectorToastsEn toasts = TranslationsWebMemoryInspectorToastsEn.internal(_root);
+	late final TranslationsWebMemoryInspectorBulkDeleteEn bulkDelete = TranslationsWebMemoryInspectorBulkDeleteEn.internal(_root);
+	late final TranslationsWebMemoryInspectorAddMemEn addMem = TranslationsWebMemoryInspectorAddMemEn.internal(_root);
+	late final TranslationsWebMemoryInspectorPickerEn picker = TranslationsWebMemoryInspectorPickerEn.internal(_root);
+	late final TranslationsWebMemoryInspectorMigrationBannerEn migrationBanner = TranslationsWebMemoryInspectorMigrationBannerEn.internal(_root);
+	late final TranslationsWebMemoryInspectorReembedEn reembed = TranslationsWebMemoryInspectorReembedEn.internal(_root);
+}
+
+// Path: web.notes
+class TranslationsWebNotesEn {
+	TranslationsWebNotesEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Notes'
+	String get title => 'Notes';
+
+	late final TranslationsWebNotesHeaderEn header = TranslationsWebNotesHeaderEn.internal(_root);
+	late final TranslationsWebNotesLeftEn left = TranslationsWebNotesLeftEn.internal(_root);
+	late final TranslationsWebNotesTagsEn tags = TranslationsWebNotesTagsEn.internal(_root);
+	late final TranslationsWebNotesTreeEn tree = TranslationsWebNotesTreeEn.internal(_root);
+	late final TranslationsWebNotesOutlineEn outline = TranslationsWebNotesOutlineEn.internal(_root);
+	late final TranslationsWebNotesNewNoteEn newNote = TranslationsWebNotesNewNoteEn.internal(_root);
+	late final TranslationsWebNotesEmptyEn empty = TranslationsWebNotesEmptyEn.internal(_root);
+	late final TranslationsWebNotesPickerEn picker = TranslationsWebNotesPickerEn.internal(_root);
+	late final TranslationsWebNotesVaultSyncEn vaultSync = TranslationsWebNotesVaultSyncEn.internal(_root);
+	late final TranslationsWebNotesSyncBadgeEn syncBadge = TranslationsWebNotesSyncBadgeEn.internal(_root);
+}
+
+// Path: web.activity
+class TranslationsWebActivityEn {
+	TranslationsWebActivityEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Activity'
+	String get title => 'Activity';
+
+	/// en: 'Per-call audit of API requests made by registered integrations. Includes both inbound calls (a third-party app calling opendray with its API key) and outbound proxied calls (admin → opendray proxy → integration). Calls made directly by this admin UI are not recorded.'
+	String get subtitle => 'Per-call audit of API requests made by registered integrations. Includes both inbound calls (a third-party app calling opendray with its API key) and outbound proxied calls (admin → opendray proxy → integration). Calls made directly by this admin UI are not recorded.';
+
+	/// en: 'Refresh'
+	String get refresh => 'Refresh';
+
+	/// en: 'Refresh'
+	String get refreshTooltip => 'Refresh';
+
+	late final TranslationsWebActivityFiltersEn filters = TranslationsWebActivityFiltersEn.internal(_root);
+
+	/// en: '{count} call'
+	String callsCount_one({required Object count}) => '${count} call';
+
+	/// en: '{count} calls'
+	String callsCount_other({required Object count}) => '${count} calls';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	late final TranslationsWebActivityTableEn table = TranslationsWebActivityTableEn.internal(_root);
+	late final TranslationsWebActivityEmptyEn empty = TranslationsWebActivityEmptyEn.internal(_root);
+	late final TranslationsWebActivityEventsEn events = TranslationsWebActivityEventsEn.internal(_root);
+}
+
+// Path: web.providers
+class TranslationsWebProvidersEn {
+	TranslationsWebProvidersEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsWebProvidersListEn list = TranslationsWebProvidersListEn.internal(_root);
+	late final TranslationsWebProvidersDetailEn detail = TranslationsWebProvidersDetailEn.internal(_root);
+	late final TranslationsWebProvidersConfigFormEn configForm = TranslationsWebProvidersConfigFormEn.internal(_root);
+	late final TranslationsWebProvidersClaudeAccountsEn claudeAccounts = TranslationsWebProvidersClaudeAccountsEn.internal(_root);
+}
+
+// Path: web.channels
+class TranslationsWebChannelsEn {
+	TranslationsWebChannelsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Channels'
+	String get title => 'Channels';
+
+	/// en: 'Bidirectional messaging integrations. Outbound notifications are filtered by each channel's <1>notify_on</1>.'
+	String get subtitle => 'Bidirectional messaging integrations. Outbound notifications are filtered by each channel\'s <1>notify_on</1>.';
+
+	/// en: 'New channel'
+	String get newButton => 'New channel';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	late final TranslationsWebChannelsEmptyEn empty = TranslationsWebChannelsEmptyEn.internal(_root);
+	late final TranslationsWebChannelsCardEn card = TranslationsWebChannelsCardEn.internal(_root);
+	late final TranslationsWebChannelsToastsEn toasts = TranslationsWebChannelsToastsEn.internal(_root);
+	late final TranslationsWebChannelsDialogEn dialog = TranslationsWebChannelsDialogEn.internal(_root);
+	late final TranslationsWebChannelsNotificationsEn notifications = TranslationsWebChannelsNotificationsEn.internal(_root);
+	late final TranslationsWebChannelsBridgeEn bridge = TranslationsWebChannelsBridgeEn.internal(_root);
+	late final TranslationsWebChannelsSetupEn setup = TranslationsWebChannelsSetupEn.internal(_root);
+}
+
+// Path: web.integrations
+class TranslationsWebIntegrationsEn {
+	TranslationsWebIntegrationsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Integrations'
+	String get title => 'Integrations';
+
+	/// en: 'External apps that consume opendray. Reverse-proxy through <1>/api/v1/proxy/&lt;prefix&gt;/…</1> and subscribe to events via the WS endpoint.'
+	String get subtitle => 'External apps that consume opendray. Reverse-proxy through <1>/api/v1/proxy/&lt;prefix&gt;/…</1> and subscribe to events via the WS endpoint.';
+
+	/// en: 'Register'
+	String get register => 'Register';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	late final TranslationsWebIntegrationsTabsEn tabs = TranslationsWebIntegrationsTabsEn.internal(_root);
+	late final TranslationsWebIntegrationsEmptyEn empty = TranslationsWebIntegrationsEmptyEn.internal(_root);
+
+	/// en: 'System (managed by opendray)'
+	String get groupSystem => 'System (managed by opendray)';
+
+	/// en: 'Operator-registered'
+	String get groupOperator => 'Operator-registered';
+
+	late final TranslationsWebIntegrationsCardEn card = TranslationsWebIntegrationsCardEn.internal(_root);
+	late final TranslationsWebIntegrationsRegisterDialogEn register_dialog = TranslationsWebIntegrationsRegisterDialogEn.internal(_root);
+	late final TranslationsWebIntegrationsRevealEn reveal = TranslationsWebIntegrationsRevealEn.internal(_root);
+	late final TranslationsWebIntegrationsEditDialogEn edit_dialog = TranslationsWebIntegrationsEditDialogEn.internal(_root);
+	late final TranslationsWebIntegrationsProxyEn proxy = TranslationsWebIntegrationsProxyEn.internal(_root);
+}
+
+// Path: web.plugins
+class TranslationsWebPluginsEn {
+	TranslationsWebPluginsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Inspector plugins'
+	String get title => 'Inspector plugins';
+
+	/// en: 'Configure data sources surfaced in the right-hand Inspector panel when a session is open. Each plugin is admin-only and shared across all sessions. Click a section header to collapse it.'
+	String get subtitle => 'Configure data sources surfaced in the right-hand Inspector panel when a session is open. Each plugin is admin-only and shared across all sessions. Click a section header to collapse it.';
+
+	late final TranslationsWebPluginsCommonEn common = TranslationsWebPluginsCommonEn.internal(_root);
+	late final TranslationsWebPluginsMcpEn mcp = TranslationsWebPluginsMcpEn.internal(_root);
+	late final TranslationsWebPluginsMcpSecretsEn mcpSecrets = TranslationsWebPluginsMcpSecretsEn.internal(_root);
+	late final TranslationsWebPluginsSkillsEn skills = TranslationsWebPluginsSkillsEn.internal(_root);
+	late final TranslationsWebPluginsCustomTasksEn customTasks = TranslationsWebPluginsCustomTasksEn.internal(_root);
+	late final TranslationsWebPluginsGitHostsEn gitHosts = TranslationsWebPluginsGitHostsEn.internal(_root);
+}
+
+// Path: web.backups
+class TranslationsWebBackupsEn {
+	TranslationsWebBackupsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Backups'
+	String get title => 'Backups';
+
+	/// en: 'Encrypted PostgreSQL dumps written to a pluggable target. Configure schedules + retention, or trigger one-off backups for a quick safety net.'
+	String get subtitle => 'Encrypted PostgreSQL dumps written to a pluggable target. Configure schedules + retention, or trigger one-off backups for a quick safety net.';
+
+	/// en: 'Export data'
+	String get exportData => 'Export data';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'Failed to load backup status'
+	String get loadStatusFailedToast => 'Failed to load backup status';
+
+	late final TranslationsWebBackupsTabsEn tabs = TranslationsWebBackupsTabsEn.internal(_root);
+	late final TranslationsWebBackupsInventoryEn inventory = TranslationsWebBackupsInventoryEn.internal(_root);
+	late final TranslationsWebBackupsRestartEn restart = TranslationsWebBackupsRestartEn.internal(_root);
+	late final TranslationsWebBackupsSetupEn setup = TranslationsWebBackupsSetupEn.internal(_root);
+	late final TranslationsWebBackupsGeneratedEn generated = TranslationsWebBackupsGeneratedEn.internal(_root);
+	late final TranslationsWebBackupsStatusEn status = TranslationsWebBackupsStatusEn.internal(_root);
+	late final TranslationsWebBackupsBackupsTabEn backupsTab = TranslationsWebBackupsBackupsTabEn.internal(_root);
+	late final TranslationsWebBackupsRestoreEn restore = TranslationsWebBackupsRestoreEn.internal(_root);
+	late final TranslationsWebBackupsSchedulesTabEn schedulesTab = TranslationsWebBackupsSchedulesTabEn.internal(_root);
+	late final TranslationsWebBackupsNewScheduleEn newSchedule = TranslationsWebBackupsNewScheduleEn.internal(_root);
+	late final TranslationsWebBackupsTargetsTabEn targetsTab = TranslationsWebBackupsTargetsTabEn.internal(_root);
+	late final TranslationsWebBackupsTargetEditorEn targetEditor = TranslationsWebBackupsTargetEditorEn.internal(_root);
+}
+
+// Path: web.serverSettings
+class TranslationsWebServerSettingsEn {
+	TranslationsWebServerSettingsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsWebServerSettingsSectionsEn sections = TranslationsWebServerSettingsSectionsEn.internal(_root);
+
+	/// en: 'Loading server settings…'
+	String get loading => 'Loading server settings…';
+
+	/// en: 'Failed to load: {message}'
+	String loadFailed({required Object message}) => 'Failed to load: ${message}';
+
+	/// en: 'opendray was started without a -config flag. Settings are loaded from environment variables only and cannot be edited here.'
+	String get noConfigFlag => 'opendray was started without a -config flag. Settings are loaded from environment variables only and cannot be edited here.';
+
+	/// en: 'Reset'
+	String get resetButton => 'Reset';
+
+	/// en: 'Discard unsaved changes in this section'
+	String get resetButtonTitle => 'Discard unsaved changes in this section';
+
+	/// en: 'Reset "{section}" to last-saved values?'
+	String resetConfirm({required Object section}) => 'Reset "${section}" to last-saved values?';
+
+	/// en: 'restart required'
+	String get badgeRestartRequired => 'restart required';
+
+	/// en: 'unsaved'
+	String get badgeUnsaved => 'unsaved';
+
+	/// en: 'Save changes'
+	String get saveButton => 'Save changes';
+
+	/// en: 'Settings saved'
+	String get saveToastTitle => 'Settings saved';
+
+	/// en: 'Click Restart to apply.'
+	String get saveToastDesc => 'Click Restart to apply.';
+
+	/// en: 'Save failed'
+	String get saveErrorTitle => 'Save failed';
+
+	/// en: 'You changed listen address / admin user / admin password. After restart you may need to re-authenticate or use the new address. Continue?'
+	String get dangerousConfirm => 'You changed listen address / admin user / admin password. After restart you may need to re-authenticate or use the new address. Continue?';
+
+	/// en: 'You have unsaved changes'
+	String get unsavedHint => 'You have unsaved changes';
+
+	/// en: 'All changes saved'
+	String get savedHint => 'All changes saved';
+
+	/// en: 'Filter fields…'
+	String get searchPlaceholder => 'Filter fields…';
+
+	late final TranslationsWebServerSettingsRestartEn restart = TranslationsWebServerSettingsRestartEn.internal(_root);
+	late final TranslationsWebServerSettingsFormGroupsEn formGroups = TranslationsWebServerSettingsFormGroupsEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsEn fields = TranslationsWebServerSettingsFieldsEn.internal(_root);
+	late final TranslationsWebServerSettingsLiveTailEn liveTail = TranslationsWebServerSettingsLiveTailEn.internal(_root);
+	late final TranslationsWebServerSettingsMemoryInspectorCardEn memoryInspectorCard = TranslationsWebServerSettingsMemoryInspectorCardEn.internal(_root);
+
+	/// en: 'Requires the binary to be compiled with <1>-tags local_onnx</1>. The standard build returns a clear stub error when this backend is selected. See <3>Memory → Local ONNX</3> tutorial for setup steps.'
+	String get localOnnxBanner => 'Requires the binary to be compiled with <1>-tags local_onnx</1>. The standard build returns a clear stub error when this backend is selected. See <3>Memory → Local ONNX</3> tutorial for setup steps.';
+
+	late final TranslationsWebServerSettingsStringListEn stringList = TranslationsWebServerSettingsStringListEn.internal(_root);
+	late final TranslationsWebServerSettingsHttpHelpersEn httpHelpers = TranslationsWebServerSettingsHttpHelpersEn.internal(_root);
+	late final TranslationsWebServerSettingsProbeEn probe = TranslationsWebServerSettingsProbeEn.internal(_root);
+	late final TranslationsWebServerSettingsBackupEn backup = TranslationsWebServerSettingsBackupEn.internal(_root);
+	late final TranslationsWebServerSettingsTargetRowEn targetRow = TranslationsWebServerSettingsTargetRowEn.internal(_root);
+}
+
+// Path: web.settings
+class TranslationsWebSettingsEn {
+	TranslationsWebSettingsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Settings'
+	String get title => 'Settings';
+
+	/// en: 'Workspace, account, and gateway config.'
+	String get subtitle => 'Workspace, account, and gateway config.';
+
+	late final TranslationsWebSettingsGroupsEn groups = TranslationsWebSettingsGroupsEn.internal(_root);
+	late final TranslationsWebSettingsItemsEn items = TranslationsWebSettingsItemsEn.internal(_root);
+	late final TranslationsWebSettingsHealthEn health = TranslationsWebSettingsHealthEn.internal(_root);
+	late final TranslationsWebSettingsBreadcrumbEn breadcrumb = TranslationsWebSettingsBreadcrumbEn.internal(_root);
+	late final TranslationsWebSettingsAppearanceEn appearance = TranslationsWebSettingsAppearanceEn.internal(_root);
+	late final TranslationsWebSettingsFontEn font = TranslationsWebSettingsFontEn.internal(_root);
+	late final TranslationsWebSettingsAccountEn account = TranslationsWebSettingsAccountEn.internal(_root);
+	late final TranslationsWebSettingsChangeCredentialsEn changeCredentials = TranslationsWebSettingsChangeCredentialsEn.internal(_root);
+	late final TranslationsWebSettingsSystemEn system = TranslationsWebSettingsSystemEn.internal(_root);
+	late final TranslationsWebSettingsAboutEn about = TranslationsWebSettingsAboutEn.internal(_root);
+}
+
+// Path: web.logViewer
+class TranslationsWebLogViewerEn {
+	TranslationsWebLogViewerEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Filter…'
+	String get filterPlaceholder => 'Filter…';
+
+	/// en: 'Debug count'
+	String get debugTooltip => 'Debug count';
+
+	/// en: 'Info count'
+	String get infoTooltip => 'Info count';
+
+	/// en: 'Warn count'
+	String get warnTooltip => 'Warn count';
+
+	/// en: 'Error count'
+	String get errorTooltip => 'Error count';
+
+	/// en: 'Streaming'
+	String get streaming => 'Streaming';
+
+	/// en: 'Disconnected'
+	String get disconnected => 'Disconnected';
+
+	/// en: 'live'
+	String get live => 'live';
+
+	/// en: 'offline'
+	String get offline => 'offline';
+
+	/// en: 'Pause auto-scroll'
+	String get pauseTooltip => 'Pause auto-scroll';
+
+	/// en: 'Resume auto-scroll'
+	String get resumeTooltip => 'Resume auto-scroll';
+
+	/// en: 'Clear local view (server ring untouched)'
+	String get clearTooltip => 'Clear local view (server ring untouched)';
+
+	/// en: 'Download full ring as .log file'
+	String get downloadTooltip => 'Download full ring as .log file';
+
+	/// en: 'Waiting for log records…'
+	String get emptyWaiting => 'Waiting for log records…';
+
+	/// en: 'No records match "{query}"'
+	String emptyFiltered({required Object query}) => 'No records match "${query}"';
+}
+
+// Path: web.pathInput
+class TranslationsWebPathInputEn {
+	TranslationsWebPathInputEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Test'
+	String get testButton => 'Test';
+
+	/// en: 'Resolve and check this path'
+	String get testTooltip => 'Resolve and check this path';
+
+	/// en: 'not found ·'
+	String get notFound => 'not found ·';
+
+	/// en: 'children'
+	String get childrenSuffix => 'children';
+
+	/// en: '· expected directory'
+	String get expectedDirectory => '· expected directory';
+}
+
+// Path: web.memoryAmbient
+class TranslationsWebMemoryAmbientEn {
+	TranslationsWebMemoryAmbientEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsWebMemoryAmbientHeaderEn header = TranslationsWebMemoryAmbientHeaderEn.internal(_root);
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	late final TranslationsWebMemoryAmbientProvidersEn providers = TranslationsWebMemoryAmbientProvidersEn.internal(_root);
+	late final TranslationsWebMemoryAmbientRulesEn rules = TranslationsWebMemoryAmbientRulesEn.internal(_root);
+	late final TranslationsWebMemoryAmbientProfilesEn profiles = TranslationsWebMemoryAmbientProfilesEn.internal(_root);
+	late final TranslationsWebMemoryAmbientCostEn cost = TranslationsWebMemoryAmbientCostEn.internal(_root);
+}
+
+// Path: web.noteEditor
+class TranslationsWebNoteEditorEn {
+	TranslationsWebNoteEditorEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'Source'
+	String get source => 'Source';
+
+	/// en: 'Preview'
+	String get preview => 'Preview';
+
+	/// en: 'tag #{tag}'
+	String tagTitle({required Object tag}) => 'tag #${tag}';
+
+	/// en: 'Empty note. Switch to Source to start writing.'
+	String get emptyNote => 'Empty note. Switch to Source to start writing.';
+
+	/// en: 'Save failed'
+	String get saveFailedToast => 'Save failed';
+
+	late final TranslationsWebNoteEditorStatusEn status = TranslationsWebNoteEditorStatusEn.internal(_root);
+}
+
+// Path: web.export
+class TranslationsWebExportEn {
+	TranslationsWebExportEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Export data'
+	String get title => 'Export data';
+
+	/// en: 'Take a one-shot zip bundle of selected logical entities. Bundles are kept on the server for 24 hours, then automatically reaped.'
+	String get subtitle => 'Take a one-shot zip bundle of selected logical entities. Bundles are kept on the server for 24 hours, then automatically reaped.';
+
+	/// en: '← Backups'
+	String get backToBackups => '← Backups';
+
+	late final TranslationsWebExportSectionsEn sections = TranslationsWebExportSectionsEn.internal(_root);
+	late final TranslationsWebExportFormEn form = TranslationsWebExportFormEn.internal(_root);
+	late final TranslationsWebExportHistoryEn history = TranslationsWebExportHistoryEn.internal(_root);
+	late final TranslationsWebExportImportEn import = TranslationsWebExportImportEn.internal(_root);
+	late final TranslationsWebExportImportsEn imports = TranslationsWebExportImportsEn.internal(_root);
+}
+
 // Path: more.identity
 class TranslationsMoreIdentityEn {
 	TranslationsMoreIdentityEn.internal(this._root);
@@ -3242,6 +4100,4145 @@ class TranslationsSettingsServerSettingsEn {
 	String validateNumber({required Object field}) => '"${field}" must be a number';
 }
 
+// Path: web.sessions.list
+class TranslationsWebSessionsListEn {
+	TranslationsWebSessionsListEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Sessions'
+	String get title => 'Sessions';
+
+	/// en: '·'
+	String get countSeparator => '·';
+
+	/// en: 'Spawn new session'
+	String get newAria => 'Spawn new session';
+
+	/// en: 'New session'
+	String get newTooltip => 'New session';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'No sessions yet.'
+	String get emptyTitle => 'No sessions yet.';
+
+	/// en: 'Press {kbd} to spawn.'
+	String emptyHint({required Object kbd}) => 'Press ${kbd} to spawn.';
+
+	/// en: 'Ended ({count})'
+	String endedHeader({required Object count}) => 'Ended (${count})';
+
+	/// en: 'Clear all'
+	String get clearAll => 'Clear all';
+
+	/// en: 'Remove all {count} ended sessions?'
+	String confirmClearAll({required Object count}) => 'Remove all ${count} ended sessions?';
+
+	/// en: 'Terminate and remove {name}?'
+	String confirmTerminate({required Object name}) => 'Terminate and remove ${name}?';
+
+	/// en: ' {count} child task session will be promoted to top-level.'
+	String childPromoted({required Object count}) => ' ${count} child task session will be promoted to top-level.';
+
+	/// en: ' {count} child task sessions will be promoted to top-level.'
+	String childPromotedPlural({required Object count}) => ' ${count} child task sessions will be promoted to top-level.';
+
+	/// en: '{live} live · {ended} ended'
+	String footer({required Object live, required Object ended}) => '${live} live · ${ended} ended';
+
+	late final TranslationsWebSessionsListRowEn row = TranslationsWebSessionsListRowEn.internal(_root);
+
+	/// en: 'Delete failed'
+	String get deleteFailedToast => 'Delete failed';
+}
+
+// Path: web.sessions.tabs
+class TranslationsWebSessionsTabsEn {
+	TranslationsWebSessionsTabsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Close tab and remove session'
+	String get closeAria => 'Close tab and remove session';
+
+	/// en: 'Close tab and remove session'
+	String get closeTitle => 'Close tab and remove session';
+}
+
+// Path: web.sessions.page
+class TranslationsWebSessionsPageEn {
+	TranslationsWebSessionsPageEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Session removed'
+	String get removedToast => 'Session removed';
+
+	/// en: 'Remove failed'
+	String get removeFailedToast => 'Remove failed';
+
+	/// en: 'Session stopped'
+	String get stoppedToast => 'Session stopped';
+
+	/// en: 'Stop failed'
+	String get stopFailedToast => 'Stop failed';
+
+	/// en: 'Session restarted'
+	String get restartedToast => 'Session restarted';
+
+	/// en: 'Restart failed'
+	String get restartFailedToast => 'Restart failed';
+
+	/// en: 'Stop and remove "{name}"?'
+	String confirmCloseTabTitle({required Object name}) => 'Stop and remove "${name}"?';
+
+	/// en: 'The CLI process will be terminated and the row deleted.'
+	String get confirmCloseTabDescription => 'The CLI process will be terminated and the row deleted.';
+
+	/// en: 'Stop and remove'
+	String get confirmCloseTabConfirm => 'Stop and remove';
+
+	/// en: 'Remove {name}?'
+	String confirmRemoveTitle({required Object name}) => 'Remove ${name}?';
+
+	/// en: 'Remove session?'
+	String get confirmRemoveTitleFallback => 'Remove session?';
+
+	/// en: 'This deletes the row.'
+	String get confirmRemoveDescription => 'This deletes the row.';
+
+	/// en: 'Remove'
+	String get confirmRemoveConfirm => 'Remove';
+}
+
+// Path: web.sessions.empty
+class TranslationsWebSessionsEmptyEn {
+	TranslationsWebSessionsEmptyEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'No session open'
+	String get title => 'No session open';
+
+	/// en: 'Pick a session from the list, or spawn a new one. Keyboard: {kbdN} new, {kbdW} close, {kbdRange} switch.'
+	String hint({required Object kbdN, required Object kbdW, required Object kbdRange}) => 'Pick a session from the list, or spawn a new one. Keyboard: ${kbdN} new, ${kbdW} close, ${kbdRange} switch.';
+
+	/// en: 'Spawn session'
+	String get spawn => 'Spawn session';
+}
+
+// Path: web.sessions.header
+class TranslationsWebSessionsHeaderEn {
+	TranslationsWebSessionsHeaderEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Loading session…'
+	String get loadingSession => 'Loading session…';
+
+	/// en: 'Show session list'
+	String get showList => 'Show session list';
+
+	/// en: 'Hide session list'
+	String get hideList => 'Hide session list';
+
+	/// en: 'Show inspector'
+	String get showInspector => 'Show inspector';
+
+	/// en: 'Hide inspector'
+	String get hideInspector => 'Hide inspector';
+
+	/// en: 'Attach image'
+	String get attachImage => 'Attach image';
+
+	/// en: 'Attach image (or paste / drop into terminal)'
+	String get attachImageTooltip => 'Attach image (or paste / drop into terminal)';
+
+	/// en: 'Restart'
+	String get restart => 'Restart';
+
+	/// en: 'Restarting…'
+	String get restarting => 'Restarting…';
+
+	/// en: 'Remove'
+	String get remove => 'Remove';
+
+	/// en: 'Removing…'
+	String get removing => 'Removing…';
+
+	/// en: 'Stop'
+	String get stop => 'Stop';
+
+	/// en: 'Stopping…'
+	String get stopping => 'Stopping…';
+
+	/// en: 'pid {pid}'
+	String pid({required Object pid}) => 'pid ${pid}';
+}
+
+// Path: web.sessions.terminal
+class TranslationsWebSessionsTerminalEn {
+	TranslationsWebSessionsTerminalEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Uploading image…'
+	String get uploadingToast => 'Uploading image…';
+
+	/// en: 'Image attached'
+	String get uploadedToast => 'Image attached';
+
+	/// en: 'Upload failed'
+	String get uploadFailedToast => 'Upload failed';
+
+	/// en: 'Only image files can be attached'
+	String get uploadInvalidTypeToast => 'Only image files can be attached';
+
+	/// en: 'Drop image to attach'
+	String get dropToAttach => 'Drop image to attach';
+}
+
+// Path: web.sessions.spawn
+class TranslationsWebSessionsSpawnEn {
+	TranslationsWebSessionsSpawnEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Spawn session'
+	String get title => 'Spawn session';
+
+	/// en: 'Start a CLI session under a registered provider.'
+	String get description => 'Start a CLI session under a registered provider.';
+
+	/// en: 'Provider'
+	String get provider => 'Provider';
+
+	/// en: 'Claude account'
+	String get claudeAccount => 'Claude account';
+
+	/// en: 'Loading accounts…'
+	String get loadingAccounts => 'Loading accounts…';
+
+	/// en: 'No Claude accounts configured — the gateway will use the system ANTHROPIC_API_KEY.'
+	String get noAccounts => 'No Claude accounts configured — the gateway will use the system ANTHROPIC_API_KEY.';
+
+	/// en: 'Default'
+	String get kDefault => 'Default';
+
+	/// en: 'Use system keychain / env'
+	String get defaultTooltip => 'Use system keychain / env';
+
+	/// en: '·empty'
+	String get tokenEmptyBadge => '·empty';
+
+	/// en: 'No token set — set token in Providers panel first'
+	String get tokenMissingTooltip => 'No token set — set token in Providers panel first';
+
+	/// en: 'Multiple accounts configured — pick one for this session.'
+	String get multiAccountHint => 'Multiple accounts configured — pick one for this session.';
+
+	/// en: 'Working directory'
+	String get cwd => 'Working directory';
+
+	/// en: '/Users/you/projects/foo'
+	String get cwdPlaceholder => '/Users/you/projects/foo';
+
+	/// en: 'Browse'
+	String get browse => 'Browse';
+
+	/// en: 'Name (optional)'
+	String get nameLabel => 'Name (optional)';
+
+	/// en: 'claude in pet-tracker'
+	String get namePlaceholder => 'claude in pet-tracker';
+
+	/// en: 'CLI args (one per line)'
+	String get argsLabel => 'CLI args (one per line)';
+
+	/// en: 'Bypass permission prompts'
+	String get bypassClaude => 'Bypass permission prompts';
+
+	/// en: 'Auto-approve (--ask-for-approval never)'
+	String get bypassCodex => 'Auto-approve (--ask-for-approval never)';
+
+	/// en: 'YOLO mode (--yolo)'
+	String get bypassGemini => 'YOLO mode (--yolo)';
+
+	/// en: 'This session will run with elevated autonomy.'
+	String get bypassOnHint => 'This session will run with elevated autonomy.';
+
+	/// en: 'Off — confirmations and prompts behave normally.'
+	String get bypassOffHint => 'Off — confirmations and prompts behave normally.';
+
+	/// en: 'Pick a provider.'
+	String get errorPickProvider => 'Pick a provider.';
+
+	/// en: 'cwd is required.'
+	String get errorCwdRequired => 'cwd is required.';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Spawn'
+	String get submit => 'Spawn';
+
+	/// en: 'Spawning…'
+	String get submitting => 'Spawning…';
+
+	/// en: 'Session spawned'
+	String get spawnedToast => 'Session spawned';
+
+	/// en: '{provider} · pid {pid}'
+	String spawnedDescription({required Object provider, required Object pid}) => '${provider} · pid ${pid}';
+
+	/// en: '—'
+	String get pidFallback => '—';
+}
+
+// Path: web.sessions.accountSwitcher
+class TranslationsWebSessionsAccountSwitcherEn {
+	TranslationsWebSessionsAccountSwitcherEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Switch Claude account (restarts the CLI process)'
+	String get tooltip => 'Switch Claude account (restarts the CLI process)';
+
+	/// en: 'default'
+	String get currentDefault => 'default';
+
+	/// en: 'Switch Claude account'
+	String get menuTitle => 'Switch Claude account';
+
+	/// en: 'Default'
+	String get defaultName => 'Default';
+
+	/// en: 'CLI's system keychain / env'
+	String get defaultSubtitle => 'CLI\'s system keychain / env';
+
+	/// en: '·empty'
+	String get tokenEmpty => '·empty';
+
+	/// en: 'Switching account will restart the Claude CLI process. In-progress conversation state inside the CLI will be lost. Continue?'
+	String get confirmSwitch => 'Switching account will restart the Claude CLI process. In-progress conversation state inside the CLI will be lost. Continue?';
+
+	/// en: 'Account switched'
+	String get switchedToast => 'Account switched';
+
+	/// en: 'Now using @{account} · pid {pid}'
+	String switchedDescription({required Object account, required Object pid}) => 'Now using @${account} · pid ${pid}';
+
+	/// en: 'default'
+	String get switchedDefault => 'default';
+
+	/// en: 'Switch failed'
+	String get switchFailedToast => 'Switch failed';
+}
+
+// Path: web.sessions.inspector
+class TranslationsWebSessionsInspectorEn {
+	TranslationsWebSessionsInspectorEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsWebSessionsInspectorTabsEn tabs = TranslationsWebSessionsInspectorTabsEn.internal(_root);
+}
+
+// Path: web.sessions.ended
+class TranslationsWebSessionsEndedEn {
+	TranslationsWebSessionsEndedEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: '[buffer unavailable]'
+	String get bufferUnavailable => '[buffer unavailable]';
+
+	/// en: '[session ended — read-only buffer]'
+	String get readOnlyBanner => '[session ended — read-only buffer]';
+}
+
+// Path: web.sessions.fileBrowser
+class TranslationsWebSessionsFileBrowserEn {
+	TranslationsWebSessionsFileBrowserEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Choose working directory'
+	String get title => 'Choose working directory';
+
+	/// en: 'Browse the gateway host's filesystem and pick a folder.'
+	String get description => 'Browse the gateway host\'s filesystem and pick a folder.';
+
+	/// en: 'Parent directory'
+	String get parent => 'Parent directory';
+
+	/// en: 'Home directory'
+	String get home => 'Home directory';
+
+	/// en: 'Refresh'
+	String get refresh => 'Refresh';
+
+	/// en: '/Users/you/projects'
+	String get pathPlaceholder => '/Users/you/projects';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'Empty directory.'
+	String get empty => 'Empty directory.';
+
+	/// en: 'New folder'
+	String get newFolder => 'New folder';
+
+	/// en: 'new-folder-name'
+	String get newFolderPlaceholder => 'new-folder-name';
+
+	/// en: 'Create'
+	String get create => 'Create';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Use this folder'
+	String get useThisFolder => 'Use this folder';
+
+	/// en: 'Directory created'
+	String get createdToast => 'Directory created';
+
+	/// en: 'Mkdir failed'
+	String get mkdirFailedToast => 'Mkdir failed';
+
+	/// en: 'Failed to read home'
+	String get homeFailedToast => 'Failed to read home';
+}
+
+// Path: web.memoryWorkers.tasks
+class TranslationsWebMemoryWorkersTasksEn {
+	TranslationsWebMemoryWorkersTasksEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsWebMemoryWorkersTasksGatekeeperEn gatekeeper = TranslationsWebMemoryWorkersTasksGatekeeperEn.internal(_root);
+	late final TranslationsWebMemoryWorkersTasksCleanerEn cleaner = TranslationsWebMemoryWorkersTasksCleanerEn.internal(_root);
+	late final TranslationsWebMemoryWorkersTasksGitactivityEn gitactivity = TranslationsWebMemoryWorkersTasksGitactivityEn.internal(_root);
+	late final TranslationsWebMemoryWorkersTasksTranscriptEn transcript = TranslationsWebMemoryWorkersTasksTranscriptEn.internal(_root);
+}
+
+// Path: web.project.picker
+class TranslationsWebProjectPickerEn {
+	TranslationsWebProjectPickerEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Pick a project'
+	String get title => 'Pick a project';
+
+	/// en: 'Project memory is scoped by working directory. Pick one to manage its goal, plan, journal, and cleanup queue.'
+	String get subtitle => 'Project memory is scoped by working directory. Pick one to manage its goal, plan, journal, and cleanup queue.';
+
+	/// en: '/path/to/your/project'
+	String get pathPlaceholder => '/path/to/your/project';
+
+	/// en: 'Browse'
+	String get browse => 'Browse';
+
+	/// en: 'Browse the gateway host's filesystem'
+	String get browseTooltip => 'Browse the gateway host\'s filesystem';
+
+	/// en: 'Open'
+	String get open => 'Open';
+
+	/// en: 'Recent projects (from stored memory):'
+	String get recentLabel => 'Recent projects (from stored memory):';
+
+	/// en: 'Looks like a truncated scope_key (old mirror import bug). May have no project docs.'
+	String get orphanTooltip => 'Looks like a truncated scope_key (old mirror import bug). May have no project docs.';
+
+	/// en: 'orphan'
+	String get orphanBadge => 'orphan';
+}
+
+// Path: web.project.header
+class TranslationsWebProjectHeaderEn {
+	TranslationsWebProjectHeaderEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: '{count} doc'
+	String docsCount_one({required Object count}) => '${count} doc';
+
+	/// en: '{count} docs'
+	String docsCount_other({required Object count}) => '${count} docs';
+
+	/// en: '{count} journal entry'
+	String journalEntries_one({required Object count}) => '${count} journal entry';
+
+	/// en: '{count} journal entries'
+	String journalEntries_other({required Object count}) => '${count} journal entries';
+
+	/// en: '{count} pending proposal'
+	String pendingProposals_one({required Object count}) => '${count} pending proposal';
+
+	/// en: '{count} pending proposals'
+	String pendingProposals_other({required Object count}) => '${count} pending proposals';
+
+	/// en: '{count} cleanup pending'
+	String cleanupPending({required Object count}) => '${count} cleanup pending';
+}
+
+// Path: web.project.tabs
+class TranslationsWebProjectTabsEn {
+	TranslationsWebProjectTabsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Goal'
+	String get goal => 'Goal';
+
+	/// en: 'Plan'
+	String get plan => 'Plan';
+
+	/// en: 'Tech'
+	String get tech => 'Tech';
+
+	/// en: 'Activity'
+	String get activity => 'Activity';
+
+	/// en: 'Journal'
+	String get journal => 'Journal';
+
+	/// en: 'Inbox'
+	String get inbox => 'Inbox';
+
+	/// en: 'Cleanup'
+	String get cleanup => 'Cleanup';
+}
+
+// Path: web.project.docLabel
+class TranslationsWebProjectDocLabelEn {
+	TranslationsWebProjectDocLabelEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Goal'
+	String get goal => 'Goal';
+
+	/// en: 'Plan'
+	String get plan => 'Plan';
+
+	/// en: 'Tech stack'
+	String get tech_stack => 'Tech stack';
+
+	/// en: 'Recent activity'
+	String get recent_activity => 'Recent activity';
+}
+
+// Path: web.project.verdictLabel
+class TranslationsWebProjectVerdictLabelEn {
+	TranslationsWebProjectVerdictLabelEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Delete'
+	String get stale => 'Delete';
+
+	/// en: 'Merge'
+	String get duplicate => 'Merge';
+
+	/// en: 'Keep'
+	String get keep => 'Keep';
+}
+
+// Path: web.project.editor
+class TranslationsWebProjectEditorEn {
+	TranslationsWebProjectEditorEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Updated by'
+	String get updatedBy => 'Updated by';
+
+	/// en: 'No {label} set yet.'
+	String noDocSet({required Object label}) => 'No ${label} set yet.';
+
+	/// en: 'Save'
+	String get save => 'Save';
+
+	/// en: 'Save failed'
+	String get saveFailedToast => 'Save failed';
+
+	/// en: '{label} saved'
+	String savedToast({required Object label}) => '${label} saved';
+
+	/// en: 'What are we building? One paragraph. Read by every agent on spawn.'
+	String get goalPlaceholder => 'What are we building? One paragraph. Read by every agent on spawn.';
+
+	/// en: 'Active plan — what we are doing right now and what is next. Updated as work progresses.'
+	String get planPlaceholder => 'Active plan — what we are doing right now and what is next. Updated as work progresses.';
+}
+
+// Path: web.project.readonly
+class TranslationsWebProjectReadonlyEn {
+	TranslationsWebProjectReadonlyEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsWebProjectReadonlyTechStackEn tech_stack = TranslationsWebProjectReadonlyTechStackEn.internal(_root);
+	late final TranslationsWebProjectReadonlyRecentActivityEn recent_activity = TranslationsWebProjectReadonlyRecentActivityEn.internal(_root);
+
+	/// en: 'No {label} captured yet.'
+	String noneCaptured({required Object label}) => 'No ${label} captured yet.';
+
+	/// en: 'Generated by'
+	String get generatedBy => 'Generated by';
+
+	/// en: 'last refresh'
+	String get lastRefresh => 'last refresh';
+}
+
+// Path: web.project.journal
+class TranslationsWebProjectJournalEn {
+	TranslationsWebProjectJournalEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'No journal entries yet. Each session-end appends one automatically.'
+	String get empty => 'No journal entries yet. Each session-end appends one automatically.';
+}
+
+// Path: web.project.inbox
+class TranslationsWebProjectInboxEn {
+	TranslationsWebProjectInboxEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'Inbox empty.'
+	String get emptyTitle => 'Inbox empty.';
+
+	/// en: 'Agents file proposals here via `project_goal_set` / `project_plan_set` MCP tools.'
+	String get emptyHint => 'Agents file proposals here via `project_goal_set` / `project_plan_set` MCP tools.';
+
+	/// en: '{label} updated'
+	String approvedToast({required Object label}) => '${label} updated';
+
+	/// en: 'Approve failed'
+	String get approveFailedToast => 'Approve failed';
+
+	/// en: 'Rejected'
+	String get rejectedToast => 'Rejected';
+
+	/// en: 'Reject failed'
+	String get rejectFailedToast => 'Reject failed';
+
+	/// en: 'ses'
+	String get sessionPrefix => 'ses';
+
+	/// en: 'Approve will REPLACE the current {label} entirely.'
+	String warning({required Object label}) => 'Approve will REPLACE the current ${label} entirely.';
+
+	/// en: 'Review the diff below; this isn't a merge.'
+	String get warningSuffix => 'Review the diff below; this isn\'t a merge.';
+
+	/// en: 'Current'
+	String get current => 'Current';
+
+	/// en: 'Proposed'
+	String get proposed => 'Proposed';
+
+	/// en: '(empty)'
+	String get emptyBody => '(empty)';
+
+	/// en: 'Approve'
+	String get approve => 'Approve';
+
+	/// en: 'Reject'
+	String get reject => 'Reject';
+
+	/// en: 'Replace {label}?'
+	String confirmDialogTitle({required Object label}) => 'Replace ${label}?';
+
+	/// en: 'The current {label} will be overwritten with the proposed content. This cannot be undone via this UI (you can manually edit it back).'
+	String confirmDialogDescription({required Object label}) => 'The current ${label} will be overwritten with the proposed content. This cannot be undone via this UI (you can manually edit it back).';
+
+	/// en: 'Cancel'
+	String get confirmCancel => 'Cancel';
+
+	/// en: 'Confirm replace'
+	String get confirmReplace => 'Confirm replace';
+}
+
+// Path: web.project.cleanup
+class TranslationsWebProjectCleanupEn {
+	TranslationsWebProjectCleanupEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'The LLM librarian proposes keep / stale / duplicate verdicts for this project's memories. You approve before anything is deleted.'
+	String get hint => 'The LLM librarian proposes keep / stale / duplicate verdicts for this project\'s memories. You approve before anything is deleted.';
+
+	/// en: 'Run cleanup now'
+	String get runNow => 'Run cleanup now';
+
+	/// en: 'Cleanup run: {decided} decisions queued ({scanned} scanned)'
+	String runSucceededToast({required Object decided, required Object scanned}) => 'Cleanup run: ${decided} decisions queued (${scanned} scanned)';
+
+	/// en: 'Cleanup run failed'
+	String get runFailedToast => 'Cleanup run failed';
+
+	/// en: 'No pending decisions. Either nothing aged into eligibility or the last run found everything load-bearing.'
+	String get empty => 'No pending decisions. Either nothing aged into eligibility or the last run found everything load-bearing.';
+
+	/// en: '→ merge into'
+	String get mergeIntoPrefix => '→ merge into';
+
+	/// en: 'Reason:'
+	String get reasonPrefix => 'Reason:';
+
+	/// en: 'Execute'
+	String get executeButton => 'Execute';
+
+	/// en: 'Confirm keep'
+	String get confirmKeepButton => 'Confirm keep';
+
+	/// en: 'Reject'
+	String get rejectButton => 'Reject';
+
+	/// en: '{label} executed'
+	String approvedExecutedToast({required Object label}) => '${label} executed';
+
+	/// en: 'Approve failed'
+	String get approveFailedToast => 'Approve failed';
+
+	/// en: 'Rejected — memory kept'
+	String get rejectedToast => 'Rejected — memory kept';
+
+	/// en: 'Reject failed'
+	String get rejectFailedToast => 'Reject failed';
+}
+
+// Path: web.project.reset
+class TranslationsWebProjectResetEn {
+	TranslationsWebProjectResetEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Reset'
+	String get button => 'Reset';
+
+	/// en: 'Reset project memory?'
+	String get dialogTitle => 'Reset project memory?';
+
+	/// en: 'Deletes all stored project context for this cwd. This cannot be undone.'
+	String get dialogDescription => 'Deletes all stored project context for this cwd. This cannot be undone.';
+
+	/// en: 'Always deleted: goal, plan, proposals, journal, cleanup decisions.'
+	String get alwaysDeleted => 'Always deleted: goal, plan, proposals, journal, cleanup decisions.';
+
+	/// en: 'Also delete scanner docs'
+	String get alsoDeleteScannerLabel => 'Also delete scanner docs';
+
+	/// en: '(tech_stack + recent_activity).'
+	String get alsoDeleteScannerSuffix => '(tech_stack + recent_activity).';
+
+	/// en: 'Auto-rebuild on next spawn anyway — leaving unchecked is usually fine.'
+	String get alsoDeleteScannerHint => 'Auto-rebuild on next spawn anyway — leaving unchecked is usually fine.';
+
+	/// en: 'Also delete pgvector memories'
+	String get alsoDeleteMemoriesLabel => 'Also delete pgvector memories';
+
+	/// en: 'for this scope_key.'
+	String get alsoDeleteMemoriesSuffix => 'for this scope_key.';
+
+	/// en: 'Long-term facts the agent stored (user preferences, project facts). Cannot be recovered.'
+	String get alsoDeleteMemoriesHint => 'Long-term facts the agent stored (user preferences, project facts). Cannot be recovered.';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Delete forever'
+	String get deleteForever => 'Delete forever';
+
+	/// en: 'Reset: deleted {summary}'
+	String successToast({required Object summary}) => 'Reset: deleted ${summary}';
+
+	late final TranslationsWebProjectResetSummaryEn summary = TranslationsWebProjectResetSummaryEn.internal(_root);
+
+	/// en: 'Reset failed'
+	String get failedToast => 'Reset failed';
+}
+
+// Path: web.memoryInspector.status
+class TranslationsWebMemoryInspectorStatusEn {
+	TranslationsWebMemoryInspectorStatusEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Active embedder'
+	String get label => 'Active embedder';
+
+	/// en: 'unavailable'
+	String get unavailable => 'unavailable';
+
+	/// en: 'probing…'
+	String get probing => 'probing…';
+
+	/// en: '{dim}-dim · {state}'
+	String dimensions({required Object dim, required Object state}) => '${dim}-dim · ${state}';
+
+	/// en: 'enabled'
+	String get enabled => 'enabled';
+
+	/// en: 'disabled'
+	String get disabled => 'disabled';
+
+	/// en: 'Test embedder'
+	String get testButton => 'Test embedder';
+}
+
+// Path: web.memoryInspector.scope
+class TranslationsWebMemoryInspectorScopeEn {
+	TranslationsWebMemoryInspectorScopeEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Scope'
+	String get label => 'Scope';
+
+	/// en: 'Scope key'
+	String get scopeKey => 'Scope key';
+
+	/// en: '(ignored for global)'
+	String get scopeKeyIgnored => '(ignored for global)';
+
+	/// en: '(cwd of the project)'
+	String get scopeKeyCwd => '(cwd of the project)';
+
+	/// en: '(session id)'
+	String get scopeKeySession => '(session id)';
+
+	/// en: '/path/to/project (cwd)'
+	String get placeholderProject => '/path/to/project (cwd)';
+
+	/// en: 'session id'
+	String get placeholderSession => 'session id';
+
+	/// en: 'Sync .md'
+	String get syncMd => 'Sync .md';
+
+	/// en: 'Re-ingest Claude's <cwd>/.claude/memory/*.md files into pgvector'
+	String get syncTooltip => 'Re-ingest Claude\'s <cwd>/.claude/memory/*.md files into pgvector';
+
+	late final TranslationsWebMemoryInspectorScopeValuesEn values = TranslationsWebMemoryInspectorScopeValuesEn.internal(_root);
+}
+
+// Path: web.memoryInspector.search
+class TranslationsWebMemoryInspectorSearchEn {
+	TranslationsWebMemoryInspectorSearchEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Semantic search query (Enter to run; empty = browse)'
+	String get placeholder => 'Semantic search query (Enter to run; empty = browse)';
+
+	/// en: 'Search'
+	String get run => 'Search';
+
+	/// en: 'Clear'
+	String get clear => 'Clear';
+
+	/// en: 'Search failed'
+	String get failedToast => 'Search failed';
+}
+
+// Path: web.memoryInspector.records
+class TranslationsWebMemoryInspectorRecordsEn {
+	TranslationsWebMemoryInspectorRecordsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'No memories yet'
+	String get noMemories => 'No memories yet';
+
+	/// en: '{count} match'
+	String matches_one({required Object count}) => '${count} match';
+
+	/// en: '{count} matches'
+	String matches_other({required Object count}) => '${count} matches';
+
+	/// en: '{count} memory'
+	String memories_one({required Object count}) => '${count} memory';
+
+	/// en: '{count} memories'
+	String memories_other({required Object count}) => '${count} memories';
+
+	/// en: ' (global)'
+	String get scopeGlobalSuffix => ' (global)';
+
+	/// en: ' in {scope}: '
+	String scopeInSuffix({required Object scope}) => ' in ${scope}: ';
+
+	/// en: 'Add memory'
+	String get addButton => 'Add memory';
+
+	/// en: 'Manually create a memory in this scope'
+	String get addTooltip => 'Manually create a memory in this scope';
+
+	/// en: 'Delete all'
+	String get deleteAll => 'Delete all';
+
+	/// en: 'Delete every memory under this scope/scope_key'
+	String get deleteAllTooltip => 'Delete every memory under this scope/scope_key';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'Enter a scope key to browse memories.'
+	String get enterScopeKeyHint => 'Enter a scope key to browse memories.';
+
+	/// en: 'No matches for "{query}"'
+	String noMatchesForQuery({required Object query}) => 'No matches for "${query}"';
+
+	/// en: 'No memories in this scope yet.'
+	String get noMemoriesInScope => 'No memories in this scope yet.';
+}
+
+// Path: web.memoryInspector.row
+class TranslationsWebMemoryInspectorRowEn {
+	TranslationsWebMemoryInspectorRowEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'sim {value}'
+	String simBadge({required Object value}) => 'sim ${value}';
+
+	/// en: '{count} hit'
+	String hits_one({required Object count}) => '${count} hit';
+
+	/// en: '{count} hits'
+	String hits_other({required Object count}) => '${count} hits';
+
+	/// en: 'Last hit {relative}'
+	String lastHitTooltip({required Object relative}) => 'Last hit ${relative}';
+
+	/// en: 'Memory text — Cmd/Ctrl+Enter to save · Esc to cancel'
+	String get editPlaceholder => 'Memory text — Cmd/Ctrl+Enter to save · Esc to cancel';
+
+	/// en: 'Save (Cmd/Ctrl+Enter)'
+	String get saveTooltip => 'Save (Cmd/Ctrl+Enter)';
+
+	/// en: 'Cancel (Esc)'
+	String get cancelTooltip => 'Cancel (Esc)';
+
+	/// en: 'Edit this memory'
+	String get editTooltip => 'Edit this memory';
+
+	/// en: 'Delete this memory'
+	String get deleteTooltip => 'Delete this memory';
+
+	/// en: 'Memory text cannot be empty'
+	String get emptyError => 'Memory text cannot be empty';
+
+	/// en: 'Delete memory {id}? This is permanent.'
+	String deleteConfirm({required Object id}) => 'Delete memory ${id}? This is permanent.';
+}
+
+// Path: web.memoryInspector.toasts
+class TranslationsWebMemoryInspectorToastsEn {
+	TranslationsWebMemoryInspectorToastsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Memory deleted'
+	String get deleted => 'Memory deleted';
+
+	/// en: 'Delete failed'
+	String get deleteFailed => 'Delete failed';
+
+	/// en: 'Deleted {count} memory from this scope'
+	String bulkDeleted_one({required Object count}) => 'Deleted ${count} memory from this scope';
+
+	/// en: 'Deleted {count} memories from this scope'
+	String bulkDeleted_other({required Object count}) => 'Deleted ${count} memories from this scope';
+
+	/// en: 'Bulk delete failed'
+	String get bulkDeleteFailed => 'Bulk delete failed';
+
+	/// en: 'Memory created'
+	String get created => 'Memory created';
+
+	/// en: 'Create failed'
+	String get createFailed => 'Create failed';
+
+	/// en: 'Memory updated'
+	String get updated => 'Memory updated';
+
+	/// en: 'Update failed'
+	String get updateFailed => 'Update failed';
+
+	/// en: 'Migrated {reembed}/{examined} memories to {to}'
+	String migrated({required Object reembed, required Object examined, required Object to}) => 'Migrated ${reembed}/${examined} memories to ${to}';
+
+	/// en: 'Migration failed'
+	String get migrationFailed => 'Migration failed';
+
+	/// en: 'Ingested {count} new memory file'
+	String syncIngested_one({required Object count}) => 'Ingested ${count} new memory file';
+
+	/// en: 'Ingested {count} new memory files'
+	String syncIngested_other({required Object count}) => 'Ingested ${count} new memory files';
+
+	/// en: 'No new .md files to sync'
+	String get syncEmpty => 'No new .md files to sync';
+
+	/// en: 'Already in sync, or no Claude memory dir for this cwd.'
+	String get syncEmptyDescription => 'Already in sync, or no Claude memory dir for this cwd.';
+
+	/// en: 'Sync failed'
+	String get syncFailed => 'Sync failed';
+
+	/// en: 'Embedder OK: {embedder} · {dim} dimensions'
+	String testOk({required Object embedder, required Object dim}) => 'Embedder OK: ${embedder} · ${dim} dimensions';
+
+	/// en: 'vector_preview = [{preview}…]'
+	String testOkDescription({required Object preview}) => 'vector_preview = [${preview}…]';
+
+	/// en: 'Embedder probe failed'
+	String get testFailed => 'Embedder probe failed';
+}
+
+// Path: web.memoryInspector.bulkDelete
+class TranslationsWebMemoryInspectorBulkDeleteEn {
+	TranslationsWebMemoryInspectorBulkDeleteEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Delete every memory in this scope?'
+	String get title => 'Delete every memory in this scope?';
+
+	/// en: 'This is a single SQL operation — all memories under the specified scope are removed atomically. Memories that were ingested via the Claude mirror reappear on the next <1>Sync .md</1> run; everything else is gone for good.'
+	String get description => 'This is a single SQL operation — all memories under the specified scope are removed atomically. Memories that were ingested via the Claude mirror reappear on the next <1>Sync .md</1> run; everything else is gone for good.';
+
+	/// en: 'Scope'
+	String get scope => 'Scope';
+
+	/// en: 'Scope key'
+	String get scopeKey => 'Scope key';
+
+	/// en: 'Currently visible'
+	String get currentlyVisible => 'Currently visible';
+
+	/// en: '{count} memory item'
+	String items_one({required Object count}) => '${count} memory item';
+
+	/// en: '{count} memory items'
+	String items_other({required Object count}) => '${count} memory items';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Delete all'
+	String get deleteAll => 'Delete all';
+}
+
+// Path: web.memoryInspector.addMem
+class TranslationsWebMemoryInspectorAddMemEn {
+	TranslationsWebMemoryInspectorAddMemEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Add memory'
+	String get title => 'Add memory';
+
+	/// en: 'Manually create a memory. Agents create these automatically via the <1>memory_store</1> MCP tool — this form is for cases where the operator wants to seed a fact without going through an agent.'
+	String get description => 'Manually create a memory. Agents create these automatically via the <1>memory_store</1> MCP tool — this form is for cases where the operator wants to seed a fact without going through an agent.';
+
+	/// en: 'Text'
+	String get textLabel => 'Text';
+
+	/// en: 'Plain prose. The embedder turns this into a vector at store time; agents will retrieve it via memory_search.'
+	String get textPlaceholder => 'Plain prose. The embedder turns this into a vector at store time; agents will retrieve it via memory_search.';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Create'
+	String get create => 'Create';
+}
+
+// Path: web.memoryInspector.picker
+class TranslationsWebMemoryInspectorPickerEn {
+	TranslationsWebMemoryInspectorPickerEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Pick'
+	String get button => 'Pick';
+
+	/// en: 'Pick from saved scope keys or active sessions'
+	String get buttonTooltip => 'Pick from saved scope keys or active sessions';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'No saved keys or active sessions for {scope}.'
+	String empty({required Object scope}) => 'No saved keys or active sessions for ${scope}.';
+
+	/// en: 'Saved memories'
+	String get savedHeader => 'Saved memories';
+
+	/// en: 'Active sessions'
+	String get activeHeader => 'Active sessions';
+}
+
+// Path: web.memoryInspector.migrationBanner
+class TranslationsWebMemoryInspectorMigrationBannerEn {
+	TranslationsWebMemoryInspectorMigrationBannerEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: '{count} memory won't appear in searches'
+	String headline_one({required Object count}) => '${count} memory won\'t appear in searches';
+
+	/// en: '{count} memories won't appear in searches'
+	String headline_other({required Object count}) => '${count} memories won\'t appear in searches';
+
+	/// en: '{summary} — current embedder is <1>{current}</1>. pgvector partitions its similarity index by embedder, so older entries are silent until reembedded.'
+	String subtitle({required Object summary, required Object current}) => '${summary} — current embedder is <1>${current}</1>. pgvector partitions its similarity index by embedder, so older entries are silent until reembedded.';
+
+	/// en: '{count} on {name}'
+	String summaryItem({required Object count, required Object name}) => '${count} on ${name}';
+
+	/// en: 'Migrate'
+	String get migrateButton => 'Migrate';
+}
+
+// Path: web.memoryInspector.reembed
+class TranslationsWebMemoryInspectorReembedEn {
+	TranslationsWebMemoryInspectorReembedEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Reembed memories'
+	String get title => 'Reembed memories';
+
+	/// en: 'Recompute vectors for memories stored under a different embedder so they become searchable again.'
+	String get description => 'Recompute vectors for memories stored under a different embedder so they become searchable again.';
+
+	/// en: 'Target embedder'
+	String get targetEmbedder => 'Target embedder';
+
+	/// en: 'on'
+	String get onName => 'on';
+
+	/// en: 'Total to reembed'
+	String get totalToReembed => 'Total to reembed';
+
+	/// en: 'Each memory's text gets re-sent to the current embedder; the new vector replaces the old one in place. ID, scope, scope_key, metadata and timestamps are preserved. Search results take effect immediately — no restart needed.'
+	String get explainer => 'Each memory\'s text gets re-sent to the current embedder; the new vector replaces the old one in place. ID, scope, scope_key, metadata and timestamps are preserved. Search results take effect immediately — no restart needed.';
+
+	/// en: 'Examined'
+	String get reportExamined => 'Examined';
+
+	/// en: 'Reembedded'
+	String get reportReembedded => 'Reembedded';
+
+	/// en: 'Failed'
+	String get reportFailed => 'Failed';
+
+	/// en: 'From'
+	String get reportFrom => 'From';
+
+	/// en: '{count} error'
+	String errors_one({required Object count}) => '${count} error';
+
+	/// en: '{count} errors'
+	String errors_other({required Object count}) => '${count} errors';
+
+	/// en: 'Done'
+	String get done => 'Done';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Reembedding…'
+	String get reembedding => 'Reembedding…';
+
+	/// en: 'Reembed {total}'
+	String reembedTotal({required Object total}) => 'Reembed ${total}';
+}
+
+// Path: web.notes.header
+class TranslationsWebNotesHeaderEn {
+	TranslationsWebNotesHeaderEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Outline'
+	String get outline => 'Outline';
+
+	/// en: 'Show outline'
+	String get showOutline => 'Show outline';
+
+	/// en: 'Hide outline'
+	String get hideOutline => 'Hide outline';
+
+	/// en: 'Today'
+	String get today => 'Today';
+
+	/// en: 'Open or create today's daily note'
+	String get todayTooltip => 'Open or create today\'s daily note';
+
+	/// en: 'New'
+	String get kNew => 'New';
+}
+
+// Path: web.notes.left
+class TranslationsWebNotesLeftEn {
+	TranslationsWebNotesLeftEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Tree'
+	String get tree => 'Tree';
+
+	/// en: 'Tags'
+	String get tags => 'Tags';
+
+	/// en: 'Filter notes…'
+	String get filterNotes => 'Filter notes…';
+
+	/// en: 'Filter tags…'
+	String get filterTags => 'Filter tags…';
+
+	/// en: 'filtered by'
+	String get filteredBy => 'filtered by';
+
+	/// en: 'Clear tag filter'
+	String get clearTagTooltip => 'Clear tag filter';
+
+	/// en: 'Expand all'
+	String get expandAll => 'Expand all';
+
+	/// en: 'Expand every folder'
+	String get expandAllTooltip => 'Expand every folder';
+
+	/// en: 'Collapse all'
+	String get collapseAll => 'Collapse all';
+
+	/// en: 'Collapse every folder'
+	String get collapseAllTooltip => 'Collapse every folder';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: '{visible} / {total} notes'
+	String footer({required Object visible, required Object total}) => '${visible} / ${total} notes';
+}
+
+// Path: web.notes.tags
+class TranslationsWebNotesTagsEn {
+	TranslationsWebNotesTagsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'No tags in vault yet.'
+	String get emptyVault => 'No tags in vault yet.';
+
+	/// en: 'No matches for "{query}".'
+	String noMatches({required Object query}) => 'No matches for "${query}".';
+}
+
+// Path: web.notes.tree
+class TranslationsWebNotesTreeEn {
+	TranslationsWebNotesTreeEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Vault is empty.'
+	String get empty => 'Vault is empty.';
+}
+
+// Path: web.notes.outline
+class TranslationsWebNotesOutlineEn {
+	TranslationsWebNotesOutlineEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Outline'
+	String get label => 'Outline';
+
+	/// en: 'No headings in this note. Add <1>## Title</1> lines to populate the outline.'
+	String get empty => 'No headings in this note. Add <1>## Title</1> lines to populate the outline.';
+}
+
+// Path: web.notes.newNote
+class TranslationsWebNotesNewNoteEn {
+	TranslationsWebNotesNewNoteEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'New note path (vault-relative, must end .md)'
+	String get prompt => 'New note path (vault-relative, must end .md)';
+
+	/// en: 'library/notes-{date}.md'
+	String defaultPath({required Object date}) => 'library/notes-${date}.md';
+
+	/// en: 'Path must end in .md'
+	String get errorMustEndMd => 'Path must end in .md';
+
+	/// en: 'Note created'
+	String get createdToast => 'Note created';
+
+	/// en: 'Create failed'
+	String get createFailedToast => 'Create failed';
+}
+
+// Path: web.notes.empty
+class TranslationsWebNotesEmptyEn {
+	TranslationsWebNotesEmptyEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'No note selected'
+	String get title => 'No note selected';
+
+	/// en: 'Pick a note from the tree on the left, jump straight to today's daily log, or create a fresh one. AI-written project docs live under <1>projects/</1>; your personal scratchpads under <3>personal/</3>.'
+	String get hint => 'Pick a note from the tree on the left, jump straight to today\'s daily log, or create a fresh one. AI-written project docs live under <1>projects/</1>; your personal scratchpads under <3>personal/</3>.';
+
+	/// en: 'Today's daily note'
+	String get today => 'Today\'s daily note';
+
+	/// en: 'New note'
+	String get kNew => 'New note';
+}
+
+// Path: web.notes.picker
+class TranslationsWebNotesPickerEn {
+	TranslationsWebNotesPickerEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Browse folders'
+	String get browseAria => 'Browse folders';
+
+	/// en: '{count} match'
+	String matches_one({required Object count}) => '${count} match';
+
+	/// en: '{count} matches'
+	String matches_other({required Object count}) => '${count} matches';
+
+	/// en: '{count} folders in vault'
+	String foldersInVault({required Object count}) => '${count} folders in vault';
+
+	/// en: 'No existing folder matches. Save anyway to use <1>{value}</1> (lazy-created on first write).'
+	String noMatch({required Object value}) => 'No existing folder matches. Save anyway to use <1>${value}</1> (lazy-created on first write).';
+}
+
+// Path: web.notes.vaultSync
+class TranslationsWebNotesVaultSyncEn {
+	TranslationsWebNotesVaultSyncEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Vault sync'
+	String get title => 'Vault sync';
+
+	/// en: 'Commit, pull, and push the notes vault as a git repository. Authentication uses your gateway host's git credentials (SSH agent / credential helper).'
+	String get description => 'Commit, pull, and push the notes vault as a git repository. Authentication uses your gateway host\'s git credentials (SSH agent / credential helper).';
+
+	/// en: 'Reading vault state…'
+	String get reading => 'Reading vault state…';
+
+	late final TranslationsWebNotesVaultSyncInitEn init = TranslationsWebNotesVaultSyncInitEn.internal(_root);
+	late final TranslationsWebNotesVaultSyncBranchEn branch = TranslationsWebNotesVaultSyncBranchEn.internal(_root);
+	late final TranslationsWebNotesVaultSyncActionEn action = TranslationsWebNotesVaultSyncActionEn.internal(_root);
+	late final TranslationsWebNotesVaultSyncCommitEn commit = TranslationsWebNotesVaultSyncCommitEn.internal(_root);
+	late final TranslationsWebNotesVaultSyncFileListEn fileList = TranslationsWebNotesVaultSyncFileListEn.internal(_root);
+	late final TranslationsWebNotesVaultSyncRemoteEn remote = TranslationsWebNotesVaultSyncRemoteEn.internal(_root);
+	late final TranslationsWebNotesVaultSyncHistoryEn history = TranslationsWebNotesVaultSyncHistoryEn.internal(_root);
+	late final TranslationsWebNotesVaultSyncConflictEn conflict = TranslationsWebNotesVaultSyncConflictEn.internal(_root);
+	late final TranslationsWebNotesVaultSyncAuthEn auth = TranslationsWebNotesVaultSyncAuthEn.internal(_root);
+	late final TranslationsWebNotesVaultSyncAutoSyncEn autoSync = TranslationsWebNotesVaultSyncAutoSyncEn.internal(_root);
+}
+
+// Path: web.notes.syncBadge
+class TranslationsWebNotesSyncBadgeEn {
+	TranslationsWebNotesSyncBadgeEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'Sync'
+	String get syncLabel => 'Sync';
+
+	/// en: 'Init'
+	String get initLabel => 'Init';
+
+	/// en: 'Vault is not a git repo yet'
+	String get initTooltip => 'Vault is not a git repo yet';
+
+	/// en: 'Conflict'
+	String get conflictLabel => 'Conflict';
+
+	/// en: 'Vault has unresolved conflicts — click to recover'
+	String get conflictTooltip => 'Vault has unresolved conflicts — click to recover';
+
+	/// en: 'sync'
+	String get syncFallback => 'sync';
+
+	/// en: 'branch {branch} · {files} changes · {ahead} ahead · {behind} behind'
+	String tooltip({required Object branch, required Object files, required Object ahead, required Object behind}) => 'branch ${branch} · ${files} changes · ${ahead} ahead · ${behind} behind';
+
+	/// en: ' · auto-sync on'
+	String get tooltipAutoOn => ' · auto-sync on';
+
+	/// en: ' · last error: {error}'
+	String tooltipLastError({required Object error}) => ' · last error: ${error}';
+
+	/// en: '—'
+	String get branchPlaceholder => '—';
+}
+
+// Path: web.activity.filters
+class TranslationsWebActivityFiltersEn {
+	TranslationsWebActivityFiltersEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Integration'
+	String get integration => 'Integration';
+
+	/// en: 'Direction'
+	String get direction => 'Direction';
+
+	/// en: 'Status'
+	String get status => 'Status';
+
+	/// en: 'All integrations'
+	String get allIntegrations => 'All integrations';
+
+	/// en: 'All'
+	String get all => 'All';
+
+	/// en: 'Inbound'
+	String get inbound => 'Inbound';
+
+	/// en: 'Outbound'
+	String get outbound => 'Outbound';
+
+	/// en: 'All statuses'
+	String get allStatuses => 'All statuses';
+
+	/// en: '2xx success'
+	String get status2 => '2xx success';
+
+	/// en: '3xx redirect'
+	String get status3 => '3xx redirect';
+
+	/// en: '4xx client error'
+	String get status4 => '4xx client error';
+
+	/// en: '5xx server error'
+	String get status5 => '5xx server error';
+}
+
+// Path: web.activity.table
+class TranslationsWebActivityTableEn {
+	TranslationsWebActivityTableEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Time'
+	String get time => 'Time';
+
+	/// en: 'Integration'
+	String get integration => 'Integration';
+
+	/// en: 'Direction'
+	String get directionTitle => 'Direction';
+
+	/// en: 'Method'
+	String get method => 'Method';
+
+	/// en: 'Path'
+	String get path => 'Path';
+
+	/// en: 'Status'
+	String get status => 'Status';
+
+	/// en: 'Duration'
+	String get duration => 'Duration';
+
+	/// en: 'inbound'
+	String get inboundAria => 'inbound';
+
+	/// en: 'outbound'
+	String get outboundAria => 'outbound';
+}
+
+// Path: web.activity.empty
+class TranslationsWebActivityEmptyEn {
+	TranslationsWebActivityEmptyEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'No calls match these filters.'
+	String get filtered => 'No calls match these filters.';
+
+	/// en: 'No API calls recorded yet'
+	String get title => 'No API calls recorded yet';
+
+	/// en: 'When a third-party app calls opendray with its integration API key, every request is logged here.'
+	String get description => 'When a third-party app calls opendray with its integration API key, every request is logged here.';
+
+	/// en: 'Use an existing integration's API key in your third-party app'
+	String get stepWithIntegrations => 'Use an existing integration\'s API key in your third-party app';
+
+	/// en: 'Register an integration in Integrations → New'
+	String get stepRegister => 'Register an integration in Integrations → New';
+
+	/// en: 'Call any endpoint, e.g. <1>POST /api/v1/sessions</1>'
+	String get stepCallEndpoint => 'Call any endpoint, e.g. <1>POST /api/v1/sessions</1>';
+
+	/// en: 'Calls appear here within seconds'
+	String get stepAppears => 'Calls appear here within seconds';
+
+	/// en: 'Calls you make from this admin UI are not logged — only integration-attributed traffic is recorded.'
+	String get footnote => 'Calls you make from this admin UI are not logged — only integration-attributed traffic is recorded.';
+}
+
+// Path: web.activity.events
+class TranslationsWebActivityEventsEn {
+	TranslationsWebActivityEventsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Loading events…'
+	String get loading => 'Loading events…';
+
+	/// en: 'No events yet.'
+	String get empty => 'No events yet.';
+
+	/// en: 'No matching events.'
+	String get emptyFiltered => 'No matching events.';
+
+	/// en: 'Load older events'
+	String get loadOlder => 'Load older events';
+
+	/// en: 'Today'
+	String get today => 'Today';
+
+	/// en: 'Yesterday'
+	String get yesterday => 'Yesterday';
+}
+
+// Path: web.providers.list
+class TranslationsWebProvidersListEn {
+	TranslationsWebProvidersListEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Providers'
+	String get title => 'Providers';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'disabled'
+	String get disabledBadge => 'disabled';
+
+	/// en: 'No provider selected.'
+	String get noneSelected => 'No provider selected.';
+}
+
+// Path: web.providers.detail
+class TranslationsWebProvidersDetailEn {
+	TranslationsWebProvidersDetailEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Enabled'
+	String get enabled => 'Enabled';
+
+	/// en: 'Disabled'
+	String get disabled => 'Disabled';
+
+	/// en: 'Toggle {name}'
+	String toggleAria({required Object name}) => 'Toggle ${name}';
+
+	/// en: 'Configuration'
+	String get configuration => 'Configuration';
+
+	/// en: 'This provider has no user-configurable fields.'
+	String get noConfig => 'This provider has no user-configurable fields.';
+
+	/// en: 'executable:'
+	String get executable => 'executable:';
+
+	/// en: 'manifest_hash:'
+	String get manifestHash => 'manifest_hash:';
+
+	/// en: 'Reset'
+	String get reset => 'Reset';
+
+	/// en: 'Save changes'
+	String get save => 'Save changes';
+
+	/// en: 'Saving…'
+	String get saving => 'Saving…';
+
+	/// en: 'Provider config saved'
+	String get savedToast => 'Provider config saved';
+
+	/// en: 'Save failed'
+	String get saveFailedToast => 'Save failed';
+
+	/// en: 'Toggle failed'
+	String get toggleFailedToast => 'Toggle failed';
+
+	late final TranslationsWebProvidersDetailCapsEn caps = TranslationsWebProvidersDetailCapsEn.internal(_root);
+}
+
+// Path: web.providers.configForm
+class TranslationsWebProvidersConfigFormEn {
+	TranslationsWebProvidersConfigFormEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Select…'
+	String get selectPlaceholder => 'Select…';
+
+	/// en: '(default)'
+	String get defaultOption => '(default)';
+
+	/// en: 'On'
+	String get switchOn => 'On';
+
+	/// en: 'Off'
+	String get switchOff => 'Off';
+
+	/// en: 'Show secret'
+	String get showSecret => 'Show secret';
+
+	/// en: 'Hide secret'
+	String get hideSecret => 'Hide secret';
+}
+
+// Path: web.providers.claudeAccounts
+class TranslationsWebProvidersClaudeAccountsEn {
+	TranslationsWebProvidersClaudeAccountsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Claude accounts'
+	String get title => 'Claude accounts';
+
+	/// en: 'Open the multi-account tutorial section'
+	String get tutorialTooltip => 'Open the multi-account tutorial section';
+
+	/// en: 'Import local'
+	String get importLocal => 'Import local';
+
+	/// en: 'Scan ~/.claude-accounts/ on the gateway host and register any new directories. The button is gateway-host only — see the tutorial.'
+	String get importLocalTooltip => 'Scan ~/.claude-accounts/ on the gateway host and register any new directories. The button is gateway-host only — see the tutorial.';
+
+	/// en: 'Nothing to import — accounts already in sync.'
+	String get importedNothingToast => 'Nothing to import — accounts already in sync.';
+
+	/// en: 'Imported {count} account from ~/.claude-accounts'
+	String importedToast_one({required Object count}) => 'Imported ${count} account from ~/.claude-accounts';
+
+	/// en: 'Imported {count} accounts from ~/.claude-accounts'
+	String importedToast_other({required Object count}) => 'Imported ${count} accounts from ~/.claude-accounts';
+
+	/// en: 'Import failed'
+	String get importFailedToast => 'Import failed';
+
+	/// en: 'Adding a new account.'
+	String get addingTitle => 'Adding a new account.';
+
+	/// en: 'Run on the gateway host:'
+	String get addingBodyPrefix => 'Run on the gateway host:';
+
+	/// en: 'opendray's filesystem watcher will register the new directory automatically, or click <1>Import local</1> to scan immediately.'
+	String get addingBodySuffix => 'opendray\'s filesystem watcher will register the new directory automatically, or click <1>Import local</1> to scan immediately.';
+
+	/// en: 'Architecture & full guide →'
+	String get architectureLink => 'Architecture & full guide →';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'No Claude accounts yet. Run the shell command above on the gateway host, then click <1>Import local</1> to scan.'
+	String get empty => 'No Claude accounts yet. Run the shell command above on the gateway host, then click <1>Import local</1> to scan.';
+
+	/// en: 'no token yet'
+	String get noTokenYet => 'no token yet';
+
+	/// en: 'config_dir:'
+	String get configDir => 'config_dir:';
+
+	/// en: 'token_path:'
+	String get tokenPath => 'token_path:';
+
+	/// en: 'Toggle failed'
+	String get toggleFailedToast => 'Toggle failed';
+
+	/// en: 'Remove account "{name}"?'
+	String removeConfirm({required Object name}) => 'Remove account "${name}"?';
+
+	/// en: 'Account removed'
+	String get removedToast => 'Account removed';
+
+	/// en: 'Remove failed'
+	String get removeFailedToast => 'Remove failed';
+
+	/// en: 'Toggle {name}'
+	String toggleAria({required Object name}) => 'Toggle ${name}';
+
+	/// en: 'Remove {name}'
+	String removeAria({required Object name}) => 'Remove ${name}';
+}
+
+// Path: web.channels.empty
+class TranslationsWebChannelsEmptyEn {
+	TranslationsWebChannelsEmptyEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'No channels yet'
+	String get title => 'No channels yet';
+
+	/// en: 'Bundled kinds: Telegram · Slack · Discord · Feishu · DingTalk · WeCom. Pick one and paste credentials, or use <1>bridge</1> for a custom platform via WebSocket.'
+	String get description => 'Bundled kinds: Telegram · Slack · Discord · Feishu · DingTalk · WeCom. Pick one and paste credentials, or use <1>bridge</1> for a custom platform via WebSocket.';
+}
+
+// Path: web.channels.card
+class TranslationsWebChannelsCardEn {
+	TranslationsWebChannelsCardEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'running'
+	String get running => 'running';
+
+	/// en: 'starting…'
+	String get starting => 'starting…';
+
+	/// en: 'disabled'
+	String get disabled => 'disabled';
+
+	/// en: 'muted'
+	String get muted => 'muted';
+
+	/// en: 'token:'
+	String get tokenLabel => 'token:';
+
+	/// en: 'chat_id:'
+	String get chatIdLabel => 'chat_id:';
+
+	/// en: 'channel_id:'
+	String get channelIdLabel => 'channel_id:';
+
+	/// en: 'notify_on:'
+	String get notifyOnLabel => 'notify_on:';
+
+	/// en: 'webhook:'
+	String get webhookLabel => 'webhook:';
+
+	/// en: 'Copy webhook URL'
+	String get copyWebhookTooltip => 'Copy webhook URL';
+
+	/// en: 'Webhook URL copied'
+	String get webhookCopiedToast => 'Webhook URL copied';
+
+	/// en: 'Setup'
+	String get setup => 'Setup';
+
+	/// en: 'Show adapter connection details + sample code'
+	String get setupTooltip => 'Show adapter connection details + sample code';
+
+	/// en: 'Test'
+	String get test => 'Test';
+
+	/// en: 'Channel must be running'
+	String get testNotRunningTooltip => 'Channel must be running';
+
+	/// en: 'Bridge channels cannot be tested from the admin — connect an adapter first'
+	String get testBridgeTooltip => 'Bridge channels cannot be tested from the admin — connect an adapter first';
+
+	/// en: 'Edit channel'
+	String get editAria => 'Edit channel';
+
+	/// en: 'Edit channel config'
+	String get editTooltip => 'Edit channel config';
+
+	/// en: 'Delete channel'
+	String get deleteAria => 'Delete channel';
+
+	/// en: '(bridge)'
+	String get bridgeSuffix => '(bridge)';
+}
+
+// Path: web.channels.toasts
+class TranslationsWebChannelsToastsEn {
+	TranslationsWebChannelsToastsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Test message sent'
+	String get testSent => 'Test message sent';
+
+	/// en: 'Test failed'
+	String get testFailed => 'Test failed';
+
+	/// en: 'Delete channel {id}?'
+	String deleteConfirm({required Object id}) => 'Delete channel ${id}?';
+
+	/// en: 'Channel deleted'
+	String get deleted => 'Channel deleted';
+
+	/// en: 'Channel created'
+	String get created => 'Channel created';
+
+	/// en: 'Channel updated'
+	String get updated => 'Channel updated';
+}
+
+// Path: web.channels.dialog
+class TranslationsWebChannelsDialogEn {
+	TranslationsWebChannelsDialogEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Edit channel'
+	String get editTitle => 'Edit channel';
+
+	/// en: 'Register channel'
+	String get createTitle => 'Register channel';
+
+	/// en: 'External adapter (Python/Node/...) connects via WebSocket and presents this token.'
+	String get descriptionBridge => 'External adapter (Python/Node/...) connects via WebSocket and presents this token.';
+
+	/// en: 'Configure messaging integration.'
+	String get descriptionDefault => 'Configure messaging integration.';
+
+	/// en: 'Kind'
+	String get kindLabel => 'Kind';
+
+	/// en: '(immutable — delete and recreate to change kind)'
+	String get kindImmutable => '(immutable — delete and recreate to change kind)';
+
+	/// en: 'Enabled'
+	String get enabledLabel => 'Enabled';
+
+	/// en: ' (accept adapter connections immediately)'
+	String get enabledBridgeHint => ' (accept adapter connections immediately)';
+
+	/// en: ' (start receiving webhooks immediately)'
+	String get enabledWebhookHint => ' (start receiving webhooks immediately)';
+
+	/// en: ' (start immediately)'
+	String get enabledDefaultHint => ' (start immediately)';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Save'
+	String get save => 'Save';
+
+	/// en: 'Saving…'
+	String get saving => 'Saving…';
+
+	/// en: 'Create'
+	String get create => 'Create';
+
+	/// en: 'Creating…'
+	String get creating => 'Creating…';
+
+	/// en: 'Unknown kind: {kind}'
+	String unknownKind({required Object kind}) => 'Unknown kind: ${kind}';
+
+	/// en: 'name is required'
+	String get nameRequired => 'name is required';
+
+	/// en: 'token is required'
+	String get tokenRequired => 'token is required';
+
+	/// en: 'Topic IDs must be numeric (got {value})'
+	String topicIdsNumeric({required Object value}) => 'Topic IDs must be numeric (got ${value})';
+
+	/// en: '{label} is required'
+	String fieldRequired({required Object label}) => '${label} is required';
+
+	/// en: 'Cooldown must be a non-negative number of seconds'
+	String get cooldownInvalid => 'Cooldown must be a non-negative number of seconds';
+
+	/// en: 'Snippet cap must be a non-negative number'
+	String get snippetCapInvalid => 'Snippet cap must be a non-negative number';
+}
+
+// Path: web.channels.notifications
+class TranslationsWebChannelsNotificationsEn {
+	TranslationsWebChannelsNotificationsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Session notifications'
+	String get sectionTitle => 'Session notifications';
+
+	/// en: 'Notify on'
+	String get notifyOnLabel => 'Notify on';
+
+	/// en: 'Receiving every session event. Click a tag to opt out.'
+	String get hintAll => 'Receiving every session event. Click a tag to opt out.';
+
+	/// en: 'No events selected — outbound notifications muted.'
+	String get hintNone => 'No events selected — outbound notifications muted.';
+
+	/// en: 'Only {selected} of {total} topics selected.'
+	String hintSome({required Object selected, required Object total}) => 'Only ${selected} of ${total} topics selected.';
+
+	/// en: 'Repeat policy'
+	String get repeatPolicyLabel => 'Repeat policy';
+
+	/// en: 'Cooldown duration'
+	String get cooldownLabel => 'Cooldown duration';
+
+	/// en: 'Replying with non-command text in this chat resets the suppression — opendray forwards your reply to the session's stdin and re-arms the notifier.'
+	String get onceReplyHint => 'Replying with non-command text in this chat resets the suppression — opendray forwards your reply to the session\'s stdin and re-arms the notifier.';
+
+	/// en: 'Terminal snippet'
+	String get terminalSnippetLabel => 'Terminal snippet';
+
+	/// en: 'Embed the recent terminal screen in idle notifications'
+	String get embedSnippetLabel => 'Embed the recent terminal screen in idle notifications';
+
+	/// en: 'When enabled, the idle card includes a code-block snippet of what the user would see in the live web terminal — Claude TUI chrome (status spinner, "bypass permissions" hint, separator lines) is filtered out automatically.'
+	String get snippetExplainer => 'When enabled, the idle card includes a code-block snippet of what the user would see in the live web terminal — Claude TUI chrome (status spinner, "bypass permissions" hint, separator lines) is filtered out automatically.';
+
+	late final TranslationsWebChannelsNotificationsModesEn modes = TranslationsWebChannelsNotificationsModesEn.internal(_root);
+	late final TranslationsWebChannelsNotificationsCooldownsEn cooldowns = TranslationsWebChannelsNotificationsCooldownsEn.internal(_root);
+	late final TranslationsWebChannelsNotificationsSnippetCapsEn snippetCaps = TranslationsWebChannelsNotificationsSnippetCapsEn.internal(_root);
+}
+
+// Path: web.channels.bridge
+class TranslationsWebChannelsBridgeEn {
+	TranslationsWebChannelsBridgeEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Bridge name'
+	String get nameLabel => 'Bridge name';
+
+	/// en: 'wechat / discord-custom / whatsapp...'
+	String get namePlaceholder => 'wechat / discord-custom / whatsapp...';
+
+	/// en: 'Human label for the adapter. Shown in the channels list.'
+	String get nameHint => 'Human label for the adapter. Shown in the channels list.';
+
+	/// en: 'Adapter token'
+	String get tokenLabel => 'Adapter token';
+
+	/// en: 'Regenerate'
+	String get regenerateTooltip => 'Regenerate';
+
+	/// en: 'Copy'
+	String get copyTooltip => 'Copy';
+
+	/// en: 'Token copied'
+	String get tokenCopiedToast => 'Token copied';
+
+	/// en: 'Adapter authenticates by sending this in the WS register frame (or as <1>X-Bridge-Token</1> header).'
+	String get tokenHint => 'Adapter authenticates by sending this in the WS register frame (or as <1>X-Bridge-Token</1> header).';
+
+	/// en: 'Accept capabilities (optional whitelist)'
+	String get capsLabel => 'Accept capabilities (optional whitelist)';
+
+	/// en: 'Empty = accept whatever the adapter declares. Selected = only allow these capabilities even if the adapter offers more.'
+	String get capsHint => 'Empty = accept whatever the adapter declares. Selected = only allow these capabilities even if the adapter offers more.';
+
+	/// en: 'After <1>Create</1>, the adapter setup dialog opens automatically with the WebSocket URL and copy-pasteable Python / Node / wscat starter code.'
+	String get afterCreate => 'After <1>Create</1>, the adapter setup dialog opens automatically with the WebSocket URL and copy-pasteable Python / Node / wscat starter code.';
+}
+
+// Path: web.channels.setup
+class TranslationsWebChannelsSetupEn {
+	TranslationsWebChannelsSetupEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Adapter setup — {name}'
+	String title({required Object name}) => 'Adapter setup — ${name}';
+
+	/// en: 'Run an adapter (any language) that connects to opendray over WebSocket using these credentials. opendray will route session notifications and slash-command actions through it.'
+	String get description => 'Run an adapter (any language) that connects to opendray over WebSocket using these credentials. opendray will route session notifications and slash-command actions through it.';
+
+	/// en: 'WebSocket URL'
+	String get wsUrlLabel => 'WebSocket URL';
+
+	/// en: 'Adapter token'
+	String get tokenLabel => 'Adapter token';
+
+	/// en: '<1>Auth:</1> send the token as <3>X-Bridge-Token</3> header, <5>?token=</5> query param, or <7>Authorization: Bearer …</7>. The first WS frame must be <9>{frame}</9>. Full spec: <11>docs/bridge-protocol.md</11> in the repo.'
+	String authInfo({required Object frame}) => '<1>Auth:</1> send the token as <3>X-Bridge-Token</3> header, <5>?token=</5> query param, or <7>Authorization: Bearer …</7>. The first WS frame must be <9>${frame}</9>. Full spec: <11>docs/bridge-protocol.md</11> in the repo.';
+
+	/// en: 'Install: <1>pip install websockets</1>. Run: <3>python adapter.py</3>.'
+	String get pythonInstall => 'Install: <1>pip install websockets</1>. Run: <3>python adapter.py</3>.';
+
+	/// en: 'Install: <1>npm i ws</1>. Run: <3>node adapter.mjs</3>.'
+	String get nodeInstall => 'Install: <1>npm i ws</1>. Run: <3>node adapter.mjs</3>.';
+
+	/// en: 'Install: <1>npm i -g wscat</1>. Once connected, paste the JSON line shown above to register, then send further frames manually.'
+	String get wscatInstall => 'Install: <1>npm i -g wscat</1>. Once connected, paste the JSON line shown above to register, then send further frames manually.';
+
+	/// en: 'Close'
+	String get close => 'Close';
+
+	/// en: 'Hide'
+	String get copyHide => 'Hide';
+
+	/// en: 'Show'
+	String get copyShow => 'Show';
+
+	/// en: '{label} copied'
+	String copyLabelToast({required Object label}) => '${label} copied';
+
+	/// en: 'Copy'
+	String get copyCode => 'Copy';
+
+	/// en: 'Copied'
+	String get copied => 'Copied';
+
+	/// en: 'Code copied'
+	String get codeCopiedToast => 'Code copied';
+}
+
+// Path: web.integrations.tabs
+class TranslationsWebIntegrationsTabsEn {
+	TranslationsWebIntegrationsTabsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Registered'
+	String get registered => 'Registered';
+
+	/// en: 'Reverse proxy'
+	String get console => 'Reverse proxy';
+}
+
+// Path: web.integrations.empty
+class TranslationsWebIntegrationsEmptyEn {
+	TranslationsWebIntegrationsEmptyEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'No integrations yet'
+	String get title => 'No integrations yet';
+
+	/// en: 'Register an external app to give it a scoped API key. Its code stays out of this repo.'
+	String get description => 'Register an external app to give it a scoped API key. Its code stays out of this repo.';
+
+	/// en: 'Register integration'
+	String get register => 'Register integration';
+}
+
+// Path: web.integrations.card
+class TranslationsWebIntegrationsCardEn {
+	TranslationsWebIntegrationsCardEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'managed'
+	String get managedBadge => 'managed';
+
+	/// en: 'opendray manages this integration. Editing or rotating its key would orphan running sessions whose mcp.json holds the previous bearer.'
+	String get managedTooltip => 'opendray manages this integration. Editing or rotating its key would orphan running sessions whose mcp.json holds the previous bearer.';
+
+	/// en: 'consumer'
+	String get consumerBadge => 'consumer';
+
+	/// en: 'Consumer-only integration — no HTTP service to probe'
+	String get consumerTooltip => 'Consumer-only integration — no HTTP service to probe';
+
+	/// en: 'disabled'
+	String get disabledBadge => 'disabled';
+
+	/// en: 'Consumes opendray's API. No reverse proxy mounted.'
+	String get consumerOnlyHint => 'Consumes opendray\'s API. No reverse proxy mounted.';
+
+	/// en: 'last probed {relative}'
+	String lastProbed({required Object relative}) => 'last probed ${relative}';
+
+	/// en: 'rotated {relative}'
+	String rotated({required Object relative}) => 'rotated ${relative}';
+
+	/// en: 'read-only — opendray bakes its key into every spawn's mcp.json'
+	String get managedReadOnly => 'read-only — opendray bakes its key into every spawn\'s mcp.json';
+
+	/// en: 'opendray manages this row. To reset: delete ~/.opendray/memory.key and restart, or delete this row directly via SQL — it'll be re-bootstrapped at next startup.'
+	String get managedReadOnlyTooltip => 'opendray manages this row. To reset: delete ~/.opendray/memory.key and restart, or delete this row directly via SQL — it\'ll be re-bootstrapped at next startup.';
+
+	/// en: 'Edit integration'
+	String get editAria => 'Edit integration';
+
+	/// en: 'Edit scopes / base URL / version'
+	String get editTooltip => 'Edit scopes / base URL / version';
+
+	/// en: 'Rotate key'
+	String get rotateKey => 'Rotate key';
+
+	/// en: 'Delete integration'
+	String get deleteAria => 'Delete integration';
+
+	/// en: 'Rotate the API key for "{name}"? The current key will stop working immediately.'
+	String rotateConfirm({required Object name}) => 'Rotate the API key for "${name}"? The current key will stop working immediately.';
+
+	/// en: 'Delete integration {name}?'
+	String deleteConfirm({required Object name}) => 'Delete integration ${name}?';
+
+	/// en: 'Integration removed'
+	String get removedToast => 'Integration removed';
+}
+
+// Path: web.integrations.register_dialog
+class TranslationsWebIntegrationsRegisterDialogEn {
+	TranslationsWebIntegrationsRegisterDialogEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Register integration'
+	String get title => 'Register integration';
+
+	/// en: 'Issues a one-time API key. Copy it before closing — opendray never displays the plaintext again.'
+	String get description => 'Issues a one-time API key. Copy it before closing — opendray never displays the plaintext again.';
+
+	/// en: 'Name'
+	String get nameLabel => 'Name';
+
+	/// en: 'PetTracker'
+	String get namePlaceholder => 'PetTracker';
+
+	/// en: 'Leave the next two fields blank for a <1>consumer-only</1> integration (third-party app that calls opendray's API but doesn't expose its own service). Fill both for a <3>reverse-proxy</3> integration.'
+	String get modeHint => 'Leave the next two fields blank for a <1>consumer-only</1> integration (third-party app that calls opendray\'s API but doesn\'t expose its own service). Fill both for a <3>reverse-proxy</3> integration.';
+
+	/// en: 'Base URL'
+	String get baseUrlLabel => 'Base URL';
+
+	/// en: '(optional)'
+	String get optionalSuffix => '(optional)';
+
+	/// en: 'http://192.168.3.42:8080'
+	String get baseUrlPlaceholder => 'http://192.168.3.42:8080';
+
+	/// en: 'Route prefix'
+	String get routePrefixLabel => 'Route prefix';
+
+	/// en: 'pet-tracker'
+	String get routePrefixPlaceholder => 'pet-tracker';
+
+	/// en: 'Reachable at <1>/api/v1/proxy/{prefix}/*</1>.'
+	String routePrefixHint({required Object prefix}) => 'Reachable at <1>/api/v1/proxy/${prefix}/*</1>.';
+
+	/// en: '<prefix>'
+	String get routePrefixPlaceholderToken => '<prefix>';
+
+	/// en: 'Version (optional)'
+	String get versionLabel => 'Version (optional)';
+
+	/// en: '0.1.0'
+	String get versionPlaceholder => '0.1.0';
+
+	/// en: 'Scopes'
+	String get scopesLabel => 'Scopes';
+
+	/// en: 'Pick the API surface this integration is allowed to call. Each toggle maps to a Bearer-token claim — opendray rejects requests that touch endpoints outside the granted set.'
+	String get scopesIntro => 'Pick the API surface this integration is allowed to call. Each toggle maps to a Bearer-token claim — opendray rejects requests that touch endpoints outside the granted set.';
+
+	/// en: 'Name is required.'
+	String get errorNameRequired => 'Name is required.';
+
+	/// en: 'base_url and route_prefix go together. Set both for a reverse-proxy integration, leave both blank for a consumer-only integration.'
+	String get errorBothOrNeither => 'base_url and route_prefix go together. Set both for a reverse-proxy integration, leave both blank for a consumer-only integration.';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Register'
+	String get submit => 'Register';
+
+	/// en: 'Registering…'
+	String get submitting => 'Registering…';
+}
+
+// Path: web.integrations.reveal
+class TranslationsWebIntegrationsRevealEn {
+	TranslationsWebIntegrationsRevealEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'API key issued'
+	String get titleIssued => 'API key issued';
+
+	/// en: 'API key rotated'
+	String get titleRotated => 'API key rotated';
+
+	/// en: 'This is the only time the plaintext key will be shown. Copy it now and update every consumer app — the previous key (if any) no longer authenticates.'
+	String get description => 'This is the only time the plaintext key will be shown. Copy it now and update every consumer app — the previous key (if any) no longer authenticates.';
+
+	/// en: 'Discard new key'
+	String get discardAria => 'Discard new key';
+
+	/// en: 'Discard the new key (rotation already happened — old key is gone too)'
+	String get discardTooltip => 'Discard the new key (rotation already happened — old key is gone too)';
+
+	/// en: 'Discard the new key? Rotation has already invalidated the old key — discarding means you have NO working key for this integration until you rotate again.'
+	String get discardConfirm => 'Discard the new key? Rotation has already invalidated the old key — discarding means you have NO working key for this integration until you rotate again.';
+
+	/// en: 'Copy'
+	String get copy => 'Copy';
+
+	/// en: 'Copied'
+	String get copied => 'Copied';
+
+	/// en: '<1>Update every consumer app with this new key.</1> The previous key has been invalidated server-side and will return <3>401 unauthorized</3> on the next request.'
+	String get updateHint => '<1>Update every consumer app with this new key.</1> The previous key has been invalidated server-side and will return <3>401 unauthorized</3> on the next request.';
+
+	/// en: 'I have copied the key and will update my consumer apps. I understand opendray will not display it again.'
+	String get acknowledge => 'I have copied the key and will update my consumer apps. I understand opendray will not display it again.';
+
+	/// en: 'Discard'
+	String get discard => 'Discard';
+
+	/// en: 'Done'
+	String get done => 'Done';
+}
+
+// Path: web.integrations.edit_dialog
+class TranslationsWebIntegrationsEditDialogEn {
+	TranslationsWebIntegrationsEditDialogEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Edit integration · {name}'
+	String title({required Object name}) => 'Edit integration · ${name}';
+
+	/// en: 'Change scopes, version, or base URL. Name and route prefix are immutable — delete + re-register if you need to change those.'
+	String get description => 'Change scopes, version, or base URL. Name and route prefix are immutable — delete + re-register if you need to change those.';
+
+	/// en: 'Name'
+	String get nameLabel => 'Name';
+
+	/// en: 'Route prefix'
+	String get routePrefixLabel => 'Route prefix';
+
+	/// en: '(consumer-only)'
+	String get consumerOnlyLabel => '(consumer-only)';
+
+	/// en: 'Base URL'
+	String get baseUrlLabel => 'Base URL';
+
+	/// en: '(consumer-only — leave blank)'
+	String get baseUrlConsumerSuffix => '(consumer-only — leave blank)';
+
+	/// en: '(reverse-proxy target)'
+	String get baseUrlProxySuffix => '(reverse-proxy target)';
+
+	/// en: '(blank — this integration consumes opendray's API)'
+	String get baseUrlConsumerPlaceholder => '(blank — this integration consumes opendray\'s API)';
+
+	/// en: 'http://127.0.0.1:8080'
+	String get baseUrlProxyPlaceholder => 'http://127.0.0.1:8080';
+
+	/// en: 'This is a consumer-only integration. Changing base URL here would also require a route prefix; do that with delete + re-register.'
+	String get consumerHint => 'This is a consumer-only integration. Changing base URL here would also require a route prefix; do that with delete + re-register.';
+
+	/// en: 'Version'
+	String get versionLabel => 'Version';
+
+	/// en: '0.1.0'
+	String get versionPlaceholder => '0.1.0';
+
+	/// en: 'Scopes'
+	String get scopesLabel => 'Scopes';
+
+	/// en: 'Trim or widen the API surface this integration's API key authorises. Live tokens are unaffected — the new scope set takes effect on the next request.'
+	String get scopesIntro => 'Trim or widen the API surface this integration\'s API key authorises. Live tokens are unaffected — the new scope set takes effect on the next request.';
+
+	/// en: 'Switching between consumer-only and reverse-proxy mode requires deleting the integration and re-registering — name and route_prefix can't change in place.'
+	String get errorModeSwitch => 'Switching between consumer-only and reverse-proxy mode requires deleting the integration and re-registering — name and route_prefix can\'t change in place.';
+
+	/// en: 'Integration updated'
+	String get updatedToast => 'Integration updated';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Save changes'
+	String get save => 'Save changes';
+}
+
+// Path: web.integrations.proxy
+class TranslationsWebIntegrationsProxyEn {
+	TranslationsWebIntegrationsProxyEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'No integrations registered'
+	String get emptyTitle => 'No integrations registered';
+
+	/// en: 'Register an integration first; the console proxies through /api/v1/proxy/{prefix}/* using the admin token.'
+	String emptyDescription({required Object prefix}) => 'Register an integration first; the console proxies through /api/v1/proxy/${prefix}/* using the admin token.';
+
+	/// en: 'Target'
+	String get targetLabel => 'Target';
+
+	/// en: 'Select integration…'
+	String get selectPlaceholder => 'Select integration…';
+
+	/// en: 'base:'
+	String get baseLabel => 'base:';
+
+	/// en: 'History'
+	String get history => 'History';
+
+	/// en: 'no past requests for this integration'
+	String get historyEmpty => 'no past requests for this integration';
+
+	/// en: 'Send'
+	String get send => 'Send';
+
+	/// en: 'Sending…'
+	String get sending => 'Sending…';
+
+	/// en: 'Extra headers (one per line, Name: Value)'
+	String get extraHeadersLabel => 'Extra headers (one per line, Name: Value)';
+
+	/// en: 'Body'
+	String get bodyLabel => 'Body';
+
+	/// en: 'Headers'
+	String get headers => 'Headers';
+
+	/// en: 'Body'
+	String get body => 'Body';
+
+	/// en: '(empty)'
+	String get emptyBody => '(empty)';
+
+	/// en: 'request failed'
+	String get requestFailed => 'request failed';
+
+	/// en: 'Send a request to see the upstream response.'
+	String get stubText => 'Send a request to see the upstream response.';
+
+	/// en: 'opendray injects <1>X-Integration-ID</1> and strips your <3>Authorization</3> header.'
+	String get stubInjects => 'opendray injects <1>X-Integration-ID</1> and strips your <3>Authorization</3> header.';
+
+	/// en: '<prefix>'
+	String get prefixPlaceholder => '<prefix>';
+}
+
+// Path: web.plugins.common
+class TranslationsWebPluginsCommonEn {
+	TranslationsWebPluginsCommonEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Edit'
+	String get edit => 'Edit';
+
+	/// en: 'Add'
+	String get add => 'Add';
+
+	/// en: 'Save'
+	String get save => 'Save';
+
+	/// en: 'Create'
+	String get create => 'Create';
+}
+
+// Path: web.plugins.mcp
+class TranslationsWebPluginsMcpEn {
+	TranslationsWebPluginsMcpEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'MCP servers'
+	String get title => 'MCP servers';
+
+	/// en: 'Model Context Protocol servers injected into every spawn (claude / codex). Vault entries live at <1>~/.opendray/vault/mcp/&lt;id&gt;/mcp.json</1>; secrets (referenced as <3>${KEY}</3> in env / headers) come from the <5>MCP secrets</5> section below.'
+	String description({required Object KEY}) => 'Model Context Protocol servers injected into every spawn (claude / codex). Vault entries live at <1>~/.opendray/vault/mcp/&lt;id&gt;/mcp.json</1>; secrets (referenced as <3>\$${KEY}</3> in env / headers) come from the <5>MCP secrets</5> section below.';
+
+	/// en: 'New server'
+	String get newServer => 'New server';
+
+	/// en: 'No MCP servers yet. Add one to expose extra tools to your agent sessions.'
+	String get empty => 'No MCP servers yet. Add one to expose extra tools to your agent sessions.';
+
+	late final TranslationsWebPluginsMcpColumnsEn columns = TranslationsWebPluginsMcpColumnsEn.internal(_root);
+
+	/// en: 'no url'
+	String get noUrl => 'no url';
+
+	/// en: 'no command'
+	String get noCommand => 'no command';
+
+	/// en: 'Delete MCP server "{id}"?'
+	String deleteConfirm({required Object id}) => 'Delete MCP server "${id}"?';
+
+	/// en: 'MCP server removed'
+	String get removedToast => 'MCP server removed';
+
+	/// en: 'Delete failed'
+	String get deleteFailedToast => 'Delete failed';
+
+	/// en: 'Toggle failed'
+	String get toggleFailedToast => 'Toggle failed';
+
+	late final TranslationsWebPluginsMcpEditorEn editor = TranslationsWebPluginsMcpEditorEn.internal(_root);
+}
+
+// Path: web.plugins.mcpSecrets
+class TranslationsWebPluginsMcpSecretsEn {
+	TranslationsWebPluginsMcpSecretsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'MCP secrets'
+	String get title => 'MCP secrets';
+
+	/// en: 'encrypted'
+	String get encryptedBadge => 'encrypted';
+
+	/// en: 'plaintext'
+	String get plaintextBadge => 'plaintext';
+
+	/// en: 'AES-GCM encrypted on disk; key stored in OS keychain'
+	String get encryptedTooltip => 'AES-GCM encrypted on disk; key stored in OS keychain';
+
+	/// en: 'OS keychain unavailable — file is plaintext on disk. Check the gateway log.'
+	String get plaintextTooltip => 'OS keychain unavailable — file is plaintext on disk. Check the gateway log.';
+
+	/// en: 'Values referenced from <1>${KEY}</1> placeholders in any <3>mcp.json</3> get substituted at spawn time. <5>Saved values are never returned over the API</5> — you can overwrite or delete them but not read them back.'
+	String description({required Object KEY}) => 'Values referenced from <1>\$${KEY}</1> placeholders in any <3>mcp.json</3> get substituted at spawn time. <5>Saved values are never returned over the API</5> — you can overwrite or delete them but not read them back.';
+
+	/// en: ' Stored at <1>{path}</1>.'
+	String descriptionStored({required Object path}) => ' Stored at <1>${path}</1>.';
+
+	/// en: 'Add secret'
+	String get addSecret => 'Add secret';
+
+	/// en: 'No secrets stored. Add one to start referencing it as <1>${KEY}</1> in your MCP server configs.'
+	String empty({required Object KEY}) => 'No secrets stored. Add one to start referencing it as <1>\$${KEY}</1> in your MCP server configs.';
+
+	late final TranslationsWebPluginsMcpSecretsColumnsEn columns = TranslationsWebPluginsMcpSecretsColumnsEn.internal(_root);
+
+	/// en: 'Overwrite the stored value'
+	String get editTooltip => 'Overwrite the stored value';
+
+	/// en: 'Delete secret "{key}"? Any mcp.json that references ${'$'}{{key}} will fall back to the literal placeholder until you set a new value.'
+	String deleteConfirm({required Object key, required Object \'\$\', required Object {key}) => 'Delete secret "${key}"? Any mcp.json that references \$${\'\$\'}${{key}} will fall back to the literal placeholder until you set a new value.';
+
+	/// en: 'Secret removed'
+	String get removedToast => 'Secret removed';
+
+	/// en: 'Delete failed'
+	String get deleteFailedToast => 'Delete failed';
+
+	late final TranslationsWebPluginsMcpSecretsEditorEn editor = TranslationsWebPluginsMcpSecretsEditorEn.internal(_root);
+}
+
+// Path: web.plugins.skills
+class TranslationsWebPluginsSkillsEn {
+	TranslationsWebPluginsSkillsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Agent skills'
+	String get title => 'Agent skills';
+
+	/// en: 'Reusable capabilities injected into Claude sessions as a Tier 1 index — the agent loads full SKILL.md on demand via <1>opendray skill describe &lt;id&gt;</1>. Built-ins ship in the binary but can be <3>customized</3> — your edits land at <5>~/.opendray/vault/skills/&lt;id&gt;/SKILL.md</5> and override the embedded version. Use Reset to revert.'
+	String get description => 'Reusable capabilities injected into Claude sessions as a Tier 1 index — the agent loads full SKILL.md on demand via <1>opendray skill describe &lt;id&gt;</1>. Built-ins ship in the binary but can be <3>customized</3> — your edits land at <5>~/.opendray/vault/skills/&lt;id&gt;/SKILL.md</5> and override the embedded version. Use Reset to revert.';
+
+	/// en: 'New skill'
+	String get newSkill => 'New skill';
+
+	/// en: 'No skills found.'
+	String get empty => 'No skills found.';
+
+	late final TranslationsWebPluginsSkillsColumnsEn columns = TranslationsWebPluginsSkillsColumnsEn.internal(_root);
+
+	/// en: 'no description'
+	String get noDescription => 'no description';
+
+	/// en: 'builtin'
+	String get builtinBadge => 'builtin';
+
+	/// en: 'Embedded in the opendray binary — click Customize to override in your vault'
+	String get builtinTooltip => 'Embedded in the opendray binary — click Customize to override in your vault';
+
+	/// en: 'vault'
+	String get vaultBadge => 'vault';
+
+	/// en: 'overrides builtin'
+	String get overridesBuiltin => 'overrides builtin';
+
+	/// en: 'This vault skill overrides the built-in version of the same id'
+	String get overridesBuiltinTooltip => 'This vault skill overrides the built-in version of the same id';
+
+	/// en: 'Customize'
+	String get customize => 'Customize';
+
+	/// en: 'Open the SKILL.md and save changes as a vault override'
+	String get customizeTooltip => 'Open the SKILL.md and save changes as a vault override';
+
+	/// en: 'Edit this vault skill'
+	String get editTooltip => 'Edit this vault skill';
+
+	/// en: 'Delete vault override and fall back to the built-in version'
+	String get resetTooltip => 'Delete vault override and fall back to the built-in version';
+
+	/// en: 'Reset'
+	String get reset => 'Reset';
+
+	/// en: 'Reset "{id}" to the built-in version? This deletes your vault SKILL.md and falls back to the embedded copy.'
+	String resetConfirm({required Object id}) => 'Reset "${id}" to the built-in version? This deletes your vault SKILL.md and falls back to the embedded copy.';
+
+	/// en: 'Delete skill "{id}" from your vault? This removes the SKILL.md file.'
+	String deleteConfirm({required Object id}) => 'Delete skill "${id}" from your vault? This removes the SKILL.md file.';
+
+	/// en: 'Skill removed'
+	String get removedToast => 'Skill removed';
+
+	/// en: 'Delete failed'
+	String get deleteFailedToast => 'Delete failed';
+
+	late final TranslationsWebPluginsSkillsEditorEn editor = TranslationsWebPluginsSkillsEditorEn.internal(_root);
+}
+
+// Path: web.plugins.customTasks
+class TranslationsWebPluginsCustomTasksEn {
+	TranslationsWebPluginsCustomTasksEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Custom tasks'
+	String get title => 'Custom tasks';
+
+	/// en: 'Click-to-run shortcuts surfaced in the Tasks tab. Leave cwd blank for global tasks visible in every session, or pin to an absolute path to scope.'
+	String get description => 'Click-to-run shortcuts surfaced in the Tasks tab. Leave cwd blank for global tasks visible in every session, or pin to an absolute path to scope.';
+
+	/// en: 'Add task'
+	String get addTask => 'Add task';
+
+	/// en: 'No custom tasks yet.'
+	String get empty => 'No custom tasks yet.';
+
+	late final TranslationsWebPluginsCustomTasksColumnsEn columns = TranslationsWebPluginsCustomTasksColumnsEn.internal(_root);
+
+	/// en: 'global'
+	String get globalScope => 'global';
+
+	/// en: 'Delete custom task "{name}"?'
+	String deleteConfirm({required Object name}) => 'Delete custom task "${name}"?';
+
+	/// en: 'Task removed'
+	String get removedToast => 'Task removed';
+
+	/// en: 'Delete failed'
+	String get deleteFailedToast => 'Delete failed';
+
+	late final TranslationsWebPluginsCustomTasksDialogEn dialog = TranslationsWebPluginsCustomTasksDialogEn.internal(_root);
+}
+
+// Path: web.plugins.gitHosts
+class TranslationsWebPluginsGitHostsEn {
+	TranslationsWebPluginsGitHostsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Git hosts'
+	String get title => 'Git hosts';
+
+	/// en: 'One token per host — used by the Git tab to fetch pull requests <1>and by the Notes vault sync</1> when its remote uses HTTPS to a private repo on the same host. GitHub.com, self-hosted GitHub Enterprise, Gitea, and GitLab are supported.'
+	String get description => 'One token per host — used by the Git tab to fetch pull requests <1>and by the Notes vault sync</1> when its remote uses HTTPS to a private repo on the same host. GitHub.com, self-hosted GitHub Enterprise, Gitea, and GitLab are supported.';
+
+	/// en: 'Add host'
+	String get addHost => 'Add host';
+
+	/// en: 'No git hosts configured. Add one to enable the PR list in the inspector's Git tab.'
+	String get empty => 'No git hosts configured.\nAdd one to enable the PR list in the inspector\'s Git tab.';
+
+	late final TranslationsWebPluginsGitHostsColumnsEn columns = TranslationsWebPluginsGitHostsColumnsEn.internal(_root);
+
+	/// en: 'enabled'
+	String get statusEnabled => 'enabled';
+
+	/// en: 'disabled'
+	String get statusDisabled => 'disabled';
+
+	/// en: 'Remove git host {host}? PR queries against this host will stop working.'
+	String deleteConfirm({required Object host}) => 'Remove git host ${host}? PR queries against this host will stop working.';
+
+	/// en: 'Git host removed'
+	String get removedToast => 'Git host removed';
+
+	/// en: 'Delete failed'
+	String get deleteFailedToast => 'Delete failed';
+
+	late final TranslationsWebPluginsGitHostsDialogEn dialog = TranslationsWebPluginsGitHostsDialogEn.internal(_root);
+}
+
+// Path: web.backups.tabs
+class TranslationsWebBackupsTabsEn {
+	TranslationsWebBackupsTabsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Backups'
+	String get backups => 'Backups';
+
+	/// en: 'Schedules'
+	String get schedules => 'Schedules';
+
+	/// en: 'Targets'
+	String get targets => 'Targets';
+}
+
+// Path: web.backups.inventory
+class TranslationsWebBackupsInventoryEn {
+	TranslationsWebBackupsInventoryEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'What's in a backup?'
+	String get title => 'What\'s in a backup?';
+
+	/// en: '{rows} rows across {tables} tables'
+	String summary({required Object rows, required Object tables}) => '${rows} rows across ${tables} tables';
+
+	/// en: 'Each backup is a <1>pg_dump --format=custom</1> of every table below, plus <3>manifest.json</3> and (optionally) <5>config.toml</5>. Counts are live; the bundle captures whatever's there at backup time.'
+	String get description => 'Each backup is a <1>pg_dump --format=custom</1> of every table below, plus <3>manifest.json</3> and (optionally) <5>config.toml</5>. Counts are live; the bundle captures whatever\'s there at backup time.';
+
+	/// en: 'Failed to load inventory'
+	String get loadFailedToast => 'Failed to load inventory';
+
+	/// en: 'rows'
+	String get rowsLabel => 'rows';
+}
+
+// Path: web.backups.restart
+class TranslationsWebBackupsRestartEn {
+	TranslationsWebBackupsRestartEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Restart opendray to activate backups'
+	String get title => 'Restart opendray to activate backups';
+
+	/// en: 'Your passphrase is saved. The gateway only loads it at startup, so the feature stays off until you bounce the process.'
+	String get description => 'Your passphrase is saved. The gateway only loads it at startup, so the feature stays off until you bounce the process.';
+
+	/// en: 'Key file:'
+	String get keyFile => 'Key file:';
+
+	/// en: 'Configured via:'
+	String get configuredVia => 'Configured via:';
+
+	/// en: 'OPENDRAY_BACKUP_KEY env var'
+	String get envVar => 'OPENDRAY_BACKUP_KEY env var';
+
+	/// en: 'Check again'
+	String get checkAgain => 'Check again';
+}
+
+// Path: web.backups.setup
+class TranslationsWebBackupsSetupEn {
+	TranslationsWebBackupsSetupEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Set up backups'
+	String get title => 'Set up backups';
+
+	/// en: 'Choose a master passphrase. opendray uses it to encrypt every backup blob. <1>Lose it and your backups become unrecoverable</1>, so save it in a password manager (Vaultwarden, 1Password, …) before continuing.'
+	String get description => 'Choose a master passphrase. opendray uses it to encrypt every backup blob. <1>Lose it and your backups become unrecoverable</1>, so save it in a password manager (Vaultwarden, 1Password, …) before continuing.';
+
+	/// en: 'Generate'
+	String get generate => 'Generate';
+
+	/// en: 'Paste my own'
+	String get pasteOwn => 'Paste my own';
+
+	/// en: '256-bit random key'
+	String get generateTitle => '256-bit random key';
+
+	/// en: 'Server generates a cryptographically random passphrase and shows it once. You must copy it before continuing — there is no recovery path.'
+	String get generateHint => 'Server generates a cryptographically random passphrase and shows it once. You must copy it before continuing — there is no recovery path.';
+
+	/// en: 'Your passphrase'
+	String get pasteLabel => 'Your passphrase';
+
+	/// en: 'At least 20 characters'
+	String get pastePlaceholder => 'At least 20 characters';
+
+	/// en: 'Recommended: 40+ characters from a password manager.'
+	String get pasteHint => 'Recommended: 40+ characters from a password manager.';
+
+	/// en: 'Saves to:'
+	String get savesTo => 'Saves to:';
+
+	/// en: 'Saving…'
+	String get saving => 'Saving…';
+
+	/// en: 'Generate and save'
+	String get generateAndSave => 'Generate and save';
+
+	/// en: 'Save'
+	String get save => 'Save';
+}
+
+// Path: web.backups.generated
+class TranslationsWebBackupsGeneratedEn {
+	TranslationsWebBackupsGeneratedEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Save this passphrase NOW'
+	String get title => 'Save this passphrase NOW';
+
+	/// en: 'This is shown <1>once</1>. It will not be retrievable from opendray or anywhere else. Copy it into a password manager before continuing.'
+	String get description => 'This is shown <1>once</1>. It will not be retrievable from opendray or anywhere else. Copy it into a password manager before continuing.';
+
+	/// en: 'Copy'
+	String get copy => 'Copy';
+
+	/// en: 'Passphrase copied to clipboard'
+	String get copiedToast => 'Passphrase copied to clipboard';
+
+	/// en: 'Copy failed — select and copy manually'
+	String get copyFailedToast => 'Copy failed — select and copy manually';
+
+	/// en: 'Saved to:'
+	String get savedTo => 'Saved to:';
+
+	/// en: 'I have saved this passphrase to my password manager'
+	String get ack => 'I have saved this passphrase to my password manager';
+
+	/// en: 'Continue'
+	String get kContinue => 'Continue';
+}
+
+// Path: web.backups.status
+class TranslationsWebBackupsStatusEn {
+	TranslationsWebBackupsStatusEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Key fingerprint:'
+	String get keyFingerprint => 'Key fingerprint:';
+
+	/// en: 'pg_dump:'
+	String get pgDump => 'pg_dump:';
+
+	/// en: 'unavailable'
+	String get pgDumpUnavailable => 'unavailable';
+
+	/// en: 'Backups can't run until pg_dump is on PATH (or its absolute path is set in <1>backup.pg_dump_path</1>). Install <3>postgresql-client</3> matching your server's major version and restart.'
+	String get pgDumpHint => 'Backups can\'t run until pg_dump is on PATH (or its absolute path is set in <1>backup.pg_dump_path</1>). Install <3>postgresql-client</3> matching your server\'s major version and restart.';
+}
+
+// Path: web.backups.backupsTab
+class TranslationsWebBackupsBackupsTabEn {
+	TranslationsWebBackupsBackupsTabEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Backup now'
+	String get backupNow => 'Backup now';
+
+	/// en: 'Triggering…'
+	String get triggering => 'Triggering…';
+
+	/// en: 'include config.toml'
+	String get includeConfig => 'include config.toml';
+
+	/// en: 'Restore from file'
+	String get restoreFromFile => 'Restore from file';
+
+	/// en: 'Refresh'
+	String get refresh => 'Refresh';
+
+	/// en: 'Backup queued'
+	String get queuedToast => 'Backup queued';
+
+	/// en: 'Trigger failed'
+	String get triggerFailedToast => 'Trigger failed';
+
+	/// en: 'Failed to list backups'
+	String get listFailedToast => 'Failed to list backups';
+
+	/// en: 'Delete backup {id}? The blob is removed from its target.'
+	String deleteConfirm({required Object id}) => 'Delete backup ${id}? The blob is removed from its target.';
+
+	/// en: 'Backup deleted'
+	String get deletedToast => 'Backup deleted';
+
+	/// en: 'Delete failed'
+	String get deleteFailedToast => 'Delete failed';
+
+	/// en: 'No backups yet. Click "Backup now" above to take the first one.'
+	String get empty => 'No backups yet. Click "Backup now" above to take the first one.';
+
+	late final TranslationsWebBackupsBackupsTabColumnsEn columns = TranslationsWebBackupsBackupsTabColumnsEn.internal(_root);
+
+	/// en: 'Download'
+	String get downloadTooltip => 'Download';
+
+	/// en: 'Delete'
+	String get deleteTooltip => 'Delete';
+}
+
+// Path: web.backups.restore
+class TranslationsWebBackupsRestoreEn {
+	TranslationsWebBackupsRestoreEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Restore from backup bundle'
+	String get title => 'Restore from backup bundle';
+
+	/// en: 'Encrypted bundle (.tar.gz.enc)'
+	String get bundleLabel => 'Encrypted bundle (.tar.gz.enc)';
+
+	/// en: 'Target database DSN'
+	String get targetDsnLabel => 'Target database DSN';
+
+	/// en: '(blank = opendray's own DB — DANGEROUS)'
+	String get targetDsnHint => '(blank = opendray\'s own DB — DANGEROUS)';
+
+	/// en: 'postgres://user:pass@host:5432/dbname'
+	String get targetDsnPlaceholder => 'postgres://user:pass@host:5432/dbname';
+
+	/// en: '--clean --if-exists (drop existing schema first; required when restoring over a populated DB)'
+	String get cleanLabel => '--clean --if-exists (drop existing schema first; required when restoring over a populated DB)';
+
+	/// en: 'Audit note (optional)'
+	String get auditNoteLabel => 'Audit note (optional)';
+
+	/// en: 'Reason for restore — appears in slog'
+	String get auditNotePlaceholder => 'Reason for restore — appears in slog';
+
+	/// en: 'You're restoring into <1>opendray's own database</1>. With "--clean" enabled this drops every table and replays the backup verbatim — irreversible. Type <3>I understand</3> to proceed.'
+	String get ownDbWarning => 'You\'re restoring into <1>opendray\'s own database</1>. With "--clean" enabled this drops every table and replays the backup verbatim — irreversible. Type <3>I understand</3> to proceed.';
+
+	/// en: 'I understand'
+	String get confirmPlaceholder => 'I understand';
+
+	/// en: 'I understand'
+	String get confirmSentinel => 'I understand';
+
+	/// en: 'pg_restore output (last 8 KiB)'
+	String get pgRestoreOutput => 'pg_restore output (last 8 KiB)';
+
+	/// en: '(no pg_restore output)'
+	String get noPgRestoreOutput => '(no pg_restore output)';
+
+	/// en: 'Pick a bundle file first'
+	String get pickFileToast => 'Pick a bundle file first';
+
+	/// en: 'Restore succeeded'
+	String get succeededToast => 'Restore succeeded';
+
+	/// en: '{bytes} replayed from manifest {id}'
+	String replayedDescription({required Object bytes, required Object id}) => '${bytes} replayed from manifest ${id}';
+
+	/// en: 'Restore failed'
+	String get failedToast => 'Restore failed';
+
+	/// en: 'Restoring…'
+	String get restoring => 'Restoring…';
+
+	/// en: 'Restore'
+	String get restore => 'Restore';
+}
+
+// Path: web.backups.schedulesTab
+class TranslationsWebBackupsSchedulesTabEn {
+	TranslationsWebBackupsSchedulesTabEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Recurring backups. The scheduler polls every 30s and runs the oldest due schedule.'
+	String get description => 'Recurring backups. The scheduler polls every 30s and runs the oldest due schedule.';
+
+	/// en: 'New schedule'
+	String get newSchedule => 'New schedule';
+
+	/// en: 'Failed to load schedules'
+	String get loadFailedToast => 'Failed to load schedules';
+
+	/// en: 'Delete schedule {id}?'
+	String deleteConfirm({required Object id}) => 'Delete schedule ${id}?';
+
+	/// en: 'Schedule deleted'
+	String get deletedToast => 'Schedule deleted';
+
+	/// en: 'Delete failed'
+	String get deleteFailedToast => 'Delete failed';
+
+	/// en: 'Toggle failed'
+	String get toggleFailedToast => 'Toggle failed';
+
+	/// en: 'No schedules. Add one to take automatic recurring backups.'
+	String get empty => 'No schedules. Add one to take automatic recurring backups.';
+
+	late final TranslationsWebBackupsSchedulesTabColumnsEn columns = TranslationsWebBackupsSchedulesTabColumnsEn.internal(_root);
+
+	/// en: '{count} backups'
+	String keepCount({required Object count}) => '${count} backups';
+
+	/// en: 'Delete'
+	String get deleteTooltip => 'Delete';
+}
+
+// Path: web.backups.newSchedule
+class TranslationsWebBackupsNewScheduleEn {
+	TranslationsWebBackupsNewScheduleEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'New backup schedule'
+	String get title => 'New backup schedule';
+
+	/// en: 'Target'
+	String get targetLabel => 'Target';
+
+	/// en: 'Every (hours)'
+	String get everyHoursLabel => 'Every (hours)';
+
+	/// en: 'Keep last N'
+	String get keepLastNLabel => 'Keep last N';
+
+	/// en: 'Enable immediately'
+	String get enableImmediately => 'Enable immediately';
+
+	/// en: 'Schedule created'
+	String get createdToast => 'Schedule created';
+
+	/// en: 'Create failed'
+	String get createFailedToast => 'Create failed';
+
+	/// en: 'Creating…'
+	String get creating => 'Creating…';
+
+	/// en: 'Create'
+	String get create => 'Create';
+}
+
+// Path: web.backups.targetsTab
+class TranslationsWebBackupsTargetsTabEn {
+	TranslationsWebBackupsTargetsTabEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Storage destinations. v1 supports <1>local</1> (disk on the opendray host) and <3>smb</3> (any SMB / CIFS share, e.g. UNAS or Synology).'
+	String get description => 'Storage destinations. v1 supports <1>local</1> (disk on the opendray host) and <3>smb</3> (any SMB / CIFS share, e.g. UNAS or Synology).';
+
+	/// en: 'New target'
+	String get newTarget => 'New target';
+
+	/// en: 'Failed to list targets'
+	String get listFailedToast => 'Failed to list targets';
+
+	/// en: 'Delete target {id}? Schedules referencing it will block the delete.'
+	String deleteConfirm({required Object id}) => 'Delete target ${id}? Schedules referencing it will block the delete.';
+
+	/// en: 'Target deleted'
+	String get deletedToast => 'Target deleted';
+
+	/// en: 'Delete failed'
+	String get deleteFailedToast => 'Delete failed';
+
+	/// en: 'Connection OK'
+	String get connectionOkToast => 'Connection OK';
+
+	/// en: 'Connection failed'
+	String get connectionFailedToast => 'Connection failed';
+
+	/// en: 'Test failed'
+	String get testFailedToast => 'Test failed';
+
+	late final TranslationsWebBackupsTargetsTabColumnsEn columns = TranslationsWebBackupsTargetsTabColumnsEn.internal(_root);
+
+	/// en: 'on'
+	String get on => 'on';
+
+	/// en: 'off'
+	String get off => 'off';
+
+	/// en: 'Test'
+	String get test => 'Test';
+
+	/// en: 'Testing…'
+	String get testing => 'Testing…';
+
+	/// en: 'Delete'
+	String get deleteTooltip => 'Delete';
+}
+
+// Path: web.backups.targetEditor
+class TranslationsWebBackupsTargetEditorEn {
+	TranslationsWebBackupsTargetEditorEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'New backup target'
+	String get title => 'New backup target';
+
+	/// en: 'Where do you want to back up to?'
+	String get kindPicker => 'Where do you want to back up to?';
+
+	/// en: 'ID (optional)'
+	String get idLabel => 'ID (optional)';
+
+	/// en: 'auto-generated if blank, e.g. tgt_xxx'
+	String get idPlaceholder => 'auto-generated if blank, e.g. tgt_xxx';
+
+	/// en: 'Target created'
+	String get createdToast => 'Target created';
+
+	/// en: 'Create failed'
+	String get createFailedToast => 'Create failed';
+
+	/// en: 'Creating…'
+	String get creating => 'Creating…';
+
+	/// en: 'Create target'
+	String get create => 'Create target';
+
+	/// en: 'Enable immediately (otherwise saved as disabled — useful for "configure now, turn on later")'
+	String get enableImmediately => 'Enable immediately (otherwise saved as disabled — useful for "configure now, turn on later")';
+
+	late final TranslationsWebBackupsTargetEditorLocalEn local = TranslationsWebBackupsTargetEditorLocalEn.internal(_root);
+	late final TranslationsWebBackupsTargetEditorSmbEn smb = TranslationsWebBackupsTargetEditorSmbEn.internal(_root);
+	late final TranslationsWebBackupsTargetEditorS3En s3 = TranslationsWebBackupsTargetEditorS3En.internal(_root);
+	late final TranslationsWebBackupsTargetEditorWebdavEn webdav = TranslationsWebBackupsTargetEditorWebdavEn.internal(_root);
+	late final TranslationsWebBackupsTargetEditorSftpEn sftp = TranslationsWebBackupsTargetEditorSftpEn.internal(_root);
+	late final TranslationsWebBackupsTargetEditorRcloneEn rclone = TranslationsWebBackupsTargetEditorRcloneEn.internal(_root);
+}
+
+// Path: web.serverSettings.sections
+class TranslationsWebServerSettingsSectionsEn {
+	TranslationsWebServerSettingsSectionsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsWebServerSettingsSectionsGeneralEn general = TranslationsWebServerSettingsSectionsGeneralEn.internal(_root);
+	late final TranslationsWebServerSettingsSectionsLoggingEn logging = TranslationsWebServerSettingsSectionsLoggingEn.internal(_root);
+	late final TranslationsWebServerSettingsSectionsSessionsEn sessions = TranslationsWebServerSettingsSectionsSessionsEn.internal(_root);
+	late final TranslationsWebServerSettingsSectionsVaultEn vault = TranslationsWebServerSettingsSectionsVaultEn.internal(_root);
+	late final TranslationsWebServerSettingsSectionsMcpEn mcp = TranslationsWebServerSettingsSectionsMcpEn.internal(_root);
+	late final TranslationsWebServerSettingsSectionsMemoryEn memory = TranslationsWebServerSettingsSectionsMemoryEn.internal(_root);
+	late final TranslationsWebServerSettingsSectionsMemoryAmbientEn memoryAmbient = TranslationsWebServerSettingsSectionsMemoryAmbientEn.internal(_root);
+	late final TranslationsWebServerSettingsSectionsBackupEn backup = TranslationsWebServerSettingsSectionsBackupEn.internal(_root);
+	late final TranslationsWebServerSettingsSectionsClaudeEn claude = TranslationsWebServerSettingsSectionsClaudeEn.internal(_root);
+	late final TranslationsWebServerSettingsSectionsCodexEn codex = TranslationsWebServerSettingsSectionsCodexEn.internal(_root);
+	late final TranslationsWebServerSettingsSectionsGeminiEn gemini = TranslationsWebServerSettingsSectionsGeminiEn.internal(_root);
+}
+
+// Path: web.serverSettings.restart
+class TranslationsWebServerSettingsRestartEn {
+	TranslationsWebServerSettingsRestartEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Restart server'
+	String get button => 'Restart server';
+
+	/// en: 'Self-exec the gateway process'
+	String get buttonTitle => 'Self-exec the gateway process';
+
+	/// en: 'You have unsaved changes. Restart will use the LAST SAVED config. Continue?'
+	String get dirtyConfirm => 'You have unsaved changes. Restart will use the LAST SAVED config. Continue?';
+
+	/// en: 'Restart the opendray gateway? All open terminal sessions will reconnect automatically.'
+	String get confirm => 'Restart the opendray gateway? All open terminal sessions will reconnect automatically.';
+
+	/// en: 'Restarting server…'
+	String get overlay => 'Restarting server…';
+
+	/// en: 'Waiting for /health · {tick}s'
+	String waiting({required Object tick}) => 'Waiting for /health · ${tick}s';
+
+	/// en: 'Restart timed out'
+	String get timedOutTitle => 'Restart timed out';
+
+	/// en: 'Health endpoint never came back. Check server logs.'
+	String get timedOutDesc => 'Health endpoint never came back. Check server logs.';
+
+	/// en: 'Server restarted'
+	String get successToast => 'Server restarted';
+}
+
+// Path: web.serverSettings.formGroups
+class TranslationsWebServerSettingsFormGroupsEn {
+	TranslationsWebServerSettingsFormGroupsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Network'
+	String get network => 'Network';
+
+	/// en: 'Operator account'
+	String get operatorAccount => 'Operator account';
+
+	/// en: 'Configuration'
+	String get memoryConfiguration => 'Configuration';
+
+	/// en: 'HTTP backend (used when backend=http)'
+	String get memoryHttp => 'HTTP backend (used when backend=http)';
+
+	/// en: 'Local ONNX (used when backend=local)'
+	String get memoryLocal => 'Local ONNX (used when backend=local)';
+
+	/// en: 'Status'
+	String get backupStatus => 'Status';
+
+	/// en: 'Where backups go'
+	String get backupWhere => 'Where backups go';
+
+	/// en: 'Schedules'
+	String get backupSchedules => 'Schedules';
+
+	/// en: 'What's in a backup?'
+	String get backupWhatsInside => 'What\'s in a backup?';
+}
+
+// Path: web.serverSettings.fields
+class TranslationsWebServerSettingsFieldsEn {
+	TranslationsWebServerSettingsFieldsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsWebServerSettingsFieldsListenAddressEn listenAddress = TranslationsWebServerSettingsFieldsListenAddressEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsUsernameEn username = TranslationsWebServerSettingsFieldsUsernameEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsPasswordEn password = TranslationsWebServerSettingsFieldsPasswordEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsTokenTTLEn tokenTTL = TranslationsWebServerSettingsFieldsTokenTTLEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsLogLevelEn logLevel = TranslationsWebServerSettingsFieldsLogLevelEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsLogFormatEn logFormat = TranslationsWebServerSettingsFieldsLogFormatEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsLogFileEn logFile = TranslationsWebServerSettingsFieldsLogFileEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsIdleThresholdEn idleThreshold = TranslationsWebServerSettingsFieldsIdleThresholdEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsIdlePollIntervalEn idlePollInterval = TranslationsWebServerSettingsFieldsIdlePollIntervalEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsVaultRootEn vaultRoot = TranslationsWebServerSettingsFieldsVaultRootEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsNotesDirectoryEn notesDirectory = TranslationsWebServerSettingsFieldsNotesDirectoryEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsSkillsDirectoryEn skillsDirectory = TranslationsWebServerSettingsFieldsSkillsDirectoryEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsGitRootEn gitRoot = TranslationsWebServerSettingsFieldsGitRootEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsPersonalPrefixEn personalPrefix = TranslationsWebServerSettingsFieldsPersonalPrefixEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsProjectsPrefixEn projectsPrefix = TranslationsWebServerSettingsFieldsProjectsPrefixEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsRegistryRootEn registryRoot = TranslationsWebServerSettingsFieldsRegistryRootEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsSecretsFileEn secretsFile = TranslationsWebServerSettingsFieldsSecretsFileEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsMemoryBackendEn memoryBackend = TranslationsWebServerSettingsFieldsMemoryBackendEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsMemoryStoreEn memoryStore = TranslationsWebServerSettingsFieldsMemoryStoreEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsMemoryTopKEn memoryTopK = TranslationsWebServerSettingsFieldsMemoryTopKEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsMemoryThresholdEn memoryThreshold = TranslationsWebServerSettingsFieldsMemoryThresholdEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsMemoryScopeEn memoryScope = TranslationsWebServerSettingsFieldsMemoryScopeEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsMemoryBaseUrlEn memoryBaseUrl = TranslationsWebServerSettingsFieldsMemoryBaseUrlEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsMemoryModelEn memoryModel = TranslationsWebServerSettingsFieldsMemoryModelEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsMemoryApiKeyEn memoryApiKey = TranslationsWebServerSettingsFieldsMemoryApiKeyEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsMemoryLocalModelEn memoryLocalModel = TranslationsWebServerSettingsFieldsMemoryLocalModelEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsMemoryLibraryPathEn memoryLibraryPath = TranslationsWebServerSettingsFieldsMemoryLibraryPathEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsMemoryModelPathEn memoryModelPath = TranslationsWebServerSettingsFieldsMemoryModelPathEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsMemoryTokenizerPathEn memoryTokenizerPath = TranslationsWebServerSettingsFieldsMemoryTokenizerPathEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsMemoryMaxSeqLenEn memoryMaxSeqLen = TranslationsWebServerSettingsFieldsMemoryMaxSeqLenEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsClaudeHistoryRootsEn claudeHistoryRoots = TranslationsWebServerSettingsFieldsClaudeHistoryRootsEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsClaudeAccountsDirEn claudeAccountsDir = TranslationsWebServerSettingsFieldsClaudeAccountsDirEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsCodexSessionsRootEn codexSessionsRoot = TranslationsWebServerSettingsFieldsCodexSessionsRootEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsGeminiTmpRootEn geminiTmpRoot = TranslationsWebServerSettingsFieldsGeminiTmpRootEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsGeminiProjectsFileEn geminiProjectsFile = TranslationsWebServerSettingsFieldsGeminiProjectsFileEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsBackupLocalDirEn backupLocalDir = TranslationsWebServerSettingsFieldsBackupLocalDirEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsBackupExportDirEn backupExportDir = TranslationsWebServerSettingsFieldsBackupExportDirEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsBackupPgDumpPathEn backupPgDumpPath = TranslationsWebServerSettingsFieldsBackupPgDumpPathEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsBackupPgRestorePathEn backupPgRestorePath = TranslationsWebServerSettingsFieldsBackupPgRestorePathEn.internal(_root);
+}
+
+// Path: web.serverSettings.liveTail
+class TranslationsWebServerSettingsLiveTailEn {
+	TranslationsWebServerSettingsLiveTailEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Live tail'
+	String get heading => 'Live tail';
+
+	/// en: 'In-memory ring buffer (last ~2,000 records). Resets on restart.'
+	String get description => 'In-memory ring buffer (last ~2,000 records). Resets on restart.';
+}
+
+// Path: web.serverSettings.memoryInspectorCard
+class TranslationsWebServerSettingsMemoryInspectorCardEn {
+	TranslationsWebServerSettingsMemoryInspectorCardEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Inspector'
+	String get heading => 'Inspector';
+
+	/// en: 'Browse, search and edit stored memories on the dedicated page.'
+	String get description => 'Browse, search and edit stored memories on the dedicated page.';
+
+	/// en: 'Open Memory →'
+	String get openButton => 'Open Memory →';
+}
+
+// Path: web.serverSettings.stringList
+class TranslationsWebServerSettingsStringListEn {
+	TranslationsWebServerSettingsStringListEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: '(none — using built-in defaults)'
+	String get noneDefault => '(none — using built-in defaults)';
+
+	/// en: 'Add path'
+	String get addPath => 'Add path';
+
+	/// en: 'Remove'
+	String get removeTitle => 'Remove';
+}
+
+// Path: web.serverSettings.httpHelpers
+class TranslationsWebServerSettingsHttpHelpersEn {
+	TranslationsWebServerSettingsHttpHelpersEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Auto-detected at startup'
+	String get autoDetected => 'Auto-detected at startup';
+
+	/// en: '{count} model(s) — click to use'
+	String modelCount({required Object count}) => '${count} model(s) — click to use';
+
+	/// en: 'Presets:'
+	String get presets => 'Presets:';
+
+	/// en: 'Test connection'
+	String get testConnection => 'Test connection';
+
+	late final TranslationsWebServerSettingsHttpHelpersPresetTipEn presetTip = TranslationsWebServerSettingsHttpHelpersPresetTipEn.internal(_root);
+}
+
+// Path: web.serverSettings.probe
+class TranslationsWebServerSettingsProbeEn {
+	TranslationsWebServerSettingsProbeEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: '✗ unreachable: {error}'
+	String unreachable({required Object error}) => '✗ unreachable: ${error}';
+
+	/// en: 'connection failed'
+	String get connectionFailed => 'connection failed';
+
+	/// en: '✓ reachable {detected}· {total} model(s) total · {embedding} embedding'
+	String reachable({required Object detected, required Object total, required Object embedding}) => '✓ reachable ${detected}· ${total} model(s) total · ${embedding} embedding';
+
+	/// en: '⚠ Configured model {model} isn't in the list. Pick one of the embedding models below or fix the name.'
+	String modelMissing({required Object model}) => '⚠ Configured model ${model} isn\'t in the list. Pick one of the embedding models below or fix the name.';
+
+	/// en: 'embedding models:'
+	String get embeddingModelsLabel => 'embedding models:';
+
+	/// en: '+{count} more'
+	String moreModels({required Object count}) => '+${count} more';
+
+	/// en: '⚠ No model name contains "embed". The endpoint might not have an embedding model loaded — check your local server.'
+	String get noEmbeddingFound => '⚠ No model name contains "embed". The endpoint might not have an embedding model loaded — check your local server.';
+
+	/// en: 'Currently configured'
+	String get configuredTitle => 'Currently configured';
+
+	/// en: 'Click to apply'
+	String get applyTitle => 'Click to apply';
+}
+
+// Path: web.serverSettings.backup
+class TranslationsWebServerSettingsBackupEn {
+	TranslationsWebServerSettingsBackupEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Feature disabled'
+	String get featureDisabledTitle => 'Feature disabled';
+
+	/// en: 'Set <1>OPENDRAY_BACKUP_ENABLED=1</1> + <3>OPENDRAY_BACKUP_KEY=&lt;passphrase&gt;</3> in opendray's environment, then restart. The master passphrase is env-only — it never touches config.toml.'
+	String get featureDisabledHint => 'Set <1>OPENDRAY_BACKUP_ENABLED=1</1> + <3>OPENDRAY_BACKUP_KEY=&lt;passphrase&gt;</3> in opendray\'s environment, then restart. The master passphrase is env-only — it never touches config.toml.';
+
+	/// en: 'Status'
+	String get statusRowLabel => 'Status';
+
+	/// en: 'enabled · healthy'
+	String get enabledHealthy => 'enabled · healthy';
+
+	/// en: 'enabled · degraded'
+	String get enabledDegraded => 'enabled · degraded';
+
+	/// en: 'Key fingerprint'
+	String get keyFingerprintLabel => 'Key fingerprint';
+
+	/// en: 'record in Vaultwarden — losing it locks all prior backups'
+	String get keyFingerprintHint => 'record in Vaultwarden — losing it locks all prior backups';
+
+	/// en: 'pg_dump'
+	String get pgDumpLabel => 'pg_dump';
+
+	/// en: 'unavailable'
+	String get pgDumpUnavailable => 'unavailable';
+
+	/// en: 'pg_restore'
+	String get pgRestoreLabel => 'pg_restore';
+
+	/// en: '(not resolved)'
+	String get pgRestoreNotResolved => '(not resolved)';
+
+	/// en: 'Open Backups page →'
+	String get openBackups => 'Open Backups page →';
+
+	/// en: 'Open Export / Import →'
+	String get openExport => 'Open Export / Import →';
+
+	/// en: 'Each target is one place a backup blob can be written. opendray supports <1>local disk</1>, <3>SMB/CIFS</3> (Windows / NAS), <5>S3-compatible</5> (AWS, R2, B2, MinIO, Alibaba Cloud OSS, Tencent Cloud COS, ...), <7>WebDAV</7> (Nextcloud, Synology, Jianguoyun), <9>SFTP</9>, plus an <11>rclone</11> passthrough that taps into 70+ extra backends (Google Drive, OneDrive, Dropbox, Baidu Pan, Aliyun Drive, ...).'
+	String get whereDesc => 'Each target is one place a backup blob can be written. opendray supports <1>local disk</1>, <3>SMB/CIFS</3> (Windows / NAS), <5>S3-compatible</5> (AWS, R2, B2, MinIO, Alibaba Cloud OSS, Tencent Cloud COS, ...), <7>WebDAV</7> (Nextcloud, Synology, Jianguoyun), <9>SFTP</9>, plus an <11>rclone</11> passthrough that taps into 70+ extra backends (Google Drive, OneDrive, Dropbox, Baidu Pan, Aliyun Drive, ...).';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'No targets yet. Add one to start backing up.'
+	String get noTargets => 'No targets yet. Add one to start backing up.';
+
+	/// en: 'Add target'
+	String get addTarget => 'Add target';
+
+	/// en: 'No recurring schedules. Add one on <1>/backups → Schedules</1> to take backups automatically.'
+	String get noSchedulesHint => 'No recurring schedules. Add one on <1>/backups → Schedules</1> to take backups automatically.';
+
+	late final TranslationsWebServerSettingsBackupScheduleHeadersEn scheduleHeaders = TranslationsWebServerSettingsBackupScheduleHeadersEn.internal(_root);
+
+	/// en: 'every {interval}'
+	String every({required Object interval}) => 'every ${interval}';
+
+	/// en: '{count} backups'
+	String backupsKeep({required Object count}) => '${count} backups';
+
+	/// en: 'enabled'
+	String get stateEnabled => 'enabled';
+
+	/// en: 'paused'
+	String get statePaused => 'paused';
+
+	/// en: 'Manage on /backups → Schedules →'
+	String get manageSchedules => 'Manage on /backups → Schedules →';
+
+	/// en: 'Each backup is a <1>pg_dump --format=custom</1> of every opendray table (sessions, integrations, memories, audit_log, etc.) plus a <3>manifest.json</3> and (optionally) the live <5>config.toml</5>. Open the "What's in a backup?" panel on the <7>Backups page</7> to see the live inventory with row counts.'
+	String get whatsInsideDesc => 'Each backup is a <1>pg_dump --format=custom</1> of every opendray table (sessions, integrations, memories, audit_log, etc.) plus a <3>manifest.json</3> and (optionally) the live <5>config.toml</5>. Open the "What\'s in a backup?" panel on the <7>Backups page</7> to see the live inventory with row counts.';
+
+	/// en: 'Advanced (paths & client binaries) — restart required'
+	String get advancedToggle => 'Advanced (paths & client binaries) — restart required';
+}
+
+// Path: web.serverSettings.targetRow
+class TranslationsWebServerSettingsTargetRowEn {
+	TranslationsWebServerSettingsTargetRowEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'on'
+	String get on => 'on';
+
+	/// en: 'off'
+	String get off => 'off';
+
+	/// en: 'Test'
+	String get test => 'Test';
+
+	/// en: 'Testing…'
+	String get testing => 'Testing…';
+
+	/// en: 'Delete'
+	String get delete => 'Delete';
+
+	/// en: '{id}: connection OK'
+	String connectionOk({required Object id}) => '${id}: connection OK';
+
+	/// en: 'Connection failed'
+	String get connectionFailedTitle => 'Connection failed';
+
+	/// en: 'Test failed'
+	String get testFailedTitle => 'Test failed';
+
+	/// en: 'Delete target "{id}"? Schedules referencing it will block the delete.'
+	String deleteConfirm({required Object id}) => 'Delete target "${id}"? Schedules referencing it will block the delete.';
+
+	/// en: 'Target deleted'
+	String get deleteSuccess => 'Target deleted';
+
+	/// en: 'Delete failed'
+	String get deleteFailedTitle => 'Delete failed';
+
+	/// en: 'Unknown error'
+	String get unknownError => 'Unknown error';
+}
+
+// Path: web.settings.groups
+class TranslationsWebSettingsGroupsEn {
+	TranslationsWebSettingsGroupsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Workspace'
+	String get workspace => 'Workspace';
+
+	/// en: 'Server'
+	String get server => 'Server';
+
+	/// en: 'System'
+	String get system => 'System';
+}
+
+// Path: web.settings.items
+class TranslationsWebSettingsItemsEn {
+	TranslationsWebSettingsItemsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Appearance'
+	String get appearance => 'Appearance';
+
+	/// en: 'Font size'
+	String get font => 'Font size';
+
+	/// en: 'Account'
+	String get account => 'Account';
+
+	/// en: 'Status'
+	String get status => 'Status';
+
+	/// en: 'About'
+	String get about => 'About';
+}
+
+// Path: web.settings.health
+class TranslationsWebSettingsHealthEn {
+	TranslationsWebSettingsHealthEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'connecting…'
+	String get connecting => 'connecting…';
+
+	/// en: 'db ok'
+	String get dbOk => 'db ok';
+
+	/// en: 'db down'
+	String get dbDown => 'db down';
+}
+
+// Path: web.settings.breadcrumb
+class TranslationsWebSettingsBreadcrumbEn {
+	TranslationsWebSettingsBreadcrumbEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Server'
+	String get server => 'Server';
+}
+
+// Path: web.settings.appearance
+class TranslationsWebSettingsAppearanceEn {
+	TranslationsWebSettingsAppearanceEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Appearance'
+	String get title => 'Appearance';
+
+	/// en: 'Choose how opendray looks.'
+	String get description => 'Choose how opendray looks.';
+
+	late final TranslationsWebSettingsAppearanceOptionsEn options = TranslationsWebSettingsAppearanceOptionsEn.internal(_root);
+}
+
+// Path: web.settings.font
+class TranslationsWebSettingsFontEn {
+	TranslationsWebSettingsFontEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Font size'
+	String get title => 'Font size';
+
+	/// en: 'Scales the entire interface. Persisted per browser.'
+	String get description => 'Scales the entire interface. Persisted per browser.';
+
+	late final TranslationsWebSettingsFontOptionsEn options = TranslationsWebSettingsFontOptionsEn.internal(_root);
+}
+
+// Path: web.settings.account
+class TranslationsWebSettingsAccountEn {
+	TranslationsWebSettingsAccountEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Account'
+	String get title => 'Account';
+
+	/// en: 'Operator and current bearer token.'
+	String get description => 'Operator and current bearer token.';
+
+	/// en: 'Username'
+	String get username => 'Username';
+
+	/// en: 'Token expires'
+	String get tokenExpires => 'Token expires';
+
+	/// en: 'Change credentials'
+	String get changeCredentials => 'Change credentials';
+}
+
+// Path: web.settings.changeCredentials
+class TranslationsWebSettingsChangeCredentialsEn {
+	TranslationsWebSettingsChangeCredentialsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Change credentials'
+	String get title => 'Change credentials';
+
+	/// en: 'Verify your current password, then pick new credentials. All other signed-in sessions will be revoked.'
+	String get description => 'Verify your current password, then pick new credentials. All other signed-in sessions will be revoked.';
+
+	/// en: 'Current password'
+	String get currentPassword => 'Current password';
+
+	/// en: 'New username'
+	String get newUsername => 'New username';
+
+	/// en: 'New password'
+	String get newPassword => 'New password';
+
+	/// en: 'At least 8 characters.'
+	String get newPasswordHint => 'At least 8 characters.';
+
+	/// en: 'Confirm new password'
+	String get confirm => 'Confirm new password';
+
+	/// en: 'New password must be at least 8 characters.'
+	String get errorTooShort => 'New password must be at least 8 characters.';
+
+	/// en: 'New password and confirmation don't match.'
+	String get errorMismatch => 'New password and confirmation don\'t match.';
+
+	/// en: 'Current password is wrong.'
+	String get errorWrongPassword => 'Current password is wrong.';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Update'
+	String get update => 'Update';
+
+	/// en: 'Saving…'
+	String get saving => 'Saving…';
+}
+
+// Path: web.settings.system
+class TranslationsWebSettingsSystemEn {
+	TranslationsWebSettingsSystemEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'System status'
+	String get title => 'System status';
+
+	/// en: 'Live status from the gateway's /health endpoint.'
+	String get description => 'Live status from the gateway\'s /health endpoint.';
+
+	/// en: 'Status'
+	String get status => 'Status';
+
+	/// en: 'Version'
+	String get version => 'Version';
+
+	/// en: 'Uptime'
+	String get uptime => 'Uptime';
+
+	/// en: 'Database'
+	String get database => 'Database';
+
+	/// en: 'reachable'
+	String get reachable => 'reachable';
+
+	/// en: 'unreachable'
+	String get unreachable => 'unreachable';
+}
+
+// Path: web.settings.about
+class TranslationsWebSettingsAboutEn {
+	TranslationsWebSettingsAboutEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'About'
+	String get title => 'About';
+
+	/// en: 'opendray v2 — the multiplexer + integration gateway for AI agent CLIs. Source under Apache 2.0.'
+	String get description => 'opendray v2 — the multiplexer + integration gateway for AI agent CLIs. Source under Apache 2.0.';
+}
+
+// Path: web.memoryAmbient.header
+class TranslationsWebMemoryAmbientHeaderEn {
+	TranslationsWebMemoryAmbientHeaderEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Ambient memory — auto-capture & inject'
+	String get title => 'Ambient memory — auto-capture & inject';
+
+	/// en: 'opendray polls every live agent session every 10 seconds, extracts durable facts via a configurable LLM, and dedups before storing them in the shared memory pool. Configure which LLM does the extraction (Provider), when extraction fires (Capture rule), and what — if anything — gets prepended to the agent's system prompt at spawn (Injection profile).'
+	String get body => 'opendray polls every live agent session every 10 seconds, extracts durable facts via a configurable LLM, and dedups before storing them in the shared memory pool. Configure which LLM does the extraction (Provider), when extraction fires (Capture rule), and what — if anything — gets prepended to the agent\'s system prompt at spawn (Injection profile).';
+}
+
+// Path: web.memoryAmbient.providers
+class TranslationsWebMemoryAmbientProvidersEn {
+	TranslationsWebMemoryAmbientProvidersEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Summarizer providers'
+	String get title => 'Summarizer providers';
+
+	/// en: 'Add provider'
+	String get addButton => 'Add provider';
+
+	/// en: 'At least one enabled provider is required for capture to actually fire. Local options (Ollama, LM Studio, Integration) keep your transcripts off external networks.'
+	String get intro => 'At least one enabled provider is required for capture to actually fire. Local options (Ollama, LM Studio, Integration) keep your transcripts off external networks.';
+
+	/// en: 'No providers configured yet.'
+	String get empty => 'No providers configured yet.';
+
+	late final TranslationsWebMemoryAmbientProvidersRowEn row = TranslationsWebMemoryAmbientProvidersRowEn.internal(_root);
+	late final TranslationsWebMemoryAmbientProvidersDialogEn dialog = TranslationsWebMemoryAmbientProvidersDialogEn.internal(_root);
+}
+
+// Path: web.memoryAmbient.rules
+class TranslationsWebMemoryAmbientRulesEn {
+	TranslationsWebMemoryAmbientRulesEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Capture rules'
+	String get title => 'Capture rules';
+
+	/// en: 'Add rule'
+	String get addButton => 'Add rule';
+
+	/// en: 'Each rule says "when this trigger fires, summarize new transcript messages and store the durable facts." Per-session rules override the global default. v1 ships 4 trigger kinds.'
+	String get intro => 'Each rule says "when this trigger fires, summarize new transcript messages and store the durable facts." Per-session rules override the global default. v1 ships 4 trigger kinds.';
+
+	/// en: 'No capture rules yet. Add one to enable auto-capture.'
+	String get empty => 'No capture rules yet. Add one to enable auto-capture.';
+
+	late final TranslationsWebMemoryAmbientRulesRowEn row = TranslationsWebMemoryAmbientRulesRowEn.internal(_root);
+	late final TranslationsWebMemoryAmbientRulesDialogEn dialog = TranslationsWebMemoryAmbientRulesDialogEn.internal(_root);
+}
+
+// Path: web.memoryAmbient.profiles
+class TranslationsWebMemoryAmbientProfilesEn {
+	TranslationsWebMemoryAmbientProfilesEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Injection profiles'
+	String get title => 'Injection profiles';
+
+	/// en: 'Add profile'
+	String get addButton => 'Add profile';
+
+	/// en: 'At spawn time opendray prepends a markdown banner of recent project memories to the agent's system prompt — IF a profile is configured. Without a profile, the model still uses memory_search on demand.'
+	String get intro => 'At spawn time opendray prepends a markdown banner of recent project memories to the agent\'s system prompt — IF a profile is configured. Without a profile, the model still uses memory_search on demand.';
+
+	/// en: 'No injection profile. Memories are not auto-injected at spawn — model still uses memory_search.'
+	String get empty => 'No injection profile. Memories are not auto-injected at spawn — model still uses memory_search.';
+
+	late final TranslationsWebMemoryAmbientProfilesRowEn row = TranslationsWebMemoryAmbientProfilesRowEn.internal(_root);
+	late final TranslationsWebMemoryAmbientProfilesDialogEn dialog = TranslationsWebMemoryAmbientProfilesDialogEn.internal(_root);
+}
+
+// Path: web.memoryAmbient.cost
+class TranslationsWebMemoryAmbientCostEn {
+	TranslationsWebMemoryAmbientCostEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Token cost (all-time)'
+	String get title => 'Token cost (all-time)';
+
+	/// en: 'Per-provider summary aggregated from <1>memory_summarizer_calls</1>. Local providers (Ollama, LM Studio, Integration) are priced as $0 — operator owns hardware cost.'
+	String get intro => 'Per-provider summary aggregated from <1>memory_summarizer_calls</1>. Local providers (Ollama, LM Studio, Integration) are priced as \$0 — operator owns hardware cost.';
+
+	/// en: 'No enabled providers — no cost data.'
+	String get empty => 'No enabled providers — no cost data.';
+
+	late final TranslationsWebMemoryAmbientCostColumnsEn columns = TranslationsWebMemoryAmbientCostColumnsEn.internal(_root);
+}
+
+// Path: web.noteEditor.status
+class TranslationsWebNoteEditorStatusEn {
+	TranslationsWebNoteEditorStatusEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'save failed'
+	String get saveFailed => 'save failed';
+
+	/// en: 'saving…'
+	String get saving => 'saving…';
+
+	/// en: 'unsaved'
+	String get unsaved => 'unsaved';
+
+	/// en: 'new note'
+	String get newNote => 'new note';
+
+	/// en: 'saved'
+	String get saved => 'saved';
+}
+
+// Path: web.export.sections
+class TranslationsWebExportSectionsEn {
+	TranslationsWebExportSectionsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Export'
+	String get export => 'Export';
+
+	/// en: 'Import'
+	String get import => 'Import';
+}
+
+// Path: web.export.form
+class TranslationsWebExportFormEn {
+	TranslationsWebExportFormEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Scope'
+	String get scope => 'Scope';
+
+	/// en: 'Memories'
+	String get memories => 'Memories';
+
+	/// en: 'Cross-CLI persistent memory rows (text + scope + metadata). Embedding vectors are omitted; importer re-embeds.'
+	String get memoriesHint => 'Cross-CLI persistent memory rows (text + scope + metadata). Embedding vectors are omitted; importer re-embeds.';
+
+	/// en: 'Integrations'
+	String get integrations => 'Integrations';
+
+	/// en: 'Custom tasks'
+	String get customTasks => 'Custom tasks';
+
+	/// en: 'Operator-defined tasks shown in the Inspector's Tasks tab.'
+	String get customTasksHint => 'Operator-defined tasks shown in the Inspector\'s Tasks tab.';
+
+	late final TranslationsWebExportFormIntegrationOptionsEn integrationOptions = TranslationsWebExportFormIntegrationOptionsEn.internal(_root);
+
+	/// en: 'Type <1>I understand</1> to confirm. opendray currently stores only bcrypt hashes — selecting plaintext does NOT export any plaintext (the feature is reserved for a future release that keeps plaintext caches).'
+	String get confirmWarning => 'Type <1>I understand</1> to confirm. opendray currently stores only bcrypt hashes — selecting plaintext does NOT export any plaintext (the feature is reserved for a future release that keeps plaintext caches).';
+
+	/// en: 'I understand'
+	String get confirmPlaceholder => 'I understand';
+
+	/// en: 'i understand'
+	String get confirmSentinel => 'i understand';
+
+	/// en: 'Audit logs and session transcripts are out of scope — covered by /backups (operator dump) instead.'
+	String get footnote => 'Audit logs and session transcripts are out of scope — covered by /backups (operator dump) instead.';
+
+	/// en: 'Building…'
+	String get building => 'Building…';
+
+	/// en: 'Create export'
+	String get create => 'Create export';
+
+	/// en: 'Export ready'
+	String get readyToast => 'Export ready';
+
+	/// en: '{bytes} bytes'
+	String readyDescription({required Object bytes}) => '${bytes} bytes';
+
+	/// en: 'Export failed'
+	String get failedToast => 'Export failed';
+}
+
+// Path: web.export.history
+class TranslationsWebExportHistoryEn {
+	TranslationsWebExportHistoryEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'No exports yet. Use the form above to create one.'
+	String get empty => 'No exports yet. Use the form above to create one.';
+
+	/// en: 'History'
+	String get title => 'History';
+
+	late final TranslationsWebExportHistoryColumnsEn columns = TranslationsWebExportHistoryColumnsEn.internal(_root);
+
+	/// en: 'Download'
+	String get download => 'Download';
+
+	/// en: 'Delete'
+	String get deleteTooltip => 'Delete';
+
+	/// en: 'Failed to list exports'
+	String get listFailedToast => 'Failed to list exports';
+
+	/// en: 'Download failed'
+	String get downloadFailedToast => 'Download failed';
+
+	/// en: 'No download token (expired?)'
+	String get noTokenToast => 'No download token (expired?)';
+
+	/// en: 'Delete export {id}?'
+	String deleteConfirm({required Object id}) => 'Delete export ${id}?';
+
+	/// en: 'Export deleted'
+	String get deletedToast => 'Export deleted';
+
+	/// en: 'Delete failed'
+	String get deleteFailedToast => 'Delete failed';
+
+	/// en: '(empty)'
+	String get scopeEmpty => '(empty)';
+}
+
+// Path: web.export.import
+class TranslationsWebExportImportEn {
+	TranslationsWebExportImportEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Replay an export bundle (zip) into the live database. Conflicts (matching id, or unique route_prefix for integrations) are <1>skipped</1> by default. Memories are tagged <3>embedder=imported_v1</3> and need a re-embed pass before search returns them; trigger re-embed under <5>Memory → Maintenance</5>. Integrations are imported with <7>enabled=false</7> and a non-bcrypt placeholder key — operator must rotate before use.'
+	String get intro => 'Replay an export bundle (zip) into the live database. Conflicts (matching id, or unique route_prefix for integrations) are <1>skipped</1> by default. Memories are tagged <3>embedder=imported_v1</3> and need a re-embed pass before search returns them; trigger re-embed under <5>Memory → Maintenance</5>. Integrations are imported with <7>enabled=false</7> and a non-bcrypt placeholder key — operator must rotate before use.';
+
+	/// en: 'Memory → Maintenance'
+	String get memoryLink => 'Memory → Maintenance';
+
+	/// en: 'Bundle (.zip)'
+	String get bundleLabel => 'Bundle (.zip)';
+
+	/// en: 'Memories'
+	String get memoriesLabel => 'Memories';
+
+	/// en: 'Integrations (metadata only — keys never imported)'
+	String get integrationsLabel => 'Integrations (metadata only — keys never imported)';
+
+	/// en: 'Custom tasks'
+	String get customTasksLabel => 'Custom tasks';
+
+	/// en: 'Importing…'
+	String get importing => 'Importing…';
+
+	/// en: 'Import bundle'
+	String get importBundle => 'Import bundle';
+
+	/// en: 'Pick a bundle file first'
+	String get pickFileToast => 'Pick a bundle file first';
+
+	/// en: 'Import done'
+	String get doneToast => 'Import done';
+
+	/// en: 'Import finished with errors'
+	String get finishedWithErrors => 'Import finished with errors';
+
+	/// en: 'Import failed'
+	String get failedToast => 'Import failed';
+
+	late final TranslationsWebExportImportSummaryCardEn summaryCard = TranslationsWebExportImportSummaryCardEn.internal(_root);
+}
+
+// Path: web.export.imports
+class TranslationsWebExportImportsEn {
+	TranslationsWebExportImportsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'No imports yet.'
+	String get empty => 'No imports yet.';
+
+	/// en: 'History'
+	String get title => 'History';
+
+	late final TranslationsWebExportImportsColumnsEn columns = TranslationsWebExportImportsColumnsEn.internal(_root);
+
+	/// en: '(none)'
+	String get noneCounts => '(none)';
+
+	/// en: 'Failed to list imports'
+	String get listFailedToast => 'Failed to list imports';
+}
+
 // Path: more.items.integrations
 class TranslationsMoreItemsIntegrationsEn {
 	TranslationsMoreItemsIntegrationsEn.internal(this._root);
@@ -4597,6 +9594,2586 @@ class TranslationsSettingsServerSettingsFieldsEn {
 	String get projectsJson => 'projects.json';
 }
 
+// Path: web.sessions.list.row
+class TranslationsWebSessionsListRowEn {
+	TranslationsWebSessionsListRowEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Delete session'
+	String get deleteAria => 'Delete session';
+
+	/// en: 'Remove from history'
+	String get titleRemoveHistory => 'Remove from history';
+
+	/// en: 'Terminate and remove'
+	String get titleTerminate => 'Terminate and remove';
+
+	/// en: 'Remove'
+	String get titleRemove => 'Remove';
+
+	/// en: 'Claude account: {label}'
+	String claudeAccountTitle({required Object label}) => 'Claude account: ${label}';
+}
+
+// Path: web.sessions.inspector.tabs
+class TranslationsWebSessionsInspectorTabsEn {
+	TranslationsWebSessionsInspectorTabsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Files'
+	String get files => 'Files';
+
+	/// en: 'Git'
+	String get git => 'Git';
+
+	/// en: 'Search'
+	String get search => 'Search';
+
+	/// en: 'Tasks'
+	String get tasks => 'Tasks';
+
+	/// en: 'History'
+	String get history => 'History';
+
+	/// en: 'Notes'
+	String get notes => 'Notes';
+
+	/// en: 'Memory'
+	String get memory => 'Memory';
+}
+
+// Path: web.memoryWorkers.tasks.gatekeeper
+class TranslationsWebMemoryWorkersTasksGatekeeperEn {
+	TranslationsWebMemoryWorkersTasksGatekeeperEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Gatekeeper'
+	String get label => 'Gatekeeper';
+
+	/// en: 'Pre-write filter on every memory_store. High frequency (<500ms target) — summarizer-only.'
+	String get description => 'Pre-write filter on every memory_store. High frequency (<500ms target) — summarizer-only.';
+}
+
+// Path: web.memoryWorkers.tasks.cleaner
+class TranslationsWebMemoryWorkersTasksCleanerEn {
+	TranslationsWebMemoryWorkersTasksCleanerEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Cleaner librarian'
+	String get label => 'Cleaner librarian';
+
+	/// en: 'Periodic LLM librarian. Judges aged memories as keep / stale / duplicate.'
+	String get description => 'Periodic LLM librarian. Judges aged memories as keep / stale / duplicate.';
+}
+
+// Path: web.memoryWorkers.tasks.gitactivity
+class TranslationsWebMemoryWorkersTasksGitactivityEn {
+	TranslationsWebMemoryWorkersTasksGitactivityEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Git activity summariser'
+	String get label => 'Git activity summariser';
+
+	/// en: 'git log → 2-3 paragraph narrative every 24h. Naturally fits an agent worker.'
+	String get description => 'git log → 2-3 paragraph narrative every 24h. Naturally fits an agent worker.';
+}
+
+// Path: web.memoryWorkers.tasks.transcript
+class TranslationsWebMemoryWorkersTasksTranscriptEn {
+	TranslationsWebMemoryWorkersTasksTranscriptEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Session transcript summariser'
+	String get label => 'Session transcript summariser';
+
+	/// en: 'Session-end "what did the agent do" summary. Naturally fits an agent worker.'
+	String get description => 'Session-end "what did the agent do" summary. Naturally fits an agent worker.';
+}
+
+// Path: web.project.readonly.tech_stack
+class TranslationsWebProjectReadonlyTechStackEn {
+	TranslationsWebProjectReadonlyTechStackEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Tech stack & structure'
+	String get label => 'Tech stack & structure';
+
+	/// en: 'Run a Claude session in this project — scanner refreshes on every spawn.'
+	String get empty => 'Run a Claude session in this project — scanner refreshes on every spawn.';
+}
+
+// Path: web.project.readonly.recent_activity
+class TranslationsWebProjectReadonlyRecentActivityEn {
+	TranslationsWebProjectReadonlyRecentActivityEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Recent activity (git → LLM)'
+	String get label => 'Recent activity (git → LLM)';
+
+	/// en: 'The git activity summariser runs every 24h; check back after the next scheduler tick.'
+	String get empty => 'The git activity summariser runs every 24h; check back after the next scheduler tick.';
+}
+
+// Path: web.project.reset.summary
+class TranslationsWebProjectResetSummaryEn {
+	TranslationsWebProjectResetSummaryEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: '{count} doc'
+	String docs_one({required Object count}) => '${count} doc';
+
+	/// en: '{count} docs'
+	String docs_other({required Object count}) => '${count} docs';
+
+	/// en: '{count} journal'
+	String journal({required Object count}) => '${count} journal';
+
+	/// en: '{count} proposal'
+	String proposals_one({required Object count}) => '${count} proposal';
+
+	/// en: '{count} proposals'
+	String proposals_other({required Object count}) => '${count} proposals';
+
+	/// en: '{count} cleanup'
+	String cleanup({required Object count}) => '${count} cleanup';
+
+	/// en: '{count} memories'
+	String memories({required Object count}) => '${count} memories';
+}
+
+// Path: web.memoryInspector.scope.values
+class TranslationsWebMemoryInspectorScopeValuesEn {
+	TranslationsWebMemoryInspectorScopeValuesEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'project'
+	String get project => 'project';
+
+	/// en: 'session'
+	String get session => 'session';
+
+	/// en: 'global'
+	String get global => 'global';
+}
+
+// Path: web.notes.vaultSync.init
+class TranslationsWebNotesVaultSyncInitEn {
+	TranslationsWebNotesVaultSyncInitEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Vault is not a git repo yet'
+	String get title => 'Vault is not a git repo yet';
+
+	/// en: 'Initialising will run <1>git init -b main</1> in your vault root and add a sane <3>.gitignore</3>. After that you can commit your notes and configure a remote (GitHub / Gitea / GitLab) for cross-machine sync.'
+	String get body => 'Initialising will run <1>git init -b main</1> in your vault root and add a sane <3>.gitignore</3>. After that you can commit your notes and configure a remote (GitHub / Gitea / GitLab) for cross-machine sync.';
+
+	/// en: 'Initialise vault as git repo'
+	String get button => 'Initialise vault as git repo';
+
+	/// en: 'Vault initialised as git repo'
+	String get initToast => 'Vault initialised as git repo';
+
+	/// en: 'Init failed'
+	String get initFailedToast => 'Init failed';
+}
+
+// Path: web.notes.vaultSync.branch
+class TranslationsWebNotesVaultSyncBranchEn {
+	TranslationsWebNotesVaultSyncBranchEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'clean'
+	String get clean => 'clean';
+
+	/// en: '{count} staged'
+	String staged({required Object count}) => '${count} staged';
+
+	/// en: '{count} modified'
+	String modified({required Object count}) => '${count} modified';
+
+	/// en: '{count} untracked'
+	String untracked({required Object count}) => '${count} untracked';
+}
+
+// Path: web.notes.vaultSync.action
+class TranslationsWebNotesVaultSyncActionEn {
+	TranslationsWebNotesVaultSyncActionEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Pull'
+	String get pull => 'Pull';
+
+	/// en: 'Push'
+	String get push => 'Push';
+
+	/// en: 'Configure a remote first'
+	String get pullTitleNoRemote => 'Configure a remote first';
+
+	/// en: 'git pull --rebase --autostash'
+	String get pullTitleHasUpstream => 'git pull --rebase --autostash';
+
+	/// en: 'Pulls origin's HEAD; sets up tracking implicitly'
+	String get pullTitleNoUpstream => 'Pulls origin\'s HEAD; sets up tracking implicitly';
+
+	/// en: 'Configure a remote first'
+	String get pushTitleNoRemote => 'Configure a remote first';
+
+	/// en: 'git push -u origin HEAD'
+	String get pushTitleHasUpstream => 'git push -u origin HEAD';
+
+	/// en: 'First push — will set upstream to origin/HEAD'
+	String get pushTitleNoUpstream => 'First push — will set upstream to origin/HEAD';
+
+	/// en: 'No remote configured — pull/push disabled'
+	String get noRemote => 'No remote configured — pull/push disabled';
+
+	/// en: 'No upstream tracking yet — first push will set it.'
+	String get noUpstream => 'No upstream tracking yet — first push will set it.';
+
+	/// en: 'Pulled'
+	String get pulledToast => 'Pulled';
+
+	/// en: 'Pull failed'
+	String get pullFailedToast => 'Pull failed';
+
+	/// en: 'Pushed'
+	String get pushedToast => 'Pushed';
+
+	/// en: 'Push failed'
+	String get pushFailedToast => 'Push failed';
+}
+
+// Path: web.notes.vaultSync.commit
+class TranslationsWebNotesVaultSyncCommitEn {
+	TranslationsWebNotesVaultSyncCommitEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Commit'
+	String get title => 'Commit';
+
+	/// en: 'Notes: {date} (default)'
+	String placeholder({required Object date}) => 'Notes: ${date} (default)';
+
+	/// en: 'Commit all'
+	String get commitAll => 'Commit all';
+
+	/// en: 'Stages every change (<1>git add .</1>) then commits with this message. Empty message defaults to a timestamped subject.'
+	String get hint => 'Stages every change (<1>git add .</1>) then commits with this message. Empty message defaults to a timestamped subject.';
+
+	/// en: 'Committed {hash}'
+	String committedToast({required Object hash}) => 'Committed ${hash}';
+
+	/// en: 'Commit failed'
+	String get commitFailedToast => 'Commit failed';
+}
+
+// Path: web.notes.vaultSync.fileList
+class TranslationsWebNotesVaultSyncFileListEn {
+	TranslationsWebNotesVaultSyncFileListEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Working tree · {count}'
+	String title({required Object count}) => 'Working tree · ${count}';
+
+	/// en: '+{count} more'
+	String moreSuffix({required Object count}) => '+${count} more';
+}
+
+// Path: web.notes.vaultSync.remote
+class TranslationsWebNotesVaultSyncRemoteEn {
+	TranslationsWebNotesVaultSyncRemoteEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Remote (origin)'
+	String get title => 'Remote (origin)';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Change'
+	String get change => 'Change';
+
+	/// en: 'Configure'
+	String get configure => 'Configure';
+
+	/// en: 'No remote set. Add an HTTPS or SSH URL (e.g. <1>git@github.com:you/notes.git</1> or <3>https://tea.linivek.online/you/notes.git</3>) to enable push / pull.'
+	String get empty => 'No remote set. Add an HTTPS or SSH URL (e.g. <1>git@github.com:you/notes.git</1> or <3>https://tea.linivek.online/you/notes.git</3>) to enable push / pull.';
+
+	/// en: 'URL (HTTPS or SSH)'
+	String get urlLabel => 'URL (HTTPS or SSH)';
+
+	/// en: 'git@host:owner/notes.git'
+	String get urlPlaceholder => 'git@host:owner/notes.git';
+
+	/// en: 'Save'
+	String get save => 'Save';
+
+	/// en: 'Remote saved'
+	String get savedToast => 'Remote saved';
+
+	/// en: 'Set remote failed'
+	String get saveFailedToast => 'Set remote failed';
+}
+
+// Path: web.notes.vaultSync.history
+class TranslationsWebNotesVaultSyncHistoryEn {
+	TranslationsWebNotesVaultSyncHistoryEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Recent commits'
+	String get title => 'Recent commits';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'No commits yet.'
+	String get empty => 'No commits yet.';
+}
+
+// Path: web.notes.vaultSync.conflict
+class TranslationsWebNotesVaultSyncConflictEn {
+	TranslationsWebNotesVaultSyncConflictEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsWebNotesVaultSyncConflictKindsEn kinds = TranslationsWebNotesVaultSyncConflictKindsEn.internal(_root);
+
+	/// en: 'Vault has a paused {kind} with unresolved conflicts'
+	String headline({required Object kind}) => 'Vault has a paused ${kind} with unresolved conflicts';
+
+	/// en: 'Pull, push and commit are blocked until the {kind} finishes. You can either <1>abort</1> (restore the working tree to its state before the {kind} — keeps your local commits, drops the remote ones) or <3>force reset to remote</3> (discard ALL local commits + uncommitted changes; vault becomes an exact mirror of origin).'
+	String explainer({required Object kind}) => 'Pull, push and commit are blocked until the ${kind} finishes. You can either <1>abort</1> (restore the working tree to its state before the ${kind} — keeps your local commits, drops the remote ones) or <3>force reset to remote</3> (discard ALL local commits + uncommitted changes; vault becomes an exact mirror of origin).';
+
+	/// en: 'Conflicted files · {count}'
+	String conflictedHeader({required Object count}) => 'Conflicted files · ${count}';
+
+	/// en: 'Abort {kind}'
+	String abort({required Object kind}) => 'Abort ${kind}';
+
+	/// en: 'git {kind} --abort'
+	String abortTitle({required Object kind}) => 'git ${kind} --abort';
+
+	/// en: 'Force reset to remote'
+	String get forceReset => 'Force reset to remote';
+
+	/// en: 'git fetch && git reset --hard origin/<branch> && git clean -fd'
+	String get forceResetTitle => 'git fetch && git reset --hard origin/<branch> && git clean -fd';
+
+	/// en: 'DESTRUCTIVE: this will • abort the in-progress {kind} • run git fetch origin • reset --hard to origin/<branch> • clean -fd (drop untracked files) Any local commits not pushed to origin AND any uncommitted edits will be PERMANENTLY LOST. Continue?'
+	String forceResetConfirm({required Object kind}) => 'DESTRUCTIVE: this will\n  • abort the in-progress ${kind}\n  • run git fetch origin\n  • reset --hard to origin/<branch>\n  • clean -fd (drop untracked files)\n\nAny local commits not pushed to origin AND any uncommitted edits will be PERMANENTLY LOST.\n\nContinue?';
+
+	/// en: 'Aborted {kind}'
+	String abortedToast({required Object kind}) => 'Aborted ${kind}';
+
+	/// en: 'Working tree restored to pre-operation state.'
+	String get abortedDescription => 'Working tree restored to pre-operation state.';
+
+	/// en: 'Abort failed'
+	String get abortFailedToast => 'Abort failed';
+
+	/// en: 'Reset to {branch}'
+	String resetToast({required Object branch}) => 'Reset to ${branch}';
+
+	/// en: 'Local changes discarded; vault matches remote.'
+	String get resetDescription => 'Local changes discarded; vault matches remote.';
+
+	/// en: 'Reset failed'
+	String get resetFailedToast => 'Reset failed';
+}
+
+// Path: web.notes.vaultSync.auth
+class TranslationsWebNotesVaultSyncAuthEn {
+	TranslationsWebNotesVaultSyncAuthEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Authentication'
+	String get title => 'Authentication';
+
+	/// en: 'Will use the token stored for <1>{host}</1> in Plugins → Git hosts. ✓'
+	String httpsTokenOk({required Object host}) => 'Will use the token stored for <1>${host}</1> in Plugins → Git hosts. ✓';
+
+	/// en: 'HTTPS remote on <1>{host}</1> with no opendray token configured. Push / pull will likely fail for private repos until you add one.'
+	String httpsTokenMissing({required Object host}) => 'HTTPS remote on <1>${host}</1> with no opendray token configured. Push / pull will likely fail for private repos until you add one.';
+
+	/// en: 'SSH remote on <1>{host}</1>. Auth uses the gateway host's <3>~/.ssh/</3> (ssh-agent, identity file, host config). Verify with <5>ssh -T git@{host}</5> from the host shell.'
+	String ssh({required Object host}) => 'SSH remote on <1>${host}</1>. Auth uses the gateway host\'s <3>~/.ssh/</3> (ssh-agent, identity file, host config). Verify with <5>ssh -T git@${host}</5> from the host shell.';
+
+	/// en: '→ Configure git host token'
+	String get configureTokenLink => '→ Configure git host token';
+}
+
+// Path: web.notes.vaultSync.autoSync
+class TranslationsWebNotesVaultSyncAutoSyncEn {
+	TranslationsWebNotesVaultSyncAutoSyncEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Loading auto-sync settings…'
+	String get loading => 'Loading auto-sync settings…';
+
+	/// en: 'Auto-sync'
+	String get title => 'Auto-sync';
+
+	/// en: 'on'
+	String get on => 'on';
+
+	/// en: 'Run now'
+	String get runNow => 'Run now';
+
+	/// en: 'Wake the sync loop now (skips the wait, then runs whichever steps are due)'
+	String get runNowTooltip => 'Wake the sync loop now (skips the wait, then runs whichever steps are due)';
+
+	/// en: 'Configure'
+	String get configure => 'Configure';
+
+	/// en: 'Hide'
+	String get hide => 'Hide';
+
+	/// en: 'Enabled'
+	String get enabled => 'Enabled';
+
+	/// en: 'Configure a remote first to enable auto-sync'
+	String get enabledTooltipNoRemote => 'Configure a remote first to enable auto-sync';
+
+	/// en: 'No remote — push/pull will be skipped.'
+	String get noRemoteHint => 'No remote — push/pull will be skipped.';
+
+	/// en: 'Commit every'
+	String get commitEvery => 'Commit every';
+
+	/// en: 'Examples: <1>30s</1>, <3>10m</3>, <5>2h</5>. Min 30s.'
+	String get commitEveryExamples => 'Examples: <1>30s</1>, <3>10m</3>, <5>2h</5>. Min 30s.';
+
+	/// en: 'Pull every'
+	String get pullEvery => 'Pull every';
+
+	/// en: 'Only used when Pull is enabled.'
+	String get pullEveryHint => 'Only used when Pull is enabled.';
+
+	/// en: 'Push after commit'
+	String get pushAfterCommit => 'Push after commit';
+
+	/// en: 'Pull periodically'
+	String get pullPeriodically => 'Pull periodically';
+
+	/// en: 'Commit message template'
+	String get commitTemplateLabel => 'Commit message template';
+
+	/// en: 'Auto-sync: {date} (default if empty)'
+	String commitTemplatePlaceholder({required Object date}) => 'Auto-sync: ${date}  (default if empty)';
+
+	/// en: 'Save settings'
+	String get saveSettings => 'Save settings';
+
+	/// en: 'Discard'
+	String get discard => 'Discard';
+
+	/// en: 'last commit'
+	String get lastCommit => 'last commit';
+
+	/// en: 'last push'
+	String get lastPush => 'last push';
+
+	/// en: 'last pull'
+	String get lastPull => 'last pull';
+
+	/// en: 'never'
+	String get never => 'never';
+
+	/// en: 'Auto-sync settings saved'
+	String get savedToast => 'Auto-sync settings saved';
+
+	/// en: 'Save failed'
+	String get saveFailedToast => 'Save failed';
+
+	/// en: 'Auto-sync triggered'
+	String get triggeredToast => 'Auto-sync triggered';
+
+	/// en: 'Run failed'
+	String get runFailedToast => 'Run failed';
+}
+
+// Path: web.providers.detail.caps
+class TranslationsWebProvidersDetailCapsEn {
+	TranslationsWebProvidersDetailCapsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'resume'
+	String get resume => 'resume';
+
+	/// en: 'stream'
+	String get stream => 'stream';
+
+	/// en: 'images'
+	String get images => 'images';
+
+	/// en: 'mcp'
+	String get mcp => 'mcp';
+}
+
+// Path: web.channels.notifications.modes
+class TranslationsWebChannelsNotificationsModesEn {
+	TranslationsWebChannelsNotificationsModesEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Once per session (recommended)'
+	String get onceLabel => 'Once per session (recommended)';
+
+	/// en: 'Fire once when a session goes idle, then stay silent until either the session ends or you reply via this channel.'
+	String get onceHint => 'Fire once when a session goes idle, then stay silent until either the session ends or you reply via this channel.';
+
+	/// en: 'Time-window cooldown'
+	String get cooldownLabel => 'Time-window cooldown';
+
+	/// en: 'Suppress repeats for the same (session, event) within the chosen window.'
+	String get cooldownHint => 'Suppress repeats for the same (session, event) within the chosen window.';
+
+	/// en: 'Every event (noisy)'
+	String get everyLabel => 'Every event (noisy)';
+
+	/// en: 'No suppression. Use only for low-frequency channels.'
+	String get everyHint => 'No suppression. Use only for low-frequency channels.';
+}
+
+// Path: web.channels.notifications.cooldowns
+class TranslationsWebChannelsNotificationsCooldownsEn {
+	TranslationsWebChannelsNotificationsCooldownsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: '1 minute'
+	String get k60 => '1 minute';
+
+	/// en: '5 minutes'
+	String get k300 => '5 minutes';
+
+	/// en: '15 minutes'
+	String get k900 => '15 minutes';
+
+	/// en: '30 minutes'
+	String get k1800 => '30 minutes';
+
+	/// en: '1 hour'
+	String get k3600 => '1 hour';
+}
+
+// Path: web.channels.notifications.snippetCaps
+class TranslationsWebChannelsNotificationsSnippetCapsEn {
+	TranslationsWebChannelsNotificationsSnippetCapsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'No cap — chunk into multiple messages (default)'
+	String get k0 => 'No cap — chunk into multiple messages (default)';
+
+	/// en: '1000 chars (terse)'
+	String get k1000 => '1000 chars (terse)';
+
+	/// en: '3000 chars'
+	String get k3000 => '3000 chars';
+
+	/// en: '6000 chars'
+	String get k6000 => '6000 chars';
+
+	/// en: '12000 chars'
+	String get k12000 => '12000 chars';
+}
+
+// Path: web.plugins.mcp.columns
+class TranslationsWebPluginsMcpColumnsEn {
+	TranslationsWebPluginsMcpColumnsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Name'
+	String get name => 'Name';
+
+	/// en: 'Transport'
+	String get transport => 'Transport';
+
+	/// en: 'Spec'
+	String get spec => 'Spec';
+
+	/// en: 'Enabled'
+	String get enabled => 'Enabled';
+}
+
+// Path: web.plugins.mcp.editor
+class TranslationsWebPluginsMcpEditorEn {
+	TranslationsWebPluginsMcpEditorEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'New MCP server'
+	String get createTitle => 'New MCP server';
+
+	/// en: 'Edit MCP: {id}'
+	String editTitle({required Object id}) => 'Edit MCP: ${id}';
+
+	/// en: 'JSON shape: <1>command</1>+<3>args</3>+<5>env</5> for stdio (default), or <7>transport</7> +<9> url</9>+<11>headers</11> for sse / http. Reference secrets as <13>${API_KEY}</13> — they get substituted at spawn time from the secrets file.'
+	String description({required Object API_KEY}) => 'JSON shape: <1>command</1>+<3>args</3>+<5>env</5> for stdio (default), or <7>transport</7> +<9> url</9>+<11>headers</11> for sse / http. Reference secrets as <13>\$${API_KEY}</13> — they get substituted at spawn time from the secrets file.';
+
+	/// en: 'ID'
+	String get idLabel => 'ID';
+
+	/// en: 'filesystem'
+	String get idPlaceholder => 'filesystem';
+
+	/// en: 'Lowercase / digits / dash / underscore. Becomes both the directory name and the default <1>name</1>.'
+	String get idHint => 'Lowercase / digits / dash / underscore. Becomes both the directory name and the default <1>name</1>.';
+
+	/// en: 'mcp.json'
+	String get bodyLabel => 'mcp.json';
+
+	/// en: 'Invalid JSON: {error}'
+	String invalidJson({required Object error}) => 'Invalid JSON: ${error}';
+
+	/// en: 'MCP server created'
+	String get createdToast => 'MCP server created';
+
+	/// en: 'MCP server saved'
+	String get savedToast => 'MCP server saved';
+
+	/// en: 'Create failed'
+	String get createFailedToast => 'Create failed';
+
+	/// en: 'Save failed'
+	String get saveFailedToast => 'Save failed';
+}
+
+// Path: web.plugins.mcpSecrets.columns
+class TranslationsWebPluginsMcpSecretsColumnsEn {
+	TranslationsWebPluginsMcpSecretsColumnsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Key'
+	String get key => 'Key';
+
+	/// en: 'Value'
+	String get value => 'Value';
+}
+
+// Path: web.plugins.mcpSecrets.editor
+class TranslationsWebPluginsMcpSecretsEditorEn {
+	TranslationsWebPluginsMcpSecretsEditorEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Add secret'
+	String get addTitle => 'Add secret';
+
+	/// en: 'Update {key}'
+	String updateTitle({required Object key}) => 'Update ${key}';
+
+	/// en: 'Stored encrypted on disk if the OS keychain is available. Reference it from any mcp.json env / headers / args / url with ${KEY}.'
+	String addDescription({required Object KEY}) => 'Stored encrypted on disk if the OS keychain is available. Reference it from any mcp.json env / headers / args / url with \$${KEY}.';
+
+	/// en: 'Enter the new value to overwrite. The previous value cannot be recovered.'
+	String get editDescription => 'Enter the new value to overwrite. The previous value cannot be recovered.';
+
+	/// en: 'Key'
+	String get keyLabel => 'Key';
+
+	/// en: 'BRAVE_API_KEY'
+	String get keyPlaceholder => 'BRAVE_API_KEY';
+
+	/// en: 'Must match <1>[A-Za-z_][A-Za-z0-9_]*</1>'
+	String get keyPattern => 'Must match <1>[A-Za-z_][A-Za-z0-9_]*</1>';
+
+	/// en: 'Already exists — use Edit instead, or pick a different name.'
+	String get keyCollision => 'Already exists — use Edit instead, or pick a different name.';
+
+	/// en: 'Value'
+	String get valueLabel => 'Value';
+
+	/// en: 'Hidden as you type. Saved value is never returned over the API.'
+	String get valueHint => 'Hidden as you type. Saved value is never returned over the API.';
+
+	/// en: 'Secret added'
+	String get addedToast => 'Secret added';
+
+	/// en: 'Secret updated'
+	String get updatedToast => 'Secret updated';
+
+	/// en: 'Save failed'
+	String get saveFailedToast => 'Save failed';
+}
+
+// Path: web.plugins.skills.columns
+class TranslationsWebPluginsSkillsColumnsEn {
+	TranslationsWebPluginsSkillsColumnsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'ID'
+	String get id => 'ID';
+
+	/// en: 'Description'
+	String get description => 'Description';
+
+	/// en: 'Source'
+	String get source => 'Source';
+}
+
+// Path: web.plugins.skills.editor
+class TranslationsWebPluginsSkillsEditorEn {
+	TranslationsWebPluginsSkillsEditorEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'New skill'
+	String get createTitle => 'New skill';
+
+	/// en: 'Customize built-in: {id}'
+	String customizeTitle({required Object id}) => 'Customize built-in: ${id}';
+
+	/// en: 'Edit skill: {id}'
+	String editTitle({required Object id}) => 'Edit skill: ${id}';
+
+	/// en: 'You're viewing a built-in skill embedded in opendray. Saving will create a vault override at the same id — your edits live under ~/.opendray/vault/skills/<id>/SKILL.md and shadow the built-in until you Reset.'
+	String get customizeDescription => 'You\'re viewing a built-in skill embedded in opendray. Saving will create a vault override at the same id — your edits live under ~/.opendray/vault/skills/<id>/SKILL.md and shadow the built-in until you Reset.';
+
+	/// en: 'SKILL.md format — frontmatter with name + description, then markdown instructions. The description appears in the agent's Tier 1 index.'
+	String get editDescription => 'SKILL.md format — frontmatter with name + description, then markdown instructions. The description appears in the agent\'s Tier 1 index.';
+
+	/// en: 'ID'
+	String get idLabel => 'ID';
+
+	/// en: 'my-helper'
+	String get idPlaceholder => 'my-helper';
+
+	/// en: 'Lowercase / digits / dash / underscore. Becomes the directory name under <1>~/.opendray/vault/skills/&lt;id&gt;/</1>.'
+	String get idHint => 'Lowercase / digits / dash / underscore. Becomes the directory name under <1>~/.opendray/vault/skills/&lt;id&gt;/</1>.';
+
+	/// en: 'SKILL.md'
+	String get bodyLabel => 'SKILL.md';
+
+	/// en: 'Skill created'
+	String get createdToast => 'Skill created';
+
+	/// en: 'Skill saved'
+	String get savedToast => 'Skill saved';
+
+	/// en: 'Saved as vault override'
+	String get savedOverrideToast => 'Saved as vault override';
+
+	/// en: 'Create failed'
+	String get createFailedToast => 'Create failed';
+
+	/// en: 'Save failed'
+	String get saveFailedToast => 'Save failed';
+
+	/// en: 'Save as vault override'
+	String get saveAsOverride => 'Save as vault override';
+}
+
+// Path: web.plugins.customTasks.columns
+class TranslationsWebPluginsCustomTasksColumnsEn {
+	TranslationsWebPluginsCustomTasksColumnsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Name'
+	String get name => 'Name';
+
+	/// en: 'Command'
+	String get command => 'Command';
+
+	/// en: 'Scope'
+	String get scope => 'Scope';
+}
+
+// Path: web.plugins.customTasks.dialog
+class TranslationsWebPluginsCustomTasksDialogEn {
+	TranslationsWebPluginsCustomTasksDialogEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Add custom task'
+	String get addTitle => 'Add custom task';
+
+	/// en: 'Edit {name}'
+	String editTitle({required Object name}) => 'Edit ${name}';
+
+	/// en: 'The command is sent verbatim into the session's terminal. Same as typing it at the prompt and pressing Enter.'
+	String get description => 'The command is sent verbatim into the session\'s terminal. Same as typing it at the prompt and pressing Enter.';
+
+	/// en: 'Name'
+	String get nameLabel => 'Name';
+
+	/// en: 'dev'
+	String get namePlaceholder => 'dev';
+
+	/// en: 'Command'
+	String get commandLabel => 'Command';
+
+	/// en: 'docker compose up --build'
+	String get commandPlaceholder => 'docker compose up --build';
+
+	/// en: 'Description (optional)'
+	String get descLabel => 'Description (optional)';
+
+	/// en: 'Boots dev infra and tails logs'
+	String get descPlaceholder => 'Boots dev infra and tails logs';
+
+	/// en: 'Cwd scope (optional)'
+	String get cwdLabel => 'Cwd scope (optional)';
+
+	/// en: '/Users/me/projects/foo (blank = global)'
+	String get cwdPlaceholder => '/Users/me/projects/foo  (blank = global)';
+
+	/// en: 'Blank = visible in every session. Otherwise the task only shows when the session's cwd matches this absolute path.'
+	String get cwdHint => 'Blank = visible in every session. Otherwise the task only shows when the session\'s cwd matches this absolute path.';
+
+	/// en: 'Task added'
+	String get addedToast => 'Task added';
+
+	/// en: 'Task updated'
+	String get updatedToast => 'Task updated';
+
+	/// en: 'Add failed'
+	String get addFailedToast => 'Add failed';
+
+	/// en: 'Update failed'
+	String get updateFailedToast => 'Update failed';
+}
+
+// Path: web.plugins.gitHosts.columns
+class TranslationsWebPluginsGitHostsColumnsEn {
+	TranslationsWebPluginsGitHostsColumnsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Host'
+	String get host => 'Host';
+
+	/// en: 'Kind'
+	String get kind => 'Kind';
+
+	/// en: 'Token'
+	String get token => 'Token';
+
+	/// en: 'Enabled'
+	String get enabled => 'Enabled';
+}
+
+// Path: web.plugins.gitHosts.dialog
+class TranslationsWebPluginsGitHostsDialogEn {
+	TranslationsWebPluginsGitHostsDialogEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Add git host'
+	String get addTitle => 'Add git host';
+
+	/// en: 'Edit {host}'
+	String editTitle({required Object host}) => 'Edit ${host}';
+
+	/// en: 'Token is stored on the gateway. Used only for read-only API calls (list PRs, etc.).'
+	String get description => 'Token is stored on the gateway. Used only for read-only API calls (list PRs, etc.).';
+
+	/// en: 'Kind'
+	String get kindLabel => 'Kind';
+
+	/// en: 'GitHub'
+	String get kindGitHub => 'GitHub';
+
+	/// en: 'Gitea'
+	String get kindGitea => 'Gitea';
+
+	/// en: 'GitLab'
+	String get kindGitLab => 'GitLab';
+
+	/// en: 'Host'
+	String get hostLabel => 'Host';
+
+	/// en: 'github.com'
+	String get hostPlaceholder => 'github.com';
+
+	/// en: 'Display name (optional)'
+	String get displayNameLabel => 'Display name (optional)';
+
+	/// en: 'Personal'
+	String get displayNamePlaceholder => 'Personal';
+
+	/// en: 'Token'
+	String get tokenLabel => 'Token';
+
+	/// en: 'New token (leave blank to keep)'
+	String get newTokenLabel => 'New token (leave blank to keep)';
+
+	/// en: 'ghp_… / gho_… / glpat-…'
+	String get tokenPlaceholder => 'ghp_… / gho_… / glpat-…';
+
+	/// en: '…'
+	String get tokenPlaceholderEdit => '…';
+
+	/// en: 'GitHub: PAT with <1>repo</1> scope. Gitea: token with <3>read:repository</3>. GitLab: PAT with <5>read_api</5>.'
+	String get tokenHint => 'GitHub: PAT with <1>repo</1> scope. Gitea: token with <3>read:repository</3>. GitLab: PAT with <5>read_api</5>.';
+
+	/// en: 'Enabled'
+	String get enabledLabel => 'Enabled';
+
+	/// en: 'Git host added'
+	String get addedToast => 'Git host added';
+
+	/// en: 'Git host updated'
+	String get updatedToast => 'Git host updated';
+
+	/// en: 'Add failed'
+	String get addFailedToast => 'Add failed';
+
+	/// en: 'Update failed'
+	String get updateFailedToast => 'Update failed';
+}
+
+// Path: web.backups.backupsTab.columns
+class TranslationsWebBackupsBackupsTabColumnsEn {
+	TranslationsWebBackupsBackupsTabColumnsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'ID'
+	String get id => 'ID';
+
+	/// en: 'Target'
+	String get target => 'Target';
+
+	/// en: 'Status'
+	String get status => 'Status';
+
+	/// en: 'Started'
+	String get started => 'Started';
+
+	/// en: 'Size'
+	String get size => 'Size';
+
+	/// en: 'Actions'
+	String get actions => 'Actions';
+}
+
+// Path: web.backups.schedulesTab.columns
+class TranslationsWebBackupsSchedulesTabColumnsEn {
+	TranslationsWebBackupsSchedulesTabColumnsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'ID'
+	String get id => 'ID';
+
+	/// en: 'Target'
+	String get target => 'Target';
+
+	/// en: 'Interval'
+	String get interval => 'Interval';
+
+	/// en: 'Keep'
+	String get keep => 'Keep';
+
+	/// en: 'Next run'
+	String get nextRun => 'Next run';
+
+	/// en: 'Enabled'
+	String get enabled => 'Enabled';
+
+	/// en: 'Actions'
+	String get actions => 'Actions';
+}
+
+// Path: web.backups.targetsTab.columns
+class TranslationsWebBackupsTargetsTabColumnsEn {
+	TranslationsWebBackupsTargetsTabColumnsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'ID'
+	String get id => 'ID';
+
+	/// en: 'Kind'
+	String get kind => 'Kind';
+
+	/// en: 'Config'
+	String get config => 'Config';
+
+	/// en: 'Enabled'
+	String get enabled => 'Enabled';
+
+	/// en: 'Actions'
+	String get actions => 'Actions';
+}
+
+// Path: web.backups.targetEditor.local
+class TranslationsWebBackupsTargetEditorLocalEn {
+	TranslationsWebBackupsTargetEditorLocalEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Root directory'
+	String get rootLabel => 'Root directory';
+
+	/// en: 'Empty = cfg.backup.local_dir (~/.opendray/backups)'
+	String get rootHint => 'Empty = cfg.backup.local_dir (~/.opendray/backups)';
+
+	/// en: '~/backups/opendray or /mnt/external-hdd/opendray'
+	String get rootPlaceholder => '~/backups/opendray  or  /mnt/external-hdd/opendray';
+}
+
+// Path: web.backups.targetEditor.smb
+class TranslationsWebBackupsTargetEditorSmbEn {
+	TranslationsWebBackupsTargetEditorSmbEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Host'
+	String get hostLabel => 'Host';
+
+	/// en: '192.168.9.8'
+	String get hostPlaceholder => '192.168.9.8';
+
+	/// en: 'Port'
+	String get portLabel => 'Port';
+
+	/// en: 'Share'
+	String get shareLabel => 'Share';
+
+	/// en: 'Top-level share name on the SMB server'
+	String get shareHint => 'Top-level share name on the SMB server';
+
+	/// en: 'Claude_Workspace'
+	String get sharePlaceholder => 'Claude_Workspace';
+
+	/// en: 'User'
+	String get userLabel => 'User';
+
+	/// en: 'Password'
+	String get passwordLabel => 'Password';
+
+	/// en: 'Path prefix'
+	String get pathPrefixLabel => 'Path prefix';
+
+	/// en: 'Sub-folder under the share root (optional)'
+	String get pathPrefixHint => 'Sub-folder under the share root (optional)';
+
+	/// en: 'opendray/backups'
+	String get pathPrefixPlaceholder => 'opendray/backups';
+}
+
+// Path: web.backups.targetEditor.s3
+class TranslationsWebBackupsTargetEditorS3En {
+	TranslationsWebBackupsTargetEditorS3En.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Endpoint'
+	String get endpointLabel => 'Endpoint';
+
+	/// en: 'Host (no protocol). AWS: s3.amazonaws.com · R2: <accountid>.r2.cloudflarestorage.com · MinIO: minio.local:9000'
+	String get endpointHint => 'Host (no protocol). AWS: s3.amazonaws.com · R2: <accountid>.r2.cloudflarestorage.com · MinIO: minio.local:9000';
+
+	/// en: 's3.amazonaws.com'
+	String get endpointPlaceholder => 's3.amazonaws.com';
+
+	/// en: 'Region'
+	String get regionLabel => 'Region';
+
+	/// en: 'AWS only; R2 use 'auto''
+	String get regionHint => 'AWS only; R2 use \'auto\'';
+
+	/// en: 'us-east-1 / auto'
+	String get regionPlaceholder => 'us-east-1 / auto';
+
+	/// en: 'Bucket'
+	String get bucketLabel => 'Bucket';
+
+	/// en: 'opendray-backups'
+	String get bucketPlaceholder => 'opendray-backups';
+
+	/// en: 'Access key'
+	String get accessKeyLabel => 'Access key';
+
+	/// en: 'Secret key'
+	String get secretKeyLabel => 'Secret key';
+
+	/// en: 'Stored AES-256-GCM encrypted; never echoed back'
+	String get secretKeyHint => 'Stored AES-256-GCM encrypted; never echoed back';
+
+	/// en: 'Path prefix'
+	String get pathPrefixLabel => 'Path prefix';
+
+	/// en: 'Object-key prefix (optional)'
+	String get pathPrefixHint => 'Object-key prefix (optional)';
+
+	/// en: 'opendray/backups'
+	String get pathPrefixPlaceholder => 'opendray/backups';
+
+	/// en: 'Use HTTPS'
+	String get useHttps => 'Use HTTPS';
+
+	/// en: 'Path-style addressing (legacy / MinIO)'
+	String get pathStyle => 'Path-style addressing (legacy / MinIO)';
+}
+
+// Path: web.backups.targetEditor.webdav
+class TranslationsWebBackupsTargetEditorWebdavEn {
+	TranslationsWebBackupsTargetEditorWebdavEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Base URL'
+	String get baseUrlLabel => 'Base URL';
+
+	/// en: 'Full URL including any path. Examples: https://cloud.example.com/remote.php/dav/files/me/ (Nextcloud), https://nas.local:5006/ (Synology), https://dav.jianguoyun.com/dav/ (Jianguoyun / 坚果云)'
+	String get baseUrlHint => 'Full URL including any path. Examples: https://cloud.example.com/remote.php/dav/files/me/ (Nextcloud), https://nas.local:5006/ (Synology), https://dav.jianguoyun.com/dav/ (Jianguoyun / 坚果云)';
+
+	/// en: 'https://cloud.example.com/remote.php/dav/files/<user>/'
+	String get baseUrlPlaceholder => 'https://cloud.example.com/remote.php/dav/files/<user>/';
+
+	/// en: 'User'
+	String get userLabel => 'User';
+
+	/// en: 'Password'
+	String get passwordLabel => 'Password';
+
+	/// en: 'Path prefix'
+	String get pathPrefixLabel => 'Path prefix';
+
+	/// en: 'Sub-folder under the base URL (optional)'
+	String get pathPrefixHint => 'Sub-folder under the base URL (optional)';
+
+	/// en: 'opendray/backups'
+	String get pathPrefixPlaceholder => 'opendray/backups';
+}
+
+// Path: web.backups.targetEditor.sftp
+class TranslationsWebBackupsTargetEditorSftpEn {
+	TranslationsWebBackupsTargetEditorSftpEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Host'
+	String get hostLabel => 'Host';
+
+	/// en: 'vps.example.com'
+	String get hostPlaceholder => 'vps.example.com';
+
+	/// en: 'Port'
+	String get portLabel => 'Port';
+
+	/// en: 'User'
+	String get userLabel => 'User';
+
+	/// en: 'Password'
+	String get passwordLabel => 'Password';
+
+	/// en: 'Either password OR private key required. If both, password is treated as the key passphrase.'
+	String get passwordHint => 'Either password OR private key required. If both, password is treated as the key passphrase.';
+
+	/// en: 'Private key (PEM)'
+	String get privateKeyLabel => 'Private key (PEM)';
+
+	/// en: 'Paste contents of an OpenSSH/PEM private key (e.g. ~/.ssh/id_ed25519). Leave blank for password-only auth.'
+	String get privateKeyHint => 'Paste contents of an OpenSSH/PEM private key (e.g. ~/.ssh/id_ed25519). Leave blank for password-only auth.';
+
+	/// en: '-----BEGIN OPENSSH PRIVATE KEY-----...'
+	String get privateKeyPlaceholder => '-----BEGIN OPENSSH PRIVATE KEY-----...';
+
+	/// en: 'Host key (pinning)'
+	String get hostKeyLabel => 'Host key (pinning)';
+
+	/// en: 'OpenSSH-style server public key (run `ssh-keyscan host` to obtain). Leave blank to disable pinning (NOT recommended outside LAN).'
+	String get hostKeyHint => 'OpenSSH-style server public key (run `ssh-keyscan host` to obtain). Leave blank to disable pinning (NOT recommended outside LAN).';
+
+	/// en: 'ssh-ed25519 AAAA...'
+	String get hostKeyPlaceholder => 'ssh-ed25519 AAAA...';
+
+	/// en: 'Path prefix'
+	String get pathPrefixLabel => 'Path prefix';
+
+	/// en: 'Absolute or relative to user home (optional)'
+	String get pathPrefixHint => 'Absolute or relative to user home (optional)';
+
+	/// en: '/var/backups/opendray or opendray-backups'
+	String get pathPrefixPlaceholder => '/var/backups/opendray  or  opendray-backups';
+}
+
+// Path: web.backups.targetEditor.rclone
+class TranslationsWebBackupsTargetEditorRcloneEn {
+	TranslationsWebBackupsTargetEditorRcloneEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Requires the <1>rclone</1> CLI installed on the opendray host. First configure your remote with <3>rclone config</3>, then use the remote name below. opendray invokes <5>rclone rcat / cat / lsd</5> under the hood.'
+	String get rcloneHint => 'Requires the <1>rclone</1> CLI installed on the opendray host. First configure your remote with <3>rclone config</3>, then use the remote name below. opendray invokes <5>rclone rcat / cat / lsd</5> under the hood.';
+
+	/// en: 'Remote name'
+	String get remoteLabel => 'Remote name';
+
+	/// en: 'Name from `rclone config` (no colon). Example: gdrive, onedrive, dropbox-personal, baidu-pan'
+	String get remoteHint => 'Name from `rclone config` (no colon). Example: gdrive, onedrive, dropbox-personal, baidu-pan';
+
+	/// en: 'gdrive'
+	String get remotePlaceholder => 'gdrive';
+
+	/// en: 'Path prefix'
+	String get pathPrefixLabel => 'Path prefix';
+
+	/// en: 'Sub-folder under the remote root (optional)'
+	String get pathPrefixHint => 'Sub-folder under the remote root (optional)';
+
+	/// en: 'opendray/backups'
+	String get pathPrefixPlaceholder => 'opendray/backups';
+
+	/// en: 'Binary path'
+	String get binaryPathLabel => 'Binary path';
+
+	/// en: 'Override `which rclone`. Empty uses PATH lookup.'
+	String get binaryPathHint => 'Override `which rclone`. Empty uses PATH lookup.';
+
+	/// en: '/opt/homebrew/bin/rclone'
+	String get binaryPathPlaceholder => '/opt/homebrew/bin/rclone';
+
+	/// en: 'Config path'
+	String get configPathLabel => 'Config path';
+
+	/// en: 'Override --config (default ~/.config/rclone/rclone.conf or ~/.rclone.conf)'
+	String get configPathHint => 'Override --config (default ~/.config/rclone/rclone.conf or ~/.rclone.conf)';
+
+	/// en: 'leave blank for rclone default'
+	String get configPathPlaceholder => 'leave blank for rclone default';
+}
+
+// Path: web.serverSettings.sections.general
+class TranslationsWebServerSettingsSectionsGeneralEn {
+	TranslationsWebServerSettingsSectionsGeneralEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'General'
+	String get title => 'General';
+
+	/// en: 'Listen address, operator account, token TTL.'
+	String get desc => 'Listen address, operator account, token TTL.';
+}
+
+// Path: web.serverSettings.sections.logging
+class TranslationsWebServerSettingsSectionsLoggingEn {
+	TranslationsWebServerSettingsSectionsLoggingEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Logging'
+	String get title => 'Logging';
+
+	/// en: 'Verbosity, format, and live tail.'
+	String get desc => 'Verbosity, format, and live tail.';
+}
+
+// Path: web.serverSettings.sections.sessions
+class TranslationsWebServerSettingsSectionsSessionsEn {
+	TranslationsWebServerSettingsSectionsSessionsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Sessions'
+	String get title => 'Sessions';
+
+	/// en: 'Idle detection thresholds.'
+	String get desc => 'Idle detection thresholds.';
+}
+
+// Path: web.serverSettings.sections.vault
+class TranslationsWebServerSettingsSectionsVaultEn {
+	TranslationsWebServerSettingsSectionsVaultEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Vault'
+	String get title => 'Vault';
+
+	/// en: 'Notes, skills, and git-versioned root.'
+	String get desc => 'Notes, skills, and git-versioned root.';
+}
+
+// Path: web.serverSettings.sections.mcp
+class TranslationsWebServerSettingsSectionsMcpEn {
+	TranslationsWebServerSettingsSectionsMcpEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'MCP registry'
+	String get title => 'MCP registry';
+
+	/// en: 'Server registry + secrets.'
+	String get desc => 'Server registry + secrets.';
+}
+
+// Path: web.serverSettings.sections.memory
+class TranslationsWebServerSettingsSectionsMemoryEn {
+	TranslationsWebServerSettingsSectionsMemoryEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Memory'
+	String get title => 'Memory';
+
+	/// en: 'Cross-CLI persistent memory subsystem.'
+	String get desc => 'Cross-CLI persistent memory subsystem.';
+}
+
+// Path: web.serverSettings.sections.memoryAmbient
+class TranslationsWebServerSettingsSectionsMemoryAmbientEn {
+	TranslationsWebServerSettingsSectionsMemoryAmbientEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Memory · Ambient'
+	String get title => 'Memory · Ambient';
+
+	/// en: 'Auto-capture conversations into memory + spawn-time injection.'
+	String get desc => 'Auto-capture conversations into memory + spawn-time injection.';
+}
+
+// Path: web.serverSettings.sections.backup
+class TranslationsWebServerSettingsSectionsBackupEn {
+	TranslationsWebServerSettingsSectionsBackupEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Backup'
+	String get title => 'Backup';
+
+	/// en: 'Encrypted DB backups, restore, and admin data exports.'
+	String get desc => 'Encrypted DB backups, restore, and admin data exports.';
+}
+
+// Path: web.serverSettings.sections.claude
+class TranslationsWebServerSettingsSectionsClaudeEn {
+	TranslationsWebServerSettingsSectionsClaudeEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Storage · Claude'
+	String get title => 'Storage · Claude';
+
+	/// en: 'Where Claude transcripts live on disk.'
+	String get desc => 'Where Claude transcripts live on disk.';
+}
+
+// Path: web.serverSettings.sections.codex
+class TranslationsWebServerSettingsSectionsCodexEn {
+	TranslationsWebServerSettingsSectionsCodexEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Storage · Codex'
+	String get title => 'Storage · Codex';
+
+	/// en: 'Codex sessions root.'
+	String get desc => 'Codex sessions root.';
+}
+
+// Path: web.serverSettings.sections.gemini
+class TranslationsWebServerSettingsSectionsGeminiEn {
+	TranslationsWebServerSettingsSectionsGeminiEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Storage · Gemini'
+	String get title => 'Storage · Gemini';
+
+	/// en: 'Gemini per-project tmp + projects.json.'
+	String get desc => 'Gemini per-project tmp + projects.json.';
+}
+
+// Path: web.serverSettings.fields.listenAddress
+class TranslationsWebServerSettingsFieldsListenAddressEn {
+	TranslationsWebServerSettingsFieldsListenAddressEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Listen address'
+	String get label => 'Listen address';
+
+	/// en: 'The host:port the HTTP server binds to. Example: 0.0.0.0:8770.'
+	String get hint => 'The host:port the HTTP server binds to. Example: 0.0.0.0:8770.';
+}
+
+// Path: web.serverSettings.fields.username
+class TranslationsWebServerSettingsFieldsUsernameEn {
+	TranslationsWebServerSettingsFieldsUsernameEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Username'
+	String get label => 'Username';
+
+	/// en: 'Login name used in the sign-in form. Changing this forces a re-login on the next request.'
+	String get hint => 'Login name used in the sign-in form. Changing this forces a re-login on the next request.';
+}
+
+// Path: web.serverSettings.fields.password
+class TranslationsWebServerSettingsFieldsPasswordEn {
+	TranslationsWebServerSettingsFieldsPasswordEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Password'
+	String get label => 'Password';
+
+	/// en: 'Leave blank to keep the current password. Sending a value overwrites it.'
+	String get hint => 'Leave blank to keep the current password. Sending a value overwrites it.';
+
+	/// en: 'Hide'
+	String get hideTitle => 'Hide';
+
+	/// en: 'Reveal'
+	String get revealTitle => 'Reveal';
+}
+
+// Path: web.serverSettings.fields.tokenTTL
+class TranslationsWebServerSettingsFieldsTokenTTLEn {
+	TranslationsWebServerSettingsFieldsTokenTTLEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Token TTL'
+	String get label => 'Token TTL';
+
+	/// en: 'Bearer-token lifetime as a Go duration, e.g. "24h", "30m". Empty = never expire.'
+	String get hint => 'Bearer-token lifetime as a Go duration, e.g. "24h", "30m". Empty = never expire.';
+}
+
+// Path: web.serverSettings.fields.logLevel
+class TranslationsWebServerSettingsFieldsLogLevelEn {
+	TranslationsWebServerSettingsFieldsLogLevelEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Log level'
+	String get label => 'Log level';
+
+	/// en: 'Lines below this level are dropped.'
+	String get hint => 'Lines below this level are dropped.';
+}
+
+// Path: web.serverSettings.fields.logFormat
+class TranslationsWebServerSettingsFieldsLogFormatEn {
+	TranslationsWebServerSettingsFieldsLogFormatEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Format'
+	String get label => 'Format';
+
+	/// en: '"text" is human-readable; "json" is machine-parsable.'
+	String get hint => '"text" is human-readable; "json" is machine-parsable.';
+}
+
+// Path: web.serverSettings.fields.logFile
+class TranslationsWebServerSettingsFieldsLogFileEn {
+	TranslationsWebServerSettingsFieldsLogFileEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Log file'
+	String get label => 'Log file';
+
+	/// en: 'Optional file path. Auto-rotates at 10 MB, keeps 5 backups. Empty = stderr only.'
+	String get hint => 'Optional file path. Auto-rotates at 10 MB, keeps 5 backups. Empty = stderr only.';
+}
+
+// Path: web.serverSettings.fields.idleThreshold
+class TranslationsWebServerSettingsFieldsIdleThresholdEn {
+	TranslationsWebServerSettingsFieldsIdleThresholdEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Idle threshold'
+	String get label => 'Idle threshold';
+
+	/// en: 'A session is silent for this long before session.idle fires. Empty = 30s.'
+	String get hint => 'A session is silent for this long before session.idle fires. Empty = 30s.';
+}
+
+// Path: web.serverSettings.fields.idlePollInterval
+class TranslationsWebServerSettingsFieldsIdlePollIntervalEn {
+	TranslationsWebServerSettingsFieldsIdlePollIntervalEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Idle poll interval'
+	String get label => 'Idle poll interval';
+
+	/// en: 'How often the idle detector wakes up. Lower = lower latency, more wakeups. Empty = 5s.'
+	String get hint => 'How often the idle detector wakes up. Lower = lower latency, more wakeups. Empty = 5s.';
+}
+
+// Path: web.serverSettings.fields.vaultRoot
+class TranslationsWebServerSettingsFieldsVaultRootEn {
+	TranslationsWebServerSettingsFieldsVaultRootEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Vault root'
+	String get label => 'Vault root';
+
+	/// en: 'Top-level directory for notes, skills, and MCP registry.'
+	String get hint => 'Top-level directory for notes, skills, and MCP registry.';
+}
+
+// Path: web.serverSettings.fields.notesDirectory
+class TranslationsWebServerSettingsFieldsNotesDirectoryEn {
+	TranslationsWebServerSettingsFieldsNotesDirectoryEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Notes directory'
+	String get label => 'Notes directory';
+
+	/// en: 'Override notes location. Defaults to <vault root>/notes.'
+	String get hint => 'Override notes location. Defaults to <vault root>/notes.';
+}
+
+// Path: web.serverSettings.fields.skillsDirectory
+class TranslationsWebServerSettingsFieldsSkillsDirectoryEn {
+	TranslationsWebServerSettingsFieldsSkillsDirectoryEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Skills directory'
+	String get label => 'Skills directory';
+
+	/// en: 'Override skills location. Defaults to <vault root>/skills.'
+	String get hint => 'Override skills location. Defaults to <vault root>/skills.';
+}
+
+// Path: web.serverSettings.fields.gitRoot
+class TranslationsWebServerSettingsFieldsGitRootEn {
+	TranslationsWebServerSettingsFieldsGitRootEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Git root'
+	String get label => 'Git root';
+
+	/// en: 'Working tree the Vault Sync feature commits to.'
+	String get hint => 'Working tree the Vault Sync feature commits to.';
+}
+
+// Path: web.serverSettings.fields.personalPrefix
+class TranslationsWebServerSettingsFieldsPersonalPrefixEn {
+	TranslationsWebServerSettingsFieldsPersonalPrefixEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Personal prefix'
+	String get label => 'Personal prefix';
+
+	/// en: 'Folder name used for personal notes when auto-deriving paths. Default "personal".'
+	String get hint => 'Folder name used for personal notes when auto-deriving paths. Default "personal".';
+}
+
+// Path: web.serverSettings.fields.projectsPrefix
+class TranslationsWebServerSettingsFieldsProjectsPrefixEn {
+	TranslationsWebServerSettingsFieldsProjectsPrefixEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Projects prefix'
+	String get label => 'Projects prefix';
+
+	/// en: 'Folder name used for project notes. Default "projects".'
+	String get hint => 'Folder name used for project notes. Default "projects".';
+}
+
+// Path: web.serverSettings.fields.registryRoot
+class TranslationsWebServerSettingsFieldsRegistryRootEn {
+	TranslationsWebServerSettingsFieldsRegistryRootEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Registry root'
+	String get label => 'Registry root';
+
+	/// en: 'Directory holding MCP server JSON definitions. Defaults to <vault>/mcp.'
+	String get hint => 'Directory holding MCP server JSON definitions. Defaults to <vault>/mcp.';
+}
+
+// Path: web.serverSettings.fields.secretsFile
+class TranslationsWebServerSettingsFieldsSecretsFileEn {
+	TranslationsWebServerSettingsFieldsSecretsFileEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Secrets file'
+	String get label => 'Secrets file';
+
+	/// en: 'key=value file substituted into MCP server commands at spawn time.'
+	String get hint => 'key=value file substituted into MCP server commands at spawn time.';
+}
+
+// Path: web.serverSettings.fields.memoryBackend
+class TranslationsWebServerSettingsFieldsMemoryBackendEn {
+	TranslationsWebServerSettingsFieldsMemoryBackendEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Embedder backend'
+	String get label => 'Embedder backend';
+
+	/// en: '"auto" / "bm25" use the cgo-free pure-Go keyword path. "http" calls any OpenAI-compatible /v1/embeddings (ollama / OpenAI / LocalAI). "local" runs an ONNX sentence-transformer in-process — requires a binary built with `-tags local_onnx`.'
+	String get hint => '"auto" / "bm25" use the cgo-free pure-Go keyword path. "http" calls any OpenAI-compatible /v1/embeddings (ollama / OpenAI / LocalAI). "local" runs an ONNX sentence-transformer in-process — requires a binary built with `-tags local_onnx`.';
+}
+
+// Path: web.serverSettings.fields.memoryStore
+class TranslationsWebServerSettingsFieldsMemoryStoreEn {
+	TranslationsWebServerSettingsFieldsMemoryStoreEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Store'
+	String get label => 'Store';
+
+	/// en: '"pgvector" reuses opendray's existing PG with the vector extension; only option in v1.'
+	String get hint => '"pgvector" reuses opendray\'s existing PG with the vector extension; only option in v1.';
+}
+
+// Path: web.serverSettings.fields.memoryTopK
+class TranslationsWebServerSettingsFieldsMemoryTopKEn {
+	TranslationsWebServerSettingsFieldsMemoryTopKEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Default top-K'
+	String get label => 'Default top-K';
+
+	/// en: 'How many hits memory_search returns when the agent doesn't specify. Empty = 5.'
+	String get hint => 'How many hits memory_search returns when the agent doesn\'t specify. Empty = 5.';
+}
+
+// Path: web.serverSettings.fields.memoryThreshold
+class TranslationsWebServerSettingsFieldsMemoryThresholdEn {
+	TranslationsWebServerSettingsFieldsMemoryThresholdEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Similarity threshold'
+	String get label => 'Similarity threshold';
+
+	/// en: 'Hits below this score are dropped. Empty = 0.1 (permissive — BM25 sparse vectors rarely break 0.5).'
+	String get hint => 'Hits below this score are dropped. Empty = 0.1 (permissive — BM25 sparse vectors rarely break 0.5).';
+}
+
+// Path: web.serverSettings.fields.memoryScope
+class TranslationsWebServerSettingsFieldsMemoryScopeEn {
+	TranslationsWebServerSettingsFieldsMemoryScopeEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Default scope'
+	String get label => 'Default scope';
+
+	/// en: 'What memory_store uses when the agent doesn't specify. "project" (recommended) groups by cwd; "session" isolates per session; "global" shares across cwds.'
+	String get hint => 'What memory_store uses when the agent doesn\'t specify. "project" (recommended) groups by cwd; "session" isolates per session; "global" shares across cwds.';
+}
+
+// Path: web.serverSettings.fields.memoryBaseUrl
+class TranslationsWebServerSettingsFieldsMemoryBaseUrlEn {
+	TranslationsWebServerSettingsFieldsMemoryBaseUrlEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Base URL'
+	String get label => 'Base URL';
+
+	/// en: 'e.g. "http://localhost:11434/v1" for ollama, "https://api.openai.com/v1" for OpenAI.'
+	String get hint => 'e.g. "http://localhost:11434/v1" for ollama, "https://api.openai.com/v1" for OpenAI.';
+}
+
+// Path: web.serverSettings.fields.memoryModel
+class TranslationsWebServerSettingsFieldsMemoryModelEn {
+	TranslationsWebServerSettingsFieldsMemoryModelEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Model'
+	String get label => 'Model';
+
+	/// en: 'e.g. "nomic-embed-text" for ollama, "text-embedding-3-small" for OpenAI.'
+	String get hint => 'e.g. "nomic-embed-text" for ollama, "text-embedding-3-small" for OpenAI.';
+}
+
+// Path: web.serverSettings.fields.memoryApiKey
+class TranslationsWebServerSettingsFieldsMemoryApiKeyEn {
+	TranslationsWebServerSettingsFieldsMemoryApiKeyEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'API key'
+	String get label => 'API key';
+
+	/// en: 'Empty for ollama / local servers. Required for OpenAI / Voyage / hosted services.'
+	String get hint => 'Empty for ollama / local servers. Required for OpenAI / Voyage / hosted services.';
+}
+
+// Path: web.serverSettings.fields.memoryLocalModel
+class TranslationsWebServerSettingsFieldsMemoryLocalModelEn {
+	TranslationsWebServerSettingsFieldsMemoryLocalModelEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Model name'
+	String get label => 'Model name';
+
+	/// en: 'Cosmetic — appears in logs / Inspector. e.g. "bge-m3", "bge-small-en-v1.5".'
+	String get hint => 'Cosmetic — appears in logs / Inspector. e.g. "bge-m3", "bge-small-en-v1.5".';
+}
+
+// Path: web.serverSettings.fields.memoryLibraryPath
+class TranslationsWebServerSettingsFieldsMemoryLibraryPathEn {
+	TranslationsWebServerSettingsFieldsMemoryLibraryPathEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Library path'
+	String get label => 'Library path';
+
+	/// en: 'Directory holding libonnxruntime.dylib (macOS) / libonnxruntime.so (Linux). After `brew install onnxruntime`, that's /opt/homebrew/opt/onnxruntime/lib.'
+	String get hint => 'Directory holding libonnxruntime.dylib (macOS) / libonnxruntime.so (Linux). After `brew install onnxruntime`, that\'s /opt/homebrew/opt/onnxruntime/lib.';
+}
+
+// Path: web.serverSettings.fields.memoryModelPath
+class TranslationsWebServerSettingsFieldsMemoryModelPathEn {
+	TranslationsWebServerSettingsFieldsMemoryModelPathEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Model path'
+	String get label => 'Model path';
+
+	/// en: 'Absolute path to the .onnx weights. Download from HuggingFace, e.g. Xenova/bge-m3 or Xenova/bge-small-en-v1.5.'
+	String get hint => 'Absolute path to the .onnx weights. Download from HuggingFace, e.g. Xenova/bge-m3 or Xenova/bge-small-en-v1.5.';
+}
+
+// Path: web.serverSettings.fields.memoryTokenizerPath
+class TranslationsWebServerSettingsFieldsMemoryTokenizerPathEn {
+	TranslationsWebServerSettingsFieldsMemoryTokenizerPathEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Tokenizer path'
+	String get label => 'Tokenizer path';
+
+	/// en: 'Absolute path to tokenizer.json (HuggingFace standard format) — usually right next to the model.'
+	String get hint => 'Absolute path to tokenizer.json (HuggingFace standard format) — usually right next to the model.';
+}
+
+// Path: web.serverSettings.fields.memoryMaxSeqLen
+class TranslationsWebServerSettingsFieldsMemoryMaxSeqLenEn {
+	TranslationsWebServerSettingsFieldsMemoryMaxSeqLenEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Max sequence length'
+	String get label => 'Max sequence length';
+
+	/// en: 'Tokens beyond this are truncated. bge-m3 default is 512. Empty = 512.'
+	String get hint => 'Tokens beyond this are truncated. bge-m3 default is 512. Empty = 512.';
+}
+
+// Path: web.serverSettings.fields.claudeHistoryRoots
+class TranslationsWebServerSettingsFieldsClaudeHistoryRootsEn {
+	TranslationsWebServerSettingsFieldsClaudeHistoryRootsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'History roots'
+	String get label => 'History roots';
+
+	/// en: 'Directories scanned for Claude per-project JSONL transcripts. Empty = scan ~/.claude/projects + every ~/.claude-accounts/*/projects.'
+	String get hint => 'Directories scanned for Claude per-project JSONL transcripts. Empty = scan ~/.claude/projects + every ~/.claude-accounts/*/projects.';
+}
+
+// Path: web.serverSettings.fields.claudeAccountsDir
+class TranslationsWebServerSettingsFieldsClaudeAccountsDirEn {
+	TranslationsWebServerSettingsFieldsClaudeAccountsDirEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Accounts directory'
+	String get label => 'Accounts directory';
+
+	/// en: 'Root used for opendray-managed Claude account ConfigDirs. Default ~/.claude-accounts.'
+	String get hint => 'Root used for opendray-managed Claude account ConfigDirs. Default ~/.claude-accounts.';
+}
+
+// Path: web.serverSettings.fields.codexSessionsRoot
+class TranslationsWebServerSettingsFieldsCodexSessionsRootEn {
+	TranslationsWebServerSettingsFieldsCodexSessionsRootEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Sessions root'
+	String get label => 'Sessions root';
+
+	/// en: 'Directory walked for Codex rollout JSONL files. Default ~/.codex/sessions.'
+	String get hint => 'Directory walked for Codex rollout JSONL files. Default ~/.codex/sessions.';
+}
+
+// Path: web.serverSettings.fields.geminiTmpRoot
+class TranslationsWebServerSettingsFieldsGeminiTmpRootEn {
+	TranslationsWebServerSettingsFieldsGeminiTmpRootEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Tmp directory'
+	String get label => 'Tmp directory';
+
+	/// en: 'Root holding Gemini per-project tmp folders. Default ~/.gemini/tmp.'
+	String get hint => 'Root holding Gemini per-project tmp folders. Default ~/.gemini/tmp.';
+}
+
+// Path: web.serverSettings.fields.geminiProjectsFile
+class TranslationsWebServerSettingsFieldsGeminiProjectsFileEn {
+	TranslationsWebServerSettingsFieldsGeminiProjectsFileEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'projects.json'
+	String get label => 'projects.json';
+
+	/// en: 'Path to Gemini's cwd→short-name mapping file. Default ~/.gemini/projects.json.'
+	String get hint => 'Path to Gemini\'s cwd→short-name mapping file. Default ~/.gemini/projects.json.';
+}
+
+// Path: web.serverSettings.fields.backupLocalDir
+class TranslationsWebServerSettingsFieldsBackupLocalDirEn {
+	TranslationsWebServerSettingsFieldsBackupLocalDirEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Local backup directory'
+	String get label => 'Local backup directory';
+
+	/// en: 'Default root for the auto-created `local` target. Empty = ~/.opendray/backups. Restart required.'
+	String get hint => 'Default root for the auto-created `local` target. Empty = ~/.opendray/backups. Restart required.';
+}
+
+// Path: web.serverSettings.fields.backupExportDir
+class TranslationsWebServerSettingsFieldsBackupExportDirEn {
+	TranslationsWebServerSettingsFieldsBackupExportDirEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Export directory'
+	String get label => 'Export directory';
+
+	/// en: 'Where one-shot export zips are staged on disk. Empty = ~/.opendray/exports. Bundles auto-expire after 24h. Restart required.'
+	String get hint => 'Where one-shot export zips are staged on disk. Empty = ~/.opendray/exports. Bundles auto-expire after 24h. Restart required.';
+}
+
+// Path: web.serverSettings.fields.backupPgDumpPath
+class TranslationsWebServerSettingsFieldsBackupPgDumpPathEn {
+	TranslationsWebServerSettingsFieldsBackupPgDumpPathEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'pg_dump path'
+	String get label => 'pg_dump path';
+
+	/// en: 'Absolute path to pg_dump. Major version must be ≥ the server's. Empty = first pg_dump on PATH.'
+	String get hint => 'Absolute path to pg_dump. Major version must be ≥ the server\'s. Empty = first pg_dump on PATH.';
+}
+
+// Path: web.serverSettings.fields.backupPgRestorePath
+class TranslationsWebServerSettingsFieldsBackupPgRestorePathEn {
+	TranslationsWebServerSettingsFieldsBackupPgRestorePathEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'pg_restore path'
+	String get label => 'pg_restore path';
+
+	/// en: 'Absolute path to pg_restore for the /backups/restore flow. Same major-version rule.'
+	String get hint => 'Absolute path to pg_restore for the /backups/restore flow. Same major-version rule.';
+}
+
+// Path: web.serverSettings.httpHelpers.presetTip
+class TranslationsWebServerSettingsHttpHelpersPresetTipEn {
+	TranslationsWebServerSettingsHttpHelpersPresetTipEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Local ollama daemon'
+	String get ollama => 'Local ollama daemon';
+
+	/// en: 'LM Studio local server'
+	String get lmStudio => 'LM Studio local server';
+
+	/// en: 'OpenAI cloud (needs API key)'
+	String get openai => 'OpenAI cloud (needs API key)';
+}
+
+// Path: web.serverSettings.backup.scheduleHeaders
+class TranslationsWebServerSettingsBackupScheduleHeadersEn {
+	TranslationsWebServerSettingsBackupScheduleHeadersEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Schedule'
+	String get schedule => 'Schedule';
+
+	/// en: 'Target'
+	String get target => 'Target';
+
+	/// en: 'Cadence'
+	String get cadence => 'Cadence';
+
+	/// en: 'Keep'
+	String get keep => 'Keep';
+
+	/// en: 'State'
+	String get state => 'State';
+}
+
+// Path: web.settings.appearance.options
+class TranslationsWebSettingsAppearanceOptionsEn {
+	TranslationsWebSettingsAppearanceOptionsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Light'
+	String get light => 'Light';
+
+	/// en: 'Always light'
+	String get lightDesc => 'Always light';
+
+	/// en: 'Dark'
+	String get dark => 'Dark';
+
+	/// en: 'Always dark'
+	String get darkDesc => 'Always dark';
+
+	/// en: 'System'
+	String get system => 'System';
+
+	/// en: 'Follow the OS setting'
+	String get systemDesc => 'Follow the OS setting';
+}
+
+// Path: web.settings.font.options
+class TranslationsWebSettingsFontOptionsEn {
+	TranslationsWebSettingsFontOptionsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Compact'
+	String get compact => 'Compact';
+
+	/// en: 'Default'
+	String get kDefault => 'Default';
+
+	/// en: 'Comfy'
+	String get comfy => 'Comfy';
+
+	/// en: 'Large'
+	String get large => 'Large';
+}
+
+// Path: web.memoryAmbient.providers.row
+class TranslationsWebMemoryAmbientProvidersRowEn {
+	TranslationsWebMemoryAmbientProvidersRowEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: '★ default'
+	String get defaultBadge => '★ default';
+
+	/// en: 'Make default'
+	String get makeDefault => 'Make default';
+
+	/// en: 'Test'
+	String get test => 'Test';
+
+	/// en: 'Testing…'
+	String get testing => 'Testing…';
+
+	/// en: 'Delete'
+	String get delete => 'Delete';
+
+	/// en: '{name}: connection OK'
+	String testOk({required Object name}) => '${name}: connection OK';
+
+	/// en: 'Test failed'
+	String get testFailedToast => 'Test failed';
+
+	/// en: 'Delete provider "{name}"?'
+	String deleteConfirm({required Object name}) => 'Delete provider "${name}"?';
+
+	/// en: 'Provider deleted'
+	String get deletedToast => 'Provider deleted';
+
+	/// en: 'Delete failed'
+	String get deleteFailedToast => 'Delete failed';
+
+	/// en: 'Update failed'
+	String get updateFailedToast => 'Update failed';
+
+	/// en: '{name} is now the default'
+	String madeDefaultToast({required Object name}) => '${name} is now the default';
+}
+
+// Path: web.memoryAmbient.providers.dialog
+class TranslationsWebMemoryAmbientProvidersDialogEn {
+	TranslationsWebMemoryAmbientProvidersDialogEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Add summarizer provider'
+	String get title => 'Add summarizer provider';
+
+	/// en: 'Kind'
+	String get kindLabel => 'Kind';
+
+	/// en: 'Name'
+	String get nameLabel => 'Name';
+
+	/// en: 'e.g. lmstudio-qwen'
+	String get namePlaceholder => 'e.g. lmstudio-qwen';
+
+	/// en: 'Model'
+	String get modelLabel => 'Model';
+
+	/// en: 'Base URL'
+	String get baseUrlLabel => 'Base URL';
+
+	/// en: 'Integration providers resolve their base URL from a registered integration. Configure that under Integrations first; advanced wiring (extra_config) is DB-only in this release.'
+	String get integrationNote => 'Integration providers resolve their base URL from a registered integration. Configure that under Integrations first; advanced wiring (extra_config) is DB-only in this release.';
+
+	/// en: 'API key'
+	String get apiKeyLabel => 'API key';
+
+	/// en: 'Stored encrypted (AES-GCM with the backup master passphrase). Never echoed back; only the fingerprint is shown after save.'
+	String get apiKeyHint => 'Stored encrypted (AES-GCM with the backup master passphrase). Never echoed back; only the fingerprint is shown after save.';
+
+	/// en: 'Make this the default provider'
+	String get makeDefaultLabel => 'Make this the default provider';
+
+	/// en: 'Create'
+	String get create => 'Create';
+
+	/// en: 'Name is required'
+	String get nameRequiredToast => 'Name is required';
+
+	/// en: 'Provider {name} created'
+	String createdToast({required Object name}) => 'Provider ${name} created';
+
+	/// en: 'Create failed'
+	String get createFailedToast => 'Create failed';
+}
+
+// Path: web.memoryAmbient.rules.row
+class TranslationsWebMemoryAmbientRulesRowEn {
+	TranslationsWebMemoryAmbientRulesRowEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'global default'
+	String get globalDefault => 'global default';
+
+	/// en: 'scope:'
+	String get scopeLabel => 'scope:';
+
+	/// en: 'dedup:'
+	String get dedupLabel => 'dedup:';
+
+	/// en: 'Run now'
+	String get runNow => 'Run now';
+
+	/// en: 'Running…'
+	String get running => 'Running…';
+
+	/// en: 'Delete'
+	String get delete => 'Delete';
+
+	/// en: 'Rule fired across {sessions} session(s)'
+	String firedToast({required Object sessions}) => 'Rule fired across ${sessions} session(s)';
+
+	/// en: 'Run-now failed'
+	String get runNowFailedToast => 'Run-now failed';
+
+	/// en: 'Delete rule "{name}"?'
+	String deleteConfirm({required Object name}) => 'Delete rule "${name}"?';
+
+	/// en: 'Rule deleted'
+	String get deletedToast => 'Rule deleted';
+
+	/// en: 'Delete failed'
+	String get deleteFailedToast => 'Delete failed';
+
+	late final TranslationsWebMemoryAmbientRulesRowSummaryEn summary = TranslationsWebMemoryAmbientRulesRowSummaryEn.internal(_root);
+}
+
+// Path: web.memoryAmbient.rules.dialog
+class TranslationsWebMemoryAmbientRulesDialogEn {
+	TranslationsWebMemoryAmbientRulesDialogEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Add capture rule'
+	String get title => 'Add capture rule';
+
+	/// en: 'Name'
+	String get nameLabel => 'Name';
+
+	/// en: 'Trigger'
+	String get triggerLabel => 'Trigger';
+
+	/// en: 'N (messages)'
+	String get nLabel => 'N (messages)';
+
+	/// en: 'Idle seconds'
+	String get idleLabel => 'Idle seconds';
+
+	/// en: 'K (characters)'
+	String get kLabel => 'K (characters)';
+
+	/// en: 'Target scope'
+	String get scopeLabel => 'Target scope';
+
+	/// en: 'session'
+	String get scopeSession => 'session';
+
+	/// en: 'project (recommended)'
+	String get scopeProject => 'project (recommended)';
+
+	/// en: 'global'
+	String get scopeGlobal => 'global';
+
+	/// en: 'Dedup threshold (0.0 – 1.0)'
+	String get dedupLabel => 'Dedup threshold (0.0 – 1.0)';
+
+	/// en: 'Higher = stricter de-duplication. 0.85 is the recommended sweet spot.'
+	String get dedupHint => 'Higher = stricter de-duplication. 0.85 is the recommended sweet spot.';
+
+	/// en: 'Create'
+	String get create => 'Create';
+
+	/// en: 'Name is required'
+	String get nameRequiredToast => 'Name is required';
+
+	/// en: 'Rule {name} created'
+	String createdToast({required Object name}) => 'Rule ${name} created';
+
+	/// en: 'Create failed'
+	String get createFailedToast => 'Create failed';
+}
+
+// Path: web.memoryAmbient.profiles.row
+class TranslationsWebMemoryAmbientProfilesRowEn {
+	TranslationsWebMemoryAmbientProfilesRowEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'global default'
+	String get globalDefault => 'global default';
+
+	/// en: 'Delete'
+	String get delete => 'Delete';
+
+	/// en: 'Delete this injection profile?'
+	String get deleteConfirm => 'Delete this injection profile?';
+
+	/// en: 'Profile deleted'
+	String get deletedToast => 'Profile deleted';
+
+	/// en: 'Delete failed'
+	String get deleteFailedToast => 'Delete failed';
+}
+
+// Path: web.memoryAmbient.profiles.dialog
+class TranslationsWebMemoryAmbientProfilesDialogEn {
+	TranslationsWebMemoryAmbientProfilesDialogEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Add injection profile'
+	String get title => 'Add injection profile';
+
+	/// en: 'Strategy'
+	String get strategyLabel => 'Strategy';
+
+	/// en: 'K (top memories to inject)'
+	String get kLabel => 'K (top memories to inject)';
+
+	/// en: 'One profile per session_id (or global default). Per-session profiles can be added later via API; UI currently only manages the global default.'
+	String get hint => 'One profile per session_id (or global default). Per-session profiles can be added later via API; UI currently only manages the global default.';
+
+	/// en: 'Create'
+	String get create => 'Create';
+
+	/// en: 'Profile created'
+	String get createdToast => 'Profile created';
+
+	/// en: 'Create failed'
+	String get createFailedToast => 'Create failed';
+}
+
+// Path: web.memoryAmbient.cost.columns
+class TranslationsWebMemoryAmbientCostColumnsEn {
+	TranslationsWebMemoryAmbientCostColumnsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Provider'
+	String get provider => 'Provider';
+
+	/// en: 'Calls'
+	String get calls => 'Calls';
+
+	/// en: 'In tokens'
+	String get inTokens => 'In tokens';
+
+	/// en: 'Out tokens'
+	String get outTokens => 'Out tokens';
+
+	/// en: 'USD est.'
+	String get usdEst => 'USD est.';
+}
+
+// Path: web.export.form.integrationOptions
+class TranslationsWebExportFormIntegrationOptionsEn {
+	TranslationsWebExportFormIntegrationOptionsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'None'
+	String get none => 'None';
+
+	/// en: 'Skip the integrations table entirely.'
+	String get noneHint => 'Skip the integrations table entirely.';
+
+	/// en: 'Metadata only (recommended)'
+	String get metadata => 'Metadata only (recommended)';
+
+	/// en: 'ID, name, route prefix, scopes — no API key material.'
+	String get metadataHint => 'ID, name, route prefix, scopes — no API key material.';
+
+	/// en: 'Include plaintext API keys'
+	String get plaintext => 'Include plaintext API keys';
+
+	/// en: 'v1 bcrypt-only: no recoverable plaintext exists. Manifest documents this; nothing leaks.'
+	String get plaintextHint => 'v1 bcrypt-only: no recoverable plaintext exists. Manifest documents this; nothing leaks.';
+}
+
+// Path: web.export.history.columns
+class TranslationsWebExportHistoryColumnsEn {
+	TranslationsWebExportHistoryColumnsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'ID'
+	String get id => 'ID';
+
+	/// en: 'Status'
+	String get status => 'Status';
+
+	/// en: 'Scope'
+	String get scope => 'Scope';
+
+	/// en: 'Size'
+	String get size => 'Size';
+
+	/// en: 'Expires'
+	String get expires => 'Expires';
+
+	/// en: 'Actions'
+	String get actions => 'Actions';
+}
+
+// Path: web.export.import.summaryCard
+class TranslationsWebExportImportSummaryCardEn {
+	TranslationsWebExportImportSummaryCardEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Memories'
+	String get memories => 'Memories';
+
+	/// en: 'Integrations'
+	String get integrations => 'Integrations';
+
+	/// en: 'Custom tasks'
+	String get customTasks => 'Custom tasks';
+
+	/// en: 'created'
+	String get created => 'created';
+
+	/// en: 'skipped'
+	String get skipped => 'skipped';
+
+	/// en: 'failed'
+	String get failed => 'failed';
+}
+
+// Path: web.export.imports.columns
+class TranslationsWebExportImportsColumnsEn {
+	TranslationsWebExportImportsColumnsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'ID'
+	String get id => 'ID';
+
+	/// en: 'Status'
+	String get status => 'Status';
+
+	/// en: 'Source'
+	String get source => 'Source';
+
+	/// en: 'Counts'
+	String get counts => 'Counts';
+
+	/// en: 'When'
+	String get when => 'When';
+}
+
 // Path: sessions.inspector.shell.tabs
 class TranslationsSessionsInspectorShellTabsEn {
 	TranslationsSessionsInspectorShellTabsEn.internal(this._root);
@@ -4619,6 +12196,48 @@ class TranslationsSessionsInspectorShellTabsEn {
 
 	/// en: 'Notes'
 	String get notes => 'Notes';
+}
+
+// Path: web.notes.vaultSync.conflict.kinds
+class TranslationsWebNotesVaultSyncConflictKindsEn {
+	TranslationsWebNotesVaultSyncConflictKindsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'rebase'
+	String get rebase => 'rebase';
+
+	/// en: 'merge'
+	String get merge => 'merge';
+
+	/// en: 'cherry-pick'
+	String get cherryPick => 'cherry-pick';
+
+	/// en: 'operation'
+	String get operation => 'operation';
+}
+
+// Path: web.memoryAmbient.rules.row.summary
+class TranslationsWebMemoryAmbientRulesRowSummaryEn {
+	TranslationsWebMemoryAmbientRulesRowSummaryEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'every {n} messages'
+	String afterMessages({required Object n}) => 'every ${n} messages';
+
+	/// en: 'idle ≥ {seconds}s'
+	String onIdle({required Object seconds}) => 'idle ≥ ${seconds}s';
+
+	/// en: '≥ {k} chars'
+	String kChars({required Object k}) => '≥ ${k} chars';
+
+	/// en: 'manual only'
+	String get manual => 'manual only';
 }
 
 /// The flat map containing all translations for locale <en>.
@@ -4646,12 +12265,1714 @@ extension on Translations {
 			'auth.username' => 'Username',
 			'auth.password' => 'Password',
 			'auth.signIn' => 'Sign in',
+			'auth.signingIn' => 'Signing in…',
+			'auth.subtitle' => 'Use your operator credentials.',
 			'auth.errorRequired' => 'Username and password are required',
 			'auth.errorGeneric' => ({required Object error}) => 'Login failed: ${error}',
+			'auth.errorFallback' => 'Login failed',
 			'nav.sessions' => 'Sessions',
 			'nav.memory' => 'Memory',
 			'nav.notes' => 'Notes',
 			'nav.more' => 'More',
+			'nav.activity' => 'Activity',
+			'nav.providers' => 'Providers',
+			'nav.channels' => 'Channels',
+			'nav.integrations' => 'Integrations',
+			'nav.plugins' => 'Plugins',
+			'nav.backups' => 'Backups',
+			'nav.settings' => 'Settings',
+			'nav.tutorial' => 'Tutorial',
+			'nav.workspace' => 'Workspace',
+			'web.brand' => 'opendray',
+			'web.loading' => 'Loading…',
+			'web.topbar.expandSidebar' => 'Expand sidebar',
+			'web.topbar.collapseSidebar' => 'Collapse sidebar',
+			'web.topbar.search' => 'Search',
+			'web.topbar.openPalette' => 'Open command palette',
+			'web.topbar.theme' => 'Theme',
+			'web.topbar.themeLabel' => ({required Object mode}) => 'Theme: ${mode}',
+			'web.topbar.appearance' => 'Appearance',
+			'web.topbar.themeLight' => 'Light',
+			'web.topbar.themeDark' => 'Dark',
+			'web.topbar.themeSystem' => 'System',
+			'web.topbar.language' => 'Language',
+			'web.topbar.languageEnglish' => 'English',
+			'web.topbar.languageChinese' => '中文',
+			'web.topbar.signedInAs' => 'Signed in as',
+			'web.topbar.tokenExpires' => 'Token expires',
+			'web.topbar.signOut' => 'Sign out',
+			'web.sessions.list.title' => 'Sessions',
+			'web.sessions.list.countSeparator' => '·',
+			'web.sessions.list.newAria' => 'Spawn new session',
+			'web.sessions.list.newTooltip' => 'New session',
+			'web.sessions.list.loading' => 'Loading…',
+			'web.sessions.list.emptyTitle' => 'No sessions yet.',
+			'web.sessions.list.emptyHint' => ({required Object kbd}) => 'Press ${kbd} to spawn.',
+			'web.sessions.list.endedHeader' => ({required Object count}) => 'Ended (${count})',
+			'web.sessions.list.clearAll' => 'Clear all',
+			'web.sessions.list.confirmClearAll' => ({required Object count}) => 'Remove all ${count} ended sessions?',
+			'web.sessions.list.confirmTerminate' => ({required Object name}) => 'Terminate and remove ${name}?',
+			'web.sessions.list.childPromoted' => ({required Object count}) => ' ${count} child task session will be promoted to top-level.',
+			'web.sessions.list.childPromotedPlural' => ({required Object count}) => ' ${count} child task sessions will be promoted to top-level.',
+			'web.sessions.list.footer' => ({required Object live, required Object ended}) => '${live} live · ${ended} ended',
+			'web.sessions.list.row.deleteAria' => 'Delete session',
+			'web.sessions.list.row.titleRemoveHistory' => 'Remove from history',
+			'web.sessions.list.row.titleTerminate' => 'Terminate and remove',
+			'web.sessions.list.row.titleRemove' => 'Remove',
+			'web.sessions.list.row.claudeAccountTitle' => ({required Object label}) => 'Claude account: ${label}',
+			'web.sessions.list.deleteFailedToast' => 'Delete failed',
+			'web.sessions.tabs.closeAria' => 'Close tab and remove session',
+			'web.sessions.tabs.closeTitle' => 'Close tab and remove session',
+			'web.sessions.page.removedToast' => 'Session removed',
+			'web.sessions.page.removeFailedToast' => 'Remove failed',
+			'web.sessions.page.stoppedToast' => 'Session stopped',
+			'web.sessions.page.stopFailedToast' => 'Stop failed',
+			'web.sessions.page.restartedToast' => 'Session restarted',
+			'web.sessions.page.restartFailedToast' => 'Restart failed',
+			'web.sessions.page.confirmCloseTabTitle' => ({required Object name}) => 'Stop and remove "${name}"?',
+			'web.sessions.page.confirmCloseTabDescription' => 'The CLI process will be terminated and the row deleted.',
+			'web.sessions.page.confirmCloseTabConfirm' => 'Stop and remove',
+			'web.sessions.page.confirmRemoveTitle' => ({required Object name}) => 'Remove ${name}?',
+			'web.sessions.page.confirmRemoveTitleFallback' => 'Remove session?',
+			'web.sessions.page.confirmRemoveDescription' => 'This deletes the row.',
+			'web.sessions.page.confirmRemoveConfirm' => 'Remove',
+			'web.sessions.empty.title' => 'No session open',
+			'web.sessions.empty.hint' => ({required Object kbdN, required Object kbdW, required Object kbdRange}) => 'Pick a session from the list, or spawn a new one. Keyboard: ${kbdN} new, ${kbdW} close, ${kbdRange} switch.',
+			'web.sessions.empty.spawn' => 'Spawn session',
+			'web.sessions.header.loadingSession' => 'Loading session…',
+			'web.sessions.header.showList' => 'Show session list',
+			'web.sessions.header.hideList' => 'Hide session list',
+			'web.sessions.header.showInspector' => 'Show inspector',
+			'web.sessions.header.hideInspector' => 'Hide inspector',
+			'web.sessions.header.attachImage' => 'Attach image',
+			'web.sessions.header.attachImageTooltip' => 'Attach image (or paste / drop into terminal)',
+			'web.sessions.header.restart' => 'Restart',
+			'web.sessions.header.restarting' => 'Restarting…',
+			'web.sessions.header.remove' => 'Remove',
+			'web.sessions.header.removing' => 'Removing…',
+			'web.sessions.header.stop' => 'Stop',
+			'web.sessions.header.stopping' => 'Stopping…',
+			'web.sessions.header.pid' => ({required Object pid}) => 'pid ${pid}',
+			'web.sessions.terminal.uploadingToast' => 'Uploading image…',
+			'web.sessions.terminal.uploadedToast' => 'Image attached',
+			'web.sessions.terminal.uploadFailedToast' => 'Upload failed',
+			'web.sessions.terminal.uploadInvalidTypeToast' => 'Only image files can be attached',
+			'web.sessions.terminal.dropToAttach' => 'Drop image to attach',
+			'web.sessions.spawn.title' => 'Spawn session',
+			'web.sessions.spawn.description' => 'Start a CLI session under a registered provider.',
+			'web.sessions.spawn.provider' => 'Provider',
+			'web.sessions.spawn.claudeAccount' => 'Claude account',
+			'web.sessions.spawn.loadingAccounts' => 'Loading accounts…',
+			'web.sessions.spawn.noAccounts' => 'No Claude accounts configured — the gateway will use the system ANTHROPIC_API_KEY.',
+			'web.sessions.spawn.kDefault' => 'Default',
+			'web.sessions.spawn.defaultTooltip' => 'Use system keychain / env',
+			'web.sessions.spawn.tokenEmptyBadge' => '·empty',
+			'web.sessions.spawn.tokenMissingTooltip' => 'No token set — set token in Providers panel first',
+			'web.sessions.spawn.multiAccountHint' => 'Multiple accounts configured — pick one for this session.',
+			'web.sessions.spawn.cwd' => 'Working directory',
+			'web.sessions.spawn.cwdPlaceholder' => '/Users/you/projects/foo',
+			'web.sessions.spawn.browse' => 'Browse',
+			'web.sessions.spawn.nameLabel' => 'Name (optional)',
+			'web.sessions.spawn.namePlaceholder' => 'claude in pet-tracker',
+			'web.sessions.spawn.argsLabel' => 'CLI args (one per line)',
+			'web.sessions.spawn.bypassClaude' => 'Bypass permission prompts',
+			'web.sessions.spawn.bypassCodex' => 'Auto-approve (--ask-for-approval never)',
+			'web.sessions.spawn.bypassGemini' => 'YOLO mode (--yolo)',
+			'web.sessions.spawn.bypassOnHint' => 'This session will run with elevated autonomy.',
+			'web.sessions.spawn.bypassOffHint' => 'Off — confirmations and prompts behave normally.',
+			'web.sessions.spawn.errorPickProvider' => 'Pick a provider.',
+			'web.sessions.spawn.errorCwdRequired' => 'cwd is required.',
+			'web.sessions.spawn.cancel' => 'Cancel',
+			'web.sessions.spawn.submit' => 'Spawn',
+			'web.sessions.spawn.submitting' => 'Spawning…',
+			'web.sessions.spawn.spawnedToast' => 'Session spawned',
+			'web.sessions.spawn.spawnedDescription' => ({required Object provider, required Object pid}) => '${provider} · pid ${pid}',
+			'web.sessions.spawn.pidFallback' => '—',
+			'web.sessions.accountSwitcher.tooltip' => 'Switch Claude account (restarts the CLI process)',
+			'web.sessions.accountSwitcher.currentDefault' => 'default',
+			'web.sessions.accountSwitcher.menuTitle' => 'Switch Claude account',
+			'web.sessions.accountSwitcher.defaultName' => 'Default',
+			'web.sessions.accountSwitcher.defaultSubtitle' => 'CLI\'s system keychain / env',
+			'web.sessions.accountSwitcher.tokenEmpty' => '·empty',
+			'web.sessions.accountSwitcher.confirmSwitch' => 'Switching account will restart the Claude CLI process. In-progress conversation state inside the CLI will be lost. Continue?',
+			'web.sessions.accountSwitcher.switchedToast' => 'Account switched',
+			'web.sessions.accountSwitcher.switchedDescription' => ({required Object account, required Object pid}) => 'Now using @${account} · pid ${pid}',
+			'web.sessions.accountSwitcher.switchedDefault' => 'default',
+			'web.sessions.accountSwitcher.switchFailedToast' => 'Switch failed',
+			'web.sessions.inspector.tabs.files' => 'Files',
+			'web.sessions.inspector.tabs.git' => 'Git',
+			'web.sessions.inspector.tabs.search' => 'Search',
+			'web.sessions.inspector.tabs.tasks' => 'Tasks',
+			'web.sessions.inspector.tabs.history' => 'History',
+			'web.sessions.inspector.tabs.notes' => 'Notes',
+			'web.sessions.inspector.tabs.memory' => 'Memory',
+			'web.sessions.ended.bufferUnavailable' => '[buffer unavailable]',
+			'web.sessions.ended.readOnlyBanner' => '[session ended — read-only buffer]',
+			'web.sessions.fileBrowser.title' => 'Choose working directory',
+			'web.sessions.fileBrowser.description' => 'Browse the gateway host\'s filesystem and pick a folder.',
+			'web.sessions.fileBrowser.parent' => 'Parent directory',
+			'web.sessions.fileBrowser.home' => 'Home directory',
+			'web.sessions.fileBrowser.refresh' => 'Refresh',
+			'web.sessions.fileBrowser.pathPlaceholder' => '/Users/you/projects',
+			'web.sessions.fileBrowser.loading' => 'Loading…',
+			'web.sessions.fileBrowser.empty' => 'Empty directory.',
+			'web.sessions.fileBrowser.newFolder' => 'New folder',
+			'web.sessions.fileBrowser.newFolderPlaceholder' => 'new-folder-name',
+			'web.sessions.fileBrowser.create' => 'Create',
+			'web.sessions.fileBrowser.cancel' => 'Cancel',
+			'web.sessions.fileBrowser.useThisFolder' => 'Use this folder',
+			'web.sessions.fileBrowser.createdToast' => 'Directory created',
+			'web.sessions.fileBrowser.mkdirFailedToast' => 'Mkdir failed',
+			'web.sessions.fileBrowser.homeFailedToast' => 'Failed to read home',
+			'web.memory.title' => 'Memory',
+			'web.memory.subtitle' => 'Browse, search and edit memories agents have stored via the opendray-memory MCP server.',
+			'web.memory.navProject' => 'Project',
+			'web.memory.navCleanupInbox' => 'Cleanup inbox',
+			'web.memory.navWorkers' => 'Workers',
+			'web.memory.navConfiguration' => 'Configuration →',
+			'web.memoryWorkers.title' => 'Memory workers',
+			'web.memoryWorkers.loading' => 'Loading worker config…',
+			'web.memoryWorkers.errorTitle' => 'Endpoint not reachable.',
+			'web.memoryWorkers.errorDescription' => 'The /api/v1/memory/workers routes are new in M25 — the opendray binary may need a restart to mount them and run migration 0029.',
+			'web.memoryWorkers.intro' => 'Each memory-system LLM touchpoint can be served independently by the local <1>summarizer</1> endpoint (LM Studio / OpenAI-compat) or by spawning a headless <3>Claude / Gemini agent</3> in <5>--print</5> mode. High-quality narrative tasks (gitactivity, transcript) benefit from agent workers; high-frequency tasks (gatekeeper) stay on the local endpoint by design.',
+			'web.memoryWorkers.enabledBadge' => 'enabled',
+			'web.memoryWorkers.disabledBadge' => 'disabled',
+			'web.memoryWorkers.summarizerOnlyBadge' => 'summarizer-only',
+			'web.memoryWorkers.callsCount' => ({required Object count}) => '${count} calls · 24h',
+			'web.memoryWorkers.avgMs' => ({required Object ms}) => 'avg ${ms}ms',
+			'web.memoryWorkers.errorsCount' => ({required Object count}) => '${count} errors',
+			'web.memoryWorkers.workerLabel' => 'Worker',
+			'web.memoryWorkers.summarizerHttp' => 'Summarizer (HTTP)',
+			'web.memoryWorkers.agentCliPrint' => 'Agent (CLI --print)',
+			'web.memoryWorkers.summarizerProviderLabel' => 'Summarizer provider',
+			'web.memoryWorkers.registryDefault' => 'Registry default',
+			'web.memoryWorkers.cliLabel' => 'CLI',
+			'web.memoryWorkers.selectPlaceholder' => 'Select',
+			'web.memoryWorkers.cliClaude' => 'Claude',
+			'web.memoryWorkers.cliGemini' => 'Gemini',
+			'web.memoryWorkers.claudeAccountLabel' => 'Claude account',
+			'web.memoryWorkers.claudeAccountDefault' => 'Default',
+			'web.memoryWorkers.agentWarning' => 'Agent mode spawns a headless CLI per call. Latency rises from <1>~1s</1> (summarizer) to <3>~5-15s</3>; cost shifts from CPU to your Claude/Gemini quota.',
+			'web.memoryWorkers.enabledCheckbox' => 'Enabled',
+			'web.memoryWorkers.testButton' => 'Test',
+			'web.memoryWorkers.saveButton' => 'Save',
+			'web.memoryWorkers.recentCalls' => ({required Object count}) => 'Recent calls (${count})',
+			'web.memoryWorkers.tableWhen' => 'when',
+			'web.memoryWorkers.tableWorker' => 'worker',
+			'web.memoryWorkers.tableMs' => 'ms',
+			'web.memoryWorkers.tableOk' => 'ok',
+			'web.memoryWorkers.savedToast' => ({required Object label}) => '${label} updated',
+			'web.memoryWorkers.saveFailedToast' => 'Save failed',
+			'web.memoryWorkers.testOkToast' => ({required Object label, required Object ms}) => '${label} OK — ${ms}ms',
+			'web.memoryWorkers.testFailedToast' => ({required Object label}) => '${label} failed',
+			'web.memoryWorkers.testCallFailedToast' => 'Test call failed',
+			'web.memoryWorkers.unknownError' => 'unknown error',
+			'web.memoryWorkers.tasks.gatekeeper.label' => 'Gatekeeper',
+			'web.memoryWorkers.tasks.gatekeeper.description' => 'Pre-write filter on every memory_store. High frequency (<500ms target) — summarizer-only.',
+			'web.memoryWorkers.tasks.cleaner.label' => 'Cleaner librarian',
+			'web.memoryWorkers.tasks.cleaner.description' => 'Periodic LLM librarian. Judges aged memories as keep / stale / duplicate.',
+			'web.memoryWorkers.tasks.gitactivity.label' => 'Git activity summariser',
+			'web.memoryWorkers.tasks.gitactivity.description' => 'git log → 2-3 paragraph narrative every 24h. Naturally fits an agent worker.',
+			'web.memoryWorkers.tasks.transcript.label' => 'Session transcript summariser',
+			'web.memoryWorkers.tasks.transcript.description' => 'Session-end "what did the agent do" summary. Naturally fits an agent worker.',
+			'web.cleanupInbox.loading' => 'Loading…',
+			'web.cleanupInbox.emptyTitle' => 'Cleanup inbox empty',
+			'web.cleanupInbox.emptyDescription' => 'No pending cleanup decisions across any project. The LLM librarian either hasn\'t run yet for the eligible memories, or it found everything load-bearing.',
+			'web.cleanupInbox.title' => 'Cleanup inbox',
+			'web.cleanupInbox.subtitle' => 'Cross-project pending decisions from the LLM memory librarian. Approving stale → deletes, approving duplicate → merges, approving keep → freezes the entry from being re-judged for a while.',
+			'web.cleanupInbox.globalScope' => '(global)',
+			'web.cleanupInbox.orphanBadge' => 'orphan',
+			'web.cleanupInbox.orphanTitle' => 'Truncated scope_key (old mirror import). Not a navigable project.',
+			'web.cleanupInbox.openProject' => 'Open project',
+			'web.cleanupInbox.mergeIntoPrefix' => '→ merge into',
+			'web.cleanupInbox.reasonPrefix' => 'Reason:',
+			'web.cleanupInbox.executeButton' => 'Execute',
+			'web.cleanupInbox.confirmKeepButton' => 'Confirm keep',
+			'web.cleanupInbox.rejectButton' => 'Reject',
+			'web.cleanupInbox.approvedKeptToast' => 'Kept',
+			'web.cleanupInbox.approvedExecutedToast' => ({required Object verdict}) => '${verdict} executed',
+			'web.cleanupInbox.approveFailedToast' => 'Approve failed',
+			'web.cleanupInbox.rejectedToast' => 'Rejected — memory kept',
+			'web.cleanupInbox.rejectFailedToast' => 'Reject failed',
+			'web.project.picker.title' => 'Pick a project',
+			'web.project.picker.subtitle' => 'Project memory is scoped by working directory. Pick one to manage its goal, plan, journal, and cleanup queue.',
+			'web.project.picker.pathPlaceholder' => '/path/to/your/project',
+			'web.project.picker.browse' => 'Browse',
+			'web.project.picker.browseTooltip' => 'Browse the gateway host\'s filesystem',
+			'web.project.picker.open' => 'Open',
+			'web.project.picker.recentLabel' => 'Recent projects (from stored memory):',
+			'web.project.picker.orphanTooltip' => 'Looks like a truncated scope_key (old mirror import bug). May have no project docs.',
+			'web.project.picker.orphanBadge' => 'orphan',
+			'web.project.noCwd' => 'Pick a project to manage its memory.',
+			'web.project.header.docsCount_one' => ({required Object count}) => '${count} doc',
+			'web.project.header.docsCount_other' => ({required Object count}) => '${count} docs',
+			'web.project.header.journalEntries_one' => ({required Object count}) => '${count} journal entry',
+			'web.project.header.journalEntries_other' => ({required Object count}) => '${count} journal entries',
+			'web.project.header.pendingProposals_one' => ({required Object count}) => '${count} pending proposal',
+			'web.project.header.pendingProposals_other' => ({required Object count}) => '${count} pending proposals',
+			'web.project.header.cleanupPending' => ({required Object count}) => '${count} cleanup pending',
+			'web.project.tabs.goal' => 'Goal',
+			'web.project.tabs.plan' => 'Plan',
+			'web.project.tabs.tech' => 'Tech',
+			'web.project.tabs.activity' => 'Activity',
+			'web.project.tabs.journal' => 'Journal',
+			'web.project.tabs.inbox' => 'Inbox',
+			'web.project.tabs.cleanup' => 'Cleanup',
+			'web.project.docLabel.goal' => 'Goal',
+			'web.project.docLabel.plan' => 'Plan',
+			'web.project.docLabel.tech_stack' => 'Tech stack',
+			'web.project.docLabel.recent_activity' => 'Recent activity',
+			'web.project.verdictLabel.stale' => 'Delete',
+			'web.project.verdictLabel.duplicate' => 'Merge',
+			'web.project.verdictLabel.keep' => 'Keep',
+			'web.project.editor.updatedBy' => 'Updated by',
+			'web.project.editor.noDocSet' => ({required Object label}) => 'No ${label} set yet.',
+			'web.project.editor.save' => 'Save',
+			'web.project.editor.saveFailedToast' => 'Save failed',
+			'web.project.editor.savedToast' => ({required Object label}) => '${label} saved',
+			'web.project.editor.goalPlaceholder' => 'What are we building? One paragraph. Read by every agent on spawn.',
+			'web.project.editor.planPlaceholder' => 'Active plan — what we are doing right now and what is next. Updated as work progresses.',
+			'web.project.readonly.tech_stack.label' => 'Tech stack & structure',
+			'web.project.readonly.tech_stack.empty' => 'Run a Claude session in this project — scanner refreshes on every spawn.',
+			'web.project.readonly.recent_activity.label' => 'Recent activity (git → LLM)',
+			'web.project.readonly.recent_activity.empty' => 'The git activity summariser runs every 24h; check back after the next scheduler tick.',
+			'web.project.readonly.noneCaptured' => ({required Object label}) => 'No ${label} captured yet.',
+			'web.project.readonly.generatedBy' => 'Generated by',
+			'web.project.readonly.lastRefresh' => 'last refresh',
+			'web.project.journal.loading' => 'Loading…',
+			'web.project.journal.empty' => 'No journal entries yet. Each session-end appends one automatically.',
+			'web.project.inbox.loading' => 'Loading…',
+			'web.project.inbox.emptyTitle' => 'Inbox empty.',
+			'web.project.inbox.emptyHint' => 'Agents file proposals here via `project_goal_set` / `project_plan_set` MCP tools.',
+			'web.project.inbox.approvedToast' => ({required Object label}) => '${label} updated',
+			'web.project.inbox.approveFailedToast' => 'Approve failed',
+			'web.project.inbox.rejectedToast' => 'Rejected',
+			'web.project.inbox.rejectFailedToast' => 'Reject failed',
+			'web.project.inbox.sessionPrefix' => 'ses',
+			'web.project.inbox.warning' => ({required Object label}) => 'Approve will REPLACE the current ${label} entirely.',
+			'web.project.inbox.warningSuffix' => 'Review the diff below; this isn\'t a merge.',
+			'web.project.inbox.current' => 'Current',
+			'web.project.inbox.proposed' => 'Proposed',
+			'web.project.inbox.emptyBody' => '(empty)',
+			'web.project.inbox.approve' => 'Approve',
+			'web.project.inbox.reject' => 'Reject',
+			'web.project.inbox.confirmDialogTitle' => ({required Object label}) => 'Replace ${label}?',
+			'web.project.inbox.confirmDialogDescription' => ({required Object label}) => 'The current ${label} will be overwritten with the proposed content. This cannot be undone via this UI (you can manually edit it back).',
+			'web.project.inbox.confirmCancel' => 'Cancel',
+			'web.project.inbox.confirmReplace' => 'Confirm replace',
+			'web.project.cleanup.hint' => 'The LLM librarian proposes keep / stale / duplicate verdicts for this project\'s memories. You approve before anything is deleted.',
+			'web.project.cleanup.runNow' => 'Run cleanup now',
+			'web.project.cleanup.runSucceededToast' => ({required Object decided, required Object scanned}) => 'Cleanup run: ${decided} decisions queued (${scanned} scanned)',
+			'web.project.cleanup.runFailedToast' => 'Cleanup run failed',
+			'web.project.cleanup.empty' => 'No pending decisions. Either nothing aged into eligibility or the last run found everything load-bearing.',
+			'web.project.cleanup.mergeIntoPrefix' => '→ merge into',
+			'web.project.cleanup.reasonPrefix' => 'Reason:',
+			'web.project.cleanup.executeButton' => 'Execute',
+			'web.project.cleanup.confirmKeepButton' => 'Confirm keep',
+			'web.project.cleanup.rejectButton' => 'Reject',
+			'web.project.cleanup.approvedExecutedToast' => ({required Object label}) => '${label} executed',
+			'web.project.cleanup.approveFailedToast' => 'Approve failed',
+			'web.project.cleanup.rejectedToast' => 'Rejected — memory kept',
+			'web.project.cleanup.rejectFailedToast' => 'Reject failed',
+			'web.project.reset.button' => 'Reset',
+			'web.project.reset.dialogTitle' => 'Reset project memory?',
+			'web.project.reset.dialogDescription' => 'Deletes all stored project context for this cwd. This cannot be undone.',
+			'web.project.reset.alwaysDeleted' => 'Always deleted: goal, plan, proposals, journal, cleanup decisions.',
+			'web.project.reset.alsoDeleteScannerLabel' => 'Also delete scanner docs',
+			'web.project.reset.alsoDeleteScannerSuffix' => '(tech_stack + recent_activity).',
+			'web.project.reset.alsoDeleteScannerHint' => 'Auto-rebuild on next spawn anyway — leaving unchecked is usually fine.',
+			'web.project.reset.alsoDeleteMemoriesLabel' => 'Also delete pgvector memories',
+			'web.project.reset.alsoDeleteMemoriesSuffix' => 'for this scope_key.',
+			'web.project.reset.alsoDeleteMemoriesHint' => 'Long-term facts the agent stored (user preferences, project facts). Cannot be recovered.',
+			'web.project.reset.cancel' => 'Cancel',
+			'web.project.reset.deleteForever' => 'Delete forever',
+			'web.project.reset.successToast' => ({required Object summary}) => 'Reset: deleted ${summary}',
+			'web.project.reset.summary.docs_one' => ({required Object count}) => '${count} doc',
+			'web.project.reset.summary.docs_other' => ({required Object count}) => '${count} docs',
+			'web.project.reset.summary.journal' => ({required Object count}) => '${count} journal',
+			'web.project.reset.summary.proposals_one' => ({required Object count}) => '${count} proposal',
+			'web.project.reset.summary.proposals_other' => ({required Object count}) => '${count} proposals',
+			'web.project.reset.summary.cleanup' => ({required Object count}) => '${count} cleanup',
+			'web.project.reset.summary.memories' => ({required Object count}) => '${count} memories',
+			'web.project.reset.failedToast' => 'Reset failed',
+			'web.memoryInspector.status.label' => 'Active embedder',
+			'web.memoryInspector.status.unavailable' => 'unavailable',
+			'web.memoryInspector.status.probing' => 'probing…',
+			'web.memoryInspector.status.dimensions' => ({required Object dim, required Object state}) => '${dim}-dim · ${state}',
+			'web.memoryInspector.status.enabled' => 'enabled',
+			'web.memoryInspector.status.disabled' => 'disabled',
+			'web.memoryInspector.status.testButton' => 'Test embedder',
+			'web.memoryInspector.statusBody' => 'This is the embedder the gateway is currently using for every <1>memory_search</1> / <3>memory_store</3> call. If this doesn\'t match the configuration above, you have unsaved changes — click Save then Restart server to apply.',
+			'web.memoryInspector.scope.label' => 'Scope',
+			'web.memoryInspector.scope.scopeKey' => 'Scope key',
+			'web.memoryInspector.scope.scopeKeyIgnored' => '(ignored for global)',
+			'web.memoryInspector.scope.scopeKeyCwd' => '(cwd of the project)',
+			'web.memoryInspector.scope.scopeKeySession' => '(session id)',
+			'web.memoryInspector.scope.placeholderProject' => '/path/to/project (cwd)',
+			'web.memoryInspector.scope.placeholderSession' => 'session id',
+			'web.memoryInspector.scope.syncMd' => 'Sync .md',
+			'web.memoryInspector.scope.syncTooltip' => 'Re-ingest Claude\'s <cwd>/.claude/memory/*.md files into pgvector',
+			'web.memoryInspector.scope.values.project' => 'project',
+			'web.memoryInspector.scope.values.session' => 'session',
+			'web.memoryInspector.scope.values.global' => 'global',
+			'web.memoryInspector.search.placeholder' => 'Semantic search query (Enter to run; empty = browse)',
+			'web.memoryInspector.search.run' => 'Search',
+			'web.memoryInspector.search.clear' => 'Clear',
+			'web.memoryInspector.search.failedToast' => 'Search failed',
+			'web.memoryInspector.records.noMemories' => 'No memories yet',
+			'web.memoryInspector.records.matches_one' => ({required Object count}) => '${count} match',
+			'web.memoryInspector.records.matches_other' => ({required Object count}) => '${count} matches',
+			'web.memoryInspector.records.memories_one' => ({required Object count}) => '${count} memory',
+			'web.memoryInspector.records.memories_other' => ({required Object count}) => '${count} memories',
+			'web.memoryInspector.records.scopeGlobalSuffix' => ' (global)',
+			'web.memoryInspector.records.scopeInSuffix' => ({required Object scope}) => ' in ${scope}: ',
+			'web.memoryInspector.records.addButton' => 'Add memory',
+			'web.memoryInspector.records.addTooltip' => 'Manually create a memory in this scope',
+			'web.memoryInspector.records.deleteAll' => 'Delete all',
+			'web.memoryInspector.records.deleteAllTooltip' => 'Delete every memory under this scope/scope_key',
+			'web.memoryInspector.records.loading' => 'Loading…',
+			'web.memoryInspector.records.enterScopeKeyHint' => 'Enter a scope key to browse memories.',
+			'web.memoryInspector.records.noMatchesForQuery' => ({required Object query}) => 'No matches for "${query}"',
+			'web.memoryInspector.records.noMemoriesInScope' => 'No memories in this scope yet.',
+			'web.memoryInspector.row.simBadge' => ({required Object value}) => 'sim ${value}',
+			'web.memoryInspector.row.hits_one' => ({required Object count}) => '${count} hit',
+			'web.memoryInspector.row.hits_other' => ({required Object count}) => '${count} hits',
+			'web.memoryInspector.row.lastHitTooltip' => ({required Object relative}) => 'Last hit ${relative}',
+			'web.memoryInspector.row.editPlaceholder' => 'Memory text — Cmd/Ctrl+Enter to save · Esc to cancel',
+			'web.memoryInspector.row.saveTooltip' => 'Save (Cmd/Ctrl+Enter)',
+			'web.memoryInspector.row.cancelTooltip' => 'Cancel (Esc)',
+			'web.memoryInspector.row.editTooltip' => 'Edit this memory',
+			'web.memoryInspector.row.deleteTooltip' => 'Delete this memory',
+			'web.memoryInspector.row.emptyError' => 'Memory text cannot be empty',
+			'web.memoryInspector.row.deleteConfirm' => ({required Object id}) => 'Delete memory ${id}? This is permanent.',
+			'web.memoryInspector.toasts.deleted' => 'Memory deleted',
+			'web.memoryInspector.toasts.deleteFailed' => 'Delete failed',
+			'web.memoryInspector.toasts.bulkDeleted_one' => ({required Object count}) => 'Deleted ${count} memory from this scope',
+			'web.memoryInspector.toasts.bulkDeleted_other' => ({required Object count}) => 'Deleted ${count} memories from this scope',
+			'web.memoryInspector.toasts.bulkDeleteFailed' => 'Bulk delete failed',
+			'web.memoryInspector.toasts.created' => 'Memory created',
+			'web.memoryInspector.toasts.createFailed' => 'Create failed',
+			'web.memoryInspector.toasts.updated' => 'Memory updated',
+			'web.memoryInspector.toasts.updateFailed' => 'Update failed',
+			'web.memoryInspector.toasts.migrated' => ({required Object reembed, required Object examined, required Object to}) => 'Migrated ${reembed}/${examined} memories to ${to}',
+			'web.memoryInspector.toasts.migrationFailed' => 'Migration failed',
+			'web.memoryInspector.toasts.syncIngested_one' => ({required Object count}) => 'Ingested ${count} new memory file',
+			'web.memoryInspector.toasts.syncIngested_other' => ({required Object count}) => 'Ingested ${count} new memory files',
+			'web.memoryInspector.toasts.syncEmpty' => 'No new .md files to sync',
+			'web.memoryInspector.toasts.syncEmptyDescription' => 'Already in sync, or no Claude memory dir for this cwd.',
+			'web.memoryInspector.toasts.syncFailed' => 'Sync failed',
+			'web.memoryInspector.toasts.testOk' => ({required Object embedder, required Object dim}) => 'Embedder OK: ${embedder} · ${dim} dimensions',
+			'web.memoryInspector.toasts.testOkDescription' => ({required Object preview}) => 'vector_preview = [${preview}…]',
+			'web.memoryInspector.toasts.testFailed' => 'Embedder probe failed',
+			'web.memoryInspector.bulkDelete.title' => 'Delete every memory in this scope?',
+			'web.memoryInspector.bulkDelete.description' => 'This is a single SQL operation — all memories under the specified scope are removed atomically. Memories that were ingested via the Claude mirror reappear on the next <1>Sync .md</1> run; everything else is gone for good.',
+			'web.memoryInspector.bulkDelete.scope' => 'Scope',
+			'web.memoryInspector.bulkDelete.scopeKey' => 'Scope key',
+			'web.memoryInspector.bulkDelete.currentlyVisible' => 'Currently visible',
+			'web.memoryInspector.bulkDelete.items_one' => ({required Object count}) => '${count} memory item',
+			'web.memoryInspector.bulkDelete.items_other' => ({required Object count}) => '${count} memory items',
+			'web.memoryInspector.bulkDelete.cancel' => 'Cancel',
+			'web.memoryInspector.bulkDelete.deleteAll' => 'Delete all',
+			'web.memoryInspector.addMem.title' => 'Add memory',
+			'web.memoryInspector.addMem.description' => 'Manually create a memory. Agents create these automatically via the <1>memory_store</1> MCP tool — this form is for cases where the operator wants to seed a fact without going through an agent.',
+			'web.memoryInspector.addMem.textLabel' => 'Text',
+			'web.memoryInspector.addMem.textPlaceholder' => 'Plain prose. The embedder turns this into a vector at store time; agents will retrieve it via memory_search.',
+			'web.memoryInspector.addMem.cancel' => 'Cancel',
+			'web.memoryInspector.addMem.create' => 'Create',
+			'web.memoryInspector.picker.button' => 'Pick',
+			'web.memoryInspector.picker.buttonTooltip' => 'Pick from saved scope keys or active sessions',
+			'web.memoryInspector.picker.loading' => 'Loading…',
+			'web.memoryInspector.picker.empty' => ({required Object scope}) => 'No saved keys or active sessions for ${scope}.',
+			'web.memoryInspector.picker.savedHeader' => 'Saved memories',
+			'web.memoryInspector.picker.activeHeader' => 'Active sessions',
+			'web.memoryInspector.migrationBanner.headline_one' => ({required Object count}) => '${count} memory won\'t appear in searches',
+			'web.memoryInspector.migrationBanner.headline_other' => ({required Object count}) => '${count} memories won\'t appear in searches',
+			'web.memoryInspector.migrationBanner.subtitle' => ({required Object summary, required Object current}) => '${summary} — current embedder is <1>${current}</1>. pgvector partitions its similarity index by embedder, so older entries are silent until reembedded.',
+			'web.memoryInspector.migrationBanner.summaryItem' => ({required Object count, required Object name}) => '${count} on ${name}',
+			'web.memoryInspector.migrationBanner.migrateButton' => 'Migrate',
+			'web.memoryInspector.reembed.title' => 'Reembed memories',
+			'web.memoryInspector.reembed.description' => 'Recompute vectors for memories stored under a different embedder so they become searchable again.',
+			'web.memoryInspector.reembed.targetEmbedder' => 'Target embedder',
+			'web.memoryInspector.reembed.onName' => 'on',
+			'web.memoryInspector.reembed.totalToReembed' => 'Total to reembed',
+			'web.memoryInspector.reembed.explainer' => 'Each memory\'s text gets re-sent to the current embedder; the new vector replaces the old one in place. ID, scope, scope_key, metadata and timestamps are preserved. Search results take effect immediately — no restart needed.',
+			'web.memoryInspector.reembed.reportExamined' => 'Examined',
+			'web.memoryInspector.reembed.reportReembedded' => 'Reembedded',
+			'web.memoryInspector.reembed.reportFailed' => 'Failed',
+			'web.memoryInspector.reembed.reportFrom' => 'From',
+			'web.memoryInspector.reembed.errors_one' => ({required Object count}) => '${count} error',
+			'web.memoryInspector.reembed.errors_other' => ({required Object count}) => '${count} errors',
+			'web.memoryInspector.reembed.done' => 'Done',
+			'web.memoryInspector.reembed.cancel' => 'Cancel',
+			'web.memoryInspector.reembed.reembedding' => 'Reembedding…',
+			'web.memoryInspector.reembed.reembedTotal' => ({required Object total}) => 'Reembed ${total}',
+			'web.notes.title' => 'Notes',
+			'web.notes.header.outline' => 'Outline',
+			'web.notes.header.showOutline' => 'Show outline',
+			'web.notes.header.hideOutline' => 'Hide outline',
+			'web.notes.header.today' => 'Today',
+			'web.notes.header.todayTooltip' => 'Open or create today\'s daily note',
+			'web.notes.header.kNew' => 'New',
+			'web.notes.left.tree' => 'Tree',
+			'web.notes.left.tags' => 'Tags',
+			'web.notes.left.filterNotes' => 'Filter notes…',
+			'web.notes.left.filterTags' => 'Filter tags…',
+			'web.notes.left.filteredBy' => 'filtered by',
+			'web.notes.left.clearTagTooltip' => 'Clear tag filter',
+			'web.notes.left.expandAll' => 'Expand all',
+			'web.notes.left.expandAllTooltip' => 'Expand every folder',
+			'web.notes.left.collapseAll' => 'Collapse all',
+			'web.notes.left.collapseAllTooltip' => 'Collapse every folder',
+			'web.notes.left.loading' => 'Loading…',
+			'web.notes.left.footer' => ({required Object visible, required Object total}) => '${visible} / ${total} notes',
+			'web.notes.tags.emptyVault' => 'No tags in vault yet.',
+			'web.notes.tags.noMatches' => ({required Object query}) => 'No matches for "${query}".',
+			'web.notes.tree.empty' => 'Vault is empty.',
+			'web.notes.outline.label' => 'Outline',
+			'web.notes.outline.empty' => 'No headings in this note. Add <1>## Title</1> lines to populate the outline.',
+			'web.notes.newNote.prompt' => 'New note path (vault-relative, must end .md)',
+			'web.notes.newNote.defaultPath' => ({required Object date}) => 'library/notes-${date}.md',
+			'web.notes.newNote.errorMustEndMd' => 'Path must end in .md',
+			'web.notes.newNote.createdToast' => 'Note created',
+			'web.notes.newNote.createFailedToast' => 'Create failed',
+			'web.notes.empty.title' => 'No note selected',
+			'web.notes.empty.hint' => 'Pick a note from the tree on the left, jump straight to today\'s daily log, or create a fresh one. AI-written project docs live under <1>projects/</1>; your personal scratchpads under <3>personal/</3>.',
+			'web.notes.empty.today' => 'Today\'s daily note',
+			'web.notes.empty.kNew' => 'New note',
+			'web.notes.picker.browseAria' => 'Browse folders',
+			'web.notes.picker.matches_one' => ({required Object count}) => '${count} match',
+			'web.notes.picker.matches_other' => ({required Object count}) => '${count} matches',
+			'web.notes.picker.foldersInVault' => ({required Object count}) => '${count} folders in vault',
+			'web.notes.picker.noMatch' => ({required Object value}) => 'No existing folder matches. Save anyway to use <1>${value}</1> (lazy-created on first write).',
+			'web.notes.vaultSync.title' => 'Vault sync',
+			'web.notes.vaultSync.description' => 'Commit, pull, and push the notes vault as a git repository. Authentication uses your gateway host\'s git credentials (SSH agent / credential helper).',
+			'web.notes.vaultSync.reading' => 'Reading vault state…',
+			'web.notes.vaultSync.init.title' => 'Vault is not a git repo yet',
+			'web.notes.vaultSync.init.body' => 'Initialising will run <1>git init -b main</1> in your vault root and add a sane <3>.gitignore</3>. After that you can commit your notes and configure a remote (GitHub / Gitea / GitLab) for cross-machine sync.',
+			'web.notes.vaultSync.init.button' => 'Initialise vault as git repo',
+			'web.notes.vaultSync.init.initToast' => 'Vault initialised as git repo',
+			'web.notes.vaultSync.init.initFailedToast' => 'Init failed',
+			'web.notes.vaultSync.branch.clean' => 'clean',
+			'web.notes.vaultSync.branch.staged' => ({required Object count}) => '${count} staged',
+			'web.notes.vaultSync.branch.modified' => ({required Object count}) => '${count} modified',
+			'web.notes.vaultSync.branch.untracked' => ({required Object count}) => '${count} untracked',
+			'web.notes.vaultSync.action.pull' => 'Pull',
+			'web.notes.vaultSync.action.push' => 'Push',
+			'web.notes.vaultSync.action.pullTitleNoRemote' => 'Configure a remote first',
+			'web.notes.vaultSync.action.pullTitleHasUpstream' => 'git pull --rebase --autostash',
+			_ => null,
+		} ?? switch (path) {
+			'web.notes.vaultSync.action.pullTitleNoUpstream' => 'Pulls origin\'s HEAD; sets up tracking implicitly',
+			'web.notes.vaultSync.action.pushTitleNoRemote' => 'Configure a remote first',
+			'web.notes.vaultSync.action.pushTitleHasUpstream' => 'git push -u origin HEAD',
+			'web.notes.vaultSync.action.pushTitleNoUpstream' => 'First push — will set upstream to origin/HEAD',
+			'web.notes.vaultSync.action.noRemote' => 'No remote configured — pull/push disabled',
+			'web.notes.vaultSync.action.noUpstream' => 'No upstream tracking yet — first push will set it.',
+			'web.notes.vaultSync.action.pulledToast' => 'Pulled',
+			'web.notes.vaultSync.action.pullFailedToast' => 'Pull failed',
+			'web.notes.vaultSync.action.pushedToast' => 'Pushed',
+			'web.notes.vaultSync.action.pushFailedToast' => 'Push failed',
+			'web.notes.vaultSync.commit.title' => 'Commit',
+			'web.notes.vaultSync.commit.placeholder' => ({required Object date}) => 'Notes: ${date} (default)',
+			'web.notes.vaultSync.commit.commitAll' => 'Commit all',
+			'web.notes.vaultSync.commit.hint' => 'Stages every change (<1>git add .</1>) then commits with this message. Empty message defaults to a timestamped subject.',
+			'web.notes.vaultSync.commit.committedToast' => ({required Object hash}) => 'Committed ${hash}',
+			'web.notes.vaultSync.commit.commitFailedToast' => 'Commit failed',
+			'web.notes.vaultSync.fileList.title' => ({required Object count}) => 'Working tree · ${count}',
+			'web.notes.vaultSync.fileList.moreSuffix' => ({required Object count}) => '+${count} more',
+			'web.notes.vaultSync.remote.title' => 'Remote (origin)',
+			'web.notes.vaultSync.remote.cancel' => 'Cancel',
+			'web.notes.vaultSync.remote.change' => 'Change',
+			'web.notes.vaultSync.remote.configure' => 'Configure',
+			'web.notes.vaultSync.remote.empty' => 'No remote set. Add an HTTPS or SSH URL (e.g. <1>git@github.com:you/notes.git</1> or <3>https://tea.linivek.online/you/notes.git</3>) to enable push / pull.',
+			'web.notes.vaultSync.remote.urlLabel' => 'URL (HTTPS or SSH)',
+			'web.notes.vaultSync.remote.urlPlaceholder' => 'git@host:owner/notes.git',
+			'web.notes.vaultSync.remote.save' => 'Save',
+			'web.notes.vaultSync.remote.savedToast' => 'Remote saved',
+			'web.notes.vaultSync.remote.saveFailedToast' => 'Set remote failed',
+			'web.notes.vaultSync.history.title' => 'Recent commits',
+			'web.notes.vaultSync.history.loading' => 'Loading…',
+			'web.notes.vaultSync.history.empty' => 'No commits yet.',
+			'web.notes.vaultSync.conflict.kinds.rebase' => 'rebase',
+			'web.notes.vaultSync.conflict.kinds.merge' => 'merge',
+			'web.notes.vaultSync.conflict.kinds.cherryPick' => 'cherry-pick',
+			'web.notes.vaultSync.conflict.kinds.operation' => 'operation',
+			'web.notes.vaultSync.conflict.headline' => ({required Object kind}) => 'Vault has a paused ${kind} with unresolved conflicts',
+			'web.notes.vaultSync.conflict.explainer' => ({required Object kind}) => 'Pull, push and commit are blocked until the ${kind} finishes. You can either <1>abort</1> (restore the working tree to its state before the ${kind} — keeps your local commits, drops the remote ones) or <3>force reset to remote</3> (discard ALL local commits + uncommitted changes; vault becomes an exact mirror of origin).',
+			'web.notes.vaultSync.conflict.conflictedHeader' => ({required Object count}) => 'Conflicted files · ${count}',
+			'web.notes.vaultSync.conflict.abort' => ({required Object kind}) => 'Abort ${kind}',
+			'web.notes.vaultSync.conflict.abortTitle' => ({required Object kind}) => 'git ${kind} --abort',
+			'web.notes.vaultSync.conflict.forceReset' => 'Force reset to remote',
+			'web.notes.vaultSync.conflict.forceResetTitle' => 'git fetch && git reset --hard origin/<branch> && git clean -fd',
+			'web.notes.vaultSync.conflict.forceResetConfirm' => ({required Object kind}) => 'DESTRUCTIVE: this will\n  • abort the in-progress ${kind}\n  • run git fetch origin\n  • reset --hard to origin/<branch>\n  • clean -fd (drop untracked files)\n\nAny local commits not pushed to origin AND any uncommitted edits will be PERMANENTLY LOST.\n\nContinue?',
+			'web.notes.vaultSync.conflict.abortedToast' => ({required Object kind}) => 'Aborted ${kind}',
+			'web.notes.vaultSync.conflict.abortedDescription' => 'Working tree restored to pre-operation state.',
+			'web.notes.vaultSync.conflict.abortFailedToast' => 'Abort failed',
+			'web.notes.vaultSync.conflict.resetToast' => ({required Object branch}) => 'Reset to ${branch}',
+			'web.notes.vaultSync.conflict.resetDescription' => 'Local changes discarded; vault matches remote.',
+			'web.notes.vaultSync.conflict.resetFailedToast' => 'Reset failed',
+			'web.notes.vaultSync.auth.title' => 'Authentication',
+			'web.notes.vaultSync.auth.httpsTokenOk' => ({required Object host}) => 'Will use the token stored for <1>${host}</1> in Plugins → Git hosts. ✓',
+			'web.notes.vaultSync.auth.httpsTokenMissing' => ({required Object host}) => 'HTTPS remote on <1>${host}</1> with no opendray token configured. Push / pull will likely fail for private repos until you add one.',
+			'web.notes.vaultSync.auth.ssh' => ({required Object host}) => 'SSH remote on <1>${host}</1>. Auth uses the gateway host\'s <3>~/.ssh/</3> (ssh-agent, identity file, host config). Verify with <5>ssh -T git@${host}</5> from the host shell.',
+			'web.notes.vaultSync.auth.configureTokenLink' => '→ Configure git host token',
+			'web.notes.vaultSync.autoSync.loading' => 'Loading auto-sync settings…',
+			'web.notes.vaultSync.autoSync.title' => 'Auto-sync',
+			'web.notes.vaultSync.autoSync.on' => 'on',
+			'web.notes.vaultSync.autoSync.runNow' => 'Run now',
+			'web.notes.vaultSync.autoSync.runNowTooltip' => 'Wake the sync loop now (skips the wait, then runs whichever steps are due)',
+			'web.notes.vaultSync.autoSync.configure' => 'Configure',
+			'web.notes.vaultSync.autoSync.hide' => 'Hide',
+			'web.notes.vaultSync.autoSync.enabled' => 'Enabled',
+			'web.notes.vaultSync.autoSync.enabledTooltipNoRemote' => 'Configure a remote first to enable auto-sync',
+			'web.notes.vaultSync.autoSync.noRemoteHint' => 'No remote — push/pull will be skipped.',
+			'web.notes.vaultSync.autoSync.commitEvery' => 'Commit every',
+			'web.notes.vaultSync.autoSync.commitEveryExamples' => 'Examples: <1>30s</1>, <3>10m</3>, <5>2h</5>. Min 30s.',
+			'web.notes.vaultSync.autoSync.pullEvery' => 'Pull every',
+			'web.notes.vaultSync.autoSync.pullEveryHint' => 'Only used when Pull is enabled.',
+			'web.notes.vaultSync.autoSync.pushAfterCommit' => 'Push after commit',
+			'web.notes.vaultSync.autoSync.pullPeriodically' => 'Pull periodically',
+			'web.notes.vaultSync.autoSync.commitTemplateLabel' => 'Commit message template',
+			'web.notes.vaultSync.autoSync.commitTemplatePlaceholder' => ({required Object date}) => 'Auto-sync: ${date}  (default if empty)',
+			'web.notes.vaultSync.autoSync.saveSettings' => 'Save settings',
+			'web.notes.vaultSync.autoSync.discard' => 'Discard',
+			'web.notes.vaultSync.autoSync.lastCommit' => 'last commit',
+			'web.notes.vaultSync.autoSync.lastPush' => 'last push',
+			'web.notes.vaultSync.autoSync.lastPull' => 'last pull',
+			'web.notes.vaultSync.autoSync.never' => 'never',
+			'web.notes.vaultSync.autoSync.savedToast' => 'Auto-sync settings saved',
+			'web.notes.vaultSync.autoSync.saveFailedToast' => 'Save failed',
+			'web.notes.vaultSync.autoSync.triggeredToast' => 'Auto-sync triggered',
+			'web.notes.vaultSync.autoSync.runFailedToast' => 'Run failed',
+			'web.notes.syncBadge.loading' => 'Loading…',
+			'web.notes.syncBadge.syncLabel' => 'Sync',
+			'web.notes.syncBadge.initLabel' => 'Init',
+			'web.notes.syncBadge.initTooltip' => 'Vault is not a git repo yet',
+			'web.notes.syncBadge.conflictLabel' => 'Conflict',
+			'web.notes.syncBadge.conflictTooltip' => 'Vault has unresolved conflicts — click to recover',
+			'web.notes.syncBadge.syncFallback' => 'sync',
+			'web.notes.syncBadge.tooltip' => ({required Object branch, required Object files, required Object ahead, required Object behind}) => 'branch ${branch} · ${files} changes · ${ahead} ahead · ${behind} behind',
+			'web.notes.syncBadge.tooltipAutoOn' => ' · auto-sync on',
+			'web.notes.syncBadge.tooltipLastError' => ({required Object error}) => ' · last error: ${error}',
+			'web.notes.syncBadge.branchPlaceholder' => '—',
+			'web.activity.title' => 'Activity',
+			'web.activity.subtitle' => 'Per-call audit of API requests made by registered integrations. Includes both inbound calls (a third-party app calling opendray with its API key) and outbound proxied calls (admin → opendray proxy → integration). Calls made directly by this admin UI are not recorded.',
+			'web.activity.refresh' => 'Refresh',
+			'web.activity.refreshTooltip' => 'Refresh',
+			'web.activity.filters.integration' => 'Integration',
+			'web.activity.filters.direction' => 'Direction',
+			'web.activity.filters.status' => 'Status',
+			'web.activity.filters.allIntegrations' => 'All integrations',
+			'web.activity.filters.all' => 'All',
+			'web.activity.filters.inbound' => 'Inbound',
+			'web.activity.filters.outbound' => 'Outbound',
+			'web.activity.filters.allStatuses' => 'All statuses',
+			'web.activity.filters.status2' => '2xx success',
+			'web.activity.filters.status3' => '3xx redirect',
+			'web.activity.filters.status4' => '4xx client error',
+			'web.activity.filters.status5' => '5xx server error',
+			'web.activity.callsCount_one' => ({required Object count}) => '${count} call',
+			'web.activity.callsCount_other' => ({required Object count}) => '${count} calls',
+			'web.activity.loading' => 'Loading…',
+			'web.activity.table.time' => 'Time',
+			'web.activity.table.integration' => 'Integration',
+			'web.activity.table.directionTitle' => 'Direction',
+			'web.activity.table.method' => 'Method',
+			'web.activity.table.path' => 'Path',
+			'web.activity.table.status' => 'Status',
+			'web.activity.table.duration' => 'Duration',
+			'web.activity.table.inboundAria' => 'inbound',
+			'web.activity.table.outboundAria' => 'outbound',
+			'web.activity.empty.filtered' => 'No calls match these filters.',
+			'web.activity.empty.title' => 'No API calls recorded yet',
+			'web.activity.empty.description' => 'When a third-party app calls opendray with its integration API key, every request is logged here.',
+			'web.activity.empty.stepWithIntegrations' => 'Use an existing integration\'s API key in your third-party app',
+			'web.activity.empty.stepRegister' => 'Register an integration in Integrations → New',
+			'web.activity.empty.stepCallEndpoint' => 'Call any endpoint, e.g. <1>POST /api/v1/sessions</1>',
+			'web.activity.empty.stepAppears' => 'Calls appear here within seconds',
+			'web.activity.empty.footnote' => 'Calls you make from this admin UI are not logged — only integration-attributed traffic is recorded.',
+			'web.activity.events.loading' => 'Loading events…',
+			'web.activity.events.empty' => 'No events yet.',
+			'web.activity.events.emptyFiltered' => 'No matching events.',
+			'web.activity.events.loadOlder' => 'Load older events',
+			'web.activity.events.today' => 'Today',
+			'web.activity.events.yesterday' => 'Yesterday',
+			'web.providers.list.title' => 'Providers',
+			'web.providers.list.loading' => 'Loading…',
+			'web.providers.list.disabledBadge' => 'disabled',
+			'web.providers.list.noneSelected' => 'No provider selected.',
+			'web.providers.detail.enabled' => 'Enabled',
+			'web.providers.detail.disabled' => 'Disabled',
+			'web.providers.detail.toggleAria' => ({required Object name}) => 'Toggle ${name}',
+			'web.providers.detail.configuration' => 'Configuration',
+			'web.providers.detail.noConfig' => 'This provider has no user-configurable fields.',
+			'web.providers.detail.executable' => 'executable:',
+			'web.providers.detail.manifestHash' => 'manifest_hash:',
+			'web.providers.detail.reset' => 'Reset',
+			'web.providers.detail.save' => 'Save changes',
+			'web.providers.detail.saving' => 'Saving…',
+			'web.providers.detail.savedToast' => 'Provider config saved',
+			'web.providers.detail.saveFailedToast' => 'Save failed',
+			'web.providers.detail.toggleFailedToast' => 'Toggle failed',
+			'web.providers.detail.caps.resume' => 'resume',
+			'web.providers.detail.caps.stream' => 'stream',
+			'web.providers.detail.caps.images' => 'images',
+			'web.providers.detail.caps.mcp' => 'mcp',
+			'web.providers.configForm.selectPlaceholder' => 'Select…',
+			'web.providers.configForm.defaultOption' => '(default)',
+			'web.providers.configForm.switchOn' => 'On',
+			'web.providers.configForm.switchOff' => 'Off',
+			'web.providers.configForm.showSecret' => 'Show secret',
+			'web.providers.configForm.hideSecret' => 'Hide secret',
+			'web.providers.claudeAccounts.title' => 'Claude accounts',
+			'web.providers.claudeAccounts.tutorialTooltip' => 'Open the multi-account tutorial section',
+			'web.providers.claudeAccounts.importLocal' => 'Import local',
+			'web.providers.claudeAccounts.importLocalTooltip' => 'Scan ~/.claude-accounts/ on the gateway host and register any new directories. The button is gateway-host only — see the tutorial.',
+			'web.providers.claudeAccounts.importedNothingToast' => 'Nothing to import — accounts already in sync.',
+			'web.providers.claudeAccounts.importedToast_one' => ({required Object count}) => 'Imported ${count} account from ~/.claude-accounts',
+			'web.providers.claudeAccounts.importedToast_other' => ({required Object count}) => 'Imported ${count} accounts from ~/.claude-accounts',
+			'web.providers.claudeAccounts.importFailedToast' => 'Import failed',
+			'web.providers.claudeAccounts.addingTitle' => 'Adding a new account.',
+			'web.providers.claudeAccounts.addingBodyPrefix' => 'Run on the gateway host:',
+			'web.providers.claudeAccounts.addingBodySuffix' => 'opendray\'s filesystem watcher will register the new directory automatically, or click <1>Import local</1> to scan immediately.',
+			'web.providers.claudeAccounts.architectureLink' => 'Architecture & full guide →',
+			'web.providers.claudeAccounts.loading' => 'Loading…',
+			'web.providers.claudeAccounts.empty' => 'No Claude accounts yet. Run the shell command above on the gateway host, then click <1>Import local</1> to scan.',
+			'web.providers.claudeAccounts.noTokenYet' => 'no token yet',
+			'web.providers.claudeAccounts.configDir' => 'config_dir:',
+			'web.providers.claudeAccounts.tokenPath' => 'token_path:',
+			'web.providers.claudeAccounts.toggleFailedToast' => 'Toggle failed',
+			'web.providers.claudeAccounts.removeConfirm' => ({required Object name}) => 'Remove account "${name}"?',
+			'web.providers.claudeAccounts.removedToast' => 'Account removed',
+			'web.providers.claudeAccounts.removeFailedToast' => 'Remove failed',
+			'web.providers.claudeAccounts.toggleAria' => ({required Object name}) => 'Toggle ${name}',
+			'web.providers.claudeAccounts.removeAria' => ({required Object name}) => 'Remove ${name}',
+			'web.channels.title' => 'Channels',
+			'web.channels.subtitle' => 'Bidirectional messaging integrations. Outbound notifications are filtered by each channel\'s <1>notify_on</1>.',
+			'web.channels.newButton' => 'New channel',
+			'web.channels.loading' => 'Loading…',
+			'web.channels.empty.title' => 'No channels yet',
+			'web.channels.empty.description' => 'Bundled kinds: Telegram · Slack · Discord · Feishu · DingTalk · WeCom. Pick one and paste credentials, or use <1>bridge</1> for a custom platform via WebSocket.',
+			'web.channels.card.running' => 'running',
+			'web.channels.card.starting' => 'starting…',
+			'web.channels.card.disabled' => 'disabled',
+			'web.channels.card.muted' => 'muted',
+			'web.channels.card.tokenLabel' => 'token:',
+			'web.channels.card.chatIdLabel' => 'chat_id:',
+			'web.channels.card.channelIdLabel' => 'channel_id:',
+			'web.channels.card.notifyOnLabel' => 'notify_on:',
+			'web.channels.card.webhookLabel' => 'webhook:',
+			'web.channels.card.copyWebhookTooltip' => 'Copy webhook URL',
+			'web.channels.card.webhookCopiedToast' => 'Webhook URL copied',
+			'web.channels.card.setup' => 'Setup',
+			'web.channels.card.setupTooltip' => 'Show adapter connection details + sample code',
+			'web.channels.card.test' => 'Test',
+			'web.channels.card.testNotRunningTooltip' => 'Channel must be running',
+			'web.channels.card.testBridgeTooltip' => 'Bridge channels cannot be tested from the admin — connect an adapter first',
+			'web.channels.card.editAria' => 'Edit channel',
+			'web.channels.card.editTooltip' => 'Edit channel config',
+			'web.channels.card.deleteAria' => 'Delete channel',
+			'web.channels.card.bridgeSuffix' => '(bridge)',
+			'web.channels.toasts.testSent' => 'Test message sent',
+			'web.channels.toasts.testFailed' => 'Test failed',
+			'web.channels.toasts.deleteConfirm' => ({required Object id}) => 'Delete channel ${id}?',
+			'web.channels.toasts.deleted' => 'Channel deleted',
+			'web.channels.toasts.created' => 'Channel created',
+			'web.channels.toasts.updated' => 'Channel updated',
+			'web.channels.dialog.editTitle' => 'Edit channel',
+			'web.channels.dialog.createTitle' => 'Register channel',
+			'web.channels.dialog.descriptionBridge' => 'External adapter (Python/Node/...) connects via WebSocket and presents this token.',
+			'web.channels.dialog.descriptionDefault' => 'Configure messaging integration.',
+			'web.channels.dialog.kindLabel' => 'Kind',
+			'web.channels.dialog.kindImmutable' => '(immutable — delete and recreate to change kind)',
+			'web.channels.dialog.enabledLabel' => 'Enabled',
+			'web.channels.dialog.enabledBridgeHint' => ' (accept adapter connections immediately)',
+			'web.channels.dialog.enabledWebhookHint' => ' (start receiving webhooks immediately)',
+			'web.channels.dialog.enabledDefaultHint' => ' (start immediately)',
+			'web.channels.dialog.cancel' => 'Cancel',
+			'web.channels.dialog.save' => 'Save',
+			'web.channels.dialog.saving' => 'Saving…',
+			'web.channels.dialog.create' => 'Create',
+			'web.channels.dialog.creating' => 'Creating…',
+			'web.channels.dialog.unknownKind' => ({required Object kind}) => 'Unknown kind: ${kind}',
+			'web.channels.dialog.nameRequired' => 'name is required',
+			'web.channels.dialog.tokenRequired' => 'token is required',
+			'web.channels.dialog.topicIdsNumeric' => ({required Object value}) => 'Topic IDs must be numeric (got ${value})',
+			'web.channels.dialog.fieldRequired' => ({required Object label}) => '${label} is required',
+			'web.channels.dialog.cooldownInvalid' => 'Cooldown must be a non-negative number of seconds',
+			'web.channels.dialog.snippetCapInvalid' => 'Snippet cap must be a non-negative number',
+			'web.channels.notifications.sectionTitle' => 'Session notifications',
+			'web.channels.notifications.notifyOnLabel' => 'Notify on',
+			'web.channels.notifications.hintAll' => 'Receiving every session event. Click a tag to opt out.',
+			'web.channels.notifications.hintNone' => 'No events selected — outbound notifications muted.',
+			'web.channels.notifications.hintSome' => ({required Object selected, required Object total}) => 'Only ${selected} of ${total} topics selected.',
+			'web.channels.notifications.repeatPolicyLabel' => 'Repeat policy',
+			'web.channels.notifications.cooldownLabel' => 'Cooldown duration',
+			'web.channels.notifications.onceReplyHint' => 'Replying with non-command text in this chat resets the suppression — opendray forwards your reply to the session\'s stdin and re-arms the notifier.',
+			'web.channels.notifications.terminalSnippetLabel' => 'Terminal snippet',
+			'web.channels.notifications.embedSnippetLabel' => 'Embed the recent terminal screen in idle notifications',
+			'web.channels.notifications.snippetExplainer' => 'When enabled, the idle card includes a code-block snippet of what the user would see in the live web terminal — Claude TUI chrome (status spinner, "bypass permissions" hint, separator lines) is filtered out automatically.',
+			'web.channels.notifications.modes.onceLabel' => 'Once per session (recommended)',
+			'web.channels.notifications.modes.onceHint' => 'Fire once when a session goes idle, then stay silent until either the session ends or you reply via this channel.',
+			'web.channels.notifications.modes.cooldownLabel' => 'Time-window cooldown',
+			'web.channels.notifications.modes.cooldownHint' => 'Suppress repeats for the same (session, event) within the chosen window.',
+			'web.channels.notifications.modes.everyLabel' => 'Every event (noisy)',
+			'web.channels.notifications.modes.everyHint' => 'No suppression. Use only for low-frequency channels.',
+			'web.channels.notifications.cooldowns.k60' => '1 minute',
+			'web.channels.notifications.cooldowns.k300' => '5 minutes',
+			'web.channels.notifications.cooldowns.k900' => '15 minutes',
+			'web.channels.notifications.cooldowns.k1800' => '30 minutes',
+			'web.channels.notifications.cooldowns.k3600' => '1 hour',
+			'web.channels.notifications.snippetCaps.k0' => 'No cap — chunk into multiple messages (default)',
+			'web.channels.notifications.snippetCaps.k1000' => '1000 chars (terse)',
+			'web.channels.notifications.snippetCaps.k3000' => '3000 chars',
+			'web.channels.notifications.snippetCaps.k6000' => '6000 chars',
+			'web.channels.notifications.snippetCaps.k12000' => '12000 chars',
+			'web.channels.bridge.nameLabel' => 'Bridge name',
+			'web.channels.bridge.namePlaceholder' => 'wechat / discord-custom / whatsapp...',
+			'web.channels.bridge.nameHint' => 'Human label for the adapter. Shown in the channels list.',
+			'web.channels.bridge.tokenLabel' => 'Adapter token',
+			'web.channels.bridge.regenerateTooltip' => 'Regenerate',
+			'web.channels.bridge.copyTooltip' => 'Copy',
+			'web.channels.bridge.tokenCopiedToast' => 'Token copied',
+			'web.channels.bridge.tokenHint' => 'Adapter authenticates by sending this in the WS register frame (or as <1>X-Bridge-Token</1> header).',
+			'web.channels.bridge.capsLabel' => 'Accept capabilities (optional whitelist)',
+			'web.channels.bridge.capsHint' => 'Empty = accept whatever the adapter declares. Selected = only allow these capabilities even if the adapter offers more.',
+			'web.channels.bridge.afterCreate' => 'After <1>Create</1>, the adapter setup dialog opens automatically with the WebSocket URL and copy-pasteable Python / Node / wscat starter code.',
+			'web.channels.setup.title' => ({required Object name}) => 'Adapter setup — ${name}',
+			'web.channels.setup.description' => 'Run an adapter (any language) that connects to opendray over WebSocket using these credentials. opendray will route session notifications and slash-command actions through it.',
+			'web.channels.setup.wsUrlLabel' => 'WebSocket URL',
+			'web.channels.setup.tokenLabel' => 'Adapter token',
+			'web.channels.setup.authInfo' => ({required Object frame}) => '<1>Auth:</1> send the token as <3>X-Bridge-Token</3> header, <5>?token=</5> query param, or <7>Authorization: Bearer …</7>. The first WS frame must be <9>${frame}</9>. Full spec: <11>docs/bridge-protocol.md</11> in the repo.',
+			'web.channels.setup.pythonInstall' => 'Install: <1>pip install websockets</1>. Run: <3>python adapter.py</3>.',
+			'web.channels.setup.nodeInstall' => 'Install: <1>npm i ws</1>. Run: <3>node adapter.mjs</3>.',
+			'web.channels.setup.wscatInstall' => 'Install: <1>npm i -g wscat</1>. Once connected, paste the JSON line shown above to register, then send further frames manually.',
+			'web.channels.setup.close' => 'Close',
+			'web.channels.setup.copyHide' => 'Hide',
+			'web.channels.setup.copyShow' => 'Show',
+			'web.channels.setup.copyLabelToast' => ({required Object label}) => '${label} copied',
+			'web.channels.setup.copyCode' => 'Copy',
+			'web.channels.setup.copied' => 'Copied',
+			'web.channels.setup.codeCopiedToast' => 'Code copied',
+			'web.integrations.title' => 'Integrations',
+			'web.integrations.subtitle' => 'External apps that consume opendray. Reverse-proxy through <1>/api/v1/proxy/&lt;prefix&gt;/…</1> and subscribe to events via the WS endpoint.',
+			'web.integrations.register' => 'Register',
+			'web.integrations.loading' => 'Loading…',
+			'web.integrations.tabs.registered' => 'Registered',
+			'web.integrations.tabs.console' => 'Reverse proxy',
+			'web.integrations.empty.title' => 'No integrations yet',
+			'web.integrations.empty.description' => 'Register an external app to give it a scoped API key. Its code stays out of this repo.',
+			'web.integrations.empty.register' => 'Register integration',
+			'web.integrations.groupSystem' => 'System (managed by opendray)',
+			'web.integrations.groupOperator' => 'Operator-registered',
+			'web.integrations.card.managedBadge' => 'managed',
+			'web.integrations.card.managedTooltip' => 'opendray manages this integration. Editing or rotating its key would orphan running sessions whose mcp.json holds the previous bearer.',
+			'web.integrations.card.consumerBadge' => 'consumer',
+			'web.integrations.card.consumerTooltip' => 'Consumer-only integration — no HTTP service to probe',
+			'web.integrations.card.disabledBadge' => 'disabled',
+			'web.integrations.card.consumerOnlyHint' => 'Consumes opendray\'s API. No reverse proxy mounted.',
+			'web.integrations.card.lastProbed' => ({required Object relative}) => 'last probed ${relative}',
+			'web.integrations.card.rotated' => ({required Object relative}) => 'rotated ${relative}',
+			'web.integrations.card.managedReadOnly' => 'read-only — opendray bakes its key into every spawn\'s mcp.json',
+			'web.integrations.card.managedReadOnlyTooltip' => 'opendray manages this row. To reset: delete ~/.opendray/memory.key and restart, or delete this row directly via SQL — it\'ll be re-bootstrapped at next startup.',
+			'web.integrations.card.editAria' => 'Edit integration',
+			'web.integrations.card.editTooltip' => 'Edit scopes / base URL / version',
+			'web.integrations.card.rotateKey' => 'Rotate key',
+			'web.integrations.card.deleteAria' => 'Delete integration',
+			'web.integrations.card.rotateConfirm' => ({required Object name}) => 'Rotate the API key for "${name}"? The current key will stop working immediately.',
+			'web.integrations.card.deleteConfirm' => ({required Object name}) => 'Delete integration ${name}?',
+			'web.integrations.card.removedToast' => 'Integration removed',
+			'web.integrations.register_dialog.title' => 'Register integration',
+			'web.integrations.register_dialog.description' => 'Issues a one-time API key. Copy it before closing — opendray never displays the plaintext again.',
+			'web.integrations.register_dialog.nameLabel' => 'Name',
+			'web.integrations.register_dialog.namePlaceholder' => 'PetTracker',
+			'web.integrations.register_dialog.modeHint' => 'Leave the next two fields blank for a <1>consumer-only</1> integration (third-party app that calls opendray\'s API but doesn\'t expose its own service). Fill both for a <3>reverse-proxy</3> integration.',
+			'web.integrations.register_dialog.baseUrlLabel' => 'Base URL',
+			'web.integrations.register_dialog.optionalSuffix' => '(optional)',
+			'web.integrations.register_dialog.baseUrlPlaceholder' => 'http://192.168.3.42:8080',
+			'web.integrations.register_dialog.routePrefixLabel' => 'Route prefix',
+			'web.integrations.register_dialog.routePrefixPlaceholder' => 'pet-tracker',
+			'web.integrations.register_dialog.routePrefixHint' => ({required Object prefix}) => 'Reachable at <1>/api/v1/proxy/${prefix}/*</1>.',
+			'web.integrations.register_dialog.routePrefixPlaceholderToken' => '<prefix>',
+			'web.integrations.register_dialog.versionLabel' => 'Version (optional)',
+			'web.integrations.register_dialog.versionPlaceholder' => '0.1.0',
+			'web.integrations.register_dialog.scopesLabel' => 'Scopes',
+			'web.integrations.register_dialog.scopesIntro' => 'Pick the API surface this integration is allowed to call. Each toggle maps to a Bearer-token claim — opendray rejects requests that touch endpoints outside the granted set.',
+			'web.integrations.register_dialog.errorNameRequired' => 'Name is required.',
+			'web.integrations.register_dialog.errorBothOrNeither' => 'base_url and route_prefix go together. Set both for a reverse-proxy integration, leave both blank for a consumer-only integration.',
+			'web.integrations.register_dialog.cancel' => 'Cancel',
+			'web.integrations.register_dialog.submit' => 'Register',
+			'web.integrations.register_dialog.submitting' => 'Registering…',
+			'web.integrations.reveal.titleIssued' => 'API key issued',
+			'web.integrations.reveal.titleRotated' => 'API key rotated',
+			'web.integrations.reveal.description' => 'This is the only time the plaintext key will be shown. Copy it now and update every consumer app — the previous key (if any) no longer authenticates.',
+			'web.integrations.reveal.discardAria' => 'Discard new key',
+			'web.integrations.reveal.discardTooltip' => 'Discard the new key (rotation already happened — old key is gone too)',
+			'web.integrations.reveal.discardConfirm' => 'Discard the new key? Rotation has already invalidated the old key — discarding means you have NO working key for this integration until you rotate again.',
+			'web.integrations.reveal.copy' => 'Copy',
+			'web.integrations.reveal.copied' => 'Copied',
+			'web.integrations.reveal.updateHint' => '<1>Update every consumer app with this new key.</1> The previous key has been invalidated server-side and will return <3>401 unauthorized</3> on the next request.',
+			'web.integrations.reveal.acknowledge' => 'I have copied the key and will update my consumer apps. I understand opendray will not display it again.',
+			'web.integrations.reveal.discard' => 'Discard',
+			'web.integrations.reveal.done' => 'Done',
+			'web.integrations.edit_dialog.title' => ({required Object name}) => 'Edit integration · ${name}',
+			'web.integrations.edit_dialog.description' => 'Change scopes, version, or base URL. Name and route prefix are immutable — delete + re-register if you need to change those.',
+			'web.integrations.edit_dialog.nameLabel' => 'Name',
+			'web.integrations.edit_dialog.routePrefixLabel' => 'Route prefix',
+			'web.integrations.edit_dialog.consumerOnlyLabel' => '(consumer-only)',
+			'web.integrations.edit_dialog.baseUrlLabel' => 'Base URL',
+			'web.integrations.edit_dialog.baseUrlConsumerSuffix' => '(consumer-only — leave blank)',
+			'web.integrations.edit_dialog.baseUrlProxySuffix' => '(reverse-proxy target)',
+			'web.integrations.edit_dialog.baseUrlConsumerPlaceholder' => '(blank — this integration consumes opendray\'s API)',
+			'web.integrations.edit_dialog.baseUrlProxyPlaceholder' => 'http://127.0.0.1:8080',
+			'web.integrations.edit_dialog.consumerHint' => 'This is a consumer-only integration. Changing base URL here would also require a route prefix; do that with delete + re-register.',
+			'web.integrations.edit_dialog.versionLabel' => 'Version',
+			'web.integrations.edit_dialog.versionPlaceholder' => '0.1.0',
+			'web.integrations.edit_dialog.scopesLabel' => 'Scopes',
+			'web.integrations.edit_dialog.scopesIntro' => 'Trim or widen the API surface this integration\'s API key authorises. Live tokens are unaffected — the new scope set takes effect on the next request.',
+			'web.integrations.edit_dialog.errorModeSwitch' => 'Switching between consumer-only and reverse-proxy mode requires deleting the integration and re-registering — name and route_prefix can\'t change in place.',
+			'web.integrations.edit_dialog.updatedToast' => 'Integration updated',
+			'web.integrations.edit_dialog.cancel' => 'Cancel',
+			'web.integrations.edit_dialog.save' => 'Save changes',
+			'web.integrations.proxy.emptyTitle' => 'No integrations registered',
+			'web.integrations.proxy.emptyDescription' => ({required Object prefix}) => 'Register an integration first; the console proxies through /api/v1/proxy/${prefix}/* using the admin token.',
+			'web.integrations.proxy.targetLabel' => 'Target',
+			'web.integrations.proxy.selectPlaceholder' => 'Select integration…',
+			'web.integrations.proxy.baseLabel' => 'base:',
+			'web.integrations.proxy.history' => 'History',
+			'web.integrations.proxy.historyEmpty' => 'no past requests for this integration',
+			'web.integrations.proxy.send' => 'Send',
+			'web.integrations.proxy.sending' => 'Sending…',
+			'web.integrations.proxy.extraHeadersLabel' => 'Extra headers (one per line, Name: Value)',
+			'web.integrations.proxy.bodyLabel' => 'Body',
+			'web.integrations.proxy.headers' => 'Headers',
+			'web.integrations.proxy.body' => 'Body',
+			'web.integrations.proxy.emptyBody' => '(empty)',
+			'web.integrations.proxy.requestFailed' => 'request failed',
+			'web.integrations.proxy.stubText' => 'Send a request to see the upstream response.',
+			'web.integrations.proxy.stubInjects' => 'opendray injects <1>X-Integration-ID</1> and strips your <3>Authorization</3> header.',
+			'web.integrations.proxy.prefixPlaceholder' => '<prefix>',
+			'web.plugins.title' => 'Inspector plugins',
+			'web.plugins.subtitle' => 'Configure data sources surfaced in the right-hand Inspector panel when a session is open. Each plugin is admin-only and shared across all sessions. Click a section header to collapse it.',
+			'web.plugins.common.loading' => 'Loading…',
+			'web.plugins.common.cancel' => 'Cancel',
+			'web.plugins.common.edit' => 'Edit',
+			'web.plugins.common.add' => 'Add',
+			'web.plugins.common.save' => 'Save',
+			'web.plugins.common.create' => 'Create',
+			'web.plugins.mcp.title' => 'MCP servers',
+			'web.plugins.mcp.description' => ({required Object KEY}) => 'Model Context Protocol servers injected into every spawn (claude / codex). Vault entries live at <1>~/.opendray/vault/mcp/&lt;id&gt;/mcp.json</1>; secrets (referenced as <3>\$${KEY}</3> in env / headers) come from the <5>MCP secrets</5> section below.',
+			'web.plugins.mcp.newServer' => 'New server',
+			'web.plugins.mcp.empty' => 'No MCP servers yet. Add one to expose extra tools to your agent sessions.',
+			'web.plugins.mcp.columns.name' => 'Name',
+			'web.plugins.mcp.columns.transport' => 'Transport',
+			'web.plugins.mcp.columns.spec' => 'Spec',
+			'web.plugins.mcp.columns.enabled' => 'Enabled',
+			'web.plugins.mcp.noUrl' => 'no url',
+			'web.plugins.mcp.noCommand' => 'no command',
+			'web.plugins.mcp.deleteConfirm' => ({required Object id}) => 'Delete MCP server "${id}"?',
+			'web.plugins.mcp.removedToast' => 'MCP server removed',
+			'web.plugins.mcp.deleteFailedToast' => 'Delete failed',
+			'web.plugins.mcp.toggleFailedToast' => 'Toggle failed',
+			'web.plugins.mcp.editor.createTitle' => 'New MCP server',
+			'web.plugins.mcp.editor.editTitle' => ({required Object id}) => 'Edit MCP: ${id}',
+			'web.plugins.mcp.editor.description' => ({required Object API_KEY}) => 'JSON shape: <1>command</1>+<3>args</3>+<5>env</5> for stdio (default), or <7>transport</7> +<9> url</9>+<11>headers</11> for sse / http. Reference secrets as <13>\$${API_KEY}</13> — they get substituted at spawn time from the secrets file.',
+			'web.plugins.mcp.editor.idLabel' => 'ID',
+			'web.plugins.mcp.editor.idPlaceholder' => 'filesystem',
+			'web.plugins.mcp.editor.idHint' => 'Lowercase / digits / dash / underscore. Becomes both the directory name and the default <1>name</1>.',
+			'web.plugins.mcp.editor.bodyLabel' => 'mcp.json',
+			'web.plugins.mcp.editor.invalidJson' => ({required Object error}) => 'Invalid JSON: ${error}',
+			'web.plugins.mcp.editor.createdToast' => 'MCP server created',
+			'web.plugins.mcp.editor.savedToast' => 'MCP server saved',
+			'web.plugins.mcp.editor.createFailedToast' => 'Create failed',
+			'web.plugins.mcp.editor.saveFailedToast' => 'Save failed',
+			'web.plugins.mcpSecrets.title' => 'MCP secrets',
+			'web.plugins.mcpSecrets.encryptedBadge' => 'encrypted',
+			'web.plugins.mcpSecrets.plaintextBadge' => 'plaintext',
+			'web.plugins.mcpSecrets.encryptedTooltip' => 'AES-GCM encrypted on disk; key stored in OS keychain',
+			'web.plugins.mcpSecrets.plaintextTooltip' => 'OS keychain unavailable — file is plaintext on disk. Check the gateway log.',
+			'web.plugins.mcpSecrets.description' => ({required Object KEY}) => 'Values referenced from <1>\$${KEY}</1> placeholders in any <3>mcp.json</3> get substituted at spawn time. <5>Saved values are never returned over the API</5> — you can overwrite or delete them but not read them back.',
+			'web.plugins.mcpSecrets.descriptionStored' => ({required Object path}) => ' Stored at <1>${path}</1>.',
+			'web.plugins.mcpSecrets.addSecret' => 'Add secret',
+			'web.plugins.mcpSecrets.empty' => ({required Object KEY}) => 'No secrets stored. Add one to start referencing it as <1>\$${KEY}</1> in your MCP server configs.',
+			'web.plugins.mcpSecrets.columns.key' => 'Key',
+			'web.plugins.mcpSecrets.columns.value' => 'Value',
+			'web.plugins.mcpSecrets.editTooltip' => 'Overwrite the stored value',
+			'web.plugins.mcpSecrets.deleteConfirm' => ({required Object key, required Object \'\$\', required Object {key}) => 'Delete secret "${key}"? Any mcp.json that references \$${\'\$\'}${{key}} will fall back to the literal placeholder until you set a new value.',
+			'web.plugins.mcpSecrets.removedToast' => 'Secret removed',
+			'web.plugins.mcpSecrets.deleteFailedToast' => 'Delete failed',
+			'web.plugins.mcpSecrets.editor.addTitle' => 'Add secret',
+			'web.plugins.mcpSecrets.editor.updateTitle' => ({required Object key}) => 'Update ${key}',
+			'web.plugins.mcpSecrets.editor.addDescription' => ({required Object KEY}) => 'Stored encrypted on disk if the OS keychain is available. Reference it from any mcp.json env / headers / args / url with \$${KEY}.',
+			'web.plugins.mcpSecrets.editor.editDescription' => 'Enter the new value to overwrite. The previous value cannot be recovered.',
+			'web.plugins.mcpSecrets.editor.keyLabel' => 'Key',
+			'web.plugins.mcpSecrets.editor.keyPlaceholder' => 'BRAVE_API_KEY',
+			'web.plugins.mcpSecrets.editor.keyPattern' => 'Must match <1>[A-Za-z_][A-Za-z0-9_]*</1>',
+			'web.plugins.mcpSecrets.editor.keyCollision' => 'Already exists — use Edit instead, or pick a different name.',
+			'web.plugins.mcpSecrets.editor.valueLabel' => 'Value',
+			'web.plugins.mcpSecrets.editor.valueHint' => 'Hidden as you type. Saved value is never returned over the API.',
+			'web.plugins.mcpSecrets.editor.addedToast' => 'Secret added',
+			'web.plugins.mcpSecrets.editor.updatedToast' => 'Secret updated',
+			'web.plugins.mcpSecrets.editor.saveFailedToast' => 'Save failed',
+			'web.plugins.skills.title' => 'Agent skills',
+			'web.plugins.skills.description' => 'Reusable capabilities injected into Claude sessions as a Tier 1 index — the agent loads full SKILL.md on demand via <1>opendray skill describe &lt;id&gt;</1>. Built-ins ship in the binary but can be <3>customized</3> — your edits land at <5>~/.opendray/vault/skills/&lt;id&gt;/SKILL.md</5> and override the embedded version. Use Reset to revert.',
+			'web.plugins.skills.newSkill' => 'New skill',
+			'web.plugins.skills.empty' => 'No skills found.',
+			'web.plugins.skills.columns.id' => 'ID',
+			'web.plugins.skills.columns.description' => 'Description',
+			'web.plugins.skills.columns.source' => 'Source',
+			'web.plugins.skills.noDescription' => 'no description',
+			'web.plugins.skills.builtinBadge' => 'builtin',
+			'web.plugins.skills.builtinTooltip' => 'Embedded in the opendray binary — click Customize to override in your vault',
+			'web.plugins.skills.vaultBadge' => 'vault',
+			'web.plugins.skills.overridesBuiltin' => 'overrides builtin',
+			'web.plugins.skills.overridesBuiltinTooltip' => 'This vault skill overrides the built-in version of the same id',
+			'web.plugins.skills.customize' => 'Customize',
+			'web.plugins.skills.customizeTooltip' => 'Open the SKILL.md and save changes as a vault override',
+			'web.plugins.skills.editTooltip' => 'Edit this vault skill',
+			'web.plugins.skills.resetTooltip' => 'Delete vault override and fall back to the built-in version',
+			'web.plugins.skills.reset' => 'Reset',
+			'web.plugins.skills.resetConfirm' => ({required Object id}) => 'Reset "${id}" to the built-in version? This deletes your vault SKILL.md and falls back to the embedded copy.',
+			'web.plugins.skills.deleteConfirm' => ({required Object id}) => 'Delete skill "${id}" from your vault? This removes the SKILL.md file.',
+			'web.plugins.skills.removedToast' => 'Skill removed',
+			'web.plugins.skills.deleteFailedToast' => 'Delete failed',
+			'web.plugins.skills.editor.createTitle' => 'New skill',
+			'web.plugins.skills.editor.customizeTitle' => ({required Object id}) => 'Customize built-in: ${id}',
+			'web.plugins.skills.editor.editTitle' => ({required Object id}) => 'Edit skill: ${id}',
+			'web.plugins.skills.editor.customizeDescription' => 'You\'re viewing a built-in skill embedded in opendray. Saving will create a vault override at the same id — your edits live under ~/.opendray/vault/skills/<id>/SKILL.md and shadow the built-in until you Reset.',
+			'web.plugins.skills.editor.editDescription' => 'SKILL.md format — frontmatter with name + description, then markdown instructions. The description appears in the agent\'s Tier 1 index.',
+			'web.plugins.skills.editor.idLabel' => 'ID',
+			'web.plugins.skills.editor.idPlaceholder' => 'my-helper',
+			'web.plugins.skills.editor.idHint' => 'Lowercase / digits / dash / underscore. Becomes the directory name under <1>~/.opendray/vault/skills/&lt;id&gt;/</1>.',
+			'web.plugins.skills.editor.bodyLabel' => 'SKILL.md',
+			'web.plugins.skills.editor.createdToast' => 'Skill created',
+			'web.plugins.skills.editor.savedToast' => 'Skill saved',
+			'web.plugins.skills.editor.savedOverrideToast' => 'Saved as vault override',
+			'web.plugins.skills.editor.createFailedToast' => 'Create failed',
+			'web.plugins.skills.editor.saveFailedToast' => 'Save failed',
+			'web.plugins.skills.editor.saveAsOverride' => 'Save as vault override',
+			'web.plugins.customTasks.title' => 'Custom tasks',
+			'web.plugins.customTasks.description' => 'Click-to-run shortcuts surfaced in the Tasks tab. Leave cwd blank for global tasks visible in every session, or pin to an absolute path to scope.',
+			'web.plugins.customTasks.addTask' => 'Add task',
+			'web.plugins.customTasks.empty' => 'No custom tasks yet.',
+			'web.plugins.customTasks.columns.name' => 'Name',
+			'web.plugins.customTasks.columns.command' => 'Command',
+			'web.plugins.customTasks.columns.scope' => 'Scope',
+			'web.plugins.customTasks.globalScope' => 'global',
+			'web.plugins.customTasks.deleteConfirm' => ({required Object name}) => 'Delete custom task "${name}"?',
+			'web.plugins.customTasks.removedToast' => 'Task removed',
+			'web.plugins.customTasks.deleteFailedToast' => 'Delete failed',
+			'web.plugins.customTasks.dialog.addTitle' => 'Add custom task',
+			'web.plugins.customTasks.dialog.editTitle' => ({required Object name}) => 'Edit ${name}',
+			'web.plugins.customTasks.dialog.description' => 'The command is sent verbatim into the session\'s terminal. Same as typing it at the prompt and pressing Enter.',
+			'web.plugins.customTasks.dialog.nameLabel' => 'Name',
+			'web.plugins.customTasks.dialog.namePlaceholder' => 'dev',
+			'web.plugins.customTasks.dialog.commandLabel' => 'Command',
+			'web.plugins.customTasks.dialog.commandPlaceholder' => 'docker compose up --build',
+			'web.plugins.customTasks.dialog.descLabel' => 'Description (optional)',
+			'web.plugins.customTasks.dialog.descPlaceholder' => 'Boots dev infra and tails logs',
+			'web.plugins.customTasks.dialog.cwdLabel' => 'Cwd scope (optional)',
+			'web.plugins.customTasks.dialog.cwdPlaceholder' => '/Users/me/projects/foo  (blank = global)',
+			'web.plugins.customTasks.dialog.cwdHint' => 'Blank = visible in every session. Otherwise the task only shows when the session\'s cwd matches this absolute path.',
+			_ => null,
+		} ?? switch (path) {
+			'web.plugins.customTasks.dialog.addedToast' => 'Task added',
+			'web.plugins.customTasks.dialog.updatedToast' => 'Task updated',
+			'web.plugins.customTasks.dialog.addFailedToast' => 'Add failed',
+			'web.plugins.customTasks.dialog.updateFailedToast' => 'Update failed',
+			'web.plugins.gitHosts.title' => 'Git hosts',
+			'web.plugins.gitHosts.description' => 'One token per host — used by the Git tab to fetch pull requests <1>and by the Notes vault sync</1> when its remote uses HTTPS to a private repo on the same host. GitHub.com, self-hosted GitHub Enterprise, Gitea, and GitLab are supported.',
+			'web.plugins.gitHosts.addHost' => 'Add host',
+			'web.plugins.gitHosts.empty' => 'No git hosts configured.\nAdd one to enable the PR list in the inspector\'s Git tab.',
+			'web.plugins.gitHosts.columns.host' => 'Host',
+			'web.plugins.gitHosts.columns.kind' => 'Kind',
+			'web.plugins.gitHosts.columns.token' => 'Token',
+			'web.plugins.gitHosts.columns.enabled' => 'Enabled',
+			'web.plugins.gitHosts.statusEnabled' => 'enabled',
+			'web.plugins.gitHosts.statusDisabled' => 'disabled',
+			'web.plugins.gitHosts.deleteConfirm' => ({required Object host}) => 'Remove git host ${host}? PR queries against this host will stop working.',
+			'web.plugins.gitHosts.removedToast' => 'Git host removed',
+			'web.plugins.gitHosts.deleteFailedToast' => 'Delete failed',
+			'web.plugins.gitHosts.dialog.addTitle' => 'Add git host',
+			'web.plugins.gitHosts.dialog.editTitle' => ({required Object host}) => 'Edit ${host}',
+			'web.plugins.gitHosts.dialog.description' => 'Token is stored on the gateway. Used only for read-only API calls (list PRs, etc.).',
+			'web.plugins.gitHosts.dialog.kindLabel' => 'Kind',
+			'web.plugins.gitHosts.dialog.kindGitHub' => 'GitHub',
+			'web.plugins.gitHosts.dialog.kindGitea' => 'Gitea',
+			'web.plugins.gitHosts.dialog.kindGitLab' => 'GitLab',
+			'web.plugins.gitHosts.dialog.hostLabel' => 'Host',
+			'web.plugins.gitHosts.dialog.hostPlaceholder' => 'github.com',
+			'web.plugins.gitHosts.dialog.displayNameLabel' => 'Display name (optional)',
+			'web.plugins.gitHosts.dialog.displayNamePlaceholder' => 'Personal',
+			'web.plugins.gitHosts.dialog.tokenLabel' => 'Token',
+			'web.plugins.gitHosts.dialog.newTokenLabel' => 'New token (leave blank to keep)',
+			'web.plugins.gitHosts.dialog.tokenPlaceholder' => 'ghp_… / gho_… / glpat-…',
+			'web.plugins.gitHosts.dialog.tokenPlaceholderEdit' => '…',
+			'web.plugins.gitHosts.dialog.tokenHint' => 'GitHub: PAT with <1>repo</1> scope. Gitea: token with <3>read:repository</3>. GitLab: PAT with <5>read_api</5>.',
+			'web.plugins.gitHosts.dialog.enabledLabel' => 'Enabled',
+			'web.plugins.gitHosts.dialog.addedToast' => 'Git host added',
+			'web.plugins.gitHosts.dialog.updatedToast' => 'Git host updated',
+			'web.plugins.gitHosts.dialog.addFailedToast' => 'Add failed',
+			'web.plugins.gitHosts.dialog.updateFailedToast' => 'Update failed',
+			'web.backups.title' => 'Backups',
+			'web.backups.subtitle' => 'Encrypted PostgreSQL dumps written to a pluggable target. Configure schedules + retention, or trigger one-off backups for a quick safety net.',
+			'web.backups.exportData' => 'Export data',
+			'web.backups.loading' => 'Loading…',
+			'web.backups.loadStatusFailedToast' => 'Failed to load backup status',
+			'web.backups.tabs.backups' => 'Backups',
+			'web.backups.tabs.schedules' => 'Schedules',
+			'web.backups.tabs.targets' => 'Targets',
+			'web.backups.inventory.title' => 'What\'s in a backup?',
+			'web.backups.inventory.summary' => ({required Object rows, required Object tables}) => '${rows} rows across ${tables} tables',
+			'web.backups.inventory.description' => 'Each backup is a <1>pg_dump --format=custom</1> of every table below, plus <3>manifest.json</3> and (optionally) <5>config.toml</5>. Counts are live; the bundle captures whatever\'s there at backup time.',
+			'web.backups.inventory.loadFailedToast' => 'Failed to load inventory',
+			'web.backups.inventory.rowsLabel' => 'rows',
+			'web.backups.restart.title' => 'Restart opendray to activate backups',
+			'web.backups.restart.description' => 'Your passphrase is saved. The gateway only loads it at startup, so the feature stays off until you bounce the process.',
+			'web.backups.restart.keyFile' => 'Key file:',
+			'web.backups.restart.configuredVia' => 'Configured via:',
+			'web.backups.restart.envVar' => 'OPENDRAY_BACKUP_KEY env var',
+			'web.backups.restart.checkAgain' => 'Check again',
+			'web.backups.setup.title' => 'Set up backups',
+			'web.backups.setup.description' => 'Choose a master passphrase. opendray uses it to encrypt every backup blob. <1>Lose it and your backups become unrecoverable</1>, so save it in a password manager (Vaultwarden, 1Password, …) before continuing.',
+			'web.backups.setup.generate' => 'Generate',
+			'web.backups.setup.pasteOwn' => 'Paste my own',
+			'web.backups.setup.generateTitle' => '256-bit random key',
+			'web.backups.setup.generateHint' => 'Server generates a cryptographically random passphrase and shows it once. You must copy it before continuing — there is no recovery path.',
+			'web.backups.setup.pasteLabel' => 'Your passphrase',
+			'web.backups.setup.pastePlaceholder' => 'At least 20 characters',
+			'web.backups.setup.pasteHint' => 'Recommended: 40+ characters from a password manager.',
+			'web.backups.setup.savesTo' => 'Saves to:',
+			'web.backups.setup.saving' => 'Saving…',
+			'web.backups.setup.generateAndSave' => 'Generate and save',
+			'web.backups.setup.save' => 'Save',
+			'web.backups.generated.title' => 'Save this passphrase NOW',
+			'web.backups.generated.description' => 'This is shown <1>once</1>. It will not be retrievable from opendray or anywhere else. Copy it into a password manager before continuing.',
+			'web.backups.generated.copy' => 'Copy',
+			'web.backups.generated.copiedToast' => 'Passphrase copied to clipboard',
+			'web.backups.generated.copyFailedToast' => 'Copy failed — select and copy manually',
+			'web.backups.generated.savedTo' => 'Saved to:',
+			'web.backups.generated.ack' => 'I have saved this passphrase to my password manager',
+			'web.backups.generated.kContinue' => 'Continue',
+			'web.backups.status.keyFingerprint' => 'Key fingerprint:',
+			'web.backups.status.pgDump' => 'pg_dump:',
+			'web.backups.status.pgDumpUnavailable' => 'unavailable',
+			'web.backups.status.pgDumpHint' => 'Backups can\'t run until pg_dump is on PATH (or its absolute path is set in <1>backup.pg_dump_path</1>). Install <3>postgresql-client</3> matching your server\'s major version and restart.',
+			'web.backups.backupsTab.backupNow' => 'Backup now',
+			'web.backups.backupsTab.triggering' => 'Triggering…',
+			'web.backups.backupsTab.includeConfig' => 'include config.toml',
+			'web.backups.backupsTab.restoreFromFile' => 'Restore from file',
+			'web.backups.backupsTab.refresh' => 'Refresh',
+			'web.backups.backupsTab.queuedToast' => 'Backup queued',
+			'web.backups.backupsTab.triggerFailedToast' => 'Trigger failed',
+			'web.backups.backupsTab.listFailedToast' => 'Failed to list backups',
+			'web.backups.backupsTab.deleteConfirm' => ({required Object id}) => 'Delete backup ${id}? The blob is removed from its target.',
+			'web.backups.backupsTab.deletedToast' => 'Backup deleted',
+			'web.backups.backupsTab.deleteFailedToast' => 'Delete failed',
+			'web.backups.backupsTab.empty' => 'No backups yet. Click "Backup now" above to take the first one.',
+			'web.backups.backupsTab.columns.id' => 'ID',
+			'web.backups.backupsTab.columns.target' => 'Target',
+			'web.backups.backupsTab.columns.status' => 'Status',
+			'web.backups.backupsTab.columns.started' => 'Started',
+			'web.backups.backupsTab.columns.size' => 'Size',
+			'web.backups.backupsTab.columns.actions' => 'Actions',
+			'web.backups.backupsTab.downloadTooltip' => 'Download',
+			'web.backups.backupsTab.deleteTooltip' => 'Delete',
+			'web.backups.restore.title' => 'Restore from backup bundle',
+			'web.backups.restore.bundleLabel' => 'Encrypted bundle (.tar.gz.enc)',
+			'web.backups.restore.targetDsnLabel' => 'Target database DSN',
+			'web.backups.restore.targetDsnHint' => '(blank = opendray\'s own DB — DANGEROUS)',
+			'web.backups.restore.targetDsnPlaceholder' => 'postgres://user:pass@host:5432/dbname',
+			'web.backups.restore.cleanLabel' => '--clean --if-exists (drop existing schema first; required when restoring over a populated DB)',
+			'web.backups.restore.auditNoteLabel' => 'Audit note (optional)',
+			'web.backups.restore.auditNotePlaceholder' => 'Reason for restore — appears in slog',
+			'web.backups.restore.ownDbWarning' => 'You\'re restoring into <1>opendray\'s own database</1>. With "--clean" enabled this drops every table and replays the backup verbatim — irreversible. Type <3>I understand</3> to proceed.',
+			'web.backups.restore.confirmPlaceholder' => 'I understand',
+			'web.backups.restore.confirmSentinel' => 'I understand',
+			'web.backups.restore.pgRestoreOutput' => 'pg_restore output (last 8 KiB)',
+			'web.backups.restore.noPgRestoreOutput' => '(no pg_restore output)',
+			'web.backups.restore.pickFileToast' => 'Pick a bundle file first',
+			'web.backups.restore.succeededToast' => 'Restore succeeded',
+			'web.backups.restore.replayedDescription' => ({required Object bytes, required Object id}) => '${bytes} replayed from manifest ${id}',
+			'web.backups.restore.failedToast' => 'Restore failed',
+			'web.backups.restore.restoring' => 'Restoring…',
+			'web.backups.restore.restore' => 'Restore',
+			'web.backups.schedulesTab.description' => 'Recurring backups. The scheduler polls every 30s and runs the oldest due schedule.',
+			'web.backups.schedulesTab.newSchedule' => 'New schedule',
+			'web.backups.schedulesTab.loadFailedToast' => 'Failed to load schedules',
+			'web.backups.schedulesTab.deleteConfirm' => ({required Object id}) => 'Delete schedule ${id}?',
+			'web.backups.schedulesTab.deletedToast' => 'Schedule deleted',
+			'web.backups.schedulesTab.deleteFailedToast' => 'Delete failed',
+			'web.backups.schedulesTab.toggleFailedToast' => 'Toggle failed',
+			'web.backups.schedulesTab.empty' => 'No schedules. Add one to take automatic recurring backups.',
+			'web.backups.schedulesTab.columns.id' => 'ID',
+			'web.backups.schedulesTab.columns.target' => 'Target',
+			'web.backups.schedulesTab.columns.interval' => 'Interval',
+			'web.backups.schedulesTab.columns.keep' => 'Keep',
+			'web.backups.schedulesTab.columns.nextRun' => 'Next run',
+			'web.backups.schedulesTab.columns.enabled' => 'Enabled',
+			'web.backups.schedulesTab.columns.actions' => 'Actions',
+			'web.backups.schedulesTab.keepCount' => ({required Object count}) => '${count} backups',
+			'web.backups.schedulesTab.deleteTooltip' => 'Delete',
+			'web.backups.newSchedule.title' => 'New backup schedule',
+			'web.backups.newSchedule.targetLabel' => 'Target',
+			'web.backups.newSchedule.everyHoursLabel' => 'Every (hours)',
+			'web.backups.newSchedule.keepLastNLabel' => 'Keep last N',
+			'web.backups.newSchedule.enableImmediately' => 'Enable immediately',
+			'web.backups.newSchedule.createdToast' => 'Schedule created',
+			'web.backups.newSchedule.createFailedToast' => 'Create failed',
+			'web.backups.newSchedule.creating' => 'Creating…',
+			'web.backups.newSchedule.create' => 'Create',
+			'web.backups.targetsTab.description' => 'Storage destinations. v1 supports <1>local</1> (disk on the opendray host) and <3>smb</3> (any SMB / CIFS share, e.g. UNAS or Synology).',
+			'web.backups.targetsTab.newTarget' => 'New target',
+			'web.backups.targetsTab.listFailedToast' => 'Failed to list targets',
+			'web.backups.targetsTab.deleteConfirm' => ({required Object id}) => 'Delete target ${id}? Schedules referencing it will block the delete.',
+			'web.backups.targetsTab.deletedToast' => 'Target deleted',
+			'web.backups.targetsTab.deleteFailedToast' => 'Delete failed',
+			'web.backups.targetsTab.connectionOkToast' => 'Connection OK',
+			'web.backups.targetsTab.connectionFailedToast' => 'Connection failed',
+			'web.backups.targetsTab.testFailedToast' => 'Test failed',
+			'web.backups.targetsTab.columns.id' => 'ID',
+			'web.backups.targetsTab.columns.kind' => 'Kind',
+			'web.backups.targetsTab.columns.config' => 'Config',
+			'web.backups.targetsTab.columns.enabled' => 'Enabled',
+			'web.backups.targetsTab.columns.actions' => 'Actions',
+			'web.backups.targetsTab.on' => 'on',
+			'web.backups.targetsTab.off' => 'off',
+			'web.backups.targetsTab.test' => 'Test',
+			'web.backups.targetsTab.testing' => 'Testing…',
+			'web.backups.targetsTab.deleteTooltip' => 'Delete',
+			'web.backups.targetEditor.title' => 'New backup target',
+			'web.backups.targetEditor.kindPicker' => 'Where do you want to back up to?',
+			'web.backups.targetEditor.idLabel' => 'ID (optional)',
+			'web.backups.targetEditor.idPlaceholder' => 'auto-generated if blank, e.g. tgt_xxx',
+			'web.backups.targetEditor.createdToast' => 'Target created',
+			'web.backups.targetEditor.createFailedToast' => 'Create failed',
+			'web.backups.targetEditor.creating' => 'Creating…',
+			'web.backups.targetEditor.create' => 'Create target',
+			'web.backups.targetEditor.enableImmediately' => 'Enable immediately (otherwise saved as disabled — useful for "configure now, turn on later")',
+			'web.backups.targetEditor.local.rootLabel' => 'Root directory',
+			'web.backups.targetEditor.local.rootHint' => 'Empty = cfg.backup.local_dir (~/.opendray/backups)',
+			'web.backups.targetEditor.local.rootPlaceholder' => '~/backups/opendray  or  /mnt/external-hdd/opendray',
+			'web.backups.targetEditor.smb.hostLabel' => 'Host',
+			'web.backups.targetEditor.smb.hostPlaceholder' => '192.168.9.8',
+			'web.backups.targetEditor.smb.portLabel' => 'Port',
+			'web.backups.targetEditor.smb.shareLabel' => 'Share',
+			'web.backups.targetEditor.smb.shareHint' => 'Top-level share name on the SMB server',
+			'web.backups.targetEditor.smb.sharePlaceholder' => 'Claude_Workspace',
+			'web.backups.targetEditor.smb.userLabel' => 'User',
+			'web.backups.targetEditor.smb.passwordLabel' => 'Password',
+			'web.backups.targetEditor.smb.pathPrefixLabel' => 'Path prefix',
+			'web.backups.targetEditor.smb.pathPrefixHint' => 'Sub-folder under the share root (optional)',
+			'web.backups.targetEditor.smb.pathPrefixPlaceholder' => 'opendray/backups',
+			'web.backups.targetEditor.s3.endpointLabel' => 'Endpoint',
+			'web.backups.targetEditor.s3.endpointHint' => 'Host (no protocol). AWS: s3.amazonaws.com · R2: <accountid>.r2.cloudflarestorage.com · MinIO: minio.local:9000',
+			'web.backups.targetEditor.s3.endpointPlaceholder' => 's3.amazonaws.com',
+			'web.backups.targetEditor.s3.regionLabel' => 'Region',
+			'web.backups.targetEditor.s3.regionHint' => 'AWS only; R2 use \'auto\'',
+			'web.backups.targetEditor.s3.regionPlaceholder' => 'us-east-1 / auto',
+			'web.backups.targetEditor.s3.bucketLabel' => 'Bucket',
+			'web.backups.targetEditor.s3.bucketPlaceholder' => 'opendray-backups',
+			'web.backups.targetEditor.s3.accessKeyLabel' => 'Access key',
+			'web.backups.targetEditor.s3.secretKeyLabel' => 'Secret key',
+			'web.backups.targetEditor.s3.secretKeyHint' => 'Stored AES-256-GCM encrypted; never echoed back',
+			'web.backups.targetEditor.s3.pathPrefixLabel' => 'Path prefix',
+			'web.backups.targetEditor.s3.pathPrefixHint' => 'Object-key prefix (optional)',
+			'web.backups.targetEditor.s3.pathPrefixPlaceholder' => 'opendray/backups',
+			'web.backups.targetEditor.s3.useHttps' => 'Use HTTPS',
+			'web.backups.targetEditor.s3.pathStyle' => 'Path-style addressing (legacy / MinIO)',
+			'web.backups.targetEditor.webdav.baseUrlLabel' => 'Base URL',
+			'web.backups.targetEditor.webdav.baseUrlHint' => 'Full URL including any path. Examples: https://cloud.example.com/remote.php/dav/files/me/ (Nextcloud), https://nas.local:5006/ (Synology), https://dav.jianguoyun.com/dav/ (Jianguoyun / 坚果云)',
+			'web.backups.targetEditor.webdav.baseUrlPlaceholder' => 'https://cloud.example.com/remote.php/dav/files/<user>/',
+			'web.backups.targetEditor.webdav.userLabel' => 'User',
+			'web.backups.targetEditor.webdav.passwordLabel' => 'Password',
+			'web.backups.targetEditor.webdav.pathPrefixLabel' => 'Path prefix',
+			'web.backups.targetEditor.webdav.pathPrefixHint' => 'Sub-folder under the base URL (optional)',
+			'web.backups.targetEditor.webdav.pathPrefixPlaceholder' => 'opendray/backups',
+			'web.backups.targetEditor.sftp.hostLabel' => 'Host',
+			'web.backups.targetEditor.sftp.hostPlaceholder' => 'vps.example.com',
+			'web.backups.targetEditor.sftp.portLabel' => 'Port',
+			'web.backups.targetEditor.sftp.userLabel' => 'User',
+			'web.backups.targetEditor.sftp.passwordLabel' => 'Password',
+			'web.backups.targetEditor.sftp.passwordHint' => 'Either password OR private key required. If both, password is treated as the key passphrase.',
+			'web.backups.targetEditor.sftp.privateKeyLabel' => 'Private key (PEM)',
+			'web.backups.targetEditor.sftp.privateKeyHint' => 'Paste contents of an OpenSSH/PEM private key (e.g. ~/.ssh/id_ed25519). Leave blank for password-only auth.',
+			'web.backups.targetEditor.sftp.privateKeyPlaceholder' => '-----BEGIN OPENSSH PRIVATE KEY-----...',
+			'web.backups.targetEditor.sftp.hostKeyLabel' => 'Host key (pinning)',
+			'web.backups.targetEditor.sftp.hostKeyHint' => 'OpenSSH-style server public key (run `ssh-keyscan host` to obtain). Leave blank to disable pinning (NOT recommended outside LAN).',
+			'web.backups.targetEditor.sftp.hostKeyPlaceholder' => 'ssh-ed25519 AAAA...',
+			'web.backups.targetEditor.sftp.pathPrefixLabel' => 'Path prefix',
+			'web.backups.targetEditor.sftp.pathPrefixHint' => 'Absolute or relative to user home (optional)',
+			'web.backups.targetEditor.sftp.pathPrefixPlaceholder' => '/var/backups/opendray  or  opendray-backups',
+			'web.backups.targetEditor.rclone.rcloneHint' => 'Requires the <1>rclone</1> CLI installed on the opendray host. First configure your remote with <3>rclone config</3>, then use the remote name below. opendray invokes <5>rclone rcat / cat / lsd</5> under the hood.',
+			'web.backups.targetEditor.rclone.remoteLabel' => 'Remote name',
+			'web.backups.targetEditor.rclone.remoteHint' => 'Name from `rclone config` (no colon). Example: gdrive, onedrive, dropbox-personal, baidu-pan',
+			'web.backups.targetEditor.rclone.remotePlaceholder' => 'gdrive',
+			'web.backups.targetEditor.rclone.pathPrefixLabel' => 'Path prefix',
+			'web.backups.targetEditor.rclone.pathPrefixHint' => 'Sub-folder under the remote root (optional)',
+			'web.backups.targetEditor.rclone.pathPrefixPlaceholder' => 'opendray/backups',
+			'web.backups.targetEditor.rclone.binaryPathLabel' => 'Binary path',
+			'web.backups.targetEditor.rclone.binaryPathHint' => 'Override `which rclone`. Empty uses PATH lookup.',
+			'web.backups.targetEditor.rclone.binaryPathPlaceholder' => '/opt/homebrew/bin/rclone',
+			'web.backups.targetEditor.rclone.configPathLabel' => 'Config path',
+			'web.backups.targetEditor.rclone.configPathHint' => 'Override --config (default ~/.config/rclone/rclone.conf or ~/.rclone.conf)',
+			'web.backups.targetEditor.rclone.configPathPlaceholder' => 'leave blank for rclone default',
+			'web.serverSettings.sections.general.title' => 'General',
+			'web.serverSettings.sections.general.desc' => 'Listen address, operator account, token TTL.',
+			'web.serverSettings.sections.logging.title' => 'Logging',
+			'web.serverSettings.sections.logging.desc' => 'Verbosity, format, and live tail.',
+			'web.serverSettings.sections.sessions.title' => 'Sessions',
+			'web.serverSettings.sections.sessions.desc' => 'Idle detection thresholds.',
+			'web.serverSettings.sections.vault.title' => 'Vault',
+			'web.serverSettings.sections.vault.desc' => 'Notes, skills, and git-versioned root.',
+			'web.serverSettings.sections.mcp.title' => 'MCP registry',
+			'web.serverSettings.sections.mcp.desc' => 'Server registry + secrets.',
+			'web.serverSettings.sections.memory.title' => 'Memory',
+			'web.serverSettings.sections.memory.desc' => 'Cross-CLI persistent memory subsystem.',
+			'web.serverSettings.sections.memoryAmbient.title' => 'Memory · Ambient',
+			'web.serverSettings.sections.memoryAmbient.desc' => 'Auto-capture conversations into memory + spawn-time injection.',
+			'web.serverSettings.sections.backup.title' => 'Backup',
+			'web.serverSettings.sections.backup.desc' => 'Encrypted DB backups, restore, and admin data exports.',
+			'web.serverSettings.sections.claude.title' => 'Storage · Claude',
+			'web.serverSettings.sections.claude.desc' => 'Where Claude transcripts live on disk.',
+			'web.serverSettings.sections.codex.title' => 'Storage · Codex',
+			'web.serverSettings.sections.codex.desc' => 'Codex sessions root.',
+			'web.serverSettings.sections.gemini.title' => 'Storage · Gemini',
+			'web.serverSettings.sections.gemini.desc' => 'Gemini per-project tmp + projects.json.',
+			'web.serverSettings.loading' => 'Loading server settings…',
+			'web.serverSettings.loadFailed' => ({required Object message}) => 'Failed to load: ${message}',
+			'web.serverSettings.noConfigFlag' => 'opendray was started without a -config flag. Settings are loaded from environment variables only and cannot be edited here.',
+			'web.serverSettings.resetButton' => 'Reset',
+			'web.serverSettings.resetButtonTitle' => 'Discard unsaved changes in this section',
+			'web.serverSettings.resetConfirm' => ({required Object section}) => 'Reset "${section}" to last-saved values?',
+			'web.serverSettings.badgeRestartRequired' => 'restart required',
+			'web.serverSettings.badgeUnsaved' => 'unsaved',
+			'web.serverSettings.saveButton' => 'Save changes',
+			'web.serverSettings.saveToastTitle' => 'Settings saved',
+			'web.serverSettings.saveToastDesc' => 'Click Restart to apply.',
+			'web.serverSettings.saveErrorTitle' => 'Save failed',
+			'web.serverSettings.dangerousConfirm' => 'You changed listen address / admin user / admin password. After restart you may need to re-authenticate or use the new address. Continue?',
+			'web.serverSettings.unsavedHint' => 'You have unsaved changes',
+			'web.serverSettings.savedHint' => 'All changes saved',
+			'web.serverSettings.searchPlaceholder' => 'Filter fields…',
+			'web.serverSettings.restart.button' => 'Restart server',
+			'web.serverSettings.restart.buttonTitle' => 'Self-exec the gateway process',
+			'web.serverSettings.restart.dirtyConfirm' => 'You have unsaved changes. Restart will use the LAST SAVED config. Continue?',
+			'web.serverSettings.restart.confirm' => 'Restart the opendray gateway? All open terminal sessions will reconnect automatically.',
+			'web.serverSettings.restart.overlay' => 'Restarting server…',
+			'web.serverSettings.restart.waiting' => ({required Object tick}) => 'Waiting for /health · ${tick}s',
+			'web.serverSettings.restart.timedOutTitle' => 'Restart timed out',
+			'web.serverSettings.restart.timedOutDesc' => 'Health endpoint never came back. Check server logs.',
+			'web.serverSettings.restart.successToast' => 'Server restarted',
+			'web.serverSettings.formGroups.network' => 'Network',
+			'web.serverSettings.formGroups.operatorAccount' => 'Operator account',
+			'web.serverSettings.formGroups.memoryConfiguration' => 'Configuration',
+			'web.serverSettings.formGroups.memoryHttp' => 'HTTP backend (used when backend=http)',
+			'web.serverSettings.formGroups.memoryLocal' => 'Local ONNX (used when backend=local)',
+			'web.serverSettings.formGroups.backupStatus' => 'Status',
+			'web.serverSettings.formGroups.backupWhere' => 'Where backups go',
+			'web.serverSettings.formGroups.backupSchedules' => 'Schedules',
+			'web.serverSettings.formGroups.backupWhatsInside' => 'What\'s in a backup?',
+			'web.serverSettings.fields.listenAddress.label' => 'Listen address',
+			'web.serverSettings.fields.listenAddress.hint' => 'The host:port the HTTP server binds to. Example: 0.0.0.0:8770.',
+			'web.serverSettings.fields.username.label' => 'Username',
+			'web.serverSettings.fields.username.hint' => 'Login name used in the sign-in form. Changing this forces a re-login on the next request.',
+			'web.serverSettings.fields.password.label' => 'Password',
+			'web.serverSettings.fields.password.hint' => 'Leave blank to keep the current password. Sending a value overwrites it.',
+			'web.serverSettings.fields.password.hideTitle' => 'Hide',
+			'web.serverSettings.fields.password.revealTitle' => 'Reveal',
+			'web.serverSettings.fields.tokenTTL.label' => 'Token TTL',
+			'web.serverSettings.fields.tokenTTL.hint' => 'Bearer-token lifetime as a Go duration, e.g. "24h", "30m". Empty = never expire.',
+			'web.serverSettings.fields.logLevel.label' => 'Log level',
+			'web.serverSettings.fields.logLevel.hint' => 'Lines below this level are dropped.',
+			'web.serverSettings.fields.logFormat.label' => 'Format',
+			'web.serverSettings.fields.logFormat.hint' => '"text" is human-readable; "json" is machine-parsable.',
+			'web.serverSettings.fields.logFile.label' => 'Log file',
+			'web.serverSettings.fields.logFile.hint' => 'Optional file path. Auto-rotates at 10 MB, keeps 5 backups. Empty = stderr only.',
+			'web.serverSettings.fields.idleThreshold.label' => 'Idle threshold',
+			'web.serverSettings.fields.idleThreshold.hint' => 'A session is silent for this long before session.idle fires. Empty = 30s.',
+			'web.serverSettings.fields.idlePollInterval.label' => 'Idle poll interval',
+			'web.serverSettings.fields.idlePollInterval.hint' => 'How often the idle detector wakes up. Lower = lower latency, more wakeups. Empty = 5s.',
+			'web.serverSettings.fields.vaultRoot.label' => 'Vault root',
+			'web.serverSettings.fields.vaultRoot.hint' => 'Top-level directory for notes, skills, and MCP registry.',
+			'web.serverSettings.fields.notesDirectory.label' => 'Notes directory',
+			'web.serverSettings.fields.notesDirectory.hint' => 'Override notes location. Defaults to <vault root>/notes.',
+			'web.serverSettings.fields.skillsDirectory.label' => 'Skills directory',
+			'web.serverSettings.fields.skillsDirectory.hint' => 'Override skills location. Defaults to <vault root>/skills.',
+			'web.serverSettings.fields.gitRoot.label' => 'Git root',
+			'web.serverSettings.fields.gitRoot.hint' => 'Working tree the Vault Sync feature commits to.',
+			'web.serverSettings.fields.personalPrefix.label' => 'Personal prefix',
+			'web.serverSettings.fields.personalPrefix.hint' => 'Folder name used for personal notes when auto-deriving paths. Default "personal".',
+			'web.serverSettings.fields.projectsPrefix.label' => 'Projects prefix',
+			'web.serverSettings.fields.projectsPrefix.hint' => 'Folder name used for project notes. Default "projects".',
+			'web.serverSettings.fields.registryRoot.label' => 'Registry root',
+			'web.serverSettings.fields.registryRoot.hint' => 'Directory holding MCP server JSON definitions. Defaults to <vault>/mcp.',
+			'web.serverSettings.fields.secretsFile.label' => 'Secrets file',
+			'web.serverSettings.fields.secretsFile.hint' => 'key=value file substituted into MCP server commands at spawn time.',
+			'web.serverSettings.fields.memoryBackend.label' => 'Embedder backend',
+			'web.serverSettings.fields.memoryBackend.hint' => '"auto" / "bm25" use the cgo-free pure-Go keyword path. "http" calls any OpenAI-compatible /v1/embeddings (ollama / OpenAI / LocalAI). "local" runs an ONNX sentence-transformer in-process — requires a binary built with `-tags local_onnx`.',
+			'web.serverSettings.fields.memoryStore.label' => 'Store',
+			'web.serverSettings.fields.memoryStore.hint' => '"pgvector" reuses opendray\'s existing PG with the vector extension; only option in v1.',
+			'web.serverSettings.fields.memoryTopK.label' => 'Default top-K',
+			'web.serverSettings.fields.memoryTopK.hint' => 'How many hits memory_search returns when the agent doesn\'t specify. Empty = 5.',
+			'web.serverSettings.fields.memoryThreshold.label' => 'Similarity threshold',
+			'web.serverSettings.fields.memoryThreshold.hint' => 'Hits below this score are dropped. Empty = 0.1 (permissive — BM25 sparse vectors rarely break 0.5).',
+			'web.serverSettings.fields.memoryScope.label' => 'Default scope',
+			'web.serverSettings.fields.memoryScope.hint' => 'What memory_store uses when the agent doesn\'t specify. "project" (recommended) groups by cwd; "session" isolates per session; "global" shares across cwds.',
+			'web.serverSettings.fields.memoryBaseUrl.label' => 'Base URL',
+			'web.serverSettings.fields.memoryBaseUrl.hint' => 'e.g. "http://localhost:11434/v1" for ollama, "https://api.openai.com/v1" for OpenAI.',
+			'web.serverSettings.fields.memoryModel.label' => 'Model',
+			'web.serverSettings.fields.memoryModel.hint' => 'e.g. "nomic-embed-text" for ollama, "text-embedding-3-small" for OpenAI.',
+			'web.serverSettings.fields.memoryApiKey.label' => 'API key',
+			'web.serverSettings.fields.memoryApiKey.hint' => 'Empty for ollama / local servers. Required for OpenAI / Voyage / hosted services.',
+			'web.serverSettings.fields.memoryLocalModel.label' => 'Model name',
+			'web.serverSettings.fields.memoryLocalModel.hint' => 'Cosmetic — appears in logs / Inspector. e.g. "bge-m3", "bge-small-en-v1.5".',
+			'web.serverSettings.fields.memoryLibraryPath.label' => 'Library path',
+			'web.serverSettings.fields.memoryLibraryPath.hint' => 'Directory holding libonnxruntime.dylib (macOS) / libonnxruntime.so (Linux). After `brew install onnxruntime`, that\'s /opt/homebrew/opt/onnxruntime/lib.',
+			'web.serverSettings.fields.memoryModelPath.label' => 'Model path',
+			'web.serverSettings.fields.memoryModelPath.hint' => 'Absolute path to the .onnx weights. Download from HuggingFace, e.g. Xenova/bge-m3 or Xenova/bge-small-en-v1.5.',
+			'web.serverSettings.fields.memoryTokenizerPath.label' => 'Tokenizer path',
+			'web.serverSettings.fields.memoryTokenizerPath.hint' => 'Absolute path to tokenizer.json (HuggingFace standard format) — usually right next to the model.',
+			'web.serverSettings.fields.memoryMaxSeqLen.label' => 'Max sequence length',
+			'web.serverSettings.fields.memoryMaxSeqLen.hint' => 'Tokens beyond this are truncated. bge-m3 default is 512. Empty = 512.',
+			'web.serverSettings.fields.claudeHistoryRoots.label' => 'History roots',
+			'web.serverSettings.fields.claudeHistoryRoots.hint' => 'Directories scanned for Claude per-project JSONL transcripts. Empty = scan ~/.claude/projects + every ~/.claude-accounts/*/projects.',
+			'web.serverSettings.fields.claudeAccountsDir.label' => 'Accounts directory',
+			'web.serverSettings.fields.claudeAccountsDir.hint' => 'Root used for opendray-managed Claude account ConfigDirs. Default ~/.claude-accounts.',
+			'web.serverSettings.fields.codexSessionsRoot.label' => 'Sessions root',
+			'web.serverSettings.fields.codexSessionsRoot.hint' => 'Directory walked for Codex rollout JSONL files. Default ~/.codex/sessions.',
+			'web.serverSettings.fields.geminiTmpRoot.label' => 'Tmp directory',
+			'web.serverSettings.fields.geminiTmpRoot.hint' => 'Root holding Gemini per-project tmp folders. Default ~/.gemini/tmp.',
+			'web.serverSettings.fields.geminiProjectsFile.label' => 'projects.json',
+			'web.serverSettings.fields.geminiProjectsFile.hint' => 'Path to Gemini\'s cwd→short-name mapping file. Default ~/.gemini/projects.json.',
+			'web.serverSettings.fields.backupLocalDir.label' => 'Local backup directory',
+			'web.serverSettings.fields.backupLocalDir.hint' => 'Default root for the auto-created `local` target. Empty = ~/.opendray/backups. Restart required.',
+			'web.serverSettings.fields.backupExportDir.label' => 'Export directory',
+			'web.serverSettings.fields.backupExportDir.hint' => 'Where one-shot export zips are staged on disk. Empty = ~/.opendray/exports. Bundles auto-expire after 24h. Restart required.',
+			'web.serverSettings.fields.backupPgDumpPath.label' => 'pg_dump path',
+			'web.serverSettings.fields.backupPgDumpPath.hint' => 'Absolute path to pg_dump. Major version must be ≥ the server\'s. Empty = first pg_dump on PATH.',
+			'web.serverSettings.fields.backupPgRestorePath.label' => 'pg_restore path',
+			'web.serverSettings.fields.backupPgRestorePath.hint' => 'Absolute path to pg_restore for the /backups/restore flow. Same major-version rule.',
+			'web.serverSettings.liveTail.heading' => 'Live tail',
+			'web.serverSettings.liveTail.description' => 'In-memory ring buffer (last ~2,000 records). Resets on restart.',
+			'web.serverSettings.memoryInspectorCard.heading' => 'Inspector',
+			'web.serverSettings.memoryInspectorCard.description' => 'Browse, search and edit stored memories on the dedicated page.',
+			'web.serverSettings.memoryInspectorCard.openButton' => 'Open Memory →',
+			'web.serverSettings.localOnnxBanner' => 'Requires the binary to be compiled with <1>-tags local_onnx</1>. The standard build returns a clear stub error when this backend is selected. See <3>Memory → Local ONNX</3> tutorial for setup steps.',
+			'web.serverSettings.stringList.noneDefault' => '(none — using built-in defaults)',
+			'web.serverSettings.stringList.addPath' => 'Add path',
+			'web.serverSettings.stringList.removeTitle' => 'Remove',
+			'web.serverSettings.httpHelpers.autoDetected' => 'Auto-detected at startup',
+			'web.serverSettings.httpHelpers.modelCount' => ({required Object count}) => '${count} model(s) — click to use',
+			'web.serverSettings.httpHelpers.presets' => 'Presets:',
+			'web.serverSettings.httpHelpers.testConnection' => 'Test connection',
+			'web.serverSettings.httpHelpers.presetTip.ollama' => 'Local ollama daemon',
+			'web.serverSettings.httpHelpers.presetTip.lmStudio' => 'LM Studio local server',
+			'web.serverSettings.httpHelpers.presetTip.openai' => 'OpenAI cloud (needs API key)',
+			'web.serverSettings.probe.unreachable' => ({required Object error}) => '✗ unreachable: ${error}',
+			'web.serverSettings.probe.connectionFailed' => 'connection failed',
+			'web.serverSettings.probe.reachable' => ({required Object detected, required Object total, required Object embedding}) => '✓ reachable ${detected}· ${total} model(s) total · ${embedding} embedding',
+			'web.serverSettings.probe.modelMissing' => ({required Object model}) => '⚠ Configured model ${model} isn\'t in the list. Pick one of the embedding models below or fix the name.',
+			'web.serverSettings.probe.embeddingModelsLabel' => 'embedding models:',
+			'web.serverSettings.probe.moreModels' => ({required Object count}) => '+${count} more',
+			'web.serverSettings.probe.noEmbeddingFound' => '⚠ No model name contains "embed". The endpoint might not have an embedding model loaded — check your local server.',
+			'web.serverSettings.probe.configuredTitle' => 'Currently configured',
+			'web.serverSettings.probe.applyTitle' => 'Click to apply',
+			'web.serverSettings.backup.featureDisabledTitle' => 'Feature disabled',
+			'web.serverSettings.backup.featureDisabledHint' => 'Set <1>OPENDRAY_BACKUP_ENABLED=1</1> + <3>OPENDRAY_BACKUP_KEY=&lt;passphrase&gt;</3> in opendray\'s environment, then restart. The master passphrase is env-only — it never touches config.toml.',
+			'web.serverSettings.backup.statusRowLabel' => 'Status',
+			'web.serverSettings.backup.enabledHealthy' => 'enabled · healthy',
+			'web.serverSettings.backup.enabledDegraded' => 'enabled · degraded',
+			'web.serverSettings.backup.keyFingerprintLabel' => 'Key fingerprint',
+			'web.serverSettings.backup.keyFingerprintHint' => 'record in Vaultwarden — losing it locks all prior backups',
+			'web.serverSettings.backup.pgDumpLabel' => 'pg_dump',
+			'web.serverSettings.backup.pgDumpUnavailable' => 'unavailable',
+			'web.serverSettings.backup.pgRestoreLabel' => 'pg_restore',
+			'web.serverSettings.backup.pgRestoreNotResolved' => '(not resolved)',
+			'web.serverSettings.backup.openBackups' => 'Open Backups page →',
+			'web.serverSettings.backup.openExport' => 'Open Export / Import →',
+			'web.serverSettings.backup.whereDesc' => 'Each target is one place a backup blob can be written. opendray supports <1>local disk</1>, <3>SMB/CIFS</3> (Windows / NAS), <5>S3-compatible</5> (AWS, R2, B2, MinIO, Alibaba Cloud OSS, Tencent Cloud COS, ...), <7>WebDAV</7> (Nextcloud, Synology, Jianguoyun), <9>SFTP</9>, plus an <11>rclone</11> passthrough that taps into 70+ extra backends (Google Drive, OneDrive, Dropbox, Baidu Pan, Aliyun Drive, ...).',
+			'web.serverSettings.backup.loading' => 'Loading…',
+			'web.serverSettings.backup.noTargets' => 'No targets yet. Add one to start backing up.',
+			'web.serverSettings.backup.addTarget' => 'Add target',
+			'web.serverSettings.backup.noSchedulesHint' => 'No recurring schedules. Add one on <1>/backups → Schedules</1> to take backups automatically.',
+			'web.serverSettings.backup.scheduleHeaders.schedule' => 'Schedule',
+			'web.serverSettings.backup.scheduleHeaders.target' => 'Target',
+			'web.serverSettings.backup.scheduleHeaders.cadence' => 'Cadence',
+			'web.serverSettings.backup.scheduleHeaders.keep' => 'Keep',
+			'web.serverSettings.backup.scheduleHeaders.state' => 'State',
+			'web.serverSettings.backup.every' => ({required Object interval}) => 'every ${interval}',
+			'web.serverSettings.backup.backupsKeep' => ({required Object count}) => '${count} backups',
+			'web.serverSettings.backup.stateEnabled' => 'enabled',
+			'web.serverSettings.backup.statePaused' => 'paused',
+			'web.serverSettings.backup.manageSchedules' => 'Manage on /backups → Schedules →',
+			'web.serverSettings.backup.whatsInsideDesc' => 'Each backup is a <1>pg_dump --format=custom</1> of every opendray table (sessions, integrations, memories, audit_log, etc.) plus a <3>manifest.json</3> and (optionally) the live <5>config.toml</5>. Open the "What\'s in a backup?" panel on the <7>Backups page</7> to see the live inventory with row counts.',
+			'web.serverSettings.backup.advancedToggle' => 'Advanced (paths & client binaries) — restart required',
+			'web.serverSettings.targetRow.on' => 'on',
+			'web.serverSettings.targetRow.off' => 'off',
+			'web.serverSettings.targetRow.test' => 'Test',
+			'web.serverSettings.targetRow.testing' => 'Testing…',
+			'web.serverSettings.targetRow.delete' => 'Delete',
+			'web.serverSettings.targetRow.connectionOk' => ({required Object id}) => '${id}: connection OK',
+			'web.serverSettings.targetRow.connectionFailedTitle' => 'Connection failed',
+			'web.serverSettings.targetRow.testFailedTitle' => 'Test failed',
+			'web.serverSettings.targetRow.deleteConfirm' => ({required Object id}) => 'Delete target "${id}"? Schedules referencing it will block the delete.',
+			'web.serverSettings.targetRow.deleteSuccess' => 'Target deleted',
+			'web.serverSettings.targetRow.deleteFailedTitle' => 'Delete failed',
+			'web.serverSettings.targetRow.unknownError' => 'Unknown error',
+			'web.settings.title' => 'Settings',
+			'web.settings.subtitle' => 'Workspace, account, and gateway config.',
+			'web.settings.groups.workspace' => 'Workspace',
+			'web.settings.groups.server' => 'Server',
+			'web.settings.groups.system' => 'System',
+			'web.settings.items.appearance' => 'Appearance',
+			'web.settings.items.font' => 'Font size',
+			'web.settings.items.account' => 'Account',
+			'web.settings.items.status' => 'Status',
+			'web.settings.items.about' => 'About',
+			'web.settings.health.connecting' => 'connecting…',
+			'web.settings.health.dbOk' => 'db ok',
+			'web.settings.health.dbDown' => 'db down',
+			'web.settings.breadcrumb.server' => 'Server',
+			'web.settings.appearance.title' => 'Appearance',
+			'web.settings.appearance.description' => 'Choose how opendray looks.',
+			'web.settings.appearance.options.light' => 'Light',
+			'web.settings.appearance.options.lightDesc' => 'Always light',
+			'web.settings.appearance.options.dark' => 'Dark',
+			'web.settings.appearance.options.darkDesc' => 'Always dark',
+			'web.settings.appearance.options.system' => 'System',
+			'web.settings.appearance.options.systemDesc' => 'Follow the OS setting',
+			'web.settings.font.title' => 'Font size',
+			'web.settings.font.description' => 'Scales the entire interface. Persisted per browser.',
+			'web.settings.font.options.compact' => 'Compact',
+			'web.settings.font.options.kDefault' => 'Default',
+			'web.settings.font.options.comfy' => 'Comfy',
+			'web.settings.font.options.large' => 'Large',
+			'web.settings.account.title' => 'Account',
+			'web.settings.account.description' => 'Operator and current bearer token.',
+			'web.settings.account.username' => 'Username',
+			'web.settings.account.tokenExpires' => 'Token expires',
+			'web.settings.account.changeCredentials' => 'Change credentials',
+			'web.settings.changeCredentials.title' => 'Change credentials',
+			'web.settings.changeCredentials.description' => 'Verify your current password, then pick new credentials. All other signed-in sessions will be revoked.',
+			'web.settings.changeCredentials.currentPassword' => 'Current password',
+			'web.settings.changeCredentials.newUsername' => 'New username',
+			'web.settings.changeCredentials.newPassword' => 'New password',
+			'web.settings.changeCredentials.newPasswordHint' => 'At least 8 characters.',
+			'web.settings.changeCredentials.confirm' => 'Confirm new password',
+			'web.settings.changeCredentials.errorTooShort' => 'New password must be at least 8 characters.',
+			'web.settings.changeCredentials.errorMismatch' => 'New password and confirmation don\'t match.',
+			'web.settings.changeCredentials.errorWrongPassword' => 'Current password is wrong.',
+			'web.settings.changeCredentials.cancel' => 'Cancel',
+			'web.settings.changeCredentials.update' => 'Update',
+			'web.settings.changeCredentials.saving' => 'Saving…',
+			'web.settings.system.title' => 'System status',
+			'web.settings.system.description' => 'Live status from the gateway\'s /health endpoint.',
+			'web.settings.system.status' => 'Status',
+			'web.settings.system.version' => 'Version',
+			'web.settings.system.uptime' => 'Uptime',
+			'web.settings.system.database' => 'Database',
+			'web.settings.system.reachable' => 'reachable',
+			'web.settings.system.unreachable' => 'unreachable',
+			'web.settings.about.title' => 'About',
+			'web.settings.about.description' => 'opendray v2 — the multiplexer + integration gateway for AI agent CLIs. Source under Apache 2.0.',
+			'web.logViewer.filterPlaceholder' => 'Filter…',
+			'web.logViewer.debugTooltip' => 'Debug count',
+			'web.logViewer.infoTooltip' => 'Info count',
+			'web.logViewer.warnTooltip' => 'Warn count',
+			'web.logViewer.errorTooltip' => 'Error count',
+			'web.logViewer.streaming' => 'Streaming',
+			'web.logViewer.disconnected' => 'Disconnected',
+			'web.logViewer.live' => 'live',
+			'web.logViewer.offline' => 'offline',
+			'web.logViewer.pauseTooltip' => 'Pause auto-scroll',
+			'web.logViewer.resumeTooltip' => 'Resume auto-scroll',
+			'web.logViewer.clearTooltip' => 'Clear local view (server ring untouched)',
+			_ => null,
+		} ?? switch (path) {
+			'web.logViewer.downloadTooltip' => 'Download full ring as .log file',
+			'web.logViewer.emptyWaiting' => 'Waiting for log records…',
+			'web.logViewer.emptyFiltered' => ({required Object query}) => 'No records match "${query}"',
+			'web.pathInput.testButton' => 'Test',
+			'web.pathInput.testTooltip' => 'Resolve and check this path',
+			'web.pathInput.notFound' => 'not found ·',
+			'web.pathInput.childrenSuffix' => 'children',
+			'web.pathInput.expectedDirectory' => '· expected directory',
+			'web.memoryAmbient.header.title' => 'Ambient memory — auto-capture & inject',
+			'web.memoryAmbient.header.body' => 'opendray polls every live agent session every 10 seconds, extracts durable facts via a configurable LLM, and dedups before storing them in the shared memory pool. Configure which LLM does the extraction (Provider), when extraction fires (Capture rule), and what — if anything — gets prepended to the agent\'s system prompt at spawn (Injection profile).',
+			'web.memoryAmbient.loading' => 'Loading…',
+			'web.memoryAmbient.providers.title' => 'Summarizer providers',
+			'web.memoryAmbient.providers.addButton' => 'Add provider',
+			'web.memoryAmbient.providers.intro' => 'At least one enabled provider is required for capture to actually fire. Local options (Ollama, LM Studio, Integration) keep your transcripts off external networks.',
+			'web.memoryAmbient.providers.empty' => 'No providers configured yet.',
+			'web.memoryAmbient.providers.row.defaultBadge' => '★ default',
+			'web.memoryAmbient.providers.row.makeDefault' => 'Make default',
+			'web.memoryAmbient.providers.row.test' => 'Test',
+			'web.memoryAmbient.providers.row.testing' => 'Testing…',
+			'web.memoryAmbient.providers.row.delete' => 'Delete',
+			'web.memoryAmbient.providers.row.testOk' => ({required Object name}) => '${name}: connection OK',
+			'web.memoryAmbient.providers.row.testFailedToast' => 'Test failed',
+			'web.memoryAmbient.providers.row.deleteConfirm' => ({required Object name}) => 'Delete provider "${name}"?',
+			'web.memoryAmbient.providers.row.deletedToast' => 'Provider deleted',
+			'web.memoryAmbient.providers.row.deleteFailedToast' => 'Delete failed',
+			'web.memoryAmbient.providers.row.updateFailedToast' => 'Update failed',
+			'web.memoryAmbient.providers.row.madeDefaultToast' => ({required Object name}) => '${name} is now the default',
+			'web.memoryAmbient.providers.dialog.title' => 'Add summarizer provider',
+			'web.memoryAmbient.providers.dialog.kindLabel' => 'Kind',
+			'web.memoryAmbient.providers.dialog.nameLabel' => 'Name',
+			'web.memoryAmbient.providers.dialog.namePlaceholder' => 'e.g. lmstudio-qwen',
+			'web.memoryAmbient.providers.dialog.modelLabel' => 'Model',
+			'web.memoryAmbient.providers.dialog.baseUrlLabel' => 'Base URL',
+			'web.memoryAmbient.providers.dialog.integrationNote' => 'Integration providers resolve their base URL from a registered integration. Configure that under Integrations first; advanced wiring (extra_config) is DB-only in this release.',
+			'web.memoryAmbient.providers.dialog.apiKeyLabel' => 'API key',
+			'web.memoryAmbient.providers.dialog.apiKeyHint' => 'Stored encrypted (AES-GCM with the backup master passphrase). Never echoed back; only the fingerprint is shown after save.',
+			'web.memoryAmbient.providers.dialog.makeDefaultLabel' => 'Make this the default provider',
+			'web.memoryAmbient.providers.dialog.create' => 'Create',
+			'web.memoryAmbient.providers.dialog.nameRequiredToast' => 'Name is required',
+			'web.memoryAmbient.providers.dialog.createdToast' => ({required Object name}) => 'Provider ${name} created',
+			'web.memoryAmbient.providers.dialog.createFailedToast' => 'Create failed',
+			'web.memoryAmbient.rules.title' => 'Capture rules',
+			'web.memoryAmbient.rules.addButton' => 'Add rule',
+			'web.memoryAmbient.rules.intro' => 'Each rule says "when this trigger fires, summarize new transcript messages and store the durable facts." Per-session rules override the global default. v1 ships 4 trigger kinds.',
+			'web.memoryAmbient.rules.empty' => 'No capture rules yet. Add one to enable auto-capture.',
+			'web.memoryAmbient.rules.row.globalDefault' => 'global default',
+			'web.memoryAmbient.rules.row.scopeLabel' => 'scope:',
+			'web.memoryAmbient.rules.row.dedupLabel' => 'dedup:',
+			'web.memoryAmbient.rules.row.runNow' => 'Run now',
+			'web.memoryAmbient.rules.row.running' => 'Running…',
+			'web.memoryAmbient.rules.row.delete' => 'Delete',
+			'web.memoryAmbient.rules.row.firedToast' => ({required Object sessions}) => 'Rule fired across ${sessions} session(s)',
+			'web.memoryAmbient.rules.row.runNowFailedToast' => 'Run-now failed',
+			'web.memoryAmbient.rules.row.deleteConfirm' => ({required Object name}) => 'Delete rule "${name}"?',
+			'web.memoryAmbient.rules.row.deletedToast' => 'Rule deleted',
+			'web.memoryAmbient.rules.row.deleteFailedToast' => 'Delete failed',
+			'web.memoryAmbient.rules.row.summary.afterMessages' => ({required Object n}) => 'every ${n} messages',
+			'web.memoryAmbient.rules.row.summary.onIdle' => ({required Object seconds}) => 'idle ≥ ${seconds}s',
+			'web.memoryAmbient.rules.row.summary.kChars' => ({required Object k}) => '≥ ${k} chars',
+			'web.memoryAmbient.rules.row.summary.manual' => 'manual only',
+			'web.memoryAmbient.rules.dialog.title' => 'Add capture rule',
+			'web.memoryAmbient.rules.dialog.nameLabel' => 'Name',
+			'web.memoryAmbient.rules.dialog.triggerLabel' => 'Trigger',
+			'web.memoryAmbient.rules.dialog.nLabel' => 'N (messages)',
+			'web.memoryAmbient.rules.dialog.idleLabel' => 'Idle seconds',
+			'web.memoryAmbient.rules.dialog.kLabel' => 'K (characters)',
+			'web.memoryAmbient.rules.dialog.scopeLabel' => 'Target scope',
+			'web.memoryAmbient.rules.dialog.scopeSession' => 'session',
+			'web.memoryAmbient.rules.dialog.scopeProject' => 'project (recommended)',
+			'web.memoryAmbient.rules.dialog.scopeGlobal' => 'global',
+			'web.memoryAmbient.rules.dialog.dedupLabel' => 'Dedup threshold (0.0 – 1.0)',
+			'web.memoryAmbient.rules.dialog.dedupHint' => 'Higher = stricter de-duplication. 0.85 is the recommended sweet spot.',
+			'web.memoryAmbient.rules.dialog.create' => 'Create',
+			'web.memoryAmbient.rules.dialog.nameRequiredToast' => 'Name is required',
+			'web.memoryAmbient.rules.dialog.createdToast' => ({required Object name}) => 'Rule ${name} created',
+			'web.memoryAmbient.rules.dialog.createFailedToast' => 'Create failed',
+			'web.memoryAmbient.profiles.title' => 'Injection profiles',
+			'web.memoryAmbient.profiles.addButton' => 'Add profile',
+			'web.memoryAmbient.profiles.intro' => 'At spawn time opendray prepends a markdown banner of recent project memories to the agent\'s system prompt — IF a profile is configured. Without a profile, the model still uses memory_search on demand.',
+			'web.memoryAmbient.profiles.empty' => 'No injection profile. Memories are not auto-injected at spawn — model still uses memory_search.',
+			'web.memoryAmbient.profiles.row.globalDefault' => 'global default',
+			'web.memoryAmbient.profiles.row.delete' => 'Delete',
+			'web.memoryAmbient.profiles.row.deleteConfirm' => 'Delete this injection profile?',
+			'web.memoryAmbient.profiles.row.deletedToast' => 'Profile deleted',
+			'web.memoryAmbient.profiles.row.deleteFailedToast' => 'Delete failed',
+			'web.memoryAmbient.profiles.dialog.title' => 'Add injection profile',
+			'web.memoryAmbient.profiles.dialog.strategyLabel' => 'Strategy',
+			'web.memoryAmbient.profiles.dialog.kLabel' => 'K (top memories to inject)',
+			'web.memoryAmbient.profiles.dialog.hint' => 'One profile per session_id (or global default). Per-session profiles can be added later via API; UI currently only manages the global default.',
+			'web.memoryAmbient.profiles.dialog.create' => 'Create',
+			'web.memoryAmbient.profiles.dialog.createdToast' => 'Profile created',
+			'web.memoryAmbient.profiles.dialog.createFailedToast' => 'Create failed',
+			'web.memoryAmbient.cost.title' => 'Token cost (all-time)',
+			'web.memoryAmbient.cost.intro' => 'Per-provider summary aggregated from <1>memory_summarizer_calls</1>. Local providers (Ollama, LM Studio, Integration) are priced as \$0 — operator owns hardware cost.',
+			'web.memoryAmbient.cost.empty' => 'No enabled providers — no cost data.',
+			'web.memoryAmbient.cost.columns.provider' => 'Provider',
+			'web.memoryAmbient.cost.columns.calls' => 'Calls',
+			'web.memoryAmbient.cost.columns.inTokens' => 'In tokens',
+			'web.memoryAmbient.cost.columns.outTokens' => 'Out tokens',
+			'web.memoryAmbient.cost.columns.usdEst' => 'USD est.',
+			'web.noteEditor.loading' => 'Loading…',
+			'web.noteEditor.source' => 'Source',
+			'web.noteEditor.preview' => 'Preview',
+			'web.noteEditor.tagTitle' => ({required Object tag}) => 'tag #${tag}',
+			'web.noteEditor.emptyNote' => 'Empty note. Switch to Source to start writing.',
+			'web.noteEditor.saveFailedToast' => 'Save failed',
+			'web.noteEditor.status.saveFailed' => 'save failed',
+			'web.noteEditor.status.saving' => 'saving…',
+			'web.noteEditor.status.unsaved' => 'unsaved',
+			'web.noteEditor.status.newNote' => 'new note',
+			'web.noteEditor.status.saved' => 'saved',
+			'web.export.title' => 'Export data',
+			'web.export.subtitle' => 'Take a one-shot zip bundle of selected logical entities. Bundles are kept on the server for 24 hours, then automatically reaped.',
+			'web.export.backToBackups' => '← Backups',
+			'web.export.sections.export' => 'Export',
+			'web.export.sections.import' => 'Import',
+			'web.export.form.scope' => 'Scope',
+			'web.export.form.memories' => 'Memories',
+			'web.export.form.memoriesHint' => 'Cross-CLI persistent memory rows (text + scope + metadata). Embedding vectors are omitted; importer re-embeds.',
+			'web.export.form.integrations' => 'Integrations',
+			'web.export.form.customTasks' => 'Custom tasks',
+			'web.export.form.customTasksHint' => 'Operator-defined tasks shown in the Inspector\'s Tasks tab.',
+			'web.export.form.integrationOptions.none' => 'None',
+			'web.export.form.integrationOptions.noneHint' => 'Skip the integrations table entirely.',
+			'web.export.form.integrationOptions.metadata' => 'Metadata only (recommended)',
+			'web.export.form.integrationOptions.metadataHint' => 'ID, name, route prefix, scopes — no API key material.',
+			'web.export.form.integrationOptions.plaintext' => 'Include plaintext API keys',
+			'web.export.form.integrationOptions.plaintextHint' => 'v1 bcrypt-only: no recoverable plaintext exists. Manifest documents this; nothing leaks.',
+			'web.export.form.confirmWarning' => 'Type <1>I understand</1> to confirm. opendray currently stores only bcrypt hashes — selecting plaintext does NOT export any plaintext (the feature is reserved for a future release that keeps plaintext caches).',
+			'web.export.form.confirmPlaceholder' => 'I understand',
+			'web.export.form.confirmSentinel' => 'i understand',
+			'web.export.form.footnote' => 'Audit logs and session transcripts are out of scope — covered by /backups (operator dump) instead.',
+			'web.export.form.building' => 'Building…',
+			'web.export.form.create' => 'Create export',
+			'web.export.form.readyToast' => 'Export ready',
+			'web.export.form.readyDescription' => ({required Object bytes}) => '${bytes} bytes',
+			'web.export.form.failedToast' => 'Export failed',
+			'web.export.history.loading' => 'Loading…',
+			'web.export.history.empty' => 'No exports yet. Use the form above to create one.',
+			'web.export.history.title' => 'History',
+			'web.export.history.columns.id' => 'ID',
+			'web.export.history.columns.status' => 'Status',
+			'web.export.history.columns.scope' => 'Scope',
+			'web.export.history.columns.size' => 'Size',
+			'web.export.history.columns.expires' => 'Expires',
+			'web.export.history.columns.actions' => 'Actions',
+			'web.export.history.download' => 'Download',
+			'web.export.history.deleteTooltip' => 'Delete',
+			'web.export.history.listFailedToast' => 'Failed to list exports',
+			'web.export.history.downloadFailedToast' => 'Download failed',
+			'web.export.history.noTokenToast' => 'No download token (expired?)',
+			'web.export.history.deleteConfirm' => ({required Object id}) => 'Delete export ${id}?',
+			'web.export.history.deletedToast' => 'Export deleted',
+			'web.export.history.deleteFailedToast' => 'Delete failed',
+			'web.export.history.scopeEmpty' => '(empty)',
+			'web.export.import.intro' => 'Replay an export bundle (zip) into the live database. Conflicts (matching id, or unique route_prefix for integrations) are <1>skipped</1> by default. Memories are tagged <3>embedder=imported_v1</3> and need a re-embed pass before search returns them; trigger re-embed under <5>Memory → Maintenance</5>. Integrations are imported with <7>enabled=false</7> and a non-bcrypt placeholder key — operator must rotate before use.',
+			'web.export.import.memoryLink' => 'Memory → Maintenance',
+			'web.export.import.bundleLabel' => 'Bundle (.zip)',
+			'web.export.import.memoriesLabel' => 'Memories',
+			'web.export.import.integrationsLabel' => 'Integrations (metadata only — keys never imported)',
+			'web.export.import.customTasksLabel' => 'Custom tasks',
+			'web.export.import.importing' => 'Importing…',
+			'web.export.import.importBundle' => 'Import bundle',
+			'web.export.import.pickFileToast' => 'Pick a bundle file first',
+			'web.export.import.doneToast' => 'Import done',
+			'web.export.import.finishedWithErrors' => 'Import finished with errors',
+			'web.export.import.failedToast' => 'Import failed',
+			'web.export.import.summaryCard.memories' => 'Memories',
+			'web.export.import.summaryCard.integrations' => 'Integrations',
+			'web.export.import.summaryCard.customTasks' => 'Custom tasks',
+			'web.export.import.summaryCard.created' => 'created',
+			'web.export.import.summaryCard.skipped' => 'skipped',
+			'web.export.import.summaryCard.failed' => 'failed',
+			'web.export.imports.loading' => 'Loading…',
+			'web.export.imports.empty' => 'No imports yet.',
+			'web.export.imports.title' => 'History',
+			'web.export.imports.columns.id' => 'ID',
+			'web.export.imports.columns.status' => 'Status',
+			'web.export.imports.columns.source' => 'Source',
+			'web.export.imports.columns.counts' => 'Counts',
+			'web.export.imports.columns.when' => 'When',
+			'web.export.imports.noneCounts' => '(none)',
+			'web.export.imports.listFailedToast' => 'Failed to list imports',
 			'more.title' => 'More',
 			'more.identity.signedInAs' => 'Signed in as',
 			'more.identity.server' => 'Server',
@@ -4981,6 +14302,8 @@ extension on Translations {
 			'integrations.edit' => 'Edit',
 			'integrations.editTitle' => ({required Object name}) => 'Edit ${name}',
 			'integrations.enabledLabel' => 'Enabled',
+			_ => null,
+		} ?? switch (path) {
 			'integrations.iSavedIt' => 'I\'ve saved it',
 			'integrations.apiKeyForName' => ({required Object name}) => 'API key for ${name}',
 			'integrations.apiKeySubtitleRegister' => ({required Object routePrefix}) => 'Hand this to the integration so it can authenticate against /api/v1/${routePrefix}/…',
@@ -5141,8 +14464,6 @@ extension on Translations {
 			'backups.emptyMissingDeps.body' => 'Install postgresql-client and restart opendray.',
 			'backups.emptyNoTargets.headline' => 'No backup targets configured',
 			'backups.emptyNoTargets.body' => 'Open the More menu → Targets to add a destination (local / S3 / SMB / SFTP / WebDAV / rclone). Then come back and tap "Run now".',
-			_ => null,
-		} ?? switch (path) {
 			'backups.emptyNoBackups.headline' => 'No backups yet',
 			'backups.emptyNoBackups.body' => 'Tap "Run now" to take a fresh snapshot, or open Schedules to set up recurring runs.',
 			'backups.restartToActivate' => 'Restart opendray to activate backups',
@@ -5495,6 +14816,8 @@ extension on Translations {
 			'customTasks.cwdHelper' => 'Absolute path. Sessions spawned with this exact cwd will see the task.',
 			'customTasks.saving' => 'Saving…',
 			'customTasks.save' => 'Save',
+			_ => null,
+		} ?? switch (path) {
 			'customTasks.create' => 'Create',
 			'customTasks.failedToLoad' => 'Failed to load custom tasks',
 			'notesPage.title' => 'Notes',
@@ -5655,8 +14978,6 @@ extension on Translations {
 			'settings.serverSettings.fields.adminUserHelper' => 'Effective when no keyfile or env var is set. Otherwise see Settings → Account.',
 			'settings.serverSettings.fields.adminPassword' => 'Admin password',
 			'settings.serverSettings.fields.adminPasswordHelper' => 'Send blank to preserve. For ongoing rotations use Settings → Account (keyfile-backed, no restart).',
-			_ => null,
-		} ?? switch (path) {
 			'settings.serverSettings.fields.tokenTtlWeb' => 'Token TTL (web)',
 			'settings.serverSettings.fields.tokenTtlHelper' => 'Go duration string, e.g. 24h, 30m.',
 			'settings.serverSettings.fields.level' => 'Level',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -4374,8 +4374,8 @@ class TranslationsWebSessionsSpawnEn {
 	/// en: 'Bypass permission prompts'
 	String get bypassClaude => 'Bypass permission prompts';
 
-	/// en: 'Auto-approve (--ask-for-approval never)'
-	String get bypassCodex => 'Auto-approve (--ask-for-approval never)';
+	/// en: 'Bypass approvals & sandbox (--dangerously-bypass-approvals-and-sandbox)'
+	String get bypassCodex => 'Bypass approvals & sandbox (--dangerously-bypass-approvals-and-sandbox)';
 
 	/// en: 'YOLO mode (--yolo)'
 	String get bypassGemini => 'YOLO mode (--yolo)';
@@ -8828,8 +8828,8 @@ class TranslationsSessionsSpawnSheetBypassEn {
 	/// en: 'Bypass permissions'
 	String get labelClaude => 'Bypass permissions';
 
-	/// en: 'Auto-approve (never ask)'
-	String get labelCodex => 'Auto-approve (never ask)';
+	/// en: 'Bypass approvals & sandbox'
+	String get labelCodex => 'Bypass approvals & sandbox';
 
 	/// en: 'YOLO mode'
 	String get labelGemini => 'YOLO mode';
@@ -12376,7 +12376,7 @@ extension on Translations {
 			'web.sessions.spawn.namePlaceholder' => 'claude in pet-tracker',
 			'web.sessions.spawn.argsLabel' => 'CLI args (one per line)',
 			'web.sessions.spawn.bypassClaude' => 'Bypass permission prompts',
-			'web.sessions.spawn.bypassCodex' => 'Auto-approve (--ask-for-approval never)',
+			'web.sessions.spawn.bypassCodex' => 'Bypass approvals & sandbox (--dangerously-bypass-approvals-and-sandbox)',
 			'web.sessions.spawn.bypassGemini' => 'YOLO mode (--yolo)',
 			'web.sessions.spawn.bypassOnHint' => 'This session will run with elevated autonomy.',
 			'web.sessions.spawn.bypassOffHint' => 'Off — confirmations and prompts behave normally.',
@@ -14163,7 +14163,7 @@ extension on Translations {
 			'sessions.spawnSheet.argsHint' => '--continue --verbose',
 			'sessions.spawnSheet.argsHelper' => 'Whitespace-separated; blank uses the provider\'s defaults.',
 			'sessions.spawnSheet.bypass.labelClaude' => 'Bypass permissions',
-			'sessions.spawnSheet.bypass.labelCodex' => 'Auto-approve (never ask)',
+			'sessions.spawnSheet.bypass.labelCodex' => 'Bypass approvals & sandbox',
 			'sessions.spawnSheet.bypass.labelGemini' => 'YOLO mode',
 			'sessions.spawnSheet.bypass.subtitleOn' => 'This session will run with elevated autonomy.',
 			'sessions.spawnSheet.bypass.subtitleOff' => 'Off — confirmations and prompts behave normally.',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -42,6 +42,7 @@ class TranslationsZh extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsCommonZh common = _TranslationsCommonZh._(_root);
 	@override late final _TranslationsAuthZh auth = _TranslationsAuthZh._(_root);
 	@override late final _TranslationsNavZh nav = _TranslationsNavZh._(_root);
+	@override late final _TranslationsWebZh web = _TranslationsWebZh._(_root);
 	@override late final _TranslationsMoreZh more = _TranslationsMoreZh._(_root);
 	@override late final _TranslationsSessionsZh sessions = _TranslationsSessionsZh._(_root);
 	@override late final _TranslationsMcpZh mcp = _TranslationsMcpZh._(_root);
@@ -98,8 +99,11 @@ class _TranslationsAuthZh extends TranslationsAuthEn {
 	@override String get username => '用户名';
 	@override String get password => '密码';
 	@override String get signIn => '登录';
+	@override String get signingIn => '登录中…';
+	@override String get subtitle => '请使用运维账号登录。';
 	@override String get errorRequired => '请输入用户名和密码';
 	@override String errorGeneric({required Object error}) => '登录失败：${error}';
+	@override String get errorFallback => '登录失败';
 }
 
 // Path: nav
@@ -113,6 +117,47 @@ class _TranslationsNavZh extends TranslationsNavEn {
 	@override String get memory => '记忆';
 	@override String get notes => '笔记';
 	@override String get more => '更多';
+	@override String get activity => '活动';
+	@override String get providers => '提供方';
+	@override String get channels => '频道';
+	@override String get integrations => '集成';
+	@override String get plugins => '插件';
+	@override String get backups => '备份';
+	@override String get settings => '设置';
+	@override String get tutorial => '教程';
+	@override String get workspace => '工作区';
+}
+
+// Path: web
+class _TranslationsWebZh extends TranslationsWebEn {
+	_TranslationsWebZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get brand => 'opendray';
+	@override String get loading => '加载中…';
+	@override late final _TranslationsWebTopbarZh topbar = _TranslationsWebTopbarZh._(_root);
+	@override late final _TranslationsWebSessionsZh sessions = _TranslationsWebSessionsZh._(_root);
+	@override late final _TranslationsWebMemoryZh memory = _TranslationsWebMemoryZh._(_root);
+	@override late final _TranslationsWebMemoryWorkersZh memoryWorkers = _TranslationsWebMemoryWorkersZh._(_root);
+	@override late final _TranslationsWebCleanupInboxZh cleanupInbox = _TranslationsWebCleanupInboxZh._(_root);
+	@override late final _TranslationsWebProjectZh project = _TranslationsWebProjectZh._(_root);
+	@override late final _TranslationsWebMemoryInspectorZh memoryInspector = _TranslationsWebMemoryInspectorZh._(_root);
+	@override late final _TranslationsWebNotesZh notes = _TranslationsWebNotesZh._(_root);
+	@override late final _TranslationsWebActivityZh activity = _TranslationsWebActivityZh._(_root);
+	@override late final _TranslationsWebProvidersZh providers = _TranslationsWebProvidersZh._(_root);
+	@override late final _TranslationsWebChannelsZh channels = _TranslationsWebChannelsZh._(_root);
+	@override late final _TranslationsWebIntegrationsZh integrations = _TranslationsWebIntegrationsZh._(_root);
+	@override late final _TranslationsWebPluginsZh plugins = _TranslationsWebPluginsZh._(_root);
+	@override late final _TranslationsWebBackupsZh backups = _TranslationsWebBackupsZh._(_root);
+	@override late final _TranslationsWebServerSettingsZh serverSettings = _TranslationsWebServerSettingsZh._(_root);
+	@override late final _TranslationsWebSettingsZh settings = _TranslationsWebSettingsZh._(_root);
+	@override late final _TranslationsWebLogViewerZh logViewer = _TranslationsWebLogViewerZh._(_root);
+	@override late final _TranslationsWebPathInputZh pathInput = _TranslationsWebPathInputZh._(_root);
+	@override late final _TranslationsWebMemoryAmbientZh memoryAmbient = _TranslationsWebMemoryAmbientZh._(_root);
+	@override late final _TranslationsWebNoteEditorZh noteEditor = _TranslationsWebNoteEditorZh._(_root);
+	@override late final _TranslationsWebExportZh export = _TranslationsWebExportZh._(_root);
 }
 
 // Path: more
@@ -783,6 +828,465 @@ class _TranslationsSettingsZh extends TranslationsSettingsEn {
 	@override late final _TranslationsSettingsChangeCredentialsZh changeCredentials = _TranslationsSettingsChangeCredentialsZh._(_root);
 	@override late final _TranslationsSettingsLogViewerZh logViewer = _TranslationsSettingsLogViewerZh._(_root);
 	@override late final _TranslationsSettingsServerSettingsZh serverSettings = _TranslationsSettingsServerSettingsZh._(_root);
+}
+
+// Path: web.topbar
+class _TranslationsWebTopbarZh extends TranslationsWebTopbarEn {
+	_TranslationsWebTopbarZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get expandSidebar => '展开侧边栏';
+	@override String get collapseSidebar => '收起侧边栏';
+	@override String get search => '搜索';
+	@override String get openPalette => '打开命令面板';
+	@override String get theme => '主题';
+	@override String themeLabel({required Object mode}) => '主题：${mode}';
+	@override String get appearance => '外观';
+	@override String get themeLight => '浅色';
+	@override String get themeDark => '深色';
+	@override String get themeSystem => '跟随系统';
+	@override String get language => '语言';
+	@override String get languageEnglish => 'English';
+	@override String get languageChinese => '中文';
+	@override String get signedInAs => '登录账号';
+	@override String get tokenExpires => '令牌到期';
+	@override String get signOut => '退出登录';
+}
+
+// Path: web.sessions
+class _TranslationsWebSessionsZh extends TranslationsWebSessionsEn {
+	_TranslationsWebSessionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsWebSessionsListZh list = _TranslationsWebSessionsListZh._(_root);
+	@override late final _TranslationsWebSessionsTabsZh tabs = _TranslationsWebSessionsTabsZh._(_root);
+	@override late final _TranslationsWebSessionsPageZh page = _TranslationsWebSessionsPageZh._(_root);
+	@override late final _TranslationsWebSessionsEmptyZh empty = _TranslationsWebSessionsEmptyZh._(_root);
+	@override late final _TranslationsWebSessionsHeaderZh header = _TranslationsWebSessionsHeaderZh._(_root);
+	@override late final _TranslationsWebSessionsTerminalZh terminal = _TranslationsWebSessionsTerminalZh._(_root);
+	@override late final _TranslationsWebSessionsSpawnZh spawn = _TranslationsWebSessionsSpawnZh._(_root);
+	@override late final _TranslationsWebSessionsAccountSwitcherZh accountSwitcher = _TranslationsWebSessionsAccountSwitcherZh._(_root);
+	@override late final _TranslationsWebSessionsInspectorZh inspector = _TranslationsWebSessionsInspectorZh._(_root);
+	@override late final _TranslationsWebSessionsEndedZh ended = _TranslationsWebSessionsEndedZh._(_root);
+	@override late final _TranslationsWebSessionsFileBrowserZh fileBrowser = _TranslationsWebSessionsFileBrowserZh._(_root);
+}
+
+// Path: web.memory
+class _TranslationsWebMemoryZh extends TranslationsWebMemoryEn {
+	_TranslationsWebMemoryZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '记忆';
+	@override String get subtitle => '浏览、搜索并编辑 Agent 通过 opendray-memory MCP 服务器存储的记忆。';
+	@override String get navProject => '项目';
+	@override String get navCleanupInbox => '清理收件箱';
+	@override String get navWorkers => 'Workers';
+	@override String get navConfiguration => '配置 →';
+}
+
+// Path: web.memoryWorkers
+class _TranslationsWebMemoryWorkersZh extends TranslationsWebMemoryWorkersEn {
+	_TranslationsWebMemoryWorkersZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Memory workers';
+	@override String get loading => '正在加载 worker 配置…';
+	@override String get errorTitle => '无法访问该接口。';
+	@override String get errorDescription => '/api/v1/memory/workers 路由在 M25 中新增 — opendray 二进制可能需要重启以挂载它们并执行 migration 0029。';
+	@override String get intro => 'Memory 子系统的每个 LLM 接入点都可由本地 <1>summarizer</1>（LM Studio / OpenAI 兼容）端点服务，或通过以 <5>--print</5> 模式启动的无头 <3>Claude / Gemini agent</3> 服务。叙事性任务（gitactivity、transcript）从 agent worker 中获益；高频任务（gatekeeper）按设计仍走本地端点。';
+	@override String get enabledBadge => '已启用';
+	@override String get disabledBadge => '已禁用';
+	@override String get summarizerOnlyBadge => '仅 summarizer';
+	@override String callsCount({required Object count}) => '${count} 次调用 · 24 小时';
+	@override String avgMs({required Object ms}) => '平均 ${ms}ms';
+	@override String errorsCount({required Object count}) => '${count} 次错误';
+	@override String get workerLabel => 'Worker';
+	@override String get summarizerHttp => 'Summarizer (HTTP)';
+	@override String get agentCliPrint => 'Agent (CLI --print)';
+	@override String get summarizerProviderLabel => 'Summarizer Provider';
+	@override String get registryDefault => '注册表默认值';
+	@override String get cliLabel => 'CLI';
+	@override String get selectPlaceholder => '选择';
+	@override String get cliClaude => 'Claude';
+	@override String get cliGemini => 'Gemini';
+	@override String get claudeAccountLabel => 'Claude 账号';
+	@override String get claudeAccountDefault => '默认';
+	@override String get agentWarning => 'Agent 模式每次调用都会启动一个无头 CLI。延迟从 <1>~1s</1>（summarizer）上升到 <3>~5-15s</3>；成本从 CPU 转移到 Claude/Gemini 配额。';
+	@override String get enabledCheckbox => '启用';
+	@override String get testButton => '测试';
+	@override String get saveButton => '保存';
+	@override String recentCalls({required Object count}) => '最近调用 (${count})';
+	@override String get tableWhen => '时间';
+	@override String get tableWorker => 'worker';
+	@override String get tableMs => 'ms';
+	@override String get tableOk => 'ok';
+	@override String savedToast({required Object label}) => '${label} 已更新';
+	@override String get saveFailedToast => '保存失败';
+	@override String testOkToast({required Object label, required Object ms}) => '${label} OK — ${ms}ms';
+	@override String testFailedToast({required Object label}) => '${label} 失败';
+	@override String get testCallFailedToast => '测试调用失败';
+	@override String get unknownError => '未知错误';
+	@override late final _TranslationsWebMemoryWorkersTasksZh tasks = _TranslationsWebMemoryWorkersTasksZh._(_root);
+}
+
+// Path: web.cleanupInbox
+class _TranslationsWebCleanupInboxZh extends TranslationsWebCleanupInboxEn {
+	_TranslationsWebCleanupInboxZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get loading => '加载中…';
+	@override String get emptyTitle => '清理收件箱为空';
+	@override String get emptyDescription => '目前所有项目均无待处理的清理决策。LLM librarian 要么尚未跑过这些记忆，要么判断全部仍是关键内容。';
+	@override String get title => '清理收件箱';
+	@override String get subtitle => 'LLM memory librarian 的跨项目待处理决策。批准 stale → 删除，批准 duplicate → 合并，批准 keep → 一段时间内冻结该条目不再被重新判断。';
+	@override String get globalScope => '(全局)';
+	@override String get orphanBadge => '孤立';
+	@override String get orphanTitle => 'scope_key 被截断（老旧的镜像导入数据）。不是可导航的项目。';
+	@override String get openProject => '打开项目';
+	@override String get mergeIntoPrefix => '→ 合并到';
+	@override String get reasonPrefix => '原因：';
+	@override String get executeButton => '执行';
+	@override String get confirmKeepButton => '确认保留';
+	@override String get rejectButton => '驳回';
+	@override String get approvedKeptToast => '已保留';
+	@override String approvedExecutedToast({required Object verdict}) => '已执行 ${verdict}';
+	@override String get approveFailedToast => '批准失败';
+	@override String get rejectedToast => '已驳回 — 记忆保留';
+	@override String get rejectFailedToast => '驳回失败';
+}
+
+// Path: web.project
+class _TranslationsWebProjectZh extends TranslationsWebProjectEn {
+	_TranslationsWebProjectZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsWebProjectPickerZh picker = _TranslationsWebProjectPickerZh._(_root);
+	@override String get noCwd => '选择一个项目以管理其记忆。';
+	@override late final _TranslationsWebProjectHeaderZh header = _TranslationsWebProjectHeaderZh._(_root);
+	@override late final _TranslationsWebProjectTabsZh tabs = _TranslationsWebProjectTabsZh._(_root);
+	@override late final _TranslationsWebProjectDocLabelZh docLabel = _TranslationsWebProjectDocLabelZh._(_root);
+	@override late final _TranslationsWebProjectVerdictLabelZh verdictLabel = _TranslationsWebProjectVerdictLabelZh._(_root);
+	@override late final _TranslationsWebProjectEditorZh editor = _TranslationsWebProjectEditorZh._(_root);
+	@override late final _TranslationsWebProjectReadonlyZh readonly = _TranslationsWebProjectReadonlyZh._(_root);
+	@override late final _TranslationsWebProjectJournalZh journal = _TranslationsWebProjectJournalZh._(_root);
+	@override late final _TranslationsWebProjectInboxZh inbox = _TranslationsWebProjectInboxZh._(_root);
+	@override late final _TranslationsWebProjectCleanupZh cleanup = _TranslationsWebProjectCleanupZh._(_root);
+	@override late final _TranslationsWebProjectResetZh reset = _TranslationsWebProjectResetZh._(_root);
+}
+
+// Path: web.memoryInspector
+class _TranslationsWebMemoryInspectorZh extends TranslationsWebMemoryInspectorEn {
+	_TranslationsWebMemoryInspectorZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsWebMemoryInspectorStatusZh status = _TranslationsWebMemoryInspectorStatusZh._(_root);
+	@override String get statusBody => '这是网关当前用于每次 <1>memory_search</1> / <3>memory_store</3> 调用的 embedder。如果与上方配置不一致，说明有未保存的更改 — 点击 Save 后重启服务即可生效。';
+	@override late final _TranslationsWebMemoryInspectorScopeZh scope = _TranslationsWebMemoryInspectorScopeZh._(_root);
+	@override late final _TranslationsWebMemoryInspectorSearchZh search = _TranslationsWebMemoryInspectorSearchZh._(_root);
+	@override late final _TranslationsWebMemoryInspectorRecordsZh records = _TranslationsWebMemoryInspectorRecordsZh._(_root);
+	@override late final _TranslationsWebMemoryInspectorRowZh row = _TranslationsWebMemoryInspectorRowZh._(_root);
+	@override late final _TranslationsWebMemoryInspectorToastsZh toasts = _TranslationsWebMemoryInspectorToastsZh._(_root);
+	@override late final _TranslationsWebMemoryInspectorBulkDeleteZh bulkDelete = _TranslationsWebMemoryInspectorBulkDeleteZh._(_root);
+	@override late final _TranslationsWebMemoryInspectorAddMemZh addMem = _TranslationsWebMemoryInspectorAddMemZh._(_root);
+	@override late final _TranslationsWebMemoryInspectorPickerZh picker = _TranslationsWebMemoryInspectorPickerZh._(_root);
+	@override late final _TranslationsWebMemoryInspectorMigrationBannerZh migrationBanner = _TranslationsWebMemoryInspectorMigrationBannerZh._(_root);
+	@override late final _TranslationsWebMemoryInspectorReembedZh reembed = _TranslationsWebMemoryInspectorReembedZh._(_root);
+}
+
+// Path: web.notes
+class _TranslationsWebNotesZh extends TranslationsWebNotesEn {
+	_TranslationsWebNotesZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '笔记';
+	@override late final _TranslationsWebNotesHeaderZh header = _TranslationsWebNotesHeaderZh._(_root);
+	@override late final _TranslationsWebNotesLeftZh left = _TranslationsWebNotesLeftZh._(_root);
+	@override late final _TranslationsWebNotesTagsZh tags = _TranslationsWebNotesTagsZh._(_root);
+	@override late final _TranslationsWebNotesTreeZh tree = _TranslationsWebNotesTreeZh._(_root);
+	@override late final _TranslationsWebNotesOutlineZh outline = _TranslationsWebNotesOutlineZh._(_root);
+	@override late final _TranslationsWebNotesNewNoteZh newNote = _TranslationsWebNotesNewNoteZh._(_root);
+	@override late final _TranslationsWebNotesEmptyZh empty = _TranslationsWebNotesEmptyZh._(_root);
+	@override late final _TranslationsWebNotesPickerZh picker = _TranslationsWebNotesPickerZh._(_root);
+	@override late final _TranslationsWebNotesVaultSyncZh vaultSync = _TranslationsWebNotesVaultSyncZh._(_root);
+	@override late final _TranslationsWebNotesSyncBadgeZh syncBadge = _TranslationsWebNotesSyncBadgeZh._(_root);
+}
+
+// Path: web.activity
+class _TranslationsWebActivityZh extends TranslationsWebActivityEn {
+	_TranslationsWebActivityZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '活动';
+	@override String get subtitle => '按调用维度审计每个由注册集成发起的 API 请求。包括入站调用（第三方应用以集成 API key 调用 opendray）和出站代理调用（admin → opendray 代理 → 集成）。本管理端 UI 直接发起的调用不会被记录。';
+	@override String get refresh => '刷新';
+	@override String get refreshTooltip => '刷新';
+	@override late final _TranslationsWebActivityFiltersZh filters = _TranslationsWebActivityFiltersZh._(_root);
+	@override String callsCount_one({required Object count}) => '${count} 次调用';
+	@override String callsCount_other({required Object count}) => '${count} 次调用';
+	@override String get loading => '加载中…';
+	@override late final _TranslationsWebActivityTableZh table = _TranslationsWebActivityTableZh._(_root);
+	@override late final _TranslationsWebActivityEmptyZh empty = _TranslationsWebActivityEmptyZh._(_root);
+	@override late final _TranslationsWebActivityEventsZh events = _TranslationsWebActivityEventsZh._(_root);
+}
+
+// Path: web.providers
+class _TranslationsWebProvidersZh extends TranslationsWebProvidersEn {
+	_TranslationsWebProvidersZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsWebProvidersListZh list = _TranslationsWebProvidersListZh._(_root);
+	@override late final _TranslationsWebProvidersDetailZh detail = _TranslationsWebProvidersDetailZh._(_root);
+	@override late final _TranslationsWebProvidersConfigFormZh configForm = _TranslationsWebProvidersConfigFormZh._(_root);
+	@override late final _TranslationsWebProvidersClaudeAccountsZh claudeAccounts = _TranslationsWebProvidersClaudeAccountsZh._(_root);
+}
+
+// Path: web.channels
+class _TranslationsWebChannelsZh extends TranslationsWebChannelsEn {
+	_TranslationsWebChannelsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '频道';
+	@override String get subtitle => '双向消息集成。每个频道的出站通知按其 <1>notify_on</1> 过滤。';
+	@override String get newButton => '新建频道';
+	@override String get loading => '加载中…';
+	@override late final _TranslationsWebChannelsEmptyZh empty = _TranslationsWebChannelsEmptyZh._(_root);
+	@override late final _TranslationsWebChannelsCardZh card = _TranslationsWebChannelsCardZh._(_root);
+	@override late final _TranslationsWebChannelsToastsZh toasts = _TranslationsWebChannelsToastsZh._(_root);
+	@override late final _TranslationsWebChannelsDialogZh dialog = _TranslationsWebChannelsDialogZh._(_root);
+	@override late final _TranslationsWebChannelsNotificationsZh notifications = _TranslationsWebChannelsNotificationsZh._(_root);
+	@override late final _TranslationsWebChannelsBridgeZh bridge = _TranslationsWebChannelsBridgeZh._(_root);
+	@override late final _TranslationsWebChannelsSetupZh setup = _TranslationsWebChannelsSetupZh._(_root);
+}
+
+// Path: web.integrations
+class _TranslationsWebIntegrationsZh extends TranslationsWebIntegrationsEn {
+	_TranslationsWebIntegrationsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '集成';
+	@override String get subtitle => '调用 opendray 的外部应用。通过 <1>/api/v1/proxy/&lt;prefix&gt;/…</1> 反向代理，并通过 WS 端点订阅事件。';
+	@override String get register => '注册';
+	@override String get loading => '加载中…';
+	@override late final _TranslationsWebIntegrationsTabsZh tabs = _TranslationsWebIntegrationsTabsZh._(_root);
+	@override late final _TranslationsWebIntegrationsEmptyZh empty = _TranslationsWebIntegrationsEmptyZh._(_root);
+	@override String get groupSystem => '系统（由 opendray 管理）';
+	@override String get groupOperator => '用户注册';
+	@override late final _TranslationsWebIntegrationsCardZh card = _TranslationsWebIntegrationsCardZh._(_root);
+	@override late final _TranslationsWebIntegrationsRegisterDialogZh register_dialog = _TranslationsWebIntegrationsRegisterDialogZh._(_root);
+	@override late final _TranslationsWebIntegrationsRevealZh reveal = _TranslationsWebIntegrationsRevealZh._(_root);
+	@override late final _TranslationsWebIntegrationsEditDialogZh edit_dialog = _TranslationsWebIntegrationsEditDialogZh._(_root);
+	@override late final _TranslationsWebIntegrationsProxyZh proxy = _TranslationsWebIntegrationsProxyZh._(_root);
+}
+
+// Path: web.plugins
+class _TranslationsWebPluginsZh extends TranslationsWebPluginsEn {
+	_TranslationsWebPluginsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '检查器插件';
+	@override String get subtitle => '配置在会话打开时右侧检查器面板呈现的数据源。每个插件都是管理员级别且在所有会话间共享。点击章节标题可折叠。';
+	@override late final _TranslationsWebPluginsCommonZh common = _TranslationsWebPluginsCommonZh._(_root);
+	@override late final _TranslationsWebPluginsMcpZh mcp = _TranslationsWebPluginsMcpZh._(_root);
+	@override late final _TranslationsWebPluginsMcpSecretsZh mcpSecrets = _TranslationsWebPluginsMcpSecretsZh._(_root);
+	@override late final _TranslationsWebPluginsSkillsZh skills = _TranslationsWebPluginsSkillsZh._(_root);
+	@override late final _TranslationsWebPluginsCustomTasksZh customTasks = _TranslationsWebPluginsCustomTasksZh._(_root);
+	@override late final _TranslationsWebPluginsGitHostsZh gitHosts = _TranslationsWebPluginsGitHostsZh._(_root);
+}
+
+// Path: web.backups
+class _TranslationsWebBackupsZh extends TranslationsWebBackupsEn {
+	_TranslationsWebBackupsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '备份';
+	@override String get subtitle => '写入到可插拔目标的加密 PostgreSQL dump。配置计划与保留策略，或触发一次性备份作为快速安全网。';
+	@override String get exportData => '导出数据';
+	@override String get loading => '加载中…';
+	@override String get loadStatusFailedToast => '加载备份状态失败';
+	@override late final _TranslationsWebBackupsTabsZh tabs = _TranslationsWebBackupsTabsZh._(_root);
+	@override late final _TranslationsWebBackupsInventoryZh inventory = _TranslationsWebBackupsInventoryZh._(_root);
+	@override late final _TranslationsWebBackupsRestartZh restart = _TranslationsWebBackupsRestartZh._(_root);
+	@override late final _TranslationsWebBackupsSetupZh setup = _TranslationsWebBackupsSetupZh._(_root);
+	@override late final _TranslationsWebBackupsGeneratedZh generated = _TranslationsWebBackupsGeneratedZh._(_root);
+	@override late final _TranslationsWebBackupsStatusZh status = _TranslationsWebBackupsStatusZh._(_root);
+	@override late final _TranslationsWebBackupsBackupsTabZh backupsTab = _TranslationsWebBackupsBackupsTabZh._(_root);
+	@override late final _TranslationsWebBackupsRestoreZh restore = _TranslationsWebBackupsRestoreZh._(_root);
+	@override late final _TranslationsWebBackupsSchedulesTabZh schedulesTab = _TranslationsWebBackupsSchedulesTabZh._(_root);
+	@override late final _TranslationsWebBackupsNewScheduleZh newSchedule = _TranslationsWebBackupsNewScheduleZh._(_root);
+	@override late final _TranslationsWebBackupsTargetsTabZh targetsTab = _TranslationsWebBackupsTargetsTabZh._(_root);
+	@override late final _TranslationsWebBackupsTargetEditorZh targetEditor = _TranslationsWebBackupsTargetEditorZh._(_root);
+}
+
+// Path: web.serverSettings
+class _TranslationsWebServerSettingsZh extends TranslationsWebServerSettingsEn {
+	_TranslationsWebServerSettingsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsWebServerSettingsSectionsZh sections = _TranslationsWebServerSettingsSectionsZh._(_root);
+	@override String get loading => '正在加载服务器设置…';
+	@override String loadFailed({required Object message}) => '加载失败：${message}';
+	@override String get noConfigFlag => 'opendray 启动时未指定 -config，设置仅从环境变量加载，无法在此编辑。';
+	@override String get resetButton => '重置';
+	@override String get resetButtonTitle => '丢弃此分区中未保存的修改';
+	@override String resetConfirm({required Object section}) => '将"${section}"重置为上次保存的值？';
+	@override String get badgeRestartRequired => '需要重启';
+	@override String get badgeUnsaved => '未保存';
+	@override String get saveButton => '保存修改';
+	@override String get saveToastTitle => '设置已保存';
+	@override String get saveToastDesc => '点击「重启」以应用。';
+	@override String get saveErrorTitle => '保存失败';
+	@override String get dangerousConfirm => '您更改了监听地址 / 管理员账号 / 管理员密码。重启后可能需要重新登录或使用新地址。是否继续？';
+	@override String get unsavedHint => '有未保存的修改';
+	@override String get savedHint => '所有修改已保存';
+	@override String get searchPlaceholder => '筛选字段…';
+	@override late final _TranslationsWebServerSettingsRestartZh restart = _TranslationsWebServerSettingsRestartZh._(_root);
+	@override late final _TranslationsWebServerSettingsFormGroupsZh formGroups = _TranslationsWebServerSettingsFormGroupsZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsZh fields = _TranslationsWebServerSettingsFieldsZh._(_root);
+	@override late final _TranslationsWebServerSettingsLiveTailZh liveTail = _TranslationsWebServerSettingsLiveTailZh._(_root);
+	@override late final _TranslationsWebServerSettingsMemoryInspectorCardZh memoryInspectorCard = _TranslationsWebServerSettingsMemoryInspectorCardZh._(_root);
+	@override String get localOnnxBanner => '需要使用 <1>-tags local_onnx</1> 编译二进制。标准构建在选择此后端时会返回明确的 stub 错误。设置步骤参见 <3>记忆 → 本地 ONNX</3> 教程。';
+	@override late final _TranslationsWebServerSettingsStringListZh stringList = _TranslationsWebServerSettingsStringListZh._(_root);
+	@override late final _TranslationsWebServerSettingsHttpHelpersZh httpHelpers = _TranslationsWebServerSettingsHttpHelpersZh._(_root);
+	@override late final _TranslationsWebServerSettingsProbeZh probe = _TranslationsWebServerSettingsProbeZh._(_root);
+	@override late final _TranslationsWebServerSettingsBackupZh backup = _TranslationsWebServerSettingsBackupZh._(_root);
+	@override late final _TranslationsWebServerSettingsTargetRowZh targetRow = _TranslationsWebServerSettingsTargetRowZh._(_root);
+}
+
+// Path: web.settings
+class _TranslationsWebSettingsZh extends TranslationsWebSettingsEn {
+	_TranslationsWebSettingsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '设置';
+	@override String get subtitle => '工作区、账号与网关配置。';
+	@override late final _TranslationsWebSettingsGroupsZh groups = _TranslationsWebSettingsGroupsZh._(_root);
+	@override late final _TranslationsWebSettingsItemsZh items = _TranslationsWebSettingsItemsZh._(_root);
+	@override late final _TranslationsWebSettingsHealthZh health = _TranslationsWebSettingsHealthZh._(_root);
+	@override late final _TranslationsWebSettingsBreadcrumbZh breadcrumb = _TranslationsWebSettingsBreadcrumbZh._(_root);
+	@override late final _TranslationsWebSettingsAppearanceZh appearance = _TranslationsWebSettingsAppearanceZh._(_root);
+	@override late final _TranslationsWebSettingsFontZh font = _TranslationsWebSettingsFontZh._(_root);
+	@override late final _TranslationsWebSettingsAccountZh account = _TranslationsWebSettingsAccountZh._(_root);
+	@override late final _TranslationsWebSettingsChangeCredentialsZh changeCredentials = _TranslationsWebSettingsChangeCredentialsZh._(_root);
+	@override late final _TranslationsWebSettingsSystemZh system = _TranslationsWebSettingsSystemZh._(_root);
+	@override late final _TranslationsWebSettingsAboutZh about = _TranslationsWebSettingsAboutZh._(_root);
+}
+
+// Path: web.logViewer
+class _TranslationsWebLogViewerZh extends TranslationsWebLogViewerEn {
+	_TranslationsWebLogViewerZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get filterPlaceholder => '过滤…';
+	@override String get debugTooltip => 'Debug 计数';
+	@override String get infoTooltip => 'Info 计数';
+	@override String get warnTooltip => 'Warn 计数';
+	@override String get errorTooltip => 'Error 计数';
+	@override String get streaming => '正在流式传输';
+	@override String get disconnected => '已断开';
+	@override String get live => '实时';
+	@override String get offline => '离线';
+	@override String get pauseTooltip => '暂停自动滚动';
+	@override String get resumeTooltip => '恢复自动滚动';
+	@override String get clearTooltip => '清空本地视图（服务端 ring 不受影响）';
+	@override String get downloadTooltip => '下载完整 ring 为 .log 文件';
+	@override String get emptyWaiting => '等待日志记录…';
+	@override String emptyFiltered({required Object query}) => '没有匹配 "${query}" 的记录';
+}
+
+// Path: web.pathInput
+class _TranslationsWebPathInputZh extends TranslationsWebPathInputEn {
+	_TranslationsWebPathInputZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get testButton => '测试';
+	@override String get testTooltip => '解析并检查此路径';
+	@override String get notFound => '未找到 ·';
+	@override String get childrenSuffix => '项';
+	@override String get expectedDirectory => '· 期望是目录';
+}
+
+// Path: web.memoryAmbient
+class _TranslationsWebMemoryAmbientZh extends TranslationsWebMemoryAmbientEn {
+	_TranslationsWebMemoryAmbientZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsWebMemoryAmbientHeaderZh header = _TranslationsWebMemoryAmbientHeaderZh._(_root);
+	@override String get loading => '加载中…';
+	@override late final _TranslationsWebMemoryAmbientProvidersZh providers = _TranslationsWebMemoryAmbientProvidersZh._(_root);
+	@override late final _TranslationsWebMemoryAmbientRulesZh rules = _TranslationsWebMemoryAmbientRulesZh._(_root);
+	@override late final _TranslationsWebMemoryAmbientProfilesZh profiles = _TranslationsWebMemoryAmbientProfilesZh._(_root);
+	@override late final _TranslationsWebMemoryAmbientCostZh cost = _TranslationsWebMemoryAmbientCostZh._(_root);
+}
+
+// Path: web.noteEditor
+class _TranslationsWebNoteEditorZh extends TranslationsWebNoteEditorEn {
+	_TranslationsWebNoteEditorZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get loading => '加载中…';
+	@override String get source => '源码';
+	@override String get preview => '预览';
+	@override String tagTitle({required Object tag}) => '标签 #${tag}';
+	@override String get emptyNote => '空白笔记。切换到源码标签开始书写。';
+	@override String get saveFailedToast => '保存失败';
+	@override late final _TranslationsWebNoteEditorStatusZh status = _TranslationsWebNoteEditorStatusZh._(_root);
+}
+
+// Path: web.export
+class _TranslationsWebExportZh extends TranslationsWebExportEn {
+	_TranslationsWebExportZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '导出数据';
+	@override String get subtitle => '把选中的逻辑实体打成一份一次性 zip 包。服务器上保留 24 小时后自动回收。';
+	@override String get backToBackups => '← 备份';
+	@override late final _TranslationsWebExportSectionsZh sections = _TranslationsWebExportSectionsZh._(_root);
+	@override late final _TranslationsWebExportFormZh form = _TranslationsWebExportFormZh._(_root);
+	@override late final _TranslationsWebExportHistoryZh history = _TranslationsWebExportHistoryZh._(_root);
+	@override late final _TranslationsWebExportImportZh import = _TranslationsWebExportImportZh._(_root);
+	@override late final _TranslationsWebExportImportsZh imports = _TranslationsWebExportImportsZh._(_root);
 }
 
 // Path: more.identity
@@ -1652,6 +2156,2143 @@ class _TranslationsSettingsServerSettingsZh extends TranslationsSettingsServerSe
 	@override String validateNumber({required Object field}) => '「${field}」必须是数字';
 }
 
+// Path: web.sessions.list
+class _TranslationsWebSessionsListZh extends TranslationsWebSessionsListEn {
+	_TranslationsWebSessionsListZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '会话';
+	@override String get countSeparator => '·';
+	@override String get newAria => '创建新会话';
+	@override String get newTooltip => '新建会话';
+	@override String get loading => '加载中…';
+	@override String get emptyTitle => '暂无会话。';
+	@override String emptyHint({required Object kbd}) => '按 ${kbd} 创建。';
+	@override String endedHeader({required Object count}) => '已结束 (${count})';
+	@override String get clearAll => '清空全部';
+	@override String confirmClearAll({required Object count}) => '确定移除全部 ${count} 个已结束的会话?';
+	@override String confirmTerminate({required Object name}) => '终止并移除 ${name}?';
+	@override String childPromoted({required Object count}) => '其 ${count} 个子任务会话将被提升为顶级。';
+	@override String childPromotedPlural({required Object count}) => '其 ${count} 个子任务会话将被提升为顶级。';
+	@override String footer({required Object live, required Object ended}) => '${live} 运行中 · ${ended} 已结束';
+	@override late final _TranslationsWebSessionsListRowZh row = _TranslationsWebSessionsListRowZh._(_root);
+	@override String get deleteFailedToast => '删除失败';
+}
+
+// Path: web.sessions.tabs
+class _TranslationsWebSessionsTabsZh extends TranslationsWebSessionsTabsEn {
+	_TranslationsWebSessionsTabsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get closeAria => '关闭标签并移除会话';
+	@override String get closeTitle => '关闭标签并移除会话';
+}
+
+// Path: web.sessions.page
+class _TranslationsWebSessionsPageZh extends TranslationsWebSessionsPageEn {
+	_TranslationsWebSessionsPageZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get removedToast => '会话已移除';
+	@override String get removeFailedToast => '移除失败';
+	@override String get stoppedToast => '会话已停止';
+	@override String get stopFailedToast => '停止失败';
+	@override String get restartedToast => '会话已重启';
+	@override String get restartFailedToast => '重启失败';
+	@override String confirmCloseTabTitle({required Object name}) => '停止并移除 "${name}"?';
+	@override String get confirmCloseTabDescription => 'CLI 进程将被终止并删除该记录。';
+	@override String get confirmCloseTabConfirm => '停止并移除';
+	@override String confirmRemoveTitle({required Object name}) => '移除 ${name}?';
+	@override String get confirmRemoveTitleFallback => '移除会话?';
+	@override String get confirmRemoveDescription => '这将删除该记录。';
+	@override String get confirmRemoveConfirm => '移除';
+}
+
+// Path: web.sessions.empty
+class _TranslationsWebSessionsEmptyZh extends TranslationsWebSessionsEmptyEn {
+	_TranslationsWebSessionsEmptyZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '未打开任何会话';
+	@override String hint({required Object kbdN, required Object kbdW, required Object kbdRange}) => '从列表中挑选一个会话，或新建一个。快捷键：${kbdN} 新建，${kbdW} 关闭，${kbdRange} 切换。';
+	@override String get spawn => '创建会话';
+}
+
+// Path: web.sessions.header
+class _TranslationsWebSessionsHeaderZh extends TranslationsWebSessionsHeaderEn {
+	_TranslationsWebSessionsHeaderZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get loadingSession => '正在加载会话…';
+	@override String get showList => '显示会话列表';
+	@override String get hideList => '隐藏会话列表';
+	@override String get showInspector => '显示检查器';
+	@override String get hideInspector => '隐藏检查器';
+	@override String get attachImage => '附加图片';
+	@override String get attachImageTooltip => '附加图片（或直接粘贴 / 拖入终端）';
+	@override String get restart => '重启';
+	@override String get restarting => '重启中…';
+	@override String get remove => '移除';
+	@override String get removing => '移除中…';
+	@override String get stop => '停止';
+	@override String get stopping => '停止中…';
+	@override String pid({required Object pid}) => 'pid ${pid}';
+}
+
+// Path: web.sessions.terminal
+class _TranslationsWebSessionsTerminalZh extends TranslationsWebSessionsTerminalEn {
+	_TranslationsWebSessionsTerminalZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get uploadingToast => '正在上传图片…';
+	@override String get uploadedToast => '图片已附加';
+	@override String get uploadFailedToast => '上传失败';
+	@override String get uploadInvalidTypeToast => '仅支持图片文件';
+	@override String get dropToAttach => '释放以附加图片';
+}
+
+// Path: web.sessions.spawn
+class _TranslationsWebSessionsSpawnZh extends TranslationsWebSessionsSpawnEn {
+	_TranslationsWebSessionsSpawnZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '创建会话';
+	@override String get description => '在已注册的 Provider 下启动一个 CLI 会话。';
+	@override String get provider => 'Provider';
+	@override String get claudeAccount => 'Claude 账号';
+	@override String get loadingAccounts => '正在加载账号…';
+	@override String get noAccounts => '尚未配置 Claude 账号 — 网关将使用系统的 ANTHROPIC_API_KEY。';
+	@override String get kDefault => '默认';
+	@override String get defaultTooltip => '使用系统 keychain / 环境变量';
+	@override String get tokenEmptyBadge => '·未填';
+	@override String get tokenMissingTooltip => '未设置 token — 请先在 Providers 面板中填入';
+	@override String get multiAccountHint => '已配置多个账号 — 请为本次会话挑选一个。';
+	@override String get cwd => '工作目录';
+	@override String get cwdPlaceholder => '/Users/you/projects/foo';
+	@override String get browse => '浏览';
+	@override String get nameLabel => '名称（可选）';
+	@override String get namePlaceholder => 'claude in pet-tracker';
+	@override String get argsLabel => 'CLI 参数（每行一个）';
+	@override String get bypassClaude => '跳过权限提示';
+	@override String get bypassCodex => '自动批准 (--ask-for-approval never)';
+	@override String get bypassGemini => 'YOLO 模式 (--yolo)';
+	@override String get bypassOnHint => '本次会话将以更高的自主权运行。';
+	@override String get bypassOffHint => '关闭 — 确认与提示按正常流程处理。';
+	@override String get errorPickProvider => '请选择一个 Provider。';
+	@override String get errorCwdRequired => '请填写工作目录。';
+	@override String get cancel => '取消';
+	@override String get submit => '创建';
+	@override String get submitting => '创建中…';
+	@override String get spawnedToast => '会话已创建';
+	@override String spawnedDescription({required Object provider, required Object pid}) => '${provider} · pid ${pid}';
+	@override String get pidFallback => '—';
+}
+
+// Path: web.sessions.accountSwitcher
+class _TranslationsWebSessionsAccountSwitcherZh extends TranslationsWebSessionsAccountSwitcherEn {
+	_TranslationsWebSessionsAccountSwitcherZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get tooltip => '切换 Claude 账号（将重启 CLI 进程）';
+	@override String get currentDefault => '默认';
+	@override String get menuTitle => '切换 Claude 账号';
+	@override String get defaultName => '默认';
+	@override String get defaultSubtitle => 'CLI 的系统 keychain / 环境变量';
+	@override String get tokenEmpty => '·未填';
+	@override String get confirmSwitch => '切换账号将重启 Claude CLI 进程。CLI 内部进行中的对话状态将丢失。继续？';
+	@override String get switchedToast => '账号已切换';
+	@override String switchedDescription({required Object account, required Object pid}) => '当前使用 @${account} · pid ${pid}';
+	@override String get switchedDefault => '默认';
+	@override String get switchFailedToast => '切换失败';
+}
+
+// Path: web.sessions.inspector
+class _TranslationsWebSessionsInspectorZh extends TranslationsWebSessionsInspectorEn {
+	_TranslationsWebSessionsInspectorZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsWebSessionsInspectorTabsZh tabs = _TranslationsWebSessionsInspectorTabsZh._(_root);
+}
+
+// Path: web.sessions.ended
+class _TranslationsWebSessionsEndedZh extends TranslationsWebSessionsEndedEn {
+	_TranslationsWebSessionsEndedZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get bufferUnavailable => '[缓冲区不可用]';
+	@override String get readOnlyBanner => '[会话已结束 — 只读缓冲区]';
+}
+
+// Path: web.sessions.fileBrowser
+class _TranslationsWebSessionsFileBrowserZh extends TranslationsWebSessionsFileBrowserEn {
+	_TranslationsWebSessionsFileBrowserZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '选择工作目录';
+	@override String get description => '浏览网关主机的文件系统并选择一个文件夹。';
+	@override String get parent => '上级目录';
+	@override String get home => '家目录';
+	@override String get refresh => '刷新';
+	@override String get pathPlaceholder => '/Users/you/projects';
+	@override String get loading => '加载中…';
+	@override String get empty => '目录为空。';
+	@override String get newFolder => '新建文件夹';
+	@override String get newFolderPlaceholder => 'new-folder-name';
+	@override String get create => '创建';
+	@override String get cancel => '取消';
+	@override String get useThisFolder => '使用此文件夹';
+	@override String get createdToast => '文件夹已创建';
+	@override String get mkdirFailedToast => '创建失败';
+	@override String get homeFailedToast => '读取家目录失败';
+}
+
+// Path: web.memoryWorkers.tasks
+class _TranslationsWebMemoryWorkersTasksZh extends TranslationsWebMemoryWorkersTasksEn {
+	_TranslationsWebMemoryWorkersTasksZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsWebMemoryWorkersTasksGatekeeperZh gatekeeper = _TranslationsWebMemoryWorkersTasksGatekeeperZh._(_root);
+	@override late final _TranslationsWebMemoryWorkersTasksCleanerZh cleaner = _TranslationsWebMemoryWorkersTasksCleanerZh._(_root);
+	@override late final _TranslationsWebMemoryWorkersTasksGitactivityZh gitactivity = _TranslationsWebMemoryWorkersTasksGitactivityZh._(_root);
+	@override late final _TranslationsWebMemoryWorkersTasksTranscriptZh transcript = _TranslationsWebMemoryWorkersTasksTranscriptZh._(_root);
+}
+
+// Path: web.project.picker
+class _TranslationsWebProjectPickerZh extends TranslationsWebProjectPickerEn {
+	_TranslationsWebProjectPickerZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '选择项目';
+	@override String get subtitle => '项目记忆按工作目录划分。选择一个以管理它的目标、计划、日志和清理队列。';
+	@override String get pathPlaceholder => '/path/to/your/project';
+	@override String get browse => '浏览';
+	@override String get browseTooltip => '浏览网关主机的文件系统';
+	@override String get open => '打开';
+	@override String get recentLabel => '最近的项目（来自已存记忆）：';
+	@override String get orphanTooltip => '看上去是被截断的 scope_key（老旧镜像导入 bug）。可能没有项目文档。';
+	@override String get orphanBadge => '孤立';
+}
+
+// Path: web.project.header
+class _TranslationsWebProjectHeaderZh extends TranslationsWebProjectHeaderEn {
+	_TranslationsWebProjectHeaderZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String docsCount_one({required Object count}) => '${count} 份文档';
+	@override String docsCount_other({required Object count}) => '${count} 份文档';
+	@override String journalEntries_one({required Object count}) => '${count} 条日志';
+	@override String journalEntries_other({required Object count}) => '${count} 条日志';
+	@override String pendingProposals_one({required Object count}) => '${count} 条待处理提案';
+	@override String pendingProposals_other({required Object count}) => '${count} 条待处理提案';
+	@override String cleanupPending({required Object count}) => '${count} 条待清理';
+}
+
+// Path: web.project.tabs
+class _TranslationsWebProjectTabsZh extends TranslationsWebProjectTabsEn {
+	_TranslationsWebProjectTabsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get goal => '目标';
+	@override String get plan => '计划';
+	@override String get tech => '技术栈';
+	@override String get activity => '活动';
+	@override String get journal => '日志';
+	@override String get inbox => '收件箱';
+	@override String get cleanup => '清理';
+}
+
+// Path: web.project.docLabel
+class _TranslationsWebProjectDocLabelZh extends TranslationsWebProjectDocLabelEn {
+	_TranslationsWebProjectDocLabelZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get goal => '目标';
+	@override String get plan => '计划';
+	@override String get tech_stack => '技术栈';
+	@override String get recent_activity => '最近活动';
+}
+
+// Path: web.project.verdictLabel
+class _TranslationsWebProjectVerdictLabelZh extends TranslationsWebProjectVerdictLabelEn {
+	_TranslationsWebProjectVerdictLabelZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get stale => '删除';
+	@override String get duplicate => '合并';
+	@override String get keep => '保留';
+}
+
+// Path: web.project.editor
+class _TranslationsWebProjectEditorZh extends TranslationsWebProjectEditorEn {
+	_TranslationsWebProjectEditorZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get updatedBy => '更新者';
+	@override String noDocSet({required Object label}) => '尚未设置${label}。';
+	@override String get save => '保存';
+	@override String get saveFailedToast => '保存失败';
+	@override String savedToast({required Object label}) => '${label}已保存';
+	@override String get goalPlaceholder => '我们在做什么？一段文字。每个 agent 在 spawn 时都会读取。';
+	@override String get planPlaceholder => '当前计划 — 现在在做什么、下一步是什么。随进度更新。';
+}
+
+// Path: web.project.readonly
+class _TranslationsWebProjectReadonlyZh extends TranslationsWebProjectReadonlyEn {
+	_TranslationsWebProjectReadonlyZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsWebProjectReadonlyTechStackZh tech_stack = _TranslationsWebProjectReadonlyTechStackZh._(_root);
+	@override late final _TranslationsWebProjectReadonlyRecentActivityZh recent_activity = _TranslationsWebProjectReadonlyRecentActivityZh._(_root);
+	@override String noneCaptured({required Object label}) => '尚未捕获${label}。';
+	@override String get generatedBy => '生成者';
+	@override String get lastRefresh => '最近刷新';
+}
+
+// Path: web.project.journal
+class _TranslationsWebProjectJournalZh extends TranslationsWebProjectJournalEn {
+	_TranslationsWebProjectJournalZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get loading => '加载中…';
+	@override String get empty => '暂无日志条目。每次会话结束都会自动追加一条。';
+}
+
+// Path: web.project.inbox
+class _TranslationsWebProjectInboxZh extends TranslationsWebProjectInboxEn {
+	_TranslationsWebProjectInboxZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get loading => '加载中…';
+	@override String get emptyTitle => '收件箱为空。';
+	@override String get emptyHint => 'Agent 通过 `project_goal_set` / `project_plan_set` MCP 工具在这里提交提案。';
+	@override String approvedToast({required Object label}) => '${label}已更新';
+	@override String get approveFailedToast => '批准失败';
+	@override String get rejectedToast => '已驳回';
+	@override String get rejectFailedToast => '驳回失败';
+	@override String get sessionPrefix => 'ses';
+	@override String warning({required Object label}) => '批准将完全替换当前${label}。';
+	@override String get warningSuffix => '请检查下方 diff；这不是合并。';
+	@override String get current => '当前';
+	@override String get proposed => '提议';
+	@override String get emptyBody => '(空)';
+	@override String get approve => '批准';
+	@override String get reject => '驳回';
+	@override String confirmDialogTitle({required Object label}) => '替换${label}?';
+	@override String confirmDialogDescription({required Object label}) => '当前${label}将被提议内容覆盖。无法通过本界面撤销（可手动改回）。';
+	@override String get confirmCancel => '取消';
+	@override String get confirmReplace => '确认替换';
+}
+
+// Path: web.project.cleanup
+class _TranslationsWebProjectCleanupZh extends TranslationsWebProjectCleanupEn {
+	_TranslationsWebProjectCleanupZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get hint => 'LLM librarian 为该项目的记忆提出保留 / 过期 / 重复 的判定。删除前需你批准。';
+	@override String get runNow => '立即运行清理';
+	@override String runSucceededToast({required Object decided, required Object scanned}) => '清理已运行：${decided} 条决策入队（扫描了 ${scanned} 条）';
+	@override String get runFailedToast => '清理运行失败';
+	@override String get empty => '暂无待处理决策。要么没有记忆达到判定年龄，要么上次运行判断全部仍是关键内容。';
+	@override String get mergeIntoPrefix => '→ 合并到';
+	@override String get reasonPrefix => '原因：';
+	@override String get executeButton => '执行';
+	@override String get confirmKeepButton => '确认保留';
+	@override String get rejectButton => '驳回';
+	@override String approvedExecutedToast({required Object label}) => '已执行${label}';
+	@override String get approveFailedToast => '批准失败';
+	@override String get rejectedToast => '已驳回 — 记忆保留';
+	@override String get rejectFailedToast => '驳回失败';
+}
+
+// Path: web.project.reset
+class _TranslationsWebProjectResetZh extends TranslationsWebProjectResetEn {
+	_TranslationsWebProjectResetZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get button => '重置';
+	@override String get dialogTitle => '重置项目记忆?';
+	@override String get dialogDescription => '删除该 cwd 下存储的所有项目上下文。不可撤销。';
+	@override String get alwaysDeleted => '始终删除：目标、计划、提案、日志、清理决策。';
+	@override String get alsoDeleteScannerLabel => '同时删除 scanner 文档';
+	@override String get alsoDeleteScannerSuffix => '(tech_stack + recent_activity)。';
+	@override String get alsoDeleteScannerHint => '下次 spawn 会自动重建 — 通常不勾选即可。';
+	@override String get alsoDeleteMemoriesLabel => '同时删除 pgvector 记忆';
+	@override String get alsoDeleteMemoriesSuffix => '（该 scope_key 下的）。';
+	@override String get alsoDeleteMemoriesHint => 'Agent 存储的长期事实（用户偏好、项目事实）。无法恢复。';
+	@override String get cancel => '取消';
+	@override String get deleteForever => '永久删除';
+	@override String successToast({required Object summary}) => '重置：已删除 ${summary}';
+	@override late final _TranslationsWebProjectResetSummaryZh summary = _TranslationsWebProjectResetSummaryZh._(_root);
+	@override String get failedToast => '重置失败';
+}
+
+// Path: web.memoryInspector.status
+class _TranslationsWebMemoryInspectorStatusZh extends TranslationsWebMemoryInspectorStatusEn {
+	_TranslationsWebMemoryInspectorStatusZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '当前 embedder';
+	@override String get unavailable => '不可用';
+	@override String get probing => '探测中…';
+	@override String dimensions({required Object dim, required Object state}) => '${dim} 维 · ${state}';
+	@override String get enabled => '已启用';
+	@override String get disabled => '已禁用';
+	@override String get testButton => '测试 embedder';
+}
+
+// Path: web.memoryInspector.scope
+class _TranslationsWebMemoryInspectorScopeZh extends TranslationsWebMemoryInspectorScopeEn {
+	_TranslationsWebMemoryInspectorScopeZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'Scope';
+	@override String get scopeKey => 'Scope key';
+	@override String get scopeKeyIgnored => '(global 时忽略)';
+	@override String get scopeKeyCwd => '(项目的 cwd)';
+	@override String get scopeKeySession => '(session id)';
+	@override String get placeholderProject => '/path/to/project (cwd)';
+	@override String get placeholderSession => 'session id';
+	@override String get syncMd => '同步 .md';
+	@override String get syncTooltip => '把 Claude 的 <cwd>/.claude/memory/*.md 重新摄取到 pgvector';
+	@override late final _TranslationsWebMemoryInspectorScopeValuesZh values = _TranslationsWebMemoryInspectorScopeValuesZh._(_root);
+}
+
+// Path: web.memoryInspector.search
+class _TranslationsWebMemoryInspectorSearchZh extends TranslationsWebMemoryInspectorSearchEn {
+	_TranslationsWebMemoryInspectorSearchZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get placeholder => '语义搜索查询（Enter 运行；为空则浏览）';
+	@override String get run => '搜索';
+	@override String get clear => '清空';
+	@override String get failedToast => '搜索失败';
+}
+
+// Path: web.memoryInspector.records
+class _TranslationsWebMemoryInspectorRecordsZh extends TranslationsWebMemoryInspectorRecordsEn {
+	_TranslationsWebMemoryInspectorRecordsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get noMemories => '暂无记忆';
+	@override String matches_one({required Object count}) => '${count} 条匹配';
+	@override String matches_other({required Object count}) => '${count} 条匹配';
+	@override String memories_one({required Object count}) => '${count} 条记忆';
+	@override String memories_other({required Object count}) => '${count} 条记忆';
+	@override String get scopeGlobalSuffix => '（全局）';
+	@override String scopeInSuffix({required Object scope}) => '（${scope}：';
+	@override String get addButton => '添加记忆';
+	@override String get addTooltip => '手动在此 scope 创建一条记忆';
+	@override String get deleteAll => '全部删除';
+	@override String get deleteAllTooltip => '删除该 scope/scope_key 下的全部记忆';
+	@override String get loading => '加载中…';
+	@override String get enterScopeKeyHint => '输入 scope key 以浏览记忆。';
+	@override String noMatchesForQuery({required Object query}) => '未找到匹配 "${query}"';
+	@override String get noMemoriesInScope => '此 scope 暂无记忆。';
+}
+
+// Path: web.memoryInspector.row
+class _TranslationsWebMemoryInspectorRowZh extends TranslationsWebMemoryInspectorRowEn {
+	_TranslationsWebMemoryInspectorRowZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String simBadge({required Object value}) => '相似度 ${value}';
+	@override String hits_one({required Object count}) => '命中 ${count} 次';
+	@override String hits_other({required Object count}) => '命中 ${count} 次';
+	@override String lastHitTooltip({required Object relative}) => '最近命中 ${relative}';
+	@override String get editPlaceholder => '记忆文本 — Cmd/Ctrl+Enter 保存 · Esc 取消';
+	@override String get saveTooltip => '保存 (Cmd/Ctrl+Enter)';
+	@override String get cancelTooltip => '取消 (Esc)';
+	@override String get editTooltip => '编辑该记忆';
+	@override String get deleteTooltip => '删除该记忆';
+	@override String get emptyError => '记忆文本不能为空';
+	@override String deleteConfirm({required Object id}) => '删除记忆 ${id}? 不可恢复。';
+}
+
+// Path: web.memoryInspector.toasts
+class _TranslationsWebMemoryInspectorToastsZh extends TranslationsWebMemoryInspectorToastsEn {
+	_TranslationsWebMemoryInspectorToastsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get deleted => '记忆已删除';
+	@override String get deleteFailed => '删除失败';
+	@override String bulkDeleted_one({required Object count}) => '已从此 scope 删除 ${count} 条记忆';
+	@override String bulkDeleted_other({required Object count}) => '已从此 scope 删除 ${count} 条记忆';
+	@override String get bulkDeleteFailed => '批量删除失败';
+	@override String get created => '记忆已创建';
+	@override String get createFailed => '创建失败';
+	@override String get updated => '记忆已更新';
+	@override String get updateFailed => '更新失败';
+	@override String migrated({required Object reembed, required Object examined, required Object to}) => '已迁移 ${reembed}/${examined} 条记忆到 ${to}';
+	@override String get migrationFailed => '迁移失败';
+	@override String syncIngested_one({required Object count}) => '已摄取 ${count} 个新记忆文件';
+	@override String syncIngested_other({required Object count}) => '已摄取 ${count} 个新记忆文件';
+	@override String get syncEmpty => '没有需要同步的新 .md 文件';
+	@override String get syncEmptyDescription => '已是最新，或该 cwd 没有 Claude memory 目录。';
+	@override String get syncFailed => '同步失败';
+	@override String testOk({required Object embedder, required Object dim}) => 'Embedder OK：${embedder} · ${dim} 维';
+	@override String testOkDescription({required Object preview}) => 'vector_preview = [${preview}…]';
+	@override String get testFailed => 'Embedder 探测失败';
+}
+
+// Path: web.memoryInspector.bulkDelete
+class _TranslationsWebMemoryInspectorBulkDeleteZh extends TranslationsWebMemoryInspectorBulkDeleteEn {
+	_TranslationsWebMemoryInspectorBulkDeleteZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '删除此 scope 的全部记忆?';
+	@override String get description => '这是一次 SQL 操作 — 该 scope 下全部记忆将被原子性删除。通过 Claude 镜像摄取的记忆会在下次 <1>同步 .md</1> 时重新出现；其余内容永久消失。';
+	@override String get scope => 'Scope';
+	@override String get scopeKey => 'Scope key';
+	@override String get currentlyVisible => '当前可见';
+	@override String items_one({required Object count}) => '${count} 条记忆';
+	@override String items_other({required Object count}) => '${count} 条记忆';
+	@override String get cancel => '取消';
+	@override String get deleteAll => '全部删除';
+}
+
+// Path: web.memoryInspector.addMem
+class _TranslationsWebMemoryInspectorAddMemZh extends TranslationsWebMemoryInspectorAddMemEn {
+	_TranslationsWebMemoryInspectorAddMemZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '添加记忆';
+	@override String get description => '手动创建一条记忆。Agent 会通过 <1>memory_store</1> MCP 工具自动创建；此表单用于运维想跳过 agent 直接录入事实的场景。';
+	@override String get textLabel => '文本';
+	@override String get textPlaceholder => '纯文本。Embedder 在存储时把它转成向量；agent 通过 memory_search 取回。';
+	@override String get cancel => '取消';
+	@override String get create => '创建';
+}
+
+// Path: web.memoryInspector.picker
+class _TranslationsWebMemoryInspectorPickerZh extends TranslationsWebMemoryInspectorPickerEn {
+	_TranslationsWebMemoryInspectorPickerZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get button => '选择';
+	@override String get buttonTooltip => '从已保存的 scope key 或活跃会话中选择';
+	@override String get loading => '加载中…';
+	@override String empty({required Object scope}) => '${scope} 暂无已保存的 key 或活跃会话。';
+	@override String get savedHeader => '已保存的记忆';
+	@override String get activeHeader => '活跃会话';
+}
+
+// Path: web.memoryInspector.migrationBanner
+class _TranslationsWebMemoryInspectorMigrationBannerZh extends TranslationsWebMemoryInspectorMigrationBannerEn {
+	_TranslationsWebMemoryInspectorMigrationBannerZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String headline_one({required Object count}) => '${count} 条记忆不会出现在搜索结果中';
+	@override String headline_other({required Object count}) => '${count} 条记忆不会出现在搜索结果中';
+	@override String subtitle({required Object summary, required Object current}) => '${summary} — 当前 embedder 为 <1>${current}</1>。pgvector 按 embedder 分区其相似度索引，旧条目在重嵌入前不会被检索到。';
+	@override String summaryItem({required Object count, required Object name}) => '${count} 条在 ${name}';
+	@override String get migrateButton => '迁移';
+}
+
+// Path: web.memoryInspector.reembed
+class _TranslationsWebMemoryInspectorReembedZh extends TranslationsWebMemoryInspectorReembedEn {
+	_TranslationsWebMemoryInspectorReembedZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '重新嵌入记忆';
+	@override String get description => '对存储在其他 embedder 下的记忆重新计算向量，使它们再次可被搜索到。';
+	@override String get targetEmbedder => '目标 embedder';
+	@override String get onName => '在';
+	@override String get totalToReembed => '待重嵌入总数';
+	@override String get explainer => '每条记忆的文本会重新发送到当前 embedder；新向量原地替换旧向量。ID、scope、scope_key、metadata 与时间戳保持不变。搜索结果立即生效 — 无需重启。';
+	@override String get reportExamined => '已检查';
+	@override String get reportReembedded => '已重嵌入';
+	@override String get reportFailed => '失败';
+	@override String get reportFrom => '来源';
+	@override String errors_one({required Object count}) => '${count} 个错误';
+	@override String errors_other({required Object count}) => '${count} 个错误';
+	@override String get done => '完成';
+	@override String get cancel => '取消';
+	@override String get reembedding => '重嵌入中…';
+	@override String reembedTotal({required Object total}) => '重嵌入 ${total} 条';
+}
+
+// Path: web.notes.header
+class _TranslationsWebNotesHeaderZh extends TranslationsWebNotesHeaderEn {
+	_TranslationsWebNotesHeaderZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get outline => '大纲';
+	@override String get showOutline => '显示大纲';
+	@override String get hideOutline => '隐藏大纲';
+	@override String get today => '今天';
+	@override String get todayTooltip => '打开或创建今天的日志笔记';
+	@override String get kNew => '新建';
+}
+
+// Path: web.notes.left
+class _TranslationsWebNotesLeftZh extends TranslationsWebNotesLeftEn {
+	_TranslationsWebNotesLeftZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get tree => '目录树';
+	@override String get tags => '标签';
+	@override String get filterNotes => '过滤笔记…';
+	@override String get filterTags => '过滤标签…';
+	@override String get filteredBy => '已筛选';
+	@override String get clearTagTooltip => '清除标签筛选';
+	@override String get expandAll => '全部展开';
+	@override String get expandAllTooltip => '展开全部文件夹';
+	@override String get collapseAll => '全部收起';
+	@override String get collapseAllTooltip => '收起全部文件夹';
+	@override String get loading => '加载中…';
+	@override String footer({required Object visible, required Object total}) => '${visible} / ${total} 条笔记';
+}
+
+// Path: web.notes.tags
+class _TranslationsWebNotesTagsZh extends TranslationsWebNotesTagsEn {
+	_TranslationsWebNotesTagsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get emptyVault => 'vault 中暂无标签。';
+	@override String noMatches({required Object query}) => '未找到匹配 "${query}"。';
+}
+
+// Path: web.notes.tree
+class _TranslationsWebNotesTreeZh extends TranslationsWebNotesTreeEn {
+	_TranslationsWebNotesTreeZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get empty => 'vault 为空。';
+}
+
+// Path: web.notes.outline
+class _TranslationsWebNotesOutlineZh extends TranslationsWebNotesOutlineEn {
+	_TranslationsWebNotesOutlineZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '大纲';
+	@override String get empty => '此笔记没有标题。添加 <1>## 标题</1> 行以填充大纲。';
+}
+
+// Path: web.notes.newNote
+class _TranslationsWebNotesNewNoteZh extends TranslationsWebNotesNewNoteEn {
+	_TranslationsWebNotesNewNoteZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get prompt => '新笔记路径（相对 vault，必须以 .md 结尾）';
+	@override String defaultPath({required Object date}) => 'library/notes-${date}.md';
+	@override String get errorMustEndMd => '路径必须以 .md 结尾';
+	@override String get createdToast => '笔记已创建';
+	@override String get createFailedToast => '创建失败';
+}
+
+// Path: web.notes.empty
+class _TranslationsWebNotesEmptyZh extends TranslationsWebNotesEmptyEn {
+	_TranslationsWebNotesEmptyZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '未选择笔记';
+	@override String get hint => '从左侧目录树挑选一条笔记，直接跳到今天的日志，或新建一条。AI 生成的项目文档位于 <1>projects/</1>；个人草稿位于 <3>personal/</3>。';
+	@override String get today => '今天的日志笔记';
+	@override String get kNew => '新建笔记';
+}
+
+// Path: web.notes.picker
+class _TranslationsWebNotesPickerZh extends TranslationsWebNotesPickerEn {
+	_TranslationsWebNotesPickerZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get browseAria => '浏览文件夹';
+	@override String matches_one({required Object count}) => '${count} 个匹配';
+	@override String matches_other({required Object count}) => '${count} 个匹配';
+	@override String foldersInVault({required Object count}) => 'vault 中 ${count} 个文件夹';
+	@override String noMatch({required Object value}) => '未找到匹配的文件夹。直接保存即可使用 <1>${value}</1>（首次写入时懒创建）。';
+}
+
+// Path: web.notes.vaultSync
+class _TranslationsWebNotesVaultSyncZh extends TranslationsWebNotesVaultSyncEn {
+	_TranslationsWebNotesVaultSyncZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Vault 同步';
+	@override String get description => '把 notes vault 作为 git 仓库进行 commit、pull 与 push。认证使用网关主机的 git 凭据（SSH agent / credential helper）。';
+	@override String get reading => '正在读取 vault 状态…';
+	@override late final _TranslationsWebNotesVaultSyncInitZh init = _TranslationsWebNotesVaultSyncInitZh._(_root);
+	@override late final _TranslationsWebNotesVaultSyncBranchZh branch = _TranslationsWebNotesVaultSyncBranchZh._(_root);
+	@override late final _TranslationsWebNotesVaultSyncActionZh action = _TranslationsWebNotesVaultSyncActionZh._(_root);
+	@override late final _TranslationsWebNotesVaultSyncCommitZh commit = _TranslationsWebNotesVaultSyncCommitZh._(_root);
+	@override late final _TranslationsWebNotesVaultSyncFileListZh fileList = _TranslationsWebNotesVaultSyncFileListZh._(_root);
+	@override late final _TranslationsWebNotesVaultSyncRemoteZh remote = _TranslationsWebNotesVaultSyncRemoteZh._(_root);
+	@override late final _TranslationsWebNotesVaultSyncHistoryZh history = _TranslationsWebNotesVaultSyncHistoryZh._(_root);
+	@override late final _TranslationsWebNotesVaultSyncConflictZh conflict = _TranslationsWebNotesVaultSyncConflictZh._(_root);
+	@override late final _TranslationsWebNotesVaultSyncAuthZh auth = _TranslationsWebNotesVaultSyncAuthZh._(_root);
+	@override late final _TranslationsWebNotesVaultSyncAutoSyncZh autoSync = _TranslationsWebNotesVaultSyncAutoSyncZh._(_root);
+}
+
+// Path: web.notes.syncBadge
+class _TranslationsWebNotesSyncBadgeZh extends TranslationsWebNotesSyncBadgeEn {
+	_TranslationsWebNotesSyncBadgeZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get loading => '加载中…';
+	@override String get syncLabel => '同步';
+	@override String get initLabel => '初始化';
+	@override String get initTooltip => 'vault 尚未初始化为 git 仓库';
+	@override String get conflictLabel => '冲突';
+	@override String get conflictTooltip => 'vault 存在未解决的冲突 — 点击进入恢复';
+	@override String get syncFallback => 'sync';
+	@override String tooltip({required Object branch, required Object files, required Object ahead, required Object behind}) => '分支 ${branch} · ${files} 处改动 · 领先 ${ahead} · 落后 ${behind}';
+	@override String get tooltipAutoOn => ' · 自动同步已开启';
+	@override String tooltipLastError({required Object error}) => ' · 上次错误：${error}';
+	@override String get branchPlaceholder => '—';
+}
+
+// Path: web.activity.filters
+class _TranslationsWebActivityFiltersZh extends TranslationsWebActivityFiltersEn {
+	_TranslationsWebActivityFiltersZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get integration => '集成';
+	@override String get direction => '方向';
+	@override String get status => '状态';
+	@override String get allIntegrations => '所有集成';
+	@override String get all => '全部';
+	@override String get inbound => '入站';
+	@override String get outbound => '出站';
+	@override String get allStatuses => '所有状态';
+	@override String get status2 => '2xx 成功';
+	@override String get status3 => '3xx 重定向';
+	@override String get status4 => '4xx 客户端错误';
+	@override String get status5 => '5xx 服务端错误';
+}
+
+// Path: web.activity.table
+class _TranslationsWebActivityTableZh extends TranslationsWebActivityTableEn {
+	_TranslationsWebActivityTableZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get time => '时间';
+	@override String get integration => '集成';
+	@override String get directionTitle => '方向';
+	@override String get method => '方法';
+	@override String get path => '路径';
+	@override String get status => '状态';
+	@override String get duration => '耗时';
+	@override String get inboundAria => '入站';
+	@override String get outboundAria => '出站';
+}
+
+// Path: web.activity.empty
+class _TranslationsWebActivityEmptyZh extends TranslationsWebActivityEmptyEn {
+	_TranslationsWebActivityEmptyZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get filtered => '没有调用符合当前筛选条件。';
+	@override String get title => '尚未记录任何 API 调用';
+	@override String get description => '当第三方应用以其集成 API key 调用 opendray 时，每次请求都会被记录在这里。';
+	@override String get stepWithIntegrations => '在你的第三方应用中使用已有集成的 API key';
+	@override String get stepRegister => '在 集成 → 新建 中注册一个集成';
+	@override String get stepCallEndpoint => '调用任意接口，例如 <1>POST /api/v1/sessions</1>';
+	@override String get stepAppears => '调用会在几秒内出现在这里';
+	@override String get footnote => '你在本管理端 UI 中发起的调用不会被记录 — 仅集成归属的流量会被记录。';
+}
+
+// Path: web.activity.events
+class _TranslationsWebActivityEventsZh extends TranslationsWebActivityEventsEn {
+	_TranslationsWebActivityEventsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get loading => '正在加载事件…';
+	@override String get empty => '尚无事件。';
+	@override String get emptyFiltered => '没有匹配的事件。';
+	@override String get loadOlder => '加载更早的事件';
+	@override String get today => '今天';
+	@override String get yesterday => '昨天';
+}
+
+// Path: web.providers.list
+class _TranslationsWebProvidersListZh extends TranslationsWebProvidersListEn {
+	_TranslationsWebProvidersListZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Providers';
+	@override String get loading => '加载中…';
+	@override String get disabledBadge => '已禁用';
+	@override String get noneSelected => '未选择任何 Provider。';
+}
+
+// Path: web.providers.detail
+class _TranslationsWebProvidersDetailZh extends TranslationsWebProvidersDetailEn {
+	_TranslationsWebProvidersDetailZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get enabled => '已启用';
+	@override String get disabled => '已禁用';
+	@override String toggleAria({required Object name}) => '切换 ${name}';
+	@override String get configuration => '配置';
+	@override String get noConfig => '此 Provider 没有可配置字段。';
+	@override String get executable => 'executable:';
+	@override String get manifestHash => 'manifest_hash:';
+	@override String get reset => '重置';
+	@override String get save => '保存更改';
+	@override String get saving => '保存中…';
+	@override String get savedToast => 'Provider 配置已保存';
+	@override String get saveFailedToast => '保存失败';
+	@override String get toggleFailedToast => '切换失败';
+	@override late final _TranslationsWebProvidersDetailCapsZh caps = _TranslationsWebProvidersDetailCapsZh._(_root);
+}
+
+// Path: web.providers.configForm
+class _TranslationsWebProvidersConfigFormZh extends TranslationsWebProvidersConfigFormEn {
+	_TranslationsWebProvidersConfigFormZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get selectPlaceholder => '选择…';
+	@override String get defaultOption => '(默认)';
+	@override String get switchOn => '开';
+	@override String get switchOff => '关';
+	@override String get showSecret => '显示密钥';
+	@override String get hideSecret => '隐藏密钥';
+}
+
+// Path: web.providers.claudeAccounts
+class _TranslationsWebProvidersClaudeAccountsZh extends TranslationsWebProvidersClaudeAccountsEn {
+	_TranslationsWebProvidersClaudeAccountsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Claude 账号';
+	@override String get tutorialTooltip => '打开多账号教程章节';
+	@override String get importLocal => '导入本地';
+	@override String get importLocalTooltip => '扫描网关主机上的 ~/.claude-accounts/ 目录并注册新的目录。该按钮仅在网关主机环境下工作 — 详见教程。';
+	@override String get importedNothingToast => '无需导入 — 账号已同步。';
+	@override String importedToast_one({required Object count}) => '已从 ~/.claude-accounts 导入 ${count} 个账号';
+	@override String importedToast_other({required Object count}) => '已从 ~/.claude-accounts 导入 ${count} 个账号';
+	@override String get importFailedToast => '导入失败';
+	@override String get addingTitle => '添加新账号。';
+	@override String get addingBodyPrefix => '在网关主机执行：';
+	@override String get addingBodySuffix => 'opendray 的文件系统监听会自动注册新目录，或点击 <1>导入本地</1> 立即扫描。';
+	@override String get architectureLink => '架构与完整指南 →';
+	@override String get loading => '加载中…';
+	@override String get empty => '尚无 Claude 账号。在网关主机执行上面的 shell 命令，然后点击 <1>导入本地</1> 扫描。';
+	@override String get noTokenYet => '尚无 token';
+	@override String get configDir => 'config_dir:';
+	@override String get tokenPath => 'token_path:';
+	@override String get toggleFailedToast => '切换失败';
+	@override String removeConfirm({required Object name}) => '移除账号 "${name}"?';
+	@override String get removedToast => '账号已移除';
+	@override String get removeFailedToast => '移除失败';
+	@override String toggleAria({required Object name}) => '切换 ${name}';
+	@override String removeAria({required Object name}) => '移除 ${name}';
+}
+
+// Path: web.channels.empty
+class _TranslationsWebChannelsEmptyZh extends TranslationsWebChannelsEmptyEn {
+	_TranslationsWebChannelsEmptyZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '暂无频道';
+	@override String get description => '内置类型：Telegram · Slack · Discord · 飞书 · 钉钉 · 企业微信。挑选一个并填入凭证，或使用 <1>bridge</1> 通过 WebSocket 接入自定义平台。';
+}
+
+// Path: web.channels.card
+class _TranslationsWebChannelsCardZh extends TranslationsWebChannelsCardEn {
+	_TranslationsWebChannelsCardZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get running => '运行中';
+	@override String get starting => '启动中…';
+	@override String get disabled => '已禁用';
+	@override String get muted => '已静音';
+	@override String get tokenLabel => 'token:';
+	@override String get chatIdLabel => 'chat_id:';
+	@override String get channelIdLabel => 'channel_id:';
+	@override String get notifyOnLabel => 'notify_on:';
+	@override String get webhookLabel => 'webhook:';
+	@override String get copyWebhookTooltip => '复制 webhook URL';
+	@override String get webhookCopiedToast => '已复制 webhook URL';
+	@override String get setup => '配置';
+	@override String get setupTooltip => '查看适配器连接信息和示例代码';
+	@override String get test => '测试';
+	@override String get testNotRunningTooltip => '频道必须处于运行状态';
+	@override String get testBridgeTooltip => 'Bridge 频道无法从管理端测试 — 请先连接一个适配器';
+	@override String get editAria => '编辑频道';
+	@override String get editTooltip => '编辑频道配置';
+	@override String get deleteAria => '删除频道';
+	@override String get bridgeSuffix => '(bridge)';
+}
+
+// Path: web.channels.toasts
+class _TranslationsWebChannelsToastsZh extends TranslationsWebChannelsToastsEn {
+	_TranslationsWebChannelsToastsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get testSent => '测试消息已发送';
+	@override String get testFailed => '测试失败';
+	@override String deleteConfirm({required Object id}) => '删除频道 ${id}?';
+	@override String get deleted => '频道已删除';
+	@override String get created => '频道已创建';
+	@override String get updated => '频道已更新';
+}
+
+// Path: web.channels.dialog
+class _TranslationsWebChannelsDialogZh extends TranslationsWebChannelsDialogEn {
+	_TranslationsWebChannelsDialogZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get editTitle => '编辑频道';
+	@override String get createTitle => '注册频道';
+	@override String get descriptionBridge => '外部适配器（Python/Node/...）通过 WebSocket 连接并出示此 token。';
+	@override String get descriptionDefault => '配置消息集成。';
+	@override String get kindLabel => '类型';
+	@override String get kindImmutable => '（不可更改 — 如需更换类型请删除后重建）';
+	@override String get enabledLabel => '启用';
+	@override String get enabledBridgeHint => '（立即开始接受适配器连接）';
+	@override String get enabledWebhookHint => '（立即开始接收 webhook）';
+	@override String get enabledDefaultHint => '（立即启动）';
+	@override String get cancel => '取消';
+	@override String get save => '保存';
+	@override String get saving => '保存中…';
+	@override String get create => '创建';
+	@override String get creating => '创建中…';
+	@override String unknownKind({required Object kind}) => '未知类型：${kind}';
+	@override String get nameRequired => 'name 不能为空';
+	@override String get tokenRequired => 'token 不能为空';
+	@override String topicIdsNumeric({required Object value}) => 'Topic ID 必须是数字（收到 ${value}）';
+	@override String fieldRequired({required Object label}) => '${label} 不能为空';
+	@override String get cooldownInvalid => 'Cooldown 必须是非负整数秒';
+	@override String get snippetCapInvalid => 'Snippet cap 必须是非负数字';
+}
+
+// Path: web.channels.notifications
+class _TranslationsWebChannelsNotificationsZh extends TranslationsWebChannelsNotificationsEn {
+	_TranslationsWebChannelsNotificationsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get sectionTitle => '会话通知';
+	@override String get notifyOnLabel => '通知触发条件';
+	@override String get hintAll => '接收全部会话事件。点击标签可退订。';
+	@override String get hintNone => '未选择任何事件 — 出站通知已静音。';
+	@override String hintSome({required Object total, required Object selected}) => '只选择了 ${total} 中的 ${selected} 个 topic。';
+	@override String get repeatPolicyLabel => '重复策略';
+	@override String get cooldownLabel => '冷却时长';
+	@override String get onceReplyHint => '在该聊天中以非命令文本回复会重置抑制 — opendray 会把你的回复转发到会话的 stdin 并重新启用通知。';
+	@override String get terminalSnippetLabel => '终端片段';
+	@override String get embedSnippetLabel => '在 idle 通知中嵌入最近的终端画面';
+	@override String get snippetExplainer => '开启后，idle 卡片会包含一段代码块片段，呈现用户在网页终端中会看到的内容 — Claude TUI 自身的装饰（状态 spinner、"bypass permissions" 提示、分隔线）会被自动过滤。';
+	@override late final _TranslationsWebChannelsNotificationsModesZh modes = _TranslationsWebChannelsNotificationsModesZh._(_root);
+	@override late final _TranslationsWebChannelsNotificationsCooldownsZh cooldowns = _TranslationsWebChannelsNotificationsCooldownsZh._(_root);
+	@override late final _TranslationsWebChannelsNotificationsSnippetCapsZh snippetCaps = _TranslationsWebChannelsNotificationsSnippetCapsZh._(_root);
+}
+
+// Path: web.channels.bridge
+class _TranslationsWebChannelsBridgeZh extends TranslationsWebChannelsBridgeEn {
+	_TranslationsWebChannelsBridgeZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get nameLabel => 'Bridge 名称';
+	@override String get namePlaceholder => 'wechat / discord-custom / whatsapp...';
+	@override String get nameHint => '适配器的人类可读标签。会显示在频道列表中。';
+	@override String get tokenLabel => '适配器 token';
+	@override String get regenerateTooltip => '重新生成';
+	@override String get copyTooltip => '复制';
+	@override String get tokenCopiedToast => '已复制 token';
+	@override String get tokenHint => '适配器通过 WS register 帧发送此 token（也可作为 <1>X-Bridge-Token</1> header）。';
+	@override String get capsLabel => '接受的能力（可选白名单）';
+	@override String get capsHint => '为空 = 接受适配器声明的任意能力。已选 = 即使适配器提供更多能力，也只允许这些。';
+	@override String get afterCreate => '点击 <1>创建</1> 后，适配器设置对话框会自动打开，里面包含 WebSocket URL 和可直接复制的 Python / Node / wscat 起步代码。';
+}
+
+// Path: web.channels.setup
+class _TranslationsWebChannelsSetupZh extends TranslationsWebChannelsSetupEn {
+	_TranslationsWebChannelsSetupZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String title({required Object name}) => '适配器设置 — ${name}';
+	@override String get description => '运行一个任意语言的适配器，使用这些凭证通过 WebSocket 连接到 opendray。opendray 会通过它路由会话通知和 slash 命令。';
+	@override String get wsUrlLabel => 'WebSocket URL';
+	@override String get tokenLabel => '适配器 token';
+	@override String authInfo({required Object frame}) => '<1>认证：</1>通过 <3>X-Bridge-Token</3> header、<5>?token=</5> query 参数或 <7>Authorization: Bearer …</7> 之一发送 token。首个 WS 帧必须是 <9>${frame}</9>。完整协议见仓库中的 <11>docs/bridge-protocol.md</11>。';
+	@override String get pythonInstall => '安装：<1>pip install websockets</1>。运行：<3>python adapter.py</3>。';
+	@override String get nodeInstall => '安装：<1>npm i ws</1>。运行：<3>node adapter.mjs</3>。';
+	@override String get wscatInstall => '安装：<1>npm i -g wscat</1>。连接后，粘贴上方的 JSON 注册帧，然后手动发送后续帧。';
+	@override String get close => '关闭';
+	@override String get copyHide => '隐藏';
+	@override String get copyShow => '显示';
+	@override String copyLabelToast({required Object label}) => '已复制 ${label}';
+	@override String get copyCode => '复制';
+	@override String get copied => '已复制';
+	@override String get codeCopiedToast => '已复制代码';
+}
+
+// Path: web.integrations.tabs
+class _TranslationsWebIntegrationsTabsZh extends TranslationsWebIntegrationsTabsEn {
+	_TranslationsWebIntegrationsTabsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get registered => '已注册';
+	@override String get console => '反向代理';
+}
+
+// Path: web.integrations.empty
+class _TranslationsWebIntegrationsEmptyZh extends TranslationsWebIntegrationsEmptyEn {
+	_TranslationsWebIntegrationsEmptyZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '暂无集成';
+	@override String get description => '注册一个外部应用，给它一个受限的 API key。它的代码不需要进入本仓库。';
+	@override String get register => '注册集成';
+}
+
+// Path: web.integrations.card
+class _TranslationsWebIntegrationsCardZh extends TranslationsWebIntegrationsCardEn {
+	_TranslationsWebIntegrationsCardZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get managedBadge => '受管';
+	@override String get managedTooltip => 'opendray 管理这个集成。编辑或轮换它的 key 会导致正在运行的会话（mcp.json 中持有旧 bearer）失效。';
+	@override String get consumerBadge => 'consumer';
+	@override String get consumerTooltip => '仅消费型集成 — 没有可供探测的 HTTP 服务';
+	@override String get disabledBadge => '已禁用';
+	@override String get consumerOnlyHint => '消费 opendray 的 API。未挂载反向代理。';
+	@override String lastProbed({required Object relative}) => '${relative} 探测过';
+	@override String rotated({required Object relative}) => '${relative} 轮换过';
+	@override String get managedReadOnly => '只读 — opendray 把它的 key 烤进每次 spawn 的 mcp.json';
+	@override String get managedReadOnlyTooltip => 'opendray 管理此行。如需重置：删除 ~/.opendray/memory.key 后重启，或直接通过 SQL 删除此行 — 下次启动时会重新引导。';
+	@override String get editAria => '编辑集成';
+	@override String get editTooltip => '编辑 scopes / base URL / version';
+	@override String get rotateKey => '轮换 key';
+	@override String get deleteAria => '删除集成';
+	@override String rotateConfirm({required Object name}) => '轮换 "${name}" 的 API key? 当前 key 将立即失效。';
+	@override String deleteConfirm({required Object name}) => '删除集成 ${name}?';
+	@override String get removedToast => '集成已移除';
+}
+
+// Path: web.integrations.register_dialog
+class _TranslationsWebIntegrationsRegisterDialogZh extends TranslationsWebIntegrationsRegisterDialogEn {
+	_TranslationsWebIntegrationsRegisterDialogZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '注册集成';
+	@override String get description => '签发一次性 API key。关闭前请复制它 — opendray 不会再显示明文。';
+	@override String get nameLabel => '名称';
+	@override String get namePlaceholder => 'PetTracker';
+	@override String get modeHint => '如果是 <1>仅消费型</1> 集成（第三方应用调用 opendray API 但不暴露自身服务），保留下面两个字段为空。两个都填则是 <3>反向代理型</3> 集成。';
+	@override String get baseUrlLabel => 'Base URL';
+	@override String get optionalSuffix => '(可选)';
+	@override String get baseUrlPlaceholder => 'http://192.168.3.42:8080';
+	@override String get routePrefixLabel => 'Route prefix';
+	@override String get routePrefixPlaceholder => 'pet-tracker';
+	@override String routePrefixHint({required Object prefix}) => '可通过 <1>/api/v1/proxy/${prefix}/*</1> 访问。';
+	@override String get routePrefixPlaceholderToken => '<prefix>';
+	@override String get versionLabel => 'Version（可选）';
+	@override String get versionPlaceholder => '0.1.0';
+	@override String get scopesLabel => 'Scopes';
+	@override String get scopesIntro => '选择该集成允许调用的 API 范围。每个开关映射到一个 Bearer token 声明 — opendray 会拒绝任何越权请求。';
+	@override String get errorNameRequired => 'Name 不能为空。';
+	@override String get errorBothOrNeither => 'base_url 和 route_prefix 必须成对设置。同时填入 = 反向代理集成；同时留空 = 仅消费型集成。';
+	@override String get cancel => '取消';
+	@override String get submit => '注册';
+	@override String get submitting => '注册中…';
+}
+
+// Path: web.integrations.reveal
+class _TranslationsWebIntegrationsRevealZh extends TranslationsWebIntegrationsRevealEn {
+	_TranslationsWebIntegrationsRevealZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get titleIssued => 'API key 已签发';
+	@override String get titleRotated => 'API key 已轮换';
+	@override String get description => '这是明文 key 唯一一次显示的机会。立即复制并更新所有消费端 — 旧 key（如有）将不再有效。';
+	@override String get discardAria => '丢弃新 key';
+	@override String get discardTooltip => '丢弃新 key（轮换已经发生 — 旧 key 同样失效）';
+	@override String get discardConfirm => '确定丢弃新 key? 轮换已经使旧 key 失效 — 丢弃意味着此集成将没有任何可用 key，直到再次轮换。';
+	@override String get copy => '复制';
+	@override String get copied => '已复制';
+	@override String get updateHint => '<1>请用此新 key 更新每个消费端应用。</1> 旧 key 已在服务端失效，下次请求会返回 <3>401 unauthorized</3>。';
+	@override String get acknowledge => '我已复制 key 并会更新消费端应用。我了解 opendray 不会再显示它。';
+	@override String get discard => '丢弃';
+	@override String get done => '完成';
+}
+
+// Path: web.integrations.edit_dialog
+class _TranslationsWebIntegrationsEditDialogZh extends TranslationsWebIntegrationsEditDialogEn {
+	_TranslationsWebIntegrationsEditDialogZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String title({required Object name}) => '编辑集成 · ${name}';
+	@override String get description => '修改 scopes、version 或 base URL。Name 和 route prefix 不可更改 — 如需修改请删除并重新注册。';
+	@override String get nameLabel => 'Name';
+	@override String get routePrefixLabel => 'Route prefix';
+	@override String get consumerOnlyLabel => '(仅消费型)';
+	@override String get baseUrlLabel => 'Base URL';
+	@override String get baseUrlConsumerSuffix => '(仅消费型 — 留空)';
+	@override String get baseUrlProxySuffix => '(反向代理目标)';
+	@override String get baseUrlConsumerPlaceholder => '(留空 — 此集成消费 opendray API)';
+	@override String get baseUrlProxyPlaceholder => 'http://127.0.0.1:8080';
+	@override String get consumerHint => '这是一个仅消费型集成。在此修改 base URL 还需要 route prefix；请删除后重新注册。';
+	@override String get versionLabel => 'Version';
+	@override String get versionPlaceholder => '0.1.0';
+	@override String get scopesLabel => 'Scopes';
+	@override String get scopesIntro => '收窄或放宽此集成 API key 授权的 API 范围。已颁发的 token 不受影响 — 新的 scope 集在下次请求时生效。';
+	@override String get errorModeSwitch => '在仅消费型与反向代理型之间切换需要删除并重新注册 — name 和 route_prefix 无法原地修改。';
+	@override String get updatedToast => '集成已更新';
+	@override String get cancel => '取消';
+	@override String get save => '保存更改';
+}
+
+// Path: web.integrations.proxy
+class _TranslationsWebIntegrationsProxyZh extends TranslationsWebIntegrationsProxyEn {
+	_TranslationsWebIntegrationsProxyZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get emptyTitle => '尚未注册集成';
+	@override String emptyDescription({required Object prefix}) => '请先注册一个集成；控制台通过 /api/v1/proxy/${prefix}/* 以 admin token 代理请求。';
+	@override String get targetLabel => '目标';
+	@override String get selectPlaceholder => '选择集成…';
+	@override String get baseLabel => 'base:';
+	@override String get history => '历史';
+	@override String get historyEmpty => '此集成尚无历史请求';
+	@override String get send => '发送';
+	@override String get sending => '发送中…';
+	@override String get extraHeadersLabel => '额外 header（每行一条，Name: Value）';
+	@override String get bodyLabel => 'Body';
+	@override String get headers => 'Headers';
+	@override String get body => 'Body';
+	@override String get emptyBody => '(空)';
+	@override String get requestFailed => '请求失败';
+	@override String get stubText => '发送一个请求即可查看上游响应。';
+	@override String get stubInjects => 'opendray 会注入 <1>X-Integration-ID</1>，并剥离你的 <3>Authorization</3> header。';
+	@override String get prefixPlaceholder => '<prefix>';
+}
+
+// Path: web.plugins.common
+class _TranslationsWebPluginsCommonZh extends TranslationsWebPluginsCommonEn {
+	_TranslationsWebPluginsCommonZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get loading => '加载中…';
+	@override String get cancel => '取消';
+	@override String get edit => '编辑';
+	@override String get add => '添加';
+	@override String get save => '保存';
+	@override String get create => '创建';
+}
+
+// Path: web.plugins.mcp
+class _TranslationsWebPluginsMcpZh extends TranslationsWebPluginsMcpEn {
+	_TranslationsWebPluginsMcpZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'MCP 服务器';
+	@override String description({required Object KEY}) => '注入到每次 spawn（claude / codex）的 Model Context Protocol 服务器。Vault 条目位于 <1>~/.opendray/vault/mcp/&lt;id&gt;/mcp.json</1>；env / headers 中以 <3>\$${KEY}</3> 引用的密钥来自下方 <5>MCP secrets</5>。';
+	@override String get newServer => '新建服务器';
+	@override String get empty => '尚无 MCP 服务器。添加一个以为 agent 会话暴露额外工具。';
+	@override late final _TranslationsWebPluginsMcpColumnsZh columns = _TranslationsWebPluginsMcpColumnsZh._(_root);
+	@override String get noUrl => '无 URL';
+	@override String get noCommand => '无 command';
+	@override String deleteConfirm({required Object id}) => '删除 MCP 服务器 "${id}"?';
+	@override String get removedToast => 'MCP 服务器已移除';
+	@override String get deleteFailedToast => '删除失败';
+	@override String get toggleFailedToast => '切换失败';
+	@override late final _TranslationsWebPluginsMcpEditorZh editor = _TranslationsWebPluginsMcpEditorZh._(_root);
+}
+
+// Path: web.plugins.mcpSecrets
+class _TranslationsWebPluginsMcpSecretsZh extends TranslationsWebPluginsMcpSecretsEn {
+	_TranslationsWebPluginsMcpSecretsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'MCP 密钥';
+	@override String get encryptedBadge => '已加密';
+	@override String get plaintextBadge => '明文';
+	@override String get encryptedTooltip => 'AES-GCM 在磁盘上加密；密钥位于操作系统 keychain';
+	@override String get plaintextTooltip => '操作系统 keychain 不可用 — 文件以明文存储。请检查网关日志。';
+	@override String description({required Object KEY}) => '在任意 <3>mcp.json</3> 中以 <1>\$${KEY}</1> 占位符引用的值在 spawn 时会被替换。<5>已保存的值不会通过 API 返回</5> — 可以覆盖或删除，但无法读回。';
+	@override String descriptionStored({required Object path}) => ' 存储于 <1>${path}</1>。';
+	@override String get addSecret => '添加密钥';
+	@override String empty({required Object KEY}) => '暂无已存密钥。添加后即可在 MCP 服务器配置中以 <1>\$${KEY}</1> 引用。';
+	@override late final _TranslationsWebPluginsMcpSecretsColumnsZh columns = _TranslationsWebPluginsMcpSecretsColumnsZh._(_root);
+	@override String get editTooltip => '覆盖已存的值';
+	@override String deleteConfirm({required Object key, required Object \'\$\', required Object {key}) => '删除密钥 "${key}"? 任何引用 \$${\'\$\'}${{key}} 的 mcp.json 在你重新设置之前都会回退到字面占位符。';
+	@override String get removedToast => '密钥已移除';
+	@override String get deleteFailedToast => '删除失败';
+	@override late final _TranslationsWebPluginsMcpSecretsEditorZh editor = _TranslationsWebPluginsMcpSecretsEditorZh._(_root);
+}
+
+// Path: web.plugins.skills
+class _TranslationsWebPluginsSkillsZh extends TranslationsWebPluginsSkillsEn {
+	_TranslationsWebPluginsSkillsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Agent skills';
+	@override String get description => '作为 Tier 1 索引注入到 Claude 会话的可复用能力 — agent 通过 <1>opendray skill describe &lt;id&gt;</1> 按需加载完整 SKILL.md。内置 skill 随二进制发布但可被 <3>自定义</3> — 你的修改保存到 <5>~/.opendray/vault/skills/&lt;id&gt;/SKILL.md</5> 并覆盖内置版本。点击重置可还原。';
+	@override String get newSkill => '新建 skill';
+	@override String get empty => '未找到任何 skill。';
+	@override late final _TranslationsWebPluginsSkillsColumnsZh columns = _TranslationsWebPluginsSkillsColumnsZh._(_root);
+	@override String get noDescription => '无描述';
+	@override String get builtinBadge => '内置';
+	@override String get builtinTooltip => '嵌入 opendray 二进制 — 点击自定义可在 vault 中覆盖';
+	@override String get vaultBadge => 'vault';
+	@override String get overridesBuiltin => '覆盖内置';
+	@override String get overridesBuiltinTooltip => '此 vault skill 覆盖了同 id 的内置版本';
+	@override String get customize => '自定义';
+	@override String get customizeTooltip => '打开 SKILL.md 并保存为 vault 覆盖';
+	@override String get editTooltip => '编辑此 vault skill';
+	@override String get resetTooltip => '删除 vault 覆盖并回退到内置版本';
+	@override String get reset => '重置';
+	@override String resetConfirm({required Object id}) => '将 "${id}" 重置为内置版本? 这会删除你的 vault SKILL.md 并回退到嵌入副本。';
+	@override String deleteConfirm({required Object id}) => '从 vault 删除 skill "${id}"? 这会移除该 SKILL.md 文件。';
+	@override String get removedToast => 'Skill 已移除';
+	@override String get deleteFailedToast => '删除失败';
+	@override late final _TranslationsWebPluginsSkillsEditorZh editor = _TranslationsWebPluginsSkillsEditorZh._(_root);
+}
+
+// Path: web.plugins.customTasks
+class _TranslationsWebPluginsCustomTasksZh extends TranslationsWebPluginsCustomTasksEn {
+	_TranslationsWebPluginsCustomTasksZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '自定义任务';
+	@override String get description => '在 Tasks 选项卡中以点选即运行的方式呈现的快捷方式。留空 cwd 即为所有会话可见的全局任务，或填写绝对路径以限定 scope。';
+	@override String get addTask => '添加任务';
+	@override String get empty => '尚无自定义任务。';
+	@override late final _TranslationsWebPluginsCustomTasksColumnsZh columns = _TranslationsWebPluginsCustomTasksColumnsZh._(_root);
+	@override String get globalScope => '全局';
+	@override String deleteConfirm({required Object name}) => '删除自定义任务 "${name}"?';
+	@override String get removedToast => '任务已移除';
+	@override String get deleteFailedToast => '删除失败';
+	@override late final _TranslationsWebPluginsCustomTasksDialogZh dialog = _TranslationsWebPluginsCustomTasksDialogZh._(_root);
+}
+
+// Path: web.plugins.gitHosts
+class _TranslationsWebPluginsGitHostsZh extends TranslationsWebPluginsGitHostsEn {
+	_TranslationsWebPluginsGitHostsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Git 主机';
+	@override String get description => '每个主机一个 token — 被 Git 选项卡用来拉取 pull request，<1>也被 Notes vault sync</1> 使用（当其 remote 通过 HTTPS 指向同一主机上的私有仓库时）。支持 GitHub.com、自托管 GitHub Enterprise、Gitea 与 GitLab。';
+	@override String get addHost => '添加主机';
+	@override String get empty => '尚未配置任何 git 主机。\n添加一个以在检查器 Git 选项卡中启用 PR 列表。';
+	@override late final _TranslationsWebPluginsGitHostsColumnsZh columns = _TranslationsWebPluginsGitHostsColumnsZh._(_root);
+	@override String get statusEnabled => '已启用';
+	@override String get statusDisabled => '已禁用';
+	@override String deleteConfirm({required Object host}) => '移除 git 主机 ${host}? 对该主机的 PR 查询将停止工作。';
+	@override String get removedToast => 'Git 主机已移除';
+	@override String get deleteFailedToast => '删除失败';
+	@override late final _TranslationsWebPluginsGitHostsDialogZh dialog = _TranslationsWebPluginsGitHostsDialogZh._(_root);
+}
+
+// Path: web.backups.tabs
+class _TranslationsWebBackupsTabsZh extends TranslationsWebBackupsTabsEn {
+	_TranslationsWebBackupsTabsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get backups => '备份';
+	@override String get schedules => '计划';
+	@override String get targets => '目标';
+}
+
+// Path: web.backups.inventory
+class _TranslationsWebBackupsInventoryZh extends TranslationsWebBackupsInventoryEn {
+	_TranslationsWebBackupsInventoryZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '备份里包含什么？';
+	@override String summary({required Object tables, required Object rows}) => '${tables} 张表共 ${rows} 行';
+	@override String get description => '每次备份是一个对下方所有表执行 <1>pg_dump --format=custom</1> 的产物，外加 <3>manifest.json</3> 和（可选的）<5>config.toml</5>。计数是实时的；bundle 捕获的是备份发生那一刻的数据。';
+	@override String get loadFailedToast => '加载清单失败';
+	@override String get rowsLabel => '行';
+}
+
+// Path: web.backups.restart
+class _TranslationsWebBackupsRestartZh extends TranslationsWebBackupsRestartEn {
+	_TranslationsWebBackupsRestartZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '请重启 opendray 以激活备份';
+	@override String get description => '你的口令已保存。网关仅在启动时加载它，因此该功能在进程重启之前保持关闭。';
+	@override String get keyFile => '密钥文件：';
+	@override String get configuredVia => '配置方式：';
+	@override String get envVar => 'OPENDRAY_BACKUP_KEY 环境变量';
+	@override String get checkAgain => '再次检查';
+}
+
+// Path: web.backups.setup
+class _TranslationsWebBackupsSetupZh extends TranslationsWebBackupsSetupEn {
+	_TranslationsWebBackupsSetupZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '设置备份';
+	@override String get description => '选择一个主口令。opendray 会用它加密每个备份 blob。<1>丢失它意味着你的备份无法恢复</1>，请在继续之前把它保存到密码管理器（Vaultwarden、1Password 等）。';
+	@override String get generate => '生成';
+	@override String get pasteOwn => '粘贴自定义';
+	@override String get generateTitle => '256 位随机密钥';
+	@override String get generateHint => '服务端生成一个加密随机的口令并仅显示一次。你必须在继续前复制它 — 没有恢复路径。';
+	@override String get pasteLabel => '你的口令';
+	@override String get pastePlaceholder => '至少 20 个字符';
+	@override String get pasteHint => '建议：使用密码管理器生成 40 个以上字符。';
+	@override String get savesTo => '保存到：';
+	@override String get saving => '保存中…';
+	@override String get generateAndSave => '生成并保存';
+	@override String get save => '保存';
+}
+
+// Path: web.backups.generated
+class _TranslationsWebBackupsGeneratedZh extends TranslationsWebBackupsGeneratedEn {
+	_TranslationsWebBackupsGeneratedZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '立即保存此口令';
+	@override String get description => '这是 <1>唯一一次</1> 显示。opendray 与任何其他地方都将无法取回。请在继续前复制到密码管理器。';
+	@override String get copy => '复制';
+	@override String get copiedToast => '口令已复制到剪贴板';
+	@override String get copyFailedToast => '复制失败 — 请手动选中并复制';
+	@override String get savedTo => '已保存到：';
+	@override String get ack => '我已将此口令保存到密码管理器';
+	@override String get kContinue => '继续';
+}
+
+// Path: web.backups.status
+class _TranslationsWebBackupsStatusZh extends TranslationsWebBackupsStatusEn {
+	_TranslationsWebBackupsStatusZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get keyFingerprint => '密钥指纹：';
+	@override String get pgDump => 'pg_dump：';
+	@override String get pgDumpUnavailable => '不可用';
+	@override String get pgDumpHint => '备份在 pg_dump 进入 PATH 之前无法运行（也可通过 <1>backup.pg_dump_path</1> 设置绝对路径）。请安装与你的服务器主版本匹配的 <3>postgresql-client</3> 并重启。';
+}
+
+// Path: web.backups.backupsTab
+class _TranslationsWebBackupsBackupsTabZh extends TranslationsWebBackupsBackupsTabEn {
+	_TranslationsWebBackupsBackupsTabZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get backupNow => '立即备份';
+	@override String get triggering => '触发中…';
+	@override String get includeConfig => '包含 config.toml';
+	@override String get restoreFromFile => '从文件恢复';
+	@override String get refresh => '刷新';
+	@override String get queuedToast => '备份已排队';
+	@override String get triggerFailedToast => '触发失败';
+	@override String get listFailedToast => '加载备份列表失败';
+	@override String deleteConfirm({required Object id}) => '删除备份 ${id}? 该 blob 将从目标中移除。';
+	@override String get deletedToast => '备份已删除';
+	@override String get deleteFailedToast => '删除失败';
+	@override String get empty => '暂无备份。点击上方 "立即备份" 进行第一次。';
+	@override late final _TranslationsWebBackupsBackupsTabColumnsZh columns = _TranslationsWebBackupsBackupsTabColumnsZh._(_root);
+	@override String get downloadTooltip => '下载';
+	@override String get deleteTooltip => '删除';
+}
+
+// Path: web.backups.restore
+class _TranslationsWebBackupsRestoreZh extends TranslationsWebBackupsRestoreEn {
+	_TranslationsWebBackupsRestoreZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '从备份 bundle 恢复';
+	@override String get bundleLabel => '加密 bundle（.tar.gz.enc）';
+	@override String get targetDsnLabel => '目标数据库 DSN';
+	@override String get targetDsnHint => '（留空 = opendray 自己的 DB — 危险）';
+	@override String get targetDsnPlaceholder => 'postgres://user:pass@host:5432/dbname';
+	@override String get cleanLabel => '--clean --if-exists（先 drop 现有 schema；恢复到已填充的 DB 上时必需）';
+	@override String get auditNoteLabel => '审计备注（可选）';
+	@override String get auditNotePlaceholder => '恢复原因 — 会出现在 slog 中';
+	@override String get ownDbWarning => '你正在恢复到 <1>opendray 自己的数据库</1>。启用 "--clean" 时会 drop 每张表并按字面回放备份 — 不可逆。请输入 <3>I understand</3> 以继续。';
+	@override String get confirmPlaceholder => 'I understand';
+	@override String get confirmSentinel => 'I understand';
+	@override String get pgRestoreOutput => 'pg_restore 输出（最后 8 KiB）';
+	@override String get noPgRestoreOutput => '（无 pg_restore 输出）';
+	@override String get pickFileToast => '请先选择一个 bundle 文件';
+	@override String get succeededToast => '恢复成功';
+	@override String replayedDescription({required Object bytes, required Object id}) => '已回放 ${bytes}，来自 manifest ${id}';
+	@override String get failedToast => '恢复失败';
+	@override String get restoring => '恢复中…';
+	@override String get restore => '恢复';
+}
+
+// Path: web.backups.schedulesTab
+class _TranslationsWebBackupsSchedulesTabZh extends TranslationsWebBackupsSchedulesTabEn {
+	_TranslationsWebBackupsSchedulesTabZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get description => '周期备份。调度器每 30 秒轮询一次，并运行最旧的到期计划。';
+	@override String get newSchedule => '新建计划';
+	@override String get loadFailedToast => '加载计划失败';
+	@override String deleteConfirm({required Object id}) => '删除计划 ${id}?';
+	@override String get deletedToast => '计划已删除';
+	@override String get deleteFailedToast => '删除失败';
+	@override String get toggleFailedToast => '切换失败';
+	@override String get empty => '暂无计划。添加一个以进行周期性自动备份。';
+	@override late final _TranslationsWebBackupsSchedulesTabColumnsZh columns = _TranslationsWebBackupsSchedulesTabColumnsZh._(_root);
+	@override String keepCount({required Object count}) => '${count} 个备份';
+	@override String get deleteTooltip => '删除';
+}
+
+// Path: web.backups.newSchedule
+class _TranslationsWebBackupsNewScheduleZh extends TranslationsWebBackupsNewScheduleEn {
+	_TranslationsWebBackupsNewScheduleZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '新建备份计划';
+	@override String get targetLabel => '目标';
+	@override String get everyHoursLabel => '每隔（小时）';
+	@override String get keepLastNLabel => '保留最近 N 个';
+	@override String get enableImmediately => '立即启用';
+	@override String get createdToast => '计划已创建';
+	@override String get createFailedToast => '创建失败';
+	@override String get creating => '创建中…';
+	@override String get create => '创建';
+}
+
+// Path: web.backups.targetsTab
+class _TranslationsWebBackupsTargetsTabZh extends TranslationsWebBackupsTargetsTabEn {
+	_TranslationsWebBackupsTargetsTabZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get description => '存储目标。v1 支持 <1>local</1>（opendray 主机磁盘）与 <3>smb</3>（任意 SMB / CIFS 共享，如 UNAS 或群晖）。';
+	@override String get newTarget => '新建目标';
+	@override String get listFailedToast => '加载目标列表失败';
+	@override String deleteConfirm({required Object id}) => '删除目标 ${id}? 引用它的计划会阻止删除。';
+	@override String get deletedToast => '目标已删除';
+	@override String get deleteFailedToast => '删除失败';
+	@override String get connectionOkToast => '连接成功';
+	@override String get connectionFailedToast => '连接失败';
+	@override String get testFailedToast => '测试失败';
+	@override late final _TranslationsWebBackupsTargetsTabColumnsZh columns = _TranslationsWebBackupsTargetsTabColumnsZh._(_root);
+	@override String get on => '开';
+	@override String get off => '关';
+	@override String get test => '测试';
+	@override String get testing => '测试中…';
+	@override String get deleteTooltip => '删除';
+}
+
+// Path: web.backups.targetEditor
+class _TranslationsWebBackupsTargetEditorZh extends TranslationsWebBackupsTargetEditorEn {
+	_TranslationsWebBackupsTargetEditorZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '新建备份目标';
+	@override String get kindPicker => '你想备份到哪里？';
+	@override String get idLabel => 'ID（可选）';
+	@override String get idPlaceholder => '留空则自动生成，例如 tgt_xxx';
+	@override String get createdToast => '目标已创建';
+	@override String get createFailedToast => '创建失败';
+	@override String get creating => '创建中…';
+	@override String get create => '创建目标';
+	@override String get enableImmediately => '立即启用（否则保存为禁用 — 适合 "先配置好，稍后开启"）';
+	@override late final _TranslationsWebBackupsTargetEditorLocalZh local = _TranslationsWebBackupsTargetEditorLocalZh._(_root);
+	@override late final _TranslationsWebBackupsTargetEditorSmbZh smb = _TranslationsWebBackupsTargetEditorSmbZh._(_root);
+	@override late final _TranslationsWebBackupsTargetEditorS3Zh s3 = _TranslationsWebBackupsTargetEditorS3Zh._(_root);
+	@override late final _TranslationsWebBackupsTargetEditorWebdavZh webdav = _TranslationsWebBackupsTargetEditorWebdavZh._(_root);
+	@override late final _TranslationsWebBackupsTargetEditorSftpZh sftp = _TranslationsWebBackupsTargetEditorSftpZh._(_root);
+	@override late final _TranslationsWebBackupsTargetEditorRcloneZh rclone = _TranslationsWebBackupsTargetEditorRcloneZh._(_root);
+}
+
+// Path: web.serverSettings.sections
+class _TranslationsWebServerSettingsSectionsZh extends TranslationsWebServerSettingsSectionsEn {
+	_TranslationsWebServerSettingsSectionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsWebServerSettingsSectionsGeneralZh general = _TranslationsWebServerSettingsSectionsGeneralZh._(_root);
+	@override late final _TranslationsWebServerSettingsSectionsLoggingZh logging = _TranslationsWebServerSettingsSectionsLoggingZh._(_root);
+	@override late final _TranslationsWebServerSettingsSectionsSessionsZh sessions = _TranslationsWebServerSettingsSectionsSessionsZh._(_root);
+	@override late final _TranslationsWebServerSettingsSectionsVaultZh vault = _TranslationsWebServerSettingsSectionsVaultZh._(_root);
+	@override late final _TranslationsWebServerSettingsSectionsMcpZh mcp = _TranslationsWebServerSettingsSectionsMcpZh._(_root);
+	@override late final _TranslationsWebServerSettingsSectionsMemoryZh memory = _TranslationsWebServerSettingsSectionsMemoryZh._(_root);
+	@override late final _TranslationsWebServerSettingsSectionsMemoryAmbientZh memoryAmbient = _TranslationsWebServerSettingsSectionsMemoryAmbientZh._(_root);
+	@override late final _TranslationsWebServerSettingsSectionsBackupZh backup = _TranslationsWebServerSettingsSectionsBackupZh._(_root);
+	@override late final _TranslationsWebServerSettingsSectionsClaudeZh claude = _TranslationsWebServerSettingsSectionsClaudeZh._(_root);
+	@override late final _TranslationsWebServerSettingsSectionsCodexZh codex = _TranslationsWebServerSettingsSectionsCodexZh._(_root);
+	@override late final _TranslationsWebServerSettingsSectionsGeminiZh gemini = _TranslationsWebServerSettingsSectionsGeminiZh._(_root);
+}
+
+// Path: web.serverSettings.restart
+class _TranslationsWebServerSettingsRestartZh extends TranslationsWebServerSettingsRestartEn {
+	_TranslationsWebServerSettingsRestartZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get button => '重启服务器';
+	@override String get buttonTitle => '对网关进程执行 self-exec';
+	@override String get dirtyConfirm => '您有未保存的修改。重启将使用「上次保存」的配置，是否继续？';
+	@override String get confirm => '重启 opendray 网关？所有打开的终端会话将自动重新连接。';
+	@override String get overlay => '正在重启服务器…';
+	@override String waiting({required Object tick}) => '等待 /health · ${tick}s';
+	@override String get timedOutTitle => '重启超时';
+	@override String get timedOutDesc => 'Health 接口未恢复。请查看服务器日志。';
+	@override String get successToast => '服务器已重启';
+}
+
+// Path: web.serverSettings.formGroups
+class _TranslationsWebServerSettingsFormGroupsZh extends TranslationsWebServerSettingsFormGroupsEn {
+	_TranslationsWebServerSettingsFormGroupsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get network => '网络';
+	@override String get operatorAccount => '操作员账号';
+	@override String get memoryConfiguration => '配置';
+	@override String get memoryHttp => 'HTTP 后端（当 backend=http 时使用）';
+	@override String get memoryLocal => '本地 ONNX（当 backend=local 时使用）';
+	@override String get backupStatus => '状态';
+	@override String get backupWhere => '备份目标位置';
+	@override String get backupSchedules => '计划任务';
+	@override String get backupWhatsInside => '备份里有什么？';
+}
+
+// Path: web.serverSettings.fields
+class _TranslationsWebServerSettingsFieldsZh extends TranslationsWebServerSettingsFieldsEn {
+	_TranslationsWebServerSettingsFieldsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsWebServerSettingsFieldsListenAddressZh listenAddress = _TranslationsWebServerSettingsFieldsListenAddressZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsUsernameZh username = _TranslationsWebServerSettingsFieldsUsernameZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsPasswordZh password = _TranslationsWebServerSettingsFieldsPasswordZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsTokenTTLZh tokenTTL = _TranslationsWebServerSettingsFieldsTokenTTLZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsLogLevelZh logLevel = _TranslationsWebServerSettingsFieldsLogLevelZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsLogFormatZh logFormat = _TranslationsWebServerSettingsFieldsLogFormatZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsLogFileZh logFile = _TranslationsWebServerSettingsFieldsLogFileZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsIdleThresholdZh idleThreshold = _TranslationsWebServerSettingsFieldsIdleThresholdZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsIdlePollIntervalZh idlePollInterval = _TranslationsWebServerSettingsFieldsIdlePollIntervalZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsVaultRootZh vaultRoot = _TranslationsWebServerSettingsFieldsVaultRootZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsNotesDirectoryZh notesDirectory = _TranslationsWebServerSettingsFieldsNotesDirectoryZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsSkillsDirectoryZh skillsDirectory = _TranslationsWebServerSettingsFieldsSkillsDirectoryZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsGitRootZh gitRoot = _TranslationsWebServerSettingsFieldsGitRootZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsPersonalPrefixZh personalPrefix = _TranslationsWebServerSettingsFieldsPersonalPrefixZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsProjectsPrefixZh projectsPrefix = _TranslationsWebServerSettingsFieldsProjectsPrefixZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsRegistryRootZh registryRoot = _TranslationsWebServerSettingsFieldsRegistryRootZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsSecretsFileZh secretsFile = _TranslationsWebServerSettingsFieldsSecretsFileZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsMemoryBackendZh memoryBackend = _TranslationsWebServerSettingsFieldsMemoryBackendZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsMemoryStoreZh memoryStore = _TranslationsWebServerSettingsFieldsMemoryStoreZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsMemoryTopKZh memoryTopK = _TranslationsWebServerSettingsFieldsMemoryTopKZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsMemoryThresholdZh memoryThreshold = _TranslationsWebServerSettingsFieldsMemoryThresholdZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsMemoryScopeZh memoryScope = _TranslationsWebServerSettingsFieldsMemoryScopeZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsMemoryBaseUrlZh memoryBaseUrl = _TranslationsWebServerSettingsFieldsMemoryBaseUrlZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsMemoryModelZh memoryModel = _TranslationsWebServerSettingsFieldsMemoryModelZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsMemoryApiKeyZh memoryApiKey = _TranslationsWebServerSettingsFieldsMemoryApiKeyZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsMemoryLocalModelZh memoryLocalModel = _TranslationsWebServerSettingsFieldsMemoryLocalModelZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsMemoryLibraryPathZh memoryLibraryPath = _TranslationsWebServerSettingsFieldsMemoryLibraryPathZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsMemoryModelPathZh memoryModelPath = _TranslationsWebServerSettingsFieldsMemoryModelPathZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsMemoryTokenizerPathZh memoryTokenizerPath = _TranslationsWebServerSettingsFieldsMemoryTokenizerPathZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsMemoryMaxSeqLenZh memoryMaxSeqLen = _TranslationsWebServerSettingsFieldsMemoryMaxSeqLenZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsClaudeHistoryRootsZh claudeHistoryRoots = _TranslationsWebServerSettingsFieldsClaudeHistoryRootsZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsClaudeAccountsDirZh claudeAccountsDir = _TranslationsWebServerSettingsFieldsClaudeAccountsDirZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsCodexSessionsRootZh codexSessionsRoot = _TranslationsWebServerSettingsFieldsCodexSessionsRootZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsGeminiTmpRootZh geminiTmpRoot = _TranslationsWebServerSettingsFieldsGeminiTmpRootZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsGeminiProjectsFileZh geminiProjectsFile = _TranslationsWebServerSettingsFieldsGeminiProjectsFileZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsBackupLocalDirZh backupLocalDir = _TranslationsWebServerSettingsFieldsBackupLocalDirZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsBackupExportDirZh backupExportDir = _TranslationsWebServerSettingsFieldsBackupExportDirZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsBackupPgDumpPathZh backupPgDumpPath = _TranslationsWebServerSettingsFieldsBackupPgDumpPathZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsBackupPgRestorePathZh backupPgRestorePath = _TranslationsWebServerSettingsFieldsBackupPgRestorePathZh._(_root);
+}
+
+// Path: web.serverSettings.liveTail
+class _TranslationsWebServerSettingsLiveTailZh extends TranslationsWebServerSettingsLiveTailEn {
+	_TranslationsWebServerSettingsLiveTailZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get heading => '实时日志';
+	@override String get description => '内存中的环形缓冲区（最近约 2,000 条）。重启后清空。';
+}
+
+// Path: web.serverSettings.memoryInspectorCard
+class _TranslationsWebServerSettingsMemoryInspectorCardZh extends TranslationsWebServerSettingsMemoryInspectorCardEn {
+	_TranslationsWebServerSettingsMemoryInspectorCardZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get heading => '检查器';
+	@override String get description => '在专门页面浏览、搜索、编辑已存储的记忆。';
+	@override String get openButton => '打开记忆 →';
+}
+
+// Path: web.serverSettings.stringList
+class _TranslationsWebServerSettingsStringListZh extends TranslationsWebServerSettingsStringListEn {
+	_TranslationsWebServerSettingsStringListZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get noneDefault => '（无 — 使用内置默认值）';
+	@override String get addPath => '添加路径';
+	@override String get removeTitle => '移除';
+}
+
+// Path: web.serverSettings.httpHelpers
+class _TranslationsWebServerSettingsHttpHelpersZh extends TranslationsWebServerSettingsHttpHelpersEn {
+	_TranslationsWebServerSettingsHttpHelpersZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get autoDetected => '启动时自动检测到';
+	@override String modelCount({required Object count}) => '${count} 个模型 — 点击使用';
+	@override String get presets => '预设：';
+	@override String get testConnection => '测试连接';
+	@override late final _TranslationsWebServerSettingsHttpHelpersPresetTipZh presetTip = _TranslationsWebServerSettingsHttpHelpersPresetTipZh._(_root);
+}
+
+// Path: web.serverSettings.probe
+class _TranslationsWebServerSettingsProbeZh extends TranslationsWebServerSettingsProbeEn {
+	_TranslationsWebServerSettingsProbeZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String unreachable({required Object error}) => '✗ 不可达：${error}';
+	@override String get connectionFailed => '连接失败';
+	@override String reachable({required Object detected, required Object total, required Object embedding}) => '✓ 可达 ${detected}· 共 ${total} 个模型 · ${embedding} 个嵌入';
+	@override String modelMissing({required Object model}) => '⚠ 配置的模型 ${model} 不在列表中。从下方嵌入模型中选一个，或修正名称。';
+	@override String get embeddingModelsLabel => '嵌入模型：';
+	@override String moreModels({required Object count}) => '还有 ${count} 个';
+	@override String get noEmbeddingFound => '⚠ 没有模型名包含 "embed"。该端点可能未加载嵌入模型 — 请检查本地服务。';
+	@override String get configuredTitle => '当前已配置';
+	@override String get applyTitle => '点击应用';
+}
+
+// Path: web.serverSettings.backup
+class _TranslationsWebServerSettingsBackupZh extends TranslationsWebServerSettingsBackupEn {
+	_TranslationsWebServerSettingsBackupZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get featureDisabledTitle => '功能已禁用';
+	@override String get featureDisabledHint => '在 opendray 的环境变量中设置 <1>OPENDRAY_BACKUP_ENABLED=1</1> + <3>OPENDRAY_BACKUP_KEY=&lt;passphrase&gt;</3>，然后重启。主密码仅来自环境变量 — 永不写入 config.toml。';
+	@override String get statusRowLabel => '状态';
+	@override String get enabledHealthy => '已启用 · 健康';
+	@override String get enabledDegraded => '已启用 · 异常';
+	@override String get keyFingerprintLabel => '密钥指纹';
+	@override String get keyFingerprintHint => '记录到 Vaultwarden — 丢失会锁死所有先前的备份';
+	@override String get pgDumpLabel => 'pg_dump';
+	@override String get pgDumpUnavailable => '不可用';
+	@override String get pgRestoreLabel => 'pg_restore';
+	@override String get pgRestoreNotResolved => '（未解析）';
+	@override String get openBackups => '打开备份页 →';
+	@override String get openExport => '打开导出 / 导入 →';
+	@override String get whereDesc => '每个目标都是备份块可写入的一个地方。opendray 支持 <1>本地磁盘</1>、<3>SMB/CIFS</3>（Windows / NAS）、<5>S3 兼容</5>（AWS、R2、B2、MinIO、阿里云 OSS、腾讯云 COS …）、<7>WebDAV</7>（Nextcloud、群晖、坚果云）、<9>SFTP</9>，外加 <11>rclone</11> 透传，接入另外 70+ 个后端（Google Drive、OneDrive、Dropbox、百度云、阿里云盘 …）。';
+	@override String get loading => '加载中…';
+	@override String get noTargets => '尚未添加目标。添加一个开始备份。';
+	@override String get addTarget => '添加目标';
+	@override String get noSchedulesHint => '没有循环计划。在 <1>/backups → 计划任务</1> 添加一个以自动执行备份。';
+	@override late final _TranslationsWebServerSettingsBackupScheduleHeadersZh scheduleHeaders = _TranslationsWebServerSettingsBackupScheduleHeadersZh._(_root);
+	@override String every({required Object interval}) => '每 ${interval}';
+	@override String backupsKeep({required Object count}) => '${count} 份备份';
+	@override String get stateEnabled => '已启用';
+	@override String get statePaused => '已暂停';
+	@override String get manageSchedules => '在 /backups → 计划任务 管理 →';
+	@override String get whatsInsideDesc => '每份备份都是所有 opendray 表（sessions、integrations、memories、audit_log 等）的 <1>pg_dump --format=custom</1>，加上一个 <3>manifest.json</3>，以及（可选）当前的 <5>config.toml</5>。在 <7>备份页</7> 打开「备份里有什么？」面板可以看到带行数的实时清单。';
+	@override String get advancedToggle => '高级选项（路径与客户端二进制）— 需要重启';
+}
+
+// Path: web.serverSettings.targetRow
+class _TranslationsWebServerSettingsTargetRowZh extends TranslationsWebServerSettingsTargetRowEn {
+	_TranslationsWebServerSettingsTargetRowZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get on => '开';
+	@override String get off => '关';
+	@override String get test => '测试';
+	@override String get testing => '测试中…';
+	@override String get delete => '删除';
+	@override String connectionOk({required Object id}) => '${id}：连接正常';
+	@override String get connectionFailedTitle => '连接失败';
+	@override String get testFailedTitle => '测试失败';
+	@override String deleteConfirm({required Object id}) => '删除目标 "${id}"？引用它的计划任务将阻止删除。';
+	@override String get deleteSuccess => '目标已删除';
+	@override String get deleteFailedTitle => '删除失败';
+	@override String get unknownError => '未知错误';
+}
+
+// Path: web.settings.groups
+class _TranslationsWebSettingsGroupsZh extends TranslationsWebSettingsGroupsEn {
+	_TranslationsWebSettingsGroupsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get workspace => '工作区';
+	@override String get server => '服务器';
+	@override String get system => '系统';
+}
+
+// Path: web.settings.items
+class _TranslationsWebSettingsItemsZh extends TranslationsWebSettingsItemsEn {
+	_TranslationsWebSettingsItemsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get appearance => '外观';
+	@override String get font => '字号';
+	@override String get account => '账号';
+	@override String get status => '状态';
+	@override String get about => '关于';
+}
+
+// Path: web.settings.health
+class _TranslationsWebSettingsHealthZh extends TranslationsWebSettingsHealthEn {
+	_TranslationsWebSettingsHealthZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get connecting => '连接中…';
+	@override String get dbOk => 'db 正常';
+	@override String get dbDown => 'db 异常';
+}
+
+// Path: web.settings.breadcrumb
+class _TranslationsWebSettingsBreadcrumbZh extends TranslationsWebSettingsBreadcrumbEn {
+	_TranslationsWebSettingsBreadcrumbZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get server => '服务器';
+}
+
+// Path: web.settings.appearance
+class _TranslationsWebSettingsAppearanceZh extends TranslationsWebSettingsAppearanceEn {
+	_TranslationsWebSettingsAppearanceZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '外观';
+	@override String get description => '选择 opendray 的外观风格。';
+	@override late final _TranslationsWebSettingsAppearanceOptionsZh options = _TranslationsWebSettingsAppearanceOptionsZh._(_root);
+}
+
+// Path: web.settings.font
+class _TranslationsWebSettingsFontZh extends TranslationsWebSettingsFontEn {
+	_TranslationsWebSettingsFontZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '字号';
+	@override String get description => '缩放整个界面。按浏览器保存。';
+	@override late final _TranslationsWebSettingsFontOptionsZh options = _TranslationsWebSettingsFontOptionsZh._(_root);
+}
+
+// Path: web.settings.account
+class _TranslationsWebSettingsAccountZh extends TranslationsWebSettingsAccountEn {
+	_TranslationsWebSettingsAccountZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '账号';
+	@override String get description => '运维与当前 bearer token。';
+	@override String get username => '用户名';
+	@override String get tokenExpires => 'Token 过期';
+	@override String get changeCredentials => '修改凭证';
+}
+
+// Path: web.settings.changeCredentials
+class _TranslationsWebSettingsChangeCredentialsZh extends TranslationsWebSettingsChangeCredentialsEn {
+	_TranslationsWebSettingsChangeCredentialsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '修改凭证';
+	@override String get description => '先验证当前密码，再选择新凭证。所有其它已登录会话都将被吊销。';
+	@override String get currentPassword => '当前密码';
+	@override String get newUsername => '新用户名';
+	@override String get newPassword => '新密码';
+	@override String get newPasswordHint => '至少 8 个字符。';
+	@override String get confirm => '确认新密码';
+	@override String get errorTooShort => '新密码至少 8 个字符。';
+	@override String get errorMismatch => '新密码和确认不一致。';
+	@override String get errorWrongPassword => '当前密码不正确。';
+	@override String get cancel => '取消';
+	@override String get update => '更新';
+	@override String get saving => '保存中…';
+}
+
+// Path: web.settings.system
+class _TranslationsWebSettingsSystemZh extends TranslationsWebSettingsSystemEn {
+	_TranslationsWebSettingsSystemZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '系统状态';
+	@override String get description => '来自网关 /health 接口的实时状态。';
+	@override String get status => '状态';
+	@override String get version => '版本';
+	@override String get uptime => '运行时长';
+	@override String get database => '数据库';
+	@override String get reachable => '可达';
+	@override String get unreachable => '不可达';
+}
+
+// Path: web.settings.about
+class _TranslationsWebSettingsAboutZh extends TranslationsWebSettingsAboutEn {
+	_TranslationsWebSettingsAboutZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '关于';
+	@override String get description => 'opendray v2 — 面向 AI agent CLI 的多路复用 + 集成网关。源码采用 Apache 2.0 协议。';
+}
+
+// Path: web.memoryAmbient.header
+class _TranslationsWebMemoryAmbientHeaderZh extends TranslationsWebMemoryAmbientHeaderEn {
+	_TranslationsWebMemoryAmbientHeaderZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '环境记忆 — 自动捕获与注入';
+	@override String get body => 'opendray 每 10 秒轮询所有运行中的 agent 会话，通过可配置的 LLM 提取持久事实，去重后存入共享记忆池。配置由哪个 LLM 做提取（Provider）、何时触发提取（Capture rule）、以及在 spawn 时把什么内容（如果有）拼接到 agent 的 system prompt（Injection profile）。';
+}
+
+// Path: web.memoryAmbient.providers
+class _TranslationsWebMemoryAmbientProvidersZh extends TranslationsWebMemoryAmbientProvidersEn {
+	_TranslationsWebMemoryAmbientProvidersZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Summarizer Providers';
+	@override String get addButton => '添加 provider';
+	@override String get intro => '至少需要一个已启用的 provider 才能真正触发捕获。本地选项（Ollama、LM Studio、Integration）让你的会话内容不出外网。';
+	@override String get empty => '尚未配置 provider。';
+	@override late final _TranslationsWebMemoryAmbientProvidersRowZh row = _TranslationsWebMemoryAmbientProvidersRowZh._(_root);
+	@override late final _TranslationsWebMemoryAmbientProvidersDialogZh dialog = _TranslationsWebMemoryAmbientProvidersDialogZh._(_root);
+}
+
+// Path: web.memoryAmbient.rules
+class _TranslationsWebMemoryAmbientRulesZh extends TranslationsWebMemoryAmbientRulesEn {
+	_TranslationsWebMemoryAmbientRulesZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '捕获规则';
+	@override String get addButton => '添加规则';
+	@override String get intro => '每条规则表示 "当此 trigger 触发时，对新的会话消息做总结并存储持久事实。" 单会话规则覆盖全局默认。v1 内置 4 种 trigger 类型。';
+	@override String get empty => '尚无捕获规则。添加一条以启用自动捕获。';
+	@override late final _TranslationsWebMemoryAmbientRulesRowZh row = _TranslationsWebMemoryAmbientRulesRowZh._(_root);
+	@override late final _TranslationsWebMemoryAmbientRulesDialogZh dialog = _TranslationsWebMemoryAmbientRulesDialogZh._(_root);
+}
+
+// Path: web.memoryAmbient.profiles
+class _TranslationsWebMemoryAmbientProfilesZh extends TranslationsWebMemoryAmbientProfilesEn {
+	_TranslationsWebMemoryAmbientProfilesZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Injection Profiles';
+	@override String get addButton => '添加 profile';
+	@override String get intro => 'spawn 时，opendray 会把最近的项目记忆作为一段 markdown banner 拼接到 agent 的 system prompt — 前提是配置了 profile。没有 profile 时，模型仍可按需调用 memory_search。';
+	@override String get empty => '尚无 injection profile。spawn 时不会自动注入记忆 — 模型仍可使用 memory_search。';
+	@override late final _TranslationsWebMemoryAmbientProfilesRowZh row = _TranslationsWebMemoryAmbientProfilesRowZh._(_root);
+	@override late final _TranslationsWebMemoryAmbientProfilesDialogZh dialog = _TranslationsWebMemoryAmbientProfilesDialogZh._(_root);
+}
+
+// Path: web.memoryAmbient.cost
+class _TranslationsWebMemoryAmbientCostZh extends TranslationsWebMemoryAmbientCostEn {
+	_TranslationsWebMemoryAmbientCostZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Token 成本（总计）';
+	@override String get intro => '按 provider 聚合自 <1>memory_summarizer_calls</1>。本地 provider（Ollama、LM Studio、Integration）按 \$0 计价 — 硬件成本由运维承担。';
+	@override String get empty => '暂无已启用的 provider — 没有成本数据。';
+	@override late final _TranslationsWebMemoryAmbientCostColumnsZh columns = _TranslationsWebMemoryAmbientCostColumnsZh._(_root);
+}
+
+// Path: web.noteEditor.status
+class _TranslationsWebNoteEditorStatusZh extends TranslationsWebNoteEditorStatusEn {
+	_TranslationsWebNoteEditorStatusZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get saveFailed => '保存失败';
+	@override String get saving => '保存中…';
+	@override String get unsaved => '未保存';
+	@override String get newNote => '新笔记';
+	@override String get saved => '已保存';
+}
+
+// Path: web.export.sections
+class _TranslationsWebExportSectionsZh extends TranslationsWebExportSectionsEn {
+	_TranslationsWebExportSectionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get export => '导出';
+	@override String get import => '导入';
+}
+
+// Path: web.export.form
+class _TranslationsWebExportFormZh extends TranslationsWebExportFormEn {
+	_TranslationsWebExportFormZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get scope => '范围';
+	@override String get memories => '记忆';
+	@override String get memoriesHint => '跨 CLI 持久化的记忆行（text + scope + metadata）。向量被省略；导入端重嵌入。';
+	@override String get integrations => '集成';
+	@override String get customTasks => '自定义任务';
+	@override String get customTasksHint => '在 Inspector 的 Tasks 标签里展示的运维自定义任务。';
+	@override late final _TranslationsWebExportFormIntegrationOptionsZh integrationOptions = _TranslationsWebExportFormIntegrationOptionsZh._(_root);
+	@override String get confirmWarning => '输入 <1>I understand</1> 以确认。opendray 当前只存 bcrypt 哈希 — 选择明文也不会导出任何明文（该选项为将来保留明文缓存的版本而预留）。';
+	@override String get confirmPlaceholder => 'I understand';
+	@override String get confirmSentinel => 'i understand';
+	@override String get footnote => '审计日志与会话记录不在范围内 — 由 /backups（运维 dump）覆盖。';
+	@override String get building => '构建中…';
+	@override String get create => '创建导出';
+	@override String get readyToast => '导出就绪';
+	@override String readyDescription({required Object bytes}) => '${bytes} 字节';
+	@override String get failedToast => '导出失败';
+}
+
+// Path: web.export.history
+class _TranslationsWebExportHistoryZh extends TranslationsWebExportHistoryEn {
+	_TranslationsWebExportHistoryZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get loading => '加载中…';
+	@override String get empty => '暂无导出。请使用上面的表单创建一个。';
+	@override String get title => '历史';
+	@override late final _TranslationsWebExportHistoryColumnsZh columns = _TranslationsWebExportHistoryColumnsZh._(_root);
+	@override String get download => '下载';
+	@override String get deleteTooltip => '删除';
+	@override String get listFailedToast => '加载导出列表失败';
+	@override String get downloadFailedToast => '下载失败';
+	@override String get noTokenToast => '没有下载 token（已过期？）';
+	@override String deleteConfirm({required Object id}) => '删除导出 ${id}?';
+	@override String get deletedToast => '导出已删除';
+	@override String get deleteFailedToast => '删除失败';
+	@override String get scopeEmpty => '(空)';
+}
+
+// Path: web.export.import
+class _TranslationsWebExportImportZh extends TranslationsWebExportImportEn {
+	_TranslationsWebExportImportZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get intro => '将一个导出 bundle（zip）回放到当前数据库。冲突项（id 一致，或 integrations 的 route_prefix 唯一冲突）默认 <1>跳过</1>。记忆条目会被标记为 <3>embedder=imported_v1</3>，需要做一次重嵌入后搜索才能返回；可在 <5>Memory → 维护</5> 触发。集成以 <7>enabled=false</7> 导入并使用非 bcrypt 的占位 key — 启用前请轮换。';
+	@override String get memoryLink => 'Memory → 维护';
+	@override String get bundleLabel => 'Bundle (.zip)';
+	@override String get memoriesLabel => '记忆';
+	@override String get integrationsLabel => '集成（仅元数据 — 不会导入 key）';
+	@override String get customTasksLabel => '自定义任务';
+	@override String get importing => '导入中…';
+	@override String get importBundle => '导入 bundle';
+	@override String get pickFileToast => '请先选择一个 bundle 文件';
+	@override String get doneToast => '导入完成';
+	@override String get finishedWithErrors => '导入完成但有错误';
+	@override String get failedToast => '导入失败';
+	@override late final _TranslationsWebExportImportSummaryCardZh summaryCard = _TranslationsWebExportImportSummaryCardZh._(_root);
+}
+
+// Path: web.export.imports
+class _TranslationsWebExportImportsZh extends TranslationsWebExportImportsEn {
+	_TranslationsWebExportImportsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get loading => '加载中…';
+	@override String get empty => '暂无导入。';
+	@override String get title => '历史';
+	@override late final _TranslationsWebExportImportsColumnsZh columns = _TranslationsWebExportImportsColumnsZh._(_root);
+	@override String get noneCounts => '(无)';
+	@override String get listFailedToast => '加载导入列表失败';
+}
+
 // Path: more.items.integrations
 class _TranslationsMoreItemsIntegrationsZh extends TranslationsMoreItemsIntegrationsEn {
 	_TranslationsMoreItemsIntegrationsZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -2416,6 +5057,1515 @@ class _TranslationsSettingsServerSettingsFieldsZh extends TranslationsSettingsSe
 	@override String get projectsJson => 'projects.json';
 }
 
+// Path: web.sessions.list.row
+class _TranslationsWebSessionsListRowZh extends TranslationsWebSessionsListRowEn {
+	_TranslationsWebSessionsListRowZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get deleteAria => '删除会话';
+	@override String get titleRemoveHistory => '从历史中移除';
+	@override String get titleTerminate => '终止并移除';
+	@override String get titleRemove => '移除';
+	@override String claudeAccountTitle({required Object label}) => 'Claude 账号：${label}';
+}
+
+// Path: web.sessions.inspector.tabs
+class _TranslationsWebSessionsInspectorTabsZh extends TranslationsWebSessionsInspectorTabsEn {
+	_TranslationsWebSessionsInspectorTabsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get files => '文件';
+	@override String get git => 'Git';
+	@override String get search => '搜索';
+	@override String get tasks => '任务';
+	@override String get history => '历史';
+	@override String get notes => '笔记';
+	@override String get memory => '记忆';
+}
+
+// Path: web.memoryWorkers.tasks.gatekeeper
+class _TranslationsWebMemoryWorkersTasksGatekeeperZh extends TranslationsWebMemoryWorkersTasksGatekeeperEn {
+	_TranslationsWebMemoryWorkersTasksGatekeeperZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'Gatekeeper';
+	@override String get description => '每次 memory_store 前的预写过滤器。高频（目标 <500ms） — 仅 summarizer。';
+}
+
+// Path: web.memoryWorkers.tasks.cleaner
+class _TranslationsWebMemoryWorkersTasksCleanerZh extends TranslationsWebMemoryWorkersTasksCleanerEn {
+	_TranslationsWebMemoryWorkersTasksCleanerZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'Cleaner librarian';
+	@override String get description => '周期性 LLM 整理。对旧记忆判定为保留 / 过期 / 重复。';
+}
+
+// Path: web.memoryWorkers.tasks.gitactivity
+class _TranslationsWebMemoryWorkersTasksGitactivityZh extends TranslationsWebMemoryWorkersTasksGitactivityEn {
+	_TranslationsWebMemoryWorkersTasksGitactivityZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'Git 活动总结器';
+	@override String get description => 'git log → 每 24 小时生成 2-3 段叙事。天然适合 agent worker。';
+}
+
+// Path: web.memoryWorkers.tasks.transcript
+class _TranslationsWebMemoryWorkersTasksTranscriptZh extends TranslationsWebMemoryWorkersTasksTranscriptEn {
+	_TranslationsWebMemoryWorkersTasksTranscriptZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '会话记录总结器';
+	@override String get description => '会话结束时的“agent 都做了什么”总结。天然适合 agent worker。';
+}
+
+// Path: web.project.readonly.tech_stack
+class _TranslationsWebProjectReadonlyTechStackZh extends TranslationsWebProjectReadonlyTechStackEn {
+	_TranslationsWebProjectReadonlyTechStackZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '技术栈与结构';
+	@override String get empty => '在该项目运行一次 Claude 会话 — scanner 会在每次 spawn 时刷新。';
+}
+
+// Path: web.project.readonly.recent_activity
+class _TranslationsWebProjectReadonlyRecentActivityZh extends TranslationsWebProjectReadonlyRecentActivityEn {
+	_TranslationsWebProjectReadonlyRecentActivityZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '最近活动 (git → LLM)';
+	@override String get empty => 'Git 活动总结每 24 小时运行；下次调度后再来看看。';
+}
+
+// Path: web.project.reset.summary
+class _TranslationsWebProjectResetSummaryZh extends TranslationsWebProjectResetSummaryEn {
+	_TranslationsWebProjectResetSummaryZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String docs_one({required Object count}) => '${count} 份文档';
+	@override String docs_other({required Object count}) => '${count} 份文档';
+	@override String journal({required Object count}) => '${count} 条日志';
+	@override String proposals_one({required Object count}) => '${count} 条提案';
+	@override String proposals_other({required Object count}) => '${count} 条提案';
+	@override String cleanup({required Object count}) => '${count} 条清理';
+	@override String memories({required Object count}) => '${count} 条记忆';
+}
+
+// Path: web.memoryInspector.scope.values
+class _TranslationsWebMemoryInspectorScopeValuesZh extends TranslationsWebMemoryInspectorScopeValuesEn {
+	_TranslationsWebMemoryInspectorScopeValuesZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get project => 'project';
+	@override String get session => 'session';
+	@override String get global => 'global';
+}
+
+// Path: web.notes.vaultSync.init
+class _TranslationsWebNotesVaultSyncInitZh extends TranslationsWebNotesVaultSyncInitEn {
+	_TranslationsWebNotesVaultSyncInitZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'vault 尚未初始化为 git 仓库';
+	@override String get body => '初始化会在 vault 根目录运行 <1>git init -b main</1> 并加入一份合理的 <3>.gitignore</3>。之后你就可以提交笔记并配置 remote（GitHub / Gitea / GitLab）进行跨机同步。';
+	@override String get button => '把 vault 初始化为 git 仓库';
+	@override String get initToast => 'vault 已初始化为 git 仓库';
+	@override String get initFailedToast => '初始化失败';
+}
+
+// Path: web.notes.vaultSync.branch
+class _TranslationsWebNotesVaultSyncBranchZh extends TranslationsWebNotesVaultSyncBranchEn {
+	_TranslationsWebNotesVaultSyncBranchZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get clean => '干净';
+	@override String staged({required Object count}) => '${count} 已暂存';
+	@override String modified({required Object count}) => '${count} 已修改';
+	@override String untracked({required Object count}) => '${count} 未跟踪';
+}
+
+// Path: web.notes.vaultSync.action
+class _TranslationsWebNotesVaultSyncActionZh extends TranslationsWebNotesVaultSyncActionEn {
+	_TranslationsWebNotesVaultSyncActionZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get pull => '拉取';
+	@override String get push => '推送';
+	@override String get pullTitleNoRemote => '请先配置 remote';
+	@override String get pullTitleHasUpstream => 'git pull --rebase --autostash';
+	@override String get pullTitleNoUpstream => '拉取 origin 的 HEAD；隐式建立 tracking';
+	@override String get pushTitleNoRemote => '请先配置 remote';
+	@override String get pushTitleHasUpstream => 'git push -u origin HEAD';
+	@override String get pushTitleNoUpstream => '首次推送 — 会将 upstream 设为 origin/HEAD';
+	@override String get noRemote => '尚未配置 remote — pull/push 已禁用';
+	@override String get noUpstream => '尚无 upstream tracking — 首次推送会自动建立。';
+	@override String get pulledToast => '已拉取';
+	@override String get pullFailedToast => '拉取失败';
+	@override String get pushedToast => '已推送';
+	@override String get pushFailedToast => '推送失败';
+}
+
+// Path: web.notes.vaultSync.commit
+class _TranslationsWebNotesVaultSyncCommitZh extends TranslationsWebNotesVaultSyncCommitEn {
+	_TranslationsWebNotesVaultSyncCommitZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '提交';
+	@override String placeholder({required Object date}) => 'Notes: ${date}（默认）';
+	@override String get commitAll => '提交全部';
+	@override String get hint => '暂存所有变更（<1>git add .</1>）然后用此 message 提交。message 为空则使用带时间戳的默认值。';
+	@override String committedToast({required Object hash}) => '已提交 ${hash}';
+	@override String get commitFailedToast => '提交失败';
+}
+
+// Path: web.notes.vaultSync.fileList
+class _TranslationsWebNotesVaultSyncFileListZh extends TranslationsWebNotesVaultSyncFileListEn {
+	_TranslationsWebNotesVaultSyncFileListZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String title({required Object count}) => '工作树 · ${count}';
+	@override String moreSuffix({required Object count}) => '+${count} 更多';
+}
+
+// Path: web.notes.vaultSync.remote
+class _TranslationsWebNotesVaultSyncRemoteZh extends TranslationsWebNotesVaultSyncRemoteEn {
+	_TranslationsWebNotesVaultSyncRemoteZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Remote（origin）';
+	@override String get cancel => '取消';
+	@override String get change => '更换';
+	@override String get configure => '配置';
+	@override String get empty => '尚未设置 remote。添加一个 HTTPS 或 SSH URL（例如 <1>git@github.com:you/notes.git</1> 或 <3>https://tea.linivek.online/you/notes.git</3>）以启用 push / pull。';
+	@override String get urlLabel => 'URL（HTTPS 或 SSH）';
+	@override String get urlPlaceholder => 'git@host:owner/notes.git';
+	@override String get save => '保存';
+	@override String get savedToast => 'Remote 已保存';
+	@override String get saveFailedToast => '设置 remote 失败';
+}
+
+// Path: web.notes.vaultSync.history
+class _TranslationsWebNotesVaultSyncHistoryZh extends TranslationsWebNotesVaultSyncHistoryEn {
+	_TranslationsWebNotesVaultSyncHistoryZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '最近提交';
+	@override String get loading => '加载中…';
+	@override String get empty => '暂无提交。';
+}
+
+// Path: web.notes.vaultSync.conflict
+class _TranslationsWebNotesVaultSyncConflictZh extends TranslationsWebNotesVaultSyncConflictEn {
+	_TranslationsWebNotesVaultSyncConflictZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsWebNotesVaultSyncConflictKindsZh kinds = _TranslationsWebNotesVaultSyncConflictKindsZh._(_root);
+	@override String headline({required Object kind}) => 'vault 存在暂停的 ${kind} 且有未解决的冲突';
+	@override String explainer({required Object kind}) => '在 ${kind} 完成之前，pull、push 与 commit 都被阻塞。你可以选择 <1>中止</1>（把工作树恢复到 ${kind} 之前的状态 — 保留本地提交，丢弃远端提交），或 <3>强制重置到 remote</3>（丢弃所有本地提交 + 未提交修改；vault 变成 origin 的精确镜像）。';
+	@override String conflictedHeader({required Object count}) => '冲突文件 · ${count}';
+	@override String abort({required Object kind}) => '中止 ${kind}';
+	@override String abortTitle({required Object kind}) => 'git ${kind} --abort';
+	@override String get forceReset => '强制重置到 remote';
+	@override String get forceResetTitle => 'git fetch && git reset --hard origin/<branch> && git clean -fd';
+	@override String forceResetConfirm({required Object kind}) => '破坏性操作：将\n  • 中止进行中的 ${kind}\n  • 运行 git fetch origin\n  • reset --hard 到 origin/<branch>\n  • clean -fd（删除未跟踪文件）\n\n任何尚未推送到 origin 的本地提交以及任何未提交修改都将永久丢失。\n\n继续？';
+	@override String abortedToast({required Object kind}) => '已中止 ${kind}';
+	@override String get abortedDescription => '工作树已恢复到操作前状态。';
+	@override String get abortFailedToast => '中止失败';
+	@override String resetToast({required Object branch}) => '已重置到 ${branch}';
+	@override String get resetDescription => '本地更改已丢弃；vault 与 remote 一致。';
+	@override String get resetFailedToast => '重置失败';
+}
+
+// Path: web.notes.vaultSync.auth
+class _TranslationsWebNotesVaultSyncAuthZh extends TranslationsWebNotesVaultSyncAuthEn {
+	_TranslationsWebNotesVaultSyncAuthZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '认证';
+	@override String httpsTokenOk({required Object host}) => '将使用 Plugins → Git hosts 中为 <1>${host}</1> 存的 token。✓';
+	@override String httpsTokenMissing({required Object host}) => '<1>${host}</1> 上的 HTTPS remote，opendray 中没有配置 token。在你为其添加 token 之前，私有仓库的 push / pull 很可能失败。';
+	@override String ssh({required Object host}) => '<1>${host}</1> 上的 SSH remote。认证使用网关主机的 <3>~/.ssh/</3>（ssh-agent、identity 文件、host config）。可在主机 shell 用 <5>ssh -T git@${host}</5> 验证。';
+	@override String get configureTokenLink => '→ 配置 git host token';
+}
+
+// Path: web.notes.vaultSync.autoSync
+class _TranslationsWebNotesVaultSyncAutoSyncZh extends TranslationsWebNotesVaultSyncAutoSyncEn {
+	_TranslationsWebNotesVaultSyncAutoSyncZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get loading => '加载自动同步设置…';
+	@override String get title => '自动同步';
+	@override String get on => '开';
+	@override String get runNow => '立即运行';
+	@override String get runNowTooltip => '立即唤醒同步循环（跳过等待，然后运行所有到期的步骤）';
+	@override String get configure => '配置';
+	@override String get hide => '隐藏';
+	@override String get enabled => '启用';
+	@override String get enabledTooltipNoRemote => '请先配置 remote 才能启用自动同步';
+	@override String get noRemoteHint => '尚无 remote — push/pull 将被跳过。';
+	@override String get commitEvery => '提交间隔';
+	@override String get commitEveryExamples => '示例：<1>30s</1>、<3>10m</3>、<5>2h</5>。最小 30s。';
+	@override String get pullEvery => '拉取间隔';
+	@override String get pullEveryHint => '仅在启用 Pull 时使用。';
+	@override String get pushAfterCommit => '提交后 push';
+	@override String get pullPeriodically => '周期性 pull';
+	@override String get commitTemplateLabel => '提交 message 模板';
+	@override String commitTemplatePlaceholder({required Object date}) => 'Auto-sync: ${date}（留空则使用默认）';
+	@override String get saveSettings => '保存设置';
+	@override String get discard => '丢弃';
+	@override String get lastCommit => '最近 commit';
+	@override String get lastPush => '最近 push';
+	@override String get lastPull => '最近 pull';
+	@override String get never => '从未';
+	@override String get savedToast => '自动同步设置已保存';
+	@override String get saveFailedToast => '保存失败';
+	@override String get triggeredToast => '已触发自动同步';
+	@override String get runFailedToast => '运行失败';
+}
+
+// Path: web.providers.detail.caps
+class _TranslationsWebProvidersDetailCapsZh extends TranslationsWebProvidersDetailCapsEn {
+	_TranslationsWebProvidersDetailCapsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get resume => 'resume';
+	@override String get stream => 'stream';
+	@override String get images => 'images';
+	@override String get mcp => 'mcp';
+}
+
+// Path: web.channels.notifications.modes
+class _TranslationsWebChannelsNotificationsModesZh extends TranslationsWebChannelsNotificationsModesEn {
+	_TranslationsWebChannelsNotificationsModesZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get onceLabel => '每个会话仅一次（推荐）';
+	@override String get onceHint => '当会话变为 idle 时通知一次，然后保持静默，直到会话结束或你通过该频道回复。';
+	@override String get cooldownLabel => '时间窗口冷却';
+	@override String get cooldownHint => '对同一 (会话, 事件) 在所选时间窗口内抑制重复通知。';
+	@override String get everyLabel => '每次事件都通知（嘈杂）';
+	@override String get everyHint => '不做抑制。仅用于低频频道。';
+}
+
+// Path: web.channels.notifications.cooldowns
+class _TranslationsWebChannelsNotificationsCooldownsZh extends TranslationsWebChannelsNotificationsCooldownsEn {
+	_TranslationsWebChannelsNotificationsCooldownsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get k60 => '1 分钟';
+	@override String get k300 => '5 分钟';
+	@override String get k900 => '15 分钟';
+	@override String get k1800 => '30 分钟';
+	@override String get k3600 => '1 小时';
+}
+
+// Path: web.channels.notifications.snippetCaps
+class _TranslationsWebChannelsNotificationsSnippetCapsZh extends TranslationsWebChannelsNotificationsSnippetCapsEn {
+	_TranslationsWebChannelsNotificationsSnippetCapsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get k0 => '不限制 — 拆分到多条消息（默认）';
+	@override String get k1000 => '1000 字符（精简）';
+	@override String get k3000 => '3000 字符';
+	@override String get k6000 => '6000 字符';
+	@override String get k12000 => '12000 字符';
+}
+
+// Path: web.plugins.mcp.columns
+class _TranslationsWebPluginsMcpColumnsZh extends TranslationsWebPluginsMcpColumnsEn {
+	_TranslationsWebPluginsMcpColumnsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get name => '名称';
+	@override String get transport => 'Transport';
+	@override String get spec => '规范';
+	@override String get enabled => '启用';
+}
+
+// Path: web.plugins.mcp.editor
+class _TranslationsWebPluginsMcpEditorZh extends TranslationsWebPluginsMcpEditorEn {
+	_TranslationsWebPluginsMcpEditorZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get createTitle => '新建 MCP 服务器';
+	@override String editTitle({required Object id}) => '编辑 MCP: ${id}';
+	@override String description({required Object API_KEY}) => 'JSON 结构：stdio（默认）使用 <1>command</1>+<3>args</3>+<5>env</5>；sse / http 使用 <7>transport</7> +<9> url</9>+<11>headers</11>。以 <13>\$${API_KEY}</13> 引用密钥 — spawn 时会从密钥文件替换。';
+	@override String get idLabel => 'ID';
+	@override String get idPlaceholder => 'filesystem';
+	@override String get idHint => '小写字母 / 数字 / 短横 / 下划线。同时作为目录名与默认 <1>name</1>。';
+	@override String get bodyLabel => 'mcp.json';
+	@override String invalidJson({required Object error}) => '无效的 JSON：${error}';
+	@override String get createdToast => 'MCP 服务器已创建';
+	@override String get savedToast => 'MCP 服务器已保存';
+	@override String get createFailedToast => '创建失败';
+	@override String get saveFailedToast => '保存失败';
+}
+
+// Path: web.plugins.mcpSecrets.columns
+class _TranslationsWebPluginsMcpSecretsColumnsZh extends TranslationsWebPluginsMcpSecretsColumnsEn {
+	_TranslationsWebPluginsMcpSecretsColumnsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get key => 'Key';
+	@override String get value => 'Value';
+}
+
+// Path: web.plugins.mcpSecrets.editor
+class _TranslationsWebPluginsMcpSecretsEditorZh extends TranslationsWebPluginsMcpSecretsEditorEn {
+	_TranslationsWebPluginsMcpSecretsEditorZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get addTitle => '添加密钥';
+	@override String updateTitle({required Object key}) => '更新 ${key}';
+	@override String addDescription({required Object KEY}) => '若操作系统 keychain 可用，则在磁盘上加密存储。可在任意 mcp.json 的 env / headers / args / url 中以 \$${KEY} 引用。';
+	@override String get editDescription => '输入新值以覆盖。旧值无法恢复。';
+	@override String get keyLabel => 'Key';
+	@override String get keyPlaceholder => 'BRAVE_API_KEY';
+	@override String get keyPattern => '必须匹配 <1>[A-Za-z_][A-Za-z0-9_]*</1>';
+	@override String get keyCollision => '已存在 — 请使用编辑，或选择另一个名称。';
+	@override String get valueLabel => 'Value';
+	@override String get valueHint => '输入时隐藏。已保存的值不会通过 API 返回。';
+	@override String get addedToast => '密钥已添加';
+	@override String get updatedToast => '密钥已更新';
+	@override String get saveFailedToast => '保存失败';
+}
+
+// Path: web.plugins.skills.columns
+class _TranslationsWebPluginsSkillsColumnsZh extends TranslationsWebPluginsSkillsColumnsEn {
+	_TranslationsWebPluginsSkillsColumnsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get id => 'ID';
+	@override String get description => '描述';
+	@override String get source => '来源';
+}
+
+// Path: web.plugins.skills.editor
+class _TranslationsWebPluginsSkillsEditorZh extends TranslationsWebPluginsSkillsEditorEn {
+	_TranslationsWebPluginsSkillsEditorZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get createTitle => '新建 skill';
+	@override String customizeTitle({required Object id}) => '自定义内置：${id}';
+	@override String editTitle({required Object id}) => '编辑 skill：${id}';
+	@override String get customizeDescription => '你正在查看一个嵌入到 opendray 的内置 skill。保存会在相同 id 上创建一个 vault 覆盖 — 你的修改保存在 ~/.opendray/vault/skills/<id>/SKILL.md 中并遮盖内置版本，直到你点击重置。';
+	@override String get editDescription => 'SKILL.md 格式 — frontmatter（name + description），然后是 markdown 指令。description 会出现在 agent 的 Tier 1 索引中。';
+	@override String get idLabel => 'ID';
+	@override String get idPlaceholder => 'my-helper';
+	@override String get idHint => '小写字母 / 数字 / 短横 / 下划线。作为 <1>~/.opendray/vault/skills/&lt;id&gt;/</1> 下的目录名。';
+	@override String get bodyLabel => 'SKILL.md';
+	@override String get createdToast => 'Skill 已创建';
+	@override String get savedToast => 'Skill 已保存';
+	@override String get savedOverrideToast => '已保存为 vault 覆盖';
+	@override String get createFailedToast => '创建失败';
+	@override String get saveFailedToast => '保存失败';
+	@override String get saveAsOverride => '保存为 vault 覆盖';
+}
+
+// Path: web.plugins.customTasks.columns
+class _TranslationsWebPluginsCustomTasksColumnsZh extends TranslationsWebPluginsCustomTasksColumnsEn {
+	_TranslationsWebPluginsCustomTasksColumnsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get name => '名称';
+	@override String get command => '命令';
+	@override String get scope => 'Scope';
+}
+
+// Path: web.plugins.customTasks.dialog
+class _TranslationsWebPluginsCustomTasksDialogZh extends TranslationsWebPluginsCustomTasksDialogEn {
+	_TranslationsWebPluginsCustomTasksDialogZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get addTitle => '添加自定义任务';
+	@override String editTitle({required Object name}) => '编辑 ${name}';
+	@override String get description => '命令会原样发送到会话的终端中，等同于在 prompt 处键入并回车。';
+	@override String get nameLabel => '名称';
+	@override String get namePlaceholder => 'dev';
+	@override String get commandLabel => '命令';
+	@override String get commandPlaceholder => 'docker compose up --build';
+	@override String get descLabel => '描述（可选）';
+	@override String get descPlaceholder => '启动开发环境并跟踪日志';
+	@override String get cwdLabel => 'cwd scope（可选）';
+	@override String get cwdPlaceholder => '/Users/me/projects/foo（留空 = 全局）';
+	@override String get cwdHint => '留空 = 在每个会话中都可见。否则只有当会话的 cwd 与此绝对路径匹配时才显示。';
+	@override String get addedToast => '任务已添加';
+	@override String get updatedToast => '任务已更新';
+	@override String get addFailedToast => '添加失败';
+	@override String get updateFailedToast => '更新失败';
+}
+
+// Path: web.plugins.gitHosts.columns
+class _TranslationsWebPluginsGitHostsColumnsZh extends TranslationsWebPluginsGitHostsColumnsEn {
+	_TranslationsWebPluginsGitHostsColumnsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get host => '主机';
+	@override String get kind => '类型';
+	@override String get token => 'Token';
+	@override String get enabled => '启用';
+}
+
+// Path: web.plugins.gitHosts.dialog
+class _TranslationsWebPluginsGitHostsDialogZh extends TranslationsWebPluginsGitHostsDialogEn {
+	_TranslationsWebPluginsGitHostsDialogZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get addTitle => '添加 git 主机';
+	@override String editTitle({required Object host}) => '编辑 ${host}';
+	@override String get description => 'Token 存储在网关上。仅用于只读 API 调用（列出 PR 等）。';
+	@override String get kindLabel => '类型';
+	@override String get kindGitHub => 'GitHub';
+	@override String get kindGitea => 'Gitea';
+	@override String get kindGitLab => 'GitLab';
+	@override String get hostLabel => '主机';
+	@override String get hostPlaceholder => 'github.com';
+	@override String get displayNameLabel => '显示名称（可选）';
+	@override String get displayNamePlaceholder => 'Personal';
+	@override String get tokenLabel => 'Token';
+	@override String get newTokenLabel => '新 token（留空表示保留）';
+	@override String get tokenPlaceholder => 'ghp_… / gho_… / glpat-…';
+	@override String get tokenPlaceholderEdit => '…';
+	@override String get tokenHint => 'GitHub：带 <1>repo</1> scope 的 PAT。Gitea：带 <3>read:repository</3> 的 token。GitLab：带 <5>read_api</5> 的 PAT。';
+	@override String get enabledLabel => '启用';
+	@override String get addedToast => 'Git 主机已添加';
+	@override String get updatedToast => 'Git 主机已更新';
+	@override String get addFailedToast => '添加失败';
+	@override String get updateFailedToast => '更新失败';
+}
+
+// Path: web.backups.backupsTab.columns
+class _TranslationsWebBackupsBackupsTabColumnsZh extends TranslationsWebBackupsBackupsTabColumnsEn {
+	_TranslationsWebBackupsBackupsTabColumnsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get id => 'ID';
+	@override String get target => '目标';
+	@override String get status => '状态';
+	@override String get started => '开始';
+	@override String get size => '大小';
+	@override String get actions => '操作';
+}
+
+// Path: web.backups.schedulesTab.columns
+class _TranslationsWebBackupsSchedulesTabColumnsZh extends TranslationsWebBackupsSchedulesTabColumnsEn {
+	_TranslationsWebBackupsSchedulesTabColumnsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get id => 'ID';
+	@override String get target => '目标';
+	@override String get interval => '间隔';
+	@override String get keep => '保留';
+	@override String get nextRun => '下次运行';
+	@override String get enabled => '启用';
+	@override String get actions => '操作';
+}
+
+// Path: web.backups.targetsTab.columns
+class _TranslationsWebBackupsTargetsTabColumnsZh extends TranslationsWebBackupsTargetsTabColumnsEn {
+	_TranslationsWebBackupsTargetsTabColumnsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get id => 'ID';
+	@override String get kind => '类型';
+	@override String get config => '配置';
+	@override String get enabled => '启用';
+	@override String get actions => '操作';
+}
+
+// Path: web.backups.targetEditor.local
+class _TranslationsWebBackupsTargetEditorLocalZh extends TranslationsWebBackupsTargetEditorLocalEn {
+	_TranslationsWebBackupsTargetEditorLocalZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get rootLabel => '根目录';
+	@override String get rootHint => '留空 = cfg.backup.local_dir (~/.opendray/backups)';
+	@override String get rootPlaceholder => '~/backups/opendray  或  /mnt/external-hdd/opendray';
+}
+
+// Path: web.backups.targetEditor.smb
+class _TranslationsWebBackupsTargetEditorSmbZh extends TranslationsWebBackupsTargetEditorSmbEn {
+	_TranslationsWebBackupsTargetEditorSmbZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get hostLabel => '主机';
+	@override String get hostPlaceholder => '192.168.9.8';
+	@override String get portLabel => '端口';
+	@override String get shareLabel => 'Share';
+	@override String get shareHint => 'SMB 服务器上的顶层共享名';
+	@override String get sharePlaceholder => 'Claude_Workspace';
+	@override String get userLabel => '用户';
+	@override String get passwordLabel => '密码';
+	@override String get pathPrefixLabel => '路径前缀';
+	@override String get pathPrefixHint => '共享根下的子文件夹（可选）';
+	@override String get pathPrefixPlaceholder => 'opendray/backups';
+}
+
+// Path: web.backups.targetEditor.s3
+class _TranslationsWebBackupsTargetEditorS3Zh extends TranslationsWebBackupsTargetEditorS3En {
+	_TranslationsWebBackupsTargetEditorS3Zh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get endpointLabel => 'Endpoint';
+	@override String get endpointHint => '主机（不要带协议）。AWS: s3.amazonaws.com · R2: <accountid>.r2.cloudflarestorage.com · MinIO: minio.local:9000';
+	@override String get endpointPlaceholder => 's3.amazonaws.com';
+	@override String get regionLabel => 'Region';
+	@override String get regionHint => '仅 AWS；R2 用 \'auto\'';
+	@override String get regionPlaceholder => 'us-east-1 / auto';
+	@override String get bucketLabel => 'Bucket';
+	@override String get bucketPlaceholder => 'opendray-backups';
+	@override String get accessKeyLabel => 'Access key';
+	@override String get secretKeyLabel => 'Secret key';
+	@override String get secretKeyHint => 'AES-256-GCM 加密存储；不会被回显';
+	@override String get pathPrefixLabel => 'Path prefix';
+	@override String get pathPrefixHint => 'Object-key 前缀（可选）';
+	@override String get pathPrefixPlaceholder => 'opendray/backups';
+	@override String get useHttps => '使用 HTTPS';
+	@override String get pathStyle => 'Path-style 寻址（legacy / MinIO）';
+}
+
+// Path: web.backups.targetEditor.webdav
+class _TranslationsWebBackupsTargetEditorWebdavZh extends TranslationsWebBackupsTargetEditorWebdavEn {
+	_TranslationsWebBackupsTargetEditorWebdavZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get baseUrlLabel => 'Base URL';
+	@override String get baseUrlHint => '包含任意路径的完整 URL。示例：https://cloud.example.com/remote.php/dav/files/me/（Nextcloud）、https://nas.local:5006/（群晖）、https://dav.jianguoyun.com/dav/（坚果云）';
+	@override String get baseUrlPlaceholder => 'https://cloud.example.com/remote.php/dav/files/<user>/';
+	@override String get userLabel => '用户';
+	@override String get passwordLabel => '密码';
+	@override String get pathPrefixLabel => '路径前缀';
+	@override String get pathPrefixHint => 'Base URL 下的子文件夹（可选）';
+	@override String get pathPrefixPlaceholder => 'opendray/backups';
+}
+
+// Path: web.backups.targetEditor.sftp
+class _TranslationsWebBackupsTargetEditorSftpZh extends TranslationsWebBackupsTargetEditorSftpEn {
+	_TranslationsWebBackupsTargetEditorSftpZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get hostLabel => '主机';
+	@override String get hostPlaceholder => 'vps.example.com';
+	@override String get portLabel => '端口';
+	@override String get userLabel => '用户';
+	@override String get passwordLabel => '密码';
+	@override String get passwordHint => '密码或私钥二选一。若两者都填，密码会被作为私钥口令使用。';
+	@override String get privateKeyLabel => '私钥（PEM）';
+	@override String get privateKeyHint => '粘贴 OpenSSH/PEM 格式的私钥内容（例如 ~/.ssh/id_ed25519）。留空则仅用密码认证。';
+	@override String get privateKeyPlaceholder => '-----BEGIN OPENSSH PRIVATE KEY-----...';
+	@override String get hostKeyLabel => 'Host key（pinning）';
+	@override String get hostKeyHint => 'OpenSSH 风格的服务器公钥（运行 `ssh-keyscan host` 获取）。留空则禁用 pinning（LAN 之外不推荐）。';
+	@override String get hostKeyPlaceholder => 'ssh-ed25519 AAAA...';
+	@override String get pathPrefixLabel => '路径前缀';
+	@override String get pathPrefixHint => '绝对路径或相对家目录（可选）';
+	@override String get pathPrefixPlaceholder => '/var/backups/opendray  或  opendray-backups';
+}
+
+// Path: web.backups.targetEditor.rclone
+class _TranslationsWebBackupsTargetEditorRcloneZh extends TranslationsWebBackupsTargetEditorRcloneEn {
+	_TranslationsWebBackupsTargetEditorRcloneZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get rcloneHint => '要求 opendray 主机上已安装 <1>rclone</1> CLI。请先通过 <3>rclone config</3> 配置 remote，然后在下面填写 remote 名。opendray 在内部调用 <5>rclone rcat / cat / lsd</5>。';
+	@override String get remoteLabel => 'Remote name';
+	@override String get remoteHint => '来自 `rclone config` 的名字（不带冒号）。例如：gdrive、onedrive、dropbox-personal、baidu-pan';
+	@override String get remotePlaceholder => 'gdrive';
+	@override String get pathPrefixLabel => '路径前缀';
+	@override String get pathPrefixHint => 'Remote 根下的子文件夹（可选）';
+	@override String get pathPrefixPlaceholder => 'opendray/backups';
+	@override String get binaryPathLabel => '二进制路径';
+	@override String get binaryPathHint => '覆盖 `which rclone`。留空则走 PATH 查找。';
+	@override String get binaryPathPlaceholder => '/opt/homebrew/bin/rclone';
+	@override String get configPathLabel => 'Config 路径';
+	@override String get configPathHint => '覆盖 --config（默认 ~/.config/rclone/rclone.conf 或 ~/.rclone.conf）';
+	@override String get configPathPlaceholder => '留空则使用 rclone 默认';
+}
+
+// Path: web.serverSettings.sections.general
+class _TranslationsWebServerSettingsSectionsGeneralZh extends TranslationsWebServerSettingsSectionsGeneralEn {
+	_TranslationsWebServerSettingsSectionsGeneralZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '通用';
+	@override String get desc => '监听地址、操作员账号、令牌 TTL。';
+}
+
+// Path: web.serverSettings.sections.logging
+class _TranslationsWebServerSettingsSectionsLoggingZh extends TranslationsWebServerSettingsSectionsLoggingEn {
+	_TranslationsWebServerSettingsSectionsLoggingZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '日志';
+	@override String get desc => '日志级别、格式与实时跟踪。';
+}
+
+// Path: web.serverSettings.sections.sessions
+class _TranslationsWebServerSettingsSectionsSessionsZh extends TranslationsWebServerSettingsSectionsSessionsEn {
+	_TranslationsWebServerSettingsSectionsSessionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '会话';
+	@override String get desc => '空闲检测阈值。';
+}
+
+// Path: web.serverSettings.sections.vault
+class _TranslationsWebServerSettingsSectionsVaultZh extends TranslationsWebServerSettingsSectionsVaultEn {
+	_TranslationsWebServerSettingsSectionsVaultZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Vault';
+	@override String get desc => '笔记、技能与 git 版本化根目录。';
+}
+
+// Path: web.serverSettings.sections.mcp
+class _TranslationsWebServerSettingsSectionsMcpZh extends TranslationsWebServerSettingsSectionsMcpEn {
+	_TranslationsWebServerSettingsSectionsMcpZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'MCP 注册表';
+	@override String get desc => '服务器注册表与密钥。';
+}
+
+// Path: web.serverSettings.sections.memory
+class _TranslationsWebServerSettingsSectionsMemoryZh extends TranslationsWebServerSettingsSectionsMemoryEn {
+	_TranslationsWebServerSettingsSectionsMemoryZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '记忆';
+	@override String get desc => '跨 CLI 的持久化记忆子系统。';
+}
+
+// Path: web.serverSettings.sections.memoryAmbient
+class _TranslationsWebServerSettingsSectionsMemoryAmbientZh extends TranslationsWebServerSettingsSectionsMemoryAmbientEn {
+	_TranslationsWebServerSettingsSectionsMemoryAmbientZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '记忆 · 环境感知';
+	@override String get desc => '自动捕获对话进入记忆，并在 spawn 时注入。';
+}
+
+// Path: web.serverSettings.sections.backup
+class _TranslationsWebServerSettingsSectionsBackupZh extends TranslationsWebServerSettingsSectionsBackupEn {
+	_TranslationsWebServerSettingsSectionsBackupZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '备份';
+	@override String get desc => '加密数据库备份、恢复，以及管理员数据导出。';
+}
+
+// Path: web.serverSettings.sections.claude
+class _TranslationsWebServerSettingsSectionsClaudeZh extends TranslationsWebServerSettingsSectionsClaudeEn {
+	_TranslationsWebServerSettingsSectionsClaudeZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '存储 · Claude';
+	@override String get desc => 'Claude 会话记录在磁盘上的位置。';
+}
+
+// Path: web.serverSettings.sections.codex
+class _TranslationsWebServerSettingsSectionsCodexZh extends TranslationsWebServerSettingsSectionsCodexEn {
+	_TranslationsWebServerSettingsSectionsCodexZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '存储 · Codex';
+	@override String get desc => 'Codex 会话根目录。';
+}
+
+// Path: web.serverSettings.sections.gemini
+class _TranslationsWebServerSettingsSectionsGeminiZh extends TranslationsWebServerSettingsSectionsGeminiEn {
+	_TranslationsWebServerSettingsSectionsGeminiZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '存储 · Gemini';
+	@override String get desc => 'Gemini 每项目 tmp 与 projects.json。';
+}
+
+// Path: web.serverSettings.fields.listenAddress
+class _TranslationsWebServerSettingsFieldsListenAddressZh extends TranslationsWebServerSettingsFieldsListenAddressEn {
+	_TranslationsWebServerSettingsFieldsListenAddressZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '监听地址';
+	@override String get hint => 'HTTP 服务绑定的 host:port，例如：0.0.0.0:8770。';
+}
+
+// Path: web.serverSettings.fields.username
+class _TranslationsWebServerSettingsFieldsUsernameZh extends TranslationsWebServerSettingsFieldsUsernameEn {
+	_TranslationsWebServerSettingsFieldsUsernameZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '用户名';
+	@override String get hint => '登录表单使用的账号。修改后下次请求会强制重新登录。';
+}
+
+// Path: web.serverSettings.fields.password
+class _TranslationsWebServerSettingsFieldsPasswordZh extends TranslationsWebServerSettingsFieldsPasswordEn {
+	_TranslationsWebServerSettingsFieldsPasswordZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '密码';
+	@override String get hint => '留空保持当前密码不变；填值则会覆盖。';
+	@override String get hideTitle => '隐藏';
+	@override String get revealTitle => '显示';
+}
+
+// Path: web.serverSettings.fields.tokenTTL
+class _TranslationsWebServerSettingsFieldsTokenTTLZh extends TranslationsWebServerSettingsFieldsTokenTTLEn {
+	_TranslationsWebServerSettingsFieldsTokenTTLZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '令牌 TTL';
+	@override String get hint => 'Bearer 令牌生命周期，使用 Go duration，如 "24h"、"30m"。留空 = 永不过期。';
+}
+
+// Path: web.serverSettings.fields.logLevel
+class _TranslationsWebServerSettingsFieldsLogLevelZh extends TranslationsWebServerSettingsFieldsLogLevelEn {
+	_TranslationsWebServerSettingsFieldsLogLevelZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '日志级别';
+	@override String get hint => '低于此级别的日志将被丢弃。';
+}
+
+// Path: web.serverSettings.fields.logFormat
+class _TranslationsWebServerSettingsFieldsLogFormatZh extends TranslationsWebServerSettingsFieldsLogFormatEn {
+	_TranslationsWebServerSettingsFieldsLogFormatZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '格式';
+	@override String get hint => '"text" 适合人读；"json" 便于机器解析。';
+}
+
+// Path: web.serverSettings.fields.logFile
+class _TranslationsWebServerSettingsFieldsLogFileZh extends TranslationsWebServerSettingsFieldsLogFileEn {
+	_TranslationsWebServerSettingsFieldsLogFileZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '日志文件';
+	@override String get hint => '可选的文件路径。10MB 自动轮转，保留 5 个备份。留空 = 仅输出到 stderr。';
+}
+
+// Path: web.serverSettings.fields.idleThreshold
+class _TranslationsWebServerSettingsFieldsIdleThresholdZh extends TranslationsWebServerSettingsFieldsIdleThresholdEn {
+	_TranslationsWebServerSettingsFieldsIdleThresholdZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '空闲阈值';
+	@override String get hint => '会话静默这么久后触发 session.idle。留空 = 30s。';
+}
+
+// Path: web.serverSettings.fields.idlePollInterval
+class _TranslationsWebServerSettingsFieldsIdlePollIntervalZh extends TranslationsWebServerSettingsFieldsIdlePollIntervalEn {
+	_TranslationsWebServerSettingsFieldsIdlePollIntervalZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '空闲轮询间隔';
+	@override String get hint => '空闲检测器的唤醒频率。越低 = 延迟越低、唤醒越多。留空 = 5s。';
+}
+
+// Path: web.serverSettings.fields.vaultRoot
+class _TranslationsWebServerSettingsFieldsVaultRootZh extends TranslationsWebServerSettingsFieldsVaultRootEn {
+	_TranslationsWebServerSettingsFieldsVaultRootZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'Vault 根目录';
+	@override String get hint => '笔记、技能和 MCP 注册表的顶层目录。';
+}
+
+// Path: web.serverSettings.fields.notesDirectory
+class _TranslationsWebServerSettingsFieldsNotesDirectoryZh extends TranslationsWebServerSettingsFieldsNotesDirectoryEn {
+	_TranslationsWebServerSettingsFieldsNotesDirectoryZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '笔记目录';
+	@override String get hint => '覆盖笔记位置。默认为 <vault root>/notes。';
+}
+
+// Path: web.serverSettings.fields.skillsDirectory
+class _TranslationsWebServerSettingsFieldsSkillsDirectoryZh extends TranslationsWebServerSettingsFieldsSkillsDirectoryEn {
+	_TranslationsWebServerSettingsFieldsSkillsDirectoryZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '技能目录';
+	@override String get hint => '覆盖技能位置。默认为 <vault root>/skills。';
+}
+
+// Path: web.serverSettings.fields.gitRoot
+class _TranslationsWebServerSettingsFieldsGitRootZh extends TranslationsWebServerSettingsFieldsGitRootEn {
+	_TranslationsWebServerSettingsFieldsGitRootZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'Git 根目录';
+	@override String get hint => 'Vault Sync 功能提交到的工作树。';
+}
+
+// Path: web.serverSettings.fields.personalPrefix
+class _TranslationsWebServerSettingsFieldsPersonalPrefixZh extends TranslationsWebServerSettingsFieldsPersonalPrefixEn {
+	_TranslationsWebServerSettingsFieldsPersonalPrefixZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '个人前缀';
+	@override String get hint => '自动派生路径时用于个人笔记的文件夹名。默认 "personal"。';
+}
+
+// Path: web.serverSettings.fields.projectsPrefix
+class _TranslationsWebServerSettingsFieldsProjectsPrefixZh extends TranslationsWebServerSettingsFieldsProjectsPrefixEn {
+	_TranslationsWebServerSettingsFieldsProjectsPrefixZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '项目前缀';
+	@override String get hint => '项目笔记的文件夹名。默认 "projects"。';
+}
+
+// Path: web.serverSettings.fields.registryRoot
+class _TranslationsWebServerSettingsFieldsRegistryRootZh extends TranslationsWebServerSettingsFieldsRegistryRootEn {
+	_TranslationsWebServerSettingsFieldsRegistryRootZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '注册表根目录';
+	@override String get hint => '存放 MCP server JSON 定义的目录。默认为 <vault>/mcp。';
+}
+
+// Path: web.serverSettings.fields.secretsFile
+class _TranslationsWebServerSettingsFieldsSecretsFileZh extends TranslationsWebServerSettingsFieldsSecretsFileEn {
+	_TranslationsWebServerSettingsFieldsSecretsFileZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '密钥文件';
+	@override String get hint => 'spawn 时替换进 MCP server 命令的 key=value 文件。';
+}
+
+// Path: web.serverSettings.fields.memoryBackend
+class _TranslationsWebServerSettingsFieldsMemoryBackendZh extends TranslationsWebServerSettingsFieldsMemoryBackendEn {
+	_TranslationsWebServerSettingsFieldsMemoryBackendZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '嵌入器后端';
+	@override String get hint => '"auto" / "bm25" 使用纯 Go 关键词路径（无需 cgo）；"http" 调用任何兼容 OpenAI 的 /v1/embeddings（ollama / OpenAI / LocalAI）；"local" 进程内运行 ONNX sentence-transformer — 需要用 `-tags local_onnx` 编译的二进制。';
+}
+
+// Path: web.serverSettings.fields.memoryStore
+class _TranslationsWebServerSettingsFieldsMemoryStoreZh extends TranslationsWebServerSettingsFieldsMemoryStoreEn {
+	_TranslationsWebServerSettingsFieldsMemoryStoreZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '存储';
+	@override String get hint => '"pgvector" 复用 opendray 已有的 PG + vector 扩展；v1 唯一选项。';
+}
+
+// Path: web.serverSettings.fields.memoryTopK
+class _TranslationsWebServerSettingsFieldsMemoryTopKZh extends TranslationsWebServerSettingsFieldsMemoryTopKEn {
+	_TranslationsWebServerSettingsFieldsMemoryTopKZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '默认 top-K';
+	@override String get hint => 'agent 未指定时 memory_search 返回多少条命中。留空 = 5。';
+}
+
+// Path: web.serverSettings.fields.memoryThreshold
+class _TranslationsWebServerSettingsFieldsMemoryThresholdZh extends TranslationsWebServerSettingsFieldsMemoryThresholdEn {
+	_TranslationsWebServerSettingsFieldsMemoryThresholdZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '相似度阈值';
+	@override String get hint => '分数低于此值的命中将被丢弃。留空 = 0.1（宽松 — BM25 稀疏向量很少超过 0.5）。';
+}
+
+// Path: web.serverSettings.fields.memoryScope
+class _TranslationsWebServerSettingsFieldsMemoryScopeZh extends TranslationsWebServerSettingsFieldsMemoryScopeEn {
+	_TranslationsWebServerSettingsFieldsMemoryScopeZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '默认作用域';
+	@override String get hint => 'agent 未指定时 memory_store 使用的作用域。"project"（推荐）按 cwd 分组；"session" 按会话隔离；"global" 跨 cwd 共享。';
+}
+
+// Path: web.serverSettings.fields.memoryBaseUrl
+class _TranslationsWebServerSettingsFieldsMemoryBaseUrlZh extends TranslationsWebServerSettingsFieldsMemoryBaseUrlEn {
+	_TranslationsWebServerSettingsFieldsMemoryBaseUrlZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'Base URL';
+	@override String get hint => '如 ollama 用 "http://localhost:11434/v1"，OpenAI 用 "https://api.openai.com/v1"。';
+}
+
+// Path: web.serverSettings.fields.memoryModel
+class _TranslationsWebServerSettingsFieldsMemoryModelZh extends TranslationsWebServerSettingsFieldsMemoryModelEn {
+	_TranslationsWebServerSettingsFieldsMemoryModelZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '模型';
+	@override String get hint => '如 ollama 用 "nomic-embed-text"，OpenAI 用 "text-embedding-3-small"。';
+}
+
+// Path: web.serverSettings.fields.memoryApiKey
+class _TranslationsWebServerSettingsFieldsMemoryApiKeyZh extends TranslationsWebServerSettingsFieldsMemoryApiKeyEn {
+	_TranslationsWebServerSettingsFieldsMemoryApiKeyZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'API 密钥';
+	@override String get hint => 'ollama / 本地服务可留空；OpenAI / Voyage / 托管服务必填。';
+}
+
+// Path: web.serverSettings.fields.memoryLocalModel
+class _TranslationsWebServerSettingsFieldsMemoryLocalModelZh extends TranslationsWebServerSettingsFieldsMemoryLocalModelEn {
+	_TranslationsWebServerSettingsFieldsMemoryLocalModelZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '模型名';
+	@override String get hint => '仅作显示用 — 出现在日志 / Inspector 中。如 "bge-m3"、"bge-small-en-v1.5"。';
+}
+
+// Path: web.serverSettings.fields.memoryLibraryPath
+class _TranslationsWebServerSettingsFieldsMemoryLibraryPathZh extends TranslationsWebServerSettingsFieldsMemoryLibraryPathEn {
+	_TranslationsWebServerSettingsFieldsMemoryLibraryPathZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '库路径';
+	@override String get hint => '存放 libonnxruntime.dylib (macOS) / libonnxruntime.so (Linux) 的目录。`brew install onnxruntime` 后即 /opt/homebrew/opt/onnxruntime/lib。';
+}
+
+// Path: web.serverSettings.fields.memoryModelPath
+class _TranslationsWebServerSettingsFieldsMemoryModelPathZh extends TranslationsWebServerSettingsFieldsMemoryModelPathEn {
+	_TranslationsWebServerSettingsFieldsMemoryModelPathZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '模型路径';
+	@override String get hint => '.onnx 权重的绝对路径。从 HuggingFace 下载，如 Xenova/bge-m3 或 Xenova/bge-small-en-v1.5。';
+}
+
+// Path: web.serverSettings.fields.memoryTokenizerPath
+class _TranslationsWebServerSettingsFieldsMemoryTokenizerPathZh extends TranslationsWebServerSettingsFieldsMemoryTokenizerPathEn {
+	_TranslationsWebServerSettingsFieldsMemoryTokenizerPathZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'Tokenizer 路径';
+	@override String get hint => 'tokenizer.json（HuggingFace 标准格式）的绝对路径 — 通常和模型放在一起。';
+}
+
+// Path: web.serverSettings.fields.memoryMaxSeqLen
+class _TranslationsWebServerSettingsFieldsMemoryMaxSeqLenZh extends TranslationsWebServerSettingsFieldsMemoryMaxSeqLenEn {
+	_TranslationsWebServerSettingsFieldsMemoryMaxSeqLenZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '最大序列长度';
+	@override String get hint => '超过这个 token 数会被截断。bge-m3 默认 512。留空 = 512。';
+}
+
+// Path: web.serverSettings.fields.claudeHistoryRoots
+class _TranslationsWebServerSettingsFieldsClaudeHistoryRootsZh extends TranslationsWebServerSettingsFieldsClaudeHistoryRootsEn {
+	_TranslationsWebServerSettingsFieldsClaudeHistoryRootsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '历史根目录';
+	@override String get hint => '扫描 Claude 每项目 JSONL 记录的目录。留空 = 扫描 ~/.claude/projects + 所有 ~/.claude-accounts/*/projects。';
+}
+
+// Path: web.serverSettings.fields.claudeAccountsDir
+class _TranslationsWebServerSettingsFieldsClaudeAccountsDirZh extends TranslationsWebServerSettingsFieldsClaudeAccountsDirEn {
+	_TranslationsWebServerSettingsFieldsClaudeAccountsDirZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '账号目录';
+	@override String get hint => 'opendray 管理的 Claude 账号 ConfigDir 根目录。默认 ~/.claude-accounts。';
+}
+
+// Path: web.serverSettings.fields.codexSessionsRoot
+class _TranslationsWebServerSettingsFieldsCodexSessionsRootZh extends TranslationsWebServerSettingsFieldsCodexSessionsRootEn {
+	_TranslationsWebServerSettingsFieldsCodexSessionsRootZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '会话根目录';
+	@override String get hint => '遍历 Codex rollout JSONL 文件的目录。默认 ~/.codex/sessions。';
+}
+
+// Path: web.serverSettings.fields.geminiTmpRoot
+class _TranslationsWebServerSettingsFieldsGeminiTmpRootZh extends TranslationsWebServerSettingsFieldsGeminiTmpRootEn {
+	_TranslationsWebServerSettingsFieldsGeminiTmpRootZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'tmp 目录';
+	@override String get hint => '存放 Gemini 每项目 tmp 文件夹的根目录。默认 ~/.gemini/tmp。';
+}
+
+// Path: web.serverSettings.fields.geminiProjectsFile
+class _TranslationsWebServerSettingsFieldsGeminiProjectsFileZh extends TranslationsWebServerSettingsFieldsGeminiProjectsFileEn {
+	_TranslationsWebServerSettingsFieldsGeminiProjectsFileZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'projects.json';
+	@override String get hint => 'Gemini cwd→短名映射文件的路径。默认 ~/.gemini/projects.json。';
+}
+
+// Path: web.serverSettings.fields.backupLocalDir
+class _TranslationsWebServerSettingsFieldsBackupLocalDirZh extends TranslationsWebServerSettingsFieldsBackupLocalDirEn {
+	_TranslationsWebServerSettingsFieldsBackupLocalDirZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '本地备份目录';
+	@override String get hint => '自动创建的 `local` 目标的默认根目录。留空 = ~/.opendray/backups。需要重启。';
+}
+
+// Path: web.serverSettings.fields.backupExportDir
+class _TranslationsWebServerSettingsFieldsBackupExportDirZh extends TranslationsWebServerSettingsFieldsBackupExportDirEn {
+	_TranslationsWebServerSettingsFieldsBackupExportDirZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '导出目录';
+	@override String get hint => '一次性导出 zip 在磁盘上的暂存位置。留空 = ~/.opendray/exports。包将在 24 小时后自动过期。需要重启。';
+}
+
+// Path: web.serverSettings.fields.backupPgDumpPath
+class _TranslationsWebServerSettingsFieldsBackupPgDumpPathZh extends TranslationsWebServerSettingsFieldsBackupPgDumpPathEn {
+	_TranslationsWebServerSettingsFieldsBackupPgDumpPathZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'pg_dump 路径';
+	@override String get hint => 'pg_dump 的绝对路径。主版本号必须 ≥ 服务器的。留空 = PATH 上的第一个 pg_dump。';
+}
+
+// Path: web.serverSettings.fields.backupPgRestorePath
+class _TranslationsWebServerSettingsFieldsBackupPgRestorePathZh extends TranslationsWebServerSettingsFieldsBackupPgRestorePathEn {
+	_TranslationsWebServerSettingsFieldsBackupPgRestorePathZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'pg_restore 路径';
+	@override String get hint => '/backups/restore 流程使用的 pg_restore 绝对路径。同样的主版本号规则。';
+}
+
+// Path: web.serverSettings.httpHelpers.presetTip
+class _TranslationsWebServerSettingsHttpHelpersPresetTipZh extends TranslationsWebServerSettingsHttpHelpersPresetTipEn {
+	_TranslationsWebServerSettingsHttpHelpersPresetTipZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get ollama => '本地 ollama 守护进程';
+	@override String get lmStudio => 'LM Studio 本地服务';
+	@override String get openai => 'OpenAI 云端（需要 API key）';
+}
+
+// Path: web.serverSettings.backup.scheduleHeaders
+class _TranslationsWebServerSettingsBackupScheduleHeadersZh extends TranslationsWebServerSettingsBackupScheduleHeadersEn {
+	_TranslationsWebServerSettingsBackupScheduleHeadersZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get schedule => '计划';
+	@override String get target => '目标';
+	@override String get cadence => '频率';
+	@override String get keep => '保留';
+	@override String get state => '状态';
+}
+
+// Path: web.settings.appearance.options
+class _TranslationsWebSettingsAppearanceOptionsZh extends TranslationsWebSettingsAppearanceOptionsEn {
+	_TranslationsWebSettingsAppearanceOptionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get light => '浅色';
+	@override String get lightDesc => '始终浅色';
+	@override String get dark => '深色';
+	@override String get darkDesc => '始终深色';
+	@override String get system => '跟随系统';
+	@override String get systemDesc => '跟随操作系统设置';
+}
+
+// Path: web.settings.font.options
+class _TranslationsWebSettingsFontOptionsZh extends TranslationsWebSettingsFontOptionsEn {
+	_TranslationsWebSettingsFontOptionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get compact => '紧凑';
+	@override String get kDefault => '默认';
+	@override String get comfy => '舒适';
+	@override String get large => '大';
+}
+
+// Path: web.memoryAmbient.providers.row
+class _TranslationsWebMemoryAmbientProvidersRowZh extends TranslationsWebMemoryAmbientProvidersRowEn {
+	_TranslationsWebMemoryAmbientProvidersRowZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get defaultBadge => '★ 默认';
+	@override String get makeDefault => '设为默认';
+	@override String get test => '测试';
+	@override String get testing => '测试中…';
+	@override String get delete => '删除';
+	@override String testOk({required Object name}) => '${name}：连接成功';
+	@override String get testFailedToast => '测试失败';
+	@override String deleteConfirm({required Object name}) => '删除 provider "${name}"?';
+	@override String get deletedToast => 'Provider 已删除';
+	@override String get deleteFailedToast => '删除失败';
+	@override String get updateFailedToast => '更新失败';
+	@override String madeDefaultToast({required Object name}) => '${name} 已设为默认';
+}
+
+// Path: web.memoryAmbient.providers.dialog
+class _TranslationsWebMemoryAmbientProvidersDialogZh extends TranslationsWebMemoryAmbientProvidersDialogEn {
+	_TranslationsWebMemoryAmbientProvidersDialogZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '添加 summarizer provider';
+	@override String get kindLabel => '类型';
+	@override String get nameLabel => '名称';
+	@override String get namePlaceholder => '例如 lmstudio-qwen';
+	@override String get modelLabel => '模型';
+	@override String get baseUrlLabel => 'Base URL';
+	@override String get integrationNote => 'Integration 类型 provider 通过一个已注册的集成解析 base URL。请先在 Integrations 中配置；更高级的 wiring（extra_config）在本版本中仅 DB 配置。';
+	@override String get apiKeyLabel => 'API key';
+	@override String get apiKeyHint => 'AES-GCM 加密存储（使用 backup 主口令）。不会被回显；保存后只显示指纹。';
+	@override String get makeDefaultLabel => '将此设为默认 provider';
+	@override String get create => '创建';
+	@override String get nameRequiredToast => '名称不能为空';
+	@override String createdToast({required Object name}) => '已创建 Provider ${name}';
+	@override String get createFailedToast => '创建失败';
+}
+
+// Path: web.memoryAmbient.rules.row
+class _TranslationsWebMemoryAmbientRulesRowZh extends TranslationsWebMemoryAmbientRulesRowEn {
+	_TranslationsWebMemoryAmbientRulesRowZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get globalDefault => '全局默认';
+	@override String get scopeLabel => 'scope:';
+	@override String get dedupLabel => 'dedup:';
+	@override String get runNow => '立即运行';
+	@override String get running => '运行中…';
+	@override String get delete => '删除';
+	@override String firedToast({required Object sessions}) => '规则已对 ${sessions} 个会话触发';
+	@override String get runNowFailedToast => '立即运行失败';
+	@override String deleteConfirm({required Object name}) => '删除规则 "${name}"?';
+	@override String get deletedToast => '规则已删除';
+	@override String get deleteFailedToast => '删除失败';
+	@override late final _TranslationsWebMemoryAmbientRulesRowSummaryZh summary = _TranslationsWebMemoryAmbientRulesRowSummaryZh._(_root);
+}
+
+// Path: web.memoryAmbient.rules.dialog
+class _TranslationsWebMemoryAmbientRulesDialogZh extends TranslationsWebMemoryAmbientRulesDialogEn {
+	_TranslationsWebMemoryAmbientRulesDialogZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '添加捕获规则';
+	@override String get nameLabel => '名称';
+	@override String get triggerLabel => 'Trigger';
+	@override String get nLabel => 'N（消息条数）';
+	@override String get idleLabel => 'Idle 秒数';
+	@override String get kLabel => 'K（字符数）';
+	@override String get scopeLabel => '目标 scope';
+	@override String get scopeSession => 'session';
+	@override String get scopeProject => 'project（推荐）';
+	@override String get scopeGlobal => 'global';
+	@override String get dedupLabel => '去重阈值（0.0 – 1.0）';
+	@override String get dedupHint => '越高 = 去重越严格。0.85 是推荐的平衡点。';
+	@override String get create => '创建';
+	@override String get nameRequiredToast => '名称不能为空';
+	@override String createdToast({required Object name}) => '已创建规则 ${name}';
+	@override String get createFailedToast => '创建失败';
+}
+
+// Path: web.memoryAmbient.profiles.row
+class _TranslationsWebMemoryAmbientProfilesRowZh extends TranslationsWebMemoryAmbientProfilesRowEn {
+	_TranslationsWebMemoryAmbientProfilesRowZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get globalDefault => '全局默认';
+	@override String get delete => '删除';
+	@override String get deleteConfirm => '删除该 injection profile?';
+	@override String get deletedToast => 'Profile 已删除';
+	@override String get deleteFailedToast => '删除失败';
+}
+
+// Path: web.memoryAmbient.profiles.dialog
+class _TranslationsWebMemoryAmbientProfilesDialogZh extends TranslationsWebMemoryAmbientProfilesDialogEn {
+	_TranslationsWebMemoryAmbientProfilesDialogZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '添加 injection profile';
+	@override String get strategyLabel => '策略';
+	@override String get kLabel => 'K（注入的 top memory 数）';
+	@override String get hint => '每个 session_id 一个 profile（或全局默认）。单会话 profile 暂只能通过 API 添加；UI 当前只管理全局默认。';
+	@override String get create => '创建';
+	@override String get createdToast => 'Profile 已创建';
+	@override String get createFailedToast => '创建失败';
+}
+
+// Path: web.memoryAmbient.cost.columns
+class _TranslationsWebMemoryAmbientCostColumnsZh extends TranslationsWebMemoryAmbientCostColumnsEn {
+	_TranslationsWebMemoryAmbientCostColumnsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get provider => 'Provider';
+	@override String get calls => '调用';
+	@override String get inTokens => '输入 token';
+	@override String get outTokens => '输出 token';
+	@override String get usdEst => 'USD 估算';
+}
+
+// Path: web.export.form.integrationOptions
+class _TranslationsWebExportFormIntegrationOptionsZh extends TranslationsWebExportFormIntegrationOptionsEn {
+	_TranslationsWebExportFormIntegrationOptionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get none => '无';
+	@override String get noneHint => '完全跳过 integrations 表。';
+	@override String get metadata => '仅元数据（推荐）';
+	@override String get metadataHint => 'ID、name、route prefix、scopes — 不包含任何 API key 凭证。';
+	@override String get plaintext => '包含明文 API key';
+	@override String get plaintextHint => 'v1 仅 bcrypt：不存在可恢复的明文。Manifest 会记录此事实；不会泄露任何内容。';
+}
+
+// Path: web.export.history.columns
+class _TranslationsWebExportHistoryColumnsZh extends TranslationsWebExportHistoryColumnsEn {
+	_TranslationsWebExportHistoryColumnsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get id => 'ID';
+	@override String get status => '状态';
+	@override String get scope => '范围';
+	@override String get size => '大小';
+	@override String get expires => '过期';
+	@override String get actions => '操作';
+}
+
+// Path: web.export.import.summaryCard
+class _TranslationsWebExportImportSummaryCardZh extends TranslationsWebExportImportSummaryCardEn {
+	_TranslationsWebExportImportSummaryCardZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get memories => '记忆';
+	@override String get integrations => '集成';
+	@override String get customTasks => '自定义任务';
+	@override String get created => '已创建';
+	@override String get skipped => '已跳过';
+	@override String get failed => '失败';
+}
+
+// Path: web.export.imports.columns
+class _TranslationsWebExportImportsColumnsZh extends TranslationsWebExportImportsColumnsEn {
+	_TranslationsWebExportImportsColumnsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get id => 'ID';
+	@override String get status => '状态';
+	@override String get source => '来源';
+	@override String get counts => '计数';
+	@override String get when => '时间';
+}
+
 // Path: sessions.inspector.shell.tabs
 class _TranslationsSessionsInspectorShellTabsZh extends TranslationsSessionsInspectorShellTabsEn {
 	_TranslationsSessionsInspectorShellTabsZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -2428,6 +6578,32 @@ class _TranslationsSessionsInspectorShellTabsZh extends TranslationsSessionsInsp
 	@override String get tasks => '任务';
 	@override String get history => '历史';
 	@override String get notes => '笔记';
+}
+
+// Path: web.notes.vaultSync.conflict.kinds
+class _TranslationsWebNotesVaultSyncConflictKindsZh extends TranslationsWebNotesVaultSyncConflictKindsEn {
+	_TranslationsWebNotesVaultSyncConflictKindsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get rebase => 'rebase';
+	@override String get merge => 'merge';
+	@override String get cherryPick => 'cherry-pick';
+	@override String get operation => 'operation';
+}
+
+// Path: web.memoryAmbient.rules.row.summary
+class _TranslationsWebMemoryAmbientRulesRowSummaryZh extends TranslationsWebMemoryAmbientRulesRowSummaryEn {
+	_TranslationsWebMemoryAmbientRulesRowSummaryZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String afterMessages({required Object n}) => '每 ${n} 条消息';
+	@override String onIdle({required Object seconds}) => 'idle ≥ ${seconds}s';
+	@override String kChars({required Object k}) => '≥ ${k} 字符';
+	@override String get manual => '仅手动';
 }
 
 /// The flat map containing all translations for locale <zh>.
@@ -2455,12 +6631,1714 @@ extension on TranslationsZh {
 			'auth.username' => '用户名',
 			'auth.password' => '密码',
 			'auth.signIn' => '登录',
+			'auth.signingIn' => '登录中…',
+			'auth.subtitle' => '请使用运维账号登录。',
 			'auth.errorRequired' => '请输入用户名和密码',
 			'auth.errorGeneric' => ({required Object error}) => '登录失败：${error}',
+			'auth.errorFallback' => '登录失败',
 			'nav.sessions' => '会话',
 			'nav.memory' => '记忆',
 			'nav.notes' => '笔记',
 			'nav.more' => '更多',
+			'nav.activity' => '活动',
+			'nav.providers' => '提供方',
+			'nav.channels' => '频道',
+			'nav.integrations' => '集成',
+			'nav.plugins' => '插件',
+			'nav.backups' => '备份',
+			'nav.settings' => '设置',
+			'nav.tutorial' => '教程',
+			'nav.workspace' => '工作区',
+			'web.brand' => 'opendray',
+			'web.loading' => '加载中…',
+			'web.topbar.expandSidebar' => '展开侧边栏',
+			'web.topbar.collapseSidebar' => '收起侧边栏',
+			'web.topbar.search' => '搜索',
+			'web.topbar.openPalette' => '打开命令面板',
+			'web.topbar.theme' => '主题',
+			'web.topbar.themeLabel' => ({required Object mode}) => '主题：${mode}',
+			'web.topbar.appearance' => '外观',
+			'web.topbar.themeLight' => '浅色',
+			'web.topbar.themeDark' => '深色',
+			'web.topbar.themeSystem' => '跟随系统',
+			'web.topbar.language' => '语言',
+			'web.topbar.languageEnglish' => 'English',
+			'web.topbar.languageChinese' => '中文',
+			'web.topbar.signedInAs' => '登录账号',
+			'web.topbar.tokenExpires' => '令牌到期',
+			'web.topbar.signOut' => '退出登录',
+			'web.sessions.list.title' => '会话',
+			'web.sessions.list.countSeparator' => '·',
+			'web.sessions.list.newAria' => '创建新会话',
+			'web.sessions.list.newTooltip' => '新建会话',
+			'web.sessions.list.loading' => '加载中…',
+			'web.sessions.list.emptyTitle' => '暂无会话。',
+			'web.sessions.list.emptyHint' => ({required Object kbd}) => '按 ${kbd} 创建。',
+			'web.sessions.list.endedHeader' => ({required Object count}) => '已结束 (${count})',
+			'web.sessions.list.clearAll' => '清空全部',
+			'web.sessions.list.confirmClearAll' => ({required Object count}) => '确定移除全部 ${count} 个已结束的会话?',
+			'web.sessions.list.confirmTerminate' => ({required Object name}) => '终止并移除 ${name}?',
+			'web.sessions.list.childPromoted' => ({required Object count}) => '其 ${count} 个子任务会话将被提升为顶级。',
+			'web.sessions.list.childPromotedPlural' => ({required Object count}) => '其 ${count} 个子任务会话将被提升为顶级。',
+			'web.sessions.list.footer' => ({required Object live, required Object ended}) => '${live} 运行中 · ${ended} 已结束',
+			'web.sessions.list.row.deleteAria' => '删除会话',
+			'web.sessions.list.row.titleRemoveHistory' => '从历史中移除',
+			'web.sessions.list.row.titleTerminate' => '终止并移除',
+			'web.sessions.list.row.titleRemove' => '移除',
+			'web.sessions.list.row.claudeAccountTitle' => ({required Object label}) => 'Claude 账号：${label}',
+			'web.sessions.list.deleteFailedToast' => '删除失败',
+			'web.sessions.tabs.closeAria' => '关闭标签并移除会话',
+			'web.sessions.tabs.closeTitle' => '关闭标签并移除会话',
+			'web.sessions.page.removedToast' => '会话已移除',
+			'web.sessions.page.removeFailedToast' => '移除失败',
+			'web.sessions.page.stoppedToast' => '会话已停止',
+			'web.sessions.page.stopFailedToast' => '停止失败',
+			'web.sessions.page.restartedToast' => '会话已重启',
+			'web.sessions.page.restartFailedToast' => '重启失败',
+			'web.sessions.page.confirmCloseTabTitle' => ({required Object name}) => '停止并移除 "${name}"?',
+			'web.sessions.page.confirmCloseTabDescription' => 'CLI 进程将被终止并删除该记录。',
+			'web.sessions.page.confirmCloseTabConfirm' => '停止并移除',
+			'web.sessions.page.confirmRemoveTitle' => ({required Object name}) => '移除 ${name}?',
+			'web.sessions.page.confirmRemoveTitleFallback' => '移除会话?',
+			'web.sessions.page.confirmRemoveDescription' => '这将删除该记录。',
+			'web.sessions.page.confirmRemoveConfirm' => '移除',
+			'web.sessions.empty.title' => '未打开任何会话',
+			'web.sessions.empty.hint' => ({required Object kbdN, required Object kbdW, required Object kbdRange}) => '从列表中挑选一个会话，或新建一个。快捷键：${kbdN} 新建，${kbdW} 关闭，${kbdRange} 切换。',
+			'web.sessions.empty.spawn' => '创建会话',
+			'web.sessions.header.loadingSession' => '正在加载会话…',
+			'web.sessions.header.showList' => '显示会话列表',
+			'web.sessions.header.hideList' => '隐藏会话列表',
+			'web.sessions.header.showInspector' => '显示检查器',
+			'web.sessions.header.hideInspector' => '隐藏检查器',
+			'web.sessions.header.attachImage' => '附加图片',
+			'web.sessions.header.attachImageTooltip' => '附加图片（或直接粘贴 / 拖入终端）',
+			'web.sessions.header.restart' => '重启',
+			'web.sessions.header.restarting' => '重启中…',
+			'web.sessions.header.remove' => '移除',
+			'web.sessions.header.removing' => '移除中…',
+			'web.sessions.header.stop' => '停止',
+			'web.sessions.header.stopping' => '停止中…',
+			'web.sessions.header.pid' => ({required Object pid}) => 'pid ${pid}',
+			'web.sessions.terminal.uploadingToast' => '正在上传图片…',
+			'web.sessions.terminal.uploadedToast' => '图片已附加',
+			'web.sessions.terminal.uploadFailedToast' => '上传失败',
+			'web.sessions.terminal.uploadInvalidTypeToast' => '仅支持图片文件',
+			'web.sessions.terminal.dropToAttach' => '释放以附加图片',
+			'web.sessions.spawn.title' => '创建会话',
+			'web.sessions.spawn.description' => '在已注册的 Provider 下启动一个 CLI 会话。',
+			'web.sessions.spawn.provider' => 'Provider',
+			'web.sessions.spawn.claudeAccount' => 'Claude 账号',
+			'web.sessions.spawn.loadingAccounts' => '正在加载账号…',
+			'web.sessions.spawn.noAccounts' => '尚未配置 Claude 账号 — 网关将使用系统的 ANTHROPIC_API_KEY。',
+			'web.sessions.spawn.kDefault' => '默认',
+			'web.sessions.spawn.defaultTooltip' => '使用系统 keychain / 环境变量',
+			'web.sessions.spawn.tokenEmptyBadge' => '·未填',
+			'web.sessions.spawn.tokenMissingTooltip' => '未设置 token — 请先在 Providers 面板中填入',
+			'web.sessions.spawn.multiAccountHint' => '已配置多个账号 — 请为本次会话挑选一个。',
+			'web.sessions.spawn.cwd' => '工作目录',
+			'web.sessions.spawn.cwdPlaceholder' => '/Users/you/projects/foo',
+			'web.sessions.spawn.browse' => '浏览',
+			'web.sessions.spawn.nameLabel' => '名称（可选）',
+			'web.sessions.spawn.namePlaceholder' => 'claude in pet-tracker',
+			'web.sessions.spawn.argsLabel' => 'CLI 参数（每行一个）',
+			'web.sessions.spawn.bypassClaude' => '跳过权限提示',
+			'web.sessions.spawn.bypassCodex' => '自动批准 (--ask-for-approval never)',
+			'web.sessions.spawn.bypassGemini' => 'YOLO 模式 (--yolo)',
+			'web.sessions.spawn.bypassOnHint' => '本次会话将以更高的自主权运行。',
+			'web.sessions.spawn.bypassOffHint' => '关闭 — 确认与提示按正常流程处理。',
+			'web.sessions.spawn.errorPickProvider' => '请选择一个 Provider。',
+			'web.sessions.spawn.errorCwdRequired' => '请填写工作目录。',
+			'web.sessions.spawn.cancel' => '取消',
+			'web.sessions.spawn.submit' => '创建',
+			'web.sessions.spawn.submitting' => '创建中…',
+			'web.sessions.spawn.spawnedToast' => '会话已创建',
+			'web.sessions.spawn.spawnedDescription' => ({required Object provider, required Object pid}) => '${provider} · pid ${pid}',
+			'web.sessions.spawn.pidFallback' => '—',
+			'web.sessions.accountSwitcher.tooltip' => '切换 Claude 账号（将重启 CLI 进程）',
+			'web.sessions.accountSwitcher.currentDefault' => '默认',
+			'web.sessions.accountSwitcher.menuTitle' => '切换 Claude 账号',
+			'web.sessions.accountSwitcher.defaultName' => '默认',
+			'web.sessions.accountSwitcher.defaultSubtitle' => 'CLI 的系统 keychain / 环境变量',
+			'web.sessions.accountSwitcher.tokenEmpty' => '·未填',
+			'web.sessions.accountSwitcher.confirmSwitch' => '切换账号将重启 Claude CLI 进程。CLI 内部进行中的对话状态将丢失。继续？',
+			'web.sessions.accountSwitcher.switchedToast' => '账号已切换',
+			'web.sessions.accountSwitcher.switchedDescription' => ({required Object account, required Object pid}) => '当前使用 @${account} · pid ${pid}',
+			'web.sessions.accountSwitcher.switchedDefault' => '默认',
+			'web.sessions.accountSwitcher.switchFailedToast' => '切换失败',
+			'web.sessions.inspector.tabs.files' => '文件',
+			'web.sessions.inspector.tabs.git' => 'Git',
+			'web.sessions.inspector.tabs.search' => '搜索',
+			'web.sessions.inspector.tabs.tasks' => '任务',
+			'web.sessions.inspector.tabs.history' => '历史',
+			'web.sessions.inspector.tabs.notes' => '笔记',
+			'web.sessions.inspector.tabs.memory' => '记忆',
+			'web.sessions.ended.bufferUnavailable' => '[缓冲区不可用]',
+			'web.sessions.ended.readOnlyBanner' => '[会话已结束 — 只读缓冲区]',
+			'web.sessions.fileBrowser.title' => '选择工作目录',
+			'web.sessions.fileBrowser.description' => '浏览网关主机的文件系统并选择一个文件夹。',
+			'web.sessions.fileBrowser.parent' => '上级目录',
+			'web.sessions.fileBrowser.home' => '家目录',
+			'web.sessions.fileBrowser.refresh' => '刷新',
+			'web.sessions.fileBrowser.pathPlaceholder' => '/Users/you/projects',
+			'web.sessions.fileBrowser.loading' => '加载中…',
+			'web.sessions.fileBrowser.empty' => '目录为空。',
+			'web.sessions.fileBrowser.newFolder' => '新建文件夹',
+			'web.sessions.fileBrowser.newFolderPlaceholder' => 'new-folder-name',
+			'web.sessions.fileBrowser.create' => '创建',
+			'web.sessions.fileBrowser.cancel' => '取消',
+			'web.sessions.fileBrowser.useThisFolder' => '使用此文件夹',
+			'web.sessions.fileBrowser.createdToast' => '文件夹已创建',
+			'web.sessions.fileBrowser.mkdirFailedToast' => '创建失败',
+			'web.sessions.fileBrowser.homeFailedToast' => '读取家目录失败',
+			'web.memory.title' => '记忆',
+			'web.memory.subtitle' => '浏览、搜索并编辑 Agent 通过 opendray-memory MCP 服务器存储的记忆。',
+			'web.memory.navProject' => '项目',
+			'web.memory.navCleanupInbox' => '清理收件箱',
+			'web.memory.navWorkers' => 'Workers',
+			'web.memory.navConfiguration' => '配置 →',
+			'web.memoryWorkers.title' => 'Memory workers',
+			'web.memoryWorkers.loading' => '正在加载 worker 配置…',
+			'web.memoryWorkers.errorTitle' => '无法访问该接口。',
+			'web.memoryWorkers.errorDescription' => '/api/v1/memory/workers 路由在 M25 中新增 — opendray 二进制可能需要重启以挂载它们并执行 migration 0029。',
+			'web.memoryWorkers.intro' => 'Memory 子系统的每个 LLM 接入点都可由本地 <1>summarizer</1>（LM Studio / OpenAI 兼容）端点服务，或通过以 <5>--print</5> 模式启动的无头 <3>Claude / Gemini agent</3> 服务。叙事性任务（gitactivity、transcript）从 agent worker 中获益；高频任务（gatekeeper）按设计仍走本地端点。',
+			'web.memoryWorkers.enabledBadge' => '已启用',
+			'web.memoryWorkers.disabledBadge' => '已禁用',
+			'web.memoryWorkers.summarizerOnlyBadge' => '仅 summarizer',
+			'web.memoryWorkers.callsCount' => ({required Object count}) => '${count} 次调用 · 24 小时',
+			'web.memoryWorkers.avgMs' => ({required Object ms}) => '平均 ${ms}ms',
+			'web.memoryWorkers.errorsCount' => ({required Object count}) => '${count} 次错误',
+			'web.memoryWorkers.workerLabel' => 'Worker',
+			'web.memoryWorkers.summarizerHttp' => 'Summarizer (HTTP)',
+			'web.memoryWorkers.agentCliPrint' => 'Agent (CLI --print)',
+			'web.memoryWorkers.summarizerProviderLabel' => 'Summarizer Provider',
+			'web.memoryWorkers.registryDefault' => '注册表默认值',
+			'web.memoryWorkers.cliLabel' => 'CLI',
+			'web.memoryWorkers.selectPlaceholder' => '选择',
+			'web.memoryWorkers.cliClaude' => 'Claude',
+			'web.memoryWorkers.cliGemini' => 'Gemini',
+			'web.memoryWorkers.claudeAccountLabel' => 'Claude 账号',
+			'web.memoryWorkers.claudeAccountDefault' => '默认',
+			'web.memoryWorkers.agentWarning' => 'Agent 模式每次调用都会启动一个无头 CLI。延迟从 <1>~1s</1>（summarizer）上升到 <3>~5-15s</3>；成本从 CPU 转移到 Claude/Gemini 配额。',
+			'web.memoryWorkers.enabledCheckbox' => '启用',
+			'web.memoryWorkers.testButton' => '测试',
+			'web.memoryWorkers.saveButton' => '保存',
+			'web.memoryWorkers.recentCalls' => ({required Object count}) => '最近调用 (${count})',
+			'web.memoryWorkers.tableWhen' => '时间',
+			'web.memoryWorkers.tableWorker' => 'worker',
+			'web.memoryWorkers.tableMs' => 'ms',
+			'web.memoryWorkers.tableOk' => 'ok',
+			'web.memoryWorkers.savedToast' => ({required Object label}) => '${label} 已更新',
+			'web.memoryWorkers.saveFailedToast' => '保存失败',
+			'web.memoryWorkers.testOkToast' => ({required Object label, required Object ms}) => '${label} OK — ${ms}ms',
+			'web.memoryWorkers.testFailedToast' => ({required Object label}) => '${label} 失败',
+			'web.memoryWorkers.testCallFailedToast' => '测试调用失败',
+			'web.memoryWorkers.unknownError' => '未知错误',
+			'web.memoryWorkers.tasks.gatekeeper.label' => 'Gatekeeper',
+			'web.memoryWorkers.tasks.gatekeeper.description' => '每次 memory_store 前的预写过滤器。高频（目标 <500ms） — 仅 summarizer。',
+			'web.memoryWorkers.tasks.cleaner.label' => 'Cleaner librarian',
+			'web.memoryWorkers.tasks.cleaner.description' => '周期性 LLM 整理。对旧记忆判定为保留 / 过期 / 重复。',
+			'web.memoryWorkers.tasks.gitactivity.label' => 'Git 活动总结器',
+			'web.memoryWorkers.tasks.gitactivity.description' => 'git log → 每 24 小时生成 2-3 段叙事。天然适合 agent worker。',
+			'web.memoryWorkers.tasks.transcript.label' => '会话记录总结器',
+			'web.memoryWorkers.tasks.transcript.description' => '会话结束时的“agent 都做了什么”总结。天然适合 agent worker。',
+			'web.cleanupInbox.loading' => '加载中…',
+			'web.cleanupInbox.emptyTitle' => '清理收件箱为空',
+			'web.cleanupInbox.emptyDescription' => '目前所有项目均无待处理的清理决策。LLM librarian 要么尚未跑过这些记忆，要么判断全部仍是关键内容。',
+			'web.cleanupInbox.title' => '清理收件箱',
+			'web.cleanupInbox.subtitle' => 'LLM memory librarian 的跨项目待处理决策。批准 stale → 删除，批准 duplicate → 合并，批准 keep → 一段时间内冻结该条目不再被重新判断。',
+			'web.cleanupInbox.globalScope' => '(全局)',
+			'web.cleanupInbox.orphanBadge' => '孤立',
+			'web.cleanupInbox.orphanTitle' => 'scope_key 被截断（老旧的镜像导入数据）。不是可导航的项目。',
+			'web.cleanupInbox.openProject' => '打开项目',
+			'web.cleanupInbox.mergeIntoPrefix' => '→ 合并到',
+			'web.cleanupInbox.reasonPrefix' => '原因：',
+			'web.cleanupInbox.executeButton' => '执行',
+			'web.cleanupInbox.confirmKeepButton' => '确认保留',
+			'web.cleanupInbox.rejectButton' => '驳回',
+			'web.cleanupInbox.approvedKeptToast' => '已保留',
+			'web.cleanupInbox.approvedExecutedToast' => ({required Object verdict}) => '已执行 ${verdict}',
+			'web.cleanupInbox.approveFailedToast' => '批准失败',
+			'web.cleanupInbox.rejectedToast' => '已驳回 — 记忆保留',
+			'web.cleanupInbox.rejectFailedToast' => '驳回失败',
+			'web.project.picker.title' => '选择项目',
+			'web.project.picker.subtitle' => '项目记忆按工作目录划分。选择一个以管理它的目标、计划、日志和清理队列。',
+			'web.project.picker.pathPlaceholder' => '/path/to/your/project',
+			'web.project.picker.browse' => '浏览',
+			'web.project.picker.browseTooltip' => '浏览网关主机的文件系统',
+			'web.project.picker.open' => '打开',
+			'web.project.picker.recentLabel' => '最近的项目（来自已存记忆）：',
+			'web.project.picker.orphanTooltip' => '看上去是被截断的 scope_key（老旧镜像导入 bug）。可能没有项目文档。',
+			'web.project.picker.orphanBadge' => '孤立',
+			'web.project.noCwd' => '选择一个项目以管理其记忆。',
+			'web.project.header.docsCount_one' => ({required Object count}) => '${count} 份文档',
+			'web.project.header.docsCount_other' => ({required Object count}) => '${count} 份文档',
+			'web.project.header.journalEntries_one' => ({required Object count}) => '${count} 条日志',
+			'web.project.header.journalEntries_other' => ({required Object count}) => '${count} 条日志',
+			'web.project.header.pendingProposals_one' => ({required Object count}) => '${count} 条待处理提案',
+			'web.project.header.pendingProposals_other' => ({required Object count}) => '${count} 条待处理提案',
+			'web.project.header.cleanupPending' => ({required Object count}) => '${count} 条待清理',
+			'web.project.tabs.goal' => '目标',
+			'web.project.tabs.plan' => '计划',
+			'web.project.tabs.tech' => '技术栈',
+			'web.project.tabs.activity' => '活动',
+			'web.project.tabs.journal' => '日志',
+			'web.project.tabs.inbox' => '收件箱',
+			'web.project.tabs.cleanup' => '清理',
+			'web.project.docLabel.goal' => '目标',
+			'web.project.docLabel.plan' => '计划',
+			'web.project.docLabel.tech_stack' => '技术栈',
+			'web.project.docLabel.recent_activity' => '最近活动',
+			'web.project.verdictLabel.stale' => '删除',
+			'web.project.verdictLabel.duplicate' => '合并',
+			'web.project.verdictLabel.keep' => '保留',
+			'web.project.editor.updatedBy' => '更新者',
+			'web.project.editor.noDocSet' => ({required Object label}) => '尚未设置${label}。',
+			'web.project.editor.save' => '保存',
+			'web.project.editor.saveFailedToast' => '保存失败',
+			'web.project.editor.savedToast' => ({required Object label}) => '${label}已保存',
+			'web.project.editor.goalPlaceholder' => '我们在做什么？一段文字。每个 agent 在 spawn 时都会读取。',
+			'web.project.editor.planPlaceholder' => '当前计划 — 现在在做什么、下一步是什么。随进度更新。',
+			'web.project.readonly.tech_stack.label' => '技术栈与结构',
+			'web.project.readonly.tech_stack.empty' => '在该项目运行一次 Claude 会话 — scanner 会在每次 spawn 时刷新。',
+			'web.project.readonly.recent_activity.label' => '最近活动 (git → LLM)',
+			'web.project.readonly.recent_activity.empty' => 'Git 活动总结每 24 小时运行；下次调度后再来看看。',
+			'web.project.readonly.noneCaptured' => ({required Object label}) => '尚未捕获${label}。',
+			'web.project.readonly.generatedBy' => '生成者',
+			'web.project.readonly.lastRefresh' => '最近刷新',
+			'web.project.journal.loading' => '加载中…',
+			'web.project.journal.empty' => '暂无日志条目。每次会话结束都会自动追加一条。',
+			'web.project.inbox.loading' => '加载中…',
+			'web.project.inbox.emptyTitle' => '收件箱为空。',
+			'web.project.inbox.emptyHint' => 'Agent 通过 `project_goal_set` / `project_plan_set` MCP 工具在这里提交提案。',
+			'web.project.inbox.approvedToast' => ({required Object label}) => '${label}已更新',
+			'web.project.inbox.approveFailedToast' => '批准失败',
+			'web.project.inbox.rejectedToast' => '已驳回',
+			'web.project.inbox.rejectFailedToast' => '驳回失败',
+			'web.project.inbox.sessionPrefix' => 'ses',
+			'web.project.inbox.warning' => ({required Object label}) => '批准将完全替换当前${label}。',
+			'web.project.inbox.warningSuffix' => '请检查下方 diff；这不是合并。',
+			'web.project.inbox.current' => '当前',
+			'web.project.inbox.proposed' => '提议',
+			'web.project.inbox.emptyBody' => '(空)',
+			'web.project.inbox.approve' => '批准',
+			'web.project.inbox.reject' => '驳回',
+			'web.project.inbox.confirmDialogTitle' => ({required Object label}) => '替换${label}?',
+			'web.project.inbox.confirmDialogDescription' => ({required Object label}) => '当前${label}将被提议内容覆盖。无法通过本界面撤销（可手动改回）。',
+			'web.project.inbox.confirmCancel' => '取消',
+			'web.project.inbox.confirmReplace' => '确认替换',
+			'web.project.cleanup.hint' => 'LLM librarian 为该项目的记忆提出保留 / 过期 / 重复 的判定。删除前需你批准。',
+			'web.project.cleanup.runNow' => '立即运行清理',
+			'web.project.cleanup.runSucceededToast' => ({required Object decided, required Object scanned}) => '清理已运行：${decided} 条决策入队（扫描了 ${scanned} 条）',
+			'web.project.cleanup.runFailedToast' => '清理运行失败',
+			'web.project.cleanup.empty' => '暂无待处理决策。要么没有记忆达到判定年龄，要么上次运行判断全部仍是关键内容。',
+			'web.project.cleanup.mergeIntoPrefix' => '→ 合并到',
+			'web.project.cleanup.reasonPrefix' => '原因：',
+			'web.project.cleanup.executeButton' => '执行',
+			'web.project.cleanup.confirmKeepButton' => '确认保留',
+			'web.project.cleanup.rejectButton' => '驳回',
+			'web.project.cleanup.approvedExecutedToast' => ({required Object label}) => '已执行${label}',
+			'web.project.cleanup.approveFailedToast' => '批准失败',
+			'web.project.cleanup.rejectedToast' => '已驳回 — 记忆保留',
+			'web.project.cleanup.rejectFailedToast' => '驳回失败',
+			'web.project.reset.button' => '重置',
+			'web.project.reset.dialogTitle' => '重置项目记忆?',
+			'web.project.reset.dialogDescription' => '删除该 cwd 下存储的所有项目上下文。不可撤销。',
+			'web.project.reset.alwaysDeleted' => '始终删除：目标、计划、提案、日志、清理决策。',
+			'web.project.reset.alsoDeleteScannerLabel' => '同时删除 scanner 文档',
+			'web.project.reset.alsoDeleteScannerSuffix' => '(tech_stack + recent_activity)。',
+			'web.project.reset.alsoDeleteScannerHint' => '下次 spawn 会自动重建 — 通常不勾选即可。',
+			'web.project.reset.alsoDeleteMemoriesLabel' => '同时删除 pgvector 记忆',
+			'web.project.reset.alsoDeleteMemoriesSuffix' => '（该 scope_key 下的）。',
+			'web.project.reset.alsoDeleteMemoriesHint' => 'Agent 存储的长期事实（用户偏好、项目事实）。无法恢复。',
+			'web.project.reset.cancel' => '取消',
+			'web.project.reset.deleteForever' => '永久删除',
+			'web.project.reset.successToast' => ({required Object summary}) => '重置：已删除 ${summary}',
+			'web.project.reset.summary.docs_one' => ({required Object count}) => '${count} 份文档',
+			'web.project.reset.summary.docs_other' => ({required Object count}) => '${count} 份文档',
+			'web.project.reset.summary.journal' => ({required Object count}) => '${count} 条日志',
+			'web.project.reset.summary.proposals_one' => ({required Object count}) => '${count} 条提案',
+			'web.project.reset.summary.proposals_other' => ({required Object count}) => '${count} 条提案',
+			'web.project.reset.summary.cleanup' => ({required Object count}) => '${count} 条清理',
+			'web.project.reset.summary.memories' => ({required Object count}) => '${count} 条记忆',
+			'web.project.reset.failedToast' => '重置失败',
+			'web.memoryInspector.status.label' => '当前 embedder',
+			'web.memoryInspector.status.unavailable' => '不可用',
+			'web.memoryInspector.status.probing' => '探测中…',
+			'web.memoryInspector.status.dimensions' => ({required Object dim, required Object state}) => '${dim} 维 · ${state}',
+			'web.memoryInspector.status.enabled' => '已启用',
+			'web.memoryInspector.status.disabled' => '已禁用',
+			'web.memoryInspector.status.testButton' => '测试 embedder',
+			'web.memoryInspector.statusBody' => '这是网关当前用于每次 <1>memory_search</1> / <3>memory_store</3> 调用的 embedder。如果与上方配置不一致，说明有未保存的更改 — 点击 Save 后重启服务即可生效。',
+			'web.memoryInspector.scope.label' => 'Scope',
+			'web.memoryInspector.scope.scopeKey' => 'Scope key',
+			'web.memoryInspector.scope.scopeKeyIgnored' => '(global 时忽略)',
+			'web.memoryInspector.scope.scopeKeyCwd' => '(项目的 cwd)',
+			'web.memoryInspector.scope.scopeKeySession' => '(session id)',
+			'web.memoryInspector.scope.placeholderProject' => '/path/to/project (cwd)',
+			'web.memoryInspector.scope.placeholderSession' => 'session id',
+			'web.memoryInspector.scope.syncMd' => '同步 .md',
+			'web.memoryInspector.scope.syncTooltip' => '把 Claude 的 <cwd>/.claude/memory/*.md 重新摄取到 pgvector',
+			'web.memoryInspector.scope.values.project' => 'project',
+			'web.memoryInspector.scope.values.session' => 'session',
+			'web.memoryInspector.scope.values.global' => 'global',
+			'web.memoryInspector.search.placeholder' => '语义搜索查询（Enter 运行；为空则浏览）',
+			'web.memoryInspector.search.run' => '搜索',
+			'web.memoryInspector.search.clear' => '清空',
+			'web.memoryInspector.search.failedToast' => '搜索失败',
+			'web.memoryInspector.records.noMemories' => '暂无记忆',
+			'web.memoryInspector.records.matches_one' => ({required Object count}) => '${count} 条匹配',
+			'web.memoryInspector.records.matches_other' => ({required Object count}) => '${count} 条匹配',
+			'web.memoryInspector.records.memories_one' => ({required Object count}) => '${count} 条记忆',
+			'web.memoryInspector.records.memories_other' => ({required Object count}) => '${count} 条记忆',
+			'web.memoryInspector.records.scopeGlobalSuffix' => '（全局）',
+			'web.memoryInspector.records.scopeInSuffix' => ({required Object scope}) => '（${scope}：',
+			'web.memoryInspector.records.addButton' => '添加记忆',
+			'web.memoryInspector.records.addTooltip' => '手动在此 scope 创建一条记忆',
+			'web.memoryInspector.records.deleteAll' => '全部删除',
+			'web.memoryInspector.records.deleteAllTooltip' => '删除该 scope/scope_key 下的全部记忆',
+			'web.memoryInspector.records.loading' => '加载中…',
+			'web.memoryInspector.records.enterScopeKeyHint' => '输入 scope key 以浏览记忆。',
+			'web.memoryInspector.records.noMatchesForQuery' => ({required Object query}) => '未找到匹配 "${query}"',
+			'web.memoryInspector.records.noMemoriesInScope' => '此 scope 暂无记忆。',
+			'web.memoryInspector.row.simBadge' => ({required Object value}) => '相似度 ${value}',
+			'web.memoryInspector.row.hits_one' => ({required Object count}) => '命中 ${count} 次',
+			'web.memoryInspector.row.hits_other' => ({required Object count}) => '命中 ${count} 次',
+			'web.memoryInspector.row.lastHitTooltip' => ({required Object relative}) => '最近命中 ${relative}',
+			'web.memoryInspector.row.editPlaceholder' => '记忆文本 — Cmd/Ctrl+Enter 保存 · Esc 取消',
+			'web.memoryInspector.row.saveTooltip' => '保存 (Cmd/Ctrl+Enter)',
+			'web.memoryInspector.row.cancelTooltip' => '取消 (Esc)',
+			'web.memoryInspector.row.editTooltip' => '编辑该记忆',
+			'web.memoryInspector.row.deleteTooltip' => '删除该记忆',
+			'web.memoryInspector.row.emptyError' => '记忆文本不能为空',
+			'web.memoryInspector.row.deleteConfirm' => ({required Object id}) => '删除记忆 ${id}? 不可恢复。',
+			'web.memoryInspector.toasts.deleted' => '记忆已删除',
+			'web.memoryInspector.toasts.deleteFailed' => '删除失败',
+			'web.memoryInspector.toasts.bulkDeleted_one' => ({required Object count}) => '已从此 scope 删除 ${count} 条记忆',
+			'web.memoryInspector.toasts.bulkDeleted_other' => ({required Object count}) => '已从此 scope 删除 ${count} 条记忆',
+			'web.memoryInspector.toasts.bulkDeleteFailed' => '批量删除失败',
+			'web.memoryInspector.toasts.created' => '记忆已创建',
+			'web.memoryInspector.toasts.createFailed' => '创建失败',
+			'web.memoryInspector.toasts.updated' => '记忆已更新',
+			'web.memoryInspector.toasts.updateFailed' => '更新失败',
+			'web.memoryInspector.toasts.migrated' => ({required Object reembed, required Object examined, required Object to}) => '已迁移 ${reembed}/${examined} 条记忆到 ${to}',
+			'web.memoryInspector.toasts.migrationFailed' => '迁移失败',
+			'web.memoryInspector.toasts.syncIngested_one' => ({required Object count}) => '已摄取 ${count} 个新记忆文件',
+			'web.memoryInspector.toasts.syncIngested_other' => ({required Object count}) => '已摄取 ${count} 个新记忆文件',
+			'web.memoryInspector.toasts.syncEmpty' => '没有需要同步的新 .md 文件',
+			'web.memoryInspector.toasts.syncEmptyDescription' => '已是最新，或该 cwd 没有 Claude memory 目录。',
+			'web.memoryInspector.toasts.syncFailed' => '同步失败',
+			'web.memoryInspector.toasts.testOk' => ({required Object embedder, required Object dim}) => 'Embedder OK：${embedder} · ${dim} 维',
+			'web.memoryInspector.toasts.testOkDescription' => ({required Object preview}) => 'vector_preview = [${preview}…]',
+			'web.memoryInspector.toasts.testFailed' => 'Embedder 探测失败',
+			'web.memoryInspector.bulkDelete.title' => '删除此 scope 的全部记忆?',
+			'web.memoryInspector.bulkDelete.description' => '这是一次 SQL 操作 — 该 scope 下全部记忆将被原子性删除。通过 Claude 镜像摄取的记忆会在下次 <1>同步 .md</1> 时重新出现；其余内容永久消失。',
+			'web.memoryInspector.bulkDelete.scope' => 'Scope',
+			'web.memoryInspector.bulkDelete.scopeKey' => 'Scope key',
+			'web.memoryInspector.bulkDelete.currentlyVisible' => '当前可见',
+			'web.memoryInspector.bulkDelete.items_one' => ({required Object count}) => '${count} 条记忆',
+			'web.memoryInspector.bulkDelete.items_other' => ({required Object count}) => '${count} 条记忆',
+			'web.memoryInspector.bulkDelete.cancel' => '取消',
+			'web.memoryInspector.bulkDelete.deleteAll' => '全部删除',
+			'web.memoryInspector.addMem.title' => '添加记忆',
+			'web.memoryInspector.addMem.description' => '手动创建一条记忆。Agent 会通过 <1>memory_store</1> MCP 工具自动创建；此表单用于运维想跳过 agent 直接录入事实的场景。',
+			'web.memoryInspector.addMem.textLabel' => '文本',
+			'web.memoryInspector.addMem.textPlaceholder' => '纯文本。Embedder 在存储时把它转成向量；agent 通过 memory_search 取回。',
+			'web.memoryInspector.addMem.cancel' => '取消',
+			'web.memoryInspector.addMem.create' => '创建',
+			'web.memoryInspector.picker.button' => '选择',
+			'web.memoryInspector.picker.buttonTooltip' => '从已保存的 scope key 或活跃会话中选择',
+			'web.memoryInspector.picker.loading' => '加载中…',
+			'web.memoryInspector.picker.empty' => ({required Object scope}) => '${scope} 暂无已保存的 key 或活跃会话。',
+			'web.memoryInspector.picker.savedHeader' => '已保存的记忆',
+			'web.memoryInspector.picker.activeHeader' => '活跃会话',
+			'web.memoryInspector.migrationBanner.headline_one' => ({required Object count}) => '${count} 条记忆不会出现在搜索结果中',
+			'web.memoryInspector.migrationBanner.headline_other' => ({required Object count}) => '${count} 条记忆不会出现在搜索结果中',
+			'web.memoryInspector.migrationBanner.subtitle' => ({required Object summary, required Object current}) => '${summary} — 当前 embedder 为 <1>${current}</1>。pgvector 按 embedder 分区其相似度索引，旧条目在重嵌入前不会被检索到。',
+			'web.memoryInspector.migrationBanner.summaryItem' => ({required Object count, required Object name}) => '${count} 条在 ${name}',
+			'web.memoryInspector.migrationBanner.migrateButton' => '迁移',
+			'web.memoryInspector.reembed.title' => '重新嵌入记忆',
+			'web.memoryInspector.reembed.description' => '对存储在其他 embedder 下的记忆重新计算向量，使它们再次可被搜索到。',
+			'web.memoryInspector.reembed.targetEmbedder' => '目标 embedder',
+			'web.memoryInspector.reembed.onName' => '在',
+			'web.memoryInspector.reembed.totalToReembed' => '待重嵌入总数',
+			'web.memoryInspector.reembed.explainer' => '每条记忆的文本会重新发送到当前 embedder；新向量原地替换旧向量。ID、scope、scope_key、metadata 与时间戳保持不变。搜索结果立即生效 — 无需重启。',
+			'web.memoryInspector.reembed.reportExamined' => '已检查',
+			'web.memoryInspector.reembed.reportReembedded' => '已重嵌入',
+			'web.memoryInspector.reembed.reportFailed' => '失败',
+			'web.memoryInspector.reembed.reportFrom' => '来源',
+			'web.memoryInspector.reembed.errors_one' => ({required Object count}) => '${count} 个错误',
+			'web.memoryInspector.reembed.errors_other' => ({required Object count}) => '${count} 个错误',
+			'web.memoryInspector.reembed.done' => '完成',
+			'web.memoryInspector.reembed.cancel' => '取消',
+			'web.memoryInspector.reembed.reembedding' => '重嵌入中…',
+			'web.memoryInspector.reembed.reembedTotal' => ({required Object total}) => '重嵌入 ${total} 条',
+			'web.notes.title' => '笔记',
+			'web.notes.header.outline' => '大纲',
+			'web.notes.header.showOutline' => '显示大纲',
+			'web.notes.header.hideOutline' => '隐藏大纲',
+			'web.notes.header.today' => '今天',
+			'web.notes.header.todayTooltip' => '打开或创建今天的日志笔记',
+			'web.notes.header.kNew' => '新建',
+			'web.notes.left.tree' => '目录树',
+			'web.notes.left.tags' => '标签',
+			'web.notes.left.filterNotes' => '过滤笔记…',
+			'web.notes.left.filterTags' => '过滤标签…',
+			'web.notes.left.filteredBy' => '已筛选',
+			'web.notes.left.clearTagTooltip' => '清除标签筛选',
+			'web.notes.left.expandAll' => '全部展开',
+			'web.notes.left.expandAllTooltip' => '展开全部文件夹',
+			'web.notes.left.collapseAll' => '全部收起',
+			'web.notes.left.collapseAllTooltip' => '收起全部文件夹',
+			'web.notes.left.loading' => '加载中…',
+			'web.notes.left.footer' => ({required Object visible, required Object total}) => '${visible} / ${total} 条笔记',
+			'web.notes.tags.emptyVault' => 'vault 中暂无标签。',
+			'web.notes.tags.noMatches' => ({required Object query}) => '未找到匹配 "${query}"。',
+			'web.notes.tree.empty' => 'vault 为空。',
+			'web.notes.outline.label' => '大纲',
+			'web.notes.outline.empty' => '此笔记没有标题。添加 <1>## 标题</1> 行以填充大纲。',
+			'web.notes.newNote.prompt' => '新笔记路径（相对 vault，必须以 .md 结尾）',
+			'web.notes.newNote.defaultPath' => ({required Object date}) => 'library/notes-${date}.md',
+			'web.notes.newNote.errorMustEndMd' => '路径必须以 .md 结尾',
+			'web.notes.newNote.createdToast' => '笔记已创建',
+			'web.notes.newNote.createFailedToast' => '创建失败',
+			'web.notes.empty.title' => '未选择笔记',
+			'web.notes.empty.hint' => '从左侧目录树挑选一条笔记，直接跳到今天的日志，或新建一条。AI 生成的项目文档位于 <1>projects/</1>；个人草稿位于 <3>personal/</3>。',
+			'web.notes.empty.today' => '今天的日志笔记',
+			'web.notes.empty.kNew' => '新建笔记',
+			'web.notes.picker.browseAria' => '浏览文件夹',
+			'web.notes.picker.matches_one' => ({required Object count}) => '${count} 个匹配',
+			'web.notes.picker.matches_other' => ({required Object count}) => '${count} 个匹配',
+			'web.notes.picker.foldersInVault' => ({required Object count}) => 'vault 中 ${count} 个文件夹',
+			'web.notes.picker.noMatch' => ({required Object value}) => '未找到匹配的文件夹。直接保存即可使用 <1>${value}</1>（首次写入时懒创建）。',
+			'web.notes.vaultSync.title' => 'Vault 同步',
+			'web.notes.vaultSync.description' => '把 notes vault 作为 git 仓库进行 commit、pull 与 push。认证使用网关主机的 git 凭据（SSH agent / credential helper）。',
+			'web.notes.vaultSync.reading' => '正在读取 vault 状态…',
+			'web.notes.vaultSync.init.title' => 'vault 尚未初始化为 git 仓库',
+			'web.notes.vaultSync.init.body' => '初始化会在 vault 根目录运行 <1>git init -b main</1> 并加入一份合理的 <3>.gitignore</3>。之后你就可以提交笔记并配置 remote（GitHub / Gitea / GitLab）进行跨机同步。',
+			'web.notes.vaultSync.init.button' => '把 vault 初始化为 git 仓库',
+			'web.notes.vaultSync.init.initToast' => 'vault 已初始化为 git 仓库',
+			'web.notes.vaultSync.init.initFailedToast' => '初始化失败',
+			'web.notes.vaultSync.branch.clean' => '干净',
+			'web.notes.vaultSync.branch.staged' => ({required Object count}) => '${count} 已暂存',
+			'web.notes.vaultSync.branch.modified' => ({required Object count}) => '${count} 已修改',
+			'web.notes.vaultSync.branch.untracked' => ({required Object count}) => '${count} 未跟踪',
+			'web.notes.vaultSync.action.pull' => '拉取',
+			'web.notes.vaultSync.action.push' => '推送',
+			'web.notes.vaultSync.action.pullTitleNoRemote' => '请先配置 remote',
+			'web.notes.vaultSync.action.pullTitleHasUpstream' => 'git pull --rebase --autostash',
+			_ => null,
+		} ?? switch (path) {
+			'web.notes.vaultSync.action.pullTitleNoUpstream' => '拉取 origin 的 HEAD；隐式建立 tracking',
+			'web.notes.vaultSync.action.pushTitleNoRemote' => '请先配置 remote',
+			'web.notes.vaultSync.action.pushTitleHasUpstream' => 'git push -u origin HEAD',
+			'web.notes.vaultSync.action.pushTitleNoUpstream' => '首次推送 — 会将 upstream 设为 origin/HEAD',
+			'web.notes.vaultSync.action.noRemote' => '尚未配置 remote — pull/push 已禁用',
+			'web.notes.vaultSync.action.noUpstream' => '尚无 upstream tracking — 首次推送会自动建立。',
+			'web.notes.vaultSync.action.pulledToast' => '已拉取',
+			'web.notes.vaultSync.action.pullFailedToast' => '拉取失败',
+			'web.notes.vaultSync.action.pushedToast' => '已推送',
+			'web.notes.vaultSync.action.pushFailedToast' => '推送失败',
+			'web.notes.vaultSync.commit.title' => '提交',
+			'web.notes.vaultSync.commit.placeholder' => ({required Object date}) => 'Notes: ${date}（默认）',
+			'web.notes.vaultSync.commit.commitAll' => '提交全部',
+			'web.notes.vaultSync.commit.hint' => '暂存所有变更（<1>git add .</1>）然后用此 message 提交。message 为空则使用带时间戳的默认值。',
+			'web.notes.vaultSync.commit.committedToast' => ({required Object hash}) => '已提交 ${hash}',
+			'web.notes.vaultSync.commit.commitFailedToast' => '提交失败',
+			'web.notes.vaultSync.fileList.title' => ({required Object count}) => '工作树 · ${count}',
+			'web.notes.vaultSync.fileList.moreSuffix' => ({required Object count}) => '+${count} 更多',
+			'web.notes.vaultSync.remote.title' => 'Remote（origin）',
+			'web.notes.vaultSync.remote.cancel' => '取消',
+			'web.notes.vaultSync.remote.change' => '更换',
+			'web.notes.vaultSync.remote.configure' => '配置',
+			'web.notes.vaultSync.remote.empty' => '尚未设置 remote。添加一个 HTTPS 或 SSH URL（例如 <1>git@github.com:you/notes.git</1> 或 <3>https://tea.linivek.online/you/notes.git</3>）以启用 push / pull。',
+			'web.notes.vaultSync.remote.urlLabel' => 'URL（HTTPS 或 SSH）',
+			'web.notes.vaultSync.remote.urlPlaceholder' => 'git@host:owner/notes.git',
+			'web.notes.vaultSync.remote.save' => '保存',
+			'web.notes.vaultSync.remote.savedToast' => 'Remote 已保存',
+			'web.notes.vaultSync.remote.saveFailedToast' => '设置 remote 失败',
+			'web.notes.vaultSync.history.title' => '最近提交',
+			'web.notes.vaultSync.history.loading' => '加载中…',
+			'web.notes.vaultSync.history.empty' => '暂无提交。',
+			'web.notes.vaultSync.conflict.kinds.rebase' => 'rebase',
+			'web.notes.vaultSync.conflict.kinds.merge' => 'merge',
+			'web.notes.vaultSync.conflict.kinds.cherryPick' => 'cherry-pick',
+			'web.notes.vaultSync.conflict.kinds.operation' => 'operation',
+			'web.notes.vaultSync.conflict.headline' => ({required Object kind}) => 'vault 存在暂停的 ${kind} 且有未解决的冲突',
+			'web.notes.vaultSync.conflict.explainer' => ({required Object kind}) => '在 ${kind} 完成之前，pull、push 与 commit 都被阻塞。你可以选择 <1>中止</1>（把工作树恢复到 ${kind} 之前的状态 — 保留本地提交，丢弃远端提交），或 <3>强制重置到 remote</3>（丢弃所有本地提交 + 未提交修改；vault 变成 origin 的精确镜像）。',
+			'web.notes.vaultSync.conflict.conflictedHeader' => ({required Object count}) => '冲突文件 · ${count}',
+			'web.notes.vaultSync.conflict.abort' => ({required Object kind}) => '中止 ${kind}',
+			'web.notes.vaultSync.conflict.abortTitle' => ({required Object kind}) => 'git ${kind} --abort',
+			'web.notes.vaultSync.conflict.forceReset' => '强制重置到 remote',
+			'web.notes.vaultSync.conflict.forceResetTitle' => 'git fetch && git reset --hard origin/<branch> && git clean -fd',
+			'web.notes.vaultSync.conflict.forceResetConfirm' => ({required Object kind}) => '破坏性操作：将\n  • 中止进行中的 ${kind}\n  • 运行 git fetch origin\n  • reset --hard 到 origin/<branch>\n  • clean -fd（删除未跟踪文件）\n\n任何尚未推送到 origin 的本地提交以及任何未提交修改都将永久丢失。\n\n继续？',
+			'web.notes.vaultSync.conflict.abortedToast' => ({required Object kind}) => '已中止 ${kind}',
+			'web.notes.vaultSync.conflict.abortedDescription' => '工作树已恢复到操作前状态。',
+			'web.notes.vaultSync.conflict.abortFailedToast' => '中止失败',
+			'web.notes.vaultSync.conflict.resetToast' => ({required Object branch}) => '已重置到 ${branch}',
+			'web.notes.vaultSync.conflict.resetDescription' => '本地更改已丢弃；vault 与 remote 一致。',
+			'web.notes.vaultSync.conflict.resetFailedToast' => '重置失败',
+			'web.notes.vaultSync.auth.title' => '认证',
+			'web.notes.vaultSync.auth.httpsTokenOk' => ({required Object host}) => '将使用 Plugins → Git hosts 中为 <1>${host}</1> 存的 token。✓',
+			'web.notes.vaultSync.auth.httpsTokenMissing' => ({required Object host}) => '<1>${host}</1> 上的 HTTPS remote，opendray 中没有配置 token。在你为其添加 token 之前，私有仓库的 push / pull 很可能失败。',
+			'web.notes.vaultSync.auth.ssh' => ({required Object host}) => '<1>${host}</1> 上的 SSH remote。认证使用网关主机的 <3>~/.ssh/</3>（ssh-agent、identity 文件、host config）。可在主机 shell 用 <5>ssh -T git@${host}</5> 验证。',
+			'web.notes.vaultSync.auth.configureTokenLink' => '→ 配置 git host token',
+			'web.notes.vaultSync.autoSync.loading' => '加载自动同步设置…',
+			'web.notes.vaultSync.autoSync.title' => '自动同步',
+			'web.notes.vaultSync.autoSync.on' => '开',
+			'web.notes.vaultSync.autoSync.runNow' => '立即运行',
+			'web.notes.vaultSync.autoSync.runNowTooltip' => '立即唤醒同步循环（跳过等待，然后运行所有到期的步骤）',
+			'web.notes.vaultSync.autoSync.configure' => '配置',
+			'web.notes.vaultSync.autoSync.hide' => '隐藏',
+			'web.notes.vaultSync.autoSync.enabled' => '启用',
+			'web.notes.vaultSync.autoSync.enabledTooltipNoRemote' => '请先配置 remote 才能启用自动同步',
+			'web.notes.vaultSync.autoSync.noRemoteHint' => '尚无 remote — push/pull 将被跳过。',
+			'web.notes.vaultSync.autoSync.commitEvery' => '提交间隔',
+			'web.notes.vaultSync.autoSync.commitEveryExamples' => '示例：<1>30s</1>、<3>10m</3>、<5>2h</5>。最小 30s。',
+			'web.notes.vaultSync.autoSync.pullEvery' => '拉取间隔',
+			'web.notes.vaultSync.autoSync.pullEveryHint' => '仅在启用 Pull 时使用。',
+			'web.notes.vaultSync.autoSync.pushAfterCommit' => '提交后 push',
+			'web.notes.vaultSync.autoSync.pullPeriodically' => '周期性 pull',
+			'web.notes.vaultSync.autoSync.commitTemplateLabel' => '提交 message 模板',
+			'web.notes.vaultSync.autoSync.commitTemplatePlaceholder' => ({required Object date}) => 'Auto-sync: ${date}（留空则使用默认）',
+			'web.notes.vaultSync.autoSync.saveSettings' => '保存设置',
+			'web.notes.vaultSync.autoSync.discard' => '丢弃',
+			'web.notes.vaultSync.autoSync.lastCommit' => '最近 commit',
+			'web.notes.vaultSync.autoSync.lastPush' => '最近 push',
+			'web.notes.vaultSync.autoSync.lastPull' => '最近 pull',
+			'web.notes.vaultSync.autoSync.never' => '从未',
+			'web.notes.vaultSync.autoSync.savedToast' => '自动同步设置已保存',
+			'web.notes.vaultSync.autoSync.saveFailedToast' => '保存失败',
+			'web.notes.vaultSync.autoSync.triggeredToast' => '已触发自动同步',
+			'web.notes.vaultSync.autoSync.runFailedToast' => '运行失败',
+			'web.notes.syncBadge.loading' => '加载中…',
+			'web.notes.syncBadge.syncLabel' => '同步',
+			'web.notes.syncBadge.initLabel' => '初始化',
+			'web.notes.syncBadge.initTooltip' => 'vault 尚未初始化为 git 仓库',
+			'web.notes.syncBadge.conflictLabel' => '冲突',
+			'web.notes.syncBadge.conflictTooltip' => 'vault 存在未解决的冲突 — 点击进入恢复',
+			'web.notes.syncBadge.syncFallback' => 'sync',
+			'web.notes.syncBadge.tooltip' => ({required Object branch, required Object files, required Object ahead, required Object behind}) => '分支 ${branch} · ${files} 处改动 · 领先 ${ahead} · 落后 ${behind}',
+			'web.notes.syncBadge.tooltipAutoOn' => ' · 自动同步已开启',
+			'web.notes.syncBadge.tooltipLastError' => ({required Object error}) => ' · 上次错误：${error}',
+			'web.notes.syncBadge.branchPlaceholder' => '—',
+			'web.activity.title' => '活动',
+			'web.activity.subtitle' => '按调用维度审计每个由注册集成发起的 API 请求。包括入站调用（第三方应用以集成 API key 调用 opendray）和出站代理调用（admin → opendray 代理 → 集成）。本管理端 UI 直接发起的调用不会被记录。',
+			'web.activity.refresh' => '刷新',
+			'web.activity.refreshTooltip' => '刷新',
+			'web.activity.filters.integration' => '集成',
+			'web.activity.filters.direction' => '方向',
+			'web.activity.filters.status' => '状态',
+			'web.activity.filters.allIntegrations' => '所有集成',
+			'web.activity.filters.all' => '全部',
+			'web.activity.filters.inbound' => '入站',
+			'web.activity.filters.outbound' => '出站',
+			'web.activity.filters.allStatuses' => '所有状态',
+			'web.activity.filters.status2' => '2xx 成功',
+			'web.activity.filters.status3' => '3xx 重定向',
+			'web.activity.filters.status4' => '4xx 客户端错误',
+			'web.activity.filters.status5' => '5xx 服务端错误',
+			'web.activity.callsCount_one' => ({required Object count}) => '${count} 次调用',
+			'web.activity.callsCount_other' => ({required Object count}) => '${count} 次调用',
+			'web.activity.loading' => '加载中…',
+			'web.activity.table.time' => '时间',
+			'web.activity.table.integration' => '集成',
+			'web.activity.table.directionTitle' => '方向',
+			'web.activity.table.method' => '方法',
+			'web.activity.table.path' => '路径',
+			'web.activity.table.status' => '状态',
+			'web.activity.table.duration' => '耗时',
+			'web.activity.table.inboundAria' => '入站',
+			'web.activity.table.outboundAria' => '出站',
+			'web.activity.empty.filtered' => '没有调用符合当前筛选条件。',
+			'web.activity.empty.title' => '尚未记录任何 API 调用',
+			'web.activity.empty.description' => '当第三方应用以其集成 API key 调用 opendray 时，每次请求都会被记录在这里。',
+			'web.activity.empty.stepWithIntegrations' => '在你的第三方应用中使用已有集成的 API key',
+			'web.activity.empty.stepRegister' => '在 集成 → 新建 中注册一个集成',
+			'web.activity.empty.stepCallEndpoint' => '调用任意接口，例如 <1>POST /api/v1/sessions</1>',
+			'web.activity.empty.stepAppears' => '调用会在几秒内出现在这里',
+			'web.activity.empty.footnote' => '你在本管理端 UI 中发起的调用不会被记录 — 仅集成归属的流量会被记录。',
+			'web.activity.events.loading' => '正在加载事件…',
+			'web.activity.events.empty' => '尚无事件。',
+			'web.activity.events.emptyFiltered' => '没有匹配的事件。',
+			'web.activity.events.loadOlder' => '加载更早的事件',
+			'web.activity.events.today' => '今天',
+			'web.activity.events.yesterday' => '昨天',
+			'web.providers.list.title' => 'Providers',
+			'web.providers.list.loading' => '加载中…',
+			'web.providers.list.disabledBadge' => '已禁用',
+			'web.providers.list.noneSelected' => '未选择任何 Provider。',
+			'web.providers.detail.enabled' => '已启用',
+			'web.providers.detail.disabled' => '已禁用',
+			'web.providers.detail.toggleAria' => ({required Object name}) => '切换 ${name}',
+			'web.providers.detail.configuration' => '配置',
+			'web.providers.detail.noConfig' => '此 Provider 没有可配置字段。',
+			'web.providers.detail.executable' => 'executable:',
+			'web.providers.detail.manifestHash' => 'manifest_hash:',
+			'web.providers.detail.reset' => '重置',
+			'web.providers.detail.save' => '保存更改',
+			'web.providers.detail.saving' => '保存中…',
+			'web.providers.detail.savedToast' => 'Provider 配置已保存',
+			'web.providers.detail.saveFailedToast' => '保存失败',
+			'web.providers.detail.toggleFailedToast' => '切换失败',
+			'web.providers.detail.caps.resume' => 'resume',
+			'web.providers.detail.caps.stream' => 'stream',
+			'web.providers.detail.caps.images' => 'images',
+			'web.providers.detail.caps.mcp' => 'mcp',
+			'web.providers.configForm.selectPlaceholder' => '选择…',
+			'web.providers.configForm.defaultOption' => '(默认)',
+			'web.providers.configForm.switchOn' => '开',
+			'web.providers.configForm.switchOff' => '关',
+			'web.providers.configForm.showSecret' => '显示密钥',
+			'web.providers.configForm.hideSecret' => '隐藏密钥',
+			'web.providers.claudeAccounts.title' => 'Claude 账号',
+			'web.providers.claudeAccounts.tutorialTooltip' => '打开多账号教程章节',
+			'web.providers.claudeAccounts.importLocal' => '导入本地',
+			'web.providers.claudeAccounts.importLocalTooltip' => '扫描网关主机上的 ~/.claude-accounts/ 目录并注册新的目录。该按钮仅在网关主机环境下工作 — 详见教程。',
+			'web.providers.claudeAccounts.importedNothingToast' => '无需导入 — 账号已同步。',
+			'web.providers.claudeAccounts.importedToast_one' => ({required Object count}) => '已从 ~/.claude-accounts 导入 ${count} 个账号',
+			'web.providers.claudeAccounts.importedToast_other' => ({required Object count}) => '已从 ~/.claude-accounts 导入 ${count} 个账号',
+			'web.providers.claudeAccounts.importFailedToast' => '导入失败',
+			'web.providers.claudeAccounts.addingTitle' => '添加新账号。',
+			'web.providers.claudeAccounts.addingBodyPrefix' => '在网关主机执行：',
+			'web.providers.claudeAccounts.addingBodySuffix' => 'opendray 的文件系统监听会自动注册新目录，或点击 <1>导入本地</1> 立即扫描。',
+			'web.providers.claudeAccounts.architectureLink' => '架构与完整指南 →',
+			'web.providers.claudeAccounts.loading' => '加载中…',
+			'web.providers.claudeAccounts.empty' => '尚无 Claude 账号。在网关主机执行上面的 shell 命令，然后点击 <1>导入本地</1> 扫描。',
+			'web.providers.claudeAccounts.noTokenYet' => '尚无 token',
+			'web.providers.claudeAccounts.configDir' => 'config_dir:',
+			'web.providers.claudeAccounts.tokenPath' => 'token_path:',
+			'web.providers.claudeAccounts.toggleFailedToast' => '切换失败',
+			'web.providers.claudeAccounts.removeConfirm' => ({required Object name}) => '移除账号 "${name}"?',
+			'web.providers.claudeAccounts.removedToast' => '账号已移除',
+			'web.providers.claudeAccounts.removeFailedToast' => '移除失败',
+			'web.providers.claudeAccounts.toggleAria' => ({required Object name}) => '切换 ${name}',
+			'web.providers.claudeAccounts.removeAria' => ({required Object name}) => '移除 ${name}',
+			'web.channels.title' => '频道',
+			'web.channels.subtitle' => '双向消息集成。每个频道的出站通知按其 <1>notify_on</1> 过滤。',
+			'web.channels.newButton' => '新建频道',
+			'web.channels.loading' => '加载中…',
+			'web.channels.empty.title' => '暂无频道',
+			'web.channels.empty.description' => '内置类型：Telegram · Slack · Discord · 飞书 · 钉钉 · 企业微信。挑选一个并填入凭证，或使用 <1>bridge</1> 通过 WebSocket 接入自定义平台。',
+			'web.channels.card.running' => '运行中',
+			'web.channels.card.starting' => '启动中…',
+			'web.channels.card.disabled' => '已禁用',
+			'web.channels.card.muted' => '已静音',
+			'web.channels.card.tokenLabel' => 'token:',
+			'web.channels.card.chatIdLabel' => 'chat_id:',
+			'web.channels.card.channelIdLabel' => 'channel_id:',
+			'web.channels.card.notifyOnLabel' => 'notify_on:',
+			'web.channels.card.webhookLabel' => 'webhook:',
+			'web.channels.card.copyWebhookTooltip' => '复制 webhook URL',
+			'web.channels.card.webhookCopiedToast' => '已复制 webhook URL',
+			'web.channels.card.setup' => '配置',
+			'web.channels.card.setupTooltip' => '查看适配器连接信息和示例代码',
+			'web.channels.card.test' => '测试',
+			'web.channels.card.testNotRunningTooltip' => '频道必须处于运行状态',
+			'web.channels.card.testBridgeTooltip' => 'Bridge 频道无法从管理端测试 — 请先连接一个适配器',
+			'web.channels.card.editAria' => '编辑频道',
+			'web.channels.card.editTooltip' => '编辑频道配置',
+			'web.channels.card.deleteAria' => '删除频道',
+			'web.channels.card.bridgeSuffix' => '(bridge)',
+			'web.channels.toasts.testSent' => '测试消息已发送',
+			'web.channels.toasts.testFailed' => '测试失败',
+			'web.channels.toasts.deleteConfirm' => ({required Object id}) => '删除频道 ${id}?',
+			'web.channels.toasts.deleted' => '频道已删除',
+			'web.channels.toasts.created' => '频道已创建',
+			'web.channels.toasts.updated' => '频道已更新',
+			'web.channels.dialog.editTitle' => '编辑频道',
+			'web.channels.dialog.createTitle' => '注册频道',
+			'web.channels.dialog.descriptionBridge' => '外部适配器（Python/Node/...）通过 WebSocket 连接并出示此 token。',
+			'web.channels.dialog.descriptionDefault' => '配置消息集成。',
+			'web.channels.dialog.kindLabel' => '类型',
+			'web.channels.dialog.kindImmutable' => '（不可更改 — 如需更换类型请删除后重建）',
+			'web.channels.dialog.enabledLabel' => '启用',
+			'web.channels.dialog.enabledBridgeHint' => '（立即开始接受适配器连接）',
+			'web.channels.dialog.enabledWebhookHint' => '（立即开始接收 webhook）',
+			'web.channels.dialog.enabledDefaultHint' => '（立即启动）',
+			'web.channels.dialog.cancel' => '取消',
+			'web.channels.dialog.save' => '保存',
+			'web.channels.dialog.saving' => '保存中…',
+			'web.channels.dialog.create' => '创建',
+			'web.channels.dialog.creating' => '创建中…',
+			'web.channels.dialog.unknownKind' => ({required Object kind}) => '未知类型：${kind}',
+			'web.channels.dialog.nameRequired' => 'name 不能为空',
+			'web.channels.dialog.tokenRequired' => 'token 不能为空',
+			'web.channels.dialog.topicIdsNumeric' => ({required Object value}) => 'Topic ID 必须是数字（收到 ${value}）',
+			'web.channels.dialog.fieldRequired' => ({required Object label}) => '${label} 不能为空',
+			'web.channels.dialog.cooldownInvalid' => 'Cooldown 必须是非负整数秒',
+			'web.channels.dialog.snippetCapInvalid' => 'Snippet cap 必须是非负数字',
+			'web.channels.notifications.sectionTitle' => '会话通知',
+			'web.channels.notifications.notifyOnLabel' => '通知触发条件',
+			'web.channels.notifications.hintAll' => '接收全部会话事件。点击标签可退订。',
+			'web.channels.notifications.hintNone' => '未选择任何事件 — 出站通知已静音。',
+			'web.channels.notifications.hintSome' => ({required Object total, required Object selected}) => '只选择了 ${total} 中的 ${selected} 个 topic。',
+			'web.channels.notifications.repeatPolicyLabel' => '重复策略',
+			'web.channels.notifications.cooldownLabel' => '冷却时长',
+			'web.channels.notifications.onceReplyHint' => '在该聊天中以非命令文本回复会重置抑制 — opendray 会把你的回复转发到会话的 stdin 并重新启用通知。',
+			'web.channels.notifications.terminalSnippetLabel' => '终端片段',
+			'web.channels.notifications.embedSnippetLabel' => '在 idle 通知中嵌入最近的终端画面',
+			'web.channels.notifications.snippetExplainer' => '开启后，idle 卡片会包含一段代码块片段，呈现用户在网页终端中会看到的内容 — Claude TUI 自身的装饰（状态 spinner、"bypass permissions" 提示、分隔线）会被自动过滤。',
+			'web.channels.notifications.modes.onceLabel' => '每个会话仅一次（推荐）',
+			'web.channels.notifications.modes.onceHint' => '当会话变为 idle 时通知一次，然后保持静默，直到会话结束或你通过该频道回复。',
+			'web.channels.notifications.modes.cooldownLabel' => '时间窗口冷却',
+			'web.channels.notifications.modes.cooldownHint' => '对同一 (会话, 事件) 在所选时间窗口内抑制重复通知。',
+			'web.channels.notifications.modes.everyLabel' => '每次事件都通知（嘈杂）',
+			'web.channels.notifications.modes.everyHint' => '不做抑制。仅用于低频频道。',
+			'web.channels.notifications.cooldowns.k60' => '1 分钟',
+			'web.channels.notifications.cooldowns.k300' => '5 分钟',
+			'web.channels.notifications.cooldowns.k900' => '15 分钟',
+			'web.channels.notifications.cooldowns.k1800' => '30 分钟',
+			'web.channels.notifications.cooldowns.k3600' => '1 小时',
+			'web.channels.notifications.snippetCaps.k0' => '不限制 — 拆分到多条消息（默认）',
+			'web.channels.notifications.snippetCaps.k1000' => '1000 字符（精简）',
+			'web.channels.notifications.snippetCaps.k3000' => '3000 字符',
+			'web.channels.notifications.snippetCaps.k6000' => '6000 字符',
+			'web.channels.notifications.snippetCaps.k12000' => '12000 字符',
+			'web.channels.bridge.nameLabel' => 'Bridge 名称',
+			'web.channels.bridge.namePlaceholder' => 'wechat / discord-custom / whatsapp...',
+			'web.channels.bridge.nameHint' => '适配器的人类可读标签。会显示在频道列表中。',
+			'web.channels.bridge.tokenLabel' => '适配器 token',
+			'web.channels.bridge.regenerateTooltip' => '重新生成',
+			'web.channels.bridge.copyTooltip' => '复制',
+			'web.channels.bridge.tokenCopiedToast' => '已复制 token',
+			'web.channels.bridge.tokenHint' => '适配器通过 WS register 帧发送此 token（也可作为 <1>X-Bridge-Token</1> header）。',
+			'web.channels.bridge.capsLabel' => '接受的能力（可选白名单）',
+			'web.channels.bridge.capsHint' => '为空 = 接受适配器声明的任意能力。已选 = 即使适配器提供更多能力，也只允许这些。',
+			'web.channels.bridge.afterCreate' => '点击 <1>创建</1> 后，适配器设置对话框会自动打开，里面包含 WebSocket URL 和可直接复制的 Python / Node / wscat 起步代码。',
+			'web.channels.setup.title' => ({required Object name}) => '适配器设置 — ${name}',
+			'web.channels.setup.description' => '运行一个任意语言的适配器，使用这些凭证通过 WebSocket 连接到 opendray。opendray 会通过它路由会话通知和 slash 命令。',
+			'web.channels.setup.wsUrlLabel' => 'WebSocket URL',
+			'web.channels.setup.tokenLabel' => '适配器 token',
+			'web.channels.setup.authInfo' => ({required Object frame}) => '<1>认证：</1>通过 <3>X-Bridge-Token</3> header、<5>?token=</5> query 参数或 <7>Authorization: Bearer …</7> 之一发送 token。首个 WS 帧必须是 <9>${frame}</9>。完整协议见仓库中的 <11>docs/bridge-protocol.md</11>。',
+			'web.channels.setup.pythonInstall' => '安装：<1>pip install websockets</1>。运行：<3>python adapter.py</3>。',
+			'web.channels.setup.nodeInstall' => '安装：<1>npm i ws</1>。运行：<3>node adapter.mjs</3>。',
+			'web.channels.setup.wscatInstall' => '安装：<1>npm i -g wscat</1>。连接后，粘贴上方的 JSON 注册帧，然后手动发送后续帧。',
+			'web.channels.setup.close' => '关闭',
+			'web.channels.setup.copyHide' => '隐藏',
+			'web.channels.setup.copyShow' => '显示',
+			'web.channels.setup.copyLabelToast' => ({required Object label}) => '已复制 ${label}',
+			'web.channels.setup.copyCode' => '复制',
+			'web.channels.setup.copied' => '已复制',
+			'web.channels.setup.codeCopiedToast' => '已复制代码',
+			'web.integrations.title' => '集成',
+			'web.integrations.subtitle' => '调用 opendray 的外部应用。通过 <1>/api/v1/proxy/&lt;prefix&gt;/…</1> 反向代理，并通过 WS 端点订阅事件。',
+			'web.integrations.register' => '注册',
+			'web.integrations.loading' => '加载中…',
+			'web.integrations.tabs.registered' => '已注册',
+			'web.integrations.tabs.console' => '反向代理',
+			'web.integrations.empty.title' => '暂无集成',
+			'web.integrations.empty.description' => '注册一个外部应用，给它一个受限的 API key。它的代码不需要进入本仓库。',
+			'web.integrations.empty.register' => '注册集成',
+			'web.integrations.groupSystem' => '系统（由 opendray 管理）',
+			'web.integrations.groupOperator' => '用户注册',
+			'web.integrations.card.managedBadge' => '受管',
+			'web.integrations.card.managedTooltip' => 'opendray 管理这个集成。编辑或轮换它的 key 会导致正在运行的会话（mcp.json 中持有旧 bearer）失效。',
+			'web.integrations.card.consumerBadge' => 'consumer',
+			'web.integrations.card.consumerTooltip' => '仅消费型集成 — 没有可供探测的 HTTP 服务',
+			'web.integrations.card.disabledBadge' => '已禁用',
+			'web.integrations.card.consumerOnlyHint' => '消费 opendray 的 API。未挂载反向代理。',
+			'web.integrations.card.lastProbed' => ({required Object relative}) => '${relative} 探测过',
+			'web.integrations.card.rotated' => ({required Object relative}) => '${relative} 轮换过',
+			'web.integrations.card.managedReadOnly' => '只读 — opendray 把它的 key 烤进每次 spawn 的 mcp.json',
+			'web.integrations.card.managedReadOnlyTooltip' => 'opendray 管理此行。如需重置：删除 ~/.opendray/memory.key 后重启，或直接通过 SQL 删除此行 — 下次启动时会重新引导。',
+			'web.integrations.card.editAria' => '编辑集成',
+			'web.integrations.card.editTooltip' => '编辑 scopes / base URL / version',
+			'web.integrations.card.rotateKey' => '轮换 key',
+			'web.integrations.card.deleteAria' => '删除集成',
+			'web.integrations.card.rotateConfirm' => ({required Object name}) => '轮换 "${name}" 的 API key? 当前 key 将立即失效。',
+			'web.integrations.card.deleteConfirm' => ({required Object name}) => '删除集成 ${name}?',
+			'web.integrations.card.removedToast' => '集成已移除',
+			'web.integrations.register_dialog.title' => '注册集成',
+			'web.integrations.register_dialog.description' => '签发一次性 API key。关闭前请复制它 — opendray 不会再显示明文。',
+			'web.integrations.register_dialog.nameLabel' => '名称',
+			'web.integrations.register_dialog.namePlaceholder' => 'PetTracker',
+			'web.integrations.register_dialog.modeHint' => '如果是 <1>仅消费型</1> 集成（第三方应用调用 opendray API 但不暴露自身服务），保留下面两个字段为空。两个都填则是 <3>反向代理型</3> 集成。',
+			'web.integrations.register_dialog.baseUrlLabel' => 'Base URL',
+			'web.integrations.register_dialog.optionalSuffix' => '(可选)',
+			'web.integrations.register_dialog.baseUrlPlaceholder' => 'http://192.168.3.42:8080',
+			'web.integrations.register_dialog.routePrefixLabel' => 'Route prefix',
+			'web.integrations.register_dialog.routePrefixPlaceholder' => 'pet-tracker',
+			'web.integrations.register_dialog.routePrefixHint' => ({required Object prefix}) => '可通过 <1>/api/v1/proxy/${prefix}/*</1> 访问。',
+			'web.integrations.register_dialog.routePrefixPlaceholderToken' => '<prefix>',
+			'web.integrations.register_dialog.versionLabel' => 'Version（可选）',
+			'web.integrations.register_dialog.versionPlaceholder' => '0.1.0',
+			'web.integrations.register_dialog.scopesLabel' => 'Scopes',
+			'web.integrations.register_dialog.scopesIntro' => '选择该集成允许调用的 API 范围。每个开关映射到一个 Bearer token 声明 — opendray 会拒绝任何越权请求。',
+			'web.integrations.register_dialog.errorNameRequired' => 'Name 不能为空。',
+			'web.integrations.register_dialog.errorBothOrNeither' => 'base_url 和 route_prefix 必须成对设置。同时填入 = 反向代理集成；同时留空 = 仅消费型集成。',
+			'web.integrations.register_dialog.cancel' => '取消',
+			'web.integrations.register_dialog.submit' => '注册',
+			'web.integrations.register_dialog.submitting' => '注册中…',
+			'web.integrations.reveal.titleIssued' => 'API key 已签发',
+			'web.integrations.reveal.titleRotated' => 'API key 已轮换',
+			'web.integrations.reveal.description' => '这是明文 key 唯一一次显示的机会。立即复制并更新所有消费端 — 旧 key（如有）将不再有效。',
+			'web.integrations.reveal.discardAria' => '丢弃新 key',
+			'web.integrations.reveal.discardTooltip' => '丢弃新 key（轮换已经发生 — 旧 key 同样失效）',
+			'web.integrations.reveal.discardConfirm' => '确定丢弃新 key? 轮换已经使旧 key 失效 — 丢弃意味着此集成将没有任何可用 key，直到再次轮换。',
+			'web.integrations.reveal.copy' => '复制',
+			'web.integrations.reveal.copied' => '已复制',
+			'web.integrations.reveal.updateHint' => '<1>请用此新 key 更新每个消费端应用。</1> 旧 key 已在服务端失效，下次请求会返回 <3>401 unauthorized</3>。',
+			'web.integrations.reveal.acknowledge' => '我已复制 key 并会更新消费端应用。我了解 opendray 不会再显示它。',
+			'web.integrations.reveal.discard' => '丢弃',
+			'web.integrations.reveal.done' => '完成',
+			'web.integrations.edit_dialog.title' => ({required Object name}) => '编辑集成 · ${name}',
+			'web.integrations.edit_dialog.description' => '修改 scopes、version 或 base URL。Name 和 route prefix 不可更改 — 如需修改请删除并重新注册。',
+			'web.integrations.edit_dialog.nameLabel' => 'Name',
+			'web.integrations.edit_dialog.routePrefixLabel' => 'Route prefix',
+			'web.integrations.edit_dialog.consumerOnlyLabel' => '(仅消费型)',
+			'web.integrations.edit_dialog.baseUrlLabel' => 'Base URL',
+			'web.integrations.edit_dialog.baseUrlConsumerSuffix' => '(仅消费型 — 留空)',
+			'web.integrations.edit_dialog.baseUrlProxySuffix' => '(反向代理目标)',
+			'web.integrations.edit_dialog.baseUrlConsumerPlaceholder' => '(留空 — 此集成消费 opendray API)',
+			'web.integrations.edit_dialog.baseUrlProxyPlaceholder' => 'http://127.0.0.1:8080',
+			'web.integrations.edit_dialog.consumerHint' => '这是一个仅消费型集成。在此修改 base URL 还需要 route prefix；请删除后重新注册。',
+			'web.integrations.edit_dialog.versionLabel' => 'Version',
+			'web.integrations.edit_dialog.versionPlaceholder' => '0.1.0',
+			'web.integrations.edit_dialog.scopesLabel' => 'Scopes',
+			'web.integrations.edit_dialog.scopesIntro' => '收窄或放宽此集成 API key 授权的 API 范围。已颁发的 token 不受影响 — 新的 scope 集在下次请求时生效。',
+			'web.integrations.edit_dialog.errorModeSwitch' => '在仅消费型与反向代理型之间切换需要删除并重新注册 — name 和 route_prefix 无法原地修改。',
+			'web.integrations.edit_dialog.updatedToast' => '集成已更新',
+			'web.integrations.edit_dialog.cancel' => '取消',
+			'web.integrations.edit_dialog.save' => '保存更改',
+			'web.integrations.proxy.emptyTitle' => '尚未注册集成',
+			'web.integrations.proxy.emptyDescription' => ({required Object prefix}) => '请先注册一个集成；控制台通过 /api/v1/proxy/${prefix}/* 以 admin token 代理请求。',
+			'web.integrations.proxy.targetLabel' => '目标',
+			'web.integrations.proxy.selectPlaceholder' => '选择集成…',
+			'web.integrations.proxy.baseLabel' => 'base:',
+			'web.integrations.proxy.history' => '历史',
+			'web.integrations.proxy.historyEmpty' => '此集成尚无历史请求',
+			'web.integrations.proxy.send' => '发送',
+			'web.integrations.proxy.sending' => '发送中…',
+			'web.integrations.proxy.extraHeadersLabel' => '额外 header（每行一条，Name: Value）',
+			'web.integrations.proxy.bodyLabel' => 'Body',
+			'web.integrations.proxy.headers' => 'Headers',
+			'web.integrations.proxy.body' => 'Body',
+			'web.integrations.proxy.emptyBody' => '(空)',
+			'web.integrations.proxy.requestFailed' => '请求失败',
+			'web.integrations.proxy.stubText' => '发送一个请求即可查看上游响应。',
+			'web.integrations.proxy.stubInjects' => 'opendray 会注入 <1>X-Integration-ID</1>，并剥离你的 <3>Authorization</3> header。',
+			'web.integrations.proxy.prefixPlaceholder' => '<prefix>',
+			'web.plugins.title' => '检查器插件',
+			'web.plugins.subtitle' => '配置在会话打开时右侧检查器面板呈现的数据源。每个插件都是管理员级别且在所有会话间共享。点击章节标题可折叠。',
+			'web.plugins.common.loading' => '加载中…',
+			'web.plugins.common.cancel' => '取消',
+			'web.plugins.common.edit' => '编辑',
+			'web.plugins.common.add' => '添加',
+			'web.plugins.common.save' => '保存',
+			'web.plugins.common.create' => '创建',
+			'web.plugins.mcp.title' => 'MCP 服务器',
+			'web.plugins.mcp.description' => ({required Object KEY}) => '注入到每次 spawn（claude / codex）的 Model Context Protocol 服务器。Vault 条目位于 <1>~/.opendray/vault/mcp/&lt;id&gt;/mcp.json</1>；env / headers 中以 <3>\$${KEY}</3> 引用的密钥来自下方 <5>MCP secrets</5>。',
+			'web.plugins.mcp.newServer' => '新建服务器',
+			'web.plugins.mcp.empty' => '尚无 MCP 服务器。添加一个以为 agent 会话暴露额外工具。',
+			'web.plugins.mcp.columns.name' => '名称',
+			'web.plugins.mcp.columns.transport' => 'Transport',
+			'web.plugins.mcp.columns.spec' => '规范',
+			'web.plugins.mcp.columns.enabled' => '启用',
+			'web.plugins.mcp.noUrl' => '无 URL',
+			'web.plugins.mcp.noCommand' => '无 command',
+			'web.plugins.mcp.deleteConfirm' => ({required Object id}) => '删除 MCP 服务器 "${id}"?',
+			'web.plugins.mcp.removedToast' => 'MCP 服务器已移除',
+			'web.plugins.mcp.deleteFailedToast' => '删除失败',
+			'web.plugins.mcp.toggleFailedToast' => '切换失败',
+			'web.plugins.mcp.editor.createTitle' => '新建 MCP 服务器',
+			'web.plugins.mcp.editor.editTitle' => ({required Object id}) => '编辑 MCP: ${id}',
+			'web.plugins.mcp.editor.description' => ({required Object API_KEY}) => 'JSON 结构：stdio（默认）使用 <1>command</1>+<3>args</3>+<5>env</5>；sse / http 使用 <7>transport</7> +<9> url</9>+<11>headers</11>。以 <13>\$${API_KEY}</13> 引用密钥 — spawn 时会从密钥文件替换。',
+			'web.plugins.mcp.editor.idLabel' => 'ID',
+			'web.plugins.mcp.editor.idPlaceholder' => 'filesystem',
+			'web.plugins.mcp.editor.idHint' => '小写字母 / 数字 / 短横 / 下划线。同时作为目录名与默认 <1>name</1>。',
+			'web.plugins.mcp.editor.bodyLabel' => 'mcp.json',
+			'web.plugins.mcp.editor.invalidJson' => ({required Object error}) => '无效的 JSON：${error}',
+			'web.plugins.mcp.editor.createdToast' => 'MCP 服务器已创建',
+			'web.plugins.mcp.editor.savedToast' => 'MCP 服务器已保存',
+			'web.plugins.mcp.editor.createFailedToast' => '创建失败',
+			'web.plugins.mcp.editor.saveFailedToast' => '保存失败',
+			'web.plugins.mcpSecrets.title' => 'MCP 密钥',
+			'web.plugins.mcpSecrets.encryptedBadge' => '已加密',
+			'web.plugins.mcpSecrets.plaintextBadge' => '明文',
+			'web.plugins.mcpSecrets.encryptedTooltip' => 'AES-GCM 在磁盘上加密；密钥位于操作系统 keychain',
+			'web.plugins.mcpSecrets.plaintextTooltip' => '操作系统 keychain 不可用 — 文件以明文存储。请检查网关日志。',
+			'web.plugins.mcpSecrets.description' => ({required Object KEY}) => '在任意 <3>mcp.json</3> 中以 <1>\$${KEY}</1> 占位符引用的值在 spawn 时会被替换。<5>已保存的值不会通过 API 返回</5> — 可以覆盖或删除，但无法读回。',
+			'web.plugins.mcpSecrets.descriptionStored' => ({required Object path}) => ' 存储于 <1>${path}</1>。',
+			'web.plugins.mcpSecrets.addSecret' => '添加密钥',
+			'web.plugins.mcpSecrets.empty' => ({required Object KEY}) => '暂无已存密钥。添加后即可在 MCP 服务器配置中以 <1>\$${KEY}</1> 引用。',
+			'web.plugins.mcpSecrets.columns.key' => 'Key',
+			'web.plugins.mcpSecrets.columns.value' => 'Value',
+			'web.plugins.mcpSecrets.editTooltip' => '覆盖已存的值',
+			'web.plugins.mcpSecrets.deleteConfirm' => ({required Object key, required Object \'\$\', required Object {key}) => '删除密钥 "${key}"? 任何引用 \$${\'\$\'}${{key}} 的 mcp.json 在你重新设置之前都会回退到字面占位符。',
+			'web.plugins.mcpSecrets.removedToast' => '密钥已移除',
+			'web.plugins.mcpSecrets.deleteFailedToast' => '删除失败',
+			'web.plugins.mcpSecrets.editor.addTitle' => '添加密钥',
+			'web.plugins.mcpSecrets.editor.updateTitle' => ({required Object key}) => '更新 ${key}',
+			'web.plugins.mcpSecrets.editor.addDescription' => ({required Object KEY}) => '若操作系统 keychain 可用，则在磁盘上加密存储。可在任意 mcp.json 的 env / headers / args / url 中以 \$${KEY} 引用。',
+			'web.plugins.mcpSecrets.editor.editDescription' => '输入新值以覆盖。旧值无法恢复。',
+			'web.plugins.mcpSecrets.editor.keyLabel' => 'Key',
+			'web.plugins.mcpSecrets.editor.keyPlaceholder' => 'BRAVE_API_KEY',
+			'web.plugins.mcpSecrets.editor.keyPattern' => '必须匹配 <1>[A-Za-z_][A-Za-z0-9_]*</1>',
+			'web.plugins.mcpSecrets.editor.keyCollision' => '已存在 — 请使用编辑，或选择另一个名称。',
+			'web.plugins.mcpSecrets.editor.valueLabel' => 'Value',
+			'web.plugins.mcpSecrets.editor.valueHint' => '输入时隐藏。已保存的值不会通过 API 返回。',
+			'web.plugins.mcpSecrets.editor.addedToast' => '密钥已添加',
+			'web.plugins.mcpSecrets.editor.updatedToast' => '密钥已更新',
+			'web.plugins.mcpSecrets.editor.saveFailedToast' => '保存失败',
+			'web.plugins.skills.title' => 'Agent skills',
+			'web.plugins.skills.description' => '作为 Tier 1 索引注入到 Claude 会话的可复用能力 — agent 通过 <1>opendray skill describe &lt;id&gt;</1> 按需加载完整 SKILL.md。内置 skill 随二进制发布但可被 <3>自定义</3> — 你的修改保存到 <5>~/.opendray/vault/skills/&lt;id&gt;/SKILL.md</5> 并覆盖内置版本。点击重置可还原。',
+			'web.plugins.skills.newSkill' => '新建 skill',
+			'web.plugins.skills.empty' => '未找到任何 skill。',
+			'web.plugins.skills.columns.id' => 'ID',
+			'web.plugins.skills.columns.description' => '描述',
+			'web.plugins.skills.columns.source' => '来源',
+			'web.plugins.skills.noDescription' => '无描述',
+			'web.plugins.skills.builtinBadge' => '内置',
+			'web.plugins.skills.builtinTooltip' => '嵌入 opendray 二进制 — 点击自定义可在 vault 中覆盖',
+			'web.plugins.skills.vaultBadge' => 'vault',
+			'web.plugins.skills.overridesBuiltin' => '覆盖内置',
+			'web.plugins.skills.overridesBuiltinTooltip' => '此 vault skill 覆盖了同 id 的内置版本',
+			'web.plugins.skills.customize' => '自定义',
+			'web.plugins.skills.customizeTooltip' => '打开 SKILL.md 并保存为 vault 覆盖',
+			'web.plugins.skills.editTooltip' => '编辑此 vault skill',
+			'web.plugins.skills.resetTooltip' => '删除 vault 覆盖并回退到内置版本',
+			'web.plugins.skills.reset' => '重置',
+			'web.plugins.skills.resetConfirm' => ({required Object id}) => '将 "${id}" 重置为内置版本? 这会删除你的 vault SKILL.md 并回退到嵌入副本。',
+			'web.plugins.skills.deleteConfirm' => ({required Object id}) => '从 vault 删除 skill "${id}"? 这会移除该 SKILL.md 文件。',
+			'web.plugins.skills.removedToast' => 'Skill 已移除',
+			'web.plugins.skills.deleteFailedToast' => '删除失败',
+			'web.plugins.skills.editor.createTitle' => '新建 skill',
+			'web.plugins.skills.editor.customizeTitle' => ({required Object id}) => '自定义内置：${id}',
+			'web.plugins.skills.editor.editTitle' => ({required Object id}) => '编辑 skill：${id}',
+			'web.plugins.skills.editor.customizeDescription' => '你正在查看一个嵌入到 opendray 的内置 skill。保存会在相同 id 上创建一个 vault 覆盖 — 你的修改保存在 ~/.opendray/vault/skills/<id>/SKILL.md 中并遮盖内置版本，直到你点击重置。',
+			'web.plugins.skills.editor.editDescription' => 'SKILL.md 格式 — frontmatter（name + description），然后是 markdown 指令。description 会出现在 agent 的 Tier 1 索引中。',
+			'web.plugins.skills.editor.idLabel' => 'ID',
+			'web.plugins.skills.editor.idPlaceholder' => 'my-helper',
+			'web.plugins.skills.editor.idHint' => '小写字母 / 数字 / 短横 / 下划线。作为 <1>~/.opendray/vault/skills/&lt;id&gt;/</1> 下的目录名。',
+			'web.plugins.skills.editor.bodyLabel' => 'SKILL.md',
+			'web.plugins.skills.editor.createdToast' => 'Skill 已创建',
+			'web.plugins.skills.editor.savedToast' => 'Skill 已保存',
+			'web.plugins.skills.editor.savedOverrideToast' => '已保存为 vault 覆盖',
+			'web.plugins.skills.editor.createFailedToast' => '创建失败',
+			'web.plugins.skills.editor.saveFailedToast' => '保存失败',
+			'web.plugins.skills.editor.saveAsOverride' => '保存为 vault 覆盖',
+			'web.plugins.customTasks.title' => '自定义任务',
+			'web.plugins.customTasks.description' => '在 Tasks 选项卡中以点选即运行的方式呈现的快捷方式。留空 cwd 即为所有会话可见的全局任务，或填写绝对路径以限定 scope。',
+			'web.plugins.customTasks.addTask' => '添加任务',
+			'web.plugins.customTasks.empty' => '尚无自定义任务。',
+			'web.plugins.customTasks.columns.name' => '名称',
+			'web.plugins.customTasks.columns.command' => '命令',
+			'web.plugins.customTasks.columns.scope' => 'Scope',
+			'web.plugins.customTasks.globalScope' => '全局',
+			'web.plugins.customTasks.deleteConfirm' => ({required Object name}) => '删除自定义任务 "${name}"?',
+			'web.plugins.customTasks.removedToast' => '任务已移除',
+			'web.plugins.customTasks.deleteFailedToast' => '删除失败',
+			'web.plugins.customTasks.dialog.addTitle' => '添加自定义任务',
+			'web.plugins.customTasks.dialog.editTitle' => ({required Object name}) => '编辑 ${name}',
+			'web.plugins.customTasks.dialog.description' => '命令会原样发送到会话的终端中，等同于在 prompt 处键入并回车。',
+			'web.plugins.customTasks.dialog.nameLabel' => '名称',
+			'web.plugins.customTasks.dialog.namePlaceholder' => 'dev',
+			'web.plugins.customTasks.dialog.commandLabel' => '命令',
+			'web.plugins.customTasks.dialog.commandPlaceholder' => 'docker compose up --build',
+			'web.plugins.customTasks.dialog.descLabel' => '描述（可选）',
+			'web.plugins.customTasks.dialog.descPlaceholder' => '启动开发环境并跟踪日志',
+			'web.plugins.customTasks.dialog.cwdLabel' => 'cwd scope（可选）',
+			'web.plugins.customTasks.dialog.cwdPlaceholder' => '/Users/me/projects/foo（留空 = 全局）',
+			'web.plugins.customTasks.dialog.cwdHint' => '留空 = 在每个会话中都可见。否则只有当会话的 cwd 与此绝对路径匹配时才显示。',
+			_ => null,
+		} ?? switch (path) {
+			'web.plugins.customTasks.dialog.addedToast' => '任务已添加',
+			'web.plugins.customTasks.dialog.updatedToast' => '任务已更新',
+			'web.plugins.customTasks.dialog.addFailedToast' => '添加失败',
+			'web.plugins.customTasks.dialog.updateFailedToast' => '更新失败',
+			'web.plugins.gitHosts.title' => 'Git 主机',
+			'web.plugins.gitHosts.description' => '每个主机一个 token — 被 Git 选项卡用来拉取 pull request，<1>也被 Notes vault sync</1> 使用（当其 remote 通过 HTTPS 指向同一主机上的私有仓库时）。支持 GitHub.com、自托管 GitHub Enterprise、Gitea 与 GitLab。',
+			'web.plugins.gitHosts.addHost' => '添加主机',
+			'web.plugins.gitHosts.empty' => '尚未配置任何 git 主机。\n添加一个以在检查器 Git 选项卡中启用 PR 列表。',
+			'web.plugins.gitHosts.columns.host' => '主机',
+			'web.plugins.gitHosts.columns.kind' => '类型',
+			'web.plugins.gitHosts.columns.token' => 'Token',
+			'web.plugins.gitHosts.columns.enabled' => '启用',
+			'web.plugins.gitHosts.statusEnabled' => '已启用',
+			'web.plugins.gitHosts.statusDisabled' => '已禁用',
+			'web.plugins.gitHosts.deleteConfirm' => ({required Object host}) => '移除 git 主机 ${host}? 对该主机的 PR 查询将停止工作。',
+			'web.plugins.gitHosts.removedToast' => 'Git 主机已移除',
+			'web.plugins.gitHosts.deleteFailedToast' => '删除失败',
+			'web.plugins.gitHosts.dialog.addTitle' => '添加 git 主机',
+			'web.plugins.gitHosts.dialog.editTitle' => ({required Object host}) => '编辑 ${host}',
+			'web.plugins.gitHosts.dialog.description' => 'Token 存储在网关上。仅用于只读 API 调用（列出 PR 等）。',
+			'web.plugins.gitHosts.dialog.kindLabel' => '类型',
+			'web.plugins.gitHosts.dialog.kindGitHub' => 'GitHub',
+			'web.plugins.gitHosts.dialog.kindGitea' => 'Gitea',
+			'web.plugins.gitHosts.dialog.kindGitLab' => 'GitLab',
+			'web.plugins.gitHosts.dialog.hostLabel' => '主机',
+			'web.plugins.gitHosts.dialog.hostPlaceholder' => 'github.com',
+			'web.plugins.gitHosts.dialog.displayNameLabel' => '显示名称（可选）',
+			'web.plugins.gitHosts.dialog.displayNamePlaceholder' => 'Personal',
+			'web.plugins.gitHosts.dialog.tokenLabel' => 'Token',
+			'web.plugins.gitHosts.dialog.newTokenLabel' => '新 token（留空表示保留）',
+			'web.plugins.gitHosts.dialog.tokenPlaceholder' => 'ghp_… / gho_… / glpat-…',
+			'web.plugins.gitHosts.dialog.tokenPlaceholderEdit' => '…',
+			'web.plugins.gitHosts.dialog.tokenHint' => 'GitHub：带 <1>repo</1> scope 的 PAT。Gitea：带 <3>read:repository</3> 的 token。GitLab：带 <5>read_api</5> 的 PAT。',
+			'web.plugins.gitHosts.dialog.enabledLabel' => '启用',
+			'web.plugins.gitHosts.dialog.addedToast' => 'Git 主机已添加',
+			'web.plugins.gitHosts.dialog.updatedToast' => 'Git 主机已更新',
+			'web.plugins.gitHosts.dialog.addFailedToast' => '添加失败',
+			'web.plugins.gitHosts.dialog.updateFailedToast' => '更新失败',
+			'web.backups.title' => '备份',
+			'web.backups.subtitle' => '写入到可插拔目标的加密 PostgreSQL dump。配置计划与保留策略，或触发一次性备份作为快速安全网。',
+			'web.backups.exportData' => '导出数据',
+			'web.backups.loading' => '加载中…',
+			'web.backups.loadStatusFailedToast' => '加载备份状态失败',
+			'web.backups.tabs.backups' => '备份',
+			'web.backups.tabs.schedules' => '计划',
+			'web.backups.tabs.targets' => '目标',
+			'web.backups.inventory.title' => '备份里包含什么？',
+			'web.backups.inventory.summary' => ({required Object tables, required Object rows}) => '${tables} 张表共 ${rows} 行',
+			'web.backups.inventory.description' => '每次备份是一个对下方所有表执行 <1>pg_dump --format=custom</1> 的产物，外加 <3>manifest.json</3> 和（可选的）<5>config.toml</5>。计数是实时的；bundle 捕获的是备份发生那一刻的数据。',
+			'web.backups.inventory.loadFailedToast' => '加载清单失败',
+			'web.backups.inventory.rowsLabel' => '行',
+			'web.backups.restart.title' => '请重启 opendray 以激活备份',
+			'web.backups.restart.description' => '你的口令已保存。网关仅在启动时加载它，因此该功能在进程重启之前保持关闭。',
+			'web.backups.restart.keyFile' => '密钥文件：',
+			'web.backups.restart.configuredVia' => '配置方式：',
+			'web.backups.restart.envVar' => 'OPENDRAY_BACKUP_KEY 环境变量',
+			'web.backups.restart.checkAgain' => '再次检查',
+			'web.backups.setup.title' => '设置备份',
+			'web.backups.setup.description' => '选择一个主口令。opendray 会用它加密每个备份 blob。<1>丢失它意味着你的备份无法恢复</1>，请在继续之前把它保存到密码管理器（Vaultwarden、1Password 等）。',
+			'web.backups.setup.generate' => '生成',
+			'web.backups.setup.pasteOwn' => '粘贴自定义',
+			'web.backups.setup.generateTitle' => '256 位随机密钥',
+			'web.backups.setup.generateHint' => '服务端生成一个加密随机的口令并仅显示一次。你必须在继续前复制它 — 没有恢复路径。',
+			'web.backups.setup.pasteLabel' => '你的口令',
+			'web.backups.setup.pastePlaceholder' => '至少 20 个字符',
+			'web.backups.setup.pasteHint' => '建议：使用密码管理器生成 40 个以上字符。',
+			'web.backups.setup.savesTo' => '保存到：',
+			'web.backups.setup.saving' => '保存中…',
+			'web.backups.setup.generateAndSave' => '生成并保存',
+			'web.backups.setup.save' => '保存',
+			'web.backups.generated.title' => '立即保存此口令',
+			'web.backups.generated.description' => '这是 <1>唯一一次</1> 显示。opendray 与任何其他地方都将无法取回。请在继续前复制到密码管理器。',
+			'web.backups.generated.copy' => '复制',
+			'web.backups.generated.copiedToast' => '口令已复制到剪贴板',
+			'web.backups.generated.copyFailedToast' => '复制失败 — 请手动选中并复制',
+			'web.backups.generated.savedTo' => '已保存到：',
+			'web.backups.generated.ack' => '我已将此口令保存到密码管理器',
+			'web.backups.generated.kContinue' => '继续',
+			'web.backups.status.keyFingerprint' => '密钥指纹：',
+			'web.backups.status.pgDump' => 'pg_dump：',
+			'web.backups.status.pgDumpUnavailable' => '不可用',
+			'web.backups.status.pgDumpHint' => '备份在 pg_dump 进入 PATH 之前无法运行（也可通过 <1>backup.pg_dump_path</1> 设置绝对路径）。请安装与你的服务器主版本匹配的 <3>postgresql-client</3> 并重启。',
+			'web.backups.backupsTab.backupNow' => '立即备份',
+			'web.backups.backupsTab.triggering' => '触发中…',
+			'web.backups.backupsTab.includeConfig' => '包含 config.toml',
+			'web.backups.backupsTab.restoreFromFile' => '从文件恢复',
+			'web.backups.backupsTab.refresh' => '刷新',
+			'web.backups.backupsTab.queuedToast' => '备份已排队',
+			'web.backups.backupsTab.triggerFailedToast' => '触发失败',
+			'web.backups.backupsTab.listFailedToast' => '加载备份列表失败',
+			'web.backups.backupsTab.deleteConfirm' => ({required Object id}) => '删除备份 ${id}? 该 blob 将从目标中移除。',
+			'web.backups.backupsTab.deletedToast' => '备份已删除',
+			'web.backups.backupsTab.deleteFailedToast' => '删除失败',
+			'web.backups.backupsTab.empty' => '暂无备份。点击上方 "立即备份" 进行第一次。',
+			'web.backups.backupsTab.columns.id' => 'ID',
+			'web.backups.backupsTab.columns.target' => '目标',
+			'web.backups.backupsTab.columns.status' => '状态',
+			'web.backups.backupsTab.columns.started' => '开始',
+			'web.backups.backupsTab.columns.size' => '大小',
+			'web.backups.backupsTab.columns.actions' => '操作',
+			'web.backups.backupsTab.downloadTooltip' => '下载',
+			'web.backups.backupsTab.deleteTooltip' => '删除',
+			'web.backups.restore.title' => '从备份 bundle 恢复',
+			'web.backups.restore.bundleLabel' => '加密 bundle（.tar.gz.enc）',
+			'web.backups.restore.targetDsnLabel' => '目标数据库 DSN',
+			'web.backups.restore.targetDsnHint' => '（留空 = opendray 自己的 DB — 危险）',
+			'web.backups.restore.targetDsnPlaceholder' => 'postgres://user:pass@host:5432/dbname',
+			'web.backups.restore.cleanLabel' => '--clean --if-exists（先 drop 现有 schema；恢复到已填充的 DB 上时必需）',
+			'web.backups.restore.auditNoteLabel' => '审计备注（可选）',
+			'web.backups.restore.auditNotePlaceholder' => '恢复原因 — 会出现在 slog 中',
+			'web.backups.restore.ownDbWarning' => '你正在恢复到 <1>opendray 自己的数据库</1>。启用 "--clean" 时会 drop 每张表并按字面回放备份 — 不可逆。请输入 <3>I understand</3> 以继续。',
+			'web.backups.restore.confirmPlaceholder' => 'I understand',
+			'web.backups.restore.confirmSentinel' => 'I understand',
+			'web.backups.restore.pgRestoreOutput' => 'pg_restore 输出（最后 8 KiB）',
+			'web.backups.restore.noPgRestoreOutput' => '（无 pg_restore 输出）',
+			'web.backups.restore.pickFileToast' => '请先选择一个 bundle 文件',
+			'web.backups.restore.succeededToast' => '恢复成功',
+			'web.backups.restore.replayedDescription' => ({required Object bytes, required Object id}) => '已回放 ${bytes}，来自 manifest ${id}',
+			'web.backups.restore.failedToast' => '恢复失败',
+			'web.backups.restore.restoring' => '恢复中…',
+			'web.backups.restore.restore' => '恢复',
+			'web.backups.schedulesTab.description' => '周期备份。调度器每 30 秒轮询一次，并运行最旧的到期计划。',
+			'web.backups.schedulesTab.newSchedule' => '新建计划',
+			'web.backups.schedulesTab.loadFailedToast' => '加载计划失败',
+			'web.backups.schedulesTab.deleteConfirm' => ({required Object id}) => '删除计划 ${id}?',
+			'web.backups.schedulesTab.deletedToast' => '计划已删除',
+			'web.backups.schedulesTab.deleteFailedToast' => '删除失败',
+			'web.backups.schedulesTab.toggleFailedToast' => '切换失败',
+			'web.backups.schedulesTab.empty' => '暂无计划。添加一个以进行周期性自动备份。',
+			'web.backups.schedulesTab.columns.id' => 'ID',
+			'web.backups.schedulesTab.columns.target' => '目标',
+			'web.backups.schedulesTab.columns.interval' => '间隔',
+			'web.backups.schedulesTab.columns.keep' => '保留',
+			'web.backups.schedulesTab.columns.nextRun' => '下次运行',
+			'web.backups.schedulesTab.columns.enabled' => '启用',
+			'web.backups.schedulesTab.columns.actions' => '操作',
+			'web.backups.schedulesTab.keepCount' => ({required Object count}) => '${count} 个备份',
+			'web.backups.schedulesTab.deleteTooltip' => '删除',
+			'web.backups.newSchedule.title' => '新建备份计划',
+			'web.backups.newSchedule.targetLabel' => '目标',
+			'web.backups.newSchedule.everyHoursLabel' => '每隔（小时）',
+			'web.backups.newSchedule.keepLastNLabel' => '保留最近 N 个',
+			'web.backups.newSchedule.enableImmediately' => '立即启用',
+			'web.backups.newSchedule.createdToast' => '计划已创建',
+			'web.backups.newSchedule.createFailedToast' => '创建失败',
+			'web.backups.newSchedule.creating' => '创建中…',
+			'web.backups.newSchedule.create' => '创建',
+			'web.backups.targetsTab.description' => '存储目标。v1 支持 <1>local</1>（opendray 主机磁盘）与 <3>smb</3>（任意 SMB / CIFS 共享，如 UNAS 或群晖）。',
+			'web.backups.targetsTab.newTarget' => '新建目标',
+			'web.backups.targetsTab.listFailedToast' => '加载目标列表失败',
+			'web.backups.targetsTab.deleteConfirm' => ({required Object id}) => '删除目标 ${id}? 引用它的计划会阻止删除。',
+			'web.backups.targetsTab.deletedToast' => '目标已删除',
+			'web.backups.targetsTab.deleteFailedToast' => '删除失败',
+			'web.backups.targetsTab.connectionOkToast' => '连接成功',
+			'web.backups.targetsTab.connectionFailedToast' => '连接失败',
+			'web.backups.targetsTab.testFailedToast' => '测试失败',
+			'web.backups.targetsTab.columns.id' => 'ID',
+			'web.backups.targetsTab.columns.kind' => '类型',
+			'web.backups.targetsTab.columns.config' => '配置',
+			'web.backups.targetsTab.columns.enabled' => '启用',
+			'web.backups.targetsTab.columns.actions' => '操作',
+			'web.backups.targetsTab.on' => '开',
+			'web.backups.targetsTab.off' => '关',
+			'web.backups.targetsTab.test' => '测试',
+			'web.backups.targetsTab.testing' => '测试中…',
+			'web.backups.targetsTab.deleteTooltip' => '删除',
+			'web.backups.targetEditor.title' => '新建备份目标',
+			'web.backups.targetEditor.kindPicker' => '你想备份到哪里？',
+			'web.backups.targetEditor.idLabel' => 'ID（可选）',
+			'web.backups.targetEditor.idPlaceholder' => '留空则自动生成，例如 tgt_xxx',
+			'web.backups.targetEditor.createdToast' => '目标已创建',
+			'web.backups.targetEditor.createFailedToast' => '创建失败',
+			'web.backups.targetEditor.creating' => '创建中…',
+			'web.backups.targetEditor.create' => '创建目标',
+			'web.backups.targetEditor.enableImmediately' => '立即启用（否则保存为禁用 — 适合 "先配置好，稍后开启"）',
+			'web.backups.targetEditor.local.rootLabel' => '根目录',
+			'web.backups.targetEditor.local.rootHint' => '留空 = cfg.backup.local_dir (~/.opendray/backups)',
+			'web.backups.targetEditor.local.rootPlaceholder' => '~/backups/opendray  或  /mnt/external-hdd/opendray',
+			'web.backups.targetEditor.smb.hostLabel' => '主机',
+			'web.backups.targetEditor.smb.hostPlaceholder' => '192.168.9.8',
+			'web.backups.targetEditor.smb.portLabel' => '端口',
+			'web.backups.targetEditor.smb.shareLabel' => 'Share',
+			'web.backups.targetEditor.smb.shareHint' => 'SMB 服务器上的顶层共享名',
+			'web.backups.targetEditor.smb.sharePlaceholder' => 'Claude_Workspace',
+			'web.backups.targetEditor.smb.userLabel' => '用户',
+			'web.backups.targetEditor.smb.passwordLabel' => '密码',
+			'web.backups.targetEditor.smb.pathPrefixLabel' => '路径前缀',
+			'web.backups.targetEditor.smb.pathPrefixHint' => '共享根下的子文件夹（可选）',
+			'web.backups.targetEditor.smb.pathPrefixPlaceholder' => 'opendray/backups',
+			'web.backups.targetEditor.s3.endpointLabel' => 'Endpoint',
+			'web.backups.targetEditor.s3.endpointHint' => '主机（不要带协议）。AWS: s3.amazonaws.com · R2: <accountid>.r2.cloudflarestorage.com · MinIO: minio.local:9000',
+			'web.backups.targetEditor.s3.endpointPlaceholder' => 's3.amazonaws.com',
+			'web.backups.targetEditor.s3.regionLabel' => 'Region',
+			'web.backups.targetEditor.s3.regionHint' => '仅 AWS；R2 用 \'auto\'',
+			'web.backups.targetEditor.s3.regionPlaceholder' => 'us-east-1 / auto',
+			'web.backups.targetEditor.s3.bucketLabel' => 'Bucket',
+			'web.backups.targetEditor.s3.bucketPlaceholder' => 'opendray-backups',
+			'web.backups.targetEditor.s3.accessKeyLabel' => 'Access key',
+			'web.backups.targetEditor.s3.secretKeyLabel' => 'Secret key',
+			'web.backups.targetEditor.s3.secretKeyHint' => 'AES-256-GCM 加密存储；不会被回显',
+			'web.backups.targetEditor.s3.pathPrefixLabel' => 'Path prefix',
+			'web.backups.targetEditor.s3.pathPrefixHint' => 'Object-key 前缀（可选）',
+			'web.backups.targetEditor.s3.pathPrefixPlaceholder' => 'opendray/backups',
+			'web.backups.targetEditor.s3.useHttps' => '使用 HTTPS',
+			'web.backups.targetEditor.s3.pathStyle' => 'Path-style 寻址（legacy / MinIO）',
+			'web.backups.targetEditor.webdav.baseUrlLabel' => 'Base URL',
+			'web.backups.targetEditor.webdav.baseUrlHint' => '包含任意路径的完整 URL。示例：https://cloud.example.com/remote.php/dav/files/me/（Nextcloud）、https://nas.local:5006/（群晖）、https://dav.jianguoyun.com/dav/（坚果云）',
+			'web.backups.targetEditor.webdav.baseUrlPlaceholder' => 'https://cloud.example.com/remote.php/dav/files/<user>/',
+			'web.backups.targetEditor.webdav.userLabel' => '用户',
+			'web.backups.targetEditor.webdav.passwordLabel' => '密码',
+			'web.backups.targetEditor.webdav.pathPrefixLabel' => '路径前缀',
+			'web.backups.targetEditor.webdav.pathPrefixHint' => 'Base URL 下的子文件夹（可选）',
+			'web.backups.targetEditor.webdav.pathPrefixPlaceholder' => 'opendray/backups',
+			'web.backups.targetEditor.sftp.hostLabel' => '主机',
+			'web.backups.targetEditor.sftp.hostPlaceholder' => 'vps.example.com',
+			'web.backups.targetEditor.sftp.portLabel' => '端口',
+			'web.backups.targetEditor.sftp.userLabel' => '用户',
+			'web.backups.targetEditor.sftp.passwordLabel' => '密码',
+			'web.backups.targetEditor.sftp.passwordHint' => '密码或私钥二选一。若两者都填，密码会被作为私钥口令使用。',
+			'web.backups.targetEditor.sftp.privateKeyLabel' => '私钥（PEM）',
+			'web.backups.targetEditor.sftp.privateKeyHint' => '粘贴 OpenSSH/PEM 格式的私钥内容（例如 ~/.ssh/id_ed25519）。留空则仅用密码认证。',
+			'web.backups.targetEditor.sftp.privateKeyPlaceholder' => '-----BEGIN OPENSSH PRIVATE KEY-----...',
+			'web.backups.targetEditor.sftp.hostKeyLabel' => 'Host key（pinning）',
+			'web.backups.targetEditor.sftp.hostKeyHint' => 'OpenSSH 风格的服务器公钥（运行 `ssh-keyscan host` 获取）。留空则禁用 pinning（LAN 之外不推荐）。',
+			'web.backups.targetEditor.sftp.hostKeyPlaceholder' => 'ssh-ed25519 AAAA...',
+			'web.backups.targetEditor.sftp.pathPrefixLabel' => '路径前缀',
+			'web.backups.targetEditor.sftp.pathPrefixHint' => '绝对路径或相对家目录（可选）',
+			'web.backups.targetEditor.sftp.pathPrefixPlaceholder' => '/var/backups/opendray  或  opendray-backups',
+			'web.backups.targetEditor.rclone.rcloneHint' => '要求 opendray 主机上已安装 <1>rclone</1> CLI。请先通过 <3>rclone config</3> 配置 remote，然后在下面填写 remote 名。opendray 在内部调用 <5>rclone rcat / cat / lsd</5>。',
+			'web.backups.targetEditor.rclone.remoteLabel' => 'Remote name',
+			'web.backups.targetEditor.rclone.remoteHint' => '来自 `rclone config` 的名字（不带冒号）。例如：gdrive、onedrive、dropbox-personal、baidu-pan',
+			'web.backups.targetEditor.rclone.remotePlaceholder' => 'gdrive',
+			'web.backups.targetEditor.rclone.pathPrefixLabel' => '路径前缀',
+			'web.backups.targetEditor.rclone.pathPrefixHint' => 'Remote 根下的子文件夹（可选）',
+			'web.backups.targetEditor.rclone.pathPrefixPlaceholder' => 'opendray/backups',
+			'web.backups.targetEditor.rclone.binaryPathLabel' => '二进制路径',
+			'web.backups.targetEditor.rclone.binaryPathHint' => '覆盖 `which rclone`。留空则走 PATH 查找。',
+			'web.backups.targetEditor.rclone.binaryPathPlaceholder' => '/opt/homebrew/bin/rclone',
+			'web.backups.targetEditor.rclone.configPathLabel' => 'Config 路径',
+			'web.backups.targetEditor.rclone.configPathHint' => '覆盖 --config（默认 ~/.config/rclone/rclone.conf 或 ~/.rclone.conf）',
+			'web.backups.targetEditor.rclone.configPathPlaceholder' => '留空则使用 rclone 默认',
+			'web.serverSettings.sections.general.title' => '通用',
+			'web.serverSettings.sections.general.desc' => '监听地址、操作员账号、令牌 TTL。',
+			'web.serverSettings.sections.logging.title' => '日志',
+			'web.serverSettings.sections.logging.desc' => '日志级别、格式与实时跟踪。',
+			'web.serverSettings.sections.sessions.title' => '会话',
+			'web.serverSettings.sections.sessions.desc' => '空闲检测阈值。',
+			'web.serverSettings.sections.vault.title' => 'Vault',
+			'web.serverSettings.sections.vault.desc' => '笔记、技能与 git 版本化根目录。',
+			'web.serverSettings.sections.mcp.title' => 'MCP 注册表',
+			'web.serverSettings.sections.mcp.desc' => '服务器注册表与密钥。',
+			'web.serverSettings.sections.memory.title' => '记忆',
+			'web.serverSettings.sections.memory.desc' => '跨 CLI 的持久化记忆子系统。',
+			'web.serverSettings.sections.memoryAmbient.title' => '记忆 · 环境感知',
+			'web.serverSettings.sections.memoryAmbient.desc' => '自动捕获对话进入记忆，并在 spawn 时注入。',
+			'web.serverSettings.sections.backup.title' => '备份',
+			'web.serverSettings.sections.backup.desc' => '加密数据库备份、恢复，以及管理员数据导出。',
+			'web.serverSettings.sections.claude.title' => '存储 · Claude',
+			'web.serverSettings.sections.claude.desc' => 'Claude 会话记录在磁盘上的位置。',
+			'web.serverSettings.sections.codex.title' => '存储 · Codex',
+			'web.serverSettings.sections.codex.desc' => 'Codex 会话根目录。',
+			'web.serverSettings.sections.gemini.title' => '存储 · Gemini',
+			'web.serverSettings.sections.gemini.desc' => 'Gemini 每项目 tmp 与 projects.json。',
+			'web.serverSettings.loading' => '正在加载服务器设置…',
+			'web.serverSettings.loadFailed' => ({required Object message}) => '加载失败：${message}',
+			'web.serverSettings.noConfigFlag' => 'opendray 启动时未指定 -config，设置仅从环境变量加载，无法在此编辑。',
+			'web.serverSettings.resetButton' => '重置',
+			'web.serverSettings.resetButtonTitle' => '丢弃此分区中未保存的修改',
+			'web.serverSettings.resetConfirm' => ({required Object section}) => '将"${section}"重置为上次保存的值？',
+			'web.serverSettings.badgeRestartRequired' => '需要重启',
+			'web.serverSettings.badgeUnsaved' => '未保存',
+			'web.serverSettings.saveButton' => '保存修改',
+			'web.serverSettings.saveToastTitle' => '设置已保存',
+			'web.serverSettings.saveToastDesc' => '点击「重启」以应用。',
+			'web.serverSettings.saveErrorTitle' => '保存失败',
+			'web.serverSettings.dangerousConfirm' => '您更改了监听地址 / 管理员账号 / 管理员密码。重启后可能需要重新登录或使用新地址。是否继续？',
+			'web.serverSettings.unsavedHint' => '有未保存的修改',
+			'web.serverSettings.savedHint' => '所有修改已保存',
+			'web.serverSettings.searchPlaceholder' => '筛选字段…',
+			'web.serverSettings.restart.button' => '重启服务器',
+			'web.serverSettings.restart.buttonTitle' => '对网关进程执行 self-exec',
+			'web.serverSettings.restart.dirtyConfirm' => '您有未保存的修改。重启将使用「上次保存」的配置，是否继续？',
+			'web.serverSettings.restart.confirm' => '重启 opendray 网关？所有打开的终端会话将自动重新连接。',
+			'web.serverSettings.restart.overlay' => '正在重启服务器…',
+			'web.serverSettings.restart.waiting' => ({required Object tick}) => '等待 /health · ${tick}s',
+			'web.serverSettings.restart.timedOutTitle' => '重启超时',
+			'web.serverSettings.restart.timedOutDesc' => 'Health 接口未恢复。请查看服务器日志。',
+			'web.serverSettings.restart.successToast' => '服务器已重启',
+			'web.serverSettings.formGroups.network' => '网络',
+			'web.serverSettings.formGroups.operatorAccount' => '操作员账号',
+			'web.serverSettings.formGroups.memoryConfiguration' => '配置',
+			'web.serverSettings.formGroups.memoryHttp' => 'HTTP 后端（当 backend=http 时使用）',
+			'web.serverSettings.formGroups.memoryLocal' => '本地 ONNX（当 backend=local 时使用）',
+			'web.serverSettings.formGroups.backupStatus' => '状态',
+			'web.serverSettings.formGroups.backupWhere' => '备份目标位置',
+			'web.serverSettings.formGroups.backupSchedules' => '计划任务',
+			'web.serverSettings.formGroups.backupWhatsInside' => '备份里有什么？',
+			'web.serverSettings.fields.listenAddress.label' => '监听地址',
+			'web.serverSettings.fields.listenAddress.hint' => 'HTTP 服务绑定的 host:port，例如：0.0.0.0:8770。',
+			'web.serverSettings.fields.username.label' => '用户名',
+			'web.serverSettings.fields.username.hint' => '登录表单使用的账号。修改后下次请求会强制重新登录。',
+			'web.serverSettings.fields.password.label' => '密码',
+			'web.serverSettings.fields.password.hint' => '留空保持当前密码不变；填值则会覆盖。',
+			'web.serverSettings.fields.password.hideTitle' => '隐藏',
+			'web.serverSettings.fields.password.revealTitle' => '显示',
+			'web.serverSettings.fields.tokenTTL.label' => '令牌 TTL',
+			'web.serverSettings.fields.tokenTTL.hint' => 'Bearer 令牌生命周期，使用 Go duration，如 "24h"、"30m"。留空 = 永不过期。',
+			'web.serverSettings.fields.logLevel.label' => '日志级别',
+			'web.serverSettings.fields.logLevel.hint' => '低于此级别的日志将被丢弃。',
+			'web.serverSettings.fields.logFormat.label' => '格式',
+			'web.serverSettings.fields.logFormat.hint' => '"text" 适合人读；"json" 便于机器解析。',
+			'web.serverSettings.fields.logFile.label' => '日志文件',
+			'web.serverSettings.fields.logFile.hint' => '可选的文件路径。10MB 自动轮转，保留 5 个备份。留空 = 仅输出到 stderr。',
+			'web.serverSettings.fields.idleThreshold.label' => '空闲阈值',
+			'web.serverSettings.fields.idleThreshold.hint' => '会话静默这么久后触发 session.idle。留空 = 30s。',
+			'web.serverSettings.fields.idlePollInterval.label' => '空闲轮询间隔',
+			'web.serverSettings.fields.idlePollInterval.hint' => '空闲检测器的唤醒频率。越低 = 延迟越低、唤醒越多。留空 = 5s。',
+			'web.serverSettings.fields.vaultRoot.label' => 'Vault 根目录',
+			'web.serverSettings.fields.vaultRoot.hint' => '笔记、技能和 MCP 注册表的顶层目录。',
+			'web.serverSettings.fields.notesDirectory.label' => '笔记目录',
+			'web.serverSettings.fields.notesDirectory.hint' => '覆盖笔记位置。默认为 <vault root>/notes。',
+			'web.serverSettings.fields.skillsDirectory.label' => '技能目录',
+			'web.serverSettings.fields.skillsDirectory.hint' => '覆盖技能位置。默认为 <vault root>/skills。',
+			'web.serverSettings.fields.gitRoot.label' => 'Git 根目录',
+			'web.serverSettings.fields.gitRoot.hint' => 'Vault Sync 功能提交到的工作树。',
+			'web.serverSettings.fields.personalPrefix.label' => '个人前缀',
+			'web.serverSettings.fields.personalPrefix.hint' => '自动派生路径时用于个人笔记的文件夹名。默认 "personal"。',
+			'web.serverSettings.fields.projectsPrefix.label' => '项目前缀',
+			'web.serverSettings.fields.projectsPrefix.hint' => '项目笔记的文件夹名。默认 "projects"。',
+			'web.serverSettings.fields.registryRoot.label' => '注册表根目录',
+			'web.serverSettings.fields.registryRoot.hint' => '存放 MCP server JSON 定义的目录。默认为 <vault>/mcp。',
+			'web.serverSettings.fields.secretsFile.label' => '密钥文件',
+			'web.serverSettings.fields.secretsFile.hint' => 'spawn 时替换进 MCP server 命令的 key=value 文件。',
+			'web.serverSettings.fields.memoryBackend.label' => '嵌入器后端',
+			'web.serverSettings.fields.memoryBackend.hint' => '"auto" / "bm25" 使用纯 Go 关键词路径（无需 cgo）；"http" 调用任何兼容 OpenAI 的 /v1/embeddings（ollama / OpenAI / LocalAI）；"local" 进程内运行 ONNX sentence-transformer — 需要用 `-tags local_onnx` 编译的二进制。',
+			'web.serverSettings.fields.memoryStore.label' => '存储',
+			'web.serverSettings.fields.memoryStore.hint' => '"pgvector" 复用 opendray 已有的 PG + vector 扩展；v1 唯一选项。',
+			'web.serverSettings.fields.memoryTopK.label' => '默认 top-K',
+			'web.serverSettings.fields.memoryTopK.hint' => 'agent 未指定时 memory_search 返回多少条命中。留空 = 5。',
+			'web.serverSettings.fields.memoryThreshold.label' => '相似度阈值',
+			'web.serverSettings.fields.memoryThreshold.hint' => '分数低于此值的命中将被丢弃。留空 = 0.1（宽松 — BM25 稀疏向量很少超过 0.5）。',
+			'web.serverSettings.fields.memoryScope.label' => '默认作用域',
+			'web.serverSettings.fields.memoryScope.hint' => 'agent 未指定时 memory_store 使用的作用域。"project"（推荐）按 cwd 分组；"session" 按会话隔离；"global" 跨 cwd 共享。',
+			'web.serverSettings.fields.memoryBaseUrl.label' => 'Base URL',
+			'web.serverSettings.fields.memoryBaseUrl.hint' => '如 ollama 用 "http://localhost:11434/v1"，OpenAI 用 "https://api.openai.com/v1"。',
+			'web.serverSettings.fields.memoryModel.label' => '模型',
+			'web.serverSettings.fields.memoryModel.hint' => '如 ollama 用 "nomic-embed-text"，OpenAI 用 "text-embedding-3-small"。',
+			'web.serverSettings.fields.memoryApiKey.label' => 'API 密钥',
+			'web.serverSettings.fields.memoryApiKey.hint' => 'ollama / 本地服务可留空；OpenAI / Voyage / 托管服务必填。',
+			'web.serverSettings.fields.memoryLocalModel.label' => '模型名',
+			'web.serverSettings.fields.memoryLocalModel.hint' => '仅作显示用 — 出现在日志 / Inspector 中。如 "bge-m3"、"bge-small-en-v1.5"。',
+			'web.serverSettings.fields.memoryLibraryPath.label' => '库路径',
+			'web.serverSettings.fields.memoryLibraryPath.hint' => '存放 libonnxruntime.dylib (macOS) / libonnxruntime.so (Linux) 的目录。`brew install onnxruntime` 后即 /opt/homebrew/opt/onnxruntime/lib。',
+			'web.serverSettings.fields.memoryModelPath.label' => '模型路径',
+			'web.serverSettings.fields.memoryModelPath.hint' => '.onnx 权重的绝对路径。从 HuggingFace 下载，如 Xenova/bge-m3 或 Xenova/bge-small-en-v1.5。',
+			'web.serverSettings.fields.memoryTokenizerPath.label' => 'Tokenizer 路径',
+			'web.serverSettings.fields.memoryTokenizerPath.hint' => 'tokenizer.json（HuggingFace 标准格式）的绝对路径 — 通常和模型放在一起。',
+			'web.serverSettings.fields.memoryMaxSeqLen.label' => '最大序列长度',
+			'web.serverSettings.fields.memoryMaxSeqLen.hint' => '超过这个 token 数会被截断。bge-m3 默认 512。留空 = 512。',
+			'web.serverSettings.fields.claudeHistoryRoots.label' => '历史根目录',
+			'web.serverSettings.fields.claudeHistoryRoots.hint' => '扫描 Claude 每项目 JSONL 记录的目录。留空 = 扫描 ~/.claude/projects + 所有 ~/.claude-accounts/*/projects。',
+			'web.serverSettings.fields.claudeAccountsDir.label' => '账号目录',
+			'web.serverSettings.fields.claudeAccountsDir.hint' => 'opendray 管理的 Claude 账号 ConfigDir 根目录。默认 ~/.claude-accounts。',
+			'web.serverSettings.fields.codexSessionsRoot.label' => '会话根目录',
+			'web.serverSettings.fields.codexSessionsRoot.hint' => '遍历 Codex rollout JSONL 文件的目录。默认 ~/.codex/sessions。',
+			'web.serverSettings.fields.geminiTmpRoot.label' => 'tmp 目录',
+			'web.serverSettings.fields.geminiTmpRoot.hint' => '存放 Gemini 每项目 tmp 文件夹的根目录。默认 ~/.gemini/tmp。',
+			'web.serverSettings.fields.geminiProjectsFile.label' => 'projects.json',
+			'web.serverSettings.fields.geminiProjectsFile.hint' => 'Gemini cwd→短名映射文件的路径。默认 ~/.gemini/projects.json。',
+			'web.serverSettings.fields.backupLocalDir.label' => '本地备份目录',
+			'web.serverSettings.fields.backupLocalDir.hint' => '自动创建的 `local` 目标的默认根目录。留空 = ~/.opendray/backups。需要重启。',
+			'web.serverSettings.fields.backupExportDir.label' => '导出目录',
+			'web.serverSettings.fields.backupExportDir.hint' => '一次性导出 zip 在磁盘上的暂存位置。留空 = ~/.opendray/exports。包将在 24 小时后自动过期。需要重启。',
+			'web.serverSettings.fields.backupPgDumpPath.label' => 'pg_dump 路径',
+			'web.serverSettings.fields.backupPgDumpPath.hint' => 'pg_dump 的绝对路径。主版本号必须 ≥ 服务器的。留空 = PATH 上的第一个 pg_dump。',
+			'web.serverSettings.fields.backupPgRestorePath.label' => 'pg_restore 路径',
+			'web.serverSettings.fields.backupPgRestorePath.hint' => '/backups/restore 流程使用的 pg_restore 绝对路径。同样的主版本号规则。',
+			'web.serverSettings.liveTail.heading' => '实时日志',
+			'web.serverSettings.liveTail.description' => '内存中的环形缓冲区（最近约 2,000 条）。重启后清空。',
+			'web.serverSettings.memoryInspectorCard.heading' => '检查器',
+			'web.serverSettings.memoryInspectorCard.description' => '在专门页面浏览、搜索、编辑已存储的记忆。',
+			'web.serverSettings.memoryInspectorCard.openButton' => '打开记忆 →',
+			'web.serverSettings.localOnnxBanner' => '需要使用 <1>-tags local_onnx</1> 编译二进制。标准构建在选择此后端时会返回明确的 stub 错误。设置步骤参见 <3>记忆 → 本地 ONNX</3> 教程。',
+			'web.serverSettings.stringList.noneDefault' => '（无 — 使用内置默认值）',
+			'web.serverSettings.stringList.addPath' => '添加路径',
+			'web.serverSettings.stringList.removeTitle' => '移除',
+			'web.serverSettings.httpHelpers.autoDetected' => '启动时自动检测到',
+			'web.serverSettings.httpHelpers.modelCount' => ({required Object count}) => '${count} 个模型 — 点击使用',
+			'web.serverSettings.httpHelpers.presets' => '预设：',
+			'web.serverSettings.httpHelpers.testConnection' => '测试连接',
+			'web.serverSettings.httpHelpers.presetTip.ollama' => '本地 ollama 守护进程',
+			'web.serverSettings.httpHelpers.presetTip.lmStudio' => 'LM Studio 本地服务',
+			'web.serverSettings.httpHelpers.presetTip.openai' => 'OpenAI 云端（需要 API key）',
+			'web.serverSettings.probe.unreachable' => ({required Object error}) => '✗ 不可达：${error}',
+			'web.serverSettings.probe.connectionFailed' => '连接失败',
+			'web.serverSettings.probe.reachable' => ({required Object detected, required Object total, required Object embedding}) => '✓ 可达 ${detected}· 共 ${total} 个模型 · ${embedding} 个嵌入',
+			'web.serverSettings.probe.modelMissing' => ({required Object model}) => '⚠ 配置的模型 ${model} 不在列表中。从下方嵌入模型中选一个，或修正名称。',
+			'web.serverSettings.probe.embeddingModelsLabel' => '嵌入模型：',
+			'web.serverSettings.probe.moreModels' => ({required Object count}) => '还有 ${count} 个',
+			'web.serverSettings.probe.noEmbeddingFound' => '⚠ 没有模型名包含 "embed"。该端点可能未加载嵌入模型 — 请检查本地服务。',
+			'web.serverSettings.probe.configuredTitle' => '当前已配置',
+			'web.serverSettings.probe.applyTitle' => '点击应用',
+			'web.serverSettings.backup.featureDisabledTitle' => '功能已禁用',
+			'web.serverSettings.backup.featureDisabledHint' => '在 opendray 的环境变量中设置 <1>OPENDRAY_BACKUP_ENABLED=1</1> + <3>OPENDRAY_BACKUP_KEY=&lt;passphrase&gt;</3>，然后重启。主密码仅来自环境变量 — 永不写入 config.toml。',
+			'web.serverSettings.backup.statusRowLabel' => '状态',
+			'web.serverSettings.backup.enabledHealthy' => '已启用 · 健康',
+			'web.serverSettings.backup.enabledDegraded' => '已启用 · 异常',
+			'web.serverSettings.backup.keyFingerprintLabel' => '密钥指纹',
+			'web.serverSettings.backup.keyFingerprintHint' => '记录到 Vaultwarden — 丢失会锁死所有先前的备份',
+			'web.serverSettings.backup.pgDumpLabel' => 'pg_dump',
+			'web.serverSettings.backup.pgDumpUnavailable' => '不可用',
+			'web.serverSettings.backup.pgRestoreLabel' => 'pg_restore',
+			'web.serverSettings.backup.pgRestoreNotResolved' => '（未解析）',
+			'web.serverSettings.backup.openBackups' => '打开备份页 →',
+			'web.serverSettings.backup.openExport' => '打开导出 / 导入 →',
+			'web.serverSettings.backup.whereDesc' => '每个目标都是备份块可写入的一个地方。opendray 支持 <1>本地磁盘</1>、<3>SMB/CIFS</3>（Windows / NAS）、<5>S3 兼容</5>（AWS、R2、B2、MinIO、阿里云 OSS、腾讯云 COS …）、<7>WebDAV</7>（Nextcloud、群晖、坚果云）、<9>SFTP</9>，外加 <11>rclone</11> 透传，接入另外 70+ 个后端（Google Drive、OneDrive、Dropbox、百度云、阿里云盘 …）。',
+			'web.serverSettings.backup.loading' => '加载中…',
+			'web.serverSettings.backup.noTargets' => '尚未添加目标。添加一个开始备份。',
+			'web.serverSettings.backup.addTarget' => '添加目标',
+			'web.serverSettings.backup.noSchedulesHint' => '没有循环计划。在 <1>/backups → 计划任务</1> 添加一个以自动执行备份。',
+			'web.serverSettings.backup.scheduleHeaders.schedule' => '计划',
+			'web.serverSettings.backup.scheduleHeaders.target' => '目标',
+			'web.serverSettings.backup.scheduleHeaders.cadence' => '频率',
+			'web.serverSettings.backup.scheduleHeaders.keep' => '保留',
+			'web.serverSettings.backup.scheduleHeaders.state' => '状态',
+			'web.serverSettings.backup.every' => ({required Object interval}) => '每 ${interval}',
+			'web.serverSettings.backup.backupsKeep' => ({required Object count}) => '${count} 份备份',
+			'web.serverSettings.backup.stateEnabled' => '已启用',
+			'web.serverSettings.backup.statePaused' => '已暂停',
+			'web.serverSettings.backup.manageSchedules' => '在 /backups → 计划任务 管理 →',
+			'web.serverSettings.backup.whatsInsideDesc' => '每份备份都是所有 opendray 表（sessions、integrations、memories、audit_log 等）的 <1>pg_dump --format=custom</1>，加上一个 <3>manifest.json</3>，以及（可选）当前的 <5>config.toml</5>。在 <7>备份页</7> 打开「备份里有什么？」面板可以看到带行数的实时清单。',
+			'web.serverSettings.backup.advancedToggle' => '高级选项（路径与客户端二进制）— 需要重启',
+			'web.serverSettings.targetRow.on' => '开',
+			'web.serverSettings.targetRow.off' => '关',
+			'web.serverSettings.targetRow.test' => '测试',
+			'web.serverSettings.targetRow.testing' => '测试中…',
+			'web.serverSettings.targetRow.delete' => '删除',
+			'web.serverSettings.targetRow.connectionOk' => ({required Object id}) => '${id}：连接正常',
+			'web.serverSettings.targetRow.connectionFailedTitle' => '连接失败',
+			'web.serverSettings.targetRow.testFailedTitle' => '测试失败',
+			'web.serverSettings.targetRow.deleteConfirm' => ({required Object id}) => '删除目标 "${id}"？引用它的计划任务将阻止删除。',
+			'web.serverSettings.targetRow.deleteSuccess' => '目标已删除',
+			'web.serverSettings.targetRow.deleteFailedTitle' => '删除失败',
+			'web.serverSettings.targetRow.unknownError' => '未知错误',
+			'web.settings.title' => '设置',
+			'web.settings.subtitle' => '工作区、账号与网关配置。',
+			'web.settings.groups.workspace' => '工作区',
+			'web.settings.groups.server' => '服务器',
+			'web.settings.groups.system' => '系统',
+			'web.settings.items.appearance' => '外观',
+			'web.settings.items.font' => '字号',
+			'web.settings.items.account' => '账号',
+			'web.settings.items.status' => '状态',
+			'web.settings.items.about' => '关于',
+			'web.settings.health.connecting' => '连接中…',
+			'web.settings.health.dbOk' => 'db 正常',
+			'web.settings.health.dbDown' => 'db 异常',
+			'web.settings.breadcrumb.server' => '服务器',
+			'web.settings.appearance.title' => '外观',
+			'web.settings.appearance.description' => '选择 opendray 的外观风格。',
+			'web.settings.appearance.options.light' => '浅色',
+			'web.settings.appearance.options.lightDesc' => '始终浅色',
+			'web.settings.appearance.options.dark' => '深色',
+			'web.settings.appearance.options.darkDesc' => '始终深色',
+			'web.settings.appearance.options.system' => '跟随系统',
+			'web.settings.appearance.options.systemDesc' => '跟随操作系统设置',
+			'web.settings.font.title' => '字号',
+			'web.settings.font.description' => '缩放整个界面。按浏览器保存。',
+			'web.settings.font.options.compact' => '紧凑',
+			'web.settings.font.options.kDefault' => '默认',
+			'web.settings.font.options.comfy' => '舒适',
+			'web.settings.font.options.large' => '大',
+			'web.settings.account.title' => '账号',
+			'web.settings.account.description' => '运维与当前 bearer token。',
+			'web.settings.account.username' => '用户名',
+			'web.settings.account.tokenExpires' => 'Token 过期',
+			'web.settings.account.changeCredentials' => '修改凭证',
+			'web.settings.changeCredentials.title' => '修改凭证',
+			'web.settings.changeCredentials.description' => '先验证当前密码，再选择新凭证。所有其它已登录会话都将被吊销。',
+			'web.settings.changeCredentials.currentPassword' => '当前密码',
+			'web.settings.changeCredentials.newUsername' => '新用户名',
+			'web.settings.changeCredentials.newPassword' => '新密码',
+			'web.settings.changeCredentials.newPasswordHint' => '至少 8 个字符。',
+			'web.settings.changeCredentials.confirm' => '确认新密码',
+			'web.settings.changeCredentials.errorTooShort' => '新密码至少 8 个字符。',
+			'web.settings.changeCredentials.errorMismatch' => '新密码和确认不一致。',
+			'web.settings.changeCredentials.errorWrongPassword' => '当前密码不正确。',
+			'web.settings.changeCredentials.cancel' => '取消',
+			'web.settings.changeCredentials.update' => '更新',
+			'web.settings.changeCredentials.saving' => '保存中…',
+			'web.settings.system.title' => '系统状态',
+			'web.settings.system.description' => '来自网关 /health 接口的实时状态。',
+			'web.settings.system.status' => '状态',
+			'web.settings.system.version' => '版本',
+			'web.settings.system.uptime' => '运行时长',
+			'web.settings.system.database' => '数据库',
+			'web.settings.system.reachable' => '可达',
+			'web.settings.system.unreachable' => '不可达',
+			'web.settings.about.title' => '关于',
+			'web.settings.about.description' => 'opendray v2 — 面向 AI agent CLI 的多路复用 + 集成网关。源码采用 Apache 2.0 协议。',
+			'web.logViewer.filterPlaceholder' => '过滤…',
+			'web.logViewer.debugTooltip' => 'Debug 计数',
+			'web.logViewer.infoTooltip' => 'Info 计数',
+			'web.logViewer.warnTooltip' => 'Warn 计数',
+			'web.logViewer.errorTooltip' => 'Error 计数',
+			'web.logViewer.streaming' => '正在流式传输',
+			'web.logViewer.disconnected' => '已断开',
+			'web.logViewer.live' => '实时',
+			'web.logViewer.offline' => '离线',
+			'web.logViewer.pauseTooltip' => '暂停自动滚动',
+			'web.logViewer.resumeTooltip' => '恢复自动滚动',
+			'web.logViewer.clearTooltip' => '清空本地视图（服务端 ring 不受影响）',
+			_ => null,
+		} ?? switch (path) {
+			'web.logViewer.downloadTooltip' => '下载完整 ring 为 .log 文件',
+			'web.logViewer.emptyWaiting' => '等待日志记录…',
+			'web.logViewer.emptyFiltered' => ({required Object query}) => '没有匹配 "${query}" 的记录',
+			'web.pathInput.testButton' => '测试',
+			'web.pathInput.testTooltip' => '解析并检查此路径',
+			'web.pathInput.notFound' => '未找到 ·',
+			'web.pathInput.childrenSuffix' => '项',
+			'web.pathInput.expectedDirectory' => '· 期望是目录',
+			'web.memoryAmbient.header.title' => '环境记忆 — 自动捕获与注入',
+			'web.memoryAmbient.header.body' => 'opendray 每 10 秒轮询所有运行中的 agent 会话，通过可配置的 LLM 提取持久事实，去重后存入共享记忆池。配置由哪个 LLM 做提取（Provider）、何时触发提取（Capture rule）、以及在 spawn 时把什么内容（如果有）拼接到 agent 的 system prompt（Injection profile）。',
+			'web.memoryAmbient.loading' => '加载中…',
+			'web.memoryAmbient.providers.title' => 'Summarizer Providers',
+			'web.memoryAmbient.providers.addButton' => '添加 provider',
+			'web.memoryAmbient.providers.intro' => '至少需要一个已启用的 provider 才能真正触发捕获。本地选项（Ollama、LM Studio、Integration）让你的会话内容不出外网。',
+			'web.memoryAmbient.providers.empty' => '尚未配置 provider。',
+			'web.memoryAmbient.providers.row.defaultBadge' => '★ 默认',
+			'web.memoryAmbient.providers.row.makeDefault' => '设为默认',
+			'web.memoryAmbient.providers.row.test' => '测试',
+			'web.memoryAmbient.providers.row.testing' => '测试中…',
+			'web.memoryAmbient.providers.row.delete' => '删除',
+			'web.memoryAmbient.providers.row.testOk' => ({required Object name}) => '${name}：连接成功',
+			'web.memoryAmbient.providers.row.testFailedToast' => '测试失败',
+			'web.memoryAmbient.providers.row.deleteConfirm' => ({required Object name}) => '删除 provider "${name}"?',
+			'web.memoryAmbient.providers.row.deletedToast' => 'Provider 已删除',
+			'web.memoryAmbient.providers.row.deleteFailedToast' => '删除失败',
+			'web.memoryAmbient.providers.row.updateFailedToast' => '更新失败',
+			'web.memoryAmbient.providers.row.madeDefaultToast' => ({required Object name}) => '${name} 已设为默认',
+			'web.memoryAmbient.providers.dialog.title' => '添加 summarizer provider',
+			'web.memoryAmbient.providers.dialog.kindLabel' => '类型',
+			'web.memoryAmbient.providers.dialog.nameLabel' => '名称',
+			'web.memoryAmbient.providers.dialog.namePlaceholder' => '例如 lmstudio-qwen',
+			'web.memoryAmbient.providers.dialog.modelLabel' => '模型',
+			'web.memoryAmbient.providers.dialog.baseUrlLabel' => 'Base URL',
+			'web.memoryAmbient.providers.dialog.integrationNote' => 'Integration 类型 provider 通过一个已注册的集成解析 base URL。请先在 Integrations 中配置；更高级的 wiring（extra_config）在本版本中仅 DB 配置。',
+			'web.memoryAmbient.providers.dialog.apiKeyLabel' => 'API key',
+			'web.memoryAmbient.providers.dialog.apiKeyHint' => 'AES-GCM 加密存储（使用 backup 主口令）。不会被回显；保存后只显示指纹。',
+			'web.memoryAmbient.providers.dialog.makeDefaultLabel' => '将此设为默认 provider',
+			'web.memoryAmbient.providers.dialog.create' => '创建',
+			'web.memoryAmbient.providers.dialog.nameRequiredToast' => '名称不能为空',
+			'web.memoryAmbient.providers.dialog.createdToast' => ({required Object name}) => '已创建 Provider ${name}',
+			'web.memoryAmbient.providers.dialog.createFailedToast' => '创建失败',
+			'web.memoryAmbient.rules.title' => '捕获规则',
+			'web.memoryAmbient.rules.addButton' => '添加规则',
+			'web.memoryAmbient.rules.intro' => '每条规则表示 "当此 trigger 触发时，对新的会话消息做总结并存储持久事实。" 单会话规则覆盖全局默认。v1 内置 4 种 trigger 类型。',
+			'web.memoryAmbient.rules.empty' => '尚无捕获规则。添加一条以启用自动捕获。',
+			'web.memoryAmbient.rules.row.globalDefault' => '全局默认',
+			'web.memoryAmbient.rules.row.scopeLabel' => 'scope:',
+			'web.memoryAmbient.rules.row.dedupLabel' => 'dedup:',
+			'web.memoryAmbient.rules.row.runNow' => '立即运行',
+			'web.memoryAmbient.rules.row.running' => '运行中…',
+			'web.memoryAmbient.rules.row.delete' => '删除',
+			'web.memoryAmbient.rules.row.firedToast' => ({required Object sessions}) => '规则已对 ${sessions} 个会话触发',
+			'web.memoryAmbient.rules.row.runNowFailedToast' => '立即运行失败',
+			'web.memoryAmbient.rules.row.deleteConfirm' => ({required Object name}) => '删除规则 "${name}"?',
+			'web.memoryAmbient.rules.row.deletedToast' => '规则已删除',
+			'web.memoryAmbient.rules.row.deleteFailedToast' => '删除失败',
+			'web.memoryAmbient.rules.row.summary.afterMessages' => ({required Object n}) => '每 ${n} 条消息',
+			'web.memoryAmbient.rules.row.summary.onIdle' => ({required Object seconds}) => 'idle ≥ ${seconds}s',
+			'web.memoryAmbient.rules.row.summary.kChars' => ({required Object k}) => '≥ ${k} 字符',
+			'web.memoryAmbient.rules.row.summary.manual' => '仅手动',
+			'web.memoryAmbient.rules.dialog.title' => '添加捕获规则',
+			'web.memoryAmbient.rules.dialog.nameLabel' => '名称',
+			'web.memoryAmbient.rules.dialog.triggerLabel' => 'Trigger',
+			'web.memoryAmbient.rules.dialog.nLabel' => 'N（消息条数）',
+			'web.memoryAmbient.rules.dialog.idleLabel' => 'Idle 秒数',
+			'web.memoryAmbient.rules.dialog.kLabel' => 'K（字符数）',
+			'web.memoryAmbient.rules.dialog.scopeLabel' => '目标 scope',
+			'web.memoryAmbient.rules.dialog.scopeSession' => 'session',
+			'web.memoryAmbient.rules.dialog.scopeProject' => 'project（推荐）',
+			'web.memoryAmbient.rules.dialog.scopeGlobal' => 'global',
+			'web.memoryAmbient.rules.dialog.dedupLabel' => '去重阈值（0.0 – 1.0）',
+			'web.memoryAmbient.rules.dialog.dedupHint' => '越高 = 去重越严格。0.85 是推荐的平衡点。',
+			'web.memoryAmbient.rules.dialog.create' => '创建',
+			'web.memoryAmbient.rules.dialog.nameRequiredToast' => '名称不能为空',
+			'web.memoryAmbient.rules.dialog.createdToast' => ({required Object name}) => '已创建规则 ${name}',
+			'web.memoryAmbient.rules.dialog.createFailedToast' => '创建失败',
+			'web.memoryAmbient.profiles.title' => 'Injection Profiles',
+			'web.memoryAmbient.profiles.addButton' => '添加 profile',
+			'web.memoryAmbient.profiles.intro' => 'spawn 时，opendray 会把最近的项目记忆作为一段 markdown banner 拼接到 agent 的 system prompt — 前提是配置了 profile。没有 profile 时，模型仍可按需调用 memory_search。',
+			'web.memoryAmbient.profiles.empty' => '尚无 injection profile。spawn 时不会自动注入记忆 — 模型仍可使用 memory_search。',
+			'web.memoryAmbient.profiles.row.globalDefault' => '全局默认',
+			'web.memoryAmbient.profiles.row.delete' => '删除',
+			'web.memoryAmbient.profiles.row.deleteConfirm' => '删除该 injection profile?',
+			'web.memoryAmbient.profiles.row.deletedToast' => 'Profile 已删除',
+			'web.memoryAmbient.profiles.row.deleteFailedToast' => '删除失败',
+			'web.memoryAmbient.profiles.dialog.title' => '添加 injection profile',
+			'web.memoryAmbient.profiles.dialog.strategyLabel' => '策略',
+			'web.memoryAmbient.profiles.dialog.kLabel' => 'K（注入的 top memory 数）',
+			'web.memoryAmbient.profiles.dialog.hint' => '每个 session_id 一个 profile（或全局默认）。单会话 profile 暂只能通过 API 添加；UI 当前只管理全局默认。',
+			'web.memoryAmbient.profiles.dialog.create' => '创建',
+			'web.memoryAmbient.profiles.dialog.createdToast' => 'Profile 已创建',
+			'web.memoryAmbient.profiles.dialog.createFailedToast' => '创建失败',
+			'web.memoryAmbient.cost.title' => 'Token 成本（总计）',
+			'web.memoryAmbient.cost.intro' => '按 provider 聚合自 <1>memory_summarizer_calls</1>。本地 provider（Ollama、LM Studio、Integration）按 \$0 计价 — 硬件成本由运维承担。',
+			'web.memoryAmbient.cost.empty' => '暂无已启用的 provider — 没有成本数据。',
+			'web.memoryAmbient.cost.columns.provider' => 'Provider',
+			'web.memoryAmbient.cost.columns.calls' => '调用',
+			'web.memoryAmbient.cost.columns.inTokens' => '输入 token',
+			'web.memoryAmbient.cost.columns.outTokens' => '输出 token',
+			'web.memoryAmbient.cost.columns.usdEst' => 'USD 估算',
+			'web.noteEditor.loading' => '加载中…',
+			'web.noteEditor.source' => '源码',
+			'web.noteEditor.preview' => '预览',
+			'web.noteEditor.tagTitle' => ({required Object tag}) => '标签 #${tag}',
+			'web.noteEditor.emptyNote' => '空白笔记。切换到源码标签开始书写。',
+			'web.noteEditor.saveFailedToast' => '保存失败',
+			'web.noteEditor.status.saveFailed' => '保存失败',
+			'web.noteEditor.status.saving' => '保存中…',
+			'web.noteEditor.status.unsaved' => '未保存',
+			'web.noteEditor.status.newNote' => '新笔记',
+			'web.noteEditor.status.saved' => '已保存',
+			'web.export.title' => '导出数据',
+			'web.export.subtitle' => '把选中的逻辑实体打成一份一次性 zip 包。服务器上保留 24 小时后自动回收。',
+			'web.export.backToBackups' => '← 备份',
+			'web.export.sections.export' => '导出',
+			'web.export.sections.import' => '导入',
+			'web.export.form.scope' => '范围',
+			'web.export.form.memories' => '记忆',
+			'web.export.form.memoriesHint' => '跨 CLI 持久化的记忆行（text + scope + metadata）。向量被省略；导入端重嵌入。',
+			'web.export.form.integrations' => '集成',
+			'web.export.form.customTasks' => '自定义任务',
+			'web.export.form.customTasksHint' => '在 Inspector 的 Tasks 标签里展示的运维自定义任务。',
+			'web.export.form.integrationOptions.none' => '无',
+			'web.export.form.integrationOptions.noneHint' => '完全跳过 integrations 表。',
+			'web.export.form.integrationOptions.metadata' => '仅元数据（推荐）',
+			'web.export.form.integrationOptions.metadataHint' => 'ID、name、route prefix、scopes — 不包含任何 API key 凭证。',
+			'web.export.form.integrationOptions.plaintext' => '包含明文 API key',
+			'web.export.form.integrationOptions.plaintextHint' => 'v1 仅 bcrypt：不存在可恢复的明文。Manifest 会记录此事实；不会泄露任何内容。',
+			'web.export.form.confirmWarning' => '输入 <1>I understand</1> 以确认。opendray 当前只存 bcrypt 哈希 — 选择明文也不会导出任何明文（该选项为将来保留明文缓存的版本而预留）。',
+			'web.export.form.confirmPlaceholder' => 'I understand',
+			'web.export.form.confirmSentinel' => 'i understand',
+			'web.export.form.footnote' => '审计日志与会话记录不在范围内 — 由 /backups（运维 dump）覆盖。',
+			'web.export.form.building' => '构建中…',
+			'web.export.form.create' => '创建导出',
+			'web.export.form.readyToast' => '导出就绪',
+			'web.export.form.readyDescription' => ({required Object bytes}) => '${bytes} 字节',
+			'web.export.form.failedToast' => '导出失败',
+			'web.export.history.loading' => '加载中…',
+			'web.export.history.empty' => '暂无导出。请使用上面的表单创建一个。',
+			'web.export.history.title' => '历史',
+			'web.export.history.columns.id' => 'ID',
+			'web.export.history.columns.status' => '状态',
+			'web.export.history.columns.scope' => '范围',
+			'web.export.history.columns.size' => '大小',
+			'web.export.history.columns.expires' => '过期',
+			'web.export.history.columns.actions' => '操作',
+			'web.export.history.download' => '下载',
+			'web.export.history.deleteTooltip' => '删除',
+			'web.export.history.listFailedToast' => '加载导出列表失败',
+			'web.export.history.downloadFailedToast' => '下载失败',
+			'web.export.history.noTokenToast' => '没有下载 token（已过期？）',
+			'web.export.history.deleteConfirm' => ({required Object id}) => '删除导出 ${id}?',
+			'web.export.history.deletedToast' => '导出已删除',
+			'web.export.history.deleteFailedToast' => '删除失败',
+			'web.export.history.scopeEmpty' => '(空)',
+			'web.export.import.intro' => '将一个导出 bundle（zip）回放到当前数据库。冲突项（id 一致，或 integrations 的 route_prefix 唯一冲突）默认 <1>跳过</1>。记忆条目会被标记为 <3>embedder=imported_v1</3>，需要做一次重嵌入后搜索才能返回；可在 <5>Memory → 维护</5> 触发。集成以 <7>enabled=false</7> 导入并使用非 bcrypt 的占位 key — 启用前请轮换。',
+			'web.export.import.memoryLink' => 'Memory → 维护',
+			'web.export.import.bundleLabel' => 'Bundle (.zip)',
+			'web.export.import.memoriesLabel' => '记忆',
+			'web.export.import.integrationsLabel' => '集成（仅元数据 — 不会导入 key）',
+			'web.export.import.customTasksLabel' => '自定义任务',
+			'web.export.import.importing' => '导入中…',
+			'web.export.import.importBundle' => '导入 bundle',
+			'web.export.import.pickFileToast' => '请先选择一个 bundle 文件',
+			'web.export.import.doneToast' => '导入完成',
+			'web.export.import.finishedWithErrors' => '导入完成但有错误',
+			'web.export.import.failedToast' => '导入失败',
+			'web.export.import.summaryCard.memories' => '记忆',
+			'web.export.import.summaryCard.integrations' => '集成',
+			'web.export.import.summaryCard.customTasks' => '自定义任务',
+			'web.export.import.summaryCard.created' => '已创建',
+			'web.export.import.summaryCard.skipped' => '已跳过',
+			'web.export.import.summaryCard.failed' => '失败',
+			'web.export.imports.loading' => '加载中…',
+			'web.export.imports.empty' => '暂无导入。',
+			'web.export.imports.title' => '历史',
+			'web.export.imports.columns.id' => 'ID',
+			'web.export.imports.columns.status' => '状态',
+			'web.export.imports.columns.source' => '来源',
+			'web.export.imports.columns.counts' => '计数',
+			'web.export.imports.columns.when' => '时间',
+			'web.export.imports.noneCounts' => '(无)',
+			'web.export.imports.listFailedToast' => '加载导入列表失败',
 			'more.title' => '更多',
 			'more.identity.signedInAs' => '登录账号',
 			'more.identity.server' => '服务器',
@@ -2790,6 +8668,8 @@ extension on TranslationsZh {
 			'integrations.edit' => '编辑',
 			'integrations.editTitle' => ({required Object name}) => '编辑 ${name}',
 			'integrations.enabledLabel' => '已启用',
+			_ => null,
+		} ?? switch (path) {
 			'integrations.iSavedIt' => '我已保存',
 			'integrations.apiKeyForName' => ({required Object name}) => '${name} 的 API key',
 			'integrations.apiKeySubtitleRegister' => ({required Object routePrefix}) => '将其交给集成方，使其能够通过 /api/v1/${routePrefix}/… 进行认证。',
@@ -2950,8 +8830,6 @@ extension on TranslationsZh {
 			'backups.emptyMissingDeps.body' => '安装 postgresql-client 并重启 opendray。',
 			'backups.emptyNoTargets.headline' => '未配置任何备份目标',
 			'backups.emptyNoTargets.body' => '打开「更多」菜单 → 目标，添加一个目的地（本地 / S3 / SMB / SFTP / WebDAV / rclone）。然后返回并点击「立即运行」。',
-			_ => null,
-		} ?? switch (path) {
 			'backups.emptyNoBackups.headline' => '暂无备份',
 			'backups.emptyNoBackups.body' => '点击「立即运行」生成一次新快照，或打开「计划」设置定期运行。',
 			'backups.restartToActivate' => '重启 opendray 以激活备份',
@@ -3304,6 +9182,8 @@ extension on TranslationsZh {
 			'customTasks.cwdHelper' => '绝对路径。以此 cwd 启动的会话将看到该任务。',
 			'customTasks.saving' => '保存中…',
 			'customTasks.save' => '保存',
+			_ => null,
+		} ?? switch (path) {
 			'customTasks.create' => '创建',
 			'customTasks.failedToLoad' => '加载自定义任务失败',
 			'notesPage.title' => '笔记',
@@ -3464,8 +9344,6 @@ extension on TranslationsZh {
 			'settings.serverSettings.fields.adminUserHelper' => '当未设置密钥文件或环境变量时生效。否则参见 设置 → 账户。',
 			'settings.serverSettings.fields.adminPassword' => '管理员密码',
 			'settings.serverSettings.fields.adminPasswordHelper' => '留空 = 保留。日常轮换请用 设置 → 账户（密钥文件支持，无需重启）。',
-			_ => null,
-		} ?? switch (path) {
 			'settings.serverSettings.fields.tokenTtlWeb' => '令牌 TTL（Web）',
 			'settings.serverSettings.fields.tokenTtlHelper' => 'Go duration 字符串，如 24h、30m。',
 			'settings.serverSettings.fields.level' => '级别',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -2288,7 +2288,7 @@ class _TranslationsWebSessionsSpawnZh extends TranslationsWebSessionsSpawnEn {
 	@override String get namePlaceholder => 'claude in pet-tracker';
 	@override String get argsLabel => 'CLI 参数（每行一个）';
 	@override String get bypassClaude => '跳过权限提示';
-	@override String get bypassCodex => '自动批准 (--ask-for-approval never)';
+	@override String get bypassCodex => '跳过所有批准与沙盒 (--dangerously-bypass-approvals-and-sandbox)';
 	@override String get bypassGemini => 'YOLO 模式 (--yolo)';
 	@override String get bypassOnHint => '本次会话将以更高的自主权运行。';
 	@override String get bypassOffHint => '关闭 — 确认与提示按正常流程处理。';
@@ -4644,7 +4644,7 @@ class _TranslationsSessionsSpawnSheetBypassZh extends TranslationsSessionsSpawnS
 
 	// Translations
 	@override String get labelClaude => '绕过权限';
-	@override String get labelCodex => '自动批准（从不询问）';
+	@override String get labelCodex => '跳过批准与沙盒';
 	@override String get labelGemini => 'YOLO 模式';
 	@override String get subtitleOn => '此会话将以提升的自主权运行。';
 	@override String get subtitleOff => '关闭 — 确认和提示按正常方式处理。';
@@ -6742,7 +6742,7 @@ extension on TranslationsZh {
 			'web.sessions.spawn.namePlaceholder' => 'claude in pet-tracker',
 			'web.sessions.spawn.argsLabel' => 'CLI 参数（每行一个）',
 			'web.sessions.spawn.bypassClaude' => '跳过权限提示',
-			'web.sessions.spawn.bypassCodex' => '自动批准 (--ask-for-approval never)',
+			'web.sessions.spawn.bypassCodex' => '跳过所有批准与沙盒 (--dangerously-bypass-approvals-and-sandbox)',
 			'web.sessions.spawn.bypassGemini' => 'YOLO 模式 (--yolo)',
 			'web.sessions.spawn.bypassOnHint' => '本次会话将以更高的自主权运行。',
 			'web.sessions.spawn.bypassOffHint' => '关闭 — 确认与提示按正常流程处理。',
@@ -8529,7 +8529,7 @@ extension on TranslationsZh {
 			'sessions.spawnSheet.argsHint' => '--continue --verbose',
 			'sessions.spawnSheet.argsHelper' => '以空格分隔；留空使用提供商默认值。',
 			'sessions.spawnSheet.bypass.labelClaude' => '绕过权限',
-			'sessions.spawnSheet.bypass.labelCodex' => '自动批准（从不询问）',
+			'sessions.spawnSheet.bypass.labelCodex' => '跳过批准与沙盒',
 			'sessions.spawnSheet.bypass.labelGemini' => 'YOLO 模式',
 			'sessions.spawnSheet.bypass.subtitleOn' => '此会话将以提升的自主权运行。',
 			'sessions.spawnSheet.bypass.subtitleOff' => '关闭 — 确认和提示按正常方式处理。',

--- a/app/mobile/lib/features/sessions/spawn_session_sheet.dart
+++ b/app/mobile/lib/features/sessions/spawn_session_sheet.dart
@@ -20,14 +20,16 @@ const _claudeProviderId = 'claude';
 // toggle below is purely additive — when OFF we send no extra
 // args, when ON we append the flag(s) the user picked.
 //
-// Backend already concatenates session args after config args, so
-// passing the flag a second time when the provider config already
-// has it is harmless: claude/gemini boolean flags are idempotent;
-// codex's --ask-for-approval gets overridden by the second occurrence
-// (later wins in cobra parse).
+// claude/gemini bool flags are idempotent so duplicates are safe.
+// codex requires its true "skip everything" switch
+// (--dangerously-bypass-approvals-and-sandbox) — --ask-for-approval=never
+// only auto-approves shell exec, not MCP tool calls, and clap rejects
+// duplicate --ask-for-approval flags. The backend session manager strips
+// any provider-config flags (--ask-for-approval, -s) that conflict with
+// codex's ArgGroup, so this single flag is sufficient.
 const Map<String, List<String>> _bypassFlagsByProvider = {
   'claude': ['--dangerously-skip-permissions'],
-  'codex': ['--ask-for-approval', 'never', '-c', 'approval_policy="never"'],
+  'codex': ['--dangerously-bypass-approvals-and-sandbox'],
   'gemini': ['--yolo'],
 };
 

--- a/app/web/src/components/sessions/SpawnDialog.tsx
+++ b/app/web/src/components/sessions/SpawnDialog.tsx
@@ -35,9 +35,14 @@ const HOME_HINT = '/Users/' // macOS-friendly default; user can edit.
 // (Settings → Providers) may also bake these in; the per-session
 // toggle below is purely additive. Keeping the list here as a const
 // table avoids importing config logic from the gateway side.
+// codex's --ask-for-approval=never only auto-approves shell exec calls;
+// MCP tool invocations still prompt. --dangerously-bypass-approvals-and-sandbox
+// is codex's true "skip everything" switch (parallels claude's
+// --dangerously-skip-permissions) and also disables the sandbox — the
+// per-session toggle below is the right place to opt into that.
 const BYPASS_FLAGS: Record<string, string[]> = {
   claude: ['--dangerously-skip-permissions'],
-  codex: ['--ask-for-approval', 'never', '-c', 'approval_policy="never"'],
+  codex: ['--dangerously-bypass-approvals-and-sandbox'],
   gemini: ['--yolo'],
 }
 

--- a/app/web/src/tutorial/sections/02-sessions/02-spawning.md
+++ b/app/web/src/tutorial/sections/02-sessions/02-spawning.md
@@ -84,7 +84,7 @@ The flag is provider-specific:
 | Provider | Toggle label | Appended flag(s) |
 |---|---|---|
 | Claude | `Bypass permission prompts` | `--dangerously-skip-permissions` |
-| Codex | `Auto-approve (--ask-for-approval never)` | `--ask-for-approval never` |
+| Codex | `Bypass approvals & sandbox` | `--dangerously-bypass-approvals-and-sandbox` |
 | Gemini | `YOLO mode (--yolo)` | `--yolo` |
 
 The toggle is **additive** — it doesn't disable a provider-wide
@@ -93,9 +93,17 @@ Approval / YOLO**. If the provider config already has bypass on,
 every session bypasses regardless of this toggle. Leave the
 provider default off if you want per-session control.
 
-Bypass flags are appended *before* anything you type into **Args**
-above, so your explicit args win on conflicts (codex's
-`--ask-for-approval` is last-wins in the upstream parser).
+Per-session bypass flags are appended *before* anything you type
+into **Args** above. When the same flag exists in the provider's
+saved config (e.g. codex's saved `--ask-for-approval on-request`),
+the session-level value wins — opendray drops the provider's copy
+to avoid duplicates that codex's parser would reject.
+
+For codex specifically: `--ask-for-approval never` only
+auto-approves shell exec commands, **not** MCP tool calls. The
+session toggle uses `--dangerously-bypass-approvals-and-sandbox`
+instead, which is codex's "skip everything" switch (also disables
+the workspace sandbox).
 
 The toggle resets to OFF on provider change + after each spawn, so
 the next session is always a deliberate opt-in.

--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -280,6 +281,7 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 		ID:         p.Manifest.ID,
 		Executable: exe,
 		Args:       args,
+		Conflicts:  providerConflicts(p.Manifest.ID),
 	}
 
 	// Account selection: only meaningful for the Claude provider —
@@ -759,39 +761,90 @@ func resolveMCPSecrets(servers []MCPServer, path string, log *slog.Logger) ([]MC
 	return out, missing
 }
 
-// mirrorCodexHome symlinks every entry of src into dest, skipping
-// files we layer ourselves (config.toml, instructions.md). Lets the
-// codex CLI see the user's auth.json + history.jsonl + cache while
-// our skill index sits alongside as a real file.
+// mirrorCodexHome copies the minimal subset of the user's Codex home
+// that a session scratch dir needs to start authenticated inside a
+// sandbox.
+//
+// We intentionally do NOT symlink the whole ~/.codex tree anymore.
+// Under codex's workspace-write sandbox, symlinked sqlite/log/cache
+// files still resolve to paths outside the writable scratch dir, so
+// startup fails with "attempt to write a readonly database". Keeping
+// mutable runtime state local to dest avoids that while still
+// preserving auth and user rules/plugins.
 func mirrorCodexHome(src, dest string) error {
 	if err := os.MkdirAll(dest, 0o700); err != nil {
 		return err
 	}
-	entries, err := os.ReadDir(src)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
+	allow := map[string]bool{
+		"auth.json":                true,
+		".codex-global-state.json": true,
+		"installation_id":          true,
+		"version.json":             true,
+		"plugins":                  true,
+		"rules":                    true,
+		"skills":                   true,
 	}
-	skip := map[string]bool{
-		"config.toml":     true,
-		"instructions.md": true,
-	}
-	for _, e := range entries {
-		if skip[e.Name()] {
-			continue
-		}
-		srcPath := filepath.Join(src, e.Name())
-		dstPath := filepath.Join(dest, e.Name())
-		if err := os.Symlink(srcPath, dstPath); err != nil {
-			if os.IsExist(err) {
+	for name := range allow {
+		srcPath := filepath.Join(src, name)
+		if _, err := os.Stat(srcPath); err != nil {
+			if os.IsNotExist(err) {
 				continue
 			}
-			return fmt.Errorf("symlink %s: %w", e.Name(), err)
+			return err
+		}
+		dstPath := filepath.Join(dest, name)
+		if err := copyPath(srcPath, dstPath); err != nil {
+			return fmt.Errorf("copy %s: %w", name, err)
 		}
 	}
 	return nil
+}
+
+func copyPath(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if li, lerr := os.Lstat(src); lerr == nil && li.Mode()&os.ModeSymlink != 0 {
+				// Dangling symlink in user's codex home — skip rather than
+				// fail the whole mirror. Stale skill links are common when
+				// a source repo is moved or deleted.
+				return nil
+			}
+		}
+		return err
+	}
+	if info.IsDir() {
+		if err := os.MkdirAll(dst, info.Mode().Perm()); err != nil {
+			return err
+		}
+		entries, err := os.ReadDir(src)
+		if err != nil {
+			return err
+		}
+		for _, e := range entries {
+			if err := copyPath(filepath.Join(src, e.Name()), filepath.Join(dst, e.Name())); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
 }
 
 func ensureCodexScratchTrust(home, cwd string) error {
@@ -819,6 +872,30 @@ func ensureCodexScratchTrust(home, cwd string) error {
 	}
 	body += projectHeader + "\ntrust_level = \"trusted\"\n"
 	return os.WriteFile(path, []byte(body), 0o600)
+}
+
+// providerConflicts returns the static CLI argument-group rules for
+// a provider. Each entry maps a "trigger" flag (one that may appear in
+// user spawn args) to the set of provider-config flags that conflict
+// with it and must be stripped before exec.
+//
+// Currently only codex needs this: its clap ArgGroup makes
+// --dangerously-bypass-approvals-and-sandbox mutually exclusive with
+// --ask-for-approval (-a) and --sandbox (-s). Without this stripping
+// step the spawn fails because the saved provider config keeps emitting
+// the default approval/sandbox flags.
+func providerConflicts(providerID string) map[string][]string {
+	switch providerID {
+	case "codex":
+		return map[string][]string{
+			"--dangerously-bypass-approvals-and-sandbox": {
+				"--ask-for-approval", "-a",
+				"--sandbox", "-s",
+			},
+		}
+	default:
+		return nil
+	}
 }
 
 // defaultStr returns def when s is empty after trimming, otherwise s.

--- a/internal/catalog/inject_test.go
+++ b/internal/catalog/inject_test.go
@@ -199,3 +199,92 @@ func TestEnsureCodexScratchTrust_AppendsCurrentCwd(t *testing.T) {
 		t.Errorf("trust level missing: %s", str)
 	}
 }
+
+func TestMirrorCodexHome_CopiesMinimalAuthSubset(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(src, "auth.json"), []byte(`{"token":"x"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "state_5.sqlite"), []byte("sqlite"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(src, "rules"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "rules", "team.md"), []byte("rule"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(src, "plugins"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "plugins", "marketplace.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mirrorCodexHome(src, dest); err != nil {
+		t.Fatal(err)
+	}
+
+	authPath := filepath.Join(dest, "auth.json")
+	info, err := os.Lstat(authPath)
+	if err != nil {
+		t.Fatalf("auth.json missing: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("auth.json should be copied, not symlinked")
+	}
+	body, err := os.ReadFile(authPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != `{"token":"x"}` {
+		t.Fatalf("auth.json content mismatch: %s", body)
+	}
+
+	if _, err := os.Stat(filepath.Join(dest, "rules", "team.md")); err != nil {
+		t.Fatalf("rules directory should be copied: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "plugins", "marketplace.json")); err != nil {
+		t.Fatalf("plugins directory should be copied: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "state_5.sqlite")); !os.IsNotExist(err) {
+		t.Fatalf("sqlite runtime should not be mirrored, got err=%v", err)
+	}
+}
+
+func TestMirrorCodexHome_SkipsDanglingSymlinks(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(src, "auth.json"), []byte(`{"token":"x"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	skillsDir := filepath.Join(src, "skills")
+	if err := os.MkdirAll(skillsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Real skill alongside a dangling symlink — mirrors the user's actual
+	// ~/.codex/skills layout when a skill source repo has been deleted.
+	if err := os.MkdirAll(filepath.Join(skillsDir, "good"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillsDir, "good", "SKILL.md"), []byte("ok"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(src, "nonexistent-target"), filepath.Join(skillsDir, "broken")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mirrorCodexHome(src, dest); err != nil {
+		t.Fatalf("mirror should tolerate dangling symlinks: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dest, "skills", "good", "SKILL.md")); err != nil {
+		t.Fatalf("valid skill should be copied: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(dest, "skills", "broken")); !os.IsNotExist(err) {
+		t.Fatalf("dangling symlink should be skipped, got err=%v", err)
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -361,7 +361,16 @@ func (m *Manager) spawn(ctx context.Context, sess Session, reactivate bool) (*ru
 		}
 	}
 
-	args := append([]string(nil), p.Args...)
+	// User-supplied spawn args take precedence over provider-config-derived
+	// args: drop any flag from p.Args that the user is re-specifying, plus
+	// any provider-side flag that the catalog declares mutually exclusive
+	// with a user-supplied flag. Without this, CLIs that reject duplicate
+	// flags (codex's clap rejects a second --ask-for-approval) or
+	// ArgGroup conflicts (codex's --dangerously-bypass-approvals-and-sandbox
+	// vs --ask-for-approval) fail to spawn.
+	providerArgs := dropOverriddenFlags(p.Args, sess.Args)
+	providerArgs = dropConflictingFlags(providerArgs, sess.Args, p.Conflicts)
+	args := append([]string(nil), providerArgs...)
 	args = append(args, extraArgs...)
 	args = append(args, sess.Args...)
 
@@ -814,4 +823,120 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+// dropOverriddenFlags returns providerArgs with any flag (and its value)
+// removed when the same flag is also present in userArgs. Lets per-session
+// spawn args override saved provider config without producing duplicates
+// that CLI parsers reject (e.g. codex's clap rejects repeated
+// --ask-for-approval).
+//
+// Value-flag detection is a peek heuristic: a flag is treated as taking a
+// value when the following token does not itself start with "-". This
+// matches every flag opendray's bundled providers actually emit (codex,
+// claude, gemini). It does NOT support flag values that start with "-"
+// (e.g. negative numbers); none of our providers use such values.
+func dropOverriddenFlags(providerArgs, userArgs []string) []string {
+	if len(providerArgs) == 0 || len(userArgs) == 0 {
+		return providerArgs
+	}
+	override := map[string]struct{}{}
+	for _, a := range userArgs {
+		if name, ok := flagName(a); ok {
+			override[name] = struct{}{}
+		}
+	}
+	if len(override) == 0 {
+		return providerArgs
+	}
+	out := make([]string, 0, len(providerArgs))
+	for i := 0; i < len(providerArgs); i++ {
+		tok := providerArgs[i]
+		name, isFlag := flagName(tok)
+		if !isFlag {
+			out = append(out, tok)
+			continue
+		}
+		if _, drop := override[name]; !drop {
+			out = append(out, tok)
+			continue
+		}
+		// Drop this flag. If it's the "--key=value" form the value is
+		// already attached; otherwise peek the next token and drop it
+		// too when it looks like a value (not another flag).
+		if strings.Contains(tok, "=") {
+			continue
+		}
+		if i+1 < len(providerArgs) {
+			next := providerArgs[i+1]
+			if _, nextIsFlag := flagName(next); !nextIsFlag {
+				i++
+			}
+		}
+	}
+	return out
+}
+
+// dropConflictingFlags strips from providerArgs every flag in the
+// conflict set triggered by any user spawn arg. Used for CLI parsers
+// where two distinct flags can't appear together (clap ArgGroup); the
+// catalog declares the rules per provider in ProviderInfo.Conflicts.
+//
+// Example for codex: when userArgs contains
+// --dangerously-bypass-approvals-and-sandbox, every occurrence of
+// --ask-for-approval, -a, --sandbox, -s (plus their values) is removed
+// from providerArgs.
+func dropConflictingFlags(providerArgs, userArgs []string, conflicts map[string][]string) []string {
+	if len(providerArgs) == 0 || len(userArgs) == 0 || len(conflicts) == 0 {
+		return providerArgs
+	}
+	drop := map[string]struct{}{}
+	for _, a := range userArgs {
+		name, ok := flagName(a)
+		if !ok {
+			continue
+		}
+		for _, victim := range conflicts[name] {
+			drop[victim] = struct{}{}
+		}
+	}
+	if len(drop) == 0 {
+		return providerArgs
+	}
+	out := make([]string, 0, len(providerArgs))
+	for i := 0; i < len(providerArgs); i++ {
+		tok := providerArgs[i]
+		name, isFlag := flagName(tok)
+		if !isFlag {
+			out = append(out, tok)
+			continue
+		}
+		if _, victim := drop[name]; !victim {
+			out = append(out, tok)
+			continue
+		}
+		if strings.Contains(tok, "=") {
+			continue
+		}
+		if i+1 < len(providerArgs) {
+			next := providerArgs[i+1]
+			if _, nextIsFlag := flagName(next); !nextIsFlag {
+				i++
+			}
+		}
+	}
+	return out
+}
+
+// flagName returns the canonical name of a CLI flag token ("--ask-for-approval"
+// for "--ask-for-approval=never" or "--ask-for-approval"), with ok=false for
+// non-flag tokens (positional args, values).
+func flagName(tok string) (string, bool) {
+	if len(tok) < 2 || tok[0] != '-' {
+		return "", false
+	}
+	if eq := strings.IndexByte(tok, '='); eq > 0 {
+		return tok[:eq], true
+	}
+	return tok, true
 }

--- a/internal/session/manager_args_test.go
+++ b/internal/session/manager_args_test.go
@@ -1,0 +1,186 @@
+package session
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDropOverriddenFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider []string
+		user     []string
+		want     []string
+	}{
+		{
+			name:     "no user args returns provider untouched",
+			provider: []string{"--ask-for-approval", "on-request", "-s", "workspace-write"},
+			user:     nil,
+			want:     []string{"--ask-for-approval", "on-request", "-s", "workspace-write"},
+		},
+		{
+			name:     "user value-flag drops provider value-flag with value",
+			provider: []string{"--ask-for-approval", "on-request", "-s", "workspace-write"},
+			user:     []string{"--ask-for-approval", "never"},
+			want:     []string{"-s", "workspace-write"},
+		},
+		{
+			name:     "user bool-flag drops provider bool-flag (no value follows)",
+			provider: []string{"--verbose", "--debug"},
+			user:     []string{"--verbose"},
+			want:     []string{"--debug"},
+		},
+		{
+			name:     "user --key=value form is recognized by name",
+			provider: []string{"--model", "gpt-4", "-s", "read-only"},
+			user:     []string{"--model=gpt-5"},
+			want:     []string{"-s", "read-only"},
+		},
+		{
+			name:     "provider --key=value form is dropped wholesale",
+			provider: []string{"--model=gpt-4", "-s", "read-only"},
+			user:     []string{"--model", "gpt-5"},
+			want:     []string{"-s", "read-only"},
+		},
+		{
+			name:     "short flag with value (-s workspace-write) is dropped properly",
+			provider: []string{"-s", "workspace-write", "--ask-for-approval", "on-request"},
+			user:     []string{"-s", "danger-full-access"},
+			want:     []string{"--ask-for-approval", "on-request"},
+		},
+		{
+			name:     "non-overridden flags survive",
+			provider: []string{"--ask-for-approval", "on-request", "-s", "workspace-write"},
+			user:     []string{"-c", "model=gpt-5"},
+			want:     []string{"--ask-for-approval", "on-request", "-s", "workspace-write"},
+		},
+		{
+			name:     "user provides bare flag for provider value-flag drops both via peek",
+			provider: []string{"--ask-for-approval", "on-request"},
+			user:     []string{"--ask-for-approval"},
+			want:     []string{},
+		},
+		{
+			name:     "positional values in provider args are kept",
+			provider: []string{"--ask-for-approval", "on-request", "prompt-here"},
+			user:     []string{"--ask-for-approval", "never"},
+			want:     []string{"prompt-here"},
+		},
+		{
+			name:     "regression: codex bypass scenario from SpawnDialog",
+			provider: []string{"--ask-for-approval", "on-request", "-s", "workspace-write"},
+			user:     []string{"--ask-for-approval", "never", "-c", `approval_policy="never"`},
+			want:     []string{"-s", "workspace-write"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dropOverriddenFlags(tc.provider, tc.user)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("dropOverriddenFlags(%v, %v) = %v, want %v",
+					tc.provider, tc.user, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDropConflictingFlags(t *testing.T) {
+	codexConflicts := map[string][]string{
+		"--dangerously-bypass-approvals-and-sandbox": {
+			"--ask-for-approval", "-a",
+			"--sandbox", "-s",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		provider  []string
+		user      []string
+		conflicts map[string][]string
+		want      []string
+	}{
+		{
+			name:      "codex bypass strips approval and sandbox",
+			provider:  []string{"--ask-for-approval", "on-request", "-s", "workspace-write"},
+			user:      []string{"--dangerously-bypass-approvals-and-sandbox"},
+			conflicts: codexConflicts,
+			want:      []string{},
+		},
+		{
+			name:      "codex bypass strips short-form approval too",
+			provider:  []string{"-a", "on-request", "-s", "workspace-write"},
+			user:      []string{"--dangerously-bypass-approvals-and-sandbox"},
+			conflicts: codexConflicts,
+			want:      []string{},
+		},
+		{
+			name:      "codex bypass strips --key=value form",
+			provider:  []string{"--ask-for-approval=on-request", "--sandbox=read-only"},
+			user:      []string{"--dangerously-bypass-approvals-and-sandbox"},
+			conflicts: codexConflicts,
+			want:      []string{},
+		},
+		{
+			name:      "no trigger flag keeps provider args intact",
+			provider:  []string{"--ask-for-approval", "on-request", "-s", "workspace-write"},
+			user:      []string{"--verbose"},
+			conflicts: codexConflicts,
+			want:      []string{"--ask-for-approval", "on-request", "-s", "workspace-write"},
+		},
+		{
+			name:      "non-conflict provider flags survive",
+			provider:  []string{"--ask-for-approval", "on-request", "-c", "model=gpt-5"},
+			user:      []string{"--dangerously-bypass-approvals-and-sandbox"},
+			conflicts: codexConflicts,
+			want:      []string{"-c", "model=gpt-5"},
+		},
+		{
+			name:      "nil conflicts map is a no-op",
+			provider:  []string{"--ask-for-approval", "on-request"},
+			user:      []string{"--dangerously-bypass-approvals-and-sandbox"},
+			conflicts: nil,
+			want:      []string{"--ask-for-approval", "on-request"},
+		},
+		{
+			name:      "positional values preserved",
+			provider:  []string{"--ask-for-approval", "on-request", "prompt-here"},
+			user:      []string{"--dangerously-bypass-approvals-and-sandbox"},
+			conflicts: codexConflicts,
+			want:      []string{"prompt-here"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dropConflictingFlags(tc.provider, tc.user, tc.conflicts)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("dropConflictingFlags(%v, %v, %v) = %v, want %v",
+					tc.provider, tc.user, tc.conflicts, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFlagName(t *testing.T) {
+	tests := []struct {
+		in   string
+		name string
+		ok   bool
+	}{
+		{"--ask-for-approval", "--ask-for-approval", true},
+		{"--ask-for-approval=never", "--ask-for-approval", true},
+		{"-s", "-s", true},
+		{"-s=workspace-write", "-s", true},
+		{"workspace-write", "", false},
+		{"", "", false},
+		{"-", "", false},
+	}
+	for _, tc := range tests {
+		gotName, gotOk := flagName(tc.in)
+		if gotName != tc.name || gotOk != tc.ok {
+			t.Errorf("flagName(%q) = (%q, %v); want (%q, %v)",
+				tc.in, gotName, gotOk, tc.name, tc.ok)
+		}
+	}
+}

--- a/internal/session/provider.go
+++ b/internal/session/provider.go
@@ -13,7 +13,20 @@ type ProviderInfo struct {
 	ID         string
 	Executable string
 	Args       []string
-	Prepare    PrepareFunc
+
+	// Conflicts declares provider-specific CLI argument-group rules.
+	// When a user spawn arg matches a key flag, every flag listed in
+	// the value slice is stripped from Args before exec (along with
+	// the value following each flag, when applicable).
+	//
+	// Use this for CLI parsers that reject "this flag cannot be used
+	// with that flag" (clap ArgGroup), where simple name-based dedup
+	// is insufficient. E.g. codex's
+	// --dangerously-bypass-approvals-and-sandbox is mutually exclusive
+	// with --ask-for-approval and -s/--sandbox.
+	Conflicts map[string][]string
+
+	Prepare PrepareFunc
 }
 
 // PrepareFunc is the spawn-time hook signature.


### PR DESCRIPTION
## Summary

Fixes three independent codex session bugs surfaced while debugging the per-session bypass toggle.

### 1. Dangling skill symlinks crashed session prepare

`~/.codex/skills/` accumulates symlinks to user skill source repos; when a source repo is deleted, the link goes dangling. The new copy-based `mirrorCodexHome` (replacing the old symlink-mirror) was calling `os.Stat` on every entry, which returns `ENOENT` for broken links and aborted the whole mirror.

`copyPath` now treats dangling links as a skip rather than a fatal error.

### 2. clap rejected duplicate `--ask-for-approval`

When SpawnDialog's "auto-approve" toggle was on, the user-side bypass flag and the provider-config-derived flag both emitted `--ask-for-approval`. codex's clap rejects this (the `last-wins` assumption in the old comment is no longer true).

Added `dropOverriddenFlags` in the session manager: any flag the user re-specifies in spawn args is stripped from `p.Args` before exec. Generic, provider-agnostic.

### 3. `--ask-for-approval=never` does NOT cover MCP tool approvals

This was the actual user-reported symptom: even with auto-approve enabled, `opendray-memory.memory_load_context` still prompted. `--ask-for-approval=never` only auto-approves shell exec calls; MCP tool invocations have their own approval path.

codex's true "skip everything" switch is `--dangerously-bypass-approvals-and-sandbox` (parallel to claude's `--dangerously-skip-permissions`). clap puts it in an ArgGroup with `--ask-for-approval`/`-a`/`--sandbox`/`-s`, so:

- Web (`SpawnDialog.tsx`) and mobile (`spawn_session_sheet.dart`) bypass tables now emit only this single flag.
- i18n labels updated: "Bypass approvals & sandbox" / "跳过批准与沙盒" so operators know sandbox also goes away.
- `ProviderInfo.Conflicts map[string][]string` lets the catalog declare ArgGroup rules; session manager's new `dropConflictingFlags` strips conflicting provider-config flags when a user trigger flag is present.

### Architecture

- `dropOverriddenFlags` handles **same-name** duplicates (generic CLI hygiene).
- `dropConflictingFlags` handles **different-name** mutual exclusions (clap ArgGroup), driven by a per-provider table the catalog declares.

The two functions are layered intentionally — same-name dedup is universally safe; conflict-stripping is provider-specific knowledge.

## Test plan

- [x] `go test -race ./internal/session/ ./internal/catalog/` — green
- [x] `dart analyze` on touched mobile dirs — clean
- [x] `pnpm tsc --noEmit` on web — green
- [x] Manual: create codex session with bypass ON, MCP tool call no longer prompts
- [x] Manual: create codex session with bypass OFF, normal approvals still work
- [x] Regression tests cover the exact scenarios from each report (dangling symlink, duplicate `--ask-for-approval`, ArgGroup conflict)

## Commits

1. `chore(mobile): regenerate slang strings and refresh ios Podfile.lock` — pure generator output drift catch-up; no behavior change. The bulk of the line count.
2. `fix(codex): bypass MCP tool approvals + tolerate stale skill symlinks` — the actual ~400-line business change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)