### PR TITLE
chore(github): issue / PR templates + Contributor Covenant CoC

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: 🐞 Bug report
+description: Something broken in opendray — reproducible behaviour that doesn't match the docs.
+title: "bug: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. The fields below let us
+        reproduce the issue without a back-and-forth.
+
+        Before filing:
+        - Check the [open Issues](https://github.com/Opendray/opendray_v2/issues) for a duplicate.
+        - For "how do I..." or "is this expected" questions, use
+          [Discussions](https://github.com/Opendray/opendray_v2/discussions) instead.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences. What did you expect, what actually happened?
+      placeholder: |
+        e.g. `docker compose up` exits with `relation "providers" does not exist`
+        on a fresh Postgres. README says it should auto-migrate.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: opendray version
+      description: Output of `opendray version` (or the release tag / docker image tag).
+      placeholder: "v2.0.0 (abc1234, 2026-05-17T...)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deploy
+    attributes:
+      label: Deployment method
+      options:
+        - Docker Compose (docker-compose.yml at repo root)
+        - systemd (deploy/systemd/opendray.service)
+        - macOS launchd (deploy/launchd/...)
+        - Direct binary + custom supervisor
+        - go run from source
+        - Other (please describe in additional context)
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Host OS / arch
+      placeholder: "Ubuntu 24.04 LXC, amd64 / macOS 14.5 Sonoma, arm64 / Debian 13, arm64"
+    validations:
+      required: true
+
+  - type: input
+    id: postgres
+    attributes:
+      label: Postgres version + pgvector
+      description: Output of `SELECT version();` and `SELECT * FROM pg_extension WHERE extname='vector';`. Skip if not DB-related.
+      placeholder: "PG 17.5, pgvector 0.8.0"
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Smallest possible sequence. Copy-paste commands or click paths.
+      placeholder: |
+        1. Fresh PG (or my existing PG with these credentials)
+        2. `cp .env.example .env` + set passwords
+        3. `docker compose up -d`
+        4. Wait for opendray-migrate to finish
+        5. Observe ... (what?)
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste `docker compose logs opendray`, `journalctl -u opendray -n 200`, or the browser console output. **Redact secrets before pasting.**
+      render: shell
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else — screenshots, related issues, workarounds you've tried.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,18 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & how-do-I (Discussions)
+    url: https://github.com/Opendray/opendray_v2/discussions
+    about: |
+      Questions about how to use opendray, deployment troubleshooting, or "is this
+      expected behaviour?" belong in Discussions — Issues are for confirmed bugs
+      and concrete feature proposals.
+  - name: 🔒 Security disclosure
+    url: https://github.com/Opendray/opendray_v2/blob/main/SECURITY.md
+    about: |
+      Report security vulnerabilities privately — do not file a public issue.
+      See SECURITY.md for the disclosure flow.
+  - name: 📖 Documentation (English / 简体中文)
+    url: https://github.com/Opendray/opendray_v2#install
+    about: |
+      Install paths (Docker Compose / systemd / launchd / direct binary), quickstart,
+      operator guide, API reference, and architecture decision records.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,83 @@
+name: 💡 Feature request
+description: Propose a new capability or a non-trivial enhancement.
+title: "feat: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing:
+        - Check the [open Issues](https://github.com/Opendray/opendray_v2/issues?q=is%3Aissue+label%3Aenhancement) for a duplicate.
+        - For early-stage "what if we..." ideas, prefer
+          [Discussions → Ideas](https://github.com/Opendray/opendray_v2/discussions) —
+          formal issues are for ideas that already feel concrete.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Tell us the user-facing problem first, not the proposed solution.
+      placeholder: |
+        e.g. I run opendray on a Mac mini with multiple Claude accounts. When I switch
+        accounts via the UI, the spawn dialog forgets which account I last used for
+        each project — I have to re-pick every time.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How should opendray behave? Be concrete (UI flow, API shape, default values).
+      placeholder: |
+        e.g. Persist the last-used (account_id, cwd) pair per session-launch and
+        default the spawn dialog's account picker to it. Fall back to the global
+        default account if no per-cwd history exists.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else would solve the same problem? Why did you reject them?
+      placeholder: |
+        - A `default_account_id` field in opendray config — rejected because it's
+          global, doesn't capture per-project context.
+        - A keyboard shortcut to repeat-last-spawn — narrower, doesn't solve the
+          dropdown ergonomics.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Which surface(s)?
+      multiple: true
+      options:
+        - Backend (Go) — internal/*
+        - Web admin (React) — app/web/
+        - Mobile app (Flutter) — app/mobile/
+        - Channel adapter (Telegram / Slack / Discord / Feishu / DingTalk / WeCom / Bridge)
+        - Integration API (REST / WS)
+        - Memory subsystem
+        - Backup / restore
+        - Notes vault
+        - Plugins / Skills / MCP
+        - Documentation
+        - Other / Cross-cutting
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: willing_to_pr
+    attributes:
+      label: Are you willing to submit a PR?
+      options:
+        - label: I'm willing to draft the implementation in a PR.
+        - label: I can help with design discussion / review but not implementation.
+        - label: I'm only proposing; happy to wait for someone else to pick it up.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, related issues, links to similar features in other tools.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,78 @@
+<!--
+  Thanks for sending a PR! Filling this in helps reviewers land your change
+  quickly. The conventions below are what we follow internally.
+
+  PR title: conventional-commits format
+    feat(scope): ...        new user-facing capability
+    fix(scope): ...         bug fix
+    docs(scope): ...        documentation only
+    ci(scope): ...          CI / build / release pipeline
+    chore(scope): ...       infra, dependency bumps, repo housekeeping
+    refactor(scope): ...    non-behaviour-changing internal restructure
+
+  See CONTRIBUTING.md for full conventions.
+-->
+
+## Summary
+
+<!-- 1-3 sentences. What does this change do and why? -->
+
+## Related issue
+
+<!-- `Closes #N` if this fully resolves an issue (auto-closes on merge). Use
+     `Refs #N` for partial work or follow-ups. -->
+
+Closes #
+
+## Type of change
+
+- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
+- [ ] ✨ New feature (non-breaking change that adds capability)
+- [ ] 💥 Breaking change (existing behaviour changes — bump VERSIONING.md if user-visible)
+- [ ] 📖 Documentation only
+- [ ] 🔧 CI / build / release pipeline
+- [ ] 🧹 Chore (deps, refactor, repo housekeeping)
+
+## Surface(s) touched
+
+<!-- Tick all that apply so reviewers know what to focus on. -->
+
+- [ ] Backend (Go) — `internal/*`, `cmd/*`
+- [ ] Web admin (React) — `app/web/`
+- [ ] Mobile app (Flutter) — `app/mobile/`
+- [ ] Channel adapter — `internal/channel/*`
+- [ ] Memory subsystem — `internal/memory/*`
+- [ ] Backup / restore — `internal/backup/*`
+- [ ] Notes / vault — `internal/notes/*`, `internal/vaultgit/*`
+- [ ] Integration API — `internal/integration/*`, `internal/gateway/*`
+- [ ] DB migrations — `internal/store/migrations/*`
+- [ ] Deploy artefacts — `deploy/`, `Dockerfile`, `docker-compose*.yml`
+- [ ] Docs — `README*`, `docs/`, `CHANGELOG.md`
+
+## Test plan
+
+<!-- How did you verify this? Be concrete enough that a reviewer can repeat it. -->
+
+- [ ] `go test -race ./...` passes locally (or DB-skipped tests skip cleanly)
+- [ ] `cd app/web && pnpm build` (TS strict + Vite prod) succeeds
+- [ ] Manual smoke: ...
+- [ ] Tested against a fresh database (if DB-touching)
+- [ ] Tested with both `config.toml` and pure env-var modes (if config-touching)
+
+## DB / config / operator impact
+
+<!-- Tick whichever applies. Be explicit when 'no' so the reviewer doesn't have to check. -->
+
+- [ ] No DB migration
+- [ ] Adds a new migration (`internal/store/migrations/NNNN_*.sql`) — idempotent + safe to re-run
+- [ ] Changes existing user-facing config (env var rename, key removal, ...) — call out as **BREAKING** in CHANGELOG
+- [ ] Adds new env vars / config keys — documented in `config.example.toml` and `docs/operator-guide.md`
+- [ ] None of the above
+
+## Screenshots / before-after (UI changes)
+
+<!-- Drop screenshots or GIFs if web/mobile UI changed. -->
+
+## Anything else?
+
+<!-- Trade-offs, design choices to flag, follow-ups left intentionally unimplemented. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in
+opendray's community a harassment-free experience for everyone, regardless of
+age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political
+  attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action
+in response to any behavior that they deem inappropriate, threatening,
+offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, and will communicate reasons
+for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces — including the
+opendray GitHub repository (issues, pull requests, discussions, code review),
+release announcements, and any official channel where opendray is the
+subject — and also applies when an individual is officially representing the
+community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers via the contact channel listed in
+[SECURITY.md](SECURITY.md). All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of
+the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of this
+Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations


### PR DESCRIPTION
OpenDray went public yesterday with strong internal documentation
(README × 2 languages, VERSIONING.md, CHANGELOG.md, operator guide,
quickstart, integration guide, 18 ADRs, deploy artefacts) but no
GitHub-meta files. This PR adds the standard set so the external-
visitor experience matches the internal docs strength — first
contact knows immediately:

- where to file a bug (template guides them, won't lose key info)
- where to propose a feature (template forces "problem first,
  solution second")
- where questions go (Discussions, not Issues)
- where to disclose security issues (SECURITY.md contact)
- the project has a Code of Conduct

## Files

### \`.github/ISSUE_TEMPLATE/bug_report.yml\` (new)
GitHub Forms format. Required fields:
- opendray version (from \`opendray version\`)
- Deploy method dropdown (Docker / systemd / launchd / direct / source)
- Host OS / arch
- Postgres + pgvector version
- Reproducer
- Logs (with redact-secrets reminder)

Forms ⮕ structured fields ⮕ no more "doesn't work, please help" issues.

### \`.github/ISSUE_TEMPLATE/feature_request.yml\` (new)
Forms format. Forces "what problem are you trying to solve" before
"proposed solution" so we don't design past the actual constraint.
Multi-select surface dropdown so reviewers know what's touched
without reading the body. "Are you willing to PR" checkbox sets
expectations early.

### \`.github/ISSUE_TEMPLATE/config.yml\` (new)
- Disables blank issues (forces template selection)
- Contact links:
  - Discussions for "how do I..." questions
  - SECURITY.md for vulnerability disclosure
  - README Install for docs

### \`.github/pull_request_template.md\` (new)
- Conventional-commits title hint
- Type-of-change tickbox
- Surface-touched multi-select (cross-cutting PRs misroute easily)
- Test plan section
- Explicit DB/config/operator-impact checklist — a migration PR
  can't silently land without flagging

### \`CODE_OF_CONDUCT.md\` (new)
Contributor Covenant 2.1, standard text. Points the reporting
channel at SECURITY.md so we don't introduce a second contact
surface.

## Adjacent (not in this PR — already done via API)

The repo's About section was empty (no description, no topics,
no homepage) when public went live. Set via \`gh repo edit\` and
\`gh api PUT topics\`:

- **Description**: "Self-hosted gateway for AI coding agents
  (Claude Code · Codex · Gemini · shell). Remote-control sessions
  from web / mobile / messaging apps — Telegram, Slack, Discord,
  飞书, 钉钉, 企业微信."
- **Topics** (20): \`ai-agents\` · \`ai-coding\` · \`claude-code\` ·
  \`codex-cli\` · \`gemini-cli\` · \`mcp\` · \`self-hosted\` ·
  \`telegram-bot\` · \`slack-bot\` · \`discord-bot\` · \`feishu\` ·
  \`dingtalk\` · \`wecom\` · \`pgvector\` · \`go\` · \`flutter\` ·
  \`react\` · \`llm\` · \`agent-framework\` · \`gateway\`

## Test plan

- [x] \`git diff\` reviewed — pure docs, no code touched
- [ ] After merge: open a test issue from each template — verify
      both load + the contact-links page redirects to Discussions
- [ ] After merge: open a test draft PR — verify the body
      pre-populates with the template

🤖 Generated with [Claude Code](https://claude.com/claude-code)