### PR TITLE
fix(git): delete-branch 404 on names with slash

### DIFF
--- a/app/mobile/lib/core/api/git_api.dart
+++ b/app/mobile/lib/core/api/git_api.dart
@@ -500,7 +500,9 @@ class GitApi {
     }
   }
 
-  // DELETE /git/write/branches/{name}. force=true upgrades the
+  // DELETE /git/write/branches?path=&name=&force=. Name lives in
+  // the query (not the path) because feat/foo-style branches break
+  // chi's single-segment {name} matcher. force=true upgrades the
   // safe -d to -D (forces deletion of unmerged branches).
   Future<void> deleteBranch({
     required String dir,
@@ -509,8 +511,12 @@ class GitApi {
   }) async {
     try {
       await _dio.delete<void>(
-        '/api/v1/git/write/branches/$name',
-        queryParameters: {'path': dir, if (force) 'force': 'true'},
+        '/api/v1/git/write/branches',
+        queryParameters: {
+          'path': dir,
+          'name': name,
+          if (force) 'force': 'true',
+        },
       );
     } on Object catch (e) {
       throw toApiException(e);

--- a/app/shared/src/lib/git.ts
+++ b/app/shared/src/lib/git.ts
@@ -110,12 +110,13 @@ export async function deleteGitBranch(
   name: string,
   force = false,
 ): Promise<void> {
-  const params = new URLSearchParams({ path })
+  // Name in query (not path) because feat/foo-style branches
+  // break chi's single-segment {name} matcher and 404.
+  const params = new URLSearchParams({ path, name })
   if (force) params.set('force', 'true')
-  await api(
-    `/api/v1/git/write/branches/${encodeURIComponent(name)}?${params.toString()}`,
-    { method: 'DELETE' },
-  )
+  await api(`/api/v1/git/write/branches?${params.toString()}`, {
+    method: 'DELETE',
+  })
 }
 
 // Empty files[] stages all (`.`).

--- a/internal/git/write.go
+++ b/internal/git/write.go
@@ -47,7 +47,10 @@ func (h *Handlers) MountWrite(r chi.Router) {
 		r.Get("/branches", h.listBranches)
 		r.Post("/branches", h.createBranch)
 		r.Post("/checkout", h.checkoutBranch)
-		r.Delete("/branches/{name}", h.deleteBranch)
+		// Branch names contain '/' (feat/foo) so we can't use a
+		// {name} path segment — chi reads each '/' as a path
+		// boundary and 404s. Query param keeps it unambiguous.
+		r.Delete("/branches", h.deleteBranch)
 		r.Post("/stage", h.stageFiles)
 		r.Post("/unstage", h.unstageFiles)
 		r.Post("/commit", h.commit)
@@ -278,7 +281,7 @@ func (h *Handlers) deleteBranch(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
-	name := chi.URLParam(r, "name")
+	name := strings.TrimSpace(r.URL.Query().Get("name"))
 	if !validBranchName(name) {
 		writeError(w, http.StatusBadRequest, errors.New("invalid branch name"))
 		return
@@ -292,7 +295,14 @@ func (h *Handlers) deleteBranch(w http.ResponseWriter, r *http.Request) {
 		flag = "-D"
 	}
 	if out, err := runCombined(r.Context(), dir, "branch", flag, name); err != nil {
-		writeError(w, http.StatusInternalServerError,
+		// "not fully merged" is git's safe-delete refusal — surface
+		// it as 409 Conflict so the client can offer a force-delete
+		// flow without string-matching the body.
+		status := http.StatusInternalServerError
+		if strings.Contains(strings.ToLower(out), "not fully merged") {
+			status = http.StatusConflict
+		}
+		writeError(w, status,
 			fmt.Errorf("delete branch: %w (%s)", err, out))
 		return
 	}


### PR DESCRIPTION
## Summary

`DELETE /api/v1/git/write/branches/feat/gitwork` was returning 404 because chi's `{name}` path matcher only accepts a single segment — the embedded `/` was read as a path boundary. URL-encoding `%2F` doesn't help either; Go's net/http decodes `URL.Path` before chi sees it.

Move the name to a query parameter so encoding stays unambiguous and the embedded slash never reaches the router:
- Server: `DELETE /branches?path=&name=&force=`
- Surface git's "not fully merged" refusal as **409 Conflict** so clients can offer a force-delete flow without string-matching the body.
- Mobile + web clients updated to match.

## Test plan

- [x] `go build` + `go test ./internal/git/...`
- [x] `flutter analyze` clean
- [ ] Manual: on mobile, delete `feat/gitwork` from the picker sheet → succeeds
- [ ] Manual: delete an unmerged branch → 409 → force-delete prompt → confirmed → deleted
- [ ] Manual: web inspector branch delete still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)