### PR TITLE
feat(git): stash & switch checkout flow + dirty file surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ go.work
 go.work.sum
 vendor/
 /opendray
+/opendray.log
 
 # embedded web bundle — produced by `cd app/web && pnpm build`
 internal/web/dist/

--- a/app/mobile/ios/Podfile.lock
+++ b/app/mobile/ios/Podfile.lock
@@ -1,4 +1,38 @@
 PODS:
+  - DKImagePickerController/Core (4.3.9):
+    - DKImagePickerController/ImageDataManager
+    - DKImagePickerController/Resource
+  - DKImagePickerController/ImageDataManager (4.3.9)
+  - DKImagePickerController/PhotoGallery (4.3.9):
+    - DKImagePickerController/Core
+    - DKPhotoGallery
+  - DKImagePickerController/Resource (4.3.9)
+  - DKPhotoGallery (0.0.19):
+    - DKPhotoGallery/Core (= 0.0.19)
+    - DKPhotoGallery/Model (= 0.0.19)
+    - DKPhotoGallery/Preview (= 0.0.19)
+    - DKPhotoGallery/Resource (= 0.0.19)
+    - SDWebImage
+    - SwiftyGif
+  - DKPhotoGallery/Core (0.0.19):
+    - DKPhotoGallery/Model
+    - DKPhotoGallery/Preview
+    - SDWebImage
+    - SwiftyGif
+  - DKPhotoGallery/Model (0.0.19):
+    - SDWebImage
+    - SwiftyGif
+  - DKPhotoGallery/Preview (0.0.19):
+    - DKPhotoGallery/Model
+    - DKPhotoGallery/Resource
+    - SDWebImage
+    - SwiftyGif
+  - DKPhotoGallery/Resource (0.0.19):
+    - SDWebImage
+    - SwiftyGif
+  - file_picker (0.0.1):
+    - DKImagePickerController/PhotoGallery
+    - Flutter
   - Flutter (1.0.0)
   - flutter_secure_storage (6.0.0):
     - Flutter
@@ -9,11 +43,16 @@ PODS:
     - FlutterMacOS
   - package_info_plus (0.4.5):
     - Flutter
+  - SDWebImage (5.21.7):
+    - SDWebImage/Core (= 5.21.7)
+  - SDWebImage/Core (5.21.7)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - SwiftyGif (5.4.5)
 
 DEPENDENCIES:
+  - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
@@ -21,7 +60,16 @@ DEPENDENCIES:
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
 
+SPEC REPOS:
+  trunk:
+    - DKImagePickerController
+    - DKPhotoGallery
+    - SDWebImage
+    - SwiftyGif
+
 EXTERNAL SOURCES:
+  file_picker:
+    :path: ".symlinks/plugins/file_picker/ios"
   Flutter:
     :path: Flutter
   flutter_secure_storage:
@@ -36,12 +84,17 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
 
 SPEC CHECKSUMS:
+  DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
+  DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
+  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
 
 PODFILE CHECKSUM: f8c2dcdfb50bb67645580d28a6bf814fca30bdec
 

--- a/app/mobile/lib/core/api/git_api.dart
+++ b/app/mobile/lib/core/api/git_api.dart
@@ -484,17 +484,23 @@ class GitApi {
     }
   }
 
-  // POST /git/write/checkout — refuses on dirty tree (server
-  // returns 409, surfaces as ApiException with that status).
-  Future<void> checkoutBranch({
+  // POST /git/write/checkout — refuses on dirty tree with 409 +
+  // `dirty_files` array in the body. stash=true asks the server to
+  // `git stash push -u` before checkout; the response then
+  // includes stashed=true + stash_ref for the operator to see what
+  // was saved. Returns the parsed JSON map so callers can read
+  // the stash ref.
+  Future<Map<String, dynamic>> checkoutBranch({
     required String dir,
     required String name,
+    bool stash = false,
   }) async {
     try {
-      await _dio.post<void>(
+      final res = await _dio.post<Map<String, dynamic>>(
         '/api/v1/git/write/checkout',
-        data: {'dir': dir, 'name': name},
+        data: {'dir': dir, 'name': name, if (stash) 'stash': true},
       );
+      return res.data ?? const {};
     } on Object catch (e) {
       throw toApiException(e);
     }

--- a/app/mobile/lib/features/sessions/inspector/git_branch_controls.dart
+++ b/app/mobile/lib/features/sessions/inspector/git_branch_controls.dart
@@ -59,19 +59,41 @@ class _GitBranchControlsState extends ConsumerState<GitBranchControls> {
     }
   }
 
-  Future<void> _checkout(String name) async {
+  Future<void> _checkout(String name, {bool stash = false}) async {
     setState(() => _busy = true);
     final messenger = ScaffoldMessenger.of(context);
     try {
-      await ref
+      final res = await ref
           .read(gitApiProvider)
-          .checkoutBranch(dir: widget.cwd, name: name);
+          .checkoutBranch(dir: widget.cwd, name: name, stash: stash);
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text('Switched to $name')));
+      final stashed = res['stashed'] == true;
+      final stashRef = (res['stash_ref'] as String?) ?? '';
+      final msg = stashed
+          ? 'Switched to $name (stashed${stashRef.isEmpty ? '' : ' as $stashRef'})'
+          : 'Switched to $name';
+      messenger.showSnackBar(SnackBar(content: Text(msg)));
       widget.onChanged();
       await _load();
     } on ApiException catch (e) {
       if (!mounted) return;
+      // 409 = dirty tree. Pull the file list out of the body and
+      // offer the operator a Stash & switch flow rather than just
+      // a dead-end toast.
+      if (e.statusCode == 409 && !stash) {
+        final body = e.body;
+        final files = <String>[];
+        if (body is Map && body['dirty_files'] is List) {
+          for (final f in body['dirty_files'] as List) {
+            if (f is String) files.add(f);
+          }
+        }
+        final go = await _confirmStashAndSwitch(name, files);
+        if ((go ?? false) && mounted) {
+          await _checkout(name, stash: true);
+        }
+        return;
+      }
       messenger.showSnackBar(
         SnackBar(
           content: Text('Checkout failed: ${e.message}'),
@@ -81,6 +103,73 @@ class _GitBranchControlsState extends ConsumerState<GitBranchControls> {
     } finally {
       if (mounted) setState(() => _busy = false);
     }
+  }
+
+  Future<bool?> _confirmStashAndSwitch(String target, List<String> files) {
+    return showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('Switch to $target?'),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                files.isEmpty
+                    ? 'Working tree has uncommitted changes.'
+                    : '${files.length} file${files.length == 1 ? '' : 's'} '
+                          'will be stashed:',
+                style: const TextStyle(fontSize: 13),
+              ),
+              if (files.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                ConstrainedBox(
+                  constraints: const BoxConstraints(maxHeight: 220),
+                  child: SingleChildScrollView(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        for (final f in files)
+                          Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 2),
+                            child: Text(
+                              f,
+                              style: const TextStyle(
+                                fontFamily: 'monospace',
+                                fontSize: 12,
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+              const SizedBox(height: 12),
+              Text(
+                'Recover later with `git stash pop`.',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: Theme.of(ctx).textTheme.bodySmall?.color,
+                ),
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Stash & switch'),
+          ),
+        ],
+      ),
+    );
   }
 
   // _delete runs `git branch -d` first; if the branch is unmerged

--- a/app/shared/src/lib/git.ts
+++ b/app/shared/src/lib/git.ts
@@ -95,13 +95,28 @@ export async function createGitBranch(
   await api('/api/v1/git/write/branches', { method: 'POST', body: req })
 }
 
+export interface CheckoutResult {
+  current: string
+  stashed?: boolean
+  stash_ref?: string
+}
+
+// 409 response body shape when the working tree is dirty. The
+// client should surface `dirty_files` to the operator and offer a
+// retry with `stash: true`.
+export interface DirtyTreeBody {
+  error: string
+  dirty_files?: string[]
+}
+
 export async function checkoutGitBranch(
   dir: string,
   name: string,
-): Promise<void> {
-  await api('/api/v1/git/write/checkout', {
+  stash = false,
+): Promise<CheckoutResult> {
+  return api<CheckoutResult>('/api/v1/git/write/checkout', {
     method: 'POST',
-    body: { dir, name },
+    body: { dir, name, ...(stash ? { stash: true } : {}) },
   })
 }
 

--- a/app/web/src/components/sessions/inspector/BranchControls.tsx
+++ b/app/web/src/components/sessions/inspector/BranchControls.tsx
@@ -3,11 +3,13 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { GitBranchPlus, GitMerge, Loader2, Upload } from 'lucide-react'
 import { toast } from 'sonner'
 
+import { APIError } from '@/lib/api'
 import {
   checkoutGitBranch,
   createGitBranch,
   listGitBranches,
   pushGit,
+  type DirtyTreeBody,
 } from '@/lib/git'
 import { cn } from '@/lib/utils'
 
@@ -34,15 +36,49 @@ export function BranchControls({ cwd, ahead, upstream }: BranchControlsProps) {
     refetchInterval: 30_000,
   })
 
+  // On a clean tree we just checkout. On 409 (dirty tree) we
+  // surface the file list in a confirm-toast with a "Stash &
+  // switch" action that retries with stash=true. Web doesn't have
+  // a modal helper here so toast.action is the cheapest equivalent
+  // of the mobile dialog — clicking the action button performs the
+  // stash retry.
+  const doCheckout = async (name: string, stash: boolean) => {
+    const res = await checkoutGitBranch(cwd, name, stash)
+    const suffix = res.stashed
+      ? ` (stashed${res.stash_ref ? ` as ${res.stash_ref}` : ''})`
+      : ''
+    toast.success(`Switched to ${name}${suffix}`)
+    qc.invalidateQueries({ queryKey: ['git', 'status', cwd] })
+    qc.invalidateQueries({ queryKey: ['git', 'branches', cwd] })
+    qc.invalidateQueries({ queryKey: ['git', 'log', cwd] })
+  }
+
   const checkout = useMutation({
-    mutationFn: (name: string) => checkoutGitBranch(cwd, name),
-    onSuccess: (_, name) => {
-      toast.success(`Switched to ${name}`)
-      qc.invalidateQueries({ queryKey: ['git', 'status', cwd] })
-      qc.invalidateQueries({ queryKey: ['git', 'branches', cwd] })
-      qc.invalidateQueries({ queryKey: ['git', 'log', cwd] })
-    },
-    onError: (err) => {
+    mutationFn: (name: string) => doCheckout(name, false),
+    onError: (err, name) => {
+      if (err instanceof APIError && err.status === 409) {
+        const body = err.body as DirtyTreeBody | null
+        const files = body?.dirty_files ?? []
+        const preview = files.slice(0, 4).join(', ')
+        const more = files.length > 4 ? ` +${files.length - 4} more` : ''
+        toast.warning(`Uncommitted changes block switch to ${name}`, {
+          description: files.length
+            ? `${preview}${more}`
+            : 'Working tree has uncommitted changes.',
+          action: {
+            label: 'Stash & switch',
+            onClick: () => {
+              void doCheckout(name, true).catch((e) => {
+                toast.error('Stash & switch failed', {
+                  description: (e as Error).message,
+                })
+              })
+            },
+          },
+          duration: 10_000,
+        })
+        return
+      }
       toast.error('Checkout failed', { description: (err as Error).message })
     },
   })

--- a/internal/git/write.go
+++ b/internal/git/write.go
@@ -234,6 +234,11 @@ func (h *Handlers) createBranch(w http.ResponseWriter, r *http.Request) {
 type CheckoutRequest struct {
 	Dir  string `json:"dir"`
 	Name string `json:"name"`
+	// Stash=true asks the server to `git stash push -u` before
+	// checkout. The client typically sets this in response to a
+	// 409 returned from a stash=false attempt, after showing the
+	// operator the dirty file list.
+	Stash bool `json:"stash"`
 }
 
 func (h *Handlers) checkoutBranch(w http.ResponseWriter, r *http.Request) {
@@ -250,23 +255,49 @@ func (h *Handlers) checkoutBranch(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, errors.New("invalid branch name"))
 		return
 	}
-	// Refuse on dirty tree — checkout would either fail mid-flight
-	// (uncommitted changes block) or silently carry changes across,
-	// which is rarely what the operator wants from a click.
-	if dirty, err := isDirty(r.Context(), req.Dir); err != nil {
+	files, err := dirtyFiles(r.Context(), req.Dir)
+	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
-	} else if dirty {
-		writeError(w, http.StatusConflict,
-			errors.New("working tree has uncommitted changes; commit or stash first"))
-		return
+	}
+	stashed := false
+	stashRef := ""
+	if len(files) > 0 {
+		if !req.Stash {
+			// Surface the dirty file list so the client can show
+			// the operator exactly what's at stake before they
+			// hit "Stash & switch".
+			writeJSON(w, http.StatusConflict, map[string]any{
+				"error":       "working tree has uncommitted changes; commit or stash first",
+				"dirty_files": files,
+			})
+			return
+		}
+		msg := fmt.Sprintf("opendray-auto: switch to %s", req.Name)
+		if out, err := runCombined(r.Context(), req.Dir,
+			"stash", "push", "--include-untracked", "-m", msg); err != nil {
+			writeError(w, http.StatusInternalServerError,
+				fmt.Errorf("stash: %w (%s)", err, out))
+			return
+		}
+		stashed = true
+		// Read back the just-created stash ref (stash@{0}) so the
+		// client can show "stashed as X" and offer pop later.
+		if out, err := run(r.Context(), req.Dir,
+			"rev-parse", "--short", "refs/stash"); err == nil {
+			stashRef = strings.TrimSpace(string(out))
+		}
 	}
 	if out, err := runCombined(r.Context(), req.Dir, "checkout", req.Name); err != nil {
 		writeError(w, http.StatusInternalServerError,
 			fmt.Errorf("checkout: %w (%s)", err, out))
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"current": req.Name})
+	writeJSON(w, http.StatusOK, map[string]any{
+		"current":   req.Name,
+		"stashed":   stashed,
+		"stash_ref": stashRef,
+	})
 }
 
 // ── Branch delete ──────────────────────────────────────────────
@@ -486,14 +517,26 @@ func runCombined(ctx context.Context, dir string, args ...string) (string, error
 	return strings.TrimSpace(string(out)), err
 }
 
-// isDirty asks git whether the working tree has uncommitted
-// changes. Used by checkout to block lossy switches.
-func isDirty(ctx context.Context, dir string) (bool, error) {
+// dirtyFiles returns the list of working-tree paths reported by
+// `git status --porcelain` (both staged and unstaged, plus
+// untracked). Empty slice means the tree is clean. Callers use it
+// to block lossy switches AND to render the dirty list to the
+// operator so they know what a stash would carry.
+func dirtyFiles(ctx context.Context, dir string) ([]string, error) {
 	out, err := run(ctx, dir, "status", "--porcelain")
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	return strings.TrimSpace(string(out)) != "", nil
+	var files []string
+	for _, line := range strings.Split(string(out), "\n") {
+		// Porcelain v1 format: XY␣path. Drop the 2-char status
+		// prefix + the single space separator.
+		if len(line) < 4 {
+			continue
+		}
+		files = append(files, strings.TrimSpace(line[3:]))
+	}
+	return files, nil
 }
 
 // validateWritePath enforces the same rules as dirParam for write


### PR DESCRIPTION
## Summary

Switching branches was refused on any dirty tree, which is too aggressive — operators routinely want to carry uncommitted work across a switch via stash. Reshape the flow so the dirty tree is informative, not a dead end.

- **Server**: `CheckoutRequest` gains a `stash` flag. On dirty tree with `stash:false` → **409** with `dirty_files` array in the body. With `stash:true` → `git stash push --include-untracked -m "opendray-auto: ..."` then checkout, response includes `stashed` + `stash_ref` so the operator sees what was saved.
- `isDirty()` → `dirtyFiles()` helper returning the porcelain paths.
- **Mobile**: `_checkout` catches 409, parses `dirty_files`, opens a confirm dialog listing the files with a "Stash & switch" button that retries with `stash:true`. Toast shows `Switched to X (stashed as <ref>)` so `git stash pop` recovery is obvious.
- **Web**: `BranchControls` surfaces the same flow via a sonner toast with action button.
- Gitignore `/opendray.log` so the gateway's runtime log doesn't pollute the tree.
- Commit `Podfile.lock` (the pod install diff produced by the recent mobile rebuild).

## Test plan

- [x] `go build` + `go test ./internal/git/...`
- [x] `flutter analyze` clean
- [x] `pnpm tsc --noEmit` web clean
- [ ] Manual: on mobile with a dirty tree, tap a different branch → dialog shows file list + "Stash & switch" → confirm → toast "Switched to X (stashed as ...)" → on the new branch
- [ ] Manual: `git stash list` shows the auto-named stash, `git stash pop` restores cleanly
- [ ] Manual: with a clean tree, switch works as before
- [ ] Manual: web inspector shows the action toast when tree is dirty

🤖 Generated with [Claude Code](https://claude.com/claude-code)