### PR TITLE
feat(memory-ui): ranking-math tooltip + journal bulk-prune + conflict quick-actions (Phase D)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -220,6 +220,18 @@
       "navWorkers": "Workers",
       "navConfiguration": "Configuration →"
     },
+    "journalStale": {
+      "title": "Prune stale entries",
+      "subtitle": "(older than {days} days, no pending conflicts)",
+      "daysLabel": "Older than (days):",
+      "loading": "Scanning…",
+      "empty": "Nothing stale to prune.",
+      "selectAll": "Select all",
+      "deselectAll": "Deselect all",
+      "deleteSelected": "Delete ({count})",
+      "deleted_one": "{count} entry deleted",
+      "deleted_other": "{count} entries deleted"
+    },
     "conflicts": {
       "title": "Cross-layer conflicts",
       "subtitle": "Contradictions the daily detector found between facts, plan, goal, and journal entries.",
@@ -232,6 +244,13 @@
       "dismiss": "Dismiss",
       "accepted": "Conflict accepted — remember to apply the fix",
       "dismissed": "Conflict dismissed",
+      "deletedFact": "Fact deleted and conflict accepted",
+      "quickActions": "Fix:",
+      "deleteFact": "Delete fact",
+      "openLayer": {
+        "plan": "Open plan editor",
+        "goal": "Open goal editor"
+      },
       "severity": {
         "low": "low",
         "medium": "medium",
@@ -526,6 +545,8 @@
       },
       "row": {
         "simBadge": "sim {value}",
+        "rankBadge": "rank {value}",
+        "rankTooltip": "effective {effective} = sim {similarity} × age {age} ({days}d) × hits {hits} × conf {confidence}",
         "hits_one": "{count} hit",
         "hits_other": "{count} hits",
         "lastHitTooltip": "Last hit {relative}",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -220,6 +220,18 @@
       "navWorkers": "Workers",
       "navConfiguration": "配置 →"
     },
+    "journalStale": {
+      "title": "清理陈旧条目",
+      "subtitle": "（超过 {days} 天、无 pending 冲突引用）",
+      "daysLabel": "超过（天）：",
+      "loading": "扫描中…",
+      "empty": "没有可清理的陈旧条目。",
+      "selectAll": "全选",
+      "deselectAll": "取消全选",
+      "deleteSelected": "删除 ({count})",
+      "deleted_one": "已删除 {count} 条",
+      "deleted_other": "已删除 {count} 条"
+    },
     "conflicts": {
       "title": "跨层冲突",
       "subtitle": "每日 detector 在 facts/plan/goal/journal 之间发现的矛盾。",
@@ -232,6 +244,13 @@
       "dismiss": "驳回",
       "accepted": "已采纳 — 别忘了实际修正",
       "dismissed": "已驳回",
+      "deletedFact": "已删除 fact 并采纳冲突",
+      "quickActions": "快速修复：",
+      "deleteFact": "删除 fact",
+      "openLayer": {
+        "plan": "打开计划编辑器",
+        "goal": "打开目标编辑器"
+      },
       "severity": {
         "low": "低",
         "medium": "中",
@@ -526,6 +545,8 @@
       },
       "row": {
         "simBadge": "相似度 {value}",
+        "rankBadge": "排名分 {value}",
+        "rankTooltip": "有效分 {effective} = 相似度 {similarity} × 时效 {age} ({days}d) × 命中 {hits} × 置信 {confidence}",
         "hits_one": "命中 {count} 次",
         "hits_other": "命中 {count} 次",
         "lastHitTooltip": "最近命中 {relative}",

--- a/app/shared/src/lib/memory.ts
+++ b/app/shared/src/lib/memory.ts
@@ -22,11 +22,20 @@ export interface MemoryRecord {
   hit_count: number
   /** Timestamp of the most recent hit, or null if never used. */
   last_hit_at?: string | null
+  /** Optional summarizer-supplied confidence in [0,1]; nil means "unknown". */
+  confidence?: number | null
 }
 
 export interface SearchHit {
   memory: MemoryRecord
   similarity: number
+  /**
+   * M-PC ranking signal — similarity dampened by age and lifted by
+   * hit_count + stored confidence. Used by Service.Search to order
+   * results. Omitted when the backend doesn't compute it
+   * (legacy callers).
+   */
+  effective_score?: number
 }
 
 export interface ProbeResult {

--- a/app/shared/src/lib/memoryRanking.ts
+++ b/app/shared/src/lib/memoryRanking.ts
@@ -1,0 +1,63 @@
+// Mirror of internal/memory/ranking.go — kept in sync manually
+// (the formula is small, the cost of a TypeScript port is zero,
+// and the value of letting UI explain "why this ranks where it
+// does" without a backend round-trip is high).
+
+import type { MemoryRecord } from './memory'
+
+export const AGE_DECAY_DAYS = 180
+export const AGE_FLOOR = 0.5
+export const HITS_PER_BOOST_UNIT = 0.02
+export const HIT_BOOST_CAP = 0.5
+export const CONFIDENCE_FLOOR = 0.3
+
+export interface RankingBreakdown {
+  similarity: number
+  ageMultiplier: number
+  hitMultiplier: number
+  confidenceMultiplier: number
+  effectiveScore: number
+  ageDays: number
+}
+
+/**
+ * Compute the same effective score the Go backend uses, plus the
+ * intermediate multipliers so the UI can show a tooltip
+ * explaining the math. `similarity` is optional — for the
+ * inspector (which lists memories without a query) callers pass
+ * 1.0 to see the "if we matched perfectly, how would this rank"
+ * baseline.
+ */
+export function rankingBreakdown(
+  mem: MemoryRecord,
+  similarity = 1,
+  now: Date = new Date(),
+): RankingBreakdown {
+  if (similarity <= 0) {
+    return {
+      similarity: 0,
+      ageMultiplier: 0,
+      hitMultiplier: 0,
+      confidenceMultiplier: 0,
+      effectiveScore: 0,
+      ageDays: 0,
+    }
+  }
+  const ageMs = now.getTime() - new Date(mem.created_at).getTime()
+  const ageDays = Math.max(0, ageMs / 86_400_000)
+  const ageMultiplier = Math.max(AGE_FLOOR, 1 - ageDays / AGE_DECAY_DAYS)
+  const hitBoost = Math.min(mem.hit_count * HITS_PER_BOOST_UNIT, HIT_BOOST_CAP)
+  const hitMultiplier = 1 + hitBoost
+  const conf =
+    mem.confidence == null
+      ? 1
+      : Math.min(1, Math.max(CONFIDENCE_FLOOR, mem.confidence))
+  return {
+    similarity,
+    ageMultiplier,
+    hitMultiplier,
+    confidenceMultiplier: conf,
+    effectiveScore: similarity * ageMultiplier * hitMultiplier * conf,
+    ageDays,
+  }
+}

--- a/app/shared/src/lib/projectDocs.ts
+++ b/app/shared/src/lib/projectDocs.ts
@@ -137,6 +137,20 @@ export async function deleteSessionLog(id: string): Promise<void> {
   await api(`/api/v1/session-logs/${id}`, { method: 'DELETE' })
 }
 
+// M-PD — list stale journal entries that the daily conflict
+// detector hasn't tied to any pending finding. Used by the
+// Journal tab's Stale subview to bulk-prune accumulated noise.
+export async function listStaleSessionLogs(
+  cwd: string,
+  days = 90,
+): Promise<SessionLogEntry[]> {
+  const qs = new URLSearchParams({ cwd, days: String(days) })
+  const res = await api<{ stale: SessionLogEntry[] }>(
+    `/api/v1/session-logs/stale?${qs}`,
+  )
+  return res.stale ?? []
+}
+
 // ── reset ─────────────────────────────────────────────────────
 
 export interface ResetProjectMemoryOptions {

--- a/app/web/src/components/project/ConflictsPanel.tsx
+++ b/app/web/src/components/project/ConflictsPanel.tsx
@@ -22,12 +22,19 @@ import {
   detectMemoryConflicts,
   listMemoryConflicts,
 } from '@/lib/memoryConflicts'
+import { deleteMemory } from '@/lib/memory'
 
 interface ConflictsPanelProps {
   cwd: string
+  /**
+   * Optional callback the parent can pass so the panel's quick-
+   * actions can jump to another tab (e.g. "Open plan editor"
+   * navigates to the Plan tab). Omit to disable the jump button.
+   */
+  onJumpTab?: (tab: string) => void
 }
 
-export function ConflictsPanel({ cwd }: ConflictsPanelProps) {
+export function ConflictsPanel({ cwd, onJumpTab }: ConflictsPanelProps) {
   const { t } = useTranslation()
   const qc = useQueryClient()
 
@@ -61,6 +68,25 @@ export function ConflictsPanel({ cwd }: ConflictsPanelProps) {
     onSuccess: (n) => {
       toast.success(t('web.conflicts.detected', { count: n }))
       qc.invalidateQueries({ queryKey: ['memory-conflicts', cwd] })
+    },
+    onError: (err: unknown) => {
+      toast.error(`${err}`)
+    },
+  })
+
+  // M-PD quick-action: "Delete this fact" — yanks the offending
+  // memory row and auto-accepts the conflict so the inbox clears
+  // in one click. Plan/goal sides delegate to a tab-jump instead
+  // (we don't want one-click overwriting of operator-owned docs).
+  const deleteFactAndAccept = useMutation({
+    mutationFn: async (input: { conflictId: string; factId: string }) => {
+      await deleteMemory(input.factId)
+      await decideMemoryConflict(input.conflictId, 'accepted')
+    },
+    onSuccess: () => {
+      toast.success(t('web.conflicts.deletedFact'))
+      qc.invalidateQueries({ queryKey: ['memory-conflicts', cwd] })
+      qc.invalidateQueries({ queryKey: ['memories'] })
     },
     onError: (err: unknown) => {
       toast.error(`${err}`)
@@ -119,7 +145,11 @@ export function ConflictsPanel({ cwd }: ConflictsPanelProps) {
               key={c.id}
               conflict={c}
               onDecide={(action) => decide.mutate({ id: c.id, action })}
-              disabled={decide.isPending}
+              disabled={decide.isPending || deleteFactAndAccept.isPending}
+              onDeleteFact={(factId) =>
+                deleteFactAndAccept.mutate({ conflictId: c.id, factId })
+              }
+              onJumpTab={onJumpTab}
             />
           ))}
         </div>
@@ -131,10 +161,18 @@ export function ConflictsPanel({ cwd }: ConflictsPanelProps) {
 interface ConflictCardProps {
   conflict: MemoryConflict
   onDecide: (action: 'accepted' | 'dismissed') => void
+  onDeleteFact: (factId: string) => void
+  onJumpTab?: (tab: string) => void
   disabled: boolean
 }
 
-function ConflictCard({ conflict, onDecide, disabled }: ConflictCardProps) {
+function ConflictCard({
+  conflict,
+  onDecide,
+  onDeleteFact,
+  onJumpTab,
+  disabled,
+}: ConflictCardProps) {
   const { t } = useTranslation()
   const severityTone =
     conflict.severity === 'high'
@@ -142,6 +180,33 @@ function ConflictCard({ conflict, onDecide, disabled }: ConflictCardProps) {
       : conflict.severity === 'medium'
         ? 'warn'
         : 'muted'
+
+  // Quick-action targets — first fact side gets a delete shortcut,
+  // first plan/goal side gets a jump-to-editor link. We don't show
+  // both for the same side (the action is unambiguous per layer).
+  type QuickAction =
+    | { kind: 'delete-fact'; refId: string }
+    | { kind: 'open-tab'; tab: string; label: string }
+  const quick: QuickAction[] = []
+  ;[
+    { layer: conflict.layer_a, ref: conflict.ref_a },
+    { layer: conflict.layer_b, ref: conflict.ref_b },
+  ].forEach(({ layer, ref }) => {
+    if (layer === 'fact') {
+      if (!quick.some((q) => q.kind === 'delete-fact')) {
+        quick.push({ kind: 'delete-fact', refId: ref })
+      }
+    } else if (layer === 'plan' || layer === 'goal') {
+      if (!quick.some((q) => q.kind === 'open-tab' && q.tab === layer)) {
+        quick.push({
+          kind: 'open-tab',
+          tab: layer,
+          label: t(`web.conflicts.openLayer.${layer}`),
+        })
+      }
+    }
+  })
+
   return (
     <div className="bg-card/50 rounded-md border p-3">
       <div className="mb-2 flex items-center justify-between gap-2">
@@ -183,6 +248,41 @@ function ConflictCard({ conflict, onDecide, disabled }: ConflictCardProps) {
         </div>
       </div>
       <p className="text-[12px] whitespace-pre-wrap">{conflict.evidence}</p>
+      {quick.length > 0 && (
+        <div className="border-border/50 mt-2 flex items-center gap-2 border-t pt-2 text-[11px]">
+          <span className="text-muted-foreground">
+            {t('web.conflicts.quickActions')}
+          </span>
+          {quick.map((q, i) => {
+            if (q.kind === 'delete-fact') {
+              return (
+                <Button
+                  key={i}
+                  size="sm"
+                  variant="outline"
+                  onClick={() => onDeleteFact(q.refId)}
+                  disabled={disabled}
+                  className="h-6 text-[10px]"
+                >
+                  {t('web.conflicts.deleteFact')}
+                </Button>
+              )
+            }
+            return (
+              <Button
+                key={i}
+                size="sm"
+                variant="ghost"
+                onClick={() => onJumpTab?.(q.tab)}
+                disabled={!onJumpTab}
+                className="h-6 text-[10px]"
+              >
+                {q.label}
+              </Button>
+            )
+          })}
+        </div>
+      )}
     </div>
   )
 }

--- a/app/web/src/components/project/JournalStalePanel.tsx
+++ b/app/web/src/components/project/JournalStalePanel.tsx
@@ -1,0 +1,183 @@
+// JournalStalePanel — M-PD bulk-prune view for journal entries
+// older than 90 days that aren't tied to any pending conflict.
+// Operators click the chevron to expand, tick the entries they
+// want gone, and bulk-delete in one shot.
+
+import { useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
+import { ChevronDown, ChevronRight, Loader2, Trash2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+  deleteSessionLog,
+  listStaleSessionLogs,
+} from '@/lib/projectDocs'
+
+interface JournalStalePanelProps {
+  cwd: string
+}
+
+const DEFAULT_DAYS = 90
+
+export function JournalStalePanel({ cwd }: JournalStalePanelProps) {
+  const { t } = useTranslation()
+  const qc = useQueryClient()
+  const [expanded, setExpanded] = useState(false)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [days, setDays] = useState(DEFAULT_DAYS)
+
+  const staleQuery = useQuery({
+    queryKey: ['session-logs-stale', cwd, days],
+    queryFn: () => listStaleSessionLogs(cwd, days),
+    enabled: !!cwd && expanded,
+  })
+
+  const bulkDelete = useMutation({
+    mutationFn: async (ids: string[]) => {
+      // Sequential rather than parallel so a 5xx on one doesn't
+      // leave a partial result in the UI's optimistic state.
+      for (const id of ids) {
+        await deleteSessionLog(id)
+      }
+      return ids.length
+    },
+    onSuccess: (n) => {
+      toast.success(t('web.journalStale.deleted', { count: n }))
+      setSelected(new Set())
+      qc.invalidateQueries({ queryKey: ['session-logs-stale', cwd] })
+      qc.invalidateQueries({ queryKey: ['session-logs', cwd] })
+    },
+    onError: (err) => {
+      toast.error(`${err}`)
+    },
+  })
+
+  const entries = staleQuery.data ?? []
+  const allChecked = entries.length > 0 && selected.size === entries.length
+  const toggleAll = () => {
+    if (allChecked) setSelected(new Set())
+    else setSelected(new Set(entries.map((e) => e.id)))
+  }
+  const toggleOne = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+  const selectedIds = useMemo(() => Array.from(selected), [selected])
+
+  return (
+    <div className="bg-card/30 mb-3 rounded-md border">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="hover:bg-muted/30 flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-[12px]"
+      >
+        <span className="flex items-center gap-2">
+          {expanded ? (
+            <ChevronDown className="size-3.5" />
+          ) : (
+            <ChevronRight className="size-3.5" />
+          )}
+          <span className="font-medium">{t('web.journalStale.title')}</span>
+          <span className="text-muted-foreground">
+            {t('web.journalStale.subtitle', { days })}
+          </span>
+        </span>
+        {expanded && staleQuery.data && entries.length > 0 && (
+          <Badge variant="muted">{entries.length}</Badge>
+        )}
+      </button>
+
+      {expanded && (
+        <div className="border-t px-3 py-2">
+          <div className="mb-2 flex items-center gap-2">
+            <label className="text-muted-foreground text-[11px]">
+              {t('web.journalStale.daysLabel')}
+            </label>
+            <input
+              type="number"
+              min={1}
+              max={3650}
+              value={days}
+              onChange={(e) => setDays(Math.max(1, Number(e.target.value)))}
+              className="border-border bg-background h-7 w-16 rounded border px-2 text-[12px]"
+            />
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={toggleAll}
+              disabled={entries.length === 0}
+              className="h-7 text-[11px]"
+            >
+              {allChecked
+                ? t('web.journalStale.deselectAll')
+                : t('web.journalStale.selectAll')}
+            </Button>
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() => bulkDelete.mutate(selectedIds)}
+              disabled={selected.size === 0 || bulkDelete.isPending}
+              className="ml-auto h-7 text-[11px]"
+            >
+              {bulkDelete.isPending ? (
+                <Loader2 className="mr-1 size-3 animate-spin" />
+              ) : (
+                <Trash2 className="mr-1 size-3" />
+              )}
+              {t('web.journalStale.deleteSelected', { count: selected.size })}
+            </Button>
+          </div>
+
+          {staleQuery.isLoading && (
+            <div className="text-muted-foreground flex items-center gap-2 text-[11px]">
+              <Loader2 className="size-3 animate-spin" />
+              {t('web.journalStale.loading')}
+            </div>
+          )}
+          {!staleQuery.isLoading && entries.length === 0 && (
+            <p className="text-muted-foreground text-[11px] italic">
+              {t('web.journalStale.empty')}
+            </p>
+          )}
+          <ul className="space-y-1">
+            {entries.map((e) => (
+              <li
+                key={e.id}
+                className="flex items-start gap-2 rounded border p-2 text-[12px]"
+              >
+                <input
+                  type="checkbox"
+                  className="mt-0.5"
+                  checked={selected.has(e.id)}
+                  onChange={() => toggleOne(e.id)}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="text-muted-foreground flex items-center gap-2 text-[10px]">
+                    <span className="font-mono">{e.id}</span>
+                    <span>{new Date(e.created_at).toLocaleDateString()}</span>
+                    {e.kind && (
+                      <Badge variant="outline" className="font-mono">
+                        {e.kind}
+                      </Badge>
+                    )}
+                  </div>
+                  {e.title && <div className="font-semibold">{e.title}</div>}
+                  <p className="text-muted-foreground line-clamp-2 text-[11px]">
+                    {e.content}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/web/src/components/project/ProjectScreen.tsx
+++ b/app/web/src/components/project/ProjectScreen.tsx
@@ -61,6 +61,7 @@ import {
 import { deleteMemoriesByScope } from '@/lib/memory'
 import { MemoryHealthCard } from '@/components/project/MemoryHealthCard'
 import { ConflictsPanel } from '@/components/project/ConflictsPanel'
+import { JournalStalePanel } from '@/components/project/JournalStalePanel'
 
 interface ProjectScreenProps {
   cwd: string
@@ -84,6 +85,10 @@ function useVerdictLabel() {
 export function ProjectScreen({ cwd }: ProjectScreenProps) {
   const { t } = useTranslation()
   const qc = useQueryClient()
+  // Controlled tabs so quick-actions in ConflictsPanel can jump
+  // directly to the Plan / Goal editor without the operator
+  // hunting for the right tab.
+  const [activeTab, setActiveTab] = useState('health')
 
   const docsQuery = useQuery({
     queryKey: ['project-docs', cwd],
@@ -185,7 +190,11 @@ export function ProjectScreen({ cwd }: ProjectScreenProps) {
         </div>
       </div>
 
-      <Tabs defaultValue="health" className="flex flex-1 flex-col overflow-hidden">
+      <Tabs
+        value={activeTab}
+        onValueChange={setActiveTab}
+        className="flex flex-1 flex-col overflow-hidden"
+      >
         <TabsList className="bg-muted/30 mx-4 mt-3 w-fit">
           <TabsTrigger value="health">{t('web.project.tabs.health')}</TabsTrigger>
           <TabsTrigger value="goal">{t('web.project.tabs.goal')}</TabsTrigger>
@@ -249,6 +258,7 @@ export function ProjectScreen({ cwd }: ProjectScreenProps) {
         </TabsContent>
 
         <TabsContent value="journal" className="flex-1 overflow-auto p-4">
+          <JournalStalePanel cwd={cwd} />
           <JournalTab entries={logsQuery.data ?? []} loading={logsQuery.isLoading} />
         </TabsContent>
 
@@ -264,7 +274,7 @@ export function ProjectScreen({ cwd }: ProjectScreenProps) {
         </TabsContent>
 
         <TabsContent value="conflicts" className="flex-1 overflow-auto">
-          <ConflictsPanel cwd={cwd} />
+          <ConflictsPanel cwd={cwd} onJumpTab={setActiveTab} />
         </TabsContent>
 
         <TabsContent value="cleanup" className="flex-1 overflow-auto p-4">

--- a/app/web/src/components/settings/MemoryInspector.tsx
+++ b/app/web/src/components/settings/MemoryInspector.tsx
@@ -52,6 +52,7 @@ import {
   type SearchHit,
   type Scope,
 } from '@/lib/memory'
+import { rankingBreakdown } from '@/lib/memoryRanking'
 import { listSessions } from '@/lib/sessions'
 
 // MemoryInspector shows the live state of opendray's memory
@@ -1002,6 +1003,14 @@ function Row({
   const [expanded, setExpanded] = useState(false)
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(mem.text)
+  // M-PD — compute the same effective-score the backend ranking
+  // uses so operators can see WHY a row sits where it does. When
+  // there's no active similarity (browse view) we pass 1.0 to get
+  // the "this row's intrinsic boost" reading.
+  const rank = useMemo(
+    () => rankingBreakdown(mem, similarity ?? 1),
+    [mem, similarity],
+  )
   const [saving, setSaving] = useState(false)
   const source = (mem.metadata?.source as string | undefined) ?? null
   const sourcePath = (mem.metadata?.source_path as string | undefined) ?? null
@@ -1063,6 +1072,21 @@ function Row({
                 })}
               </span>
             )}
+            <span
+              className="text-[10px] px-1.5 py-0.5 rounded border border-border text-muted-foreground/80 font-mono"
+              title={t('web.memoryInspector.row.rankTooltip', {
+                similarity: rank.similarity.toFixed(3),
+                age: rank.ageMultiplier.toFixed(2),
+                hits: rank.hitMultiplier.toFixed(2),
+                confidence: rank.confidenceMultiplier.toFixed(2),
+                effective: rank.effectiveScore.toFixed(3),
+                days: Math.round(rank.ageDays),
+              })}
+            >
+              {t('web.memoryInspector.row.rankBadge', {
+                value: rank.effectiveScore.toFixed(2),
+              })}
+            </span>
             {source && (
               <span className="text-[10px] text-muted-foreground/60">
                 <CheckCircle2 className="inline size-2.5 mr-0.5" />

--- a/docs/memory-system.md
+++ b/docs/memory-system.md
@@ -431,6 +431,53 @@ that aren't referenced by any pending conflict. Operators use
 this list to prune accumulated noise without losing any
 journaling that's still doing work via the conflict detector.
 
+## Operator UX polish (M-PD, shipped)
+
+The Phase A-C plumbing surfaced new signals (effective_score,
+journal staleness, cross-layer conflicts); Phase D wires them
+into the operator UI so they're actionable in two clicks.
+
+### Ranking math visible in the inspector
+
+Every row in **Memory** (`/memory`) now shows a `rank` badge next
+to `sim`. Hover for a tooltip that spells out the formula:
+
+```
+effective 0.43 = sim 0.78 × age 0.72 (50d) × hits 1.08 × conf 1.00
+```
+
+Operators can see at a glance *why* a row sits where it does and
+which factor dominates. Backed by `app/shared/src/lib/memoryRanking.ts`
+which mirrors `internal/memory/ranking.go` so the explanation
+matches what the backend ranker actually computed.
+
+### Journal bulk-prune
+
+The Journal tab (`/memory/project` → Journal) gains a collapsed
+"Prune stale entries" panel. Expand it, optionally tune the age
+threshold (default 90 days), select entries with the checkboxes,
+and bulk-delete in one shot. Entries currently referenced by a
+pending conflict are hidden from the list (server-side filter)
+so operators don't accidentally lose context the detector still
+considers load-bearing.
+
+### Conflict quick-actions
+
+Each conflict card on the **Conflicts** tab now grows a
+"Fix:" row at the bottom with context-aware shortcuts:
+
+- `fact` side → **Delete fact** (yanks the memory row + auto-
+  accepts the conflict; one click clears the row from the
+  inbox and the offending fact from search results).
+- `plan` / `goal` side → **Open plan/goal editor** (jumps to
+  the corresponding ProjectScreen tab so the operator can
+  rewrite the doc; the conflict stays pending until they hit
+  Accept after editing).
+
+The "Open editor" jumps work because `ProjectScreen`'s Tabs
+component is controlled (`activeTab` state) — the panel exposes
+an `onJumpTab(tab: string)` callback that flips it.
+
 ## Roadmap
 
 - **Codex session UUID capture**. Codex lacks `--session-id`; a


### PR DESCRIPTION
## Summary

Phase D is the operator-UX layer on top of the Phase A-C plumbing. The smart-ranking formula, journal staleness query, and cross-layer conflicts that landed in PR #130 finally become things the operator can act on without dropping to SQL or the API.

- **Ranking math visible.** Every memory row in `/memory` now shows a `rank` badge next to `sim`; hover reveals the full formula (similarity × age × hits × confidence) plus the row's age in days. Backed by a TypeScript mirror of `internal/memory/ranking.go` — no backend round-trip.
- **Journal bulk-prune.** New collapsed panel at the top of the Journal tab. Expand → list session_logs older than N days (default 90) with checkboxes → "Delete (N)" wipes them in one shot. Entries currently referenced by a pending conflict are excluded server-side, so the operator can't accidentally lose context the detector still cares about.
- **Conflict quick-actions.** Each conflict card grows a "Fix:" footer with one-click shortcuts: delete the offending fact (auto-accepts the conflict in the same call), or jump straight to the plan/goal editor for layered docs.

No new endpoints, no schema changes — pure UI work against the M-PC backend.

## What changed

| Area | Files |
|---|---|
| Ranking math | `app/shared/src/lib/memoryRanking.ts` (new), `app/shared/src/lib/memory.ts` (confidence + effective_score fields), `app/web/src/components/settings/MemoryInspector.tsx` (Row badge + tooltip) |
| Journal bulk-prune | `app/web/src/components/project/JournalStalePanel.tsx` (new), `app/shared/src/lib/projectDocs.ts` (listStaleSessionLogs), `app/web/src/components/project/ProjectScreen.tsx` (mounted at top of Journal tab) |
| Conflict quick-actions | `app/web/src/components/project/ConflictsPanel.tsx` (delete-fact mutation + tab-jump prop, footer buttons), `app/web/src/components/project/ProjectScreen.tsx` (Tabs converted to controlled state) |
| i18n | `app/i18n/{en,zh}.json` (rank badge / journal prune / conflict quick-actions / openLayer.*) |
| Docs | `docs/memory-system.md` (M-PD operator-UX section) |

## Failure modes deliberately tolerated

- Stale-journal endpoint returns 5xx → toast + retain selection so the operator can retry without reselecting.
- Delete-fact succeeds but conflict accept fails → toast surfaces the second error; operator can manually accept the now-fact-less conflict from the same panel.
- onJumpTab not provided → Open editor buttons render disabled (defensive; the only caller currently passes it, but the prop stays optional so the panel works in isolation).
- Confidence field absent in MemoryRecord → tooltip just shows `conf 1.00` (the formula's no-op multiplier).

## Test plan

- [x] `pnpm tsc --noEmit` green
- [x] `go test -race ./...` green (no backend changes; existing tests cover the endpoints these surfaces consume)
- [x] `gofmt -l ./...` clean
- [x] i18n JSON parses (both en and zh)
- [ ] Manual: open `/memory`, hover the rank badge on a memory row, verify tooltip math matches `similarity * age_decay * hit_boost * conf_floor`
- [ ] Manual: open `/memory/project` → Journal, expand "Prune stale entries", lower the day threshold to expose some entries, select + bulk-delete, verify removed from both stale list + main journal list
- [ ] Manual: trigger a conflict between a fact and the plan, verify "Delete fact" yanks the memory + clears the conflict in one click, and "Open plan editor" jumps to the Plan tab

## Phase A-D shipped — what's next

This wraps the four-phase memory-system upgrade started in PR #128. The four phases together:

- **A**: plan-drift auto-proposals + memory health dashboard
- **B**: journal embedding + cross-layer search + spawn token budget
- **C**: smart ranking formula + cross-layer conflict detection + stale-journal helper
- **D**: ranking math UI + journal bulk-prune + conflict quick-actions

Next memory-system iterations are operator-driven (no Phase E queued).