### PR TITLE
fix(channel): type forwarded text rune-by-rune to defeat Gemini paste heuristic

### DIFF
--- a/internal/channel/hub.go
+++ b/internal/channel/hub.go
@@ -85,14 +85,22 @@ const outboundIndexMax = 256
 // per channel.
 const defaultCooldown = 5 * time.Minute
 
-// submitDelay is the pause between writing forwarded text and the
-// trailing carriage return. Long enough that Ink-style input
-// handlers (Gemini in particular) finish processing the text as a
-// keypress sequence before the Enter byte arrives — short enough
-// to feel instantaneous to the human on the other end. Empirically
-// ~30 ms is the sweet spot; the human-perception threshold is
-// ~100 ms.
+// submitDelay is the settle window between the final typed rune
+// and the carriage-return byte that fires Enter. Long enough that
+// Ink-style input handlers (Gemini in particular) process the
+// preceding text as keystrokes before the Enter arrives — short
+// enough to feel instantaneous to the human on the other end.
+// ~30 ms is the empirical sweet spot; the human-perception
+// threshold for unrelated chat interactions is ~100 ms.
 const submitDelay = 30 * time.Millisecond
+
+// perRuneDelay paces the rune-by-rune typing in submitToSession.
+// 5 ms is faster than any real human but slow enough that the
+// Ink event loop processes each rune as its own keystroke event
+// — i.e. the CLI cannot collapse the burst into a paste-mode
+// classification. A 20-rune chat message ends up taking ~100 ms
+// to "type", invisible against any chat round-trip.
+const perRuneDelay = 5 * time.Millisecond
 
 func NewHub(pool *pgxpool.Pool, bus *eventbus.Hub, log *slog.Logger) *Hub {
 	if log == nil {
@@ -843,28 +851,53 @@ func (h *Hub) setActiveSession(channelID, sessionID string) {
 	h.activeSess[channelID] = sessionID
 }
 
-// submitToSession writes forwarded text to a session's PTY in two
-// stages: the body, a brief pause, then the Enter terminator. See
-// the comment block above handleInbound's forwarding branch for
-// why a single combined write breaks Gemini's input detection.
+// submitToSession types `text` into a session's PTY rune-by-rune,
+// mimicking what xterm.js does for keyboard input — each rune is
+// its own write, with a brief inter-key pause — then sends a
+// final \r on its own as the Enter keypress.
+//
+// Why not a single text+\r write: Gemini's Ink-based input handler
+// classifies any multi-byte PTY write as a paste burst. In paste
+// mode the trailing Enter is swallowed as part of the paste
+// payload (multi-line paste with embedded newline) instead of
+// firing the submit handler. xterm.js sidesteps this by emitting
+// one PTY write per real keystroke; we mirror that exactly so the
+// CLI cannot tell our input apart from a human typing.
+//
+// Cost: ~5 ms per rune means a 20-rune chat message takes ~100 ms
+// to "type" — at or below the human-perception threshold for
+// chat interactions, and trivial compared to the round-trip to a
+// remote Gemini API. Long pastes (a multi-KB blob) would degrade,
+// but operators paste those into the web admin, not Telegram.
 //
 // Cancellable via ctx — partial sends are surfaced as errors so
 // the caller can report failure back to the chat. Submitting an
-// empty body is a no-op (returns nil); submitting only the Enter
-// is supported and exercised by tests.
+// empty body is a no-op for the typing loop but still emits the
+// final Enter (useful for chat platforms that surface tap-Enter
+// gestures as empty submissions).
 func (h *Hub) submitToSession(ctx context.Context, sid, text string) error {
 	if h.input == nil {
 		return errors.New("session input not configured")
 	}
-	if text != "" {
-		if err := h.input.Input(ctx, sid, []byte(text)); err != nil {
+	for _, r := range text {
+		if err := h.input.Input(ctx, sid, []byte(string(r))); err != nil {
 			return err
 		}
 		select {
-		case <-time.After(submitDelay):
+		case <-time.After(perRuneDelay):
 		case <-ctx.Done():
 			return ctx.Err()
 		}
+	}
+	// A slightly larger settle window between the last keystroke
+	// and the Enter byte, mirroring the natural human pause before
+	// pressing Return. Empirically this is what makes Gemini fire
+	// the submit handler instead of treating Enter as part of the
+	// paste payload.
+	select {
+	case <-time.After(submitDelay):
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 	if err := h.input.Input(ctx, sid, []byte{'\r'}); err != nil {
 		return fmt.Errorf("submit: %w", err)

--- a/internal/channel/hub_submit_test.go
+++ b/internal/channel/hub_submit_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 // recordingInputter captures every Input call with a timestamp so
-// tests can assert both the byte split (text vs Enter) and the
-// ordering / gap between them.
+// tests can assert both the byte split (one write per rune + one
+// for Enter) and the inter-key timing.
 type recordingInputter struct {
 	mu    sync.Mutex
 	calls []recordedInput
@@ -29,7 +29,6 @@ func (r *recordingInputter) Input(_ context.Context, sid string, data []byte) er
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	// Copy data because callers may reuse the slice.
 	cp := make([]byte, len(data))
 	copy(cp, data)
 	r.calls = append(r.calls, recordedInput{sid: sid, data: cp, ts: time.Now()})
@@ -44,38 +43,12 @@ func (r *recordingInputter) snapshot() []recordedInput {
 	return out
 }
 
-// The headline regression: forwarding "hello" to a session must
-// produce TWO PTY writes — body first, Enter byte second — with
-// the body alone in the first write. A single combined "hello\r"
-// write is what made Gemini swallow the Enter.
-func TestSubmitToSession_TwoWritesWithEnterAlone(t *testing.T) {
-	h := newTestHub(t)
-	rec := &recordingInputter{}
-	h.SetSessionInput(rec)
-
-	if err := h.submitToSession(context.Background(), "ses_x", "hello"); err != nil {
-		t.Fatal(err)
-	}
-	got := rec.snapshot()
-	if len(got) != 2 {
-		t.Fatalf("want 2 PTY writes, got %d: %v", len(got), got)
-	}
-	if string(got[0].data) != "hello" {
-		t.Errorf("first write should be body only, got %q", got[0].data)
-	}
-	if len(got[1].data) != 1 || got[1].data[0] != '\r' {
-		t.Errorf("second write should be \\r alone, got %q", got[1].data)
-	}
-	if got[0].sid != "ses_x" || got[1].sid != "ses_x" {
-		t.Errorf("both writes should target the same session: %v", got)
-	}
-}
-
-// The pause between the two writes is what gives the Ink input
-// handler time to process the body as keystrokes before the Enter
-// byte arrives. Verify it's actually sleeping at least the
-// declared delay (with a small fudge for scheduling jitter).
-func TestSubmitToSession_PausesBetweenWrites(t *testing.T) {
+// The headline regression: forwarding "hi" must produce three
+// PTY writes — 'h', 'i', '\r' — each on its own. A single combined
+// write made Gemini classify the burst as a paste and swallow the
+// trailing Enter. xterm.js emits one write per real keystroke; we
+// mirror that.
+func TestSubmitToSession_RuneByRuneThenEnter(t *testing.T) {
 	h := newTestHub(t)
 	rec := &recordingInputter{}
 	h.SetSessionInput(rec)
@@ -84,21 +57,88 @@ func TestSubmitToSession_PausesBetweenWrites(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := rec.snapshot()
-	if len(got) != 2 {
-		t.Fatalf("want 2 writes, got %d", len(got))
+	if len(got) != 3 {
+		t.Fatalf("want 3 PTY writes (h, i, \\r), got %d: %v", len(got), got)
 	}
-	gap := got[1].ts.Sub(got[0].ts)
-	// Allow 5 ms slack — submitDelay is 30 ms, so even a noisy
-	// scheduler should comfortably clear 25 ms.
-	if gap < submitDelay-5*time.Millisecond {
-		t.Errorf("write gap %v shorter than submitDelay %v; submit may be batched",
-			gap, submitDelay)
+	if string(got[0].data) != "h" {
+		t.Errorf("write[0] should be 'h' alone, got %q", got[0].data)
+	}
+	if string(got[1].data) != "i" {
+		t.Errorf("write[1] should be 'i' alone, got %q", got[1].data)
+	}
+	if len(got[2].data) != 1 || got[2].data[0] != '\r' {
+		t.Errorf("write[2] should be \\r alone, got %q", got[2].data)
+	}
+	for i, c := range got {
+		if c.sid != "ses_x" {
+			t.Errorf("write[%d] sid = %q, want ses_x", i, c.sid)
+		}
 	}
 }
 
-// Empty body should skip the body write but still emit the Enter
-// alone — useful for "tap Enter" gestures that the chat platform
-// might surface as empty-text submissions.
+// UTF-8 must be split by RUNE, not byte. A Chinese character is
+// 3 bytes — sending one byte at a time would deliver three garbled
+// bytes to the CLI's UTF-8 decoder. Each rune is one keystroke.
+func TestSubmitToSession_UTF8SplitByRune(t *testing.T) {
+	h := newTestHub(t)
+	rec := &recordingInputter{}
+	h.SetSessionInput(rec)
+
+	if err := h.submitToSession(context.Background(), "ses_x", "你好"); err != nil {
+		t.Fatal(err)
+	}
+	got := rec.snapshot()
+	// 2 runes + 1 Enter = 3 writes
+	if len(got) != 3 {
+		t.Fatalf("want 3 writes (你, 好, \\r), got %d", len(got))
+	}
+	if string(got[0].data) != "你" {
+		t.Errorf("first rune mangled: %q", got[0].data)
+	}
+	if string(got[1].data) != "好" {
+		t.Errorf("second rune mangled: %q", got[1].data)
+	}
+	if got[2].data[0] != '\r' {
+		t.Errorf("expected Enter last, got %q", got[2].data)
+	}
+}
+
+// Between every adjacent pair of writes there must be a delay —
+// either perRuneDelay (between two runes / between last rune and
+// Enter pause start) or at least submitDelay (between last rune
+// and Enter). We don't need to nail the exact value, just verify
+// the writes aren't all bunched in the same millisecond (which is
+// what a single PTY write or zero-delay loop would produce).
+func TestSubmitToSession_HasInterKeyDelay(t *testing.T) {
+	h := newTestHub(t)
+	rec := &recordingInputter{}
+	h.SetSessionInput(rec)
+
+	if err := h.submitToSession(context.Background(), "ses_x", "ab"); err != nil {
+		t.Fatal(err)
+	}
+	got := rec.snapshot()
+	if len(got) != 3 {
+		t.Fatalf("want 3 writes, got %d", len(got))
+	}
+	betweenRunes := got[1].ts.Sub(got[0].ts)
+	// Allow generous slack: perRuneDelay is 5ms, but a noisy
+	// scheduler might still come close to zero. Require at least
+	// 1ms so single-write or zero-delay regressions can't pass.
+	if betweenRunes < time.Millisecond {
+		t.Errorf("no delay between runes: %v — keystrokes may be batched", betweenRunes)
+	}
+	beforeEnter := got[2].ts.Sub(got[1].ts)
+	// Final pause should be the larger submitDelay (30ms).
+	if beforeEnter < submitDelay-5*time.Millisecond {
+		t.Errorf("settle pause before Enter %v shorter than submitDelay %v",
+			beforeEnter, submitDelay)
+	}
+}
+
+// Empty body skips the typing loop but still emits the Enter —
+// useful for chat platforms that might surface tap-Enter gestures
+// as empty-text submissions.
 func TestSubmitToSession_EmptyBodyOnlySendsEnter(t *testing.T) {
 	h := newTestHub(t)
 	rec := &recordingInputter{}
@@ -116,25 +156,32 @@ func TestSubmitToSession_EmptyBodyOnlySendsEnter(t *testing.T) {
 	}
 }
 
-// A cancelled ctx during the pause should bail out — we already
-// wrote the body, so the test asserts (body sent, no Enter, error
-// returned). The caller surfaces this to the chat as a delivery
-// failure.
-func TestSubmitToSession_CancelledDuringPause(t *testing.T) {
+// Cancelled context aborts cleanly between keystrokes — whatever
+// runes already arrived at the PTY are not "undone", but the
+// caller gets context.Canceled so it can report failure to the
+// chat and won't keep typing into a defunct session.
+func TestSubmitToSession_CancelledDuringTyping(t *testing.T) {
 	h := newTestHub(t)
 	rec := &recordingInputter{}
 	h.SetSessionInput(rec)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // cancel before the call so the select's ctx.Done path fires
+	cancel() // cancel before the call so the very first select fires
 
 	err := h.submitToSession(ctx, "ses_x", "hello")
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("want context.Canceled, got %v", err)
 	}
+	// At least the first rune should have been written before the
+	// post-rune select observed the cancel.
 	got := rec.snapshot()
-	if len(got) != 1 || string(got[0].data) != "hello" {
-		t.Errorf("body should have been sent before cancel: %v", got)
+	if len(got) == 0 {
+		t.Error("expected at least the first rune to have been written")
+	}
+	for _, c := range got {
+		if len(c.data) > 0 && c.data[0] == '\r' {
+			t.Error("Enter should not have been emitted after cancel")
+		}
 	}
 }
 
@@ -156,7 +203,6 @@ func TestSubmitToSession_PropagatesPtyWriteError(t *testing.T) {
 // should refuse cleanly instead of nil-derefing.
 func TestSubmitToSession_NoInputterReturnsError(t *testing.T) {
 	h := newTestHub(t)
-	// h.input is nil
 	err := h.submitToSession(context.Background(), "ses_x", "hi")
 	if err == nil {
 		t.Error("want error when no SessionInputter wired, got nil")


### PR DESCRIPTION
## Stacked on #146 + #147; this is the final piece
- #146 split body and Enter into two writes.
- #147 stripped the Device-Attribute response that was poisoning Gemini's parser state.
- Both helped but Telegram→Gemini submit *still* failed. Text now arrives cleanly in the prompt, but Enter doesn't fire.

## Final root cause
Gemini's Ink-based input handler classifies a **single multi-byte PTY write as a paste burst**, regardless of any delay that follows. In paste mode the next Enter is treated as part of the paste payload (embedded newline) rather than as the submit gesture. xterm.js doesn't trip this because real keyboard input lands as **one PTY write per keystroke** — we hadn't been mirroring that.

## Fix
\`submitToSession\` now types the body **rune-by-rune**:
- Each rune is its own PTY write with \`perRuneDelay\` (5 ms) between writes.
- Then a \`submitDelay\` (30 ms) settle pause.
- Then the final \`\\r\` byte on its own.

Cost: ~100 ms to "type" a 20-rune chat message — invisible against any chat round-trip, well under the 100 ms human-perception threshold for unrelated interactions. Long blobs would degrade linearly; chat isn't where operators paste those.

**Rune-level splitting** (not byte-level) keeps UTF-8 intact: a 3-byte CJK character ships as ONE write, not three, so the CLI's UTF-8 decoder sees the whole codepoint atomically.

Claude and Codex are unaffected — they happily process either a single bulk write or a rune-by-rune stream; only the latency profile changes (still imperceptible).

## Tests
- \`TestSubmitToSession_RuneByRuneThenEnter\` — pins one write per rune + one for \`\\r\`
- \`TestSubmitToSession_UTF8SplitByRune\` — \`你好\\r\` emits THREE writes (not five), each rune delivered as a complete codepoint
- \`TestSubmitToSession_HasInterKeyDelay\` — verifies actual time gap between writes (regression to single-write compresses all writes to the same millisecond)
- \`TestSubmitToSession_EmptyBodyOnlySendsEnter\`, \`_CancelledDuringTyping\`, \`_PropagatesPtyWriteError\`, \`_NoInputterReturnsError\` — preserved from #146

## Test plan
- [ ] \`go test ./internal/channel/... -run TestSubmitToSession -v\` — all 7 pass.
- [ ] Restart gateway. Spawn a fresh Gemini session. Send a message from Telegram → verify it submits without manual Enter, and that response prose comes back as expected.
- [ ] Try a Chinese message (\`获取项目记忆\`) → verify UTF-8 lands intact (no garbled bytes).
- [ ] Send a long-ish multi-sentence message (~100 chars) → verify the ~500 ms typing latency is acceptable.
- [ ] Claude session: no regression.
- [ ] Codex session: no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)