### PR TITLE
docs: strengthen Docker-deploy scope warnings (no session spawn)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,26 +77,19 @@ rolling Unreleased section for what's landing next.
 > is for picking a deploy path; the guide stitches everything
 > around it.
 
-Pick the path that fits how you want to run it:
+**👉 Before picking: do you want to spawn Claude / Codex / Gemini sessions from the web admin?**
+- **Yes** → choose a 🟢 **Full** path below (binary / systemd / launchd / source). **Skip Docker.**
+- **No, just channels + integrations + notes + API** → 🐳 Docker Compose is fine.
+
+Why: the Docker image is distroless (no Node, no AI CLIs, no `pg_dump`) and opendray's PTY can't reach a host binary from inside a container. See the §A callout for the full breakdown.
 
 | Path | Best for | Features | Jump to |
 |---|---|---|---|
-| 📦 **Pre-built binary** | "Just run it" — Linux / macOS, any supervisor | ✨ Full | [Releases page](https://github.com/Opendray/opendray_v2/releases) → see [Production deploy](#production-deploy) |
-| 🐳 **Docker Compose** | Gateway / channels / integrations / notes / API on a Docker host | ⚠️ No session spawn, no backups (see §A) | [Production deploy §A](#option-a--docker-compose-gateway-use-cases) |
-| 🐧 **systemd unit** | Bare-metal / VM / LXC Linux box | ✨ Full | [Production deploy §B](#option-b--systemd-bare-metal--vm--lxc) |
-| 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio as home server | ✨ Full | [Production deploy §D](#option-d--macos-launchd-mac-mini--studio-as-home-server) |
-| 🛠 **Build from source** | Dev / contributing / custom builds | ✨ Full | [Quickstart](#quickstart-5-minute-dev-path) below |
-
-> **Full vs gateway-only**: "Full" means everything including
-> spawning Claude / Codex / Gemini / shell sessions from the Sessions
-> page, and encrypted backups via `pg_dump`. Docker Compose ships a
-> minimal distroless image that bundles only the opendray binary —
-> no Node runtime, no AI CLIs, no `pg_dump` — so session spawn and
-> backup require deploying opendray directly on a host with those
-> tools installed (systemd / launchd / direct binary). The Docker
-> path is the right choice when you want opendray as a network
-> gateway for channels + integrations + notes + memory + API
-> consumers, without local CLI sessions.
+| 📦 **Pre-built binary** | "Just run it" — Linux / macOS, any supervisor | 🟢 Full | [Releases page](https://github.com/Opendray/opendray_v2/releases) → see [Production deploy](#production-deploy) |
+| 🐧 **systemd unit** | Bare-metal / VM / LXC Linux box | 🟢 Full | [Production deploy §B](#option-b--systemd-bare-metal--vm--lxc) |
+| 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio as home server | 🟢 Full | [Production deploy §D](#option-d--macos-launchd-mac-mini--studio-as-home-server) |
+| 🛠 **Build from source** | Dev / contributing / custom builds | 🟢 Full | [Quickstart](#quickstart-5-minute-dev-path) below |
+| 🐳 **Docker Compose** | Gateway / channels / integrations / notes / API on a Docker host | 🟡 **Gateway-only** — ❌ no session spawn, ❌ no backups | [Production deploy §A](#option-a--docker-compose-gateway-only-no-session-spawn) |
 
 ## Quickstart (5-minute dev path)
 
@@ -131,21 +124,33 @@ Four supported deploy paths, pick whichever fits your environment.
 Each one gives you auto-restart on crash, persistent state, and
 separation of secrets from config.
 
-### Option A — Docker Compose (gateway use cases)
+### Option A — Docker Compose (gateway-only, no session spawn)
 
-> **What works inside the container** — channels (Telegram / Slack /
+> ## ⚠️ Read this before you pick Docker
+>
+> This path **does not support session spawning**. If you want to
+> spawn Claude / Codex / Gemini / shell sessions from the Sessions
+> page, **stop and use [Option B](#option-b--systemd-bare-metal--vm--lxc)
+> (systemd) or [Option D](#option-d--macos-launchd-mac-mini--studio-as-home-server)
+> (macOS launchd) instead** — opendray and the AI CLIs share auth,
+> project state, and tool definitions on the same host, so they
+> cohabit naturally there. Trying to make Docker work for session
+> spawn means either (a) maintaining a custom fat image with Node +
+> every CLI baked in, or (b) accepting that the Sessions tab will
+> error out for every spawn click.
+>
+> **What works** inside the container — channels (Telegram / Slack /
 > Discord / Feishu / DingTalk / WeCom), integrations API + reverse
-> proxy + events WebSocket, notes vault + git sync, memory subsystem,
-> web admin, mobile-app backend.
+> proxy + events WebSocket, notes vault + git sync, memory
+> subsystem, web admin, mobile-app backend.
 >
 > **What doesn't** — spawning Claude / Codex / Gemini / shell
-> sessions, and encrypted backups via `pg_dump`. The bundled image
-> is distroless (no Node runtime, no AI CLIs, no `pg_dump`), and
-> opendray's PTY can't reach a host binary from inside a container.
-> If you need those, deploy on the host via Option B (systemd) or
-> Option D (macOS launchd) instead — opendray and the AI CLIs share
-> auth, project state, and tool definitions on the same host, so
-> they cohabit naturally there.
+> sessions (no Node, no AI CLIs, no host PATH bridging), and
+> encrypted backups via `pg_dump` (image is distroless, no
+> `pg_dump`).
+>
+> Pick Docker only when this LXC / VPS / NAS is a dedicated channel
+> + integration gateway and you run AI sessions somewhere else.
 
 For deployments that want opendray as a long-running gateway on a
 home server, NAS, VPS, or LXC with Docker:

--- a/README.zh.md
+++ b/README.zh.md
@@ -73,23 +73,19 @@
 > Postgres、部署 opendray、收到第一条 Telegram idle 通知。下面这个表
 > 只是挑部署路径,getting-started 把表前后的所有事情串起来。
 
-选一种最适合你环境的方式:
+**👉 选之前先问自己:你要不要在 Web 后台 spawn Claude / Codex / Gemini 会话?**
+- **要** → 选下表 🟢 **完整** 路径(binary / systemd / launchd / 源码)。**跳过 Docker。**
+- **不要,只要 channels + integrations + notes + API 网关** → 🐳 Docker Compose 适合你。
+
+为什么:Docker 镜像是 distroless(没 Node、没 AI CLI、没 `pg_dump`),opendray 的 PTY 也无法从容器内访问 host 二进制。详见 §A 的 callout。
 
 | 方式 | 适合 | 功能 | 跳转到 |
 |---|---|---|---|
-| 📦 **预构建二进制** | "拿来就跑" — Linux / macOS,搭配任意进程管理器 | ✨ 完整 | [Releases 页](https://github.com/Opendray/opendray_v2/releases) → 见下方 [生产部署](#生产部署) |
-| 🐳 **Docker Compose** | 把 opendray 当网关:channels / integrations / notes / API,跑在 Docker host 上 | ⚠️ 不支持 CLI 会话 spawn 与备份(见 §A) | [生产部署 §A](#方案-a--docker-composegateway-用例) |
-| 🐧 **systemd unit** | 裸机 / VM / Linux LXC | ✨ 完整 | [生产部署 §B](#方案-b--systemd裸机--vm--lxc) |
-| 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio 当家用 server | ✨ 完整 | [生产部署 §D](#方案-d--macos-launchdmac-mini--studio-当家用-server) |
-| 🛠 **从源码构建** | 开发 / 贡献代码 / 定制构建 | ✨ 完整 | [快速开始](#快速开始5-分钟开发版) |
-
-> **完整 vs 仅网关**:"完整"意味着所有功能 —— 包括从 Sessions 页 spawn
-> Claude / Codex / Gemini / shell 会话,以及通过 `pg_dump` 做加密备份。
-> Docker Compose 用的是 distroless 最小镜像,只打包了 opendray 二进制 —— 没有
-> Node 运行时、没有 AI CLI、没有 `pg_dump` —— 所以 session spawn 和 backup
-> 必须把 opendray 直接部署在装了那些工具的 host 上(systemd / launchd /
-> 直接二进制)。Docker 路径适合"把 opendray 当成 channels + integrations +
-> notes + memory + API 消费方的网络网关",不在本地 spawn CLI 会话的场景。
+| 📦 **预构建二进制** | "拿来就跑" — Linux / macOS,搭配任意进程管理器 | 🟢 完整 | [Releases 页](https://github.com/Opendray/opendray_v2/releases) → 见下方 [生产部署](#生产部署) |
+| 🐧 **systemd unit** | 裸机 / VM / Linux LXC | 🟢 完整 | [生产部署 §B](#方案-b--systemd裸机--vm--lxc) |
+| 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio 当家用 server | 🟢 完整 | [生产部署 §D](#方案-d--macos-launchdmac-mini--studio-当家用-server) |
+| 🛠 **从源码构建** | 开发 / 贡献代码 / 定制构建 | 🟢 完整 | [快速开始](#快速开始5-分钟开发版) |
+| 🐳 **Docker Compose** | 把 opendray 当网关:channels / integrations / notes / API,跑在 Docker host 上 | 🟡 **仅网关** — ❌ 不支持 session spawn,❌ 不支持备份 | [生产部署 §A](#方案-a--docker-compose仅网关不支持-session-spawn) |
 
 ## 快速开始(5 分钟开发版)
 
@@ -124,18 +120,29 @@ go run ./cmd/opendray serve -config config.toml
 四种受支持的部署路径,按你的环境挑一种。每种都提供:
 崩溃后自动重启、状态持久化、secrets 跟 config 分离。
 
-### 方案 A — Docker Compose(gateway 用例)
+### 方案 A — Docker Compose(仅网关,不支持 session spawn)
 
+> ## ⚠️ 选 Docker 之前一定要读这一段
+>
+> 这条路径 **不支持 session spawn**。如果你要在 Sessions 页 spawn
+> Claude / Codex / Gemini / shell 会话,**立刻停下来,用
+> [方案 B](#方案-b--systemd裸机--vm--lxc)(systemd)或
+> [方案 D](#方案-d--macos-launchdmac-mini--studio-当家用-server)
+> (macOS launchd)** —— opendray 跟 AI CLI 共享同一 host 上的认证、
+> 项目状态、工具定义,天然适合放一起。硬要让 Docker 跑 session spawn,
+> 要么 (a) 自己维护一个塞 Node + 所有 CLI 的 fat image,要么
+> (b) 接受 Sessions tab 上每次 spawn 都报错。
+>
 > **容器内能跑的** —— channels(Telegram / Slack / Discord / 飞书 /
 > 钉钉 / 企业微信)、integrations API + 反向代理 + events WebSocket、
 > notes vault + git 同步、memory 子系统、Web 后台、移动端后端。
 >
-> **容器内跑不了的** —— spawn Claude / Codex / Gemini / shell 会话,
-> 以及通过 `pg_dump` 的加密备份。打包的镜像是 distroless(没 Node 运行时、
-> 没 AI CLI、没 `pg_dump`),opendray 的 PTY 也无法从容器内访问 host 二进制。
-> 如果需要这些功能,改用方案 B(systemd)或 D(macOS launchd)直接在
-> host 上部署 —— opendray 跟 AI CLI 共享同一 host 上的认证、项目状态、
-> 工具定义,天然适合放一起。
+> **容器内跑不了的** —— spawn Claude / Codex / Gemini / shell 会话
+> (没 Node、没 AI CLI、没法跨 container 边界调 host PATH),以及通过
+> `pg_dump` 的加密备份(镜像 distroless,没 `pg_dump`)。
+>
+> 只在这台 LXC / VPS / NAS 是**专用 channel + integration 网关**、
+> AI session 在别的地方跑的场景下,才选 Docker。
 
 适合把 opendray 当成长期运行的网关,放在家用服务器、NAS、VPS 或装了
 Docker 的 LXC 上:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -131,16 +131,31 @@ You should see `check: ok` and no errors.
 
 ## Step 3 — pick a deploy path and install opendray
 
-The README has the full table; the most common picks for a first
-try:
+**Decision question first**: are you here for the session spawn
+feature (drive Claude / Codex / Gemini from the web Sessions page)?
+
+### If YES — you need a "Full" path
 
 | Your host | Path | README section |
 |---|---|---|
 | macOS as 24/7 home server | macOS LaunchDaemon | [Option D](../README.md#option-d--macos-launchd-mac-mini--studio-as-home-server) |
 | Linux box / VPS / LXC | systemd | [Option B](../README.md#option-b--systemd-bare-metal--vm--lxc) |
-| Docker host (no CLI session spawn needed) | Docker Compose | [Option A](../README.md#option-a--docker-compose-gateway-use-cases) — read the limit callout |
 | Just testing in foreground | `go run` from source | [Quickstart](../README.md#quickstart-5-minute-dev-path) |
 | Hand-rolled supervisor (s6 / runit / launchd Agent) | Direct binary | [Option C](../README.md#option-c--direct-binary--your-own-process-supervisor) |
+
+> Skip Docker. The image is distroless (no Node, no AI CLIs, no
+> `pg_dump`), so the Sessions tab will error on every spawn click.
+> See the §A callout for the architectural reason.
+
+### If NO — you only need channels / integrations / notes / API
+
+| Your host | Path | README section |
+|---|---|---|
+| Docker host (LXC / VPS / NAS) | Docker Compose | [Option A](../README.md#option-a--docker-compose-gateway-only-no-session-spawn) |
+
+You can still receive messages on Telegram / Slack / etc., write
+notes, hit the integration API, and view the web admin. You just
+can't spawn local AI CLI sessions from this deployment.
 
 All paths converge on:
 

--- a/docs/getting-started.zh.md
+++ b/docs/getting-started.zh.md
@@ -125,15 +125,29 @@ PGPASSWORD='<密码>' psql -h <pg-host> -U opendray_user -d opendray -c "SELECT 
 
 ## 第 3 步 —— 选部署路径、装 opendray
 
-README 有完整表;新手最常见的选择:
+**先问自己**:你来这里是为了 session spawn 功能吗(在 web Sessions
+页 spawn Claude / Codex / Gemini)?
+
+### 如果是 —— 需要 "完整" 路径
 
 | 你的 host | 路径 | README 章节 |
 |---|---|---|
 | macOS 24/7 家用 server | macOS LaunchDaemon | [方案 D](../README.zh.md#方案-d--macos-launchdmac-mini--studio-当家用-server) |
 | Linux 机器 / VPS / LXC | systemd | [方案 B](../README.zh.md#方案-b--systemd裸机--vm--lxc) |
-| 装了 Docker 的 host(不需要 session spawn) | Docker Compose | [方案 A](../README.zh.md#方案-a--docker-composegateway-用例) —— 看 callout 里的限制 |
 | 前台测试 | 源码 `go run` | [快速开始](../README.zh.md#快速开始5-分钟开发版) |
 | 自己的进程管理器(s6 / runit / launchd Agent) | 直接二进制 | [方案 C](../README.zh.md#方案-c--直接跑二进制--你自己的进程管理器) |
+
+> 跳过 Docker。镜像是 distroless(没 Node、没 AI CLI、没 `pg_dump`),
+> Sessions tab 每次 spawn 都会报错。架构原因见 §A 的 callout。
+
+### 如果不是 —— 只需要 channels / integrations / notes / API
+
+| 你的 host | 路径 | README 章节 |
+|---|---|---|
+| Docker host(LXC / VPS / NAS) | Docker Compose | [方案 A](../README.zh.md#方案-a--docker-compose仅网关不支持-session-spawn) |
+
+仍然可以收 Telegram / Slack 等消息、写 notes、调集成 API、看 Web 后台。
+只是不能从这个部署里 spawn 本地 AI CLI 会话。
 
 每条路径都汇聚到这里:
 


### PR DESCRIPTION
A real reader followed the docs to install on an LXC, chose Docker
Compose, and **missed all six existing warnings** that Docker can't
spawn AI sessions. Diagnosis: the warnings were "discoverable but
not assertive" — phrased as ⚠️ asides inside blockquotes, with
Docker still listed second in the Install table (high visibility,
no decision-gate framing).

This PR changes the framing from "here are five options, one has
a footnote" to **"answer the decision question first, then pick from
the matching set."**

## What changes

### Install section now opens with a decision question

> **👉 Before picking: do you want to spawn Claude / Codex /
> Gemini sessions from the web admin?**
> - **Yes** → choose a 🟢 Full path below (binary / systemd /
>   launchd / source). **Skip Docker.**
> - **No, just channels + integrations + notes + API** → 🐳
>   Docker Compose is fine.

Reader self-selects before scanning the table.

### Install table reordered

Docker dropped from row 2 (peer with pre-built binary) to row 5
(last). Visibility downgrade signals it's a specialised choice,
not a default.

### Features column escalated

Docker row: `⚠️ No session spawn, no backups (see §A)` →
`🟡 Gateway-only — ❌ no session spawn, ❌ no backups`.

The ❌ glyphs are harder to skim past than ⚠️. Other paths get a
🟢 Full label.

### §A title bakes in the limit

`Option A — Docker Compose (gateway use cases)` →
`Option A — Docker Compose (gateway-only, no session spawn)`

Title alone signals the limit. Anchor links updated everywhere
the section is referenced.

### §A callout escalated to an h2 banner

The "What works / What doesn't" pair is now preceded by:

> ## ⚠️ Read this before you pick Docker
>
> This path **does not support session spawning**. If you want to
> spawn ... **stop and use Option B (systemd) or Option D (macOS
> launchd) instead** — ...

Redirect to Options B / D is the *first* sentence, so a reader who
realises they want session spawn bounces out before reading the
rest of §A.

### docs/getting-started.md Step 3 re-framed

From "here's a table for various hosts" to **"are you here for
session spawn?"** with YES/NO branches. Docker is only in the NO
table.

### Chinese mirrors

`README.zh.md` and `docs/getting-started.zh.md` get the same
restructure with idiomatic Chinese phrasing.

## Files

| File | Change |
|---|---|
| `README.md` | Install section + §A title + §A callout |
| `README.zh.md` | mirror |
| `docs/getting-started.md` | Step 3 re-framed |
| `docs/getting-started.zh.md` | mirror |

No code, no compose / Dockerfile changes — the actual technical
scope of the Docker deployment is unchanged. This is purely about
how readers find out about that scope.

## Test plan

- [x] `git diff --stat` reviewed — 4 files only
- [ ] Render in GitHub markdown — verify:
      - Decision callout at top of Install renders prominently
      - §A title shows the new "gateway-only, no session spawn"
      - All anchor links resolve (`#option-a--docker-compose-gateway-only-no-session-spawn`)
      - YES/NO tables in getting-started step 3 are visually distinct

🤖 Generated with [Claude Code](https://claude.com/claude-code)