### PR TITLE
fix(web): auto-fit font to PTY canvas — fills window without driving PTY size

### DIFF
--- a/app/shared/src/lib/ws.ts
+++ b/app/shared/src/lib/ws.ts
@@ -12,6 +12,15 @@ export function wsURL(path: string, token: string): string {
 
 export interface BinaryWSCallbacks {
   onMessage?: (data: Uint8Array) => void
+  /**
+   * Optional handler for TextMessage frames. opendray's session
+   * stream uses these for out-of-band control payloads (currently
+   * just `{"type":"pty_size","cols":N,"rows":M}` at handshake +
+   * future PTY-size pushes). When unset, text frames fall through
+   * to onMessage as UTF-8 bytes — preserving pre-existing
+   * behaviour for callers that don't care about the distinction.
+   */
+  onText?: (text: string) => void
   onOpen?: () => void
   onClose?: () => void
   onError?: (err: Event) => void
@@ -82,7 +91,13 @@ export class BinaryWS {
       if (ev.data instanceof ArrayBuffer) {
         this.cb.onMessage?.(new Uint8Array(ev.data))
       } else if (typeof ev.data === 'string') {
-        this.cb.onMessage?.(new TextEncoder().encode(ev.data))
+        if (this.cb.onText) {
+          this.cb.onText(ev.data)
+        } else {
+          // Legacy fallback: deliver text frames as UTF-8 bytes so
+          // callers that haven't opted into onText still see them.
+          this.cb.onMessage?.(new TextEncoder().encode(ev.data))
+        }
       }
     }
     ws.onerror = (ev) => {

--- a/app/web/src/components/sessions/Terminal.tsx
+++ b/app/web/src/components/sessions/Terminal.tsx
@@ -7,7 +7,6 @@ import {
   useState,
 } from 'react'
 import { Terminal as XTerm } from '@xterm/xterm'
-import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
 import { toast } from 'sonner'
@@ -16,7 +15,40 @@ import { useTranslation } from 'react-i18next'
 import { useAuth } from '@/stores/auth'
 import { useTheme } from '@/stores/theme'
 import { BinaryWS, wsURL } from '@/lib/ws'
-import { resizeSession, uploadSessionFile } from '@/lib/sessions'
+import { uploadSessionFile } from '@/lib/sessions'
+
+// Heuristic monospace-cell aspect ratio for JetBrains Mono /
+// generic monospace. cellWidth ~= 0.6 × fontSize, cellHeight ~=
+// fontSize × lineHeight. Used by computeFontSize to fit a fixed
+// xterm grid into the container by scaling font alone.
+const CELL_W_RATIO = 0.6
+const LINE_HEIGHT = 1.25
+
+// Bounds keep font size sane on extreme container sizes:
+// minimum keeps text legible on a small split view; maximum keeps
+// the TUI from looking absurdly chunky on an ultrawide monitor.
+const MIN_FONT_SIZE = 9
+const MAX_FONT_SIZE = 28
+
+// computeFontSize returns the largest pixel font size such that a
+// `cols × rows` xterm grid fits inside a container of
+// `containerWidth × containerHeight`. Picks the limiting axis so
+// the grid fills one dimension entirely without overflowing the
+// other.
+function computeFontSize(
+  cols: number,
+  rows: number,
+  containerWidth: number,
+  containerHeight: number,
+): number {
+  if (cols <= 0 || rows <= 0) return 13
+  const cellWFromContainer = containerWidth / cols
+  const cellHFromContainer = containerHeight / rows
+  const fromWidth = cellWFromContainer / CELL_W_RATIO
+  const fromHeight = cellHFromContainer / LINE_HEIGHT
+  const raw = Math.floor(Math.min(fromWidth, fromHeight))
+  return Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, raw))
+}
 
 interface TerminalProps {
   sessionId: string
@@ -80,7 +112,13 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
 ) {
   const containerRef = useRef<HTMLDivElement>(null)
   const xtermRef = useRef<XTerm | null>(null)
-  const fitRef = useRef<FitAddon | null>(null)
+  // Grid dims locked to the server's PTY canvas (delivered via the
+  // first pty_size control frame). Container ResizeObserver scales
+  // fontSize against these to fill the browser viewport.
+  const gridRef = useRef<{ cols: number; rows: number }>({
+    cols: 100,
+    rows: 32,
+  })
   const wsRef = useRef<BinaryWS | null>(null)
   const token = useAuth((s) => s.token)
   const themeApplied = useTheme((s) => s.applied())
@@ -153,63 +191,97 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       allowProposedApi: true,
       convertEol: true,
     })
-    const fit = new FitAddon()
     const links = new WebLinksAddon()
-    term.loadAddon(fit)
     term.loadAddon(links)
     term.open(containerRef.current)
-    fit.fit()
     xtermRef.current = term
-    fitRef.current = fit
+    // Initial grid: matches the in-ref default; the server's first
+    // pty_size frame overrides as soon as the WS connects.
+    term.resize(gridRef.current.cols, gridRef.current.rows)
 
-    // alive flips false on cleanup so any straggler resize/onOpen
-    // callbacks scheduled before unmount don't fire `/resize` against
-    // a session that's just transitioned to ended — server returns
-    // 404 and browser logs it red in console even though we .catch().
+    // alive flips false on cleanup so any straggler ResizeObserver
+    // / onOpen callbacks scheduled before unmount don't act on a
+    // disposed terminal.
     let alive = true
+
+    // applyFontSize fits the locked grid into the current
+    // container by recomputing pixel font size. Pure-local: never
+    // touches the PTY. The server's pty_size frame already locked
+    // the grid; this just decides how big to render each cell.
+    const applyFontSize = () => {
+      if (!alive || !containerRef.current) return
+      const { cols, rows } = gridRef.current
+      const w = containerRef.current.clientWidth
+      const h = containerRef.current.clientHeight
+      if (w <= 0 || h <= 0) return
+      const size = computeFontSize(cols, rows, w, h)
+      if (term.options.fontSize !== size) {
+        term.options.fontSize = size
+      }
+      // term.resize is idempotent when dims haven't changed; the
+      // call ensures xterm reflows after font/size changes so the
+      // grid actually paints at the new cell dimensions.
+      term.resize(cols, rows)
+    }
 
     // `?client=web` tags this subscriber so the server's
     // Manager.Resize gate can suppress this client's resize
-    // requests while a mobile client is attached. Mobile picks the
-    // PTY size when both are connected; web adapts locally
-    // (letterboxing / scroll / browser zoom).
-    const ws = new BinaryWS(wsURL(`/api/v1/sessions/${sessionId}/stream?client=web`, token), {
-      onMessage: (data) => term.write(data),
-      onClose: () => {
-        if (!alive) return
-        term.writeln('')
-        term.writeln('\x1b[33m[disconnected — reconnecting…]\x1b[0m')
+    // requests while a mobile client is attached. With auto-
+    // fontSize the web grid is always pinned to the server's PTY
+    // size; the gate is now a safety net rather than a
+    // user-visible mechanism.
+    const ws = new BinaryWS(
+      wsURL(`/api/v1/sessions/${sessionId}/stream?client=web`, token),
+      {
+        onMessage: (data) => term.write(data),
+        onText: (text) => {
+          // Currently the only control frame is pty_size. Quietly
+          // ignore anything else — future server-pushed control
+          // payloads can land alongside.
+          try {
+            const msg = JSON.parse(text) as {
+              type?: string
+              cols?: number
+              rows?: number
+            }
+            if (
+              msg.type === 'pty_size' &&
+              typeof msg.cols === 'number' &&
+              typeof msg.rows === 'number' &&
+              msg.cols > 0 &&
+              msg.rows > 0
+            ) {
+              gridRef.current = { cols: msg.cols, rows: msg.rows }
+              term.resize(msg.cols, msg.rows)
+              applyFontSize()
+            }
+          } catch {
+            /* malformed control frame — ignore */
+          }
+        },
+        onClose: () => {
+          if (!alive) return
+          term.writeln('')
+          term.writeln('\x1b[33m[disconnected — reconnecting…]\x1b[0m')
+        },
       },
-      onOpen: () => {
-        // After (re)connect, push current dimensions so server sizes the PTY.
-        if (!alive) return
-        const { cols, rows } = term
-        if (cols && rows) {
-          resizeSession(sessionId, cols, rows).catch(() => {})
-        }
-      },
-    })
+    )
     wsRef.current = ws
     ws.start()
 
     term.onData((d) => {
       const enc = new TextEncoder().encode(d)
-      ws.send(enc.buffer.slice(enc.byteOffset, enc.byteOffset + enc.byteLength) as ArrayBuffer)
-    })
-    term.onResize(({ cols, rows }) => {
-      if (!alive) return
-      resizeSession(sessionId, cols, rows).catch(() => {})
+      ws.send(
+        enc.buffer.slice(
+          enc.byteOffset,
+          enc.byteOffset + enc.byteLength,
+        ) as ArrayBuffer,
+      )
     })
 
-    const ro = new ResizeObserver(() => {
-      if (!alive) return
-      try {
-        fit.fit()
-      } catch {
-        /* element not measured yet */
-      }
-    })
+    const ro = new ResizeObserver(applyFontSize)
     ro.observe(containerRef.current)
+    applyFontSize() // initial fit before first pty_size lands
 
     return () => {
       alive = false
@@ -217,7 +289,6 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       ws.close()
       term.dispose()
       xtermRef.current = null
-      fitRef.current = null
       wsRef.current = null
     }
   }, [sessionId, token])
@@ -306,12 +377,13 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     }
   }, [uploadFile, t])
 
-  // Refresh xterm theme when the site theme changes.
+  // Refresh xterm theme when the site theme changes. No fit call
+  // here — the grid is server-pinned and font sizing is handled by
+  // the container ResizeObserver inside the mount effect.
   useEffect(() => {
     const term = xtermRef.current
     if (!term) return
     term.options.theme = buildTheme(themeApplied)
-    fitRef.current?.fit()
   }, [themeApplied])
 
   return (

--- a/internal/session/handler.go
+++ b/internal/session/handler.go
@@ -35,6 +35,7 @@ type Service interface {
 	Input(ctx context.Context, id string, data []byte) error
 	Resize(ctx context.Context, id string, kind ClientKind, cols, rows uint16) error
 	Subscribe(ctx context.Context, id string, kind ClientKind) (<-chan []byte, func(), error)
+	PTYSize(ctx context.Context, id string) (cols, rows uint16, err error)
 	Buffer(ctx context.Context, id string, since int64) (Replay, error)
 	SwitchClaudeAccount(ctx context.Context, id, accountID string) (Session, error)
 	History(ctx context.Context, id string, limit int) (HistoryResponse, error)
@@ -255,6 +256,20 @@ func (h *Handlers) stream(w http.ResponseWriter, r *http.Request) {
 	}
 	defer conn.Close()
 	defer unsub()
+
+	// Send the current PTY canvas size as a JSON control frame
+	// (TextMessage) before any byte stream lands. Web clients use
+	// this to size their xterm grid to match the PTY and then
+	// adjust font size locally to fill the browser window — the
+	// alternative ("FitAddon makes the grid bigger than PTY")
+	// leaves vast empty cells on the right of the TUI. Mobile
+	// ignores this frame; it drives the PTY size itself.
+	if cols, rows, err := h.svc.PTYSize(r.Context(), id); err == nil {
+		ctrl := fmt.Sprintf(`{"type":"pty_size","cols":%d,"rows":%d}`, cols, rows)
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(ctrl)); err != nil {
+			return
+		}
+	}
 
 	if rep, err := h.svc.Buffer(r.Context(), id, 0); err == nil && len(rep.Bytes) > 0 {
 		if err := conn.WriteMessage(websocket.BinaryMessage, rep.Bytes); err != nil {

--- a/internal/session/handler_test.go
+++ b/internal/session/handler_test.go
@@ -102,6 +102,13 @@ func (f *fakeSvc) Resize(_ context.Context, id string, _ ClientKind, _, _ uint16
 	return nil
 }
 
+func (f *fakeSvc) PTYSize(_ context.Context, id string) (uint16, uint16, error) {
+	if _, ok := f.sessions[id]; !ok {
+		return 0, 0, ErrNotFound
+	}
+	return defaultPTYCols, defaultPTYRows, nil
+}
+
 func (f *fakeSvc) Subscribe(_ context.Context, id string, _ ClientKind) (<-chan []byte, func(), error) {
 	if _, ok := f.sessions[id]; !ok {
 		return nil, nil, ErrNotFound

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -37,6 +37,16 @@ const (
 	// canvas. Cards rendering wider than this get clipped.
 	defaultVTCols = 120
 	defaultVTRows = 40
+
+	// defaultPTYCols / defaultPTYRows is the canvas the PTY is seeded
+	// to when a session spawns. The TUI uses this until a client
+	// connects and asks for a different size. 100x32 is roughly the
+	// middle ground between a typical desktop terminal (120-160) and
+	// a portrait-phone xterm (60-80) — wide enough that Claude /
+	// Gemini layouts don't truncate, narrow enough that mobile
+	// xterm-equivalent forks don't have to scroll.
+	defaultPTYCols = 100
+	defaultPTYRows = 32
 )
 
 // ClientKind tags a subscriber so the manager can gate resize
@@ -415,6 +425,12 @@ func (m *Manager) spawn(ctx context.Context, sess Session, reactivate bool) (*ru
 		_ = os.RemoveAll(tempDir)
 		return nil, fmt.Errorf("pty.Start: %w", err)
 	}
+	// Seed a default PTY canvas at spawn so the TUI has a sensible
+	// initial layout even before any client connects and resizes.
+	// Whoever attaches first (typically mobile) may then resize via
+	// Manager.Resize; whoever attaches second adapts its viewport
+	// (font scaling on web) rather than re-driving the canvas.
+	_ = pty.Setsize(ptmx, &pty.Winsize{Cols: defaultPTYCols, Rows: defaultPTYRows})
 
 	sess.PID = cmd.Process.Pid
 	sess.State = StateRunning
@@ -762,6 +778,23 @@ func (m *Manager) Resize(_ context.Context, id string, kind ClientKind, cols, ro
 		rs.vt.Resize(int(cols), int(rows))
 	}
 	return pty.Setsize(rs.pty, &pty.Winsize{Cols: cols, Rows: rows})
+}
+
+// PTYSize returns the current cols × rows of the session's PTY,
+// as the kernel sees it. Used by the WS handshake to tell web
+// clients what canvas size to render at — web's xterm grid
+// locks to this size and the client adjusts font scaling locally
+// to fill its window. Mobile clients drive the size via Resize.
+func (m *Manager) PTYSize(_ context.Context, id string) (cols, rows uint16, err error) {
+	rs := m.lookup(id)
+	if rs == nil {
+		return 0, 0, ErrNotFound
+	}
+	r, c, gerr := pty.Getsize(rs.pty)
+	if gerr != nil {
+		return 0, 0, fmt.Errorf("pty getsize: %w", gerr)
+	}
+	return uint16(c), uint16(r), nil
 }
 
 // Subscribe registers a channel that receives every chunk of stdout


### PR DESCRIPTION
## Problem
#151's gate stopped web from disrupting mobile's PTY size, but exposed a separate issue: web's FitAddon still locally enlarged xterm's grid to fill the browser window, while the server kept the PTY at mobile's small size. Result: TUI content rendered in the upper-left of a much-larger grid, with the rest of the canvas black-emptied. On an ultrawide monitor the Gemini TUI showed up as a tiny tooltip in the leftmost ~30% of the window.

## Architecture flip
- PTY size is delivered **from the server to web** on subscribe.
- Web's xterm grid **locks** to that server-pinned size.
- Web stops calling \`/resize\` entirely; mobile drives the PTY.
- Web's container ResizeObserver recomputes pixel **fontSize** so the locked grid fills the browser window — small grid + large font = TUI that visually fills the screen.

## Implementation

**Server (Go):**
- Default PTY canvas at spawn: 100×32 (sensible cross-device starting size; mobile re-sizes on connect for portrait phones).
- New \`Manager.PTYSize(id)\` → reads \`pty.Getsize()\`.
- Stream handler sends a JSON TextMessage control frame as the first WS write: \`{\"type\":\"pty_size\",\"cols\":N,\"rows\":M}\`. The existing binary buffer + live stream follow unchanged.

**Shared (TS):**
- \`BinaryWS\` gains optional \`onText\` callback; control frames arrive via TextMessage (already supported by browser WS), distinct from the binary stdout stream. Callers that don't set \`onText\` still see legacy fallback (text → UTF-8 bytes routed to \`onMessage\`).

**Web (React):**
- \`Terminal.tsx\` drops FitAddon entirely; no more \`/resize\` POST from web.
- On \`pty_size\` control frame, \`term.resize(cols, rows)\` locks the grid. Subsequent ResizeObserver events recompute font size via \`computeFontSize(cols, rows, containerWidth, containerHeight)\` — picks the largest font that fits the grid into the container, bounded 9–28 px.
- Theme refresh effect drops its stale \`fit()\` call.

**Mobile:** intentionally unchanged. Still drives the PTY. The #151 gate is now a safety net for legacy clients that ignore the push-down protocol.

## User-visible
| Scenario | Behaviour |
|---|---|
| Mobile alone | Unchanged — mobile sets PTY, mobile renders 1:1 |
| Web alone | PTY stays at 100×32; web xterm 100×32 grid with auto-scaled font filling the window. Bigger text than before but no awkward black borders. |
| Mobile + web | PTY = mobile size. Web xterm at mobile grid with auto-scaled font filling the browser window. **Both clients show the same TUI rendered at their native visual size.** |

## Test plan
- [ ] \`go test ./internal/session/...\` — all green.
- [ ] Restart gateway. Start a session **on mobile only** → mobile looks normal, web tab not yet open.
- [ ] Open the same session in **web admin** → web shows the TUI auto-scaled to fill the browser window, no black borders on the right.
- [ ] Drag the web window narrow → web TUI auto-shrinks font to stay fitted (no truncation). Mobile layout stays untouched throughout.
- [ ] Web alone (no mobile): resize browser → TUI rescales font, no \`/resize\` calls leak to server (check \`/tmp/opendray.log\`).
- [ ] Claude session: identical behaviour, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)