### PR TITLE
feat(memory): route capture engine through worker fabric (Agent / Summarizer choice)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -349,6 +349,18 @@
         "transcript": {
           "label": "Session transcript summariser",
           "description": "Session-end \"what did the agent do\" summary. Naturally fits an agent worker."
+        },
+        "plan_drift": {
+          "label": "Plan drift detector",
+          "description": "After each session ends, checks whether the project plan needs updating and files a proposal. Fits an agent worker for richer reasoning."
+        },
+        "conflict_detector": {
+          "label": "Cross-layer conflict detector",
+          "description": "Daily scan that finds contradictions between facts / plan / goal / journal. Higher-quality model = fewer false positives."
+        },
+        "capture": {
+          "label": "Capture engine",
+          "description": "Per-trigger fact extraction from session transcripts. Agent mode gives noticeably better facts on long sessions; summarizer mode is cheap and local."
         }
       }
     },

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -349,6 +349,18 @@
         "transcript": {
           "label": "会话记录总结器",
           "description": "会话结束时的“agent 都做了什么”总结。天然适合 agent worker。"
+        },
+        "plan_drift": {
+          "label": "计划漂移检测",
+          "description": "每个 session 结束后判断项目 plan 是否需要更新并提出 proposal。用 agent 推理质量更高。"
+        },
+        "conflict_detector": {
+          "label": "跨层冲突检测",
+          "description": "每日扫描 facts/plan/goal/journal 之间的矛盾。模型越强，误报越少。"
+        },
+        "capture": {
+          "label": "Capture 引擎",
+          "description": "按触发器从 session transcript 抽取 fact。Agent 模式在长会话上 fact 质量明显更好；summarizer 模式便宜且本地。"
         }
       }
     },

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -461,6 +461,13 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		History:  captureHistoryAdapter,
 		CallLog:  summarizerStore,
 		Log:      log,
+		// M-PE — route the engine's default provider through the
+		// worker fabric so operators can switch capture between
+		// summarizer-HTTP and Agent (CLI --print) at runtime from
+		// /memory/workers. Rules that pin an explicit
+		// SummarizerProviderID still win (pre-M-PE behaviour).
+		WorkerProvider: memworker.NewSummarizerProvider(
+			memoryWorkerRegistry, memworker.TaskCapture),
 	})
 	if ceErr != nil {
 		st.Close()

--- a/internal/memory/capture/engine.go
+++ b/internal/memory/capture/engine.go
@@ -20,8 +20,9 @@ const DefaultTickInterval = 10 * time.Second
 // practical N for after_messages triggers.
 const DefaultHistoryLimit = 200
 
-// Deps groups the dependencies the engine wires together. All
-// required.
+// Deps groups the dependencies the engine wires together. Rules /
+// Registry / Memory / Sessions / History / CallLog are required;
+// the rest are optional with sensible defaults.
 type Deps struct {
 	Rules    *RuleStore
 	Registry *summarizer.Registry
@@ -34,6 +35,13 @@ type Deps struct {
 	TickInterval time.Duration
 	// HistoryLimit — 0 falls back to DefaultHistoryLimit.
 	HistoryLimit int
+	// WorkerProvider is the M-PE worker-fabric-backed default
+	// provider. Nil keeps the pre-M-PE behaviour
+	// (summarizer.Registry.Default() for rules with no pinned
+	// SummarizerProviderID). When non-nil, no-pinning rules
+	// dispatch through the worker fabric so operators can choose
+	// Agent (CLI --print) for capture from the Memory → Workers UI.
+	WorkerProvider summarizer.Provider
 }
 
 // Engine drives the ambient capture loop: every TickInterval, list
@@ -82,14 +90,15 @@ func NewEngine(deps Deps) (*Engine, error) {
 	}
 	state := newStateMap()
 	r := &runner{
-		rules:        deps.Rules,
-		registry:     deps.Registry,
-		memory:       deps.Memory,
-		history:      deps.History,
-		callLog:      deps.CallLog,
-		state:        state,
-		historyLimit: deps.HistoryLimit,
-		log:          deps.Log.With("component", "capture-runner"),
+		rules:          deps.Rules,
+		registry:       deps.Registry,
+		workerProvider: deps.WorkerProvider,
+		memory:         deps.Memory,
+		history:        deps.History,
+		callLog:        deps.CallLog,
+		state:          state,
+		historyLimit:   deps.HistoryLimit,
+		log:            deps.Log.With("component", "capture-runner"),
 	}
 	return &Engine{
 		deps:   deps,

--- a/internal/memory/capture/service.go
+++ b/internal/memory/capture/service.go
@@ -65,14 +65,22 @@ type SummarizerCallLogger interface {
 // Errors at step 3-5 don't abort the engine — they're logged into
 // the call log + bumped on the failure streak. Engine keeps ticking.
 type runner struct {
-	rules        *RuleStore
-	registry     *summarizer.Registry
-	memory       MemoryWriter
-	history      HistoryReader
-	callLog      SummarizerCallLogger
-	state        *stateMap
-	historyLimit int
-	log          *slog.Logger
+	rules    *RuleStore
+	registry *summarizer.Registry
+	// workerProvider is the M-PE worker-fabric-backed default. When
+	// non-nil and a rule doesn't pin SummarizerProviderID, the
+	// capture engine resolves its provider through the worker
+	// registry (so operators can pick Agent (CLI --print) for
+	// capture the same way they do for gitactivity / transcript /
+	// cleaner). Nil falls back to the pre-M-PE behaviour:
+	// summarizer.Registry.Default() returns an HTTP provider.
+	workerProvider summarizer.Provider
+	memory         MemoryWriter
+	history        HistoryReader
+	callLog        SummarizerCallLogger
+	state          *stateMap
+	historyLimit   int
+	log            *slog.Logger
 }
 
 // runForceForSession bypasses trigger evaluation and pause state,
@@ -258,11 +266,21 @@ func (r *runner) runForSessionWithForce(ctx context.Context, rule Rule, sess Ses
 }
 
 // pickProvider resolves the runtime provider:
-//  1. If rule pins SummarizerProviderID, build that.
-//  2. Else, registry.Default().
+//  1. If rule pins SummarizerProviderID, build that — explicit
+//     overrides win, so existing operator configurations don't
+//     change behaviour after M-PE.
+//  2. Else, if a worker-fabric provider is wired (M-PE default),
+//     dispatch through it. The worker registry decides
+//     summarizer-HTTP vs agent-CLI per task config.
+//  3. Else, fall back to summarizer.Registry.Default() — the
+//     pre-M-PE behaviour, preserved for installs that haven't
+//     wired the worker registry yet.
 func (r *runner) pickProvider(ctx context.Context, rule Rule) (summarizer.Provider, error) {
 	if rule.SummarizerProviderID != "" {
 		return r.registry.Build(ctx, rule.SummarizerProviderID)
+	}
+	if r.workerProvider != nil {
+		return r.workerProvider, nil
 	}
 	return r.registry.Default(ctx)
 }

--- a/internal/memory/worker/summarizer_adapter.go
+++ b/internal/memory/worker/summarizer_adapter.go
@@ -1,0 +1,177 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/opendray/opendray-v2/internal/memory/summarizer"
+)
+
+// summarizerAdapter wraps Registry so callers that expect a
+// summarizer.Provider (notably the capture engine) can transparently
+// route through the worker fabric. When the worker for `task` is
+// configured as kind=summarizer, behaviour is identical to calling
+// the underlying summarizer.Provider directly; when kind=agent,
+// the adapter assembles a textual prompt with the embedded JSON
+// schema and parses the model's response into []summarizer.Fact.
+type summarizerAdapter struct {
+	reg  *Registry
+	task TaskKind
+}
+
+// NewSummarizerProvider returns a summarizer.Provider that resolves
+// its backing implementation lazily from Registry on each call.
+// This means operators can change a task's worker (summarizer ⇄
+// agent) from the UI without restarting any subsystem.
+func NewSummarizerProvider(reg *Registry, task TaskKind) summarizer.Provider {
+	return &summarizerAdapter{reg: reg, task: task}
+}
+
+func (a *summarizerAdapter) Name() string {
+	return fmt.Sprintf("worker:%s", a.task)
+}
+func (a *summarizerAdapter) Kind() string {
+	return fmt.Sprintf("worker:%s", a.task)
+}
+
+// Available pokes the registry the same way Summarize would. We
+// don't fully resolve the agent / HTTP provider here — that would
+// add a hot-path roundtrip — just confirm a worker row exists.
+func (a *summarizerAdapter) Available(ctx context.Context) error {
+	if a.reg == nil {
+		return fmt.Errorf("%w: worker registry not wired", summarizer.ErrUnreachable)
+	}
+	if _, err := a.reg.WorkerFor(ctx, a.task); err != nil {
+		if errors.Is(err, ErrNoWorkerConfigured) {
+			return fmt.Errorf("%w: %v", summarizer.ErrUnreachable, err)
+		}
+		return err
+	}
+	return nil
+}
+
+// Summarize feeds the messages into the configured worker (either
+// HTTP summarizer or headless agent CLI), expecting a JSON envelope
+// matching summarizer.FactsToolJSONSchema. The 5 min timeout
+// matches the other worker.Run callers — agents need it; HTTP
+// summarizers usually finish in <10s.
+func (a *summarizerAdapter) Summarize(ctx context.Context, msgs []summarizer.Message) (summarizer.SummarizeResult, error) {
+	if a.reg == nil {
+		return summarizer.SummarizeResult{}, fmt.Errorf("%w: worker registry not wired", summarizer.ErrUnreachable)
+	}
+	if len(msgs) == 0 {
+		return summarizer.SummarizeResult{}, summarizer.ErrEmptyConversation
+	}
+
+	transcript := summarizer.MessagesToTranscriptText(msgs)
+	if strings.TrimSpace(transcript) == "" {
+		return summarizer.SummarizeResult{}, summarizer.ErrEmptyConversation
+	}
+
+	resp, err := a.reg.Run(ctx, Request{
+		Task:                     a.task,
+		SystemPrompt:             summarizer.SystemPrompt(),
+		UserInput:                transcript,
+		MaxTokens:                4096,
+		Timeout:                  5 * time.Minute,
+		ResponseFormatJSONSchema: capturePromptResponseSchema,
+	})
+	if err != nil {
+		if errors.Is(err, ErrNoWorkerConfigured) {
+			return summarizer.SummarizeResult{},
+				fmt.Errorf("%w: %v", summarizer.ErrUnreachable, err)
+		}
+		return summarizer.SummarizeResult{}, err
+	}
+
+	facts, parseErr := parseFactsJSON(resp.Content)
+	if parseErr != nil {
+		return summarizer.SummarizeResult{
+			RawResponse: truncate(resp.Content, 4096),
+		}, fmt.Errorf("%w: %v", summarizer.ErrInvalidResponse, parseErr)
+	}
+
+	return summarizer.SummarizeResult{
+		Facts:        facts,
+		InputTokens:  resp.TokensIn,
+		OutputTokens: resp.TokensOut,
+		Latency:      time.Duration(resp.DurationMS) * time.Millisecond,
+		RawResponse:  truncate(resp.Content, 4096),
+	}, nil
+}
+
+// capturePromptResponseSchema wraps the summarizer's existing
+// FactsToolJSONSchema in the response_format=json_schema envelope
+// our workers expect. Summarizer-mode workers translate it to
+// OpenAI-style response_format; agent-mode workers append the
+// schema instructions to the system prompt.
+var capturePromptResponseSchema = func() string {
+	return `{
+  "name": "capture_facts",
+  "schema": ` + summarizer.FactsToolJSONSchema + `,
+  "strict": true
+}`
+}()
+
+// parseFactsJSON tolerates the same response-shape variations as
+// projectdoc's drift parser: clean JSON, ```fenced``` blocks,
+// leading or trailing prose. Returns ErrInvalidResponse when no
+// JSON object can be located OR when the object doesn't contain a
+// "facts" array.
+func parseFactsJSON(raw string) ([]summarizer.Fact, error) {
+	body := strings.TrimSpace(raw)
+	if body == "" {
+		return nil, fmt.Errorf("empty response")
+	}
+	if fenced := stripJSONFence(body); fenced != "" {
+		body = fenced
+	}
+	if i := strings.IndexByte(body, '{'); i >= 0 {
+		if j := strings.LastIndexByte(body, '}'); j > i {
+			body = body[i : j+1]
+		}
+	}
+	var wrapper struct {
+		Facts []struct {
+			Text       string  `json:"text"`
+			Category   string  `json:"category"`
+			Confidence float32 `json:"confidence"`
+		} `json:"facts"`
+	}
+	if err := json.Unmarshal([]byte(body), &wrapper); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	out := make([]summarizer.Fact, 0, len(wrapper.Facts))
+	for _, f := range wrapper.Facts {
+		text := strings.TrimSpace(f.Text)
+		if text == "" {
+			continue
+		}
+		out = append(out, summarizer.Fact{
+			Text:       text,
+			Category:   summarizer.Category(f.Category),
+			Confidence: f.Confidence,
+		})
+	}
+	return out, nil
+}
+
+func stripJSONFence(s string) string {
+	const fence = "```"
+	i := strings.Index(s, fence)
+	if i < 0 {
+		return ""
+	}
+	rest := s[i+len(fence):]
+	rest = strings.TrimPrefix(rest, "json")
+	rest = strings.TrimLeft(rest, " \t\r\n")
+	j := strings.Index(rest, fence)
+	if j < 0 {
+		return strings.TrimSpace(rest)
+	}
+	return strings.TrimSpace(rest[:j])
+}

--- a/internal/memory/worker/summarizer_adapter_test.go
+++ b/internal/memory/worker/summarizer_adapter_test.go
@@ -1,0 +1,96 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/opendray/opendray-v2/internal/memory/summarizer"
+)
+
+func TestParseFactsJSON_Clean(t *testing.T) {
+	raw := `{"facts":[{"text":"User prefers pnpm","category":"preference","confidence":0.9}]}`
+	got, err := parseFactsJSON(raw)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 1 || got[0].Text != "User prefers pnpm" ||
+		got[0].Category != summarizer.CategoryPreference || got[0].Confidence != 0.9 {
+		t.Errorf("unexpected: %+v", got)
+	}
+}
+
+func TestParseFactsJSON_Fenced(t *testing.T) {
+	raw := "```json\n{\"facts\":[]}\n```"
+	got, err := parseFactsJSON(raw)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %d", len(got))
+	}
+}
+
+func TestParseFactsJSON_PreambleAndTrailingProse(t *testing.T) {
+	raw := `Sure, here you go:
+{"facts":[{"text":"DB host db.example.com","category":"identifier","confidence":0.95}]}
+— end of output`
+	got, err := parseFactsJSON(raw)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 1 || got[0].Category != summarizer.CategoryIdentifier {
+		t.Errorf("unexpected: %+v", got)
+	}
+}
+
+func TestParseFactsJSON_EmptyTextEntriesSkipped(t *testing.T) {
+	raw := `{"facts":[
+    {"text":"keep","category":"other","confidence":0.5},
+    {"text":"   ","category":"other","confidence":0.4}
+  ]}`
+	got, err := parseFactsJSON(raw)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 1 || got[0].Text != "keep" {
+		t.Errorf("unexpected: %+v", got)
+	}
+}
+
+func TestParseFactsJSON_Garbage(t *testing.T) {
+	if _, err := parseFactsJSON("not json"); err == nil {
+		t.Error("expected error for garbage input")
+	}
+	if _, err := parseFactsJSON(""); err == nil {
+		t.Error("expected error for empty input")
+	}
+}
+
+func TestStripJSONFence(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no fence", "{}", ""},
+		{"json-tagged", "```json\n{\"x\":1}\n```", `{"x":1}`},
+		{"untagged", "```\n{\"x\":1}\n```", `{"x":1}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripJSONFence(tc.in)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSummarizerAdapter_NameAndKind(t *testing.T) {
+	a := NewSummarizerProvider(nil, TaskCapture)
+	if name := a.Name(); name != "worker:capture" {
+		t.Errorf("Name: got %q", name)
+	}
+	if kind := a.Kind(); kind != "worker:capture" {
+		t.Errorf("Kind: got %q", kind)
+	}
+}

--- a/internal/memory/worker/worker.go
+++ b/internal/memory/worker/worker.go
@@ -48,6 +48,13 @@ const (
 	TaskTranscript       TaskKind = "transcript"
 	TaskPlanDrift        TaskKind = "plan_drift"
 	TaskConflictDetector TaskKind = "conflict_detector"
+	// TaskCapture is the capture-engine touchpoint. Pre-M-PE the
+	// capture engine talked to summarizer.Registry directly so it
+	// could only use HTTP summarizer providers. Routing through
+	// worker.Registry lets operators pick a headless Claude /
+	// Gemini agent for capture (higher quality but slower and
+	// more expensive), matching the other 5 touchpoints.
+	TaskCapture TaskKind = "capture"
 )
 
 // AllTasks returns every recognised TaskKind in a stable order.
@@ -56,7 +63,7 @@ const (
 func AllTasks() []TaskKind {
 	return []TaskKind{
 		TaskGatekeeper, TaskCleaner, TaskGitActivity, TaskTranscript,
-		TaskPlanDrift, TaskConflictDetector,
+		TaskPlanDrift, TaskConflictDetector, TaskCapture,
 	}
 }
 
@@ -165,7 +172,7 @@ type Config struct {
 func (c Config) Valid() error {
 	switch c.Task {
 	case TaskGatekeeper, TaskCleaner, TaskGitActivity, TaskTranscript,
-		TaskPlanDrift, TaskConflictDetector:
+		TaskPlanDrift, TaskConflictDetector, TaskCapture:
 	default:
 		return errors.New("memory worker: invalid task")
 	}

--- a/internal/store/migrations/0033_memory_workers_capture.sql
+++ b/internal/store/migrations/0033_memory_workers_capture.sql
@@ -1,0 +1,27 @@
+-- M-PE — Add capture to the memory_workers task catalogue.
+--
+-- Pre M-PE the capture engine talked to summarizer.Registry
+-- directly, so operators could only point it at HTTP summarizer
+-- endpoints (Ollama / LM Studio / Anthropic / OpenAI / Integration).
+-- The other five touchpoints (gatekeeper / cleaner / gitactivity /
+-- transcript / plan_drift / conflict_detector) had already gone
+-- through the worker fabric, giving them the choice of Agent (CLI
+-- --print) for higher-quality Claude / Gemini runs.
+--
+-- This migration lets operators pick the same Agent mode for
+-- capture. The default seed stays kind='summarizer' so existing
+-- deployments behave identically until an operator flips it.
+
+ALTER TABLE memory_workers
+    DROP CONSTRAINT IF EXISTS memory_workers_task_check;
+
+ALTER TABLE memory_workers
+    ADD CONSTRAINT memory_workers_task_check
+        CHECK (task IN (
+            'gatekeeper','cleaner','gitactivity','transcript',
+            'plan_drift','conflict_detector','capture'
+        ));
+
+INSERT INTO memory_workers (task, kind) VALUES
+    ('capture', 'summarizer')
+ON CONFLICT (task) DO NOTHING;


### PR DESCRIPTION
## Summary

Pre-M-PE the capture engine talked to \`summarizer.Registry\` directly — it could only use HTTP summarizer providers (Ollama / LM Studio / Anthropic / OpenAI / Integration). The other six memory touchpoints (gatekeeper / cleaner / gitactivity / transcript / plan_drift / conflict_detector) had already moved to the worker fabric in PRs #128–#130, giving them the choice of Agent (CLI \`--print\`) mode for headless Claude / Gemini runs.

Operators on machines that can't run a local model — or those who want higher-quality fact extraction from cloud agents — had no path to use Claude or Gemini for capture. This PR closes that gap.

## What changed

| File | Change |
|---|---|
| \`internal/memory/worker/worker.go\` | New \`TaskCapture\` (7th TaskKind); AllTasks + Config.Valid updated |
| \`internal/store/migrations/0033_memory_workers_capture.sql\` | Widens task CHECK to include 'capture'; seeds row with kind='summarizer' so existing installs behave identically |
| \`internal/memory/worker/summarizer_adapter.go\` (new) | Wraps \`Registry\` behind \`summarizer.Provider\` so capture's runner doesn't care which route operator picked; \`Summarize()\` builds the user prompt, calls \`worker.Run\` with \`FactsToolJSONSchema\` as \`response_format\`, parses model's JSON back into \`[]summarizer.Fact\` (tolerates fenced blocks + preamble) |
| \`internal/memory/capture/engine.go\` | \`Deps\` gains optional \`WorkerProvider\`; when set, no-pin rules dispatch through it |
| \`internal/memory/capture/service.go\` | \`pickProvider\` falls through worker provider before the legacy \`summarizer.Registry.Default()\`; rule-pinned \`SummarizerProviderID\` still wins |
| \`internal/app/app.go\` | Passes \`memworker.NewSummarizerProvider(memoryWorkerRegistry, memworker.TaskCapture)\` as \`Deps.WorkerProvider\` |
| \`app/i18n/{en,zh}.json\` | New \`memoryWorkers.tasks.capture.*\` entries + back-fills missing \`plan_drift\` + \`conflict_detector\` labels from Phase A/C |

## Failure modes deliberately tolerated

- Memory → Workers UI auto-shows the 7th card after migration runs (frontend iterates whatever API returns; no UI code change needed)
- Rule pins \`SummarizerProviderID\` → legacy path: explicit override always wins
- WorkerProvider not wired (older deploys) → \`pickProvider\` falls back to \`summarizer.Registry.Default()\`, the pre-M-PE behaviour
- Agent worker returns malformed JSON → wrapped as \`summarizer.ErrInvalidResponse\` with truncated raw response in the call log for debugging
- \`memory_workers.capture\` row missing (migration didn't run) → adapter returns \`summarizer.ErrUnreachable\`; capture engine logs and moves on

## Test plan

- [x] \`go test -race ./...\` green
- [x] \`pnpm tsc --noEmit\` green
- [x] \`gofmt -l ./...\` clean
- [x] Unit tests for \`parseFactsJSON\` (clean / fenced / preamble+trailing / empty-text filter / garbage rejected) and \`stripJSONFence\`
- [x] i18n JSON parses (en + zh)
- [ ] Manual: \`./opendray migrate -config config.toml\` applies 0033; \`SELECT count(*) FROM memory_workers\` returns 7
- [ ] Manual: Memory → Workers shows new 'capture' card with summarizer/agent dropdown
- [ ] Manual: switch capture to Agent (CLI --print) with Claude / kev account; spawn a session, run a capture rule, verify facts land in \`memories\` table tagged with source

## Operator notes

After merge + deploy:

1. \`./opendray migrate -config config.toml\` to apply 0033 (without this, the new TaskCapture lookup will return ErrNoWorkerConfigured and capture will degrade silently to no-op)
2. **Memory → Workers** page should show 7 cards; the new \`Capture engine\` card defaults to summarizer mode (your existing LM Studio / Ollama / etc.)
3. Flip it to \`Agent (CLI --print)\` if you want Claude/Gemini to do the fact extraction; pick a Claude account from the dropdown
4. Capture rules with no pinned \`summarizer_provider_id\` now follow the worker setting; rules with an explicit pin still use that provider