### PR TITLE
feat(mobile): bring memory pages to Phase A→F web parity (Mobile PR-1)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -2840,6 +2840,18 @@
       "transcript": {
         "label": "Session transcript summariser",
         "description": "Session-end 'what did the agent do' summary. Naturally fits an agent worker."
+      },
+      "planDrift": {
+        "label": "Plan drift detector",
+        "description": "After each session ends, checks whether the project plan needs updating and files a proposal. Fits an agent worker for richer reasoning."
+      },
+      "conflictDetector": {
+        "label": "Cross-layer conflict detector",
+        "description": "Daily scan that finds contradictions between facts / plan / goal / journal. Higher-quality model = fewer false positives."
+      },
+      "capture": {
+        "label": "Capture engine",
+        "description": "Per-trigger fact extraction from session transcripts. Agent mode gives noticeably better facts on long sessions; summarizer mode is cheap and local."
       }
     }
   },
@@ -2853,6 +2865,40 @@
   "project": {
     "title": "Project",
     "pickFirst": "Pick a project first.",
+    "health": {
+      "title": "Memory health — last {days} days",
+      "subtitle": "Aggregate signals across both memory subsystems for this project.",
+      "newFacts": "New facts",
+      "newFactsHint": "{total} stored in total",
+      "captureFires": "Capture fires",
+      "captureFiresHint": "{stored} stored · {deduped} deduped",
+      "newJournal": "Journal entries",
+      "newJournalHint": "{total} in total",
+      "planAge": "Plan last updated",
+      "planAgeHint": "{count} plan-drift proposal(s) pending",
+      "planAgeHintNone": "No plan-drift proposals pending",
+      "goalAge": "Goal last updated",
+      "pending": "Pending proposals",
+      "pendingHint": "oldest {days}d old",
+      "topHit": "Top hit · {hits} retrievals",
+      "zeroHit": "{count} facts older than 7d with zero retrievals — candidates for cleanup.",
+      "never": "never",
+      "today": "today",
+      "daysAgo": "{count}d ago"
+    },
+    "conflicts": {
+      "subtitle": "Contradictions the daily detector found between facts, plan, goal, and journal entries.",
+      "empty": "No pending conflicts. Tap Detect now for an on-demand sweep.",
+      "detectNow": "Detect now",
+      "detected": "{count} new conflict(s) found",
+      "accept": "Accept",
+      "dismiss": "Dismiss",
+      "severity": {
+        "low": "low",
+        "medium": "medium",
+        "high": "high"
+      }
+    },
     "loadFailed": "Failed to load: {error}",
     "projectsLoadFailed": "Failed to load projects: {error}",
     "projectLabel": "Project",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -2840,6 +2840,18 @@
       "transcript": {
         "label": "会话记录摘要器",
         "description": "会话结束时的「agent 做了什么」摘要。天然适合 agent 工作器。"
+      },
+      "planDrift": {
+        "label": "计划漂移检测",
+        "description": "每个 session 结束后判断项目 plan 是否需要更新并提出 proposal。用 agent 推理质量更高。"
+      },
+      "conflictDetector": {
+        "label": "跨层冲突检测",
+        "description": "每日扫描 facts/plan/goal/journal 之间的矛盾。模型越强，误报越少。"
+      },
+      "capture": {
+        "label": "Capture 引擎",
+        "description": "按触发器从 session transcript 抽取 fact。Agent 模式在长会话上 fact 质量明显更好；summarizer 模式便宜且本地。"
       }
     }
   },
@@ -2853,6 +2865,40 @@
   "project": {
     "title": "项目",
     "pickFirst": "请先选择一个项目。",
+    "health": {
+      "title": "记忆健康 — 最近 {days} 天",
+      "subtitle": "本项目两套记忆子系统的运行情况聚合。",
+      "newFacts": "新增 facts",
+      "newFactsHint": "累计 {total} 条",
+      "captureFires": "Capture 触发次数",
+      "captureFiresHint": "存入 {stored} · 去重 {deduped}",
+      "newJournal": "新增日志条目",
+      "newJournalHint": "累计 {total} 条",
+      "planAge": "计划最近更新",
+      "planAgeHint": "{count} 条 plan-drift 提案待审",
+      "planAgeHintNone": "无 plan-drift 提案待审",
+      "goalAge": "目标最近更新",
+      "pending": "待审提案",
+      "pendingHint": "最久 {days} 天",
+      "topHit": "命中最多 · {hits} 次",
+      "zeroHit": "{count} 条超过 7 天未命中的 fact — 清理候选。",
+      "never": "从未",
+      "today": "今日",
+      "daysAgo": "{count} 天前"
+    },
+    "conflicts": {
+      "subtitle": "每日 detector 在 facts/plan/goal/journal 之间发现的矛盾。",
+      "empty": "无待处理冲突。点击「立即检测」运行一次按需扫描。",
+      "detectNow": "立即检测",
+      "detected": "新发现 {count} 条冲突",
+      "accept": "采纳",
+      "dismiss": "驳回",
+      "severity": {
+        "low": "低",
+        "medium": "中",
+        "high": "高"
+      }
+    },
     "loadFailed": "加载失败：{error}",
     "projectsLoadFailed": "加载项目列表失败：{error}",
     "projectLabel": "项目",

--- a/app/mobile/lib/core/api/memory_conflicts_api.dart
+++ b/app/mobile/lib/core/api/memory_conflicts_api.dart
@@ -1,0 +1,171 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/api/dio_provider.dart';
+
+// /api/v1/memory/conflicts — M-PC cross-layer conflict inbox.
+// Mobile mirror of app/shared/src/lib/memoryConflicts.ts.
+
+enum ConflictLayer { fact, plan, goal, journal }
+
+extension ConflictLayerX on ConflictLayer {
+  String get wire => name;
+  static ConflictLayer parse(String s) {
+    switch (s) {
+      case 'plan':
+        return ConflictLayer.plan;
+      case 'goal':
+        return ConflictLayer.goal;
+      case 'journal':
+        return ConflictLayer.journal;
+      default:
+        return ConflictLayer.fact;
+    }
+  }
+}
+
+enum ConflictSeverity { low, medium, high }
+
+extension ConflictSeverityX on ConflictSeverity {
+  static ConflictSeverity parse(String s) {
+    switch (s) {
+      case 'low':
+        return ConflictSeverity.low;
+      case 'high':
+        return ConflictSeverity.high;
+      default:
+        return ConflictSeverity.medium;
+    }
+  }
+}
+
+enum ConflictStatus { pending, accepted, dismissed, expired }
+
+extension ConflictStatusX on ConflictStatus {
+  String get wire => name;
+  static ConflictStatus parse(String s) {
+    switch (s) {
+      case 'accepted':
+        return ConflictStatus.accepted;
+      case 'dismissed':
+        return ConflictStatus.dismissed;
+      case 'expired':
+        return ConflictStatus.expired;
+      default:
+        return ConflictStatus.pending;
+    }
+  }
+}
+
+class MemoryConflict {
+  MemoryConflict({
+    required this.id,
+    required this.cwd,
+    required this.layerA,
+    required this.refA,
+    required this.layerB,
+    required this.refB,
+    required this.evidence,
+    required this.severity,
+    required this.status,
+    required this.detectedAt,
+    this.decidedAt,
+    this.decidedBy,
+  });
+
+  factory MemoryConflict.fromJson(Map<String, dynamic> j) {
+    DateTime parseTs(Object? v) =>
+        v is String ? (DateTime.tryParse(v) ?? DateTime.now()) : DateTime.now();
+    DateTime? parseTsNullable(Object? v) =>
+        v is String && v.isNotEmpty ? DateTime.tryParse(v) : null;
+    return MemoryConflict(
+      id: (j['id'] as String?) ?? '',
+      cwd: (j['cwd'] as String?) ?? '',
+      layerA: ConflictLayerX.parse((j['layer_a'] as String?) ?? 'fact'),
+      refA: (j['ref_a'] as String?) ?? '',
+      layerB: ConflictLayerX.parse((j['layer_b'] as String?) ?? 'fact'),
+      refB: (j['ref_b'] as String?) ?? '',
+      evidence: (j['evidence'] as String?) ?? '',
+      severity:
+          ConflictSeverityX.parse((j['severity'] as String?) ?? 'medium'),
+      status: ConflictStatusX.parse((j['status'] as String?) ?? 'pending'),
+      detectedAt: parseTs(j['detected_at']),
+      decidedAt: parseTsNullable(j['decided_at']),
+      decidedBy: j['decided_by'] as String?,
+    );
+  }
+
+  final String id;
+  final String cwd;
+  final ConflictLayer layerA;
+  final String refA;
+  final ConflictLayer layerB;
+  final String refB;
+  final String evidence;
+  final ConflictSeverity severity;
+  final ConflictStatus status;
+  final DateTime detectedAt;
+  final DateTime? decidedAt;
+  final String? decidedBy;
+}
+
+class MemoryConflictsApi {
+  MemoryConflictsApi(this._dio);
+  final Dio _dio;
+
+  Future<List<MemoryConflict>> list({
+    required String cwd,
+    ConflictStatus? status,
+    int limit = 50,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/memory/conflicts',
+        queryParameters: {
+          'cwd': cwd,
+          if (status != null) 'status': status.wire,
+          'n': limit,
+        },
+      );
+      final raw = res.data?['conflicts'];
+      if (raw is! List) return const [];
+      return raw
+          .whereType<Map<String, dynamic>>()
+          .map(MemoryConflict.fromJson)
+          .toList();
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // Marks the conflict accepted ("operator agrees a contradiction
+  // exists and will fix it manually") or dismissed ("detector got
+  // it wrong"). action must match ConflictStatus.{accepted|dismissed}.
+  Future<void> decide(String id, String action) async {
+    try {
+      await _dio.post<Map<String, dynamic>>(
+        '/api/v1/memory/conflicts/$id/$action',
+      );
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // Forces a fresh sweep against the configured conflict_detector
+  // worker. Returns the number of new conflicts written.
+  Future<int> detect(String cwd) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/memory/conflicts/detect',
+        queryParameters: {'cwd': cwd},
+      );
+      return (res.data?['detected'] as int?) ?? 0;
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+}
+
+final memoryConflictsApiProvider = Provider<MemoryConflictsApi>((ref) {
+  return MemoryConflictsApi(ref.watch(dioProvider));
+});

--- a/app/mobile/lib/core/api/memory_health_api.dart
+++ b/app/mobile/lib/core/api/memory_health_api.dart
@@ -1,0 +1,113 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/api/dio_provider.dart';
+
+// /api/v1/memory/health — M-PA memory health dashboard, mobile
+// mirror of app/shared/src/lib/memoryHealth.ts. One aggregate read
+// crossing both memory subsystems for a given project cwd.
+
+class MemoryHealthSnapshot {
+  MemoryHealthSnapshot({
+    required this.cwd,
+    required this.generatedAt,
+    required this.lookbackDays,
+    required this.newFactsCount,
+    required this.totalFactsCount,
+    required this.zeroHitFactsCount,
+    required this.topHitFactText,
+    required this.topHitFactHits,
+    required this.captureFires,
+    required this.captureFactsExtracted,
+    required this.captureFactsStored,
+    required this.captureFactsDeduped,
+    required this.captureFailedFires,
+    required this.newJournalCount,
+    required this.totalJournalCount,
+    required this.pendingProposals,
+    required this.oldestPendingDays,
+    required this.planDriftProposals,
+    this.planLastUpdatedAt,
+    this.goalLastUpdatedAt,
+  });
+
+  factory MemoryHealthSnapshot.fromJson(Map<String, dynamic> j) {
+    DateTime? parseTs(Object? v) {
+      if (v is String && v.isNotEmpty) return DateTime.tryParse(v);
+      return null;
+    }
+
+    return MemoryHealthSnapshot(
+      cwd: (j['cwd'] as String?) ?? '',
+      generatedAt: parseTs(j['generated_at']) ?? DateTime.now().toUtc(),
+      lookbackDays: (j['lookback_days'] as int?) ?? 7,
+      newFactsCount: (j['new_facts_count'] as int?) ?? 0,
+      totalFactsCount: (j['total_facts_count'] as int?) ?? 0,
+      zeroHitFactsCount: (j['zero_hit_facts_count'] as int?) ?? 0,
+      topHitFactText: (j['top_hit_fact_text'] as String?) ?? '',
+      topHitFactHits: (j['top_hit_fact_hits'] as int?) ?? 0,
+      captureFires: (j['capture_fires'] as int?) ?? 0,
+      captureFactsExtracted: (j['capture_facts_extracted'] as int?) ?? 0,
+      captureFactsStored: (j['capture_facts_stored'] as int?) ?? 0,
+      captureFactsDeduped: (j['capture_facts_deduped'] as int?) ?? 0,
+      captureFailedFires: (j['capture_failed_fires'] as int?) ?? 0,
+      newJournalCount: (j['new_journal_count'] as int?) ?? 0,
+      totalJournalCount: (j['total_journal_count'] as int?) ?? 0,
+      pendingProposals: (j['pending_proposals'] as int?) ?? 0,
+      oldestPendingDays: (j['oldest_pending_days'] as int?) ?? 0,
+      planDriftProposals: (j['plan_drift_proposals'] as int?) ?? 0,
+      planLastUpdatedAt: parseTs(j['plan_last_updated_at']),
+      goalLastUpdatedAt: parseTs(j['goal_last_updated_at']),
+    );
+  }
+
+  final String cwd;
+  final DateTime generatedAt;
+  final int lookbackDays;
+
+  // Layer 5 — discrete facts.
+  final int newFactsCount;
+  final int totalFactsCount;
+  final int zeroHitFactsCount;
+  final String topHitFactText;
+  final int topHitFactHits;
+
+  // Capture engine activity.
+  final int captureFires;
+  final int captureFactsExtracted;
+  final int captureFactsStored;
+  final int captureFactsDeduped;
+  final int captureFailedFires;
+
+  // Layer 4 — journal.
+  final int newJournalCount;
+  final int totalJournalCount;
+
+  // Layers 2-3 — operator-owned docs.
+  final DateTime? planLastUpdatedAt;
+  final DateTime? goalLastUpdatedAt;
+  final int pendingProposals;
+  final int oldestPendingDays;
+  final int planDriftProposals;
+}
+
+class MemoryHealthApi {
+  MemoryHealthApi(this._dio);
+  final Dio _dio;
+
+  Future<MemoryHealthSnapshot> get(String cwd) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/memory/health',
+        queryParameters: {'cwd': cwd},
+      );
+      return MemoryHealthSnapshot.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+}
+
+final memoryHealthApiProvider = Provider<MemoryHealthApi>((ref) {
+  return MemoryHealthApi(ref.watch(dioProvider));
+});

--- a/app/mobile/lib/core/api/memory_workers_api.dart
+++ b/app/mobile/lib/core/api/memory_workers_api.dart
@@ -7,10 +7,44 @@ import 'package:opendray/core/api/dio_provider.dart';
 // configuration + metrics surface. Mirrors web's
 // app/shared/src/lib/memoryWorkers.ts.
 
-enum WorkerTaskKind { gatekeeper, cleaner, gitactivity, transcript }
+// Mobile-side mirror of internal/memory/worker.TaskKind. Stays in
+// lockstep with that file — adding a 4th/5th/6th/7th touchpoint
+// here is purely a UI surface, the backend rows already exist
+// after the M-PA / M-PC / M-PE migrations.
+enum WorkerTaskKind {
+  gatekeeper,
+  cleaner,
+  gitactivity,
+  transcript,
+  planDrift,
+  conflictDetector,
+  capture,
+}
 
 extension WorkerTaskKindX on WorkerTaskKind {
-  String get wire => name;
+  // Persisted wire string. Matches memory_workers.task CHECK
+  // constraint values; uses snake_case where the camelCase Dart
+  // enum can't represent the spelling directly. Exhaustive switch
+  // (no default) so Dart will flag any future enum addition.
+  String get wire {
+    switch (this) {
+      case WorkerTaskKind.gatekeeper:
+        return 'gatekeeper';
+      case WorkerTaskKind.cleaner:
+        return 'cleaner';
+      case WorkerTaskKind.gitactivity:
+        return 'gitactivity';
+      case WorkerTaskKind.transcript:
+        return 'transcript';
+      case WorkerTaskKind.planDrift:
+        return 'plan_drift';
+      case WorkerTaskKind.conflictDetector:
+        return 'conflict_detector';
+      case WorkerTaskKind.capture:
+        return 'capture';
+    }
+  }
+
   String get label {
     switch (this) {
       case WorkerTaskKind.gatekeeper:
@@ -21,6 +55,12 @@ extension WorkerTaskKindX on WorkerTaskKind {
         return 'Git activity summariser';
       case WorkerTaskKind.transcript:
         return 'Session transcript summariser';
+      case WorkerTaskKind.planDrift:
+        return 'Plan drift detector';
+      case WorkerTaskKind.conflictDetector:
+        return 'Cross-layer conflict detector';
+      case WorkerTaskKind.capture:
+        return 'Capture engine';
     }
   }
 
@@ -34,9 +74,17 @@ extension WorkerTaskKindX on WorkerTaskKind {
         return 'git log → 2-3 paragraph narrative every 24h. Naturally fits an agent worker.';
       case WorkerTaskKind.transcript:
         return 'Session-end "what did the agent do" summary. Naturally fits an agent worker.';
+      case WorkerTaskKind.planDrift:
+        return 'After each session ends, checks whether the project plan needs updating and files a proposal. Fits an agent worker for richer reasoning.';
+      case WorkerTaskKind.conflictDetector:
+        return 'Daily scan that finds contradictions between facts / plan / goal / journal. Higher-quality model = fewer false positives.';
+      case WorkerTaskKind.capture:
+        return 'Per-trigger fact extraction from session transcripts. Agent mode gives noticeably better facts on long sessions; summarizer mode is cheap and local.';
     }
   }
 
+  // Gatekeeper stays summarizer-only (<500ms latency budget on the
+  // memory_store hot path). Every other task supports Agent mode.
   bool get agentSupported => this != WorkerTaskKind.gatekeeper;
 }
 
@@ -70,6 +118,12 @@ class WorkerConfig {
           return WorkerTaskKind.gitactivity;
         case 'transcript':
           return WorkerTaskKind.transcript;
+        case 'plan_drift':
+          return WorkerTaskKind.planDrift;
+        case 'conflict_detector':
+          return WorkerTaskKind.conflictDetector;
+        case 'capture':
+          return WorkerTaskKind.capture;
         default:
           return WorkerTaskKind.transcript;
       }
@@ -122,6 +176,12 @@ class CallSummary {
           return WorkerTaskKind.gitactivity;
         case 'transcript':
           return WorkerTaskKind.transcript;
+        case 'plan_drift':
+          return WorkerTaskKind.planDrift;
+        case 'conflict_detector':
+          return WorkerTaskKind.conflictDetector;
+        case 'capture':
+          return WorkerTaskKind.capture;
         default:
           return WorkerTaskKind.transcript;
       }

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 5724 (2862 per locale)
+/// Strings: 5792 (2896 per locale)
 ///
 /// Built on 2026-05-15 at 11:21 UTC
 

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 5630 (2815 per locale)
+/// Strings: 5724 (2862 per locale)
 ///
-/// Built on 2026-05-15 at 02:44 UTC
+/// Built on 2026-05-15 at 11:21 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -726,6 +726,9 @@ class TranslationsProjectEn {
 	/// en: 'Pick a project first.'
 	String get pickFirst => 'Pick a project first.';
 
+	late final TranslationsProjectHealthEn health = TranslationsProjectHealthEn.internal(_root);
+	late final TranslationsProjectConflictsEn conflicts = TranslationsProjectConflictsEn.internal(_root);
+
 	/// en: 'Failed to load: {error}'
 	String loadFailed({required Object error}) => 'Failed to load: ${error}';
 
@@ -3439,6 +3442,104 @@ class TranslationsMemoryWorkersTasksEn {
 	late final TranslationsMemoryWorkersTasksCleanerEn cleaner = TranslationsMemoryWorkersTasksCleanerEn.internal(_root);
 	late final TranslationsMemoryWorkersTasksGitactivityEn gitactivity = TranslationsMemoryWorkersTasksGitactivityEn.internal(_root);
 	late final TranslationsMemoryWorkersTasksTranscriptEn transcript = TranslationsMemoryWorkersTasksTranscriptEn.internal(_root);
+	late final TranslationsMemoryWorkersTasksPlanDriftEn planDrift = TranslationsMemoryWorkersTasksPlanDriftEn.internal(_root);
+	late final TranslationsMemoryWorkersTasksConflictDetectorEn conflictDetector = TranslationsMemoryWorkersTasksConflictDetectorEn.internal(_root);
+	late final TranslationsMemoryWorkersTasksCaptureEn capture = TranslationsMemoryWorkersTasksCaptureEn.internal(_root);
+}
+
+// Path: project.health
+class TranslationsProjectHealthEn {
+	TranslationsProjectHealthEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Memory health — last {days} days'
+	String title({required Object days}) => 'Memory health — last ${days} days';
+
+	/// en: 'Aggregate signals across both memory subsystems for this project.'
+	String get subtitle => 'Aggregate signals across both memory subsystems for this project.';
+
+	/// en: 'New facts'
+	String get newFacts => 'New facts';
+
+	/// en: '{total} stored in total'
+	String newFactsHint({required Object total}) => '${total} stored in total';
+
+	/// en: 'Capture fires'
+	String get captureFires => 'Capture fires';
+
+	/// en: '{stored} stored · {deduped} deduped'
+	String captureFiresHint({required Object stored, required Object deduped}) => '${stored} stored · ${deduped} deduped';
+
+	/// en: 'Journal entries'
+	String get newJournal => 'Journal entries';
+
+	/// en: '{total} in total'
+	String newJournalHint({required Object total}) => '${total} in total';
+
+	/// en: 'Plan last updated'
+	String get planAge => 'Plan last updated';
+
+	/// en: '{count} plan-drift proposal(s) pending'
+	String planAgeHint({required Object count}) => '${count} plan-drift proposal(s) pending';
+
+	/// en: 'No plan-drift proposals pending'
+	String get planAgeHintNone => 'No plan-drift proposals pending';
+
+	/// en: 'Goal last updated'
+	String get goalAge => 'Goal last updated';
+
+	/// en: 'Pending proposals'
+	String get pending => 'Pending proposals';
+
+	/// en: 'oldest {days}d old'
+	String pendingHint({required Object days}) => 'oldest ${days}d old';
+
+	/// en: 'Top hit · {hits} retrievals'
+	String topHit({required Object hits}) => 'Top hit · ${hits} retrievals';
+
+	/// en: '{count} facts older than 7d with zero retrievals — candidates for cleanup.'
+	String zeroHit({required Object count}) => '${count} facts older than 7d with zero retrievals — candidates for cleanup.';
+
+	/// en: 'never'
+	String get never => 'never';
+
+	/// en: 'today'
+	String get today => 'today';
+
+	/// en: '{count}d ago'
+	String daysAgo({required Object count}) => '${count}d ago';
+}
+
+// Path: project.conflicts
+class TranslationsProjectConflictsEn {
+	TranslationsProjectConflictsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Contradictions the daily detector found between facts, plan, goal, and journal entries.'
+	String get subtitle => 'Contradictions the daily detector found between facts, plan, goal, and journal entries.';
+
+	/// en: 'No pending conflicts. Tap Detect now for an on-demand sweep.'
+	String get empty => 'No pending conflicts. Tap Detect now for an on-demand sweep.';
+
+	/// en: 'Detect now'
+	String get detectNow => 'Detect now';
+
+	/// en: '{count} new conflict(s) found'
+	String detected({required Object count}) => '${count} new conflict(s) found';
+
+	/// en: 'Accept'
+	String get accept => 'Accept';
+
+	/// en: 'Dismiss'
+	String get dismiss => 'Dismiss';
+
+	late final TranslationsProjectConflictsSeverityEn severity = TranslationsProjectConflictsSeverityEn.internal(_root);
 }
 
 // Path: backups.kv
@@ -9326,6 +9427,69 @@ class TranslationsMemoryWorkersTasksTranscriptEn {
 	String get description => 'Session-end \'what did the agent do\' summary. Naturally fits an agent worker.';
 }
 
+// Path: memoryWorkers.tasks.planDrift
+class TranslationsMemoryWorkersTasksPlanDriftEn {
+	TranslationsMemoryWorkersTasksPlanDriftEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Plan drift detector'
+	String get label => 'Plan drift detector';
+
+	/// en: 'After each session ends, checks whether the project plan needs updating and files a proposal. Fits an agent worker for richer reasoning.'
+	String get description => 'After each session ends, checks whether the project plan needs updating and files a proposal. Fits an agent worker for richer reasoning.';
+}
+
+// Path: memoryWorkers.tasks.conflictDetector
+class TranslationsMemoryWorkersTasksConflictDetectorEn {
+	TranslationsMemoryWorkersTasksConflictDetectorEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Cross-layer conflict detector'
+	String get label => 'Cross-layer conflict detector';
+
+	/// en: 'Daily scan that finds contradictions between facts / plan / goal / journal. Higher-quality model = fewer false positives.'
+	String get description => 'Daily scan that finds contradictions between facts / plan / goal / journal. Higher-quality model = fewer false positives.';
+}
+
+// Path: memoryWorkers.tasks.capture
+class TranslationsMemoryWorkersTasksCaptureEn {
+	TranslationsMemoryWorkersTasksCaptureEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Capture engine'
+	String get label => 'Capture engine';
+
+	/// en: 'Per-trigger fact extraction from session transcripts. Agent mode gives noticeably better facts on long sessions; summarizer mode is cheap and local.'
+	String get description => 'Per-trigger fact extraction from session transcripts. Agent mode gives noticeably better facts on long sessions; summarizer mode is cheap and local.';
+}
+
+// Path: project.conflicts.severity
+class TranslationsProjectConflictsSeverityEn {
+	TranslationsProjectConflictsSeverityEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'low'
+	String get low => 'low';
+
+	/// en: 'medium'
+	String get medium => 'medium';
+
+	/// en: 'high'
+	String get high => 'high';
+}
+
 // Path: backupTargetEditor.kinds.local
 class TranslationsBackupTargetEditorKindsLocalEn {
 	TranslationsBackupTargetEditorKindsLocalEn.internal(this._root);
@@ -14863,6 +15027,12 @@ extension on Translations {
 			'memoryWorkers.tasks.gitactivity.description' => 'git log → 2-3 paragraph narrative every 24h. Naturally fits an agent worker.',
 			'memoryWorkers.tasks.transcript.label' => 'Session transcript summariser',
 			'memoryWorkers.tasks.transcript.description' => 'Session-end \'what did the agent do\' summary. Naturally fits an agent worker.',
+			'memoryWorkers.tasks.planDrift.label' => 'Plan drift detector',
+			'memoryWorkers.tasks.planDrift.description' => 'After each session ends, checks whether the project plan needs updating and files a proposal. Fits an agent worker for richer reasoning.',
+			'memoryWorkers.tasks.conflictDetector.label' => 'Cross-layer conflict detector',
+			'memoryWorkers.tasks.conflictDetector.description' => 'Daily scan that finds contradictions between facts / plan / goal / journal. Higher-quality model = fewer false positives.',
+			'memoryWorkers.tasks.capture.label' => 'Capture engine',
+			'memoryWorkers.tasks.capture.description' => 'Per-trigger fact extraction from session transcripts. Agent mode gives noticeably better facts on long sessions; summarizer mode is cheap and local.',
 			'memoryCleanup.title' => 'Memory cleanup',
 			'memoryCleanup.approveFailed' => ({required Object error}) => 'Approve failed: ${error}',
 			'memoryCleanup.rejectFailed' => ({required Object error}) => 'Reject failed: ${error}',
@@ -14870,6 +15040,34 @@ extension on Translations {
 			'memoryCleanup.reject' => 'Reject',
 			'project.title' => 'Project',
 			'project.pickFirst' => 'Pick a project first.',
+			'project.health.title' => ({required Object days}) => 'Memory health — last ${days} days',
+			'project.health.subtitle' => 'Aggregate signals across both memory subsystems for this project.',
+			'project.health.newFacts' => 'New facts',
+			'project.health.newFactsHint' => ({required Object total}) => '${total} stored in total',
+			'project.health.captureFires' => 'Capture fires',
+			'project.health.captureFiresHint' => ({required Object stored, required Object deduped}) => '${stored} stored · ${deduped} deduped',
+			'project.health.newJournal' => 'Journal entries',
+			'project.health.newJournalHint' => ({required Object total}) => '${total} in total',
+			'project.health.planAge' => 'Plan last updated',
+			'project.health.planAgeHint' => ({required Object count}) => '${count} plan-drift proposal(s) pending',
+			'project.health.planAgeHintNone' => 'No plan-drift proposals pending',
+			'project.health.goalAge' => 'Goal last updated',
+			'project.health.pending' => 'Pending proposals',
+			'project.health.pendingHint' => ({required Object days}) => 'oldest ${days}d old',
+			'project.health.topHit' => ({required Object hits}) => 'Top hit · ${hits} retrievals',
+			'project.health.zeroHit' => ({required Object count}) => '${count} facts older than 7d with zero retrievals — candidates for cleanup.',
+			'project.health.never' => 'never',
+			'project.health.today' => 'today',
+			'project.health.daysAgo' => ({required Object count}) => '${count}d ago',
+			'project.conflicts.subtitle' => 'Contradictions the daily detector found between facts, plan, goal, and journal entries.',
+			'project.conflicts.empty' => 'No pending conflicts. Tap Detect now for an on-demand sweep.',
+			'project.conflicts.detectNow' => 'Detect now',
+			'project.conflicts.detected' => ({required Object count}) => '${count} new conflict(s) found',
+			'project.conflicts.accept' => 'Accept',
+			'project.conflicts.dismiss' => 'Dismiss',
+			'project.conflicts.severity.low' => 'low',
+			'project.conflicts.severity.medium' => 'medium',
+			'project.conflicts.severity.high' => 'high',
 			'project.loadFailed' => ({required Object error}) => 'Failed to load: ${error}',
 			'project.projectsLoadFailed' => ({required Object error}) => 'Failed to load projects: ${error}',
 			'project.projectLabel' => 'Project',
@@ -15165,6 +15363,8 @@ extension on Translations {
 			'channels.snacks.channelDeleted' => 'Channel deleted.',
 			'channels.errorPrefix.test' => 'Test failed',
 			'channels.errorPrefix.toggle' => 'Toggle failed',
+			_ => null,
+		} ?? switch (path) {
 			'channels.errorPrefix.muteToggle' => 'Mute toggle failed',
 			'channels.errorPrefix.update' => 'Update failed',
 			'channels.errorPrefix.delete' => 'Delete failed',
@@ -15199,8 +15399,6 @@ extension on Translations {
 			'channels.kinds.dingtalk.description' => 'Custom group robot. Outbound only. Group chat → Robots → Add → Sign mode → copy webhook + secret.',
 			'channels.kinds.dingtalk.webhookUrlLabel' => 'Webhook URL',
 			'channels.kinds.dingtalk.secretLabel' => 'Sign secret',
-			_ => null,
-		} ?? switch (path) {
 			'channels.kinds.dingtalk.secretHint' => 'When the robot is set to "Sign" security mode, copy the secret here. opendray adds the timestamp + sign params automatically.',
 			'channels.kinds.wecom.description' => 'Group robot webhook. Outbound only (text + markdown). Group settings → Group robots → Add → copy webhook URL.',
 			'channels.kinds.wecom.webhookKeyLabel' => 'Webhook key',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -216,8 +216,10 @@ class TranslationsWebEn {
 	late final TranslationsWebTopbarEn topbar = TranslationsWebTopbarEn.internal(_root);
 	late final TranslationsWebSessionsEn sessions = TranslationsWebSessionsEn.internal(_root);
 	late final TranslationsWebMemoryEn memory = TranslationsWebMemoryEn.internal(_root);
+	late final TranslationsWebJournalStaleEn journalStale = TranslationsWebJournalStaleEn.internal(_root);
 	late final TranslationsWebConflictsEn conflicts = TranslationsWebConflictsEn.internal(_root);
 	late final TranslationsWebMemoryHealthEn memoryHealth = TranslationsWebMemoryHealthEn.internal(_root);
+	late final TranslationsWebMemoryConfigEn memoryConfig = TranslationsWebMemoryConfigEn.internal(_root);
 	late final TranslationsWebMemoryWorkersEn memoryWorkers = TranslationsWebMemoryWorkersEn.internal(_root);
 	late final TranslationsWebCleanupInboxEn cleanupInbox = TranslationsWebCleanupInboxEn.internal(_root);
 	late final TranslationsWebProjectEn project = TranslationsWebProjectEn.internal(_root);
@@ -1890,6 +1892,45 @@ class TranslationsWebMemoryEn {
 	String get navConfiguration => 'Configuration →';
 }
 
+// Path: web.journalStale
+class TranslationsWebJournalStaleEn {
+	TranslationsWebJournalStaleEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Prune stale entries'
+	String get title => 'Prune stale entries';
+
+	/// en: '(older than {days} days, no pending conflicts)'
+	String subtitle({required Object days}) => '(older than ${days} days, no pending conflicts)';
+
+	/// en: 'Older than (days):'
+	String get daysLabel => 'Older than (days):';
+
+	/// en: 'Scanning…'
+	String get loading => 'Scanning…';
+
+	/// en: 'Nothing stale to prune.'
+	String get empty => 'Nothing stale to prune.';
+
+	/// en: 'Select all'
+	String get selectAll => 'Select all';
+
+	/// en: 'Deselect all'
+	String get deselectAll => 'Deselect all';
+
+	/// en: 'Delete ({count})'
+	String deleteSelected({required Object count}) => 'Delete (${count})';
+
+	/// en: '{count} entry deleted'
+	String deleted_one({required Object count}) => '${count} entry deleted';
+
+	/// en: '{count} entries deleted'
+	String deleted_other({required Object count}) => '${count} entries deleted';
+}
+
 // Path: web.conflicts
 class TranslationsWebConflictsEn {
 	TranslationsWebConflictsEn.internal(this._root);
@@ -1931,6 +1972,20 @@ class TranslationsWebConflictsEn {
 	/// en: 'Conflict dismissed'
 	String get dismissed => 'Conflict dismissed';
 
+	/// en: 'Fact deleted and conflict accepted'
+	String get deletedFact => 'Fact deleted and conflict accepted';
+
+	/// en: 'Fix:'
+	String get quickActions => 'Fix:';
+
+	/// en: 'Delete fact'
+	String get deleteFact => 'Delete fact';
+
+	/// en: 'Delete {side}: {ref}'
+	String deleteFactSide({required Object side, required Object ref}) => 'Delete ${side}: ${ref}';
+
+	late final TranslationsWebConflictsConfirmDeleteEn confirmDelete = TranslationsWebConflictsConfirmDeleteEn.internal(_root);
+	late final TranslationsWebConflictsOpenLayerEn openLayer = TranslationsWebConflictsOpenLayerEn.internal(_root);
 	late final TranslationsWebConflictsSeverityEn severity = TranslationsWebConflictsSeverityEn.internal(_root);
 }
 
@@ -2010,6 +2065,25 @@ class TranslationsWebMemoryHealthEn {
 
 	/// en: '{count} days ago'
 	String daysAgo_other({required Object count}) => '${count} days ago';
+}
+
+// Path: web.memoryConfig
+class TranslationsWebMemoryConfigEn {
+	TranslationsWebMemoryConfigEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Memory configuration'
+	String get title => 'Memory configuration';
+
+	/// en: 'All memory-related knobs in one place: HTTP providers, per-task worker routing, capture triggers, spawn-time injection, and audit costs.'
+	String get subtitle => 'All memory-related knobs in one place: HTTP providers, per-task worker routing, capture triggers, spawn-time injection, and audit costs.';
+
+	late final TranslationsWebMemoryConfigSectionsEn sections = TranslationsWebMemoryConfigSectionsEn.internal(_root);
+	late final TranslationsWebMemoryConfigSectionHintsEn sectionHints = TranslationsWebMemoryConfigSectionHintsEn.internal(_root);
+	late final TranslationsWebMemoryConfigMoveBannerEn moveBanner = TranslationsWebMemoryConfigMoveBannerEn.internal(_root);
 }
 
 // Path: web.memoryWorkers
@@ -4659,6 +4733,60 @@ class TranslationsWebSessionsFileBrowserEn {
 	String get homeFailedToast => 'Failed to read home';
 }
 
+// Path: web.conflicts.confirmDelete
+class TranslationsWebConflictsConfirmDeleteEn {
+	TranslationsWebConflictsConfirmDeleteEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Delete fact {side}?'
+	String title({required Object side}) => 'Delete fact ${side}?';
+
+	/// en: 'This permanently removes the fact and accepts the conflict. The other side stays as the surviving claim.'
+	String get description => 'This permanently removes the fact and accepts the conflict. The other side stays as the surviving claim.';
+
+	/// en: 'Will delete (side {side}):'
+	String targetLabel({required Object side}) => 'Will delete (side ${side}):';
+
+	/// en: 'Will keep (side {side}):'
+	String keepLabel({required Object side}) => 'Will keep (side ${side}):';
+
+	/// en: '({layer} entry — open the corresponding tab to inspect)'
+	String nonFactOther({required Object layer}) => '(${layer} entry — open the corresponding tab to inspect)';
+
+	/// en: 'Detector evidence:'
+	String get evidenceLabel => 'Detector evidence:';
+
+	/// en: 'Loading fact text…'
+	String get loading => 'Loading fact text…';
+
+	/// en: 'Failed to load fact text. Inspect on the Memory page.'
+	String get loadError => 'Failed to load fact text. Inspect on the Memory page.';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Delete {side}'
+	String confirm({required Object side}) => 'Delete ${side}';
+}
+
+// Path: web.conflicts.openLayer
+class TranslationsWebConflictsOpenLayerEn {
+	TranslationsWebConflictsOpenLayerEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Open plan editor'
+	String get plan => 'Open plan editor';
+
+	/// en: 'Open goal editor'
+	String get goal => 'Open goal editor';
+}
+
 // Path: web.conflicts.severity
 class TranslationsWebConflictsSeverityEn {
 	TranslationsWebConflictsSeverityEn.internal(this._root);
@@ -4677,6 +4805,72 @@ class TranslationsWebConflictsSeverityEn {
 	String get high => 'high';
 }
 
+// Path: web.memoryConfig.sections
+class TranslationsWebMemoryConfigSectionsEn {
+	TranslationsWebMemoryConfigSectionsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Providers'
+	String get providers => 'Providers';
+
+	/// en: 'Workers'
+	String get workers => 'Workers';
+
+	/// en: 'Capture rules'
+	String get rules => 'Capture rules';
+
+	/// en: 'Injection profiles'
+	String get profiles => 'Injection profiles';
+
+	/// en: 'Token cost'
+	String get costs => 'Token cost';
+}
+
+// Path: web.memoryConfig.sectionHints
+class TranslationsWebMemoryConfigSectionHintsEn {
+	TranslationsWebMemoryConfigSectionHintsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Registered HTTP endpoints (Ollama / LM Studio / Anthropic / OpenAI / Integration) that any task can dispatch to.'
+	String get providers => 'Registered HTTP endpoints (Ollama / LM Studio / Anthropic / OpenAI / Integration) that any task can dispatch to.';
+
+	/// en: 'For each touchpoint pick HTTP provider (cheap, local) or headless Claude / Gemini Agent (higher quality, costs CLI tokens).'
+	String get workers => 'For each touchpoint pick HTTP provider (cheap, local) or headless Claude / Gemini Agent (higher quality, costs CLI tokens).';
+
+	/// en: 'When the capture engine fires per session (after N messages / on idle / K characters / manual). Rules without a pinned provider follow the Capture worker setting above.'
+	String get rules => 'When the capture engine fires per session (after N messages / on idle / K characters / manual). Rules without a pinned provider follow the Capture worker setting above.';
+
+	/// en: 'How prior memories get injected into the agent's system prompt at session spawn (recency, relevance, hybrid, or off).'
+	String get profiles => 'How prior memories get injected into the agent\'s system prompt at session spawn (recency, relevance, hybrid, or off).';
+
+	/// en: 'Aggregate spend reconstructed from memory_summarizer_calls. Local providers (Ollama, LM Studio, Integration) are free; cloud providers show real-world cost.'
+	String get costs => 'Aggregate spend reconstructed from memory_summarizer_calls. Local providers (Ollama, LM Studio, Integration) are free; cloud providers show real-world cost.';
+}
+
+// Path: web.memoryConfig.moveBanner
+class TranslationsWebMemoryConfigMoveBannerEn {
+	TranslationsWebMemoryConfigMoveBannerEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Memory configuration has moved'
+	String get title => 'Memory configuration has moved';
+
+	/// en: 'All memory-related settings (providers / capture rules / injection profiles / cost) now live alongside Workers in one page so related knobs sit together.'
+	String get body => 'All memory-related settings (providers / capture rules / injection profiles / cost) now live alongside Workers in one page so related knobs sit together.';
+
+	/// en: 'Open Memory configuration →'
+	String get openButton => 'Open Memory configuration →';
+}
+
 // Path: web.memoryWorkers.tasks
 class TranslationsWebMemoryWorkersTasksEn {
 	TranslationsWebMemoryWorkersTasksEn.internal(this._root);
@@ -4688,6 +4882,9 @@ class TranslationsWebMemoryWorkersTasksEn {
 	late final TranslationsWebMemoryWorkersTasksCleanerEn cleaner = TranslationsWebMemoryWorkersTasksCleanerEn.internal(_root);
 	late final TranslationsWebMemoryWorkersTasksGitactivityEn gitactivity = TranslationsWebMemoryWorkersTasksGitactivityEn.internal(_root);
 	late final TranslationsWebMemoryWorkersTasksTranscriptEn transcript = TranslationsWebMemoryWorkersTasksTranscriptEn.internal(_root);
+	late final TranslationsWebMemoryWorkersTasksPlanDriftEn plan_drift = TranslationsWebMemoryWorkersTasksPlanDriftEn.internal(_root);
+	late final TranslationsWebMemoryWorkersTasksConflictDetectorEn conflict_detector = TranslationsWebMemoryWorkersTasksConflictDetectorEn.internal(_root);
+	late final TranslationsWebMemoryWorkersTasksCaptureEn capture = TranslationsWebMemoryWorkersTasksCaptureEn.internal(_root);
 }
 
 // Path: web.project.picker
@@ -5219,6 +5416,12 @@ class TranslationsWebMemoryInspectorRowEn {
 
 	/// en: 'sim {value}'
 	String simBadge({required Object value}) => 'sim ${value}';
+
+	/// en: 'rank {value}'
+	String rankBadge({required Object value}) => 'rank ${value}';
+
+	/// en: 'effective {effective} = sim {similarity} × age {age} ({days}d) × hits {hits} × conf {confidence}'
+	String rankTooltip({required Object effective, required Object similarity, required Object age, required Object days, required Object hits, required Object confidence}) => 'effective ${effective} = sim ${similarity} × age ${age} (${days}d) × hits ${hits} × conf ${confidence}';
 
 	/// en: '{count} hit'
 	String hits_one({required Object count}) => '${count} hit';
@@ -7471,7 +7674,6 @@ class TranslationsWebServerSettingsSectionsEn {
 	late final TranslationsWebServerSettingsSectionsVaultEn vault = TranslationsWebServerSettingsSectionsVaultEn.internal(_root);
 	late final TranslationsWebServerSettingsSectionsMcpEn mcp = TranslationsWebServerSettingsSectionsMcpEn.internal(_root);
 	late final TranslationsWebServerSettingsSectionsMemoryEn memory = TranslationsWebServerSettingsSectionsMemoryEn.internal(_root);
-	late final TranslationsWebServerSettingsSectionsMemoryAmbientEn memoryAmbient = TranslationsWebServerSettingsSectionsMemoryAmbientEn.internal(_root);
 	late final TranslationsWebServerSettingsSectionsBackupEn backup = TranslationsWebServerSettingsSectionsBackupEn.internal(_root);
 	late final TranslationsWebServerSettingsSectionsClaudeEn claude = TranslationsWebServerSettingsSectionsClaudeEn.internal(_root);
 	late final TranslationsWebServerSettingsSectionsCodexEn codex = TranslationsWebServerSettingsSectionsCodexEn.internal(_root);
@@ -9859,6 +10061,51 @@ class TranslationsWebMemoryWorkersTasksTranscriptEn {
 	String get description => 'Session-end "what did the agent do" summary. Naturally fits an agent worker.';
 }
 
+// Path: web.memoryWorkers.tasks.plan_drift
+class TranslationsWebMemoryWorkersTasksPlanDriftEn {
+	TranslationsWebMemoryWorkersTasksPlanDriftEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Plan drift detector'
+	String get label => 'Plan drift detector';
+
+	/// en: 'After each session ends, checks whether the project plan needs updating and files a proposal. Fits an agent worker for richer reasoning.'
+	String get description => 'After each session ends, checks whether the project plan needs updating and files a proposal. Fits an agent worker for richer reasoning.';
+}
+
+// Path: web.memoryWorkers.tasks.conflict_detector
+class TranslationsWebMemoryWorkersTasksConflictDetectorEn {
+	TranslationsWebMemoryWorkersTasksConflictDetectorEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Cross-layer conflict detector'
+	String get label => 'Cross-layer conflict detector';
+
+	/// en: 'Daily scan that finds contradictions between facts / plan / goal / journal. Higher-quality model = fewer false positives.'
+	String get description => 'Daily scan that finds contradictions between facts / plan / goal / journal. Higher-quality model = fewer false positives.';
+}
+
+// Path: web.memoryWorkers.tasks.capture
+class TranslationsWebMemoryWorkersTasksCaptureEn {
+	TranslationsWebMemoryWorkersTasksCaptureEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Capture engine'
+	String get label => 'Capture engine';
+
+	/// en: 'Per-trigger fact extraction from session transcripts. Agent mode gives noticeably better facts on long sessions; summarizer mode is cheap and local.'
+	String get description => 'Per-trigger fact extraction from session transcripts. Agent mode gives noticeably better facts on long sessions; summarizer mode is cheap and local.';
+}
+
 // Path: web.project.readonly.tech_stack
 class TranslationsWebProjectReadonlyTechStackEn {
 	TranslationsWebProjectReadonlyTechStackEn.internal(this._root);
@@ -11187,21 +11434,6 @@ class TranslationsWebServerSettingsSectionsMemoryEn {
 
 	/// en: 'Cross-CLI persistent memory subsystem.'
 	String get desc => 'Cross-CLI persistent memory subsystem.';
-}
-
-// Path: web.serverSettings.sections.memoryAmbient
-class TranslationsWebServerSettingsSectionsMemoryAmbientEn {
-	TranslationsWebServerSettingsSectionsMemoryAmbientEn.internal(this._root);
-
-	final Translations _root; // ignore: unused_field
-
-	// Translations
-
-	/// en: 'Memory · Ambient'
-	String get title => 'Memory · Ambient';
-
-	/// en: 'Auto-capture conversations into memory + spawn-time injection.'
-	String get desc => 'Auto-capture conversations into memory + spawn-time injection.';
 }
 
 // Path: web.serverSettings.sections.backup
@@ -12581,6 +12813,16 @@ extension on Translations {
 			'web.memory.navCleanupInbox' => 'Cleanup inbox',
 			'web.memory.navWorkers' => 'Workers',
 			'web.memory.navConfiguration' => 'Configuration →',
+			'web.journalStale.title' => 'Prune stale entries',
+			'web.journalStale.subtitle' => ({required Object days}) => '(older than ${days} days, no pending conflicts)',
+			'web.journalStale.daysLabel' => 'Older than (days):',
+			'web.journalStale.loading' => 'Scanning…',
+			'web.journalStale.empty' => 'Nothing stale to prune.',
+			'web.journalStale.selectAll' => 'Select all',
+			'web.journalStale.deselectAll' => 'Deselect all',
+			'web.journalStale.deleteSelected' => ({required Object count}) => 'Delete (${count})',
+			'web.journalStale.deleted_one' => ({required Object count}) => '${count} entry deleted',
+			'web.journalStale.deleted_other' => ({required Object count}) => '${count} entries deleted',
 			'web.conflicts.title' => 'Cross-layer conflicts',
 			'web.conflicts.subtitle' => 'Contradictions the daily detector found between facts, plan, goal, and journal entries.',
 			'web.conflicts.loading' => 'Loading conflicts…',
@@ -12592,6 +12834,22 @@ extension on Translations {
 			'web.conflicts.dismiss' => 'Dismiss',
 			'web.conflicts.accepted' => 'Conflict accepted — remember to apply the fix',
 			'web.conflicts.dismissed' => 'Conflict dismissed',
+			'web.conflicts.deletedFact' => 'Fact deleted and conflict accepted',
+			'web.conflicts.quickActions' => 'Fix:',
+			'web.conflicts.deleteFact' => 'Delete fact',
+			'web.conflicts.deleteFactSide' => ({required Object side, required Object ref}) => 'Delete ${side}: ${ref}',
+			'web.conflicts.confirmDelete.title' => ({required Object side}) => 'Delete fact ${side}?',
+			'web.conflicts.confirmDelete.description' => 'This permanently removes the fact and accepts the conflict. The other side stays as the surviving claim.',
+			'web.conflicts.confirmDelete.targetLabel' => ({required Object side}) => 'Will delete (side ${side}):',
+			'web.conflicts.confirmDelete.keepLabel' => ({required Object side}) => 'Will keep (side ${side}):',
+			'web.conflicts.confirmDelete.nonFactOther' => ({required Object layer}) => '(${layer} entry — open the corresponding tab to inspect)',
+			'web.conflicts.confirmDelete.evidenceLabel' => 'Detector evidence:',
+			'web.conflicts.confirmDelete.loading' => 'Loading fact text…',
+			'web.conflicts.confirmDelete.loadError' => 'Failed to load fact text. Inspect on the Memory page.',
+			'web.conflicts.confirmDelete.cancel' => 'Cancel',
+			'web.conflicts.confirmDelete.confirm' => ({required Object side}) => 'Delete ${side}',
+			'web.conflicts.openLayer.plan' => 'Open plan editor',
+			'web.conflicts.openLayer.goal' => 'Open goal editor',
 			'web.conflicts.severity.low' => 'low',
 			'web.conflicts.severity.medium' => 'medium',
 			'web.conflicts.severity.high' => 'high',
@@ -12618,6 +12876,21 @@ extension on Translations {
 			'web.memoryHealth.today' => 'today',
 			'web.memoryHealth.daysAgo_one' => ({required Object count}) => '${count} day ago',
 			'web.memoryHealth.daysAgo_other' => ({required Object count}) => '${count} days ago',
+			'web.memoryConfig.title' => 'Memory configuration',
+			'web.memoryConfig.subtitle' => 'All memory-related knobs in one place: HTTP providers, per-task worker routing, capture triggers, spawn-time injection, and audit costs.',
+			'web.memoryConfig.sections.providers' => 'Providers',
+			'web.memoryConfig.sections.workers' => 'Workers',
+			'web.memoryConfig.sections.rules' => 'Capture rules',
+			'web.memoryConfig.sections.profiles' => 'Injection profiles',
+			'web.memoryConfig.sections.costs' => 'Token cost',
+			'web.memoryConfig.sectionHints.providers' => 'Registered HTTP endpoints (Ollama / LM Studio / Anthropic / OpenAI / Integration) that any task can dispatch to.',
+			'web.memoryConfig.sectionHints.workers' => 'For each touchpoint pick HTTP provider (cheap, local) or headless Claude / Gemini Agent (higher quality, costs CLI tokens).',
+			'web.memoryConfig.sectionHints.rules' => 'When the capture engine fires per session (after N messages / on idle / K characters / manual). Rules without a pinned provider follow the Capture worker setting above.',
+			'web.memoryConfig.sectionHints.profiles' => 'How prior memories get injected into the agent\'s system prompt at session spawn (recency, relevance, hybrid, or off).',
+			'web.memoryConfig.sectionHints.costs' => 'Aggregate spend reconstructed from memory_summarizer_calls. Local providers (Ollama, LM Studio, Integration) are free; cloud providers show real-world cost.',
+			'web.memoryConfig.moveBanner.title' => 'Memory configuration has moved',
+			'web.memoryConfig.moveBanner.body' => 'All memory-related settings (providers / capture rules / injection profiles / cost) now live alongside Workers in one page so related knobs sit together.',
+			'web.memoryConfig.moveBanner.openButton' => 'Open Memory configuration →',
 			'web.memoryWorkers.title' => 'Memory workers',
 			'web.memoryWorkers.loading' => 'Loading worker config…',
 			'web.memoryWorkers.errorTitle' => 'Endpoint not reachable.',
@@ -12663,6 +12936,12 @@ extension on Translations {
 			'web.memoryWorkers.tasks.gitactivity.description' => 'git log → 2-3 paragraph narrative every 24h. Naturally fits an agent worker.',
 			'web.memoryWorkers.tasks.transcript.label' => 'Session transcript summariser',
 			'web.memoryWorkers.tasks.transcript.description' => 'Session-end "what did the agent do" summary. Naturally fits an agent worker.',
+			'web.memoryWorkers.tasks.plan_drift.label' => 'Plan drift detector',
+			'web.memoryWorkers.tasks.plan_drift.description' => 'After each session ends, checks whether the project plan needs updating and files a proposal. Fits an agent worker for richer reasoning.',
+			'web.memoryWorkers.tasks.conflict_detector.label' => 'Cross-layer conflict detector',
+			'web.memoryWorkers.tasks.conflict_detector.description' => 'Daily scan that finds contradictions between facts / plan / goal / journal. Higher-quality model = fewer false positives.',
+			'web.memoryWorkers.tasks.capture.label' => 'Capture engine',
+			'web.memoryWorkers.tasks.capture.description' => 'Per-trigger fact extraction from session transcripts. Agent mode gives noticeably better facts on long sessions; summarizer mode is cheap and local.',
 			'web.cleanupInbox.loading' => 'Loading…',
 			'web.cleanupInbox.emptyTitle' => 'Cleanup inbox empty',
 			'web.cleanupInbox.emptyDescription' => 'No pending cleanup decisions across any project. The LLM librarian either hasn\'t run yet for the eligible memories, or it found everything load-bearing.',
@@ -12825,6 +13104,8 @@ extension on Translations {
 			'web.memoryInspector.records.noMatchesForQuery' => ({required Object query}) => 'No matches for "${query}"',
 			'web.memoryInspector.records.noMemoriesInScope' => 'No memories in this scope yet.',
 			'web.memoryInspector.row.simBadge' => ({required Object value}) => 'sim ${value}',
+			'web.memoryInspector.row.rankBadge' => ({required Object value}) => 'rank ${value}',
+			'web.memoryInspector.row.rankTooltip' => ({required Object effective, required Object similarity, required Object age, required Object days, required Object hits, required Object confidence}) => 'effective ${effective} = sim ${similarity} × age ${age} (${days}d) × hits ${hits} × conf ${confidence}',
 			'web.memoryInspector.row.hits_one' => ({required Object count}) => '${count} hit',
 			'web.memoryInspector.row.hits_other' => ({required Object count}) => '${count} hits',
 			'web.memoryInspector.row.lastHitTooltip' => ({required Object relative}) => 'Last hit ${relative}',
@@ -12862,6 +13143,8 @@ extension on Translations {
 			'web.memoryInspector.bulkDelete.items_one' => ({required Object count}) => '${count} memory item',
 			'web.memoryInspector.bulkDelete.items_other' => ({required Object count}) => '${count} memory items',
 			'web.memoryInspector.bulkDelete.cancel' => 'Cancel',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryInspector.bulkDelete.deleteAll' => 'Delete all',
 			'web.memoryInspector.addMem.title' => 'Add memory',
 			'web.memoryInspector.addMem.description' => 'Manually create a memory. Agents create these automatically via the <1>memory_store</1> MCP tool — this form is for cases where the operator wants to seed a fact without going through an agent.',
@@ -12911,8 +13194,6 @@ extension on Translations {
 			'web.notes.left.clearTagTooltip' => 'Clear tag filter',
 			'web.notes.left.expandAll' => 'Expand all',
 			'web.notes.left.expandAllTooltip' => 'Expand every folder',
-			_ => null,
-		} ?? switch (path) {
 			'web.notes.left.collapseAll' => 'Collapse all',
 			'web.notes.left.collapseAllTooltip' => 'Collapse every folder',
 			'web.notes.left.loading' => 'Loading…',
@@ -13376,6 +13657,8 @@ extension on Translations {
 			'web.plugins.mcp.editor.savedToast' => 'MCP server saved',
 			'web.plugins.mcp.editor.createFailedToast' => 'Create failed',
 			'web.plugins.mcp.editor.saveFailedToast' => 'Save failed',
+			_ => null,
+		} ?? switch (path) {
 			'web.plugins.mcpSecrets.title' => 'MCP secrets',
 			'web.plugins.mcpSecrets.encryptedBadge' => 'encrypted',
 			'web.plugins.mcpSecrets.plaintextBadge' => 'plaintext',
@@ -13425,8 +13708,6 @@ extension on Translations {
 			'web.plugins.skills.resetConfirm' => ({required Object id}) => 'Reset "${id}" to the built-in version? This deletes your vault SKILL.md and falls back to the embedded copy.',
 			'web.plugins.skills.deleteConfirm' => ({required Object id}) => 'Delete skill "${id}" from your vault? This removes the SKILL.md file.',
 			'web.plugins.skills.removedToast' => 'Skill removed',
-			_ => null,
-		} ?? switch (path) {
 			'web.plugins.skills.deleteFailedToast' => 'Delete failed',
 			'web.plugins.skills.editor.createTitle' => 'New skill',
 			'web.plugins.skills.editor.customizeTitle' => ({required Object id}) => 'Customize built-in: ${id}',
@@ -13719,8 +14000,6 @@ extension on Translations {
 			'web.serverSettings.sections.mcp.desc' => 'Server registry + secrets.',
 			'web.serverSettings.sections.memory.title' => 'Memory',
 			'web.serverSettings.sections.memory.desc' => 'Cross-CLI persistent memory subsystem.',
-			'web.serverSettings.sections.memoryAmbient.title' => 'Memory · Ambient',
-			'web.serverSettings.sections.memoryAmbient.desc' => 'Auto-capture conversations into memory + spawn-time injection.',
 			'web.serverSettings.sections.backup.title' => 'Backup',
 			'web.serverSettings.sections.backup.desc' => 'Encrypted DB backups, restore, and admin data exports.',
 			'web.serverSettings.sections.claude.title' => 'Storage · Claude',
@@ -13892,6 +14171,8 @@ extension on Translations {
 			'web.serverSettings.backup.scheduleHeaders.keep' => 'Keep',
 			'web.serverSettings.backup.scheduleHeaders.state' => 'State',
 			'web.serverSettings.backup.every' => ({required Object interval}) => 'every ${interval}',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.backup.backupsKeep' => ({required Object count}) => '${count} backups',
 			'web.serverSettings.backup.stateEnabled' => 'enabled',
 			'web.serverSettings.backup.statePaused' => 'paused',
@@ -13939,8 +14220,6 @@ extension on Translations {
 			'web.settings.font.options.comfy' => 'Comfy',
 			'web.settings.font.options.large' => 'Large',
 			'web.settings.account.title' => 'Account',
-			_ => null,
-		} ?? switch (path) {
 			'web.settings.account.description' => 'Operator and current bearer token.',
 			'web.settings.account.username' => 'Username',
 			'web.settings.account.tokenExpires' => 'Token expires',
@@ -14406,6 +14685,8 @@ extension on Translations {
 			'mcp.secret.keyHint' => 'GITHUB_TOKEN, OPENAI_KEY, …',
 			'mcp.secret.valueLabel' => 'Value',
 			'mcp.secret.keyRequired' => 'Key is required.',
+			_ => null,
+		} ?? switch (path) {
 			'mcp.secret.keyInvalid' => 'Key must match [A-Za-z_][A-Za-z0-9_]* — same rules as a shell env var.',
 			'mcp.secret.valueRequired' => 'Value is required.',
 			'mcp.secret.replaceTitle' => 'Replace secret value',
@@ -14453,8 +14734,6 @@ extension on Translations {
 			'providers.errorPrefix.delete' => 'Delete failed',
 			'providers.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}: ${error}',
 			'providers.accounts.rename' => 'Rename',
-			_ => null,
-		} ?? switch (path) {
 			'providers.accounts.renameTitle' => ({required Object name}) => 'Rename ${name}',
 			'providers.accounts.displayNameLabel' => 'Display name',
 			'providers.accounts.displayNameHint' => 'Work account',
@@ -14920,6 +15199,8 @@ extension on Translations {
 			'channels.kinds.dingtalk.description' => 'Custom group robot. Outbound only. Group chat → Robots → Add → Sign mode → copy webhook + secret.',
 			'channels.kinds.dingtalk.webhookUrlLabel' => 'Webhook URL',
 			'channels.kinds.dingtalk.secretLabel' => 'Sign secret',
+			_ => null,
+		} ?? switch (path) {
 			'channels.kinds.dingtalk.secretHint' => 'When the robot is set to "Sign" security mode, copy the secret here. opendray adds the timestamp + sign params automatically.',
 			'channels.kinds.wecom.description' => 'Group robot webhook. Outbound only (text + markdown). Group settings → Group robots → Add → copy webhook URL.',
 			'channels.kinds.wecom.webhookKeyLabel' => 'Webhook key',
@@ -14967,8 +15248,6 @@ extension on Translations {
 			'skills.resetTooltip' => 'Reset to built-in',
 			'skills.deleteTooltip' => 'Delete',
 			'skills.saving' => 'Saving…',
-			_ => null,
-		} ?? switch (path) {
 			'skills.saveOverride' => 'Save override',
 			'skills.overrideBanner' => 'Saving creates a vault override with the same id. Sessions will use this body instead of the built-in until you reset.',
 			'skills.idHelper' => 'Lowercase letters / digits / dash. Locked once created.',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -384,6 +384,8 @@ class _TranslationsProjectZh extends TranslationsProjectEn {
 	// Translations
 	@override String get title => '项目';
 	@override String get pickFirst => '请先选择一个项目。';
+	@override late final _TranslationsProjectHealthZh health = _TranslationsProjectHealthZh._(_root);
+	@override late final _TranslationsProjectConflictsZh conflicts = _TranslationsProjectConflictsZh._(_root);
 	@override String loadFailed({required Object error}) => '加载失败：${error}';
 	@override String projectsLoadFailed({required Object error}) => '加载项目列表失败：${error}';
 	@override String get projectLabel => '项目';
@@ -1761,6 +1763,53 @@ class _TranslationsMemoryWorkersTasksZh extends TranslationsMemoryWorkersTasksEn
 	@override late final _TranslationsMemoryWorkersTasksCleanerZh cleaner = _TranslationsMemoryWorkersTasksCleanerZh._(_root);
 	@override late final _TranslationsMemoryWorkersTasksGitactivityZh gitactivity = _TranslationsMemoryWorkersTasksGitactivityZh._(_root);
 	@override late final _TranslationsMemoryWorkersTasksTranscriptZh transcript = _TranslationsMemoryWorkersTasksTranscriptZh._(_root);
+	@override late final _TranslationsMemoryWorkersTasksPlanDriftZh planDrift = _TranslationsMemoryWorkersTasksPlanDriftZh._(_root);
+	@override late final _TranslationsMemoryWorkersTasksConflictDetectorZh conflictDetector = _TranslationsMemoryWorkersTasksConflictDetectorZh._(_root);
+	@override late final _TranslationsMemoryWorkersTasksCaptureZh capture = _TranslationsMemoryWorkersTasksCaptureZh._(_root);
+}
+
+// Path: project.health
+class _TranslationsProjectHealthZh extends TranslationsProjectHealthEn {
+	_TranslationsProjectHealthZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String title({required Object days}) => '记忆健康 — 最近 ${days} 天';
+	@override String get subtitle => '本项目两套记忆子系统的运行情况聚合。';
+	@override String get newFacts => '新增 facts';
+	@override String newFactsHint({required Object total}) => '累计 ${total} 条';
+	@override String get captureFires => 'Capture 触发次数';
+	@override String captureFiresHint({required Object stored, required Object deduped}) => '存入 ${stored} · 去重 ${deduped}';
+	@override String get newJournal => '新增日志条目';
+	@override String newJournalHint({required Object total}) => '累计 ${total} 条';
+	@override String get planAge => '计划最近更新';
+	@override String planAgeHint({required Object count}) => '${count} 条 plan-drift 提案待审';
+	@override String get planAgeHintNone => '无 plan-drift 提案待审';
+	@override String get goalAge => '目标最近更新';
+	@override String get pending => '待审提案';
+	@override String pendingHint({required Object days}) => '最久 ${days} 天';
+	@override String topHit({required Object hits}) => '命中最多 · ${hits} 次';
+	@override String zeroHit({required Object count}) => '${count} 条超过 7 天未命中的 fact — 清理候选。';
+	@override String get never => '从未';
+	@override String get today => '今日';
+	@override String daysAgo({required Object count}) => '${count} 天前';
+}
+
+// Path: project.conflicts
+class _TranslationsProjectConflictsZh extends TranslationsProjectConflictsEn {
+	_TranslationsProjectConflictsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get subtitle => '每日 detector 在 facts/plan/goal/journal 之间发现的矛盾。';
+	@override String get empty => '无待处理冲突。点击「立即检测」运行一次按需扫描。';
+	@override String get detectNow => '立即检测';
+	@override String detected({required Object count}) => '新发现 ${count} 条冲突';
+	@override String get accept => '采纳';
+	@override String get dismiss => '驳回';
+	@override late final _TranslationsProjectConflictsSeverityZh severity = _TranslationsProjectConflictsSeverityZh._(_root);
 }
 
 // Path: backups.kv
@@ -4919,6 +4968,51 @@ class _TranslationsMemoryWorkersTasksTranscriptZh extends TranslationsMemoryWork
 	// Translations
 	@override String get label => '会话记录摘要器';
 	@override String get description => '会话结束时的「agent 做了什么」摘要。天然适合 agent 工作器。';
+}
+
+// Path: memoryWorkers.tasks.planDrift
+class _TranslationsMemoryWorkersTasksPlanDriftZh extends TranslationsMemoryWorkersTasksPlanDriftEn {
+	_TranslationsMemoryWorkersTasksPlanDriftZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '计划漂移检测';
+	@override String get description => '每个 session 结束后判断项目 plan 是否需要更新并提出 proposal。用 agent 推理质量更高。';
+}
+
+// Path: memoryWorkers.tasks.conflictDetector
+class _TranslationsMemoryWorkersTasksConflictDetectorZh extends TranslationsMemoryWorkersTasksConflictDetectorEn {
+	_TranslationsMemoryWorkersTasksConflictDetectorZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '跨层冲突检测';
+	@override String get description => '每日扫描 facts/plan/goal/journal 之间的矛盾。模型越强，误报越少。';
+}
+
+// Path: memoryWorkers.tasks.capture
+class _TranslationsMemoryWorkersTasksCaptureZh extends TranslationsMemoryWorkersTasksCaptureEn {
+	_TranslationsMemoryWorkersTasksCaptureZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'Capture 引擎';
+	@override String get description => '按触发器从 session transcript 抽取 fact。Agent 模式在长会话上 fact 质量明显更好；summarizer 模式便宜且本地。';
+}
+
+// Path: project.conflicts.severity
+class _TranslationsProjectConflictsSeverityZh extends TranslationsProjectConflictsSeverityEn {
+	_TranslationsProjectConflictsSeverityZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get low => '低';
+	@override String get medium => '中';
+	@override String get high => '高';
 }
 
 // Path: backupTargetEditor.kinds.local
@@ -9053,6 +9147,12 @@ extension on TranslationsZh {
 			'memoryWorkers.tasks.gitactivity.description' => 'git log → 每 24 小时的 2-3 段叙事。天然适合 agent 工作器。',
 			'memoryWorkers.tasks.transcript.label' => '会话记录摘要器',
 			'memoryWorkers.tasks.transcript.description' => '会话结束时的「agent 做了什么」摘要。天然适合 agent 工作器。',
+			'memoryWorkers.tasks.planDrift.label' => '计划漂移检测',
+			'memoryWorkers.tasks.planDrift.description' => '每个 session 结束后判断项目 plan 是否需要更新并提出 proposal。用 agent 推理质量更高。',
+			'memoryWorkers.tasks.conflictDetector.label' => '跨层冲突检测',
+			'memoryWorkers.tasks.conflictDetector.description' => '每日扫描 facts/plan/goal/journal 之间的矛盾。模型越强，误报越少。',
+			'memoryWorkers.tasks.capture.label' => 'Capture 引擎',
+			'memoryWorkers.tasks.capture.description' => '按触发器从 session transcript 抽取 fact。Agent 模式在长会话上 fact 质量明显更好；summarizer 模式便宜且本地。',
 			'memoryCleanup.title' => '记忆清理',
 			'memoryCleanup.approveFailed' => ({required Object error}) => '批准失败：${error}',
 			'memoryCleanup.rejectFailed' => ({required Object error}) => '拒绝失败：${error}',
@@ -9060,6 +9160,34 @@ extension on TranslationsZh {
 			'memoryCleanup.reject' => '拒绝',
 			'project.title' => '项目',
 			'project.pickFirst' => '请先选择一个项目。',
+			'project.health.title' => ({required Object days}) => '记忆健康 — 最近 ${days} 天',
+			'project.health.subtitle' => '本项目两套记忆子系统的运行情况聚合。',
+			'project.health.newFacts' => '新增 facts',
+			'project.health.newFactsHint' => ({required Object total}) => '累计 ${total} 条',
+			'project.health.captureFires' => 'Capture 触发次数',
+			'project.health.captureFiresHint' => ({required Object stored, required Object deduped}) => '存入 ${stored} · 去重 ${deduped}',
+			'project.health.newJournal' => '新增日志条目',
+			'project.health.newJournalHint' => ({required Object total}) => '累计 ${total} 条',
+			'project.health.planAge' => '计划最近更新',
+			'project.health.planAgeHint' => ({required Object count}) => '${count} 条 plan-drift 提案待审',
+			'project.health.planAgeHintNone' => '无 plan-drift 提案待审',
+			'project.health.goalAge' => '目标最近更新',
+			'project.health.pending' => '待审提案',
+			'project.health.pendingHint' => ({required Object days}) => '最久 ${days} 天',
+			'project.health.topHit' => ({required Object hits}) => '命中最多 · ${hits} 次',
+			'project.health.zeroHit' => ({required Object count}) => '${count} 条超过 7 天未命中的 fact — 清理候选。',
+			'project.health.never' => '从未',
+			'project.health.today' => '今日',
+			'project.health.daysAgo' => ({required Object count}) => '${count} 天前',
+			'project.conflicts.subtitle' => '每日 detector 在 facts/plan/goal/journal 之间发现的矛盾。',
+			'project.conflicts.empty' => '无待处理冲突。点击「立即检测」运行一次按需扫描。',
+			'project.conflicts.detectNow' => '立即检测',
+			'project.conflicts.detected' => ({required Object count}) => '新发现 ${count} 条冲突',
+			'project.conflicts.accept' => '采纳',
+			'project.conflicts.dismiss' => '驳回',
+			'project.conflicts.severity.low' => '低',
+			'project.conflicts.severity.medium' => '中',
+			'project.conflicts.severity.high' => '高',
 			'project.loadFailed' => ({required Object error}) => '加载失败：${error}',
 			'project.projectsLoadFailed' => ({required Object error}) => '加载项目列表失败：${error}',
 			'project.projectLabel' => '项目',
@@ -9355,6 +9483,8 @@ extension on TranslationsZh {
 			'channels.snacks.channelDeleted' => '通道已删除。',
 			'channels.errorPrefix.test' => '测试失败',
 			'channels.errorPrefix.toggle' => '切换失败',
+			_ => null,
+		} ?? switch (path) {
 			'channels.errorPrefix.muteToggle' => '静音切换失败',
 			'channels.errorPrefix.update' => '更新失败',
 			'channels.errorPrefix.delete' => '删除失败',
@@ -9389,8 +9519,6 @@ extension on TranslationsZh {
 			'channels.kinds.dingtalk.description' => '自定义群机器人。仅外发。群聊 → 机器人 → 添加 → 加签模式 → 复制 webhook + secret。',
 			'channels.kinds.dingtalk.webhookUrlLabel' => 'Webhook URL',
 			'channels.kinds.dingtalk.secretLabel' => '加签 secret',
-			_ => null,
-		} ?? switch (path) {
 			'channels.kinds.dingtalk.secretHint' => '当机器人为「加签」安全模式时，将 secret 复制到这里。opendray 自动添加 timestamp + sign 参数。',
 			'channels.kinds.wecom.description' => '群机器人 webhook。仅外发（文本 + markdown）。群设置 → 群机器人 → 添加 → 复制 webhook URL。',
 			'channels.kinds.wecom.webhookKeyLabel' => 'Webhook key',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -140,8 +140,10 @@ class _TranslationsWebZh extends TranslationsWebEn {
 	@override late final _TranslationsWebTopbarZh topbar = _TranslationsWebTopbarZh._(_root);
 	@override late final _TranslationsWebSessionsZh sessions = _TranslationsWebSessionsZh._(_root);
 	@override late final _TranslationsWebMemoryZh memory = _TranslationsWebMemoryZh._(_root);
+	@override late final _TranslationsWebJournalStaleZh journalStale = _TranslationsWebJournalStaleZh._(_root);
 	@override late final _TranslationsWebConflictsZh conflicts = _TranslationsWebConflictsZh._(_root);
 	@override late final _TranslationsWebMemoryHealthZh memoryHealth = _TranslationsWebMemoryHealthZh._(_root);
+	@override late final _TranslationsWebMemoryConfigZh memoryConfig = _TranslationsWebMemoryConfigZh._(_root);
 	@override late final _TranslationsWebMemoryWorkersZh memoryWorkers = _TranslationsWebMemoryWorkersZh._(_root);
 	@override late final _TranslationsWebCleanupInboxZh cleanupInbox = _TranslationsWebCleanupInboxZh._(_root);
 	@override late final _TranslationsWebProjectZh project = _TranslationsWebProjectZh._(_root);
@@ -892,6 +894,25 @@ class _TranslationsWebMemoryZh extends TranslationsWebMemoryEn {
 	@override String get navConfiguration => '配置 →';
 }
 
+// Path: web.journalStale
+class _TranslationsWebJournalStaleZh extends TranslationsWebJournalStaleEn {
+	_TranslationsWebJournalStaleZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '清理陈旧条目';
+	@override String subtitle({required Object days}) => '（超过 ${days} 天、无 pending 冲突引用）';
+	@override String get daysLabel => '超过（天）：';
+	@override String get loading => '扫描中…';
+	@override String get empty => '没有可清理的陈旧条目。';
+	@override String get selectAll => '全选';
+	@override String get deselectAll => '取消全选';
+	@override String deleteSelected({required Object count}) => '删除 (${count})';
+	@override String deleted_one({required Object count}) => '已删除 ${count} 条';
+	@override String deleted_other({required Object count}) => '已删除 ${count} 条';
+}
+
 // Path: web.conflicts
 class _TranslationsWebConflictsZh extends TranslationsWebConflictsEn {
 	_TranslationsWebConflictsZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -910,6 +931,12 @@ class _TranslationsWebConflictsZh extends TranslationsWebConflictsEn {
 	@override String get dismiss => '驳回';
 	@override String get accepted => '已采纳 — 别忘了实际修正';
 	@override String get dismissed => '已驳回';
+	@override String get deletedFact => '已删除 fact 并采纳冲突';
+	@override String get quickActions => '快速修复：';
+	@override String get deleteFact => '删除 fact';
+	@override String deleteFactSide({required Object side, required Object ref}) => '删除 ${side}: ${ref}';
+	@override late final _TranslationsWebConflictsConfirmDeleteZh confirmDelete = _TranslationsWebConflictsConfirmDeleteZh._(_root);
+	@override late final _TranslationsWebConflictsOpenLayerZh openLayer = _TranslationsWebConflictsOpenLayerZh._(_root);
 	@override late final _TranslationsWebConflictsSeverityZh severity = _TranslationsWebConflictsSeverityZh._(_root);
 }
 
@@ -943,6 +970,20 @@ class _TranslationsWebMemoryHealthZh extends TranslationsWebMemoryHealthEn {
 	@override String get today => '今日';
 	@override String daysAgo_one({required Object count}) => '${count} 天前';
 	@override String daysAgo_other({required Object count}) => '${count} 天前';
+}
+
+// Path: web.memoryConfig
+class _TranslationsWebMemoryConfigZh extends TranslationsWebMemoryConfigEn {
+	_TranslationsWebMemoryConfigZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '记忆配置';
+	@override String get subtitle => '所有记忆相关开关汇总到这里：HTTP provider、每个任务的路由、capture 触发器、spawn 时注入策略、累计花费。';
+	@override late final _TranslationsWebMemoryConfigSectionsZh sections = _TranslationsWebMemoryConfigSectionsZh._(_root);
+	@override late final _TranslationsWebMemoryConfigSectionHintsZh sectionHints = _TranslationsWebMemoryConfigSectionHintsZh._(_root);
+	@override late final _TranslationsWebMemoryConfigMoveBannerZh moveBanner = _TranslationsWebMemoryConfigMoveBannerZh._(_root);
 }
 
 // Path: web.memoryWorkers
@@ -2423,6 +2464,36 @@ class _TranslationsWebSessionsFileBrowserZh extends TranslationsWebSessionsFileB
 	@override String get homeFailedToast => '读取家目录失败';
 }
 
+// Path: web.conflicts.confirmDelete
+class _TranslationsWebConflictsConfirmDeleteZh extends TranslationsWebConflictsConfirmDeleteEn {
+	_TranslationsWebConflictsConfirmDeleteZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String title({required Object side}) => '确认删除 fact ${side}?';
+	@override String get description => '永久删除此 fact 并采纳冲突。另一侧保留为最终采信的版本。';
+	@override String targetLabel({required Object side}) => '将删除（${side} 侧）：';
+	@override String keepLabel({required Object side}) => '将保留（${side} 侧）：';
+	@override String nonFactOther({required Object layer}) => '（${layer} 条目 — 请打开对应 tab 查看完整内容）';
+	@override String get evidenceLabel => 'Detector 给出的证据：';
+	@override String get loading => '加载 fact 内容中…';
+	@override String get loadError => '无法加载 fact 内容，请在 Memory 页面手动查看。';
+	@override String get cancel => '取消';
+	@override String confirm({required Object side}) => '确认删除 ${side}';
+}
+
+// Path: web.conflicts.openLayer
+class _TranslationsWebConflictsOpenLayerZh extends TranslationsWebConflictsOpenLayerEn {
+	_TranslationsWebConflictsOpenLayerZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get plan => '打开计划编辑器';
+	@override String get goal => '打开目标编辑器';
+}
+
 // Path: web.conflicts.severity
 class _TranslationsWebConflictsSeverityZh extends TranslationsWebConflictsSeverityEn {
 	_TranslationsWebConflictsSeverityZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -2433,6 +2504,46 @@ class _TranslationsWebConflictsSeverityZh extends TranslationsWebConflictsSeveri
 	@override String get low => '低';
 	@override String get medium => '中';
 	@override String get high => '高';
+}
+
+// Path: web.memoryConfig.sections
+class _TranslationsWebMemoryConfigSectionsZh extends TranslationsWebMemoryConfigSectionsEn {
+	_TranslationsWebMemoryConfigSectionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get providers => 'Provider 池';
+	@override String get workers => '任务路由 (Workers)';
+	@override String get rules => 'Capture 规则';
+	@override String get profiles => '注入策略 (Injection profiles)';
+	@override String get costs => 'Token 成本';
+}
+
+// Path: web.memoryConfig.sectionHints
+class _TranslationsWebMemoryConfigSectionHintsZh extends TranslationsWebMemoryConfigSectionHintsEn {
+	_TranslationsWebMemoryConfigSectionHintsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get providers => '已注册的 HTTP endpoint 池 (Ollama / LM Studio / Anthropic / OpenAI / Integration)，所有任务都能引用。';
+	@override String get workers => '每个 task 选用 HTTP provider（便宜、本地）或 headless Claude / Gemini Agent（质量更高，消耗 CLI 配额）。';
+	@override String get rules => 'Capture 引擎何时触发（每 N 条消息 / 闲置 / 累计 K 字符 / 手动）。规则若没固定 provider，会跟随上面 Capture 任务的 worker 设置。';
+	@override String get profiles => 'Session 启动时把哪些历史记忆塞进 agent system prompt（按最近、按相关度、混合、关闭）。';
+	@override String get costs => 'memory_summarizer_calls 重算的累计花费。本地 provider（Ollama / LM Studio / Integration）免费；云 provider 显示真实成本。';
+}
+
+// Path: web.memoryConfig.moveBanner
+class _TranslationsWebMemoryConfigMoveBannerZh extends TranslationsWebMemoryConfigMoveBannerEn {
+	_TranslationsWebMemoryConfigMoveBannerZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '记忆配置已迁移';
+	@override String get body => '所有记忆相关设置（providers / capture rules / injection profiles / cost）现在跟 Workers 在同一页面，相关开关聚在一起。';
+	@override String get openButton => '打开 记忆配置 →';
 }
 
 // Path: web.memoryWorkers.tasks
@@ -2446,6 +2557,9 @@ class _TranslationsWebMemoryWorkersTasksZh extends TranslationsWebMemoryWorkersT
 	@override late final _TranslationsWebMemoryWorkersTasksCleanerZh cleaner = _TranslationsWebMemoryWorkersTasksCleanerZh._(_root);
 	@override late final _TranslationsWebMemoryWorkersTasksGitactivityZh gitactivity = _TranslationsWebMemoryWorkersTasksGitactivityZh._(_root);
 	@override late final _TranslationsWebMemoryWorkersTasksTranscriptZh transcript = _TranslationsWebMemoryWorkersTasksTranscriptZh._(_root);
+	@override late final _TranslationsWebMemoryWorkersTasksPlanDriftZh plan_drift = _TranslationsWebMemoryWorkersTasksPlanDriftZh._(_root);
+	@override late final _TranslationsWebMemoryWorkersTasksConflictDetectorZh conflict_detector = _TranslationsWebMemoryWorkersTasksConflictDetectorZh._(_root);
+	@override late final _TranslationsWebMemoryWorkersTasksCaptureZh capture = _TranslationsWebMemoryWorkersTasksCaptureZh._(_root);
 }
 
 // Path: web.project.picker
@@ -2721,6 +2835,8 @@ class _TranslationsWebMemoryInspectorRowZh extends TranslationsWebMemoryInspecto
 
 	// Translations
 	@override String simBadge({required Object value}) => '相似度 ${value}';
+	@override String rankBadge({required Object value}) => '排名分 ${value}';
+	@override String rankTooltip({required Object effective, required Object similarity, required Object age, required Object days, required Object hits, required Object confidence}) => '有效分 ${effective} = 相似度 ${similarity} × 时效 ${age} (${days}d) × 命中 ${hits} × 置信 ${confidence}';
 	@override String hits_one({required Object count}) => '命中 ${count} 次';
 	@override String hits_other({required Object count}) => '命中 ${count} 次';
 	@override String lastHitTooltip({required Object relative}) => '最近命中 ${relative}';
@@ -3834,7 +3950,6 @@ class _TranslationsWebServerSettingsSectionsZh extends TranslationsWebServerSett
 	@override late final _TranslationsWebServerSettingsSectionsVaultZh vault = _TranslationsWebServerSettingsSectionsVaultZh._(_root);
 	@override late final _TranslationsWebServerSettingsSectionsMcpZh mcp = _TranslationsWebServerSettingsSectionsMcpZh._(_root);
 	@override late final _TranslationsWebServerSettingsSectionsMemoryZh memory = _TranslationsWebServerSettingsSectionsMemoryZh._(_root);
-	@override late final _TranslationsWebServerSettingsSectionsMemoryAmbientZh memoryAmbient = _TranslationsWebServerSettingsSectionsMemoryAmbientZh._(_root);
 	@override late final _TranslationsWebServerSettingsSectionsBackupZh backup = _TranslationsWebServerSettingsSectionsBackupZh._(_root);
 	@override late final _TranslationsWebServerSettingsSectionsClaudeZh claude = _TranslationsWebServerSettingsSectionsClaudeZh._(_root);
 	@override late final _TranslationsWebServerSettingsSectionsCodexZh codex = _TranslationsWebServerSettingsSectionsCodexZh._(_root);
@@ -5201,6 +5316,39 @@ class _TranslationsWebMemoryWorkersTasksTranscriptZh extends TranslationsWebMemo
 	@override String get description => '会话结束时的“agent 都做了什么”总结。天然适合 agent worker。';
 }
 
+// Path: web.memoryWorkers.tasks.plan_drift
+class _TranslationsWebMemoryWorkersTasksPlanDriftZh extends TranslationsWebMemoryWorkersTasksPlanDriftEn {
+	_TranslationsWebMemoryWorkersTasksPlanDriftZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '计划漂移检测';
+	@override String get description => '每个 session 结束后判断项目 plan 是否需要更新并提出 proposal。用 agent 推理质量更高。';
+}
+
+// Path: web.memoryWorkers.tasks.conflict_detector
+class _TranslationsWebMemoryWorkersTasksConflictDetectorZh extends TranslationsWebMemoryWorkersTasksConflictDetectorEn {
+	_TranslationsWebMemoryWorkersTasksConflictDetectorZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '跨层冲突检测';
+	@override String get description => '每日扫描 facts/plan/goal/journal 之间的矛盾。模型越强，误报越少。';
+}
+
+// Path: web.memoryWorkers.tasks.capture
+class _TranslationsWebMemoryWorkersTasksCaptureZh extends TranslationsWebMemoryWorkersTasksCaptureEn {
+	_TranslationsWebMemoryWorkersTasksCaptureZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'Capture 引擎';
+	@override String get description => '按触发器从 session transcript 抽取 fact。Agent 模式在长会话上 fact 质量明显更好；summarizer 模式便宜且本地。';
+}
+
 // Path: web.project.readonly.tech_stack
 class _TranslationsWebProjectReadonlyTechStackZh extends TranslationsWebProjectReadonlyTechStackEn {
 	_TranslationsWebProjectReadonlyTechStackZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -5901,17 +6049,6 @@ class _TranslationsWebServerSettingsSectionsMemoryZh extends TranslationsWebServ
 	// Translations
 	@override String get title => '记忆';
 	@override String get desc => '跨 CLI 的持久化记忆子系统。';
-}
-
-// Path: web.serverSettings.sections.memoryAmbient
-class _TranslationsWebServerSettingsSectionsMemoryAmbientZh extends TranslationsWebServerSettingsSectionsMemoryAmbientEn {
-	_TranslationsWebServerSettingsSectionsMemoryAmbientZh._(TranslationsZh root) : this._root = root, super.internal(root);
-
-	final TranslationsZh _root; // ignore: unused_field
-
-	// Translations
-	@override String get title => '记忆 · 环境感知';
-	@override String get desc => '自动捕获对话进入记忆，并在 spawn 时注入。';
 }
 
 // Path: web.serverSettings.sections.backup
@@ -6866,6 +7003,16 @@ extension on TranslationsZh {
 			'web.memory.navCleanupInbox' => '清理收件箱',
 			'web.memory.navWorkers' => 'Workers',
 			'web.memory.navConfiguration' => '配置 →',
+			'web.journalStale.title' => '清理陈旧条目',
+			'web.journalStale.subtitle' => ({required Object days}) => '（超过 ${days} 天、无 pending 冲突引用）',
+			'web.journalStale.daysLabel' => '超过（天）：',
+			'web.journalStale.loading' => '扫描中…',
+			'web.journalStale.empty' => '没有可清理的陈旧条目。',
+			'web.journalStale.selectAll' => '全选',
+			'web.journalStale.deselectAll' => '取消全选',
+			'web.journalStale.deleteSelected' => ({required Object count}) => '删除 (${count})',
+			'web.journalStale.deleted_one' => ({required Object count}) => '已删除 ${count} 条',
+			'web.journalStale.deleted_other' => ({required Object count}) => '已删除 ${count} 条',
 			'web.conflicts.title' => '跨层冲突',
 			'web.conflicts.subtitle' => '每日 detector 在 facts/plan/goal/journal 之间发现的矛盾。',
 			'web.conflicts.loading' => '正在加载冲突…',
@@ -6877,6 +7024,22 @@ extension on TranslationsZh {
 			'web.conflicts.dismiss' => '驳回',
 			'web.conflicts.accepted' => '已采纳 — 别忘了实际修正',
 			'web.conflicts.dismissed' => '已驳回',
+			'web.conflicts.deletedFact' => '已删除 fact 并采纳冲突',
+			'web.conflicts.quickActions' => '快速修复：',
+			'web.conflicts.deleteFact' => '删除 fact',
+			'web.conflicts.deleteFactSide' => ({required Object side, required Object ref}) => '删除 ${side}: ${ref}',
+			'web.conflicts.confirmDelete.title' => ({required Object side}) => '确认删除 fact ${side}?',
+			'web.conflicts.confirmDelete.description' => '永久删除此 fact 并采纳冲突。另一侧保留为最终采信的版本。',
+			'web.conflicts.confirmDelete.targetLabel' => ({required Object side}) => '将删除（${side} 侧）：',
+			'web.conflicts.confirmDelete.keepLabel' => ({required Object side}) => '将保留（${side} 侧）：',
+			'web.conflicts.confirmDelete.nonFactOther' => ({required Object layer}) => '（${layer} 条目 — 请打开对应 tab 查看完整内容）',
+			'web.conflicts.confirmDelete.evidenceLabel' => 'Detector 给出的证据：',
+			'web.conflicts.confirmDelete.loading' => '加载 fact 内容中…',
+			'web.conflicts.confirmDelete.loadError' => '无法加载 fact 内容，请在 Memory 页面手动查看。',
+			'web.conflicts.confirmDelete.cancel' => '取消',
+			'web.conflicts.confirmDelete.confirm' => ({required Object side}) => '确认删除 ${side}',
+			'web.conflicts.openLayer.plan' => '打开计划编辑器',
+			'web.conflicts.openLayer.goal' => '打开目标编辑器',
 			'web.conflicts.severity.low' => '低',
 			'web.conflicts.severity.medium' => '中',
 			'web.conflicts.severity.high' => '高',
@@ -6903,6 +7066,21 @@ extension on TranslationsZh {
 			'web.memoryHealth.today' => '今日',
 			'web.memoryHealth.daysAgo_one' => ({required Object count}) => '${count} 天前',
 			'web.memoryHealth.daysAgo_other' => ({required Object count}) => '${count} 天前',
+			'web.memoryConfig.title' => '记忆配置',
+			'web.memoryConfig.subtitle' => '所有记忆相关开关汇总到这里：HTTP provider、每个任务的路由、capture 触发器、spawn 时注入策略、累计花费。',
+			'web.memoryConfig.sections.providers' => 'Provider 池',
+			'web.memoryConfig.sections.workers' => '任务路由 (Workers)',
+			'web.memoryConfig.sections.rules' => 'Capture 规则',
+			'web.memoryConfig.sections.profiles' => '注入策略 (Injection profiles)',
+			'web.memoryConfig.sections.costs' => 'Token 成本',
+			'web.memoryConfig.sectionHints.providers' => '已注册的 HTTP endpoint 池 (Ollama / LM Studio / Anthropic / OpenAI / Integration)，所有任务都能引用。',
+			'web.memoryConfig.sectionHints.workers' => '每个 task 选用 HTTP provider（便宜、本地）或 headless Claude / Gemini Agent（质量更高，消耗 CLI 配额）。',
+			'web.memoryConfig.sectionHints.rules' => 'Capture 引擎何时触发（每 N 条消息 / 闲置 / 累计 K 字符 / 手动）。规则若没固定 provider，会跟随上面 Capture 任务的 worker 设置。',
+			'web.memoryConfig.sectionHints.profiles' => 'Session 启动时把哪些历史记忆塞进 agent system prompt（按最近、按相关度、混合、关闭）。',
+			'web.memoryConfig.sectionHints.costs' => 'memory_summarizer_calls 重算的累计花费。本地 provider（Ollama / LM Studio / Integration）免费；云 provider 显示真实成本。',
+			'web.memoryConfig.moveBanner.title' => '记忆配置已迁移',
+			'web.memoryConfig.moveBanner.body' => '所有记忆相关设置（providers / capture rules / injection profiles / cost）现在跟 Workers 在同一页面，相关开关聚在一起。',
+			'web.memoryConfig.moveBanner.openButton' => '打开 记忆配置 →',
 			'web.memoryWorkers.title' => 'Memory workers',
 			'web.memoryWorkers.loading' => '正在加载 worker 配置…',
 			'web.memoryWorkers.errorTitle' => '无法访问该接口。',
@@ -6948,6 +7126,12 @@ extension on TranslationsZh {
 			'web.memoryWorkers.tasks.gitactivity.description' => 'git log → 每 24 小时生成 2-3 段叙事。天然适合 agent worker。',
 			'web.memoryWorkers.tasks.transcript.label' => '会话记录总结器',
 			'web.memoryWorkers.tasks.transcript.description' => '会话结束时的“agent 都做了什么”总结。天然适合 agent worker。',
+			'web.memoryWorkers.tasks.plan_drift.label' => '计划漂移检测',
+			'web.memoryWorkers.tasks.plan_drift.description' => '每个 session 结束后判断项目 plan 是否需要更新并提出 proposal。用 agent 推理质量更高。',
+			'web.memoryWorkers.tasks.conflict_detector.label' => '跨层冲突检测',
+			'web.memoryWorkers.tasks.conflict_detector.description' => '每日扫描 facts/plan/goal/journal 之间的矛盾。模型越强，误报越少。',
+			'web.memoryWorkers.tasks.capture.label' => 'Capture 引擎',
+			'web.memoryWorkers.tasks.capture.description' => '按触发器从 session transcript 抽取 fact。Agent 模式在长会话上 fact 质量明显更好；summarizer 模式便宜且本地。',
 			'web.cleanupInbox.loading' => '加载中…',
 			'web.cleanupInbox.emptyTitle' => '清理收件箱为空',
 			'web.cleanupInbox.emptyDescription' => '目前所有项目均无待处理的清理决策。LLM librarian 要么尚未跑过这些记忆，要么判断全部仍是关键内容。',
@@ -7110,6 +7294,8 @@ extension on TranslationsZh {
 			'web.memoryInspector.records.noMatchesForQuery' => ({required Object query}) => '未找到匹配 "${query}"',
 			'web.memoryInspector.records.noMemoriesInScope' => '此 scope 暂无记忆。',
 			'web.memoryInspector.row.simBadge' => ({required Object value}) => '相似度 ${value}',
+			'web.memoryInspector.row.rankBadge' => ({required Object value}) => '排名分 ${value}',
+			'web.memoryInspector.row.rankTooltip' => ({required Object effective, required Object similarity, required Object age, required Object days, required Object hits, required Object confidence}) => '有效分 ${effective} = 相似度 ${similarity} × 时效 ${age} (${days}d) × 命中 ${hits} × 置信 ${confidence}',
 			'web.memoryInspector.row.hits_one' => ({required Object count}) => '命中 ${count} 次',
 			'web.memoryInspector.row.hits_other' => ({required Object count}) => '命中 ${count} 次',
 			'web.memoryInspector.row.lastHitTooltip' => ({required Object relative}) => '最近命中 ${relative}',
@@ -7147,6 +7333,8 @@ extension on TranslationsZh {
 			'web.memoryInspector.bulkDelete.items_one' => ({required Object count}) => '${count} 条记忆',
 			'web.memoryInspector.bulkDelete.items_other' => ({required Object count}) => '${count} 条记忆',
 			'web.memoryInspector.bulkDelete.cancel' => '取消',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryInspector.bulkDelete.deleteAll' => '全部删除',
 			'web.memoryInspector.addMem.title' => '添加记忆',
 			'web.memoryInspector.addMem.description' => '手动创建一条记忆。Agent 会通过 <1>memory_store</1> MCP 工具自动创建；此表单用于运维想跳过 agent 直接录入事实的场景。',
@@ -7196,8 +7384,6 @@ extension on TranslationsZh {
 			'web.notes.left.clearTagTooltip' => '清除标签筛选',
 			'web.notes.left.expandAll' => '全部展开',
 			'web.notes.left.expandAllTooltip' => '展开全部文件夹',
-			_ => null,
-		} ?? switch (path) {
 			'web.notes.left.collapseAll' => '全部收起',
 			'web.notes.left.collapseAllTooltip' => '收起全部文件夹',
 			'web.notes.left.loading' => '加载中…',
@@ -7661,6 +7847,8 @@ extension on TranslationsZh {
 			'web.plugins.mcp.editor.savedToast' => 'MCP 服务器已保存',
 			'web.plugins.mcp.editor.createFailedToast' => '创建失败',
 			'web.plugins.mcp.editor.saveFailedToast' => '保存失败',
+			_ => null,
+		} ?? switch (path) {
 			'web.plugins.mcpSecrets.title' => 'MCP 密钥',
 			'web.plugins.mcpSecrets.encryptedBadge' => '已加密',
 			'web.plugins.mcpSecrets.plaintextBadge' => '明文',
@@ -7710,8 +7898,6 @@ extension on TranslationsZh {
 			'web.plugins.skills.resetConfirm' => ({required Object id}) => '将 "${id}" 重置为内置版本? 这会删除你的 vault SKILL.md 并回退到嵌入副本。',
 			'web.plugins.skills.deleteConfirm' => ({required Object id}) => '从 vault 删除 skill "${id}"? 这会移除该 SKILL.md 文件。',
 			'web.plugins.skills.removedToast' => 'Skill 已移除',
-			_ => null,
-		} ?? switch (path) {
 			'web.plugins.skills.deleteFailedToast' => '删除失败',
 			'web.plugins.skills.editor.createTitle' => '新建 skill',
 			'web.plugins.skills.editor.customizeTitle' => ({required Object id}) => '自定义内置：${id}',
@@ -8004,8 +8190,6 @@ extension on TranslationsZh {
 			'web.serverSettings.sections.mcp.desc' => '服务器注册表与密钥。',
 			'web.serverSettings.sections.memory.title' => '记忆',
 			'web.serverSettings.sections.memory.desc' => '跨 CLI 的持久化记忆子系统。',
-			'web.serverSettings.sections.memoryAmbient.title' => '记忆 · 环境感知',
-			'web.serverSettings.sections.memoryAmbient.desc' => '自动捕获对话进入记忆，并在 spawn 时注入。',
 			'web.serverSettings.sections.backup.title' => '备份',
 			'web.serverSettings.sections.backup.desc' => '加密数据库备份、恢复，以及管理员数据导出。',
 			'web.serverSettings.sections.claude.title' => '存储 · Claude',
@@ -8177,6 +8361,8 @@ extension on TranslationsZh {
 			'web.serverSettings.backup.scheduleHeaders.keep' => '保留',
 			'web.serverSettings.backup.scheduleHeaders.state' => '状态',
 			'web.serverSettings.backup.every' => ({required Object interval}) => '每 ${interval}',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.backup.backupsKeep' => ({required Object count}) => '${count} 份备份',
 			'web.serverSettings.backup.stateEnabled' => '已启用',
 			'web.serverSettings.backup.statePaused' => '已暂停',
@@ -8224,8 +8410,6 @@ extension on TranslationsZh {
 			'web.settings.font.options.comfy' => '舒适',
 			'web.settings.font.options.large' => '大',
 			'web.settings.account.title' => '账号',
-			_ => null,
-		} ?? switch (path) {
 			'web.settings.account.description' => '运维与当前 bearer token。',
 			'web.settings.account.username' => '用户名',
 			'web.settings.account.tokenExpires' => 'Token 过期',
@@ -8691,6 +8875,8 @@ extension on TranslationsZh {
 			'mcp.secret.keyHint' => 'GITHUB_TOKEN、OPENAI_KEY、…',
 			'mcp.secret.valueLabel' => '值',
 			'mcp.secret.keyRequired' => '必须填写键。',
+			_ => null,
+		} ?? switch (path) {
 			'mcp.secret.keyInvalid' => '键必须匹配 [A-Za-z_][A-Za-z0-9_]* — 与 shell 环境变量规则相同。',
 			'mcp.secret.valueRequired' => '必须填写值。',
 			'mcp.secret.replaceTitle' => '替换密钥值',
@@ -8738,8 +8924,6 @@ extension on TranslationsZh {
 			'providers.errorPrefix.delete' => '删除失败',
 			'providers.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}：${error}',
 			'providers.accounts.rename' => '重命名',
-			_ => null,
-		} ?? switch (path) {
 			'providers.accounts.renameTitle' => ({required Object name}) => '重命名 ${name}',
 			'providers.accounts.displayNameLabel' => '显示名',
 			'providers.accounts.displayNameHint' => '工作账号',
@@ -9205,6 +9389,8 @@ extension on TranslationsZh {
 			'channels.kinds.dingtalk.description' => '自定义群机器人。仅外发。群聊 → 机器人 → 添加 → 加签模式 → 复制 webhook + secret。',
 			'channels.kinds.dingtalk.webhookUrlLabel' => 'Webhook URL',
 			'channels.kinds.dingtalk.secretLabel' => '加签 secret',
+			_ => null,
+		} ?? switch (path) {
 			'channels.kinds.dingtalk.secretHint' => '当机器人为「加签」安全模式时，将 secret 复制到这里。opendray 自动添加 timestamp + sign 参数。',
 			'channels.kinds.wecom.description' => '群机器人 webhook。仅外发（文本 + markdown）。群设置 → 群机器人 → 添加 → 复制 webhook URL。',
 			'channels.kinds.wecom.webhookKeyLabel' => 'Webhook key',
@@ -9252,8 +9438,6 @@ extension on TranslationsZh {
 			'skills.resetTooltip' => '重置为内置',
 			'skills.deleteTooltip' => '删除',
 			'skills.saving' => '保存中…',
-			_ => null,
-		} ?? switch (path) {
 			'skills.saveOverride' => '保存覆盖',
 			'skills.overrideBanner' => '保存会以相同 id 创建一个库覆盖。会话将使用此正文而非内置版本，直到你重置。',
 			'skills.idHelper' => '小写字母 / 数字 / 横线。创建后锁定。',

--- a/app/mobile/lib/features/memory_workers/memory_workers_screen.dart
+++ b/app/mobile/lib/features/memory_workers/memory_workers_screen.dart
@@ -253,13 +253,25 @@ class _WorkerCardState extends ConsumerState<_WorkerCard> {
         WorkerTaskKind.cleaner => t.memoryWorkers.tasks.cleaner.label,
         WorkerTaskKind.gitactivity => t.memoryWorkers.tasks.gitactivity.label,
         WorkerTaskKind.transcript => t.memoryWorkers.tasks.transcript.label,
+        WorkerTaskKind.planDrift => t.memoryWorkers.tasks.planDrift.label,
+        WorkerTaskKind.conflictDetector =>
+          t.memoryWorkers.tasks.conflictDetector.label,
+        WorkerTaskKind.capture => t.memoryWorkers.tasks.capture.label,
       };
 
   String _taskDescription(WorkerTaskKind k) => switch (k) {
-        WorkerTaskKind.gatekeeper => t.memoryWorkers.tasks.gatekeeper.description,
+        WorkerTaskKind.gatekeeper =>
+          t.memoryWorkers.tasks.gatekeeper.description,
         WorkerTaskKind.cleaner => t.memoryWorkers.tasks.cleaner.description,
-        WorkerTaskKind.gitactivity => t.memoryWorkers.tasks.gitactivity.description,
-        WorkerTaskKind.transcript => t.memoryWorkers.tasks.transcript.description,
+        WorkerTaskKind.gitactivity =>
+          t.memoryWorkers.tasks.gitactivity.description,
+        WorkerTaskKind.transcript =>
+          t.memoryWorkers.tasks.transcript.description,
+        WorkerTaskKind.planDrift =>
+          t.memoryWorkers.tasks.planDrift.description,
+        WorkerTaskKind.conflictDetector =>
+          t.memoryWorkers.tasks.conflictDetector.description,
+        WorkerTaskKind.capture => t.memoryWorkers.tasks.capture.description,
       };
 
   @override

--- a/app/mobile/lib/features/project/project_screen.dart
+++ b/app/mobile/lib/features/project/project_screen.dart
@@ -4,6 +4,8 @@ import 'package:intl/intl.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/memory_api.dart';
 import 'package:opendray/core/api/memory_cleanup_api.dart';
+import 'package:opendray/core/api/memory_conflicts_api.dart';
+import 'package:opendray/core/api/memory_health_api.dart';
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/project_docs_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
@@ -42,12 +44,17 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
   AsyncValue<List<SessionLogEntry>> _logs = const AsyncValue.loading();
   AsyncValue<List<CleanupDecision>> _cleanupDecisions =
       const AsyncValue.loading();
+  AsyncValue<MemoryHealthSnapshot> _health = const AsyncValue.loading();
+  AsyncValue<List<MemoryConflict>> _conflicts = const AsyncValue.loading();
   bool _cleanupRunning = false;
+  bool _conflictDetectRunning = false;
 
   @override
   void initState() {
     super.initState();
-    _tabs = TabController(length: 7, vsync: this);
+    // Health + Goal + Plan + Tech + Activity + Journal + Inbox +
+    // Conflicts + Cleanup = 9 tabs (web parity).
+    _tabs = TabController(length: 9, vsync: this);
     _loadKeys();
   }
 
@@ -104,9 +111,13 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
       _proposals = const AsyncValue.loading();
       _logs = const AsyncValue.loading();
       _cleanupDecisions = const AsyncValue.loading();
+      _health = const AsyncValue.loading();
+      _conflicts = const AsyncValue.loading();
     });
     final api = ref.read(projectDocsApiProvider);
     final cleanupApi = ref.read(memoryCleanupApiProvider);
+    final healthApi = ref.read(memoryHealthApiProvider);
+    final conflictsApi = ref.read(memoryConflictsApiProvider);
     try {
       final docs = await api.listDocs(cwd);
       if (!mounted) return;
@@ -143,6 +154,23 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
       if (!mounted) return;
       setState(() =>
           _cleanupDecisions = AsyncValue.error(e, StackTrace.current));
+    }
+    try {
+      final snap = await healthApi.get(cwd);
+      if (!mounted) return;
+      setState(() => _health = AsyncValue.data(snap));
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      setState(() => _health = AsyncValue.error(e, StackTrace.current));
+    }
+    try {
+      final conflicts =
+          await conflictsApi.list(cwd: cwd, status: ConflictStatus.pending);
+      if (!mounted) return;
+      setState(() => _conflicts = AsyncValue.data(conflicts));
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      setState(() => _conflicts = AsyncValue.error(e, StackTrace.current));
     }
   }
 
@@ -246,12 +274,14 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
           controller: _tabs,
           isScrollable: true,
           tabs: const [
+            Tab(text: 'Health'),
             Tab(text: 'Goal'),
             Tab(text: 'Plan'),
             Tab(text: 'Tech'),
             Tab(text: 'Activity'),
             Tab(text: 'Journal'),
             Tab(text: 'Inbox'),
+            Tab(text: 'Conflicts'),
             Tab(text: 'Cleanup'),
           ],
         ),
@@ -264,6 +294,7 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
             child: TabBarView(
               controller: _tabs,
               children: [
+                _healthTab(),
                 _docTab('goal'),
                 _docTab('plan'),
                 _readonlyDocTab(
@@ -282,6 +313,7 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
                 ),
                 _journalTab(),
                 _inboxTab(),
+                _conflictsTab(),
                 _cleanupTab(),
               ],
             ),
@@ -894,6 +926,372 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
       }
     }
   }
+
+  // ── M-PA Health tab ───────────────────────────────────────────
+
+  Widget _healthTab() {
+    if (_selectedKey == null) {
+      return Center(child: Text(t.project.pickFirst));
+    }
+    return _health.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) =>
+          Center(child: Text(t.project.loadFailed(error: e.toString()))),
+      data: (snap) {
+        return RefreshIndicator(
+          onRefresh: () async => _loadAll(_selectedKey!),
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              Text(
+                t.project.health.title(days: snap.lookbackDays),
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                t.project.health.subtitle,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              const SizedBox(height: 16),
+              GridView.count(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                crossAxisCount: 2,
+                mainAxisSpacing: 8,
+                crossAxisSpacing: 8,
+                childAspectRatio: 1.6,
+                children: [
+                  _HealthCard(
+                    label: t.project.health.newFacts,
+                    value: snap.newFactsCount.toString(),
+                    hint: t.project.health
+                        .newFactsHint(total: snap.totalFactsCount),
+                  ),
+                  _HealthCard(
+                    label: t.project.health.captureFires,
+                    value: snap.captureFires.toString(),
+                    hint: t.project.health.captureFiresHint(
+                      stored: snap.captureFactsStored,
+                      deduped: snap.captureFactsDeduped,
+                    ),
+                    tone: snap.captureFailedFires > 0
+                        ? _HealthCardTone.warn
+                        : _HealthCardTone.ok,
+                  ),
+                  _HealthCard(
+                    label: t.project.health.newJournal,
+                    value: snap.newJournalCount.toString(),
+                    hint: t.project.health
+                        .newJournalHint(total: snap.totalJournalCount),
+                  ),
+                  _HealthCard(
+                    label: t.project.health.planAge,
+                    value: _relativeAge(context, snap.planLastUpdatedAt),
+                    hint: snap.planDriftProposals > 0
+                        ? t.project.health.planAgeHint(
+                            count: snap.planDriftProposals)
+                        : t.project.health.planAgeHintNone,
+                  ),
+                  _HealthCard(
+                    label: t.project.health.goalAge,
+                    value: _relativeAge(context, snap.goalLastUpdatedAt),
+                  ),
+                  _HealthCard(
+                    label: t.project.health.pending,
+                    value: snap.pendingProposals.toString(),
+                    hint: snap.pendingProposals > 0 &&
+                            snap.oldestPendingDays > 0
+                        ? t.project.health.pendingHint(
+                            days: snap.oldestPendingDays)
+                        : null,
+                    tone: snap.oldestPendingDays >= 7
+                        ? _HealthCardTone.warn
+                        : _HealthCardTone.ok,
+                  ),
+                ],
+              ),
+              if (snap.topHitFactText.isNotEmpty) ...[
+                const SizedBox(height: 16),
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          t.project.health
+                              .topHit(hits: snap.topHitFactHits),
+                          style: Theme.of(context).textTheme.labelSmall,
+                        ),
+                        const SizedBox(height: 6),
+                        Text(
+                          snap.topHitFactText,
+                          style: const TextStyle(
+                              fontFamily: 'monospace', fontSize: 12),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+              if (snap.zeroHitFactsCount > 0) ...[
+                const SizedBox(height: 12),
+                Text(
+                  t.project.health
+                      .zeroHit(count: snap.zeroHitFactsCount),
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  // ── M-PC Conflicts tab ────────────────────────────────────────
+
+  Widget _conflictsTab() {
+    if (_selectedKey == null) {
+      return Center(child: Text(t.project.pickFirst));
+    }
+    return _conflicts.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) =>
+          Center(child: Text(t.project.loadFailed(error: e.toString()))),
+      data: (conflicts) {
+        return RefreshIndicator(
+          onRefresh: () async => _loadAll(_selectedKey!),
+          child: ListView(
+            padding: const EdgeInsets.all(12),
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Expanded(
+                    child: Text(
+                      t.project.conflicts.subtitle,
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  FilledButton.tonalIcon(
+                    onPressed:
+                        _conflictDetectRunning ? null : _runConflictDetect,
+                    icon: _conflictDetectRunning
+                        ? const SizedBox(
+                            width: 14,
+                            height: 14,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.refresh, size: 16),
+                    label: Text(t.project.conflicts.detectNow),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              if (conflicts.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Center(
+                    child: Text(t.project.conflicts.empty),
+                  ),
+                )
+              else
+                ...conflicts.map((c) => _ConflictCard(
+                      conflict: c,
+                      busy: _conflictDetectRunning,
+                      onAccept: () => _decideConflict(c.id, 'accepted'),
+                      onDismiss: () => _decideConflict(c.id, 'dismissed'),
+                    )),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _runConflictDetect() async {
+    if (_selectedKey == null) return;
+    setState(() => _conflictDetectRunning = true);
+    try {
+      final n =
+          await ref.read(memoryConflictsApiProvider).detect(_selectedKey!);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(t.project.conflicts.detected(count: n))),
+      );
+      await _loadAll(_selectedKey!);
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(e.toString())),
+      );
+    } finally {
+      if (mounted) setState(() => _conflictDetectRunning = false);
+    }
+  }
+
+  Future<void> _decideConflict(String id, String action) async {
+    try {
+      await ref.read(memoryConflictsApiProvider).decide(id, action);
+      if (!mounted) return;
+      await _loadAll(_selectedKey!);
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(e.toString())),
+      );
+    }
+  }
+}
+
+// ── Helpers for the new tabs ─────────────────────────────────────
+
+enum _HealthCardTone { ok, warn }
+
+class _HealthCard extends StatelessWidget {
+  const _HealthCard({
+    required this.label,
+    required this.value,
+    this.hint,
+    this.tone = _HealthCardTone.ok,
+  });
+
+  final String label;
+  final String value;
+  final String? hint;
+  final _HealthCardTone tone;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = tone == _HealthCardTone.warn
+        ? Theme.of(context).colorScheme.tertiary
+        : Theme.of(context).colorScheme.onSurface;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(10),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(label, style: Theme.of(context).textTheme.labelSmall),
+            const SizedBox(height: 4),
+            Text(
+              value,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                    color: color,
+                    fontWeight: FontWeight.w600,
+                  ),
+            ),
+            if (hint != null) ...[
+              const SizedBox(height: 2),
+              Text(
+                hint!,
+                style: Theme.of(context).textTheme.labelSmall,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _relativeAge(BuildContext context, DateTime? when) {
+  if (when == null) return t.project.health.never;
+  final days = DateTime.now().difference(when).inDays;
+  if (days <= 0) return t.project.health.today;
+  return t.project.health.daysAgo(count: days);
+}
+
+class _ConflictCard extends StatelessWidget {
+  const _ConflictCard({
+    required this.conflict,
+    required this.busy,
+    required this.onAccept,
+    required this.onDismiss,
+  });
+
+  final MemoryConflict conflict;
+  final bool busy;
+  final VoidCallback onAccept;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final severityLabel = switch (conflict.severity) {
+      ConflictSeverity.high => t.project.conflicts.severity.high,
+      ConflictSeverity.medium => t.project.conflicts.severity.medium,
+      ConflictSeverity.low => t.project.conflicts.severity.low,
+    };
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.warning_amber_rounded,
+                    size: 18,
+                    color: conflict.severity == ConflictSeverity.high
+                        ? Theme.of(context).colorScheme.error
+                        : null),
+                const SizedBox(width: 6),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: conflict.severity == ConflictSeverity.high
+                        ? Theme.of(context).colorScheme.errorContainer
+                        : Theme.of(context).colorScheme.surfaceContainerHighest,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Text(severityLabel,
+                      style: Theme.of(context).textTheme.labelSmall),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    '${conflict.layerA.name}:${_shortRef(conflict.refA)} ⟷ '
+                    '${conflict.layerB.name}:${_shortRef(conflict.refB)}',
+                    style: const TextStyle(
+                        fontFamily: 'monospace', fontSize: 11),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(conflict.evidence,
+                style: Theme.of(context).textTheme.bodySmall),
+            const SizedBox(height: 8),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton.icon(
+                  onPressed: busy ? null : onDismiss,
+                  icon: const Icon(Icons.close, size: 16),
+                  label: Text(t.project.conflicts.dismiss),
+                ),
+                const SizedBox(width: 4),
+                FilledButton.tonalIcon(
+                  onPressed: busy ? null : onAccept,
+                  icon: const Icon(Icons.check, size: 16),
+                  label: Text(t.project.conflicts.accept),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _shortRef(String ref) =>
+      ref.length <= 12 ? ref : '${ref.substring(0, 8)}…';
 }
 
 class _DocEditor extends StatefulWidget {


### PR DESCRIPTION
## Summary

Mobile had fallen behind the memory features that landed across web PRs #128 (Phase A), #130 (Phase C), #131 (Phase D), #134 (capture-via-worker), and #135 (unified memory config). This PR closes the highest-value gaps so operators on mobile get the same Health dashboard, Conflicts inbox, and 7-worker grid web users have been using.

Remaining UX polish (rank badge, journal stale prune, conflict delete-A/B preview dialog) lands in **Mobile PR-2**.

## What changed

### Workers screen — 4 → 7 task cards

| File | Change |
|---|---|
| \`core/api/memory_workers_api.dart\` | \`WorkerTaskKind\` enum gains \`planDrift\` / \`conflictDetector\` / \`capture\`; exhaustive \`wire\` / \`label\` / \`description\` switches with **no** \`default\` fall-through so Dart flags the next addition. \`WorkerConfig.fromJson\` + \`CallSummary.fromJson\` parse the new wire strings. |
| \`features/memory_workers/memory_workers_screen.dart\` | label / description switches extended. The page auto-renders the 3 new cards because it iterates whatever the API returns. |

### Project screen — 7 → 9 tabs

- **Health tab** (Phase A): 6-card grid (new facts / capture fires / journal entries / plan age / goal age / pending proposals) + top-hit fact card + zero-hit count line. Reuses a new \`_HealthCard\` widget with \`warn\` tone for failure / overdue states.
- **Conflicts tab** (Phase C/D): rows show severity badge, two layer:ref labels, evidence paragraph, Accept / Dismiss buttons. "Detect now" button on header forces an on-demand sweep through the conflict_detector worker.

### New API clients

| File | Endpoints |
|---|---|
| \`core/api/memory_health_api.dart\` | GET \`/memory/health\` → typed \`MemoryHealthSnapshot\` (mirrors \`internal/memhealth/health.go\`) |
| \`core/api/memory_conflicts_api.dart\` | GET \`/memory/conflicts\` list, POST \`/{id}/{action}\` decide, POST \`/detect\`; typed \`MemoryConflict\` + \`ConflictLayer\` / \`ConflictSeverity\` / \`ConflictStatus\` enums |

### i18n (en + zh)

- New \`project.health.*\` group (~20 keys covering metric cards + helper labels)
- New \`project.conflicts.*\` group (severity nested + subtitle/empty/detect/accept/dismiss/detected)
- New \`memoryWorkers.tasks.{planDrift,conflictDetector,capture}\` for the 3 new worker cards

## Commit shape

PR has two commits split for review clarity:

1. \`chore(mobile): regenerate slang i18n to absorb pre-existing source drift\` — 517 lines of pure generated diff (web's accumulated i18n changes that mobile's slang regen hadn't picked up yet). No behaviour change.
2. \`feat(mobile): bring memory pages to Phase A→F web parity\` — the actual feature work, source changes + their corresponding slang regen output.

## Test plan

- [x] \`dart analyze ./app/mobile\` clean
- [x] \`dart run slang\` produces no further changes after this PR's regen
- [x] JSON parses (en + zh)
- [ ] Manual: open mobile Memory → Workers — see 7 cards
- [ ] Manual: open mobile Project → Health tab — see metric cards rendered against a real cwd
- [ ] Manual: open mobile Project → Conflicts tab — Detect now triggers sweep, Accept/Dismiss work end-to-end
- [ ] Mobile build green on Android + iOS simulators (run \`build_release.sh\` when shipping)

## Mobile PR-2 follow-ups

- Memory inspector rank badge (Phase D)
- Journal stale prune panel (Phase D)
- Conflict delete-A/B preview-and-confirm dialog (Phase D)