### PR TITLE
feat(memory-ui): unify memory configuration into one page

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -295,6 +295,29 @@
       "daysAgo_one": "{count} day ago",
       "daysAgo_other": "{count} days ago"
     },
+    "memoryConfig": {
+      "title": "Memory configuration",
+      "subtitle": "All memory-related knobs in one place: HTTP providers, per-task worker routing, capture triggers, spawn-time injection, and audit costs.",
+      "sections": {
+        "providers": "Providers",
+        "workers": "Workers",
+        "rules": "Capture rules",
+        "profiles": "Injection profiles",
+        "costs": "Token cost"
+      },
+      "sectionHints": {
+        "providers": "Registered HTTP endpoints (Ollama / LM Studio / Anthropic / OpenAI / Integration) that any task can dispatch to.",
+        "workers": "For each touchpoint pick HTTP provider (cheap, local) or headless Claude / Gemini Agent (higher quality, costs CLI tokens).",
+        "rules": "When the capture engine fires per session (after N messages / on idle / K characters / manual). Rules without a pinned provider follow the Capture worker setting above.",
+        "profiles": "How prior memories get injected into the agent's system prompt at session spawn (recency, relevance, hybrid, or off).",
+        "costs": "Aggregate spend reconstructed from memory_summarizer_calls. Local providers (Ollama, LM Studio, Integration) are free; cloud providers show real-world cost."
+      },
+      "moveBanner": {
+        "title": "Memory configuration has moved",
+        "body": "All memory-related settings (providers / capture rules / injection profiles / cost) now live alongside Workers in one page so related knobs sit together.",
+        "openButton": "Open Memory configuration →"
+      }
+    },
     "memoryWorkers": {
       "title": "Memory workers",
       "loading": "Loading worker config…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -295,6 +295,29 @@
       "daysAgo_one": "{count} 天前",
       "daysAgo_other": "{count} 天前"
     },
+    "memoryConfig": {
+      "title": "记忆配置",
+      "subtitle": "所有记忆相关开关汇总到这里：HTTP provider、每个任务的路由、capture 触发器、spawn 时注入策略、累计花费。",
+      "sections": {
+        "providers": "Provider 池",
+        "workers": "任务路由 (Workers)",
+        "rules": "Capture 规则",
+        "profiles": "注入策略 (Injection profiles)",
+        "costs": "Token 成本"
+      },
+      "sectionHints": {
+        "providers": "已注册的 HTTP endpoint 池 (Ollama / LM Studio / Anthropic / OpenAI / Integration)，所有任务都能引用。",
+        "workers": "每个 task 选用 HTTP provider（便宜、本地）或 headless Claude / Gemini Agent（质量更高，消耗 CLI 配额）。",
+        "rules": "Capture 引擎何时触发（每 N 条消息 / 闲置 / 累计 K 字符 / 手动）。规则若没固定 provider，会跟随上面 Capture 任务的 worker 设置。",
+        "profiles": "Session 启动时把哪些历史记忆塞进 agent system prompt（按最近、按相关度、混合、关闭）。",
+        "costs": "memory_summarizer_calls 重算的累计花费。本地 provider（Ollama / LM Studio / Integration）免费；云 provider 显示真实成本。"
+      },
+      "moveBanner": {
+        "title": "记忆配置已迁移",
+        "body": "所有记忆相关设置（providers / capture rules / injection profiles / cost）现在跟 Workers 在同一页面，相关开关聚在一起。",
+        "openButton": "打开 记忆配置 →"
+      }
+    },
     "memoryWorkers": {
       "title": "Memory workers",
       "loading": "正在加载 worker 配置…",

--- a/app/web/src/components/settings/MemoryAmbientSection.tsx
+++ b/app/web/src/components/settings/MemoryAmbientSection.tsx
@@ -89,7 +89,7 @@ function SectionHeader() {
 
 // ── providers ────────────────────────────────────────────────────
 
-function ProvidersBlock() {
+export function ProvidersBlock() {
   const { t } = useTranslation()
   const qc = useQueryClient()
   const [open, setOpen] = useState(false)
@@ -395,7 +395,7 @@ function NewProviderDialog({ onCreated }: { onCreated: () => void }) {
 
 // ── capture rules ────────────────────────────────────────────────
 
-function RulesBlock() {
+export function RulesBlock() {
   const { t } = useTranslation()
   const qc = useQueryClient()
   const [open, setOpen] = useState(false)
@@ -674,7 +674,7 @@ function NewRuleDialog({ onCreated }: { onCreated: () => void }) {
 
 // ── injection profiles ───────────────────────────────────────────
 
-function ProfilesBlock() {
+export function ProfilesBlock() {
   const { t } = useTranslation()
   const qc = useQueryClient()
   const [open, setOpen] = useState(false)
@@ -851,7 +851,7 @@ function NewProfileDialog({ onCreated }: { onCreated: () => void }) {
 
 // ── token cost panel ─────────────────────────────────────────────
 
-function CostBlock() {
+export function CostBlock() {
   const { t } = useTranslation()
   const { data: providers } = useQuery({
     queryKey: ['memory-summarizer-providers'],

--- a/app/web/src/components/settings/ServerSettings.tsx
+++ b/app/web/src/components/settings/ServerSettings.tsx
@@ -48,7 +48,6 @@ import {
 import { TargetEditor, targetSummary } from '@/components/backup/TargetEditor'
 
 import { LogViewer } from './LogViewer'
-import { MemoryAmbientSection } from './MemoryAmbientSection'
 import { PathInput } from './PathInput'
 
 // SECTIONS describe every server-settings panel rendered to the right
@@ -932,7 +931,29 @@ function SectionForm({
       )
 
     case 'memory-ambient':
-      return <MemoryAmbientSection />
+      // M-PF — the four sub-sections that used to live here
+      // (providers / rules / profiles / costs) have moved to the
+      // unified /memory/workers page so operators don't have to
+      // hunt for related toggles in two places. We keep this slot
+      // alive as a redirect banner so existing bookmarks still
+      // land somewhere sensible.
+      return (
+        <div className="flex flex-col gap-3 rounded-md border border-border bg-card/30 p-4 text-[13px]">
+          <div className="font-medium">
+            {t('web.memoryConfig.moveBanner.title')}
+          </div>
+          <p className="text-muted-foreground text-[12px]">
+            {t('web.memoryConfig.moveBanner.body')}
+          </p>
+          <div>
+            <Button asChild variant="outline" size="sm" className="h-8 text-[11px]">
+              <Link to="/memory/workers">
+                {t('web.memoryConfig.moveBanner.openButton')}
+              </Link>
+            </Button>
+          </div>
+        </div>
+      )
 
     case 'backup':
       return <BackupSection draft={draft} setDraft={setDraft} visible={visible} />

--- a/app/web/src/pages/MemoryWorkers.tsx
+++ b/app/web/src/pages/MemoryWorkers.tsx
@@ -1,9 +1,17 @@
-// /memory/workers — M25 per-task worker settings.
+// /memory/workers — unified Memory configuration page.
 //
-// Surfaces the four memory-system LLM touchpoints (gatekeeper,
-// cleaner, gitactivity, transcript) as a configurable list:
-// each row picks summarizer vs agent + the underlying provider,
-// runs a connectivity test, and shows recent invocation latency.
+// Originally just per-task worker settings (M25); M-PF reworks
+// this into a single landing for every memory-related knob so
+// operators stop hunting between Settings → Memory.Ambient and
+// /memory/workers for related toggles:
+//
+//   1. Providers     — HTTP endpoint registry (was Settings)
+//   2. Workers       — per-task summarizer/agent routing (original)
+//   3. Capture rules — trigger config (was Settings)
+//   4. Injection     — spawn-time strategy (was Settings)
+//   5. Token cost    — all-time call audit (was Settings)
+//
+// Settings → Memory.Ambient becomes a thin redirect banner.
 
 import { useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
@@ -42,6 +50,12 @@ import {
 } from '@/lib/memoryWorkers'
 import { listProviders as listSummarizerProviders } from '@/lib/memoryAmbient'
 import { listClaudeAccounts } from '@/lib/claudeAccounts'
+import {
+  CostBlock,
+  ProfilesBlock,
+  ProvidersBlock,
+  RulesBlock,
+} from '@/components/settings/MemoryAmbientSection'
 
 function useTaskLabels() {
   const { t } = useTranslation()
@@ -110,31 +124,107 @@ export function MemoryWorkersPage() {
   }
 
   return (
-    <div className="mx-auto max-w-3xl space-y-6 p-6">
+    <div className="mx-auto max-w-3xl space-y-10 p-6">
       <header>
         <h1 className="text-xl font-semibold">
-          {t('web.memoryWorkers.title')}
+          {t('web.memoryConfig.title')}
         </h1>
         <p className="text-muted-foreground mt-1 text-sm">
+          {t('web.memoryConfig.subtitle')}
+        </p>
+      </header>
+
+      {/* § 1. Providers — HTTP endpoint registry consumed by both
+          Workers and (legacy) Capture rule pins. */}
+      <section className="space-y-3">
+        <SectionTitle
+          step={1}
+          title={t('web.memoryConfig.sections.providers')}
+          hint={t('web.memoryConfig.sectionHints.providers')}
+        />
+        <ProvidersBlock />
+      </section>
+
+      {/* § 2. Workers — per-task routing decisions (summarizer
+          provider vs headless Claude/Gemini agent). */}
+      <section className="space-y-3">
+        <SectionTitle
+          step={2}
+          title={t('web.memoryConfig.sections.workers')}
+          hint={t('web.memoryConfig.sectionHints.workers')}
+        />
+        <p className="text-muted-foreground text-sm">
           <Trans
             i18nKey="web.memoryWorkers.intro"
             components={{ 1: <strong />, 3: <strong />, 5: <code /> }}
           />
         </p>
-      </header>
+        <div className="space-y-4">
+          {(workersQuery.data ?? []).map((w) => (
+            <WorkerCard
+              key={w.task}
+              config={w}
+              summarizers={summarizersQuery.data ?? []}
+              accounts={accountsQuery.data ?? []}
+              calls={(callsQuery.data ?? []).filter((c) => c.task === w.task)}
+              onSaved={refresh}
+            />
+          ))}
+        </div>
+      </section>
 
-      <div className="space-y-4">
-        {(workersQuery.data ?? []).map((w) => (
-          <WorkerCard
-            key={w.task}
-            config={w}
-            summarizers={summarizersQuery.data ?? []}
-            accounts={accountsQuery.data ?? []}
-            calls={(callsQuery.data ?? []).filter((c) => c.task === w.task)}
-            onSaved={refresh}
-          />
-        ))}
-      </div>
+      {/* § 3. Capture rules — when/how the capture engine fires. */}
+      <section className="space-y-3">
+        <SectionTitle
+          step={3}
+          title={t('web.memoryConfig.sections.rules')}
+          hint={t('web.memoryConfig.sectionHints.rules')}
+        />
+        <RulesBlock />
+      </section>
+
+      {/* § 4. Injection profiles — spawn-time memory banner
+          strategy (top_k_recent / relevant / hybrid / none). */}
+      <section className="space-y-3">
+        <SectionTitle
+          step={4}
+          title={t('web.memoryConfig.sections.profiles')}
+          hint={t('web.memoryConfig.sectionHints.profiles')}
+        />
+        <ProfilesBlock />
+      </section>
+
+      {/* § 5. Token cost — all-time audit summary across providers. */}
+      <section className="space-y-3">
+        <SectionTitle
+          step={5}
+          title={t('web.memoryConfig.sections.costs')}
+          hint={t('web.memoryConfig.sectionHints.costs')}
+        />
+        <CostBlock />
+      </section>
+    </div>
+  )
+}
+
+function SectionTitle({
+  step,
+  title,
+  hint,
+}: {
+  step: number
+  title: string
+  hint: string
+}) {
+  return (
+    <div className="border-border border-b pb-2">
+      <h2 className="text-base font-semibold">
+        <span className="text-muted-foreground mr-2 font-mono text-[12px]">
+          §{step}
+        </span>
+        {title}
+      </h2>
+      <p className="text-muted-foreground mt-0.5 text-[12px]">{hint}</p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

The same memory knobs were spread across two pages:

| Settings → Memory.Ambient | Memory → Workers |
|---|---|
| Providers (HTTP pool) | Per-task routing |
| Capture rules | — |
| Injection profiles | — |
| Token cost | — |

After PR #134 (capture via worker fabric), this got actively confusing: a capture rule could pin a summarizer provider (legacy) OR follow the Workers → Capture setting, with no UI hint which one won.

This patch promotes \`/memory/workers\` into a single **Memory configuration** landing with five numbered sections, in the order operators reach for them:

- §1 Providers — HTTP endpoint registry
- §2 Workers — per-task summarizer/agent routing
- §3 Capture rules — trigger config
- §4 Injection profiles — spawn-time strategy
- §5 Token cost — all-time audit

Settings → Memory.Ambient becomes a redirect banner so bookmarks still land somewhere sensible.

## What changed

| File | Change |
|---|---|
| \`MemoryAmbientSection.tsx\` | Export 4 sub-blocks (\`ProvidersBlock\` / \`RulesBlock\` / \`ProfilesBlock\` / \`CostBlock\`) — they were already self-contained internal functions; no logic change |
| \`MemoryWorkers.tsx\` | Re-laid out as 5 numbered sections; existing per-task \`WorkerCard\` grid stays as §2 |
| \`ServerSettings.tsx\` | Replaces in-place section render with a "moved" card linking to \`/memory/workers\` |
| \`app/i18n/{en,zh}.json\` | New \`web.memoryConfig.*\` group (page title, 5 section titles + hints, redirect banner) in en + zh |

## Failure modes deliberately tolerated

- URL stays \`/memory/workers\` so external bookmarks + the existing \`/memory\` landing nav button keep working
- Existing \`memoryAmbient.*\` / \`memoryWorkers.*\` i18n keys stay untouched — the four block components render identically
- Capture rule's legacy \`summarizer_provider_id\` pin field is kept (still useful as an override); we didn't hide it behind "Advanced" in this PR to keep diff scope tight — can layer that on later if pain remains

## Test plan

- [x] \`pnpm tsc --noEmit\` green
- [x] VS Code diagnostics empty on all three touched files
- [x] JSON parses (en + zh)
- [ ] Manual: open \`/memory/workers\` — see 5 numbered sections, original Workers grid intact under §2
- [ ] Manual: open Settings → Memory.Ambient — see redirect card; click button → lands on \`/memory/workers\`
- [ ] Manual: switch language en ↔ zh — all 5 section titles + hints render correctly in both