### PR TITLE
docs(changelog): revert v2.1.0 header — move content to [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,12 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
-## [v2.1.0] — 2026-05-18
-
 ### Added — install / uninstall / update tooling
 
-This release is dominated by lifecycle scripts and binary
-subcommands that grew out of a fresh-LXC end-to-end install test.
-Everything below is `curl | bash`–reachable, idempotent, and works
-on Linux (Ubuntu / Debian) + macOS; Windows is funneled through
-WSL2.
+Lifecycle scripts and binary subcommands that grew out of a fresh-
+LXC end-to-end install test. Everything below is `curl | bash`–
+reachable, idempotent, and works on Linux (Ubuntu / Debian) +
+macOS; Windows is funneled through WSL2.
 
 - **One-line installer wizard** (#185 #186)
   - `scripts/install.sh` — dual-mode entry: dispatches to the OS


### PR DESCRIPTION
## Why

The `v2.1.0` release (#195) was published and then immediately taken
down — the tag, GitHub release, and queued GHCR push were rolled
back so we can verify the install walkthrough on the reporter's LXC
before cutting the real release. But the CHANGELOG header was still
asserting "v2.1.0 — 2026-05-18", which is now misleading: anyone
reading the changelog would see a date for a release that doesn't
exist on GitHub.

This PR moves the v2.1.0 content (untouched — it still accurately
describes the work landed since v2.0.0) back under `## [Unreleased]`.

## Side effects of the v2.1.0 rollback (already applied)

| Action | State |
|---|---|
| `git tag v2.1.0` | deleted (local + remote) |
| GitHub release v2.1.0 | deleted (artefacts + tag cleanup via `gh release delete --cleanup-tag`) |
| GHCR push workflow run #26020515601 | cancelled mid-flight (image never landed on ghcr.io) |
| `api/.../releases/latest` | returns v2.0.0 again |

## When v2.1.0 ships for real

After the install walkthrough verifies end-to-end on the LXC, the
next commit on the release branch re-adds `## [v2.1.0] — <date>`
above this content, push the tag, and the existing release.yml
workflow rebuilds + signs + publishes.

## Test plan

- [ ] CI passes (docs-only — Backend Go / Frontend / Lint Go /
      CodeQL / Analyze should all be no-ops).
- [ ] After merge, `gh release view v2.1.0` continues to return
      "release not found".

🤖 Generated with [Claude Code](https://claude.com/claude-code)