### PR TITLE
feat(mobile): full backup parity with web — restore + inventory + data export/import

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -2353,6 +2353,10 @@
         "title": "Backups",
         "subtitle": "Latest backup status & run-now"
       },
+      "dataExport": {
+        "title": "Data export & import",
+        "subtitle": "User-level data bundles (memories / integrations / custom tasks)"
+      },
       "settings": {
         "title": "Settings",
         "subtitle": "Language, appearance, account"
@@ -3028,6 +3032,56 @@
       "passphraseLabel": "Your passphrase",
       "passphraseHint": "At least 20 characters",
       "passphraseCopied": "Passphrase copied to clipboard"
+    },
+    "restoreFromFile": "Restore from file",
+    "restore": {
+      "title": "Restore from bundle",
+      "subtitle": "Replay an encrypted .tar.gz.enc bundle into a Postgres database. The bundle is uploaded from this phone — pick a file produced by a prior backup.",
+      "bundleLabel": "Bundle file (.tar.gz.enc)",
+      "pickFile": "Pick file",
+      "fileSelected": "{name} · {size}",
+      "noFile": "No file selected",
+      "targetDsnLabel": "Target Postgres DSN",
+      "targetDsnHint": "Leave empty to restore into opendray's own DB.",
+      "targetDsnPlaceholder": "postgres://user:pass@host:5432/dbname",
+      "cleanLabel": "pg_restore --clean --if-exists",
+      "cleanHint": "Drops existing objects before recreating them.",
+      "auditNoteLabel": "Audit note (optional)",
+      "auditNotePlaceholder": "e.g. recovering from #INC-481",
+      "ownDbWarning": "Restoring into opendray's OWN database will rewrite the rows this gateway is currently serving. Type \"I understand\" to confirm.",
+      "confirmPlaceholder": "Type \"I understand\"",
+      "confirmSentinel": "I understand",
+      "restoring": "Restoring…",
+      "restore": "Restore",
+      "succeededTitle": "Restore succeeded",
+      "succeededBody": "Replayed {bytes} from backup {id}.",
+      "failedTitle": "Restore failed",
+      "pickFileToast": "Pick a bundle file first.",
+      "outputTitle": "pg_restore output",
+      "noPgRestoreOutput": "(empty — restore completed silently)",
+      "manifestTitle": "Manifest",
+      "manifestBackupId": "Backup ID",
+      "manifestVersion": "Manifest version",
+      "manifestCreatedAt": "Created",
+      "manifestPgVersion": "pg_version",
+      "manifestOpendrayVersion": "opendray version",
+      "fingerprint": "Key fingerprint",
+      "fingerprintOk": "matched",
+      "fingerprintMismatch": "MISMATCH",
+      "encryptionAlgo": "Encryption",
+      "bytesRead": "Bytes read",
+      "targetDsnUsed": "Target DSN",
+      "targetDsnSelfLabel": "(opendray's own DB)",
+      "done": "Done"
+    },
+    "inventory": {
+      "title": "What's in a backup",
+      "summary": "{rows} rows · {tables} tables",
+      "description": "Live row counts from opendray's Postgres database. Backups capture every row below; binary artifacts on disk are not included.",
+      "rowsLabel": "rows",
+      "loadFailedToast": "Failed to load inventory",
+      "loading": "Loading…",
+      "tap": "Tap to expand"
     }
   },
   "backupTargets": {
@@ -3438,6 +3492,120 @@
       "saveFailedApi": "Save failed: {error}",
       "saveFailedGeneric": "Save failed: {error}",
       "savedAt": "Saved {time}"
+    }
+  },
+  "dataExport": {
+    "title": "Data export & import",
+    "subtitle": "User-level bundles for migration or verification — separate from /backups (disaster recovery).",
+    "sections": {
+      "export": "Export",
+      "import": "Import"
+    },
+    "form": {
+      "scope": "Scope",
+      "memories": "Memories",
+      "memoriesHint": "All persisted memories + their embeddings.",
+      "integrations": "Integrations",
+      "integrationOptions": {
+        "none": "Skip",
+        "noneHint": "Don't include the /integrations registry.",
+        "metadata": "Metadata only (default)",
+        "metadataHint": "Per-integration name + endpoint, no API keys.",
+        "plaintext": "Plaintext keys",
+        "plaintextHint": "DANGEROUS: includes raw API tokens. v1 stores only bcrypt hashes, so this is effectively a no-op today; surface anyway."
+      },
+      "confirmWarning": "Plaintext key export contains decryptable secrets. Type \"I understand\" to confirm.",
+      "confirmPlaceholder": "Type \"I understand\"",
+      "confirmSentinel": "I understand",
+      "customTasks": "Custom tasks",
+      "customTasksHint": "Per-user task definitions (cron schedules + script bodies).",
+      "footnote": "Bundles expire 7 days after creation. Download link is single-use.",
+      "create": "Create bundle",
+      "building": "Building…",
+      "readyToast": "Bundle ready",
+      "readyDescription": "{bytes} bytes — download from the history below.",
+      "failedToast": "Bundle creation failed: {error}"
+    },
+    "history": {
+      "title": "Export history",
+      "loading": "Loading…",
+      "empty": "No exports yet.",
+      "listFailedToast": "Failed to load exports: {error}",
+      "downloadFailedToast": "Failed to fetch download token: {error}",
+      "noTokenToast": "This export has no usable download token (already consumed or expired).",
+      "deletedToast": "Export deleted.",
+      "deleteFailedToast": "Failed to delete export: {error}",
+      "deleteConfirmTitle": "Delete export?",
+      "deleteConfirmBody": "Removes the bundle and revokes the download token. {id}",
+      "download": "Download",
+      "delete": "Delete",
+      "downloadCopiedToast": "Download URL copied to clipboard. Paste into a browser to fetch (single-use).",
+      "columns": {
+        "scope": "Scope",
+        "size": "Size",
+        "expires": "Expires",
+        "actions": "Actions"
+      },
+      "scopeEmpty": "(empty)",
+      "scopeMemories": "memories",
+      "scopeIntegrations": "integrations({mode})",
+      "scopeCustomTasks": "custom_tasks"
+    },
+    "import": {
+      "intro": "Replays a bundle previously produced by Export. Only the entities you tick below are imported; everything else in the bundle is ignored.",
+      "bundleLabel": "Bundle file (.zip)",
+      "pickFile": "Pick file",
+      "fileSelected": "{name} · {size}",
+      "noFile": "No file selected",
+      "memoriesLabel": "Memories",
+      "integrationsLabel": "Integrations",
+      "customTasksLabel": "Custom tasks",
+      "importBundle": "Import bundle",
+      "importing": "Importing…",
+      "pickFileToast": "Pick a bundle file first.",
+      "doneToast": "Import done",
+      "finishedWithErrors": "Import finished with errors",
+      "failedToast": "Import failed: {error}",
+      "summaryCard": {
+        "memories": "Memories",
+        "integrations": "Integrations",
+        "customTasks": "Custom tasks",
+        "created": "created",
+        "skipped": "skipped",
+        "failed": "failed"
+      }
+    },
+    "imports": {
+      "title": "Import history",
+      "loading": "Loading…",
+      "empty": "No imports yet.",
+      "listFailedToast": "Failed to load imports: {error}",
+      "noneCounts": "(no counts)",
+      "sourceUnknown": "(unknown source)",
+      "columns": {
+        "id": "ID",
+        "status": "Status",
+        "source": "Source",
+        "counts": "Counts",
+        "when": "When"
+      }
+    },
+    "relative": {
+      "inSeconds": "in {n}s",
+      "inMinutes": "in {n}m",
+      "inHours": "in {n}h",
+      "inDays": "in {n}d",
+      "secondsAgo": "{n}s ago",
+      "minutesAgo": "{n}m ago",
+      "hoursAgo": "{n}h ago"
+    },
+    "status": {
+      "pending": "pending",
+      "running": "running",
+      "ready": "ready",
+      "failed": "failed",
+      "expired": "expired",
+      "succeeded": "succeeded"
     }
   },
   "memory": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -2353,6 +2353,10 @@
         "title": "备份",
         "subtitle": "最新备份状态与立即运行"
       },
+      "dataExport": {
+        "title": "数据导出与导入",
+        "subtitle": "用户级数据包（记忆 / 集成 / 自定义任务）"
+      },
       "settings": {
         "title": "设置",
         "subtitle": "语言、外观、账户"
@@ -3028,6 +3032,56 @@
       "passphraseLabel": "你的密语",
       "passphraseHint": "至少 20 个字符",
       "passphraseCopied": "密语已复制到剪贴板"
+    },
+    "restoreFromFile": "从文件恢复",
+    "restore": {
+      "title": "从备份包恢复",
+      "subtitle": "将加密的 .tar.gz.enc 备份包重放到 Postgres 数据库。备份包将从本机上传 — 请选择此前生成的文件。",
+      "bundleLabel": "备份文件（.tar.gz.enc）",
+      "pickFile": "选择文件",
+      "fileSelected": "{name} · {size}",
+      "noFile": "未选择文件",
+      "targetDsnLabel": "目标 Postgres DSN",
+      "targetDsnHint": "留空表示恢复到 opendray 自身的数据库。",
+      "targetDsnPlaceholder": "postgres://user:pass@host:5432/dbname",
+      "cleanLabel": "pg_restore --clean --if-exists",
+      "cleanHint": "重新创建之前先删除已存在的对象。",
+      "auditNoteLabel": "审计备注（可选）",
+      "auditNotePlaceholder": "例如：恢复 #INC-481",
+      "ownDbWarning": "恢复到 opendray 自身的数据库将覆写本网关当前提供服务的数据。请输入 \"I understand\" 以确认。",
+      "confirmPlaceholder": "输入 \"I understand\"",
+      "confirmSentinel": "I understand",
+      "restoring": "恢复中…",
+      "restore": "恢复",
+      "succeededTitle": "恢复成功",
+      "succeededBody": "已从备份 {id} 重放 {bytes}。",
+      "failedTitle": "恢复失败",
+      "pickFileToast": "请先选择一个备份文件。",
+      "outputTitle": "pg_restore 输出",
+      "noPgRestoreOutput": "（空 — 恢复无声完成）",
+      "manifestTitle": "清单",
+      "manifestBackupId": "备份 ID",
+      "manifestVersion": "清单版本",
+      "manifestCreatedAt": "创建时间",
+      "manifestPgVersion": "pg_version",
+      "manifestOpendrayVersion": "opendray 版本",
+      "fingerprint": "密钥指纹",
+      "fingerprintOk": "已匹配",
+      "fingerprintMismatch": "不匹配",
+      "encryptionAlgo": "加密算法",
+      "bytesRead": "已读字节",
+      "targetDsnUsed": "目标 DSN",
+      "targetDsnSelfLabel": "（opendray 自身数据库）",
+      "done": "完成"
+    },
+    "inventory": {
+      "title": "备份里有什么",
+      "summary": "{rows} 行 · {tables} 表",
+      "description": "opendray Postgres 数据库的实时行数。备份会捕获以下所有行；磁盘上的二进制工件不包含在内。",
+      "rowsLabel": "行",
+      "loadFailedToast": "加载清单失败",
+      "loading": "加载中…",
+      "tap": "点击展开"
     }
   },
   "backupTargets": {
@@ -3438,6 +3492,120 @@
       "saveFailedApi": "保存失败：{error}",
       "saveFailedGeneric": "保存失败：{error}",
       "savedAt": "{time} 已保存"
+    }
+  },
+  "dataExport": {
+    "title": "数据导出与导入",
+    "subtitle": "面向用户的数据包，用于迁移或验证 — 与 /backups（灾难恢复）相互独立。",
+    "sections": {
+      "export": "导出",
+      "import": "导入"
+    },
+    "form": {
+      "scope": "范围",
+      "memories": "记忆",
+      "memoriesHint": "所有已持久化的记忆及其向量。",
+      "integrations": "集成",
+      "integrationOptions": {
+        "none": "跳过",
+        "noneHint": "不包含 /integrations 注册表。",
+        "metadata": "仅元数据（默认）",
+        "metadataHint": "每个集成的名称 + 端点，不含 API 密钥。",
+        "plaintext": "明文密钥",
+        "plaintextHint": "危险：包含原始 API 令牌。v1 仅存储 bcrypt 哈希，因此此选项当前实际为空操作；仍然提供以提示这一事实。"
+      },
+      "confirmWarning": "明文密钥导出包含可解密的机密。请输入 \"I understand\" 以确认。",
+      "confirmPlaceholder": "输入 \"I understand\"",
+      "confirmSentinel": "I understand",
+      "customTasks": "自定义任务",
+      "customTasksHint": "用户级任务定义（cron 计划 + 脚本主体）。",
+      "footnote": "数据包在创建后 7 天过期。下载链接为单次使用。",
+      "create": "创建数据包",
+      "building": "构建中…",
+      "readyToast": "数据包已就绪",
+      "readyDescription": "{bytes} 字节 — 在下方历史中下载。",
+      "failedToast": "数据包创建失败：{error}"
+    },
+    "history": {
+      "title": "导出历史",
+      "loading": "加载中…",
+      "empty": "暂无导出。",
+      "listFailedToast": "加载导出失败：{error}",
+      "downloadFailedToast": "获取下载令牌失败：{error}",
+      "noTokenToast": "该导出无可用的下载令牌（已消费或过期）。",
+      "deletedToast": "已删除导出。",
+      "deleteFailedToast": "删除导出失败：{error}",
+      "deleteConfirmTitle": "删除导出？",
+      "deleteConfirmBody": "移除数据包并撤销下载令牌。{id}",
+      "download": "下载",
+      "delete": "删除",
+      "downloadCopiedToast": "下载 URL 已复制到剪贴板。在浏览器中粘贴以获取（单次使用）。",
+      "columns": {
+        "scope": "范围",
+        "size": "大小",
+        "expires": "过期",
+        "actions": "操作"
+      },
+      "scopeEmpty": "（空）",
+      "scopeMemories": "记忆",
+      "scopeIntegrations": "集成({mode})",
+      "scopeCustomTasks": "自定义任务"
+    },
+    "import": {
+      "intro": "重放此前由「导出」生成的数据包。仅勾选的实体会被导入；数据包中其余内容会被忽略。",
+      "bundleLabel": "数据包文件（.zip）",
+      "pickFile": "选择文件",
+      "fileSelected": "{name} · {size}",
+      "noFile": "未选择文件",
+      "memoriesLabel": "记忆",
+      "integrationsLabel": "集成",
+      "customTasksLabel": "自定义任务",
+      "importBundle": "导入数据包",
+      "importing": "导入中…",
+      "pickFileToast": "请先选择数据包文件。",
+      "doneToast": "导入完成",
+      "finishedWithErrors": "导入完成但有错误",
+      "failedToast": "导入失败：{error}",
+      "summaryCard": {
+        "memories": "记忆",
+        "integrations": "集成",
+        "customTasks": "自定义任务",
+        "created": "创建",
+        "skipped": "跳过",
+        "failed": "失败"
+      }
+    },
+    "imports": {
+      "title": "导入历史",
+      "loading": "加载中…",
+      "empty": "暂无导入。",
+      "listFailedToast": "加载导入失败：{error}",
+      "noneCounts": "（无计数）",
+      "sourceUnknown": "（未知来源）",
+      "columns": {
+        "id": "ID",
+        "status": "状态",
+        "source": "来源",
+        "counts": "计数",
+        "when": "时间"
+      }
+    },
+    "relative": {
+      "inSeconds": "{n} 秒后",
+      "inMinutes": "{n} 分钟后",
+      "inHours": "{n} 小时后",
+      "inDays": "{n} 天后",
+      "secondsAgo": "{n} 秒前",
+      "minutesAgo": "{n} 分钟前",
+      "hoursAgo": "{n} 小时前"
+    },
+    "status": {
+      "pending": "等待",
+      "running": "运行中",
+      "ready": "就绪",
+      "failed": "失败",
+      "expired": "过期",
+      "succeeded": "成功"
     }
   },
   "memory": {

--- a/app/mobile/lib/core/api/backups_api.dart
+++ b/app/mobile/lib/core/api/backups_api.dart
@@ -1,12 +1,15 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:opendray/core/api/dio_provider.dart';
 
-// Wraps /api/v1/backups — list + run-now. Mobile is intentionally a
-// thin observability surface: schedule editing and download/restore
-// stay on the web admin where uploading multi-GB blobs from a phone
-// is neither practical nor safe.
+// Wraps /api/v1/backups — full feature parity with the web admin:
+// schedules + targets CRUD, restore from bundle, live inventory,
+// Plan-C exports + imports. The file-upload paths (restore +
+// imports) accept a phone-side File via file_picker; the web client
+// uses <input type=file>, which dart:html doesn't expose on mobile.
 
 class BackupRow {
   BackupRow({
@@ -24,21 +27,22 @@ class BackupRow {
   });
 
   factory BackupRow.fromJson(Map<String, dynamic> json) => BackupRow(
-        id: json['id'] as String? ?? '',
-        scheduleId: json['schedule_id'] as String?,
-        targetId: json['target_id'] as String? ?? '',
-        status: json['status'] as String? ?? '',
-        triggeredBy: json['triggered_by'] as String? ?? '',
-        startedAt:
-            DateTime.tryParse(json['started_at'] as String? ?? '')?.toUtc() ??
-                DateTime.now().toUtc(),
-        finishedAt:
-            DateTime.tryParse(json['finished_at'] as String? ?? '')?.toUtc(),
-        bytes: (json['bytes'] as num?)?.toInt() ?? 0,
-        encrypted: json['encrypted'] as bool? ?? false,
-        targetPath: json['target_path'] as String?,
-        error: json['error'] as String?,
-      );
+    id: json['id'] as String? ?? '',
+    scheduleId: json['schedule_id'] as String?,
+    targetId: json['target_id'] as String? ?? '',
+    status: json['status'] as String? ?? '',
+    triggeredBy: json['triggered_by'] as String? ?? '',
+    startedAt:
+        DateTime.tryParse(json['started_at'] as String? ?? '')?.toUtc() ??
+        DateTime.now().toUtc(),
+    finishedAt: DateTime.tryParse(
+      json['finished_at'] as String? ?? '',
+    )?.toUtc(),
+    bytes: (json['bytes'] as num?)?.toInt() ?? 0,
+    encrypted: json['encrypted'] as bool? ?? false,
+    targetPath: json['target_path'] as String?,
+    error: json['error'] as String?,
+  );
 
   final String id;
   final String? scheduleId;
@@ -67,22 +71,20 @@ class BackupSchedule {
     this.lastRunAt,
   });
 
-  factory BackupSchedule.fromJson(Map<String, dynamic> json) =>
-      BackupSchedule(
-        id: json['id'] as String? ?? '',
-        targetId: json['target_id'] as String? ?? '',
-        intervalSec: (json['interval_sec'] as num?)?.toInt() ?? 0,
-        retention: (json['retention'] as num?)?.toInt() ?? 0,
-        enabled: json['enabled'] as bool? ?? false,
-        lastRunAt:
-            DateTime.tryParse(json['last_run_at'] as String? ?? '')?.toUtc(),
-        nextRunAt:
-            DateTime.tryParse(json['next_run_at'] as String? ?? '')?.toUtc() ??
-                DateTime.now().toUtc(),
-        createdAt:
-            DateTime.tryParse(json['created_at'] as String? ?? '')?.toUtc() ??
-                DateTime.fromMillisecondsSinceEpoch(0),
-      );
+  factory BackupSchedule.fromJson(Map<String, dynamic> json) => BackupSchedule(
+    id: json['id'] as String? ?? '',
+    targetId: json['target_id'] as String? ?? '',
+    intervalSec: (json['interval_sec'] as num?)?.toInt() ?? 0,
+    retention: (json['retention'] as num?)?.toInt() ?? 0,
+    enabled: json['enabled'] as bool? ?? false,
+    lastRunAt: DateTime.tryParse(json['last_run_at'] as String? ?? '')?.toUtc(),
+    nextRunAt:
+        DateTime.tryParse(json['next_run_at'] as String? ?? '')?.toUtc() ??
+        DateTime.now().toUtc(),
+    createdAt:
+        DateTime.tryParse(json['created_at'] as String? ?? '')?.toUtc() ??
+        DateTime.fromMillisecondsSinceEpoch(0),
+  );
 
   final String id;
   final String targetId;
@@ -197,15 +199,14 @@ class BackupTarget {
     return BackupTarget(
       id: json['id'] as String? ?? '',
       kind: json['kind'] as String? ?? '',
-      config:
-          cfg is Map ? Map<String, dynamic>.from(cfg) : <String, dynamic>{},
+      config: cfg is Map ? Map<String, dynamic>.from(cfg) : <String, dynamic>{},
       enabled: json['enabled'] as bool? ?? false,
       createdAt:
           DateTime.tryParse(json['created_at'] as String? ?? '')?.toUtc() ??
-              DateTime.fromMillisecondsSinceEpoch(0),
+          DateTime.fromMillisecondsSinceEpoch(0),
       updatedAt:
           DateTime.tryParse(json['updated_at'] as String? ?? '')?.toUtc() ??
-              DateTime.fromMillisecondsSinceEpoch(0),
+          DateTime.fromMillisecondsSinceEpoch(0),
     );
   }
 
@@ -220,6 +221,325 @@ class BackupTarget {
   final DateTime updatedAt;
 }
 
+// ── restore ──────────────────────────────────────────────────────
+
+class RestoreManifest {
+  RestoreManifest({
+    required this.version,
+    required this.backupId,
+    required this.createdAt,
+    required this.encryptionAlgo,
+    required this.encryptionFingerprint,
+    this.opendrayVersion,
+    this.pgVersion,
+  });
+
+  factory RestoreManifest.fromJson(Map<String, dynamic> json) {
+    final enc = json['encryption'];
+    final encMap = enc is Map
+        ? Map<String, dynamic>.from(enc)
+        : <String, dynamic>{};
+    return RestoreManifest(
+      version: json['version'] as String? ?? '',
+      backupId: json['backup_id'] as String? ?? '',
+      createdAt:
+          DateTime.tryParse(json['created_at'] as String? ?? '')?.toUtc() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      opendrayVersion: json['opendray_version'] as String?,
+      pgVersion: json['pg_version'] as String?,
+      encryptionAlgo: encMap['algo'] as String? ?? '',
+      encryptionFingerprint: encMap['fingerprint'] as String? ?? '',
+    );
+  }
+
+  final String version;
+  final String backupId;
+  final DateTime createdAt;
+  final String? opendrayVersion;
+  final String? pgVersion;
+  final String encryptionAlgo;
+  final String encryptionFingerprint;
+}
+
+// Result body returned by POST /backups/restore. On success the
+// fingerprint matched, pg_restore ran cleanly, and `bytesRead`
+// reflects how much of the bundle was processed. On partial
+// failure (mid-restore pg_restore exit) the server returns 500
+// with a nested `result` carrying this same shape; the API
+// client surfaces that as ApiException and the caller is on its
+// own to inspect the body.
+class RestoreResult {
+  RestoreResult({
+    required this.manifest,
+    required this.bytesRead,
+    required this.targetDsnUsed,
+    required this.fingerprintOk,
+    required this.pgRestoreOutput,
+    required this.startedAt,
+    required this.finishedAt,
+  });
+
+  factory RestoreResult.fromJson(Map<String, dynamic> json) {
+    final manifest = json['manifest'];
+    final manifestMap = manifest is Map
+        ? Map<String, dynamic>.from(manifest)
+        : <String, dynamic>{};
+    return RestoreResult(
+      manifest: RestoreManifest.fromJson(manifestMap),
+      bytesRead: (json['bytes_read'] as num?)?.toInt() ?? 0,
+      targetDsnUsed: json['target_dsn_used'] as String? ?? '',
+      fingerprintOk: json['fingerprint_ok'] as bool? ?? false,
+      pgRestoreOutput: json['pg_restore_output'] as String? ?? '',
+      startedAt:
+          DateTime.tryParse(json['started_at'] as String? ?? '')?.toUtc() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      finishedAt:
+          DateTime.tryParse(json['finished_at'] as String? ?? '')?.toUtc() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+    );
+  }
+
+  final RestoreManifest manifest;
+  final int bytesRead;
+  // Empty string when target_dsn was omitted (restored into
+  // opendray's own DB).
+  final String targetDsnUsed;
+  final bool fingerprintOk;
+  final String pgRestoreOutput;
+  final DateTime startedAt;
+  final DateTime finishedAt;
+}
+
+// ── inventory ────────────────────────────────────────────────────
+
+class InventoryTable {
+  InventoryTable({required this.name, required this.count});
+
+  factory InventoryTable.fromJson(Map<String, dynamic> json) => InventoryTable(
+    name: json['name'] as String? ?? '',
+    count: (json['count'] as num?)?.toInt() ?? 0,
+  );
+
+  final String name;
+  final int count;
+}
+
+class InventoryGroup {
+  InventoryGroup({
+    required this.id,
+    required this.label,
+    required this.description,
+    required this.tables,
+  });
+
+  factory InventoryGroup.fromJson(Map<String, dynamic> json) {
+    final raw = json['tables'];
+    final tables = raw is List
+        ? raw
+              .whereType<Map<String, dynamic>>()
+              .map(InventoryTable.fromJson)
+              .toList()
+        : <InventoryTable>[];
+    return InventoryGroup(
+      id: json['id'] as String? ?? '',
+      label: json['label'] as String? ?? '',
+      description: json['description'] as String? ?? '',
+      tables: tables,
+    );
+  }
+
+  final String id;
+  final String label;
+  final String description;
+  final List<InventoryTable> tables;
+}
+
+// ── exports (Plan C) ─────────────────────────────────────────────
+
+// Mode flag for the `integrations` scope on an export. Wire values
+// match the Go side and the web TS.
+enum IntegrationExportMode {
+  none('none'),
+  metadata('metadata'),
+  plaintext('plaintext');
+
+  const IntegrationExportMode(this.wire);
+  final String wire;
+
+  static IntegrationExportMode fromWire(String? wire) {
+    return switch (wire) {
+      'plaintext' => IntegrationExportMode.plaintext,
+      'metadata' => IntegrationExportMode.metadata,
+      _ => IntegrationExportMode.none,
+    };
+  }
+}
+
+class ExportScope {
+  ExportScope({
+    required this.memories,
+    required this.integrations,
+    required this.customTasks,
+  });
+
+  factory ExportScope.fromJson(Map<String, dynamic> json) => ExportScope(
+    memories: json['memories'] as bool? ?? false,
+    integrations: IntegrationExportMode.fromWire(
+      json['integrations'] as String?,
+    ),
+    customTasks: json['custom_tasks'] as bool? ?? false,
+  );
+
+  final bool memories;
+  final IntegrationExportMode integrations;
+  final bool customTasks;
+}
+
+class ExportRecord {
+  ExportRecord({
+    required this.id,
+    required this.status,
+    required this.requestedBy,
+    required this.scope,
+    required this.startedAt,
+    required this.expiresAt,
+    required this.bytes,
+    this.finishedAt,
+    this.sha256,
+    this.downloadToken,
+    this.error,
+  });
+
+  factory ExportRecord.fromJson(Map<String, dynamic> json) {
+    final scope = json['scope'];
+    final scopeMap = scope is Map
+        ? Map<String, dynamic>.from(scope)
+        : <String, dynamic>{};
+    return ExportRecord(
+      id: json['id'] as String? ?? '',
+      status: json['status'] as String? ?? '',
+      requestedBy: json['requested_by'] as String? ?? '',
+      scope: ExportScope.fromJson(scopeMap),
+      startedAt:
+          DateTime.tryParse(json['started_at'] as String? ?? '')?.toUtc() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      finishedAt: DateTime.tryParse(
+        json['finished_at'] as String? ?? '',
+      )?.toUtc(),
+      expiresAt:
+          DateTime.tryParse(json['expires_at'] as String? ?? '')?.toUtc() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      bytes: (json['bytes'] as num?)?.toInt() ?? 0,
+      sha256: json['sha256'] as String?,
+      downloadToken: json['download_token'] as String?,
+      error: json['error'] as String?,
+    );
+  }
+
+  final String id;
+  // pending | running | ready | failed | expired
+  final String status;
+  final String requestedBy;
+  final ExportScope scope;
+  final DateTime startedAt;
+  final DateTime? finishedAt;
+  final DateTime expiresAt;
+  final int bytes;
+  final String? sha256;
+  // Single-use bearer token for the download URL — only present
+  // once the export is in status==ready.
+  final String? downloadToken;
+  final String? error;
+}
+
+// ── imports (C reverse) ──────────────────────────────────────────
+
+class EntityCounts {
+  EntityCounts({
+    required this.created,
+    required this.skipped,
+    required this.failed,
+  });
+
+  factory EntityCounts.fromJson(Map<String, dynamic>? json) {
+    final m = json ?? <String, dynamic>{};
+    return EntityCounts(
+      created: (m['created'] as num?)?.toInt() ?? 0,
+      skipped: (m['skipped'] as num?)?.toInt() ?? 0,
+      failed: (m['failed'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  final int created;
+  final int skipped;
+  final int failed;
+}
+
+class ImportRecord {
+  ImportRecord({
+    required this.id,
+    required this.status,
+    required this.requestedBy,
+    required this.startedAt,
+    required this.sourceBytes,
+    required this.memories,
+    required this.integrations,
+    required this.customTasks,
+    this.finishedAt,
+    this.sourceFilename,
+    this.error,
+  });
+
+  factory ImportRecord.fromJson(Map<String, dynamic> json) {
+    final counts = json['counts'];
+    final countsMap = counts is Map
+        ? Map<String, dynamic>.from(counts)
+        : <String, dynamic>{};
+    return ImportRecord(
+      id: json['id'] as String? ?? '',
+      status: json['status'] as String? ?? '',
+      requestedBy: json['requested_by'] as String? ?? '',
+      startedAt:
+          DateTime.tryParse(json['started_at'] as String? ?? '')?.toUtc() ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      finishedAt: DateTime.tryParse(
+        json['finished_at'] as String? ?? '',
+      )?.toUtc(),
+      sourceFilename: json['source_filename'] as String?,
+      sourceBytes: (json['source_bytes'] as num?)?.toInt() ?? 0,
+      memories: EntityCounts.fromJson(
+        countsMap['memories'] is Map
+            ? Map<String, dynamic>.from(countsMap['memories'] as Map)
+            : null,
+      ),
+      integrations: EntityCounts.fromJson(
+        countsMap['integrations'] is Map
+            ? Map<String, dynamic>.from(countsMap['integrations'] as Map)
+            : null,
+      ),
+      customTasks: EntityCounts.fromJson(
+        countsMap['custom_tasks'] is Map
+            ? Map<String, dynamic>.from(countsMap['custom_tasks'] as Map)
+            : null,
+      ),
+      error: json['error'] as String?,
+    );
+  }
+
+  final String id;
+  // pending | running | succeeded | failed
+  final String status;
+  final String requestedBy;
+  final DateTime startedAt;
+  final DateTime? finishedAt;
+  final String? sourceFilename;
+  final int sourceBytes;
+  final EntityCounts memories;
+  final EntityCounts integrations;
+  final EntityCounts customTasks;
+  final String? error;
+}
+
 class BackupsApi {
   BackupsApi(this._dio);
   final Dio _dio;
@@ -230,8 +550,7 @@ class BackupsApi {
   // from HTTP error codes.
   Future<BackupStatusReport> status() async {
     try {
-      final res =
-          await _dio.get<Map<String, dynamic>>('/api/v1/backup-status');
+      final res = await _dio.get<Map<String, dynamic>>('/api/v1/backup-status');
       return BackupStatusReport.fromJson(res.data ?? {});
     } on Object catch (e) {
       throw toApiException(e);
@@ -249,10 +568,7 @@ class BackupsApi {
     try {
       final res = await _dio.post<Map<String, dynamic>>(
         '/api/v1/backup-setup',
-        data: {
-          'mode': mode,
-          if (passphrase != null) 'passphrase': passphrase,
-        },
+        data: {'mode': mode, if (passphrase != null) 'passphrase': passphrase},
       );
       return BackupSetupResult.fromJson(res.data ?? {});
     } on Object catch (e) {
@@ -322,8 +638,9 @@ class BackupsApi {
   // as the default target if you POST without specifying one.
   Future<List<BackupSchedule>> listSchedules() async {
     try {
-      final res =
-          await _dio.get<Map<String, dynamic>>('/api/v1/backup-schedules');
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/backup-schedules',
+      );
       final raw = res.data?['schedules'];
       if (raw is! List) return const [];
       return raw
@@ -394,8 +711,9 @@ class BackupsApi {
   // long secrets) stays web-only.
   Future<List<BackupTarget>> listTargets() async {
     try {
-      final res =
-          await _dio.get<Map<String, dynamic>>('/api/v1/backup-targets');
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/backup-targets',
+      );
       final raw = res.data?['targets'];
       if (raw is! List) return const [];
       return raw
@@ -485,6 +803,204 @@ class BackupsApi {
   Future<void> deleteTarget(String id) async {
     try {
       await _dio.delete<void>('/api/v1/backup-targets/$id');
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // ── restore ──────────────────────────────────────────────────
+
+  // POST /backups/restore — multipart bundle upload. When
+  // [targetDsn] is empty the server restores into opendray's own
+  // database and requires [confirm]=="I understand"; otherwise it
+  // dials [targetDsn] and runs pg_restore against that DSN.
+  //
+  // Cap is 256 MiB (server-side ParseMultipartForm); the mobile
+  // client honors that by streaming via MultipartFile.fromFile.
+  Future<RestoreResult> restore({
+    required File bundle,
+    String? targetDsn,
+    bool clean = false,
+    String? confirm,
+    String? note,
+  }) async {
+    try {
+      final form = FormData.fromMap({
+        'bundle': await MultipartFile.fromFile(
+          bundle.path,
+          filename: bundle.uri.pathSegments.isNotEmpty
+              ? bundle.uri.pathSegments.last
+              : 'bundle.tar.gz.enc',
+        ),
+        if (targetDsn != null && targetDsn.isNotEmpty) 'target_dsn': targetDsn,
+        'clean': clean ? 'true' : 'false',
+        if (confirm != null && confirm.isNotEmpty) 'confirm': confirm,
+        if (note != null && note.isNotEmpty) 'note': note,
+      });
+      // Restore can run for minutes on a large DB; the default
+      // dio receive timeout (the gateway's) is fine, but we
+      // explicitly disable any per-request timeout here so a
+      // long pg_restore doesn't get killed mid-stream.
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/backups/restore',
+        data: form,
+        options: Options(
+          sendTimeout: Duration.zero,
+          receiveTimeout: Duration.zero,
+        ),
+      );
+      return RestoreResult.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // ── inventory ────────────────────────────────────────────────
+
+  // GET /backup-inventory — live row counts grouped by feature
+  // area (memories, integrations, custom tasks, ...). Used by
+  // the main screen's "what's actually backed up" card.
+  Future<List<InventoryGroup>> inventory() async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/backup-inventory',
+      );
+      final raw = res.data?['groups'];
+      if (raw is! List) return const [];
+      return raw
+          .whereType<Map<String, dynamic>>()
+          .map(InventoryGroup.fromJson)
+          .toList();
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // ── exports (Plan C) ─────────────────────────────────────────
+
+  Future<List<ExportRecord>> listExports() async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>('/api/v1/exports');
+      final raw = res.data?['exports'];
+      if (raw is! List) return const [];
+      return raw
+          .whereType<Map<String, dynamic>>()
+          .map(ExportRecord.fromJson)
+          .toList();
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  Future<ExportRecord> getExport(String id) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>('/api/v1/exports/$id');
+      return ExportRecord.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // POST /exports — kick off a new export. The server returns
+  // immediately with status=pending; the worker runs the actual
+  // bundling asynchronously. Client should poll list() (or
+  // getExport(id)) until status transitions to ready/failed.
+  Future<ExportRecord> createExport({
+    required bool memories,
+    required IntegrationExportMode integrations,
+    required bool customTasks,
+  }) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/exports',
+        data: {
+          'memories': memories,
+          'integrations': integrations.wire,
+          'custom_tasks': customTasks,
+        },
+      );
+      return ExportRecord.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  Future<void> deleteExport(String id) async {
+    try {
+      await _dio.delete<void>('/api/v1/exports/$id');
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // Absolute URL for the export download endpoint. The token
+  // is a single-use bearer in the `download_token` field of a
+  // ready ExportRecord; the gateway invalidates it after one
+  // successful GET. Returns a relative path that
+  // url_launcher / dio download can resolve against baseUrl.
+  String exportDownloadUrl(String id, String token) {
+    final encId = Uri.encodeComponent(id);
+    final encTok = Uri.encodeComponent(token);
+    return '/api/v1/exports/$encId/download?token=$encTok';
+  }
+
+  // ── imports (C reverse) ──────────────────────────────────────
+
+  Future<List<ImportRecord>> listImports({int limit = 20}) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/imports',
+        queryParameters: {'limit': limit},
+      );
+      final raw = res.data?['imports'];
+      if (raw is! List) return const [];
+      return raw
+          .whereType<Map<String, dynamic>>()
+          .map(ImportRecord.fromJson)
+          .toList();
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  Future<ImportRecord> getImport(String id) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>('/api/v1/imports/$id');
+      return ImportRecord.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // POST /imports — multipart bundle upload. Bundle must be a
+  // .opd JSON package previously produced by /exports.
+  Future<ImportRecord> createImport({
+    required File bundle,
+    required bool memories,
+    required bool integrations,
+    required bool customTasks,
+  }) async {
+    try {
+      final form = FormData.fromMap({
+        'bundle': await MultipartFile.fromFile(
+          bundle.path,
+          filename: bundle.uri.pathSegments.isNotEmpty
+              ? bundle.uri.pathSegments.last
+              : 'bundle.opd',
+        ),
+        'memories': memories ? 'true' : 'false',
+        'integrations': integrations ? 'true' : 'false',
+        'custom_tasks': customTasks ? 'true' : 'false',
+      });
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/imports',
+        data: form,
+        options: Options(
+          sendTimeout: Duration.zero,
+          receiveTimeout: Duration.zero,
+        ),
+      );
+      return ImportRecord.fromJson(res.data ?? {});
     } on Object catch (e) {
       throw toApiException(e);
     }

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 5848 (2924 per locale)
+/// Strings: 6124 (3062 per locale)
 ///
-/// Built on 2026-05-15 at 11:53 UTC
+/// Built on 2026-05-15 at 12:30 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -62,6 +62,7 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	late final TranslationsSkillsEn skills = TranslationsSkillsEn.internal(_root);
 	late final TranslationsCustomTasksEn customTasks = TranslationsCustomTasksEn.internal(_root);
 	late final TranslationsNotesPageEn notesPage = TranslationsNotesPageEn.internal(_root);
+	late final TranslationsDataExportEn dataExport = TranslationsDataExportEn.internal(_root);
 	late final TranslationsMemoryEn memory = TranslationsMemoryEn.internal(_root);
 	late final TranslationsAboutEn about = TranslationsAboutEn.internal(_root);
 	late final TranslationsSettingsEn settings = TranslationsSettingsEn.internal(_root);
@@ -933,6 +934,12 @@ class TranslationsBackupsEn {
 	String get pgDumpMissing => 'pg_dump is not on PATH. Install postgresql-client and restart opendray.';
 
 	late final TranslationsBackupsEncryptionEn encryption = TranslationsBackupsEncryptionEn.internal(_root);
+
+	/// en: 'Restore from file'
+	String get restoreFromFile => 'Restore from file';
+
+	late final TranslationsBackupsRestoreEn restore = TranslationsBackupsRestoreEn.internal(_root);
+	late final TranslationsBackupsInventoryEn inventory = TranslationsBackupsInventoryEn.internal(_root);
 }
 
 // Path: backupTargets
@@ -1687,6 +1694,29 @@ class TranslationsNotesPageEn {
 	String get pathHelper => 'Auto-appends .md if missing.';
 
 	late final TranslationsNotesPageEditorEn editor = TranslationsNotesPageEditorEn.internal(_root);
+}
+
+// Path: dataExport
+class TranslationsDataExportEn {
+	TranslationsDataExportEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Data export & import'
+	String get title => 'Data export & import';
+
+	/// en: 'User-level bundles for migration or verification — separate from /backups (disaster recovery).'
+	String get subtitle => 'User-level bundles for migration or verification — separate from /backups (disaster recovery).';
+
+	late final TranslationsDataExportSectionsEn sections = TranslationsDataExportSectionsEn.internal(_root);
+	late final TranslationsDataExportFormEn form = TranslationsDataExportFormEn.internal(_root);
+	late final TranslationsDataExportHistoryEn history = TranslationsDataExportHistoryEn.internal(_root);
+	late final TranslationsDataExportImportEn import = TranslationsDataExportImportEn.internal(_root);
+	late final TranslationsDataExportImportsEn imports = TranslationsDataExportImportsEn.internal(_root);
+	late final TranslationsDataExportRelativeEn relative = TranslationsDataExportRelativeEn.internal(_root);
+	late final TranslationsDataExportStatusEn status = TranslationsDataExportStatusEn.internal(_root);
 }
 
 // Path: memory
@@ -2825,6 +2855,7 @@ class TranslationsMoreItemsEn {
 	late final TranslationsMoreItemsProjectMemoryEn projectMemory = TranslationsMoreItemsProjectMemoryEn.internal(_root);
 	late final TranslationsMoreItemsCleanupInboxEn cleanupInbox = TranslationsMoreItemsCleanupInboxEn.internal(_root);
 	late final TranslationsMoreItemsBackupsEn backups = TranslationsMoreItemsBackupsEn.internal(_root);
+	late final TranslationsMoreItemsDataExportEn dataExport = TranslationsMoreItemsDataExportEn.internal(_root);
 	late final TranslationsMoreItemsSettingsEn settings = TranslationsMoreItemsSettingsEn.internal(_root);
 	late final TranslationsMoreItemsAboutEn about = TranslationsMoreItemsAboutEn.internal(_root);
 }
@@ -3764,6 +3795,159 @@ class TranslationsBackupsEncryptionEn {
 	String get passphraseCopied => 'Passphrase copied to clipboard';
 }
 
+// Path: backups.restore
+class TranslationsBackupsRestoreEn {
+	TranslationsBackupsRestoreEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Restore from bundle'
+	String get title => 'Restore from bundle';
+
+	/// en: 'Replay an encrypted .tar.gz.enc bundle into a Postgres database. The bundle is uploaded from this phone — pick a file produced by a prior backup.'
+	String get subtitle => 'Replay an encrypted .tar.gz.enc bundle into a Postgres database. The bundle is uploaded from this phone — pick a file produced by a prior backup.';
+
+	/// en: 'Bundle file (.tar.gz.enc)'
+	String get bundleLabel => 'Bundle file (.tar.gz.enc)';
+
+	/// en: 'Pick file'
+	String get pickFile => 'Pick file';
+
+	/// en: '{name} · {size}'
+	String fileSelected({required Object name, required Object size}) => '${name} · ${size}';
+
+	/// en: 'No file selected'
+	String get noFile => 'No file selected';
+
+	/// en: 'Target Postgres DSN'
+	String get targetDsnLabel => 'Target Postgres DSN';
+
+	/// en: 'Leave empty to restore into opendray's own DB.'
+	String get targetDsnHint => 'Leave empty to restore into opendray\'s own DB.';
+
+	/// en: 'postgres://user:pass@host:5432/dbname'
+	String get targetDsnPlaceholder => 'postgres://user:pass@host:5432/dbname';
+
+	/// en: 'pg_restore --clean --if-exists'
+	String get cleanLabel => 'pg_restore --clean --if-exists';
+
+	/// en: 'Drops existing objects before recreating them.'
+	String get cleanHint => 'Drops existing objects before recreating them.';
+
+	/// en: 'Audit note (optional)'
+	String get auditNoteLabel => 'Audit note (optional)';
+
+	/// en: 'e.g. recovering from #INC-481'
+	String get auditNotePlaceholder => 'e.g. recovering from #INC-481';
+
+	/// en: 'Restoring into opendray's OWN database will rewrite the rows this gateway is currently serving. Type "I understand" to confirm.'
+	String get ownDbWarning => 'Restoring into opendray\'s OWN database will rewrite the rows this gateway is currently serving. Type "I understand" to confirm.';
+
+	/// en: 'Type "I understand"'
+	String get confirmPlaceholder => 'Type "I understand"';
+
+	/// en: 'I understand'
+	String get confirmSentinel => 'I understand';
+
+	/// en: 'Restoring…'
+	String get restoring => 'Restoring…';
+
+	/// en: 'Restore'
+	String get restore => 'Restore';
+
+	/// en: 'Restore succeeded'
+	String get succeededTitle => 'Restore succeeded';
+
+	/// en: 'Replayed {bytes} from backup {id}.'
+	String succeededBody({required Object bytes, required Object id}) => 'Replayed ${bytes} from backup ${id}.';
+
+	/// en: 'Restore failed'
+	String get failedTitle => 'Restore failed';
+
+	/// en: 'Pick a bundle file first.'
+	String get pickFileToast => 'Pick a bundle file first.';
+
+	/// en: 'pg_restore output'
+	String get outputTitle => 'pg_restore output';
+
+	/// en: '(empty — restore completed silently)'
+	String get noPgRestoreOutput => '(empty — restore completed silently)';
+
+	/// en: 'Manifest'
+	String get manifestTitle => 'Manifest';
+
+	/// en: 'Backup ID'
+	String get manifestBackupId => 'Backup ID';
+
+	/// en: 'Manifest version'
+	String get manifestVersion => 'Manifest version';
+
+	/// en: 'Created'
+	String get manifestCreatedAt => 'Created';
+
+	/// en: 'pg_version'
+	String get manifestPgVersion => 'pg_version';
+
+	/// en: 'opendray version'
+	String get manifestOpendrayVersion => 'opendray version';
+
+	/// en: 'Key fingerprint'
+	String get fingerprint => 'Key fingerprint';
+
+	/// en: 'matched'
+	String get fingerprintOk => 'matched';
+
+	/// en: 'MISMATCH'
+	String get fingerprintMismatch => 'MISMATCH';
+
+	/// en: 'Encryption'
+	String get encryptionAlgo => 'Encryption';
+
+	/// en: 'Bytes read'
+	String get bytesRead => 'Bytes read';
+
+	/// en: 'Target DSN'
+	String get targetDsnUsed => 'Target DSN';
+
+	/// en: '(opendray's own DB)'
+	String get targetDsnSelfLabel => '(opendray\'s own DB)';
+
+	/// en: 'Done'
+	String get done => 'Done';
+}
+
+// Path: backups.inventory
+class TranslationsBackupsInventoryEn {
+	TranslationsBackupsInventoryEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'What's in a backup'
+	String get title => 'What\'s in a backup';
+
+	/// en: '{rows} rows · {tables} tables'
+	String summary({required Object rows, required Object tables}) => '${rows} rows · ${tables} tables';
+
+	/// en: 'Live row counts from opendray's Postgres database. Backups capture every row below; binary artifacts on disk are not included.'
+	String get description => 'Live row counts from opendray\'s Postgres database. Backups capture every row below; binary artifacts on disk are not included.';
+
+	/// en: 'rows'
+	String get rowsLabel => 'rows';
+
+	/// en: 'Failed to load inventory'
+	String get loadFailedToast => 'Failed to load inventory';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'Tap to expand'
+	String get tap => 'Tap to expand';
+}
+
 // Path: backupTargetEditor.kinds
 class TranslationsBackupTargetEditorKindsEn {
 	TranslationsBackupTargetEditorKindsEn.internal(this._root);
@@ -4100,6 +4284,278 @@ class TranslationsNotesPageEditorEn {
 
 	/// en: 'Saved {time}'
 	String savedAt({required Object time}) => 'Saved ${time}';
+}
+
+// Path: dataExport.sections
+class TranslationsDataExportSectionsEn {
+	TranslationsDataExportSectionsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Export'
+	String get export => 'Export';
+
+	/// en: 'Import'
+	String get import => 'Import';
+}
+
+// Path: dataExport.form
+class TranslationsDataExportFormEn {
+	TranslationsDataExportFormEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Scope'
+	String get scope => 'Scope';
+
+	/// en: 'Memories'
+	String get memories => 'Memories';
+
+	/// en: 'All persisted memories + their embeddings.'
+	String get memoriesHint => 'All persisted memories + their embeddings.';
+
+	/// en: 'Integrations'
+	String get integrations => 'Integrations';
+
+	late final TranslationsDataExportFormIntegrationOptionsEn integrationOptions = TranslationsDataExportFormIntegrationOptionsEn.internal(_root);
+
+	/// en: 'Plaintext key export contains decryptable secrets. Type "I understand" to confirm.'
+	String get confirmWarning => 'Plaintext key export contains decryptable secrets. Type "I understand" to confirm.';
+
+	/// en: 'Type "I understand"'
+	String get confirmPlaceholder => 'Type "I understand"';
+
+	/// en: 'I understand'
+	String get confirmSentinel => 'I understand';
+
+	/// en: 'Custom tasks'
+	String get customTasks => 'Custom tasks';
+
+	/// en: 'Per-user task definitions (cron schedules + script bodies).'
+	String get customTasksHint => 'Per-user task definitions (cron schedules + script bodies).';
+
+	/// en: 'Bundles expire 7 days after creation. Download link is single-use.'
+	String get footnote => 'Bundles expire 7 days after creation. Download link is single-use.';
+
+	/// en: 'Create bundle'
+	String get create => 'Create bundle';
+
+	/// en: 'Building…'
+	String get building => 'Building…';
+
+	/// en: 'Bundle ready'
+	String get readyToast => 'Bundle ready';
+
+	/// en: '{bytes} bytes — download from the history below.'
+	String readyDescription({required Object bytes}) => '${bytes} bytes — download from the history below.';
+
+	/// en: 'Bundle creation failed: {error}'
+	String failedToast({required Object error}) => 'Bundle creation failed: ${error}';
+}
+
+// Path: dataExport.history
+class TranslationsDataExportHistoryEn {
+	TranslationsDataExportHistoryEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Export history'
+	String get title => 'Export history';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'No exports yet.'
+	String get empty => 'No exports yet.';
+
+	/// en: 'Failed to load exports: {error}'
+	String listFailedToast({required Object error}) => 'Failed to load exports: ${error}';
+
+	/// en: 'Failed to fetch download token: {error}'
+	String downloadFailedToast({required Object error}) => 'Failed to fetch download token: ${error}';
+
+	/// en: 'This export has no usable download token (already consumed or expired).'
+	String get noTokenToast => 'This export has no usable download token (already consumed or expired).';
+
+	/// en: 'Export deleted.'
+	String get deletedToast => 'Export deleted.';
+
+	/// en: 'Failed to delete export: {error}'
+	String deleteFailedToast({required Object error}) => 'Failed to delete export: ${error}';
+
+	/// en: 'Delete export?'
+	String get deleteConfirmTitle => 'Delete export?';
+
+	/// en: 'Removes the bundle and revokes the download token. {id}'
+	String deleteConfirmBody({required Object id}) => 'Removes the bundle and revokes the download token. ${id}';
+
+	/// en: 'Download'
+	String get download => 'Download';
+
+	/// en: 'Delete'
+	String get delete => 'Delete';
+
+	/// en: 'Download URL copied to clipboard. Paste into a browser to fetch (single-use).'
+	String get downloadCopiedToast => 'Download URL copied to clipboard. Paste into a browser to fetch (single-use).';
+
+	late final TranslationsDataExportHistoryColumnsEn columns = TranslationsDataExportHistoryColumnsEn.internal(_root);
+
+	/// en: '(empty)'
+	String get scopeEmpty => '(empty)';
+
+	/// en: 'memories'
+	String get scopeMemories => 'memories';
+
+	/// en: 'integrations({mode})'
+	String scopeIntegrations({required Object mode}) => 'integrations(${mode})';
+
+	/// en: 'custom_tasks'
+	String get scopeCustomTasks => 'custom_tasks';
+}
+
+// Path: dataExport.import
+class TranslationsDataExportImportEn {
+	TranslationsDataExportImportEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Replays a bundle previously produced by Export. Only the entities you tick below are imported; everything else in the bundle is ignored.'
+	String get intro => 'Replays a bundle previously produced by Export. Only the entities you tick below are imported; everything else in the bundle is ignored.';
+
+	/// en: 'Bundle file (.zip)'
+	String get bundleLabel => 'Bundle file (.zip)';
+
+	/// en: 'Pick file'
+	String get pickFile => 'Pick file';
+
+	/// en: '{name} · {size}'
+	String fileSelected({required Object name, required Object size}) => '${name} · ${size}';
+
+	/// en: 'No file selected'
+	String get noFile => 'No file selected';
+
+	/// en: 'Memories'
+	String get memoriesLabel => 'Memories';
+
+	/// en: 'Integrations'
+	String get integrationsLabel => 'Integrations';
+
+	/// en: 'Custom tasks'
+	String get customTasksLabel => 'Custom tasks';
+
+	/// en: 'Import bundle'
+	String get importBundle => 'Import bundle';
+
+	/// en: 'Importing…'
+	String get importing => 'Importing…';
+
+	/// en: 'Pick a bundle file first.'
+	String get pickFileToast => 'Pick a bundle file first.';
+
+	/// en: 'Import done'
+	String get doneToast => 'Import done';
+
+	/// en: 'Import finished with errors'
+	String get finishedWithErrors => 'Import finished with errors';
+
+	/// en: 'Import failed: {error}'
+	String failedToast({required Object error}) => 'Import failed: ${error}';
+
+	late final TranslationsDataExportImportSummaryCardEn summaryCard = TranslationsDataExportImportSummaryCardEn.internal(_root);
+}
+
+// Path: dataExport.imports
+class TranslationsDataExportImportsEn {
+	TranslationsDataExportImportsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Import history'
+	String get title => 'Import history';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'No imports yet.'
+	String get empty => 'No imports yet.';
+
+	/// en: 'Failed to load imports: {error}'
+	String listFailedToast({required Object error}) => 'Failed to load imports: ${error}';
+
+	/// en: '(no counts)'
+	String get noneCounts => '(no counts)';
+
+	/// en: '(unknown source)'
+	String get sourceUnknown => '(unknown source)';
+
+	late final TranslationsDataExportImportsColumnsEn columns = TranslationsDataExportImportsColumnsEn.internal(_root);
+}
+
+// Path: dataExport.relative
+class TranslationsDataExportRelativeEn {
+	TranslationsDataExportRelativeEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'in {n}s'
+	String inSeconds({required Object n}) => 'in ${n}s';
+
+	/// en: 'in {n}m'
+	String inMinutes({required Object n}) => 'in ${n}m';
+
+	/// en: 'in {n}h'
+	String inHours({required Object n}) => 'in ${n}h';
+
+	/// en: 'in {n}d'
+	String inDays({required Object n}) => 'in ${n}d';
+
+	/// en: '{n}s ago'
+	String secondsAgo({required Object n}) => '${n}s ago';
+
+	/// en: '{n}m ago'
+	String minutesAgo({required Object n}) => '${n}m ago';
+
+	/// en: '{n}h ago'
+	String hoursAgo({required Object n}) => '${n}h ago';
+}
+
+// Path: dataExport.status
+class TranslationsDataExportStatusEn {
+	TranslationsDataExportStatusEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'pending'
+	String get pending => 'pending';
+
+	/// en: 'running'
+	String get running => 'running';
+
+	/// en: 'ready'
+	String get ready => 'ready';
+
+	/// en: 'failed'
+	String get failed => 'failed';
+
+	/// en: 'expired'
+	String get expired => 'expired';
+
+	/// en: 'succeeded'
+	String get succeeded => 'succeeded';
 }
 
 // Path: memory.rank
@@ -8942,6 +9398,21 @@ class TranslationsMoreItemsBackupsEn {
 	String get subtitle => 'Latest backup status & run-now';
 }
 
+// Path: more.items.dataExport
+class TranslationsMoreItemsDataExportEn {
+	TranslationsMoreItemsDataExportEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Data export & import'
+	String get title => 'Data export & import';
+
+	/// en: 'User-level data bundles (memories / integrations / custom tasks)'
+	String get subtitle => 'User-level data bundles (memories / integrations / custom tasks)';
+}
+
 // Path: more.items.settings
 class TranslationsMoreItemsSettingsEn {
 	TranslationsMoreItemsSettingsEn.internal(this._root);
@@ -9926,6 +10397,105 @@ class TranslationsChannelsKindsWechatEn {
 
 	/// en: 'When set, tapping the WeChat notification opens this page.'
 	String get urlHint => 'When set, tapping the WeChat notification opens this page.';
+}
+
+// Path: dataExport.form.integrationOptions
+class TranslationsDataExportFormIntegrationOptionsEn {
+	TranslationsDataExportFormIntegrationOptionsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Skip'
+	String get none => 'Skip';
+
+	/// en: 'Don't include the /integrations registry.'
+	String get noneHint => 'Don\'t include the /integrations registry.';
+
+	/// en: 'Metadata only (default)'
+	String get metadata => 'Metadata only (default)';
+
+	/// en: 'Per-integration name + endpoint, no API keys.'
+	String get metadataHint => 'Per-integration name + endpoint, no API keys.';
+
+	/// en: 'Plaintext keys'
+	String get plaintext => 'Plaintext keys';
+
+	/// en: 'DANGEROUS: includes raw API tokens. v1 stores only bcrypt hashes, so this is effectively a no-op today; surface anyway.'
+	String get plaintextHint => 'DANGEROUS: includes raw API tokens. v1 stores only bcrypt hashes, so this is effectively a no-op today; surface anyway.';
+}
+
+// Path: dataExport.history.columns
+class TranslationsDataExportHistoryColumnsEn {
+	TranslationsDataExportHistoryColumnsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Scope'
+	String get scope => 'Scope';
+
+	/// en: 'Size'
+	String get size => 'Size';
+
+	/// en: 'Expires'
+	String get expires => 'Expires';
+
+	/// en: 'Actions'
+	String get actions => 'Actions';
+}
+
+// Path: dataExport.import.summaryCard
+class TranslationsDataExportImportSummaryCardEn {
+	TranslationsDataExportImportSummaryCardEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Memories'
+	String get memories => 'Memories';
+
+	/// en: 'Integrations'
+	String get integrations => 'Integrations';
+
+	/// en: 'Custom tasks'
+	String get customTasks => 'Custom tasks';
+
+	/// en: 'created'
+	String get created => 'created';
+
+	/// en: 'skipped'
+	String get skipped => 'skipped';
+
+	/// en: 'failed'
+	String get failed => 'failed';
+}
+
+// Path: dataExport.imports.columns
+class TranslationsDataExportImportsColumnsEn {
+	TranslationsDataExportImportsColumnsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'ID'
+	String get id => 'ID';
+
+	/// en: 'Status'
+	String get status => 'Status';
+
+	/// en: 'Source'
+	String get source => 'Source';
+
+	/// en: 'Counts'
+	String get counts => 'Counts';
+
+	/// en: 'When'
+	String get when => 'When';
 }
 
 // Path: settings.logViewer.levels
@@ -14738,6 +15308,8 @@ extension on Translations {
 			'more.items.cleanupInbox.subtitle' => 'LLM-proposed deletions / merges across all projects',
 			'more.items.backups.title' => 'Backups',
 			'more.items.backups.subtitle' => 'Latest backup status & run-now',
+			'more.items.dataExport.title' => 'Data export & import',
+			'more.items.dataExport.subtitle' => 'User-level data bundles (memories / integrations / custom tasks)',
 			'more.items.settings.title' => 'Settings',
 			'more.items.settings.subtitle' => 'Language, appearance, account',
 			'more.items.about.title' => 'About',
@@ -14952,10 +15524,10 @@ extension on Translations {
 			'mcp.editor.create' => 'Create',
 			'mcp.secret.keyLabel' => 'Key',
 			'mcp.secret.keyHint' => 'GITHUB_TOKEN, OPENAI_KEY, …',
-			'mcp.secret.valueLabel' => 'Value',
-			'mcp.secret.keyRequired' => 'Key is required.',
 			_ => null,
 		} ?? switch (path) {
+			'mcp.secret.valueLabel' => 'Value',
+			'mcp.secret.keyRequired' => 'Key is required.',
 			'mcp.secret.keyInvalid' => 'Key must match [A-Za-z_][A-Za-z0-9_]* — same rules as a shell env var.',
 			'mcp.secret.valueRequired' => 'Value is required.',
 			'mcp.secret.replaceTitle' => 'Replace secret value',
@@ -15287,6 +15859,52 @@ extension on Translations {
 			'backups.encryption.passphraseLabel' => 'Your passphrase',
 			'backups.encryption.passphraseHint' => 'At least 20 characters',
 			'backups.encryption.passphraseCopied' => 'Passphrase copied to clipboard',
+			'backups.restoreFromFile' => 'Restore from file',
+			'backups.restore.title' => 'Restore from bundle',
+			'backups.restore.subtitle' => 'Replay an encrypted .tar.gz.enc bundle into a Postgres database. The bundle is uploaded from this phone — pick a file produced by a prior backup.',
+			'backups.restore.bundleLabel' => 'Bundle file (.tar.gz.enc)',
+			'backups.restore.pickFile' => 'Pick file',
+			'backups.restore.fileSelected' => ({required Object name, required Object size}) => '${name} · ${size}',
+			'backups.restore.noFile' => 'No file selected',
+			'backups.restore.targetDsnLabel' => 'Target Postgres DSN',
+			'backups.restore.targetDsnHint' => 'Leave empty to restore into opendray\'s own DB.',
+			'backups.restore.targetDsnPlaceholder' => 'postgres://user:pass@host:5432/dbname',
+			'backups.restore.cleanLabel' => 'pg_restore --clean --if-exists',
+			'backups.restore.cleanHint' => 'Drops existing objects before recreating them.',
+			'backups.restore.auditNoteLabel' => 'Audit note (optional)',
+			'backups.restore.auditNotePlaceholder' => 'e.g. recovering from #INC-481',
+			'backups.restore.ownDbWarning' => 'Restoring into opendray\'s OWN database will rewrite the rows this gateway is currently serving. Type "I understand" to confirm.',
+			'backups.restore.confirmPlaceholder' => 'Type "I understand"',
+			'backups.restore.confirmSentinel' => 'I understand',
+			'backups.restore.restoring' => 'Restoring…',
+			'backups.restore.restore' => 'Restore',
+			'backups.restore.succeededTitle' => 'Restore succeeded',
+			'backups.restore.succeededBody' => ({required Object bytes, required Object id}) => 'Replayed ${bytes} from backup ${id}.',
+			'backups.restore.failedTitle' => 'Restore failed',
+			'backups.restore.pickFileToast' => 'Pick a bundle file first.',
+			'backups.restore.outputTitle' => 'pg_restore output',
+			'backups.restore.noPgRestoreOutput' => '(empty — restore completed silently)',
+			'backups.restore.manifestTitle' => 'Manifest',
+			'backups.restore.manifestBackupId' => 'Backup ID',
+			'backups.restore.manifestVersion' => 'Manifest version',
+			'backups.restore.manifestCreatedAt' => 'Created',
+			'backups.restore.manifestPgVersion' => 'pg_version',
+			'backups.restore.manifestOpendrayVersion' => 'opendray version',
+			'backups.restore.fingerprint' => 'Key fingerprint',
+			'backups.restore.fingerprintOk' => 'matched',
+			'backups.restore.fingerprintMismatch' => 'MISMATCH',
+			'backups.restore.encryptionAlgo' => 'Encryption',
+			'backups.restore.bytesRead' => 'Bytes read',
+			'backups.restore.targetDsnUsed' => 'Target DSN',
+			'backups.restore.targetDsnSelfLabel' => '(opendray\'s own DB)',
+			'backups.restore.done' => 'Done',
+			'backups.inventory.title' => 'What\'s in a backup',
+			'backups.inventory.summary' => ({required Object rows, required Object tables}) => '${rows} rows · ${tables} tables',
+			'backups.inventory.description' => 'Live row counts from opendray\'s Postgres database. Backups capture every row below; binary artifacts on disk are not included.',
+			'backups.inventory.rowsLabel' => 'rows',
+			'backups.inventory.loadFailedToast' => 'Failed to load inventory',
+			'backups.inventory.loading' => 'Loading…',
+			'backups.inventory.tap' => 'Tap to expand',
 			'backupTargets.title' => 'Backup targets',
 			'backupTargets.newTarget' => 'New target',
 			'backupTargets.testConnection' => 'Test connection',
@@ -15420,6 +16038,8 @@ extension on Translations {
 			'githosts.form.tokenHintNew' => 'Paste the personal access token.',
 			'githosts.form.enabledHelper' => 'Available to sessions for PR / remote lookups.',
 			'githosts.form.validateTokenRequired' => 'Token is required when adding a host.',
+			_ => null,
+		} ?? switch (path) {
 			'githosts.form.appBarEdit' => ({required Object name}) => 'Edit ${name}',
 			'githosts.form.appBarNew' => 'Add git host',
 			'githosts.form.tokenPreviewHint' => ({required Object preview}) => 'Current preview: ${preview}',
@@ -15468,8 +16088,6 @@ extension on Translations {
 			'channels.popup.enable' => 'Enable',
 			'channels.popup.disable' => 'Disable',
 			'channels.popup.mute' => 'Mute',
-			_ => null,
-		} ?? switch (path) {
 			'channels.popup.unmute' => 'Unmute',
 			'channels.popup.deleteLabel' => 'Delete',
 			'channels.badges.running' => 'running',
@@ -15645,6 +16263,96 @@ extension on Translations {
 			'notesPage.editor.saveFailedApi' => ({required Object error}) => 'Save failed: ${error}',
 			'notesPage.editor.saveFailedGeneric' => ({required Object error}) => 'Save failed: ${error}',
 			'notesPage.editor.savedAt' => ({required Object time}) => 'Saved ${time}',
+			'dataExport.title' => 'Data export & import',
+			'dataExport.subtitle' => 'User-level bundles for migration or verification — separate from /backups (disaster recovery).',
+			'dataExport.sections.export' => 'Export',
+			'dataExport.sections.import' => 'Import',
+			'dataExport.form.scope' => 'Scope',
+			'dataExport.form.memories' => 'Memories',
+			'dataExport.form.memoriesHint' => 'All persisted memories + their embeddings.',
+			'dataExport.form.integrations' => 'Integrations',
+			'dataExport.form.integrationOptions.none' => 'Skip',
+			'dataExport.form.integrationOptions.noneHint' => 'Don\'t include the /integrations registry.',
+			'dataExport.form.integrationOptions.metadata' => 'Metadata only (default)',
+			'dataExport.form.integrationOptions.metadataHint' => 'Per-integration name + endpoint, no API keys.',
+			'dataExport.form.integrationOptions.plaintext' => 'Plaintext keys',
+			'dataExport.form.integrationOptions.plaintextHint' => 'DANGEROUS: includes raw API tokens. v1 stores only bcrypt hashes, so this is effectively a no-op today; surface anyway.',
+			'dataExport.form.confirmWarning' => 'Plaintext key export contains decryptable secrets. Type "I understand" to confirm.',
+			'dataExport.form.confirmPlaceholder' => 'Type "I understand"',
+			'dataExport.form.confirmSentinel' => 'I understand',
+			'dataExport.form.customTasks' => 'Custom tasks',
+			'dataExport.form.customTasksHint' => 'Per-user task definitions (cron schedules + script bodies).',
+			'dataExport.form.footnote' => 'Bundles expire 7 days after creation. Download link is single-use.',
+			'dataExport.form.create' => 'Create bundle',
+			'dataExport.form.building' => 'Building…',
+			'dataExport.form.readyToast' => 'Bundle ready',
+			'dataExport.form.readyDescription' => ({required Object bytes}) => '${bytes} bytes — download from the history below.',
+			'dataExport.form.failedToast' => ({required Object error}) => 'Bundle creation failed: ${error}',
+			'dataExport.history.title' => 'Export history',
+			'dataExport.history.loading' => 'Loading…',
+			'dataExport.history.empty' => 'No exports yet.',
+			'dataExport.history.listFailedToast' => ({required Object error}) => 'Failed to load exports: ${error}',
+			'dataExport.history.downloadFailedToast' => ({required Object error}) => 'Failed to fetch download token: ${error}',
+			'dataExport.history.noTokenToast' => 'This export has no usable download token (already consumed or expired).',
+			'dataExport.history.deletedToast' => 'Export deleted.',
+			'dataExport.history.deleteFailedToast' => ({required Object error}) => 'Failed to delete export: ${error}',
+			'dataExport.history.deleteConfirmTitle' => 'Delete export?',
+			'dataExport.history.deleteConfirmBody' => ({required Object id}) => 'Removes the bundle and revokes the download token. ${id}',
+			'dataExport.history.download' => 'Download',
+			'dataExport.history.delete' => 'Delete',
+			'dataExport.history.downloadCopiedToast' => 'Download URL copied to clipboard. Paste into a browser to fetch (single-use).',
+			'dataExport.history.columns.scope' => 'Scope',
+			'dataExport.history.columns.size' => 'Size',
+			'dataExport.history.columns.expires' => 'Expires',
+			'dataExport.history.columns.actions' => 'Actions',
+			'dataExport.history.scopeEmpty' => '(empty)',
+			'dataExport.history.scopeMemories' => 'memories',
+			'dataExport.history.scopeIntegrations' => ({required Object mode}) => 'integrations(${mode})',
+			'dataExport.history.scopeCustomTasks' => 'custom_tasks',
+			'dataExport.import.intro' => 'Replays a bundle previously produced by Export. Only the entities you tick below are imported; everything else in the bundle is ignored.',
+			'dataExport.import.bundleLabel' => 'Bundle file (.zip)',
+			'dataExport.import.pickFile' => 'Pick file',
+			'dataExport.import.fileSelected' => ({required Object name, required Object size}) => '${name} · ${size}',
+			'dataExport.import.noFile' => 'No file selected',
+			'dataExport.import.memoriesLabel' => 'Memories',
+			'dataExport.import.integrationsLabel' => 'Integrations',
+			'dataExport.import.customTasksLabel' => 'Custom tasks',
+			'dataExport.import.importBundle' => 'Import bundle',
+			'dataExport.import.importing' => 'Importing…',
+			'dataExport.import.pickFileToast' => 'Pick a bundle file first.',
+			'dataExport.import.doneToast' => 'Import done',
+			'dataExport.import.finishedWithErrors' => 'Import finished with errors',
+			'dataExport.import.failedToast' => ({required Object error}) => 'Import failed: ${error}',
+			'dataExport.import.summaryCard.memories' => 'Memories',
+			'dataExport.import.summaryCard.integrations' => 'Integrations',
+			'dataExport.import.summaryCard.customTasks' => 'Custom tasks',
+			'dataExport.import.summaryCard.created' => 'created',
+			'dataExport.import.summaryCard.skipped' => 'skipped',
+			'dataExport.import.summaryCard.failed' => 'failed',
+			'dataExport.imports.title' => 'Import history',
+			'dataExport.imports.loading' => 'Loading…',
+			'dataExport.imports.empty' => 'No imports yet.',
+			'dataExport.imports.listFailedToast' => ({required Object error}) => 'Failed to load imports: ${error}',
+			'dataExport.imports.noneCounts' => '(no counts)',
+			'dataExport.imports.sourceUnknown' => '(unknown source)',
+			'dataExport.imports.columns.id' => 'ID',
+			'dataExport.imports.columns.status' => 'Status',
+			'dataExport.imports.columns.source' => 'Source',
+			'dataExport.imports.columns.counts' => 'Counts',
+			'dataExport.imports.columns.when' => 'When',
+			'dataExport.relative.inSeconds' => ({required Object n}) => 'in ${n}s',
+			'dataExport.relative.inMinutes' => ({required Object n}) => 'in ${n}m',
+			'dataExport.relative.inHours' => ({required Object n}) => 'in ${n}h',
+			'dataExport.relative.inDays' => ({required Object n}) => 'in ${n}d',
+			'dataExport.relative.secondsAgo' => ({required Object n}) => '${n}s ago',
+			'dataExport.relative.minutesAgo' => ({required Object n}) => '${n}m ago',
+			'dataExport.relative.hoursAgo' => ({required Object n}) => '${n}h ago',
+			'dataExport.status.pending' => 'pending',
+			'dataExport.status.running' => 'running',
+			'dataExport.status.ready' => 'ready',
+			'dataExport.status.failed' => 'failed',
+			'dataExport.status.expired' => 'expired',
+			'dataExport.status.succeeded' => 'succeeded',
 			'memory.title' => 'Memory',
 			'memory.more' => 'More',
 			'memory.workers' => 'Memory workers',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -61,6 +61,7 @@ class TranslationsZh extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsSkillsZh skills = _TranslationsSkillsZh._(_root);
 	@override late final _TranslationsCustomTasksZh customTasks = _TranslationsCustomTasksZh._(_root);
 	@override late final _TranslationsNotesPageZh notesPage = _TranslationsNotesPageZh._(_root);
+	@override late final _TranslationsDataExportZh dataExport = _TranslationsDataExportZh._(_root);
 	@override late final _TranslationsMemoryZh memory = _TranslationsMemoryZh._(_root);
 	@override late final _TranslationsAboutZh about = _TranslationsAboutZh._(_root);
 	@override late final _TranslationsSettingsZh settings = _TranslationsSettingsZh._(_root);
@@ -464,6 +465,9 @@ class _TranslationsBackupsZh extends TranslationsBackupsEn {
 	@override String get savedConfirmCheckbox => '我已将密语保存到密码管理器';
 	@override String get pgDumpMissing => 'pg_dump 不在 PATH 中。请安装 postgresql-client 并重启 opendray。';
 	@override late final _TranslationsBackupsEncryptionZh encryption = _TranslationsBackupsEncryptionZh._(_root);
+	@override String get restoreFromFile => '从文件恢复';
+	@override late final _TranslationsBackupsRestoreZh restore = _TranslationsBackupsRestoreZh._(_root);
+	@override late final _TranslationsBackupsInventoryZh inventory = _TranslationsBackupsInventoryZh._(_root);
 }
 
 // Path: backupTargets
@@ -775,6 +779,24 @@ class _TranslationsNotesPageZh extends TranslationsNotesPageEn {
 	@override String get validatePathDots => '路径不能包含「..」';
 	@override String get pathHelper => '缺失时自动追加 .md。';
 	@override late final _TranslationsNotesPageEditorZh editor = _TranslationsNotesPageEditorZh._(_root);
+}
+
+// Path: dataExport
+class _TranslationsDataExportZh extends TranslationsDataExportEn {
+	_TranslationsDataExportZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '数据导出与导入';
+	@override String get subtitle => '面向用户的数据包，用于迁移或验证 — 与 /backups（灾难恢复）相互独立。';
+	@override late final _TranslationsDataExportSectionsZh sections = _TranslationsDataExportSectionsZh._(_root);
+	@override late final _TranslationsDataExportFormZh form = _TranslationsDataExportFormZh._(_root);
+	@override late final _TranslationsDataExportHistoryZh history = _TranslationsDataExportHistoryZh._(_root);
+	@override late final _TranslationsDataExportImportZh import = _TranslationsDataExportImportZh._(_root);
+	@override late final _TranslationsDataExportImportsZh imports = _TranslationsDataExportImportsZh._(_root);
+	@override late final _TranslationsDataExportRelativeZh relative = _TranslationsDataExportRelativeZh._(_root);
+	@override late final _TranslationsDataExportStatusZh status = _TranslationsDataExportStatusZh._(_root);
 }
 
 // Path: memory
@@ -1430,6 +1452,7 @@ class _TranslationsMoreItemsZh extends TranslationsMoreItemsEn {
 	@override late final _TranslationsMoreItemsProjectMemoryZh projectMemory = _TranslationsMoreItemsProjectMemoryZh._(_root);
 	@override late final _TranslationsMoreItemsCleanupInboxZh cleanupInbox = _TranslationsMoreItemsCleanupInboxZh._(_root);
 	@override late final _TranslationsMoreItemsBackupsZh backups = _TranslationsMoreItemsBackupsZh._(_root);
+	@override late final _TranslationsMoreItemsDataExportZh dataExport = _TranslationsMoreItemsDataExportZh._(_root);
 	@override late final _TranslationsMoreItemsSettingsZh settings = _TranslationsMoreItemsSettingsZh._(_root);
 	@override late final _TranslationsMoreItemsAboutZh about = _TranslationsMoreItemsAboutZh._(_root);
 }
@@ -1929,6 +1952,69 @@ class _TranslationsBackupsEncryptionZh extends TranslationsBackupsEncryptionEn {
 	@override String get passphraseCopied => '密语已复制到剪贴板';
 }
 
+// Path: backups.restore
+class _TranslationsBackupsRestoreZh extends TranslationsBackupsRestoreEn {
+	_TranslationsBackupsRestoreZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '从备份包恢复';
+	@override String get subtitle => '将加密的 .tar.gz.enc 备份包重放到 Postgres 数据库。备份包将从本机上传 — 请选择此前生成的文件。';
+	@override String get bundleLabel => '备份文件（.tar.gz.enc）';
+	@override String get pickFile => '选择文件';
+	@override String fileSelected({required Object name, required Object size}) => '${name} · ${size}';
+	@override String get noFile => '未选择文件';
+	@override String get targetDsnLabel => '目标 Postgres DSN';
+	@override String get targetDsnHint => '留空表示恢复到 opendray 自身的数据库。';
+	@override String get targetDsnPlaceholder => 'postgres://user:pass@host:5432/dbname';
+	@override String get cleanLabel => 'pg_restore --clean --if-exists';
+	@override String get cleanHint => '重新创建之前先删除已存在的对象。';
+	@override String get auditNoteLabel => '审计备注（可选）';
+	@override String get auditNotePlaceholder => '例如：恢复 #INC-481';
+	@override String get ownDbWarning => '恢复到 opendray 自身的数据库将覆写本网关当前提供服务的数据。请输入 "I understand" 以确认。';
+	@override String get confirmPlaceholder => '输入 "I understand"';
+	@override String get confirmSentinel => 'I understand';
+	@override String get restoring => '恢复中…';
+	@override String get restore => '恢复';
+	@override String get succeededTitle => '恢复成功';
+	@override String succeededBody({required Object id, required Object bytes}) => '已从备份 ${id} 重放 ${bytes}。';
+	@override String get failedTitle => '恢复失败';
+	@override String get pickFileToast => '请先选择一个备份文件。';
+	@override String get outputTitle => 'pg_restore 输出';
+	@override String get noPgRestoreOutput => '（空 — 恢复无声完成）';
+	@override String get manifestTitle => '清单';
+	@override String get manifestBackupId => '备份 ID';
+	@override String get manifestVersion => '清单版本';
+	@override String get manifestCreatedAt => '创建时间';
+	@override String get manifestPgVersion => 'pg_version';
+	@override String get manifestOpendrayVersion => 'opendray 版本';
+	@override String get fingerprint => '密钥指纹';
+	@override String get fingerprintOk => '已匹配';
+	@override String get fingerprintMismatch => '不匹配';
+	@override String get encryptionAlgo => '加密算法';
+	@override String get bytesRead => '已读字节';
+	@override String get targetDsnUsed => '目标 DSN';
+	@override String get targetDsnSelfLabel => '（opendray 自身数据库）';
+	@override String get done => '完成';
+}
+
+// Path: backups.inventory
+class _TranslationsBackupsInventoryZh extends TranslationsBackupsInventoryEn {
+	_TranslationsBackupsInventoryZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '备份里有什么';
+	@override String summary({required Object rows, required Object tables}) => '${rows} 行 · ${tables} 表';
+	@override String get description => 'opendray Postgres 数据库的实时行数。备份会捕获以下所有行；磁盘上的二进制工件不包含在内。';
+	@override String get rowsLabel => '行';
+	@override String get loadFailedToast => '加载清单失败';
+	@override String get loading => '加载中…';
+	@override String get tap => '点击展开';
+}
+
 // Path: backupTargetEditor.kinds
 class _TranslationsBackupTargetEditorKindsZh extends TranslationsBackupTargetEditorKindsEn {
 	_TranslationsBackupTargetEditorKindsZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -2121,6 +2207,140 @@ class _TranslationsNotesPageEditorZh extends TranslationsNotesPageEditorEn {
 	@override String saveFailedApi({required Object error}) => '保存失败：${error}';
 	@override String saveFailedGeneric({required Object error}) => '保存失败：${error}';
 	@override String savedAt({required Object time}) => '${time} 已保存';
+}
+
+// Path: dataExport.sections
+class _TranslationsDataExportSectionsZh extends TranslationsDataExportSectionsEn {
+	_TranslationsDataExportSectionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get export => '导出';
+	@override String get import => '导入';
+}
+
+// Path: dataExport.form
+class _TranslationsDataExportFormZh extends TranslationsDataExportFormEn {
+	_TranslationsDataExportFormZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get scope => '范围';
+	@override String get memories => '记忆';
+	@override String get memoriesHint => '所有已持久化的记忆及其向量。';
+	@override String get integrations => '集成';
+	@override late final _TranslationsDataExportFormIntegrationOptionsZh integrationOptions = _TranslationsDataExportFormIntegrationOptionsZh._(_root);
+	@override String get confirmWarning => '明文密钥导出包含可解密的机密。请输入 "I understand" 以确认。';
+	@override String get confirmPlaceholder => '输入 "I understand"';
+	@override String get confirmSentinel => 'I understand';
+	@override String get customTasks => '自定义任务';
+	@override String get customTasksHint => '用户级任务定义（cron 计划 + 脚本主体）。';
+	@override String get footnote => '数据包在创建后 7 天过期。下载链接为单次使用。';
+	@override String get create => '创建数据包';
+	@override String get building => '构建中…';
+	@override String get readyToast => '数据包已就绪';
+	@override String readyDescription({required Object bytes}) => '${bytes} 字节 — 在下方历史中下载。';
+	@override String failedToast({required Object error}) => '数据包创建失败：${error}';
+}
+
+// Path: dataExport.history
+class _TranslationsDataExportHistoryZh extends TranslationsDataExportHistoryEn {
+	_TranslationsDataExportHistoryZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '导出历史';
+	@override String get loading => '加载中…';
+	@override String get empty => '暂无导出。';
+	@override String listFailedToast({required Object error}) => '加载导出失败：${error}';
+	@override String downloadFailedToast({required Object error}) => '获取下载令牌失败：${error}';
+	@override String get noTokenToast => '该导出无可用的下载令牌（已消费或过期）。';
+	@override String get deletedToast => '已删除导出。';
+	@override String deleteFailedToast({required Object error}) => '删除导出失败：${error}';
+	@override String get deleteConfirmTitle => '删除导出？';
+	@override String deleteConfirmBody({required Object id}) => '移除数据包并撤销下载令牌。${id}';
+	@override String get download => '下载';
+	@override String get delete => '删除';
+	@override String get downloadCopiedToast => '下载 URL 已复制到剪贴板。在浏览器中粘贴以获取（单次使用）。';
+	@override late final _TranslationsDataExportHistoryColumnsZh columns = _TranslationsDataExportHistoryColumnsZh._(_root);
+	@override String get scopeEmpty => '（空）';
+	@override String get scopeMemories => '记忆';
+	@override String scopeIntegrations({required Object mode}) => '集成(${mode})';
+	@override String get scopeCustomTasks => '自定义任务';
+}
+
+// Path: dataExport.import
+class _TranslationsDataExportImportZh extends TranslationsDataExportImportEn {
+	_TranslationsDataExportImportZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get intro => '重放此前由「导出」生成的数据包。仅勾选的实体会被导入；数据包中其余内容会被忽略。';
+	@override String get bundleLabel => '数据包文件（.zip）';
+	@override String get pickFile => '选择文件';
+	@override String fileSelected({required Object name, required Object size}) => '${name} · ${size}';
+	@override String get noFile => '未选择文件';
+	@override String get memoriesLabel => '记忆';
+	@override String get integrationsLabel => '集成';
+	@override String get customTasksLabel => '自定义任务';
+	@override String get importBundle => '导入数据包';
+	@override String get importing => '导入中…';
+	@override String get pickFileToast => '请先选择数据包文件。';
+	@override String get doneToast => '导入完成';
+	@override String get finishedWithErrors => '导入完成但有错误';
+	@override String failedToast({required Object error}) => '导入失败：${error}';
+	@override late final _TranslationsDataExportImportSummaryCardZh summaryCard = _TranslationsDataExportImportSummaryCardZh._(_root);
+}
+
+// Path: dataExport.imports
+class _TranslationsDataExportImportsZh extends TranslationsDataExportImportsEn {
+	_TranslationsDataExportImportsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '导入历史';
+	@override String get loading => '加载中…';
+	@override String get empty => '暂无导入。';
+	@override String listFailedToast({required Object error}) => '加载导入失败：${error}';
+	@override String get noneCounts => '（无计数）';
+	@override String get sourceUnknown => '（未知来源）';
+	@override late final _TranslationsDataExportImportsColumnsZh columns = _TranslationsDataExportImportsColumnsZh._(_root);
+}
+
+// Path: dataExport.relative
+class _TranslationsDataExportRelativeZh extends TranslationsDataExportRelativeEn {
+	_TranslationsDataExportRelativeZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String inSeconds({required Object n}) => '${n} 秒后';
+	@override String inMinutes({required Object n}) => '${n} 分钟后';
+	@override String inHours({required Object n}) => '${n} 小时后';
+	@override String inDays({required Object n}) => '${n} 天后';
+	@override String secondsAgo({required Object n}) => '${n} 秒前';
+	@override String minutesAgo({required Object n}) => '${n} 分钟前';
+	@override String hoursAgo({required Object n}) => '${n} 小时前';
+}
+
+// Path: dataExport.status
+class _TranslationsDataExportStatusZh extends TranslationsDataExportStatusEn {
+	_TranslationsDataExportStatusZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get pending => '等待';
+	@override String get running => '运行中';
+	@override String get ready => '就绪';
+	@override String get failed => '失败';
+	@override String get expired => '过期';
+	@override String get succeeded => '成功';
 }
 
 // Path: memory.rank
@@ -4683,6 +4903,17 @@ class _TranslationsMoreItemsBackupsZh extends TranslationsMoreItemsBackupsEn {
 	@override String get subtitle => '最新备份状态与立即运行';
 }
 
+// Path: more.items.dataExport
+class _TranslationsMoreItemsDataExportZh extends TranslationsMoreItemsDataExportEn {
+	_TranslationsMoreItemsDataExportZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '数据导出与导入';
+	@override String get subtitle => '用户级数据包（记忆 / 集成 / 自定义任务）';
+}
+
 // Path: more.items.settings
 class _TranslationsMoreItemsSettingsZh extends TranslationsMoreItemsSettingsEn {
 	_TranslationsMoreItemsSettingsZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -5262,6 +5493,63 @@ class _TranslationsChannelsKindsWechatZh extends TranslationsChannelsKindsWechat
 	@override String get topicIdsLabel => 'Topic ID（每行一个）';
 	@override String get urlLabel => '点击跳转 URL';
 	@override String get urlHint => '设置后，点击微信通知会打开此页面。';
+}
+
+// Path: dataExport.form.integrationOptions
+class _TranslationsDataExportFormIntegrationOptionsZh extends TranslationsDataExportFormIntegrationOptionsEn {
+	_TranslationsDataExportFormIntegrationOptionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get none => '跳过';
+	@override String get noneHint => '不包含 /integrations 注册表。';
+	@override String get metadata => '仅元数据（默认）';
+	@override String get metadataHint => '每个集成的名称 + 端点，不含 API 密钥。';
+	@override String get plaintext => '明文密钥';
+	@override String get plaintextHint => '危险：包含原始 API 令牌。v1 仅存储 bcrypt 哈希，因此此选项当前实际为空操作；仍然提供以提示这一事实。';
+}
+
+// Path: dataExport.history.columns
+class _TranslationsDataExportHistoryColumnsZh extends TranslationsDataExportHistoryColumnsEn {
+	_TranslationsDataExportHistoryColumnsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get scope => '范围';
+	@override String get size => '大小';
+	@override String get expires => '过期';
+	@override String get actions => '操作';
+}
+
+// Path: dataExport.import.summaryCard
+class _TranslationsDataExportImportSummaryCardZh extends TranslationsDataExportImportSummaryCardEn {
+	_TranslationsDataExportImportSummaryCardZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get memories => '记忆';
+	@override String get integrations => '集成';
+	@override String get customTasks => '自定义任务';
+	@override String get created => '创建';
+	@override String get skipped => '跳过';
+	@override String get failed => '失败';
+}
+
+// Path: dataExport.imports.columns
+class _TranslationsDataExportImportsColumnsZh extends TranslationsDataExportImportsColumnsEn {
+	_TranslationsDataExportImportsColumnsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get id => 'ID';
+	@override String get status => '状态';
+	@override String get source => '来源';
+	@override String get counts => '计数';
+	@override String get when => '时间';
 }
 
 // Path: settings.logViewer.levels
@@ -8801,6 +9089,8 @@ extension on TranslationsZh {
 			'more.items.cleanupInbox.subtitle' => '跨项目的 LLM 提议删除 / 合并',
 			'more.items.backups.title' => '备份',
 			'more.items.backups.subtitle' => '最新备份状态与立即运行',
+			'more.items.dataExport.title' => '数据导出与导入',
+			'more.items.dataExport.subtitle' => '用户级数据包（记忆 / 集成 / 自定义任务）',
 			'more.items.settings.title' => '设置',
 			'more.items.settings.subtitle' => '语言、外观、账户',
 			'more.items.about.title' => '关于',
@@ -9015,10 +9305,10 @@ extension on TranslationsZh {
 			'mcp.editor.create' => '创建',
 			'mcp.secret.keyLabel' => '键',
 			'mcp.secret.keyHint' => 'GITHUB_TOKEN、OPENAI_KEY、…',
-			'mcp.secret.valueLabel' => '值',
-			'mcp.secret.keyRequired' => '必须填写键。',
 			_ => null,
 		} ?? switch (path) {
+			'mcp.secret.valueLabel' => '值',
+			'mcp.secret.keyRequired' => '必须填写键。',
 			'mcp.secret.keyInvalid' => '键必须匹配 [A-Za-z_][A-Za-z0-9_]* — 与 shell 环境变量规则相同。',
 			'mcp.secret.valueRequired' => '必须填写值。',
 			'mcp.secret.replaceTitle' => '替换密钥值',
@@ -9350,6 +9640,52 @@ extension on TranslationsZh {
 			'backups.encryption.passphraseLabel' => '你的密语',
 			'backups.encryption.passphraseHint' => '至少 20 个字符',
 			'backups.encryption.passphraseCopied' => '密语已复制到剪贴板',
+			'backups.restoreFromFile' => '从文件恢复',
+			'backups.restore.title' => '从备份包恢复',
+			'backups.restore.subtitle' => '将加密的 .tar.gz.enc 备份包重放到 Postgres 数据库。备份包将从本机上传 — 请选择此前生成的文件。',
+			'backups.restore.bundleLabel' => '备份文件（.tar.gz.enc）',
+			'backups.restore.pickFile' => '选择文件',
+			'backups.restore.fileSelected' => ({required Object name, required Object size}) => '${name} · ${size}',
+			'backups.restore.noFile' => '未选择文件',
+			'backups.restore.targetDsnLabel' => '目标 Postgres DSN',
+			'backups.restore.targetDsnHint' => '留空表示恢复到 opendray 自身的数据库。',
+			'backups.restore.targetDsnPlaceholder' => 'postgres://user:pass@host:5432/dbname',
+			'backups.restore.cleanLabel' => 'pg_restore --clean --if-exists',
+			'backups.restore.cleanHint' => '重新创建之前先删除已存在的对象。',
+			'backups.restore.auditNoteLabel' => '审计备注（可选）',
+			'backups.restore.auditNotePlaceholder' => '例如：恢复 #INC-481',
+			'backups.restore.ownDbWarning' => '恢复到 opendray 自身的数据库将覆写本网关当前提供服务的数据。请输入 "I understand" 以确认。',
+			'backups.restore.confirmPlaceholder' => '输入 "I understand"',
+			'backups.restore.confirmSentinel' => 'I understand',
+			'backups.restore.restoring' => '恢复中…',
+			'backups.restore.restore' => '恢复',
+			'backups.restore.succeededTitle' => '恢复成功',
+			'backups.restore.succeededBody' => ({required Object id, required Object bytes}) => '已从备份 ${id} 重放 ${bytes}。',
+			'backups.restore.failedTitle' => '恢复失败',
+			'backups.restore.pickFileToast' => '请先选择一个备份文件。',
+			'backups.restore.outputTitle' => 'pg_restore 输出',
+			'backups.restore.noPgRestoreOutput' => '（空 — 恢复无声完成）',
+			'backups.restore.manifestTitle' => '清单',
+			'backups.restore.manifestBackupId' => '备份 ID',
+			'backups.restore.manifestVersion' => '清单版本',
+			'backups.restore.manifestCreatedAt' => '创建时间',
+			'backups.restore.manifestPgVersion' => 'pg_version',
+			'backups.restore.manifestOpendrayVersion' => 'opendray 版本',
+			'backups.restore.fingerprint' => '密钥指纹',
+			'backups.restore.fingerprintOk' => '已匹配',
+			'backups.restore.fingerprintMismatch' => '不匹配',
+			'backups.restore.encryptionAlgo' => '加密算法',
+			'backups.restore.bytesRead' => '已读字节',
+			'backups.restore.targetDsnUsed' => '目标 DSN',
+			'backups.restore.targetDsnSelfLabel' => '（opendray 自身数据库）',
+			'backups.restore.done' => '完成',
+			'backups.inventory.title' => '备份里有什么',
+			'backups.inventory.summary' => ({required Object rows, required Object tables}) => '${rows} 行 · ${tables} 表',
+			'backups.inventory.description' => 'opendray Postgres 数据库的实时行数。备份会捕获以下所有行；磁盘上的二进制工件不包含在内。',
+			'backups.inventory.rowsLabel' => '行',
+			'backups.inventory.loadFailedToast' => '加载清单失败',
+			'backups.inventory.loading' => '加载中…',
+			'backups.inventory.tap' => '点击展开',
 			'backupTargets.title' => '备份目标',
 			'backupTargets.newTarget' => '新建目标',
 			'backupTargets.testConnection' => '测试连接',
@@ -9483,6 +9819,8 @@ extension on TranslationsZh {
 			'githosts.form.tokenHintNew' => '粘贴个人访问令牌。',
 			'githosts.form.enabledHelper' => '可供会话用于 PR / 远端查找。',
 			'githosts.form.validateTokenRequired' => '添加主机时必须填写 Token。',
+			_ => null,
+		} ?? switch (path) {
 			'githosts.form.appBarEdit' => ({required Object name}) => '编辑 ${name}',
 			'githosts.form.appBarNew' => '添加 Git 主机',
 			'githosts.form.tokenPreviewHint' => ({required Object preview}) => '当前预览：${preview}',
@@ -9531,8 +9869,6 @@ extension on TranslationsZh {
 			'channels.popup.enable' => '启用',
 			'channels.popup.disable' => '停用',
 			'channels.popup.mute' => '静音',
-			_ => null,
-		} ?? switch (path) {
 			'channels.popup.unmute' => '取消静音',
 			'channels.popup.deleteLabel' => '删除',
 			'channels.badges.running' => '运行中',
@@ -9708,6 +10044,96 @@ extension on TranslationsZh {
 			'notesPage.editor.saveFailedApi' => ({required Object error}) => '保存失败：${error}',
 			'notesPage.editor.saveFailedGeneric' => ({required Object error}) => '保存失败：${error}',
 			'notesPage.editor.savedAt' => ({required Object time}) => '${time} 已保存',
+			'dataExport.title' => '数据导出与导入',
+			'dataExport.subtitle' => '面向用户的数据包，用于迁移或验证 — 与 /backups（灾难恢复）相互独立。',
+			'dataExport.sections.export' => '导出',
+			'dataExport.sections.import' => '导入',
+			'dataExport.form.scope' => '范围',
+			'dataExport.form.memories' => '记忆',
+			'dataExport.form.memoriesHint' => '所有已持久化的记忆及其向量。',
+			'dataExport.form.integrations' => '集成',
+			'dataExport.form.integrationOptions.none' => '跳过',
+			'dataExport.form.integrationOptions.noneHint' => '不包含 /integrations 注册表。',
+			'dataExport.form.integrationOptions.metadata' => '仅元数据（默认）',
+			'dataExport.form.integrationOptions.metadataHint' => '每个集成的名称 + 端点，不含 API 密钥。',
+			'dataExport.form.integrationOptions.plaintext' => '明文密钥',
+			'dataExport.form.integrationOptions.plaintextHint' => '危险：包含原始 API 令牌。v1 仅存储 bcrypt 哈希，因此此选项当前实际为空操作；仍然提供以提示这一事实。',
+			'dataExport.form.confirmWarning' => '明文密钥导出包含可解密的机密。请输入 "I understand" 以确认。',
+			'dataExport.form.confirmPlaceholder' => '输入 "I understand"',
+			'dataExport.form.confirmSentinel' => 'I understand',
+			'dataExport.form.customTasks' => '自定义任务',
+			'dataExport.form.customTasksHint' => '用户级任务定义（cron 计划 + 脚本主体）。',
+			'dataExport.form.footnote' => '数据包在创建后 7 天过期。下载链接为单次使用。',
+			'dataExport.form.create' => '创建数据包',
+			'dataExport.form.building' => '构建中…',
+			'dataExport.form.readyToast' => '数据包已就绪',
+			'dataExport.form.readyDescription' => ({required Object bytes}) => '${bytes} 字节 — 在下方历史中下载。',
+			'dataExport.form.failedToast' => ({required Object error}) => '数据包创建失败：${error}',
+			'dataExport.history.title' => '导出历史',
+			'dataExport.history.loading' => '加载中…',
+			'dataExport.history.empty' => '暂无导出。',
+			'dataExport.history.listFailedToast' => ({required Object error}) => '加载导出失败：${error}',
+			'dataExport.history.downloadFailedToast' => ({required Object error}) => '获取下载令牌失败：${error}',
+			'dataExport.history.noTokenToast' => '该导出无可用的下载令牌（已消费或过期）。',
+			'dataExport.history.deletedToast' => '已删除导出。',
+			'dataExport.history.deleteFailedToast' => ({required Object error}) => '删除导出失败：${error}',
+			'dataExport.history.deleteConfirmTitle' => '删除导出？',
+			'dataExport.history.deleteConfirmBody' => ({required Object id}) => '移除数据包并撤销下载令牌。${id}',
+			'dataExport.history.download' => '下载',
+			'dataExport.history.delete' => '删除',
+			'dataExport.history.downloadCopiedToast' => '下载 URL 已复制到剪贴板。在浏览器中粘贴以获取（单次使用）。',
+			'dataExport.history.columns.scope' => '范围',
+			'dataExport.history.columns.size' => '大小',
+			'dataExport.history.columns.expires' => '过期',
+			'dataExport.history.columns.actions' => '操作',
+			'dataExport.history.scopeEmpty' => '（空）',
+			'dataExport.history.scopeMemories' => '记忆',
+			'dataExport.history.scopeIntegrations' => ({required Object mode}) => '集成(${mode})',
+			'dataExport.history.scopeCustomTasks' => '自定义任务',
+			'dataExport.import.intro' => '重放此前由「导出」生成的数据包。仅勾选的实体会被导入；数据包中其余内容会被忽略。',
+			'dataExport.import.bundleLabel' => '数据包文件（.zip）',
+			'dataExport.import.pickFile' => '选择文件',
+			'dataExport.import.fileSelected' => ({required Object name, required Object size}) => '${name} · ${size}',
+			'dataExport.import.noFile' => '未选择文件',
+			'dataExport.import.memoriesLabel' => '记忆',
+			'dataExport.import.integrationsLabel' => '集成',
+			'dataExport.import.customTasksLabel' => '自定义任务',
+			'dataExport.import.importBundle' => '导入数据包',
+			'dataExport.import.importing' => '导入中…',
+			'dataExport.import.pickFileToast' => '请先选择数据包文件。',
+			'dataExport.import.doneToast' => '导入完成',
+			'dataExport.import.finishedWithErrors' => '导入完成但有错误',
+			'dataExport.import.failedToast' => ({required Object error}) => '导入失败：${error}',
+			'dataExport.import.summaryCard.memories' => '记忆',
+			'dataExport.import.summaryCard.integrations' => '集成',
+			'dataExport.import.summaryCard.customTasks' => '自定义任务',
+			'dataExport.import.summaryCard.created' => '创建',
+			'dataExport.import.summaryCard.skipped' => '跳过',
+			'dataExport.import.summaryCard.failed' => '失败',
+			'dataExport.imports.title' => '导入历史',
+			'dataExport.imports.loading' => '加载中…',
+			'dataExport.imports.empty' => '暂无导入。',
+			'dataExport.imports.listFailedToast' => ({required Object error}) => '加载导入失败：${error}',
+			'dataExport.imports.noneCounts' => '（无计数）',
+			'dataExport.imports.sourceUnknown' => '（未知来源）',
+			'dataExport.imports.columns.id' => 'ID',
+			'dataExport.imports.columns.status' => '状态',
+			'dataExport.imports.columns.source' => '来源',
+			'dataExport.imports.columns.counts' => '计数',
+			'dataExport.imports.columns.when' => '时间',
+			'dataExport.relative.inSeconds' => ({required Object n}) => '${n} 秒后',
+			'dataExport.relative.inMinutes' => ({required Object n}) => '${n} 分钟后',
+			'dataExport.relative.inHours' => ({required Object n}) => '${n} 小时后',
+			'dataExport.relative.inDays' => ({required Object n}) => '${n} 天后',
+			'dataExport.relative.secondsAgo' => ({required Object n}) => '${n} 秒前',
+			'dataExport.relative.minutesAgo' => ({required Object n}) => '${n} 分钟前',
+			'dataExport.relative.hoursAgo' => ({required Object n}) => '${n} 小时前',
+			'dataExport.status.pending' => '等待',
+			'dataExport.status.running' => '运行中',
+			'dataExport.status.ready' => '就绪',
+			'dataExport.status.failed' => '失败',
+			'dataExport.status.expired' => '过期',
+			'dataExport.status.succeeded' => '成功',
 			'memory.title' => '记忆',
 			'memory.more' => '更多',
 			'memory.workers' => '记忆工作器',

--- a/app/mobile/lib/features/backups/backups_screen.dart
+++ b/app/mobile/lib/features/backups/backups_screen.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
+import 'dart:io';
 
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -86,12 +88,16 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
       final status = await api.status();
       if (!mounted) return;
       if (!status.enabled) {
-        setState(() => _state = AsyncValue.data(_PageData(
+        setState(
+          () => _state = AsyncValue.data(
+            _PageData(
               status: status,
               rows: const [],
               targets: const [],
               schedules: const [],
-            )));
+            ),
+          ),
+        );
         return;
       }
       final results = await Future.wait<Object>([
@@ -102,12 +108,16 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
       if (!mounted) return;
       final rows = (results[0] as List<BackupRow>)
         ..sort((a, b) => b.startedAt.compareTo(a.startedAt));
-      setState(() => _state = AsyncValue.data(_PageData(
+      setState(
+        () => _state = AsyncValue.data(
+          _PageData(
             status: status,
             rows: rows,
             targets: results[1] as List<BackupTarget>,
             schedules: results[2] as List<BackupSchedule>,
-          )));
+          ),
+        ),
+      );
     } on ApiException catch (e) {
       if (mounted) {
         setState(() => _state = AsyncValue.error(e, StackTrace.current));
@@ -136,23 +146,31 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
         // (or this is the post-setup pre-restart window). Drop
         // back to the setup/restart view rather than keep stale
         // rows.
-        setState(() => _state = AsyncValue.data(_PageData(
+        setState(
+          () => _state = AsyncValue.data(
+            _PageData(
               status: status,
               rows: const [],
               targets: const [],
               schedules: const [],
-            )));
+            ),
+          ),
+        );
         return;
       }
       final list = await api.list(limit: 50);
       if (!mounted) return;
       list.sort((a, b) => b.startedAt.compareTo(a.startedAt));
-      setState(() => _state = AsyncValue.data(_PageData(
+      setState(
+        () => _state = AsyncValue.data(
+          _PageData(
             status: status,
             rows: list,
             targets: current.targets,
             schedules: current.schedules,
-          )));
+          ),
+        ),
+      );
     } on Object {
       // Swallow soft-refresh errors — the page is already
       // rendered, no point flashing a full-screen error.
@@ -199,9 +217,11 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
       );
     } on Object catch (e) {
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(
-        content: Text(t.backups.runFailedGeneric(error: e.toString())),
-      ));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(t.backups.runFailedGeneric(error: e.toString())),
+        ),
+      );
     } finally {
       if (mounted) setState(() => _running = false);
     }
@@ -247,10 +267,13 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
         final ok = row.status == 'succeeded';
         messenger.showSnackBar(
           SnackBar(
-            content: Text(ok
-                ? t.backups.rowSucceededSnack(bytes: _formatBytes(row.bytes))
-                : t.backups.rowFailedSnack(
-                    error: row.error ?? t.backups.unknownError)),
+            content: Text(
+              ok
+                  ? t.backups.rowSucceededSnack(bytes: _formatBytes(row.bytes))
+                  : t.backups.rowFailedSnack(
+                      error: row.error ?? t.backups.unknownError,
+                    ),
+            ),
             duration: const Duration(seconds: 3),
             behavior: SnackBarBehavior.floating,
             backgroundColor: ok ? null : Theme.of(context).colorScheme.error,
@@ -291,13 +314,15 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
                 if (b.finishedAt != null)
                   _kv(
                     t.backups.kv.finished,
-                    DateFormat.yMMMd()
-                        .add_Hms()
-                        .format(b.finishedAt!.toLocal()),
+                    DateFormat.yMMMd().add_Hms().format(
+                      b.finishedAt!.toLocal(),
+                    ),
                   ),
                 _kv(t.backups.kv.size, _formatBytes(b.bytes)),
-                _kv(t.backups.kv.encrypted,
-                    b.encrypted ? t.backups.kv.yes : t.backups.kv.no),
+                _kv(
+                  t.backups.kv.encrypted,
+                  b.encrypted ? t.backups.kv.yes : t.backups.kv.no,
+                ),
                 if ((b.targetPath ?? '').isNotEmpty)
                   _kv(t.backups.kv.targetPath, b.targetPath!, mono: true),
                 if ((b.error ?? '').isNotEmpty) ...[
@@ -398,9 +423,11 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
       );
     } on Object catch (e) {
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(
-        content: Text(t.backups.deleteFailedGeneric(error: e.toString())),
-      ));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(t.backups.deleteFailedGeneric(error: e.toString())),
+        ),
+      );
     }
   }
 
@@ -450,9 +477,18 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
                       builder: (_) => const BackupTargetsScreen(),
                     ),
                   );
+                case _AppBarAction.restore:
+                  unawaited(_openRestoreSheet());
               }
             },
             itemBuilder: (_) => [
+              PopupMenuItem(
+                value: _AppBarAction.restore,
+                child: ListTile(
+                  leading: const Icon(Icons.restore_outlined),
+                  title: Text(t.backups.restoreFromFile),
+                ),
+              ),
               PopupMenuItem(
                 value: _AppBarAction.schedules,
                 child: ListTile(
@@ -509,15 +545,9 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
   Widget _buildBody(_PageData data) {
     if (data.featureOff) {
       if (data.awaitingRestart) {
-        return _RestartRequiredView(
-          status: data.status,
-          onRecheck: _load,
-        );
+        return _RestartRequiredView(status: data.status, onRecheck: _load);
       }
-      return _SetupWizardView(
-        status: data.status,
-        onComplete: _load,
-      );
+      return _SetupWizardView(status: data.status, onComplete: _load);
     }
     final status = data.status;
     final list = data.rows;
@@ -529,6 +559,7 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
         physics: const AlwaysScrollableScrollPhysics(),
         children: [
           _StatusBanner(status: status),
+          const _InventoryCard(),
           _SummaryCard(
             targets: data.targets,
             schedules: data.schedules,
@@ -547,6 +578,141 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
             ),
           // Footer padding so the FAB doesn't cover the last row.
           const SizedBox(height: 96),
+        ],
+      ),
+    );
+  }
+
+  // ── restore (from uploaded bundle) ─────────────────────────────
+
+  // Opens the multi-step Restore bottom sheet. Pulled out of the
+  // PopupMenuButton's onSelected so the sheet itself owns its own
+  // state (file pick, target DSN, clean, audit note, confirm
+  // sentinel) without the parent rebuilding on every keystroke.
+  Future<void> _openRestoreSheet() async {
+    final res = await showModalBottomSheet<RestoreResult?>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: const _RestoreSheet(),
+      ),
+    );
+    if (res != null && mounted) {
+      await _showRestoreResult(res);
+      await _softRefresh();
+    }
+  }
+
+  Future<void> _showRestoreResult(RestoreResult res) async {
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(t.backups.restore.succeededTitle),
+        content: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: MediaQuery.of(ctx).size.height * 0.7,
+            maxWidth: 480,
+          ),
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  t.backups.restore.succeededBody(
+                    bytes: _formatBytes(res.bytesRead),
+                    id: res.manifest.backupId,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  t.backups.restore.manifestTitle.toUpperCase(),
+                  style: Theme.of(ctx).textTheme.labelSmall?.copyWith(
+                    letterSpacing: 0.8,
+                    color: Theme.of(ctx).colorScheme.outline,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                _kv(
+                  t.backups.restore.manifestBackupId,
+                  res.manifest.backupId,
+                  mono: true,
+                ),
+                _kv(t.backups.restore.manifestVersion, res.manifest.version),
+                _kv(
+                  t.backups.restore.manifestCreatedAt,
+                  DateFormat.yMMMd().add_Hms().format(
+                    res.manifest.createdAt.toLocal(),
+                  ),
+                ),
+                if ((res.manifest.pgVersion ?? '').isNotEmpty)
+                  _kv(
+                    t.backups.restore.manifestPgVersion,
+                    res.manifest.pgVersion!,
+                  ),
+                if ((res.manifest.opendrayVersion ?? '').isNotEmpty)
+                  _kv(
+                    t.backups.restore.manifestOpendrayVersion,
+                    res.manifest.opendrayVersion!,
+                  ),
+                _kv(
+                  t.backups.restore.fingerprint,
+                  res.fingerprintOk
+                      ? '${res.manifest.encryptionFingerprint} '
+                            '· ${t.backups.restore.fingerprintOk}'
+                      : '${res.manifest.encryptionFingerprint} '
+                            '· ${t.backups.restore.fingerprintMismatch}',
+                  mono: true,
+                ),
+                _kv(
+                  t.backups.restore.encryptionAlgo,
+                  res.manifest.encryptionAlgo,
+                ),
+                _kv(t.backups.restore.bytesRead, _formatBytes(res.bytesRead)),
+                _kv(
+                  t.backups.restore.targetDsnUsed,
+                  res.targetDsnUsed.isEmpty
+                      ? t.backups.restore.targetDsnSelfLabel
+                      : res.targetDsnUsed,
+                  mono: res.targetDsnUsed.isNotEmpty,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  t.backups.restore.outputTitle.toUpperCase(),
+                  style: Theme.of(ctx).textTheme.labelSmall?.copyWith(
+                    letterSpacing: 0.8,
+                    color: Theme.of(ctx).colorScheme.outline,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(8),
+                  decoration: BoxDecoration(
+                    color: Theme.of(ctx).colorScheme.surfaceContainerHighest,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: SelectableText(
+                    res.pgRestoreOutput.isEmpty
+                        ? t.backups.restore.noPgRestoreOutput
+                        : res.pgRestoreOutput,
+                    style: const TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 11,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        actions: [
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: Text(t.backups.restore.done),
+          ),
         ],
       ),
     );
@@ -578,13 +744,17 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
         children: [
           Icon(icon, size: 48, color: theme.colorScheme.outline),
           const SizedBox(height: 12),
-          Text(headline,
-              style: theme.textTheme.titleMedium,
-              textAlign: TextAlign.center),
+          Text(
+            headline,
+            style: theme.textTheme.titleMedium,
+            textAlign: TextAlign.center,
+          ),
           const SizedBox(height: 6),
-          Text(body,
-              style: theme.textTheme.bodySmall,
-              textAlign: TextAlign.center),
+          Text(
+            body,
+            style: theme.textTheme.bodySmall,
+            textAlign: TextAlign.center,
+          ),
         ],
       ),
     );
@@ -593,7 +763,7 @@ class _BackupsScreenState extends ConsumerState<BackupsScreen> {
 
 enum _DetailAction { close, delete }
 
-enum _AppBarAction { schedules, targets }
+enum _AppBarAction { schedules, targets, restore }
 
 // Rendered when the operator has already set up a passphrase (env
 // var present OR key file on disk) but the feature isn't running
@@ -633,8 +803,11 @@ class _RestartRequiredView extends StatelessWidget {
           ),
           const SizedBox(height: 20),
           if (status.configuredVia == 'file' && status.keyFilePath.isNotEmpty)
-            _kvBox(context,
-                label: t.backups.keyFileLabel, value: status.keyFilePath),
+            _kvBox(
+              context,
+              label: t.backups.keyFileLabel,
+              value: status.keyFilePath,
+            ),
           if (status.configuredVia == 'env')
             _kvBox(
               context,
@@ -654,8 +827,11 @@ class _RestartRequiredView extends StatelessWidget {
     );
   }
 
-  Widget _kvBox(BuildContext context,
-      {required String label, required String value}) {
+  Widget _kvBox(
+    BuildContext context, {
+    required String label,
+    required String value,
+  }) {
     final theme = Theme.of(context);
     return Container(
       padding: const EdgeInsets.all(12),
@@ -667,9 +843,12 @@ class _RestartRequiredView extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(label,
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.outline)),
+          Text(
+            label,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.outline,
+            ),
+          ),
           const SizedBox(height: 4),
           SelectableText(
             value,
@@ -728,10 +907,7 @@ class _SetupWizardViewState extends ConsumerState<_SetupWizardView> {
       final api = ref.read(backupsApiProvider);
       final result = _mode == _SetupMode.generate
           ? await api.setup(mode: 'generate')
-          : await api.setup(
-              mode: 'paste',
-              passphrase: _pasteCtrl.text.trim(),
-            );
+          : await api.setup(mode: 'paste', passphrase: _pasteCtrl.text.trim());
       if (!mounted) return;
       if (result.passphrase != null) {
         // Generate path — keep on this screen, show the passphrase
@@ -820,7 +996,8 @@ class _SetupWizardViewState extends ConsumerState<_SetupWizardView> {
               color: theme.colorScheme.error.withValues(alpha: 0.1),
               borderRadius: BorderRadius.circular(6),
               border: Border.all(
-                  color: theme.colorScheme.error.withValues(alpha: 0.4)),
+                color: theme.colorScheme.error.withValues(alpha: 0.4),
+              ),
             ),
             child: Text(
               _error!,
@@ -838,11 +1015,13 @@ class _SetupWizardViewState extends ConsumerState<_SetupWizardView> {
                   child: CircularProgressIndicator(strokeWidth: 2),
                 )
               : const Icon(Icons.check, size: 18),
-          label: Text(_submitting
-              ? t.backups.wizard.saving
-              : _mode == _SetupMode.generate
-                  ? t.backups.wizard.generateAndSave
-                  : t.backups.wizard.savePassphrase),
+          label: Text(
+            _submitting
+                ? t.backups.wizard.saving
+                : _mode == _SetupMode.generate
+                ? t.backups.wizard.generateAndSave
+                : t.backups.wizard.savePassphrase,
+          ),
         ),
         const SizedBox(height: 20),
         if (widget.status.keyFilePath.isNotEmpty)
@@ -872,8 +1051,10 @@ class _SetupWizardViewState extends ConsumerState<_SetupWizardView> {
             children: [
               Icon(Icons.shield_outlined, size: 18, color: muted),
               const SizedBox(width: 8),
-              Text(t.backups.encryption.random256bit,
-                  style: const TextStyle(fontWeight: FontWeight.w600)),
+              Text(
+                t.backups.encryption.random256bit,
+                style: const TextStyle(fontWeight: FontWeight.w600),
+              ),
             ],
           ),
           const SizedBox(height: 6),
@@ -913,8 +1094,11 @@ class _SetupWizardViewState extends ConsumerState<_SetupWizardView> {
       padding: const EdgeInsets.all(20),
       children: [
         const SizedBox(height: 16),
-        Icon(Icons.warning_amber_rounded,
-            size: 48, color: Colors.amber.shade700),
+        Icon(
+          Icons.warning_amber_rounded,
+          size: 48,
+          color: Colors.amber.shade700,
+        ),
         const SizedBox(height: 12),
         Text(
           t.backups.wizard.saveNowHeader,
@@ -931,11 +1115,13 @@ class _SetupWizardViewState extends ConsumerState<_SetupWizardView> {
         Container(
           padding: const EdgeInsets.all(14),
           decoration: BoxDecoration(
-            color: theme.colorScheme.surfaceContainerHighest
-                .withValues(alpha: 0.4),
+            color: theme.colorScheme.surfaceContainerHighest.withValues(
+              alpha: 0.4,
+            ),
             borderRadius: BorderRadius.circular(8),
             border: Border.all(
-                color: theme.colorScheme.primary.withValues(alpha: 0.5)),
+              color: theme.colorScheme.primary.withValues(alpha: 0.5),
+            ),
           ),
           child: SelectableText(
             pass,
@@ -1034,8 +1220,11 @@ class _StatusBanner extends StatelessWidget {
         children: [
           Row(
             children: [
-              Icon(ok ? Icons.check_circle_outline : Icons.error_outline,
-                  size: 18, color: color),
+              Icon(
+                ok ? Icons.check_circle_outline : Icons.error_outline,
+                size: 18,
+                color: color,
+              ),
               const SizedBox(width: 8),
               Text(
                 ok ? t.backups.statusReady : t.backups.statusCannot,
@@ -1067,16 +1256,17 @@ class _StatusBanner extends StatelessWidget {
     );
   }
 
-  Widget _kvRow(BuildContext context, String label, String value,
-      {bool mono = false}) {
+  Widget _kvRow(
+    BuildContext context,
+    String label,
+    String value, {
+    bool mono = false,
+  }) {
     final muted = Theme.of(context).textTheme.bodySmall;
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        SizedBox(
-          width: 110,
-          child: Text(label, style: muted),
-        ),
+        SizedBox(width: 110, child: Text(label, style: muted)),
         Expanded(
           child: SelectableText(
             value,
@@ -1110,8 +1300,10 @@ class _SummaryCard extends StatelessWidget {
     final targetsEnabled = targets.where((t) => t.enabled).length;
     final schedulesEnabled = schedules.where((s) => s.enabled).length;
     final liveRows = rows.where((r) => r.status != 'deleted').toList();
-    final totalBytes =
-        liveRows.fold<int>(0, (acc, r) => acc + (r.bytes > 0 ? r.bytes : 0));
+    final totalBytes = liveRows.fold<int>(
+      0,
+      (acc, r) => acc + (r.bytes > 0 ? r.bytes : 0),
+    );
     return Container(
       margin: const EdgeInsets.fromLTRB(12, 12, 12, 4),
       decoration: BoxDecoration(
@@ -1193,17 +1385,27 @@ class _SummaryTile extends StatelessWidget {
             children: [
               Icon(icon, size: 18, color: theme.colorScheme.outline),
               const SizedBox(height: 4),
-              Text(label,
-                  style: theme.textTheme.bodySmall
-                      ?.copyWith(color: theme.colorScheme.outline)),
+              Text(
+                label,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.outline,
+                ),
+              ),
               const SizedBox(height: 2),
-              Text(value,
-                  style: const TextStyle(
-                      fontSize: 14, fontWeight: FontWeight.w600)),
+              Text(
+                value,
+                style: const TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
               if (sub != null)
-                Text(sub!,
-                    style: theme.textTheme.bodySmall
-                        ?.copyWith(color: theme.colorScheme.outline)),
+                Text(
+                  sub!,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.outline,
+                  ),
+                ),
             ],
           ),
         ),
@@ -1235,11 +1437,7 @@ class _BackupTile extends StatelessWidget {
           ),
           const SizedBox(width: 8),
           if (row.encrypted)
-            Icon(
-              Icons.lock_outline,
-              size: 13,
-              color: muted?.color,
-            ),
+            Icon(Icons.lock_outline, size: 13, color: muted?.color),
           const Spacer(),
           if (duration != null) Text(_formatDuration(duration), style: muted),
         ],
@@ -1328,6 +1526,477 @@ class _ErrorView extends StatelessWidget {
             const SizedBox(height: 16),
             FilledButton(onPressed: onRetry, child: Text(t.common.retry)),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+// Collapsible "what's actually backed up" card. Mirrors web's
+// InventoryCard — defers loading until first tap so the main screen
+// still paints instantly on a slow network. Re-fetches every time
+// the operator collapses + re-expands (data is cheap; server-side
+// it's a single COUNT(*) over each table).
+class _InventoryCard extends ConsumerStatefulWidget {
+  const _InventoryCard();
+
+  @override
+  ConsumerState<_InventoryCard> createState() => _InventoryCardState();
+}
+
+class _InventoryCardState extends ConsumerState<_InventoryCard> {
+  bool _open = false;
+  bool _loading = false;
+  List<InventoryGroup>? _groups;
+
+  Future<void> _toggle() async {
+    setState(() => _open = !_open);
+    if (!_open || _groups != null || _loading) return;
+    setState(() => _loading = true);
+    try {
+      final groups = await ref.read(backupsApiProvider).inventory();
+      if (mounted) setState(() => _groups = groups);
+    } on Object catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            '${t.backups.inventory.loadFailedToast}: ${e is ApiException ? e.message : e}',
+          ),
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final groups = _groups;
+    final totalRows = groups?.fold<int>(
+      0,
+      (acc, g) => acc + g.tables.fold<int>(0, (a, tbl) => a + tbl.count),
+    );
+    final totalTables = groups?.fold<int>(0, (acc, g) => acc + g.tables.length);
+    final fmt = NumberFormat.decimalPattern();
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          InkWell(
+            onTap: _toggle,
+            borderRadius: BorderRadius.circular(8),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Row(
+                children: [
+                  Icon(
+                    _open ? Icons.expand_more : Icons.chevron_right,
+                    size: 18,
+                    color: theme.colorScheme.outline,
+                  ),
+                  const SizedBox(width: 8),
+                  Icon(
+                    Icons.inventory_2_outlined,
+                    size: 16,
+                    color: theme.colorScheme.primary,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      t.backups.inventory.title,
+                      style: theme.textTheme.titleSmall,
+                    ),
+                  ),
+                  if (totalRows != null && totalTables != null)
+                    Text(
+                      t.backups.inventory.summary(
+                        rows: fmt.format(totalRows),
+                        tables: totalTables.toString(),
+                      ),
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.outline,
+                      ),
+                    )
+                  else
+                    Text(
+                      t.backups.inventory.tap,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.outline,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+          if (_open)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    t.backups.inventory.description,
+                    style: theme.textTheme.bodySmall,
+                  ),
+                  const SizedBox(height: 8),
+                  if (_loading)
+                    Text(
+                      t.backups.inventory.loading,
+                      style: theme.textTheme.bodySmall,
+                    ),
+                  if (groups != null)
+                    ...groups.map(
+                      (g) => Padding(
+                        padding: const EdgeInsets.only(bottom: 10),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
+                              children: [
+                                Text(
+                                  g.label,
+                                  style: theme.textTheme.titleSmall,
+                                ),
+                                const SizedBox(width: 8),
+                                Text(
+                                  '${fmt.format(g.tables.fold<int>(0, (a, t) => a + t.count))} '
+                                  '${t.backups.inventory.rowsLabel}',
+                                  style: theme.textTheme.bodySmall?.copyWith(
+                                    color: theme.colorScheme.outline,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 2),
+                            Text(
+                              g.description,
+                              style: theme.textTheme.bodySmall,
+                            ),
+                            const SizedBox(height: 6),
+                            Wrap(
+                              spacing: 6,
+                              runSpacing: 4,
+                              children: g.tables.map((tbl) {
+                                return Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 8,
+                                    vertical: 2,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: theme
+                                        .colorScheme
+                                        .surfaceContainerHighest,
+                                    border: Border.all(
+                                      color: theme.dividerColor,
+                                      width: 0.5,
+                                    ),
+                                    borderRadius: BorderRadius.circular(4),
+                                  ),
+                                  child: Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.baseline,
+                                    textBaseline: TextBaseline.alphabetic,
+                                    children: [
+                                      Text(
+                                        tbl.name,
+                                        style: const TextStyle(
+                                          fontFamily: 'monospace',
+                                          fontSize: 11,
+                                        ),
+                                      ),
+                                      const SizedBox(width: 6),
+                                      Text(
+                                        fmt.format(tbl.count),
+                                        style: theme.textTheme.bodySmall
+                                            ?.copyWith(
+                                              color: theme.colorScheme.outline,
+                                            ),
+                                      ),
+                                    ],
+                                  ),
+                                );
+                              }).toList(),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+// Bottom-sheet form for /backups/restore — file pick, target DSN,
+// clean toggle, audit note, plus the "I understand" sentinel that's
+// required when target_dsn is empty (i.e. restoring into opendray's
+// own DB). Submits via api.restore() and pops with the RestoreResult
+// on success so the parent can show the manifest dialog.
+class _RestoreSheet extends ConsumerStatefulWidget {
+  const _RestoreSheet();
+
+  @override
+  ConsumerState<_RestoreSheet> createState() => _RestoreSheetState();
+}
+
+class _RestoreSheetState extends ConsumerState<_RestoreSheet> {
+  PlatformFile? _picked;
+  final _targetDsnCtrl = TextEditingController();
+  final _noteCtrl = TextEditingController();
+  final _confirmCtrl = TextEditingController();
+  bool _clean = true;
+  bool _busy = false;
+
+  @override
+  void dispose() {
+    _targetDsnCtrl.dispose();
+    _noteCtrl.dispose();
+    _confirmCtrl.dispose();
+    super.dispose();
+  }
+
+  bool get _restoringOwn => _targetDsnCtrl.text.trim().isEmpty;
+  bool get _confirmReady =>
+      !_restoringOwn ||
+      _confirmCtrl.text.trim() == t.backups.restore.confirmSentinel;
+
+  Future<void> _pickBundle() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.any,
+      withData: false,
+    );
+    if (result == null || result.files.isEmpty) return;
+    final f = result.files.single;
+    if (f.path == null || f.path!.isEmpty) return;
+    setState(() => _picked = f);
+  }
+
+  Future<void> _submit() async {
+    final picked = _picked;
+    if (picked == null || picked.path == null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(t.backups.restore.pickFileToast)));
+      return;
+    }
+    setState(() => _busy = true);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final res = await ref
+          .read(backupsApiProvider)
+          .restore(
+            bundle: File(picked.path!),
+            targetDsn: _targetDsnCtrl.text.trim().isEmpty
+                ? null
+                : _targetDsnCtrl.text.trim(),
+            clean: _clean,
+            confirm: _restoringOwn ? t.backups.restore.confirmSentinel : null,
+            note: _noteCtrl.text.trim().isEmpty ? null : _noteCtrl.text.trim(),
+          );
+      if (!mounted) return;
+      Navigator.of(context).pop(res);
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('${t.backups.restore.failedTitle}: ${e.message}'),
+          backgroundColor: Theme.of(context).colorScheme.error,
+        ),
+      );
+    } on Object catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('${t.backups.restore.failedTitle}: $e'),
+          backgroundColor: Theme.of(context).colorScheme.error,
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                children: [
+                  Icon(
+                    Icons.restore_outlined,
+                    color: theme.colorScheme.primary,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      t.backups.restore.title,
+                      style: theme.textTheme.titleMedium,
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    onPressed: _busy ? null : () => Navigator.of(context).pop(),
+                  ),
+                ],
+              ),
+              Text(
+                t.backups.restore.subtitle,
+                style: theme.textTheme.bodySmall,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                t.backups.restore.bundleLabel,
+                style: theme.textTheme.labelMedium,
+              ),
+              const SizedBox(height: 4),
+              Row(
+                children: [
+                  OutlinedButton.icon(
+                    onPressed: _busy ? null : _pickBundle,
+                    icon: const Icon(Icons.attach_file, size: 16),
+                    label: Text(t.backups.restore.pickFile),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      _picked == null
+                          ? t.backups.restore.noFile
+                          : t.backups.restore.fileSelected(
+                              name: _picked!.name,
+                              size: _formatBytes(_picked!.size),
+                            ),
+                      style: theme.textTheme.bodySmall,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Text(
+                t.backups.restore.targetDsnLabel,
+                style: theme.textTheme.labelMedium,
+              ),
+              const SizedBox(height: 2),
+              Text(
+                t.backups.restore.targetDsnHint,
+                style: theme.textTheme.bodySmall,
+              ),
+              const SizedBox(height: 4),
+              TextField(
+                controller: _targetDsnCtrl,
+                enabled: !_busy,
+                style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+                decoration: InputDecoration(
+                  isDense: true,
+                  border: const OutlineInputBorder(),
+                  hintText: t.backups.restore.targetDsnPlaceholder,
+                ),
+                onChanged: (_) => setState(() {}),
+              ),
+              const SizedBox(height: 12),
+              SwitchListTile(
+                contentPadding: EdgeInsets.zero,
+                value: _clean,
+                onChanged: _busy ? null : (v) => setState(() => _clean = v),
+                title: Text(t.backups.restore.cleanLabel),
+                subtitle: Text(t.backups.restore.cleanHint),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                t.backups.restore.auditNoteLabel,
+                style: theme.textTheme.labelMedium,
+              ),
+              const SizedBox(height: 4),
+              TextField(
+                controller: _noteCtrl,
+                enabled: !_busy,
+                decoration: InputDecoration(
+                  isDense: true,
+                  border: const OutlineInputBorder(),
+                  hintText: t.backups.restore.auditNotePlaceholder,
+                ),
+              ),
+              if (_restoringOwn) ...[
+                const SizedBox(height: 12),
+                Container(
+                  padding: const EdgeInsets.all(10),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.errorContainer.withValues(
+                      alpha: 0.4,
+                    ),
+                    border: Border.all(color: theme.colorScheme.error),
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Icon(
+                            Icons.shield_outlined,
+                            size: 16,
+                            color: theme.colorScheme.error,
+                          ),
+                          const SizedBox(width: 6),
+                          Expanded(
+                            child: Text(
+                              t.backups.restore.ownDbWarning,
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: theme.colorScheme.error,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      TextField(
+                        controller: _confirmCtrl,
+                        enabled: !_busy,
+                        decoration: InputDecoration(
+                          isDense: true,
+                          border: const OutlineInputBorder(),
+                          hintText: t.backups.restore.confirmPlaceholder,
+                        ),
+                        onChanged: (_) => setState(() {}),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  style: FilledButton.styleFrom(
+                    backgroundColor: theme.colorScheme.error,
+                  ),
+                  onPressed: _busy || _picked == null || !_confirmReady
+                      ? null
+                      : _submit,
+                  child: Text(
+                    _busy
+                        ? t.backups.restore.restoring
+                        : t.backups.restore.restore,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 4),
+            ],
+          ),
         ),
       ),
     );

--- a/app/mobile/lib/features/data_export/data_export_screen.dart
+++ b/app/mobile/lib/features/data_export/data_export_screen.dart
@@ -1,0 +1,1189 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/api/api_exception.dart';
+import 'package:opendray/core/api/backups_api.dart';
+import 'package:opendray/core/auth/auth_state.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+
+// User-level data export & import — mirrors the web Export page.
+// Two halves on one scrollable surface: Export (create + history)
+// and Import (upload + history). Bundles expire 7 days after
+// creation; download URL is a single-use bearer.
+//
+// Mobile UX trade-off: the web "click to download" maps to "copy
+// URL to clipboard" here (single-use token paste-into-browser).
+// Avoids adding url_launcher just to download an admin blob.
+class DataExportScreen extends ConsumerStatefulWidget {
+  const DataExportScreen({super.key});
+
+  @override
+  ConsumerState<DataExportScreen> createState() => _DataExportScreenState();
+}
+
+class _DataExportScreenState extends ConsumerState<DataExportScreen> {
+  Timer? _refreshTimer;
+  List<ExportRecord>? _exports;
+  List<ImportRecord>? _imports;
+  Object? _exportsError;
+  Object? _importsError;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_refresh());
+    // Poll while the screen is mounted — pending → running → ready
+    // transitions are server-driven and the user can't push them.
+    _refreshTimer = Timer.periodic(
+      const Duration(seconds: 5),
+      (_) => unawaited(_refresh(silent: true)),
+    );
+  }
+
+  @override
+  void dispose() {
+    _refreshTimer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _refresh({bool silent = false}) async {
+    final api = ref.read(backupsApiProvider);
+    final results = await Future.wait<Object>([
+      api.listExports().catchError((Object e) {
+        if (!silent && mounted) setState(() => _exportsError = e);
+        return <ExportRecord>[];
+      }),
+      api.listImports().catchError((Object e) {
+        if (!silent && mounted) setState(() => _importsError = e);
+        return <ImportRecord>[];
+      }),
+    ]);
+    if (!mounted) return;
+    setState(() {
+      _exports = results[0] as List<ExportRecord>;
+      _imports = results[1] as List<ImportRecord>;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(t.dataExport.title),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: t.common.refresh,
+            onPressed: () => unawaited(_refresh()),
+          ),
+        ],
+      ),
+      body: RefreshIndicator(
+        onRefresh: _refresh,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          padding: const EdgeInsets.fromLTRB(12, 12, 12, 24),
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              child: Text(
+                t.dataExport.subtitle,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ),
+            const SizedBox(height: 16),
+            _SectionHeader(label: t.dataExport.sections.export),
+            const SizedBox(height: 8),
+            _ExportForm(onCreated: () => unawaited(_refresh())),
+            const SizedBox(height: 16),
+            _ExportHistory(
+              rows: _exports,
+              error: _exportsError,
+              onChanged: () => unawaited(_refresh()),
+            ),
+            const SizedBox(height: 24),
+            _SectionHeader(label: t.dataExport.sections.import),
+            const SizedBox(height: 8),
+            _ImportForm(onDone: () => unawaited(_refresh())),
+            const SizedBox(height: 16),
+            _ImportHistory(rows: _imports, error: _importsError),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── shared bits ─────────────────────────────────────────────────
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.label});
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 4, 4, 6),
+      child: Container(
+        padding: const EdgeInsets.only(bottom: 6),
+        decoration: BoxDecoration(
+          border: Border(
+            bottom: BorderSide(color: Theme.of(context).dividerColor),
+          ),
+        ),
+        child: Text(
+          label.toUpperCase(),
+          style: Theme.of(context).textTheme.labelMedium?.copyWith(
+            letterSpacing: 1.2,
+            color: Theme.of(context).colorScheme.outline,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── export form ─────────────────────────────────────────────────
+
+class _ExportForm extends ConsumerStatefulWidget {
+  const _ExportForm({required this.onCreated});
+  final VoidCallback onCreated;
+
+  @override
+  ConsumerState<_ExportForm> createState() => _ExportFormState();
+}
+
+class _ExportFormState extends ConsumerState<_ExportForm> {
+  bool _memories = true;
+  bool _customTasks = true;
+  IntegrationExportMode _integrations = IntegrationExportMode.metadata;
+  final _confirmCtrl = TextEditingController();
+  bool _busy = false;
+
+  @override
+  void dispose() {
+    _confirmCtrl.dispose();
+    super.dispose();
+  }
+
+  bool get _wantsPlaintext => _integrations == IntegrationExportMode.plaintext;
+  bool get _confirmReady =>
+      !_wantsPlaintext ||
+      _confirmCtrl.text.trim() == t.dataExport.form.confirmSentinel;
+
+  Future<void> _submit() async {
+    setState(() => _busy = true);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final exp = await ref
+          .read(backupsApiProvider)
+          .createExport(
+            memories: _memories,
+            integrations: _integrations,
+            customTasks: _customTasks,
+          );
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.dataExport.form.readyDescription(bytes: exp.bytes.toString()),
+          ),
+        ),
+      );
+      widget.onCreated();
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(t.dataExport.form.failedToast(error: e.message)),
+          backgroundColor: Theme.of(context).colorScheme.error,
+        ),
+      );
+    } on Object catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(t.dataExport.form.failedToast(error: e.toString())),
+          backgroundColor: Theme.of(context).colorScheme.error,
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              t.dataExport.form.scope.toUpperCase(),
+              style: theme.textTheme.labelSmall?.copyWith(
+                letterSpacing: 1.2,
+                color: theme.colorScheme.outline,
+              ),
+            ),
+            const SizedBox(height: 8),
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              value: _memories,
+              onChanged: _busy ? null : (v) => setState(() => _memories = v),
+              title: Text(t.dataExport.form.memories),
+              subtitle: Text(t.dataExport.form.memoriesHint),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              t.dataExport.form.integrations,
+              style: theme.textTheme.labelMedium,
+            ),
+            const SizedBox(height: 4),
+            _RadioRow(
+              checked: _integrations == IntegrationExportMode.none,
+              onTap: _busy
+                  ? null
+                  : () => setState(
+                      () => _integrations = IntegrationExportMode.none,
+                    ),
+              label: t.dataExport.form.integrationOptions.none,
+              hint: t.dataExport.form.integrationOptions.noneHint,
+            ),
+            _RadioRow(
+              checked: _integrations == IntegrationExportMode.metadata,
+              onTap: _busy
+                  ? null
+                  : () => setState(
+                      () => _integrations = IntegrationExportMode.metadata,
+                    ),
+              label: t.dataExport.form.integrationOptions.metadata,
+              hint: t.dataExport.form.integrationOptions.metadataHint,
+            ),
+            _RadioRow(
+              checked: _integrations == IntegrationExportMode.plaintext,
+              onTap: _busy
+                  ? null
+                  : () => setState(
+                      () => _integrations = IntegrationExportMode.plaintext,
+                    ),
+              label: t.dataExport.form.integrationOptions.plaintext,
+              hint: t.dataExport.form.integrationOptions.plaintextHint,
+              danger: true,
+            ),
+            if (_wantsPlaintext) ...[
+              const SizedBox(height: 8),
+              Container(
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.errorContainer.withValues(
+                    alpha: 0.4,
+                  ),
+                  border: Border.all(color: theme.colorScheme.error),
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.shield_outlined,
+                          size: 16,
+                          color: theme.colorScheme.error,
+                        ),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            t.dataExport.form.confirmWarning,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.error,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    TextField(
+                      controller: _confirmCtrl,
+                      enabled: !_busy,
+                      decoration: InputDecoration(
+                        isDense: true,
+                        border: const OutlineInputBorder(),
+                        hintText: t.dataExport.form.confirmPlaceholder,
+                      ),
+                      onChanged: (_) => setState(() {}),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+            const SizedBox(height: 12),
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              value: _customTasks,
+              onChanged: _busy ? null : (v) => setState(() => _customTasks = v),
+              title: Text(t.dataExport.form.customTasks),
+              subtitle: Text(t.dataExport.form.customTasksHint),
+            ),
+            const Divider(height: 24),
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    t.dataExport.form.footnote,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.outline,
+                    ),
+                  ),
+                ),
+                FilledButton(
+                  onPressed: _busy || !_confirmReady ? null : _submit,
+                  child: Text(
+                    _busy
+                        ? t.dataExport.form.building
+                        : t.dataExport.form.create,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RadioRow extends StatelessWidget {
+  const _RadioRow({
+    required this.checked,
+    required this.onTap,
+    required this.label,
+    required this.hint,
+    this.danger = false,
+  });
+  final bool checked;
+  final VoidCallback? onTap;
+  final String label;
+  final String hint;
+  final bool danger;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final accent = danger ? theme.colorScheme.error : theme.colorScheme.primary;
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(6),
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+        decoration: BoxDecoration(
+          border: Border.all(
+            color: checked ? accent : theme.dividerColor,
+            width: checked ? 1.5 : 0.5,
+          ),
+          borderRadius: BorderRadius.circular(6),
+          color: checked ? accent.withValues(alpha: 0.06) : Colors.transparent,
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: 16,
+              height: 16,
+              margin: const EdgeInsets.only(top: 2, right: 8),
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                border: Border.all(
+                  color: checked ? accent : theme.colorScheme.outline,
+                ),
+              ),
+              child: Center(
+                child: checked
+                    ? Container(
+                        width: 8,
+                        height: 8,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: accent,
+                        ),
+                      )
+                    : const SizedBox(),
+              ),
+            ),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(label, style: theme.textTheme.bodyMedium),
+                  Text(
+                    hint,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.outline,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── export history ───────────────────────────────────────────────
+
+class _ExportHistory extends ConsumerStatefulWidget {
+  const _ExportHistory({
+    required this.rows,
+    required this.error,
+    required this.onChanged,
+  });
+  final List<ExportRecord>? rows;
+  final Object? error;
+  final VoidCallback onChanged;
+
+  @override
+  ConsumerState<_ExportHistory> createState() => _ExportHistoryState();
+}
+
+class _ExportHistoryState extends ConsumerState<_ExportHistory> {
+  // Caches per-id download tokens. The list endpoint redacts the
+  // token (sensitive); /exports/{id} returns it once. We refetch on
+  // demand and stash so subsequent taps don't burn the rate limit.
+  final Map<String, String> _tokenCache = {};
+
+  Future<void> _onDownload(ExportRecord exp) async {
+    try {
+      var token = _tokenCache[exp.id];
+      if (token == null) {
+        final detail = await ref.read(backupsApiProvider).getExport(exp.id);
+        token = detail.downloadToken;
+      }
+      if (token == null || token.isEmpty) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(t.dataExport.history.noTokenToast)),
+        );
+        return;
+      }
+      _tokenCache[exp.id] = token;
+      final url = ref.read(backupsApiProvider).exportDownloadUrl(exp.id, token);
+      final auth = ref.read(authControllerProvider);
+      final base = switch (auth) {
+        AuthLoggedIn(serverUrl: final s) => s,
+        AuthLoggedOut(serverUrl: final s) => s,
+        _ => '',
+      };
+      final full = base.isEmpty
+          ? url
+          : '${base.replaceAll(RegExp(r'/+$'), '')}$url';
+      await Clipboard.setData(ClipboardData(text: full));
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(t.dataExport.history.downloadCopiedToast)),
+      );
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            t.dataExport.history.downloadFailedToast(error: e.message),
+          ),
+          backgroundColor: Theme.of(context).colorScheme.error,
+        ),
+      );
+    } on Object catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            t.dataExport.history.downloadFailedToast(error: e.toString()),
+          ),
+          backgroundColor: Theme.of(context).colorScheme.error,
+        ),
+      );
+    }
+  }
+
+  Future<void> _onDelete(ExportRecord exp) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(t.dataExport.history.deleteConfirmTitle),
+        content: Text(t.dataExport.history.deleteConfirmBody(id: exp.id)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(t.common.cancel),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(ctx).colorScheme.error,
+            ),
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(t.common.delete),
+          ),
+        ],
+      ),
+    );
+    if (ok != true || !mounted) return;
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref.read(backupsApiProvider).deleteExport(exp.id);
+      _tokenCache.remove(exp.id);
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(content: Text(t.dataExport.history.deletedToast)),
+      );
+      widget.onChanged();
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.dataExport.history.deleteFailedToast(error: e.message),
+          ),
+          backgroundColor: Theme.of(context).colorScheme.error,
+        ),
+      );
+    } on Object catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.dataExport.history.deleteFailedToast(error: e.toString()),
+          ),
+          backgroundColor: Theme.of(context).colorScheme.error,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final rows = widget.rows;
+    final err = widget.error;
+    if (rows == null && err == null) {
+      return Text(
+        t.dataExport.history.loading,
+        style: theme.textTheme.bodySmall,
+      );
+    }
+    if (err != null && rows == null) {
+      return Text(
+        t.dataExport.history.listFailedToast(
+          error: err is ApiException ? err.message : err.toString(),
+        ),
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.error,
+        ),
+      );
+    }
+    if (rows == null || rows.isEmpty) {
+      return Text(t.dataExport.history.empty, style: theme.textTheme.bodySmall);
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(t.dataExport.history.title, style: theme.textTheme.titleSmall),
+        const SizedBox(height: 8),
+        ...rows.map(
+          (exp) => _ExportRow(
+            exp: exp,
+            onDownload: () => unawaited(_onDownload(exp)),
+            onDelete: () => unawaited(_onDelete(exp)),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ExportRow extends StatelessWidget {
+  const _ExportRow({
+    required this.exp,
+    required this.onDownload,
+    required this.onDelete,
+  });
+  final ExportRecord exp;
+  final VoidCallback onDownload;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final ready = exp.status == 'ready';
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 8, 8, 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: SelectableText(
+                    exp.id,
+                    style: const TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 11,
+                    ),
+                  ),
+                ),
+                _StatusBadge(status: exp.status),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              _scopeSummary(exp.scope),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.outline,
+              ),
+            ),
+            const SizedBox(height: 2),
+            Row(
+              children: [
+                Text(
+                  exp.bytes > 0 ? _formatBytes(exp.bytes) : '—',
+                  style: theme.textTheme.bodySmall,
+                ),
+                const SizedBox(width: 12),
+                Text(
+                  '${t.dataExport.history.columns.expires}: '
+                  '${_formatRelative(exp.expiresAt)}',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.outline,
+                  ),
+                ),
+                const Spacer(),
+                if (ready)
+                  TextButton.icon(
+                    onPressed: onDownload,
+                    icon: const Icon(Icons.download, size: 16),
+                    label: Text(t.dataExport.history.download),
+                  ),
+                IconButton(
+                  tooltip: t.dataExport.history.delete,
+                  icon: const Icon(Icons.delete_outline, size: 18),
+                  onPressed: onDelete,
+                ),
+              ],
+            ),
+            if ((exp.error ?? '').isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 6),
+                child: SelectableText(
+                  exp.error!,
+                  style: TextStyle(
+                    color: theme.colorScheme.error,
+                    fontSize: 11,
+                    fontFamily: 'monospace',
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _scopeSummary(ExportScope s) {
+  final parts = <String>[];
+  if (s.memories) parts.add(t.dataExport.history.scopeMemories);
+  if (s.integrations != IntegrationExportMode.none) {
+    parts.add(
+      t.dataExport.history.scopeIntegrations(mode: s.integrations.wire),
+    );
+  }
+  if (s.customTasks) parts.add(t.dataExport.history.scopeCustomTasks);
+  if (parts.isEmpty) return t.dataExport.history.scopeEmpty;
+  return parts.join(' · ');
+}
+
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({required this.status});
+  final String status;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (color, label) = switch (status) {
+      'pending' => (Colors.amber, t.dataExport.status.pending),
+      'running' => (Colors.amber, t.dataExport.status.running),
+      'ready' => (Colors.green, t.dataExport.status.ready),
+      'succeeded' => (Colors.green, t.dataExport.status.succeeded),
+      'failed' => (theme.colorScheme.error, t.dataExport.status.failed),
+      'expired' => (theme.colorScheme.outline, t.dataExport.status.expired),
+      _ => (theme.colorScheme.outline, status),
+    };
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: color.withValues(alpha: 0.4), width: 0.5),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 10,
+          color: color,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+// ── import form ─────────────────────────────────────────────────
+
+class _ImportForm extends ConsumerStatefulWidget {
+  const _ImportForm({required this.onDone});
+  final VoidCallback onDone;
+
+  @override
+  ConsumerState<_ImportForm> createState() => _ImportFormState();
+}
+
+class _ImportFormState extends ConsumerState<_ImportForm> {
+  PlatformFile? _picked;
+  bool _memories = true;
+  bool _integrations = true;
+  bool _customTasks = true;
+  bool _busy = false;
+  ImportRecord? _last;
+
+  Future<void> _pickBundle() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.any,
+      withData: false,
+    );
+    if (result == null || result.files.isEmpty) return;
+    final f = result.files.single;
+    if (f.path == null || f.path!.isEmpty) return;
+    setState(() => _picked = f);
+  }
+
+  Future<void> _submit() async {
+    final picked = _picked;
+    if (picked == null || picked.path == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(t.dataExport.import.pickFileToast)),
+      );
+      return;
+    }
+    setState(() => _busy = true);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final imp = await ref
+          .read(backupsApiProvider)
+          .createImport(
+            bundle: File(picked.path!),
+            memories: _memories,
+            integrations: _integrations,
+            customTasks: _customTasks,
+          );
+      if (!mounted) return;
+      setState(() {
+        _last = imp;
+        _picked = null;
+      });
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            imp.status == 'succeeded'
+                ? t.dataExport.import.doneToast
+                : t.dataExport.import.finishedWithErrors,
+          ),
+        ),
+      );
+      widget.onDone();
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(t.dataExport.import.failedToast(error: e.message)),
+          backgroundColor: Theme.of(context).colorScheme.error,
+        ),
+      );
+    } on Object catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(t.dataExport.import.failedToast(error: e.toString())),
+          backgroundColor: Theme.of(context).colorScheme.error,
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(t.dataExport.import.intro, style: theme.textTheme.bodySmall),
+            const SizedBox(height: 12),
+            Text(
+              t.dataExport.import.bundleLabel,
+              style: theme.textTheme.labelMedium,
+            ),
+            const SizedBox(height: 4),
+            Row(
+              children: [
+                OutlinedButton.icon(
+                  onPressed: _busy ? null : _pickBundle,
+                  icon: const Icon(Icons.attach_file, size: 16),
+                  label: Text(t.dataExport.import.pickFile),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    _picked == null
+                        ? t.dataExport.import.noFile
+                        : t.dataExport.import.fileSelected(
+                            name: _picked!.name,
+                            size: _formatBytes(_picked!.size),
+                          ),
+                    style: theme.textTheme.bodySmall,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              dense: true,
+              value: _memories,
+              onChanged: _busy ? null : (v) => setState(() => _memories = v),
+              title: Text(t.dataExport.import.memoriesLabel),
+            ),
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              dense: true,
+              value: _integrations,
+              onChanged: _busy
+                  ? null
+                  : (v) => setState(() => _integrations = v),
+              title: Text(t.dataExport.import.integrationsLabel),
+            ),
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              dense: true,
+              value: _customTasks,
+              onChanged: _busy ? null : (v) => setState(() => _customTasks = v),
+              title: Text(t.dataExport.import.customTasksLabel),
+            ),
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton.icon(
+                onPressed:
+                    _busy ||
+                        _picked == null ||
+                        (!_memories && !_integrations && !_customTasks)
+                    ? null
+                    : _submit,
+                icon: const Icon(Icons.file_upload_outlined, size: 16),
+                label: Text(
+                  _busy
+                      ? t.dataExport.import.importing
+                      : t.dataExport.import.importBundle,
+                ),
+              ),
+            ),
+            if (_last != null) ...[
+              const SizedBox(height: 12),
+              _ImportSummaryCard(imp: _last!),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ImportSummaryCard extends StatelessWidget {
+  const _ImportSummaryCard({required this.imp});
+  final ImportRecord imp;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        border: Border.all(color: theme.dividerColor),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: SelectableText(
+                  imp.id,
+                  style: const TextStyle(fontFamily: 'monospace', fontSize: 11),
+                ),
+              ),
+              _StatusBadge(status: imp.status),
+            ],
+          ),
+          const SizedBox(height: 6),
+          _CountsRow(
+            label: t.dataExport.import.summaryCard.memories,
+            c: imp.memories,
+          ),
+          _CountsRow(
+            label: t.dataExport.import.summaryCard.integrations,
+            c: imp.integrations,
+          ),
+          _CountsRow(
+            label: t.dataExport.import.summaryCard.customTasks,
+            c: imp.customTasks,
+          ),
+          if ((imp.error ?? '').isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: SelectableText(
+                imp.error!,
+                style: TextStyle(
+                  color: theme.colorScheme.error,
+                  fontSize: 11,
+                  fontFamily: 'monospace',
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CountsRow extends StatelessWidget {
+  const _CountsRow({required this.label, required this.c});
+  final String label;
+  final EntityCounts c;
+
+  @override
+  Widget build(BuildContext context) {
+    if (c.created + c.skipped + c.failed == 0) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Wrap(
+        crossAxisAlignment: WrapCrossAlignment.center,
+        spacing: 10,
+        children: [
+          SizedBox(
+            width: 96,
+            child: Text(label, style: theme.textTheme.bodySmall),
+          ),
+          Text(
+            '${c.created} ${t.dataExport.import.summaryCard.created}',
+            style: theme.textTheme.bodySmall,
+          ),
+          Text(
+            '${c.skipped} ${t.dataExport.import.summaryCard.skipped}',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.outline,
+            ),
+          ),
+          if (c.failed > 0)
+            Text(
+              '${c.failed} ${t.dataExport.import.summaryCard.failed}',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.error,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── import history ───────────────────────────────────────────────
+
+class _ImportHistory extends StatelessWidget {
+  const _ImportHistory({required this.rows, required this.error});
+  final List<ImportRecord>? rows;
+  final Object? error;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (rows == null && error == null) {
+      return Text(
+        t.dataExport.imports.loading,
+        style: theme.textTheme.bodySmall,
+      );
+    }
+    if (error != null && rows == null) {
+      return Text(
+        t.dataExport.imports.listFailedToast(
+          error: error is ApiException
+              ? (error! as ApiException).message
+              : error.toString(),
+        ),
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.error,
+        ),
+      );
+    }
+    if (rows == null || rows!.isEmpty) {
+      return Text(t.dataExport.imports.empty, style: theme.textTheme.bodySmall);
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(t.dataExport.imports.title, style: theme.textTheme.titleSmall),
+        const SizedBox(height: 8),
+        ...rows!.map((imp) => _ImportRow(imp: imp)),
+      ],
+    );
+  }
+}
+
+class _ImportRow extends StatelessWidget {
+  const _ImportRow({required this.imp});
+  final ImportRecord imp;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final source = imp.sourceFilename ?? t.dataExport.imports.sourceUnknown;
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: SelectableText(
+                    imp.id,
+                    style: const TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 11,
+                    ),
+                  ),
+                ),
+                _StatusBadge(status: imp.status),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              imp.sourceBytes > 0
+                  ? '$source · ${_formatBytes(imp.sourceBytes)}'
+                  : source,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.outline,
+              ),
+            ),
+            const SizedBox(height: 2),
+            Text(_importSummary(imp), style: theme.textTheme.bodySmall),
+            Text(
+              _formatRelative(imp.startedAt),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.outline,
+              ),
+            ),
+            if ((imp.error ?? '').isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: SelectableText(
+                  imp.error!,
+                  style: TextStyle(
+                    color: theme.colorScheme.error,
+                    fontSize: 11,
+                    fontFamily: 'monospace',
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _importSummary(ImportRecord imp) {
+  final parts = <String>[];
+  final m = imp.memories;
+  final i = imp.integrations;
+  final c = imp.customTasks;
+  if (m.created > 0 || m.skipped > 0) {
+    parts.add('memories: ${m.created}/${m.created + m.skipped}');
+  }
+  if (i.created > 0 || i.skipped > 0) {
+    parts.add('integrations: ${i.created}/${i.created + i.skipped}');
+  }
+  if (c.created > 0 || c.skipped > 0) {
+    parts.add('custom_tasks: ${c.created}/${c.created + c.skipped}');
+  }
+  return parts.isEmpty ? t.dataExport.imports.noneCounts : parts.join(' · ');
+}
+
+// ── helpers ──────────────────────────────────────────────────────
+
+String _formatBytes(int n) {
+  if (n <= 0) return '—';
+  if (n < 1024) return '$n B';
+  if (n < 1024 * 1024) return '${(n / 1024).toStringAsFixed(1)} KiB';
+  if (n < 1024 * 1024 * 1024) {
+    return '${(n / (1024 * 1024)).toStringAsFixed(1)} MiB';
+  }
+  return '${(n / (1024 * 1024 * 1024)).toStringAsFixed(2)} GiB';
+}
+
+// Relative-time labels match web's behaviour: negative diff (future)
+// → "in Nx", positive diff (past) → "Nx ago". Honours the locale of
+// the running app via slang interpolation; same time-bucket
+// thresholds as web for consistency.
+String _formatRelative(DateTime ts) {
+  final diffMs = DateTime.now().toUtc().difference(ts.toUtc()).inMilliseconds;
+  if (diffMs < 0) {
+    final inSec = (-diffMs / 1000).round();
+    if (inSec < 60) return t.dataExport.relative.inSeconds(n: inSec.toString());
+    if (inSec < 3600) {
+      return t.dataExport.relative.inMinutes(
+        n: (inSec / 60).round().toString(),
+      );
+    }
+    if (inSec < 86400) {
+      return t.dataExport.relative.inHours(
+        n: (inSec / 3600).round().toString(),
+      );
+    }
+    return t.dataExport.relative.inDays(n: (inSec / 86400).round().toString());
+  }
+  final sec = (diffMs / 1000).round();
+  if (sec < 60) return t.dataExport.relative.secondsAgo(n: sec.toString());
+  if (sec < 3600) {
+    return t.dataExport.relative.minutesAgo(n: (sec / 60).round().toString());
+  }
+  return t.dataExport.relative.hoursAgo(n: (sec / 3600).round().toString());
+}

--- a/app/mobile/lib/features/more/more_screen.dart
+++ b/app/mobile/lib/features/more/more_screen.dart
@@ -7,6 +7,7 @@ import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/backups/backups_screen.dart';
 import 'package:opendray/features/channels/channels_screen.dart';
 import 'package:opendray/features/custom_tasks/custom_tasks_screen.dart';
+import 'package:opendray/features/data_export/data_export_screen.dart';
 import 'package:opendray/features/githosts/githosts_screen.dart';
 import 'package:opendray/features/integrations/integrations_screen.dart';
 import 'package:opendray/features/mcp/mcp_screen.dart';
@@ -108,6 +109,12 @@ class MoreScreen extends ConsumerWidget {
             onTap: () => _push(context, const BackupsScreen()),
           ),
           _MenuTile(
+            icon: Icons.import_export_outlined,
+            title: t.more.items.dataExport.title,
+            subtitle: t.more.items.dataExport.subtitle,
+            onTap: () => _push(context, const DataExportScreen()),
+          ),
+          _MenuTile(
             icon: Icons.tune_outlined,
             title: t.more.items.settings.title,
             subtitle: t.more.items.settings.subtitle,
@@ -126,10 +133,9 @@ class MoreScreen extends ConsumerWidget {
               style: OutlinedButton.styleFrom(
                 foregroundColor: Theme.of(context).colorScheme.error,
                 side: BorderSide(
-                  color: Theme.of(context)
-                      .colorScheme
-                      .error
-                      .withValues(alpha: 0.4),
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.error.withValues(alpha: 0.4),
                 ),
                 padding: const EdgeInsets.symmetric(vertical: 14),
               ),
@@ -144,9 +150,7 @@ class MoreScreen extends ConsumerWidget {
   }
 
   void _push(BuildContext context, Widget page) {
-    Navigator.of(context).push(
-      MaterialPageRoute<void>(builder: (_) => page),
-    );
+    Navigator.of(context).push(MaterialPageRoute<void>(builder: (_) => page));
   }
 }
 
@@ -201,12 +205,9 @@ class _SectionHeader extends StatelessWidget {
       child: Text(
         label.toUpperCase(),
         style: Theme.of(context).textTheme.labelSmall?.copyWith(
-              letterSpacing: 0.8,
-              color: Theme.of(context)
-                  .colorScheme
-                  .onSurface
-                  .withValues(alpha: 0.6),
-            ),
+          letterSpacing: 0.8,
+          color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+        ),
       ),
     );
   }
@@ -231,10 +232,7 @@ class _MenuTile extends StatelessWidget {
       onTap: onTap,
       leading: Icon(icon, color: Theme.of(context).colorScheme.primary),
       title: Text(title),
-      subtitle: Text(
-        subtitle,
-        style: Theme.of(context).textTheme.bodySmall,
-      ),
+      subtitle: Text(subtitle, style: Theme.of(context).textTheme.bodySmall),
       trailing: const Icon(Icons.chevron_right),
     );
   }

--- a/app/mobile/lib/features/settings/server_settings_screen.dart
+++ b/app/mobile/lib/features/settings/server_settings_screen.dart
@@ -364,12 +364,15 @@ List<_Section> _buildSections() => <_Section>[
         path: 'backup.local_dir',
         kind: _FieldKind.text,
         monospace: true,
+        // BackupConfig comment in internal/config/config.go.
+        placeholder: '~/.opendray/backups',
       ),
       _Field(
         label: t.settings.serverSettings.fields.backupExportDir,
         path: 'backup.export_dir',
         kind: _FieldKind.text,
         monospace: true,
+        placeholder: '~/.opendray/exports',
       ),
       _Field(
         label: t.settings.serverSettings.fields.pgDumpPath,
@@ -377,12 +380,15 @@ List<_Section> _buildSections() => <_Section>[
         kind: _FieldKind.text,
         monospace: true,
         helper: t.settings.serverSettings.fields.pathHelper,
+        // Resolved from PATH at startup when blank.
+        placeholder: 'pg_dump',
       ),
       _Field(
         label: t.settings.serverSettings.fields.pgRestorePath,
         path: 'backup.pg_restore_path',
         kind: _FieldKind.text,
         monospace: true,
+        placeholder: 'pg_restore',
       ),
     ],
   ),

--- a/app/mobile/pubspec.yaml
+++ b/app/mobile/pubspec.yaml
@@ -10,6 +10,12 @@ environment:
 dependencies:
   cupertino_icons: ^1.0.8
   dio: ^5.7.0
+  # file_picker is required for backup restore + admin import:
+  # the operator must hand opendray a .tar.gz.enc bundle or a
+  # JSON export package from the phone's file system. The web
+  # client uses <input type=file>; mobile needs an explicit
+  # native picker since dart:html isn't available.
+  file_picker: ^8.1.6
   flutter:
     sdk: flutter
   flutter_localizations:


### PR DESCRIPTION
## Summary
- Brings the mobile Backups screen + a new Data Export/Import screen up to feature parity with the web admin so operators can run disaster-recovery flows and user-level data bundles entirely from their phone.
- New API surface on `backups_api.dart`: `restore()` (multipart bundle upload), `inventory()`, exports CRUD, imports CRUD, plus the matching Dart shapes (`RestoreResult`, `InventoryGroup`/`InventoryTable`, `ExportRecord`/`ExportScope`/`IntegrationExportMode`, `ImportRecord`/`EntityCounts`).
- New widgets: collapsible Inventory card on the Backups screen, Restore bottom-sheet form with the \"I understand\" sentinel + manifest result dialog, and a brand-new `DataExportScreen` (mirrors the web `/export` page — Export form, Export history, Import form, Import history) wired into the More menu.
- Settings → Server settings now show default placeholders for the four backup paths (`backup.local_dir`, `backup.export_dir`, `backup.pg_dump_path`, `backup.pg_restore_path`).
- Adds `file_picker ^8.1.6` (required for the two multipart upload paths) and 168 new i18n keys per locale (en + zh) under `t.backups.restore.*`, `t.backups.inventory.*`, and the new top-level `t.dataExport.*`.

## Mobile UX trade-off
- The web admin uses `window.location.href` to download an export bundle in the current browser tab. On mobile the equivalent would force a `url_launcher` dep just to launch a single admin URL; instead the Download button copies the authenticated, single-use URL to the clipboard with a snackbar hint so the operator can paste it into a browser. Keeps the dep surface minimal.

## Test plan
- [ ] Open Backups → tap the AppBar overflow → \"Restore from file\" → pick a `.tar.gz.enc` bundle → verify the bottom-sheet shows the picked file name + size, the \"I understand\" gate appears when target DSN is empty, and Restore submits.
- [ ] Confirm the result dialog renders the manifest (backup_id, version, encryption fingerprint match), bytes read, target DSN used (or \"opendray's own DB\" placeholder), and the pg_restore output.
- [ ] On Backups main screen, tap the \"What's in a backup\" card → verify groups + per-table row counts render and match what /api/v1/backup-inventory returns.
- [ ] More → Data export & import → toggle Memories / Integrations(metadata) / Custom tasks → Create bundle → verify a row appears in Export history with status badge transitioning pending → ready.
- [ ] Tap Download on a ready row → verify the single-use URL is copied to clipboard + a snackbar confirms.
- [ ] Pick a .zip bundle in the Import form → toggle scopes → Import → verify Import history shows the new row + the summary card surfaces per-scope created/skipped/failed counts.
- [ ] Settings → Server settings → search for backup fields → verify defaults (\"~/.opendray/backups\", \"pg_dump\", etc.) show as placeholders when empty.
- [ ] Switch app language to zh → verify all new strings translate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)