### PR TITLE
fix(uninstall): accept OPENDRAY_PURGE=1 env var (avoid bash -s line-break trap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ irm https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-
 
 Walks through Postgres setup, AI-CLI install, admin credentials, and service registration — landing a running gateway in ~5–10 minutes. See [**`scripts/README.md`**](scripts/README.md) for what the wizard does, the file layout it creates, options, and troubleshooting.
 
-**Uninstall** (Linux / macOS) — keeps DB + data by default; add `--purge` to drop everything:
+**Uninstall** (Linux / macOS) — keeps DB + data by default; pass `OPENDRAY_PURGE=1` to drop everything:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | bash
 # or, full purge (DB, role, config, data, logs):
-curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | bash -s -- --purge
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
 ```
 
 > **Want the manual walkthrough?** Read [**docs/getting-started.md**](docs/getting-started.md) — a 15-minute end-to-end guide that mirrors what the wizard does so you can verify each step yourself.

--- a/README.zh.md
+++ b/README.zh.md
@@ -84,12 +84,12 @@ irm https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-
 
 引导你完成 Postgres 设置、AI CLI 安装、admin 凭据、服务注册,5–10 分钟拉起一个运行中的网关。详见 [**`scripts/README.md`**](scripts/README.md):wizard 做什么、生成的文件布局、参数、排错。
 
-**卸载**(Linux / macOS)—— 默认保留 DB + 数据;加 `--purge` 全部清除:
+**卸载**(Linux / macOS)—— 默认保留 DB + 数据;加 `OPENDRAY_PURGE=1` 全部清除:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | bash
 # 或者完整 purge(DB / role / config / 数据 / 日志):
-curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | bash -s -- --purge
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
 ```
 
 > **想自己一步步来?** 看 [**docs/getting-started.zh.md**](docs/getting-started.zh.md) —— 15 分钟端到端 walkthrough,跟 wizard 做的是同样的事,但每一步你都自己确认。

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -233,10 +233,23 @@ installer later picks up where you left off.
 ### Purge (delete everything)
 
 ```sh
+# Method 1: env var (safer for copy-paste — survives accidental newlines)
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
+
+# Method 2: flag via bash -s (must be one line, no manual line break!)
 curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | bash -s -- --purge
-# or
+
+# From a checkout:
 bash scripts/uninstall.sh --purge
 ```
+
+> **Heads up on `bash -s -- --purge`:** the `--` and `--purge` MUST
+> be on the same line as `bash -s`. If your terminal soft-wraps the
+> command across two lines and you actually paste a newline, the
+> shell parses it as two commands — the first one is `bash -s` with
+> no args (default-mode uninstall, keeps your data), the second is
+> `-- --purge` (which fails with `--: command not found`). The
+> env-var form (`OPENDRAY_PURGE=1`) doesn't have this footgun.
 
 Adds these destructive steps to the default flow:
 
@@ -256,10 +269,14 @@ host/user/password). The uninstaller does **not** touch:
 
 ### Other options
 
-| Flag | Effect |
-|---|---|
-| `--yes`, `-y` | Skip all confirmations. Combine with `--purge` for unattended cleanup. |
-| `-h`, `--help` | Built-in help. |
+| Flag | Env var | Effect |
+|---|---|---|
+| `--purge` | `OPENDRAY_PURGE=1` | Also drop the DB, role, config, data, logs, and the service user. |
+| `--yes`, `-y` | `OPENDRAY_YES=1` | Skip all confirmations. Combine with `--purge` for unattended cleanup. |
+| `-h`, `--help` | — | Built-in help. |
+
+Env-var forms are equivalent to the flag forms; pick whichever
+survives your copy-paste flow.
 
 ---
 

--- a/scripts/uninstall-linux.sh
+++ b/scripts/uninstall-linux.sh
@@ -26,8 +26,11 @@ source "$SCRIPT_DIR/lib/common.sh"
 : "${OPENDRAY_SERVICE_USER:=opendray}"
 : "${OPENDRAY_SERVICE_NAME:=opendray}"
 
-PURGE=0
-ASSUME_YES=0
+# Also accept env-var forms so `curl … | OPENDRAY_PURGE=1 bash` works,
+# bypassing the `bash -s -- --flag` syntax that's easy to mangle when
+# pasting a multi-line command into a terminal.
+PURGE="${OPENDRAY_PURGE:-0}"
+ASSUME_YES="${OPENDRAY_YES:-0}"
 
 for arg in "$@"; do
     case "$arg" in

--- a/scripts/uninstall-macos.sh
+++ b/scripts/uninstall-macos.sh
@@ -23,8 +23,8 @@ LABEL="com.opendray.opendray"
 USER_PLIST="$HOME/Library/LaunchAgents/${LABEL}.plist"
 SYS_PLIST="/Library/LaunchDaemons/${LABEL}.plist"
 
-PURGE=0
-ASSUME_YES=0
+PURGE="${OPENDRAY_PURGE:-0}"
+ASSUME_YES="${OPENDRAY_YES:-0}"
 
 for arg in "$@"; do
     case "$arg" in


### PR DESCRIPTION
## The bug — `bash -s -- --purge` is fragile

Reported tonight by an LXC operator. They pasted:

```sh
curl -fsSL .../uninstall.sh | bash -s
   -- --purge
```

into the terminal — soft-wrapped by their chat / editor, but with an
actual newline between `bash -s` and `--`. The shell parsed it as
two commands:

1. `curl ... | bash -s` — default-mode uninstall (keeps data)
2. `   -- --purge` — runs `--` as a program → "command not found"

So config.toml stayed on disk, even though they thought they passed
`--purge`. Confusing and easy to miss in the script's exit summary.

## Fix

`uninstall-linux.sh` and `uninstall-macos.sh` now read `OPENDRAY_PURGE`
and `OPENDRAY_YES` from the environment as defaults before parsing
the corresponding `--purge` / `--yes` flags. Env-var forms behave
identically to the flag forms:

```sh
# New (recommended) — survives any paste-newline weirdness
curl -fsSL .../uninstall.sh | OPENDRAY_PURGE=1 bash

# Still works — but must be on one line
curl -fsSL .../uninstall.sh | bash -s -- --purge
```

## Docs

| | Before | After |
|---|---|---|
| `README.md` headline example | `bash -s -- --purge` | `OPENDRAY_PURGE=1 bash` |
| `README.zh.md` headline example | `bash -s -- --purge` | `OPENDRAY_PURGE=1 bash` |
| `scripts/README.md` | Single flag example | Two forms + explicit "heads up" about the `bash -s` footgun + flag/env-var equivalence table |

## What this does NOT change

- Behaviour when the flag is used correctly is unchanged.
- All other CLI flags still work (`--yes`, `--help`).
- The bootstrap dispatcher (`uninstall.sh`) doesn't need changes —
  env vars propagate naturally across `exec`.

## Test plan

- [ ] `OPENDRAY_PURGE=1 bash scripts/uninstall-linux.sh` — wizard
      enters purge mode without `--purge` on the command line.
- [ ] `bash scripts/uninstall-linux.sh --purge` — still works as
      before.
- [ ] `OPENDRAY_PURGE=1 bash scripts/uninstall-linux.sh --purge` —
      both set, still purges (no surprises).
- [ ] `curl ... | OPENDRAY_PURGE=1 bash` end-to-end on the
      reporter's LXC.
- [ ] `bash -n` clean on modified files. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)