### PR TITLE
docs(tutorial): Git workflow web + mobile sections

### DIFF
--- a/app/web/src/tutorial/sections/02-sessions/03-inspector.md
+++ b/app/web/src/tutorial/sections/02-sessions/03-inspector.md
@@ -6,18 +6,19 @@ that doesn't fit inline in the terminal.
 
 ![Inspector panel tabs](/tutorial/sessions-inspector.png)
 
-Toggle the panel with the keyboard shortcut **`g i`** or the icon
-in the top-right of the terminal pane.
+Toggle the panel with the inspector-toggle icon in the top-right
+of the WorkbenchHeader (next to the session controls). The open
+state persists per-user across reloads.
 
 ## Sub-tabs
 
-The Inspector currently exposes six tabs in a 2×4 grid (top row
-of four + bottom row of two wider tabs):
+The Inspector exposes seven tabs in a 3-row grid (4 + 2 + 1):
 
 | Row | Tabs |
 |---|---|
 | 1 | Files · Git · Search · Tasks |
 | 2 | History · Notes |
+| 3 | Memory |
 
 All tabs scope to the **session's `cwd`** — there's nothing
 showing data outside that working directory.
@@ -37,10 +38,10 @@ subtrees on demand.
 
 ### Git
 
-Inline `git status` for the cwd: untracked / modified / staged
-files with diff previews on click. Only shown when the cwd is
-inside a git repo. Useful for the "what did the agent actually
-change?" review at the end of a session.
+A full Git workbench for the cwd: branch switching, staging,
+commits, push, and the in-panel pull-request command center.
+Only shown when the cwd is inside a git repo. See
+[Git workflow](#02-sessions-07-git-workflow) for the full tour.
 
 ### Search
 
@@ -121,14 +122,20 @@ file-based, not in-memory.
   here, since dropped. Use Search instead, or the agent's own
   scrollback.
 
-## Hiding the inspector
+## Sizing and hiding
 
-Two options:
+The panel anchors to the right edge of the workbench and is
+**user-resizable**:
 
-- **Toggle** with `g i` to slide the panel off-screen (state
-  per-user, persists across reloads).
-- **Collapse a single tab** by clicking its tab pill twice.
+- **Drag the left edge** to resize. A 6-pixel column on the
+  inspector's left edge highlights on hover; press and drag to
+  any width between **320 px** (default) and **900 px**.
+- **Double-click** the same edge to snap back to the default
+  width.
+- The width is persisted per-user (zustand `opendray.layout` in
+  `localStorage`), so it survives reloads and re-spawned
+  sessions.
 
-When opened, the panel takes ~360 px on the right. On narrow
-windows (<1200 px) it overlays the terminal instead of
-side-by-side.
+To hide the panel entirely, click the inspector-toggle icon in
+the WorkbenchHeader. The open/closed state is persisted the same
+way.

--- a/app/web/src/tutorial/sections/02-sessions/07-git-workflow.md
+++ b/app/web/src/tutorial/sections/02-sessions/07-git-workflow.md
@@ -1,0 +1,193 @@
+# Git workflow
+
+The **Git** tab on the Inspector turns the session's working
+directory into a self-contained PR command center: switch
+branches, stage files, commit, push, open a pull request, watch
+its CI checks, and merge — without leaving opendray.
+
+The tab only renders when the cwd is inside a git repo. If `git
+rev-parse` fails on the directory, the panel collapses to a
+short "not a git repo" hint.
+
+## Status header
+
+The top of the tab summarises where you are:
+
+- **Current branch** and its upstream (e.g. `feat/foo →
+  origin/feat/foo`). When there's no upstream tracked the row
+  reads "no upstream" — the **Push** button below will use
+  `--set-upstream` on first push.
+- **Ahead / behind counts** vs the upstream. `+3 / -1` means
+  three local commits not on the remote and one remote commit
+  not on you.
+- A working-tree summary — counts of staged, unstaged, and
+  untracked files. The numbers are clickable; they jump to the
+  staging area below.
+
+## Branch controls
+
+The strip under the status header has every branch operation:
+
+| Element | Purpose |
+|---|---|
+| Branch dropdown | Switch to any other local branch. The list is fetched once on tab open and refreshes when any other branch op succeeds. |
+| **+ New** | Create a branch from current HEAD and switch to it. One-input modal. |
+| **Push** | Push to upstream. First push (no upstream) uses `--set-upstream`. Disabled when ahead == 0 and an upstream is already set. |
+
+### Stash & switch
+
+Switching with a dirty tree is not blocked. If the server
+detects uncommitted changes during a `checkout`, the response is
+a **409 Conflict** whose body carries a `dirty_files: [...]`
+array. The web UI catches that and surfaces a Sonner toast like:
+
+> Uncommitted changes block switch to `main`
+> &nbsp;&nbsp;`app/foo.ts, internal/bar.go, app/baz.tsx`
+> &nbsp;&nbsp;[ Stash & switch ]
+
+Clicking **Stash & switch** retries the checkout with
+`stash: true`. The server runs `git stash push --include-untracked
+-m "opendray-auto: switch to <branch>"` first, then performs the
+checkout, and returns the stash short ref. The success toast
+shows it explicitly so recovery is one terminal command away:
+
+> Switched to `main` (stashed as `abc1234`)
+
+Recover the stashed work later with `git stash pop` (or
+`git stash apply` if you want to keep the stash around).
+
+## Staging and commit
+
+The middle pane lists every working-tree change with porcelain
+status codes (`M`, `A`, `??`, etc.). Per-row actions:
+
+- **Stage** moves an unstaged change to the index.
+- **Unstage** is the reverse for staged rows.
+- **Diff** opens a unified diff in a side drawer (read-only).
+
+Bulk actions:
+
+- **Stage all** = `git add .`
+- **Unstage all** = `git reset`
+
+The commit form sits below the file list:
+
+- Multi-line **message** field. **Cmd / Ctrl + Enter** submits
+  without needing to mouse over to the button.
+- Live staged-count badge — the **Commit** button is disabled
+  until at least one file is staged.
+- On success the form clears, the working-tree status refreshes,
+  and the new HEAD shows in the log strip on the right.
+
+## Pull requests
+
+Below the commit form is the **PR command center**. It's the
+same surface for GitHub, Gitea, and GitLab — the gateway
+normalises the API differences into one shape.
+
+### Listing
+
+The default view lists **open** PRs for the current remote.
+Switch to **Closed** or **All** via the pill toggle above the
+list. Each row shows:
+
+| Column | Notes |
+|---|---|
+| `#NN` | Click → opens the PR in a new tab on the host. |
+| Title | Truncated; full title on hover. |
+| Author | Avatar + login. |
+| Branches | `head → base` (e.g. `feat/foo → main`). |
+| Aggregate checks | Coloured pill — `success`, `failure`, `pending`, `mixed`. See the Checks subsection. |
+
+Clicking a row **expands it in place** to reveal the Checks list
+and the Merge form.
+
+### Creating
+
+The **+ Create PR** button opens an inline form:
+
+- **Title** — defaults to the last commit subject.
+- **Body** — multi-line.
+- **Head** — the current branch (read-only).
+- **Base** — defaults to the host's default branch (`main` /
+  `master` / whatever the repo is configured with). Resolved via
+  the host API, not a hard-coded string. Override freely.
+
+Submit → opens the PR, the new row appears at the top of the
+list, expanded.
+
+### Merging
+
+Each expanded PR row carries a Merge form with the standard
+GitHub merge methods:
+
+- **Merge commit** — default `--merge`.
+- **Squash and merge** — `--squash`. Recommended for the
+  one-commit-per-PR workflow this project uses.
+- **Rebase and merge** — `--rebase`. Use sparingly; rebasing
+  loses the merge anchor.
+
+**Delete branch on merge** is a checkbox below the method
+toggle. Defaults to **on** — branches accumulate fast otherwise.
+
+### Checks
+
+Once a row is expanded, opendray polls the PR's checks every
+30 s and shows them as a list. Vocabulary is normalised to
+GitHub's:
+
+| Status | Meaning |
+|---|---|
+| `success` | Job finished without errors. |
+| `failure` | Job ran and failed. |
+| `pending` | Queued or in progress. |
+| `neutral` | Job finished without a pass/fail verdict. |
+| `cancelled` | Killed before finishing. |
+| `skipped` | Conditionally skipped by the workflow. |
+
+Gitea and GitLab's commit-status endpoints map onto this
+vocabulary so you can use the same UI without worrying about
+which host emitted what.
+
+The aggregate verdict on the list row is the worst-case
+rollup: any `failure` → `failure`; otherwise any `pending` →
+`pending`; otherwise `success`. Hover the badge for a tooltip
+with the breakdown.
+
+## When something goes wrong
+
+The Git tab surfaces server errors as Sonner toasts in
+red. Common ones:
+
+- **`fatal: not a git repository`** — the cwd isn't tracked;
+  the panel will go back to "not a git repo" empty state.
+- **`Permission denied (publickey)`** on push — the gateway's
+  Git credentials don't have write access to that remote.
+  Check the PAT in **Settings → Git hosts**.
+- **`branch '<name>' not fully merged`** on delete — git's
+  safe-delete refusal. The toast offers a force-delete
+  confirmation that upgrades to `git branch -D`.
+
+## Backend routes
+
+For wire-level debugging, the endpoints powering this tab live
+under `/api/v1/git/...`:
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/git/status` | Working-tree + branch summary. |
+| GET | `/git/log` | Recent commits on HEAD. |
+| GET | `/git/write/branches` | All branches (local + remote refs). |
+| POST | `/git/write/branches` | Create + optional checkout. |
+| DELETE | `/git/write/branches` | Delete (query: `name`, `force`). |
+| POST | `/git/write/checkout` | Switch branch. `stash: true` body field auto-stashes a dirty tree. |
+| POST | `/git/write/stage` `/unstage` | Index ops. |
+| POST | `/git/write/commit` | Create a commit. |
+| POST | `/git/write/push` | `--set-upstream` on first push. |
+| GET | `/git/prs` | List PRs for the cwd's remote. |
+| POST | `/git/prs` | Create. |
+| POST | `/git/prs/{n}/merge` | Merge with method options. |
+| GET | `/git/prs/{n}/checks` | Normalised check runs. |
+
+Each route is auth-gated; the embedded web client wires the
+session token through automatically.

--- a/app/web/src/tutorial/sections/02-sessions/08-mobile-git.md
+++ b/app/web/src/tutorial/sections/02-sessions/08-mobile-git.md
@@ -1,0 +1,124 @@
+# Mobile Git workflow
+
+The mobile app mirrors the web's [Git workflow](#02-sessions-07-git-workflow)
+with a touch-first layout. Everything in this section is the
+mobile UI's equivalent of the web Git tab — the gateway routes
+are identical, so the two clients can operate on the same repo
+without stepping on each other.
+
+Open it under **Session detail → Git tab** (the second pill at
+the top of the inspector pages).
+
+## Status pane
+
+The header echoes the web tab: current branch + upstream,
+ahead/behind counts, working-tree file count. Tap the working
+tree row to expand it into the file list.
+
+## Branch picker (bottom sheet)
+
+Tapping the current-branch chip opens a **bottom sheet** that
+fills 75% of the viewport — there's no room for the web's
+dropdown on a phone screen, and the sheet gives each branch
+space for its upstream subtitle and a delete affordance.
+
+| Section | What's listed |
+|---|---|
+| **Local** | Every `refs/heads/*` ref. Current branch is pinned to the top with a checkmark icon; the rest are alphabetical. |
+| **Remote** | Every `refs/remotes/<remote>/*` ref except `HEAD` symrefs. Tapping a remote ref checks out the local branch of the same name (same as `git checkout <name>`'s remote-tracking shortcut). |
+
+Each row:
+
+- **Tap** the row → checkout that branch.
+- **Tap the trash icon** on the right → delete the branch
+  (disabled on the current branch).
+
+The "+ New" and "Push" buttons sit on the action strip
+alongside the chip, so the common ops are one tap from any
+screen.
+
+### Stash & switch
+
+If the working tree is dirty when you tap a branch, the server
+returns 409 + a `dirty_files` array. The mobile UI opens an
+AlertDialog showing the file list (scrollable, monospace) with
+two buttons:
+
+- **Cancel** — leave the tree alone.
+- **Stash & switch** — auto-stashes the tree
+  (`git stash push --include-untracked`) and switches.
+
+On success a Snackbar toast confirms `Switched to <branch>
+(stashed as abc1234)`. Recover the stash later from a terminal
+with `git stash pop`.
+
+### Delete with force fallback
+
+`-d` is the default. If git refuses with "not fully merged" the
+server returns 409, and the UI surfaces a **second** dialog —
+"Force delete? Branch is not fully merged. Forcing deletion
+will lose any commits unique to this branch." The confirm
+upgrades the call to `-D`. The two-step gating means a slip
+can't blow away work.
+
+## Commit form
+
+A simplified form lives below the file list:
+
+- **Stage all** button — there's no per-file stage UI on the
+  mobile (no hover targets). Manage individual files from the
+  web inspector or a terminal if you need finer control.
+- **Multi-line message** field — the soft keyboard reveals an
+  Enter button (added separately) so newlines work without
+  hunting the toolbar.
+- **Commit** button — disabled until something is staged.
+
+After commit, the file list and status header refresh from the
+server.
+
+## Pull requests
+
+Below the commit form is the **PR section**:
+
+- A scrollable list of open PRs, polled every 60 seconds.
+- **+ Create** opens a bottom-sheet form (title / body / base
+  with default-branch resolution).
+- Tapping a PR row expands an inline panel with the check
+  runs (polled every 30 seconds while expanded) and the merge
+  form.
+
+The merge form's options match the web's: method (merge /
+squash / rebase) and a "delete branch on merge" checkbox
+defaulting to **on**.
+
+## Polling cadence summary
+
+The mobile app polls more aggressively than the web because
+there's no event-bus subscription on iOS yet:
+
+| Source | Cadence | Stops when |
+|---|---|---|
+| Branch list | On open + after any branch op | tab unmounts |
+| Status / file list | 8 s | tab unmounts |
+| PR list | 60 s | tab unmounts |
+| PR checks (expanded row) | 30 s | row collapses |
+
+These intervals are tuned to feel "live" without burning radio
+on a phone. If you're plugged in and want faster updates,
+trigger a manual refresh via the swipe-down on the list.
+
+## Differences vs the web
+
+The web Git tab has a few capabilities the mobile doesn't yet
+mirror:
+
+- **Per-file staging** — web has stage/unstage buttons next to
+  every changed path. Mobile is stage-all only for now.
+- **Diff drawer** — web opens a unified diff on tap. Mobile
+  shows just the porcelain status code; viewing diffs needs the
+  web or a terminal.
+- **Force-with-lease push** — web has an opt-in checkbox.
+  Mobile push always uses the safe path.
+
+All other features (branches, PRs, stash & switch, etc.) are
+on parity.


### PR DESCRIPTION
## Summary

The Inspector tutorial described 6 tabs, a fixed ~360 px width, and a `g i` shortcut that doesn't exist. The Git tab itself was one paragraph about `git status` and missed every PR / branch / commit feature shipped since #155.

Refresh the tutorial to match the live UI:

- **`03-inspector.md`** — 7 tabs (Files / Git / Search / Tasks / History / Notes / Memory), drag-to-resize width **320–900 px** persisted via zustand, real toggle via the WorkbenchHeader icon. Git tab description trimmed to a pointer at the new page.
- **`07-git-workflow.md`** (new) — full web tour: status header, branch controls, stash & switch, staging + commit, PR command center (list / create / merge / normalised checks vocabulary), error toasts, plus the backend route table for wire-level debugging.
- **`08-mobile-git.md`** (new) — mobile parallel: bottom-sheet branch picker, stash dialog with file list, force-delete fallback, commit form, PR section, polling cadences, and the short list of capabilities still only on web.

## Test plan

- [x] `pnpm tsc --noEmit`
- [x] `pnpm build` regenerates the embedded bundle
- [ ] Open Tutorial → Sessions → Inspector / Git workflow / Mobile Git renders cleanly
- [ ] Cross-links from Inspector → Git workflow resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)