### PR TITLE
feat(mobile): add Enter key to session soft keyboard toolbar

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1217,7 +1217,7 @@
           "value": "Value"
         },
         "editTooltip": "Overwrite the stored value",
-        "deleteConfirm": "Delete secret \"{key}\"? Any mcp.json that references ${'$'}{{key}} will fall back to the literal placeholder until you set a new value.",
+        "deleteConfirm": "Delete secret \"{key}\"? Any mcp.json that references ${key} will fall back to the literal placeholder until you set a new value.",
         "removedToast": "Secret removed",
         "deleteFailedToast": "Delete failed",
         "editor": {

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -2349,7 +2349,8 @@
       "keyboard": {
         "copyBuffer": "Copy buffer",
         "paste": "Paste",
-        "attachImage": "Attach image"
+        "attachImage": "Attach image",
+        "enter": "Enter"
       },
       "connection": {
         "connecting": "Connecting…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -2349,7 +2349,8 @@
       "keyboard": {
         "copyBuffer": "复制缓冲",
         "paste": "粘贴",
-        "attachImage": "附加图片"
+        "attachImage": "附加图片",
+        "enter": "回车"
       },
       "connection": {
         "connecting": "连接中…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -1217,7 +1217,7 @@
           "value": "Value"
         },
         "editTooltip": "覆盖已存的值",
-        "deleteConfirm": "删除密钥 \"{key}\"? 任何引用 ${'$'}{{key}} 的 mcp.json 在你重新设置之前都会回退到字面占位符。",
+        "deleteConfirm": "删除密钥 \"{key}\"? 任何引用 ${key} 的 mcp.json 在你重新设置之前都会回退到字面占位符。",
         "removedToast": "密钥已移除",
         "deleteFailedToast": "删除失败",
         "editor": {

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 5550 (2775 per locale)
+/// Strings: 5628 (2814 per locale)
 ///
-/// Built on 2026-05-14 at 13:10 UTC
+/// Built on 2026-05-15 at 01:30 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 5628 (2814 per locale)
+/// Strings: 5630 (2815 per locale)
 ///
-/// Built on 2026-05-15 at 01:30 UTC
+/// Built on 2026-05-15 at 01:31 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -6,7 +6,7 @@
 /// Locales: 2
 /// Strings: 5630 (2815 per locale)
 ///
-/// Built on 2026-05-15 at 01:31 UTC
+/// Built on 2026-05-15 at 02:44 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -8622,6 +8622,9 @@ class TranslationsSessionsTerminalKeyboardEn {
 
 	/// en: 'Attach image'
 	String get attachImage => 'Attach image';
+
+	/// en: 'Enter'
+	String get enter => 'Enter';
 }
 
 // Path: sessions.terminal.connection
@@ -14229,6 +14232,7 @@ extension on Translations {
 			'sessions.terminal.keyboard.copyBuffer' => 'Copy buffer',
 			'sessions.terminal.keyboard.paste' => 'Paste',
 			'sessions.terminal.keyboard.attachImage' => 'Attach image',
+			'sessions.terminal.keyboard.enter' => 'Enter',
 			'sessions.terminal.connection.connecting' => 'Connecting…',
 			'sessions.terminal.connection.connected' => 'Connected',
 			'sessions.terminal.connection.reconnecting' => 'Reconnecting…',
@@ -14449,9 +14453,9 @@ extension on Translations {
 			'providers.errorPrefix.delete' => 'Delete failed',
 			'providers.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}: ${error}',
 			'providers.accounts.rename' => 'Rename',
-			'providers.accounts.renameTitle' => ({required Object name}) => 'Rename ${name}',
 			_ => null,
 		} ?? switch (path) {
+			'providers.accounts.renameTitle' => ({required Object name}) => 'Rename ${name}',
 			'providers.accounts.displayNameLabel' => 'Display name',
 			'providers.accounts.displayNameHint' => 'Work account',
 			'providers.accounts.deleteTitle' => 'Delete account?',
@@ -14963,9 +14967,9 @@ extension on Translations {
 			'skills.resetTooltip' => 'Reset to built-in',
 			'skills.deleteTooltip' => 'Delete',
 			'skills.saving' => 'Saving…',
-			'skills.saveOverride' => 'Save override',
 			_ => null,
 		} ?? switch (path) {
+			'skills.saveOverride' => 'Save override',
 			'skills.overrideBanner' => 'Saving creates a vault override with the same id. Sessions will use this body instead of the built-in until you reset.',
 			'skills.idHelper' => 'Lowercase letters / digits / dash. Locked once created.',
 			'skills.emptyList' => 'No skills configured. The gateway ships with built-ins (planner, code-reviewer, etc.).',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -216,6 +216,8 @@ class TranslationsWebEn {
 	late final TranslationsWebTopbarEn topbar = TranslationsWebTopbarEn.internal(_root);
 	late final TranslationsWebSessionsEn sessions = TranslationsWebSessionsEn.internal(_root);
 	late final TranslationsWebMemoryEn memory = TranslationsWebMemoryEn.internal(_root);
+	late final TranslationsWebConflictsEn conflicts = TranslationsWebConflictsEn.internal(_root);
+	late final TranslationsWebMemoryHealthEn memoryHealth = TranslationsWebMemoryHealthEn.internal(_root);
 	late final TranslationsWebMemoryWorkersEn memoryWorkers = TranslationsWebMemoryWorkersEn.internal(_root);
 	late final TranslationsWebCleanupInboxEn cleanupInbox = TranslationsWebCleanupInboxEn.internal(_root);
 	late final TranslationsWebProjectEn project = TranslationsWebProjectEn.internal(_root);
@@ -1886,6 +1888,128 @@ class TranslationsWebMemoryEn {
 
 	/// en: 'Configuration →'
 	String get navConfiguration => 'Configuration →';
+}
+
+// Path: web.conflicts
+class TranslationsWebConflictsEn {
+	TranslationsWebConflictsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Cross-layer conflicts'
+	String get title => 'Cross-layer conflicts';
+
+	/// en: 'Contradictions the daily detector found between facts, plan, goal, and journal entries.'
+	String get subtitle => 'Contradictions the daily detector found between facts, plan, goal, and journal entries.';
+
+	/// en: 'Loading conflicts…'
+	String get loading => 'Loading conflicts…';
+
+	/// en: 'No pending conflicts. Click "Detect now" to run an on-demand sweep.'
+	String get empty => 'No pending conflicts. Click "Detect now" to run an on-demand sweep.';
+
+	/// en: 'Pick a project to see its conflicts.'
+	String get pickCwd => 'Pick a project to see its conflicts.';
+
+	/// en: 'Detect now'
+	String get detectNow => 'Detect now';
+
+	/// en: '{count} new conflict(s) found'
+	String detected({required Object count}) => '${count} new conflict(s) found';
+
+	/// en: 'Accept'
+	String get accept => 'Accept';
+
+	/// en: 'Dismiss'
+	String get dismiss => 'Dismiss';
+
+	/// en: 'Conflict accepted — remember to apply the fix'
+	String get accepted => 'Conflict accepted — remember to apply the fix';
+
+	/// en: 'Conflict dismissed'
+	String get dismissed => 'Conflict dismissed';
+
+	late final TranslationsWebConflictsSeverityEn severity = TranslationsWebConflictsSeverityEn.internal(_root);
+}
+
+// Path: web.memoryHealth
+class TranslationsWebMemoryHealthEn {
+	TranslationsWebMemoryHealthEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Memory health — last {days} days'
+	String title({required Object days}) => 'Memory health — last ${days} days';
+
+	/// en: 'Aggregate signals across both memory subsystems for this project.'
+	String get subtitle => 'Aggregate signals across both memory subsystems for this project.';
+
+	/// en: 'Loading health snapshot…'
+	String get loading => 'Loading health snapshot…';
+
+	/// en: 'Failed to load health snapshot.'
+	String get errorLoading => 'Failed to load health snapshot.';
+
+	/// en: 'Pick a project to see its memory health.'
+	String get pickCwd => 'Pick a project to see its memory health.';
+
+	/// en: 'New facts'
+	String get newFacts => 'New facts';
+
+	/// en: '{total} stored in total'
+	String newFactsHint({required Object total}) => '${total} stored in total';
+
+	/// en: 'Capture fires'
+	String get captureFires => 'Capture fires';
+
+	/// en: '{stored} stored · {deduped} deduped'
+	String captureFiresHint({required Object stored, required Object deduped}) => '${stored} stored · ${deduped} deduped';
+
+	/// en: 'Journal entries'
+	String get newJournal => 'Journal entries';
+
+	/// en: '{total} in total'
+	String newJournalHint({required Object total}) => '${total} in total';
+
+	/// en: 'Plan last updated'
+	String get planAge => 'Plan last updated';
+
+	/// en: '{count} plan-drift proposal(s) pending'
+	String planAgeHint({required Object count}) => '${count} plan-drift proposal(s) pending';
+
+	/// en: 'No plan-drift proposals pending'
+	String get planAgeHintNone => 'No plan-drift proposals pending';
+
+	/// en: 'Goal last updated'
+	String get goalAge => 'Goal last updated';
+
+	/// en: 'Pending proposals'
+	String get pending => 'Pending proposals';
+
+	/// en: 'oldest {days}d old'
+	String pendingHint({required Object days}) => 'oldest ${days}d old';
+
+	/// en: 'Top hit · {hits} retrievals'
+	String topHit({required Object hits}) => 'Top hit · ${hits} retrievals';
+
+	/// en: '{count} facts older than 7d with zero retrievals — candidates for cleanup.'
+	String zeroHit({required Object count}) => '${count} facts older than 7d with zero retrievals — candidates for cleanup.';
+
+	/// en: 'never'
+	String get never => 'never';
+
+	/// en: 'today'
+	String get today => 'today';
+
+	/// en: '{count} day ago'
+	String daysAgo_one({required Object count}) => '${count} day ago';
+
+	/// en: '{count} days ago'
+	String daysAgo_other({required Object count}) => '${count} days ago';
 }
 
 // Path: web.memoryWorkers
@@ -4535,6 +4659,24 @@ class TranslationsWebSessionsFileBrowserEn {
 	String get homeFailedToast => 'Failed to read home';
 }
 
+// Path: web.conflicts.severity
+class TranslationsWebConflictsSeverityEn {
+	TranslationsWebConflictsSeverityEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'low'
+	String get low => 'low';
+
+	/// en: 'medium'
+	String get medium => 'medium';
+
+	/// en: 'high'
+	String get high => 'high';
+}
+
 // Path: web.memoryWorkers.tasks
 class TranslationsWebMemoryWorkersTasksEn {
 	TranslationsWebMemoryWorkersTasksEn.internal(this._root);
@@ -4622,6 +4764,9 @@ class TranslationsWebProjectTabsEn {
 
 	// Translations
 
+	/// en: 'Health'
+	String get health => 'Health';
+
 	/// en: 'Goal'
 	String get goal => 'Goal';
 
@@ -4639,6 +4784,9 @@ class TranslationsWebProjectTabsEn {
 
 	/// en: 'Inbox'
 	String get inbox => 'Inbox';
+
+	/// en: 'Conflicts'
+	String get conflicts => 'Conflicts';
 
 	/// en: 'Cleanup'
 	String get cleanup => 'Cleanup';
@@ -12430,6 +12578,43 @@ extension on Translations {
 			'web.memory.navCleanupInbox' => 'Cleanup inbox',
 			'web.memory.navWorkers' => 'Workers',
 			'web.memory.navConfiguration' => 'Configuration →',
+			'web.conflicts.title' => 'Cross-layer conflicts',
+			'web.conflicts.subtitle' => 'Contradictions the daily detector found between facts, plan, goal, and journal entries.',
+			'web.conflicts.loading' => 'Loading conflicts…',
+			'web.conflicts.empty' => 'No pending conflicts. Click "Detect now" to run an on-demand sweep.',
+			'web.conflicts.pickCwd' => 'Pick a project to see its conflicts.',
+			'web.conflicts.detectNow' => 'Detect now',
+			'web.conflicts.detected' => ({required Object count}) => '${count} new conflict(s) found',
+			'web.conflicts.accept' => 'Accept',
+			'web.conflicts.dismiss' => 'Dismiss',
+			'web.conflicts.accepted' => 'Conflict accepted — remember to apply the fix',
+			'web.conflicts.dismissed' => 'Conflict dismissed',
+			'web.conflicts.severity.low' => 'low',
+			'web.conflicts.severity.medium' => 'medium',
+			'web.conflicts.severity.high' => 'high',
+			'web.memoryHealth.title' => ({required Object days}) => 'Memory health — last ${days} days',
+			'web.memoryHealth.subtitle' => 'Aggregate signals across both memory subsystems for this project.',
+			'web.memoryHealth.loading' => 'Loading health snapshot…',
+			'web.memoryHealth.errorLoading' => 'Failed to load health snapshot.',
+			'web.memoryHealth.pickCwd' => 'Pick a project to see its memory health.',
+			'web.memoryHealth.newFacts' => 'New facts',
+			'web.memoryHealth.newFactsHint' => ({required Object total}) => '${total} stored in total',
+			'web.memoryHealth.captureFires' => 'Capture fires',
+			'web.memoryHealth.captureFiresHint' => ({required Object stored, required Object deduped}) => '${stored} stored · ${deduped} deduped',
+			'web.memoryHealth.newJournal' => 'Journal entries',
+			'web.memoryHealth.newJournalHint' => ({required Object total}) => '${total} in total',
+			'web.memoryHealth.planAge' => 'Plan last updated',
+			'web.memoryHealth.planAgeHint' => ({required Object count}) => '${count} plan-drift proposal(s) pending',
+			'web.memoryHealth.planAgeHintNone' => 'No plan-drift proposals pending',
+			'web.memoryHealth.goalAge' => 'Goal last updated',
+			'web.memoryHealth.pending' => 'Pending proposals',
+			'web.memoryHealth.pendingHint' => ({required Object days}) => 'oldest ${days}d old',
+			'web.memoryHealth.topHit' => ({required Object hits}) => 'Top hit · ${hits} retrievals',
+			'web.memoryHealth.zeroHit' => ({required Object count}) => '${count} facts older than 7d with zero retrievals — candidates for cleanup.',
+			'web.memoryHealth.never' => 'never',
+			'web.memoryHealth.today' => 'today',
+			'web.memoryHealth.daysAgo_one' => ({required Object count}) => '${count} day ago',
+			'web.memoryHealth.daysAgo_other' => ({required Object count}) => '${count} days ago',
 			'web.memoryWorkers.title' => 'Memory workers',
 			'web.memoryWorkers.loading' => 'Loading worker config…',
 			'web.memoryWorkers.errorTitle' => 'Endpoint not reachable.',
@@ -12511,12 +12696,14 @@ extension on Translations {
 			'web.project.header.pendingProposals_one' => ({required Object count}) => '${count} pending proposal',
 			'web.project.header.pendingProposals_other' => ({required Object count}) => '${count} pending proposals',
 			'web.project.header.cleanupPending' => ({required Object count}) => '${count} cleanup pending',
+			'web.project.tabs.health' => 'Health',
 			'web.project.tabs.goal' => 'Goal',
 			'web.project.tabs.plan' => 'Plan',
 			'web.project.tabs.tech' => 'Tech',
 			'web.project.tabs.activity' => 'Activity',
 			'web.project.tabs.journal' => 'Journal',
 			'web.project.tabs.inbox' => 'Inbox',
+			'web.project.tabs.conflicts' => 'Conflicts',
 			'web.project.tabs.cleanup' => 'Cleanup',
 			'web.project.docLabel.goal' => 'Goal',
 			'web.project.docLabel.plan' => 'Plan',
@@ -12721,6 +12908,8 @@ extension on Translations {
 			'web.notes.left.clearTagTooltip' => 'Clear tag filter',
 			'web.notes.left.expandAll' => 'Expand all',
 			'web.notes.left.expandAllTooltip' => 'Expand every folder',
+			_ => null,
+		} ?? switch (path) {
 			'web.notes.left.collapseAll' => 'Collapse all',
 			'web.notes.left.collapseAllTooltip' => 'Collapse every folder',
 			'web.notes.left.loading' => 'Loading…',
@@ -12760,8 +12949,6 @@ extension on Translations {
 			'web.notes.vaultSync.action.push' => 'Push',
 			'web.notes.vaultSync.action.pullTitleNoRemote' => 'Configure a remote first',
 			'web.notes.vaultSync.action.pullTitleHasUpstream' => 'git pull --rebase --autostash',
-			_ => null,
-		} ?? switch (path) {
 			'web.notes.vaultSync.action.pullTitleNoUpstream' => 'Pulls origin\'s HEAD; sets up tracking implicitly',
 			'web.notes.vaultSync.action.pushTitleNoRemote' => 'Configure a remote first',
 			'web.notes.vaultSync.action.pushTitleHasUpstream' => 'git push -u origin HEAD',
@@ -13235,6 +13422,8 @@ extension on Translations {
 			'web.plugins.skills.resetConfirm' => ({required Object id}) => 'Reset "${id}" to the built-in version? This deletes your vault SKILL.md and falls back to the embedded copy.',
 			'web.plugins.skills.deleteConfirm' => ({required Object id}) => 'Delete skill "${id}" from your vault? This removes the SKILL.md file.',
 			'web.plugins.skills.removedToast' => 'Skill removed',
+			_ => null,
+		} ?? switch (path) {
 			'web.plugins.skills.deleteFailedToast' => 'Delete failed',
 			'web.plugins.skills.editor.createTitle' => 'New skill',
 			'web.plugins.skills.editor.customizeTitle' => ({required Object id}) => 'Customize built-in: ${id}',
@@ -13274,8 +13463,6 @@ extension on Translations {
 			'web.plugins.customTasks.dialog.cwdLabel' => 'Cwd scope (optional)',
 			'web.plugins.customTasks.dialog.cwdPlaceholder' => '/Users/me/projects/foo  (blank = global)',
 			'web.plugins.customTasks.dialog.cwdHint' => 'Blank = visible in every session. Otherwise the task only shows when the session\'s cwd matches this absolute path.',
-			_ => null,
-		} ?? switch (path) {
 			'web.plugins.customTasks.dialog.addedToast' => 'Task added',
 			'web.plugins.customTasks.dialog.updatedToast' => 'Task updated',
 			'web.plugins.customTasks.dialog.addFailedToast' => 'Add failed',
@@ -13749,6 +13936,8 @@ extension on Translations {
 			'web.settings.font.options.comfy' => 'Comfy',
 			'web.settings.font.options.large' => 'Large',
 			'web.settings.account.title' => 'Account',
+			_ => null,
+		} ?? switch (path) {
 			'web.settings.account.description' => 'Operator and current bearer token.',
 			'web.settings.account.username' => 'Username',
 			'web.settings.account.tokenExpires' => 'Token expires',
@@ -13788,8 +13977,6 @@ extension on Translations {
 			'web.logViewer.pauseTooltip' => 'Pause auto-scroll',
 			'web.logViewer.resumeTooltip' => 'Resume auto-scroll',
 			'web.logViewer.clearTooltip' => 'Clear local view (server ring untouched)',
-			_ => null,
-		} ?? switch (path) {
 			'web.logViewer.downloadTooltip' => 'Download full ring as .log file',
 			'web.logViewer.emptyWaiting' => 'Waiting for log records…',
 			'web.logViewer.emptyFiltered' => ({required Object query}) => 'No records match "${query}"',
@@ -14263,6 +14450,8 @@ extension on Translations {
 			'providers.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}: ${error}',
 			'providers.accounts.rename' => 'Rename',
 			'providers.accounts.renameTitle' => ({required Object name}) => 'Rename ${name}',
+			_ => null,
+		} ?? switch (path) {
 			'providers.accounts.displayNameLabel' => 'Display name',
 			'providers.accounts.displayNameHint' => 'Work account',
 			'providers.accounts.deleteTitle' => 'Delete account?',
@@ -14302,8 +14491,6 @@ extension on Translations {
 			'integrations.edit' => 'Edit',
 			'integrations.editTitle' => ({required Object name}) => 'Edit ${name}',
 			'integrations.enabledLabel' => 'Enabled',
-			_ => null,
-		} ?? switch (path) {
 			'integrations.iSavedIt' => 'I\'ve saved it',
 			'integrations.apiKeyForName' => ({required Object name}) => 'API key for ${name}',
 			'integrations.apiKeySubtitleRegister' => ({required Object routePrefix}) => 'Hand this to the integration so it can authenticate against /api/v1/${routePrefix}/…',
@@ -14777,6 +14964,8 @@ extension on Translations {
 			'skills.deleteTooltip' => 'Delete',
 			'skills.saving' => 'Saving…',
 			'skills.saveOverride' => 'Save override',
+			_ => null,
+		} ?? switch (path) {
 			'skills.overrideBanner' => 'Saving creates a vault override with the same id. Sessions will use this body instead of the built-in until you reset.',
 			'skills.idHelper' => 'Lowercase letters / digits / dash. Locked once created.',
 			'skills.emptyList' => 'No skills configured. The gateway ships with built-ins (planner, code-reviewer, etc.).',
@@ -14816,8 +15005,6 @@ extension on Translations {
 			'customTasks.cwdHelper' => 'Absolute path. Sessions spawned with this exact cwd will see the task.',
 			'customTasks.saving' => 'Saving…',
 			'customTasks.save' => 'Save',
-			_ => null,
-		} ?? switch (path) {
 			'customTasks.create' => 'Create',
 			'customTasks.failedToLoad' => 'Failed to load custom tasks',
 			'notesPage.title' => 'Notes',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -6836,8 +6836,8 @@ class TranslationsWebPluginsMcpSecretsEn {
 	/// en: 'Overwrite the stored value'
 	String get editTooltip => 'Overwrite the stored value';
 
-	/// en: 'Delete secret "{key}"? Any mcp.json that references ${'$'}{{key}} will fall back to the literal placeholder until you set a new value.'
-	String deleteConfirm({required Object key, required Object \'\$\', required Object {key}) => 'Delete secret "${key}"? Any mcp.json that references \$${\'\$\'}${{key}} will fall back to the literal placeholder until you set a new value.';
+	/// en: 'Delete secret "{key}"? Any mcp.json that references ${key} will fall back to the literal placeholder until you set a new value.'
+	String deleteConfirm({required Object key}) => 'Delete secret "${key}"? Any mcp.json that references \$${key} will fall back to the literal placeholder until you set a new value.';
 
 	/// en: 'Secret removed'
 	String get removedToast => 'Secret removed';
@@ -13388,7 +13388,7 @@ extension on Translations {
 			'web.plugins.mcpSecrets.columns.key' => 'Key',
 			'web.plugins.mcpSecrets.columns.value' => 'Value',
 			'web.plugins.mcpSecrets.editTooltip' => 'Overwrite the stored value',
-			'web.plugins.mcpSecrets.deleteConfirm' => ({required Object key, required Object \'\$\', required Object {key}) => 'Delete secret "${key}"? Any mcp.json that references \$${\'\$\'}${{key}} will fall back to the literal placeholder until you set a new value.',
+			'web.plugins.mcpSecrets.deleteConfirm' => ({required Object key}) => 'Delete secret "${key}"? Any mcp.json that references \$${key} will fall back to the literal placeholder until you set a new value.',
 			'web.plugins.mcpSecrets.removedToast' => 'Secret removed',
 			'web.plugins.mcpSecrets.deleteFailedToast' => 'Delete failed',
 			'web.plugins.mcpSecrets.editor.addTitle' => 'Add secret',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -140,6 +140,8 @@ class _TranslationsWebZh extends TranslationsWebEn {
 	@override late final _TranslationsWebTopbarZh topbar = _TranslationsWebTopbarZh._(_root);
 	@override late final _TranslationsWebSessionsZh sessions = _TranslationsWebSessionsZh._(_root);
 	@override late final _TranslationsWebMemoryZh memory = _TranslationsWebMemoryZh._(_root);
+	@override late final _TranslationsWebConflictsZh conflicts = _TranslationsWebConflictsZh._(_root);
+	@override late final _TranslationsWebMemoryHealthZh memoryHealth = _TranslationsWebMemoryHealthZh._(_root);
 	@override late final _TranslationsWebMemoryWorkersZh memoryWorkers = _TranslationsWebMemoryWorkersZh._(_root);
 	@override late final _TranslationsWebCleanupInboxZh cleanupInbox = _TranslationsWebCleanupInboxZh._(_root);
 	@override late final _TranslationsWebProjectZh project = _TranslationsWebProjectZh._(_root);
@@ -888,6 +890,59 @@ class _TranslationsWebMemoryZh extends TranslationsWebMemoryEn {
 	@override String get navCleanupInbox => '清理收件箱';
 	@override String get navWorkers => 'Workers';
 	@override String get navConfiguration => '配置 →';
+}
+
+// Path: web.conflicts
+class _TranslationsWebConflictsZh extends TranslationsWebConflictsEn {
+	_TranslationsWebConflictsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '跨层冲突';
+	@override String get subtitle => '每日 detector 在 facts/plan/goal/journal 之间发现的矛盾。';
+	@override String get loading => '正在加载冲突…';
+	@override String get empty => '无待处理冲突。点击"立即检测"运行一次按需扫描。';
+	@override String get pickCwd => '选一个项目查看其冲突。';
+	@override String get detectNow => '立即检测';
+	@override String detected({required Object count}) => '新发现 ${count} 条冲突';
+	@override String get accept => '采纳';
+	@override String get dismiss => '驳回';
+	@override String get accepted => '已采纳 — 别忘了实际修正';
+	@override String get dismissed => '已驳回';
+	@override late final _TranslationsWebConflictsSeverityZh severity = _TranslationsWebConflictsSeverityZh._(_root);
+}
+
+// Path: web.memoryHealth
+class _TranslationsWebMemoryHealthZh extends TranslationsWebMemoryHealthEn {
+	_TranslationsWebMemoryHealthZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String title({required Object days}) => '记忆健康 — 最近 ${days} 天';
+	@override String get subtitle => '本项目两套记忆子系统的运行情况聚合。';
+	@override String get loading => '正在加载健康快照…';
+	@override String get errorLoading => '加载健康快照失败。';
+	@override String get pickCwd => '选一个项目查看其记忆健康。';
+	@override String get newFacts => '新增 facts';
+	@override String newFactsHint({required Object total}) => '累计 ${total} 条';
+	@override String get captureFires => 'Capture 触发次数';
+	@override String captureFiresHint({required Object stored, required Object deduped}) => '存入 ${stored} · 去重 ${deduped}';
+	@override String get newJournal => '新增日志条目';
+	@override String newJournalHint({required Object total}) => '累计 ${total} 条';
+	@override String get planAge => '计划最近更新';
+	@override String planAgeHint({required Object count}) => '${count} 条 plan-drift 提案待审';
+	@override String get planAgeHintNone => '无 plan-drift 提案待审';
+	@override String get goalAge => '目标最近更新';
+	@override String get pending => '待审提案';
+	@override String pendingHint({required Object days}) => '最久 ${days} 天';
+	@override String topHit({required Object hits}) => '命中最多 · ${hits} 次';
+	@override String zeroHit({required Object count}) => '${count} 条超过 7 天未命中的 fact — 清理候选。';
+	@override String get never => '从未';
+	@override String get today => '今日';
+	@override String daysAgo_one({required Object count}) => '${count} 天前';
+	@override String daysAgo_other({required Object count}) => '${count} 天前';
 }
 
 // Path: web.memoryWorkers
@@ -2368,6 +2423,18 @@ class _TranslationsWebSessionsFileBrowserZh extends TranslationsWebSessionsFileB
 	@override String get homeFailedToast => '读取家目录失败';
 }
 
+// Path: web.conflicts.severity
+class _TranslationsWebConflictsSeverityZh extends TranslationsWebConflictsSeverityEn {
+	_TranslationsWebConflictsSeverityZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get low => '低';
+	@override String get medium => '中';
+	@override String get high => '高';
+}
+
 // Path: web.memoryWorkers.tasks
 class _TranslationsWebMemoryWorkersTasksZh extends TranslationsWebMemoryWorkersTasksEn {
 	_TranslationsWebMemoryWorkersTasksZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -2422,12 +2489,14 @@ class _TranslationsWebProjectTabsZh extends TranslationsWebProjectTabsEn {
 	final TranslationsZh _root; // ignore: unused_field
 
 	// Translations
+	@override String get health => '健康';
 	@override String get goal => '目标';
 	@override String get plan => '计划';
 	@override String get tech => '技术栈';
 	@override String get activity => '活动';
 	@override String get journal => '日志';
 	@override String get inbox => '收件箱';
+	@override String get conflicts => '冲突';
 	@override String get cleanup => '清理';
 }
 
@@ -6796,6 +6865,43 @@ extension on TranslationsZh {
 			'web.memory.navCleanupInbox' => '清理收件箱',
 			'web.memory.navWorkers' => 'Workers',
 			'web.memory.navConfiguration' => '配置 →',
+			'web.conflicts.title' => '跨层冲突',
+			'web.conflicts.subtitle' => '每日 detector 在 facts/plan/goal/journal 之间发现的矛盾。',
+			'web.conflicts.loading' => '正在加载冲突…',
+			'web.conflicts.empty' => '无待处理冲突。点击"立即检测"运行一次按需扫描。',
+			'web.conflicts.pickCwd' => '选一个项目查看其冲突。',
+			'web.conflicts.detectNow' => '立即检测',
+			'web.conflicts.detected' => ({required Object count}) => '新发现 ${count} 条冲突',
+			'web.conflicts.accept' => '采纳',
+			'web.conflicts.dismiss' => '驳回',
+			'web.conflicts.accepted' => '已采纳 — 别忘了实际修正',
+			'web.conflicts.dismissed' => '已驳回',
+			'web.conflicts.severity.low' => '低',
+			'web.conflicts.severity.medium' => '中',
+			'web.conflicts.severity.high' => '高',
+			'web.memoryHealth.title' => ({required Object days}) => '记忆健康 — 最近 ${days} 天',
+			'web.memoryHealth.subtitle' => '本项目两套记忆子系统的运行情况聚合。',
+			'web.memoryHealth.loading' => '正在加载健康快照…',
+			'web.memoryHealth.errorLoading' => '加载健康快照失败。',
+			'web.memoryHealth.pickCwd' => '选一个项目查看其记忆健康。',
+			'web.memoryHealth.newFacts' => '新增 facts',
+			'web.memoryHealth.newFactsHint' => ({required Object total}) => '累计 ${total} 条',
+			'web.memoryHealth.captureFires' => 'Capture 触发次数',
+			'web.memoryHealth.captureFiresHint' => ({required Object stored, required Object deduped}) => '存入 ${stored} · 去重 ${deduped}',
+			'web.memoryHealth.newJournal' => '新增日志条目',
+			'web.memoryHealth.newJournalHint' => ({required Object total}) => '累计 ${total} 条',
+			'web.memoryHealth.planAge' => '计划最近更新',
+			'web.memoryHealth.planAgeHint' => ({required Object count}) => '${count} 条 plan-drift 提案待审',
+			'web.memoryHealth.planAgeHintNone' => '无 plan-drift 提案待审',
+			'web.memoryHealth.goalAge' => '目标最近更新',
+			'web.memoryHealth.pending' => '待审提案',
+			'web.memoryHealth.pendingHint' => ({required Object days}) => '最久 ${days} 天',
+			'web.memoryHealth.topHit' => ({required Object hits}) => '命中最多 · ${hits} 次',
+			'web.memoryHealth.zeroHit' => ({required Object count}) => '${count} 条超过 7 天未命中的 fact — 清理候选。',
+			'web.memoryHealth.never' => '从未',
+			'web.memoryHealth.today' => '今日',
+			'web.memoryHealth.daysAgo_one' => ({required Object count}) => '${count} 天前',
+			'web.memoryHealth.daysAgo_other' => ({required Object count}) => '${count} 天前',
 			'web.memoryWorkers.title' => 'Memory workers',
 			'web.memoryWorkers.loading' => '正在加载 worker 配置…',
 			'web.memoryWorkers.errorTitle' => '无法访问该接口。',
@@ -6877,12 +6983,14 @@ extension on TranslationsZh {
 			'web.project.header.pendingProposals_one' => ({required Object count}) => '${count} 条待处理提案',
 			'web.project.header.pendingProposals_other' => ({required Object count}) => '${count} 条待处理提案',
 			'web.project.header.cleanupPending' => ({required Object count}) => '${count} 条待清理',
+			'web.project.tabs.health' => '健康',
 			'web.project.tabs.goal' => '目标',
 			'web.project.tabs.plan' => '计划',
 			'web.project.tabs.tech' => '技术栈',
 			'web.project.tabs.activity' => '活动',
 			'web.project.tabs.journal' => '日志',
 			'web.project.tabs.inbox' => '收件箱',
+			'web.project.tabs.conflicts' => '冲突',
 			'web.project.tabs.cleanup' => '清理',
 			'web.project.docLabel.goal' => '目标',
 			'web.project.docLabel.plan' => '计划',
@@ -7087,6 +7195,8 @@ extension on TranslationsZh {
 			'web.notes.left.clearTagTooltip' => '清除标签筛选',
 			'web.notes.left.expandAll' => '全部展开',
 			'web.notes.left.expandAllTooltip' => '展开全部文件夹',
+			_ => null,
+		} ?? switch (path) {
 			'web.notes.left.collapseAll' => '全部收起',
 			'web.notes.left.collapseAllTooltip' => '收起全部文件夹',
 			'web.notes.left.loading' => '加载中…',
@@ -7126,8 +7236,6 @@ extension on TranslationsZh {
 			'web.notes.vaultSync.action.push' => '推送',
 			'web.notes.vaultSync.action.pullTitleNoRemote' => '请先配置 remote',
 			'web.notes.vaultSync.action.pullTitleHasUpstream' => 'git pull --rebase --autostash',
-			_ => null,
-		} ?? switch (path) {
 			'web.notes.vaultSync.action.pullTitleNoUpstream' => '拉取 origin 的 HEAD；隐式建立 tracking',
 			'web.notes.vaultSync.action.pushTitleNoRemote' => '请先配置 remote',
 			'web.notes.vaultSync.action.pushTitleHasUpstream' => 'git push -u origin HEAD',
@@ -7601,6 +7709,8 @@ extension on TranslationsZh {
 			'web.plugins.skills.resetConfirm' => ({required Object id}) => '将 "${id}" 重置为内置版本? 这会删除你的 vault SKILL.md 并回退到嵌入副本。',
 			'web.plugins.skills.deleteConfirm' => ({required Object id}) => '从 vault 删除 skill "${id}"? 这会移除该 SKILL.md 文件。',
 			'web.plugins.skills.removedToast' => 'Skill 已移除',
+			_ => null,
+		} ?? switch (path) {
 			'web.plugins.skills.deleteFailedToast' => '删除失败',
 			'web.plugins.skills.editor.createTitle' => '新建 skill',
 			'web.plugins.skills.editor.customizeTitle' => ({required Object id}) => '自定义内置：${id}',
@@ -7640,8 +7750,6 @@ extension on TranslationsZh {
 			'web.plugins.customTasks.dialog.cwdLabel' => 'cwd scope（可选）',
 			'web.plugins.customTasks.dialog.cwdPlaceholder' => '/Users/me/projects/foo（留空 = 全局）',
 			'web.plugins.customTasks.dialog.cwdHint' => '留空 = 在每个会话中都可见。否则只有当会话的 cwd 与此绝对路径匹配时才显示。',
-			_ => null,
-		} ?? switch (path) {
 			'web.plugins.customTasks.dialog.addedToast' => '任务已添加',
 			'web.plugins.customTasks.dialog.updatedToast' => '任务已更新',
 			'web.plugins.customTasks.dialog.addFailedToast' => '添加失败',
@@ -8115,6 +8223,8 @@ extension on TranslationsZh {
 			'web.settings.font.options.comfy' => '舒适',
 			'web.settings.font.options.large' => '大',
 			'web.settings.account.title' => '账号',
+			_ => null,
+		} ?? switch (path) {
 			'web.settings.account.description' => '运维与当前 bearer token。',
 			'web.settings.account.username' => '用户名',
 			'web.settings.account.tokenExpires' => 'Token 过期',
@@ -8154,8 +8264,6 @@ extension on TranslationsZh {
 			'web.logViewer.pauseTooltip' => '暂停自动滚动',
 			'web.logViewer.resumeTooltip' => '恢复自动滚动',
 			'web.logViewer.clearTooltip' => '清空本地视图（服务端 ring 不受影响）',
-			_ => null,
-		} ?? switch (path) {
 			'web.logViewer.downloadTooltip' => '下载完整 ring 为 .log 文件',
 			'web.logViewer.emptyWaiting' => '等待日志记录…',
 			'web.logViewer.emptyFiltered' => ({required Object query}) => '没有匹配 "${query}" 的记录',
@@ -8629,6 +8737,8 @@ extension on TranslationsZh {
 			'providers.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}：${error}',
 			'providers.accounts.rename' => '重命名',
 			'providers.accounts.renameTitle' => ({required Object name}) => '重命名 ${name}',
+			_ => null,
+		} ?? switch (path) {
 			'providers.accounts.displayNameLabel' => '显示名',
 			'providers.accounts.displayNameHint' => '工作账号',
 			'providers.accounts.deleteTitle' => '删除账号？',
@@ -8668,8 +8778,6 @@ extension on TranslationsZh {
 			'integrations.edit' => '编辑',
 			'integrations.editTitle' => ({required Object name}) => '编辑 ${name}',
 			'integrations.enabledLabel' => '已启用',
-			_ => null,
-		} ?? switch (path) {
 			'integrations.iSavedIt' => '我已保存',
 			'integrations.apiKeyForName' => ({required Object name}) => '${name} 的 API key',
 			'integrations.apiKeySubtitleRegister' => ({required Object routePrefix}) => '将其交给集成方，使其能够通过 /api/v1/${routePrefix}/… 进行认证。',
@@ -9143,6 +9251,8 @@ extension on TranslationsZh {
 			'skills.deleteTooltip' => '删除',
 			'skills.saving' => '保存中…',
 			'skills.saveOverride' => '保存覆盖',
+			_ => null,
+		} ?? switch (path) {
 			'skills.overrideBanner' => '保存会以相同 id 创建一个库覆盖。会话将使用此正文而非内置版本，直到你重置。',
 			'skills.idHelper' => '小写字母 / 数字 / 横线。创建后锁定。',
 			'skills.emptyList' => '未配置任何技能。网关附带内置技能（planner、code-reviewer 等）。',
@@ -9182,8 +9292,6 @@ extension on TranslationsZh {
 			'customTasks.cwdHelper' => '绝对路径。以此 cwd 启动的会话将看到该任务。',
 			'customTasks.saving' => '保存中…',
 			'customTasks.save' => '保存',
-			_ => null,
-		} ?? switch (path) {
 			'customTasks.create' => '创建',
 			'customTasks.failedToLoad' => '加载自定义任务失败',
 			'notesPage.title' => '笔记',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -4529,6 +4529,7 @@ class _TranslationsSessionsTerminalKeyboardZh extends TranslationsSessionsTermin
 	@override String get copyBuffer => '复制缓冲';
 	@override String get paste => '粘贴';
 	@override String get attachImage => '附加图片';
+	@override String get enter => '回车';
 }
 
 // Path: sessions.terminal.connection
@@ -8516,6 +8517,7 @@ extension on TranslationsZh {
 			'sessions.terminal.keyboard.copyBuffer' => '复制缓冲',
 			'sessions.terminal.keyboard.paste' => '粘贴',
 			'sessions.terminal.keyboard.attachImage' => '附加图片',
+			'sessions.terminal.keyboard.enter' => '回车',
 			'sessions.terminal.connection.connecting' => '连接中…',
 			'sessions.terminal.connection.connected' => '已连接',
 			'sessions.terminal.connection.reconnecting' => '重连中…',
@@ -8736,9 +8738,9 @@ extension on TranslationsZh {
 			'providers.errorPrefix.delete' => '删除失败',
 			'providers.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}：${error}',
 			'providers.accounts.rename' => '重命名',
-			'providers.accounts.renameTitle' => ({required Object name}) => '重命名 ${name}',
 			_ => null,
 		} ?? switch (path) {
+			'providers.accounts.renameTitle' => ({required Object name}) => '重命名 ${name}',
 			'providers.accounts.displayNameLabel' => '显示名',
 			'providers.accounts.displayNameHint' => '工作账号',
 			'providers.accounts.deleteTitle' => '删除账号？',
@@ -9250,9 +9252,9 @@ extension on TranslationsZh {
 			'skills.resetTooltip' => '重置为内置',
 			'skills.deleteTooltip' => '删除',
 			'skills.saving' => '保存中…',
-			'skills.saveOverride' => '保存覆盖',
 			_ => null,
 		} ?? switch (path) {
+			'skills.saveOverride' => '保存覆盖',
 			'skills.overrideBanner' => '保存会以相同 id 创建一个库覆盖。会话将使用此正文而非内置版本，直到你重置。',
 			'skills.idHelper' => '小写字母 / 数字 / 横线。创建后锁定。',
 			'skills.emptyList' => '未配置任何技能。网关附带内置技能（planner、code-reviewer 等）。',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -3515,7 +3515,7 @@ class _TranslationsWebPluginsMcpSecretsZh extends TranslationsWebPluginsMcpSecre
 	@override String empty({required Object KEY}) => '暂无已存密钥。添加后即可在 MCP 服务器配置中以 <1>\$${KEY}</1> 引用。';
 	@override late final _TranslationsWebPluginsMcpSecretsColumnsZh columns = _TranslationsWebPluginsMcpSecretsColumnsZh._(_root);
 	@override String get editTooltip => '覆盖已存的值';
-	@override String deleteConfirm({required Object key, required Object \'\$\', required Object {key}) => '删除密钥 "${key}"? 任何引用 \$${\'\$\'}${{key}} 的 mcp.json 在你重新设置之前都会回退到字面占位符。';
+	@override String deleteConfirm({required Object key}) => '删除密钥 "${key}"? 任何引用 \$${key} 的 mcp.json 在你重新设置之前都会回退到字面占位符。';
 	@override String get removedToast => '密钥已移除';
 	@override String get deleteFailedToast => '删除失败';
 	@override late final _TranslationsWebPluginsMcpSecretsEditorZh editor = _TranslationsWebPluginsMcpSecretsEditorZh._(_root);
@@ -7673,7 +7673,7 @@ extension on TranslationsZh {
 			'web.plugins.mcpSecrets.columns.key' => 'Key',
 			'web.plugins.mcpSecrets.columns.value' => 'Value',
 			'web.plugins.mcpSecrets.editTooltip' => '覆盖已存的值',
-			'web.plugins.mcpSecrets.deleteConfirm' => ({required Object key, required Object \'\$\', required Object {key}) => '删除密钥 "${key}"? 任何引用 \$${\'\$\'}${{key}} 的 mcp.json 在你重新设置之前都会回退到字面占位符。',
+			'web.plugins.mcpSecrets.deleteConfirm' => ({required Object key}) => '删除密钥 "${key}"? 任何引用 \$${key} 的 mcp.json 在你重新设置之前都会回退到字面占位符。',
 			'web.plugins.mcpSecrets.removedToast' => '密钥已移除',
 			'web.plugins.mcpSecrets.deleteFailedToast' => '删除失败',
 			'web.plugins.mcpSecrets.editor.addTitle' => '添加密钥',

--- a/app/mobile/lib/features/sessions/session_terminal_view.dart
+++ b/app/mobile/lib/features/sessions/session_terminal_view.dart
@@ -696,6 +696,13 @@ class _MobileKeyboardBarState extends State<_MobileKeyboardBar> {
               },
             ),
             _Key(
+              label: t.sessions.terminal.keyboard.enter,
+              onTap: () {
+                _haptic();
+                _send('\r');
+              },
+            ),
+            _Key(
               icon: Icons.content_copy,
               tooltip: t.sessions.terminal.keyboard.copyBuffer,
               onTap: () {


### PR DESCRIPTION
## Summary

Adds an **Enter** key to the mobile session soft-keyboard toolbar, placed right after the arrow keys (Esc · Tab · Ctrl · ↑ · ↓ · ← · → · **Enter** · Copy · Paste · Attach · | · …).

The toolbar already covers the keys Android/iOS system keyboards lack — Esc, Tab, Ctrl, arrows. Enter was conspicuously missing: in custom-painted terminals the OS Return key sometimes inserts a literal newline into the IME buffer instead of emitting `\r` to the PTY, so users had to dismiss the soft keyboard, tap a different IME, or use a hardware keyboard to send a command.

## What changed

- `app/mobile/lib/features/sessions/session_terminal_view.dart` — new `_Key("Enter")` between `→` and the Copy icon. Emits `\r` (carriage return), matching the convention every shell + xterm.dart already expects.
- `app/i18n/{en,zh}.json` — adds `sessions.terminal.keyboard.enter` (`"Enter"` / `"回车"`).
- `app/mobile/lib/core/i18n/strings_*.g.dart` — regenerated via `dart run slang` to pick up the new key.

A separate prior commit on this branch (`chore(mobile): regenerate slang i18n to absorb pre-existing source drift`) absorbs the unrelated drift that had accumulated since the last regen, so this commit's diff stays focused on the actual feature.

## Test plan

- [x] `dart analyze ./app/mobile` clean
- [x] `dart run slang` produces no further changes after the feature regen
- [x] JSON parses for both en and zh
- [ ] Manual: launch the mobile app, open a session, tap the new Enter key — verify the shell receives a newline (e.g. an empty line in `bash` reprints the prompt)
- [ ] Manual: with Ctrl active, tap Enter — current behaviour is "Ctrl is a letter-modifier only" so Enter still emits `\r` (no Ctrl-M C0 transform). Confirm that matches expectations.