### PR TITLE
fix(conflicts): emit both Delete-fact buttons when both sides are facts

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -247,6 +247,7 @@
       "deletedFact": "Fact deleted and conflict accepted",
       "quickActions": "Fix:",
       "deleteFact": "Delete fact",
+      "deleteFactSide": "Delete {side}: {ref}",
       "openLayer": {
         "plan": "Open plan editor",
         "goal": "Open goal editor"

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -248,6 +248,18 @@
       "quickActions": "Fix:",
       "deleteFact": "Delete fact",
       "deleteFactSide": "Delete {side}: {ref}",
+      "confirmDelete": {
+        "title": "Delete fact {side}?",
+        "description": "This permanently removes the fact and accepts the conflict. The other side stays as the surviving claim.",
+        "targetLabel": "Will delete (side {side}):",
+        "keepLabel": "Will keep (side {side}):",
+        "nonFactOther": "({layer} entry — open the corresponding tab to inspect)",
+        "evidenceLabel": "Detector evidence:",
+        "loading": "Loading fact text…",
+        "loadError": "Failed to load fact text. Inspect on the Memory page.",
+        "cancel": "Cancel",
+        "confirm": "Delete {side}"
+      },
       "openLayer": {
         "plan": "Open plan editor",
         "goal": "Open goal editor"

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -247,6 +247,7 @@
       "deletedFact": "已删除 fact 并采纳冲突",
       "quickActions": "快速修复：",
       "deleteFact": "删除 fact",
+      "deleteFactSide": "删除 {side}: {ref}",
       "openLayer": {
         "plan": "打开计划编辑器",
         "goal": "打开目标编辑器"

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -248,6 +248,18 @@
       "quickActions": "快速修复：",
       "deleteFact": "删除 fact",
       "deleteFactSide": "删除 {side}: {ref}",
+      "confirmDelete": {
+        "title": "确认删除 fact {side}?",
+        "description": "永久删除此 fact 并采纳冲突。另一侧保留为最终采信的版本。",
+        "targetLabel": "将删除（{side} 侧）：",
+        "keepLabel": "将保留（{side} 侧）：",
+        "nonFactOther": "（{layer} 条目 — 请打开对应 tab 查看完整内容）",
+        "evidenceLabel": "Detector 给出的证据：",
+        "loading": "加载 fact 内容中…",
+        "loadError": "无法加载 fact 内容，请在 Memory 页面手动查看。",
+        "cancel": "取消",
+        "confirm": "确认删除 {side}"
+      },
       "openLayer": {
         "plan": "打开计划编辑器",
         "goal": "打开目标编辑器"

--- a/app/shared/src/lib/memory.ts
+++ b/app/shared/src/lib/memory.ts
@@ -99,6 +99,14 @@ export async function deleteMemory(id: string): Promise<void> {
   await api(`/api/v1/memory/${encodeURIComponent(id)}`, { method: 'DELETE' })
 }
 
+// Fetch a single memory by id. Used by the Conflicts panel's delete
+// confirmation dialog so the operator can see the actual fact text
+// before yanking it. Returns 404 → throws so caller's useQuery flips
+// to error state.
+export async function getMemory(id: string): Promise<MemoryRecord> {
+  return api<MemoryRecord>(`/api/v1/memory/${encodeURIComponent(id)}`)
+}
+
 // deleteMemoriesByScope wipes every memory under (scope, scope_key)
 // in one server-side SQL operation. Returns the row count actually
 // removed. Server enforces:

--- a/app/web/src/components/project/ConflictsPanel.tsx
+++ b/app/web/src/components/project/ConflictsPanel.tsx
@@ -3,6 +3,7 @@
 // the two conflicting items + the LLM's evidence + accept/dismiss
 // buttons.
 
+import { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
@@ -11,18 +12,27 @@ import {
   Check,
   Loader2,
   RefreshCw,
+  Trash2,
   X,
 } from 'lucide-react'
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
   type MemoryConflict,
   decideMemoryConflict,
   detectMemoryConflicts,
   listMemoryConflicts,
 } from '@/lib/memoryConflicts'
-import { deleteMemory } from '@/lib/memory'
+import { deleteMemory, getMemory } from '@/lib/memory'
 
 interface ConflictsPanelProps {
   cwd: string
@@ -74,6 +84,16 @@ export function ConflictsPanel({ cwd, onJumpTab }: ConflictsPanelProps) {
     },
   })
 
+  // Pending fact-delete the dialog is currently confirming. We
+  // hold the conflict + which side ("A" / "B") so the dialog can
+  // render the picked-side fact prominently AND the other-side
+  // fact alongside it (the operator's actual decision is "which
+  // of these two is wrong" — they need to see both).
+  const [pendingDelete, setPendingDelete] = useState<{
+    conflict: MemoryConflict
+    side: 'A' | 'B'
+  } | null>(null)
+
   // M-PD quick-action: "Delete this fact" — yanks the offending
   // memory row and auto-accepts the conflict so the inbox clears
   // in one click. Plan/goal sides delegate to a tab-jump instead
@@ -85,6 +105,7 @@ export function ConflictsPanel({ cwd, onJumpTab }: ConflictsPanelProps) {
     },
     onSuccess: () => {
       toast.success(t('web.conflicts.deletedFact'))
+      setPendingDelete(null)
       qc.invalidateQueries({ queryKey: ['memory-conflicts', cwd] })
       qc.invalidateQueries({ queryKey: ['memories'] })
     },
@@ -146,22 +167,196 @@ export function ConflictsPanel({ cwd, onJumpTab }: ConflictsPanelProps) {
               conflict={c}
               onDecide={(action) => decide.mutate({ id: c.id, action })}
               disabled={decide.isPending || deleteFactAndAccept.isPending}
-              onDeleteFact={(factId) =>
-                deleteFactAndAccept.mutate({ conflictId: c.id, factId })
+              onRequestDeleteFact={(side) =>
+                setPendingDelete({ conflict: c, side })
               }
               onJumpTab={onJumpTab}
             />
           ))}
         </div>
       </div>
+
+      <DeleteFactConfirmDialog
+        pending={pendingDelete}
+        busy={deleteFactAndAccept.isPending}
+        onCancel={() => setPendingDelete(null)}
+        onConfirm={(factId) => {
+          if (pendingDelete) {
+            deleteFactAndAccept.mutate({
+              conflictId: pendingDelete.conflict.id,
+              factId,
+            })
+          }
+        }}
+      />
     </div>
+  )
+}
+
+// ─── Delete-fact confirmation dialog ───────────────────────────
+// Loads the two conflicting fact rows so the operator sees the
+// full text of both sides before pulling the trigger. The chosen
+// side is highlighted; the other is shown muted for reference —
+// the actual decision is "which of these two claims is wrong",
+// which needs both visible at once.
+
+interface DeleteFactConfirmDialogProps {
+  pending: { conflict: MemoryConflict; side: 'A' | 'B' } | null
+  busy: boolean
+  onCancel: () => void
+  onConfirm: (factId: string) => void
+}
+
+function DeleteFactConfirmDialog({
+  pending,
+  busy,
+  onCancel,
+  onConfirm,
+}: DeleteFactConfirmDialogProps) {
+  const { t } = useTranslation()
+
+  const open = pending !== null
+  const conflict = pending?.conflict ?? null
+  const side = pending?.side ?? 'A'
+
+  // Which ref is being deleted vs which is the "other side" the
+  // operator should compare against. Computed once per render so
+  // the queries below depend on stable strings.
+  const targetRef =
+    conflict == null
+      ? null
+      : side === 'A'
+        ? conflict.ref_a
+        : conflict.ref_b
+  const otherRef =
+    conflict == null
+      ? null
+      : side === 'A'
+        ? conflict.ref_b
+        : conflict.ref_a
+  const otherLayer =
+    conflict == null
+      ? null
+      : side === 'A'
+        ? conflict.layer_b
+        : conflict.layer_a
+
+  const targetQuery = useQuery({
+    queryKey: ['memory-by-id', targetRef],
+    queryFn: () => getMemory(targetRef as string),
+    enabled: open && !!targetRef,
+  })
+  // Only fetch the other side if it's a fact — plan/goal/journal
+  // refs aren't memories.id and would 404. We fall back to "see
+  // the {layer} tab" copy in those cases.
+  const otherIsFact = otherLayer === 'fact'
+  const otherQuery = useQuery({
+    queryKey: ['memory-by-id', otherRef],
+    queryFn: () => getMemory(otherRef as string),
+    enabled: open && otherIsFact && !!otherRef,
+  })
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel()
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {t('web.conflicts.confirmDelete.title', { side })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('web.conflicts.confirmDelete.description')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="bg-destructive/10 border-destructive/30 rounded-md border p-3">
+            <div className="text-destructive mb-1 flex items-center gap-1 text-[10px] font-semibold">
+              <Trash2 className="size-3" />
+              {t('web.conflicts.confirmDelete.targetLabel', { side })}
+              <span className="ml-1 font-mono text-muted-foreground">
+                {targetRef}
+              </span>
+            </div>
+            <p className="text-[12px] whitespace-pre-wrap">
+              {targetQuery.isLoading
+                ? t('web.conflicts.confirmDelete.loading')
+                : targetQuery.isError
+                  ? t('web.conflicts.confirmDelete.loadError')
+                  : (targetQuery.data?.text ?? '')}
+            </p>
+          </div>
+
+          <div className="bg-muted/30 border-border rounded-md border p-3">
+            <div className="text-muted-foreground mb-1 flex items-center gap-1 text-[10px] font-semibold">
+              {t('web.conflicts.confirmDelete.keepLabel', {
+                side: side === 'A' ? 'B' : 'A',
+              })}
+              <span className="ml-1 font-mono">{otherRef}</span>
+              {!otherIsFact && (
+                <Badge variant="muted" className="ml-1 text-[9px]">
+                  {otherLayer}
+                </Badge>
+              )}
+            </div>
+            <p className="text-muted-foreground text-[12px] whitespace-pre-wrap">
+              {otherIsFact
+                ? otherQuery.isLoading
+                  ? t('web.conflicts.confirmDelete.loading')
+                  : otherQuery.isError
+                    ? t('web.conflicts.confirmDelete.loadError')
+                    : (otherQuery.data?.text ?? '')
+                : t('web.conflicts.confirmDelete.nonFactOther', {
+                    layer: otherLayer ?? '',
+                  })}
+            </p>
+          </div>
+
+          {conflict && conflict.evidence && (
+            <div className="text-muted-foreground text-[11px] italic">
+              {t('web.conflicts.confirmDelete.evidenceLabel')} {conflict.evidence}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onCancel} disabled={busy}>
+            {t('web.conflicts.confirmDelete.cancel')}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => {
+              if (targetRef) onConfirm(targetRef)
+            }}
+            disabled={busy || !targetRef || targetQuery.isLoading}
+          >
+            {busy ? (
+              <Loader2 className="mr-1 size-3 animate-spin" />
+            ) : (
+              <Trash2 className="mr-1 size-3" />
+            )}
+            {t('web.conflicts.confirmDelete.confirm', { side })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }
 
 interface ConflictCardProps {
   conflict: MemoryConflict
   onDecide: (action: 'accepted' | 'dismissed') => void
-  onDeleteFact: (factId: string) => void
+  /**
+   * The card fires this when an operator clicks one of the delete
+   * buttons. Confirmation + the actual mutation live in the parent
+   * (ConflictsPanel) so the dialog can fetch fact text once instead
+   * of every card pre-loading it.
+   */
+  onRequestDeleteFact: (side: 'A' | 'B') => void
   onJumpTab?: (tab: string) => void
   disabled: boolean
 }
@@ -169,7 +364,7 @@ interface ConflictCardProps {
 function ConflictCard({
   conflict,
   onDecide,
-  onDeleteFact,
+  onRequestDeleteFact,
   onJumpTab,
   disabled,
 }: ConflictCardProps) {
@@ -182,28 +377,30 @@ function ConflictCard({
         : 'muted'
 
   // Quick-action targets — one button per conflicting side:
-  //   layer=fact   → "Delete fact A/B (mem_…)" (yanks the row +
-  //                  auto-accepts the conflict)
+  //   layer=fact   → "Delete A/B (mem_…)" → opens confirm dialog
+  //                  showing full fact text + the other side
   //   layer=plan   → "Open plan editor" (jumps to the Plan tab)
   //   layer=goal   → "Open goal editor"
-  //   layer=journal → no quick-action; operator can dismiss
+  //   layer=journal → no quick-action; operator dismisses or edits
   //
   // When both sides are facts (the common case for hard
   // contradictions like "DB is Postgres" vs "DB is SQLite"), we
   // emit TWO delete buttons — one per fact id — so the operator
-  // can pick which side is wrong without leaving the panel. Same
-  // when both sides are plan/goal we'd dedupe the editor button.
+  // can pick which side is wrong. Each button opens a confirm
+  // dialog so they can verify the fact text before committing.
+  // Plan/goal "Open editor" buttons dedupe on layer (one button
+  // per unique tab target).
   type QuickAction =
-    | { kind: 'delete-fact'; sideLabel: string; refId: string }
+    | { kind: 'delete-fact'; side: 'A' | 'B'; refId: string }
     | { kind: 'open-tab'; tab: string; label: string }
   const quick: QuickAction[] = []
   const seenTabs = new Set<string>()
   ;[
-    { side: 'A', layer: conflict.layer_a, ref: conflict.ref_a },
-    { side: 'B', layer: conflict.layer_b, ref: conflict.ref_b },
+    { side: 'A' as const, layer: conflict.layer_a, ref: conflict.ref_a },
+    { side: 'B' as const, layer: conflict.layer_b, ref: conflict.ref_b },
   ].forEach(({ side, layer, ref }) => {
     if (layer === 'fact') {
-      quick.push({ kind: 'delete-fact', sideLabel: side, refId: ref })
+      quick.push({ kind: 'delete-fact', side, refId: ref })
     } else if (layer === 'plan' || layer === 'goal') {
       if (seenTabs.has(layer)) return
       seenTabs.add(layer)
@@ -268,13 +465,13 @@ function ConflictCard({
                   key={`del-${q.refId}`}
                   size="sm"
                   variant="outline"
-                  onClick={() => onDeleteFact(q.refId)}
+                  onClick={() => onRequestDeleteFact(q.side)}
                   disabled={disabled}
                   className="h-6 text-[10px] font-mono"
                   title={q.refId}
                 >
                   {t('web.conflicts.deleteFactSide', {
-                    side: q.sideLabel,
+                    side: q.side,
                     ref: shortRef(q.refId),
                   })}
                 </Button>

--- a/app/web/src/components/project/ConflictsPanel.tsx
+++ b/app/web/src/components/project/ConflictsPanel.tsx
@@ -181,29 +181,37 @@ function ConflictCard({
         ? 'warn'
         : 'muted'
 
-  // Quick-action targets — first fact side gets a delete shortcut,
-  // first plan/goal side gets a jump-to-editor link. We don't show
-  // both for the same side (the action is unambiguous per layer).
+  // Quick-action targets — one button per conflicting side:
+  //   layer=fact   → "Delete fact A/B (mem_…)" (yanks the row +
+  //                  auto-accepts the conflict)
+  //   layer=plan   → "Open plan editor" (jumps to the Plan tab)
+  //   layer=goal   → "Open goal editor"
+  //   layer=journal → no quick-action; operator can dismiss
+  //
+  // When both sides are facts (the common case for hard
+  // contradictions like "DB is Postgres" vs "DB is SQLite"), we
+  // emit TWO delete buttons — one per fact id — so the operator
+  // can pick which side is wrong without leaving the panel. Same
+  // when both sides are plan/goal we'd dedupe the editor button.
   type QuickAction =
-    | { kind: 'delete-fact'; refId: string }
+    | { kind: 'delete-fact'; sideLabel: string; refId: string }
     | { kind: 'open-tab'; tab: string; label: string }
   const quick: QuickAction[] = []
+  const seenTabs = new Set<string>()
   ;[
-    { layer: conflict.layer_a, ref: conflict.ref_a },
-    { layer: conflict.layer_b, ref: conflict.ref_b },
-  ].forEach(({ layer, ref }) => {
+    { side: 'A', layer: conflict.layer_a, ref: conflict.ref_a },
+    { side: 'B', layer: conflict.layer_b, ref: conflict.ref_b },
+  ].forEach(({ side, layer, ref }) => {
     if (layer === 'fact') {
-      if (!quick.some((q) => q.kind === 'delete-fact')) {
-        quick.push({ kind: 'delete-fact', refId: ref })
-      }
+      quick.push({ kind: 'delete-fact', sideLabel: side, refId: ref })
     } else if (layer === 'plan' || layer === 'goal') {
-      if (!quick.some((q) => q.kind === 'open-tab' && q.tab === layer)) {
-        quick.push({
-          kind: 'open-tab',
-          tab: layer,
-          label: t(`web.conflicts.openLayer.${layer}`),
-        })
-      }
+      if (seenTabs.has(layer)) return
+      seenTabs.add(layer)
+      quick.push({
+        kind: 'open-tab',
+        tab: layer,
+        label: t(`web.conflicts.openLayer.${layer}`),
+      })
     }
   })
 
@@ -257,20 +265,24 @@ function ConflictCard({
             if (q.kind === 'delete-fact') {
               return (
                 <Button
-                  key={i}
+                  key={`del-${q.refId}`}
                   size="sm"
                   variant="outline"
                   onClick={() => onDeleteFact(q.refId)}
                   disabled={disabled}
-                  className="h-6 text-[10px]"
+                  className="h-6 text-[10px] font-mono"
+                  title={q.refId}
                 >
-                  {t('web.conflicts.deleteFact')}
+                  {t('web.conflicts.deleteFactSide', {
+                    side: q.sideLabel,
+                    ref: shortRef(q.refId),
+                  })}
                 </Button>
               )
             }
             return (
               <Button
-                key={i}
+                key={`tab-${q.tab}-${i}`}
                 size="sm"
                 variant="ghost"
                 onClick={() => onJumpTab?.(q.tab)}


### PR DESCRIPTION
## Summary

UX gap in the Phase D Conflicts panel: when both sides of a conflict are facts (e.g. \`mem_FN7O\` says "DB is PostgreSQL" and \`mem_Va5i\` says "DB is SQLite"), the panel only rendered a single "Delete fact" button pointing at \`ref_a\`. The operator had to leave the page to delete \`ref_b\` — defeating the point of the quick-action footer.

This patch removes the dedup-by-kind guard so each fact side gets its own button, labelled with the side (A/B from the layer:ref header at the top of the card) and a short ref id:

    Fix:  [Delete A: mem_FN7O…]  [Delete B: mem_Va5i…]

Plan/goal "Open editor" buttons still dedupe — one button per unique tab target — since two facts can each be deleted independently but the Plan editor is the same destination regardless of which side surfaced it.

## What changed

| File | Change |
|---|---|
| \`app/web/src/components/project/ConflictsPanel.tsx\` | Removed \`!quick.some(...)\` guard for delete-fact actions; track sideLabel (A/B) on each QuickAction; new title attribute carries full ref id on hover; key fields disambiguate identical button positions |
| \`app/i18n/{en,zh}.json\` | New key \`web.conflicts.deleteFactSide\` (\`"Delete {side}: {ref}"\` / \`"删除 {side}: {ref}"\`) |

## Failure modes deliberately tolerated

- One fact-side + one plan/goal-side → still gets the original two-button shape (one delete, one open-editor) because plan/goal hit the seenTabs dedup, fact side bypasses it.
- Both sides journal → no quick-actions; operator dismisses or manually edits the source.
- delete-fact mutation propagates the same auto-accept-on-success behaviour from Phase D, so clicking either A or B clears the conflict from the inbox.

## Test plan

- [x] \`pnpm tsc --noEmit\` green
- [x] i18n JSON parses (en + zh)
- [ ] Manual: trigger a fact ⟷ fact conflict, see two Delete buttons; click A → fact A gone + conflict cleared
- [ ] Manual: trigger a fact ⟷ plan conflict, see one Delete fact + one Open plan editor (existing behaviour preserved)