### PR TITLE
fix(install): handle root + non-root for sudo-flag callsites (-E / -u)

### DIFF
--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -166,7 +166,7 @@ fi
 
 if [ "$NODE_NEEDED" = "1" ]; then
     log_info "Installing Node.js 22 LTS via NodeSource..."
-    curl -fsSL https://deb.nodesource.com/setup_22.x | run_priv -E bash -
+    curl -fsSL https://deb.nodesource.com/setup_22.x | run_priv_env bash -
     DEBIAN_FRONTEND=noninteractive run_priv apt-get install -y -qq nodejs
     log_ok "Node.js $(node --version) installed"
 fi
@@ -340,7 +340,7 @@ ask_with_default "App DB password (Enter = random)" "$DEFAULT_DB_PW" OD_DB_PW
 run_psql_super() {
     local sql="$1"
     if [ "$PG_SUPER_PW_AUTH" = "peer" ]; then
-        run_priv -u postgres psql -v ON_ERROR_STOP=1 -d "$PG_SUPER_DB" -c "$sql"
+        run_priv_as postgres psql -v ON_ERROR_STOP=1 -d "$PG_SUPER_DB" -c "$sql"
     else
         PGPASSWORD="$PG_SUPER_PW" psql -v ON_ERROR_STOP=1 \
             -h "$PG_SUPER_HOST" -p "$PG_SUPER_PORT" -U "$PG_SUPER_USER" -d "$PG_SUPER_DB" \
@@ -369,7 +369,7 @@ run_psql_super "GRANT ALL PRIVILEGES ON DATABASE \"$OD_DB_NAME\" TO \"$OD_DB_USE
 run_psql_super_indb() {
     local sql="$1"
     if [ "$PG_SUPER_PW_AUTH" = "peer" ]; then
-        run_priv -u postgres psql -v ON_ERROR_STOP=1 -d "$OD_DB_NAME" -c "$sql"
+        run_priv_as postgres psql -v ON_ERROR_STOP=1 -d "$OD_DB_NAME" -c "$sql"
     else
         PGPASSWORD="$PG_SUPER_PW" psql -v ON_ERROR_STOP=1 \
             -h "$PG_SUPER_HOST" -p "$PG_SUPER_PORT" -U "$PG_SUPER_USER" -d "$OD_DB_NAME" \
@@ -548,7 +548,7 @@ run_priv chmod 0640 "$OD_CONFIG_PATH"
 log_ok "Config written: $OD_CONFIG_PATH (mode 0640, owned by root:$OPENDRAY_SERVICE_USER)"
 
 log_info "Applying migrations (idempotent)..."
-run_priv -u "$OPENDRAY_SERVICE_USER" "$OPENDRAY_PREFIX/bin/opendray" migrate -config "$OD_CONFIG_PATH"
+run_priv_as "$OPENDRAY_SERVICE_USER" "$OPENDRAY_PREFIX/bin/opendray" migrate -config "$OD_CONFIG_PATH"
 log_ok "Migrations applied"
 
 # ───────────────────────────────────────────────────────────────────────

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -136,7 +136,11 @@ require_cmds() {
     fi
 }
 
-# Run as root, falling back to sudo if available.
+# Run a command with root privileges.
+#   - If we're already root: exec directly.
+#   - Otherwise, prefix with sudo.
+# Don't pass sudo-only flags (-E, -u, etc.) here — those have to go through
+# run_priv_env / run_priv_as so we don't leak them to root's direct exec.
 run_priv() {
     if [ "$EUID" -eq 0 ]; then
         "$@"
@@ -144,6 +148,38 @@ run_priv() {
         sudo "$@"
     else
         log_die "This step needs root; please install sudo or rerun as root."
+    fi
+}
+
+# Run a command with root privileges, preserving the caller's environment.
+#   - Root: env is already ours, just exec.
+#   - Non-root: `sudo -E …` (preserve env). `-E` is a sudo flag; can't
+#     pass it through run_priv when we're already root, because root
+#     would try to exec `-E` as a command (that was the v2.0.0 bug).
+run_priv_env() {
+    if [ "$EUID" -eq 0 ]; then
+        "$@"
+    elif have_cmd sudo; then
+        sudo -E "$@"
+    else
+        log_die "This step needs root; please install sudo or rerun as root."
+    fi
+}
+
+# Run a command AS a specific (non-self) user.
+#   - sudo available (root or not): `sudo -u <user> …` (works for both).
+#   - root, no sudo: fall back to `runuser -u <user> -- …`.
+#   - non-root, no sudo: dead end (can't switch user without privilege).
+# Same reasoning as run_priv_env — `-u <user>` is a sudo flag that
+# root's direct exec can't consume.
+run_priv_as() {
+    local target_user="$1"; shift
+    if have_cmd sudo; then
+        sudo -u "$target_user" "$@"
+    elif [ "$EUID" -eq 0 ] && have_cmd runuser; then
+        runuser -u "$target_user" -- "$@"
+    else
+        log_die "Need sudo or runuser to run as $target_user (running as $(id -un))."
     fi
 }
 


### PR DESCRIPTION
## The bug

Reported by a fresh-LXC test:

```
Setting up build-essential (12.9) ...
[✓] Base tools ready

┌── Step 2 ── Install Node.js + pnpm
[*] Installing Node.js 22 LTS via NodeSource...
/tmp/opendray-install-774/scripts/lib/common.sh: line 142: -E: command not found
curl: (23) Failed writing body
```

User logged in as root on Debian 12.

## Root cause

`run_priv()` blindly delegates `"$@"` either to `sudo "$@"` or to a
direct exec depending on whether we're root:

```bash
run_priv() {
    if [ "$EUID" -eq 0 ]; then
        "$@"                # ← `-E bash -` → tries to exec `-E`
    elif have_cmd sudo; then
        sudo "$@"           # ← `sudo -E bash -` → sudo consumes -E
    fi
}
```

So calls like `run_priv -E bash -` (env preservation) or
`run_priv -u postgres psql ...` (run-as) worked for non-root callers
but blew up immediately on root, treating the sudo flag as the
command to exec.

Four callsites in `install-linux.sh` were affected:

| Step | Call | Purpose |
|---|---|---|
| 2 | `run_priv -E bash -` | NodeSource setup script needs env preserved |
| 5 | `run_priv -u postgres psql …` (×2) | psql peer auth as the postgres OS user during PG bootstrap |
| 8 | `run_priv -u "$OPENDRAY_SERVICE_USER" opendray migrate …` | run migrate as the freshly-created service user |

## Fix

Two new helpers in `lib/common.sh` that handle both privilege paths,
covering all three real-world cases: root + sudo, root + no sudo,
non-root + sudo.

```bash
run_priv_env <cmd...>
  root → direct exec (env is already ours)
  non-root → sudo -E <cmd...>

run_priv_as <user> <cmd...>
  sudo available → sudo -u <user> <cmd...>
  root, no sudo → runuser -u <user> -- <cmd...>
  non-root, no sudo → log_die (actionable error)
```

All four callsites updated.

`install-macos.sh` doesn't use these patterns (brew + LaunchAgent
path runs as the operator's own user; PG bootstrap uses trust-on-
socket as `$USER`, not a `postgres` OS account), so no edits needed
there.

The plain `run_priv()` function is unchanged — it's still the right
helper for commands that take no sudo-only flags.

## Test plan

- [ ] Same Debian 12 root LXC, rerun the one-liner — wizard should
      now pass Step 2 (Node install), Step 5 (PG bootstrap via
      `sudo -u postgres psql`), and Step 8 (migrate as service user).
- [ ] On a non-root user with sudo — same paths should still work
      identically (now via `sudo -E …` and `sudo -u …`).
- [ ] `bash -n` clean on all modified files. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)