### PR TITLE
ci(release): let pnpm/action-setup@v4 read version from package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,9 +65,12 @@ jobs:
       # ── Frontend tooling — goreleaser's pre-build hooks invoke
       #    `pnpm install --frozen-lockfile` and `pnpm build` so the
       #    React SPA is in internal/web/dist before the Go build.
+      #
+      #    pnpm version is read from `packageManager` in package.json
+      #    so the action-setup invocation stays version-less here.
+      #    Setting `version:` here too triggers ERR_PNPM_BAD_PM_VERSION
+      #    (pnpm/action-setup@v4 refuses multiple sources of truth).
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: "22"


### PR DESCRIPTION
## Why

Surfaced while running the release pipeline against the new
\`v2.0.0\` tag (see #165 + #170). The workflow has actually been
broken since pnpm/action-setup@v4 started enforcing single-source
config — every recent \`workflow_dispatch\` plus the tag-push trigger
on \`v2.0.0\` failed within 10s in the \`Run pnpm/action-setup@v4\`
step:

\`\`\`
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@10.27.0 in the package.json with the key "packageManager"
Remove one of these versions to avoid version mismatch errors like
ERR_PNPM_BAD_PM_VERSION
\`\`\`

## Fix

Remove the action-level \`version: 10\` override and let
\`pnpm/action-setup@v4\` read \`packageManager: pnpm@10.27.0\` from
\`package.json\` (Corepack-compatible). This is the canonical
"single source of truth" pattern from pnpm's own setup docs, and
also avoids the v10 floor drifting away from the actual pinned
10.27.0 over time.

Added a comment block explaining the rationale so a future
contributor doesn't reintroduce the collision.

## Test plan

- [x] \`git diff .github/workflows/release.yml\` — 1 file, +5/-2
- [ ] After merge: \`gh workflow run release.yml -f tag=v2.0.0\` —
      should now proceed past the pnpm setup step
- [ ] Confirm the full release pipeline (cross-compile, cosign,
      SBOM, GHCR push) completes green

## Relationship to other open PRs

- Stacks under #170 logically (you need this fix for the v2.0.0
  release to actually build), but the diffs don't conflict — merge
  in any order.
- Independent of #169 (pure docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)