### PR TITLE
feat(opendray): `update` + `providers` subcommands (self-upgrade + AI CLI mgmt)

### DIFF
--- a/cmd/opendray/main.go
+++ b/cmd/opendray/main.go
@@ -2,13 +2,16 @@
 //
 // Subcommands:
 //
-//	opendray serve   [-config FILE]   start the gateway
-//	opendray migrate [-config FILE]   apply pending DB migrations and exit
-//	opendray notes   <subcommand> ... operate on the file-system notes vault (no gateway needed)
-//	opendray skill   <subcommand> ... inspect / load agent skills (no gateway needed)
-//	opendray mcp     <subcommand> ... inspect MCP server registry (no gateway needed)
-//	opendray mcp-memory               stdio MCP server bridging agents to opendray memory (run by Claude/Codex/etc.)
-//	opendray version                  print build info and exit
+//	opendray serve     [-config FILE]   start the gateway
+//	opendray migrate   [-config FILE]   apply pending DB migrations and exit
+//	opendray update    [--check] [--force] [--yes] [--restart]
+//	                                    check + apply the latest released opendray binary
+//	opendray providers <subcommand> ... list / update the AI CLIs opendray spawns
+//	opendray notes     <subcommand> ... operate on the file-system notes vault (no gateway needed)
+//	opendray skill     <subcommand> ... inspect / load agent skills (no gateway needed)
+//	opendray mcp       <subcommand> ... inspect MCP server registry (no gateway needed)
+//	opendray mcp-memory                 stdio MCP server bridging agents to opendray memory (run by Claude/Codex/etc.)
+//	opendray version                    print build info and exit
 package main
 
 import (
@@ -40,6 +43,10 @@ func main() {
 		// where the catalog seed step would otherwise fail
 		// against tables that don't exist yet (see #162).
 		os.Exit(runMigrate(args))
+	case "update":
+		os.Exit(runUpdate(args))
+	case "providers":
+		os.Exit(runProviders(args))
 	case "notes":
 		os.Exit(runNotes(args))
 	case "skill":
@@ -91,12 +98,16 @@ func usage() {
 	fmt.Fprintln(os.Stderr, `opendray — multiplexer + integration gateway for AI agent CLIs
 
 usage:
-  opendray serve   [-config FILE]
-  opendray migrate [-config FILE]
-  opendray notes   <subcommand> [args]   (run "opendray notes --help" for details)
-  opendray skill   <subcommand> [args]   (run "opendray skill --help" for details)
-  opendray mcp     <subcommand> [args]   (run "opendray mcp --help" for details)
+  opendray serve     [-config FILE]
+  opendray migrate   [-config FILE]
+  opendray update    [--check] [--force] [--yes] [--restart]
+                                          (download + replace this binary with the latest release;
+                                           "opendray update --check" for a no-op version probe)
+  opendray providers <subcommand> [args]  (run "opendray providers --help" — list / update AI CLIs)
+  opendray notes     <subcommand> [args]  (run "opendray notes --help" for details)
+  opendray skill     <subcommand> [args]  (run "opendray skill --help" for details)
+  opendray mcp       <subcommand> [args]  (run "opendray mcp --help" for details)
   opendray mcp-memory                     (stdio MCP server — invoked by an agent CLI, not by humans)
-  opendray hook    <event>                (Claude Code hook entry — auto-write journal entries; see "opendray hook --help")
+  opendray hook      <event>              (Claude Code hook entry — auto-write journal entries)
   opendray version`)
 }

--- a/cmd/opendray/providers.go
+++ b/cmd/opendray/providers.go
@@ -1,0 +1,258 @@
+// `opendray providers` — manage the AI CLIs opendray spawns into sessions.
+//
+//	opendray providers list                       detect installed CLIs + their versions
+//	opendray providers list --json                same but machine-readable
+//	opendray providers update                     re-run `npm install -g` for each detected CLI
+//	opendray providers update --check             show current vs npm-latest, don't install
+//	opendray providers update --only claude,gemini  restrict to a subset (comma-separated)
+//
+// The "providers" here are the Claude / Codex / Gemini CLIs the user
+// installed during the install wizard. opendray doesn't bundle them —
+// it spawns whatever's on $PATH. This subcommand just centralises the
+// "is it installed, what version, npm update it" busywork.
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type providerSpec struct {
+	Bin     string // CLI name on $PATH
+	NpmPkg  string // npm package name
+	Display string // human label
+}
+
+// Order here is the same order the install wizard offers them.
+var providerCatalog = []providerSpec{
+	{Bin: "claude", NpmPkg: "@anthropic-ai/claude-code", Display: "Claude Code"},
+	{Bin: "gemini", NpmPkg: "@google/gemini-cli", Display: "Gemini CLI"},
+	{Bin: "codex", NpmPkg: "@openai/codex", Display: "Codex CLI"},
+}
+
+func runProviders(args []string) int {
+	if len(args) < 1 {
+		providersUsage()
+		return 2
+	}
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "list":
+		return providersList(rest)
+	case "update":
+		return providersUpdate(rest)
+	case "-h", "--help", "help":
+		providersUsage()
+		return 0
+	default:
+		fmt.Fprintf(os.Stderr, "unknown providers subcommand: %s\n", sub)
+		providersUsage()
+		return 2
+	}
+}
+
+func providersUsage() {
+	fmt.Fprintln(os.Stderr, `opendray providers — manage the AI CLIs opendray spawns
+
+usage:
+  opendray providers list                       detect installed CLIs + their versions
+  opendray providers list --json                machine-readable form
+  opendray providers update                     re-run "npm install -g <pkg>" for each detected CLI
+  opendray providers update --check             show current vs npm-latest; don't install
+  opendray providers update --only claude,gemini  restrict to a subset (comma-separated CLI names)
+
+Privilege: npm install -g typically writes under /usr/lib/node_modules
+and needs root. Run via sudo (or whatever wrapper your npm install uses)
+when --check is not set.`)
+}
+
+// ── list ─────────────────────────────────────────────────────────────
+
+type providerRow struct {
+	Bin       string `json:"bin"`
+	NpmPkg    string `json:"npm_pkg"`
+	Display   string `json:"display"`
+	Installed bool   `json:"installed"`
+	Path      string `json:"path,omitempty"`
+	Version   string `json:"version,omitempty"`
+}
+
+func providersList(args []string) int {
+	fs := flag.NewFlagSet("providers list", flag.ExitOnError)
+	asJSON := fs.Bool("json", false, "emit one row per provider as JSON")
+	_ = fs.Parse(args)
+
+	rows := make([]providerRow, 0, len(providerCatalog))
+	for _, p := range providerCatalog {
+		r := providerRow{Bin: p.Bin, NpmPkg: p.NpmPkg, Display: p.Display}
+		if path, err := exec.LookPath(p.Bin); err == nil {
+			r.Installed = true
+			r.Path = path
+			r.Version = cliVersion(p.Bin)
+		}
+		rows = append(rows, r)
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return jsonOK(enc.Encode(rows))
+	}
+
+	// Human table.
+	fmt.Printf("%-12s %-30s %-18s %s\n", "CLI", "NPM PACKAGE", "VERSION", "PATH")
+	fmt.Printf("%-12s %-30s %-18s %s\n", "---", "-----------", "-------", "----")
+	for _, r := range rows {
+		path := r.Path
+		if path == "" {
+			path = "(not installed)"
+		}
+		ver := r.Version
+		if ver == "" {
+			ver = "-"
+		}
+		fmt.Printf("%-12s %-30s %-18s %s\n", r.Bin, r.NpmPkg, ver, path)
+	}
+	return 0
+}
+
+// ── update ───────────────────────────────────────────────────────────
+
+func providersUpdate(args []string) int {
+	fs := flag.NewFlagSet("providers update", flag.ExitOnError)
+	checkOnly := fs.Bool("check", false, "print current vs npm-latest; don't install")
+	onlyFlag := fs.String("only", "", "comma-separated CLI names to include (default: all)")
+	_ = fs.Parse(args)
+
+	only := splitCSV(*onlyFlag)
+	rc := 0
+	checkedAny := false
+
+	for _, p := range providerCatalog {
+		if len(only) > 0 && !contains(only, p.Bin) {
+			continue
+		}
+		checkedAny = true
+
+		path, _ := exec.LookPath(p.Bin)
+		current := ""
+		if path != "" {
+			current = cliVersion(p.Bin)
+		}
+
+		if *checkOnly {
+			latest := npmLatest(p.NpmPkg)
+			label := p.Display
+			fmt.Printf("\n%s\n", label)
+			if path == "" {
+				fmt.Printf("  current: (not installed)\n")
+			} else {
+				fmt.Printf("  current: %s\n", current)
+			}
+			fmt.Printf("  npm latest: %s\n", latest)
+			continue
+		}
+
+		if path == "" {
+			fmt.Printf("[skip] %s — not installed. Add it via the install wizard or:\n", p.Display)
+			fmt.Printf("       npm install -g %s\n", p.NpmPkg)
+			continue
+		}
+
+		fmt.Printf("\n=== %s — npm install -g %s ===\n", p.Display, p.NpmPkg)
+		cmd := exec.Command("npm", "install", "-g", p.NpmPkg)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "[!] %s update failed: %v\n", p.Display, err)
+			rc = 1
+			continue
+		}
+		after := cliVersion(p.Bin)
+		if after == "" {
+			fmt.Printf("[✓] %s — upgraded (version probe failed; check `which %s`)\n", p.Display, p.Bin)
+		} else if after == current {
+			fmt.Printf("[✓] %s — already at npm-latest (%s)\n", p.Display, after)
+		} else {
+			fmt.Printf("[✓] %s — %s → %s\n", p.Display, current, after)
+		}
+	}
+
+	if !checkedAny {
+		fmt.Fprintln(os.Stderr, "no providers matched --only — known names: claude, gemini, codex")
+		return 2
+	}
+	return rc
+}
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+func cliVersion(bin string) string {
+	cmd := exec.Command(bin, "--version")
+	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	sc := bufio.NewScanner(strings.NewReader(string(out)))
+	if sc.Scan() {
+		return strings.TrimSpace(sc.Text())
+	}
+	return ""
+}
+
+// npmLatest shells out to `npm view <pkg> version`. Returns "" if npm is
+// missing or the registry is unreachable — callers print "-" for empty.
+func npmLatest(pkg string) string {
+	if _, err := exec.LookPath("npm"); err != nil {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "npm", "view", pkg, "version")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func jsonOK(err error) int {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "json encode failed: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/cmd/opendray/providers.go
+++ b/cmd/opendray/providers.go
@@ -177,11 +177,12 @@ func providersUpdate(args []string) int {
 			continue
 		}
 		after := cliVersion(p.Bin)
-		if after == "" {
+		switch after {
+		case "":
 			fmt.Printf("[✓] %s — upgraded (version probe failed; check `which %s`)\n", p.Display, p.Bin)
-		} else if after == current {
+		case current:
 			fmt.Printf("[✓] %s — already at npm-latest (%s)\n", p.Display, after)
-		} else {
+		default:
 			fmt.Printf("[✓] %s — %s → %s\n", p.Display, current, after)
 		}
 	}

--- a/cmd/opendray/providers_test.go
+++ b/cmd/opendray/providers_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitCSV(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"claude", []string{"claude"}},
+		{"claude,gemini", []string{"claude", "gemini"}},
+		{" claude , gemini , codex ", []string{"claude", "gemini", "codex"}},
+		{",,claude,,", []string{"claude"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got := splitCSV(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("splitCSV(%q) = %#v, want %#v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestContains(t *testing.T) {
+	cases := []struct {
+		haystack []string
+		needle   string
+		want     bool
+	}{
+		{[]string{"a", "b", "c"}, "b", true},
+		{[]string{"a", "b", "c"}, "z", false},
+		{nil, "anything", false},
+		{[]string{}, "anything", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.needle, func(t *testing.T) {
+			if got := contains(tc.haystack, tc.needle); got != tc.want {
+				t.Errorf("contains(%#v, %q) = %v, want %v", tc.haystack, tc.needle, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProviderCatalogShape(t *testing.T) {
+	// Defensive: rest of the wizard / CI assumes these three are
+	// the catalog. If anyone adds a new provider, update this list.
+	expected := map[string]string{
+		"claude": "@anthropic-ai/claude-code",
+		"gemini": "@google/gemini-cli",
+		"codex":  "@openai/codex",
+	}
+	if len(providerCatalog) != len(expected) {
+		t.Fatalf("providerCatalog has %d entries, expected %d", len(providerCatalog), len(expected))
+	}
+	for _, p := range providerCatalog {
+		want, ok := expected[p.Bin]
+		if !ok {
+			t.Errorf("unexpected provider bin %q in catalog", p.Bin)
+			continue
+		}
+		if p.NpmPkg != want {
+			t.Errorf("provider %q npm pkg = %q, want %q", p.Bin, p.NpmPkg, want)
+		}
+		if p.Display == "" {
+			t.Errorf("provider %q missing Display name", p.Bin)
+		}
+	}
+}

--- a/cmd/opendray/update.go
+++ b/cmd/opendray/update.go
@@ -1,0 +1,410 @@
+// `opendray update` — check + apply the latest opendray release.
+//
+//	opendray update              check and apply if newer (interactive confirm)
+//	opendray update --check      only print current vs latest; don't apply
+//	opendray update --force      re-download + replace even if already on latest
+//	opendray update --yes        skip the interactive confirmation prompt
+//	opendray update --restart    after replace, restart the systemd unit
+//	                             `opendray` (Linux only — no-op on macOS LaunchAgent)
+//
+// Mechanics: hits GitHub's releases-latest endpoint, downloads the
+// goreleaser tarball matching this host's GOOS/GOARCH, verifies the
+// SHA-256 against the release's SHA256SUMS, then atomically replaces
+// /proc/self/exe via temp+rename. The running process keeps using
+// the OLD inode until exec — that's why the unit needs a restart to
+// pick up the new code (we don't auto-restart unless asked).
+//
+// Privileges: the wizard installs the binary at /usr/local/bin/opendray
+// (Linux) or ~/.opendray/bin/opendray (macOS). The Linux path is
+// root-owned; running `opendray update` as a non-root user there
+// fails fast with a "try with sudo" hint rather than silently
+// reading old binary.
+package main
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/opendray/opendray-v2/internal/version"
+)
+
+const updateReleasesAPI = "https://api.github.com/repos/Opendray/opendray_v2/releases/latest"
+
+type ghReleaseAsset struct {
+	Name        string `json:"name"`
+	DownloadURL string `json:"browser_download_url"`
+}
+
+type ghRelease struct {
+	TagName string           `json:"tag_name"`
+	Assets  []ghReleaseAsset `json:"assets"`
+}
+
+func runUpdate(args []string) int {
+	fs := flag.NewFlagSet("update", flag.ExitOnError)
+	checkOnly := fs.Bool("check", false, "only print current vs latest; don't apply")
+	force := fs.Bool("force", false, "re-download + replace even when already on the latest")
+	yes := fs.Bool("yes", false, "skip the interactive confirmation prompt")
+	restart := fs.Bool("restart", false, "after replacing the binary, restart the 'opendray' systemd unit")
+	_ = fs.Parse(args)
+
+	current := normaliseVersion(version.Version)
+	fmt.Printf("Current opendray:   %s\n", current)
+
+	rel, err := fetchLatestRelease()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch latest release: %v\n", err)
+		return 1
+	}
+	latest := normaliseVersion(rel.TagName)
+	fmt.Printf("Latest release:     %s\n", latest)
+
+	if !*force && latest == current {
+		fmt.Println("Already on the latest release. (pass --force to re-install anyway)")
+		return 0
+	}
+	if *checkOnly {
+		if latest != current {
+			fmt.Println("(--check set; not applying — re-run without --check to upgrade)")
+		}
+		return 0
+	}
+
+	osName := runtime.GOOS
+	arch := runtime.GOARCH
+	tarballName := fmt.Sprintf("opendray_%s_%s_%s.tar.gz", latest, osName, arch)
+
+	var tarballURL, sumsURL string
+	for _, a := range rel.Assets {
+		switch a.Name {
+		case tarballName:
+			tarballURL = a.DownloadURL
+		case "SHA256SUMS":
+			sumsURL = a.DownloadURL
+		}
+	}
+	if tarballURL == "" {
+		fmt.Fprintf(os.Stderr, "no release asset matches %s — this host's %s/%s build is not published.\n", tarballName, osName, arch)
+		return 1
+	}
+
+	selfPath, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to locate current binary: %v\n", err)
+		return 1
+	}
+	// Resolve symlinks so we don't write the new binary to a symlink
+	// while leaving the actual file untouched.
+	if resolved, err := filepath.EvalSymlinks(selfPath); err == nil {
+		selfPath = resolved
+	}
+
+	if err := canWriteSameDir(selfPath); err != nil {
+		fmt.Fprintf(os.Stderr, "can't replace %s: %v\n", selfPath, err)
+		fmt.Fprintln(os.Stderr, "Re-run with elevated privileges, e.g. `sudo opendray update`.")
+		return 1
+	}
+
+	fmt.Printf("Will replace:       %s\n", selfPath)
+	fmt.Printf("Tarball:            %s\n", tarballURL)
+	if !*yes {
+		if !askYes(fmt.Sprintf("\nProceed to upgrade %s → %s? [y/N]: ", current, latest)) {
+			fmt.Println("Aborted.")
+			return 0
+		}
+	}
+
+	tarballPath, err := downloadToTemp(tarballURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "download failed: %v\n", err)
+		return 1
+	}
+	defer os.Remove(tarballPath)
+	fmt.Printf("[✓] downloaded\n")
+
+	if sumsURL != "" {
+		if err := verifyChecksum(tarballPath, sumsURL, tarballName); err != nil {
+			fmt.Fprintf(os.Stderr, "checksum verification FAILED: %v\n", err)
+			return 1
+		}
+		fmt.Println("[✓] SHA-256 verified")
+	} else {
+		fmt.Fprintln(os.Stderr, "[!] SHA256SUMS not found on the release — skipping checksum check.")
+	}
+
+	binPath, cleanup, err := extractOpendrayBinary(tarballPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "extract failed: %v\n", err)
+		return 1
+	}
+	defer cleanup()
+	fmt.Println("[✓] extracted")
+
+	if err := atomicReplace(binPath, selfPath); err != nil {
+		fmt.Fprintf(os.Stderr, "binary replace failed: %v\n", err)
+		return 1
+	}
+	fmt.Printf("[✓] installed:        %s\n", selfPath)
+
+	if *restart && runtime.GOOS == "linux" {
+		fmt.Println("Restarting systemd unit 'opendray'...")
+		cmd := exec.Command("systemctl", "restart", "opendray")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "[!] systemctl restart failed: %v\n", err)
+			fmt.Fprintln(os.Stderr, "    Restart manually with: sudo systemctl restart opendray")
+			return 1
+		}
+		fmt.Println("[✓] service restarted")
+	} else {
+		fmt.Println("\nNew binary is in place but the running service is still on the old inode.")
+		fmt.Println("Restart to pick up the new code:")
+		switch runtime.GOOS {
+		case "linux":
+			fmt.Println("  sudo systemctl restart opendray")
+		case "darwin":
+			fmt.Println("  launchctl kickstart -k gui/$(id -u)/com.opendray.opendray")
+		}
+		fmt.Println("\nIf this release contains schema migrations, also run:")
+		fmt.Println("  sudo -u opendray opendray migrate -config /etc/opendray/config.toml   # Linux")
+		fmt.Println("  opendray migrate -config ~/.opendray/config.toml                       # macOS")
+	}
+
+	return 0
+}
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+// normaliseVersion strips a leading "v" so "v2.0.0" and "2.0.0" compare equal.
+func normaliseVersion(v string) string {
+	return strings.TrimPrefix(strings.TrimSpace(v), "v")
+}
+
+func fetchLatestRelease() (*ghRelease, error) {
+	client := &http.Client{Timeout: 20 * time.Second}
+	req, err := http.NewRequest("GET", updateReleasesAPI, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "opendray-update/"+version.Version)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("github API returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var rel ghRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, fmt.Errorf("decode release JSON: %w", err)
+	}
+	if rel.TagName == "" {
+		return nil, fmt.Errorf("github returned an empty tag_name (rate-limited? auth needed?)")
+	}
+	return &rel, nil
+}
+
+// canWriteSameDir tries to create + remove a temp file in the directory
+// containing the target path, as a proxy for "we can rename onto it".
+func canWriteSameDir(targetPath string) error {
+	dir := filepath.Dir(targetPath)
+	f, err := os.CreateTemp(dir, ".opendray-update-test-")
+	if err != nil {
+		return fmt.Errorf("no write access to %s (%w)", dir, err)
+	}
+	name := f.Name()
+	f.Close()
+	_ = os.Remove(name)
+	return nil
+}
+
+func downloadToTemp(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("http: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("HTTP %d while fetching %s", resp.StatusCode, url)
+	}
+	f, err := os.CreateTemp("", "opendray-update-*.tar.gz")
+	if err != nil {
+		return "", fmt.Errorf("tempfile: %w", err)
+	}
+	defer f.Close()
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("write tempfile: %w", err)
+	}
+	return f.Name(), nil
+}
+
+func verifyChecksum(tarballPath, sumsURL, tarballName string) error {
+	resp, err := http.Get(sumsURL)
+	if err != nil {
+		return fmt.Errorf("fetch SHA256SUMS: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("SHA256SUMS HTTP %d", resp.StatusCode)
+	}
+	var expected string
+	sc := bufio.NewScanner(resp.Body)
+	for sc.Scan() {
+		// "<sha256>  <name>" — accept either single or double space.
+		fields := strings.Fields(sc.Text())
+		if len(fields) >= 2 && fields[len(fields)-1] == tarballName {
+			expected = strings.ToLower(fields[0])
+			break
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return fmt.Errorf("scan SHA256SUMS: %w", err)
+	}
+	if expected == "" {
+		return fmt.Errorf("%s not listed in SHA256SUMS", tarballName)
+	}
+
+	f, err := os.Open(tarballPath)
+	if err != nil {
+		return fmt.Errorf("open tarball: %w", err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("hash tarball: %w", err)
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if got != expected {
+		return fmt.Errorf("checksum mismatch: expected %s, got %s", expected, got)
+	}
+	return nil
+}
+
+func extractOpendrayBinary(tarballPath string) (string, func(), error) {
+	tmpDir, err := os.MkdirTemp("", "opendray-update-extract-")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("tempdir: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(tmpDir) }
+
+	f, err := os.Open(tarballPath)
+	if err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("open tarball: %w", err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("gzip: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	var binDest string
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			cleanup()
+			return "", func() {}, fmt.Errorf("tar: %w", err)
+		}
+		if h.Typeflag != tar.TypeReg {
+			continue
+		}
+		// goreleaser tarball has `opendray` at the root.
+		base := filepath.Base(h.Name)
+		if base != "opendray" {
+			continue
+		}
+		// Reject suspicious entries to be safe.
+		if strings.Contains(h.Name, "..") {
+			cleanup()
+			return "", func() {}, fmt.Errorf("tarball contains a suspicious path: %q", h.Name)
+		}
+		binDest = filepath.Join(tmpDir, "opendray")
+		dst, err := os.OpenFile(binDest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+		if err != nil {
+			cleanup()
+			return "", func() {}, fmt.Errorf("create dest: %w", err)
+		}
+		if _, err := io.Copy(dst, tr); err != nil {
+			dst.Close()
+			cleanup()
+			return "", func() {}, fmt.Errorf("copy: %w", err)
+		}
+		dst.Close()
+		break
+	}
+	if binDest == "" {
+		cleanup()
+		return "", func() {}, fmt.Errorf("no 'opendray' binary inside tarball")
+	}
+	return binDest, cleanup, nil
+}
+
+// atomicReplace puts newBin at targetPath via temp+rename in the same
+// directory, so the swap is atomic even if the running process still
+// holds the old inode.
+func atomicReplace(newBin, targetPath string) error {
+	tmp := targetPath + ".new"
+	src, err := os.Open(newBin)
+	if err != nil {
+		return fmt.Errorf("open new binary: %w", err)
+	}
+	defer src.Close()
+	dst, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", tmp, err)
+	}
+	if _, err := io.Copy(dst, src); err != nil {
+		dst.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("copy to %s: %w", tmp, err)
+	}
+	if err := dst.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("close %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, targetPath); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename %s -> %s: %w", tmp, targetPath, err)
+	}
+	return nil
+}
+
+// askYes prompts on stdin/stderr and returns true on y / Y / yes.
+// Always defaults to NO so accidental Enter doesn't trigger destructive
+// actions.
+func askYes(prompt string) bool {
+	fmt.Fprint(os.Stderr, prompt)
+	sc := bufio.NewScanner(os.Stdin)
+	if !sc.Scan() {
+		return false
+	}
+	answer := strings.ToLower(strings.TrimSpace(sc.Text()))
+	return answer == "y" || answer == "yes"
+}

--- a/cmd/opendray/update_test.go
+++ b/cmd/opendray/update_test.go
@@ -1,0 +1,22 @@
+package main
+
+import "testing"
+
+func TestNormaliseVersion(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"v2.0.0", "2.0.0"},
+		{"2.0.0", "2.0.0"},
+		{"  v2.0.0 ", "2.0.0"},
+		{"", ""},
+		{"v0.0.0-dev", "0.0.0-dev"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := normaliseVersion(tc.in); got != tc.want {
+				t.Errorf("normaliseVersion(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two new subcommands on the gateway binary so operators don't have to
remember curl one-liners for routine maintenance.

```
opendray update
opendray providers list
opendray providers update
```

Both visible via `opendray -h`:

```
usage:
  opendray serve     [-config FILE]
  opendray migrate   [-config FILE]
  opendray update    [--check] [--force] [--yes] [--restart]
                                          (download + replace this binary with the latest release;
                                           "opendray update --check" for a no-op version probe)
  opendray providers <subcommand> [args]  (run "opendray providers --help" — list / update AI CLIs)
  …
```

## `opendray update`

Fetches `https://api.github.com/repos/Opendray/opendray_v2/releases/latest`,
picks the goreleaser asset matching this host's `GOOS/GOARCH`,
verifies the SHA-256 against the release's `SHA256SUMS`, then
atomically replaces `/proc/self/exe` via temp+rename.

| Flag | Effect |
|---|---|
| `--check` | only print "current X, latest Y"; don't apply |
| `--force` | re-download + replace even when already on latest |
| `--yes` | skip the interactive confirmation prompt |
| `--restart` | after replacing the binary, run `systemctl restart opendray` (Linux only) |

**Safety:**
- Refuses to apply if the matching `<os>_<arch>` tarball isn't in
  the release's assets.
- Computes SHA-256 of the downloaded tarball against the release's
  `SHA256SUMS` line. Mismatch aborts before touching disk.
- Rejects tar entries containing `..` path components.
- temp+rename means the swap is atomic even if power dies mid-write.
- Tries to create a tempfile in the install directory first — fails
  fast with a "try with sudo" hint if the operator doesn't have
  write access.

**Privilege model:** the running process keeps using the OLD inode
after the rename. The unit needs a restart to pick up new code,
which `update` doesn't do unless `--restart` is set. Operator sees
a reminder line on success.

## `opendray providers list / update`

Manages the AI CLIs the wizard installs (Claude / Codex / Gemini)
by shelling out to `npm install -g`. opendray doesn't bundle the
CLIs — it spawns whatever's on `$PATH` — so "manage" here means
detect + version + bump.

```
$ opendray providers list
CLI          NPM PACKAGE                    VERSION                  PATH
---          -----------                    -------                  ----
claude       @anthropic-ai/claude-code      2.1.142 (Claude Code)    /usr/local/bin/claude
gemini       @google/gemini-cli             0.42.0                   /usr/local/bin/gemini
codex        @openai/codex                  codex-cli 0.130.0        /usr/local/bin/codex
```

| Flag | Effect |
|---|---|
| `--json` (list only) | machine-readable form for scripts |
| `--check` (update only) | shells out to `npm view <pkg> version` for each, prints current-vs-npm-latest; doesn't install |
| `--only X,Y` (update only) | restrict to a comma-separated subset |

## Implementation notes

- All stdlib (`net/http`, `archive/tar`, `compress/gzip`,
  `crypto/sha256`, `os/exec`). No new deps in `go.sum`.
- `update.go` writes the new binary to a sibling tempfile in the
  install directory and renames atomically.
- `providers.go`: `npm view` uses a 10s `context.WithTimeout` so a
  flaky registry doesn't hang the wizard.
- Help text updated in `main.go` + the package-level doc comment.

## Tests

```
go test -race -count=1 ./cmd/opendray/...
ok  github.com/opendray/opendray-v2/cmd/opendray  1.481s
```

Unit tests cover `normaliseVersion`, `splitCSV`, `contains`, and the
provider catalog shape. HTTP / tarball / exec paths are exercised by
manual smoke tests on a dev machine (`opendray providers list` and
`opendray update --check` both work end-to-end against the real
GitHub releases endpoint).

## Out of scope (likely follow-ups)

- Cosign verification of the release artefacts (the SHA-256 check is
  the floor; cosign is belt-and-braces).
- Auto-rollback if the new binary crashes on the first start.
- `opendray providers add <cli>` for CLIs not yet in the catalog.

## Test plan

- [ ] On the reporter's Debian LXC: run `opendray update --check`,
      verify it reports `current 2.0.0` and `latest 2.0.0`.
- [ ] Same LXC: run `opendray providers list` — verify it finds
      claude/codex/gemini and reports versions.
- [ ] Force-upgrade path: `sudo opendray update --force --yes` →
      verify SHA-256 verified line, atomic replace lands, restart
      hint prints.
- [ ] `sudo opendray update --restart` → service restarted.
- [ ] Without sudo: `opendray update` fails fast with the "try with
      sudo" hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)