### PR TITLE
docs(deploy): add Install nav, macOS launchd Option D, binary-source hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ What's in this generation:
 See [`CHANGELOG.md`](CHANGELOG.md) for the v2.0.0 entry and the
 rolling Unreleased section for what's landing next.
 
+## Install
+
+Pick the path that fits how you want to run it:
+
+| Path | Best for | Jump to |
+|---|---|---|
+| 📦 **Pre-built binary** | "Just run it" — Linux / macOS, any supervisor | [Releases page](https://github.com/Opendray/opendray_v2/releases) → see [Production deploy](#production-deploy) |
+| 🐳 **Docker Compose** | Home server / NAS / VPS / LXC with Docker | [Production deploy §A](#option-a--docker-compose-recommended-one-command) |
+| 🐧 **systemd unit** | Bare-metal / VM / LXC Linux box | [Production deploy §B](#option-b--systemd-bare-metal--vm--lxc) |
+| 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio as home server | [Production deploy §D](#option-d--macos-launchd-mac-mini--studio-as-home-server) |
+| 🛠 **Build from source** | Dev / contributing / custom builds | [Quickstart](#quickstart-5-minute-dev-path) below |
+
 ## Quickstart (5-minute dev path)
 
 For a full walkthrough with prereqs and troubleshooting, see [`docs/quickstart.md`](docs/quickstart.md). The condensed dev path:
@@ -65,9 +77,9 @@ daemon, see **Production deploy** below.
 
 ## Production deploy
 
-Three supported deploy paths, pick whichever fits your environment.
-Auto-restart on crash, persistent state, separation of secrets from
-config — all three give you those.
+Four supported deploy paths, pick whichever fits your environment.
+Each one gives you auto-restart on crash, persistent state, and
+separation of secrets from config.
 
 ### Option A — Docker Compose (recommended, one command)
 
@@ -123,8 +135,14 @@ with sandboxing (`ProtectSystem=strict`, `NoNewPrivileges`,
 `MemoryDenyWriteExecute`, capability scrub), `migrate`-then-`serve`
 boot, and a 20s graceful-stop window.
 
+**Get a binary first.** Either grab a pre-built archive from the
+[Releases page](https://github.com/Opendray/opendray_v2/releases)
+(`opendray_*_linux_<arch>.tar.gz` — unpacks to a single `opendray`
+binary), or build from source via the [Quickstart](#quickstart-5-minute-dev-path)
+above (`go build ./cmd/opendray`).
+
 ```bash
-# 1. Install the binary (or build from source; see Layout below).
+# 1. Install the binary you just grabbed (or built).
 sudo install -m 0755 /path/to/opendray /usr/local/bin/opendray
 
 # 2. Create the service user + state dir.
@@ -174,6 +192,46 @@ Then point your supervisor (s6, runit, supervisord, runwhen) at:
 Pre-flight: run `opendray migrate -config /etc/opendray/config.toml`
 once before the first `serve`, or as a pre-start hook in your
 supervisor of choice.
+
+### Option D — macOS launchd (Mac mini / Studio as home server)
+
+For Apple Silicon Mac mini / Mac Studio running 24/7. Ships a
+LaunchDaemon at
+[`deploy/launchd/com.opendray.opendray.plist`](deploy/launchd/com.opendray.opendray.plist)
+that starts at boot before any user login, restarts on crash with
+a 5s throttle, and logs to `/usr/local/var/log/opendray/`.
+
+```bash
+# 1. Install the darwin binary + config + state dirs.
+sudo install -m 0755 ./opendray /usr/local/bin/opendray
+sudo install -d -m 0755 \
+  /usr/local/etc/opendray \
+  /usr/local/var/lib/opendray \
+  /usr/local/var/log/opendray
+sudo install -m 0640 config.example.toml /usr/local/etc/opendray/config.toml
+sudo $EDITOR /usr/local/etc/opendray/config.toml    # set [database].url etc.
+
+# 2. Apply migrations once.
+sudo /usr/local/bin/opendray migrate \
+  -config /usr/local/etc/opendray/config.toml
+
+# 3. Install + load the LaunchDaemon.
+sudo cp deploy/launchd/com.opendray.opendray.plist /Library/LaunchDaemons/
+sudo chown root:wheel /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo chmod 0644 /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.opendray.opendray.plist
+
+# 4. Verify.
+sudo launchctl print system/com.opendray.opendray
+tail -f /usr/local/var/log/opendray/opendray.log
+```
+
+Restart with `sudo launchctl kickstart -k system/com.opendray.opendray`;
+unload entirely with `sudo launchctl bootout system/com.opendray.opendray`.
+
+Postgres on macOS — install via Homebrew (`brew install postgresql@17 && brew services start postgresql@17`) and point `[database].url` at
+`postgres://$USER@127.0.0.1:5432/opendray`. Or just run a Postgres
+container alongside (`docker run -d --restart unless-stopped …`).
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -33,6 +33,18 @@
 查看 [`CHANGELOG.md`](CHANGELOG.md) 了解 v2.0.0 详情和后续 Unreleased
 段中即将落地的内容。
 
+## 安装
+
+选一种最适合你环境的方式:
+
+| 方式 | 适合 | 跳转到 |
+|---|---|---|
+| 📦 **预构建二进制** | "拿来就跑" — Linux / macOS,搭配任意进程管理器 | [Releases 页](https://github.com/Opendray/opendray_v2/releases) → 见下方 [生产部署](#生产部署) |
+| 🐳 **Docker Compose** | 家用服务器 / NAS / VPS / 装 Docker 的 LXC | [生产部署 §A](#方案-a--docker-compose推荐一条命令) |
+| 🐧 **systemd unit** | 裸机 / VM / Linux LXC | [生产部署 §B](#方案-b--systemd裸机--vm--lxc) |
+| 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio 当家用 server | [生产部署 §D](#方案-d--macos-launchdmac-mini--studio-当家用-server) |
+| 🛠 **从源码构建** | 开发 / 贡献代码 / 定制构建 | [快速开始](#快速开始5-分钟开发版) |
+
 ## 快速开始(5 分钟开发版)
 
 完整 walkthrough(含前置依赖、排错、docker-compose 开发 DB)见
@@ -63,7 +75,7 @@ go run ./cmd/opendray serve -config config.toml
 
 ## 生产部署
 
-三种受支持的部署路径,按你的环境挑一种。三种方案都提供:
+四种受支持的部署路径,按你的环境挑一种。每种都提供:
 崩溃后自动重启、状态持久化、secrets 跟 config 分离。
 
 ### 方案 A — Docker Compose(推荐,一条命令)
@@ -118,8 +130,14 @@ docker compose down -v             # 全删除,包括 DB
 `MemoryDenyWriteExecute`、capability 收紧)、先 `migrate` 后 `serve`
 的启动顺序、20 秒优雅退出窗口。
 
+**先拿一个二进制。** 要么从
+[Releases 页](https://github.com/Opendray/opendray_v2/releases)
+下载预构建归档(`opendray_*_linux_<arch>.tar.gz` — 解压就是
+单一 `opendray` 二进制),要么按上面 [快速开始](#快速开始5-分钟开发版)
+从源码 build(`go build ./cmd/opendray`)。
+
 ```bash
-# 1. 安装二进制(或从源码 build,见下方 Layout)。
+# 1. 安装刚拿到的(或刚 build 的)二进制。
 sudo install -m 0755 /path/to/opendray /usr/local/bin/opendray
 
 # 2. 创建服务用户和状态目录。
@@ -168,6 +186,45 @@ ls dist/                  # opendray_*_linux_amd64.tar.gz 等
 
 预先动作:首次 `serve` 之前跑一次 `opendray migrate -config /etc/opendray/config.toml`,
 或者把它做成进程管理器的 pre-start hook。
+
+### 方案 D — macOS launchd(Mac mini / Studio 当家用 server)
+
+适合 Apple Silicon 的 Mac mini / Mac Studio 24/7 跑。
+[`deploy/launchd/com.opendray.opendray.plist`](deploy/launchd/com.opendray.opendray.plist)
+是一个 LaunchDaemon:开机即启动(不需要用户登录),崩溃后 5 秒
+节流重启,日志写到 `/usr/local/var/log/opendray/`。
+
+```bash
+# 1. 安装 darwin 二进制 + 配置 + 状态目录。
+sudo install -m 0755 ./opendray /usr/local/bin/opendray
+sudo install -d -m 0755 \
+  /usr/local/etc/opendray \
+  /usr/local/var/lib/opendray \
+  /usr/local/var/log/opendray
+sudo install -m 0640 config.example.toml /usr/local/etc/opendray/config.toml
+sudo $EDITOR /usr/local/etc/opendray/config.toml    # 设置 [database].url 等
+
+# 2. 跑一次 migrate。
+sudo /usr/local/bin/opendray migrate \
+  -config /usr/local/etc/opendray/config.toml
+
+# 3. 安装并加载 LaunchDaemon。
+sudo cp deploy/launchd/com.opendray.opendray.plist /Library/LaunchDaemons/
+sudo chown root:wheel /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo chmod 0644 /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.opendray.opendray.plist
+
+# 4. 验证。
+sudo launchctl print system/com.opendray.opendray
+tail -f /usr/local/var/log/opendray/opendray.log
+```
+
+重启:`sudo launchctl kickstart -k system/com.opendray.opendray`;
+完全卸载:`sudo launchctl bootout system/com.opendray.opendray`。
+
+macOS 上的 Postgres — 用 Homebrew 装(`brew install postgresql@17 && brew services start postgresql@17`),把 `[database].url` 指向
+`postgres://$USER@127.0.0.1:5432/opendray`。或者就跑一个 Postgres
+容器在旁边(`docker run -d --restart unless-stopped …`)。
 
 ---
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -7,6 +7,7 @@ one path:
 |---|---|
 | [`docker-compose.yml`](../docker-compose.yml) (repo root) | Daemonised opendray + Postgres in one command. Best default for home server / NAS / VPS / LXC-with-Docker. Optional bundled Cloudflare Tunnel via `--profile tunnel`. |
 | [`systemd/opendray.service`](systemd/opendray.service) | Bare-metal, VM, or LXC where OpenDray is the only service. Standard Linux box without Docker. |
+| [`launchd/com.opendray.opendray.plist`](launchd/com.opendray.opendray.plist) | macOS LaunchDaemon — Mac mini / Mac Studio as 24/7 home server. Starts at boot before any user login, restarts on crash. |
 | [`lxc/proxmox-pty-notes.md`](lxc/proxmox-pty-notes.md) | Proxmox LXC specifics — PTY allocation in unprivileged containers, networking, secrets. |
 | [`Dockerfile`](../Dockerfile) (repo root) | Single-container builds — used by `docker-compose.yml` above and by CI to push to GHCR. |
 | [`.goreleaser.yml`](../.goreleaser.yml) (repo root) | Cut a tagged release of pre-built binaries + checksums. |

--- a/deploy/launchd/com.opendray.opendray.plist
+++ b/deploy/launchd/com.opendray.opendray.plist
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  opendray v2 LaunchDaemon for macOS (Apple Silicon / Intel).
+
+  Designed for "Mac mini / Mac Studio as a home server" — opendray
+  runs at boot before any user logs in, restarts on crash, and logs
+  to /usr/local/var/log/opendray/.
+
+  Install:
+    # 1. Place binary + config + state dirs (one-time).
+    sudo install -m 0755 ./opendray /usr/local/bin/opendray
+    sudo install -d -m 0755 /usr/local/etc/opendray /usr/local/var/lib/opendray /usr/local/var/log/opendray
+    sudo install -m 0640 config.example.toml /usr/local/etc/opendray/config.toml
+    sudo $EDITOR /usr/local/etc/opendray/config.toml
+
+    # 2. Apply migrations once before bootstrapping the daemon.
+    sudo /usr/local/bin/opendray migrate -config /usr/local/etc/opendray/config.toml
+
+    # 3. Install + load the daemon.
+    sudo cp deploy/launchd/com.opendray.opendray.plist /Library/LaunchDaemons/
+    sudo chown root:wheel /Library/LaunchDaemons/com.opendray.opendray.plist
+    sudo chmod 0644 /Library/LaunchDaemons/com.opendray.opendray.plist
+    sudo launchctl bootstrap system /Library/LaunchDaemons/com.opendray.opendray.plist
+
+  Inspect:
+    sudo launchctl print system/com.opendray.opendray
+    tail -f /usr/local/var/log/opendray/opendray.log
+
+  Restart / unload:
+    sudo launchctl kickstart -k system/com.opendray.opendray    # restart
+    sudo launchctl bootout    system/com.opendray.opendray      # unload entirely
+
+  Notes:
+    * Runs as root by default because system-wide LaunchDaemons start
+      at boot before any user login. For a less-privileged setup, add
+      a <key>UserName</key><string>_opendray</string> pair and create
+      that user first (see Apple Tech Note TN2083).
+    * Don't hardcode secrets in this plist — it's world-readable by
+      design. Instead either:
+        (a) wrap ProgramArguments in a small shell script that
+            sources an /etc/opendray/env file before exec, or
+        (b) rely on the keyfile-at-rest flow (admin password gets
+            bcrypt-hashed into $HOME/.opendray/secrets/admin.key the
+            first time you change it via the UI — see
+            docs/operator-guide.md §admin).
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.opendray.opendray</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/opendray</string>
+    <string>serve</string>
+    <string>-config</string>
+    <string>/usr/local/etc/opendray/config.toml</string>
+  </array>
+
+  <!-- Start immediately on launchctl bootstrap and on every boot. -->
+  <key>RunAtLoad</key>
+  <true/>
+
+  <!-- Restart on failure (analogous to systemd Restart=on-failure).
+       NetworkState=true delays restart until the network is up,
+       matching the systemd unit's After=network-online.target. -->
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+    <key>NetworkState</key>
+    <true/>
+  </dict>
+
+  <!-- Throttle restart loop: matches systemd RestartSec=5s. -->
+  <key>ThrottleInterval</key>
+  <integer>5</integer>
+
+  <!-- Logs. Pre-create the directory with mode 0755 owned by the
+       user the daemon runs as (root by default). -->
+  <key>StandardOutPath</key>
+  <string>/usr/local/var/log/opendray/opendray.log</string>
+  <key>StandardErrorPath</key>
+  <string>/usr/local/var/log/opendray/opendray.err</string>
+
+  <!-- $HOME for the daemon — the admin keyfile and backup keyfile
+       both land under $HOME/.opendray/secrets/. Putting it in
+       /usr/local/var/lib/opendray/ keeps the secrets off Time
+       Machine if you exclude that path. -->
+  <key>WorkingDirectory</key>
+  <string>/usr/local/var/lib/opendray</string>
+</dict>
+</plist>


### PR DESCRIPTION
Three polish items to close the gap to "every reasonable deploy
target has a documented path" — building on #175.

## 1. Install nav at the top of the README

The previous flow buried the "where do I start" decision inside
Production deploy §A/B/C. New \`## Install\` table sits right after
Status and gives every visitor a one-line answer:

| Path | Best for | Jump to |
|---|---|---|
| 📦 **Pre-built binary** | "Just run it" — Linux / macOS, any supervisor | Releases page |
| 🐳 **Docker Compose** | Home server / NAS / VPS / LXC with Docker | §A |
| 🐧 **systemd unit** | Bare-metal / VM / LXC Linux box | §B |
| 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio as home server | §D |
| 🛠 **Build from source** | Dev / contributing / custom builds | Quickstart |

Anchor IDs match the GitHub-flavoured-markdown auto-IDs of the
target sections.

## 2. macOS launchd Option D (new)

Apple Silicon Mac mini / Mac Studio as a home server is a common
opendray host; previously the only daemon-mode paths were
Linux-systemd or Docker.

\`deploy/launchd/com.opendray.opendray.plist\` (new):
- \`RunAtLoad\`: starts at boot, before any user login
- \`KeepAlive { SuccessfulExit: false, NetworkState: true }\`:
  restart on failure, only after the network is up
- \`ThrottleInterval: 5\`: matches systemd \`RestartSec=5s\`
- Logs to \`/usr/local/var/log/opendray/{out,err}\`
- \`WorkingDirectory: /usr/local/var/lib/opendray\` so the
  admin/backup keyfiles (\`\$HOME/.opendray/secrets/...\`) land in a
  predictable spot
- Plist header doubles as the operator install runbook (5-step
  bootstrap, kickstart/bootout commands, security notes on
  secrets and \`UserName\` override)

README §D walks through install end-to-end and points at Homebrew
for the Postgres dependency.

## 3. systemd Option B "get a binary first" hint

Old §B assumed \`/path/to/opendray\` already existed but never said
how to get one. Added a short pointer to the Releases page and
the Quickstart \`go build\` path so first-time operators know where
to start.

## 4. deploy/README.md catch-up

Adds the launchd row to the artefacts table.

## Chinese mirror

\`README.zh.md\` gets the same three changes 1:1 — same table
structure, same launchd walkthrough, same systemd hint;
Chinese-natural phrasing throughout. "三种" → "四种" in the
Production deploy section header.

## Test plan

- [x] \`git diff --stat\` — pure docs + one new XML plist; no code touched
- [ ] Render README.md + README.zh.md — confirm:
      - All Install table anchor links resolve
      - macOS §D commands are sequential and don't reference
        anything that doesn't exist
- [ ] Validate plist syntax: \`plutil -lint deploy/launchd/com.opendray.opendray.plist\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)