### PR TITLE
feat(memory): journal embedding + cross-layer search + spawn token budget (Phase B)

### DIFF
--- a/cmd/opendray/mcp_memory.go
+++ b/cmd/opendray/mcp_memory.go
@@ -204,6 +204,9 @@ each with a different rhythm — pick the right tool for the job:
                      meaningful step, fix a bug, hit a blocker, learn
                      something the next session should know.
   decision_record    ADR-style architectural locks-in (rare).
+  project_search     CROSS-LAYER semantic search across facts, journal,
+                     goal, and plan. Use when context might live anywhere
+                     ("have we hit X before", "what did we decide about Y").
 
 CRITICAL HABITS:
 
@@ -429,6 +432,30 @@ var toolDefs = []map[string]any{
 			"required": []string{"title", "content"},
 		},
 	},
+	{
+		"name": "project_search",
+		"description": "Search ACROSS all memory layers (facts + " +
+			"journal entries + goal/plan documents) in the current " +
+			"project. Use this when you want context that might live " +
+			"anywhere — \"what did we decide about X\", \"have we " +
+			"hit Y before\", \"how does our plan handle Z\". Returns " +
+			"results ranked by semantic similarity with a time-decay " +
+			"penalty, each tagged with which layer it came from.",
+		"inputSchema": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query": map[string]any{
+					"type":        "string",
+					"description": "Natural-language query.",
+				},
+				"top_k": map[string]any{
+					"type":        "integer",
+					"description": "Max hits across all layers combined (default 10, max 100).",
+				},
+			},
+			"required": []string{"query"},
+		},
+	},
 }
 
 // handleToolCall dispatches one MCP tools/call invocation to the
@@ -472,6 +499,8 @@ func (s *memMCPServer) handleToolCall(req rpcRequest) {
 		result, err = s.callSessionLogAppend("manual", params.Arguments)
 	case "decision_record":
 		result, err = s.callSessionLogAppend("decision", params.Arguments)
+	case "project_search":
+		result, err = s.callProjectSearch(params.Arguments)
 	default:
 		s.respondErr(req.ID, -32601, "Unknown tool", params.Name)
 		return
@@ -825,6 +854,78 @@ func (s *memMCPServer) callSessionLogAppend(kind string, args json.RawMessage) (
 	return map[string]any{
 		"content": []map[string]any{
 			{"type": "text", "text": fmt.Sprintf("Appended %s journal entry %s.", kind, out.ID)},
+		},
+	}, nil
+}
+
+// callProjectSearch wraps /api/v1/project-search. Surfaces hits
+// from all five memory layers in one ranked list so the agent can
+// answer "have we touched X before" without choosing a layer
+// first. Output is rendered as a markdown bullet list so the
+// model can quote pieces back into its response naturally.
+func (s *memMCPServer) callProjectSearch(args json.RawMessage) (any, error) {
+	cwd := s.cfg.scopeKey
+	if cwd == "" {
+		return nil, errors.New("project_search requires OPENDRAY_MEMORY_SCOPE_KEY (cwd) to be set")
+	}
+	var in struct {
+		Query string `json:"query"`
+		TopK  int    `json:"top_k"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, fmt.Errorf("invalid arguments: %w", err)
+	}
+	q := strings.TrimSpace(in.Query)
+	if q == "" {
+		return nil, errors.New("query is required")
+	}
+	topK := in.TopK
+	if topK <= 0 {
+		topK = 10
+	}
+	if topK > 100 {
+		topK = 100
+	}
+
+	url := fmt.Sprintf("/api/v1/project-search?cwd=%s&q=%s&top_k=%d",
+		urlQuery(cwd), urlQuery(q), topK)
+	var resp struct {
+		Hits []struct {
+			Source         string  `json:"source"`
+			ID             string  `json:"id"`
+			Text           string  `json:"text"`
+			Title          string  `json:"title"`
+			Similarity     float32 `json:"similarity"`
+			EffectiveScore float32 `json:"effective_score"`
+			CreatedAt      string  `json:"created_at"`
+		} `json:"hits"`
+	}
+	if err := s.gatewayGetJSON(url, &resp); err != nil {
+		return nil, err
+	}
+	if len(resp.Hits) == 0 {
+		return map[string]any{
+			"content": []map[string]any{
+				{"type": "text", "text": fmt.Sprintf("No cross-layer hits for %q.", q)},
+			},
+		}, nil
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Top %d cross-layer matches for %q (effective_score · source — preview):\n\n",
+		len(resp.Hits), q)
+	for _, h := range resp.Hits {
+		text := strings.TrimSpace(h.Text)
+		if h.Title != "" && !strings.HasPrefix(text, h.Title) {
+			text = h.Title + " — " + text
+		}
+		if len(text) > 240 {
+			text = text[:240] + "…"
+		}
+		fmt.Fprintf(&b, "- **%.2f · %s** — %s\n", h.EffectiveScore, h.Source, text)
+	}
+	return map[string]any{
+		"content": []map[string]any{
+			{"type": "text", "text": b.String()},
 		},
 	}, nil
 }

--- a/docs/memory-system.md
+++ b/docs/memory-system.md
@@ -320,6 +320,57 @@ Backed by `GET /api/v1/memory/health?cwd=<cwd>` — one aggregate
 read that crosses both subsystems. No polling; refreshes on tab
 view.
 
+## Cross-layer search (M-PB, shipped)
+
+Phase B closes the second gap from Phase A: the journal was
+write-only — `session_log_append` shoved entries in but agents had
+no way to ask "what did we decide about X last month". M-PB makes
+journal entries first-class semantic-search citizens alongside
+memory facts.
+
+### What changed under the hood
+
+- Migration 0031 adds `embedding`, `embedder`, `embedding_at`
+  columns to `session_logs`.
+- Every new journal entry is embedded synchronously at
+  `AppendLog` time using the same embedder the memory subsystem
+  already runs (BM25 / bge-m3 / OpenAI). Vector lives in the same
+  space as `memories.embedding`, so cosines are directly
+  comparable.
+- A background goroutine catches up pre-feature journal rows in
+  batches of 50; runs idle when caught up.
+
+### The new search tool
+
+`project_search` MCP tool + `GET /api/v1/project-search?cwd=&q=&top_k=`
+take a natural-language query and return the top-K hits across
+**five layers** in one ranked list:
+
+- `fact` — memory_search results (layer 5)
+- `journal` — semantic match against session_logs (layer 4)
+- `goal` — lexical match against project_docs.goal (layer 2)
+- `plan` — lexical match against project_docs.plan (layer 3)
+
+Each hit carries `similarity`, `effective_score` (similarity with
+time-decay applied: 1.0 today, 0.5 floor past 180 days), and the
+`source` label so agents and UI can render layer badges.
+
+Agent guidance is rolled into the MCP `instructionsBlurb` so models
+use `project_search` for "where might this context live" queries
+instead of guessing between `memory_search` and reading journal
+pages by hand.
+
+### Banner token budget
+
+`RenderForSpawn` now has a sibling `RenderForSpawnWithBudget`
+(`maxBytes int`). Operators dial it via
+`SessionProvider.WithProjectDocBudget(N)` — 0 keeps today's
+unconstrained behaviour. When set, sections are appended in
+priority order (plan → tech_stack → goal → recent_activity →
+journal) and rendering stops once the budget is exhausted, with
+a trailing truncation note so the agent knows to visit
+`/memory/project` for the full set.
+
 ## Roadmap
 
 - **Codex session UUID capture**. Codex lacks `--session-id`; a

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -50,6 +50,7 @@ import (
 	"github.com/opendray/opendray-v2/internal/memory/injector"
 	"github.com/opendray/opendray-v2/internal/memory/summarizer"
 	memworker "github.com/opendray/opendray-v2/internal/memory/worker"
+	"github.com/opendray/opendray-v2/internal/memquery"
 	notesapi "github.com/opendray/opendray-v2/internal/notes"
 	"github.com/opendray/opendray-v2/internal/projectdoc"
 	"github.com/opendray/opendray-v2/internal/projectscan"
@@ -80,7 +81,8 @@ type App struct {
 	liveBackup           *backup.LiveBackup
 	captureEngine        *capture.Engine // ambient memory capture loop
 	journaler            *projectdoc.Journaler
-	cleanerScheduler     *cleaner.Scheduler // optional; nil when scheduler is off
+	projectDocSvc        *projectdoc.Service // owns the M-PB journal embed backfill loop
+	cleanerScheduler     *cleaner.Scheduler  // optional; nil when scheduler is off
 	gitActivityScheduler *gitactivity.Scheduler
 	server               *http.Server
 }
@@ -382,6 +384,12 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	}
 	memhealthHandlers := memhealth.NewHandlers(memhealthSvc, log)
 
+	// M-PB — cross-layer search composing memory facts + journal
+	// + goal/plan. Initialised lazily after projectDocSvc is ready
+	// to avoid a forward reference here; see further down.
+	var memquerySvc *memquery.Service
+	var memqueryHandlers *memquery.Handlers
+
 	// M12 — Gatekeeper. Wired late because the summarizer registry
 	// only exists after backup cipher + summarizer store are up.
 	// When operators set [memory.gatekeeper] enabled = true, every
@@ -469,6 +477,20 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	// group so the auto-attached opendray-memory MCP can reach it
 	// with an integration bearer.
 	projectDocSvc := projectdoc.NewService(st.Pool(), log)
+	// M-PB — share the memory service's embedder so journal vectors
+	// land in the same space as memory facts. Cross-layer search
+	// then compares cosines apples-to-apples; otherwise BM25-vs-
+	// bge-m3 hits would rank against each other meaninglessly.
+	projectDocSvc.WithEmbedder(projectdocEmbedderAdapter{emb: memorySvc.Embedder()})
+
+	// M-PB — now that projectDocSvc exists, build the cross-layer
+	// search service. memquery.New is strict about nil deps so we
+	// surface a misconfiguration at boot rather than at first hit.
+	memquerySvc, err = memquery.New(memorySvc, projectDocSvc, st.Pool())
+	if err != nil {
+		return nil, fmt.Errorf("memquery init: %w", err)
+	}
+	memqueryHandlers = memquery.NewHandlers(memquerySvc, log)
 	projectDocHandlers := projectdoc.NewHandlers(projectDocSvc, log)
 	// Inject the cross-agent goal+plan+journal banner into every
 	// spawned session's system prompt. Composed alongside the
@@ -583,6 +605,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 				summarizerHandlers.Mount(r)
 				memoryWorkerHandlers.Mount(r)
 				memhealthHandlers.Mount(r)
+				memqueryHandlers.Mount(r)
 				captureHandlers.Mount(r)
 				injectorHandlers.Mount(r)
 				if cleanerHandlers != nil {
@@ -635,6 +658,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		liveBackup:           liveBackup,
 		captureEngine:        captureEngine,
 		journaler:            journaler,
+		projectDocSvc:        projectDocSvc,
 		cleanerScheduler:     cleanerScheduler,
 		gitActivityScheduler: gitActivityScheduler,
 		server:               srv,
@@ -700,6 +724,16 @@ func (a *App) Run(ctx context.Context) error {
 	go func() {
 		a.journaler.Run(ctx)
 		close(journalerDone)
+	}()
+
+	// M-PB — backfill missing embeddings on the journal so the new
+	// cross-layer project_search hits historical entries, not just
+	// rows appended after this release shipped. Skips itself when
+	// no embedder is wired (see RunLogEmbedBackfill guard).
+	logEmbedBackfillDone := make(chan struct{})
+	go func() {
+		a.projectDocSvc.RunLogEmbedBackfill(ctx, projectdoc.LogEmbedBackfillConfig{})
+		close(logEmbedBackfillDone)
 	}()
 
 	cleanerDone := make(chan struct{})

--- a/internal/app/projectdoc_embedder.go
+++ b/internal/app/projectdoc_embedder.go
@@ -1,0 +1,35 @@
+package app
+
+import (
+	"context"
+
+	"github.com/opendray/opendray-v2/internal/memory"
+	"github.com/opendray/opendray-v2/internal/projectdoc"
+)
+
+// projectdocEmbedderAdapter bridges memory.Embedder to
+// projectdoc.LogEmbedder. Both interfaces share the same shape but
+// live in different packages on purpose — projectdoc must not
+// import internal/memory directly (it'd create a dependency from
+// the operator-owned doc layer to the agent-owned fact layer,
+// which we keep one-way for the same reasons captured in the
+// projectdoc package comment).
+type projectdocEmbedderAdapter struct {
+	emb memory.Embedder
+}
+
+var _ projectdoc.LogEmbedder = projectdocEmbedderAdapter{}
+
+func (a projectdocEmbedderAdapter) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	if a.emb == nil {
+		return make([][]float32, len(texts)), nil
+	}
+	return a.emb.Embed(ctx, texts)
+}
+
+func (a projectdocEmbedderAdapter) Name() string {
+	if a.emb == nil {
+		return ""
+	}
+	return a.emb.Name()
+}

--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -77,6 +77,13 @@ type SessionProvider struct {
 	// injection (e.g. older builds without memory layers 2-4).
 	projectDocInjector ProjectDocInjector
 
+	// projectDocBudget caps the rendered banner size in bytes. 0
+	// disables the cap (legacy behaviour). Operators dial this via
+	// WithProjectDocBudget; the catalog adapter calls
+	// RenderForSpawnWithBudget when non-zero. Default 4096 — about
+	// 1k tokens, plenty for a one-screen banner.
+	projectDocBudget int
+
 	// projectScanner, when set, auto-detects tech stack + structure
 	// at spawn time (only re-scans when the existing tech_stack doc
 	// is older than scannerMaxAge). Nil → no auto-scan, operator
@@ -106,8 +113,14 @@ type AmbientInjector interface {
 // satisfies. Returns a rendered markdown banner combining the
 // project goal, plan, tech_stack, and recent journal entries;
 // empty string means "nothing to inject — skip silently".
+//
+// The catalog adapter calls RenderForSpawnWithBudget when an
+// operator opts into a byte cap; otherwise it falls back to the
+// legacy RenderForSpawn (no cap). Implementations must support
+// both shapes to stay forward-compatible.
 type ProjectDocInjector interface {
 	RenderForSpawn(ctx context.Context, cwd string, recentLogs int) (string, error)
+	RenderForSpawnWithBudget(ctx context.Context, cwd string, recentLogs, maxBytes int) (string, error)
 }
 
 // ProjectScanner is the contract internal/projectscan.Service
@@ -207,6 +220,16 @@ func (sp *SessionProvider) WithAmbientInjector(inj AmbientInjector) *SessionProv
 // recent journal) to the agent's system prompt at spawn time.
 func (sp *SessionProvider) WithProjectDocInjector(inj ProjectDocInjector) *SessionProvider {
 	sp.projectDocInjector = inj
+	return sp
+}
+
+// WithProjectDocBudget caps the rendered banner size in bytes.
+// 0 disables the cap (legacy behaviour). Operators tune this when
+// the unbudgeted banner pushes spawn prompts past model context
+// limits; default 4096 (≈1k tokens) is a reasonable cap for
+// typical projects.
+func (sp *SessionProvider) WithProjectDocBudget(maxBytes int) *SessionProvider {
+	sp.projectDocBudget = maxBytes
 	return sp
 }
 
@@ -454,7 +477,19 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 				}
 			}
 			if cwd != "" {
-				text, err := sp.projectDocInjector.RenderForSpawn(prepareCtx, cwd, 5)
+				// M-PB — when WithProjectDocBudget is set, route to the
+				// budgeted renderer so the banner can't blow past the
+				// configured byte cap. Zero budget keeps the legacy
+				// unconstrained shape.
+				var (
+					text string
+					err  error
+				)
+				if sp.projectDocBudget > 0 {
+					text, err = sp.projectDocInjector.RenderForSpawnWithBudget(prepareCtx, cwd, 5, sp.projectDocBudget)
+				} else {
+					text, err = sp.projectDocInjector.RenderForSpawn(prepareCtx, cwd, 5)
+				}
 				if err != nil {
 					sp.log.Warn("project doc render failed; skipping inject",
 						"cwd", cwd, "err", err)

--- a/internal/memory/service.go
+++ b/internal/memory/service.go
@@ -179,6 +179,14 @@ func (s *Service) Close() error {
 func (s *Service) EmbedderName() string { return s.emb.Name() }
 func (s *Service) Dimensions() int      { return s.emb.Dimensions() }
 
+// Embedder returns the active Embedder. Exposed so cross-package
+// callers (M-PB journal indexing in projectdoc, the cross-layer
+// search service) can use the same vector space the memory store
+// already speaks — comparing vectors produced by different
+// embedders is meaningless, so sharing the instance is load-
+// bearing.
+func (s *Service) Embedder() Embedder { return s.emb }
+
 // StoreRequest is the public shape callers (MCP, HTTP debug API)
 // pass to Store. It mirrors InsertRequest minus the embedding
 // (we compute that here).

--- a/internal/memquery/handler.go
+++ b/internal/memquery/handler.go
@@ -1,0 +1,72 @@
+package memquery
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Handlers exposes cross-layer search over HTTP.
+//
+//	GET /api/v1/project-search?cwd=<cwd>&q=<query>&top_k=<N>
+//
+// Mount under admin auth — results expose every layer including
+// goal/plan content which can include private project context.
+type Handlers struct {
+	svc *Service
+	log *slog.Logger
+}
+
+func NewHandlers(svc *Service, log *slog.Logger) *Handlers {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Handlers{svc: svc, log: log.With("component", "memquery.http")}
+}
+
+func (h *Handlers) Mount(r chi.Router) {
+	r.Get("/project-search", h.search)
+}
+
+func (h *Handlers) search(w http.ResponseWriter, r *http.Request) {
+	cwd := r.URL.Query().Get("cwd")
+	if cwd == "" {
+		writeError(w, http.StatusBadRequest, "cwd query param is required")
+		return
+	}
+	query := r.URL.Query().Get("q")
+	if query == "" {
+		writeError(w, http.StatusBadRequest, "q query param is required")
+		return
+	}
+	topK := 10
+	if v := r.URL.Query().Get("top_k"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			topK = n
+		}
+	}
+	hits, err := h.svc.Search(r.Context(), SearchRequest{
+		Cwd:   cwd,
+		Query: query,
+		TopK:  topK,
+	})
+	if err != nil {
+		h.log.Warn("memquery: search failed", "cwd", cwd, "err", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"hits": hits})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]any{"error": msg})
+}

--- a/internal/memquery/memquery.go
+++ b/internal/memquery/memquery.go
@@ -1,0 +1,281 @@
+// Package memquery composes layer-5 (memory facts) and
+// layer-2-4 (projectdoc journal + goal/plan) into a single
+// search surface. Agents talk to it through the new
+// project_search MCP tool; operators get the same endpoint over
+// REST for the UI's cross-layer search panel.
+//
+// Why a separate package: memory and projectdoc are deliberately
+// kept one-way (projectdoc must not import internal/memory).
+// memquery sits above both and is consumed by the MCP / HTTP
+// layer, paralleling the memhealth split.
+package memquery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/opendray/opendray-v2/internal/memory"
+	"github.com/opendray/opendray-v2/internal/projectdoc"
+)
+
+// SourceLayer names which memory layer a hit came from. Surfaced
+// in API responses so callers can render layer badges (e.g.
+// "memory" vs "journal") and filter post hoc.
+type SourceLayer string
+
+const (
+	SourceFact    SourceLayer = "fact"    // memories table
+	SourceJournal SourceLayer = "journal" // session_logs table
+	SourceGoal    SourceLayer = "goal"    // project_docs.kind='goal'
+	SourcePlan    SourceLayer = "plan"    // project_docs.kind='plan'
+)
+
+// Hit is one merged search result. Cosine similarity gets time-
+// decayed into EffectiveScore which is what the final ordering
+// uses; raw Similarity is preserved for debugging / UI display.
+type Hit struct {
+	Source         SourceLayer `json:"source"`
+	ID             string      `json:"id"`
+	Text           string      `json:"text"`
+	Title          string      `json:"title,omitempty"`
+	CreatedAt      time.Time   `json:"created_at"`
+	Similarity     float32     `json:"similarity"`
+	EffectiveScore float32     `json:"effective_score"`
+}
+
+// SearchRequest scopes one cross-layer query.
+type SearchRequest struct {
+	Cwd   string
+	Query string
+	TopK  int
+}
+
+// Service runs cross-layer queries. Constructed once per process.
+// All three deps are required: memory.Service for fact search
+// (and the shared Embedder), projectdoc.Service for the journal
+// vector column + goal/plan reads, pgxpool because we issue raw
+// vector SQL against session_logs (projectdoc doesn't expose a
+// typed Search method yet).
+type Service struct {
+	mem  *memory.Service
+	docs *projectdoc.Service
+	pool *pgxpool.Pool
+}
+
+// New wires a Service. Returns an error when any required
+// dependency is nil so the composition root surfaces the problem
+// at boot instead of producing empty searches at runtime.
+func New(mem *memory.Service, docs *projectdoc.Service, pool *pgxpool.Pool) (*Service, error) {
+	if mem == nil {
+		return nil, errors.New("memquery: memory service required")
+	}
+	if docs == nil {
+		return nil, errors.New("memquery: projectdoc service required")
+	}
+	if pool == nil {
+		return nil, errors.New("memquery: pool required")
+	}
+	return &Service{mem: mem, docs: docs, pool: pool}, nil
+}
+
+// Search runs the three sub-searches sequentially, merges the
+// results with time decay applied, and returns the top-K by
+// effective score. Per-layer failures degrade gracefully — a
+// broken journal index doesn't stop fact + plan hits from
+// surfacing.
+func (s *Service) Search(ctx context.Context, req SearchRequest) ([]Hit, error) {
+	if strings.TrimSpace(req.Cwd) == "" {
+		return nil, errors.New("memquery: cwd required")
+	}
+	if strings.TrimSpace(req.Query) == "" {
+		return nil, errors.New("memquery: query required")
+	}
+	topK := req.TopK
+	if topK <= 0 {
+		topK = 10
+	}
+	if topK > 100 {
+		topK = 100
+	}
+
+	var all []Hit
+	all = append(all, s.searchFacts(ctx, req, topK)...)
+	all = append(all, s.searchJournal(ctx, req, topK)...)
+	all = append(all, s.searchDocs(ctx, req)...)
+
+	// Apply time decay then sort by effective score descending.
+	now := time.Now().UTC()
+	for i := range all {
+		all[i].EffectiveScore = decayScore(all[i].Similarity, now.Sub(all[i].CreatedAt))
+	}
+	sort.SliceStable(all, func(i, j int) bool {
+		return all[i].EffectiveScore > all[j].EffectiveScore
+	})
+	if len(all) > topK {
+		all = all[:topK]
+	}
+	return all, nil
+}
+
+// searchFacts runs the existing memory.Search and converts hits.
+// Failures are logged into the returned slice as zero hits — the
+// caller continues with whatever the other layers produced.
+func (s *Service) searchFacts(ctx context.Context, req SearchRequest, topK int) []Hit {
+	hits, err := s.mem.Search(ctx, memory.SearchRequest{
+		Query:    req.Query,
+		Scope:    memory.ScopeProject,
+		ScopeKey: req.Cwd,
+		TopK:     topK,
+	})
+	if err != nil {
+		return nil
+	}
+	out := make([]Hit, 0, len(hits))
+	for _, h := range hits {
+		out = append(out, Hit{
+			Source:     SourceFact,
+			ID:         h.Memory.ID,
+			Text:       h.Memory.Text,
+			CreatedAt:  h.Memory.CreatedAt,
+			Similarity: h.Similarity,
+		})
+	}
+	return out
+}
+
+// searchJournal embeds the query and runs a raw vector query
+// against session_logs. We bypass projectdoc.Service to keep
+// projectdoc free of a vector-search API surface — the package's
+// public API is doc CRUD + journal append + spawn render.
+//
+// Filters: scope by cwd; only rows with a matching embedder so
+// cosine comparisons stay sound; LIMIT by topK.
+func (s *Service) searchJournal(ctx context.Context, req SearchRequest, topK int) []Hit {
+	embedder := s.docs.Embedder()
+	if embedder == nil {
+		return nil
+	}
+	vecs, err := embedder.Embed(ctx, []string{req.Query})
+	if err != nil || len(vecs) == 0 || len(vecs[0]) == 0 {
+		return nil
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, title, content, created_at,
+		       1 - (embedding <=> $1::vector) AS similarity
+		  FROM session_logs
+		 WHERE cwd = $2
+		   AND embedder = $3
+		   AND embedding IS NOT NULL
+		 ORDER BY embedding <=> $1::vector
+		 LIMIT $4`,
+		pgvecLiteral(vecs[0]), req.Cwd, embedder.Name(), topK)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	var out []Hit
+	for rows.Next() {
+		var (
+			id, title, content string
+			createdAt          time.Time
+			similarity         float64
+		)
+		if err := rows.Scan(&id, &title, &content, &createdAt, &similarity); err != nil {
+			return out
+		}
+		out = append(out, Hit{
+			Source:     SourceJournal,
+			ID:         id,
+			Title:      title,
+			Text:       content,
+			CreatedAt:  createdAt,
+			Similarity: float32(similarity),
+		})
+	}
+	return out
+}
+
+// searchDocs lexically matches the query against goal + plan
+// content. project_docs is a tiny set per cwd (one row per kind)
+// so the cost of scanning + Lower-comparing both is negligible —
+// no embedding needed. If a match exists we attach a fixed
+// similarity of 0.6 so the doc shows up alongside vector hits
+// without dominating them.
+func (s *Service) searchDocs(ctx context.Context, req SearchRequest) []Hit {
+	docs, err := s.docs.ListDocsForCwd(ctx, req.Cwd)
+	if err != nil {
+		return nil
+	}
+	q := strings.ToLower(strings.TrimSpace(req.Query))
+	if q == "" {
+		return nil
+	}
+	var out []Hit
+	for _, d := range docs {
+		if d.Kind != projectdoc.KindGoal && d.Kind != projectdoc.KindPlan {
+			continue
+		}
+		if !strings.Contains(strings.ToLower(d.Content), q) {
+			continue
+		}
+		layer := SourceGoal
+		if d.Kind == projectdoc.KindPlan {
+			layer = SourcePlan
+		}
+		out = append(out, Hit{
+			Source:     layer,
+			ID:         d.ID,
+			Text:       d.Content,
+			CreatedAt:  d.UpdatedAt,
+			Similarity: 0.6,
+		})
+	}
+	return out
+}
+
+// decayScore applies a gentle linear decay so a 6-month-old
+// memory ranks ~50% of a brand-new one at the same cosine, but a
+// brand-new mediocre match doesn't crowd out a year-old gem. The
+// 0.5 floor means recency can never outweigh relevance entirely.
+func decayScore(similarity float32, age time.Duration) float32 {
+	days := float32(age.Hours()) / 24
+	if days < 0 {
+		days = 0
+	}
+	decay := 1 - days/180
+	if decay < 0.5 {
+		decay = 0.5
+	}
+	return similarity * decay
+}
+
+// pgvecLiteral mirrors projectdoc.pgvecString. Duplicated rather
+// than exported to keep the projectdoc API surface minimal — this
+// is an implementation detail of one query.
+func pgvecLiteral(v []float32) string {
+	if len(v) == 0 {
+		return "[]"
+	}
+	var b strings.Builder
+	b.Grow(2 + len(v)*8)
+	b.WriteByte('[')
+	for i, f := range v {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, "%g", f)
+	}
+	b.WriteByte(']')
+	return b.String()
+}
+
+// silence "imported and not used" when pgx itself is only needed
+// transitively. Some Go versions complain otherwise.
+var _ = pgx.ErrNoRows

--- a/internal/memquery/memquery_test.go
+++ b/internal/memquery/memquery_test.go
@@ -1,0 +1,56 @@
+package memquery
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestDecayScore(t *testing.T) {
+	tests := []struct {
+		name string
+		sim  float32
+		age  time.Duration
+		want float32
+	}{
+		{"brand new keeps full score", 0.9, 0, 0.9},
+		{"30d old: ~0.83 of original", 1.0, 30 * 24 * time.Hour, 1 - 30.0/180},
+		{"180d hits floor", 0.8, 180 * 24 * time.Hour, 0.5 * 0.8},
+		{"way past floor", 1.0, 365 * 24 * time.Hour, 0.5},
+		{"negative age clamps to now", 1.0, -time.Hour, 1.0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decayScore(tc.sim, tc.age)
+			if math.Abs(float64(got-tc.want)) > 0.001 {
+				t.Errorf("got %f, want %f", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPgvecLiteral(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []float32
+		want string
+	}{
+		{"empty", nil, "[]"},
+		{"single", []float32{0.5}, "[0.5]"},
+		{"multiple", []float32{0.1, 0.2, 0.3}, "[0.1,0.2,0.3]"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pgvecLiteral(tc.in)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNew_ValidationErrors(t *testing.T) {
+	if _, err := New(nil, nil, nil); err == nil {
+		t.Error("expected error for all-nil deps")
+	}
+}

--- a/internal/projectdoc/log_embed_backfill.go
+++ b/internal/projectdoc/log_embed_backfill.go
@@ -1,0 +1,166 @@
+package projectdoc
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// LogEmbedBackfillConfig tunes the M-PB backfill worker. All
+// fields have sensible defaults — pass a zero value to use them.
+type LogEmbedBackfillConfig struct {
+	// BatchSize is how many rows the worker reads + embeds per
+	// cycle. 50 balances embed latency (one HTTP call per cycle if
+	// the embedder is HTTP-backed) against memory pressure (each
+	// row carries title + content of arbitrary length).
+	BatchSize int
+
+	// Interval is the delay between cycles when the previous cycle
+	// found rows to embed. We keep moving while there's work.
+	Interval time.Duration
+
+	// IdleInterval is the delay between cycles when the previous
+	// cycle found nothing. Longer to avoid spinning when the
+	// journal is caught up.
+	IdleInterval time.Duration
+}
+
+func (c LogEmbedBackfillConfig) applyDefaults() LogEmbedBackfillConfig {
+	if c.BatchSize <= 0 {
+		c.BatchSize = 50
+	}
+	if c.Interval <= 0 {
+		c.Interval = 5 * time.Second
+	}
+	if c.IdleInterval <= 0 {
+		c.IdleInterval = 5 * time.Minute
+	}
+	return c
+}
+
+// RunLogEmbedBackfill drives the M-PB journal embedding catch-up
+// loop. Designed to run as a single goroutine launched by the
+// composition root; blocks until ctx is cancelled.
+//
+// Each cycle:
+//  1. SELECT up to BatchSize rows where embedding IS NULL,
+//     prioritising newest first so live searches benefit before
+//     ancient backlog.
+//  2. Call svc.embedder.Embed on the batch.
+//  3. UPDATE each row with its vector + embedder + timestamp,
+//     individually so one malformed row doesn't sink the batch.
+//
+// Soft-fail at every step — backfill is a non-critical
+// optimisation; an embedder outage logs and tries again next tick.
+func (s *Service) RunLogEmbedBackfill(ctx context.Context, cfg LogEmbedBackfillConfig) {
+	cfg = cfg.applyDefaults()
+	if s.embedder == nil {
+		s.log.Info("projectdoc: no embedder wired; skipping log embed backfill")
+		return
+	}
+	s.log.Info("projectdoc: log embed backfill running",
+		"batch", cfg.BatchSize, "interval", cfg.Interval, "idle_interval", cfg.IdleInterval)
+
+	for {
+		processed, err := s.backfillOneCycle(ctx, cfg.BatchSize)
+		if err != nil {
+			s.log.Warn("projectdoc: backfill cycle failed", "err", err)
+		}
+		delay := cfg.Interval
+		if processed == 0 {
+			delay = cfg.IdleInterval
+		}
+		select {
+		case <-ctx.Done():
+			s.log.Info("projectdoc: log embed backfill stopping")
+			return
+		case <-time.After(delay):
+		}
+	}
+}
+
+// backfillOneCycle reads one batch, embeds it, writes the vectors
+// back. Returns the number of rows successfully embedded so the
+// caller can pick the next sleep duration.
+func (s *Service) backfillOneCycle(ctx context.Context, batch int) (int, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, title, content
+		  FROM session_logs
+		 WHERE embedding IS NULL
+		 ORDER BY created_at DESC
+		 LIMIT $1`, batch)
+	if err != nil {
+		return 0, fmt.Errorf("scan needs_embed: %w", err)
+	}
+	type pending struct {
+		id   string
+		text string
+	}
+	var todo []pending
+	for rows.Next() {
+		var p pending
+		var title, content string
+		if err := rows.Scan(&p.id, &title, &content); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("scan row: %w", err)
+		}
+		entry := LogEntry{Title: title, Content: content}
+		p.text = embedTextForLog(entry)
+		todo = append(todo, p)
+	}
+	rows.Close()
+	if len(todo) == 0 {
+		return 0, nil
+	}
+
+	texts := make([]string, len(todo))
+	for i, p := range todo {
+		texts[i] = p.text
+	}
+	vecs, err := s.embedder.Embed(ctx, texts)
+	if err != nil {
+		return 0, fmt.Errorf("embed batch: %w", err)
+	}
+	if len(vecs) != len(todo) {
+		return 0, fmt.Errorf("embedder returned %d vectors for %d inputs", len(vecs), len(todo))
+	}
+
+	name := s.embedder.Name()
+	written := 0
+	for i, p := range todo {
+		if len(vecs[i]) == 0 {
+			// Empty vector — could be the embedder declining (e.g.
+			// the text was empty after trimming). Mark with the
+			// embedder name + NULL embedding so we don't keep
+			// retrying; the predicate `embedding IS NULL` excludes
+			// it from future cycles. Use a length-1 zero vector so
+			// the predicate flips without consuming index space.
+			if _, err := s.pool.Exec(ctx, `
+				UPDATE session_logs
+				   SET embedding = $1,
+				       embedder = $2,
+				       embedding_at = NOW()
+				 WHERE id = $3`, "[0]", name, p.id); err != nil {
+				s.log.Debug("projectdoc: backfill mark-empty failed",
+					"log_id", p.id, "err", err)
+			}
+			continue
+		}
+		if _, err := s.pool.Exec(ctx, `
+			UPDATE session_logs
+			   SET embedding = $1,
+			       embedder = $2,
+			       embedding_at = NOW()
+			 WHERE id = $3`, pgvecString(vecs[i]), name, p.id); err != nil {
+			s.log.Debug("projectdoc: backfill write failed",
+				"log_id", p.id, "err", err)
+			continue
+		}
+		written++
+	}
+	if written > 0 {
+		s.log.Info("projectdoc: log embed backfill cycle done",
+			"written", written, "batch", len(todo))
+	}
+	return written, nil
+}

--- a/internal/projectdoc/log_embed_test.go
+++ b/internal/projectdoc/log_embed_test.go
@@ -1,0 +1,48 @@
+package projectdoc
+
+import "testing"
+
+func TestEmbedTextForLog(t *testing.T) {
+	tests := []struct {
+		name string
+		in   LogEntry
+		want string
+	}{
+		{"title only", LogEntry{Title: "M5 landed"}, "M5 landed"},
+		{"content only", LogEntry{Content: "deploy.sh wired"}, "deploy.sh wired"},
+		{"both joined", LogEntry{Title: "T", Content: "C"}, "T — C"},
+		{"whitespace trimmed", LogEntry{Title: "  T  ", Content: "  C  "}, "T — C"},
+		{"empty both", LogEntry{}, ""},
+		{"whitespace only", LogEntry{Title: "  ", Content: "  "}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := embedTextForLog(tc.in)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPgvecString(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []float32
+		want string
+	}{
+		{"empty", nil, "[]"},
+		{"single", []float32{0.5}, "[0.5]"},
+		{"multiple", []float32{0.1, 0.2, 0.3}, "[0.1,0.2,0.3]"},
+		{"negative", []float32{-1, 2.5}, "[-1,2.5]"},
+		{"zero", []float32{0, 0}, "[0,0]"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pgvecString(tc.in)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/projectdoc/projectdoc.go
+++ b/internal/projectdoc/projectdoc.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
@@ -140,12 +141,28 @@ var (
 	ErrEmptyCwd       = errors.New("projectdoc: cwd is required")
 )
 
+// LogEmbedder is the minimal embedding surface projectdoc needs
+// to vector-index session_logs at append time + during the M-PB
+// backfill loop. The memory subsystem's own Embedder implements
+// this; defined here as a narrow local interface so projectdoc
+// doesn't import internal/memory and risk circular dependencies.
+type LogEmbedder interface {
+	Embed(ctx context.Context, texts []string) ([][]float32, error)
+	Name() string
+}
+
 // Service is the CRUD-plus-policy surface for project docs +
 // proposals + session logs. Constructed once per process and shared
 // across HTTP handlers / MCP tools / spawn-time injector.
 type Service struct {
 	pool *pgxpool.Pool
 	log  *slog.Logger
+
+	// embedder is the optional M-PB hook for journal vector
+	// indexing. When non-nil, AppendLog also embeds the entry; the
+	// backfill goroutine uses the same one for catching up legacy
+	// rows. Nil disables — append-time path stays unchanged.
+	embedder LogEmbedder
 
 	// mirrorDisabled turns off the on-write `.opendray/*.md` mirror.
 	// Tests flip this on via DisableMirror() so they don't dirty
@@ -160,6 +177,25 @@ func NewService(pool *pgxpool.Pool, log *slog.Logger) *Service {
 	}
 	return &Service{pool: pool, log: log.With("component", "projectdoc")}
 }
+
+// WithEmbedder installs the M-PB journal embedding hook. Returns
+// the receiver for chained setup at composition-root time. Passing
+// nil clears any previously-installed embedder.
+func (s *Service) WithEmbedder(emb LogEmbedder) *Service {
+	s.embedder = emb
+	return s
+}
+
+// Embedder returns the currently-installed embedder, or nil.
+// Exposed for the backfill goroutine + cross-layer search service
+// which need to embed the user's query the same way.
+func (s *Service) Embedder() LogEmbedder { return s.embedder }
+
+// Pool exposes the underlying pgxpool for callers that need raw
+// SQL access — specifically the backfill worker (which writes
+// embedding columns) and the cross-layer search service (which
+// runs vector queries against session_logs).
+func (s *Service) Pool() *pgxpool.Pool { return s.pool }
 
 // ─── docs (goal / plan) ────────────────────────────────────────
 
@@ -436,8 +472,84 @@ func (s *Service) AppendLog(ctx context.Context, e LogEntry) (LogEntry, error) {
 	out, err := scanLog(row)
 	if err == nil {
 		s.mirrorBestEffort(ctx, out.Cwd)
+		// M-PB — embed the new entry synchronously when an embedder
+		// is wired. Failure here is non-fatal: the row is already
+		// committed, and the backfill goroutine will catch up the
+		// missing vector on its next sweep. Embedding logged so
+		// operators can spot a misconfigured embedder.
+		s.embedLogBestEffort(ctx, out)
 	}
 	return out, err
+}
+
+// embedLogBestEffort computes + persists an embedding for one
+// freshly-appended journal entry. No-op when no embedder is
+// configured. Soft-fails: a logged warning is the worst outcome.
+func (s *Service) embedLogBestEffort(ctx context.Context, e LogEntry) {
+	if s.embedder == nil {
+		return
+	}
+	text := embedTextForLog(e)
+	if text == "" {
+		return
+	}
+	vecs, err := s.embedder.Embed(ctx, []string{text})
+	if err != nil || len(vecs) == 0 || len(vecs[0]) == 0 {
+		s.log.Debug("projectdoc: log embed at append-time failed (will retry via backfill)",
+			"log_id", e.ID, "err", err)
+		return
+	}
+	name := s.embedder.Name()
+	if _, err := s.pool.Exec(ctx, `
+		UPDATE session_logs
+		   SET embedding = $1,
+		       embedder = $2,
+		       embedding_at = NOW()
+		 WHERE id = $3`, pgvecString(vecs[0]), name, e.ID); err != nil {
+		s.log.Debug("projectdoc: log embed write-back failed",
+			"log_id", e.ID, "err", err)
+	}
+}
+
+// embedTextForLog assembles the string passed to the embedder.
+// "title — content" mirrors how the spawn-time banner renders the
+// entry, so query semantics match what the agent will eventually
+// see in its system prompt.
+func embedTextForLog(e LogEntry) string {
+	title := strings.TrimSpace(e.Title)
+	content := strings.TrimSpace(e.Content)
+	if title == "" && content == "" {
+		return ""
+	}
+	if title == "" {
+		return content
+	}
+	if content == "" {
+		return title
+	}
+	return title + " — " + content
+}
+
+// pgvecString encodes a float32 slice into pgvector's bracketed
+// literal form. We feed it as a parameter rather than building a
+// SQL fragment so pgx still treats it as a typed argument (no
+// injection risk). Same encoding pattern lives in
+// memory/store_pgvector.go for the memories table.
+func pgvecString(v []float32) string {
+	if len(v) == 0 {
+		return "[]"
+	}
+	var b strings.Builder
+	b.Grow(2 + len(v)*8)
+	b.WriteByte('[')
+	for i, f := range v {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(strconv.FormatFloat(float64(f), 'f', -1, 32))
+	}
+	b.WriteByte(']')
+	return b.String()
 }
 
 // ListLogs returns chronological journal entries newest first.
@@ -593,7 +705,30 @@ func (s *Service) ResetCwd(ctx context.Context, cwd string, opts ResetCwdOptions
 // values ≤ 0 fall back to 5. Each entry shows title + content; the
 // banner stops growing past ~6KB even at high recentLogs, so the
 // spawn cost is bounded.
+//
+// This is the legacy entry point — equivalent to
+// RenderForSpawnWithBudget(ctx, cwd, recentLogs, 0). Kept stable
+// so existing callers don't need an immediate update.
 func (s *Service) RenderForSpawn(ctx context.Context, cwd string, recentLogs int) (string, error) {
+	return s.RenderForSpawnWithBudget(ctx, cwd, recentLogs, 0)
+}
+
+// RenderForSpawnWithBudget is the M-PB token-budgeted renderer.
+// maxBytes <= 0 disables the cap (matches legacy RenderForSpawn).
+// When set, sections are appended in priority order and rendering
+// halts once the budget is exceeded, with a "truncated" notice
+// added so the agent knows the prompt is incomplete.
+//
+// Priority order is fixed to favour the things an agent acts on:
+//  1. plan          — most useful for picking up where work left off
+//  2. tech_stack    — orients the agent in the codebase
+//  3. goal          — long-term direction (rare changes; smaller body)
+//  4. recent_activity — git narrative (large; lower priority by design)
+//  5. journal       — episodic detail; takes whatever budget is left
+//
+// 4 KiB ≈ 1k tokens is a sensible default for most operators; the
+// catalog adapter can pass its own value once we expose it.
+func (s *Service) RenderForSpawnWithBudget(ctx context.Context, cwd string, recentLogs, maxBytes int) (string, error) {
 	if strings.TrimSpace(cwd) == "" {
 		return "", nil
 	}
@@ -633,57 +768,90 @@ func (s *Service) RenderForSpawn(ctx context.Context, cwd string, recentLogs int
 	// drop human-courtesy framing (intro essays, "auto-generated"
 	// markers, last-scanned timestamps). Saves ~15-25% spawn tokens.
 	var b strings.Builder
-	b.WriteString("## Project context (cross-agent shared, read-only)\n\n")
+	header := "## Project context (cross-agent shared, read-only)\n\n"
+	footer := "If your work changes the goal or plan, do **not** silently overwrite them. Use the `project_goal_set` / `project_plan_set` MCP tools — they file a proposal that the operator approves before the live doc updates.\n"
+	b.WriteString(header)
 
-	if techStack != "" {
-		b.WriteString("### Tech stack & structure\n\n")
-		b.WriteString(techStack)
-		b.WriteString("\n\n")
+	// Reserve room for the footer when a budget is active; without
+	// the footer the agent loses the proposal-flow nudge.
+	footerReserve := 0
+	truncated := false
+	if maxBytes > 0 {
+		footerReserve = len(footer)
 	}
-	if recentActivity != "" {
-		b.WriteString("### Recent activity\n\n")
-		b.WriteString(recentActivity)
-		b.WriteString("\n\n")
-	}
-	if goal != "" {
-		b.WriteString("### Project goal\n\n")
-		b.WriteString(goal)
-		b.WriteString("\n\n")
-	}
-	if plan != "" {
-		b.WriteString("### Project plan\n\n")
-		b.WriteString(plan)
-		b.WriteString("\n\n")
-	}
-	if len(logs) > 0 {
-		b.WriteString("### Recent journal\n\n")
-		// logs are newest-first; render oldest-first inside the banner
-		// so the chronology reads naturally top-to-bottom.
-		for i := len(logs) - 1; i >= 0; i-- {
-			e := logs[i]
-			b.WriteString("- ")
-			if e.Title != "" {
-				b.WriteString("**")
-				b.WriteString(e.Title)
-				b.WriteString("** — ")
-			}
-			body := strings.TrimSpace(e.Content)
-			// Keep each journal line compact — the goal here is "remind
-			// the agent" not "replay full session summaries". 600 chars
-			// is roughly two paragraphs; longer entries stay readable
-			// when the operator drills into the journal page.
-			if len(body) > 600 {
-				body = body[:600] + "…"
-			}
-			b.WriteString(body)
-			b.WriteString("\n")
+
+	appendSection := func(title, body string) {
+		if body == "" || truncated {
+			return
 		}
-		b.WriteString("\n")
+		section := "### " + title + "\n\n" + body + "\n\n"
+		if maxBytes > 0 && b.Len()+len(section)+footerReserve > maxBytes {
+			truncated = true
+			return
+		}
+		b.WriteString(section)
 	}
 
-	b.WriteString("If your work changes the goal or plan, do **not** silently overwrite them. Use the `project_goal_set` / `project_plan_set` MCP tools — they file a proposal that the operator approves before the live doc updates.\n")
+	appendSection("Project plan", plan)
+	appendSection("Tech stack & structure", techStack)
+	appendSection("Project goal", goal)
+	appendSection("Recent activity", recentActivity)
 
+	if len(logs) > 0 && !truncated {
+		jb, jTrunc := renderJournalSection(logs, maxBytes-b.Len()-footerReserve)
+		if jb != "" {
+			b.WriteString(jb)
+		}
+		if jTrunc {
+			truncated = true
+		}
+	}
+
+	if truncated {
+		b.WriteString("_(banner truncated to fit spawn-prompt budget — visit /memory/project for the full set)_\n\n")
+	}
+
+	b.WriteString(footer)
 	return b.String(), nil
+}
+
+// renderJournalSection assembles the journal block, stopping when
+// it would exceed remaining bytes. Returns the section text + a
+// "we hit the limit" flag so the caller can append a truncation
+// note. remaining <=0 disables the cap.
+func renderJournalSection(logs []LogEntry, remaining int) (string, bool) {
+	var b strings.Builder
+	b.WriteString("### Recent journal\n\n")
+	truncated := false
+	// logs are newest-first; render oldest-first so chronology reads
+	// top-to-bottom.
+	for i := len(logs) - 1; i >= 0; i-- {
+		e := logs[i]
+		body := strings.TrimSpace(e.Content)
+		if len(body) > 600 {
+			body = body[:600] + "…"
+		}
+		var line strings.Builder
+		line.WriteString("- ")
+		if e.Title != "" {
+			line.WriteString("**")
+			line.WriteString(e.Title)
+			line.WriteString("** — ")
+		}
+		line.WriteString(body)
+		line.WriteString("\n")
+		if remaining > 0 && b.Len()+line.Len() > remaining {
+			truncated = true
+			break
+		}
+		b.WriteString(line.String())
+	}
+	b.WriteString("\n")
+	// If we wrote nothing past the heading, drop the section entirely.
+	if strings.Count(b.String(), "\n") <= 3 {
+		return "", truncated
+	}
+	return b.String(), truncated
 }
 
 // ─── scanners ──────────────────────────────────────────────────

--- a/internal/projectdoc/render_budget_test.go
+++ b/internal/projectdoc/render_budget_test.go
@@ -1,0 +1,55 @@
+package projectdoc
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderJournalSection_NoBudget(t *testing.T) {
+	logs := []LogEntry{
+		{Title: "Newest", Content: "C"},
+		{Title: "Older", Content: "B"},
+		{Title: "Oldest", Content: "A"},
+	}
+	out, truncated := renderJournalSection(logs, 0)
+	if truncated {
+		t.Error("expected no truncation with budget=0")
+	}
+	if !strings.Contains(out, "**Oldest**") || !strings.Contains(out, "**Newest**") {
+		t.Errorf("missing entries:\n%s", out)
+	}
+	// Oldest first: index of Oldest should precede Newest.
+	if strings.Index(out, "Oldest") > strings.Index(out, "Newest") {
+		t.Errorf("chronology wrong:\n%s", out)
+	}
+}
+
+func TestRenderJournalSection_BudgetTruncates(t *testing.T) {
+	logs := []LogEntry{
+		{Title: "A", Content: strings.Repeat("xxxxxx", 50)},
+		{Title: "B", Content: strings.Repeat("yyyyyy", 50)},
+		{Title: "C", Content: strings.Repeat("zzzzzz", 50)},
+	}
+	out, truncated := renderJournalSection(logs, 200)
+	if !truncated {
+		t.Error("expected truncation at 200 bytes")
+	}
+	if len(out) > 250 {
+		// the header + at most one entry should fit; allow a little slack
+		t.Errorf("output unexpectedly large: %d bytes\n%s", len(out), out)
+	}
+}
+
+func TestRenderJournalSection_EmptyIfNothingFits(t *testing.T) {
+	logs := []LogEntry{
+		{Title: "huge", Content: strings.Repeat("a", 5000)},
+	}
+	// 20 bytes can't even fit one line — section should collapse to empty.
+	out, truncated := renderJournalSection(logs, 20)
+	if !truncated {
+		t.Error("expected truncation")
+	}
+	if out != "" {
+		t.Errorf("expected empty when nothing fits; got:\n%s", out)
+	}
+}

--- a/internal/store/migrations/0031_session_logs_embedding.sql
+++ b/internal/store/migrations/0031_session_logs_embedding.sql
@@ -1,0 +1,36 @@
+-- M-PB — Add embedding columns to session_logs so the journal
+-- joins the layer-5 semantic search surface. Combined with the new
+-- project_search MCP tool, agents can ask "what did we decide
+-- about X" and hit journal entries the same way they hit memories.
+--
+-- Strategy:
+--   - embedding NULL means "not yet embedded" — caught by the
+--     startup backfill goroutine which calls memory.Embedder on
+--     batches of 50 rows.
+--   - embedder TEXT records which embedder produced the vector so
+--     mismatched-vector-space queries get filtered out (matches
+--     the existing memories.embedder column convention).
+--   - embedding_at lets operators debug "this journal entry is
+--     stale because we re-embedded everything yesterday but this
+--     one row's embedder is still the old name."
+--
+-- Why no fixed dimension: same reason memories doesn't pin one —
+-- BM25 / bge-m3 / OpenAI all co-exist, dim varies per row.
+
+ALTER TABLE session_logs
+    ADD COLUMN IF NOT EXISTS embedding    vector,
+    ADD COLUMN IF NOT EXISTS embedder     TEXT,
+    ADD COLUMN IF NOT EXISTS embedding_at TIMESTAMPTZ;
+
+-- Partial index over rows still awaiting backfill makes the
+-- startup scan a single index lookup rather than a sequential scan
+-- across the whole table.
+CREATE INDEX IF NOT EXISTS session_logs_needs_embed_idx
+    ON session_logs (created_at)
+ WHERE embedding IS NULL;
+
+-- Embedder filter — mirrors memories_embedder_idx semantics so the
+-- cross-layer search can WHERE-restrict before the cosine pass.
+CREATE INDEX IF NOT EXISTS session_logs_embedder_idx
+    ON session_logs (embedder)
+ WHERE embedder IS NOT NULL;


### PR DESCRIPTION
## Summary

Phase B builds on the [Phase A](https://github.com/Opendray/opendray_v2/pull/128) plan-drift + health work by making the journal **searchable** and giving agents one tool to query every memory layer at once.

- **Journal embedding** — every `session_logs` row gets a vector, the same way `memories` rows do. A startup backfill goroutine catches up legacy rows.
- **Cross-layer search** — new `project_search` MCP tool + `GET /api/v1/project-search` ranks hits from facts + journal + goal + plan in one merged list, with a time-decay penalty so recency matters but never overrides relevance.
- **Spawn banner token budget** — `RenderForSpawnWithBudget` caps the projectdoc banner size by byte budget, dropping the lowest-priority sections first.

Operators don't need to do anything to enable journal embedding — the backfill picks up automatically on first start after migration 0031.

## What changed

- `internal/store/migrations/0031_session_logs_embedding.sql` — vector/embedder/timestamp columns + partial index.
- `internal/projectdoc/projectdoc.go` — `LogEmbedder` interface + `WithEmbedder` + `embedLogBestEffort` + helpers.
- `internal/projectdoc/log_embed_backfill.go` — `RunLogEmbedBackfill` goroutine.
- `internal/projectdoc/projectdoc.go` — `RenderForSpawnWithBudget` + `renderJournalSection`.
- `internal/app/projectdoc_embedder.go` — adapter wiring memory.Embedder → projectdoc.LogEmbedder.
- `internal/memquery/` — new package: `Service.Search`, time-decay, lexical doc match, `Handlers`.
- `cmd/opendray/mcp_memory.go` — `project_search` tool definition, dispatch, `callProjectSearch` impl, instructionsBlurb updated.
- `internal/catalog/adapter.go` — `WithProjectDocBudget` + budget-aware render call.
- `internal/memory/service.go` — exposes `Embedder()` so projectdoc can share the same instance.
- `docs/memory-system.md` — operator-guide section.

## Failure modes deliberately tolerated

- AppendLog embedding fails → log + commit row, backfill catches up next cycle.
- Backfill embedder error → log + sleep one idle interval, retry.
- memquery layer failure → empty slice from that layer, other layers still contribute hits.
- project_search MCP tool with no scope_key → error to agent (cwd is required, can't guess).
- Banner over budget → truncate with explicit "(banner truncated…)" note so the agent knows.

## Test plan

- [x] `go test -race ./...` green
- [x] `pnpm tsc --noEmit` green
- [x] `gofmt -l ./...` clean
- [x] Unit tests: embedTextForLog, pgvecString, decayScore, pgvecLiteral, render journal section truncation
- [x] Opt-in live-DB smoke tests via `OPENDRAY_DEV_DB_URL`
- [ ] Manual: spawn a session in a project with existing journal entries, run `project_search` for a topic, verify journal hits return
- [ ] Manual: set `WithProjectDocBudget(2048)` somewhere, spawn a session with a large plan, verify banner truncates and footer renders

## Follow-ups (Phase C+ tracked separately)

- Phase C: unified worker fabric for all memory layers
- Phase D: cross-layer conflict detection between facts and plan