### PR TITLE
docs(deploy): scope Docker Compose to gateway use cases + auto-migrate + pgvector image

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,24 @@ rolling Unreleased section for what's landing next.
 
 Pick the path that fits how you want to run it:
 
-| Path | Best for | Jump to |
-|---|---|---|
-| 📦 **Pre-built binary** | "Just run it" — Linux / macOS, any supervisor | [Releases page](https://github.com/Opendray/opendray_v2/releases) → see [Production deploy](#production-deploy) |
-| 🐳 **Docker Compose** | Home server / NAS / VPS / LXC with Docker | [Production deploy §A](#option-a--docker-compose-recommended-one-command) |
-| 🐧 **systemd unit** | Bare-metal / VM / LXC Linux box | [Production deploy §B](#option-b--systemd-bare-metal--vm--lxc) |
-| 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio as home server | [Production deploy §D](#option-d--macos-launchd-mac-mini--studio-as-home-server) |
-| 🛠 **Build from source** | Dev / contributing / custom builds | [Quickstart](#quickstart-5-minute-dev-path) below |
+| Path | Best for | Features | Jump to |
+|---|---|---|---|
+| 📦 **Pre-built binary** | "Just run it" — Linux / macOS, any supervisor | ✨ Full | [Releases page](https://github.com/Opendray/opendray_v2/releases) → see [Production deploy](#production-deploy) |
+| 🐳 **Docker Compose** | Gateway / channels / integrations / notes / API on a Docker host | ⚠️ No session spawn, no backups (see §A) | [Production deploy §A](#option-a--docker-compose-gateway-use-cases) |
+| 🐧 **systemd unit** | Bare-metal / VM / LXC Linux box | ✨ Full | [Production deploy §B](#option-b--systemd-bare-metal--vm--lxc) |
+| 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio as home server | ✨ Full | [Production deploy §D](#option-d--macos-launchd-mac-mini--studio-as-home-server) |
+| 🛠 **Build from source** | Dev / contributing / custom builds | ✨ Full | [Quickstart](#quickstart-5-minute-dev-path) below |
+
+> **Full vs gateway-only**: "Full" means everything including
+> spawning Claude / Codex / Gemini / shell sessions from the Sessions
+> page, and encrypted backups via `pg_dump`. Docker Compose ships a
+> minimal distroless image that bundles only the opendray binary —
+> no Node runtime, no AI CLIs, no `pg_dump` — so session spawn and
+> backup require deploying opendray directly on a host with those
+> tools installed (systemd / launchd / direct binary). The Docker
+> path is the right choice when you want opendray as a network
+> gateway for channels + integrations + notes + memory + API
+> consumers, without local CLI sessions.
 
 ## Quickstart (5-minute dev path)
 
@@ -81,10 +92,24 @@ Four supported deploy paths, pick whichever fits your environment.
 Each one gives you auto-restart on crash, persistent state, and
 separation of secrets from config.
 
-### Option A — Docker Compose (recommended, one command)
+### Option A — Docker Compose (gateway use cases)
 
-The fastest way to "just keep it running" on a home server, NAS, VPS,
-or LXC with Docker. Bundled in the repo root:
+> **What works inside the container** — channels (Telegram / Slack /
+> Discord / Feishu / DingTalk / WeCom), integrations API + reverse
+> proxy + events WebSocket, notes vault + git sync, memory subsystem,
+> web admin, mobile-app backend.
+>
+> **What doesn't** — spawning Claude / Codex / Gemini / shell
+> sessions, and encrypted backups via `pg_dump`. The bundled image
+> is distroless (no Node runtime, no AI CLIs, no `pg_dump`), and
+> opendray's PTY can't reach a host binary from inside a container.
+> If you need those, deploy on the host via Option B (systemd) or
+> Option D (macOS launchd) instead — opendray and the AI CLIs share
+> auth, project state, and tool definitions on the same host, so
+> they cohabit naturally there.
+
+For deployments that want opendray as a long-running gateway on a
+home server, NAS, VPS, or LXC with Docker:
 
 ```bash
 # 1. Set passwords (file is gitignored).
@@ -103,9 +128,16 @@ docker compose logs -f opendray
 
 OpenDray is reachable at `http://127.0.0.1:8770/admin/`. Both services
 auto-restart on crash or host reboot (`restart: unless-stopped`).
-Postgres data lives in the named volume `opendray-postgres-data`;
-OpenDray state (admin keyfile, backup keyfile, vault) lives in
-`opendray-state`.
+Database migrations apply automatically before opendray starts — a
+one-shot `opendray-migrate` service runs first, and the main
+`opendray` service waits for it via `service_completed_successfully`,
+so a fresh install just works.
+
+Postgres uses [`pgvector/pgvector:pg17`](https://hub.docker.com/r/pgvector/pgvector) — opendray's memory subsystem requires the
+pgvector extension, and this image preinstalls and auto-enables it
+on first init. Postgres data lives in the named volume
+`opendray-postgres-data`; OpenDray state (admin keyfile, vault)
+lives in `opendray-state`.
 
 **Pin to a release image** in production by commenting out `build: .`
 and uncommenting `image: ghcr.io/opendray/opendray:v2.0.0` in

--- a/README.zh.md
+++ b/README.zh.md
@@ -37,13 +37,21 @@
 
 选一种最适合你环境的方式:
 
-| 方式 | 适合 | 跳转到 |
-|---|---|---|
-| 📦 **预构建二进制** | "拿来就跑" — Linux / macOS,搭配任意进程管理器 | [Releases 页](https://github.com/Opendray/opendray_v2/releases) → 见下方 [生产部署](#生产部署) |
-| 🐳 **Docker Compose** | 家用服务器 / NAS / VPS / 装 Docker 的 LXC | [生产部署 §A](#方案-a--docker-compose推荐一条命令) |
-| 🐧 **systemd unit** | 裸机 / VM / Linux LXC | [生产部署 §B](#方案-b--systemd裸机--vm--lxc) |
-| 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio 当家用 server | [生产部署 §D](#方案-d--macos-launchdmac-mini--studio-当家用-server) |
-| 🛠 **从源码构建** | 开发 / 贡献代码 / 定制构建 | [快速开始](#快速开始5-分钟开发版) |
+| 方式 | 适合 | 功能 | 跳转到 |
+|---|---|---|---|
+| 📦 **预构建二进制** | "拿来就跑" — Linux / macOS,搭配任意进程管理器 | ✨ 完整 | [Releases 页](https://github.com/Opendray/opendray_v2/releases) → 见下方 [生产部署](#生产部署) |
+| 🐳 **Docker Compose** | 把 opendray 当网关:channels / integrations / notes / API,跑在 Docker host 上 | ⚠️ 不支持 CLI 会话 spawn 与备份(见 §A) | [生产部署 §A](#方案-a--docker-composegateway-用例) |
+| 🐧 **systemd unit** | 裸机 / VM / Linux LXC | ✨ 完整 | [生产部署 §B](#方案-b--systemd裸机--vm--lxc) |
+| 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio 当家用 server | ✨ 完整 | [生产部署 §D](#方案-d--macos-launchdmac-mini--studio-当家用-server) |
+| 🛠 **从源码构建** | 开发 / 贡献代码 / 定制构建 | ✨ 完整 | [快速开始](#快速开始5-分钟开发版) |
+
+> **完整 vs 仅网关**:"完整"意味着所有功能 —— 包括从 Sessions 页 spawn
+> Claude / Codex / Gemini / shell 会话,以及通过 `pg_dump` 做加密备份。
+> Docker Compose 用的是 distroless 最小镜像,只打包了 opendray 二进制 —— 没有
+> Node 运行时、没有 AI CLI、没有 `pg_dump` —— 所以 session spawn 和 backup
+> 必须把 opendray 直接部署在装了那些工具的 host 上(systemd / launchd /
+> 直接二进制)。Docker 路径适合"把 opendray 当成 channels + integrations +
+> notes + memory + API 消费方的网络网关",不在本地 spawn CLI 会话的场景。
 
 ## 快速开始(5 分钟开发版)
 
@@ -78,10 +86,21 @@ go run ./cmd/opendray serve -config config.toml
 四种受支持的部署路径,按你的环境挑一种。每种都提供:
 崩溃后自动重启、状态持久化、secrets 跟 config 分离。
 
-### 方案 A — Docker Compose(推荐,一条命令)
+### 方案 A — Docker Compose(gateway 用例)
 
-在家用服务器、NAS、VPS 或装了 Docker 的 LXC 上,"让它一直跑着"
-最省事的方式。仓库根目录里已经备好:
+> **容器内能跑的** —— channels(Telegram / Slack / Discord / 飞书 /
+> 钉钉 / 企业微信)、integrations API + 反向代理 + events WebSocket、
+> notes vault + git 同步、memory 子系统、Web 后台、移动端后端。
+>
+> **容器内跑不了的** —— spawn Claude / Codex / Gemini / shell 会话,
+> 以及通过 `pg_dump` 的加密备份。打包的镜像是 distroless(没 Node 运行时、
+> 没 AI CLI、没 `pg_dump`),opendray 的 PTY 也无法从容器内访问 host 二进制。
+> 如果需要这些功能,改用方案 B(systemd)或 D(macOS launchd)直接在
+> host 上部署 —— opendray 跟 AI CLI 共享同一 host 上的认证、项目状态、
+> 工具定义,天然适合放一起。
+
+适合把 opendray 当成长期运行的网关,放在家用服务器、NAS、VPS 或装了
+Docker 的 LXC 上:
 
 ```bash
 # 1. 设置密码(文件已经 gitignored)。
@@ -99,9 +118,15 @@ docker compose logs -f opendray
 ```
 
 打开 `http://127.0.0.1:8770/admin/` 就能访问。两个 service 都是
-`restart: unless-stopped` —— 崩溃或主机重启后自动起来。
-Postgres 数据在命名 volume `opendray-postgres-data`,OpenDray 自己
-的状态(admin keyfile、backup keyfile、vault)在 `opendray-state`。
+`restart: unless-stopped` —— 崩溃或主机重启后自动起来。数据库 migration
+会在 opendray 启动之前自动应用 —— 一个 oneshot `opendray-migrate`
+service 先跑,主 `opendray` service 通过
+`service_completed_successfully` 等它完成,所以全新安装可以直接 work。
+
+Postgres 用 [`pgvector/pgvector:pg17`](https://hub.docker.com/r/pgvector/pgvector) —— opendray 的 memory 子系统需要
+pgvector 扩展,这个镜像在首次 init 时预装并自动启用了它。Postgres 数据在
+命名 volume `opendray-postgres-data`,OpenDray 自己的状态
+(admin keyfile、vault)在 `opendray-state`。
 
 **在生产环境钉到 release 镜像**:注释掉 `docker-compose.yml` 里的
 `build: .`,取消 `image: ghcr.io/opendray/opendray:v2.0.0` 那一行

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -16,7 +16,12 @@
 
 services:
   postgres:
-    image: postgres:17-alpine
+    # pgvector/pgvector:pg17 = Postgres 17 with the pgvector extension
+    # preinstalled and CREATE EXTENSION vector run on first init.
+    # Required by internal/store/migrations/0011_memory.sql — plain
+    # postgres:17 would fail that migration with
+    # `type "vector" does not exist`.
+    image: pgvector/pgvector:pg17
     container_name: opendray-test-pg
     restart: unless-stopped
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,58 @@
 # Production docker compose for OpenDray v2.
 #
-# Starts a long-running OpenDray gateway plus its Postgres database,
+# Runs a long-running OpenDray gateway plus its Postgres database,
 # both restarting automatically if they crash or the host reboots.
-# Use this for "I want OpenDray running on my home server / NAS / VPS
-# and never think about it again."
+#
+# ⚠️  WHAT THIS DEPLOYMENT IS, AND WHAT IT ISN'T  ⚠️
+#
+# OpenDray's CLI session spawn feature (the Sessions page —
+# Claude Code / Codex / Gemini / shell) requires those CLI binaries
+# to be present on the SAME host as opendray, in opendray's $PATH.
+# This compose file builds a distroless image that bundles only the
+# opendray binary — no Node runtime, no Claude/Codex/Gemini CLIs, no
+# shell. So inside the container:
+#
+#   ✓ Channels (Telegram / Slack / Discord / Feishu / DingTalk / WeCom)
+#   ✓ Integrations API + reverse proxy + events WebSocket
+#   ✓ Notes vault + git sync
+#   ✓ Memory subsystem + ambient capture
+#   ✓ Web admin + mobile-app backend
+#   ✗ Spawning Claude / Codex / Gemini / shell sessions — the CLIs
+#     aren't in the image, and opendray's PTY wrapper can't reach a
+#     host binary from inside a container
+#   ✗ Encrypted backups via pg_dump — distroless has no pg_dump
+#
+# If you need session spawning or backups, deploy opendray on the
+# host directly: see Production deploy §B (systemd) or §D (macOS
+# launchd) in the README. opendray + AI CLIs naturally cohabit on
+# the same host because the CLIs already store credentials, project
+# state, and tool definitions there.
 #
 # ── Bootstrap ────────────────────────────────────────────────────────
 #
 #   # 1. Create the env file (kept out of git — sets passwords).
 #   cp .env.example .env
 #   # → Edit .env:
-#   #   * Pick OPENDRAY_ADMIN_PASSWORD (used for the first login;
-#   #     change it from the UI afterwards — see operator-guide.md).
-#   #   * Pick POSTGRES_PASSWORD (used by both Postgres and OpenDray).
-#   #   * Set OPENDRAY_BACKUP_KEY only if [backup].enabled = true
-#   #     in your config.
+#   #   * OPENDRAY_ADMIN_PASSWORD (used for the first login; change
+#   #     from the UI afterwards — see operator-guide.md §admin).
+#   #   * POSTGRES_PASSWORD (used by both Postgres and OpenDray).
 #
 #   # 2. (Optional) drop your own config.toml into ./config.toml —
-#   #    the compose bind-mounts it read-only. Default behaviour is
-#   #    pure env-mode if config.toml is absent.
+#   #    compose bind-mounts it read-only. Default behaviour is pure
+#   #    env-mode if config.toml is absent.
 #
-#   # 3. Bring it up.
+#   # 3. Bring it up. Migrations apply automatically before serve
+#   #    starts (the opendray-migrate service exits 0 on success,
+#   #    and opendray waits for that via service_completed_successfully).
 #   docker compose up -d
 #   docker compose logs -f opendray   # follow logs until "listening on …"
+#
+# ── Postgres image ───────────────────────────────────────────────────
+#
+# We use `pgvector/pgvector:pg17` (official pgvector image) instead
+# of plain postgres because opendray's memory subsystem requires the
+# pgvector extension. The image auto-loads `CREATE EXTENSION vector`
+# on first init.
 #
 # ── Build options ────────────────────────────────────────────────────
 #
@@ -35,8 +65,8 @@
 #
 # ── Reverse proxy ────────────────────────────────────────────────────
 #
-# OpenDray binds to 127.0.0.1 inside its container and exposes :8770
-# on the host loopback. For internet access, front it with one of:
+# OpenDray binds to 127.0.0.1 on the host loopback by default. For
+# internet access, front it with one of:
 #
 #   * Cloudflare Tunnel (preferred — bundled cloudflared service
 #     below, opt-in via the `tunnel` profile)
@@ -48,7 +78,13 @@
 
 services:
   postgres:
-    image: postgres:17-alpine
+    # pgvector/pgvector:pg17 = official Postgres 17 image with the
+    # pgvector extension preinstalled AND `CREATE EXTENSION vector`
+    # auto-run on first init. Required by opendray's memory layer
+    # (internal/store/migrations/0011_memory.sql) — vanilla
+    # postgres:17 would fail that migration with
+    # `type "vector" does not exist`.
+    image: pgvector/pgvector:pg17
     container_name: opendray-postgres
     restart: unless-stopped
     environment:
@@ -67,6 +103,33 @@ services:
       timeout: 3s
       retries: 10
 
+  # ── One-shot migration runner ──────────────────────────────────────
+  # Applies any pending DB migrations and exits. Runs before the main
+  # opendray service via service_completed_successfully so a fresh
+  # database gets its schema set up automatically (see issue #162 —
+  # `opendray migrate` is now safe to invoke on an empty database
+  # without crashing in catalog seeding).
+  #
+  # On subsequent boots this re-runs the migrator (idempotent — already
+  # applied versions are skipped), exits 0 immediately, and opendray
+  # starts. The overhead is ~100ms.
+  opendray-migrate:
+    build: .
+    # image: ghcr.io/opendray/opendray:v2.0.0
+    container_name: opendray-migrate
+    restart: "no"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      OPENDRAY_DATABASE_URL: "postgres://opendray:${POSTGRES_PASSWORD}@postgres:5432/opendray?sslmode=disable"
+    command:
+      - "migrate"
+      - "-config"
+      - "/etc/opendray/config.toml"
+    volumes:
+      - ./config.toml:/etc/opendray/config.toml:ro
+
   opendray:
     # Default: build locally so any source change is picked up on
     # `docker compose up --build`. To pin a published release instead,
@@ -76,8 +139,8 @@ services:
     container_name: opendray
     restart: unless-stopped
     depends_on:
-      postgres:
-        condition: service_healthy
+      opendray-migrate:
+        condition: service_completed_successfully
     environment:
       # Database — points at the postgres service over the compose
       # network, not the host. sslmode=disable is safe inside docker.
@@ -88,14 +151,14 @@ services:
       OPENDRAY_LISTEN: "0.0.0.0:8770"
 
       # Bootstrap credentials. After first boot, change the password
-      # from the UI — the bcrypt keyfile in /var/lib/opendray/.opendray/
+      # from the UI — the bcrypt keyfile in /home/nonroot/.opendray/
       # secrets/admin.key takes precedence after that. See #163.
       OPENDRAY_ADMIN_USER: ${OPENDRAY_ADMIN_USER:-admin}
       OPENDRAY_ADMIN_PASSWORD: ${OPENDRAY_ADMIN_PASSWORD:?OPENDRAY_ADMIN_PASSWORD must be set in .env}
 
-      # Encrypted backups — uncomment + set OPENDRAY_BACKUP_KEY in .env.
-      # OPENDRAY_BACKUP_ENABLED: "true"
-      # OPENDRAY_BACKUP_KEY: ${OPENDRAY_BACKUP_KEY}
+      # Encrypted backups are NOT supported in this Docker deploy —
+      # the distroless image has no pg_dump. Leave disabled here; use
+      # systemd / launchd / direct-binary on the host for backups.
     ports:
       # Bind to loopback only by default. To expose on the LAN, change
       # to "0.0.0.0:8770:8770" — but only do that behind a TLS-
@@ -105,8 +168,8 @@ services:
       # Optional config.toml — bind-mounts read-only if present.
       # Comment out if you're running env-only.
       - ./config.toml:/etc/opendray/config.toml:ro
-      # Persistent state: bcrypt admin keyfile, backup keyfile,
-      # vault root (when default), Claude account configs.
+      # Persistent state: bcrypt admin keyfile, vault root (when
+      # default), Claude account configs (when registered via UI).
       - opendray-state:/home/nonroot
     # The bundled binary defaults to `serve`, but we explicitly pass
     # the config flag so the bind-mounted config.toml is picked up

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -81,10 +81,39 @@ If you already have a Postgres 15+ instance, skip step 1 and edit `config.toml` 
 url = "postgres://your_user:your_pass@your_host:5432/your_db?sslmode=disable"
 ```
 
-Recommendations:
-- Create a project-scoped role with only the CRUD privileges opendray needs — never use `postgres` / superuser.
+### Required: pgvector extension
+
+Opendray's memory subsystem needs the [`pgvector`](https://github.com/pgvector/pgvector)
+extension. The bundled `docker-compose.test.yml` uses the
+`pgvector/pgvector:pg17` image which preinstalls and auto-enables
+it, so no manual step there. For a BYO Postgres, install pgvector
+once with a superuser before running `opendray migrate`:
+
+```sh
+# 1. Install the OS package (only needed once per host).
+#    Ubuntu / Debian:
+sudo apt install postgresql-17-pgvector
+
+#    macOS (Homebrew):
+brew install pgvector
+
+#    Other OSes / source build: see https://github.com/pgvector/pgvector#installation
+
+# 2. Enable the extension in the opendray database (one-off, requires superuser).
+psql "postgres://postgres@your_host/opendray" -c 'CREATE EXTENSION IF NOT EXISTS vector;'
+```
+
+After that, opendray's regular CRUD-only role can run migrations
+without needing further superuser access — migration `0011_memory`
+just creates the `memories` table (the extension is already
+present).
+
+### Recommendations
+
+- Create a project-scoped role with only the CRUD privileges opendray needs — never use `postgres` / superuser at runtime.
 - Rotate credentials out of band; don't commit them.
 - Connection pool size is configurable via `[database].max_conns` (default `16`).
+- Supported Postgres versions: **15, 16, 17**. The encrypted-backup subsystem additionally requires `pg_dump` / `pg_restore` matching the server's major version (see operator-guide.md `[backup]`).
 
 ## Running the test suite
 


### PR DESCRIPTION
Pre-public deep audit of every deploy path found three silent
failures in Docker Compose alone. This PR closes them together
because they're all about: "a stranger clones the repo, runs
\`docker compose up\`, and either gets a working system OR an
honest message about why their use case doesn't fit."

## The three failures

| # | Failure | User-visible symptom |
|---|---|---|
| 1 | \`postgres:17-alpine\` doesn't bundle pgvector | Fresh DB → \`opendray migrate\` crashes at migration 0011: \`type "vector" does not exist\` |
| 2 | No auto-migrate in compose | Fresh DB → \`serve\` starts → \`app.New()\` catalog seeding crashes (same class as #162): \`relation "providers" does not exist\` |
| 3 | distroless image has no \`claude\` / \`codex\` / \`gemini\` / shell / \`pg_dump\` | Spawn Claude session → "executable not found in PATH". Enable backups → \`pg_dump\` exec fails. No prior warning |

## What this PR changes

### \`docker-compose.yml\`

- Postgres image → \`pgvector/pgvector:pg17\` (closes #1)
- New \`opendray-migrate\` one-shot service; main \`opendray\` gates on
  \`service_completed_successfully\` (closes #2)
- Header rewritten to lead with what works ✓ vs what doesn't ✗
  inside the container, plus a pointer to Option B / D for the
  excluded use cases (closes #3)
- Removed backup-enabling env-var hints — would silently fail

### \`docker-compose.test.yml\`

- Same pgvector image switch (the test DB has the same memory tests
  in opendray's CI matrix)

### \`README.md\` + \`README.zh.md\`

- Install table gets a \`Features\` column —
  pre-built binary / systemd / launchd / source = "✨ Full",
  Docker Compose = "⚠️ No session spawn, no backups (see §A)"
- New paragraph below the table explaining "Full vs gateway-only"
- Option A retitled "Docker Compose (gateway use cases)" with a
  callout box listing exact in/out
- Auto-migrate + pgvector image both called out in the section body

### \`docs/quickstart.md\`

- "Using your own Postgres" gets a \`Required: pgvector extension\`
  subsection — apt/brew install paths, one-off \`CREATE EXTENSION\`
  command, note that CRUD role doesn't need superuser afterwards
- Supported Postgres versions explicit: 15, 16, 17
- pg_dump-must-match-server reminder for the backup subsystem

## Verified

- \`docker compose config --quiet\` (placeholder env vars) → clean
- Anchor links in Install table match renamed section ID
- No code change; pure docs + compose config (5 files,
  +206 / -52)

## Out of scope (deliberately)

- **Fat-image variant** that bundles Node + AI CLIs so Docker users
  get full features. Real CLI-sync / redistribute-license /
  image-bloat costs — deserves its own RFC. Will open a separate
  issue.
- **macOS launchd ↔ Homebrew Postgres ordering** — follow-up
  nice-to-have, not a blocker.

## Pre-public checklist update (after this lands)

Critical Docker Compose gaps closed. Remaining publish-prep:

- [x] Secret scan / git history clean
- [x] LICENSE / README / VERSIONING / CHANGELOG / SECURITY / CONTRIBUTING
- [x] README bilingual + 4 production paths
- [x] Personal-developer references scrubbed (#177)
- [x] Docker Compose architectural honesty (this PR)
- [ ] You: audit Issues / PR comments + Actions Secrets
- [ ] You: confirm v2.0.0 release workflow GHCR push went green
- [ ] You: publish v2.0.0 draft release
- [ ] You: flip repo visibility → public

🤖 Generated with [Claude Code](https://claude.com/claude-code)