### PR TITLE
fix(migrate): bypass app.New so it works on a fresh database

### DIFF
--- a/cmd/opendray/main.go
+++ b/cmd/opendray/main.go
@@ -35,10 +35,11 @@ func main() {
 	case "serve":
 		os.Exit(run(args, func(ctx context.Context, a *app.App) error { return a.Run(ctx) }))
 	case "migrate":
-		os.Exit(run(args, func(ctx context.Context, a *app.App) error {
-			defer a.Close()
-			return a.Migrate(ctx)
-		}))
+		// Deliberately not routed through `run` — migrate must
+		// bypass internal/app.New to work on a fresh database
+		// where the catalog seed step would otherwise fail
+		// against tables that don't exist yet (see #162).
+		os.Exit(runMigrate(args))
 	case "notes":
 		os.Exit(runNotes(args))
 	case "skill":

--- a/cmd/opendray/migrate.go
+++ b/cmd/opendray/migrate.go
@@ -1,0 +1,86 @@
+// Migrate subcommand for the opendray binary.
+//
+// Runs DB migrations against the configured Postgres DSN and exits.
+// Intentionally bypasses internal/app.New so it works on a fresh
+// database where the schema doesn't exist yet — app.New's catalog
+// subsystem upserts seed rows into a `providers` table that
+// migration 0001 hasn't yet created, which previously crashed
+// `opendray migrate` before any migration could run (see #162).
+//
+// This file deliberately mirrors the shape of `serve` only as far
+// as the lifecycle surface (config + ctx + logger). It does not
+// share `internal/app.run` because the whole point of the fix is
+// that migrate must NOT compose the full app graph.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/opendray/opendray-v2/internal/config"
+	"github.com/opendray/opendray-v2/internal/store"
+)
+
+func runMigrate(args []string) int {
+	fs := flag.NewFlagSet("migrate", flag.ExitOnError)
+	cfgPath := fs.String("config", "", "path to config.toml (env-only mode if empty)")
+	_ = fs.Parse(args)
+
+	cfg, err := config.Load(*cfgPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	log := newMigrateLogger(cfg.Log)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	st, err := store.Open(ctx, cfg.Database.URL, cfg.Database.MaxConns)
+	if err != nil {
+		log.Error("open store", "err", err)
+		return 1
+	}
+	defer st.Close()
+
+	if err := st.Migrate(ctx, log); err != nil {
+		log.Error("apply migrations", "err", err)
+		return 1
+	}
+	return 0
+}
+
+// newMigrateLogger builds a minimal slog.Logger writing to stderr,
+// honouring cfg.Log.Level and cfg.Log.Format. It deliberately skips
+// the ring buffer and rotating-file outputs that internal/app's
+// newLogger sets up — migrate is a short-lived one-shot, those
+// surfaces add no value here.
+func newMigrateLogger(cfg config.LogConfig) *slog.Logger {
+	var level slog.Level
+	switch strings.ToLower(strings.TrimSpace(cfg.Level)) {
+	case "debug":
+		level = slog.LevelDebug
+	case "warn":
+		level = slog.LevelWarn
+	case "error":
+		level = slog.LevelError
+	default:
+		level = slog.LevelInfo
+	}
+	opts := &slog.HandlerOptions{Level: level}
+	var h slog.Handler
+	if strings.EqualFold(strings.TrimSpace(cfg.Format), "json") {
+		h = slog.NewJSONHandler(os.Stderr, opts)
+	} else {
+		h = slog.NewTextHandler(os.Stderr, opts)
+	}
+	return slog.New(h).With("component", "migrate")
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -711,11 +711,6 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	}, nil
 }
 
-// Migrate applies pending DB migrations and returns. Used by `opendray migrate`.
-func (a *App) Migrate(ctx context.Context) error {
-	return a.store.Migrate(ctx, a.log)
-}
-
 // (buildTranscriptSummariser was removed in M25 — the transcript
 // summariser now routes through the memory worker registry
 // directly. See newTranscriptSummariser in transcript_summariser.go.)


### PR DESCRIPTION
Closes #162.

## Root cause

\`opendray migrate\` was routing through \`run\` in \`cmd/opendray/main.go\`,
which calls \`app.New\` before the user-supplied function. \`app.New\`
boots the catalog subsystem (\`internal/app/app.go:111-119\`), which
immediately upserts \`claude\` / \`codex\` / \`gemini\` / \`shell\` providers
into the \`providers\` table.

That table is created by migration \`0001_initial.sql\`, which hasn't
been applied yet on a fresh DB. Composition therefore crashed with:

\`\`\`
relation "providers" does not exist (SQLSTATE 42P01)
\`\`\`

…before \`a.Migrate\` was ever reached. Operators following the README
deploy path hit this wall on first install.

## Fix (issue's Option 1)

Special-case \`migrate\` so it bypasses \`app.New\` entirely.

- New \`cmd/opendray/migrate.go\` brings up the bare minimum needed by
  \`Store.Migrate\`: config + slog logger + pgx pool via \`store.Open\`.
- \`cmd/opendray/main.go\` routes \`case "migrate"\` to \`runMigrate\`
  instead of \`run\`.
- \`App.Migrate\` (method on the \`App\` struct) is removed because it
  has no remaining callers.
- New \`runMigrate\` honours \`[log].level\` and \`[log].format\` (text
  vs json slog handlers) but deliberately skips the ring buffer +
  rotating file outputs that \`internal/app\`'s \`newLogger\` sets up —
  migrate is a short-lived one-shot, those surfaces add no value.

## Why Option 1 over Option 2 (reorder \`app.New\`)

- Keeps the binary's split honest — \`migrate\` is one-shot bootstrap,
  \`serve\` is the gateway. Coupling them would hide schema changes
  inside a normal boot.
- \`serve\` still fails loudly if migrations are out of date (catalog
  upsert against missing tables), which is the right signal — the
  operator should know they forgot to migrate.
- The migrate path becomes trivial to reason about and test in
  isolation; no app graph to mock.

## Test plan

Manual sanity from the built binary (no DB connection needed):

\`\`\`
$ opendray migrate -h
  Usage of migrate:
    -config string  path to config.toml (env-only mode if empty)

$ opendray migrate -config /no/such/file
  config: decode /no/such/file: open /no/such/file: no such file or directory

$ OPENDRAY_DATABASE_URL=postgres://nobody:nope@nowhere:65432/x?sslmode=disable \
  OPENDRAY_ADMIN_PASSWORD=x opendray migrate
  level=ERROR msg="open store" component=migrate err="store: ping: ..."
\`\`\`

The third case is the contract this PR establishes: \`migrate\` now
reaches \`store.Open\` (clean ping failure when the host is fake)
rather than crashing inside \`catalog.Sync\` (\`relation "providers"
does not exist\`). Before this PR, the same command on a fresh
database would have crashed with the latter regardless of whether
the DSN was valid.

End-to-end DB integration test for \`runMigrate\` against a real
fresh Postgres is the natural next addition; intentionally left as
follow-up here so this PR stays focused on the fix.

### Touched test surface

- \`go vet ./cmd/opendray/... ./internal/app/... ./internal/store/...\` — clean
- \`go test -count=1 ./cmd/opendray/... ./internal/app/...\` — passes

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)