### PR TITLE
fix(session): stop source-level truncation of idle-notification snippet

### DIFF
--- a/internal/session/claude_jsonl.go
+++ b/internal/session/claude_jsonl.go
@@ -327,7 +327,12 @@ func claudeRecentResponse(cwd string) string {
 	if jsonlPath == "" {
 		return ""
 	}
-	out, err := renderClaudeRecentTurn(jsonlPath, 60)
+	// 5000 entries is enough headroom for marathon turns with many
+	// tool calls — the previous 60-entry window silently dropped
+	// the start of any long turn. The channel layer (and any
+	// per-channel notify_snippet_max_chars cap) is the right place
+	// to constrain user-facing output; the source emits everything.
+	out, err := renderClaudeRecentTurn(jsonlPath, 5000)
 	if err != nil {
 		return ""
 	}
@@ -648,8 +653,17 @@ func renderAssistantBlocks(out *strings.Builder, blocks []claudeContentBlock, to
 }
 
 // renderToolResults emits the textual content of any tool_result
-// blocks in this user entry. Each result is attached as "  └ <first
-// few lines>" so the reader sees the outcome of each tool call.
+// blocks in this user entry. The first line of each result gets a
+// "  └ " prefix; subsequent lines align with 4-space indent so
+// multi-line outputs (Read, Bash, web fetches) remain readable
+// inside the bullet-list flow.
+//
+// We deliberately emit the FULL result text — no 3-line / 200-rune
+// preview cap. The channel layer (notify_snippet_max_chars or
+// Telegram's per-message splitter) is the right place to constrain
+// transport-level limits. Capping here silently lost content even
+// when the operator explicitly opted into "Unlimited — split into
+// multiple messages".
 func renderToolResults(out *strings.Builder, blocks []claudeContentBlock, toolUseSummary map[string]string) {
 	for _, b := range blocks {
 		if b.Type != "tool_result" {
@@ -659,8 +673,12 @@ func renderToolResults(out *strings.Builder, blocks []claudeContentBlock, toolUs
 		if text == "" {
 			continue
 		}
-		preview := summariseToolResult(text)
-		fmt.Fprintf(out, "  └ %s\n\n", preview)
+		body := renderToolResultBody(text)
+		if body == "" {
+			continue
+		}
+		out.WriteString(body)
+		out.WriteString("\n\n")
 		// Track which tool calls have been answered.
 		delete(toolUseSummary, b.ToolUseID)
 	}
@@ -675,6 +693,14 @@ func renderToolResults(out *strings.Builder, blocks []claudeContentBlock, toolUs
 //	Edit(README.md)
 //	AskUserQuestion: choose a model
 //	WebFetch(https://example.com/api)
+//
+// Per-arg truncation here would silently lose meaningful content
+// from the chat snippet (long shell commands, web URLs, multi-line
+// question prompts). The channel layer is responsible for
+// platform-level chunking — see internal/channel/telegram. We keep
+// a generous safety cap (toolUseArgSoftCap) only to defang
+// pathological inputs like a multi-megabyte Bash blob; in normal
+// use this never fires.
 func formatToolUse(b claudeContentBlock) string {
 	name := b.Name
 	if name == "" {
@@ -690,51 +716,73 @@ func formatToolUse(b claudeContentBlock) string {
 	case in.Path != "":
 		return fmt.Sprintf("%s(%s)", name, in.Path)
 	case in.Command != "":
-		cmd := truncateRunes(in.Command, 80)
+		cmd := softTruncate(in.Command)
 		out := fmt.Sprintf("%s(%s)", name, cmd)
 		if in.Description != "" {
-			out += " — " + truncateRunes(in.Description, 60)
+			out += " — " + softTruncate(in.Description)
 		}
 		return out
 	case in.Pattern != "":
-		return fmt.Sprintf("%s(%s)", name, truncateRunes(in.Pattern, 60))
+		return fmt.Sprintf("%s(%s)", name, softTruncate(in.Pattern))
 	case in.Query != "":
-		return fmt.Sprintf("%s(%s)", name, truncateRunes(in.Query, 60))
+		return fmt.Sprintf("%s(%s)", name, softTruncate(in.Query))
 	case in.URL != "":
-		return fmt.Sprintf("%s(%s)", name, truncateRunes(in.URL, 80))
+		return fmt.Sprintf("%s(%s)", name, softTruncate(in.URL))
 	case in.Question != "":
-		return fmt.Sprintf("%s: %s", name, truncateRunes(in.Question, 80))
+		return fmt.Sprintf("%s: %s", name, softTruncate(in.Question))
 	case in.Prompt != "":
-		return fmt.Sprintf("%s: %s", name, truncateRunes(in.Prompt, 80))
+		return fmt.Sprintf("%s: %s", name, softTruncate(in.Prompt))
 	case in.Description != "":
-		return fmt.Sprintf("%s — %s", name, truncateRunes(in.Description, 80))
+		return fmt.Sprintf("%s — %s", name, softTruncate(in.Description))
 	}
 	return name
 }
 
-// summariseToolResult condenses a tool_result body to a 1–3 line
-// preview so the conversation stays scannable. For "Wrote N lines
-// to FILE" / "Read N lines" Claude's own summary lines we keep the
-// whole first line; otherwise we cap at the first ~3 non-empty
-// lines.
-func summariseToolResult(text string) string {
-	lines := strings.Split(strings.ReplaceAll(text, "\r", ""), "\n")
-	out := make([]string, 0, 3)
-	for _, l := range lines {
-		t := strings.TrimSpace(l)
-		if t == "" {
-			continue
-		}
-		out = append(out, t)
-		if len(out) >= 3 {
-			break
-		}
-	}
-	if len(out) == 0 {
+// toolUseArgSoftCap is the only place we still cap a tool_use arg.
+// Larger than any reasonable command line / URL / pattern / prompt;
+// trips only on adversarial input. The trailing "…" makes the
+// truncation obvious if it ever happens.
+const toolUseArgSoftCap = 4000
+
+func softTruncate(s string) string {
+	return truncateRunes(s, toolUseArgSoftCap)
+}
+
+// renderToolResultBody formats a tool_result for embedding under
+// its parent tool_use bullet. First non-empty line gets "  └ ";
+// subsequent lines align with a 4-space continuation indent so the
+// block reads as one logical unit:
+//
+//	● Read(file.go)
+//	  └ first matching line
+//	    second matching line
+//	    ...
+//
+// No content is dropped. CR characters are normalised; trailing
+// blank lines trimmed; that's it.
+func renderToolResultBody(text string) string {
+	if text == "" {
 		return ""
 	}
-	preview := strings.Join(out, " · ")
-	return truncateRunes(preview, 200)
+	lines := strings.Split(strings.ReplaceAll(text, "\r", ""), "\n")
+	// Trim trailing whitespace-only lines so the "\n\n" the caller
+	// appends doesn't snowball into 4+ blank lines.
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, l := range lines {
+		if i == 0 {
+			b.WriteString("  └ ")
+		} else {
+			b.WriteString("\n    ")
+		}
+		b.WriteString(l)
+	}
+	return b.String()
 }
 
 func truncateRunes(s string, n int) string {

--- a/internal/session/claude_jsonl_test.go
+++ b/internal/session/claude_jsonl_test.go
@@ -606,3 +606,147 @@ func userToolResultOnly(t *testing.T, toolUseID, ts string) map[string]any {
 		},
 	}
 }
+
+// Regression guard: with "Unlimited — split into multiple messages"
+// chosen at the channel layer, the source-level snippet must NOT
+// silently truncate. These tests pin the new behaviour (full
+// tool_use args, full tool_result body, multi-line indentation,
+// generous JSONL window). If you reintroduce a cap, do it at the
+// channel layer (notify_snippet_max_chars) — never here.
+func TestFormatToolUse_LongBashCommandNotTruncated(t *testing.T) {
+	longCmd := strings.Repeat("very-long-flag --option=value ", 30) // ~900 chars
+	b := claudeContentBlock{
+		Type: "tool_use",
+		Name: "Bash",
+		Input: newToolInput(t, map[string]string{
+			"command": longCmd,
+		}),
+	}
+	got := formatToolUse(b)
+	if !strings.Contains(got, longCmd) {
+		t.Errorf("long bash command was truncated:\ninput:  %q\nresult: %q", longCmd, got)
+	}
+	if strings.Contains(got, "…") {
+		t.Errorf("unexpected truncation ellipsis for normal-length args: %q", got)
+	}
+}
+
+func TestFormatToolUse_HugeArgStillSoftCapped(t *testing.T) {
+	huge := strings.Repeat("X", toolUseArgSoftCap+1000)
+	b := claudeContentBlock{
+		Type:  "tool_use",
+		Name:  "Bash",
+		Input: newToolInput(t, map[string]string{"command": huge}),
+	}
+	got := formatToolUse(b)
+	// Pathological input still gets clamped; the cap is generous
+	// (>3× a typical 80-col terminal line) so normal flows never
+	// hit it.
+	if !strings.HasSuffix(got, "…)") {
+		t.Errorf("expected ellipsis on pathological input, got tail: %q", got[len(got)-50:])
+	}
+}
+
+func TestRenderToolResultBody_PreservesAllLines(t *testing.T) {
+	body := "Wrote 734 lines to file.dart\n  1 import 'package:flutter/material.dart';\n  2 import 'dart:async';\n  3 \n  4 void main() {\n  5   runApp(const MyApp());\n  6 }\n  7 \n  8 // ... 727 more lines ..."
+	got := renderToolResultBody(body)
+	// First line gets the bullet; rest gets continuation indent.
+	if !strings.HasPrefix(got, "  └ Wrote 734 lines") {
+		t.Errorf("first-line prefix missing:\n%s", got)
+	}
+	// Every original non-empty line must survive.
+	for _, want := range []string{
+		"import 'package:flutter/material.dart';",
+		"runApp(const MyApp());",
+		"// ... 727 more lines ...",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("line dropped %q in:\n%s", want, got)
+		}
+	}
+	// No 200-char cap → length should match the input plus prefixes.
+	if len(got) < len(body) {
+		t.Errorf("output shorter than input — content was lost; got %d bytes for %d-byte input",
+			len(got), len(body))
+	}
+}
+
+func TestRenderToolResultBody_EmptyAndWhitespaceOnly(t *testing.T) {
+	if renderToolResultBody("") != "" {
+		t.Error("empty input should produce empty output")
+	}
+	if renderToolResultBody("   \n   \n") != "" {
+		t.Error("whitespace-only input should produce empty output")
+	}
+}
+
+// Long turn = many tool_use/tool_result entries in a row.
+// Previously capped at 60 entries, which silently dropped the start
+// of any turn longer than that. Now bumped to 5000; the test
+// constructs a long turn and asserts the EARLIEST assistant text
+// survives the window.
+func TestRenderClaudeRecentTurn_LongTurnSurvivesWindow(t *testing.T) {
+	tmp := t.TempDir()
+	jsonl := filepath.Join(tmp, "session.jsonl")
+
+	lines := []string{
+		mustEntry(t, "user", "do many things"),
+		mustEntry(t, "assistant", "FIRST_REPLY_SENTINEL — kicking off a long turn"),
+	}
+	// 78 tool_use + tool_result pairs follow → 158 entries total
+	// in the turn. Old cap of 60 would have lost everything up to
+	// entry 98.
+	for i := 0; i < 78; i++ {
+		useID := fmt.Sprintf("tool_use_%d", i)
+		lines = append(lines, assistantWithTool(t, "",
+			useID, "Bash", map[string]string{
+				"command": fmt.Sprintf("echo step-%d", i),
+			}))
+		lines = append(lines, userToolResult(t, useID,
+			fmt.Sprintf("step-%d done", i)))
+	}
+	lines = append(lines, mustEntry(t, "assistant",
+		"LAST_REPLY_SENTINEL — wrapping up"))
+
+	if err := os.WriteFile(jsonl, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := renderClaudeRecentTurn(jsonl, 5000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "FIRST_REPLY_SENTINEL") {
+		t.Errorf("start of long turn missing — entry window too small")
+	}
+	if !strings.Contains(got, "LAST_REPLY_SENTINEL") {
+		t.Errorf("end of long turn missing")
+	}
+}
+
+// Multi-line tool_result must render as "  └ first / 4-space rest",
+// preserving every line. Previously each result was compressed to
+// "  └ line1 · line2 · line3" with a 200-rune cap.
+func TestRenderToolResults_MultilineRespectsIndent(t *testing.T) {
+	useID := "tool_read"
+	summary := map[string]string{useID: "Read(big.go)"}
+	long := "Read 500 lines from big.go\n" + strings.Repeat("line content here\n", 60)
+	blocks := []claudeContentBlock{{
+		Type:       "tool_result",
+		ToolUseID:  useID,
+		RawContent: mustRawString(t, long),
+	}}
+	var b strings.Builder
+	renderToolResults(&b, blocks, summary)
+	out := b.String()
+	if !strings.Contains(out, "  └ Read 500 lines from big.go") {
+		t.Errorf("first-line bullet missing:\n%s", out)
+	}
+	if !strings.Contains(out, "\n    line content here") {
+		t.Errorf("continuation indent missing — multi-line was flattened or dropped:\n%s", out)
+	}
+	// All 60 "line content here" lines should be present.
+	if got := strings.Count(out, "line content here"); got != 60 {
+		t.Errorf("lines dropped: got %d, want 60", got)
+	}
+}

--- a/internal/session/pump.go
+++ b/internal/session/pump.go
@@ -12,10 +12,14 @@ import (
 )
 
 // idleTailLines bounds how much of the recent stdout we ship inside
-// the session.idle event. Big enough to capture a typical Claude
-// response or interactive prompt; small enough to fit in a chat
-// notification without overwhelming the reader.
-const idleTailLines = 15
+// the session.idle event when no JSONL transcript is available
+// (Codex / Gemini / shell sessions). Generous on purpose — the
+// channel layer (notify_snippet_max_chars, Telegram chunking) is
+// the right place to clamp for any specific transport. Set high
+// enough that a marathon session's last interesting screenful
+// survives. The ring buffer is 1 MiB and most output averages
+// ~80 chars/line, so this cap rarely bites in practice.
+const idleTailLines = 1000
 
 // pumpStdout copies bytes from the PTY into the ring buffer + fanout
 // subscribers. Updates lastActivity so the idle watcher resets when
@@ -86,6 +90,14 @@ func (m *Manager) idleWatcher(rs *runningSession) {
 			//   2. Virtual-terminal screen snapshot — what the user
 			//      sees in the live web terminal right now
 			//   3. Raw ring-buffer tail — defensive fallback
+			//
+			// We deliberately do NOT cap byte / line counts at the
+			// source. The channel layer owns user-facing truncation
+			// (notify_snippet_max_chars + per-platform chunking, e.g.
+			// Telegram's 3800-rune splitter). Capping here means the
+			// operator-facing "Unlimited — split into messages"
+			// option silently loses content; let the source emit
+			// everything and let the channel decide.
 			snippet := ""
 			rs.sessMu.RLock()
 			provider := rs.sess.ProviderID


### PR DESCRIPTION
## Summary
- The Telegram channel's \"Unlimited — split into multiple messages (default)\" option appeared to be ignored: operators saw aggressively trimmed snippets even though the channel layer would happily chunk longer content into multiple messages.
- Root cause was four separate caps applied **at the snippet source** (`internal/session/`), long before the channel could see the content:
  1. `renderClaudeRecentTurn` only read the last **60 JSONL entries** → any Claude turn with 60+ tool_use/tool_result pairs silently lost its start.
  2. `summariseToolResult` kept the first **3 non-empty lines** of each tool_result, joined with \" · \", capped at **200 runes** → every `Read`/`Bash`/`WebFetch` output collapsed into one short line.
  3. `formatToolUse` truncated Bash commands to **80 runes**, Pattern/Query to **60**, URL/Question/Prompt to **80** → long commands and prompts lost meaningful detail.
  4. `idleTailLines = 15` → non-Claude (Codex / Gemini / shell) sessions only ever shipped the last **15 lines** of output.
- Fix: stop capping at the source. The channel layer (`notify_snippet_max_chars` + per-platform splitters such as Telegram's 3800-rune `splitForTelegram`) is the right place to constrain transport-level output. Operators who want a hard cap still set `notify_snippet_max_chars`; operators who picked \"Unlimited — split\" now actually get every byte.

## Changes
- `internal/session/pump.go`: `idleTailLines` 15 → 1000; `claudeRecentResponse` window 60 → 5000; added a comment explaining the channel-layer-owns-caps policy so future contributors don't re-add a source-level limit.
- `internal/session/claude_jsonl.go`: replaced `summariseToolResult` with `renderToolResultBody` — emits the full tool_result body, first line prefixed `  └ `, subsequent lines aligned with a 4-space continuation indent.
- `internal/session/claude_jsonl.go`: dropped per-arg `truncateRunes` calls in `formatToolUse`; kept a generous 4000-rune `softTruncate` as an adversarial-input guard (never trips on normal flows).
- 5 new regression-guard tests pin the \"no source-level cap\" behaviour forever — long Bash command survives, multi-line tool_result keeps every line + correct indent, a 158-entry turn (78 tool_use/tool_result pairs) renders both start and end.

## Test plan
- [ ] `go test ./internal/session/... -run \"TestFormatToolUse|TestRenderToolResult|TestRenderClaudeRecentTurn\" -v` — all 10 tests pass (4 pre-existing + 6 new regression guards).
- [ ] Trigger a long Claude turn (~80 tool calls); let it go idle; verify the Telegram channel receives **multiple messages** preserving start-of-turn assistant text + every tool_use arg + every tool_result line.
- [ ] In the same channel, switch the dropdown to `1000` (hard-cap mode) → verify the snippet is truncated at ~1000 runes per the existing `trimForCardN` path (channel layer behaviour unchanged).
- [ ] Trigger a Codex/Gemini idle event → verify the ring-buffer fallback ships the last ~1000 lines instead of 15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)