### PR TITLE
feat(memory): smart ranking + cross-layer conflict detection (Phase C)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -220,6 +220,24 @@
       "navWorkers": "Workers",
       "navConfiguration": "Configuration →"
     },
+    "conflicts": {
+      "title": "Cross-layer conflicts",
+      "subtitle": "Contradictions the daily detector found between facts, plan, goal, and journal entries.",
+      "loading": "Loading conflicts…",
+      "empty": "No pending conflicts. Click \"Detect now\" to run an on-demand sweep.",
+      "pickCwd": "Pick a project to see its conflicts.",
+      "detectNow": "Detect now",
+      "detected": "{count} new conflict(s) found",
+      "accept": "Accept",
+      "dismiss": "Dismiss",
+      "accepted": "Conflict accepted — remember to apply the fix",
+      "dismissed": "Conflict dismissed",
+      "severity": {
+        "low": "low",
+        "medium": "medium",
+        "high": "high"
+      }
+    },
     "memoryHealth": {
       "title": "Memory health — last {days} days",
       "subtitle": "Aggregate signals across both memory subsystems for this project.",
@@ -353,6 +371,7 @@
         "activity": "Activity",
         "journal": "Journal",
         "inbox": "Inbox",
+        "conflicts": "Conflicts",
         "cleanup": "Cleanup"
       },
       "docLabel": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -220,6 +220,24 @@
       "navWorkers": "Workers",
       "navConfiguration": "配置 →"
     },
+    "conflicts": {
+      "title": "跨层冲突",
+      "subtitle": "每日 detector 在 facts/plan/goal/journal 之间发现的矛盾。",
+      "loading": "正在加载冲突…",
+      "empty": "无待处理冲突。点击\"立即检测\"运行一次按需扫描。",
+      "pickCwd": "选一个项目查看其冲突。",
+      "detectNow": "立即检测",
+      "detected": "新发现 {count} 条冲突",
+      "accept": "采纳",
+      "dismiss": "驳回",
+      "accepted": "已采纳 — 别忘了实际修正",
+      "dismissed": "已驳回",
+      "severity": {
+        "low": "低",
+        "medium": "中",
+        "high": "高"
+      }
+    },
     "memoryHealth": {
       "title": "记忆健康 — 最近 {days} 天",
       "subtitle": "本项目两套记忆子系统的运行情况聚合。",
@@ -353,6 +371,7 @@
         "activity": "活动",
         "journal": "日志",
         "inbox": "收件箱",
+        "conflicts": "冲突",
         "cleanup": "清理"
       },
       "docLabel": {

--- a/app/shared/src/lib/memoryConflicts.ts
+++ b/app/shared/src/lib/memoryConflicts.ts
@@ -1,0 +1,57 @@
+// Client for /api/v1/memory/conflicts — the M-PC cross-layer
+// conflict ledger.
+
+import { api } from './api'
+
+export type ConflictLayer = 'fact' | 'plan' | 'goal' | 'journal'
+export type ConflictSeverity = 'low' | 'medium' | 'high'
+export type ConflictStatus =
+  | 'pending'
+  | 'accepted'
+  | 'dismissed'
+  | 'expired'
+
+export interface MemoryConflict {
+  id: string
+  cwd: string
+  layer_a: ConflictLayer
+  ref_a: string
+  layer_b: ConflictLayer
+  ref_b: string
+  evidence: string
+  severity: ConflictSeverity
+  status: ConflictStatus
+  detected_at: string
+  decided_at?: string
+  decided_by?: string
+}
+
+export async function listMemoryConflicts(params: {
+  cwd: string
+  status?: ConflictStatus
+  limit?: number
+}): Promise<MemoryConflict[]> {
+  const qs = new URLSearchParams({ cwd: params.cwd })
+  if (params.status) qs.set('status', params.status)
+  qs.set('n', String(params.limit ?? 50))
+  const res = await api<{ conflicts: MemoryConflict[] }>(
+    `/api/v1/memory/conflicts?${qs}`,
+  )
+  return res.conflicts ?? []
+}
+
+export async function decideMemoryConflict(
+  id: string,
+  action: 'accepted' | 'dismissed',
+): Promise<void> {
+  await api(`/api/v1/memory/conflicts/${id}/${action}`, { method: 'POST' })
+}
+
+export async function detectMemoryConflicts(cwd: string): Promise<number> {
+  const qs = new URLSearchParams({ cwd })
+  const res = await api<{ detected: number }>(
+    `/api/v1/memory/conflicts/detect?${qs}`,
+    { method: 'POST' },
+  )
+  return res.detected ?? 0
+}

--- a/app/web/src/components/project/ConflictsPanel.tsx
+++ b/app/web/src/components/project/ConflictsPanel.tsx
@@ -1,0 +1,193 @@
+// ConflictsPanel — M-PC operator inbox for cross-layer
+// contradictions surfaced by the daily detector. Each row shows
+// the two conflicting items + the LLM's evidence + accept/dismiss
+// buttons.
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
+import {
+  AlertTriangle,
+  Check,
+  Loader2,
+  RefreshCw,
+  X,
+} from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  type MemoryConflict,
+  decideMemoryConflict,
+  detectMemoryConflicts,
+  listMemoryConflicts,
+} from '@/lib/memoryConflicts'
+
+interface ConflictsPanelProps {
+  cwd: string
+}
+
+export function ConflictsPanel({ cwd }: ConflictsPanelProps) {
+  const { t } = useTranslation()
+  const qc = useQueryClient()
+
+  const conflictsQuery = useQuery({
+    queryKey: ['memory-conflicts', cwd, 'pending'],
+    queryFn: () =>
+      listMemoryConflicts({ cwd, status: 'pending', limit: 100 }),
+    enabled: !!cwd,
+  })
+
+  const decide = useMutation({
+    mutationFn: (input: {
+      id: string
+      action: 'accepted' | 'dismissed'
+    }) => decideMemoryConflict(input.id, input.action),
+    onSuccess: (_data, vars) => {
+      toast.success(
+        vars.action === 'accepted'
+          ? t('web.conflicts.accepted')
+          : t('web.conflicts.dismissed'),
+      )
+      qc.invalidateQueries({ queryKey: ['memory-conflicts', cwd] })
+    },
+    onError: (err: unknown) => {
+      toast.error(`${err}`)
+    },
+  })
+
+  const detect = useMutation({
+    mutationFn: () => detectMemoryConflicts(cwd),
+    onSuccess: (n) => {
+      toast.success(t('web.conflicts.detected', { count: n }))
+      qc.invalidateQueries({ queryKey: ['memory-conflicts', cwd] })
+    },
+    onError: (err: unknown) => {
+      toast.error(`${err}`)
+    },
+  })
+
+  if (!cwd) {
+    return (
+      <div className="text-muted-foreground p-6 text-[12px]">
+        {t('web.conflicts.pickCwd')}
+      </div>
+    )
+  }
+
+  const conflicts = conflictsQuery.data ?? []
+
+  return (
+    <div className="flex flex-1 flex-col">
+      <div className="border-border flex items-center justify-between border-b px-4 py-3">
+        <div>
+          <h2 className="text-sm font-medium">{t('web.conflicts.title')}</h2>
+          <p className="text-muted-foreground text-[11px]">
+            {t('web.conflicts.subtitle')}
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => detect.mutate()}
+          disabled={detect.isPending}
+        >
+          {detect.isPending ? (
+            <Loader2 className="mr-1 size-3 animate-spin" />
+          ) : (
+            <RefreshCw className="mr-1 size-3" />
+          )}
+          {t('web.conflicts.detectNow')}
+        </Button>
+      </div>
+
+      <div className="flex-1 overflow-auto p-4">
+        {conflictsQuery.isLoading && (
+          <div className="text-muted-foreground flex items-center gap-2 text-[12px]">
+            <Loader2 className="size-3 animate-spin" />
+            {t('web.conflicts.loading')}
+          </div>
+        )}
+        {!conflictsQuery.isLoading && conflicts.length === 0 && (
+          <div className="text-muted-foreground rounded border border-dashed p-6 text-center text-[12px]">
+            {t('web.conflicts.empty')}
+          </div>
+        )}
+        <div className="space-y-3">
+          {conflicts.map((c) => (
+            <ConflictCard
+              key={c.id}
+              conflict={c}
+              onDecide={(action) => decide.mutate({ id: c.id, action })}
+              disabled={decide.isPending}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface ConflictCardProps {
+  conflict: MemoryConflict
+  onDecide: (action: 'accepted' | 'dismissed') => void
+  disabled: boolean
+}
+
+function ConflictCard({ conflict, onDecide, disabled }: ConflictCardProps) {
+  const { t } = useTranslation()
+  const severityTone =
+    conflict.severity === 'high'
+      ? 'danger'
+      : conflict.severity === 'medium'
+        ? 'warn'
+        : 'muted'
+  return (
+    <div className="bg-card/50 rounded-md border p-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <AlertTriangle
+            className={`size-3.5 ${
+              conflict.severity === 'high' ? 'text-destructive' : ''
+            }`}
+          />
+          <Badge variant={severityTone === 'danger' ? 'danger' : 'muted'}>
+            {t(`web.conflicts.severity.${conflict.severity}`)}
+          </Badge>
+          <span className="text-[10px] font-mono text-muted-foreground">
+            {conflict.layer_a}:{shortRef(conflict.ref_a)} ⟷{' '}
+            {conflict.layer_b}:{shortRef(conflict.ref_b)}
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => onDecide('accepted')}
+            disabled={disabled}
+            className="h-7 text-[11px]"
+          >
+            <Check className="mr-1 size-3" />
+            {t('web.conflicts.accept')}
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => onDecide('dismissed')}
+            disabled={disabled}
+            className="h-7 text-[11px]"
+          >
+            <X className="mr-1 size-3" />
+            {t('web.conflicts.dismiss')}
+          </Button>
+        </div>
+      </div>
+      <p className="text-[12px] whitespace-pre-wrap">{conflict.evidence}</p>
+    </div>
+  )
+}
+
+function shortRef(ref: string): string {
+  if (ref.length <= 12) return ref
+  return ref.slice(0, 8) + '…'
+}

--- a/app/web/src/components/project/ProjectScreen.tsx
+++ b/app/web/src/components/project/ProjectScreen.tsx
@@ -60,6 +60,7 @@ import {
 } from '@/lib/memoryCleanup'
 import { deleteMemoriesByScope } from '@/lib/memory'
 import { MemoryHealthCard } from '@/components/project/MemoryHealthCard'
+import { ConflictsPanel } from '@/components/project/ConflictsPanel'
 
 interface ProjectScreenProps {
   cwd: string
@@ -204,6 +205,9 @@ export function ProjectScreen({ cwd }: ProjectScreenProps) {
               </span>
             )}
           </TabsTrigger>
+          <TabsTrigger value="conflicts">
+            {t('web.project.tabs.conflicts')}
+          </TabsTrigger>
           <TabsTrigger value="cleanup" className="relative">
             {t('web.project.tabs.cleanup')}
             {cleanupCount > 0 && (
@@ -257,6 +261,10 @@ export function ProjectScreen({ cwd }: ProjectScreenProps) {
               qc.invalidateQueries({ queryKey: ['project-docs', cwd] })
             }}
           />
+        </TabsContent>
+
+        <TabsContent value="conflicts" className="flex-1 overflow-auto">
+          <ConflictsPanel cwd={cwd} />
         </TabsContent>
 
         <TabsContent value="cleanup" className="flex-1 overflow-auto p-4">

--- a/docs/memory-system.md
+++ b/docs/memory-system.md
@@ -371,6 +371,66 @@ journal) and rendering stops once the budget is exhausted, with
 a trailing truncation note so the agent knows to visit
 `/memory/project` for the full set.
 
+## Smarter ranking (M-PC, shipped)
+
+`memory_search` used to rank purely by cosine similarity. That
+let one-shot 10-month-old memories crowd out fresh high-quality
+matches, and never benefited from the fact that some memories
+get retrieved 30× while others sit at zero hits forever.
+
+The new formula:
+
+```
+effective_score = similarity
+                × age_decay(age_days)        # max(0.5, 1 - age/180d)
+                × hit_boost(hit_count)       # 1 + min(hit_count*0.02, 0.5)
+                × confidence_floor(conf)     # max(conf, 0.3)
+```
+
+Threshold filtering still uses raw `similarity` so an explicit
+`MinSimilarity` from the caller behaves like always; only the
+**ordering** changes. The result: a popular 6-month-old fact at
+0.8 similarity (score 0.60) outranks a brand-new mediocre 0.5
+match (score 0.50), which is what operators were already doing
+mentally.
+
+Tuning knobs live in `internal/memory/ranking.go` — recompile to
+change them.
+
+## Cross-layer conflict detection (M-PC, shipped)
+
+A new daily worker (`conflict_detector` TaskKind) scans each
+project's plan + top-hit facts + recent journal and asks the
+configured LLM: "do any of these claims contradict each other?"
+Findings land in `memory_conflicts` (migration 0032) with the
+two conflicting refs + the LLM's evidence + a severity tag.
+
+Operators review the inbox at `/memory/project` → **Conflicts**
+tab. Two buttons per row:
+
+- **Accept** — operator agrees a contradiction exists and will
+  apply the fix manually (delete a stale fact, update the plan,
+  etc.). Status flips to `accepted` and the row stays in the
+  audit history.
+- **Dismiss** — the detector got it wrong; status flips to
+  `dismissed` and an identical pair won't be re-flagged in
+  future sweeps.
+
+The scheduler tick is 24h with a per-cwd 10-minute LLM budget.
+Operators can force a sweep with the "Detect now" button on the
+tab or `POST /api/v1/memory/conflicts/detect?cwd=…`.
+
+Worker selection lives at **Memory → Workers → conflict_detector**;
+default is `summarizer`. Disable to skip detection entirely.
+
+## Journal cleanup helper (M-PC, shipped)
+
+`GET /api/v1/session-logs/stale?cwd=&days=` returns
+`session_summary` journal entries older than `days` (default 90)
+that aren't referenced by any pending conflict. Operators use
+this list to prune accumulated noise without losing any
+journaling that's still doing work via the conflict detector.
+
 ## Roadmap
 
 - **Codex session UUID capture**. Codex lacks `--session-id`; a

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -43,6 +43,7 @@ import (
 	githost "github.com/opendray/opendray-v2/internal/githost"
 	"github.com/opendray/opendray-v2/internal/integration"
 	mcpapi "github.com/opendray/opendray-v2/internal/mcp"
+	"github.com/opendray/opendray-v2/internal/memconflict"
 	"github.com/opendray/opendray-v2/internal/memhealth"
 	"github.com/opendray/opendray-v2/internal/memory"
 	"github.com/opendray/opendray-v2/internal/memory/capture"
@@ -84,6 +85,7 @@ type App struct {
 	projectDocSvc        *projectdoc.Service // owns the M-PB journal embed backfill loop
 	cleanerScheduler     *cleaner.Scheduler  // optional; nil when scheduler is off
 	gitActivityScheduler *gitactivity.Scheduler
+	conflictScheduler    *memconflict.Scheduler // M-PC daily cross-layer conflict scan
 	server               *http.Server
 }
 
@@ -491,6 +493,21 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		return nil, fmt.Errorf("memquery init: %w", err)
 	}
 	memqueryHandlers = memquery.NewHandlers(memquerySvc, log)
+
+	// M-PC — cross-layer conflict detector. Daily scheduler runs
+	// across every project_docs cwd and asks the configured worker
+	// LLM for contradictions; new findings land in
+	// memory_conflicts pending the operator's verdict.
+	conflictSvc, err := memconflict.New(st.Pool(), memorySvc, projectDocSvc, memoryWorkerRegistry, log)
+	if err != nil {
+		return nil, fmt.Errorf("memconflict init: %w", err)
+	}
+	conflictHandlers := memconflict.NewHandlers(conflictSvc, log)
+	conflictScheduler := memconflict.NewScheduler(
+		conflictSvc,
+		memconflict.NewSQLCwdLister(st.Pool()),
+		memconflict.SchedulerConfig{},
+	)
 	projectDocHandlers := projectdoc.NewHandlers(projectDocSvc, log)
 	// Inject the cross-agent goal+plan+journal banner into every
 	// spawned session's system prompt. Composed alongside the
@@ -606,6 +623,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 				memoryWorkerHandlers.Mount(r)
 				memhealthHandlers.Mount(r)
 				memqueryHandlers.Mount(r)
+				conflictHandlers.Mount(r)
 				captureHandlers.Mount(r)
 				injectorHandlers.Mount(r)
 				if cleanerHandlers != nil {
@@ -661,6 +679,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		projectDocSvc:        projectDocSvc,
 		cleanerScheduler:     cleanerScheduler,
 		gitActivityScheduler: gitActivityScheduler,
+		conflictScheduler:    conflictScheduler,
 		server:               srv,
 	}, nil
 }
@@ -750,6 +769,17 @@ func (a *App) Run(ctx context.Context) error {
 			a.gitActivityScheduler.Run(ctx)
 		}
 		close(gitActivityDone)
+	}()
+
+	// M-PC — daily conflict detector. Same goroutine pattern as
+	// the git activity scheduler; nil-safe so disabling the
+	// service skips cleanly.
+	conflictDone := make(chan struct{})
+	go func() {
+		if a.conflictScheduler != nil {
+			a.conflictScheduler.Run(ctx)
+		}
+		close(conflictDone)
 	}()
 
 	errCh := make(chan error, 1)

--- a/internal/memconflict/bundle.go
+++ b/internal/memconflict/bundle.go
@@ -1,0 +1,136 @@
+package memconflict
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/opendray/opendray-v2/internal/memory"
+	"github.com/opendray/opendray-v2/internal/projectdoc"
+)
+
+// detectionBundle is the input the worker LLM sees: a snapshot of
+// every memory layer the detector is allowed to reason about.
+// Kept as a struct (not just a string) so tests can pin which
+// layers actually populated.
+type detectionBundle struct {
+	cwd     string
+	plan    string
+	goal    string
+	facts   []memory.Memory
+	journal []projectdoc.LogEntry
+}
+
+func (b detectionBundle) empty() bool {
+	return strings.TrimSpace(b.plan) == "" &&
+		strings.TrimSpace(b.goal) == "" &&
+		len(b.facts) == 0 &&
+		len(b.journal) == 0
+}
+
+// gather runs the read side: pulls plan + goal + top hit facts +
+// recent journal. Each read failure degrades to empty for that
+// slice — a missing journal table shouldn't stop the detector
+// from finding a plan-vs-facts contradiction.
+func (s *Service) gather(ctx context.Context, cwd string) (detectionBundle, error) {
+	b := detectionBundle{cwd: cwd}
+
+	if plan, err := s.docs.GetDoc(ctx, cwd, projectdoc.KindPlan); err == nil {
+		b.plan = strings.TrimSpace(plan.Content)
+	}
+	if goal, err := s.docs.GetDoc(ctx, cwd, projectdoc.KindGoal); err == nil {
+		b.goal = strings.TrimSpace(goal.Content)
+	}
+	// Top-K by hit_count would ideally be a Store-level helper; for
+	// now we List with a generous cap and let the renderer pick the
+	// highest hit_count rows.
+	mems, err := s.mem.List(ctx, memory.ScopeProject, cwd, 100)
+	if err == nil {
+		b.facts = pickTopByHits(mems, 20)
+	}
+	logs, err := s.docs.ListLogs(ctx, cwd, 30)
+	if err == nil {
+		// Filter to the last 14 days — older entries dilute the prompt
+		// without adding signal because they've usually been
+		// superseded.
+		cutoff := time.Now().UTC().Add(-14 * 24 * time.Hour)
+		for _, l := range logs {
+			if l.CreatedAt.After(cutoff) {
+				b.journal = append(b.journal, l)
+			}
+		}
+	}
+	return b, nil
+}
+
+// pickTopByHits returns up to limit memories ordered by hit_count
+// desc. Ties broken by created_at desc (newer first).
+func pickTopByHits(mems []memory.Memory, limit int) []memory.Memory {
+	// Sort in place: simple selection sort since N is small (≤ 100).
+	out := make([]memory.Memory, len(mems))
+	copy(out, mems)
+	for i := range out {
+		bestIdx := i
+		for j := i + 1; j < len(out); j++ {
+			if out[j].HitCount > out[bestIdx].HitCount ||
+				(out[j].HitCount == out[bestIdx].HitCount && out[j].CreatedAt.After(out[bestIdx].CreatedAt)) {
+				bestIdx = j
+			}
+		}
+		if bestIdx != i {
+			out[i], out[bestIdx] = out[bestIdx], out[i]
+		}
+	}
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// render assembles the user-message payload. Each item gets its
+// id stamped inline so the LLM can quote ids back in its findings
+// (we reject findings with unknown ids on insert).
+func (b detectionBundle) render() string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# Project context for %s\n\n", b.cwd)
+	if b.goal != "" {
+		sb.WriteString("## Project goal (layer=goal, ref=goal-doc)\n\n")
+		sb.WriteString(b.goal)
+		sb.WriteString("\n\n")
+	}
+	if b.plan != "" {
+		sb.WriteString("## Project plan (layer=plan, ref=plan-doc)\n\n")
+		sb.WriteString(b.plan)
+		sb.WriteString("\n\n")
+	}
+	if len(b.facts) > 0 {
+		sb.WriteString("## High-hit facts (layer=fact)\n\n")
+		for _, f := range b.facts {
+			fmt.Fprintf(&sb, "- ref=`%s` hits=%d: %s\n",
+				f.ID, f.HitCount, oneLine(f.Text, 240))
+		}
+		sb.WriteString("\n")
+	}
+	if len(b.journal) > 0 {
+		sb.WriteString("## Recent journal entries (layer=journal)\n\n")
+		// ListLogs returns newest first; show oldest first so chronology reads top-to-bottom.
+		for i := len(b.journal) - 1; i >= 0; i-- {
+			e := b.journal[i]
+			fmt.Fprintf(&sb, "- ref=`%s` (%s): %s — %s\n",
+				e.ID, e.CreatedAt.Format("2006-01-02"),
+				e.Title, oneLine(e.Content, 240))
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func oneLine(s string, max int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.TrimSpace(s)
+	if len(s) > max {
+		s = s[:max] + "…"
+	}
+	return s
+}

--- a/internal/memconflict/cwd_lister.go
+++ b/internal/memconflict/cwd_lister.go
@@ -1,0 +1,40 @@
+package memconflict
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// SQLCwdLister implements CwdLister by reading distinct cwds out
+// of project_docs — the canonical "projects opendray knows about"
+// list. Sessions live in their own table but spawning into a cwd
+// without a project_doc row is rare enough to skip here; once an
+// operator seeds a goal or plan the detector picks it up.
+type SQLCwdLister struct {
+	pool *pgxpool.Pool
+}
+
+func NewSQLCwdLister(pool *pgxpool.Pool) *SQLCwdLister {
+	return &SQLCwdLister{pool: pool}
+}
+
+func (l *SQLCwdLister) ListProjectCwds(ctx context.Context) ([]string, error) {
+	rows, err := l.pool.Query(ctx, `
+		SELECT DISTINCT cwd FROM project_docs
+		 WHERE cwd <> ''
+		 ORDER BY cwd`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}

--- a/internal/memconflict/handler.go
+++ b/internal/memconflict/handler.go
@@ -1,0 +1,102 @@
+package memconflict
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Handlers serves the conflict inbox over HTTP:
+//
+//	GET  /api/v1/memory/conflicts?cwd=&status=&n=        → {conflicts:[…]}
+//	POST /api/v1/memory/conflicts/{id}/{action}           → {conflict}
+//	POST /api/v1/memory/conflicts/detect?cwd=             → {detected: N}
+//
+// Mount under admin auth — conflicts surface raw plan/fact content.
+type Handlers struct {
+	svc *Service
+	log *slog.Logger
+}
+
+func NewHandlers(svc *Service, log *slog.Logger) *Handlers {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Handlers{svc: svc, log: log.With("component", "memconflict.http")}
+}
+
+func (h *Handlers) Mount(r chi.Router) {
+	r.Route("/memory/conflicts", func(r chi.Router) {
+		r.Get("/", h.list)
+		r.Post("/detect", h.detect)
+		r.Post("/{id}/{action}", h.decide)
+	})
+}
+
+func (h *Handlers) list(w http.ResponseWriter, r *http.Request) {
+	cwd := r.URL.Query().Get("cwd")
+	if cwd == "" {
+		writeError(w, http.StatusBadRequest, "cwd query param is required")
+		return
+	}
+	status := r.URL.Query().Get("status")
+	limit := 50
+	if v := r.URL.Query().Get("n"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	conflicts, err := h.svc.List(r.Context(), cwd, status, limit)
+	if err != nil {
+		h.log.Warn("memconflict: list failed", "err", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if conflicts == nil {
+		conflicts = []Conflict{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"conflicts": conflicts})
+}
+
+func (h *Handlers) decide(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	action := chi.URLParam(r, "action")
+	if err := h.svc.Decide(r.Context(), id, action, "operator"); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+func (h *Handlers) detect(w http.ResponseWriter, r *http.Request) {
+	cwd := r.URL.Query().Get("cwd")
+	if cwd == "" {
+		writeError(w, http.StatusBadRequest, "cwd query param is required")
+		return
+	}
+	n, err := h.svc.DetectForCwd(r.Context(), cwd)
+	if err != nil {
+		h.log.Warn("memconflict: detect failed", "cwd", cwd, "err", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"detected": n})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]any{"error": msg})
+}

--- a/internal/memconflict/memconflict.go
+++ b/internal/memconflict/memconflict.go
@@ -1,0 +1,461 @@
+// Package memconflict runs the M-PC cross-layer conflict
+// detector. A daily LLM librarian asks "do any of these claims
+// contradict each other?" across the project's plan + top facts +
+// recent journal; matches land in memory_conflicts for operator
+// review.
+//
+// Why a separate package: like memquery and memhealth, this code
+// needs to read from both memory and projectdoc but neither
+// should depend on the other directly. The package depends on
+// pgxpool + worker.Registry + small read-only views into the
+// other two services.
+package memconflict
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base32"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/opendray/opendray-v2/internal/memory"
+	"github.com/opendray/opendray-v2/internal/memory/worker"
+	"github.com/opendray/opendray-v2/internal/projectdoc"
+)
+
+// Layer enumerates which memory subsystem a conflict references.
+// Mirrors the DB CHECK constraint in migration 0032.
+type Layer string
+
+const (
+	LayerFact    Layer = "fact"
+	LayerPlan    Layer = "plan"
+	LayerGoal    Layer = "goal"
+	LayerJournal Layer = "journal"
+)
+
+// Severity tags the urgency of a conflict — operators sort by it
+// in the inbox. The detector LLM picks one of three based on how
+// load-bearing the conflicting claim is.
+type Severity string
+
+const (
+	SeverityLow    Severity = "low"
+	SeverityMedium Severity = "medium"
+	SeverityHigh   Severity = "high"
+)
+
+// Status mirrors the DB CHECK.
+type Status string
+
+const (
+	StatusPending   Status = "pending"
+	StatusAccepted  Status = "accepted"  // operator agrees, applied a fix
+	StatusDismissed Status = "dismissed" // operator rejected the finding
+	StatusExpired   Status = "expired"   // superseded by a later run
+)
+
+// Conflict is one row from memory_conflicts.
+type Conflict struct {
+	ID         string     `json:"id"`
+	Cwd        string     `json:"cwd"`
+	LayerA     Layer      `json:"layer_a"`
+	RefA       string     `json:"ref_a"`
+	LayerB     Layer      `json:"layer_b"`
+	RefB       string     `json:"ref_b"`
+	Evidence   string     `json:"evidence"`
+	Severity   Severity   `json:"severity"`
+	Status     Status     `json:"status"`
+	DetectedAt time.Time  `json:"detected_at"`
+	DecidedAt  *time.Time `json:"decided_at,omitempty"`
+	DecidedBy  string     `json:"decided_by,omitempty"`
+}
+
+// Service runs detection cycles + serves the CRUD surface
+// (list, decide). Stateless beyond the deps.
+type Service struct {
+	pool     *pgxpool.Pool
+	mem      *memory.Service
+	docs     *projectdoc.Service
+	registry *worker.Registry
+	log      *slog.Logger
+}
+
+// New wires the service. Every dep is required; nil → error so
+// the composition root surfaces a boot-time misconfig.
+func New(pool *pgxpool.Pool, mem *memory.Service, docs *projectdoc.Service, reg *worker.Registry, log *slog.Logger) (*Service, error) {
+	if pool == nil {
+		return nil, errors.New("memconflict: pool required")
+	}
+	if mem == nil {
+		return nil, errors.New("memconflict: memory service required")
+	}
+	if docs == nil {
+		return nil, errors.New("memconflict: projectdoc service required")
+	}
+	if reg == nil {
+		return nil, errors.New("memconflict: worker registry required")
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Service{
+		pool:     pool,
+		mem:      mem,
+		docs:     docs,
+		registry: reg,
+		log:      log.With("component", "memconflict"),
+	}, nil
+}
+
+// DetectForCwd runs one detection cycle against a single cwd:
+//
+//  1. Gather inputs: plan doc, top-K facts ordered by hit_count,
+//     last 14 days of journal.
+//  2. Skip when the bundle is too thin to produce useful
+//     conflicts (no plan + no facts).
+//  3. Ask the configured conflict_detector worker to return a
+//     JSON list of conflicts.
+//  4. INSERT each new conflict (status=pending). Existing pending
+//     conflicts for the same (layer_a, ref_a, layer_b, ref_b)
+//     pair are left alone so the operator's prior judgements
+//     aren't re-spammed.
+//
+// Returns the number of new conflicts written.
+func (s *Service) DetectForCwd(ctx context.Context, cwd string) (int, error) {
+	if strings.TrimSpace(cwd) == "" {
+		return 0, errors.New("memconflict: cwd required")
+	}
+	bundle, err := s.gather(ctx, cwd)
+	if err != nil {
+		return 0, fmt.Errorf("gather inputs: %w", err)
+	}
+	if bundle.empty() {
+		return 0, nil
+	}
+
+	userInput := bundle.render()
+	resp, err := s.registry.Run(ctx, worker.Request{
+		Task:                     worker.TaskConflictDetector,
+		SystemPrompt:             ConflictDetectorSystemPrompt,
+		UserInput:                userInput,
+		MaxTokens:                4096,
+		Timeout:                  5 * time.Minute,
+		ResponseFormatJSONSchema: conflictJSONSchema,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("worker run: %w", err)
+	}
+	findings, err := ParseConflicts(resp.Content)
+	if err != nil {
+		s.log.Debug("memconflict: parse error", "err", err, "raw_len", len(resp.Content))
+		return 0, nil
+	}
+	written := 0
+	for _, f := range findings {
+		if !validLayer(f.LayerA) || !validLayer(f.LayerB) {
+			continue
+		}
+		ok, err := s.insertIfNew(ctx, cwd, f)
+		if err != nil {
+			s.log.Warn("memconflict: insert failed", "err", err)
+			continue
+		}
+		if ok {
+			written++
+		}
+	}
+	if written > 0 {
+		s.log.Info("memconflict: detection cycle done",
+			"cwd", cwd, "new_conflicts", written, "total_findings", len(findings))
+	}
+	return written, nil
+}
+
+// List returns conflicts under cwd filtered by status (empty =
+// all). limit ≤ 0 → 50, max 200.
+func (s *Service) List(ctx context.Context, cwd, status string, limit int) ([]Conflict, error) {
+	if strings.TrimSpace(cwd) == "" {
+		return nil, errors.New("memconflict: cwd required")
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	var (
+		rows = s.pool
+	)
+	if status == "" {
+		r, err := rows.Query(ctx, `
+			SELECT id, cwd, layer_a, ref_a, layer_b, ref_b, evidence,
+			       severity, status, detected_at, decided_at,
+			       COALESCE(decided_by, '')
+			  FROM memory_conflicts
+			 WHERE cwd = $1
+			 ORDER BY detected_at DESC
+			 LIMIT $2`, cwd, limit)
+		if err != nil {
+			return nil, err
+		}
+		defer r.Close()
+		return scanConflicts(r)
+	}
+	r, err := rows.Query(ctx, `
+		SELECT id, cwd, layer_a, ref_a, layer_b, ref_b, evidence,
+		       severity, status, detected_at, decided_at,
+		       COALESCE(decided_by, '')
+		  FROM memory_conflicts
+		 WHERE cwd = $1 AND status = $2
+		 ORDER BY detected_at DESC
+		 LIMIT $3`, cwd, status, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return scanConflicts(r)
+}
+
+// Decide updates one conflict's status. action must be one of
+// "accepted" / "dismissed". Returns ErrNotFound when the id is
+// missing or already decided.
+func (s *Service) Decide(ctx context.Context, id, action, by string) error {
+	if action != string(StatusAccepted) && action != string(StatusDismissed) {
+		return fmt.Errorf("memconflict: invalid action %q", action)
+	}
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE memory_conflicts
+		   SET status = $1,
+		       decided_at = NOW(),
+		       decided_by = $2
+		 WHERE id = $3 AND status = 'pending'`,
+		action, by, id)
+	if err != nil {
+		return fmt.Errorf("update: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ErrNotFound — the conflict id doesn't exist or is no longer
+// in pending state.
+var ErrNotFound = errors.New("memconflict: not found or already decided")
+
+// insertIfNew writes a conflict row unless an identical pending
+// pair already exists. Returns (written, error). Existing
+// non-pending rows for the same pair are ignored — operator
+// already decided; don't resurrect.
+func (s *Service) insertIfNew(ctx context.Context, cwd string, f Finding) (bool, error) {
+	// Identity is the (layers + refs) tuple; order normalises to
+	// (a < b) so swap-ordered findings dedup.
+	la, ra, lb, rb := normaliseOrder(f.LayerA, f.RefA, f.LayerB, f.RefB)
+	var existing int
+	err := s.pool.QueryRow(ctx, `
+		SELECT 1 FROM memory_conflicts
+		 WHERE cwd = $1
+		   AND layer_a = $2 AND ref_a = $3
+		   AND layer_b = $4 AND ref_b = $5
+		 LIMIT 1`, cwd, la, ra, lb, rb).Scan(&existing)
+	if err == nil {
+		return false, nil
+	}
+	id := newID()
+	_, err = s.pool.Exec(ctx, `
+		INSERT INTO memory_conflicts
+			(id, cwd, layer_a, ref_a, layer_b, ref_b, evidence, severity, status)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending')`,
+		id, cwd, la, ra, lb, rb, f.Evidence, severityOrDefault(f.Severity))
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func validLayer(l Layer) bool {
+	switch l {
+	case LayerFact, LayerPlan, LayerGoal, LayerJournal:
+		return true
+	}
+	return false
+}
+
+// normaliseOrder makes (layer_a, ref_a) < (layer_b, ref_b)
+// lexically so swapped-pair findings collapse to one row.
+func normaliseOrder(la Layer, ra string, lb Layer, rb string) (Layer, string, Layer, string) {
+	keyA := string(la) + "|" + ra
+	keyB := string(lb) + "|" + rb
+	if keyA > keyB {
+		return lb, rb, la, ra
+	}
+	return la, ra, lb, rb
+}
+
+func severityOrDefault(s Severity) Severity {
+	switch s {
+	case SeverityLow, SeverityMedium, SeverityHigh:
+		return s
+	}
+	return SeverityMedium
+}
+
+func newID() string {
+	var b [14]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic("memconflict: rand: " + err.Error())
+	}
+	enc := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(b[:])
+	if len(enc) > 22 {
+		enc = enc[:22]
+	}
+	return "mc_" + strings.ToLower(enc)
+}
+
+func scanConflicts(rows interface {
+	Next() bool
+	Scan(dest ...any) error
+	Err() error
+}) ([]Conflict, error) {
+	var out []Conflict
+	for rows.Next() {
+		var c Conflict
+		var (
+			la, lb, status, severity string
+			dec                      *time.Time
+		)
+		if err := rows.Scan(
+			&c.ID, &c.Cwd, &la, &c.RefA, &lb, &c.RefB, &c.Evidence,
+			&severity, &status, &c.DetectedAt, &dec, &c.DecidedBy,
+		); err != nil {
+			return nil, err
+		}
+		c.LayerA = Layer(la)
+		c.LayerB = Layer(lb)
+		c.Severity = Severity(severity)
+		c.Status = Status(status)
+		c.DecidedAt = dec
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// conflictJSONSchema is the response_format=json_schema body that
+// asks the model for a strict-shape reply. Same convention as the
+// plan_drift detector — workers that don't natively support
+// structured output append schema instructions to the prompt.
+const conflictJSONSchema = `{
+  "name": "memory_conflicts",
+  "schema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "conflicts": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "layer_a":  {"type": "string", "enum": ["fact","plan","goal","journal"]},
+            "ref_a":    {"type": "string"},
+            "layer_b":  {"type": "string", "enum": ["fact","plan","goal","journal"]},
+            "ref_b":    {"type": "string"},
+            "evidence": {"type": "string"},
+            "severity": {"type": "string", "enum": ["low","medium","high"]}
+          },
+          "required": ["layer_a","ref_a","layer_b","ref_b","evidence","severity"]
+        }
+      }
+    },
+    "required": ["conflicts"]
+  },
+  "strict": true
+}`
+
+// ConflictDetectorSystemPrompt is the role block the worker
+// receives. Exported for tests + alternate harness wiring.
+const ConflictDetectorSystemPrompt = `You are an opendray memory librarian.
+
+You will be given snapshots of one project's persistent context:
+- the project PLAN document
+- a list of high-hit-count FACTS the agent has stored
+- the most recent JOURNAL entries
+
+Your job: find pairs of claims that CONTRADICT each other.
+Examples of contradictions worth flagging:
+- plan says "we use sqlite", a fact says "DB is Postgres at host:5432"
+- one fact says "user prefers pnpm", another says "user wants npm"
+- journal says "we shipped feature X", plan still lists X as upcoming
+
+Do NOT flag:
+- complementary information ("X is at version Y" + "X exposes endpoint Z")
+- old facts that are simply less detailed than newer ones
+- facts that AGREE with the plan
+- speculation — only flag genuine contradictions backed by the text
+
+Output ONLY valid JSON of shape:
+{"conflicts":[
+  {"layer_a":"fact","ref_a":"<id>","layer_b":"plan","ref_b":"<id>",
+   "evidence":"one short paragraph quoting both sides","severity":"low|medium|high"}
+]}
+
+Return an empty array when nothing conflicts. Do not invent ids —
+use only the ids you were shown.`
+
+// Finding is the unparsed shape returned by the detector LLM.
+type Finding struct {
+	LayerA   Layer    `json:"layer_a"`
+	RefA     string   `json:"ref_a"`
+	LayerB   Layer    `json:"layer_b"`
+	RefB     string   `json:"ref_b"`
+	Evidence string   `json:"evidence"`
+	Severity Severity `json:"severity"`
+}
+
+// ParseConflicts pulls a []Finding out of a raw LLM response.
+// Tolerates clean JSON, fenced blocks, leading prose — same
+// resilience as projectdoc.ParseDriftResponse.
+func ParseConflicts(raw string) ([]Finding, error) {
+	body := strings.TrimSpace(raw)
+	if body == "" {
+		return nil, nil
+	}
+	if fenced := stripJSONFence(body); fenced != "" {
+		body = fenced
+	}
+	if i := strings.IndexByte(body, '{'); i >= 0 {
+		if j := strings.LastIndexByte(body, '}'); j > i {
+			body = body[i : j+1]
+		}
+	}
+	var wrapper struct {
+		Conflicts []Finding `json:"conflicts"`
+	}
+	if err := json.Unmarshal([]byte(body), &wrapper); err != nil {
+		return nil, fmt.Errorf("memconflict: parse: %w", err)
+	}
+	return wrapper.Conflicts, nil
+}
+
+func stripJSONFence(s string) string {
+	const fence = "```"
+	i := strings.Index(s, fence)
+	if i < 0 {
+		return ""
+	}
+	rest := s[i+len(fence):]
+	rest = strings.TrimPrefix(rest, "json")
+	rest = strings.TrimLeft(rest, " \t\r\n")
+	j := strings.Index(rest, fence)
+	if j < 0 {
+		return strings.TrimSpace(rest)
+	}
+	return strings.TrimSpace(rest[:j])
+}

--- a/internal/memconflict/memconflict_test.go
+++ b/internal/memconflict/memconflict_test.go
@@ -1,0 +1,126 @@
+package memconflict
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opendray/opendray-v2/internal/memory"
+)
+
+func TestParseConflicts_Empty(t *testing.T) {
+	got, err := ParseConflicts("")
+	if err != nil {
+		t.Fatalf("empty should not error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty findings, got %d", len(got))
+	}
+}
+
+func TestParseConflicts_CleanJSON(t *testing.T) {
+	raw := `{"conflicts":[{"layer_a":"fact","ref_a":"mem_1","layer_b":"plan","ref_b":"plan-doc","evidence":"X says A, Y says B","severity":"high"}]}`
+	got, err := ParseConflicts(raw)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 1 || got[0].LayerA != LayerFact || got[0].RefB != "plan-doc" || got[0].Severity != SeverityHigh {
+		t.Errorf("unexpected: %+v", got)
+	}
+}
+
+func TestParseConflicts_FencedAndPreamble(t *testing.T) {
+	raw := "Here are the conflicts:\n```json\n{\"conflicts\":[]}\n```\nthanks"
+	got, err := ParseConflicts(raw)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %d", len(got))
+	}
+}
+
+func TestNormaliseOrder_SwappedFindingsCollapse(t *testing.T) {
+	la, ra, lb, rb := normaliseOrder(LayerPlan, "plan-doc", LayerFact, "mem_1")
+	la2, ra2, lb2, rb2 := normaliseOrder(LayerFact, "mem_1", LayerPlan, "plan-doc")
+	if la != la2 || ra != ra2 || lb != lb2 || rb != rb2 {
+		t.Errorf("swap not normalised: (%s,%s,%s,%s) vs (%s,%s,%s,%s)",
+			la, ra, lb, rb, la2, ra2, lb2, rb2)
+	}
+}
+
+func TestPickTopByHits(t *testing.T) {
+	now := time.Now()
+	mems := []memory.Memory{
+		{ID: "a", HitCount: 1, CreatedAt: now},
+		{ID: "b", HitCount: 10, CreatedAt: now},
+		{ID: "c", HitCount: 5, CreatedAt: now},
+		{ID: "d", HitCount: 10, CreatedAt: now.Add(time.Hour)}, // tie-break newer
+	}
+	top := pickTopByHits(mems, 3)
+	if len(top) != 3 {
+		t.Fatalf("expected 3, got %d", len(top))
+	}
+	if top[0].ID != "d" || top[1].ID != "b" || top[2].ID != "c" {
+		t.Errorf("wrong order: %v %v %v", top[0].ID, top[1].ID, top[2].ID)
+	}
+}
+
+func TestOneLine(t *testing.T) {
+	got := oneLine("hello\nworld   ", 100)
+	if got != "hello world" {
+		t.Errorf("got %q", got)
+	}
+	got = oneLine("abcdefghij", 5)
+	if got != "abcde…" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestBundleEmpty(t *testing.T) {
+	b := detectionBundle{}
+	if !b.empty() {
+		t.Error("expected empty")
+	}
+	b.plan = "x"
+	if b.empty() {
+		t.Error("expected non-empty when plan set")
+	}
+}
+
+func TestBundleRender(t *testing.T) {
+	b := detectionBundle{
+		cwd:  "/p",
+		plan: "build app",
+		facts: []memory.Memory{
+			{ID: "mem_1", Text: "x", HitCount: 3},
+		},
+	}
+	got := b.render()
+	for _, want := range []string{"# Project context for /p", "## Project plan", "build app", "mem_1", "hits=3"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestNewID(t *testing.T) {
+	a, b := newID(), newID()
+	if a == b {
+		t.Error("expected different ids")
+	}
+	if !strings.HasPrefix(a, "mc_") {
+		t.Errorf("expected mc_ prefix, got %s", a)
+	}
+}
+
+func TestValidLayer(t *testing.T) {
+	for _, l := range []Layer{LayerFact, LayerPlan, LayerGoal, LayerJournal} {
+		if !validLayer(l) {
+			t.Errorf("%s should be valid", l)
+		}
+	}
+	if validLayer(Layer("nonsense")) {
+		t.Error("nonsense should not be valid")
+	}
+}

--- a/internal/memconflict/scheduler.go
+++ b/internal/memconflict/scheduler.go
@@ -1,0 +1,102 @@
+package memconflict
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// SchedulerConfig tunes the daily detection cadence. All fields
+// have defaults; pass zero value to use them.
+type SchedulerConfig struct {
+	// Interval between full sweeps. Default 24h. Set to 0 to keep
+	// the default; manual operators run /memory/conflicts/detect
+	// for on-demand cycles.
+	Interval time.Duration
+
+	// MaxPerCwd caps how many conflicts a single sweep writes per
+	// cwd — avoids one chatty detector flooding the inbox. The
+	// limit is enforced inside DetectForCwd via the unique-pair
+	// check, but this is the absolute brake when the LLM goes off.
+	MaxPerCwd int
+}
+
+func (c SchedulerConfig) applyDefaults() SchedulerConfig {
+	if c.Interval <= 0 {
+		c.Interval = 24 * time.Hour
+	}
+	if c.MaxPerCwd <= 0 {
+		c.MaxPerCwd = 25
+	}
+	return c
+}
+
+// CwdLister returns the set of cwds the detector should scan.
+// Tests can stub it; production wires in a query against
+// project_docs distinct cwds.
+type CwdLister interface {
+	ListProjectCwds(ctx context.Context) ([]string, error)
+}
+
+// Scheduler drives the daily detection loop. Single goroutine —
+// parallelism per cwd is not worth the complexity given each
+// detector call is minutes-apart.
+type Scheduler struct {
+	svc  *Service
+	cwds CwdLister
+	cfg  SchedulerConfig
+}
+
+func NewScheduler(svc *Service, cwds CwdLister, cfg SchedulerConfig) *Scheduler {
+	return &Scheduler{svc: svc, cwds: cwds, cfg: cfg.applyDefaults()}
+}
+
+// Run blocks until ctx is cancelled. First sweep fires
+// immediately so a fresh deploy doesn't wait a day to surface
+// the first conflict.
+func (s *Scheduler) Run(ctx context.Context) {
+	s.svc.log.Info("conflict scheduler running",
+		"interval", s.cfg.Interval, "max_per_cwd", s.cfg.MaxPerCwd)
+	t := time.NewTicker(s.cfg.Interval)
+	defer t.Stop()
+	s.tick(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			s.svc.log.Info("conflict scheduler stopping")
+			return
+		case <-t.C:
+			s.tick(ctx)
+		}
+	}
+}
+
+func (s *Scheduler) tick(ctx context.Context) {
+	cwds, err := s.cwds.ListProjectCwds(ctx)
+	if err != nil {
+		s.svc.log.Warn("conflict scheduler: list cwds failed", "err", err)
+		return
+	}
+	for _, cwd := range cwds {
+		if ctx.Err() != nil {
+			return
+		}
+		// Each cwd gets its own bounded budget so one slow LLM call
+		// can't starve the rest.
+		cycleCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+		n, err := s.svc.DetectForCwd(cycleCtx, cwd)
+		cancel()
+		if err != nil {
+			s.svc.log.Debug("conflict scheduler: detect failed",
+				"cwd", cwd, "err", err)
+			continue
+		}
+		if n > s.cfg.MaxPerCwd {
+			s.svc.log.Warn("conflict scheduler: cwd hit per-sweep limit",
+				"cwd", cwd, "written", n, "max", s.cfg.MaxPerCwd)
+		}
+	}
+}
+
+// silence the import linter when fmt is not used at compile time
+var _ = fmt.Sprintf

--- a/internal/memory/ranking.go
+++ b/internal/memory/ranking.go
@@ -1,0 +1,95 @@
+package memory
+
+import "time"
+
+// Ranking knobs — exported so operators can override at composition
+// time if a project's age/use distribution makes the defaults bite.
+// The current values balance "recency matters, but a 6-month-old
+// fact that's been hit 30 times still wins" — which is the
+// observed behaviour the M-PC redesign aims for.
+const (
+	// AgeDecayDays is the linear decay window. A memory at
+	// AgeDecayDays old has multiplier hit AgeFloor; older memories
+	// stay there rather than going to zero.
+	AgeDecayDays = 180
+
+	// AgeFloor is the minimum age multiplier — guarantees an old
+	// memory can still rank above a brand-new mediocre match.
+	AgeFloor = 0.5
+
+	// HitsPerBoostUnit controls how fast hit_count lifts the score.
+	// 50 hits = +1.0 boost cap.
+	HitsPerBoostUnit = 0.02
+
+	// HitBoostCap clamps the hit_count term so a popular-but-stale
+	// memory can't dominate fresh signals forever.
+	HitBoostCap = 0.5
+
+	// ConfidenceFloor is the minimum confidence multiplier — a
+	// memory with zero or unknown confidence still contributes
+	// (we'd rather show low-confidence info than nothing) but at
+	// reduced weight.
+	ConfidenceFloor = 0.3
+)
+
+// RankingScore is the M-PC effective-score formula. Splitting it
+// out lets memquery / cleaner share the exact same logic when
+// they need to reason about ranking outside the Search code path,
+// and gives tests a small surface to pin behaviour against.
+//
+// Formula:
+//
+//	effective = similarity
+//	          × ageDecay(age_days)
+//	          × hitBoost(hit_count)
+//	          × confidenceFloor(memory.Confidence)
+//
+// All four factors are in [0, 1+HitBoostCap]; the product stays
+// roughly in [0, 1.5] for cosine inputs in [-1, 1], which keeps
+// the threshold comparison intuitive.
+func RankingScore(similarity float32, m Memory, now time.Time) float32 {
+	if similarity <= 0 {
+		return 0
+	}
+	age := ageMultiplier(now.Sub(m.CreatedAt))
+	hits := hitMultiplier(m.HitCount)
+	conf := confidenceMultiplier(m.Confidence)
+	return similarity * age * hits * conf
+}
+
+func ageMultiplier(age time.Duration) float32 {
+	days := float32(age.Hours()) / 24
+	if days < 0 {
+		days = 0
+	}
+	decay := 1 - days/AgeDecayDays
+	if decay < AgeFloor {
+		decay = AgeFloor
+	}
+	return decay
+}
+
+func hitMultiplier(hitCount int64) float32 {
+	if hitCount <= 0 {
+		return 1
+	}
+	boost := float32(hitCount) * HitsPerBoostUnit
+	if boost > HitBoostCap {
+		boost = HitBoostCap
+	}
+	return 1 + boost
+}
+
+func confidenceMultiplier(c *float32) float32 {
+	if c == nil {
+		return 1
+	}
+	v := *c
+	if v < ConfidenceFloor {
+		return ConfidenceFloor
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}

--- a/internal/memory/ranking_test.go
+++ b/internal/memory/ranking_test.go
@@ -1,0 +1,113 @@
+package memory
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestRankingScore_BaselineFresh(t *testing.T) {
+	// Fresh memory, no hits, no confidence — should equal similarity.
+	m := Memory{CreatedAt: time.Now().UTC()}
+	got := RankingScore(0.8, m, time.Now().UTC())
+	if math.Abs(float64(got-0.8)) > 0.001 {
+		t.Errorf("fresh baseline: got %f, want ~0.8", got)
+	}
+}
+
+func TestRankingScore_AgeDecay(t *testing.T) {
+	now := time.Now().UTC()
+	tests := []struct {
+		name    string
+		age     time.Duration
+		wantMul float32
+	}{
+		{"today", 0, 1.0},
+		{"30d", 30 * 24 * time.Hour, 1 - 30.0/AgeDecayDays},
+		{"90d", 90 * 24 * time.Hour, 1 - 90.0/AgeDecayDays},
+		{"180d hits floor", AgeDecayDays * 24 * time.Hour, AgeFloor},
+		{"way past floor", 730 * 24 * time.Hour, AgeFloor},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := Memory{CreatedAt: now.Add(-tc.age)}
+			got := RankingScore(1.0, m, now)
+			if math.Abs(float64(got-tc.wantMul)) > 0.001 {
+				t.Errorf("got %f, want %f", got, tc.wantMul)
+			}
+		})
+	}
+}
+
+func TestRankingScore_HitBoost(t *testing.T) {
+	now := time.Now().UTC()
+	tests := []struct {
+		name string
+		hits int64
+		want float32
+	}{
+		{"never hit", 0, 1.0},
+		{"5 hits → +10%", 5, 1.10},
+		{"25 hits → +50%", 25, 1 + HitBoostCap},
+		{"100 hits → still capped", 100, 1 + HitBoostCap},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := Memory{CreatedAt: now, HitCount: tc.hits}
+			got := RankingScore(1.0, m, now)
+			if math.Abs(float64(got-tc.want)) > 0.001 {
+				t.Errorf("got %f, want %f", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRankingScore_Confidence(t *testing.T) {
+	now := time.Now().UTC()
+	mk := func(c float32) *float32 { return &c }
+	tests := []struct {
+		name string
+		conf *float32
+		want float32
+	}{
+		{"nil = 1.0", nil, 1.0},
+		{"0.5 = 0.5", mk(0.5), 0.5},
+		{"0.1 → floor 0.3", mk(0.1), ConfidenceFloor},
+		{"1.2 → cap 1.0", mk(1.2), 1.0},
+		{"exact floor", mk(ConfidenceFloor), ConfidenceFloor},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := Memory{CreatedAt: now, Confidence: tc.conf}
+			got := RankingScore(1.0, m, now)
+			if math.Abs(float64(got-tc.want)) > 0.001 {
+				t.Errorf("got %f, want %f", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRankingScore_OldButPopularBeatsNewMediocre(t *testing.T) {
+	// The whole point of the formula: a popular 6-month-old memory
+	// should outrank a brand-new low-similarity match.
+	now := time.Now().UTC()
+	popular := Memory{
+		CreatedAt: now.Add(-180 * 24 * time.Hour),
+		HitCount:  30, // capped boost = +0.5
+	}
+	mediocreFresh := Memory{CreatedAt: now}
+
+	popularScore := RankingScore(0.8, popular, now)        // 0.8 * 0.5 * 1.5 = 0.60
+	mediocreScore := RankingScore(0.5, mediocreFresh, now) // 0.5 * 1 * 1 = 0.50
+
+	if popularScore <= mediocreScore {
+		t.Errorf("popular old should beat mediocre fresh: %f vs %f", popularScore, mediocreScore)
+	}
+}
+
+func TestRankingScore_NegativeSimilarityIsZero(t *testing.T) {
+	got := RankingScore(-0.5, Memory{CreatedAt: time.Now().UTC()}, time.Now().UTC())
+	if got != 0 {
+		t.Errorf("negative similarity should produce 0, got %f", got)
+	}
+}

--- a/internal/memory/service.go
+++ b/internal/memory/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"time"
 )
@@ -418,12 +419,23 @@ func (s *Service) Search(ctx context.Context, req SearchRequest) ([]SearchHit, e
 	case req.MinSimilarity > 0:
 		threshold = req.MinSimilarity
 	}
+	// M-PC — compute the effective score for each hit (similarity
+	// dampened by age, lifted by hit count + stored confidence) and
+	// re-sort by it. Threshold filtering keeps using the raw
+	// similarity so an explicit MinSimilarity from the caller behaves
+	// like it always did; the new score affects ordering only.
 	out := make([]SearchHit, 0, len(hits))
+	now := time.Now().UTC()
 	for _, h := range hits {
-		if h.Similarity >= threshold {
-			out = append(out, h)
+		if h.Similarity < threshold {
+			continue
 		}
+		h.EffectiveScore = RankingScore(h.Similarity, h.Memory, now)
+		out = append(out, h)
 	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].EffectiveScore > out[j].EffectiveScore
+	})
 	// Fire-and-forget: bump hit_count for every memory we're about to
 	// return so the inspector can show "this fact has been used N times".
 	// Detach from the request context so the bump survives even if the

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -80,9 +80,16 @@ type Memory struct {
 
 // SearchHit is one match returned by Store.Search, paired with its
 // cosine similarity score for caller-side cutoff / display.
+//
+// EffectiveScore is the M-PC ranking signal — similarity adjusted
+// for memory age, retrieval frequency, and stored confidence. The
+// Store implementations leave it zero; Service.Search computes and
+// sets it. The final ordering uses EffectiveScore but Similarity
+// is preserved so the inspector can show the raw cosine number.
 type SearchHit struct {
-	Memory     Memory  `json:"memory"`
-	Similarity float32 `json:"similarity"`
+	Memory         Memory  `json:"memory"`
+	Similarity     float32 `json:"similarity"`
+	EffectiveScore float32 `json:"effective_score,omitempty"`
 }
 
 // SearchQuery describes a similarity search. ScopeKey is required

--- a/internal/memory/worker/worker.go
+++ b/internal/memory/worker/worker.go
@@ -42,18 +42,22 @@ import (
 type TaskKind string
 
 const (
-	TaskGatekeeper  TaskKind = "gatekeeper"
-	TaskCleaner     TaskKind = "cleaner"
-	TaskGitActivity TaskKind = "gitactivity"
-	TaskTranscript  TaskKind = "transcript"
-	TaskPlanDrift   TaskKind = "plan_drift"
+	TaskGatekeeper       TaskKind = "gatekeeper"
+	TaskCleaner          TaskKind = "cleaner"
+	TaskGitActivity      TaskKind = "gitactivity"
+	TaskTranscript       TaskKind = "transcript"
+	TaskPlanDrift        TaskKind = "plan_drift"
+	TaskConflictDetector TaskKind = "conflict_detector"
 )
 
 // AllTasks returns every recognised TaskKind in a stable order.
 // Used by the UI to render the config rows + by registry bootstrap
 // to seed missing entries.
 func AllTasks() []TaskKind {
-	return []TaskKind{TaskGatekeeper, TaskCleaner, TaskGitActivity, TaskTranscript, TaskPlanDrift}
+	return []TaskKind{
+		TaskGatekeeper, TaskCleaner, TaskGitActivity, TaskTranscript,
+		TaskPlanDrift, TaskConflictDetector,
+	}
 }
 
 // WorkerKind names the implementation strategy. Persisted as the
@@ -160,7 +164,8 @@ type Config struct {
 // Caller (HTTP handler) should run this before INSERT/UPDATE.
 func (c Config) Valid() error {
 	switch c.Task {
-	case TaskGatekeeper, TaskCleaner, TaskGitActivity, TaskTranscript, TaskPlanDrift:
+	case TaskGatekeeper, TaskCleaner, TaskGitActivity, TaskTranscript,
+		TaskPlanDrift, TaskConflictDetector:
 	default:
 		return errors.New("memory worker: invalid task")
 	}

--- a/internal/projectdoc/handler.go
+++ b/internal/projectdoc/handler.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -60,9 +61,37 @@ func (h *Handlers) Mount(r chi.Router) {
 	})
 	r.Route("/session-logs", func(r chi.Router) {
 		r.Get("/", h.listLogs)
+		r.Get("/stale", h.listStale)
 		r.Post("/", h.appendLog)
 		r.Delete("/{id}", h.deleteLog)
 	})
+}
+
+// listStale returns journal entries older than `days` (default 90)
+// that aren't referenced by any pending conflict. Operators use
+// this list to bulk-delete accumulated noise from the cleanup UI.
+func (h *Handlers) listStale(w http.ResponseWriter, r *http.Request) {
+	cwd := r.URL.Query().Get("cwd")
+	if cwd == "" {
+		writeError(w, http.StatusBadRequest, errors.New("cwd is required"))
+		return
+	}
+	days := 90
+	if v := r.URL.Query().Get("days"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			days = n
+		}
+	}
+	out, err := h.svc.StaleJournalEntries(r.Context(), cwd,
+		time.Duration(days)*24*time.Hour)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	if out == nil {
+		out = []LogEntry{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"stale": out})
 }
 
 // ─── project_docs ─────────────────────────────────────────────────

--- a/internal/projectdoc/projectdoc.go
+++ b/internal/projectdoc/projectdoc.go
@@ -552,6 +552,54 @@ func pgvecString(v []float32) string {
 	return b.String()
 }
 
+// StaleJournalEntries returns journal entries that are candidates
+// for cleanup: older than `olderThan`, kind=session_summary, and
+// NOT referenced by any pending memory_conflicts row. The result
+// is sorted oldest first so callers can present a prune list.
+//
+// The intent is the M-PC "cleaner extension to layer 4" — give
+// operators a one-shot view of accumulated noise without forcing
+// a destructive default. UI bulk-delete + a dedicated cleanup
+// tab can layer on top later; for now this is just the query.
+func (s *Service) StaleJournalEntries(ctx context.Context, cwd string, olderThan time.Duration) ([]LogEntry, error) {
+	if strings.TrimSpace(cwd) == "" {
+		return nil, ErrEmptyCwd
+	}
+	if olderThan <= 0 {
+		olderThan = 90 * 24 * time.Hour
+	}
+	cutoff := time.Now().UTC().Add(-olderThan)
+	rows, err := s.pool.Query(ctx, `
+		SELECT sl.id, sl.cwd, COALESCE(sl.session_id, ''), sl.kind,
+		       sl.title, sl.content, sl.updated_by, sl.created_at
+		  FROM session_logs sl
+		 WHERE sl.cwd = $1
+		   AND sl.kind = 'session_summary'
+		   AND sl.created_at < $2
+		   AND NOT EXISTS (
+		       SELECT 1 FROM memory_conflicts mc
+		        WHERE mc.cwd = sl.cwd
+		          AND mc.status = 'pending'
+		          AND ((mc.layer_a = 'journal' AND mc.ref_a = sl.id)
+		            OR (mc.layer_b = 'journal' AND mc.ref_b = sl.id))
+		   )
+		 ORDER BY sl.created_at ASC
+		 LIMIT 200`, cwd, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("projectdoc: stale journal: %w", err)
+	}
+	defer rows.Close()
+	var out []LogEntry
+	for rows.Next() {
+		l, err := scanLog(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, l)
+	}
+	return out, rows.Err()
+}
+
 // ListLogs returns chronological journal entries newest first.
 // limit ≤ 0 falls back to 50; values >200 are clamped.
 func (s *Service) ListLogs(ctx context.Context, cwd string, limit int) ([]LogEntry, error) {

--- a/internal/projectdoc/stale_journal_test.go
+++ b/internal/projectdoc/stale_journal_test.go
@@ -1,0 +1,57 @@
+package projectdoc
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// devDB mirrors the helper in other packages — skips when
+// OPENDRAY_DEV_DB_URL isn't set so CI doesn't try to talk to a
+// nonexistent database.
+func devDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	url := os.Getenv("OPENDRAY_DEV_DB_URL")
+	if url == "" {
+		t.Skip("OPENDRAY_DEV_DB_URL not set")
+	}
+	pool, err := pgxpool.New(context.Background(), url)
+	if err != nil {
+		t.Skipf("dev DB unreachable: %v", err)
+	}
+	if err := pool.Ping(context.Background()); err != nil {
+		t.Skipf("dev DB ping failed: %v", err)
+	}
+	return pool
+}
+
+func TestStaleJournalEntries_EmptyCwd(t *testing.T) {
+	svc := NewService(&pgxpool.Pool{}, nil)
+	_, err := svc.StaleJournalEntries(context.Background(), "", 0)
+	if err != ErrEmptyCwd {
+		t.Errorf("expected ErrEmptyCwd, got %v", err)
+	}
+}
+
+// TestStaleJournalEntries_LiveDB exercises the SQL against a real
+// database — verifies the query parses and returns zero rows for
+// an unknown cwd. The conflict-aware NOT EXISTS sub-select is the
+// piece most likely to break across migrations; this catches a
+// missing table or column at boot time.
+func TestStaleJournalEntries_LiveDB(t *testing.T) {
+	pool := devDB(t)
+	defer pool.Close()
+	svc := NewService(pool, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	out, err := svc.StaleJournalEntries(ctx, "/__no_such_cwd__", 90*24*time.Hour)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected empty result for unknown cwd; got %d rows", len(out))
+	}
+}

--- a/internal/store/migrations/0032_memory_conflicts.sql
+++ b/internal/store/migrations/0032_memory_conflicts.sql
@@ -1,0 +1,68 @@
+-- M-PC — Cross-layer conflict ledger.
+--
+-- A daily LLM librarian (ConflictDetector worker) scans each
+-- project's plan + top facts + recent journal and asks: "do any
+-- of these claims contradict each other?" When yes, a row lands
+-- here for operator review. Same approval-flow shape as
+-- memory_cleanup_decisions and project_doc_proposals — agents
+-- can't auto-resolve conflicts; the operator decides.
+--
+-- Why a separate table (not memory_summarizer_calls + JSON):
+-- conflicts are an addressable backlog — we GET them, change
+-- their status, and reference them from UI badges. Building that
+-- on top of an audit log would require denormalising on every
+-- read.
+--
+-- layer_a / layer_b enumerate which memory subsystem the two
+-- conflicting items come from. ref_a / ref_b are the row IDs
+-- inside that layer (memories.id for 'fact', project_docs.id for
+-- 'goal'/'plan', session_logs.id for 'journal'). One side can be
+-- 'self' when a layer contradicts itself (two facts disagree).
+--
+-- evidence is the LLM-authored markdown explaining the
+-- contradiction — shown verbatim in the inbox so the operator
+-- has the rationale on hand.
+
+CREATE TABLE IF NOT EXISTS memory_conflicts (
+    id           TEXT PRIMARY KEY,
+    cwd          TEXT NOT NULL,
+    layer_a      TEXT NOT NULL CHECK (layer_a IN ('fact','plan','goal','journal')),
+    ref_a        TEXT NOT NULL,
+    layer_b      TEXT NOT NULL CHECK (layer_b IN ('fact','plan','goal','journal')),
+    ref_b        TEXT NOT NULL,
+    evidence     TEXT NOT NULL DEFAULT '',
+    severity     TEXT NOT NULL DEFAULT 'medium'
+        CHECK (severity IN ('low','medium','high')),
+    status       TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending','accepted','dismissed','expired')),
+    detected_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    decided_at   TIMESTAMPTZ,
+    decided_by   TEXT NOT NULL DEFAULT ''
+);
+
+-- Pending conflicts under one cwd is the hot path (operator
+-- opens the Conflicts tab); index covers it directly.
+CREATE INDEX IF NOT EXISTS memory_conflicts_cwd_pending_idx
+    ON memory_conflicts (cwd, detected_at DESC)
+ WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS memory_conflicts_status_idx
+    ON memory_conflicts (status, detected_at DESC);
+
+-- Extend the memory_workers task catalogue with conflict_detector.
+-- Same idiom as 0030_memory_workers_plan_drift: drop + re-add the
+-- CHECK constraint, then seed a summarizer default.
+
+ALTER TABLE memory_workers
+    DROP CONSTRAINT IF EXISTS memory_workers_task_check;
+
+ALTER TABLE memory_workers
+    ADD CONSTRAINT memory_workers_task_check
+        CHECK (task IN (
+            'gatekeeper','cleaner','gitactivity','transcript',
+            'plan_drift','conflict_detector'
+        ));
+
+INSERT INTO memory_workers (task, kind) VALUES
+    ('conflict_detector', 'summarizer')
+ON CONFLICT (task) DO NOTHING;


### PR DESCRIPTION
## Summary

Phase C addresses two long-standing gaps in opendray's memory architecture:

1. **Search ignored signal beyond cosine similarity.** A 10-month-old one-shot memory could outrank a brand-new high-quality match purely because the cosine was a hair higher. Operators were doing the age/popularity math mentally; we make the system do it.
2. **No system-level check for cross-layer contradictions.** A `plan` saying "we use sqlite" and a fact saying "DB is Postgres at host:5432" coexisted forever because no daemon ever compared them.

This PR ships:

- **Smart ranking formula** — `similarity × age_decay × hit_boost × confidence_floor`. Re-sorts `memory_search` results without changing threshold semantics. Tuning knobs in `internal/memory/ranking.go`.
- **ConflictDetector worker** — fifth memory_workers task (6th total), runs daily across every project_docs cwd, asks the configured LLM for contradictions across plan/goal/facts/journal, writes findings to a new `memory_conflicts` table.
- **Conflicts tab in `/memory/project`** with severity badges, accept/dismiss buttons, on-demand "Detect now".
- **Journal cleanup helper** — `GET /api/v1/session-logs/stale?cwd=&days=` for operators to prune accumulated noise without losing entries that are still earning their keep via the detector.

## What changed

| Area | Files |
|---|---|
| Ranking | `internal/memory/ranking.go`, `internal/memory/ranking_test.go`, `internal/memory/service.go`, `internal/memory/store.go` (EffectiveScore field) |
| Conflict detection | `internal/store/migrations/0032_memory_conflicts.sql`, `internal/memconflict/*` (Service + bundle + scheduler + handler + CwdLister), `internal/memory/worker/worker.go` (TaskConflictDetector) |
| Wiring | `internal/app/app.go` (Service, Handlers, Scheduler init + goroutine) |
| Frontend | `app/web/src/components/project/ConflictsPanel.tsx`, `app/web/src/components/project/ProjectScreen.tsx` (new tab), `app/shared/src/lib/memoryConflicts.ts` |
| Journal helper | `internal/projectdoc/projectdoc.go` (StaleJournalEntries), `internal/projectdoc/handler.go` (listStale endpoint), `internal/projectdoc/stale_journal_test.go` |
| i18n | `app/i18n/{en,zh}.json` |
| Docs | `docs/memory-system.md` (3 new sections) |

## Failure modes deliberately tolerated

- ConflictDetector LLM returns garbage JSON → log + skip cycle.
- ConflictDetector finds zero conflicts → empty array, no rows written.
- Existing pending conflict for same (layer_a/ref_a/layer_b/ref_b) tuple → not re-inserted (operator's prior judgement respected).
- Stale-journal endpoint when memory_conflicts table doesn't exist → caught by NOT EXISTS sub-select, returns nothing rather than crashing.
- memory.Search with zero hit_count + nil confidence → still ranks correctly (multipliers default to 1.0).

## Test plan

- [x] `go test -race ./...` green
- [x] `pnpm tsc --noEmit` green
- [x] `gofmt -l ./...` clean (two files reformatted in the commit)
- [x] Unit tests for RankingScore (age/hits/confidence boundaries + regression: old-popular beats new-mediocre)
- [x] Unit tests for ParseConflicts, normaliseOrder, pickTopByHits, bundle render
- [x] Opt-in live-DB SQL parse check via `OPENDRAY_DEV_DB_URL`
- [ ] Manual: with a project that has plan+facts, invoke `POST /memory/conflicts/detect`, verify Conflicts tab shows expected hits
- [ ] Manual: accept and dismiss a conflict each, verify they leave the pending list

## Follow-ups (Phase D and beyond)

- Phase D: hit_count surfaced in inspector + per-fact decay knob UI
- Journal-bulk-delete UI tied into the new stale endpoint
- Conflict resolution shortcuts (one-click "delete fact X" / "open plan editor")