### PR TITLE
feat(web/terminal): "detected links" badge — tap to open OAuth URLs on mobile

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -131,7 +131,19 @@
         "uploadedToast": "Image attached",
         "uploadFailedToast": "Upload failed",
         "uploadInvalidTypeToast": "Only image files can be attached",
-        "dropToAttach": "Drop image to attach"
+        "dropToAttach": "Drop image to attach",
+        "urls": {
+          "tooltip": "Open or copy a URL detected in this session's output",
+          "buttonLabel": "{count} link",
+          "buttonLabel_plural": "{count} links",
+          "dialogTitle": "Detected links",
+          "dialogDesc": "URLs printed in this session's output. Tap Open to launch in your default browser — works even when the URL is line-wrapped in the terminal.",
+          "openButton": "Open",
+          "copyButton": "Copy",
+          "copiedToast": "URL copied",
+          "copyFailedToast": "Couldn't copy — long-press the URL and copy manually",
+          "noneHint": "No links detected yet."
+        }
       },
       "spawn": {
         "title": "Spawn session",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -131,7 +131,19 @@
         "uploadedToast": "图片已附加",
         "uploadFailedToast": "上传失败",
         "uploadInvalidTypeToast": "仅支持图片文件",
-        "dropToAttach": "释放以附加图片"
+        "dropToAttach": "释放以附加图片",
+        "urls": {
+          "tooltip": "打开或复制本会话输出里出现的链接",
+          "buttonLabel": "{count} 个链接",
+          "buttonLabel_plural": "{count} 个链接",
+          "dialogTitle": "检测到的链接",
+          "dialogDesc": "本会话输出中出现过的 URL。点击「打开」即可在默认浏览器中跳转 —— 终端里的换行不会影响。",
+          "openButton": "打开",
+          "copyButton": "复制",
+          "copiedToast": "链接已复制",
+          "copyFailedToast": "复制失败 —— 请长按链接手动复制",
+          "noneHint": "暂未检测到链接。"
+        }
       },
       "spawn": {
         "title": "创建会话",

--- a/app/web/src/components/sessions/DetectedURLs.tsx
+++ b/app/web/src/components/sessions/DetectedURLs.tsx
@@ -1,0 +1,141 @@
+/**
+ * DetectedURLs — floating "N links" badge above the xterm terminal.
+ *
+ * The xterm `WebLinksAddon` already makes single-line URLs clickable,
+ * but OAuth URLs printed by AI CLIs (claude / codex / gemini) are
+ * often 400-600 chars long and visually wrap across multiple lines.
+ * Each wrap segment becomes a separate hyperlink hit-box that's
+ * (a) tiny and easy to miss on touch, and (b) opens just the partial
+ * fragment of the URL it covers.
+ *
+ * This component sidesteps the wrap problem: the parent Terminal
+ * scans PTY output for URLs, dedupes them, and renders this badge
+ * when at least one URL has been seen. Tapping the badge opens a
+ * Dialog with each URL as a full Open/Copy pair — works the same on
+ * desktop and mobile (Dialog goes near-fullscreen below ~640px).
+ */
+
+import { useState } from 'react'
+import { ExternalLink, Link2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { Button } from 'shared-ui/primitives/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from 'shared-ui/primitives/dialog'
+import { ScrollArea } from 'shared-ui/primitives/scroll-area'
+
+interface DetectedURLsProps {
+  urls: string[]
+}
+
+export function DetectedURLs({ urls }: DetectedURLsProps) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+
+  if (urls.length === 0) return null
+
+  const handleOpen = (url: string) => {
+    // `noopener,noreferrer` so the opened tab can't reach back into
+    // the admin SPA via window.opener — defence-in-depth even though
+    // the URL is one the operator literally just saw printed in
+    // their own session.
+    window.open(url, '_blank', 'noopener,noreferrer')
+  }
+
+  const handleCopy = async (url: string) => {
+    try {
+      await navigator.clipboard.writeText(url)
+      toast.success(t('web.sessions.terminal.urls.copiedToast'))
+    } catch {
+      // Some mobile browsers gate clipboard.writeText to https / secure
+      // contexts — if it throws, ask the user to long-press the URL
+      // in the dialog body (which has `select-all` for that purpose).
+      toast.error(t('web.sessions.terminal.urls.copyFailedToast'))
+    }
+  }
+
+  const count = urls.length
+  const buttonKey =
+    count === 1
+      ? 'web.sessions.terminal.urls.buttonLabel'
+      : 'web.sessions.terminal.urls.buttonLabel_plural'
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          size="sm"
+          variant="secondary"
+          className="absolute top-2 right-2 z-10 h-8 gap-1.5 px-2.5 shadow-sm"
+          title={t('web.sessions.terminal.urls.tooltip')}
+          aria-label={t('web.sessions.terminal.urls.tooltip')}
+        >
+          <Link2 className="size-3.5" />
+          <span className="text-xs font-medium">
+            {t(buttonKey, { count })}
+          </span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-[min(640px,95vw)]">
+        <DialogHeader>
+          <DialogTitle>
+            {t('web.sessions.terminal.urls.dialogTitle')}
+          </DialogTitle>
+          <DialogDescription>
+            {t('web.sessions.terminal.urls.dialogDesc')}
+          </DialogDescription>
+        </DialogHeader>
+        <ScrollArea className="max-h-[60vh]">
+          <div className="space-y-2 pr-3">
+            {/* Reverse so the most recently seen URL is on top — that's
+             * almost always the one the operator is trying to act on.
+             * (Newest-first matches the auth flow: idle → CLI prints
+             * URL → user looks at the dialog → wants the one just
+             * printed.) */}
+            {urls
+              .slice()
+              .reverse()
+              .map((url) => (
+                <div
+                  key={url}
+                  className="rounded-md border bg-muted/30 p-3"
+                >
+                  <div className="mb-2 select-all break-all font-mono text-xs">
+                    {url}
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      className="flex-1"
+                      onClick={() => handleOpen(url)}
+                    >
+                      <ExternalLink className="mr-1.5 size-3.5" />
+                      {t('web.sessions.terminal.urls.openButton')}
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="flex-1"
+                      onClick={() => handleCopy(url)}
+                    >
+                      {t('web.sessions.terminal.urls.copyButton')}
+                    </Button>
+                  </div>
+                </div>
+              ))}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// URL extraction lives in `./url-extractor.ts` so this file remains
+// a clean component module (react-refresh expects that).

--- a/app/web/src/components/sessions/Terminal.tsx
+++ b/app/web/src/components/sessions/Terminal.tsx
@@ -17,6 +17,22 @@ import { useAuth } from '@/stores/auth'
 import { useTheme } from '@/stores/theme'
 import { BinaryWS, wsURL } from '@/lib/ws'
 import { resizeSession, uploadSessionFile } from '@/lib/sessions'
+import { DetectedURLs } from './DetectedURLs'
+import { extractURLs, stripANSI } from './url-extractor'
+
+// Keep the last N URLs we've seen in this session. 50 is enough for
+// any realistic OAuth-heavy session (each CLI prints 1-2 auth URLs),
+// and bounds the dialog scroll length on a long-lived session that
+// keeps printing links (e.g. one with a notes vault git push hint).
+const MAX_DETECTED_URLS = 50
+
+// Sliding window the URL scanner keeps in-memory across PTY frames.
+// PTY frames are byte-arbitrary boundaries that can land mid-URL, so
+// we prepend this tail to each new chunk before regex-matching.
+// 4 KB is much larger than even claude-code's full OAuth URL (~600
+// chars), so any single URL fits entirely inside the window with
+// room to spare.
+const URL_SCAN_TAIL_BYTES = 4096
 
 interface TerminalProps {
   sessionId: string
@@ -86,6 +102,11 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
   const themeApplied = useTheme((s) => s.applied())
   const { t } = useTranslation()
   const [dragActive, setDragActive] = useState(false)
+  // URLs spotted in this session's PTY output. Surfaced by the
+  // floating <DetectedURLs /> badge so the operator can tap one to
+  // open in a browser instead of fighting with line-wrapped text in
+  // the terminal — particularly useful for OAuth flows on mobile.
+  const [detectedURLs, setDetectedURLs] = useState<string[]>([])
 
   const sendInput = useCallback((data: string) => {
     const ws = wsRef.current
@@ -139,6 +160,11 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
   useEffect(() => {
     if (!containerRef.current || !token) return
 
+    // URL scanner state. Lives inside the effect so it resets when
+    // the session changes (different session ID → fresh URL list).
+    const textDecoder = new TextDecoder('utf-8', { fatal: false })
+    let urlScanTail = ''
+
     const term = new XTerm({
       fontFamily:
         '"JetBrains Mono Variable", "JetBrains Mono", ui-monospace, Menlo, Consolas, monospace',
@@ -169,7 +195,43 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     let alive = true
 
     const ws = new BinaryWS(wsURL(`/api/v1/sessions/${sessionId}/stream`, token), {
-      onMessage: (data) => term.write(data),
+      onMessage: (data) => {
+        term.write(data)
+        // Scan the same bytes we just gave xterm. Strip ANSI so colour
+        // resets in the middle of a URL don't truncate it; combine
+        // with the carry-over tail so URLs spanning the boundary
+        // between WS frames still match.
+        try {
+          const chunk = textDecoder.decode(data, { stream: true })
+          const combined = urlScanTail + stripANSI(chunk)
+          const found = extractURLs(combined)
+          if (found.length > 0) {
+            setDetectedURLs((prev) => {
+              const seen = new Set(prev)
+              const next = [...prev]
+              for (const u of found) {
+                if (!seen.has(u)) {
+                  seen.add(u)
+                  next.push(u)
+                }
+              }
+              // Cap retention — newest at the tail; oldest get
+              // dropped first when we overflow.
+              return next.length > MAX_DETECTED_URLS
+                ? next.slice(next.length - MAX_DETECTED_URLS)
+                : next
+            })
+          }
+          urlScanTail =
+            combined.length > URL_SCAN_TAIL_BYTES
+              ? combined.slice(combined.length - URL_SCAN_TAIL_BYTES)
+              : combined
+        } catch {
+          // URL extraction is best-effort. If decode / regex throws
+          // (malformed UTF-8, weird ANSI), drop this chunk's scan
+          // and keep the terminal stream flowing.
+        }
+      },
       onClose: () => {
         if (!alive) return
         term.writeln('')
@@ -312,6 +374,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
   return (
     <div className="h-full w-full bg-background relative">
       <div ref={containerRef} className="h-full w-full p-3" />
+      <DetectedURLs urls={detectedURLs} />
       {dragActive && (
         <div className="pointer-events-none absolute inset-2 rounded-md border-2 border-dashed border-accent/70 bg-accent/10 flex items-center justify-center">
           <div className="text-[12px] font-mono text-accent">

--- a/app/web/src/components/sessions/url-extractor.ts
+++ b/app/web/src/components/sessions/url-extractor.ts
@@ -1,0 +1,71 @@
+/**
+ * URL extraction helpers for the session terminal.
+ *
+ * Pulled out of DetectedURLs.tsx because:
+ *   - the regexes intentionally match ANSI control bytes, and that
+ *     trips eslint's `no-control-regex` only when it's inside a
+ *     `.tsx` (the eslint config tolerates control chars in `.ts`);
+ *   - keeping the helpers in a non-component file lets
+ *     `react-refresh/only-export-components` keep treating
+ *     DetectedURLs.tsx as a clean component module;
+ *   - unit-testing the regex behaviour is easier when there's no
+ *     React import in the test file.
+ */
+
+/**
+ * Match http(s) URLs in plain text (after ANSI stripping). Stops at
+ * whitespace, control chars, and angle brackets so adjacent UI text
+ * doesn't get rolled into the match.
+ */
+// eslint-disable-next-line no-control-regex -- \x00-\x1f are stop chars
+const URL_REGEX = /\bhttps?:\/\/[^\s<>"'\x00-\x1f]+/g
+
+export function extractURLs(text: string): string[] {
+  const matches = text.match(URL_REGEX)
+  if (!matches) return []
+  return matches.map(trimTrailingPunctuation).filter((u) => u.length > 0)
+}
+
+/**
+ * Drop sentence punctuation that almost never ends a URL. Handles
+ * the common "see https://example.com." → `https://example.com`
+ * case, plus stray `,` `;` `:` `!` `?` `'`. For `)` and `]` we only
+ * trim when there's no matching open bracket inside the URL — that
+ * preserves things like `https://example.com/foo(bar)`.
+ */
+function trimTrailingPunctuation(url: string): string {
+  let end = url.length
+  while (end > 0) {
+    const ch = url[end - 1]
+    if (
+      ch === '.' ||
+      ch === ',' ||
+      ch === ';' ||
+      ch === ':' ||
+      ch === '!' ||
+      ch === '?' ||
+      ch === '\'' ||
+      (ch === ')' && !url.slice(0, end - 1).includes('(')) ||
+      (ch === ']' && !url.slice(0, end - 1).includes('['))
+    ) {
+      end -= 1
+    } else {
+      break
+    }
+  }
+  return url.slice(0, end)
+}
+
+/**
+ * Strip ANSI CSI escape sequences from text so URL extraction isn't
+ * confused by colour resets or cursor moves embedded in the stream.
+ * Covers the only form we see in PTY output: ESC `[` followed by
+ * parameter bytes (digits / `;` / `?`) and a final letter — SGR
+ * (colours), DEC private modes, cursor positioning, etc.
+ */
+// eslint-disable-next-line no-control-regex -- \x1b is the literal ESC byte
+const ANSI_CSI_REGEX = /\x1b\[[0-9;?]*[a-zA-Z]/g
+
+export function stripANSI(text: string): string {
+  return text.replace(ANSI_CSI_REGEX, '')
+}


### PR DESCRIPTION
## The bug

Reported from a mobile browser pointed at the LXC's admin UI:
running `claude login` (or `codex` / `gemini`) prints a ~600-char
OAuth URL that visually wraps across 3-4 terminal rows. The
operator can't complete authentication because:

- The `WebLinksAddon` hit-box is per wrap segment, not per URL,
  so each tap opens just a fragment.
- Triple-click / long-press can't select across visual rows
  because those rows aren't real newlines — xterm soft-wraps a
  single underlying string.
- Manually re-assembling the URL by copy-pasting each segment is
  miserable on a phone.

Screenshot from the report:

```
https://claude.com/cai/oauth/authorize?code=true&client_id=…&sc
ope=org%3Acreate_api_key+user%3Aprofile+…&code_challenge=Qc_eu
I-DAmsPJP6k3f_Js0WlZvFklILlieYC2u7R3ZQ&code_challenge_method=S
256&state=cDpl1zmw6fvUZi9L71a1Yjo5Q20P3CUeAcxqwf5tnrM
```

## Fix

A floating "🔗 N links" badge in the top-right corner of the
terminal pane. Tap → Dialog with each detected URL as a row
carrying **Open** + **Copy** buttons.

| | |
|---|---|
| Open | `window.open(url, '_blank', 'noopener,noreferrer')` — hands off to the OS, which always opens the full URL regardless of terminal wrapping. |
| Copy | `navigator.clipboard.writeText(url)` with a toast. Falls back to `select-all` styling on the URL row so long-press copy works in mobile browsers that gate the Clipboard API (e.g. plain-HTTP origins, which is *exactly* the LXC case). |

The badge is hidden when no URLs have been seen, so it only
appears once the operator actually needs it.

## Scanner integration

Terminal.tsx hooks the existing WS `onMessage`. For each frame:

1. `term.write(data)` as before.
2. `TextDecoder('utf-8', { stream: true })` decodes the same bytes
   (the streaming flag handles multi-byte sequences split across
   PTY frames).
3. `stripANSI` removes CSI sequences so colour resets in the
   middle of a URL don't truncate it.
4. The result is appended to a 4 KB sliding tail so URLs
   spanning frame boundaries still match.
5. The combined window is regex-scanned for `\bhttps?://…`,
   trailing punctuation is trimmed, and the URLs are merged into
   a React state set capped at 50 (newest at the end).

Memory: O(1) regardless of session length thanks to the tail
window + cap.

## File layout

| File | Purpose |
|---|---|
| `DetectedURLs.tsx` | The component. Pure render + dialog wiring. |
| `url-extractor.ts` | Helpers (`extractURLs`, `stripANSI`). Pure functions, no React. Separate file because the regexes intentionally match control bytes — eslint's `no-control-regex` is silenced per-line, and react-refresh expects component files to export only components. |
| `Terminal.tsx` | Wires the scanner into `onMessage` + renders the badge. |
| `app/i18n/{en,zh}.json` | New keys under `web.sessions.terminal.urls.*`. |

## Verified

- `pnpm exec eslint <touched files>` — 0 errors (one pre-existing
  warning elsewhere left alone).
- `pnpm exec tsc -b` — clean.
- `pnpm exec vite build` — bundle builds.

## Out of scope here (likely follow-ups)

- The Flutter mobile app's session terminal uses a different
  renderer and needs its own URL-detector pass.
- Provider-aware detection — recognise the "Browser didn't open?"
  pattern to surface a richer "Sign in to Claude" CTA, with a QR
  code for cross-device auth. Layer this on top of the generic
  detector once it lands.

## Test plan

- [ ] Spawn a Claude session on the LXC, run `claude login`, view
      from a mobile browser pointed at the admin UI. Verify the
      "🔗 1 link" badge appears in the top-right, opens a dialog
      with the full URL, and the Open button launches Claude's
      OAuth flow in the phone's browser.
- [ ] Repeat with Codex (`codex login`) and Gemini (`gemini auth
      login`).
- [ ] Verify the badge count increments when multiple commands
      print URLs in the same session.
- [ ] Verify URLs split across WS frame boundaries still get
      captured (artificially harder to trigger; the 4 KB tail
      should make this trivial in practice).
- [ ] Desktop browser path — verify the dialog still renders
      cleanly on a wide screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)