### PR TITLE
fix(web): hide retired 'wechat' kind from channel create dropdown

### DIFF
--- a/app/web/src/pages/Channels.tsx
+++ b/app/web/src/pages/Channels.tsx
@@ -1101,8 +1101,19 @@ function buildConfigFromValues(
   return cfg
 }
 
+// Server-registered kinds that we explicitly hide from the
+// create-flow dropdown. Channels already in this state still
+// render in the channel list — only the *new channel* option is
+// suppressed. Used for kinds whose adapter still ships
+// server-side (so existing rows keep working) but whose UX we
+// no longer want operators to discover.
+const HIDDEN_KINDS = new Set(['wechat'])
+
 // orderKinds produces the dropdown order: native kinds first
 // (KIND_DEFS order), then unknown kinds, then bridge last.
+// Anything in HIDDEN_KINDS is dropped from the unknown bucket so
+// retired entries (e.g. personal-WeChat / WxPusher) don't reappear
+// just because the server still registers the adapter.
 function orderKinds(kinds: string[]): string[] {
   const known = KIND_DEFS.map((k) => k.kind)
   const set = new Set(kinds)
@@ -1111,7 +1122,9 @@ function orderKinds(kinds: string[]): string[] {
     if (set.has(k)) out.push(k)
   }
   for (const k of kinds) {
-    if (!known.includes(k) && k !== 'bridge') out.push(k)
+    if (!known.includes(k) && k !== 'bridge' && !HIDDEN_KINDS.has(k)) {
+      out.push(k)
+    }
   }
   if (set.has('bridge')) out.push('bridge')
   return out


### PR DESCRIPTION
## Summary

PR #166 removed personal-WeChat from `KIND_DEFS`, but the web's kind picker pulls from the server's `listChannelKinds()`. The server still returns `'wechat'` because the adapter is registered for back-compat. `orderKinds()` routed unknown kinds into the dropdown verbatim, so `wechat` resurfaced — with a generic envelope icon and the lowercase kind id, both of which were a giveaway that this wasn't an intentional entry.

Add an explicit `HIDDEN_KINDS` deny-list in `orderKinds` that filters the unknown bucket. Existing `wechat` channels still render in the channel list and the per-card actions still work; only the **new channel** discovery path is suppressed.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm build` regenerates the embedded bundle
- [ ] Web: open New Channel dropdown — no `wechat` entry between WeCom and bridge
- [ ] Web: existing `wechat`-kind channels (if any) still appear in the channel list

🤖 Generated with [Claude Code](https://claude.com/claude-code)