### PR TITLE
fix(lint): collapse chunkButtons loops with append-spread

### DIFF
--- a/internal/app/channel_commands.go
+++ b/internal/app/channel_commands.go
@@ -148,12 +148,8 @@ func listSessionsCardHandler(mgr sessionOps) channel.CommandCardHandler {
 			}
 		}
 		buttons := make([][]channel.ButtonOption, 0, 4)
-		for _, row := range chunkButtons(endRow, 2) {
-			buttons = append(buttons, row)
-		}
-		for _, row := range chunkButtons(resumeRow, 2) {
-			buttons = append(buttons, row)
-		}
+		buttons = append(buttons, chunkButtons(endRow, 2)...)
+		buttons = append(buttons, chunkButtons(resumeRow, 2)...)
 
 		elements := []channel.CardElement{
 			channel.CardMarkdown{Content: strings.TrimRight(b.String(), "\n")},


### PR DESCRIPTION
## Summary

Fixes the two `staticcheck S1011` warnings that are currently breaking the `Lint (Go)` job on main:

```
internal/app/channel_commands.go:151:3: S1011: should replace loop with
  buttons = append(buttons, chunkButtons(endRow, 2)...) (staticcheck)
internal/app/channel_commands.go:154:3: S1011: should replace loop with
  buttons = append(buttons, chunkButtons(resumeRow, 2)...) (staticcheck)
```

Both range-append loops are no-op iterations — every element of the returned `[][]channel.ButtonOption` is appended verbatim, with no per-element transformation. The spread form is semantically identical.

## Context

These were introduced in #145 (`/list` tappable End/Resume buttons). The warnings have been failing CI since that landed, but the failure was masked from 2026-05-15 23:28 UTC through 2026-05-16 00:30-ish UTC by a GitHub Actions billing block that prevented runners from being provisioned — every job failed in 3 seconds at the runner-allocation stage, so the actual lint output was never visible. After the org's billing was resolved and run 25947338049 was re-run, the underlying lint failure surfaced.

## Test plan

- [ ] `Lint (Go)` passes on this branch
- [ ] `Backend (Go)` still passes (channel_commands tests already cover `listSessionsCardHandler`)
- [ ] `/list` still renders End/Resume buttons in 2-per-row chunks (functionally unchanged)

## Notes for reviewer

Tiny PR — happy to fold into a larger cleanup commit if you'd rather keep these batched. The reason I split it out: HEAD is currently red, and a one-file lint fix is the fastest path to an all-green signal across the project (Frontend and Backend are already green on HEAD).