### PR TITLE
feat(web): add Docs sidebar entry linking to docs.opendray.dev

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -38,6 +38,7 @@
     "backups": "Backups",
     "settings": "Settings",
     "tutorial": "Tutorial",
+    "docs": "Docs",
     "workspace": "Workspace"
   },
   "web": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -38,6 +38,7 @@
     "backups": "备份",
     "settings": "设置",
     "tutorial": "教程",
+    "docs": "文档",
     "workspace": "工作区"
   },
   "web": {

--- a/app/web/src/components/SidebarNav.tsx
+++ b/app/web/src/components/SidebarNav.tsx
@@ -10,6 +10,7 @@ import {
   Boxes,
   NotebookPen,
   BookOpen,
+  ExternalLink,
   Brain,
   Archive,
   type LucideIcon,
@@ -20,11 +21,19 @@ import { cn } from '@/lib/utils'
 import { useLayout } from '@/stores/layout'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
+// NavItem covers both in-app routes and external links. In-app items
+// set `to`; external items set `href` (rendered as `<a target="_blank">`).
+// The Tutorial entry stays in-app while the documentation site at
+// docs.opendray.dev ramps up; once it's the canonical reference, the
+// Tutorial entry will be retired and only the external Docs link
+// remains.
 interface NavItem {
-  to: string
   icon: LucideIcon
   labelKey: string
-  shortcut: string
+  shortcut?: string
+  to?: string
+  href?: string
+  external?: boolean
 }
 
 // Three semantic groups separated by a thin divider:
@@ -48,6 +57,12 @@ const groups: NavItem[][] = [
     { to: '/backups', icon: Archive, labelKey: 'nav.backups', shortcut: 'g b' },
     { to: '/settings', icon: Settings, labelKey: 'nav.settings', shortcut: 'g ,' },
     { to: '/tutorial', icon: BookOpen, labelKey: 'nav.tutorial', shortcut: 'g h' },
+    {
+      href: 'https://docs.opendray.dev',
+      external: true,
+      icon: ExternalLink,
+      labelKey: 'nav.docs',
+    },
   ],
 ]
 
@@ -78,43 +93,73 @@ export function SidebarNav() {
               aria-hidden
             />
           )}
-          {group.map(({ to, icon: Icon, labelKey, shortcut }) => {
+          {group.map((item) => {
+            const { icon: Icon, labelKey, shortcut, to, href, external } = item
             const label = t(labelKey)
-            const active =
-              to === '/sessions'
+            const key = to ?? href ?? labelKey
+            const active = to
+              ? to === '/sessions'
                 ? location.pathname.startsWith('/sessions') ||
                   location.pathname === '/'
                 : location.pathname.startsWith(to)
-            const link = (
-              <Link
-                key={to}
-                to={to}
-                aria-label={label}
-                className={cn(
-                  'flex items-center h-7 rounded-md text-[13px] transition-all duration-100',
-                  'text-muted-foreground hover:text-foreground hover:bg-card',
-                  active && 'bg-card text-foreground',
-                  collapsed ? 'justify-center px-0' : 'gap-2.5 px-2.5',
-                )}
-              >
+              : false
+
+            const linkClassName = cn(
+              'flex items-center h-7 rounded-md text-[13px] transition-all duration-100',
+              'text-muted-foreground hover:text-foreground hover:bg-card',
+              active && 'bg-card text-foreground',
+              collapsed ? 'justify-center px-0' : 'gap-2.5 px-2.5',
+            )
+
+            const inner = (
+              <>
                 <Icon className="size-3.5 shrink-0" />
                 {!collapsed && (
                   <>
                     <span className="flex-1">{label}</span>
-                    <kbd className="opacity-0 group-hover:opacity-100">
-                      {shortcut}
-                    </kbd>
+                    {shortcut && (
+                      <kbd className="opacity-0 group-hover:opacity-100">
+                        {shortcut}
+                      </kbd>
+                    )}
                   </>
                 )}
+              </>
+            )
+
+            const link = external ? (
+              <a
+                key={key}
+                href={href}
+                target="_blank"
+                rel="noreferrer noopener"
+                aria-label={label}
+                className={linkClassName}
+              >
+                {inner}
+              </a>
+            ) : (
+              <Link
+                key={key}
+                to={to as string}
+                aria-label={label}
+                className={linkClassName}
+              >
+                {inner}
               </Link>
             )
+
             if (!collapsed) return link
             return (
-              <Tooltip key={to}>
+              <Tooltip key={key}>
                 <TooltipTrigger asChild>{link}</TooltipTrigger>
                 <TooltipContent side="right">
                   {label}
-                  <span className="ml-2 text-muted-foreground">{shortcut}</span>
+                  {shortcut && (
+                    <span className="ml-2 text-muted-foreground">
+                      {shortcut}
+                    </span>
+                  )}
                 </TooltipContent>
               </Tooltip>
             )


### PR DESCRIPTION
## Summary

Phase 1 of the docs-site migration. The documentation site at
`docs.opendray.dev` (VitePress, bilingual EN/ZH, 81 pages built from
the existing tutorial content) is the long-term home for the
tutorial. This PR plants the external link in the web sidebar so
users start discovering it; the in-app **Tutorial** page stays in
place until the docs site is fully published and verified.

- New i18n key `nav.docs` — `en: "Docs"`, `zh: "文档"`
- `SidebarNav` extended: items can now declare either `to` (in-app
  route, rendered as `<Link>`) or `href` (external, rendered as
  `<a target="_blank" rel="noreferrer noopener">`)
- New **Docs** entry with `ExternalLink` icon sits right next to
  **Tutorial** in the platform group (Plugins · Backups · Settings ·
  Tutorial · Docs↗)

## Phase 2 (separate PR, after docs.opendray.dev is live)

- Remove `app/web/src/tutorial/` (81 markdown pages + sections.ts)
- Remove `app/web/public/tutorial/` (screenshots)
- Remove `pages/Tutorial.tsx` and the `/tutorial` route in `router.tsx`
- Remove the **Tutorial** sidebar entry (only **Docs** remains)
- Rewrite the two `to="/tutorial"` deep-links in
  `components/providers/ClaudeAccountsPanel.tsx` to point at
  `https://docs.opendray.dev/providers/claude-accounts`

## Test plan

- [x] `pnpm tsc --noEmit` passes (web package)
- [ ] Sidebar shows new **Docs** entry between Tutorial and divider
- [ ] Hovering **Docs** (collapsed sidebar) shows the tooltip without
      a shortcut suffix
- [ ] Clicking **Docs** opens `docs.opendray.dev` in a new tab
- [ ] **Tutorial** in-app page still works (regression check)
- [ ] Chinese locale shows `文档` for the new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)