### PR TITLE
feat(channel): minimal useful Telegram command set + fix broken buttons

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -185,6 +185,11 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	// notified that channel — letting the operator drive a running
 	// CLI from chat without opening the web UI.
 	channelHub.SetSessionInput(sessionMgr)
+	// Session-aware slash commands (/list, /end, /resume) live in
+	// this layer rather than internal/channel so the channel package
+	// stays free of the session dependency. The matching idle-card
+	// buttons (Resume / End) emit the same `cmd:/...` payloads.
+	registerChannelCommands(channelHub, sessionMgr)
 	channelHandlers := channel.NewHandlers(channelHub, log)
 	bridgeHandlers := bridge.NewHandlers(bridge.DefaultBroker(), log)
 

--- a/internal/app/channel_commands.go
+++ b/internal/app/channel_commands.go
@@ -1,0 +1,213 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/opendray/opendray-v2/internal/channel"
+	"github.com/opendray/opendray-v2/internal/session"
+)
+
+// sessionOps is the small slice of session.Manager that the chat
+// commands need. Extracted as an interface so tests can stand in a
+// fake without spinning up a real PTY-backed Manager.
+type sessionOps interface {
+	List(ctx context.Context) ([]session.Session, error)
+	Start(ctx context.Context, id string) (session.Session, error)
+	Stop(ctx context.Context, id string) error
+}
+
+// registerChannelCommands wires the session-aware slash commands
+// (/list, /end, /resume) into the channel hub. We do it here rather
+// than inside the channel package so internal/channel stays free of
+// the session dependency — the channel layer is a transport, not a
+// session controller.
+//
+// The deliberate set is small. Operators get tired of long /help
+// dumps; chat-side actions are emergency / quick-check only, and
+// the web admin remains the authoritative session console.
+//
+//   - /list           — what's alive right now
+//   - /end <id>       — stop a running session (used by the End
+//                       inline button on the idle card as well)
+//   - /resume <id>    — re-spawn a stopped/ended session under the
+//                       same id (used by the Resume inline button)
+func registerChannelCommands(hub *channel.Hub, mgr sessionOps) {
+	hub.RegisterCommand(channel.Command{
+		Name:        "list",
+		Description: "List active sessions",
+		Source:      "builtin",
+		Handler:     listSessionsHandler(mgr),
+	})
+	hub.RegisterCommand(channel.Command{
+		Name:        "end",
+		Description: "End a session: /end <session_id>",
+		Source:      "builtin",
+		Handler:     endSessionHandler(mgr),
+	})
+	hub.RegisterCommand(channel.Command{
+		Name:        "resume",
+		Description: "Resume a stopped or ended session: /resume <session_id>",
+		Source:      "builtin",
+		Handler:     resumeSessionHandler(mgr),
+	})
+}
+
+// listSessionsHandler returns up to `listSessionsMax` sessions
+// sorted by recency. Live states (pending/running/idle) come first
+// so the operator can quickly find what's chewing CPU; recently
+// terminated sessions follow so /resume <id> has visible targets.
+const listSessionsMax = 12
+
+func listSessionsHandler(mgr sessionOps) channel.CommandHandler {
+	return func(ctx context.Context, _ channel.CommandContext) (string, error) {
+		all, err := mgr.List(ctx)
+		if err != nil {
+			return "", fmt.Errorf("list sessions: %w", err)
+		}
+		if len(all) == 0 {
+			return "No sessions yet.", nil
+		}
+		// Live first, then terminated; within each bucket newest first.
+		sort.Slice(all, func(i, j int) bool {
+			if isLiveState(all[i].State) != isLiveState(all[j].State) {
+				return isLiveState(all[i].State)
+			}
+			return sessionActivityTime(all[i]).After(sessionActivityTime(all[j]))
+		})
+		if len(all) > listSessionsMax {
+			all = all[:listSessionsMax]
+		}
+		liveCount := 0
+		for _, s := range all {
+			if isLiveState(s.State) {
+				liveCount++
+			}
+		}
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d session%s (showing %d):\n",
+			liveCount, plural(liveCount), len(all))
+		now := time.Now().UTC()
+		for _, s := range all {
+			fmt.Fprintf(&b, "  %s — %s — %s — %s\n",
+				s.ID,
+				s.ProviderID,
+				s.State,
+				relativeAge(sessionActivityTime(s), now),
+			)
+		}
+		return strings.TrimRight(b.String(), "\n"), nil
+	}
+}
+
+func endSessionHandler(mgr sessionOps) channel.CommandHandler {
+	return func(ctx context.Context, cc channel.CommandContext) (string, error) {
+		sid, ok := singleSessionArg(cc.Args)
+		if !ok {
+			return "Usage: /end <session_id>", nil
+		}
+		if err := mgr.Stop(ctx, sid); err != nil {
+			if errors.Is(err, session.ErrNotFound) {
+				return "Session " + sid + " not found.", nil
+			}
+			if errors.Is(err, session.ErrAlreadyEnded) {
+				return "Session " + sid + " is already ended.", nil
+			}
+			return "", fmt.Errorf("end %s: %w", sid, err)
+		}
+		return "Session " + sid + " stopped.", nil
+	}
+}
+
+func resumeSessionHandler(mgr sessionOps) channel.CommandHandler {
+	return func(ctx context.Context, cc channel.CommandContext) (string, error) {
+		sid, ok := singleSessionArg(cc.Args)
+		if !ok {
+			return "Usage: /resume <session_id>", nil
+		}
+		s, err := mgr.Start(ctx, sid)
+		if err != nil {
+			// Manager.Start returns a specific error when the row is
+			// already live. Surface it cleanly instead of leaking the
+			// pgx wrap chain.
+			if errors.Is(err, session.ErrAlreadyRunning) {
+				return "Session " + sid + " is already running.", nil
+			}
+			if errors.Is(err, session.ErrNotFound) {
+				return "Session " + sid + " not found.", nil
+			}
+			return "", fmt.Errorf("resume %s: %w", sid, err)
+		}
+		return fmt.Sprintf("Session %s resumed (state=%s).", sid, s.State), nil
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────
+
+func isLiveState(s session.State) bool {
+	switch s {
+	case session.StatePending, session.StateRunning, session.StateIdle:
+		return true
+	}
+	return false
+}
+
+// sessionActivityTime returns the most relevant timestamp for a
+// recency sort. EndedAt for terminated sessions; StartedAt
+// otherwise (the Manager doesn't currently expose a separate
+// last-activity field at this level).
+func sessionActivityTime(s session.Session) time.Time {
+	if s.EndedAt != nil {
+		return *s.EndedAt
+	}
+	return s.StartedAt
+}
+
+// singleSessionArg extracts a single session ID from a command's
+// args, trimming any leading "/" that operators sometimes paste in.
+// Returns ok=false when no usable id was supplied.
+func singleSessionArg(args []string) (string, bool) {
+	if len(args) == 0 {
+		return "", false
+	}
+	sid := strings.TrimSpace(args[0])
+	sid = strings.TrimPrefix(sid, "/")
+	if sid == "" {
+		return "", false
+	}
+	return sid, true
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// relativeAge renders durations the way chat readers expect ("3m
+// ago", "12h ago", "2d ago"). Same buckets as the mobile/web side
+// so users don't have to mentally translate between surfaces.
+func relativeAge(ts, now time.Time) string {
+	if ts.IsZero() {
+		return "(unknown)"
+	}
+	d := now.Sub(ts)
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < time.Minute:
+		return "now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d/time.Minute))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d/time.Hour))
+	default:
+		return fmt.Sprintf("%dd ago", int(d/(24*time.Hour)))
+	}
+}

--- a/internal/app/channel_commands.go
+++ b/internal/app/channel_commands.go
@@ -33,9 +33,9 @@ type sessionOps interface {
 //
 //   - /list           — what's alive right now
 //   - /end <id>       — stop a running session (used by the End
-//                       inline button on the idle card as well)
+//     inline button on the idle card as well)
 //   - /resume <id>    — re-spawn a stopped/ended session under the
-//                       same id (used by the Resume inline button)
+//     same id (used by the Resume inline button)
 func registerChannelCommands(hub *channel.Hub, mgr sessionOps) {
 	hub.RegisterCommand(channel.Command{
 		Name:        "list",

--- a/internal/app/channel_commands_test.go
+++ b/internal/app/channel_commands_test.go
@@ -1,0 +1,254 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opendray/opendray-v2/internal/channel"
+	"github.com/opendray/opendray-v2/internal/session"
+)
+
+// fakeSessionOps satisfies sessionOps without spinning up a real
+// PTY-backed Manager. Records every Stop/Start call so tests can
+// assert what the handlers actually invoked. Configurable errors
+// per-method drive the error-path assertions.
+type fakeSessionOps struct {
+	sessions []session.Session
+	listErr  error
+
+	stopCalls []string
+	stopErr   error
+
+	startCalls []string
+	startResp  session.Session
+	startErr   error
+}
+
+func (f *fakeSessionOps) List(_ context.Context) ([]session.Session, error) {
+	return f.sessions, f.listErr
+}
+func (f *fakeSessionOps) Stop(_ context.Context, id string) error {
+	f.stopCalls = append(f.stopCalls, id)
+	return f.stopErr
+}
+func (f *fakeSessionOps) Start(_ context.Context, id string) (session.Session, error) {
+	f.startCalls = append(f.startCalls, id)
+	return f.startResp, f.startErr
+}
+
+func TestListSessionsHandler_EmptyState(t *testing.T) {
+	h := listSessionsHandler(&fakeSessionOps{})
+	got, err := h(context.Background(), channel.CommandContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "No sessions yet." {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestListSessionsHandler_LiveFirstThenTerminated(t *testing.T) {
+	now := time.Now().UTC()
+	end := now.Add(-1 * time.Hour)
+	sessions := []session.Session{
+		{ID: "old_ended", ProviderID: "claude", State: session.StateEnded,
+			StartedAt: now.Add(-2 * time.Hour), EndedAt: &end},
+		{ID: "fresh_idle", ProviderID: "gemini", State: session.StateIdle,
+			StartedAt: now.Add(-5 * time.Minute)},
+		{ID: "newest_running", ProviderID: "claude", State: session.StateRunning,
+			StartedAt: now.Add(-30 * time.Second)},
+	}
+	h := listSessionsHandler(&fakeSessionOps{sessions: sessions})
+	got, err := h(context.Background(), channel.CommandContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Header counts active sessions only.
+	if !strings.HasPrefix(got, "2 sessions") {
+		t.Errorf("header wrong:\n%s", got)
+	}
+	// Live first (sorted by recency), terminated last.
+	wantOrder := []string{"newest_running", "fresh_idle", "old_ended"}
+	for i, want := range wantOrder {
+		if idx := strings.Index(got, want); idx < 0 {
+			t.Errorf("missing %q in output:\n%s", want, got)
+		} else if i+1 < len(wantOrder) {
+			next := wantOrder[i+1]
+			nextIdx := strings.Index(got, next)
+			if nextIdx < idx {
+				t.Errorf("order wrong: %q should precede %q\n%s", want, next, got)
+			}
+		}
+	}
+}
+
+func TestListSessionsHandler_CapsAtMax(t *testing.T) {
+	now := time.Now().UTC()
+	sessions := make([]session.Session, 0, listSessionsMax+5)
+	for i := 0; i < listSessionsMax+5; i++ {
+		sessions = append(sessions, session.Session{
+			ID:         fmt.Sprintf("s_%02d", i),
+			ProviderID: "claude",
+			State:      session.StateRunning,
+			StartedAt:  now.Add(-time.Duration(i) * time.Minute),
+		})
+	}
+	h := listSessionsHandler(&fakeSessionOps{sessions: sessions})
+	got, err := h(context.Background(), channel.CommandContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// listSessionsMax data rows + 1 header line; not 17 rows.
+	lines := strings.Count(got, "\n") + 1
+	if lines != listSessionsMax+1 {
+		t.Errorf("want %d lines (cap + header), got %d\n%s",
+			listSessionsMax+1, lines, got)
+	}
+}
+
+func TestEndSessionHandler_Usage(t *testing.T) {
+	h := endSessionHandler(&fakeSessionOps{})
+	got, err := h(context.Background(), channel.CommandContext{Args: nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(got, "Usage:") {
+		t.Errorf("missing usage hint: %q", got)
+	}
+}
+
+func TestEndSessionHandler_Success(t *testing.T) {
+	mgr := &fakeSessionOps{}
+	h := endSessionHandler(mgr)
+	got, err := h(context.Background(),
+		channel.CommandContext{Args: []string{"ses_abc"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "Session ses_abc stopped." {
+		t.Errorf("reply: %q", got)
+	}
+	if len(mgr.stopCalls) != 1 || mgr.stopCalls[0] != "ses_abc" {
+		t.Errorf("Stop not called with ses_abc: %v", mgr.stopCalls)
+	}
+}
+
+func TestEndSessionHandler_NotFoundIsFriendly(t *testing.T) {
+	h := endSessionHandler(&fakeSessionOps{stopErr: session.ErrNotFound})
+	got, err := h(context.Background(),
+		channel.CommandContext{Args: []string{"ses_ghost"}})
+	if err != nil {
+		t.Fatalf("ErrNotFound should not propagate as error: %v", err)
+	}
+	if !strings.Contains(got, "not found") {
+		t.Errorf("friendly message missing: %q", got)
+	}
+}
+
+func TestEndSessionHandler_AlreadyEndedIsFriendly(t *testing.T) {
+	h := endSessionHandler(&fakeSessionOps{stopErr: session.ErrAlreadyEnded})
+	got, err := h(context.Background(),
+		channel.CommandContext{Args: []string{"ses_done"}})
+	if err != nil {
+		t.Fatalf("ErrAlreadyEnded should not propagate: %v", err)
+	}
+	if !strings.Contains(got, "already ended") {
+		t.Errorf("friendly message missing: %q", got)
+	}
+}
+
+func TestEndSessionHandler_UnexpectedErrorPropagates(t *testing.T) {
+	h := endSessionHandler(&fakeSessionOps{stopErr: errors.New("disk full")})
+	_, err := h(context.Background(),
+		channel.CommandContext{Args: []string{"ses_x"}})
+	if err == nil {
+		t.Error("unexpected errors should propagate so the channel layer logs them")
+	}
+}
+
+func TestResumeSessionHandler_Success(t *testing.T) {
+	mgr := &fakeSessionOps{startResp: session.Session{
+		ID: "ses_abc", State: session.StateRunning,
+	}}
+	h := resumeSessionHandler(mgr)
+	got, err := h(context.Background(),
+		channel.CommandContext{Args: []string{"ses_abc"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "ses_abc") || !strings.Contains(got, "running") {
+		t.Errorf("reply missing id/state: %q", got)
+	}
+	if len(mgr.startCalls) != 1 || mgr.startCalls[0] != "ses_abc" {
+		t.Errorf("Start not called with ses_abc: %v", mgr.startCalls)
+	}
+}
+
+func TestResumeSessionHandler_AlreadyRunningIsFriendly(t *testing.T) {
+	h := resumeSessionHandler(&fakeSessionOps{startErr: session.ErrAlreadyRunning})
+	got, err := h(context.Background(),
+		channel.CommandContext{Args: []string{"ses_live"}})
+	if err != nil {
+		t.Fatalf("ErrAlreadyRunning should not propagate: %v", err)
+	}
+	if !strings.Contains(got, "already running") {
+		t.Errorf("friendly message missing: %q", got)
+	}
+}
+
+func TestResumeSessionHandler_NotFoundIsFriendly(t *testing.T) {
+	h := resumeSessionHandler(&fakeSessionOps{startErr: session.ErrNotFound})
+	got, err := h(context.Background(),
+		channel.CommandContext{Args: []string{"ses_ghost"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "not found") {
+		t.Errorf("friendly message missing: %q", got)
+	}
+}
+
+func TestSingleSessionArg_StripsLeadingSlash(t *testing.T) {
+	cases := []struct {
+		in   []string
+		want string
+		ok   bool
+	}{
+		{nil, "", false},
+		{[]string{""}, "", false},
+		{[]string{"ses_abc"}, "ses_abc", true},
+		// Operators sometimes type "/end /ses_abc" or paste IDs
+		// alongside leading slashes — defang that.
+		{[]string{"/ses_abc"}, "ses_abc", true},
+		{[]string{"  ses_abc  "}, "ses_abc", true},
+	}
+	for _, c := range cases {
+		got, ok := singleSessionArg(c.in)
+		if got != c.want || ok != c.ok {
+			t.Errorf("input %v: got %q,%v want %q,%v", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestRelativeAge_Buckets(t *testing.T) {
+	base := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		ts   time.Time
+		want string
+	}{
+		{base.Add(-30 * time.Second), "now"},
+		{base.Add(-5 * time.Minute), "5m ago"},
+		{base.Add(-3 * time.Hour), "3h ago"},
+		{base.Add(-2 * 24 * time.Hour), "2d ago"},
+		{time.Time{}, "(unknown)"},
+	}
+	for _, c := range cases {
+		if got := relativeAge(c.ts, base); got != c.want {
+			t.Errorf("ts=%v got %q want %q", c.ts, got, c.want)
+		}
+	}
+}

--- a/internal/channel/hub.go
+++ b/internal/channel/hub.go
@@ -117,6 +117,37 @@ func (h *Hub) Commands() *CommandRegistry { return h.cmds }
 // RegisterCommand is a convenience wrapper around Commands().Register().
 func (h *Hub) RegisterCommand(c Command) { h.cmds.Register(c) }
 
+// registerBuiltinCommands wires only the channel-scoped commands
+// that don't need session access. /list, /end, and /resume live in
+// the app layer (internal/app) so the channel package stays free of
+// the session dependency.
+//
+// Slash-command set (intentionally small — operators get tired of
+// long /help output and unmaintained shims):
+//
+//	/help    — list available commands (registered by NewCommandRegistry)
+//	/notify  — toggle channel notifications on/off
+//	/list    — active sessions (registered by app code)
+//	/end     — end a session (registered by app code)
+//	/resume  — resume a stopped/ended session (registered by app code)
+//
+// What we DELETED and why:
+//   - /status   — channel-level diagnostic ("which capabilities does
+//                 this channel have"). Useful exactly once, then
+//                 noise in the /help output. The web admin shows
+//                 the same info with more context.
+//   - /select   — pin a chat to a specific session_id. The reply-
+//                 to-message routing (outboundIndex) covers the
+//                 multi-session case more naturally; the pin was a
+//                 power-user feature that nobody used.
+//   - /sessions — listed sessions that had previously NOTIFIED this
+//                 channel, not currently-active sessions. Confused
+//                 operators who expected /sessions == /list.
+//
+// The pinned-session machinery (activeSess + lookupActiveSession +
+// setActiveSession) is retained as dead-code-but-load-bearing — if
+// we ever bring /select back the routing is already wired. Cheap
+// to keep; ripping it out would expand the diff for no gain.
 func (h *Hub) registerBuiltinCommands() {
 	h.cmds.Register(Command{
 		Name:        "notify",
@@ -137,95 +168,6 @@ func (h *Hub) registerBuiltinCommands() {
 				return "Notifications enabled.", nil
 			}
 			return "Notifications muted.", nil
-		},
-	})
-	h.cmds.Register(Command{
-		Name:        "status",
-		Description: "Show channel status and capabilities",
-		Source:      "builtin",
-		Handler: func(_ context.Context, cc CommandContext) (string, error) {
-			caps := Capabilities(cc.Channel)
-			parts := make([]string, len(caps))
-			for i, c := range caps {
-				parts[i] = string(c)
-			}
-			active := h.lookupActiveSession(cc.Channel.ID())
-			last := h.lookupLastSession(cc.Channel.ID())
-			lines := []string{
-				fmt.Sprintf("Channel: %s (%s)", cc.Channel.ID(), cc.Channel.Kind()),
-				fmt.Sprintf("Capabilities: %s", strings.Join(parts, ", ")),
-			}
-			if active != "" {
-				lines = append(lines, "Pinned session (/select): "+active)
-			}
-			if last != "" {
-				lines = append(lines, "Last-notified session: "+last)
-			}
-			return strings.Join(lines, "\n"), nil
-		},
-	})
-	h.cmds.Register(Command{
-		Name:        "select",
-		Description: "Pin a session for replies: /select <session_id> | /select clear",
-		Source:      "builtin",
-		Handler: func(_ context.Context, cc CommandContext) (string, error) {
-			if len(cc.Args) == 0 {
-				cur := h.lookupActiveSession(cc.Channel.ID())
-				if cur == "" {
-					return "No pinned session. Usage: /select <session_id>", nil
-				}
-				return "Pinned session: " + cur + "\nUse /select clear to unpin.", nil
-			}
-			arg := cc.Args[0]
-			if arg == "clear" || arg == "off" || arg == "none" {
-				h.setActiveSession(cc.Channel.ID(), "")
-				return "Pinned session cleared. Routing falls back to last-notified.", nil
-			}
-			h.setActiveSession(cc.Channel.ID(), arg)
-			return "Now routing replies to session " + arg + ".\nUse /select clear to unpin.", nil
-		},
-	})
-	h.cmds.Register(Command{
-		Name:        "sessions",
-		Description: "Show recently-notified sessions for this channel",
-		Source:      "builtin",
-		Handler: func(_ context.Context, cc CommandContext) (string, error) {
-			h.outboundMu.Lock()
-			chMap := h.outboundIndex[cc.Channel.ID()]
-			seen := make(map[string]time.Time, len(chMap))
-			for _, e := range chMap {
-				if t, ok := seen[e.sessionID]; !ok || e.ts.After(t) {
-					seen[e.sessionID] = e.ts
-				}
-			}
-			h.outboundMu.Unlock()
-			if len(seen) == 0 {
-				return "No sessions have notified this channel yet.", nil
-			}
-			type kv struct {
-				sid string
-				ts  time.Time
-			}
-			all := make([]kv, 0, len(seen))
-			for sid, t := range seen {
-				all = append(all, kv{sid, t})
-			}
-			sort.Slice(all, func(i, j int) bool { return all[i].ts.After(all[j].ts) })
-			active := h.lookupActiveSession(cc.Channel.ID())
-			last := h.lookupLastSession(cc.Channel.ID())
-			lines := []string{"Recently-notified sessions (most recent first):"}
-			for _, k := range all {
-				marker := ""
-				switch k.sid {
-				case active:
-					marker = "  ← /select"
-				case last:
-					marker = "  (last)"
-				}
-				lines = append(lines, fmt.Sprintf("  /select %s%s", k.sid, marker))
-			}
-			lines = append(lines, "", "Tip: replying to a notification routes to *that* session directly.")
-			return strings.Join(lines, "\n"), nil
 		},
 	})
 }
@@ -1141,9 +1083,13 @@ func buildSessionCard(ev eventbus.Event, snip snippetPrefs) *Card {
 			Header: &CardHeader{Title: "Session idle", Color: "yellow"},
 			Elements: []CardElement{
 				CardMarkdown{Content: body},
+				// Buttons emit slash-command payloads that the app
+				// wires via session.RegisterChannelCommands. Resume
+				// re-spawns a stopped/idle session; End stops a
+				// running one; Mute silences the channel.
 				CardActions{Buttons: [][]ButtonOption{{
 					{Text: "Resume", Value: "cmd:/resume " + sid, Style: "primary"},
-					{Text: "End", Value: "cmd:/cancel " + sid, Style: "danger"},
+					{Text: "End", Value: "cmd:/end " + sid, Style: "danger"},
 					{Text: "Mute", Value: "cmd:/notify off"},
 				}}},
 			},
@@ -1158,9 +1104,12 @@ func buildSessionCard(ev eventbus.Event, snip snippetPrefs) *Card {
 			Header: &CardHeader{Title: "Session ended", Color: color},
 			Elements: []CardElement{
 				CardMarkdown{Content: fmt.Sprintf("Session `%s` ended with exit_code=%d.", sid, exit)},
+				// Resume re-spawns the ended session under the same
+				// id. The legacy "Spawn similar" button was dropped
+				// because its /spawn-like handler was never wired.
 				CardActions{Buttons: [][]ButtonOption{{
+					{Text: "Resume", Value: "cmd:/resume " + sid, Style: "primary"},
 					{Text: "Open log", Value: "nav:/sessions/" + sid},
-					{Text: "Spawn similar", Value: "cmd:/spawn-like " + sid},
 				}}},
 			},
 		}

--- a/internal/channel/hub.go
+++ b/internal/channel/hub.go
@@ -133,16 +133,16 @@ func (h *Hub) RegisterCommand(c Command) { h.cmds.Register(c) }
 //
 // What we DELETED and why:
 //   - /status   — channel-level diagnostic ("which capabilities does
-//                 this channel have"). Useful exactly once, then
-//                 noise in the /help output. The web admin shows
-//                 the same info with more context.
+//     this channel have"). Useful exactly once, then
+//     noise in the /help output. The web admin shows
+//     the same info with more context.
 //   - /select   — pin a chat to a specific session_id. The reply-
-//                 to-message routing (outboundIndex) covers the
-//                 multi-session case more naturally; the pin was a
-//                 power-user feature that nobody used.
+//     to-message routing (outboundIndex) covers the
+//     multi-session case more naturally; the pin was a
+//     power-user feature that nobody used.
 //   - /sessions — listed sessions that had previously NOTIFIED this
-//                 channel, not currently-active sessions. Confused
-//                 operators who expected /sessions == /list.
+//     channel, not currently-active sessions. Confused
+//     operators who expected /sessions == /list.
 //
 // The pinned-session machinery (activeSess + lookupActiveSession +
 // setActiveSession) is retained as dead-code-but-load-bearing — if

--- a/internal/channel/telegram/telegram.go
+++ b/internal/channel/telegram/telegram.go
@@ -114,8 +114,48 @@ func (t *Telegram) Start(_ context.Context, inbound channel.InboundFunc) error {
 	t.cancel = cancel
 	t.done = make(chan struct{})
 	go t.poll(pollCtx, inbound)
+	// Best-effort autocomplete registration — Telegram caches the
+	// command list per-bot and serves it on the "/" picker in every
+	// chat. Errors here are non-fatal (the bot still works without
+	// autocomplete) so we just log and proceed.
+	go t.publishCommands(pollCtx)
 	t.log.Info("telegram channel started")
 	return nil
+}
+
+// publishCommands tells Telegram which slash commands the bot
+// exposes, so the chat client's "/" picker autocompletes them. The
+// list is hardcoded against the channel package's actual registry
+// because the Channel interface doesn't (yet) carry a hook for the
+// hub to push command metadata down into transports — small,
+// stable set, easier to mirror by hand than to plumb through.
+//
+// If we ever extend the command set, update both this list and
+// the registrations in channel.Hub.registerBuiltinCommands +
+// internal/app/channel_commands.go.
+func (t *Telegram) publishCommands(ctx context.Context) {
+	type tgCmd struct {
+		Command     string `json:"command"`
+		Description string `json:"description"`
+	}
+	cmds := []tgCmd{
+		{Command: "help", Description: "List available commands"},
+		{Command: "list", Description: "List active sessions"},
+		{Command: "end", Description: "End a session: /end <session_id>"},
+		{Command: "resume", Description: "Resume a stopped session: /resume <session_id>"},
+		{Command: "notify", Description: "Toggle notifications: /notify on|off"},
+	}
+	body := map[string]any{"commands": cmds}
+	var resp struct {
+		Ok bool `json:"ok"`
+	}
+	if err := t.callAPI(ctx, "setMyCommands", body, &resp); err != nil {
+		t.log.Warn("telegram setMyCommands failed", "err", err)
+		return
+	}
+	if !resp.Ok {
+		t.log.Warn("telegram setMyCommands rejected", "resp", resp)
+	}
 }
 
 func (t *Telegram) Stop(ctx context.Context) error {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -283,7 +283,7 @@ func (m *Manager) Start(ctx context.Context, id string) (Session, error) {
 		out := rs.sess
 		rs.sessMu.RUnlock()
 		if !state.IsTerminal() {
-			return out, fmt.Errorf("session %s is %s — already running", id, state)
+			return out, fmt.Errorf("session %s is %s: %w", id, state, ErrAlreadyRunning)
 		}
 	}
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -98,6 +98,7 @@ type SwitchAccountRequest struct {
 var (
 	ErrNotFound                 = errors.New("session not found")
 	ErrAlreadyEnded             = errors.New("session already ended")
+	ErrAlreadyRunning           = errors.New("session already running")
 	ErrUnknownProvider          = errors.New("unknown provider")
 	ErrProviderUnavailable      = errors.New("provider unavailable")
 	ErrAccountSwitchUnsupported = errors.New("account switch only supported for claude provider")


### PR DESCRIPTION
## Summary
- Old surface had 3 commands nobody found useful (\`/status\`, \`/select\`, \`/sessions\`) and the idle-card Resume / End / Spawn-similar buttons silently failed because their handlers were never registered. Net effect: operators couldn't drive anything from chat.
- This PR trims the command set to the minimum useful + wires the broken buttons + makes Telegram's native \"/\" picker autocomplete the surviving commands.

## New command set (5, plus auto-registered /help)
| Cmd | What it does |
|---|---|
| \`/help\` | List available commands |
| \`/list\` | Active sessions, newest first, capped at 12 |
| \`/end <id>\` | End a session (used by the End inline button) |
| \`/resume <id>\` | Resume a stopped/ended session (used by the Resume button) |
| \`/notify on|off\` | Toggle channel notifications |

## What got removed
- **\`/status\`** — channel-level diagnostic (\"which capabilities does this channel have\"). Useful exactly once, noise in \`/help\` after that. Web admin shows the same info with more context.
- **\`/select\`** — pin a chat to a specific \`session_id\`. The existing reply-to-message routing (\`outboundIndex\`) covers the multi-session case more naturally; the pin was a power-user feature that nobody used.
- **\`/sessions\`** — listed sessions that had previously NOTIFIED this channel, not currently-active sessions. Confused operators who expected \`/sessions == /list\`.

The pinned-session machinery (\`activeSess\` / \`lookupActiveSession\` / \`setActiveSession\`) is intentionally retained — it's small, still used by \`resolveTargetSession\`'s routing priority, and ripping it out would expand this diff for no operator-visible gain.

## Idle-card buttons now actually work
- \"End\" button payload: \`cmd:/cancel\` → \`cmd:/end\` (the handler the user clicked into now exists).
- \"Spawn similar\" button on \`session.ended\` cards: dropped (its \`/spawn-like\` handler never existed); replaced with a **\"Resume\"** button so a finished session can be revived from chat with one tap.

## Telegram \"/\" autocomplete
\`telegram.Start\` now calls \`setMyCommands\` (best-effort, non-fatal) so the chat client's slash picker actually surfaces the 5 commands with descriptions.

## Layering
\`/list\`, \`/end\`, \`/resume\` are wired from \`internal/app\` (\`registerChannelCommands\`) rather than \`internal/channel\` so the channel package stays free of the session dependency. The handlers talk to a small local \`sessionOps\` interface, which \`session.Manager\` satisfies — keeps the surface testable without spinning up a PTY-backed manager.

\`session.ErrAlreadyRunning\` is a new sentinel so \`/resume\` can surface \"already running\" cleanly instead of leaking the formatted-string error from \`Manager.Start\`.

## Tests
13 new in \`internal/app/channel_commands_test.go\`:
- \`/list\`: empty state, live-first-then-terminated ordering, capped at \`listSessionsMax\`
- \`/end\`: usage hint, success, not-found friendly, already-ended friendly, unexpected-error propagation
- \`/resume\`: success, already-running friendly, not-found friendly
- \`singleSessionArg\` trims leading \"/\" and whitespace
- \`relativeAge\` bucket boundaries

## Test plan
- [ ] \`go test ./...\` — all 13 new tests pass + no regressions.
- [ ] Restart gateway; in Telegram type \`/\` → autocomplete shows exactly the 5 commands with descriptions.
- [ ] \`/list\` returns currently-running + recently-ended sessions, newest first.
- [ ] \`/end <id>\` on a running session → \"Session X stopped.\"; on an unknown id → \"Session X not found.\"; on an already-ended one → \"Session X is already ended.\"
- [ ] \`/resume <id>\` on an ended session → resumes it under the same id.
- [ ] Trigger an idle event; tap \"End\" inline button → session ends; tap \"Resume\" → session resumes (vs. previous \"Unknown command\" silent failure).
- [ ] \`/notify off\` → channel goes silent; \`/notify on\` → notifications re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)