### PR TITLE
docs(getting-started): zero-to-first-session guide (en + zh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@
 
 ## Status
 
-## Status
-
 **v2.0.0** — first release of the opendray v2 generation (2026-05-17).
 See [`VERSIONING.md`](VERSIONING.md) for the major-as-generation policy
 (major = product generation, not strict SemVer "breaking change").
@@ -71,6 +69,13 @@ See [`CHANGELOG.md`](CHANGELOG.md) for the v2.0.0 entry and the
 rolling Unreleased section for what's landing next.
 
 ## Install
+
+> **First time here?** Read [**docs/getting-started.md**](docs/getting-started.md)
+> for a 15-minute end-to-end walkthrough — installing the AI CLIs
+> opendray wraps, bootstrapping Postgres, deploying opendray, and
+> getting your first idle notification on Telegram. The table below
+> is for picking a deploy path; the guide stitches everything
+> around it.
 
 Pick the path that fits how you want to run it:
 
@@ -381,7 +386,8 @@ Zustand + xterm.js) and per-W milestone notes.
 
 ## Documentation
 
-- [`docs/quickstart.md`](docs/quickstart.md) — full quickstart with prereqs, troubleshooting, and the docker-compose dev DB
+- [`docs/getting-started.md`](docs/getting-started.md) — **start here** if you're new: zero to first session in 15 minutes, including installing the wrapped CLIs and bootstrapping Postgres
+- [`docs/quickstart.md`](docs/quickstart.md) — 5-minute dev environment (assumes you already know the moving parts)
 - [`docs/design.md`](docs/design.md) — mission, architecture, subsystems,
   API, data model, roadmap
 - [`docs/adr/`](docs/adr/) — every binding architecture decision, dated

--- a/README.zh.md
+++ b/README.zh.md
@@ -68,6 +68,11 @@
 
 ## 安装
 
+> **第一次来?** 先看 [**docs/getting-started.zh.md**](docs/getting-started.zh.md)
+> —— 15 分钟端到端 walkthrough:装 opendray wrap 的 AI CLI、bootstrap
+> Postgres、部署 opendray、收到第一条 Telegram idle 通知。下面这个表
+> 只是挑部署路径,getting-started 把表前后的所有事情串起来。
+
 选一种最适合你环境的方式:
 
 | 方式 | 适合 | 功能 | 跳转到 |
@@ -365,7 +370,8 @@ Router/Query + Zustand + xterm.js)和每个 W 里程碑笔记见
 
 ## 文档
 
-- [`docs/quickstart.md`](docs/quickstart.md) — 完整 quickstart,含前置依赖、排错、docker-compose 开发 DB
+- [`docs/getting-started.zh.md`](docs/getting-started.zh.md) — **新手从这开始**:零到首次会话 15 分钟,含装 wrap 的 CLI + bootstrap Postgres + 收第一条 Telegram 通知
+- [`docs/quickstart.md`](docs/quickstart.md) — 5 分钟开发环境(假设你已经懂各组件)
 - [`docs/design.md`](docs/design.md) — 任务、架构、子系统、API、数据模型、路线图
 - [`docs/adr/`](docs/adr/) — 每个生效中的架构决策,按日期排序
 - [`docs/operator-guide.md`](docs/operator-guide.md) — 生产化部署 + 运维参考

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,291 @@
+# Getting started
+
+Zero-to-first-session walkthrough. Plan for ~15 minutes if Postgres
+is already on the host; 25 minutes if you need to install one too.
+
+This guide is intentionally end-to-end — it covers the things that
+sit *around* opendray (installing the CLIs it wraps, bootstrapping
+Postgres) on top of the deploy paths in the [README](../README.md#install).
+If you've used opendray before and just want to redeploy, the
+condensed paths in README Production deploy are a better fit.
+
+> **Already know "is opendray for me?"**
+> If not, read the [What is opendray?](../README.md#what-is-opendray)
+> section in the README first. The bullets there will save you
+> 15 minutes if your use case isn't a match.
+
+---
+
+## Step 0 — what you'll need
+
+| Tool | Why | Note |
+|---|---|---|
+| At least one of: Claude Code / Codex CLI / Gemini CLI | opendray is a **wrapper**, not a model — it spawns a CLI on your host | Step 1 below |
+| PostgreSQL 15 / 16 / 17 + **pgvector** extension | State, sessions, memory vectors | Step 2 below |
+| `go` 1.25+ and `pnpm` 10+ — *only* if you build from source | Skip if you grab a release binary | [Releases page](https://github.com/Opendray/opendray_v2/releases) |
+| A reachable network port (default `:8770`) for the web admin | UI + API + WebSockets | Bind to `127.0.0.1` unless behind a reverse proxy |
+
+---
+
+## Step 1 — install at least one AI CLI
+
+opendray spawns these CLIs against your local accounts. You install
+them just like you would for terminal use; opendray finds them on
+`$PATH`.
+
+### Claude Code (recommended starting point)
+
+```sh
+npm install -g @anthropic-ai/claude-code
+claude login        # browser-based OAuth
+```
+
+After login, credentials sit at `~/.claude/credentials.json`.
+opendray reads them automatically when you select the **claude**
+provider.
+
+### Codex CLI (OpenAI)
+
+```sh
+# Follow https://github.com/openai/codex
+# The exact npm package or pip target varies by release; whatever
+# you end up with should put `codex` on $PATH.
+codex --version     # sanity check
+```
+
+### Gemini CLI (Google)
+
+```sh
+npm install -g @google/gemini-cli
+gemini auth login
+```
+
+### Verify at least one is reachable
+
+```sh
+which claude codex gemini      # at least one line should resolve
+```
+
+> You can run opendray with just **one** CLI installed and add the
+> others later. The provider list is dynamic — opendray probes the
+> binary at spawn time, missing ones just show as "command not
+> found" in the Sessions error panel.
+
+---
+
+## Step 2 — install Postgres + pgvector
+
+opendray requires PostgreSQL **15, 16, or 17** with the
+[`pgvector`](https://github.com/pgvector/pgvector) extension. Pick
+the install method matching your host.
+
+### macOS (Homebrew)
+
+```sh
+brew install postgresql@17 pgvector
+brew services start postgresql@17
+```
+
+### Ubuntu / Debian
+
+```sh
+sudo apt install postgresql-17 postgresql-17-pgvector
+sudo systemctl enable --now postgresql
+```
+
+### Other Linux
+
+Use your distro's PG packages, then either install pgvector via
+package or build [from source](https://github.com/pgvector/pgvector#installation).
+
+### Bootstrap the opendray database (one-time)
+
+In `psql` connected as a superuser:
+
+```sql
+-- Locally (Homebrew default): `psql postgres`
+-- Remote: `psql -h <host> -U postgres -d postgres`
+
+CREATE DATABASE opendray;
+CREATE USER opendray_user WITH ENCRYPTED PASSWORD '<pick a strong password>';
+GRANT ALL PRIVILEGES ON DATABASE opendray TO opendray_user;
+
+\c opendray
+CREATE EXTENSION IF NOT EXISTS vector;
+GRANT ALL ON SCHEMA public TO opendray_user;
+```
+
+> `CREATE EXTENSION vector` needs **superuser**. After it lands,
+> `opendray_user` only needs the CRUD privileges granted above —
+> opendray never reconnects as superuser at runtime.
+
+Test the credentials from the host you'll run opendray on:
+
+```sh
+PGPASSWORD='<password>' psql -h <pg-host> -U opendray_user -d opendray -c "SELECT 'ok' AS check;"
+```
+
+You should see `check: ok` and no errors.
+
+---
+
+## Step 3 — pick a deploy path and install opendray
+
+The README has the full table; the most common picks for a first
+try:
+
+| Your host | Path | README section |
+|---|---|---|
+| macOS as 24/7 home server | macOS LaunchDaemon | [Option D](../README.md#option-d--macos-launchd-mac-mini--studio-as-home-server) |
+| Linux box / VPS / LXC | systemd | [Option B](../README.md#option-b--systemd-bare-metal--vm--lxc) |
+| Docker host (no CLI session spawn needed) | Docker Compose | [Option A](../README.md#option-a--docker-compose-gateway-use-cases) — read the limit callout |
+| Just testing in foreground | `go run` from source | [Quickstart](../README.md#quickstart-5-minute-dev-path) |
+| Hand-rolled supervisor (s6 / runit / launchd Agent) | Direct binary | [Option C](../README.md#option-c--direct-binary--your-own-process-supervisor) |
+
+All paths converge on:
+
+```sh
+# Bootstrap a config the gateway will read
+cp config.example.toml config.toml
+$EDITOR config.toml            # set [database].url, [admin].password
+
+# One-shot: create the schema (idempotent on re-run)
+opendray migrate -config config.toml
+
+# Run the gateway
+opendray serve -config config.toml
+```
+
+The minimum two fields in `config.toml`:
+
+```toml
+[database]
+url = "postgres://opendray_user:<password>@<host>:5432/opendray?sslmode=disable"
+
+[admin]
+password = "<initial-bootstrap-password>"
+```
+
+Everything else has sensible defaults — see `config.example.toml`
+inline comments for the full surface.
+
+---
+
+## Step 4 — first login + change admin password
+
+Open `http://localhost:8770/admin/` (or whatever host:port opendray
+is bound to via `listen` in `config.toml`).
+
+1. Log in as `admin` + the password you put in `[admin].password`.
+2. **Immediately** go to Settings → Admin → Change password.
+
+Why immediately: after the first password change, opendray writes a
+bcrypt-hashed keyfile at `$HOME/.opendray/secrets/admin.key` and the
+plaintext `[admin].password` in `config.toml` becomes inert (the
+keyfile takes precedence). Until you change it, your only protection
+is filesystem permissions on `config.toml`.
+
+The full credential precedence chain is in
+[operator-guide §admin](operator-guide.md#admin).
+
+---
+
+## Step 5 — configure a Provider
+
+Providers → click the provider you installed in Step 1 → fill in:
+
+- **Command path** — absolute path to the CLI binary
+  (`which claude` finds it; on Apple Silicon Homebrew installs land
+  at `/opt/homebrew/bin/claude`).
+- **Accounts dir** (Claude only, optional) — a directory of named
+  Claude credential sets if you want to switch identities per
+  session. Leave blank to use the default `~/.claude`.
+
+Save. opendray runs a one-off `<cli> --version` to probe; the
+provider card turns green when the binary is reachable.
+
+---
+
+## Step 6 — spawn your first session
+
+Sessions → New session → pick the provider → pick a working
+directory (any project on your machine) → Spawn.
+
+A browser-side terminal opens. Type prompts as you would in a real
+terminal. Close the tab and the session keeps running on the host;
+come back, the scrollback is intact (per
+[ADR 0003](adr/0003-session-resume-client-reconnect.md)).
+
+---
+
+## Step 7 (optional) — add a Telegram channel
+
+This is the feature that makes opendray different from
+`tmux` + `ssh`. With a channel wired up, opendray pushes
+notifications when a session goes idle (CLI is waiting on input),
+and your reply on Telegram flows back as the next stdin write.
+
+### One-time Telegram setup
+
+1. Telegram → search **@BotFather** → start chat.
+2. `/newbot` → BotFather walks you through name + username → issues a token like
+   `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`.
+3. Find your chat ID:
+   - DM your bot once (any text).
+   - Open `https://api.telegram.org/bot<token>/getUpdates` — your
+     numeric `chat.id` is in the JSON response.
+
+### In opendray
+
+Channels → New channel → kind **Telegram**:
+
+- **Bot token**: from BotFather
+- **Default chat ID**: the `chat.id` from `getUpdates`
+- **Notify on**: tick `session.idle` (or all three topics)
+
+Save → click **Test** on the channel card. Within seconds you'll
+see a test message in Telegram.
+
+Now leave a session idle for 30 seconds (the default idle threshold
+— configurable via `[session].idle_threshold`). Telegram pings you
+with the last bit of CLI output. Reply, and the text flows back
+into the session's stdin.
+
+---
+
+## What next?
+
+- **More channels**: Slack / Discord / Feishu (飞书) / DingTalk
+  (钉钉) / WeCom (企业微信) — each has its own setup in the in-app
+  Tutorial at `/admin/tutorial/`.
+- **API integrations**: [docs/integration-guide.md](integration-guide.md)
+  — scoped API keys, reverse-proxy mount, events WebSocket.
+- **Memory subsystem**: enable local-first embeddings via
+  `[memory.backend] = "local"` or wire up Ollama / LM Studio — see
+  in-app Tutorial → Memory section.
+- **Encrypted backups**: configure `[backup]` to push DB dumps to
+  S3 / R2 / B2 / SFTP / rclone — see
+  [operator-guide §backup](operator-guide.md#backup).
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `relation "providers" does not exist` on migrate | Pre-v2.0.0 binary (issue #162) | Pull the latest binary — fix is in v2.0.0 |
+| `type "vector" does not exist` on migrate | pgvector extension not enabled in the opendray database | Run `CREATE EXTENSION vector;` as superuser in `opendray` |
+| `Spawn session failed: executable file not found in $PATH` | The wrapped CLI isn't installed on the opendray host, or the Command Path in the Provider config is wrong | Step 1 above; verify with `which claude` (or whichever CLI) |
+| Telegram bot doesn't respond to replies | Bot privacy mode is on by default (bot only sees commands) | BotFather → `/setprivacy` → Disable |
+| `Bad gateway` through a reverse proxy | Proxy isn't forwarding WebSocket upgrade headers | See [operator-guide §Topology](operator-guide.md#topology) for nginx / Caddy snippets |
+| Sessions tab is empty but Channels work | Likely the binary can spawn but no Provider configured | Step 5 |
+
+---
+
+## See also
+
+- [README](../README.md) — install table, deploy paths, project status
+- [README.zh.md](../README.zh.md) — Simplified Chinese version
+- [docs/quickstart.md](quickstart.md) — 5-minute dev environment (more focused than this guide)
+- [docs/operator-guide.md](operator-guide.md) — operator reference: topology, auth, backup, logging
+- [docs/integration-guide.md](integration-guide.md) — third-party API surface
+- [VERSIONING.md](../VERSIONING.md) — major-as-generation versioning
+- [CHANGELOG.md](../CHANGELOG.md) — release history

--- a/docs/getting-started.zh.md
+++ b/docs/getting-started.zh.md
@@ -1,0 +1,277 @@
+# 快速上手
+
+零到首次会话的完整 walkthrough。Postgres 已经在 host 上的话 ~15
+分钟,需要顺便装 Postgres 的话 25 分钟。
+
+这份指南是**端到端**的 —— 把 opendray 外围的事情(装 opendray
+wrap 的 CLI、bootstrap Postgres)跟 README 里的部署路径串到一起。
+如果你之前用过 opendray、只是想重新部署,直接看 README 生产部署
+里压缩版的步骤就够。
+
+> **还没确定 "opendray 适合我吗"?**
+> 先看 README 顶部的 [opendray 是什么?](../README.zh.md#opendray-是什么)。
+> 如果用例不 match,那一段会让你省 15 分钟。
+
+---
+
+## 第 0 步 —— 你需要什么
+
+| 工具 | 为什么 | 备注 |
+|---|---|---|
+| 至少一个:Claude Code / Codex CLI / Gemini CLI | opendray 是 **wrapper**,不是模型 —— 它在 host 上 spawn 你装好的 CLI | 第 1 步 |
+| PostgreSQL 15 / 16 / 17 + **pgvector** 扩展 | 状态、会话、记忆向量 | 第 2 步 |
+| `go` 1.25+ 和 `pnpm` 10+ —— *只在* 从源码 build 时需要 | 用 release binary 的话跳过 | [Releases 页](https://github.com/Opendray/opendray_v2/releases) |
+| 一个可达的端口(默认 `:8770`)给 Web 后台 | UI + API + WebSocket | 没反向代理就绑 `127.0.0.1` |
+
+---
+
+## 第 1 步 —— 至少装一个 AI CLI
+
+opendray 用你本地的账户 spawn 这些 CLI。你像平时终端用一样装它们,
+opendray 在 `$PATH` 上找。
+
+### Claude Code(推荐起点)
+
+```sh
+npm install -g @anthropic-ai/claude-code
+claude login        # 浏览器 OAuth
+```
+
+登录后,凭据落在 `~/.claude/credentials.json`,opendray 选 **claude**
+provider 时会自动读到。
+
+### Codex CLI(OpenAI)
+
+```sh
+# 按 https://github.com/openai/codex 的官方安装步骤
+# 不同版本 npm 包/pip target 可能不同,装完 `codex` 应该在 $PATH 上
+codex --version     # 验证一下
+```
+
+### Gemini CLI(Google)
+
+```sh
+npm install -g @google/gemini-cli
+gemini auth login
+```
+
+### 验证至少一个能找到
+
+```sh
+which claude codex gemini      # 至少一行能 resolve
+```
+
+> 只装 **一个** CLI 就能跑 opendray,其他以后再加。Provider 列表是
+> 动态的 —— spawn 时 opendray 现场探测 binary,装漏的会在 Sessions
+> 错误面板里显示 "command not found"。
+
+---
+
+## 第 2 步 —— 装 Postgres + pgvector
+
+opendray 要求 PostgreSQL **15、16 或 17**,并装
+[`pgvector`](https://github.com/pgvector/pgvector) 扩展。按 host
+选安装方式。
+
+### macOS(Homebrew)
+
+```sh
+brew install postgresql@17 pgvector
+brew services start postgresql@17
+```
+
+### Ubuntu / Debian
+
+```sh
+sudo apt install postgresql-17 postgresql-17-pgvector
+sudo systemctl enable --now postgresql
+```
+
+### 其他 Linux
+
+用你发行版的 PG 包,然后 pgvector 走包管理器装,或者从
+[源码 build](https://github.com/pgvector/pgvector#installation)。
+
+### Bootstrap opendray 数据库(一次性)
+
+用 superuser 进 psql:
+
+```sql
+-- 本地(Homebrew 默认): `psql postgres`
+-- 远程: `psql -h <host> -U postgres -d postgres`
+
+CREATE DATABASE opendray;
+CREATE USER opendray_user WITH ENCRYPTED PASSWORD '<选一个强密码>';
+GRANT ALL PRIVILEGES ON DATABASE opendray TO opendray_user;
+
+\c opendray
+CREATE EXTENSION IF NOT EXISTS vector;
+GRANT ALL ON SCHEMA public TO opendray_user;
+```
+
+> `CREATE EXTENSION vector` 需要 **superuser**。装完之后,
+> `opendray_user` 只需要上面 grant 的 CRUD 权限就够 —— opendray
+> 运行时不会再以 superuser 连接。
+
+从将来要跑 opendray 的 host 上测一下凭据:
+
+```sh
+PGPASSWORD='<密码>' psql -h <pg-host> -U opendray_user -d opendray -c "SELECT 'ok' AS check;"
+```
+
+应该看到 `check: ok`、没有错误。
+
+---
+
+## 第 3 步 —— 选部署路径、装 opendray
+
+README 有完整表;新手最常见的选择:
+
+| 你的 host | 路径 | README 章节 |
+|---|---|---|
+| macOS 24/7 家用 server | macOS LaunchDaemon | [方案 D](../README.zh.md#方案-d--macos-launchdmac-mini--studio-当家用-server) |
+| Linux 机器 / VPS / LXC | systemd | [方案 B](../README.zh.md#方案-b--systemd裸机--vm--lxc) |
+| 装了 Docker 的 host(不需要 session spawn) | Docker Compose | [方案 A](../README.zh.md#方案-a--docker-composegateway-用例) —— 看 callout 里的限制 |
+| 前台测试 | 源码 `go run` | [快速开始](../README.zh.md#快速开始5-分钟开发版) |
+| 自己的进程管理器(s6 / runit / launchd Agent) | 直接二进制 | [方案 C](../README.zh.md#方案-c--直接跑二进制--你自己的进程管理器) |
+
+每条路径都汇聚到这里:
+
+```sh
+# 准备 gateway 读的配置
+cp config.example.toml config.toml
+$EDITOR config.toml            # 填 [database].url、[admin].password
+
+# 一次性:创建 schema(再次跑是 no-op)
+opendray migrate -config config.toml
+
+# 跑 gateway
+opendray serve -config config.toml
+```
+
+`config.toml` 最少必填的两个字段:
+
+```toml
+[database]
+url = "postgres://opendray_user:<密码>@<host>:5432/opendray?sslmode=disable"
+
+[admin]
+password = "<初始 bootstrap 密码>"
+```
+
+其他都有合理默认 —— `config.example.toml` 行内注释覆盖了所有 surface。
+
+---
+
+## 第 4 步 —— 首次登录 + 立刻改 admin 密码
+
+打开 `http://localhost:8770/admin/`(或者按 `config.toml` 里
+`listen` 绑定的 host:port)。
+
+1. 用 `admin` + 你 `[admin].password` 里写的密码登录。
+2. **立刻** 去 Settings → Admin → Change password。
+
+为什么要立刻:第一次改密码后,opendray 会写一个 bcrypt-hash 的
+keyfile 到 `$HOME/.opendray/secrets/admin.key`,从此 `config.toml`
+里的 `[admin].password` 明文就失效了(keyfile 优先)。改密码前,
+保护层只有 `config.toml` 的文件权限。
+
+完整凭据优先级链见
+[operator-guide §admin](operator-guide.md#admin)。
+
+---
+
+## 第 5 步 —— 配 Provider
+
+Providers → 点你第 1 步装的那个 CLI → 填:
+
+- **Command path** —— CLI 二进制的绝对路径
+  (`which claude` 可以找到;Apple Silicon Homebrew 装的一般在
+  `/opt/homebrew/bin/claude`)。
+- **Accounts dir**(只 Claude,可选) —— 多套命名的 Claude 凭据
+  目录,做"每个 session 不同账号"切换时用。留空就用默认
+  `~/.claude`。
+
+Save。opendray 会跑一次 `<cli> --version` 探测;binary 能找到就
+显示绿点。
+
+---
+
+## 第 6 步 —— spawn 第一个 session
+
+Sessions → New session → 选 provider → 选工作目录(随便一个项目) → Spawn。
+
+浏览器内开一个终端 pane。像在真实终端一样输入 prompt —— 每个字节都
+通过 opendray 的 PTY wrapper 中转。关掉浏览器 tab,session 在 host
+上继续跑;回头来,scrollback 完整(详见
+[ADR 0003](adr/0003-session-resume-client-reconnect.md))。
+
+---
+
+## 第 7 步(可选) —— 加 Telegram 频道
+
+这就是 opendray 跟 `tmux + ssh` 不同的地方。配好频道后,session
+变 idle(CLI 在等你输入)时 opendray 推 Telegram 通知,你在 Telegram
+回复,文本就 flow back 到 session 的 stdin。
+
+### Telegram 一次性设置
+
+1. Telegram → 搜 **@BotFather** → 开个 chat。
+2. `/newbot` → BotFather 引导你选 name + username → 给你一个 token,
+   长得像 `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`。
+3. 找你要让 opendray 发到哪个 chat 的 ID:
+   - 给 bot DM 一条消息(任意文字)。
+   - 浏览器开 `https://api.telegram.org/bot<token>/getUpdates`,
+     JSON response 里有 `chat.id`。
+
+### 在 opendray 里
+
+Channels → New channel → kind **Telegram**:
+
+- **Bot token**:BotFather 给的
+- **Default chat ID**:`getUpdates` 拿到的 `chat.id`
+- **Notify on**:勾 `session.idle`(或者三个 topic 都勾)
+
+Save → 点 channel 卡上的 **Test** 按钮。几秒内 Telegram 会收到测试
+消息。
+
+让一个 session idle 30 秒(默认 idle 阈值,可通过
+`[session].idle_threshold` 改)。Telegram 会推送 CLI 最近的输出。你
+回复,文本就 flow back 到 session 的 stdin。
+
+---
+
+## 下一步
+
+- **更多频道**:Slack / Discord / 飞书 / 钉钉 / 企业微信 —— 每个的
+  设置都在应用内 Tutorial(`/admin/tutorial/`)里。
+- **API 集成**:[docs/integration-guide.md](integration-guide.md)
+  —— scope 化的 API key、反向代理挂载、events WebSocket。
+- **记忆子系统**:用 `[memory.backend] = "local"` 启用本地优先
+  嵌入向量,或者接 Ollama / LM Studio —— 见应用内 Tutorial →
+  Memory 章节。
+- **加密备份**:配 `[backup]` 把 DB 备份推到 S3 / R2 / B2 / SFTP /
+  rclone —— 见 [operator-guide §backup](operator-guide.md#backup)。
+
+## 排错
+
+| 症状 | 原因 | 修复 |
+|---|---|---|
+| migrate 报 `relation "providers" does not exist` | v2.0.0 之前的二进制(issue #162) | 拉最新二进制 —— v2.0.0 已修 |
+| migrate 报 `type "vector" does not exist` | opendray 数据库里 pgvector 扩展没启用 | 用 superuser 在 `opendray` 库里跑 `CREATE EXTENSION vector;` |
+| `Spawn session failed: executable file not found in $PATH` | wrap 的 CLI 没装在 opendray host 上,或者 Provider 配置里 Command Path 不对 | 回第 1 步;`which claude`(或对应 CLI)验证 |
+| Telegram bot 不回复 | Bot 默认 privacy mode(bot 只看到 commands) | BotFather → `/setprivacy` → Disable |
+| 反向代理后面浏览器报 `Bad gateway` | 代理没转发 WebSocket upgrade header | 见 [operator-guide §Topology](operator-guide.md#topology) 里的 nginx / Caddy 片段 |
+| Sessions 页是空的但 Channels 工作 | binary 能 spawn 但没配 Provider | 第 5 步 |
+
+---
+
+## 另见
+
+- [README.zh.md](../README.zh.md) —— 安装表、部署路径、项目状态
+- [README.md](../README.md) —— English version
+- [docs/quickstart.md](quickstart.md) —— 5 分钟开发环境(更聚焦)
+- [docs/operator-guide.md](operator-guide.md) —— 运维参考:topology、认证、备份、日志
+- [docs/integration-guide.md](integration-guide.md) —— 第三方 API surface
+- [VERSIONING.md](../VERSIONING.md) —— major-as-generation 版本策略
+- [CHANGELOG.md](../CHANGELOG.md) —— 发布历史


### PR DESCRIPTION
Fresh-user audit (we walked through the deploy story end to end)
found two gaps in the existing docs that block a stranger from
"got it running."

## Gap A — install the wrapped CLI

The README assumes you already have \`claude\` / \`codex\` /
\`gemini\` on \$PATH. opendray's whole premise is wrapping these,
but a stranger arriving at the repo has no prompt to install
them first; their first Spawn session click errors with
\`executable file not found in \$PATH\`.

## Gap B — no single fresh-user walkthrough

Information is scattered across:
- README Install table (deploy paths)
- README Quickstart (dev flow)
- docs/quickstart.md (more detail)
- docs/operator-guide.md (production)
- in-app Tutorial /admin/tutorial/ (the channel walkthrough)

The in-app Tutorial is great but you can only reach it **after**
opendray is running — chicken-and-egg for a first-time install.

## What this PR adds

### \`docs/getting-started.md\` (new, en) — 7-step walkthrough

| Step | Covers |
|---|---|
| 0 | Tools matrix (CLI / Postgres / Go·pnpm / port) |
| 1 | Install at least one of Claude Code / Codex / Gemini |
| 2 | Install Postgres + pgvector + bootstrap the opendray DB |
| 3 | Pick deploy path (links to README §A–§D + Quickstart) |
| 4 | First login → immediate password rotation (with admin-keyfile rationale) |
| 5 | Configure first Provider |
| 6 | Spawn first session |
| 7 | (Optional) Telegram channel + first idle notification |

Plus a troubleshooting table for the 6 most likely first-time
failures (vector ext, migrate relation, PATH miss, bot privacy
mode, WS upgrade, empty Sessions tab).

### \`docs/getting-started.zh.md\` (new, zh) — Simplified Chinese mirror

Same structure, idiomatic Chinese phrasing.

### \`README.md\` + \`README.zh.md\`

- Install section gets a callout pointing at the guide before
  the path-selection table.
- Documentation section promotes getting-started to the top of
  the list.
- Removed the doubled \`## Status\` heading in README.md (a stray
  from an earlier merge).

## Test plan

- [x] \`git diff --stat\` reviewed — pure docs (4 files: 2 new, 2 modified)
- [ ] Render in GitHub Markdown — verify:
      - Both guides scroll cleanly
      - All cross-links resolve (especially README §A/B/C/D anchors)
      - Mermaid / tables render correctly
- [ ] Click through every link in each guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)