### PR TITLE
fix(git) + feat(mobile): branch list parsing + dialog crash + picker sheet with delete

### DIFF
--- a/app/mobile/lib/features/sessions/inspector/git_branch_controls.dart
+++ b/app/mobile/lib/features/sessions/inspector/git_branch_controls.dart
@@ -109,34 +109,17 @@ class _GitBranchControlsState extends ConsumerState<GitBranchControls> {
   }
 
   Future<String?> _promptForBranchName() async {
-    final controller = TextEditingController();
-    final name = await showDialog<String>(
+    // Use an internal StatefulWidget so the TextEditingController
+    // is owned by the dialog's State and disposed at the right
+    // time (after the TextField is detached). Disposing it from
+    // the calling Future right after showDialog returns triggers
+    // a "_dependents.isEmpty" assertion in framework.dart because
+    // the TextField is still being torn down when we dispose its
+    // listener.
+    return showDialog<String>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('New branch'),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          decoration: const InputDecoration(
-            hintText: 'feat/something',
-            border: OutlineInputBorder(),
-          ),
-          onSubmitted: (v) => Navigator.of(ctx).pop(v.trim()),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(null),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(ctx).pop(controller.text.trim()),
-            child: const Text('Create'),
-          ),
-        ],
-      ),
+      builder: (_) => const _BranchNameDialog(),
     );
-    controller.dispose();
-    return name;
   }
 
   Future<void> _push() async {
@@ -234,6 +217,61 @@ class _GitBranchControlsState extends ConsumerState<GitBranchControls> {
           ),
         ],
       ),
+    );
+  }
+}
+
+// _BranchNameDialog owns its TextEditingController via its own
+// State so the dispose order is correct — the framework unmounts
+// the TextField first, then State.dispose() runs and tears down
+// the controller. Putting that controller in the caller (the
+// async function) instead would dispose it while the TextField
+// is still listening, tripping the _dependents.isEmpty assertion.
+class _BranchNameDialog extends StatefulWidget {
+  const _BranchNameDialog();
+
+  @override
+  State<_BranchNameDialog> createState() => _BranchNameDialogState();
+}
+
+class _BranchNameDialogState extends State<_BranchNameDialog> {
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final name = _controller.text.trim();
+    if (name.isEmpty) {
+      Navigator.of(context).pop(null);
+      return;
+    }
+    Navigator.of(context).pop(name);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('New branch'),
+      content: TextField(
+        controller: _controller,
+        autofocus: true,
+        decoration: const InputDecoration(
+          hintText: 'feat/something',
+          border: OutlineInputBorder(),
+        ),
+        onSubmitted: (_) => _submit(),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(null),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(onPressed: _submit, child: const Text('Create')),
+      ],
     );
   }
 }

--- a/app/mobile/lib/features/sessions/inspector/git_branch_controls.dart
+++ b/app/mobile/lib/features/sessions/inspector/git_branch_controls.dart
@@ -7,10 +7,12 @@ import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/git_api.dart';
 
 // GitBranchControls is the per-status-pane action strip: current
-// branch + dropdown to switch + "+ New" + Push. Switching refuses
-// on a dirty tree (server returns 409 → friendly toast). Push uses
-// set-upstream on first push (no upstream tracked yet) and stays
-// disabled when nothing's ahead of an existing upstream.
+// branch chip → opens a bottom-sheet picker that shows every local
+// branch with its upstream tracking + delete affordance. The
+// dropdown shape we used initially hid all this info and gave
+// nowhere to delete from; on a phone screen a tappable chip plus a
+// full-height sheet is the only ergonomic option. "+ New" and
+// "Push" stay on the strip so the common ops are one tap away.
 class GitBranchControls extends ConsumerStatefulWidget {
   const GitBranchControls({
     required this.cwd,
@@ -81,6 +83,102 @@ class _GitBranchControlsState extends ConsumerState<GitBranchControls> {
     }
   }
 
+  // _delete runs `git branch -d` first; if the branch is unmerged
+  // git refuses with a 409 + "not fully merged" body. We surface
+  // that as a second confirmation that upgrades to -D (force).
+  // Keeping the two-step flow means a slip can't blow away work.
+  Future<void> _delete(GitBranchRef ref_) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: Text('Delete ${ref_.name}?'),
+        content: Text(
+          ref_.upstream.isEmpty
+              ? 'This branch has no upstream — make sure it has nothing you need.'
+              : 'Local branch only. Remote ${ref_.upstream} is untouched.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (!(confirmed ?? false) || !mounted) return;
+    await _doDelete(ref_, force: false);
+  }
+
+  Future<void> _doDelete(GitBranchRef ref_, {required bool force}) async {
+    setState(() => _busy = true);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref
+          .read(gitApiProvider)
+          .deleteBranch(dir: widget.cwd, name: ref_.name, force: force);
+      if (!mounted) return;
+      messenger.showSnackBar(SnackBar(content: Text('Deleted ${ref_.name}')));
+      widget.onChanged();
+      await _load();
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      // git refuses unmerged branches with status 409 + a message
+      // mentioning "not fully merged". Treat that as a force-prompt
+      // signal so the operator gets a clear second confirm rather
+      // than an opaque toast.
+      final lower = e.message.toLowerCase();
+      final canForce =
+          !force &&
+          (e.statusCode == 409 ||
+              lower.contains('not fully merged') ||
+              lower.contains('not yet merged'));
+      if (canForce) {
+        final go = await showDialog<bool>(
+          context: context,
+          builder: (_) => AlertDialog(
+            title: Text('Force delete ${ref_.name}?'),
+            content: const Text(
+              'Branch is not fully merged. Forcing deletion will lose '
+              'any commits unique to this branch.',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('Cancel'),
+              ),
+              FilledButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                style: FilledButton.styleFrom(
+                  backgroundColor: Theme.of(context).colorScheme.error,
+                ),
+                child: const Text('Force delete'),
+              ),
+            ],
+          ),
+        );
+        if ((go ?? false) && mounted) {
+          await _doDelete(ref_, force: true);
+        }
+      } else {
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text('Delete failed: ${e.message}'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
   Future<void> _create() async {
     final name = await _promptForBranchName();
     if (name == null || name.isEmpty || !mounted) return;
@@ -146,14 +244,34 @@ class _GitBranchControlsState extends ConsumerState<GitBranchControls> {
     }
   }
 
+  Future<void> _openPicker() async {
+    final list = _branches;
+    if (list == null || _busy) return;
+    final picked = await showModalBottomSheet<_PickerResult>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (sheetCtx) => _BranchPickerSheet(
+        branches: list.branches,
+        current: list.current,
+      ),
+    );
+    if (picked == null || !mounted) return;
+    if (picked.action == _PickerAction.checkout && picked.ref.name != list.current) {
+      await _checkout(picked.ref.name);
+    } else if (picked.action == _PickerAction.delete) {
+      await _delete(picked.ref);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final branches = _branches;
     if (branches == null) {
       return const SizedBox(height: 0);
     }
-    final local = branches.branches.where((b) => !b.isRemote).toList();
-    final current = branches.current;
+    final current = branches.current.isNotEmpty ? branches.current : '(detached)';
+    final localCount = branches.branches.where((b) => !b.isRemote).length;
     // Push is disabled when an upstream exists AND we're not ahead.
     // First push (no upstream) is always allowed; the operator
     // typically wants to publish the branch to start a PR.
@@ -164,30 +282,50 @@ class _GitBranchControlsState extends ConsumerState<GitBranchControls> {
       child: Row(
         children: [
           Expanded(
-            child: DropdownButtonFormField<String>(
-              initialValue: current.isNotEmpty ? current : null,
-              isDense: true,
-              decoration: const InputDecoration(
-                isDense: true,
-                contentPadding: EdgeInsets.symmetric(
-                  horizontal: 10,
-                  vertical: 6,
+            child: InkWell(
+              onTap: _busy ? null : _openPicker,
+              borderRadius: BorderRadius.circular(6),
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+                decoration: BoxDecoration(
+                  border: Border.all(color: theme.dividerColor),
+                  borderRadius: BorderRadius.circular(6),
                 ),
-                border: OutlineInputBorder(),
-                labelText: 'Branch',
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.account_tree_outlined,
+                      size: 16,
+                      color: theme.colorScheme.primary,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        current,
+                        style: const TextStyle(
+                          fontFamily: 'monospace',
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    Text(
+                      '$localCount local',
+                      style: TextStyle(
+                        fontSize: 11,
+                        color: theme.textTheme.bodySmall?.color,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    Icon(
+                      Icons.unfold_more,
+                      size: 16,
+                      color: theme.iconTheme.color?.withValues(alpha: 0.6),
+                    ),
+                  ],
+                ),
               ),
-              style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
-              items: [
-                for (final b in local)
-                  DropdownMenuItem(value: b.name, child: Text(b.name)),
-              ],
-              onChanged: _busy
-                  ? null
-                  : (v) {
-                      if (v != null && v != current) {
-                        unawaited(_checkout(v));
-                      }
-                    },
             ),
           ),
           const SizedBox(width: 6),
@@ -217,6 +355,184 @@ class _GitBranchControlsState extends ConsumerState<GitBranchControls> {
           ),
         ],
       ),
+    );
+  }
+}
+
+// _BranchPickerSheet lists every local branch in a scrollable
+// sheet so each row has space for the upstream subtitle + delete
+// affordance — none of that fits in a DropdownButtonFormField on
+// a phone screen.
+enum _PickerAction { checkout, delete }
+
+class _PickerResult {
+  _PickerResult(this.action, this.ref);
+  final _PickerAction action;
+  final GitBranchRef ref;
+}
+
+class _BranchPickerSheet extends StatelessWidget {
+  const _BranchPickerSheet({required this.branches, required this.current});
+
+  final List<GitBranchRef> branches;
+  final String current;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final local = branches.where((b) => !b.isRemote).toList()
+      ..sort((a, b) {
+        if (a.isCurrent != b.isCurrent) return a.isCurrent ? -1 : 1;
+        return a.name.compareTo(b.name);
+      });
+    final remote = branches.where((b) => b.isRemote).toList()
+      ..sort((a, b) => a.name.compareTo(b.name));
+    return SafeArea(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.of(context).size.height * 0.75,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+              child: Row(
+                children: [
+                  Text(
+                    'Branches',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const Spacer(),
+                  Text(
+                    '${local.length} local · ${remote.length} remote',
+                    style: theme.textTheme.bodySmall,
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+            Flexible(
+              child: ListView(
+                shrinkWrap: true,
+                padding: EdgeInsets.zero,
+                children: [
+                  for (final b in local)
+                    _BranchRow(
+                      ref_: b,
+                      isCurrent: b.name == current,
+                      onTap: () => Navigator.of(
+                        context,
+                      ).pop(_PickerResult(_PickerAction.checkout, b)),
+                      onDelete: b.name == current
+                          ? null
+                          : () => Navigator.of(
+                              context,
+                            ).pop(_PickerResult(_PickerAction.delete, b)),
+                    ),
+                  if (remote.isNotEmpty) ...[
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+                      child: Text(
+                        'Remote',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: theme.textTheme.bodySmall?.color,
+                          letterSpacing: 1.2,
+                        ),
+                      ),
+                    ),
+                    for (final b in remote)
+                      _BranchRow(
+                        ref_: b,
+                        isCurrent: false,
+                        // Tapping a remote ref checks out the local
+                        // branch of the same short name — same as
+                        // `git checkout <name>` resolving to the
+                        // remote-tracking branch on first switch.
+                        onTap: () => Navigator.of(context).pop(
+                          _PickerResult(
+                            _PickerAction.checkout,
+                            GitBranchRef(
+                              name: b.name,
+                              remote: '',
+                              isRemote: false,
+                              isCurrent: false,
+                              upstream: '${b.remote}/${b.name}',
+                            ),
+                          ),
+                        ),
+                        onDelete: null,
+                      ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BranchRow extends StatelessWidget {
+  const _BranchRow({
+    required this.ref_,
+    required this.isCurrent,
+    required this.onTap,
+    required this.onDelete,
+  });
+
+  final GitBranchRef ref_;
+  final bool isCurrent;
+  final VoidCallback onTap;
+  final VoidCallback? onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final subtitle = ref_.isRemote
+        ? '${ref_.remote}/${ref_.name}'
+        : (ref_.upstream.isEmpty ? 'no upstream' : '→ ${ref_.upstream}');
+    return ListTile(
+      onTap: onTap,
+      dense: true,
+      leading: Icon(
+        isCurrent
+            ? Icons.check_circle
+            : (ref_.isRemote
+                  ? Icons.cloud_outlined
+                  : Icons.account_tree_outlined),
+        size: 18,
+        color: isCurrent
+            ? theme.colorScheme.primary
+            : theme.iconTheme.color?.withValues(alpha: 0.6),
+      ),
+      title: Text(
+        ref_.name,
+        style: TextStyle(
+          fontFamily: 'monospace',
+          fontSize: 13,
+          fontWeight: isCurrent ? FontWeight.w700 : FontWeight.w500,
+        ),
+      ),
+      subtitle: Text(
+        subtitle,
+        style: TextStyle(
+          fontFamily: 'monospace',
+          fontSize: 11,
+          color: theme.textTheme.bodySmall?.color,
+        ),
+      ),
+      trailing: onDelete == null
+          ? null
+          : IconButton(
+              tooltip: 'Delete branch',
+              icon: const Icon(Icons.delete_outline, size: 20),
+              color: theme.colorScheme.error,
+              onPressed: onDelete,
+            ),
     );
   }
 }

--- a/internal/git/write.go
+++ b/internal/git/write.go
@@ -85,11 +85,14 @@ func (h *Handlers) listBranches(w http.ResponseWriter, r *http.Request) {
 		"symbolic-ref", "--quiet", "--short", "HEAD")
 	current := strings.TrimSpace(string(curBytes))
 
-	// Local + remote refs in one call, with upstream tracking
-	// info for local branches. Custom format keeps parsing cheap.
+	// Local + remote refs in one call. `refname:full` is the
+	// authoritative source of truth for local-vs-remote (we used
+	// to heuristic from the short form, which mis-classified bare
+	// `refs/remotes/origin` symrefs as local branches called
+	// "origin"). Upstream + HEAD marker round out the format.
 	out, err := run(r.Context(), dir,
 		"for-each-ref",
-		"--format=%(refname:short)|%(upstream:short)|%(HEAD)",
+		"--format=%(refname:short)|%(refname)|%(upstream:short)|%(HEAD)",
 		"refs/heads", "refs/remotes")
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
@@ -103,8 +106,15 @@ func (h *Handlers) listBranches(w http.ResponseWriter, r *http.Request) {
 }
 
 // parseBranchRefs splits the for-each-ref output. Each line is
-// "<name>|<upstream>|<head_marker>". remote refs start with the
-// remote name ("origin/foo") and are normalised into BranchRef.
+// "<short>|<full>|<upstream>|<head_marker>". Classification rule:
+//
+//   - refname:full starts with "refs/heads/"   → local
+//   - refname:full starts with "refs/remotes/" → remote
+//
+// The short refname might collide between local and remote (e.g.
+// a local branch literally named "origin" would have short
+// "origin" — same as a hypothetical bare remote HEAD symref); the
+// full refname disambiguates.
 func parseBranchRefs(out, current string) []BranchRef {
 	refs := []BranchRef{}
 	for _, line := range strings.Split(out, "\n") {
@@ -112,39 +122,51 @@ func parseBranchRefs(out, current string) []BranchRef {
 		if line == "" {
 			continue
 		}
-		parts := strings.SplitN(line, "|", 3)
-		name := parts[0]
-		upstream := ""
-		headMarker := ""
-		if len(parts) > 1 {
-			upstream = parts[1]
-		}
-		if len(parts) > 2 {
-			headMarker = strings.TrimSpace(parts[2])
-		}
-		// Filter the "origin/HEAD" symref — it points to the
-		// remote default branch, not an actual branch we'd
-		// want to switch to.
-		if strings.HasSuffix(name, "/HEAD") {
+		parts := strings.SplitN(line, "|", 4)
+		if len(parts) < 2 {
 			continue
 		}
-		isRemote := false
-		remote := ""
-		displayName := name
-		if i := strings.Index(name, "/"); i > 0 && !strings.HasPrefix(name, "refs/") {
-			// Cheap heuristic: ref names like "origin/foo" map to
-			// remote refs. Local branches can't contain "/" by
-			// convention, but git does allow it; the for-each-ref
-			// path differentiates via the refname structure though,
-			// so this only kicks in for refs/remotes/ entries.
-			head := name[:i]
-			tail := name[i+1:]
-			if isLikelyRemote(head) {
-				isRemote = true
-				remote = head
-				displayName = tail
+		shortName := parts[0]
+		fullName := parts[1]
+		upstream := ""
+		headMarker := ""
+		if len(parts) > 2 {
+			upstream = parts[2]
+		}
+		if len(parts) > 3 {
+			headMarker = strings.TrimSpace(parts[3])
+		}
+
+		// Filter:
+		//   - bare "refs/remotes/<remote>" symrefs (just the
+		//     remote head pointer, not a switchable branch).
+		//   - HEAD symrefs anywhere (origin/HEAD, etc.).
+		if strings.HasSuffix(fullName, "/HEAD") {
+			continue
+		}
+		// "refs/remotes/origin" with no further slash is the bare
+		// remote symref some setups produce. Skip it — it's not
+		// a branch.
+		if strings.HasPrefix(fullName, "refs/remotes/") {
+			trimmed := strings.TrimPrefix(fullName, "refs/remotes/")
+			if !strings.Contains(trimmed, "/") {
+				continue
 			}
 		}
+
+		isRemote := strings.HasPrefix(fullName, "refs/remotes/")
+		displayName := shortName
+		remote := ""
+		if isRemote {
+			// short form is "<remote>/<branch[/sub]*>". Split
+			// on the FIRST slash; everything after is the
+			// branch name (which itself may contain slashes).
+			if i := strings.Index(shortName, "/"); i > 0 {
+				remote = shortName[:i]
+				displayName = shortName[i+1:]
+			}
+		}
+
 		refs = append(refs, BranchRef{
 			Name:      displayName,
 			Remote:    remote,
@@ -154,16 +176,6 @@ func parseBranchRefs(out, current string) []BranchRef {
 		})
 	}
 	return refs
-}
-
-func isLikelyRemote(name string) bool {
-	// Bog-standard remote names; anything else gets treated as
-	// a local branch with a slash in its name (rare but legal).
-	switch name {
-	case "origin", "upstream", "fork":
-		return true
-	}
-	return false
 }
 
 // ── Branch create ──────────────────────────────────────────────

--- a/internal/git/write_test.go
+++ b/internal/git/write_test.go
@@ -45,18 +45,22 @@ func TestValidRelativePath(t *testing.T) {
 }
 
 func TestParseBranchRefs(t *testing.T) {
+	// Format: <short>|<full>|<upstream>|<head_marker>.
 	// Simulated for-each-ref output: local main (current) +
-	// feat/x with upstream + a remote ref (origin/main) + an
-	// origin/HEAD symref that should be filtered.
-	raw := `main|origin/main|*
-feat/x|origin/feat/x|
-origin/main||
-origin/feat/x||
-origin/HEAD||
+	// feat/x with upstream + remote refs (origin/main,
+	// origin/feat/x) + an origin/HEAD symref that should be
+	// filtered + a bare "origin" remote symref that some setups
+	// produce (also filtered).
+	raw := `main|refs/heads/main|origin/main|*
+feat/x|refs/heads/feat/x|origin/feat/x|
+origin/main|refs/remotes/origin/main||
+origin/feat/x|refs/remotes/origin/feat/x||
+origin/HEAD|refs/remotes/origin/HEAD||
+origin|refs/remotes/origin||
 `
 	got := parseBranchRefs(raw, "main")
 	if len(got) != 4 {
-		t.Fatalf("expected 4 refs (HEAD symref filtered), got %d: %+v", len(got), got)
+		t.Fatalf("expected 4 refs (HEAD + bare origin filtered), got %d: %+v", len(got), got)
 	}
 	// Find each by traits.
 	var mainRef, featRef, originMain, originFeat *BranchRef
@@ -89,25 +93,38 @@ origin/HEAD||
 	}
 }
 
+func TestParseBranchRefs_FiltersBareRemoteSymref(t *testing.T) {
+	// A bare "refs/remotes/origin" with no branch suffix should
+	// be dropped — it's a remote symref, not a switchable branch.
+	// This was the bug: it was rendering as a local branch
+	// called "origin" because the short form has no slash.
+	raw := `origin|refs/remotes/origin||
+`
+	got := parseBranchRefs(raw, "")
+	if len(got) != 0 {
+		t.Errorf("expected empty (bare origin symref filtered), got %+v", got)
+	}
+}
+
 func TestParseBranchRefs_HeadSymrefFiltered(t *testing.T) {
-	// HEAD symref alone — only entry; output must be empty.
-	got := parseBranchRefs("origin/HEAD||\n", "")
+	raw := `origin/HEAD|refs/remotes/origin/HEAD||
+`
+	got := parseBranchRefs(raw, "")
 	if len(got) != 0 {
 		t.Errorf("expected empty when only HEAD symref present, got %+v", got)
 	}
 }
 
-func TestIsLikelyRemote(t *testing.T) {
-	cases := map[string]bool{
-		"origin":   true,
-		"upstream": true,
-		"fork":     true,
-		"feat":     false, // local branch named "feat/..."
-		"":         false,
+func TestParseBranchRefs_LocalNamedOrigin(t *testing.T) {
+	// An operator can (regrettably) name a local branch "origin".
+	// `refname:full` disambiguates: refs/heads/origin is local.
+	raw := `origin|refs/heads/origin||
+`
+	got := parseBranchRefs(raw, "")
+	if len(got) != 1 || got[0].IsRemote {
+		t.Errorf("local branch named 'origin' misclassified: %+v", got)
 	}
-	for in, want := range cases {
-		if got := isLikelyRemote(in); got != want {
-			t.Errorf("isLikelyRemote(%q) = %v, want %v", in, got, want)
-		}
+	if got[0].Name != "origin" {
+		t.Errorf("name wrong: %q", got[0].Name)
 	}
 }


### PR DESCRIPTION
## Summary

Bundles three mobile-branch issues surfaced during PR #156 testing:

1. **Branch list missed every branch except current** — `parseBranchRefs` used a short-name heuristic that mis-classified the bare `refs/remotes/origin` symref as a local branch named `origin`. Switched to `refname:full` to classify; filter `*/HEAD` and bare-remote symrefs. Tests cover the bare-origin, HEAD, and local-named-origin cases.
2. **"New branch" dialog crashed** with `_dependents.isEmpty` — the `TextEditingController` was disposed by the calling async function while the TextField was still tearing down. Extracted `_BranchNameDialog` as a StatefulWidget so dispose order is correct.
3. **No way to switch / delete branches on phone, dropdown had no info** — replaced `DropdownButtonFormField` with a tappable chip that opens a `_BranchPickerSheet`. Each row shows upstream tracking + has a trailing delete icon (disabled on current branch). Delete uses safe `-d` first; on 409 / "not fully merged" it offers a force-delete confirmation that upgrades to `-D`.

## Test plan

- [x] `go test ./internal/git/...` — parseBranchRefs tests pass (bare remote, HEAD symref, local named origin)
- [x] `flutter analyze` — clean
- [ ] Manual: open mobile, tap current-branch chip → sheet lists all local + remote branches with upstream info
- [ ] Manual: tap a non-current local branch → switches
- [ ] Manual: tap delete on a merged branch → confirm → branch removed
- [ ] Manual: tap delete on an unmerged branch → safe delete refused → force prompt → force delete works
- [ ] Manual: "+ New" dialog opens, accepts a name, switches to it without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)