### PR TITLE
feat(web): resizable inspector panel

### DIFF
--- a/app/shared/src/stores/layout.ts
+++ b/app/shared/src/stores/layout.ts
@@ -8,21 +8,40 @@ interface LayoutState {
   sessionListCollapsed: boolean
   /** Right-side inspector panel (Plugins / MCP / Files / Logs). */
   inspectorOpen: boolean
+  /** Inspector width in CSS pixels. User-resizable via the drag
+   *  handle on the inspector's left edge. */
+  inspectorWidth: number
   /** UI scale applied via CSS zoom on <body>. 1 = default. */
   fontScale: number
 
   toggleSidebar: () => void
   toggleSessionList: () => void
   toggleInspector: () => void
+  setInspectorWidth: (v: number) => void
   setFontScale: (v: number) => void
 }
 
 const FONT_SCALE_MIN = 0.7
 const FONT_SCALE_MAX = 1.5
 
+// Inspector drag range. 320 matches the old hardcoded `w-80` so
+// existing sessions don't visibly shift on first load; 900 keeps
+// the terminal usable on a 1440px workspace.
+export const INSPECTOR_WIDTH_MIN = 320
+export const INSPECTOR_WIDTH_MAX = 900
+export const INSPECTOR_WIDTH_DEFAULT = 320
+
 function clampScale(v: number): number {
   if (!Number.isFinite(v)) return 1
   return Math.min(FONT_SCALE_MAX, Math.max(FONT_SCALE_MIN, v))
+}
+
+function clampInspectorWidth(v: number): number {
+  if (!Number.isFinite(v)) return INSPECTOR_WIDTH_DEFAULT
+  return Math.min(
+    INSPECTOR_WIDTH_MAX,
+    Math.max(INSPECTOR_WIDTH_MIN, Math.round(v)),
+  )
 }
 
 // Apply on <body> rather than <html>: keeps `100svh`/`100vh` correct
@@ -40,6 +59,7 @@ export const useLayout = create<LayoutState>()(
       sidebarCollapsed: false,
       sessionListCollapsed: false,
       inspectorOpen: true,
+      inspectorWidth: INSPECTOR_WIDTH_DEFAULT,
       fontScale: 1,
 
       toggleSidebar: () =>
@@ -48,6 +68,8 @@ export const useLayout = create<LayoutState>()(
         set({ sessionListCollapsed: !get().sessionListCollapsed }),
       toggleInspector: () =>
         set({ inspectorOpen: !get().inspectorOpen }),
+      setInspectorWidth: (v) =>
+        set({ inspectorWidth: clampInspectorWidth(v) }),
       setFontScale: (v) => {
         const next = clampScale(v)
         set({ fontScale: next })

--- a/app/web/src/components/sessions/InspectorPanel.tsx
+++ b/app/web/src/components/sessions/InspectorPanel.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useRef } from 'react'
 import {
   Brain,
   Folder,
@@ -11,6 +12,12 @@ import { useTranslation } from 'react-i18next'
 
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import {
+  INSPECTOR_WIDTH_DEFAULT,
+  INSPECTOR_WIDTH_MAX,
+  INSPECTOR_WIDTH_MIN,
+  useLayout,
+} from '@/stores/layout'
 import type { Session } from '@/lib/types'
 
 import { FilesPanel } from './inspector/FilesPanel'
@@ -26,11 +33,75 @@ interface InspectorPanelProps {
 }
 
 // InspectorPanel — right-hand workbench sidebar. All four tabs are
-// scoped to the current session's working directory.
+// scoped to the current session's working directory. Width is
+// user-resizable via the drag handle on the left edge; the size is
+// persisted in the layout store so it survives reloads. During the
+// drag we write the width directly to the aside's style attribute
+// (bypassing React) so the panel tracks the pointer at native
+// frame rate — the store only gets the final value on release.
 export function InspectorPanel({ session }: InspectorPanelProps) {
   const { t } = useTranslation()
+  const width = useLayout((s) => s.inspectorWidth)
+  const setWidth = useLayout((s) => s.setInspectorWidth)
+  const asideRef = useRef<HTMLElement>(null)
+
+  const onHandlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault()
+      const handle = e.currentTarget
+      handle.setPointerCapture(e.pointerId)
+      const aside = asideRef.current
+      if (!aside) return
+      const clamp = (v: number) =>
+        Math.min(INSPECTOR_WIDTH_MAX, Math.max(INSPECTOR_WIDTH_MIN, v))
+
+      const onMove = (ev: PointerEvent) => {
+        // Inspector is anchored to the right edge of the viewport,
+        // so width = viewport - pointerX.
+        const next = clamp(Math.round(window.innerWidth - ev.clientX))
+        aside.style.width = `${next}px`
+      }
+      const onUp = (ev: PointerEvent) => {
+        handle.removeEventListener('pointermove', onMove)
+        handle.removeEventListener('pointerup', onUp)
+        handle.removeEventListener('pointercancel', onUp)
+        const final = clamp(Math.round(window.innerWidth - ev.clientX))
+        setWidth(final)
+      }
+      handle.addEventListener('pointermove', onMove)
+      handle.addEventListener('pointerup', onUp)
+      handle.addEventListener('pointercancel', onUp)
+    },
+    [setWidth],
+  )
+
+  const onHandleDoubleClick = useCallback(() => {
+    if (asideRef.current) {
+      asideRef.current.style.width = `${INSPECTOR_WIDTH_DEFAULT}px`
+    }
+    setWidth(INSPECTOR_WIDTH_DEFAULT)
+  }, [setWidth])
+
   return (
-    <aside className="w-80 shrink-0 border-l border-border bg-background flex flex-col">
+    <aside
+      ref={asideRef}
+      style={{ width }}
+      className="shrink-0 border-l border-border bg-background flex flex-col relative"
+    >
+      {/* Drag handle: a 6px column on the absolute left edge of
+          the panel. Hover and active states highlight the inner
+          1px line so the operator can see what's grabbable.
+          Double-click resets to the default width. */}
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize inspector"
+        onPointerDown={onHandlePointerDown}
+        onDoubleClick={onHandleDoubleClick}
+        className="absolute left-0 top-0 bottom-0 w-1.5 -translate-x-1/2 z-10 cursor-ew-resize group"
+      >
+        <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-transparent group-hover:bg-primary/40 group-active:bg-primary transition-colors" />
+      </div>
       <Tabs defaultValue="files" className="flex-1 flex flex-col min-h-0">
         <div className="px-2 py-2 border-b border-border shrink-0">
           {/* 7 tabs in a 4-col grid → row 1: Files / Git / Search / Tasks,


### PR DESCRIPTION
## Summary

Inspector was hardcoded to `w-80` (320px), which is too narrow for the Git tab — branch rows, PR cards and the check list all clip at the right edge.

Make the panel user-resizable:
- `layout` store gains `inspectorWidth` (clamped **320–900**, persisted via the existing zustand middleware) and `setInspectorWidth`.
- `InspectorPanel` reads width from the store and renders a 6px drag handle on its left edge. During the drag the aside's `style.width` is updated directly via ref so the panel tracks the pointer at native frame rate; only the final value is committed to the store on `pointerup` — one render per drag.
- Double-click the handle resets to the default width.
- Default stays at 320 so existing users don't see a layout shift on first load.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm build` produces the web bundle
- [ ] Manual: drag the inspector's left edge → width follows pointer smoothly
- [ ] Manual: stop dragging, reload page → width persists
- [ ] Manual: double-click the handle → resets to 320
- [ ] Manual: clamp behaviour: can't shrink below 320 or grow past 900
- [ ] Manual: Git tab content (branch picker, PR rows, checks) no longer clips at wider widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)