### PR TITLE
fix(session): walk multi-account roots when resolving Claude JSONL

### DIFF
--- a/internal/session/claude_jsonl.go
+++ b/internal/session/claude_jsonl.go
@@ -340,18 +340,44 @@ func claudeRecentResponse(cwd string) string {
 }
 
 // resolveLatestClaudeJSONL finds the most recently modified .jsonl
-// file inside the projects/<encoded-cwd>/ directory matching cwd.
+// across every Claude projects root visible to opendray. We scan
+// both ~/.claude/projects (the single-account default) and every
+// ~/.claude-accounts/<acct>/projects (the multi-account routing
+// opendray uses when CLAUDE_HOME is overridden per spawn).
+//
+// Single-account-only operators are unaffected: when ~/.claude-
+// accounts doesn't exist (or is empty), the function degrades to
+// the original behaviour. Multi-account operators previously got
+// an empty snippet because the JSONL lived under .claude-accounts
+// and we never looked there — which is what made the idle Telegram
+// alert fall back to the virtual-terminal screen snapshot (~1
+// screenful instead of the full turn).
 func resolveLatestClaudeJSONL(cwd string) string {
-	home := os.Getenv("HOME")
-	if home == "" {
+	roots := resolveClaudeRoots(ClaudeHistoryConfig{})
+	if len(roots) == 0 {
 		return ""
 	}
-	root := filepath.Join(home, ".claude", "projects")
-	dir := findClaudeProjectDir(root, cwd)
-	if dir == "" {
-		return ""
+	var best string
+	var bestTime time.Time
+	for _, root := range roots {
+		dir := findClaudeProjectDir(root, cwd)
+		if dir == "" {
+			continue
+		}
+		path := findLatestClaudeJSONL(dir)
+		if path == "" {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if info.ModTime().After(bestTime) {
+			best = path
+			bestTime = info.ModTime()
+		}
 	}
-	return findLatestClaudeJSONL(dir)
+	return best
 }
 
 // findClaudeProjectDir scans projectsRoot for a directory whose

--- a/internal/session/claude_jsonl_test.go
+++ b/internal/session/claude_jsonl_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestMatchesClaudeProjectDir(t *testing.T) {
@@ -479,6 +480,82 @@ func TestResolveLatestClaudeJSONL_RealFile(t *testing.T) {
 	resp := claudeRecentResponse("/tmp/fake/cwd")
 	if !strings.Contains(resp, "hello from JSONL") {
 		t.Errorf("claudeRecentResponse = %q", resp)
+	}
+}
+
+// Multi-account routing: opendray spawns Claude under
+// ~/.claude-accounts/<acct>/ so the JSONL lands beneath
+// .claude-accounts, NOT .claude/projects. The resolver must walk
+// both roots and return whichever has the matching project dir.
+// This regression test pins the bug that made the idle-notification
+// snippet fall back to the virtual-terminal screen snapshot
+// (~1 screenful) instead of the full Claude turn.
+func TestResolveLatestClaudeJSONL_MultiAccountRouting(t *testing.T) {
+	tmpHome := t.TempDir()
+	encoded := "-tmp-fake-cwd"
+
+	// Only .claude-accounts/<acct>/projects exists — NOT
+	// .claude/projects. Old resolver returned "" here.
+	pdir := filepath.Join(tmpHome, ".claude-accounts", "shared", "projects", encoded)
+	if err := os.MkdirAll(pdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	jsonl := filepath.Join(pdir, "session-shared.jsonl")
+	body := mustEntry(t, "assistant", "FULL_TURN_FROM_SHARED_ACCOUNT") + "\n"
+	if err := os.WriteFile(jsonl, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", tmpHome)
+	got := resolveLatestClaudeJSONL("/tmp/fake/cwd")
+	if got != jsonl {
+		t.Errorf("resolver missed .claude-accounts root\n got: %q\nwant: %q", got, jsonl)
+	}
+	resp := claudeRecentResponse("/tmp/fake/cwd")
+	if !strings.Contains(resp, "FULL_TURN_FROM_SHARED_ACCOUNT") {
+		t.Errorf("claudeRecentResponse() returned empty/wrong content for multi-account cwd: %q", resp)
+	}
+}
+
+// When BOTH roots have a matching project dir, the resolver should
+// return the JSONL with the most recent mtime. Without this rule a
+// stale ~/.claude/projects copy could shadow the live transcript
+// being written under .claude-accounts/<acct>/.
+func TestResolveLatestClaudeJSONL_PicksNewestAcrossRoots(t *testing.T) {
+	tmpHome := t.TempDir()
+	encoded := "-tmp-fake-cwd"
+
+	oldDir := filepath.Join(tmpHome, ".claude", "projects", encoded)
+	newDir := filepath.Join(tmpHome, ".claude-accounts", "shared", "projects", encoded)
+	for _, d := range []string{oldDir, newDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldPath := filepath.Join(oldDir, "stale.jsonl")
+	newPath := filepath.Join(newDir, "live.jsonl")
+	if err := os.WriteFile(oldPath, []byte(mustEntry(t, "assistant", "stale")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newPath, []byte(mustEntry(t, "assistant", "live")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Force newPath's mtime to be strictly later than oldPath's,
+	// since both files were written within the same tick on fast
+	// filesystems and the test would otherwise be flaky.
+	staleTime := time.Now().Add(-time.Hour)
+	liveTime := time.Now()
+	if err := os.Chtimes(oldPath, staleTime, staleTime); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(newPath, liveTime, liveTime); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", tmpHome)
+	got := resolveLatestClaudeJSONL("/tmp/fake/cwd")
+	if got != newPath {
+		t.Errorf("resolver picked stale copy:\n got: %q\nwant: %q (newer)", got, newPath)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Follow-up to #141. After that PR landed, Telegram idle notifications were *still* showing only ~1/11 of a long Claude response — but this time because the resolver couldn't even find the JSONL file, not because of a downstream truncation cap.
- `resolveLatestClaudeJSONL` only looked at `\$HOME/.claude/projects`, but opendray's multi-account spawn path writes JSONL under `\$HOME/.claude-accounts/<acct>/projects/<encoded-cwd>/` (each cliacct gets its own isolated `CLAUDE_HOME`).
- Result: `claudeRecentResponse` always returned `\"\"` for any operator who runs opendray with the multi-account routing — and the idle-notification snippet silently fell through to `ScreenSnapshot`, which is bounded by the virtual-terminal grid (~24 rows). That's exactly the \"1/11 of the response\" symptom the user observed.

## Changes
- `internal/session/claude_jsonl.go`: `resolveLatestClaudeJSONL` now walks every root returned by `resolveClaudeRoots(ClaudeHistoryConfig{})` — the same helper `ProjectInputHistory` already uses. When multiple roots have a matching project dir, it picks the JSONL with the newest mtime so a stale single-account copy can't shadow the live multi-account transcript.
- Two new regression tests pin the multi-account behaviour:
  - `TestResolveLatestClaudeJSONL_MultiAccountRouting`: JSONL only in `~/.claude-accounts/shared/projects/<encoded>` is now found.
  - `TestResolveLatestClaudeJSONL_PicksNewestAcrossRoots`: when both roots have a copy, the resolver picks the newer mtime.

## Why this wasn't caught before
- The single-account test `TestResolveLatestClaudeJSONL_RealFile` was the only coverage for this function; it stubs `\$HOME` to a `TempDir` containing only `.claude/projects`. The multi-account case was invisible.
- The cliacct routing layer correctly sets `CLAUDE_HOME` for the spawned Claude CLI so JSONL writes go to the right place. The snippet *reader* was the one piece that hadn't been taught about the multi-account layout.

## Test plan
- [ ] `go test ./internal/session/... -run TestResolveLatestClaudeJSONL -v` — 3 tests pass (1 pre-existing + 2 new).
- [ ] Restart opendray with the new binary; trigger a long Claude turn in a multi-account session; idle 30s.
- [ ] Verify Telegram receives the **full** Claude turn (multiple messages, no missing start, all tool_use args + tool_result content intact).
- [ ] Single-account operators (no `~/.claude-accounts` dir) see no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)