### PR TITLE
fix(install): admin user field + real summary URL + heredoc ANSI

### DIFF
--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -408,11 +408,13 @@ log_ok "App user can connect to $OD_DB_NAME"
 log_step 6 "opendray admin credentials + network"
 
 cat <<'EOF'
-Pick the initial admin login. You'll be forced to rotate this password
+Pick the initial admin login. You'll be forced to rotate the password
 after your first UI login (opendray writes a bcrypt keyfile, after
 which the plaintext in config.toml is inert).
 
 EOF
+
+ask_with_default "Admin username" "admin" OD_ADMIN_USER
 
 DEFAULT_ADMIN_PW="$(gen_password 20)"
 ask_with_default "Initial admin password (Enter = random)" "$DEFAULT_ADMIN_PW" OD_ADMIN_PW
@@ -534,7 +536,11 @@ listen = "$OD_LISTEN"
 url = "$OD_DSN"
 
 [admin]
-# Initial bootstrap password. Rotate via UI immediately after first login.
+# Admin login. opendray validates {user, password} against this section
+# until you rotate the password via the UI — at which point a bcrypt
+# keyfile takes over and `password` here becomes inert. `user` stays
+# authoritative either way, so name it whatever you want.
+user     = "$OD_ADMIN_USER"
 password = "$OD_ADMIN_PW"
 
 [log]
@@ -651,12 +657,34 @@ done
 
 log_section "Install complete"
 
-WEB_URL="http://${OD_LISTEN}/admin/"
-[[ "$OD_LISTEN" == 0.0.0.0:* ]] && WEB_URL="http://<this-host>:${OD_LISTEN##*:}/admin/"
+# Build a clickable URL. For 0.0.0.0 listens, resolve the host's primary
+# LAN IP so the operator can actually click and open it from another
+# machine — `<this-host>` was a documentation placeholder that came
+# through to the terminal as literal text.
+PORT="${OD_LISTEN##*:}"
+HOST_PART="${OD_LISTEN%:*}"
+case "$HOST_PART" in
+    0.0.0.0|"")
+        LAN_IP=""
+        if have_cmd hostname; then
+            LAN_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+        fi
+        if [ -z "$LAN_IP" ] && have_cmd ip; then
+            LAN_IP="$(ip route get 1.1.1.1 2>/dev/null | awk '/src/ {for(i=1;i<=NF;i++) if($i=="src") {print $(i+1); exit}}')"
+        fi
+        [ -n "$LAN_IP" ] || LAN_IP="<this-host-ip>"
+        WEB_URL="http://${LAN_IP}:${PORT}/admin/"
+        WEB_URL_NOTE="  (LAN — reachable from any device on the same network)"
+        ;;
+    *)
+        WEB_URL="http://${OD_LISTEN}/admin/"
+        WEB_URL_NOTE=""
+        ;;
+esac
 
 cat <<EOF
-  ${C_BLU}Admin UI${C_NC}        ${WEB_URL}
-  ${C_BLU}Login as${C_NC}        admin
+  ${C_BLU}Admin UI${C_NC}        ${WEB_URL}${WEB_URL_NOTE}
+  ${C_BLU}Username${C_NC}        ${OD_ADMIN_USER}
   ${C_BLU}Password${C_NC}        ${OD_ADMIN_PW}   ${C_YEL}← rotate via Settings → Admin on first login${C_NC}
 
   ${C_BLU}Config${C_NC}          ${OD_CONFIG_PATH}
@@ -667,7 +695,8 @@ cat <<EOF
   ${C_BLU}DB password${C_NC}     ${OD_DB_PW}   ${C_YEL}← save this somewhere safe${C_NC}
 
   Next:
-    1. Open the admin UI, log in, rotate the admin password.
+    1. Open the admin UI (link above is clickable in most terminals),
+       log in as ${OD_ADMIN_USER}, rotate the admin password.
     2. Finish logging your AI CLI(s) in (claude login / gemini auth login / codex login).
     3. Providers → register the CLI binary path (e.g. \$(which claude)).
     4. Sessions → New session → spawn your first session.

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -323,11 +323,13 @@ log_ok "App user can connect"
 log_step 6 "opendray admin credentials + network"
 
 cat <<'EOF'
-Initial admin password (you'll be forced to rotate it after first UI
-login — opendray writes a bcrypt keyfile, then the plaintext below
-becomes inert).
+Pick the initial admin login. You'll be forced to rotate the password
+after first UI login (opendray writes a bcrypt keyfile, after which
+the plaintext below becomes inert — `user` stays authoritative).
 
 EOF
+ask_with_default "Admin username" "admin" OD_ADMIN_USER
+
 DEFAULT_ADMIN_PW="$(gen_password 20)"
 ask_with_default "Initial admin password (Enter = random)" "$DEFAULT_ADMIN_PW" OD_ADMIN_PW
 
@@ -427,7 +429,11 @@ listen = "$OD_LISTEN"
 url = "$OD_DSN"
 
 [admin]
-# Initial bootstrap password. Rotate via the UI after first login.
+# Admin login. opendray validates {user, password} against this section
+# until you rotate the password via the UI — at which point a bcrypt
+# keyfile takes over and `password` here becomes inert. `user` stays
+# authoritative either way.
+user     = "$OD_ADMIN_USER"
 password = "$OD_ADMIN_PW"
 
 [log]
@@ -556,12 +562,30 @@ done
 
 log_section "Install complete"
 
-WEB_URL="http://${OD_LISTEN}/admin/"
-[[ "$OD_LISTEN" == 0.0.0.0:* ]] && WEB_URL="http://<this-Mac>:${OD_LISTEN##*:}/admin/"
+# Build a clickable URL. For 0.0.0.0 listens, resolve the Mac's primary
+# IP via `ipconfig getifaddr` (en0 = Wi-Fi / wired on most setups; en1 = fallback).
+PORT="${OD_LISTEN##*:}"
+HOST_PART="${OD_LISTEN%:*}"
+case "$HOST_PART" in
+    0.0.0.0|"")
+        LAN_IP=""
+        for iface in en0 en1 en2 en3; do
+            LAN_IP="$(ipconfig getifaddr "$iface" 2>/dev/null)"
+            [ -n "$LAN_IP" ] && break
+        done
+        [ -n "$LAN_IP" ] || LAN_IP="<this-Mac-ip>"
+        WEB_URL="http://${LAN_IP}:${PORT}/admin/"
+        WEB_URL_NOTE="  (LAN — reachable from any device on the same network)"
+        ;;
+    *)
+        WEB_URL="http://${OD_LISTEN}/admin/"
+        WEB_URL_NOTE=""
+        ;;
+esac
 
 cat <<EOF
-  ${C_BLU}Admin UI${C_NC}        ${WEB_URL}
-  ${C_BLU}Login as${C_NC}        admin
+  ${C_BLU}Admin UI${C_NC}        ${WEB_URL}${WEB_URL_NOTE}
+  ${C_BLU}Username${C_NC}        ${OD_ADMIN_USER}
   ${C_BLU}Password${C_NC}        ${OD_ADMIN_PW}   ${C_YEL}← rotate via Settings → Admin on first login${C_NC}
 
   ${C_BLU}Config${C_NC}          ${OD_CONFIG_PATH}
@@ -573,7 +597,8 @@ cat <<EOF
   ${C_BLU}DB password${C_NC}     ${OD_DB_PW}   ${C_YEL}← save this somewhere safe${C_NC}
 
   Next:
-    1. Open the admin UI, log in, rotate the admin password.
+    1. Open the admin UI (link above is clickable in most terminals),
+       log in as ${OD_ADMIN_USER}, rotate the admin password.
     2. Run 'claude login' / 'gemini auth login' / 'codex login' to finish CLI auth.
     3. Providers → register the CLI binary path (e.g. \$(which claude)).
     4. Sessions → New session → spawn your first session.

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -5,14 +5,18 @@
 # Requires bash 4+ (for `printf -v`, `read -ra`, parameter expansion).
 
 # Detect colour-capable terminal once.
+# Use $'…' (ANSI-C quoting) so the vars hold *real* ESC bytes — that
+# lets `cat <<EOF` heredocs interpolate colours correctly, not just
+# printf. The old '\033[…]m' form only worked when fed through printf
+# (printf processes \033); heredocs printed the literal 4 characters.
 if [ -t 1 ] && command -v tput >/dev/null 2>&1 && [ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]; then
-    C_RED='\033[0;31m'
-    C_GRN='\033[0;32m'
-    C_YEL='\033[1;33m'
-    C_BLU='\033[0;34m'
-    C_CYA='\033[0;36m'
-    C_DIM='\033[2m'
-    C_NC='\033[0m'
+    C_RED=$'\033[0;31m'
+    C_GRN=$'\033[0;32m'
+    C_YEL=$'\033[1;33m'
+    C_BLU=$'\033[0;34m'
+    C_CYA=$'\033[0;36m'
+    C_DIM=$'\033[2m'
+    C_NC=$'\033[0m'
 else
     C_RED='' C_GRN='' C_YEL='' C_BLU='' C_CYA='' C_DIM='' C_NC=''
 fi


### PR DESCRIPTION
## Bugs reported from a complete fresh-LXC walkthrough

The wizard reached `Health endpoint OK` but the operator hit four
issues on the final summary screen / first login attempt:

### 1. Admin login fails

Root cause: `[admin]` in opendray's config requires *both* `user`
and `password`. The wizard only wrote `password`, so
`cfg.Admin.User` stayed `""` and the auth handler 401'd every
login attempt with `username=admin`.

```toml
# wizard wrote (broken):
[admin]
password = "..."

# what's actually required:
[admin]
user     = "admin"
password = "..."
```

### 2. Admin username is hard-coded

Wizard never prompted; "admin" was the only value.

### 3. `<this-host>` placeholder leaks to the terminal

When the operator picks `0.0.0.0:8770` listen, the summary printed:

```
Admin UI  http://<this-host>:8770/admin/
```

Literal placeholder text — not a real URL, not clickable.

### 4. Heredoc prints `\033` literally

```
\033[0;34mAdmin UI\033[0m  http://...
```

`cat <<EOF` doesn't interpret backslash escapes; the colour vars
held the string `'\033[0;34m'` (four characters), so the terminal
received them as literal text instead of ANSI sequences.

## Fix

| Bug | Fix |
|---|---|
| 1 | Config write now emits `user = "$OD_ADMIN_USER"` + `password = "$OD_ADMIN_PW"` under `[admin]`. |
| 2 | New prompt `Admin username [admin]:` before the password prompt. Summary prints whatever the operator chose. |
| 3 | For `0.0.0.0` listens, resolve LAN IP: `hostname -I` then `ip route get 1.1.1.1` on Linux; `ipconfig getifaddr en0…en3` on macOS. The summary URL is now a real clickable `http://<ip>:<port>/admin/`. |
| 4 | `lib/common.sh` colour vars use ANSI-C quoting (`$'\033[…]m'`) so they hold real ESC bytes — heredocs interpolate them correctly, printf still works. |

## Workaround for an already-deployed instance (no rerun)

```sh
sudo sed -i '/^\[admin\]/a user = "admin"' /etc/opendray/config.toml
sudo systemctl restart opendray
```

Then `admin` + the originally-printed password works.

## Test plan

- [ ] Fresh Debian 12 LXC: rerun the one-liner, complete the
      wizard with a non-default username (e.g. `kevin`).
- [ ] Verify the generated `/etc/opendray/config.toml` contains
      `user = "kevin"` + `password = "..."` in `[admin]`.
- [ ] Open the URL printed in the summary — should be clickable,
      show a real IP (not `<this-host>`), and login as `kevin` +
      the printed password should succeed.
- [ ] Verify the summary block is rendered in colour, not as
      literal `\033[0;34m` text.
- [ ] `bash -n` clean on all modified files. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)