### PR TITLE
fix(install): prompts work under curl | bash (reattach stdin to /dev/tty)

### DIFF
--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -19,6 +19,13 @@
 
 set -euo pipefail
 
+# Reattach stdin to the controlling terminal so prompts work even when
+# we arrived here via `curl … | bash` (the inherited stdin is the curl
+# pipe at EOF, which makes every `read` fail immediately).
+if [ ! -t 0 ] && [ -r /dev/tty ]; then
+    exec </dev/tty
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
 source "$SCRIPT_DIR/lib/common.sh"

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -8,6 +8,13 @@
 
 set -euo pipefail
 
+# Reattach stdin to the controlling terminal so prompts work even when
+# we arrived here via `curl … | bash` (the inherited stdin is the curl
+# pipe at EOF, which makes every `read` fail immediately).
+if [ ! -t 0 ] && [ -r /dev/tty ]; then
+    exec </dev/tty
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
 source "$SCRIPT_DIR/lib/common.sh"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -42,13 +42,15 @@ ask_with_default() {
     local prompt="$1"
     local default="$2"
     local var_name="$3"
-    local response
+    local response=""
     if [ -n "$default" ]; then
         printf "${C_BLU}?${C_NC} %s ${C_DIM}[%s]${C_NC}: " "$prompt" "$default"
     else
         printf "${C_BLU}?${C_NC} %s: " "$prompt"
     fi
-    read -r response
+    # `|| response=""` — never trip `set -e` if stdin EOFs (curl|bash with
+    # no /dev/tty fallback, CI containers without a controlling terminal).
+    read -r response || response=""
     printf -v "$var_name" '%s' "${response:-$default}"
 }
 
@@ -56,9 +58,9 @@ ask_with_default() {
 ask_password() {
     local prompt="$1"
     local var_name="$2"
-    local response
+    local response=""
     printf "${C_BLU}?${C_NC} %s: " "$prompt"
-    read -rs response
+    read -rs response || response=""
     echo
     printf -v "$var_name" '%s' "$response"
 }
@@ -72,7 +74,8 @@ ask_yes_no() {
     if [ "$default" = "y" ]; then hint="[Y/n]"; else hint="[y/N]"; fi
     while true; do
         printf "${C_BLU}?${C_NC} %s %s: " "$prompt" "$hint"
-        read -r response
+        response=""
+        read -r response || response=""
         response="${response:-$default}"
         case "${response,,}" in
             y|yes) printf -v "$var_name" '%s' 'y'; return 0 ;;
@@ -98,7 +101,8 @@ ask_menu() {
     done
     while true; do
         printf "  Enter 1-%d: " "${#_menu_opts[@]}"
-        read -r choice
+        choice=""
+        read -r choice || choice=""
         if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#_menu_opts[@]}" ]; then
             printf -v "$var_name" '%s' "${_menu_opts[$((choice - 1))]}"
             return 0


### PR DESCRIPTION
## The bug

Running the new one-line installer on a fresh Debian 12 LXC:

```
$ curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash
…
? Ready to start? [Y/n]: root@village-health-demo:~# y
-bash: y: command not found
```

The wizard exited at the first prompt. Reported in conversation.

## Root cause

`curl | bash` inherits stdin from the curl pipe, which is at EOF by
the time the wizard starts reading. The first `read -r response`
returned 1 (EOF). Under `set -euo pipefail` that's a fatal error and
the script terminated right after printing the prompt — the user's
shell came back, and their typed "y" landed in the shell instead of
the wizard.

## Fix

Defence in depth:

**1) Reattach stdin to /dev/tty when launched via a pipe.**

Added to the top of both `install-linux.sh` and `install-macos.sh`:

```bash
if [ ! -t 0 ] && [ -r /dev/tty ]; then
    exec </dev/tty
fi
```

This is the standard `curl | bash` interactivity pattern. After the
redirect, every `read` in the wizard talks to the operator's
terminal, regardless of how the script was launched.

**2) Defensive `|| response=""` on every `read` in `lib/common.sh`.**

If for any reason stdin still EOFs (CI, sandboxed container without
/dev/tty), the helpers now fall back to defaults instead of crashing.

## What this does NOT change

Users who already invoke the wizard from a checkout
(`bash scripts/install-linux.sh`) see no behaviour change — stdin is
already a tty there, the redirect is skipped, and the wizard prompts
the same as before.

## Test plan

- [ ] On the same Debian 12 LXC where the bug repro'd, rerun:
      `curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash`
      Verify the "Ready to start?" prompt now actually waits for input.
- [ ] From a checkout: `bash scripts/install-linux.sh` still works
      identically to before.
- [ ] Local syntax: `bash -n` clean on all three modified files. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)