### PR TITLE
ci(release): point setup-node cache at the root pnpm-lock.yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,10 @@ jobs:
         with:
           node-version: "22"
           cache: pnpm
-          cache-dependency-path: app/web/pnpm-lock.yaml
+          # Monorepo lockfile lives at the repo root (see
+          # pnpm-workspace.yaml). The pre-monorepo path
+          # app/web/pnpm-lock.yaml no longer exists.
+          cache-dependency-path: pnpm-lock.yaml
 
       - uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
Second pebble in the release pipeline after the v2.0.0 dispatch
exposed it.

## What happened

The first fix (#171) cleared the \`pnpm/action-setup\` version-
conflict that was bailing 10s into every run. With that fixed, the
v2.0.0 dispatch made it one step further and hit the next layer:

\`\`\`
Run actions/setup-node@v4
  ##[error]Some specified paths were not resolved, unable to
           cache dependencies.
\`\`\`

\`release.yml\` was caching against \`app/web/pnpm-lock.yaml\`, which
hasn't existed since the monorepo workspace landed (#45 +
\`pnpm-workspace.yaml\` at the root). The single lock file now lives
at the repo root, like \`ci.yml\` already knows.

## Fix

Change one line in \`release.yml\`:

\`\`\`diff
-          cache-dependency-path: app/web/pnpm-lock.yaml
+          cache-dependency-path: pnpm-lock.yaml
\`\`\`

Added a comment block explaining why it's at the root so a future
contributor doesn't move it back.

## Test plan

- [x] \`git diff .github/workflows/release.yml\` — 1 file, +4/-1
- [x] \`ls pnpm-lock.yaml app/web/pnpm-lock.yaml\` — root file exists,
      the old per-package one doesn't
- [x] \`grep cache-dependency-path .github/workflows/*.yml\` — confirms
      ci.yml was already on the root lock file; this just brings
      release.yml in line
- [ ] After merge: re-dispatch \`gh workflow run release.yml -f
      tag=v2.0.0\` — setup-node should cache successfully and the
      pipeline should proceed to goreleaser

🤖 Generated with [Claude Code](https://claude.com/claude-code)