### PR TITLE
feat(channel): /list shows tappable End/Resume buttons per session

### DIFF
--- a/internal/app/channel_commands.go
+++ b/internal/app/channel_commands.go
@@ -41,7 +41,11 @@ func registerChannelCommands(hub *channel.Hub, mgr sessionOps) {
 		Name:        "list",
 		Description: "List active sessions",
 		Source:      "builtin",
-		Handler:     listSessionsHandler(mgr),
+		// CardHandler so Telegram (and other CardSender channels)
+		// can render tap-to-act buttons per session — the nano-id
+		// style session IDs are too long to retype on a phone, so
+		// the buttons are the *intended* operating interface.
+		CardHandler: listSessionsCardHandler(mgr),
 	})
 	hub.RegisterCommand(channel.Command{
 		Name:        "end",
@@ -57,20 +61,37 @@ func registerChannelCommands(hub *channel.Hub, mgr sessionOps) {
 	})
 }
 
-// listSessionsHandler returns up to `listSessionsMax` sessions
-// sorted by recency. Live states (pending/running/idle) come first
-// so the operator can quickly find what's chewing CPU; recently
-// terminated sessions follow so /resume <id> has visible targets.
+// listSessionsMax caps how many rows /list returns. Telegram's
+// inline keyboard supports ~100 buttons total; we emit at most 2
+// per session (End + Resume — though only one applies at a time),
+// so 12 sessions leaves comfortable headroom.
 const listSessionsMax = 12
 
-func listSessionsHandler(mgr sessionOps) channel.CommandHandler {
-	return func(ctx context.Context, _ channel.CommandContext) (string, error) {
+// sessionShortID returns the human-pronounceable head of a session
+// id. Full nano IDs (`ses_jwwDK7iAGqA-`) are awkward in chat button
+// labels; the first 6 chars after `ses_` are still distinctive
+// across a typical operator's active set.
+func sessionShortID(full string) string {
+	stripped := strings.TrimPrefix(full, "ses_")
+	const head = 6
+	if len(stripped) <= head {
+		return stripped
+	}
+	return stripped[:head] + "…"
+}
+
+func listSessionsCardHandler(mgr sessionOps) channel.CommandCardHandler {
+	return func(ctx context.Context, _ channel.CommandContext) (*channel.Card, error) {
 		all, err := mgr.List(ctx)
 		if err != nil {
-			return "", fmt.Errorf("list sessions: %w", err)
+			return nil, fmt.Errorf("list sessions: %w", err)
 		}
 		if len(all) == 0 {
-			return "No sessions yet.", nil
+			return &channel.Card{
+				Elements: []channel.CardElement{
+					channel.CardMarkdown{Content: "No sessions yet."},
+				},
+			}, nil
 		}
 		// Live first, then terminated; within each bucket newest first.
 		sort.Slice(all, func(i, j int) bool {
@@ -88,20 +109,78 @@ func listSessionsHandler(mgr sessionOps) channel.CommandHandler {
 				liveCount++
 			}
 		}
+
+		// Body: numbered list. The full id is shown so operators
+		// who want to type /end <full> can still copy it; the
+		// buttons below carry the full id in their callback data.
 		var b strings.Builder
 		fmt.Fprintf(&b, "%d session%s (showing %d):\n",
 			liveCount, plural(liveCount), len(all))
 		now := time.Now().UTC()
-		for _, s := range all {
-			fmt.Fprintf(&b, "  %s — %s — %s — %s\n",
+		for i, s := range all {
+			fmt.Fprintf(&b, "%d. %s — %s — %s — %s\n",
+				i+1,
 				s.ID,
 				s.ProviderID,
 				s.State,
 				relativeAge(sessionActivityTime(s), now),
 			)
 		}
-		return strings.TrimRight(b.String(), "\n"), nil
+
+		// Buttons: live sessions get an End row, terminated ones a
+		// Resume row. Two per row keeps tap targets large on mobile
+		// without forcing the keyboard taller than the screen.
+		var endRow, resumeRow []channel.ButtonOption
+		for i, s := range all {
+			label := fmt.Sprintf("%d %s", i+1, sessionShortID(s.ID))
+			if isLiveState(s.State) {
+				endRow = append(endRow, channel.ButtonOption{
+					Text:  "End " + label,
+					Value: "cmd:/end " + s.ID,
+					Style: "danger",
+				})
+			} else {
+				resumeRow = append(resumeRow, channel.ButtonOption{
+					Text:  "Resume " + label,
+					Value: "cmd:/resume " + s.ID,
+					Style: "primary",
+				})
+			}
+		}
+		buttons := make([][]channel.ButtonOption, 0, 4)
+		for _, row := range chunkButtons(endRow, 2) {
+			buttons = append(buttons, row)
+		}
+		for _, row := range chunkButtons(resumeRow, 2) {
+			buttons = append(buttons, row)
+		}
+
+		elements := []channel.CardElement{
+			channel.CardMarkdown{Content: strings.TrimRight(b.String(), "\n")},
+		}
+		if len(buttons) > 0 {
+			elements = append(elements, channel.CardActions{Buttons: buttons})
+		}
+		return &channel.Card{Elements: elements}, nil
 	}
+}
+
+// chunkButtons rolls a flat slice into rows of at most `per`
+// buttons each — Telegram's inline keyboard is a 2D matrix and
+// dense rows scale better on mobile than one-per-row stacks.
+func chunkButtons(in []channel.ButtonOption, per int) [][]channel.ButtonOption {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([][]channel.ButtonOption, 0, (len(in)+per-1)/per)
+	for i := 0; i < len(in); i += per {
+		end := i + per
+		if end > len(in) {
+			end = len(in)
+		}
+		out = append(out, in[i:end])
+	}
+	return out
 }
 
 func endSessionHandler(mgr sessionOps) channel.CommandHandler {

--- a/internal/app/channel_commands_test.go
+++ b/internal/app/channel_commands_test.go
@@ -40,73 +40,177 @@ func (f *fakeSessionOps) Start(_ context.Context, id string) (session.Session, e
 	return f.startResp, f.startErr
 }
 
-func TestListSessionsHandler_EmptyState(t *testing.T) {
-	h := listSessionsHandler(&fakeSessionOps{})
+// cardText extracts the markdown body from a /list card so the
+// recency / sort assertions read like the old plain-text ones.
+func cardText(t *testing.T, c *channel.Card) string {
+	t.Helper()
+	if c == nil {
+		return ""
+	}
+	for _, el := range c.Elements {
+		if md, ok := el.(channel.CardMarkdown); ok {
+			return md.Content
+		}
+	}
+	return ""
+}
+
+// cardButtonValues returns every button's callback value in row-
+// major order. Lets tests assert that each session got the right
+// `cmd:/end <full_id>` or `cmd:/resume <full_id>` payload, even
+// when the visible label is abbreviated.
+func cardButtonValues(c *channel.Card) []string {
+	if c == nil {
+		return nil
+	}
+	var out []string
+	for _, el := range c.Elements {
+		acts, ok := el.(channel.CardActions)
+		if !ok {
+			continue
+		}
+		for _, row := range acts.Buttons {
+			for _, b := range row {
+				out = append(out, b.Value)
+			}
+		}
+	}
+	return out
+}
+
+func TestListSessionsCardHandler_EmptyState(t *testing.T) {
+	h := listSessionsCardHandler(&fakeSessionOps{})
 	got, err := h(context.Background(), channel.CommandContext{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != "No sessions yet." {
-		t.Errorf("got %q", got)
+	if cardText(t, got) != "No sessions yet." {
+		t.Errorf("body = %q", cardText(t, got))
+	}
+	if vals := cardButtonValues(got); len(vals) != 0 {
+		t.Errorf("empty state should emit no buttons, got %v", vals)
 	}
 }
 
-func TestListSessionsHandler_LiveFirstThenTerminated(t *testing.T) {
+func TestListSessionsCardHandler_LiveFirstThenTerminated(t *testing.T) {
 	now := time.Now().UTC()
 	end := now.Add(-1 * time.Hour)
 	sessions := []session.Session{
-		{ID: "old_ended", ProviderID: "claude", State: session.StateEnded,
+		{ID: "ses_old_ended", ProviderID: "claude", State: session.StateEnded,
 			StartedAt: now.Add(-2 * time.Hour), EndedAt: &end},
-		{ID: "fresh_idle", ProviderID: "gemini", State: session.StateIdle,
+		{ID: "ses_fresh_idle", ProviderID: "gemini", State: session.StateIdle,
 			StartedAt: now.Add(-5 * time.Minute)},
-		{ID: "newest_running", ProviderID: "claude", State: session.StateRunning,
+		{ID: "ses_newest_running", ProviderID: "claude", State: session.StateRunning,
 			StartedAt: now.Add(-30 * time.Second)},
 	}
-	h := listSessionsHandler(&fakeSessionOps{sessions: sessions})
+	h := listSessionsCardHandler(&fakeSessionOps{sessions: sessions})
 	got, err := h(context.Background(), channel.CommandContext{})
 	if err != nil {
 		t.Fatal(err)
 	}
+	body := cardText(t, got)
 	// Header counts active sessions only.
-	if !strings.HasPrefix(got, "2 sessions") {
-		t.Errorf("header wrong:\n%s", got)
+	if !strings.HasPrefix(body, "2 sessions") {
+		t.Errorf("header wrong:\n%s", body)
 	}
 	// Live first (sorted by recency), terminated last.
-	wantOrder := []string{"newest_running", "fresh_idle", "old_ended"}
+	wantOrder := []string{"ses_newest_running", "ses_fresh_idle", "ses_old_ended"}
 	for i, want := range wantOrder {
-		if idx := strings.Index(got, want); idx < 0 {
-			t.Errorf("missing %q in output:\n%s", want, got)
+		if idx := strings.Index(body, want); idx < 0 {
+			t.Errorf("missing %q in output:\n%s", want, body)
 		} else if i+1 < len(wantOrder) {
 			next := wantOrder[i+1]
-			nextIdx := strings.Index(got, next)
+			nextIdx := strings.Index(body, next)
 			if nextIdx < idx {
-				t.Errorf("order wrong: %q should precede %q\n%s", want, next, got)
+				t.Errorf("order wrong: %q should precede %q\n%s", want, next, body)
 			}
 		}
 	}
 }
 
-func TestListSessionsHandler_CapsAtMax(t *testing.T) {
+func TestListSessionsCardHandler_CapsAtMax(t *testing.T) {
 	now := time.Now().UTC()
 	sessions := make([]session.Session, 0, listSessionsMax+5)
 	for i := 0; i < listSessionsMax+5; i++ {
 		sessions = append(sessions, session.Session{
-			ID:         fmt.Sprintf("s_%02d", i),
+			ID:         fmt.Sprintf("ses_%02d", i),
 			ProviderID: "claude",
 			State:      session.StateRunning,
 			StartedAt:  now.Add(-time.Duration(i) * time.Minute),
 		})
 	}
-	h := listSessionsHandler(&fakeSessionOps{sessions: sessions})
+	h := listSessionsCardHandler(&fakeSessionOps{sessions: sessions})
 	got, err := h(context.Background(), channel.CommandContext{})
 	if err != nil {
 		t.Fatal(err)
 	}
+	body := cardText(t, got)
 	// listSessionsMax data rows + 1 header line; not 17 rows.
-	lines := strings.Count(got, "\n") + 1
+	lines := strings.Count(body, "\n") + 1
 	if lines != listSessionsMax+1 {
 		t.Errorf("want %d lines (cap + header), got %d\n%s",
-			listSessionsMax+1, lines, got)
+			listSessionsMax+1, lines, body)
+	}
+	// Every shown session contributed exactly one button.
+	if got := len(cardButtonValues(got)); got != listSessionsMax {
+		t.Errorf("want %d buttons (one per shown session), got %d",
+			listSessionsMax, got)
+	}
+}
+
+// The whole point of this PR: each session row in /list produces a
+// tappable button whose callback value carries the FULL session id,
+// so the operator never has to type it. Live sessions get an /end
+// button; terminated ones get /resume.
+func TestListSessionsCardHandler_ButtonsCarryFullIdAndCorrectVerb(t *testing.T) {
+	now := time.Now().UTC()
+	end := now.Add(-1 * time.Hour)
+	sessions := []session.Session{
+		{ID: "ses_running1", ProviderID: "claude", State: session.StateRunning,
+			StartedAt: now.Add(-1 * time.Minute)},
+		{ID: "ses_idle1", ProviderID: "gemini", State: session.StateIdle,
+			StartedAt: now.Add(-2 * time.Minute)},
+		{ID: "ses_ended1", ProviderID: "claude", State: session.StateEnded,
+			StartedAt: now.Add(-1 * time.Hour), EndedAt: &end},
+		{ID: "ses_stopped1", ProviderID: "claude", State: session.StateStopped,
+			StartedAt: now.Add(-2 * time.Hour), EndedAt: &end},
+	}
+	h := listSessionsCardHandler(&fakeSessionOps{sessions: sessions})
+	got, err := h(context.Background(), channel.CommandContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := cardButtonValues(got)
+	want := []string{
+		"cmd:/end ses_running1",
+		"cmd:/end ses_idle1",
+		"cmd:/resume ses_ended1",
+		"cmd:/resume ses_stopped1",
+	}
+	if len(values) != len(want) {
+		t.Fatalf("got %d buttons, want %d\nvalues: %v", len(values), len(want), values)
+	}
+	// Order: end buttons first (live sessions, in input recency
+	// order), then resume buttons (terminated sessions).
+	for i, w := range want {
+		if values[i] != w {
+			t.Errorf("button[%d] = %q, want %q\nall: %v", i, values[i], w, values)
+		}
+	}
+}
+
+func TestSessionShortID(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"ses_jwwDK7iAGqA-", "jwwDK7…"},
+		{"ses_abc", "abc"},
+		{"ses_", ""},
+		{"plain", "plain"}, // unprefixed: still abbreviated past 6 chars
+		{"plain12345", "plain1…"},
+	}
+	for _, c := range cases {
+		if got := sessionShortID(c.in); got != c.want {
+			t.Errorf("sessionShortID(%q) = %q, want %q", c.in, got, c.want)
+		}
 	}
 }
 

--- a/internal/channel/command.go
+++ b/internal/channel/command.go
@@ -8,12 +8,23 @@ import (
 	"sync"
 )
 
-// CommandHandler runs a registered command. Returns an optional reply
-// text — when non-empty the Hub posts it back to the originating
-// channel as an outbound message (with ReplyCtx preserved).
+// CommandHandler runs a registered command and returns plain text.
+// When the reply is non-empty the Hub posts it back to the
+// originating channel (with ReplyCtx preserved).
 //
 // Long-running handlers should respect ctx.Done() and return promptly.
 type CommandHandler func(ctx context.Context, cc CommandContext) (reply string, err error)
+
+// CommandCardHandler is the structured-reply alternative to
+// CommandHandler. Channels that implement CardSender (Telegram,
+// Slack, ...) render the returned Card natively — most usefully,
+// CardActions become inline-keyboard buttons so the user can
+// trigger follow-up commands by tapping rather than typing an
+// opaque session id. Channels without CardSender fall back to
+// Card.RenderText().
+//
+// Mutually exclusive with Handler — set exactly one per Command.
+type CommandCardHandler func(ctx context.Context, cc CommandContext) (*Card, error)
 
 // CommandContext is the dispatch envelope passed to each handler.
 type CommandContext struct {
@@ -25,12 +36,15 @@ type CommandContext struct {
 	Raw     string   // full original text (e.g. "/help arg1 arg2")
 }
 
-// Command describes one registered slash command.
+// Command describes one registered slash command. Exactly one of
+// Handler or CardHandler must be set; CardHandler takes precedence
+// when both are provided (config error — logged).
 type Command struct {
-	Name        string         // lowercased, no leading "/"
-	Description string         // shown in /help
-	Handler     CommandHandler // invoked when the command fires
-	Source      string         // "builtin" | "session" | "custom"
+	Name        string             // lowercased, no leading "/"
+	Description string             // shown in /help
+	Handler     CommandHandler     // plain-text reply
+	CardHandler CommandCardHandler // structured reply (cards + buttons)
+	Source      string             // "builtin" | "session" | "custom"
 }
 
 // CommandRegistry holds the set of available slash commands.

--- a/internal/channel/hub.go
+++ b/internal/channel/hub.go
@@ -383,6 +383,42 @@ func (h *Hub) handleCommand(ctx context.Context, msg ChannelMessage, mid int64, 
 		Channel: ch, Message: msg, Hub: h,
 		Command: name, Args: args, Raw: msg.Text,
 	}
+	// CardHandler wins when both are set — structured reply
+	// (buttons) is strictly more capable than plain text, and the
+	// CardSender adapters degrade to Card.RenderText() on channels
+	// that don't render buttons. We log the misconfig so future
+	// contributors notice they accidentally provided both.
+	if cmd.CardHandler != nil {
+		if cmd.Handler != nil {
+			h.log.Warn("command has both Handler and CardHandler; using CardHandler",
+				"command", name)
+		}
+		card, err := cmd.CardHandler(ctx, cc)
+		if err != nil {
+			h.log.Error("card command handler failed", "command", name, "err", err)
+			h.replyText(ctx, ch, msg,
+				fmt.Sprintf("Error running /%s: %s", name, err))
+			return
+		}
+		if card == nil {
+			return
+		}
+		out := ChannelMessage{
+			ChannelID: msg.ChannelID,
+			Direction: DirectionOutbound,
+			Text:      card.RenderText(),
+			Timestamp: time.Now().UTC(),
+			ReplyCtx:  msg.ReplyCtx,
+		}
+		if err := h.sendWithFallback(ctx, ch, out, card); err != nil {
+			h.log.Error("send card reply", "command", name, "err", err)
+		}
+		return
+	}
+	if cmd.Handler == nil {
+		h.log.Warn("command has no handler", "command", name)
+		return
+	}
 	reply, err := cmd.Handler(ctx, cc)
 	if err != nil {
 		h.log.Error("command handler failed", "command", name, "err", err)


### PR DESCRIPTION
## Summary
- Session IDs are nano-style (\`ses_jwwDK7iAGqA-\`) — opaque enough that operators basically cannot type them correctly on a phone. Even copy-paste is awkward through a Telegram chat. After #144 the commands worked but were practically unusable from mobile.
- This PR makes \`/list\` return a structured Card with one tappable button per session. Tap → executes the right \`/end <full_id>\` or \`/resume <full_id>\` without the operator ever seeing the id.

## UX
- **Live** sessions (pending/running/idle) → red **End N short…** button carrying \`cmd:/end <full_sid>\` in its callback data.
- **Terminated** sessions (stopped/ended) → blue **Resume N short…** button carrying \`cmd:/resume <full_sid>\`.
- Buttons are arranged **2 per row** for mobile tap-target density.
- The text body still lists every full session id (numbered) so operators who prefer typing or want to copy-paste can do so.

Example reply to \`/list\`:
\`\`\`
2 sessions (showing 3):
1. ses_jwwDK7iAGqA- — claude — running — 2m ago
2. ses_ZJLKi5vUrD0l — gemini — idle — 5m ago
3. ses_oldEndedAbcd — claude — ended — 1d ago

[End 1 jwwDK7…]  [End 2 ZJLKi5…]
[Resume 3 oldEnd…]
\`\`\`

## Plumbing — new CommandCardHandler
\`\`\`go
type CommandCardHandler func(ctx context.Context, cc CommandContext) (*Card, error)
\`\`\`
added alongside the existing \`CommandHandler\`. \`Command\` struct has an optional \`CardHandler\` field; \`Hub.handleCommand\` dispatches to it when set and sends via \`sendWithFallback\` so CardSender channels (Telegram) render buttons natively while non-card channels degrade to \`Card.RenderText()\`.

Card payload format is identical to the idle / ended notification cards (\`Value=\"cmd:/end <sid>\"\`), so the existing \`ParseCommand\` path in \`handleInbound\` routes button taps back into the same \`/end\` and \`/resume\` handlers — no new dispatcher needed.

## Tests
- Existing /list tests reworked to extract markdown + button slice from the Card; same recency-ordering and cap-at-max assertions.
- \`TestListSessionsCardHandler_ButtonsCarryFullIdAndCorrectVerb\` — pins that live sessions get End buttons with full IDs in the callback, terminated ones get Resume. The actual UX guarantee.
- \`TestSessionShortID\` — button-label abbreviation (\`ses_jwwDK7iAGqA-\` → \`jwwDK7…\`) is distinctive enough to disambiguate in practice.
- Empty-state and cap-at-listSessionsMax cases preserved.

## Test plan
- [ ] \`go test ./...\` — all green.
- [ ] Restart gateway; \`/list\` in Telegram returns a message with one tap-button per session (End for live, Resume for terminated).
- [ ] Tap an End button on a running session → it ends. Tap a Resume on an ended one → it resumes.
- [ ] Plain text \`/end <full_sid>\` still works for operators who copy-paste.
- [ ] Non-card channels (if any are configured) still see /list as plain text via Card.RenderText() fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)