### PR TITLE
docs(deploy): production docker compose + README deploy guide + Dockerfile monorepo fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Environment for `docker compose up`. Copy to .env (gitignored)
+# and fill in the values. None of these belong in config.toml —
+# this file is the single source of truth for secrets.
+
+# Postgres password used by both the postgres service (POSTGRES_PASSWORD)
+# and the connection string OpenDray reads (OPENDRAY_DATABASE_URL).
+# Use anything reasonably long; the DB is loopback-only so brute force
+# isn't the threat — careless leaks of this file are.
+POSTGRES_PASSWORD=change-me-postgres-password
+
+# First-boot admin credentials. After your first login through the UI,
+# change the password from Settings → Admin → Change Password. The
+# bcrypt keyfile that gets written then takes precedence and this
+# env var becomes inert (see docs/operator-guide.md §admin).
+OPENDRAY_ADMIN_USER=admin
+OPENDRAY_ADMIN_PASSWORD=change-me-admin-password
+
+# Encrypted backup keyfile (only needed if you enable [backup] in
+# config.toml). Generate with: openssl rand -base64 32
+# OPENDRAY_BACKUP_KEY=
+
+# Cloudflare Tunnel token (only needed if you run
+# `docker compose --profile tunnel up`). Issued by the Cloudflare
+# Zero Trust dashboard when you create a tunnel.
+# CLOUDFLARED_TOKEN=

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,20 +18,27 @@
 FROM node:22-alpine AS web
 
 # pnpm via corepack (ships with Node 22); pinned to v10 to match
-# CONTRIBUTING.md and the version action installs in CI.
+# the packageManager field in package.json and the version action
+# installs in CI.
 RUN corepack enable && corepack prepare pnpm@10 --activate
 
 WORKDIR /src
 
-# Cache deps independently of source changes.
-COPY app/web/package.json app/web/pnpm-lock.yaml ./app/web/
-RUN cd app/web && pnpm install --frozen-lockfile
+# Cache deps independently of source changes. The monorepo lockfile
+# and workspace manifest live at the repo root (see #45). Bringing
+# every workspace's package.json in first lets pnpm install resolve
+# the full dependency graph from the lock without pulling in source.
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY app/web/package.json ./app/web/
+COPY app/shared/package.json ./app/shared/
+COPY app/shared-ui/package.json ./app/shared-ui/
+RUN pnpm install --frozen-lockfile
 
-# Build the bundle. Output lands at internal/web/dist (vite.config.ts
-# writes there relative to app/web — internal/web/dist/ doesn't need
-# to be populated here, the gobuild stage copies it via --from=web).
-COPY app/web ./app/web
-RUN cd app/web && pnpm build
+# Bring source after lock install so changes here don't bust the
+# dependency layer. Build the web workspace — Vite writes
+# ../../internal/web/dist (the gobuild stage copies it from there).
+COPY app ./app
+RUN pnpm --filter web build
 
 # ── Stage 2: go binary ────────────────────────────────────────────────
 FROM golang:1.25-alpine AS gobuild

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ What's in this generation:
 See [`CHANGELOG.md`](CHANGELOG.md) for the v2.0.0 entry and the
 rolling Unreleased section for what's landing next.
 
-## Quickstart
+## Quickstart (5-minute dev path)
 
-For a full walkthrough with prereqs and troubleshooting, see [`docs/quickstart.md`](docs/quickstart.md). The condensed path:
+For a full walkthrough with prereqs and troubleshooting, see [`docs/quickstart.md`](docs/quickstart.md). The condensed dev path:
 
 ```bash
 # 1. Start a Postgres for local dev (or point [database].url at your own).
@@ -59,6 +59,129 @@ go run ./cmd/opendray serve -config config.toml
 # → REST + WS:  http://127.0.0.1:8770/api/v1/...
 # → Web admin:  http://127.0.0.1:8770/admin/
 ```
+
+This runs OpenDray in the foreground — Ctrl-C kills it. For a long-running
+daemon, see **Production deploy** below.
+
+## Production deploy
+
+Three supported deploy paths, pick whichever fits your environment.
+Auto-restart on crash, persistent state, separation of secrets from
+config — all three give you those.
+
+### Option A — Docker Compose (recommended, one command)
+
+The fastest way to "just keep it running" on a home server, NAS, VPS,
+or LXC with Docker. Bundled in the repo root:
+
+```bash
+# 1. Set passwords (file is gitignored).
+cp .env.example .env
+$EDITOR .env                # set POSTGRES_PASSWORD, OPENDRAY_ADMIN_PASSWORD
+
+# 2. (Optional) Drop your own config.toml at ./config.toml.
+#    Compose bind-mounts it read-only. Skip for pure env-mode.
+
+# 3. Start everything (opendray + postgres) as a long-running daemon.
+docker compose up -d
+
+# 4. Tail logs until "listening on …".
+docker compose logs -f opendray
+```
+
+OpenDray is reachable at `http://127.0.0.1:8770/admin/`. Both services
+auto-restart on crash or host reboot (`restart: unless-stopped`).
+Postgres data lives in the named volume `opendray-postgres-data`;
+OpenDray state (admin keyfile, backup keyfile, vault) lives in
+`opendray-state`.
+
+**Pin to a release image** in production by commenting out `build: .`
+and uncommenting `image: ghcr.io/opendray/opendray:v2.0.0` in
+`docker-compose.yml` — see the file header for details.
+
+**Add Cloudflare Tunnel** for internet-facing access without opening
+firewall ports — set `CLOUDFLARED_TOKEN` in `.env`, then:
+
+```bash
+docker compose --profile tunnel up -d
+```
+
+Stop / restart / fully reset:
+
+```bash
+docker compose down                # stop, keep data
+docker compose restart opendray    # restart just opendray
+docker compose down -v             # nuke everything including DB
+```
+
+### Option B — systemd (bare-metal / VM / LXC)
+
+For when OpenDray is the only service on a Linux box and you don't
+want Docker in the mix. Ships a hardened unit at
+[`deploy/systemd/opendray.service`](deploy/systemd/opendray.service)
+with sandboxing (`ProtectSystem=strict`, `NoNewPrivileges`,
+`MemoryDenyWriteExecute`, capability scrub), `migrate`-then-`serve`
+boot, and a 20s graceful-stop window.
+
+```bash
+# 1. Install the binary (or build from source; see Layout below).
+sudo install -m 0755 /path/to/opendray /usr/local/bin/opendray
+
+# 2. Create the service user + state dir.
+sudo useradd -r -s /usr/sbin/nologin -d /var/lib/opendray opendray
+sudo install -d -o opendray -g opendray -m 0700 /var/lib/opendray
+
+# 3. Drop config + secrets (root-owned; mode 0640).
+sudo install -D -m 0640 config.example.toml /etc/opendray/config.toml
+sudo $EDITOR /etc/opendray/config.toml             # set [database].url etc.
+sudo install -D -m 0640 -o root -g opendray /dev/null /etc/opendray/env.d/secrets
+sudo $EDITOR /etc/opendray/env.d/secrets           # OPENDRAY_ADMIN_PASSWORD=…
+
+# 4. Install + enable the unit.
+sudo cp deploy/systemd/opendray.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now opendray
+
+# 5. Verify.
+sudo systemctl status opendray
+sudo journalctl -u opendray -f --no-pager
+```
+
+The unit runs `opendray migrate` as `ExecStartPre`, so the first boot
+applies all migrations before `serve` ever starts. Restarts are
+`on-failure` with a 5s back-off and a 5-burst limit per minute.
+
+### Option C — Direct binary + your own process supervisor
+
+For LXC without systemd, FreeBSD `rc.d`, OpenRC, or anything else.
+Build once, run with whatever supervisor you already use:
+
+```bash
+# Cross-compile a release archive locally:
+goreleaser release --clean --snapshot
+ls dist/                  # opendray_*_linux_amd64.tar.gz etc.
+
+# Or grab a published release artefact (after v2.0.0 ships):
+# https://github.com/Opendray/opendray_v2/releases
+```
+
+Then point your supervisor (s6, runit, supervisord, runwhen) at:
+
+```
+/usr/local/bin/opendray serve -config /etc/opendray/config.toml
+```
+
+Pre-flight: run `opendray migrate -config /etc/opendray/config.toml`
+once before the first `serve`, or as a pre-start hook in your
+supervisor of choice.
+
+---
+
+For Proxmox-specific LXC notes (PTY in unprivileged containers,
+networking, cgroup tweaks), see [`deploy/lxc/proxmox-pty-notes.md`](deploy/lxc/proxmox-pty-notes.md).
+
+For reverse-proxy / TLS termination (nginx, Caddy, Traefik, Cloudflare
+Tunnel), see [`docs/operator-guide.md`](docs/operator-guide.md) §Topology.
 
 ### Optional: enable encrypted DB backups + data exports
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -33,7 +33,7 @@
 查看 [`CHANGELOG.md`](CHANGELOG.md) 了解 v2.0.0 详情和后续 Unreleased
 段中即将落地的内容。
 
-## 快速开始
+## 快速开始(5 分钟开发版)
 
 完整 walkthrough(含前置依赖、排错、docker-compose 开发 DB)见
 [`docs/quickstart.md`](docs/quickstart.md)。压缩版:
@@ -57,6 +57,125 @@ go run ./cmd/opendray serve -config config.toml
 # → REST + WS:  http://127.0.0.1:8770/api/v1/...
 # → Web admin:  http://127.0.0.1:8770/admin/
 ```
+
+上面是前台运行 —— Ctrl-C 即可结束。如果要做成长期运行的守护进程,
+看下面 **生产部署**。
+
+## 生产部署
+
+三种受支持的部署路径,按你的环境挑一种。三种方案都提供:
+崩溃后自动重启、状态持久化、secrets 跟 config 分离。
+
+### 方案 A — Docker Compose(推荐,一条命令)
+
+在家用服务器、NAS、VPS 或装了 Docker 的 LXC 上,"让它一直跑着"
+最省事的方式。仓库根目录里已经备好:
+
+```bash
+# 1. 设置密码(文件已经 gitignored)。
+cp .env.example .env
+$EDITOR .env                # 设置 POSTGRES_PASSWORD、OPENDRAY_ADMIN_PASSWORD
+
+# 2.(可选)在 ./config.toml 放你自己的配置文件。
+#    Compose 会只读 bind-mount。不需要的话保持纯 env 模式即可。
+
+# 3. 启动一切(opendray + postgres),后台守护。
+docker compose up -d
+
+# 4. 跟踪日志直到看到 "listening on …"。
+docker compose logs -f opendray
+```
+
+打开 `http://127.0.0.1:8770/admin/` 就能访问。两个 service 都是
+`restart: unless-stopped` —— 崩溃或主机重启后自动起来。
+Postgres 数据在命名 volume `opendray-postgres-data`,OpenDray 自己
+的状态(admin keyfile、backup keyfile、vault)在 `opendray-state`。
+
+**在生产环境钉到 release 镜像**:注释掉 `docker-compose.yml` 里的
+`build: .`,取消 `image: ghcr.io/opendray/opendray:v2.0.0` 那一行
+的注释 —— 详见文件头部说明。
+
+**用 Cloudflare Tunnel 暴露公网访问**,不用开防火墙端口:
+在 `.env` 设置 `CLOUDFLARED_TOKEN`,然后:
+
+```bash
+docker compose --profile tunnel up -d
+```
+
+停 / 重启 / 完全清空:
+
+```bash
+docker compose down                # 停止,保留数据
+docker compose restart opendray    # 只重启 opendray
+docker compose down -v             # 全删除,包括 DB
+```
+
+### 方案 B — systemd(裸机 / VM / LXC)
+
+当 OpenDray 是 Linux 机器上唯一的服务,且你不想引入 Docker。
+[`deploy/systemd/opendray.service`](deploy/systemd/opendray.service)
+是一个加固过的 unit:沙箱(`ProtectSystem=strict`、`NoNewPrivileges`、
+`MemoryDenyWriteExecute`、capability 收紧)、先 `migrate` 后 `serve`
+的启动顺序、20 秒优雅退出窗口。
+
+```bash
+# 1. 安装二进制(或从源码 build,见下方 Layout)。
+sudo install -m 0755 /path/to/opendray /usr/local/bin/opendray
+
+# 2. 创建服务用户和状态目录。
+sudo useradd -r -s /usr/sbin/nologin -d /var/lib/opendray opendray
+sudo install -d -o opendray -g opendray -m 0700 /var/lib/opendray
+
+# 3. 放 config 和 secrets(root 所有,mode 0640)。
+sudo install -D -m 0640 config.example.toml /etc/opendray/config.toml
+sudo $EDITOR /etc/opendray/config.toml             # 设置 [database].url 等
+sudo install -D -m 0640 -o root -g opendray /dev/null /etc/opendray/env.d/secrets
+sudo $EDITOR /etc/opendray/env.d/secrets           # OPENDRAY_ADMIN_PASSWORD=…
+
+# 4. 安装并启用 unit。
+sudo cp deploy/systemd/opendray.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now opendray
+
+# 5. 验证。
+sudo systemctl status opendray
+sudo journalctl -u opendray -f --no-pager
+```
+
+Unit 在 `ExecStartPre` 阶段跑 `opendray migrate`,首次启动会先把
+所有 migration 应用了再启动 `serve`。Restart 策略是 `on-failure`,
+5 秒退避,每分钟最多重启 5 次。
+
+### 方案 C — 直接跑二进制 + 你自己的进程管理器
+
+适合没装 systemd 的 LXC、FreeBSD `rc.d`、OpenRC,或其他任何环境。
+一次构建,任意进程管理器拉起来:
+
+```bash
+# 本地交叉编译一个 release archive:
+goreleaser release --clean --snapshot
+ls dist/                  # opendray_*_linux_amd64.tar.gz 等
+
+# 或者从已发布的 release 拿 artifact(v2.0.0 发布之后):
+# https://github.com/Opendray/opendray_v2/releases
+```
+
+让你的进程管理器(s6、runit、supervisord、runwhen)指向:
+
+```
+/usr/local/bin/opendray serve -config /etc/opendray/config.toml
+```
+
+预先动作:首次 `serve` 之前跑一次 `opendray migrate -config /etc/opendray/config.toml`,
+或者把它做成进程管理器的 pre-start hook。
+
+---
+
+Proxmox LXC 特定的说明(非特权容器里的 PTY、网络、cgroup 调整)
+见 [`deploy/lxc/proxmox-pty-notes.md`](deploy/lxc/proxmox-pty-notes.md)。
+
+反向代理 / TLS 终止(nginx、Caddy、Traefik、Cloudflare Tunnel)
+见 [`docs/operator-guide.md`](docs/operator-guide.md) §Topology。
 
 ### 可选:启用加密 DB 备份 + 数据导出
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -5,9 +5,10 @@ one path:
 
 | Artefact | When to use |
 |---|---|
-| [`systemd/opendray.service`](systemd/opendray.service) | Bare-metal, VM, or LXC where OpenDray is the only service. Standard Linux box. |
+| [`docker-compose.yml`](../docker-compose.yml) (repo root) | Daemonised opendray + Postgres in one command. Best default for home server / NAS / VPS / LXC-with-Docker. Optional bundled Cloudflare Tunnel via `--profile tunnel`. |
+| [`systemd/opendray.service`](systemd/opendray.service) | Bare-metal, VM, or LXC where OpenDray is the only service. Standard Linux box without Docker. |
 | [`lxc/proxmox-pty-notes.md`](lxc/proxmox-pty-notes.md) | Proxmox LXC specifics — PTY allocation in unprivileged containers, networking, secrets. |
-| [`Dockerfile`](../Dockerfile) (repo root) | Containerised. Build once, run anywhere with `docker run`. |
+| [`Dockerfile`](../Dockerfile) (repo root) | Single-container builds — used by `docker-compose.yml` above and by CI to push to GHCR. |
 | [`.goreleaser.yml`](../.goreleaser.yml) (repo root) | Cut a tagged release of pre-built binaries + checksums. |
 
 The systemd unit and the LXC notes are designed to compose: a Proxmox

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,146 @@
+# Production docker compose for OpenDray v2.
+#
+# Starts a long-running OpenDray gateway plus its Postgres database,
+# both restarting automatically if they crash or the host reboots.
+# Use this for "I want OpenDray running on my home server / NAS / VPS
+# and never think about it again."
+#
+# ── Bootstrap ────────────────────────────────────────────────────────
+#
+#   # 1. Create the env file (kept out of git — sets passwords).
+#   cp .env.example .env
+#   # → Edit .env:
+#   #   * Pick OPENDRAY_ADMIN_PASSWORD (used for the first login;
+#   #     change it from the UI afterwards — see operator-guide.md).
+#   #   * Pick POSTGRES_PASSWORD (used by both Postgres and OpenDray).
+#   #   * Set OPENDRAY_BACKUP_KEY only if [backup].enabled = true
+#   #     in your config.
+#
+#   # 2. (Optional) drop your own config.toml into ./config.toml —
+#   #    the compose bind-mounts it read-only. Default behaviour is
+#   #    pure env-mode if config.toml is absent.
+#
+#   # 3. Bring it up.
+#   docker compose up -d
+#   docker compose logs -f opendray   # follow logs until "listening on …"
+#
+# ── Build options ────────────────────────────────────────────────────
+#
+# Default: build from local source (`build: .`). Good for development
+# loops and when you want to test PRs before publishing.
+#
+# To run a published release image instead, comment out `build: .`
+# and uncomment the `image:` line below. Pin to a specific tag
+# (e.g. v2.0.0) in production; `:latest` only for kicking the tyres.
+#
+# ── Reverse proxy ────────────────────────────────────────────────────
+#
+# OpenDray binds to 127.0.0.1 inside its container and exposes :8770
+# on the host loopback. For internet access, front it with one of:
+#
+#   * Cloudflare Tunnel (preferred — bundled cloudflared service
+#     below, opt-in via the `tunnel` profile)
+#   * nginx / Caddy / Traefik on the host
+#   * The host's existing reverse proxy
+#
+# See deploy/README.md and docs/operator-guide.md §Topology for the
+# full guidance.
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: opendray-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: opendray
+      POSTGRES_DB: opendray
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in .env}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    # Bind to loopback only — opendray service reaches it over the
+    # internal docker network, no need to expose to the host LAN.
+    ports:
+      - "127.0.0.1:5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U opendray -d opendray"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  opendray:
+    # Default: build locally so any source change is picked up on
+    # `docker compose up --build`. To pin a published release instead,
+    # comment out the build block and uncomment the image line.
+    build: .
+    # image: ghcr.io/opendray/opendray:v2.0.0
+    container_name: opendray
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      # Database — points at the postgres service over the compose
+      # network, not the host. sslmode=disable is safe inside docker.
+      OPENDRAY_DATABASE_URL: "postgres://opendray:${POSTGRES_PASSWORD}@postgres:5432/opendray?sslmode=disable"
+
+      # Listen on all interfaces inside the container; the host port
+      # mapping below controls external exposure.
+      OPENDRAY_LISTEN: "0.0.0.0:8770"
+
+      # Bootstrap credentials. After first boot, change the password
+      # from the UI — the bcrypt keyfile in /var/lib/opendray/.opendray/
+      # secrets/admin.key takes precedence after that. See #163.
+      OPENDRAY_ADMIN_USER: ${OPENDRAY_ADMIN_USER:-admin}
+      OPENDRAY_ADMIN_PASSWORD: ${OPENDRAY_ADMIN_PASSWORD:?OPENDRAY_ADMIN_PASSWORD must be set in .env}
+
+      # Encrypted backups — uncomment + set OPENDRAY_BACKUP_KEY in .env.
+      # OPENDRAY_BACKUP_ENABLED: "true"
+      # OPENDRAY_BACKUP_KEY: ${OPENDRAY_BACKUP_KEY}
+    ports:
+      # Bind to loopback only by default. To expose on the LAN, change
+      # to "0.0.0.0:8770:8770" — but only do that behind a TLS-
+      # terminating reverse proxy (see file header).
+      - "127.0.0.1:8770:8770"
+    volumes:
+      # Optional config.toml — bind-mounts read-only if present.
+      # Comment out if you're running env-only.
+      - ./config.toml:/etc/opendray/config.toml:ro
+      # Persistent state: bcrypt admin keyfile, backup keyfile,
+      # vault root (when default), Claude account configs.
+      - opendray-state:/home/nonroot
+    # The bundled binary defaults to `serve`, but we explicitly pass
+    # the config flag so the bind-mounted config.toml is picked up
+    # when present.
+    command:
+      - "serve"
+      - "-config"
+      - "/etc/opendray/config.toml"
+    healthcheck:
+      test:
+        - "CMD"
+        - "/usr/local/bin/opendray"
+        - "version"
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  # Optional Cloudflare Tunnel — opt in with `--profile tunnel`.
+  # Provision the tunnel token via Cloudflare Zero Trust dashboard,
+  # drop it in .env as CLOUDFLARED_TOKEN, then:
+  #
+  #   docker compose --profile tunnel up -d
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: opendray-cloudflared
+    restart: unless-stopped
+    profiles: [tunnel]
+    command: ["tunnel", "--no-autoupdate", "run", "--token", "${CLOUDFLARED_TOKEN:?CLOUDFLARED_TOKEN must be set in .env when --profile tunnel is used}"]
+    depends_on:
+      opendray:
+        condition: service_started
+
+volumes:
+  postgres-data:
+    name: opendray-postgres-data
+  opendray-state:
+    name: opendray-state


### PR DESCRIPTION
The README's only deploy guidance was the 5-minute dev path
(\`go run\` in the foreground). Operators asking "how do I make
this run in the background forever" had to dig into deploy/ on
their own. This PR provides three first-class production paths
in the README plus a one-command docker-compose for the most
common case.

Also fixes a third layer of release-pipeline debt — the Dockerfile
had the same pre-monorepo \`app/web/pnpm-lock.yaml\` reference that
PR #174 fixed for \`setup-node\`. With this in, the GHCR push job
will actually build the image.

## Why now

- The v2.0.0 release dispatch yesterday succeeded on the
  goreleaser side (binaries + cosign + SBOM on the GitHub release)
  but the GHCR push job failed at \`COPY app/web/pnpm-lock.yaml\` —
  the file hasn't existed since #45 moved everything to the
  monorepo workspace.
- The README still pointed people only at \`go run\` for "running
  it". With v2.0.0 cut, having no documented "leave it running"
  path is a real first-impression hit.

## Changes at a glance

### \`Dockerfile\` — monorepo lockfile fix

\`\`\`diff
- COPY app/web/package.json app/web/pnpm-lock.yaml ./app/web/
- RUN cd app/web && pnpm install --frozen-lockfile
+ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+ COPY app/web/package.json ./app/web/
+ COPY app/shared/package.json ./app/shared/
+ COPY app/shared-ui/package.json ./app/shared-ui/
+ RUN pnpm install --frozen-lockfile
\`\`\`

Layer caching still works (deps install before source COPY).
Image surface unchanged. Build command unchanged.

### \`docker-compose.yml\` (new)

Three services, opt-in tunnel:

- \`opendray\` — \`build: .\` by default (pin to
  \`ghcr.io/opendray/opendray:vX.Y.Z\` for production by uncommenting
  one line); \`restart: unless-stopped\`; loopback-only by default;
  bind-mounts \`./config.toml\` when present.
- \`postgres\` — postgres:17-alpine with healthcheck-gated startup
  ordering and a persistent named volume.
- \`cloudflared\` — opt-in via \`--profile tunnel\` for
  internet-facing access without opening firewall ports.

### \`.env.example\` (new)

Single source of truth for the compose deploy's secrets
(\`POSTGRES_PASSWORD\`, \`OPENDRAY_ADMIN_PASSWORD\`, optional
\`OPENDRAY_BACKUP_KEY\` and \`CLOUDFLARED_TOKEN\`). \`.env\` is already
in \`.gitignore\`.

### \`README.md\` + \`README.zh.md\`

- "Quickstart" section retitled "Quickstart (5-minute dev path)"
  with a footer pointing at the production section.
- New "Production deploy" section with three first-class paths:
  - **A. Docker Compose** — fastest one-command deploy
  - **B. systemd** — uses the already-shipped
    \`deploy/systemd/opendray.service\` with install commands fully
    laid out
  - **C. Direct binary** + your own supervisor (s6, runit,
    supervisord, ...) for non-Docker non-systemd environments
- Cross-links to \`deploy/lxc/proxmox-pty-notes.md\` and
  \`docs/operator-guide.md\` §Topology for LXC and reverse-proxy
  specifics.
- Chinese mirror updates exactly the same sections.

### \`deploy/README.md\`

\`docker-compose.yml\` added to the artefact table; \`Dockerfile\`
description updated to note compose uses it.

## Test plan

- [x] \`docker compose config --quiet\` (with placeholder env vars)
      — passes; YAML + variable references parse clean
- [x] \`git diff --stat\` reviewed — no Go source touched
- [ ] After merge: re-dispatch \`gh workflow run release.yml -f tag=v2.0.0\` —
      GHCR push should now succeed (Dockerfile fix is the only
      thing that was blocking it after #174 landed)
- [ ] After merge: \`docker compose up -d\` on a clean host —
      opendray + postgres should both come up healthy, web admin
      reachable on \`http://127.0.0.1:8770/admin/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)