### PR TITLE
chore: scrub personal-developer references from public surfaces

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -785,7 +785,7 @@
           "cancel": "Cancel",
           "change": "Change",
           "configure": "Configure",
-          "empty": "No remote set. Add an HTTPS or SSH URL (e.g. <1>git@github.com:you/notes.git</1> or <3>https://tea.linivek.online/you/notes.git</3>) to enable push / pull.",
+          "empty": "No remote set. Add an HTTPS or SSH URL (e.g. <1>git@github.com:you/notes.git</1> or <3>https://gitea.example.com/you/notes.git</3>) to enable push / pull.",
           "urlLabel": "URL (HTTPS or SSH)",
           "urlPlaceholder": "git@host:owner/notes.git",
           "save": "Save",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -785,7 +785,7 @@
           "cancel": "取消",
           "change": "更换",
           "configure": "配置",
-          "empty": "尚未设置 remote。添加一个 HTTPS 或 SSH URL（例如 <1>git@github.com:you/notes.git</1> 或 <3>https://tea.linivek.online/you/notes.git</3>）以启用 push / pull。",
+          "empty": "尚未设置 remote。添加一个 HTTPS 或 SSH URL(例如 <1>git@github.com:you/notes.git</1> 或 <3>https://gitea.example.com/you/notes.git</3>)以启用 push / pull。",
           "urlLabel": "URL（HTTPS 或 SSH）",
           "urlPlaceholder": "git@host:owner/notes.git",
           "save": "保存",

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -6,7 +6,7 @@
 /// Locales: 2
 /// Strings: 6108 (3054 per locale)
 ///
-/// Built on 2026-05-16 at 07:46 UTC
+/// Built on 2026-05-17 at 05:41 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -11147,8 +11147,8 @@ class TranslationsWebNotesVaultSyncRemoteEn {
 	/// en: 'Configure'
 	String get configure => 'Configure';
 
-	/// en: 'No remote set. Add an HTTPS or SSH URL (e.g. <1>git@github.com:you/notes.git</1> or <3>https://tea.linivek.online/you/notes.git</3>) to enable push / pull.'
-	String get empty => 'No remote set. Add an HTTPS or SSH URL (e.g. <1>git@github.com:you/notes.git</1> or <3>https://tea.linivek.online/you/notes.git</3>) to enable push / pull.';
+	/// en: 'No remote set. Add an HTTPS or SSH URL (e.g. <1>git@github.com:you/notes.git</1> or <3>https://gitea.example.com/you/notes.git</3>) to enable push / pull.'
+	String get empty => 'No remote set. Add an HTTPS or SSH URL (e.g. <1>git@github.com:you/notes.git</1> or <3>https://gitea.example.com/you/notes.git</3>) to enable push / pull.';
 
 	/// en: 'URL (HTTPS or SSH)'
 	String get urlLabel => 'URL (HTTPS or SSH)';
@@ -14060,7 +14060,7 @@ extension on Translations {
 			'web.notes.vaultSync.remote.cancel' => 'Cancel',
 			'web.notes.vaultSync.remote.change' => 'Change',
 			'web.notes.vaultSync.remote.configure' => 'Configure',
-			'web.notes.vaultSync.remote.empty' => 'No remote set. Add an HTTPS or SSH URL (e.g. <1>git@github.com:you/notes.git</1> or <3>https://tea.linivek.online/you/notes.git</3>) to enable push / pull.',
+			'web.notes.vaultSync.remote.empty' => 'No remote set. Add an HTTPS or SSH URL (e.g. <1>git@github.com:you/notes.git</1> or <3>https://gitea.example.com/you/notes.git</3>) to enable push / pull.',
 			'web.notes.vaultSync.remote.urlLabel' => 'URL (HTTPS or SSH)',
 			'web.notes.vaultSync.remote.urlPlaceholder' => 'git@host:owner/notes.git',
 			'web.notes.vaultSync.remote.save' => 'Save',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -5898,7 +5898,7 @@ class _TranslationsWebNotesVaultSyncRemoteZh extends TranslationsWebNotesVaultSy
 	@override String get cancel => '取消';
 	@override String get change => '更换';
 	@override String get configure => '配置';
-	@override String get empty => '尚未设置 remote。添加一个 HTTPS 或 SSH URL（例如 <1>git@github.com:you/notes.git</1> 或 <3>https://tea.linivek.online/you/notes.git</3>）以启用 push / pull。';
+	@override String get empty => '尚未设置 remote。添加一个 HTTPS 或 SSH URL(例如 <1>git@github.com:you/notes.git</1> 或 <3>https://gitea.example.com/you/notes.git</3>)以启用 push / pull。';
 	@override String get urlLabel => 'URL（HTTPS 或 SSH）';
 	@override String get urlPlaceholder => 'git@host:owner/notes.git';
 	@override String get save => '保存';
@@ -7857,7 +7857,7 @@ extension on TranslationsZh {
 			'web.notes.vaultSync.remote.cancel' => '取消',
 			'web.notes.vaultSync.remote.change' => '更换',
 			'web.notes.vaultSync.remote.configure' => '配置',
-			'web.notes.vaultSync.remote.empty' => '尚未设置 remote。添加一个 HTTPS 或 SSH URL（例如 <1>git@github.com:you/notes.git</1> 或 <3>https://tea.linivek.online/you/notes.git</3>）以启用 push / pull。',
+			'web.notes.vaultSync.remote.empty' => '尚未设置 remote。添加一个 HTTPS 或 SSH URL(例如 <1>git@github.com:you/notes.git</1> 或 <3>https://gitea.example.com/you/notes.git</3>)以启用 push / pull。',
 			'web.notes.vaultSync.remote.urlLabel' => 'URL（HTTPS 或 SSH）',
 			'web.notes.vaultSync.remote.urlPlaceholder' => 'git@host:owner/notes.git',
 			'web.notes.vaultSync.remote.save' => '保存',

--- a/app/mobile/lib/features/sessions/sessions_screen.dart
+++ b/app/mobile/lib/features/sessions/sessions_screen.dart
@@ -381,8 +381,8 @@ String _projectTitle(SessionSummary session) {
 }
 
 // Compact a long cwd to head-ellipsis + last two segments, e.g.
-// `/Users/linivek/Documents/HomeLab/Claude_Workspace/opendray-v2`
-// → `…/Claude_Workspace/opendray-v2`. Short paths pass through.
+// `/Users/alice/Documents/work/projects/my-app`
+// → `…/projects/my-app`. Short paths pass through.
 // Keeps the project-identifying tail visible inside the card's
 // fixed width.
 String _shortCwd(String cwd) {

--- a/app/web/src/pages/Project.tsx
+++ b/app/web/src/pages/Project.tsx
@@ -125,7 +125,7 @@ export function ProjectPage() {
 }
 
 // Heuristic: a real opendray project cwd has at least two non-empty
-// path segments (`/tmp/foo`, `/Users/linivek/Documents/…`).
+// path segments (`/tmp/foo`, `/home/alice/projects/my-app`).
 // One-segment scope_keys like `/Users/` are bug data from old
 // mirror imports that truncated the source path; they shouldn't
 // be presented as live project navigation targets.

--- a/app/web/src/tutorial/sections/12-backup/03-targets.md
+++ b/app/web/src/tutorial/sections/12-backup/03-targets.md
@@ -51,7 +51,7 @@ or Docker container).
 | Host | `192.168.9.8` |
 | Port | `445` (default) |
 | Share | `Claude_Workspace` |
-| User | `linivek` |
+| User | `opendray` |
 | Password | stored AES-GCM-encrypted |
 | Path prefix | `opendray/backups` |
 

--- a/internal/auth/keyfile.go
+++ b/internal/auth/keyfile.go
@@ -7,7 +7,7 @@
 //
 // On-disk schema is a single JSON object:
 //
-//	{"user":"linivek","password_hash":"$2a$..."}
+//	{"user":"admin","password_hash":"$2a$..."}
 //
 // Stored at ~/.opendray/secrets/admin.key with mode 0600 and
 // parent dir mode 0700. password_hash is bcrypt at the standard

--- a/internal/projectdoc/render_smoke_test.go
+++ b/internal/projectdoc/render_smoke_test.go
@@ -34,7 +34,7 @@ func TestRenderForSpawn_Live(t *testing.T) {
 	defer pool.Close()
 
 	svc := NewService(pool, nil)
-	cwd := "/Users/linivek/Documents/HomeLab/Claude_Workspace/opendray-v2"
+	cwd := "/Users/alice/Documents/work/projects/opendray-v2"
 	out, err := svc.RenderForSpawn(ctx, cwd, 5)
 	if err != nil {
 		t.Fatalf("render: %v", err)

--- a/internal/session/gemini_jsonl_test.go
+++ b/internal/session/gemini_jsonl_test.go
@@ -70,7 +70,7 @@ func TestGeminiInputHistory_ShortNameFromProjectsJSON(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
-	cwd := "/Users/linivek/Documents/HomeLab/KevinCui/Androidapp/PDFStream"
+	cwd := "/Users/alice/Documents/work/android/PDFStream"
 	// projects.json maps cwd → "pdfstream"; logs.json lives under
 	// tmp/pdfstream/, NOT under tmp/<sha256(cwd)>/.
 	if err := os.MkdirAll(filepath.Join(tmpHome, ".gemini"), 0o755); err != nil {
@@ -109,7 +109,7 @@ func TestGeminiInputHistory_ProjectRootScanFallback(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
-	cwd := "/Users/linivek/some/project"
+	cwd := "/Users/alice/some/project"
 	// No projects.json, no SHA dir — only a randomly-named tmp dir
 	// with a .project_root file matching cwd.
 	dir := filepath.Join(tmpHome, ".gemini", "tmp", "random-name-xyz")


### PR DESCRIPTION
Pre-public audit found maintainer-specific strings scattered across
code comments, test fixtures, i18n source strings, a docs example,
and the mobile slang regenerated output. None are secrets, but
\`/Users/linivek/Documents/HomeLab/...\` in a public OSS repo reads
as either careless or unintentional — neither lands well on a v1
public release.

Replace each with a generic placeholder that conveys the same
meaning.

## Sweep results

| File | Before | After |
|---|---|---|
| \`app/mobile/.../sessions_screen.dart\` comment | \`/Users/linivek/Documents/HomeLab/...\` | \`/Users/alice/Documents/work/projects/my-app\` |
| \`app/web/src/pages/Project.tsx\` comment | \`/Users/linivek/Documents/…\` | \`/home/alice/projects/my-app\` |
| \`internal/projectdoc/render_smoke_test.go\` cwd | \`/Users/linivek/Documents/HomeLab/...\` | \`/Users/alice/Documents/work/projects/opendray-v2\` |
| \`internal/session/gemini_jsonl_test.go\` × 2 cwds | \`/Users/linivek/...\` | \`/Users/alice/...\` |
| \`internal/auth/keyfile.go\` doc payload | \`"user":"linivek"\` | \`"user":"admin"\` |
| \`app/web/src/tutorial/.../12-backup/03-targets.md\` SMB example | \`User: linivek\` | \`User: opendray\` |
| \`app/i18n/{en,zh}.json\` vault sync URL example | \`https://tea.linivek.online/you/notes.git\` | \`https://gitea.example.com/you/notes.git\` |
| \`app/mobile/.../strings*.g.dart\` | (slang regenerated) | mirrors the JSON above |

## Verified

- \`git ls-files | xargs grep -l linivek\` → 0 matches
- \`go test ./internal/projectdoc ./internal/session\` → still green
  (cwd strings in test fixtures are only used for path-parsing
  assertions; the actual filesystem lives in tmpHome which is
  unchanged)
- slang regen ran via \`dart pub global run slang\` — no hand edits
  to .g.dart files

## Out of scope (deliberately)

- \`192.168.x.x\` references in UI placeholders and tutorial
  examples — those are RFC 1918 private IPs used as documentation,
  exposing nothing
- Mention of "Synology / QNAP / UNAS" in NAS hardware lists —
  product names, not personal

## Next after merge

This is the last commit before the repo flips public. Suggested
order:

1. Merge this PR
2. Confirm the v2.0.0 release workflow (still running) goes green
   end-to-end including the GHCR push
3. Audit GitHub Issues / PR comments + Actions secrets one more time
4. Publish the draft v2.0.0 release (binaries + cosign + SBOM + GHCR image)
5. Flip repo visibility → public

🤖 Generated with [Claude Code](https://claude.com/claude-code)