### PR TITLE
feat(install): one-line curl|bash and PowerShell irm|iex installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,22 +70,25 @@ rolling Unreleased section for what's landing next.
 
 ## Install
 
-> **First time here?** Read [**docs/getting-started.md**](docs/getting-started.md)
-> for a 15-minute end-to-end walkthrough — installing the AI CLIs
-> opendray wraps, bootstrapping Postgres, deploying opendray, and
-> getting your first idle notification on Telegram. The table below
-> is for picking a deploy path; the guide stitches everything
-> around it.
+### One-line installer
 
-> **Or let the wizard do it.** On Linux (Ubuntu / Debian) or macOS:
-> ```sh
-> bash scripts/install-linux.sh    # or scripts/install-macos.sh
-> ```
-> Walks through Postgres setup, AI-CLI install, admin credentials,
-> and service registration — landing a running gateway in ~5 min.
-> See [`scripts/README.md`](scripts/README.md). Windows uses WSL2;
-> run [`scripts/install-windows.ps1`](scripts/install-windows.ps1)
-> for the setup helper.
+**Linux / macOS / WSL2**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash
+```
+
+**Windows** — sets up WSL2 first, then runs the Linux installer inside it. [details →](scripts/README.md#windows)
+
+```powershell
+irm https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-windows.ps1 | iex
+```
+
+Walks through Postgres setup, AI-CLI install, admin credentials, and service registration — landing a running gateway in ~5–10 minutes. See [**`scripts/README.md`**](scripts/README.md) for what the wizard does, the file layout it creates, options, and troubleshooting.
+
+> **Want the manual walkthrough?** Read [**docs/getting-started.md**](docs/getting-started.md) — a 15-minute end-to-end guide that mirrors what the wizard does so you can verify each step yourself.
+
+### Deploy path picker
 
 **👉 Before picking: do you want to spawn Claude / Codex / Gemini sessions from the web admin?**
 - **Yes** → choose a 🟢 **Full** path below (binary / systemd / launchd / source). **Skip Docker.**

--- a/README.zh.md
+++ b/README.zh.md
@@ -68,19 +68,25 @@
 
 ## 安装
 
-> **第一次来?** 先看 [**docs/getting-started.zh.md**](docs/getting-started.zh.md)
-> —— 15 分钟端到端 walkthrough:装 opendray wrap 的 AI CLI、bootstrap
-> Postgres、部署 opendray、收到第一条 Telegram idle 通知。下面这个表
-> 只是挑部署路径,getting-started 把表前后的所有事情串起来。
+### 一行命令安装
 
-> **或者让 wizard 自动完成。** 在 Linux(Ubuntu / Debian)或 macOS 上:
-> ```sh
-> bash scripts/install-linux.sh    # 或 scripts/install-macos.sh
-> ```
-> 引导你完成 Postgres 设置、AI CLI 安装、admin 凭据、服务注册,大约
-> 5 分钟拉起一个运行中的网关。详见 [`scripts/README.md`](scripts/README.md)。
-> Windows 走 WSL2,跑 [`scripts/install-windows.ps1`](scripts/install-windows.ps1)
-> 是设置 helper。
+**Linux / macOS / WSL2**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash
+```
+
+**Windows** —— 先设置 WSL2,然后在 WSL2 里跑 Linux 安装器。[详情 →](scripts/README.md#windows)
+
+```powershell
+irm https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-windows.ps1 | iex
+```
+
+引导你完成 Postgres 设置、AI CLI 安装、admin 凭据、服务注册,5–10 分钟拉起一个运行中的网关。详见 [**`scripts/README.md`**](scripts/README.md):wizard 做什么、生成的文件布局、参数、排错。
+
+> **想自己一步步来?** 看 [**docs/getting-started.zh.md**](docs/getting-started.zh.md) —— 15 分钟端到端 walkthrough,跟 wizard 做的是同样的事,但每一步你都自己确认。
+
+### 选部署路径
 
 **👉 选之前先问自己:你要不要在 Web 后台 spawn Claude / Codex / Gemini 会话?**
 - **要** → 选下表 🟢 **完整** 路径(binary / systemd / launchd / 源码)。**跳过 Docker。**

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -37,39 +37,56 @@ Those happen after the wizard, in the admin UI.
 
 ## Quick start
 
-### Linux (Ubuntu / Debian)
+### Linux / macOS / WSL2 — one-liner
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash
+```
+
+`install.sh` is dual-mode:
+
+- **Piped from curl** (no local checkout): it shallow-clones
+  `Opendray/opendray_v2` to `${TMPDIR:-/tmp}/opendray-install-$$`,
+  installs `git` first via `apt` / `brew` if it's missing, then
+  re-execs itself from the clone so the rest of the wizard sees a
+  real working directory.
+- **Run from a clone** (already inside the repo): it just `exec`s
+  the matching OS installer (`install-linux.sh` or
+  `install-macos.sh`).
+
+Either way you end up with `install-linux.sh` (or `install-macos.sh`)
+walking through the same wizard. The one-liner just removes the
+`git clone` + `cd` step.
+
+### Linux / macOS — from a checkout
+
+If you'd rather inspect the code before running anything:
 
 ```sh
 git clone https://github.com/Opendray/opendray_v2.git
 cd opendray_v2
-bash scripts/install-linux.sh
+bash scripts/install-linux.sh          # Linux (Ubuntu/Debian)
+# or:
+bash scripts/install-macos.sh          # macOS (Intel + Apple Silicon)
 ```
 
-Need `sudo` for `apt`, the `postgresql` service, and the systemd unit.
-The wizard prompts before each privileged step.
-
-### macOS (Intel + Apple Silicon)
-
-```sh
-git clone https://github.com/Opendray/opendray_v2.git
-cd opendray_v2
-bash scripts/install-macos.sh
-```
-
-Default scope is a **user LaunchAgent** (runs when you log in). Pass
-`--launchd-daemon` for a `/Library/LaunchDaemons` install (boot-time,
-all users — needs admin).
-
-Homebrew is required. If it's missing the wizard prints the install
-command and exits.
+The wizard prompts before each privileged step. macOS default scope
+is a **user LaunchAgent** (runs at login). Pass `--launchd-daemon` for
+`/Library/LaunchDaemons` (boot-time, all users — needs admin).
+Homebrew is required for the macOS path; if it's missing the wizard
+prints the install command and exits.
 
 ### Windows
 
 opendray does **not** support native Windows. The session subsystem
 spawns AI CLIs via Unix PTYs, which Windows does not expose to
-opendray.
+opendray. The PowerShell helper sets up WSL2 + Ubuntu for you:
 
-Run the PowerShell helper to set up WSL2 + Ubuntu:
+```powershell
+irm https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-windows.ps1 | iex
+```
+
+Or, from a local checkout:
 
 ```powershell
 pwsh -ExecutionPolicy Bypass -File scripts/install-windows.ps1
@@ -81,7 +98,9 @@ It either:
 2. Installs WSL2 + Ubuntu via `wsl --install -d Ubuntu` (needs admin
    + reboot) and tells you to rerun afterwards.
 
-Inside the Ubuntu shell, run `scripts/install-linux.sh` as above.
+Inside the Ubuntu shell, run the Linux one-liner above — WSL2's
+loopback forwarding makes the admin UI reachable at
+`http://localhost:8770/admin/` from the Windows host.
 
 ---
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,46 +1,164 @@
 #!/usr/bin/env bash
-# opendray universal installer dispatcher.
-# Detects the host OS and runs the matching platform installer.
+# opendray universal installer — dual-mode entry point.
 #
-# Usage:
-#   bash scripts/install.sh
+# Mode 1: local checkout
+#   Invoked as `bash scripts/install.sh` from inside a clone. We detect
+#   the sibling `lib/common.sh` and exec the matching OS installer.
 #
-# Or invoke a platform installer directly:
-#   bash scripts/install-linux.sh        # Ubuntu / Debian
-#   bash scripts/install-macos.sh        # macOS (Intel + Apple Silicon)
-#   pwsh scripts/install-windows.ps1     # Windows (WSL2 setup helper)
+# Mode 2: curl | bash bootstrap
+#   Invoked over a pipe with no on-disk script directory:
+#     curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash
+#   We install git if missing, shallow-clone the repo to a working
+#   directory, then re-execute scripts/install.sh from the clone.
+#
+# Either way the user ends up running install-linux.sh / install-macos.sh
+# from a real checkout — the bootstrap path just adds one git clone in
+# front.
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# ── Locate ourselves on disk (or detect we're piped) ──────────────────
+SCRIPT_DIR=""
+if [ -n "${BASH_SOURCE[0]:-}" ] && [ -f "${BASH_SOURCE[0]}" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fi
 
+# ── Mode 1: local checkout ───────────────────────────────────────────
+if [ -n "$SCRIPT_DIR" ] && [ -f "$SCRIPT_DIR/lib/common.sh" ]; then
+    case "$(uname -s)" in
+        Linux)
+            exec bash "$SCRIPT_DIR/install-linux.sh" "$@"
+            ;;
+        Darwin)
+            exec bash "$SCRIPT_DIR/install-macos.sh" "$@"
+            ;;
+        MINGW*|MSYS*|CYGWIN*)
+            cat <<'EOF'
+[!] Native Windows is not supported.
+    Use WSL2 + Ubuntu, then rerun this installer inside the WSL distribution.
+    See scripts/install-windows.ps1 for the WSL2 setup helper.
+EOF
+            exit 1
+            ;;
+        *)
+            echo "[!] Unsupported OS: $(uname -s)"
+            exit 1
+            ;;
+    esac
+fi
+
+# ── Mode 2: curl | bash bootstrap ────────────────────────────────────
+
+# Colours only if the parent terminal is interactive (curl|bash usually is).
+if [ -t 1 ]; then
+    C_RED=$'\033[0;31m'; C_GRN=$'\033[0;32m'; C_YEL=$'\033[1;33m'
+    C_BLU=$'\033[0;34m'; C_NC=$'\033[0m'
+else
+    C_RED=''; C_GRN=''; C_YEL=''; C_BLU=''; C_NC=''
+fi
+say()  { printf "${C_BLU}[*]${C_NC} %s\n" "$*"; }
+ok()   { printf "${C_GRN}[✓]${C_NC} %s\n" "$*"; }
+warn() { printf "${C_YEL}[!]${C_NC} %s\n" "$*"; }
+die()  { printf "${C_RED}[✗]${C_NC} %s\n" "$*" >&2; exit 1; }
+
+REPO_URL="${OPENDRAY_INSTALL_REPO:-https://github.com/Opendray/opendray_v2.git}"
+REF="${OPENDRAY_INSTALL_REF:-main}"
+INSTALL_DIR="${OPENDRAY_INSTALL_DIR:-${TMPDIR:-/tmp}/opendray-install-$$}"
+
+cat <<EOF
+${C_BLU}━━━ opendray installer — bootstrap ━━━${C_NC}
+
+  Source:   ${REPO_URL}@${REF}
+  Workdir:  ${INSTALL_DIR}
+
+This bootstrap step:
+  1. Ensures git is installed (apt / brew if missing — needs sudo).
+  2. Shallow-clones opendray_v2 to the workdir above.
+  3. Hands off to scripts/install-<os>.sh, which is the real wizard.
+
+After the wizard completes, the workdir is left on disk for re-runs.
+Delete it whenever you want — opendray itself lives elsewhere (under
+/usr/local/bin, /etc/opendray, /var/lib/opendray on Linux, or
+~/.opendray on macOS).
+
+EOF
+
+# ── Detect OS for git install fallback + downstream pivot ────────────
 case "$(uname -s)" in
     Linux)
-        # Inside WSL too — keep going, Linux installer handles WSL fine.
-        exec bash "$SCRIPT_DIR/install-linux.sh" "$@"
+        OS_KIND="linux"
         ;;
     Darwin)
-        exec bash "$SCRIPT_DIR/install-macos.sh" "$@"
+        OS_KIND="macos"
         ;;
     MINGW*|MSYS*|CYGWIN*)
         cat <<'EOF'
-[!] Native Windows is not supported.
-    opendray spawns PTY processes for AI CLIs; PTYs don't exist on
-    native Windows, so the wizard can't proceed here.
+[!] Native Windows is not supported by opendray. Use WSL2:
 
-    Recommended: install WSL2, then run install-linux.sh inside it.
-    Run the PowerShell helper for WSL2 setup guidance:
+    Open PowerShell as Administrator and run:
+        wsl --install -d Ubuntu
 
-        pwsh scripts/install-windows.ps1
+    Reboot when prompted, finish Ubuntu's first-time setup, then
+    re-run this curl | bash command inside the Ubuntu shell.
 
 EOF
         exit 1
         ;;
     *)
-        echo "[!] Unsupported OS: $(uname -s)"
-        echo "    Supported: Linux (Ubuntu/Debian), macOS."
-        echo "    See docs/getting-started.md for manual install steps."
-        exit 1
+        die "Unsupported OS: $(uname -s). Supported: Linux, macOS."
+        ;;
+esac
+ok "OS detected: $OS_KIND"
+
+# ── Install git if missing ────────────────────────────────────────────
+if ! command -v git >/dev/null 2>&1; then
+    warn "git is not installed."
+    case "$OS_KIND" in
+        linux)
+            if ! command -v apt-get >/dev/null 2>&1; then
+                die "git missing and this distro doesn't have apt-get. Install git manually then re-run."
+            fi
+            say "Installing git via apt..."
+            if [ "$EUID" -eq 0 ]; then
+                apt-get update -qq && apt-get install -y -qq git
+            elif command -v sudo >/dev/null 2>&1; then
+                sudo apt-get update -qq && sudo apt-get install -y -qq git
+            else
+                die "Need git, but no sudo. Install git manually then re-run."
+            fi
+            ;;
+        macos)
+            if command -v brew >/dev/null 2>&1; then
+                say "Installing git via Homebrew..."
+                brew install git
+            else
+                die "git missing. Install Homebrew (https://brew.sh) or run 'xcode-select --install', then re-run."
+            fi
+            ;;
+    esac
+    ok "git installed: $(git --version)"
+fi
+
+# ── Clone the repo into the workdir ───────────────────────────────────
+if [ -d "$INSTALL_DIR/.git" ]; then
+    say "Re-using existing clone at $INSTALL_DIR (fast-forwarding)..."
+    git -C "$INSTALL_DIR" fetch --depth=1 origin "$REF"
+    git -C "$INSTALL_DIR" reset --hard "origin/$REF"
+else
+    say "Cloning $REPO_URL (ref: $REF) → $INSTALL_DIR ..."
+    rm -rf "$INSTALL_DIR"
+    git clone --depth=1 --branch "$REF" "$REPO_URL" "$INSTALL_DIR" 2>&1 \
+        | grep -vE '^Cloning into|^remote: (Enumerating|Counting|Compressing|Total)' || true
+fi
+ok "Clone ready at $INSTALL_DIR"
+
+# ── Pivot to the OS-specific installer ────────────────────────────────
+cd "$INSTALL_DIR"
+case "$OS_KIND" in
+    linux)
+        exec bash scripts/install-linux.sh "$@"
+        ;;
+    macos)
+        exec bash scripts/install-macos.sh "$@"
         ;;
 esac


### PR DESCRIPTION
## Summary

Adds the headline install experience at the top of the README — a
single one-liner per platform that takes a fresh machine from "nothing
installed" to "running gateway":

**Linux / macOS / WSL2**
```sh
curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash
```

**Windows** — sets up WSL2 first, then runs the Linux installer inside it.
```powershell
irm https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-windows.ps1 | iex
```

## What changed

### `scripts/install.sh` — now dual-mode

The dispatcher now handles two invocation paths:

1. **Local checkout** (existing behaviour): when invoked as
   `bash scripts/install.sh` from inside a clone, it detects the
   sibling `lib/common.sh` and dispatches to `install-linux.sh` /
   `install-macos.sh` directly.

2. **`curl | bash` bootstrap** (new): when there's no on-disk script
   directory (`BASH_SOURCE[0]` not a real file), it:
   - Installs `git` via `apt` / `brew` if it's missing
   - Shallow-clones `Opendray/opendray_v2` to
     `${TMPDIR:-/tmp}/opendray-install-$$`
   - `exec`s `scripts/install-linux.sh` (or `install-macos.sh`) from
     the clone, with `$@` forwarded so flags propagate

Either way the OS-specific wizards run from a real working directory,
so `source lib/common.sh` resolves the same way and the wizard logic
is unchanged.

### `scripts/install-windows.ps1`

No code changes needed — already runs under `irm | iex` (no reliance
on `$MyInvocation.MyCommand.Path` or other on-disk path tricks).

### READMEs

- `README.md` / `README.zh.md` reorganised so `### One-line installer`
  is the headline option at the top of `## Install`, with the existing
  deploy-path picker demoted to `### Deploy path picker` underneath.
- `docs/getting-started.md` link preserved as the "want to read first"
  alternative.
- `scripts/README.md` Quick-start section now leads with the one-liner
  and documents the dual-mode bootstrap.

## Modeled after

Format inspired by Hermes Agent's README install section (the user
sent a screenshot). Same pattern: separate code blocks per platform,
with a "details →" link to the in-depth doc.

## Testing notes

- `bash -n scripts/install.sh` clean.
- Local-mode detection verified locally (SCRIPT_DIR resolves, lib
  exists → dispatches to install-linux.sh).
- Curl-mode bootstrap not yet hit in anger — will validate on a
  fresh LXC once this PR lands.

## Test plan

- [ ] Pipe `install.sh` through a real `curl | bash` on a fresh
      Ubuntu 24.04 LXC with no `git` installed; verify it installs
      git, clones, and the wizard takes over.
- [ ] Repeat on a fresh macOS user account.
- [ ] Verify `irm ... | iex` from Windows PowerShell detects WSL state
      correctly.
- [ ] Confirm the `[details →]` anchor in `scripts/README.md#windows`
      renders on the rendered README page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)