### PR TITLE
feat(v2.0.2): one-tap URL open + start/stop/restart/status subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+## [v2.0.2] — 2026-05-18
+
+### Added
+
+- **Service-control subcommands**: `opendray start`, `opendray stop`,
+  `opendray restart`, `opendray status`. Thin wrappers over
+  `systemctl` (Linux) and `launchctl` (macOS) so operators don't
+  have to remember the platform-native incantation. On Linux, the
+  binary auto-prepends `sudo` if the caller isn't root. On macOS,
+  defaults to the user LaunchAgent (`gui/$UID/com.opendray.opendray`);
+  pass `--system` to target the LaunchDaemon scope.
+
+### Fixed
+
+- **One-tap link open for the OAuth URL badge.** When a session has
+  exactly one detected URL (the common AI-CLI auth case: `claude
+  login` / `gemini auth login` / `codex login` each print one OAuth
+  URL), the floating "🔗 1 link" badge is now itself an
+  `<a target="_blank">` — a single tap goes straight to the
+  browser, no intermediate dialog. The dialog still appears when
+  ≥ 2 URLs are detected, so multi-link sessions still get the
+  disambiguating UI. In the dialog, the "Open" button is also a
+  real anchor now, which avoids popup-blocker gating on some
+  mobile browsers.
+
 ## [v2.0.1] — 2026-05-18
 
 ### Removed

--- a/app/web/src/components/sessions/DetectedURLs.tsx
+++ b/app/web/src/components/sessions/DetectedURLs.tsx
@@ -1,18 +1,23 @@
 /**
- * DetectedURLs — floating "N links" badge above the xterm terminal.
+ * DetectedURLs — floating "links" badge above the xterm terminal.
  *
- * The xterm `WebLinksAddon` already makes single-line URLs clickable,
- * but OAuth URLs printed by AI CLIs (claude / codex / gemini) are
- * often 400-600 chars long and visually wrap across multiple lines.
- * Each wrap segment becomes a separate hyperlink hit-box that's
- * (a) tiny and easy to miss on touch, and (b) opens just the partial
- * fragment of the URL it covers.
+ * Two render paths so the common-case auth flow (one URL, one tap)
+ * doesn't get gated behind a dialog:
  *
- * This component sidesteps the wrap problem: the parent Terminal
- * scans PTY output for URLs, dedupes them, and renders this badge
- * when at least one URL has been seen. Tapping the badge opens a
- * Dialog with each URL as a full Open/Copy pair — works the same on
- * desktop and mobile (Dialog goes near-fullscreen below ~640px).
+ *   N = 1 URL : the badge is itself an `<a target="_blank">` — one
+ *               tap and the OAuth URL opens in the browser. No
+ *               dialog, no "Open" button to find. This is what
+ *               most AI-CLI auth flows produce, and the badge
+ *               existed mainly to rescue it.
+ *
+ *   N ≥ 2 URLs: the badge opens a dialog listing every URL with
+ *               its own `<a target="_blank">` Open button and a
+ *               clipboard Copy fallback. Same UI as before.
+ *
+ * Both render paths use real `<a target="_blank">` anchors instead
+ * of `window.open(url)` from a click handler — that matters on
+ * mobile Safari and some popup-blocker configs where button-driven
+ * window.open gets gated and silently no-ops.
  */
 
 import { useState } from 'react'
@@ -35,37 +40,52 @@ interface DetectedURLsProps {
   urls: string[]
 }
 
+const BADGE_BASE_CLASS =
+  'absolute top-2 right-2 z-10 inline-flex h-8 items-center gap-1.5 ' +
+  'rounded-md border border-border bg-secondary px-2.5 text-xs ' +
+  'font-medium text-secondary-foreground shadow-sm transition-colors ' +
+  'hover:bg-secondary/80 focus-visible:outline-none focus-visible:ring-2 ' +
+  'focus-visible:ring-ring'
+
 export function DetectedURLs({ urls }: DetectedURLsProps) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
 
   if (urls.length === 0) return null
 
-  const handleOpen = (url: string) => {
-    // `noopener,noreferrer` so the opened tab can't reach back into
-    // the admin SPA via window.opener — defence-in-depth even though
-    // the URL is one the operator literally just saw printed in
-    // their own session.
-    window.open(url, '_blank', 'noopener,noreferrer')
-  }
-
-  const handleCopy = async (url: string) => {
-    try {
-      await navigator.clipboard.writeText(url)
-      toast.success(t('web.sessions.terminal.urls.copiedToast'))
-    } catch {
-      // Some mobile browsers gate clipboard.writeText to https / secure
-      // contexts — if it throws, ask the user to long-press the URL
-      // in the dialog body (which has `select-all` for that purpose).
-      toast.error(t('web.sessions.terminal.urls.copyFailedToast'))
-    }
-  }
-
   const count = urls.length
   const buttonKey =
     count === 1
       ? 'web.sessions.terminal.urls.buttonLabel'
       : 'web.sessions.terminal.urls.buttonLabel_plural'
+  const buttonText = t(buttonKey, { count })
+
+  // ── One URL: badge IS the link. One tap → browser. ────────────────
+  if (count === 1) {
+    return (
+      <a
+        href={urls[0]}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={BADGE_BASE_CLASS}
+        title={t('web.sessions.terminal.urls.tooltip')}
+        aria-label={t('web.sessions.terminal.urls.tooltip')}
+      >
+        <ExternalLink className="size-3.5" />
+        {buttonText}
+      </a>
+    )
+  }
+
+  // ── Multiple URLs: badge opens dialog so user can pick. ───────────
+  const handleCopy = async (url: string) => {
+    try {
+      await navigator.clipboard.writeText(url)
+      toast.success(t('web.sessions.terminal.urls.copiedToast'))
+    } catch {
+      toast.error(t('web.sessions.terminal.urls.copyFailedToast'))
+    }
+  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -78,9 +98,7 @@ export function DetectedURLs({ urls }: DetectedURLsProps) {
           aria-label={t('web.sessions.terminal.urls.tooltip')}
         >
           <Link2 className="size-3.5" />
-          <span className="text-xs font-medium">
-            {t(buttonKey, { count })}
-          </span>
+          <span className="text-xs font-medium">{buttonText}</span>
         </Button>
       </DialogTrigger>
       <DialogContent className="max-w-[min(640px,95vw)]">
@@ -94,11 +112,6 @@ export function DetectedURLs({ urls }: DetectedURLsProps) {
         </DialogHeader>
         <ScrollArea className="max-h-[60vh]">
           <div className="space-y-2 pr-3">
-            {/* Reverse so the most recently seen URL is on top — that's
-             * almost always the one the operator is trying to act on.
-             * (Newest-first matches the auth flow: idle → CLI prints
-             * URL → user looks at the dialog → wants the one just
-             * printed.) */}
             {urls
               .slice()
               .reverse()
@@ -111,14 +124,16 @@ export function DetectedURLs({ urls }: DetectedURLsProps) {
                     {url}
                   </div>
                   <div className="flex gap-2">
-                    <Button
-                      size="sm"
-                      className="flex-1"
-                      onClick={() => handleOpen(url)}
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex h-9 flex-1 items-center justify-center gap-1.5 rounded-md bg-primary text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90"
+                      onClick={() => setOpen(false)}
                     >
-                      <ExternalLink className="mr-1.5 size-3.5" />
+                      <ExternalLink className="size-3.5" />
                       {t('web.sessions.terminal.urls.openButton')}
-                    </Button>
+                    </a>
                     <Button
                       size="sm"
                       variant="outline"
@@ -136,6 +151,3 @@ export function DetectedURLs({ urls }: DetectedURLsProps) {
     </Dialog>
   )
 }
-
-// URL extraction lives in `./url-extractor.ts` so this file remains
-// a clean component module (react-refresh expects that).

--- a/cmd/opendray/main.go
+++ b/cmd/opendray/main.go
@@ -2,8 +2,12 @@
 //
 // Subcommands:
 //
-//	opendray serve     [-config FILE]   start the gateway
+//	opendray serve     [-config FILE]   start the gateway (foreground; for systemd/launchd ExecStart)
 //	opendray migrate   [-config FILE]   apply pending DB migrations and exit
+//	opendray start                      start the systemd/launchd service
+//	opendray stop                       stop the systemd/launchd service
+//	opendray restart                    restart the systemd/launchd service
+//	opendray status                     show service status
 //	opendray update    [--check] [--force] [--yes] [--restart]
 //	                                    check + apply the latest released opendray binary
 //	opendray providers <subcommand> ... list / update the AI CLIs opendray spawns
@@ -47,6 +51,14 @@ func main() {
 		os.Exit(runUpdate(args))
 	case "providers":
 		os.Exit(runProviders(args))
+	case "start":
+		os.Exit(runStart(args))
+	case "stop":
+		os.Exit(runStop(args))
+	case "restart":
+		os.Exit(runRestart(args))
+	case "status":
+		os.Exit(runStatus(args))
 	case "notes":
 		os.Exit(runNotes(args))
 	case "skill":
@@ -98,8 +110,12 @@ func usage() {
 	fmt.Fprintln(os.Stderr, `opendray — multiplexer + integration gateway for AI agent CLIs
 
 usage:
-  opendray serve     [-config FILE]
+  opendray serve     [-config FILE]       (foreground; what the service unit's ExecStart calls)
   opendray migrate   [-config FILE]
+  opendray start                          (start the systemd / launchd service)
+  opendray stop                           (stop the service)
+  opendray restart                        (stop + start)
+  opendray status                         (show service status)
   opendray update    [--check] [--force] [--yes] [--restart]
                                           (download + replace this binary with the latest release;
                                            "opendray update --check" for a no-op version probe)

--- a/cmd/opendray/service.go
+++ b/cmd/opendray/service.go
@@ -1,0 +1,138 @@
+// Service-control subcommands.
+//
+//	opendray start    start the opendray service (systemd on Linux, launchd on macOS)
+//	opendray stop     stop the service
+//	opendray restart  stop+start
+//	opendray status   show service status
+//
+// These are thin shells over `systemctl` (Linux) and `launchctl`
+// (macOS) — they exist so operators don't have to remember the
+// platform-native incantation. Identical surface to the systemd / launchd
+// units the install wizard sets up.
+//
+// On Linux: privilege is delegated to systemctl. If the operator isn't
+// root, the binary prepends `sudo`; if there's no sudo and no root,
+// the user is told to run with elevation.
+//
+// On macOS: assumes the user LaunchAgent at `gui/$UID/com.opendray.opendray`
+// that the macOS installer creates by default. Pass `--system` to target
+// the LaunchDaemon scope instead (matches install-macos.sh's
+// `--launchd-daemon` flag).
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+const (
+	systemdUnitName = "opendray"
+	launchdLabel    = "com.opendray.opendray"
+)
+
+func runStart(args []string) int   { return runServiceAction("start", args) }
+func runStop(args []string) int    { return runServiceAction("stop", args) }
+func runRestart(args []string) int { return runServiceAction("restart", args) }
+func runStatus(args []string) int  { return runServiceAction("status", args) }
+
+func runServiceAction(action string, args []string) int {
+	fs := flag.NewFlagSet(action, flag.ExitOnError)
+	system := fs.Bool("system", false, "macOS only: target the system LaunchDaemon instead of the user LaunchAgent")
+	_ = fs.Parse(args)
+
+	switch runtime.GOOS {
+	case "linux":
+		return linuxService(action)
+	case "darwin":
+		return macService(action, *system)
+	default:
+		fmt.Fprintf(os.Stderr, "`opendray %s` is not supported on %s — use the platform-native service manager directly.\n", action, runtime.GOOS)
+		return 1
+	}
+}
+
+func linuxService(action string) int {
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		fmt.Fprintln(os.Stderr, "systemctl not found — `opendray start/stop/restart/status` requires systemd.")
+		return 1
+	}
+
+	var cmd *exec.Cmd
+	if os.Geteuid() == 0 {
+		cmd = exec.Command("systemctl", action, systemdUnitName)
+	} else if _, err := exec.LookPath("sudo"); err == nil {
+		cmd = exec.Command("sudo", "systemctl", action, systemdUnitName)
+	} else {
+		fmt.Fprintf(os.Stderr, "service control needs root; rerun as root or install sudo.\n  systemctl %s %s\n", action, systemdUnitName)
+		return 1
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode()
+		}
+		fmt.Fprintf(os.Stderr, "systemctl %s failed: %v\n", action, err)
+		return 1
+	}
+	return 0
+}
+
+func macService(action string, system bool) int {
+	if _, err := exec.LookPath("launchctl"); err != nil {
+		fmt.Fprintln(os.Stderr, "launchctl not found — wrong macOS?")
+		return 1
+	}
+
+	var target string
+	if system {
+		target = "system/" + launchdLabel
+	} else {
+		target = fmt.Sprintf("gui/%d/%s", os.Getuid(), launchdLabel)
+	}
+
+	var cmd *exec.Cmd
+	switch action {
+	case "start":
+		cmd = exec.Command("launchctl", "kickstart", target)
+	case "stop":
+		// `bootout` removes the loaded unit so a future `start` has to
+		// `bootstrap` it again. For a pure "pause", we'd use `kill TERM`,
+		// but the user expectation of `stop` matches the install wizard's
+		// "stop the service entirely" semantics.
+		cmd = exec.Command("launchctl", "bootout", target)
+	case "restart":
+		cmd = exec.Command("launchctl", "kickstart", "-k", target)
+	case "status":
+		cmd = exec.Command("launchctl", "print", target)
+	default:
+		fmt.Fprintf(os.Stderr, "internal error: unknown action %q\n", action)
+		return 2
+	}
+
+	if system && os.Geteuid() != 0 {
+		if _, err := exec.LookPath("sudo"); err != nil {
+			fmt.Fprintln(os.Stderr, "system-scope launchd commands need root; rerun with sudo.")
+			return 1
+		}
+		// Prepend sudo by re-wrapping argv.
+		newArgs := append([]string{cmd.Path}, cmd.Args[1:]...)
+		cmd = exec.Command("sudo", newArgs...)
+	}
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode()
+		}
+		fmt.Fprintf(os.Stderr, "launchctl %s failed: %v\n", action, err)
+		return 1
+	}
+	return 0
+}


### PR DESCRIPTION
## Two issues reported on v2.0.1

### 1. URL badge still required two taps for OAuth

Screenshot showed the badge ("🔗 1 个链接") rendering correctly, but
the operator still had to tap badge → wait for dialog → tap "Open"
just to launch one URL in the browser. For AI-CLI auth flows that
**always** print exactly one URL, that's one tap too many and the
dialog adds no value (nothing to disambiguate).

### 2. No `opendray start / stop`

Operators had to switch to `systemctl start opendray` / `launchctl
kickstart …` even though the binary already self-manages everything
else (`opendray update`, `opendray providers update`, etc.).

## Fix 1: badge becomes a direct link when N=1

`DetectedURLs.tsx` now has two render paths:

| N | Render | Tap behaviour |
|---|---|---|
| 1 | `<a href={url} target="_blank">` styled as a badge | tap → browser opens the URL |
| ≥ 2 | Existing dialog with Open + Copy per row | tap → dialog → pick one |

Inside the dialog, the **Open** buttons are now real `<a target="_blank">` anchors instead of buttons calling `window.open()`. Some mobile-Safari + popup-blocker configs gate button-driven `window.open` even from a direct click handler; anchor navigation isn't blocked.

No i18n changes — the existing copy reads correctly in both paths.

## Fix 2: `opendray start / stop / restart / status`

New file `cmd/opendray/service.go`. All four subcommands are thin
wrappers over the platform-native service manager.

| Platform | Action map | Privilege |
|---|---|---|
| Linux | `systemctl <action> opendray` | auto-prepend `sudo` when not root |
| macOS | `launchctl kickstart` / `bootout` / `kickstart -k` / `print` on `gui/$UID/com.opendray.opendray` | user LaunchAgent default; `--system` switches to `system/<label>` LaunchDaemon |

```
$ opendray --help
…
opendray start                          (start the systemd / launchd service)
opendray stop                           (stop the service)
opendray restart                        (stop + start)
opendray status                         (show service status)
…
```

Privilege escalation:
- Linux non-root: prepends `sudo`. If no sudo and no root, prints
  the exact systemctl command the operator should run themselves
  (no silent failure).
- macOS `--system` non-root: prepends `sudo` for the launchctl call.

`stop` uses `bootout` (remove loaded unit) instead of `kill TERM`
because the operator's expectation of "stop the service" matches
the install wizard's "stop and unload" semantics. A future
`pause`/`resume` could use SIGTERM/SIGCONT if there's demand.

## Verified

| Check | Result |
|---|---|
| `go build ./cmd/opendray` | clean |
| `go vet ./cmd/opendray/...` | clean |
| `golangci-lint run` | 0 issues |
| `go test -race ./cmd/opendray/...` | pass |
| `pnpm exec tsc -b` | clean |
| `pnpm exec eslint <touched>` | 0 errors |
| `pnpm exec vite build` | builds |
| `opendray status` on Mac with installed LaunchAgent | prints correct launchctl snapshot |

## Test plan after merge

- [ ] Tag v2.0.2 → release workflow produces 4 tarballs + signed SHA256SUMS.
- [ ] `sudo opendray update --restart` on the LXC → version bumps to 2.0.2.
- [ ] `opendray stop` then `opendray start` then `opendray status` → service cycles correctly.
- [ ] Web admin: spawn a Claude session, run `claude login`, verify the badge appears as "🔗 1 link" and a single tap on it opens the OAuth URL in a new tab (no intermediate dialog).
- [ ] Mobile browser: same flow — single tap on the badge launches the OS browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)