### PR TITLE
feat(memory): plan-drift auto-proposals + per-project health dashboard (Phase A)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -220,6 +220,31 @@
       "navWorkers": "Workers",
       "navConfiguration": "Configuration →"
     },
+    "memoryHealth": {
+      "title": "Memory health — last {days} days",
+      "subtitle": "Aggregate signals across both memory subsystems for this project.",
+      "loading": "Loading health snapshot…",
+      "errorLoading": "Failed to load health snapshot.",
+      "pickCwd": "Pick a project to see its memory health.",
+      "newFacts": "New facts",
+      "newFactsHint": "{total} stored in total",
+      "captureFires": "Capture fires",
+      "captureFiresHint": "{stored} stored · {deduped} deduped",
+      "newJournal": "Journal entries",
+      "newJournalHint": "{total} in total",
+      "planAge": "Plan last updated",
+      "planAgeHint": "{count} plan-drift proposal(s) pending",
+      "planAgeHintNone": "No plan-drift proposals pending",
+      "goalAge": "Goal last updated",
+      "pending": "Pending proposals",
+      "pendingHint": "oldest {days}d old",
+      "topHit": "Top hit · {hits} retrievals",
+      "zeroHit": "{count} facts older than 7d with zero retrievals — candidates for cleanup.",
+      "never": "never",
+      "today": "today",
+      "daysAgo_one": "{count} day ago",
+      "daysAgo_other": "{count} days ago"
+    },
     "memoryWorkers": {
       "title": "Memory workers",
       "loading": "Loading worker config…",
@@ -321,6 +346,7 @@
         "cleanupPending": "{count} cleanup pending"
       },
       "tabs": {
+        "health": "Health",
         "goal": "Goal",
         "plan": "Plan",
         "tech": "Tech",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -220,6 +220,31 @@
       "navWorkers": "Workers",
       "navConfiguration": "配置 →"
     },
+    "memoryHealth": {
+      "title": "记忆健康 — 最近 {days} 天",
+      "subtitle": "本项目两套记忆子系统的运行情况聚合。",
+      "loading": "正在加载健康快照…",
+      "errorLoading": "加载健康快照失败。",
+      "pickCwd": "选一个项目查看其记忆健康。",
+      "newFacts": "新增 facts",
+      "newFactsHint": "累计 {total} 条",
+      "captureFires": "Capture 触发次数",
+      "captureFiresHint": "存入 {stored} · 去重 {deduped}",
+      "newJournal": "新增日志条目",
+      "newJournalHint": "累计 {total} 条",
+      "planAge": "计划最近更新",
+      "planAgeHint": "{count} 条 plan-drift 提案待审",
+      "planAgeHintNone": "无 plan-drift 提案待审",
+      "goalAge": "目标最近更新",
+      "pending": "待审提案",
+      "pendingHint": "最久 {days} 天",
+      "topHit": "命中最多 · {hits} 次",
+      "zeroHit": "{count} 条超过 7 天未命中的 fact — 清理候选。",
+      "never": "从未",
+      "today": "今日",
+      "daysAgo_one": "{count} 天前",
+      "daysAgo_other": "{count} 天前"
+    },
     "memoryWorkers": {
       "title": "Memory workers",
       "loading": "正在加载 worker 配置…",
@@ -321,6 +346,7 @@
         "cleanupPending": "{count} 条待清理"
       },
       "tabs": {
+        "health": "健康",
         "goal": "目标",
         "plan": "计划",
         "tech": "技术栈",

--- a/app/shared/src/lib/memoryHealth.ts
+++ b/app/shared/src/lib/memoryHealth.ts
@@ -1,0 +1,43 @@
+// Client for /api/v1/memory/health — the M-PA memory health
+// dashboard. Returns one aggregate snapshot per cwd combining
+// layer-5 facts, capture-engine activity, journal/proposal state.
+
+import { api } from './api'
+
+export interface MemoryHealthSnapshot {
+  cwd: string
+  generated_at: string
+  lookback_days: number
+
+  // Layer 5 — discrete facts.
+  new_facts_count: number
+  total_facts_count: number
+  zero_hit_facts_count: number
+  top_hit_fact_text: string
+  top_hit_fact_hits: number
+
+  // Capture engine.
+  capture_fires: number
+  capture_facts_extracted: number
+  capture_facts_stored: number
+  capture_facts_deduped: number
+  capture_failed_fires: number
+
+  // Layer 4 — journal.
+  new_journal_count: number
+  total_journal_count: number
+
+  // Layer 2-3 — plan / goal.
+  plan_last_updated_at?: string
+  goal_last_updated_at?: string
+  pending_proposals: number
+  oldest_pending_days: number
+  plan_drift_proposals: number
+}
+
+export async function getMemoryHealth(
+  cwd: string,
+): Promise<MemoryHealthSnapshot> {
+  const qs = new URLSearchParams({ cwd })
+  return api<MemoryHealthSnapshot>(`/api/v1/memory/health?${qs}`)
+}

--- a/app/web/src/components/project/MemoryHealthCard.tsx
+++ b/app/web/src/components/project/MemoryHealthCard.tsx
@@ -1,0 +1,195 @@
+// MemoryHealthCard — M-PA dashboard panel summarising the per-cwd
+// state of both memory subsystems. Renders inside ProjectScreen's
+// Health tab and a fetched on demand (no polling — the dashboard
+// is informational, not real-time).
+
+import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import {
+  Activity,
+  AlertCircle,
+  BookOpen,
+  Brain,
+  CheckCircle2,
+  Database,
+  Inbox,
+  Loader2,
+  TrendingUp,
+} from 'lucide-react'
+
+import { getMemoryHealth } from '@/lib/memoryHealth'
+
+interface MemoryHealthCardProps {
+  cwd: string
+}
+
+export function MemoryHealthCard({ cwd }: MemoryHealthCardProps) {
+  const { t } = useTranslation()
+  const query = useQuery({
+    queryKey: ['memory-health', cwd],
+    queryFn: () => getMemoryHealth(cwd),
+    enabled: !!cwd,
+    staleTime: 60_000,
+  })
+
+  if (!cwd) {
+    return (
+      <div className="text-muted-foreground p-6 text-[12px]">
+        {t('web.memoryHealth.pickCwd')}
+      </div>
+    )
+  }
+  if (query.isLoading) {
+    return (
+      <div className="text-muted-foreground flex items-center gap-2 p-6 text-[12px]">
+        <Loader2 className="size-3 animate-spin" />
+        {t('web.memoryHealth.loading')}
+      </div>
+    )
+  }
+  if (query.isError || !query.data) {
+    return (
+      <div className="text-destructive flex items-center gap-2 p-6 text-[12px]">
+        <AlertCircle className="size-3" />
+        {t('web.memoryHealth.errorLoading')}
+      </div>
+    )
+  }
+
+  const snap = query.data
+  const planAge = formatRelative(snap.plan_last_updated_at, t)
+  const goalAge = formatRelative(snap.goal_last_updated_at, t)
+
+  return (
+    <div className="space-y-4 p-4">
+      <header>
+        <h2 className="text-sm font-medium">
+          {t('web.memoryHealth.title', { days: snap.lookback_days })}
+        </h2>
+        <p className="text-muted-foreground mt-0.5 text-[11px]">
+          {t('web.memoryHealth.subtitle')}
+        </p>
+      </header>
+
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+        <Metric
+          icon={<Database className="size-3.5" />}
+          label={t('web.memoryHealth.newFacts')}
+          value={snap.new_facts_count}
+          hint={t('web.memoryHealth.newFactsHint', {
+            total: snap.total_facts_count,
+          })}
+        />
+        <Metric
+          icon={<Activity className="size-3.5" />}
+          label={t('web.memoryHealth.captureFires')}
+          value={snap.capture_fires}
+          hint={t('web.memoryHealth.captureFiresHint', {
+            stored: snap.capture_facts_stored,
+            deduped: snap.capture_facts_deduped,
+          })}
+          tone={snap.capture_failed_fires > 0 ? 'warn' : 'ok'}
+        />
+        <Metric
+          icon={<BookOpen className="size-3.5" />}
+          label={t('web.memoryHealth.newJournal')}
+          value={snap.new_journal_count}
+          hint={t('web.memoryHealth.newJournalHint', {
+            total: snap.total_journal_count,
+          })}
+        />
+        <Metric
+          icon={<Brain className="size-3.5" />}
+          label={t('web.memoryHealth.planAge')}
+          value={planAge}
+          hint={
+            snap.plan_drift_proposals > 0
+              ? t('web.memoryHealth.planAgeHint', {
+                  count: snap.plan_drift_proposals,
+                })
+              : t('web.memoryHealth.planAgeHintNone')
+          }
+        />
+        <Metric
+          icon={<Brain className="size-3.5" />}
+          label={t('web.memoryHealth.goalAge')}
+          value={goalAge}
+        />
+        <Metric
+          icon={<Inbox className="size-3.5" />}
+          label={t('web.memoryHealth.pending')}
+          value={snap.pending_proposals}
+          hint={
+            snap.pending_proposals > 0 && snap.oldest_pending_days > 0
+              ? t('web.memoryHealth.pendingHint', {
+                  days: snap.oldest_pending_days,
+                })
+              : undefined
+          }
+          tone={snap.oldest_pending_days >= 7 ? 'warn' : 'ok'}
+        />
+      </div>
+
+      {snap.top_hit_fact_text && (
+        <div className="bg-muted/20 rounded border p-3 text-[12px]">
+          <div className="text-muted-foreground mb-1 flex items-center gap-1 text-[10px]">
+            <TrendingUp className="size-3" />
+            {t('web.memoryHealth.topHit', { hits: snap.top_hit_fact_hits })}
+          </div>
+          <div className="font-mono break-words">{snap.top_hit_fact_text}</div>
+        </div>
+      )}
+
+      {snap.zero_hit_facts_count > 0 && (
+        <div className="text-muted-foreground flex items-center gap-2 text-[11px]">
+          <CheckCircle2 className="size-3" />
+          {t('web.memoryHealth.zeroHit', {
+            count: snap.zero_hit_facts_count,
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface MetricProps {
+  icon: React.ReactNode
+  label: string
+  value: number | string
+  hint?: string
+  tone?: 'ok' | 'warn'
+}
+
+function Metric({ icon, label, value, hint, tone = 'ok' }: MetricProps) {
+  return (
+    <div className="bg-card/50 rounded-md border p-3">
+      <div className="text-muted-foreground flex items-center gap-1 text-[10px]">
+        {icon}
+        {label}
+      </div>
+      <div
+        className={`mt-1 text-xl font-semibold ${
+          tone === 'warn' ? 'text-amber-500' : ''
+        }`}
+      >
+        {value}
+      </div>
+      {hint && (
+        <div className="text-muted-foreground mt-1 text-[10px]">{hint}</div>
+      )}
+    </div>
+  )
+}
+
+function formatRelative(
+  iso: string | undefined,
+  t: ReturnType<typeof useTranslation>['t'],
+): string {
+  if (!iso) return t('web.memoryHealth.never')
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return '—'
+  const days = Math.floor((Date.now() - then) / 86_400_000)
+  if (days <= 0) return t('web.memoryHealth.today')
+  if (days === 1) return t('web.memoryHealth.daysAgo', { count: 1 })
+  return t('web.memoryHealth.daysAgo', { count: days })
+}

--- a/app/web/src/components/project/ProjectScreen.tsx
+++ b/app/web/src/components/project/ProjectScreen.tsx
@@ -59,6 +59,7 @@ import {
   runCleanup,
 } from '@/lib/memoryCleanup'
 import { deleteMemoriesByScope } from '@/lib/memory'
+import { MemoryHealthCard } from '@/components/project/MemoryHealthCard'
 
 interface ProjectScreenProps {
   cwd: string
@@ -183,8 +184,9 @@ export function ProjectScreen({ cwd }: ProjectScreenProps) {
         </div>
       </div>
 
-      <Tabs defaultValue="goal" className="flex flex-1 flex-col overflow-hidden">
+      <Tabs defaultValue="health" className="flex flex-1 flex-col overflow-hidden">
         <TabsList className="bg-muted/30 mx-4 mt-3 w-fit">
+          <TabsTrigger value="health">{t('web.project.tabs.health')}</TabsTrigger>
           <TabsTrigger value="goal">{t('web.project.tabs.goal')}</TabsTrigger>
           <TabsTrigger value="plan">{t('web.project.tabs.plan')}</TabsTrigger>
           <TabsTrigger value="tech">{t('web.project.tabs.tech')}</TabsTrigger>
@@ -211,6 +213,10 @@ export function ProjectScreen({ cwd }: ProjectScreenProps) {
             )}
           </TabsTrigger>
         </TabsList>
+
+        <TabsContent value="health" className="flex-1 overflow-auto">
+          <MemoryHealthCard cwd={cwd} />
+        </TabsContent>
 
         <TabsContent value="goal" className="flex-1 overflow-auto p-4">
           <DocEditor

--- a/docs/memory-system.md
+++ b/docs/memory-system.md
@@ -278,6 +278,48 @@ See ADR 0019 for the architecture, the **Memory → Workers**
 tutorial (sections 15.1-15.3) for operator workflow, and the
 implementation under `internal/memory/worker/`.
 
+## Plan-drift auto-proposals (M-PA, shipped)
+
+The plan document used to update only when an agent explicitly
+called `project_plan_set` — which agents rarely did in practice,
+so plans drifted out of date as projects iterated.
+
+M-PA adds a fifth memory worker task — **`plan_drift`** — that
+runs after every `session.ended` event. Given the session's
+transcript summary, the current plan, and the last few journal
+entries, it asks the configured worker LLM: "does this plan need
+updating?" If yes, it files a proposal into the operator's inbox
+with a one-line reason. Same approval flow as a manual
+`project_plan_set` — operators always have final say.
+
+Worker selection lives at **Memory → Workers → plan_drift**;
+default is `summarizer`. Disable per task if you want the
+historical behaviour back. The drift detector is a no-op when:
+
+- the plan document is empty (refuses to seed an initial plan)
+- the transcript summariser produced no narrative
+- no worker is configured for `plan_drift`
+
+Per-fire metrics land in `memory_worker_calls` alongside the
+other four touch-points.
+
+## Memory health dashboard (M-PA, shipped)
+
+Each project's **Health** tab (`/memory/project` → first tab)
+surfaces a single-page snapshot of "is the memory system
+actually working for this project?":
+
+- New facts / journal entries this week + cumulative totals
+- Capture engine fire count, stored vs deduped, failure count
+- Plan / goal last-updated relative times
+- Pending proposal queue depth + oldest age
+- Plan-drift proposals filed this week
+- Top-hit fact (most retrieved) + count of zero-hit stale facts
+
+Backed by `GET /api/v1/memory/health?cwd=<cwd>` — one aggregate
+read that crosses both subsystems. No polling; refreshes on tab
+view.
+
 ## Roadmap
 
 - **Codex session UUID capture**. Codex lacks `--session-id`; a

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -43,6 +43,7 @@ import (
 	githost "github.com/opendray/opendray-v2/internal/githost"
 	"github.com/opendray/opendray-v2/internal/integration"
 	mcpapi "github.com/opendray/opendray-v2/internal/mcp"
+	"github.com/opendray/opendray-v2/internal/memhealth"
 	"github.com/opendray/opendray-v2/internal/memory"
 	"github.com/opendray/opendray-v2/internal/memory/capture"
 	"github.com/opendray/opendray-v2/internal/memory/cleaner"
@@ -372,6 +373,15 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		st.Pool(), summarizerRegistry, cliacctSvc, log)
 	memoryWorkerHandlers := memworker.NewHandlers(memoryWorkerRegistry, log)
 
+	// M-PA — memory health dashboard. Aggregates "is the memory
+	// system actually working?" metrics across both subsystems
+	// (layer 5 + projectdoc) for one HTTP read.
+	memhealthSvc, err := memhealth.New(st.Pool())
+	if err != nil {
+		return nil, fmt.Errorf("memhealth init: %w", err)
+	}
+	memhealthHandlers := memhealth.NewHandlers(memhealthSvc, log)
+
 	// M12 — Gatekeeper. Wired late because the summarizer registry
 	// only exists after backup cipher + summarizer store are up.
 	// When operators set [memory.gatekeeper] enabled = true, every
@@ -521,7 +531,13 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	// No upfront provider check needed: the registry handles
 	// degraded states (no summarizer configured → returns empty).
 	journaler.WithSummariser(newTranscriptSummariser(memoryWorkerRegistry))
-	log.Info("transcript-aware journaler enabled (worker-registry routing)")
+	// M-PA — same routing for the plan-drift detector. After each
+	// successful session summary the journaler asks the detector
+	// whether the project plan needs updating and files a proposal
+	// when so.
+	journaler.WithPlanDetector(newPlanDriftDetector(memoryWorkerRegistry))
+	log.Info("transcript-aware journaler enabled (worker-registry routing)",
+		"plan_drift_enabled", true)
 
 	gw := gateway.NewServer(gateway.Deps{
 		Logger:    log,
@@ -566,6 +582,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 				backupHandlers.Mount(r)
 				summarizerHandlers.Mount(r)
 				memoryWorkerHandlers.Mount(r)
+				memhealthHandlers.Mount(r)
 				captureHandlers.Mount(r)
 				injectorHandlers.Mount(r)
 				if cleanerHandlers != nil {

--- a/internal/app/plan_drift_detector.go
+++ b/internal/app/plan_drift_detector.go
@@ -1,0 +1,117 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/opendray/opendray-v2/internal/memory/worker"
+	"github.com/opendray/opendray-v2/internal/projectdoc"
+)
+
+// planDriftDetector is the M-PA implementation of
+// projectdoc.PlanDriftDetector. It routes through worker.Registry
+// so operators can pick per-task between the summarizer HTTP path
+// (cheap, local) and a headless Claude/Gemini agent (higher
+// quality, higher latency). Same shape as transcriptSummariser —
+// each touchpoint owns its own prompt assembly; only the LLM
+// dispatch is shared.
+type planDriftDetector struct {
+	registry *worker.Registry
+}
+
+// newPlanDriftDetector builds a detector backed by the given
+// worker registry. Nil registry → detector silently no-ops; same
+// degraded behaviour as transcriptSummariser.
+func newPlanDriftDetector(reg *worker.Registry) *planDriftDetector {
+	return &planDriftDetector{registry: reg}
+}
+
+// DetectDrift implements projectdoc.PlanDriftDetector.
+func (d *planDriftDetector) DetectDrift(ctx context.Context, in projectdoc.DriftInput) (projectdoc.DriftOutput, error) {
+	if d.registry == nil {
+		return projectdoc.DriftOutput{}, nil
+	}
+	if strings.TrimSpace(in.CurrentPlan) == "" {
+		// No plan to drift from — refuse to seed one to avoid
+		// hallucinated initial plans. Operator should seed the plan
+		// manually; subsequent sessions will then keep it fresh.
+		return projectdoc.DriftOutput{}, nil
+	}
+	if strings.TrimSpace(in.TranscriptSummary) == "" {
+		// Without a transcript summary the detector has nothing
+		// concrete to evaluate against. Skip rather than ask the
+		// LLM to guess.
+		return projectdoc.DriftOutput{}, nil
+	}
+
+	userInput := buildDriftUserInput(in)
+	resp, err := d.registry.Run(ctx, worker.Request{
+		Task:                     worker.TaskPlanDrift,
+		SystemPrompt:             projectdoc.PlanDriftSystemPrompt,
+		UserInput:                userInput,
+		MaxTokens:                4096,
+		Timeout:                  5 * time.Minute,
+		ResponseFormatJSONSchema: driftJSONSchema,
+	})
+	if err != nil {
+		return projectdoc.DriftOutput{}, err
+	}
+	if strings.TrimSpace(resp.Content) == "" {
+		return projectdoc.DriftOutput{}, nil
+	}
+	return projectdoc.ParseDriftResponse(resp.Content)
+}
+
+// driftJSONSchema is the response_format=json_schema body that
+// asks the model for a strict-shape reply. Workers that don't
+// support structured output (agent CLI mode) translate this to a
+// trailing instruction in the system prompt; the parser tolerates
+// both clean JSON and fenced/preambled variants either way.
+const driftJSONSchema = `{
+  "name": "plan_drift_decision",
+  "schema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "should_propose": {"type": "boolean"},
+      "new_plan":       {"type": "string"},
+      "reason":         {"type": "string"}
+    },
+    "required": ["should_propose", "new_plan", "reason"]
+  },
+  "strict": true
+}`
+
+// buildDriftUserInput assembles the user-message payload the
+// detector sends to the LLM. Kept as a top-level function so unit
+// tests can pin the exact rendered shape without spinning up a
+// worker.
+func buildDriftUserInput(in projectdoc.DriftInput) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "## Project cwd\n\n`%s`\n\n", in.Cwd)
+	b.WriteString("## Current plan\n\n")
+	b.WriteString(strings.TrimSpace(in.CurrentPlan))
+	b.WriteString("\n\n## Latest session summary\n\n")
+	b.WriteString(strings.TrimSpace(in.TranscriptSummary))
+	if len(in.RecentJournal) > 0 {
+		b.WriteString("\n\n## Recent journal entries (oldest first)\n\n")
+		// Render oldest first so chronology reads top-to-bottom — the
+		// list comes from projectdoc.ListLogs newest-first, so reverse.
+		for i := len(in.RecentJournal) - 1; i >= 0; i-- {
+			e := in.RecentJournal[i]
+			body := strings.TrimSpace(e.Content)
+			if len(body) > 600 {
+				body = body[:600] + "…"
+			}
+			if e.Title != "" {
+				fmt.Fprintf(&b, "- **%s** — %s\n", e.Title, body)
+			} else {
+				fmt.Fprintf(&b, "- %s\n", body)
+			}
+		}
+	}
+	b.WriteString("\n")
+	return b.String()
+}

--- a/internal/app/plan_drift_detector_test.go
+++ b/internal/app/plan_drift_detector_test.go
@@ -1,0 +1,119 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/opendray/opendray-v2/internal/projectdoc"
+)
+
+func TestPlanDriftDetector_NoRegistryIsNoop(t *testing.T) {
+	d := newPlanDriftDetector(nil)
+	out, err := d.DetectDrift(context.Background(), projectdoc.DriftInput{
+		Cwd:               "/p",
+		CurrentPlan:       "## Plan\n- x",
+		TranscriptSummary: "did the work",
+	})
+	if err != nil {
+		t.Fatalf("nil registry should not error: %v", err)
+	}
+	if out.ShouldPropose {
+		t.Errorf("nil registry should not propose")
+	}
+}
+
+func TestPlanDriftDetector_EmptyPlanShortCircuits(t *testing.T) {
+	// Build a detector that would normally call the registry; the
+	// short-circuit must hit before any registry call, so a nil
+	// registry being safe here means the guard ran.
+	d := newPlanDriftDetector(nil)
+	out, err := d.DetectDrift(context.Background(), projectdoc.DriftInput{
+		Cwd:               "/p",
+		CurrentPlan:       "   \n  ",
+		TranscriptSummary: "did the work",
+	})
+	if err != nil {
+		t.Fatalf("empty plan should not error: %v", err)
+	}
+	if out.ShouldPropose {
+		t.Errorf("empty plan should not propose")
+	}
+}
+
+func TestPlanDriftDetector_EmptySummaryShortCircuits(t *testing.T) {
+	d := newPlanDriftDetector(nil)
+	out, err := d.DetectDrift(context.Background(), projectdoc.DriftInput{
+		Cwd:               "/p",
+		CurrentPlan:       "## Plan\n- x",
+		TranscriptSummary: "",
+	})
+	if err != nil {
+		t.Fatalf("empty summary should not error: %v", err)
+	}
+	if out.ShouldPropose {
+		t.Errorf("empty summary should not propose")
+	}
+}
+
+func TestBuildDriftUserInput_Shape(t *testing.T) {
+	in := projectdoc.DriftInput{
+		Cwd:               "/projects/foo",
+		CurrentPlan:       "## Plan\n- M1 deploy",
+		TranscriptSummary: "Agent landed M1 deploy script",
+		RecentJournal: []projectdoc.LogEntry{
+			// newest first (as docs.ListLogs returns)
+			{Title: "M1 progress", Content: "Wired up deploy.sh"},
+			{Title: "M1 kickoff", Content: "Discussed deploy strategy"},
+		},
+	}
+	got := buildDriftUserInput(in)
+	for _, want := range []string{
+		"`/projects/foo`",
+		"## Current plan",
+		"M1 deploy",
+		"## Latest session summary",
+		"Agent landed M1 deploy script",
+		"## Recent journal entries",
+		"**M1 kickoff**", // oldest rendered first
+		"**M1 progress**",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+	// Chronology: kickoff (oldest) must appear before progress (newest).
+	if strings.Index(got, "M1 kickoff") > strings.Index(got, "M1 progress") {
+		t.Errorf("journal entries rendered in wrong chronological order:\n%s", got)
+	}
+}
+
+func TestBuildDriftUserInput_NoJournalSection(t *testing.T) {
+	got := buildDriftUserInput(projectdoc.DriftInput{
+		Cwd:               "/p",
+		CurrentPlan:       "## Plan",
+		TranscriptSummary: "did work",
+	})
+	if strings.Contains(got, "Recent journal entries") {
+		t.Errorf("journal section should be omitted when empty:\n%s", got)
+	}
+}
+
+func TestBuildDriftUserInput_LongEntryTruncated(t *testing.T) {
+	long := strings.Repeat("a", 1000)
+	in := projectdoc.DriftInput{
+		Cwd:               "/p",
+		CurrentPlan:       "## Plan",
+		TranscriptSummary: "x",
+		RecentJournal: []projectdoc.LogEntry{
+			{Title: "long", Content: long},
+		},
+	}
+	got := buildDriftUserInput(in)
+	if !strings.Contains(got, "…") {
+		t.Errorf("expected ellipsis for truncated entry; got:\n%s", got)
+	}
+	if strings.Contains(got, long) {
+		t.Errorf("entry should not be rendered in full (1000 chars)")
+	}
+}

--- a/internal/memhealth/handler.go
+++ b/internal/memhealth/handler.go
@@ -1,0 +1,61 @@
+package memhealth
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Handlers exposes ComputeForCwd over HTTP.
+//
+// Routes (under the gateway's /api/v1 prefix):
+//
+//	GET /memory/health?cwd=<cwd>   → Snapshot
+//
+// Auth: mount behind admin auth — the snapshot reveals project
+// activity volumes which can leak operator behaviour.
+type Handlers struct {
+	svc *Service
+	log *slog.Logger
+}
+
+// NewHandlers wires an HTTP surface around an existing Service.
+func NewHandlers(svc *Service, log *slog.Logger) *Handlers {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Handlers{svc: svc, log: log.With("component", "memhealth.http")}
+}
+
+// Mount registers routes on r. r should already have admin auth
+// applied by the caller; the handlers themselves do not.
+func (h *Handlers) Mount(r chi.Router) {
+	r.Get("/memory/health", h.get)
+}
+
+func (h *Handlers) get(w http.ResponseWriter, r *http.Request) {
+	cwd := r.URL.Query().Get("cwd")
+	if cwd == "" {
+		writeError(w, http.StatusBadRequest, "cwd query param is required")
+		return
+	}
+	snap, err := h.svc.ComputeForCwd(r.Context(), cwd)
+	if err != nil {
+		h.log.Warn("memhealth: compute failed", "cwd", cwd, "err", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, snap)
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]any{"error": msg})
+}

--- a/internal/memhealth/handler_test.go
+++ b/internal/memhealth/handler_test.go
@@ -1,0 +1,58 @@
+package memhealth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestHandler_MissingCwd(t *testing.T) {
+	h := NewHandlers(&Service{}, nil)
+	r := chi.NewRouter()
+	h.Mount(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/memory/health", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "cwd") {
+		t.Errorf("body should mention cwd: %s", rec.Body.String())
+	}
+}
+
+func TestHandler_LiveDB(t *testing.T) {
+	pool := devDB(t)
+	defer pool.Close()
+	svc, err := New(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := NewHandlers(svc, nil)
+	r := chi.NewRouter()
+	h.Mount(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/memory/health?cwd=/__handler_test__", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got Snapshot
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Cwd != "/__handler_test__" {
+		t.Errorf("Cwd: got %q", got.Cwd)
+	}
+	if got.LookbackDays != LookbackDays {
+		t.Errorf("LookbackDays: got %d", got.LookbackDays)
+	}
+}

--- a/internal/memhealth/health.go
+++ b/internal/memhealth/health.go
@@ -34,29 +34,29 @@ type Snapshot struct {
 	LookbackDays int       `json:"lookback_days"`
 
 	// Layer 5 — discrete facts.
-	NewFactsCount       int      `json:"new_facts_count"`
-	TotalFactsCount     int      `json:"total_facts_count"`
-	ZeroHitFactsCount   int      `json:"zero_hit_facts_count"`
-	TopHitFactText      string   `json:"top_hit_fact_text"`
-	TopHitFactHits      int      `json:"top_hit_fact_hits"`
+	NewFactsCount     int    `json:"new_facts_count"`
+	TotalFactsCount   int    `json:"total_facts_count"`
+	ZeroHitFactsCount int    `json:"zero_hit_facts_count"`
+	TopHitFactText    string `json:"top_hit_fact_text"`
+	TopHitFactHits    int    `json:"top_hit_fact_hits"`
 
 	// Capture engine — how often the layer-5 writer is firing.
-	CaptureFires           int `json:"capture_fires"`
-	CaptureFactsExtracted  int `json:"capture_facts_extracted"`
-	CaptureFactsStored     int `json:"capture_facts_stored"`
-	CaptureFactsDeduped    int `json:"capture_facts_deduped"`
-	CaptureFailedFires     int `json:"capture_failed_fires"`
+	CaptureFires          int `json:"capture_fires"`
+	CaptureFactsExtracted int `json:"capture_facts_extracted"`
+	CaptureFactsStored    int `json:"capture_facts_stored"`
+	CaptureFactsDeduped   int `json:"capture_facts_deduped"`
+	CaptureFailedFires    int `json:"capture_failed_fires"`
 
 	// Layer 4 — session journal.
 	NewJournalCount   int `json:"new_journal_count"`
 	TotalJournalCount int `json:"total_journal_count"`
 
 	// Layers 2-3 — operator-owned plan/goal.
-	PlanLastUpdatedAt    *time.Time `json:"plan_last_updated_at,omitempty"`
-	GoalLastUpdatedAt    *time.Time `json:"goal_last_updated_at,omitempty"`
-	PendingProposals     int        `json:"pending_proposals"`
-	OldestPendingDays    int        `json:"oldest_pending_days"`
-	PlanDriftProposals   int        `json:"plan_drift_proposals"`
+	PlanLastUpdatedAt  *time.Time `json:"plan_last_updated_at,omitempty"`
+	GoalLastUpdatedAt  *time.Time `json:"goal_last_updated_at,omitempty"`
+	PendingProposals   int        `json:"pending_proposals"`
+	OldestPendingDays  int        `json:"oldest_pending_days"`
+	PlanDriftProposals int        `json:"plan_drift_proposals"`
 }
 
 // Service computes Snapshots against a pgxpool. Stateless beyond

--- a/internal/memhealth/health.go
+++ b/internal/memhealth/health.go
@@ -1,0 +1,214 @@
+// Package memhealth aggregates "is the memory system actually
+// working?" metrics across both memory subsystems (internal/memory
+// and internal/projectdoc) and exposes them through one HTTP
+// endpoint backing the /memory landing-page dashboard.
+//
+// Why a separate package: the data spans two domains (layer-5 facts
+// + layer-2-4 docs/journal/proposals) and adding the aggregation
+// queries to either would create unwanted cross-imports. This
+// package only depends on pgxpool — the same shape every existing
+// store wrapper uses — and is consumed by an HTTP handler in
+// internal/app.
+package memhealth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// LookbackDays is the moving window we summarise activity over. 7
+// days is short enough to feel current and long enough that a
+// slowly-iterating project still sees non-zero numbers.
+const LookbackDays = 7
+
+// Snapshot is one read of every panel on the memory health card.
+// JSON-tagged so the HTTP handler can ship it without translation.
+type Snapshot struct {
+	Cwd          string    `json:"cwd"`
+	GeneratedAt  time.Time `json:"generated_at"`
+	LookbackDays int       `json:"lookback_days"`
+
+	// Layer 5 — discrete facts.
+	NewFactsCount       int      `json:"new_facts_count"`
+	TotalFactsCount     int      `json:"total_facts_count"`
+	ZeroHitFactsCount   int      `json:"zero_hit_facts_count"`
+	TopHitFactText      string   `json:"top_hit_fact_text"`
+	TopHitFactHits      int      `json:"top_hit_fact_hits"`
+
+	// Capture engine — how often the layer-5 writer is firing.
+	CaptureFires           int `json:"capture_fires"`
+	CaptureFactsExtracted  int `json:"capture_facts_extracted"`
+	CaptureFactsStored     int `json:"capture_facts_stored"`
+	CaptureFactsDeduped    int `json:"capture_facts_deduped"`
+	CaptureFailedFires     int `json:"capture_failed_fires"`
+
+	// Layer 4 — session journal.
+	NewJournalCount   int `json:"new_journal_count"`
+	TotalJournalCount int `json:"total_journal_count"`
+
+	// Layers 2-3 — operator-owned plan/goal.
+	PlanLastUpdatedAt    *time.Time `json:"plan_last_updated_at,omitempty"`
+	GoalLastUpdatedAt    *time.Time `json:"goal_last_updated_at,omitempty"`
+	PendingProposals     int        `json:"pending_proposals"`
+	OldestPendingDays    int        `json:"oldest_pending_days"`
+	PlanDriftProposals   int        `json:"plan_drift_proposals"`
+}
+
+// Service computes Snapshots against a pgxpool. Stateless beyond
+// the pool reference; safe to construct once per process.
+type Service struct {
+	pool *pgxpool.Pool
+}
+
+// New wires a Service against the given pool. A nil pool is a
+// programmer error — return an error instead of panicking so the
+// composition root can surface it cleanly.
+func New(pool *pgxpool.Pool) (*Service, error) {
+	if pool == nil {
+		return nil, errors.New("memhealth: pool is nil")
+	}
+	return &Service{pool: pool}, nil
+}
+
+// ComputeForCwd returns a fresh snapshot for the given project
+// cwd. Empty cwd returns an error — every panel is project-scoped.
+// Queries run sequentially; the dashboard fetches this once on
+// page load so latency is not a hot path.
+func (s *Service) ComputeForCwd(ctx context.Context, cwd string) (Snapshot, error) {
+	if cwd == "" {
+		return Snapshot{}, errors.New("memhealth: cwd is required")
+	}
+	since := time.Now().UTC().Add(-time.Duration(LookbackDays) * 24 * time.Hour)
+	snap := Snapshot{
+		Cwd:          cwd,
+		GeneratedAt:  time.Now().UTC(),
+		LookbackDays: LookbackDays,
+	}
+
+	if err := s.layer5(ctx, &snap, cwd, since); err != nil {
+		return Snapshot{}, fmt.Errorf("memhealth: layer5: %w", err)
+	}
+	if err := s.captureMetrics(ctx, &snap, cwd, since); err != nil {
+		return Snapshot{}, fmt.Errorf("memhealth: capture: %w", err)
+	}
+	if err := s.layer24(ctx, &snap, cwd, since); err != nil {
+		return Snapshot{}, fmt.Errorf("memhealth: layer24: %w", err)
+	}
+	return snap, nil
+}
+
+// layer5 fills the discrete-fact panels: counts plus the top-hit
+// memory and how many memories have never been retrieved.
+func (s *Service) layer5(ctx context.Context, snap *Snapshot, cwd string, since time.Time) error {
+	row := s.pool.QueryRow(ctx, `
+		SELECT
+			COALESCE(SUM(CASE WHEN created_at >= $2 THEN 1 ELSE 0 END), 0) AS new_count,
+			COUNT(*)                                                       AS total_count,
+			COALESCE(SUM(CASE WHEN hit_count = 0 AND created_at < $2
+			                  THEN 1 ELSE 0 END), 0)                       AS zero_hit_count
+		  FROM memories
+		 WHERE scope = 'project' AND scope_key = $1`, cwd, since)
+	if err := row.Scan(&snap.NewFactsCount, &snap.TotalFactsCount, &snap.ZeroHitFactsCount); err != nil {
+		return fmt.Errorf("layer5 counts: %w", err)
+	}
+
+	topRow := s.pool.QueryRow(ctx, `
+		SELECT text, hit_count
+		  FROM memories
+		 WHERE scope = 'project' AND scope_key = $1 AND hit_count > 0
+		 ORDER BY hit_count DESC, created_at DESC
+		 LIMIT 1`, cwd)
+	var (
+		text string
+		hits int
+	)
+	if err := topRow.Scan(&text, &hits); err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("layer5 top hit: %w", err)
+		}
+		// no hits yet → leave fields zero/empty.
+	} else {
+		snap.TopHitFactText = text
+		snap.TopHitFactHits = hits
+	}
+	return nil
+}
+
+// captureMetrics joins memory_summarizer_calls to sessions so we
+// can filter by cwd; capture-engine fires are per-session and have
+// no direct cwd column.
+func (s *Service) captureMetrics(ctx context.Context, snap *Snapshot, cwd string, since time.Time) error {
+	row := s.pool.QueryRow(ctx, `
+		SELECT
+			COUNT(*)                                            AS fires,
+			COALESCE(SUM(c.facts_extracted), 0)                 AS extracted,
+			COALESCE(SUM(c.facts_stored), 0)                    AS stored,
+			COALESCE(SUM(c.facts_skipped_dedup), 0)             AS deduped,
+			COALESCE(SUM(CASE WHEN c.status <> 'succeeded'
+			                  THEN 1 ELSE 0 END), 0)            AS failed
+		  FROM memory_summarizer_calls c
+		  JOIN sessions s ON s.id = c.session_id
+		 WHERE s.cwd = $1 AND c.started_at >= $2`, cwd, since)
+	return row.Scan(
+		&snap.CaptureFires,
+		&snap.CaptureFactsExtracted,
+		&snap.CaptureFactsStored,
+		&snap.CaptureFactsDeduped,
+		&snap.CaptureFailedFires,
+	)
+}
+
+// layer24 fills the projectdoc-side panels: journal counts, plan /
+// goal last-touched timestamps, pending proposal queue depth.
+func (s *Service) layer24(ctx context.Context, snap *Snapshot, cwd string, since time.Time) error {
+	jrow := s.pool.QueryRow(ctx, `
+		SELECT
+			COALESCE(SUM(CASE WHEN created_at >= $2 THEN 1 ELSE 0 END), 0) AS new_count,
+			COUNT(*)                                                       AS total_count
+		  FROM session_logs
+		 WHERE cwd = $1`, cwd, since)
+	if err := jrow.Scan(&snap.NewJournalCount, &snap.TotalJournalCount); err != nil {
+		return fmt.Errorf("layer24 journal: %w", err)
+	}
+
+	if err := s.scanDocTimestamp(ctx, cwd, "plan", &snap.PlanLastUpdatedAt); err != nil {
+		return err
+	}
+	if err := s.scanDocTimestamp(ctx, cwd, "goal", &snap.GoalLastUpdatedAt); err != nil {
+		return err
+	}
+
+	prow := s.pool.QueryRow(ctx, `
+		SELECT
+			COUNT(*)                                                       AS pending,
+			COALESCE(EXTRACT(EPOCH FROM (NOW() - MIN(created_at)))::int / 86400, 0) AS oldest_days,
+			COALESCE(SUM(CASE WHEN kind = 'plan' AND created_at >= $2
+			                  THEN 1 ELSE 0 END), 0)                       AS plan_drift_count
+		  FROM project_doc_proposals
+		 WHERE cwd = $1 AND decided_at IS NULL`, cwd, since)
+	return prow.Scan(&snap.PendingProposals, &snap.OldestPendingDays, &snap.PlanDriftProposals)
+}
+
+// scanDocTimestamp loads project_docs.updated_at for one (cwd,
+// kind). Missing row → leave dest nil so JSON serialisation emits
+// "no plan/goal yet".
+func (s *Service) scanDocTimestamp(ctx context.Context, cwd, kind string, dest **time.Time) error {
+	var ts time.Time
+	err := s.pool.QueryRow(ctx,
+		`SELECT updated_at FROM project_docs WHERE cwd = $1 AND kind = $2`,
+		cwd, kind).Scan(&ts)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("layer24 doc %s: %w", kind, err)
+	}
+	t := ts
+	*dest = &t
+	return nil
+}

--- a/internal/memhealth/health_test.go
+++ b/internal/memhealth/health_test.go
@@ -1,0 +1,121 @@
+package memhealth
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestNew_NilPool(t *testing.T) {
+	if _, err := New(nil); err == nil {
+		t.Fatal("expected error for nil pool")
+	}
+}
+
+func TestComputeForCwd_EmptyCwd(t *testing.T) {
+	svc, err := New(&pgxpool.Pool{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.ComputeForCwd(context.Background(), ""); err == nil {
+		t.Fatal("expected error for empty cwd")
+	}
+}
+
+// devDB is the same opt-in helper the summarizer store tests use.
+// We don't bring in a shared helper module yet — copy-paste keeps
+// the test deps minimal.
+func devDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	url := os.Getenv("OPENDRAY_DEV_DB_URL")
+	if url == "" {
+		t.Skip("OPENDRAY_DEV_DB_URL not set; export a writable Postgres DSN to run this test")
+	}
+	pool, err := pgxpool.New(context.Background(), url)
+	if err != nil {
+		t.Skipf("dev DB unreachable, skipping: %v", err)
+	}
+	if err := pool.Ping(context.Background()); err != nil {
+		t.Skipf("dev DB ping failed, skipping: %v", err)
+	}
+	return pool
+}
+
+// TestComputeForCwd_LiveDB sanity-checks that the SQL parses and
+// returns zero-valued counts for an unknown cwd. We don't seed
+// data here — that would require touching every table; the goal
+// is just "queries run, no schema regressions".
+func TestComputeForCwd_LiveDB(t *testing.T) {
+	pool := devDB(t)
+	defer pool.Close()
+
+	svc, err := New(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cwd := "/__memhealth_test_nonexistent__"
+	snap, err := svc.ComputeForCwd(ctx, cwd)
+	if err != nil {
+		t.Fatalf("ComputeForCwd: %v", err)
+	}
+	if snap.Cwd != cwd {
+		t.Errorf("Cwd: got %q, want %q", snap.Cwd, cwd)
+	}
+	if snap.LookbackDays != LookbackDays {
+		t.Errorf("LookbackDays: got %d, want %d", snap.LookbackDays, LookbackDays)
+	}
+	if snap.GeneratedAt.IsZero() {
+		t.Errorf("GeneratedAt should be set")
+	}
+	// Unknown cwd → every count must be zero.
+	for _, tc := range []struct {
+		name string
+		got  int
+	}{
+		{"NewFactsCount", snap.NewFactsCount},
+		{"TotalFactsCount", snap.TotalFactsCount},
+		{"ZeroHitFactsCount", snap.ZeroHitFactsCount},
+		{"CaptureFires", snap.CaptureFires},
+		{"NewJournalCount", snap.NewJournalCount},
+		{"TotalJournalCount", snap.TotalJournalCount},
+		{"PendingProposals", snap.PendingProposals},
+		{"PlanDriftProposals", snap.PlanDriftProposals},
+	} {
+		if tc.got != 0 {
+			t.Errorf("%s for unknown cwd: got %d, want 0", tc.name, tc.got)
+		}
+	}
+	if snap.PlanLastUpdatedAt != nil {
+		t.Errorf("PlanLastUpdatedAt: expected nil for unknown cwd, got %v", snap.PlanLastUpdatedAt)
+	}
+	if snap.GoalLastUpdatedAt != nil {
+		t.Errorf("GoalLastUpdatedAt: expected nil for unknown cwd, got %v", snap.GoalLastUpdatedAt)
+	}
+}
+
+func TestComputeForCwd_CancelledContext(t *testing.T) {
+	pool := devDB(t)
+	defer pool.Close()
+	svc, err := New(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = svc.ComputeForCwd(ctx, "/x")
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		// pgx wraps, so just ensure we got *some* error
+		t.Logf("got error (acceptable): %v", err)
+	}
+}

--- a/internal/memory/worker/worker.go
+++ b/internal/memory/worker/worker.go
@@ -46,13 +46,14 @@ const (
 	TaskCleaner     TaskKind = "cleaner"
 	TaskGitActivity TaskKind = "gitactivity"
 	TaskTranscript  TaskKind = "transcript"
+	TaskPlanDrift   TaskKind = "plan_drift"
 )
 
 // AllTasks returns every recognised TaskKind in a stable order.
-// Used by the UI to render the four config rows + by registry
-// bootstrap to seed missing entries.
+// Used by the UI to render the config rows + by registry bootstrap
+// to seed missing entries.
 func AllTasks() []TaskKind {
-	return []TaskKind{TaskGatekeeper, TaskCleaner, TaskGitActivity, TaskTranscript}
+	return []TaskKind{TaskGatekeeper, TaskCleaner, TaskGitActivity, TaskTranscript, TaskPlanDrift}
 }
 
 // WorkerKind names the implementation strategy. Persisted as the
@@ -159,7 +160,7 @@ type Config struct {
 // Caller (HTTP handler) should run this before INSERT/UPDATE.
 func (c Config) Valid() error {
 	switch c.Task {
-	case TaskGatekeeper, TaskCleaner, TaskGitActivity, TaskTranscript:
+	case TaskGatekeeper, TaskCleaner, TaskGitActivity, TaskTranscript, TaskPlanDrift:
 	default:
 		return errors.New("memory worker: invalid task")
 	}

--- a/internal/projectdoc/journaler.go
+++ b/internal/projectdoc/journaler.go
@@ -90,6 +90,18 @@ type Journaler struct {
 	// transcript-aware path; metadata-only journaling still works.
 	summariser TranscriptSummariser
 
+	// planDetector is the M-PA LLM hook. When set, every successful
+	// transcript summary kicks off a plan-drift check; if the
+	// detector says the plan needs updating, a proposal is filed
+	// into project_doc_proposals (operator approves in the inbox).
+	// Nil disables — journaling works exactly as before.
+	planDetector PlanDriftDetector
+
+	// driftJournalLookback is how many recent journal entries the
+	// drift detector sees as context. 5 is enough to give the model
+	// a sense of project momentum without exploding the prompt.
+	driftJournalLookback int
+
 	// transcriptMaxBytes caps how much transcript we feed the LLM.
 	// 16 KiB ≈ 4k tokens — enough context for a meaningful summary
 	// without paying tokens we don't need. Older content is
@@ -106,12 +118,13 @@ func NewJournaler(docs *Service, bus *eventbus.Hub, lookup SessionLookup, log *s
 		log = slog.Default()
 	}
 	return &Journaler{
-		docs:               docs,
-		bus:                bus,
-		lookup:             lookup,
-		log:                log.With("component", "projectdoc.journaler"),
-		inputsLimit:        5,
-		transcriptMaxBytes: 16 * 1024,
+		docs:                 docs,
+		bus:                  bus,
+		lookup:               lookup,
+		log:                  log.With("component", "projectdoc.journaler"),
+		inputsLimit:          5,
+		driftJournalLookback: 5,
+		transcriptMaxBytes:   16 * 1024,
 	}
 }
 
@@ -122,6 +135,17 @@ func NewJournaler(docs *Service, bus *eventbus.Hub, lookup SessionLookup, log *s
 // for chained setup.
 func (j *Journaler) WithSummariser(s TranscriptSummariser) *Journaler {
 	j.summariser = s
+	return j
+}
+
+// WithPlanDetector installs the optional M-PA plan-drift hook.
+// After the transcript summary lands, the journaler asks the
+// detector whether the project's plan document needs updating
+// based on this session's work; if so, it files a proposal that
+// the operator approves in the inbox (same flow as a manual
+// `project_plan_set` MCP call). Pass nil to disable.
+func (j *Journaler) WithPlanDetector(d PlanDriftDetector) *Journaler {
+	j.planDetector = d
 	return j
 }
 
@@ -190,7 +214,10 @@ func (j *Journaler) process(ctx context.Context, ev eventbus.Event, state string
 	// M18 — append an LLM-generated narrative when we have both a
 	// transcript reader and a summariser configured. Both calls
 	// are best-effort: failure logs + we ship the metadata-only
-	// body so the journal never goes silent.
+	// body so the journal never goes silent. transcriptSummary is
+	// reused by the M-PA plan-drift detector below so we don't
+	// re-summarise.
+	var transcriptSummary string
 	if j.summariser != nil {
 		transcript, terr := j.lookup.TranscriptText(ctx, sessionID, j.transcriptMaxBytes)
 		if terr != nil {
@@ -206,6 +233,7 @@ func (j *Journaler) process(ctx context.Context, ev eventbus.Event, state string
 				j.log.Warn("journaler: llm summarise failed; metadata-only entry",
 					"session_id", sessionID, "err", lerr)
 			} else if s := strings.TrimSpace(summary); s != "" {
+				transcriptSummary = s
 				body = body + "\n**Agent activity summary**\n\n" + s + "\n"
 			}
 		}
@@ -225,6 +253,81 @@ func (j *Journaler) process(ctx context.Context, ev eventbus.Event, state string
 	}
 	j.log.Info("journaler: appended session summary",
 		"session_id", sessionID, "cwd", sess.Cwd, "title", title)
+
+	// M-PA — once the journal entry is safely persisted, decide
+	// whether the project plan needs updating. We do this AFTER the
+	// journal write so a failure here can never block the basic
+	// journal flow.
+	j.maybeProposePlanDrift(sess, transcriptSummary)
+}
+
+// maybeProposePlanDrift runs the plan-drift detector and, if the
+// detector says the plan needs updating, files a proposal into the
+// operator's inbox. Soft-fail at every step — detector errors,
+// proposal write errors, and empty-plan short-circuits are all
+// logged but never bubbled up to the caller. The work happens on
+// its own background context because the LLM call can run minutes
+// and the event delivery goroutine must not block.
+func (j *Journaler) maybeProposePlanDrift(sess SessionInfo, transcriptSummary string) {
+	if j.planDetector == nil {
+		return
+	}
+	if strings.TrimSpace(transcriptSummary) == "" {
+		// Without a summary we have nothing concrete to feed the
+		// detector. Skip rather than asking the LLM to guess.
+		return
+	}
+
+	bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	currentDoc, err := j.docs.GetDoc(bgCtx, sess.Cwd, KindPlan)
+	if err != nil {
+		// ErrNotFound is the "fresh project" case — leave it for the
+		// operator to seed the first plan. Other errors are logged.
+		if err != ErrNotFound {
+			j.log.Debug("journaler: plan-drift get-plan failed", "cwd", sess.Cwd, "err", err)
+		}
+		return
+	}
+	if strings.TrimSpace(currentDoc.Content) == "" {
+		return
+	}
+
+	logs, err := j.docs.ListLogs(bgCtx, sess.Cwd, j.driftJournalLookback)
+	if err != nil {
+		j.log.Debug("journaler: plan-drift list-logs failed", "cwd", sess.Cwd, "err", err)
+		logs = nil
+	}
+
+	out, derr := j.planDetector.DetectDrift(bgCtx, DriftInput{
+		Cwd:               sess.Cwd,
+		CurrentPlan:       currentDoc.Content,
+		TranscriptSummary: transcriptSummary,
+		RecentJournal:     logs,
+	})
+	if derr != nil {
+		j.log.Warn("journaler: plan-drift detector failed", "cwd", sess.Cwd, "err", derr)
+		return
+	}
+	if !out.ShouldPropose {
+		j.log.Debug("journaler: plan-drift detector saw no change needed",
+			"cwd", sess.Cwd, "session_id", sess.ID)
+		return
+	}
+
+	reason := strings.TrimSpace(out.Reason)
+	if reason == "" {
+		reason = "Plan-drift detector flagged this session as a likely plan update."
+	}
+	proposal, perr := j.docs.ProposeDoc(bgCtx, sess.Cwd, KindPlan, out.NewPlan, reason, sess.ID)
+	if perr != nil {
+		j.log.Warn("journaler: plan-drift propose failed",
+			"cwd", sess.Cwd, "session_id", sess.ID, "err", perr)
+		return
+	}
+	j.log.Info("journaler: plan-drift proposal filed",
+		"cwd", sess.Cwd, "session_id", sess.ID, "proposal_id", proposal.ID)
 }
 
 // buildJournalBody assembles a deterministic markdown summary. Kept

--- a/internal/projectdoc/planner.go
+++ b/internal/projectdoc/planner.go
@@ -122,9 +122,7 @@ func stripJSONFence(s string) string {
 		return ""
 	}
 	rest := s[i+len(fence):]
-	if strings.HasPrefix(rest, "json") {
-		rest = rest[len("json"):]
-	}
+	rest = strings.TrimPrefix(rest, "json")
 	rest = strings.TrimLeft(rest, " \t\r\n")
 	j := strings.Index(rest, fence)
 	if j < 0 {

--- a/internal/projectdoc/planner.go
+++ b/internal/projectdoc/planner.go
@@ -1,0 +1,134 @@
+package projectdoc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+// PlanDriftDetector decides, post-session, whether the project plan
+// document should be updated based on what the session accomplished.
+// A nil detector is a no-op — the journaler falls back to "plan only
+// updates when an agent explicitly calls project_plan_set".
+//
+// Implementations are expected to fail closed: on LLM error, return
+// (DriftOutput{ShouldPropose:false}, error) — callers log and move
+// on without filing a proposal.
+type PlanDriftDetector interface {
+	DetectDrift(ctx context.Context, in DriftInput) (DriftOutput, error)
+}
+
+// DriftInput bundles the context the detector needs. CurrentPlan
+// being empty is the "no plan yet" signal — detectors should
+// short-circuit and return ShouldPropose=false rather than
+// hallucinating an initial plan.
+type DriftInput struct {
+	Cwd               string
+	CurrentPlan       string
+	TranscriptSummary string
+	RecentJournal     []LogEntry
+}
+
+// DriftOutput is the detector's verdict. NewPlan is the full
+// replacement markdown when ShouldPropose=true; otherwise ignored.
+// Reason surfaces in the operator's inbox so they can decide
+// whether to approve without re-reading the transcript.
+type DriftOutput struct {
+	ShouldPropose bool   `json:"should_propose"`
+	NewPlan       string `json:"new_plan"`
+	Reason        string `json:"reason"`
+}
+
+// PlanDriftSystemPrompt is the role block the detector ships with
+// every call. Exposed for reuse by callers that want to construct
+// the LLM Request themselves (e.g. the app-level worker wiring).
+const PlanDriftSystemPrompt = `You are a project plan reviewer.
+
+Given a project's CURRENT PLAN document, a summary of the agent
+session that just ended, and the last few journal entries, decide
+whether the plan should be updated.
+
+UPDATE the plan ONLY when one of these is true:
+1. The session COMPLETED a milestone the plan listed as upcoming —
+   mark it done.
+2. The session UNCOVERED work the plan didn't mention but should —
+   add it.
+3. The plan describes future work that the session made obsolete —
+   remove it.
+4. The plan's phase ordering needs to shift based on what was learned.
+
+DO NOT update when:
+- The session was exploratory / informational only.
+- Nothing in the plan was touched.
+- The agent merely answered a question without changing the project state.
+
+When updating, REWRITE the plan in full — your output replaces the
+existing document. Preserve unchanged sections verbatim.
+
+Respond ONLY with a JSON object matching this schema (no prose, no
+code fences, no commentary):
+
+{
+  "should_propose": <boolean>,
+  "new_plan":       <full markdown of the proposed replacement plan>,
+  "reason":         <one short sentence shown to the operator>
+}
+
+If should_propose is false, new_plan and reason MUST still be present
+but may be empty strings.`
+
+// ErrDetectorParse is returned when the LLM response cannot be
+// decoded into DriftOutput. Callers should treat it like any other
+// detector failure — log and skip the proposal.
+var ErrDetectorParse = errors.New("plan drift: detector returned unparseable response")
+
+// ParseDriftResponse extracts a DriftOutput from a raw LLM response.
+// Tolerates response_format=json_schema clean JSON and the common
+// failure modes where models wrap JSON in code fences or prose.
+// Returns ErrDetectorParse when nothing parseable is found.
+func ParseDriftResponse(raw string) (DriftOutput, error) {
+	body := strings.TrimSpace(raw)
+	if body == "" {
+		return DriftOutput{}, ErrDetectorParse
+	}
+	if fenced := stripJSONFence(body); fenced != "" {
+		body = fenced
+	}
+	if i := strings.IndexByte(body, '{'); i >= 0 {
+		if j := strings.LastIndexByte(body, '}'); j > i {
+			body = body[i : j+1]
+		}
+	}
+	var out DriftOutput
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		return DriftOutput{}, ErrDetectorParse
+	}
+	if out.ShouldPropose && strings.TrimSpace(out.NewPlan) == "" {
+		return DriftOutput{}, ErrDetectorParse
+	}
+	out.NewPlan = strings.TrimSpace(out.NewPlan)
+	out.Reason = strings.TrimSpace(out.Reason)
+	return out, nil
+}
+
+// stripJSONFence pulls JSON out of a ```json ... ``` or ``` ... ```
+// block. Returns "" when no fence is found so callers know to use
+// the original body.
+func stripJSONFence(s string) string {
+	const fence = "```"
+	i := strings.Index(s, fence)
+	if i < 0 {
+		return ""
+	}
+	rest := s[i+len(fence):]
+	if strings.HasPrefix(rest, "json") {
+		rest = rest[len("json"):]
+	}
+	rest = strings.TrimLeft(rest, " \t\r\n")
+	j := strings.Index(rest, fence)
+	if j < 0 {
+		return strings.TrimSpace(rest)
+	}
+	return strings.TrimSpace(rest[:j])
+}

--- a/internal/projectdoc/planner_test.go
+++ b/internal/projectdoc/planner_test.go
@@ -1,0 +1,121 @@
+package projectdoc
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseDriftResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    DriftOutput
+		wantErr error
+	}{
+		{
+			name: "clean json schema response — propose",
+			raw:  `{"should_propose": true, "new_plan": "## Phase 1\n- done", "reason": "M5 landed"}`,
+			want: DriftOutput{ShouldPropose: true, NewPlan: "## Phase 1\n- done", Reason: "M5 landed"},
+		},
+		{
+			name: "clean json schema response — no change",
+			raw:  `{"should_propose": false, "new_plan": "", "reason": ""}`,
+			want: DriftOutput{ShouldPropose: false},
+		},
+		{
+			name: "fenced code block ```json ... ```",
+			raw:  "```json\n{\"should_propose\": true, \"new_plan\": \"x\", \"reason\": \"y\"}\n```",
+			want: DriftOutput{ShouldPropose: true, NewPlan: "x", Reason: "y"},
+		},
+		{
+			name: "fenced code block without language hint",
+			raw:  "```\n{\"should_propose\": false, \"new_plan\": \"\", \"reason\": \"nothing changed\"}\n```",
+			want: DriftOutput{ShouldPropose: false, Reason: "nothing changed"},
+		},
+		{
+			name: "leading prose then json",
+			raw:  "Here is my answer:\n{\"should_propose\": true, \"new_plan\": \"plan body\", \"reason\": \"ok\"}",
+			want: DriftOutput{ShouldPropose: true, NewPlan: "plan body", Reason: "ok"},
+		},
+		{
+			name: "trailing prose after json",
+			raw:  `{"should_propose": true, "new_plan": "a", "reason": "b"} -- end`,
+			want: DriftOutput{ShouldPropose: true, NewPlan: "a", Reason: "b"},
+		},
+		{
+			name: "whitespace trimmed from fields",
+			raw:  `{"should_propose": true, "new_plan": "  body  ", "reason": "  why  "}`,
+			want: DriftOutput{ShouldPropose: true, NewPlan: "body", Reason: "why"},
+		},
+		{
+			name:    "empty response is unparseable",
+			raw:     "",
+			wantErr: ErrDetectorParse,
+		},
+		{
+			name:    "whitespace only is unparseable",
+			raw:     "   \n  ",
+			wantErr: ErrDetectorParse,
+		},
+		{
+			name:    "non-json garbage",
+			raw:     "I don't know what to do here",
+			wantErr: ErrDetectorParse,
+		},
+		{
+			name:    "should_propose=true but empty new_plan is rejected",
+			raw:     `{"should_propose": true, "new_plan": "", "reason": "vague"}`,
+			wantErr: ErrDetectorParse,
+		},
+		{
+			name:    "should_propose=true with whitespace new_plan is rejected",
+			raw:     `{"should_propose": true, "new_plan": "   \n  ", "reason": "vague"}`,
+			wantErr: ErrDetectorParse,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseDriftResponse(tc.raw)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected %v, got err=%v out=%+v", tc.wantErr, err, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.ShouldPropose != tc.want.ShouldPropose {
+				t.Errorf("ShouldPropose: got %v, want %v", got.ShouldPropose, tc.want.ShouldPropose)
+			}
+			if got.NewPlan != tc.want.NewPlan {
+				t.Errorf("NewPlan: got %q, want %q", got.NewPlan, tc.want.NewPlan)
+			}
+			if got.Reason != tc.want.Reason {
+				t.Errorf("Reason: got %q, want %q", got.Reason, tc.want.Reason)
+			}
+		})
+	}
+}
+
+func TestStripJSONFence(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no fence returns empty", "just text", ""},
+		{"json language hint", "```json\n{\"x\":1}\n```", `{"x":1}`},
+		{"no language hint", "```\n{\"x\":1}\n```", `{"x":1}`},
+		{"unterminated fence returns tail", "```json\n{\"x\":1}", `{"x":1}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripJSONFence(tc.in)
+			if strings.TrimSpace(got) != strings.TrimSpace(tc.want) {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/store/migrations/0030_memory_workers_plan_drift.sql
+++ b/internal/store/migrations/0030_memory_workers_plan_drift.sql
@@ -1,0 +1,22 @@
+-- M-PA — Add plan_drift to the memory_workers task catalogue.
+--
+-- Plan-drift detection runs after each session.ended event: given
+-- the session transcript summary + recent journal + current plan,
+-- decide whether the plan needs an update and file a proposal. Same
+-- pluggable surface as the other LLM touchpoints (summarizer vs
+-- agent) so operators can route it independently.
+--
+-- The check constraint is recreated with the new task value. Seed
+-- a summarizer default so existing deployments get the feature on
+-- next start without operator action.
+
+ALTER TABLE memory_workers
+    DROP CONSTRAINT IF EXISTS memory_workers_task_check;
+
+ALTER TABLE memory_workers
+    ADD CONSTRAINT memory_workers_task_check
+        CHECK (task IN ('gatekeeper','cleaner','gitactivity','transcript','plan_drift'));
+
+INSERT INTO memory_workers (task, kind) VALUES
+    ('plan_drift', 'summarizer')
+ON CONFLICT (task) DO NOTHING;


### PR DESCRIPTION
## Summary

Phase A of the memory system upgrade. Two complementary additions that close the biggest gap in opendray's memory architecture: plans go stale because agents rarely call `project_plan_set`, and operators have no way to verify the memory system is healthy without writing SQL.

- **Plan-drift detector** — fifth `memory_workers` task. After every `session.ended`, the journaler asks an LLM (operator-routed via the existing worker fabric) whether the project plan needs updating based on the session summary + recent journal. If yes, it files a `project_doc_proposals` row — operator approves in the existing Inbox flow.
- **Memory health dashboard** — new `Health` tab on `/memory/project` showing one snapshot of both memory subsystems for the current cwd: fact growth, capture-engine activity, journal velocity, plan/goal age, proposal backlog, top-hit fact, zero-hit stale-fact count.

Both features are opt-out: setting the `plan_drift` worker to disabled at `Memory → Workers` brings back today's behaviour exactly.

## What changed

- `internal/projectdoc/planner.go` — new `PlanDriftDetector` interface + JSON response parser (tolerates fenced blocks and prose preambles).
- `internal/app/plan_drift_detector.go` — registry-backed impl, parallel to `transcript_summariser.go`.
- `internal/projectdoc/journaler.go` — `WithPlanDetector` + `maybeProposePlanDrift` invoked after a successful summary lands.
- `internal/memory/worker/worker.go` — `TaskPlanDrift` const, `AllTasks` updated.
- `internal/store/migrations/0030_memory_workers_plan_drift.sql` — relaxes the task CHECK and seeds a summarizer default.
- `internal/memhealth/{health,handler,*_test}.go` — new aggregation package + HTTP handler at `GET /api/v1/memory/health?cwd=<cwd>`.
- `app/shared/src/lib/memoryHealth.ts` — typed client.
- `app/web/src/components/project/MemoryHealthCard.tsx` — dashboard component.
- `app/web/src/components/project/ProjectScreen.tsx` — adds Health tab as the default landing tab.
- `app/i18n/{en,zh}.json` — strings for the new tab + dashboard panels.
- `docs/memory-system.md` — operator-guide sections describing both features.

## Failure modes deliberately tolerated

- Empty plan → detector skips (refuses to seed initial plans; operator must write the first plan).
- Empty transcript summary → detector skips.
- Worker not configured / LLM error → log + skip; basic journal append still happens.
- Proposal write error → log + skip; never propagates.
- Health endpoint receives unknown cwd → returns a zero-valued snapshot, not 404.

## Test plan

- [x] `go test -race ./...` — all packages green
- [x] `pnpm tsc --noEmit` — web typecheck green
- [x] Unit tests: `ParseDriftResponse`, `planDriftDetector` short-circuits, `buildDriftUserInput` chronology + truncation, `memhealth` nil-pool / empty-cwd guards
- [x] Opt-in live-DB smoke tests gated on `OPENDRAY_DEV_DB_URL` (skipped in CI)
- [ ] Manual UI smoke: spawn a Claude session with a non-empty plan, end it, verify a plan-drift proposal lands in Inbox
- [ ] Manual UI smoke: visit `/memory/project?cwd=...`, confirm Health tab loads with snapshot panels

## Follow-ups (Phase B+ tracked separately)

- Phase B: journal embedding + cross-layer search
- Phase C: unified worker fabric for all memory layers
- Phase D: conflict detection between layer-5 facts and layer-3 plan