### PR TITLE
docs(versioning): adopt major-as-generation versioning; document v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,26 @@
 
 All notable changes to OpenDray v2 are documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Version numbers follow this project's own **major-as-generation**
+strategy — major version = product generation, minor = feature
+iteration, patch = fix / polish. See [VERSIONING.md](./VERSIONING.md)
+for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
+
+## [v2.0.0] — 2026-05-17
+
+### Versioning realignment
+
+- **Re-tagged from the previous `v1.0.0` tag** (issue #165). The
+  major version now reflects this codebase's identity as the second
+  generation of the opendray product (`opendray_v2`). The previous
+  `v1.0.0` tag was deleted (had three duplicate draft releases on
+  GitHub, all deleted; no published release; no downstream
+  installers depend on it).
+- New [VERSIONING.md](./VERSIONING.md) documents the
+  major-as-generation policy and what triggers future bumps.
 
 ### Added
 
@@ -87,7 +103,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolve the duplicate-0011 collision with `0011-channel-rich-content-and-bridge.md`.
   Updated cross-references in README, ADR 0013, and the embed-onnx stub.
 
-## [v1.0.0] — 2026-05-09
+## [v1.0.0 — retracted] — 2026-05-09
+
+> **Note.** This tag was retracted on 2026-05-17 and the work it
+> covered is folded into [v2.0.0](#v200--2026-05-17) above. See
+> issue #165 and [VERSIONING.md](./VERSIONING.md) for the rationale.
+> Original section preserved verbatim below for historical context.
 
 First stable release. Tagged at commit `fe96fd8` on `main`. Web frontend
 + backend feature-complete; mobile + Slack inbound + automated release

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,143 @@
+# Versioning
+
+This document explains how opendray version numbers work. It is
+intentionally short — but the policy it captures is deliberate, so
+read it before opening a PR that touches versioning, tags, or
+release-pipeline behaviour.
+
+## TL;DR
+
+- **Major version = product generation.** v1 is the legacy
+  `Opendray/opendray` codebase (archived). v2 is this codebase
+  (`Opendray/opendray_v2`). v3 is reserved for a future cross-
+  architecture rewrite.
+- **Minor version = feature iteration.** New channels, new providers,
+  new memory subsystems, new API endpoints — anything additive within
+  the current generation.
+- **Patch version = fix / polish / docs.** Anything not user-facing
+  and anything that fixes a regression without changing the contract.
+- We **don't** strictly follow SemVer-by-the-book. The major version
+  is a generation marker, not a "breaking-change-since-the-last-major"
+  flag.
+
+## Why not strict SemVer?
+
+SemVer's strict reading — "major bump on any backwards-incompatible
+change to the public API" — works well for libraries, where the
+public API is the only contract. opendray is a deployed system: the
+public surface is the operator-facing config schema, the database
+migrations, the channel webhooks, and the integration API. Some of
+those move on different cadences, and a strict reading would force
+either:
+
+- Constant major bumps (e.g. "we renamed an env var, bump v2 → v3"),
+  which dilutes what a major version *means*; or
+- Frozen contracts within a major version, which would stop us from
+  fixing legitimate design mistakes during a generation's lifetime.
+
+The major-as-generation approach is widely used in the JavaScript
+and infrastructure worlds — see Vue (2 → 3), React (16 → 17 → 18),
+Angular (2 → 4 → 17), Webpack (4 → 5), Vite (4 → 5 → 6), MySQL (5.7
+→ 8.0), Node.js (16 → 18 → 20), PHP (5 → 7 → 8 — skipping 6).
+opendray follows the same convention.
+
+## What a major bump means here
+
+A v3 will ship when **any** of the following is true:
+
+1. **Architectural rewrite** comparable to v1 → v2 (Flutter → Go +
+   React, hand-rolled DB → pgx + pgvector, etc.).
+2. **Forced cross-generation migration path** — operators cannot
+   in-place upgrade and must run a one-shot conversion tool or
+   re-deploy from scratch.
+3. **Replacement of the core deployment contract** — different
+   binary layout, different process model, different default
+   on-disk paths that previous versions wouldn't recognise.
+
+None of these is on the roadmap today. v2 is expected to absorb
+many iterations of additive / corrective work before v3 is
+considered.
+
+## What a minor bump means here
+
+- Adding a new channel kind (e.g. a new Bridge platform)
+- Adding a new provider (e.g. a new AI CLI alongside Claude /
+  Codex / Gemini)
+- Adding a new API endpoint or event topic
+- Adding a new top-level admin page
+- Adding a new plugin / skill / MCP host capability
+- Any feature that's net-additive to operators
+
+## What a patch bump means here
+
+- Bug fixes
+- Documentation
+- Internal refactors invisible to operators
+- Build / CI / release-pipeline tweaks
+- Dependency bumps that don't change behaviour
+
+## Handling small operator-facing changes within a generation
+
+Within a generation, some operator-facing changes will still happen
+(env var renames, DB migrations, config schema tweaks). These do
+**not** force a major bump. Instead:
+
+- They land in a **minor** release if additive or strictly opt-in
+  (e.g. a new keyfile path that an existing config keeps working
+  without).
+- They land in a **minor** release marked **BREAKING** in the
+  release notes if existing operators need to do something
+  (re-run `migrate`, move a file, set a new env var) to keep their
+  deploy working.
+- The release notes call out exactly what needs to change and
+  provide the smallest possible migration path.
+
+This is the same pattern Vue, React, and Webpack use within a major
+version (e.g. React 17 → 18's `createRoot` migration). Operators
+should always read the release notes between minor versions.
+
+## Pre-release identifiers
+
+For testing significant new functionality before a final release:
+
+- `vX.Y.Z-rc1`, `vX.Y.Z-rc2`, … — release candidates against an
+  upcoming `vX.Y.Z`. Promote the highest-numbered RC to `vX.Y.Z`
+  once it stabilises (no force-push — both tags coexist forever).
+- `vX.Y.Z-beta.N`, `vX.Y.Z-alpha.N` — earlier-stage previews. Used
+  rarely; most pre-release testing happens via `-dev` builds from
+  `main` HEAD instead.
+
+## `main` HEAD builds vs release builds
+
+Anything built from `main` HEAD (or a feature branch) is **not** a
+release. The version banner injected at build time reflects this:
+
+```
+opendray vX.Y.Z-dev.<short-sha> (commit=<sha>, date=<iso>)
+```
+
+vs a release build:
+
+```
+opendray vX.Y.Z (commit=<sha>, date=<iso>)
+```
+
+The `-dev.<sha>` suffix is set automatically by the build pipeline
+(see `Dockerfile` and `.goreleaser.yml` for the `-ldflags -X` wiring
+into `internal/version/`). Operators reading the banner should never
+mistake a `main` HEAD build for a frozen release.
+
+## Why this document exists
+
+This file exists because issue #165 surfaced a real misalignment
+between what the previous `v1.0.0` tag claimed (frozen public API)
+and what `main` actually was (114 commits of active iteration in 7
+days, including admin and backup contract rewrites). Re-tagging as
+v2.0.0 only fixes the symptom; capturing the policy here is what
+prevents the next contributor from re-introducing the same
+confusion.
+
+If you ever feel tempted to push `vX.0.0` as a milestone marker
+without it actually being a generation boundary, **stop and read
+this file again**. Use a minor (`vX.Y.0`) or a release candidate
+(`vX.Y.Z-rcN`) instead.


### PR DESCRIPTION
Closes #165.

## Summary

Adopts a **major-as-generation** versioning strategy and re-tags the
codebase from \`v1.0.0\` → \`v2.0.0\` so the version number matches
this codebase's identity as the second generation of the opendray
product (the repo name \`opendray_v2\` is the giveaway).

Inspired by how Vue (2 → 3), React (16 → 17 → 18), Angular (2 → 4 →
17), Webpack (4 → 5), MySQL (5.7 → 8.0), and Node.js (16 → 18 → 20)
use major version numbers — not strict SemVer "breaking change" flags,
but generation markers.

## Files

- **NEW** \`VERSIONING.md\` — captures the policy: what major / minor /
  patch each mean here, how operator-facing changes within a
  generation are handled, pre-release identifiers, \`main\` HEAD vs
  release banner convention, what would trigger a future v3.
- \`CHANGELOG.md\`:
  - preamble: drop strict-SemVer claim, point at \`VERSIONING.md\`
  - new \`[v2.0.0] — 2026-05-17\` section above an empty Unreleased;
    first entry documents the retag itself
  - old \`[v1.0.0]\` section preserved verbatim with a "retracted"
    banner pointing at v2.0.0 and #165 — no history rewritten

## Tag operations (already executed)

- ✅ Three duplicate \`v1.0.0\` draft GitHub Releases deleted (IDs
  320782872, 320953566, 319885552 — all were drafts, never published)
- ✅ Local + remote \`v1.0.0\` tag deleted
- ✅ Annotated \`v2.0.0\` tag created at \`9a6c510\` (main HEAD at the
  time of this PR's base) and pushed to origin
- ⏳ Published \`v2.0.0\` GitHub Release will be created after this
  PR merges, with release notes pulling from the new CHANGELOG
  section

## No code changes

The build-time version injection (\`Dockerfile\` + \`.goreleaser.yml\`
\`-ldflags -X .../version.Version={{.Version}}\`) is already
version-agnostic and picks up the new tag automatically. No source
file needs to know "we're now v2".

## Test plan

- [x] \`git tag -l\` shows only \`v2.0.0\` locally
- [x] \`git ls-remote --tags origin\` shows only \`v2.0.0\` remotely
- [x] \`gh release list\` shows zero releases (clean slate for the
      v2.0.0 publish after merge)
- [ ] After merge: build from the new tag and confirm
      \`opendray version\` reports \`v2.0.0\`
- [ ] After merge: \`gh release create v2.0.0\` (published, not draft)
      with notes from the CHANGELOG v2.0.0 section

🤖 Generated with [Claude Code](https://claude.com/claude-code)