### PR TITLE
fix(session): Gemini idle-snippet parity + lock PTY canvas size

### DIFF
--- a/internal/session/gemini_jsonl.go
+++ b/internal/session/gemini_jsonl.go
@@ -99,6 +99,64 @@ func GeminiInputHistory(cfg GeminiHistoryConfig, cwd string, limit int) []Projec
 	return out
 }
 
+// geminiRecentResponse returns Gemini's most-recent "model" reply
+// for `cwd`, suitable for embedding in a chat-side idle-notification
+// snippet. Mirrors claudeRecentResponse for the Gemini provider so
+// the snippet doesn't degrade to the ScreenSnapshot fallback (which
+// is bounded by terminal grid size, ~1 screenful — the same "1/11
+// of the actual reply" problem that fixed-for-Claude in #143).
+//
+// Schema: ~/.gemini/tmp/<dir>/logs.json is a JSON array of entries
+// `{sessionId, messageId, type, message, timestamp}`. We pick the
+// model entry with the latest timestamp (the file isn't strictly
+// sorted; Gemini appends as messages arrive, but ordering within
+// the array is not contractual).
+//
+// Returns "" when no transcript exists, the file is unreadable, or
+// no model reply is present yet. Callers fall through to the
+// next snippet source in the priority chain.
+func geminiRecentResponse(cwd string) string {
+	home := os.Getenv("HOME")
+	if home == "" {
+		return ""
+	}
+	tmpRoot := filepath.Join(home, ".gemini", "tmp")
+	projectsFile := filepath.Join(home, ".gemini", "projects.json")
+	dir := findGeminiProjectDir(projectsFile, tmpRoot, cwd)
+	if dir == "" {
+		return ""
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "logs.json"))
+	if err != nil {
+		return ""
+	}
+	var raw []geminiLogEntry
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return ""
+	}
+	// Walk all entries and remember the latest model reply. We
+	// compare by timestamp rather than trusting file order — a
+	// long-running session can have model entries interleaved with
+	// user prompts.
+	var latest *geminiLogEntry
+	for i := range raw {
+		e := &raw[i]
+		if e.Type != "model" {
+			continue
+		}
+		if strings.TrimSpace(e.Message) == "" {
+			continue
+		}
+		if latest == nil || e.Timestamp.After(latest.Timestamp) {
+			latest = e
+		}
+	}
+	if latest == nil {
+		return ""
+	}
+	return strings.TrimSpace(latest.Message)
+}
+
 // findGeminiProjectDir resolves cwd to the matching tmp/<dir>/
 // folder. Tries each strategy in order; returns "" when none hit.
 func findGeminiProjectDir(projectsFile, tmpRoot, cwd string) string {

--- a/internal/session/gemini_recent_response_test.go
+++ b/internal/session/gemini_recent_response_test.go
@@ -1,0 +1,209 @@
+package session
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeGeminiLogs writes a logs.json under the SHA-256-hashed
+// project dir for `cwd`. Returns the file path so individual tests
+// can mutate it if needed.
+func writeGeminiLogs(t *testing.T, cwd string, entries []map[string]any) string {
+	t.Helper()
+	home := os.Getenv("HOME")
+	hash := sha256.Sum256([]byte(cwd))
+	dir := filepath.Join(home, ".gemini", "tmp", hex.EncodeToString(hash[:]))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(entries)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "logs.json")
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestGeminiRecentResponse_PicksLatestModelReply(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := "/tmp/proj/gemini-test"
+	writeGeminiLogs(t, cwd, []map[string]any{
+		{
+			"sessionId": "sess-1",
+			"messageId": 0,
+			"type":      "user",
+			"message":   "first prompt",
+			"timestamp": "2026-05-04T10:00:00.000Z",
+		},
+		{
+			"sessionId": "sess-1",
+			"messageId": 1,
+			"type":      "model",
+			"message":   "earlier reply that should NOT win",
+			"timestamp": "2026-05-04T10:00:01.000Z",
+		},
+		{
+			"sessionId": "sess-1",
+			"messageId": 2,
+			"type":      "user",
+			"message":   "follow-up",
+			"timestamp": "2026-05-04T10:01:00.000Z",
+		},
+		{
+			"sessionId": "sess-1",
+			"messageId": 3,
+			"type":      "model",
+			"message":   "MOST_RECENT_REPLY_SENTINEL",
+			"timestamp": "2026-05-04T10:01:30.000Z",
+		},
+	})
+
+	got := geminiRecentResponse(cwd)
+	if got != "MOST_RECENT_REPLY_SENTINEL" {
+		t.Errorf("expected newest model reply, got %q", got)
+	}
+}
+
+// File order isn't trusted — Gemini appends as messages arrive but
+// the contract is timestamp-based. The resolver compares timestamps
+// across all entries.
+func TestGeminiRecentResponse_TimestampWinsOverFileOrder(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := "/tmp/proj/gemini-out-of-order"
+	writeGeminiLogs(t, cwd, []map[string]any{
+		// File-order LATER but timestamp EARLIER:
+		{
+			"sessionId": "sess-1",
+			"messageId": 10,
+			"type":      "model",
+			"message":   "EARLIER_BY_TIMESTAMP",
+			"timestamp": "2026-05-04T09:00:00.000Z",
+		},
+		// File-order EARLIER but timestamp LATER:
+		{
+			"sessionId": "sess-1",
+			"messageId": 1,
+			"type":      "model",
+			"message":   "LATER_BY_TIMESTAMP",
+			"timestamp": "2026-05-04T12:00:00.000Z",
+		},
+	})
+
+	got := geminiRecentResponse(cwd)
+	if got != "LATER_BY_TIMESTAMP" {
+		t.Errorf("timestamp ordering broken; got %q", got)
+	}
+}
+
+func TestGeminiRecentResponse_IgnoresUserPrompts(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := "/tmp/proj/gemini-no-model-yet"
+	writeGeminiLogs(t, cwd, []map[string]any{
+		{
+			"sessionId": "sess-1",
+			"messageId": 0,
+			"type":      "user",
+			"message":   "this should not appear",
+			"timestamp": "2026-05-04T10:00:00.000Z",
+		},
+		{
+			"sessionId": "sess-1",
+			"messageId": 1,
+			"type":      "user",
+			"message":   "neither should this",
+			"timestamp": "2026-05-04T10:00:01.000Z",
+		},
+	})
+
+	if got := geminiRecentResponse(cwd); got != "" {
+		t.Errorf("expected empty when no model reply, got %q", got)
+	}
+}
+
+func TestGeminiRecentResponse_IgnoresEmptyMessages(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := "/tmp/proj/gemini-empty-model"
+	writeGeminiLogs(t, cwd, []map[string]any{
+		{
+			"sessionId": "sess-1",
+			"messageId": 0,
+			"type":      "model",
+			"message":   "",
+			"timestamp": "2026-05-04T10:00:00.000Z",
+		},
+		{
+			"sessionId": "sess-1",
+			"messageId": 1,
+			"type":      "model",
+			"message":   "   ",
+			"timestamp": "2026-05-04T10:00:01.000Z",
+		},
+		{
+			"sessionId": "sess-1",
+			"messageId": 2,
+			"type":      "model",
+			"message":   "real content here",
+			"timestamp": "2026-05-04T10:00:02.000Z",
+		},
+	})
+
+	if got := geminiRecentResponse(cwd); got != "real content here" {
+		t.Errorf("expected non-empty model message; got %q", got)
+	}
+}
+
+func TestGeminiRecentResponse_NoTranscriptReturnsEmpty(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if got := geminiRecentResponse("/tmp/proj/never-touched"); got != "" {
+		t.Errorf("expected empty for missing transcript, got %q", got)
+	}
+}
+
+func TestGeminiRecentResponse_NoHomeReturnsEmpty(t *testing.T) {
+	t.Setenv("HOME", "")
+	if got := geminiRecentResponse("/anything"); got != "" {
+		t.Errorf("expected empty when HOME unset, got %q", got)
+	}
+}
+
+func TestGeminiRecentResponse_MalformedJSONReturnsEmpty(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	cwd := "/tmp/proj/malformed"
+	hash := sha256.Sum256([]byte(cwd))
+	dir := filepath.Join(tmpHome, ".gemini", "tmp", hex.EncodeToString(hash[:]))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "logs.json"),
+		[]byte("not valid json {"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := geminiRecentResponse(cwd); got != "" {
+		t.Errorf("expected empty on malformed json, got %q", got)
+	}
+}
+
+func TestGeminiRecentResponse_TrimsWhitespace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := "/tmp/proj/whitespace"
+	writeGeminiLogs(t, cwd, []map[string]any{
+		{
+			"sessionId": "sess-1",
+			"messageId": 0,
+			"type":      "model",
+			"message":   "\n  the actual reply  \n\n",
+			"timestamp": "2026-05-04T10:00:00.000Z",
+		},
+	})
+	if got := geminiRecentResponse(cwd); got != "the actual reply" {
+		t.Errorf("whitespace not trimmed; got %q", got)
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -30,13 +30,37 @@ const (
 	defaultIdleThreshold = 30 * time.Second
 	defaultIdleInterval  = 5 * time.Second
 
-	// defaultVTCols / defaultVTRows seed the virtual terminal we keep
-	// for screen snapshots. Most modern CLIs query the real PTY size on
-	// startup and re-render to fit, so the actual width arrives via the
-	// first /resize call — these defaults just give a sane initial
-	// canvas. Cards rendering wider than this get clipped.
-	defaultVTCols = 120
-	defaultVTRows = 40
+	// lockedPTYCols / lockedPTYRows: the fixed canvas size every
+	// session runs on. We intentionally lock it instead of letting
+	// client-side resize requests change it.
+	//
+	// Why: a PTY has exactly ONE size, but a session can have
+	// multiple clients attached at once (web + mobile + Telegram).
+	// When any client tells the gateway to resize, the TUI inside
+	// the PTY re-renders to that new size — corrupting the layout
+	// for every OTHER attached client. The web window getting
+	// dragged around shouldn't disrupt the operator's phone
+	// session, and vice versa.
+	//
+	// The chosen size is mobile-first: 100 cols is wide enough that
+	// Claude / Gemini layouts don't truncate or wrap unhelpfully,
+	// and narrow enough that portrait-phone xterms can render the
+	// full width with a comfortable font. Web clients with larger
+	// windows render the same canvas inside their viewport with
+	// the surrounding area letterboxed.
+	//
+	// Operators who need a different canvas can change these
+	// constants and rebuild; making them per-session config is a
+	// future enhancement.
+	lockedPTYCols = 100
+	lockedPTYRows = 32
+)
+
+// Backwards-compatible aliases for the previous `defaultVT*`
+// constants, in case external code referenced them.
+const (
+	defaultVTCols = lockedPTYCols
+	defaultVTRows = lockedPTYRows
 )
 
 // ManagerOption mutates Manager defaults; pass to NewManager.
@@ -383,6 +407,11 @@ func (m *Manager) spawn(ctx context.Context, sess Session, reactivate bool) (*ru
 		_ = os.RemoveAll(tempDir)
 		return nil, fmt.Errorf("pty.Start: %w", err)
 	}
+	// Lock the PTY canvas size before any TUI inside it runs. Errors
+	// here are non-fatal — a misconfigured kernel would still let the
+	// session spawn at the PTY's default size, just slightly larger
+	// or smaller than we want. The TUI re-queries on first render.
+	_ = pty.Setsize(ptmx, &pty.Winsize{Cols: lockedPTYCols, Rows: lockedPTYRows})
 
 	sess.PID = cmd.Process.Pid
 	sess.State = StateRunning
@@ -688,15 +717,22 @@ func (m *Manager) Input(_ context.Context, id string, data []byte) error {
 	return nil
 }
 
-func (m *Manager) Resize(_ context.Context, id string, cols, rows uint16) error {
-	rs := m.lookup(id)
-	if rs == nil {
+// Resize is intentionally a no-op. PTY canvas size is locked at
+// spawn (see lockedPTYCols / lockedPTYRows). The handler is kept
+// so existing clients (web xterm.js with FitAddon, mobile xterm)
+// don't see HTTP errors when they auto-fit on attach — we just
+// ignore the requested dimensions and let the TUI keep rendering
+// at the locked canvas size. Each client is responsible for
+// adapting its local viewport (letterboxing, font scaling,
+// scrolling) to the fixed canvas.
+//
+// The error path is preserved so callers can still distinguish a
+// missing session ID from a successful no-op.
+func (m *Manager) Resize(_ context.Context, id string, _, _ uint16) error {
+	if m.lookup(id) == nil {
 		return ErrNotFound
 	}
-	if rs.vt != nil && cols > 0 && rows > 0 {
-		rs.vt.Resize(int(cols), int(rows))
-	}
-	return pty.Setsize(rs.pty, &pty.Winsize{Cols: cols, Rows: rows})
+	return nil
 }
 
 // Subscribe registers a channel that receives every chunk of stdout

--- a/internal/session/pump.go
+++ b/internal/session/pump.go
@@ -85,11 +85,11 @@ func (m *Manager) idleWatcher(rs *runningSession) {
 				"idle_for_ms": m.idleThreshold.Milliseconds(),
 			}
 			// Snippet source priority:
-			//   1. Claude JSONL transcript — full clean assistant
-			//      response, no TUI chrome, no truncation
-			//   2. Virtual-terminal screen snapshot — what the user
+			//   1. Claude JSONL transcript (claude provider)
+			//   2. Gemini logs.json transcript (gemini provider)
+			//   3. Virtual-terminal screen snapshot — what the user
 			//      sees in the live web terminal right now
-			//   3. Raw ring-buffer tail — defensive fallback
+			//   4. Raw ring-buffer tail — defensive fallback
 			//
 			// We deliberately do NOT cap byte / line counts at the
 			// source. The channel layer owns user-facing truncation
@@ -105,6 +105,9 @@ func (m *Manager) idleWatcher(rs *runningSession) {
 			rs.sessMu.RUnlock()
 			if provider == "claude" && cwd != "" {
 				snippet = claudeRecentResponse(cwd)
+			}
+			if snippet == "" && provider == "gemini" && cwd != "" {
+				snippet = geminiRecentResponse(cwd)
 			}
 			if snippet == "" && rs.vt != nil {
 				snippet = ScreenSnapshot(rs.vt)


### PR DESCRIPTION
## Two unrelated mobile UX regressions, bundled

### 1. Gemini idle-notification snippet was incomplete on Telegram

\`pump.go\` only had a Claude branch in its snippet-source chain:
\`\`\`go
if provider == \"claude\" && cwd != \"\" {
    snippet = claudeRecentResponse(cwd)
}
\`\`\`
Gemini sessions fell through to \`ScreenSnapshot\` — bounded by the virtual terminal grid (~24 rows) — so operators got roughly one screenful instead of the actual model reply. Same problem we fixed for Claude in #143.

**Fix:** new \`geminiRecentResponse(cwd)\` in \`gemini_jsonl.go\` mirrors \`claudeRecentResponse\` — resolves cwd to \`~/.gemini/tmp/<dir>/logs.json\` via the existing \`findGeminiProjectDir\` helper, finds the entry with \`type==\"model\"\` and the latest timestamp, returns the trimmed \`Message\`. \`pump.go\`'s chain now tries Gemini after Claude and before \`ScreenSnapshot\`.

### 2. Web client resize was breaking mobile client display

A PTY has exactly one size, but a session can have multiple clients attached at once (web + mobile + Telegram). When any client called \`/resize\` the TUI re-rendered to that new size, **corrupting the layout for every other attached client**. Dragging the web admin window visibly shifted the operator's phone session.

**Fix:** lock the PTY canvas to a fixed size at spawn time and make \`Manager.Resize\` a no-op. New constants \`lockedPTYCols=100\` and \`lockedPTYRows=32\`:
- 100 cols wide enough that Claude / Gemini layouts don't wrap awkwardly
- Narrow enough that portrait-phone xterms render the full width with a comfortable font
- Web clients with larger windows display the same canvas letterboxed inside their viewport
- **Each client adapts its local viewport (scrolling, font scale) independently** — no more inter-client interference

The \`/resize\` HTTP endpoint and \`Manager.Resize\` signature are preserved so client-side auto-fit (FitAddon in xterm.js, the Dart fork's equivalent) doesn't see HTTP errors — we silently ignore the requested dimensions. \`ErrNotFound\` still propagates for unknown session ids.

Legacy \`defaultVTCols\` / \`defaultVTRows\` constants are kept as aliases of the new locked values for compatibility.

## Tests
8 new \`geminiRecentResponse\` cases:
- Picks latest model reply by **timestamp**, not file order
- Ignores user prompts and empty/whitespace-only messages
- Handles missing transcript / no \`HOME\` / malformed JSON
- Trims surrounding whitespace

Existing session test suite still green; the Resize no-op semantics are obvious from the code comment.

## Test plan
- [ ] \`go test ./internal/session/... -run TestGeminiRecentResponse -v\` — 8 tests pass.
- [ ] Restart gateway. Send a real Telegram message to a Gemini session, wait for idle → verify Telegram receives the **full** Gemini prose reply (no longer the screen-snapshot fallback).
- [ ] Start a session on mobile. Open web admin in browser. Drag the web window around → verify the mobile session's layout stays stable (no re-render disruption).
- [ ] Confirm web admin still displays the TUI at the locked 100×32 canvas (letterboxed if window is bigger). Adapting the web client's viewport to that canvas is a follow-up if needed.
- [ ] Claude sessions: no regression — idle snippet still works, layout still stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)