### PR TITLE
chore(memory-ui): remove empty Settings → Memory.Ambient + refresh tutorials

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1677,7 +1677,6 @@
         "vault": { "title": "Vault", "desc": "Notes, skills, and git-versioned root." },
         "mcp": { "title": "MCP registry", "desc": "Server registry + secrets." },
         "memory": { "title": "Memory", "desc": "Cross-CLI persistent memory subsystem." },
-        "memoryAmbient": { "title": "Memory · Ambient", "desc": "Auto-capture conversations into memory + spawn-time injection." },
         "backup": { "title": "Backup", "desc": "Encrypted DB backups, restore, and admin data exports." },
         "claude": { "title": "Storage · Claude", "desc": "Where Claude transcripts live on disk." },
         "codex": { "title": "Storage · Codex", "desc": "Codex sessions root." },

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -1677,7 +1677,6 @@
         "vault": { "title": "Vault", "desc": "笔记、技能与 git 版本化根目录。" },
         "mcp": { "title": "MCP 注册表", "desc": "服务器注册表与密钥。" },
         "memory": { "title": "记忆", "desc": "跨 CLI 的持久化记忆子系统。" },
-        "memoryAmbient": { "title": "记忆 · 环境感知", "desc": "自动捕获对话进入记忆，并在 spawn 时注入。" },
         "backup": { "title": "备份", "desc": "加密数据库备份、恢复，以及管理员数据导出。" },
         "claude": { "title": "存储 · Claude", "desc": "Claude 会话记录在磁盘上的位置。" },
         "codex": { "title": "存储 · Codex", "desc": "Codex 会话根目录。" },

--- a/app/web/src/components/settings/ServerSettings.tsx
+++ b/app/web/src/components/settings/ServerSettings.tsx
@@ -60,7 +60,6 @@ export const SERVER_SECTIONS = [
   { id: 'vault' },
   { id: 'mcp' },
   { id: 'memory' },
-  { id: 'memory-ambient' },
   { id: 'backup' },
   { id: 'claude' },
   { id: 'codex' },
@@ -70,8 +69,10 @@ export const SERVER_SECTIONS = [
 export type ServerSectionId = (typeof SERVER_SECTIONS)[number]['id']
 
 // Map kebab-cased section id to the i18n key segment (camelCase).
+// Currently a no-op; kept around so we don't have to refactor call
+// sites if a future section reintroduces hyphenation.
 function sectionI18nKey(id: ServerSectionId): string {
-  return id === 'memory-ambient' ? 'memoryAmbient' : id
+  return id
 }
 
 // useServerSectionLabel returns translated title + desc for a section id.
@@ -93,7 +94,6 @@ const RESTART_REQUIRED_SECTIONS: Record<ServerSectionId, boolean> = {
   vault: true,
   mcp: true,
   memory: true, // backend / store wiring is read once at app.New
-  'memory-ambient': false, // CRUD via REST; no toml binding to restart
   backup: true, // pg_dump path + cipher are bound at NewService
   claude: false, // history paths are read on each request, no restart needed
   codex: false,
@@ -930,31 +930,6 @@ function SectionForm({
         </div>
       )
 
-    case 'memory-ambient':
-      // M-PF — the four sub-sections that used to live here
-      // (providers / rules / profiles / costs) have moved to the
-      // unified /memory/workers page so operators don't have to
-      // hunt for related toggles in two places. We keep this slot
-      // alive as a redirect banner so existing bookmarks still
-      // land somewhere sensible.
-      return (
-        <div className="flex flex-col gap-3 rounded-md border border-border bg-card/30 p-4 text-[13px]">
-          <div className="font-medium">
-            {t('web.memoryConfig.moveBanner.title')}
-          </div>
-          <p className="text-muted-foreground text-[12px]">
-            {t('web.memoryConfig.moveBanner.body')}
-          </p>
-          <div>
-            <Button asChild variant="outline" size="sm" className="h-8 text-[11px]">
-              <Link to="/memory/workers">
-                {t('web.memoryConfig.moveBanner.openButton')}
-              </Link>
-            </Button>
-          </div>
-        </div>
-      )
-
     case 'backup':
       return <BackupSection draft={draft} setDraft={setDraft} visible={visible} />
 
@@ -1325,10 +1300,6 @@ function mergeSection(
       break
     case 'memory':
       out.memory = src.memory
-      break
-    case 'memory-ambient':
-      // ambient memory has no toml-mergeable state — all CRUD goes
-      // through dedicated REST endpoints (/memory-summarizer-providers etc.)
       break
     case 'backup':
       out.backup = src.backup

--- a/app/web/src/tutorial/sections/13-ambient-memory/01-overview.md
+++ b/app/web/src/tutorial/sections/13-ambient-memory/01-overview.md
@@ -28,20 +28,24 @@ injection profile).
     summarizer/           capture/                  injector/
 ```
 
-- **Provider** — which LLM extracts facts. v1 supports Anthropic,
-  OpenAI, LM Studio, Ollama, and a passthrough Integration kind
-  that lets ANY service speaking the documented `/summarize`
-  protocol act as a summarizer (zero-API-cost path).
-- **Capture rule** — when to fire. v1 ships 4 trigger kinds:
-  `after_messages`, `on_idle`, `k_chars`, `manual`.
+- **Provider** — which LLM extracts facts. Today supports Anthropic,
+  OpenAI, LM Studio, Ollama, a passthrough Integration kind (any
+  service speaking the documented `/summarize` protocol works
+  as a summarizer — zero-API-cost path), **and** the M-PE Agent
+  route which spawns a headless `claude --print` / `gemini --print`
+  for higher-quality fact extraction at the cost of CLI quota.
+- **Capture rule** — when to fire. 4 trigger kinds: `after_messages`,
+  `on_idle`, `k_chars`, `manual`.
 - **Injection profile** — how (or whether) to prepend memories to
   the agent's system prompt at spawn. 5 strategies:
   `none`, `top_k_recent`, `top_k_relevant`, `manual_only`, `hybrid`
-  (plus `on_keyword` reserved for v1.1).
+  (plus `on_keyword` reserved for a future release).
 
-Configure all three under
-**Settings → Memory · Ambient**. Per-session overrides live in the
-DB but currently UI manages the global default.
+Configure all three under **Memory → Workers** (sidebar) — that
+page, formerly just "Workers", was rebuilt as the single Memory
+configuration landing in M-PF and now hosts Providers / Workers /
+Capture rules / Injection profiles / Token cost together so related
+knobs sit next to each other instead of split across two pages.
 
 ## What you DON'T need
 

--- a/app/web/src/tutorial/sections/14-project-memory/01-overview.md
+++ b/app/web/src/tutorial/sections/14-project-memory/01-overview.md
@@ -58,6 +58,26 @@ goal once via the Project → Goal tab; the next **Codex** spawn in
 the same cwd quotes it back to you on demand. This is the whole
 point of unified memory — no manual re-explanation per CLI switch.
 
+## Tabs you'll see on the Project page
+
+Beyond the 5 layers above, the Project page (`/memory/project`)
+shows three operator-facing inboxes that landed in Phase A-D:
+
+- **Health** *(Phase A)* — first tab. Aggregate signals across
+  both memory subsystems (new facts / journal entries this week,
+  capture engine fires, plan/goal age, pending proposals, top-hit
+  fact, zero-hit stale-fact count).
+- **Inbox** — agent-proposed goal/plan edits awaiting your
+  approval (file via the `project_goal_set` / `project_plan_set`
+  MCP tools).
+- **Conflicts** *(Phase C/D)* — cross-layer contradiction detector
+  inbox. Each row shows two conflicting claims + LLM evidence +
+  Accept / Dismiss buttons. Phase D added per-side "Delete A / B"
+  quick-actions with a preview-and-confirm dialog so you see the
+  full fact text before pulling the trigger.
+- **Cleanup** — LLM librarian's keep / stale / duplicate queue
+  for layer-5 facts (covered in section 11).
+
 ## Where to next
 
 - **02 — Day-to-day workflow** walks you through setting goal/plan,

--- a/app/web/src/tutorial/sections/15-memory-workers/01-overview.md
+++ b/app/web/src/tutorial/sections/15-memory-workers/01-overview.md
@@ -1,9 +1,10 @@
 # Memory workers — overview
 
-M25 lets you pick **which LLM** powers each of opendray's four
+M25 lets you pick **which LLM** powers each of opendray's
 memory-system touchpoints — independently per touchpoint.
 
-The four touchpoints — refresher from section 14:
+The touchpoints (originally 4 in M25; grown to 7 across Phase A /
+C / E):
 
 | Touchpoint | Fires | What it does |
 |---|---|---|
@@ -11,6 +12,9 @@ The four touchpoints — refresher from section 14:
 | **Cleaner** | every 24h | LLM librarian — proposes keep/stale/duplicate verdicts on aged memories. |
 | **Git activity** | every 24h | Turns 7 days of `git log` into a 2-3 paragraph narrative for the spawn banner. |
 | **Transcript** | every session end | "What did the agent actually do this session" — 1-3 paragraph summary. |
+| **Plan drift** *(Phase A)* | every session end | Looks at the new transcript summary + current plan; files a proposal if plan needs updating. |
+| **Conflict detector** *(Phase C)* | every 24h | Cross-layer sweep — surfaces contradictions between facts / plan / goal / journal. |
+| **Capture engine** *(Phase E)* | per capture-rule trigger | Per-trigger fact extraction from session transcripts; lands rows in `memories`. |
 
 ## Two worker types
 
@@ -19,13 +23,13 @@ The four touchpoints — refresher from section 14:
 | **Summarizer** | HTTP POST to your local LM Studio / OpenAI-compat endpoint | ~0.5-2s | free (local) | medium (3-13B) |
 | **Agent** | Spawns `claude --print` or `gemini --print` headlessly | ~5-15s | Claude/Gemini quota | frontier-model |
 
-Default deployments seed all four touchpoints to **summarizer**.
+Default deployments seed every touchpoint to **summarizer**.
 Nothing changes until you flip a row.
 
 ## Why per-touchpoint config
 
-The four touchpoints have very different profiles. One global
-switch would force a bad compromise:
+The touchpoints have very different profiles. One global switch
+would force a bad compromise:
 
 - Gatekeeper runs hundreds of times a day. Even +5s/call makes
   `memory_store` feel broken. ⇒ summarizer only.
@@ -33,10 +37,13 @@ switch would force a bad compromise:
   and produces a banner every agent reads. Claude Opus here pays
   back the cost in better agent priming. ⇒ agent (Claude) makes
   sense.
-- Cleaner is somewhere in between — 24h batch but you'd run it
-  manually sometimes. Either works.
-- Transcript runs after every session end (could be many per day).
-  Latency is OK (background) but cost adds up.
+- Cleaner / Conflict detector are somewhere in between — 24h batch
+  but you'd run them manually sometimes. Either works.
+- Transcript / Plan drift run after every session end (could be
+  many per day). Latency is OK (background) but cost adds up.
+- Capture engine fires multiple times per session if you set a
+  short trigger (every 6 messages). Agent mode here gives the
+  best fact quality if your CLI quota allows it.
 
 The config table lets you pick per row, with per-row metrics so
 you can validate the tradeoff afterwards.
@@ -44,7 +51,16 @@ you can validate the tradeoff afterwards.
 ## Where it lives
 
 Open **Memory → Workers** (web sidebar) — or `/memory/workers`
-directly. You see four cards, one per touchpoint. Each card:
+directly. As of M-PF this page is the unified **Memory
+configuration** landing with five sections in one place:
+
+1. **Providers** — HTTP endpoint registry
+2. **Workers** — per-task summarizer/agent routing (this section)
+3. **Capture rules** — trigger config
+4. **Injection profiles** — spawn-time strategy
+5. **Token cost** — all-time call audit
+
+Each Worker card (in section 2) shows:
 
 - **Worker selector**: `Summarizer` ↔ `Agent` dropdown (gatekeeper
   is locked to Summarizer — see "Why gatekeeper stays put" below).


### PR DESCRIPTION
## Summary

Two follow-ups to PR #135 (unified memory config) per operator feedback:

1. **Remove the now-empty Settings → Memory.Ambient entry.** PR #135 left a redirect banner there so existing bookmarks didn't 404; the operator pointed out that an empty nav slot is itself a source of confusion ("why is this here, what config went there?"). Drop it entirely.
2. **Refresh tutorial docs** stale after Phase A → F (plan-drift, journal embedding, smart ranking, conflict detector, capture-via-worker-fabric, unified UI).

## What changed

### Settings nav cleanup

| File | Change |
|---|---|
| \`ServerSettings.tsx\` | Drop \`memory-ambient\` from \`SERVER_SECTIONS\` / \`RESTART_REQUIRED_SECTIONS\` / render switch / merge switch. \`MemoryAmbientSection.tsx\` stays — \`/memory/workers\` still imports its four exported sub-blocks. |
| \`app/i18n/{en,zh}.json\` | Drop \`web.serverSettings.sections.memoryAmbient.*\` from both locales. The \`memoryAmbient.*\` body keys used by the unified page stay. |

### Tutorial refresh

| File | Update |
|---|---|
| \`13-ambient-memory/01-overview.md\` | "Configure under Settings → Memory.Ambient" → points to Memory → Workers + explains M-PF unified five sections. Provider list mentions M-PE Agent route alongside HTTP. |
| \`14-project-memory/01-overview.md\` | New "Tabs you'll see on the Project page" section covering Health (Phase A), Inbox, Conflicts (Phase C/D), Cleanup — none of which existed when the doc was written. Notes the Phase D Delete-A/B preview-and-confirm dialog. |
| \`15-memory-workers/01-overview.md\` | Touchpoint table 4 → 7 (plan_drift, conflict_detector, capture). "Where it lives" updated to the unified Memory configuration landing layout. Per-task tradeoff bullets cover all 7 tasks. |

## Failure modes deliberately tolerated

- External bookmarks to \`/admin/settings?section=memory-ambient\` — Settings page will default to its first section when the slot is unknown; acceptable since the redirect existed only briefly and the operator confirmed it's not load-bearing.
- The \`MemoryAmbientSection\` top-level wrapper + \`SectionHeader\` inside it are now unused but kept so the file stays a single-source-of-truth for the four exported sub-blocks. Removing them would be code-cleanup churn for no behaviour change.

## Test plan

- [x] \`pnpm tsc --noEmit\` green
- [x] VS Code diagnostics empty on touched files
- [x] JSON parses (en + zh)
- [ ] Manual: open Settings — confirm no "Memory · Ambient" entry in sidebar; all other sections unchanged
- [ ] Manual: open Tutorial → memory sections 13/14/15 — confirm new content renders cleanly in both locales