### PR TITLE
fix(web/terminal): re-assemble CLI-soft-wrapped OAuth URLs (the real bug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+## [v2.0.4] — 2026-05-18
+
+### Fixed
+
+- **URL extractor now re-assembles CLI-soft-wrapped URLs.** AI CLIs
+  (claude-code, codex, gemini) hard-wrap long OAuth URLs at the
+  terminal column width by emitting literal `\n` characters every
+  ~55 chars. The v2.0.1 / v2.0.2 / v2.0.3 extractor used a `[^\s]+`
+  regex that stops at `\n`, so it captured only the first wrapped
+  segment (e.g. `https://...&client_`). Tapping the badge opened a
+  truncated URL, the OAuth provider rejected it, and the operator
+  couldn't authenticate.
+
+  The extractor is now a state-machine walker that anchors on
+  `https?://`, consumes URL-body characters, and treats a single
+  internal `\n` as a soft-wrap when the current line is ≥ 40 chars
+  long (matches real CLI wrap width; well above "<intro phrase>\n
+  <url>" prose patterns). Paragraph breaks (`\n\n`), single
+  newlines followed by non-URL characters, and short prose lines
+  still terminate the URL correctly.
+
+  Verified against the actual 450-char claude-code OAuth URL that
+  was failing in production: extractor now produces ONE complete
+  URL (vs. two truncated segments).
+
 ## [v2.0.3] — 2026-05-18
 
 ### Fixed

--- a/app/web/src/components/sessions/url-extractor.ts
+++ b/app/web/src/components/sessions/url-extractor.ts
@@ -1,29 +1,141 @@
 /**
  * URL extraction helpers for the session terminal.
  *
- * Pulled out of DetectedURLs.tsx because:
- *   - the regexes intentionally match ANSI control bytes, and that
- *     trips eslint's `no-control-regex` only when it's inside a
- *     `.tsx` (the eslint config tolerates control chars in `.ts`);
- *   - keeping the helpers in a non-component file lets
- *     `react-refresh/only-export-components` keep treating
- *     DetectedURLs.tsx as a clean component module;
- *   - unit-testing the regex behaviour is easier when there's no
- *     React import in the test file.
+ * Pulled out of DetectedURLs.tsx because the regexes intentionally
+ * match ANSI control bytes (eslint's `no-control-regex` only trips
+ * on `.tsx` here), and to keep DetectedURLs.tsx a clean component
+ * module for `react-refresh/only-export-components`.
  */
 
 /**
- * Match http(s) URLs in plain text (after ANSI stripping). Stops at
- * whitespace, control chars, and angle brackets so adjacent UI text
- * doesn't get rolled into the match.
+ * URL syntax characters per RFC 3986 — the body of an http(s) URL
+ * is any of these. Used by the state-machine walker below to decide
+ * whether a `\n` mid-URL is a CLI-inserted soft-wrap (continue) or
+ * a real terminator (stop).
  */
-// eslint-disable-next-line no-control-regex -- \x00-\x1f are stop chars
-const URL_REGEX = /\bhttps?:\/\/[^\s<>"'\x00-\x1f]+/g
+const URL_BODY_CHAR = /[A-Za-z0-9!$&'()*+,\-./:;=?@_~%#[\]]/
+
+/**
+ * Strip ANSI CSI escape sequences from text so URL extraction isn't
+ * confused by colour resets or cursor moves embedded in the stream.
+ */
+// eslint-disable-next-line no-control-regex -- \x1b is the literal ESC byte
+const ANSI_CSI_REGEX = /\x1b\[[0-9;?]*[a-zA-Z]/g
+
+export function stripANSI(text: string): string {
+  return text.replace(ANSI_CSI_REGEX, '')
+}
+
+/**
+ * Extract http(s) URLs from text. Handles the case AI CLIs (notably
+ * claude-code) actively hard-wrap long OAuth URLs across multiple
+ * terminal lines by inserting literal `\n` chars every N columns:
+ *
+ *     https://claude.com/cai/oauth/authorize?code=true&client_
+ *     id=9d1c250a-...&state=oJ-...
+ *
+ * A naive `\bhttps?://[^\s]+` regex stops at the first `\n` and
+ * captures only the first soft-wrapped segment — exactly the bug
+ * the v2.0.3 badge ran into. (Pre-processing the text to strip
+ * `\n`-between-URL-chars almost works, but it also destroys word
+ * boundaries between prose lines and gluing "open\nhttps://…" into
+ * one word makes the `\b` anchor fail entirely.)
+ *
+ * Approach instead: anchor on `https?://`, then walk char by char,
+ * consuming URL-body chars (and skipping ONE intermediate `\r`/`\n`
+ * if it's followed by another URL-body char). Stop on:
+ *   - Real horizontal whitespace (` `, `\t`)
+ *   - Quote / angle bracket (`"`, `'`, `<`, `>`)
+ *   - Two or more consecutive newlines (paragraph break)
+ *   - Single newline followed by non-URL char (prose continuation)
+ *   - Other ASCII control characters
+ *
+ * Embedded `\n`s are stripped from the captured URL before return.
+ */
+const URL_START_REGEX = /https?:\/\//g
+
+// Minimum length of the "current line" for a single `\n` to be treated
+// as a CLI soft-wrap. Lines shorter than this are assumed to be real
+// content breaks (prose, multi-paragraph output, …). 40 cols is well
+// below where AI CLIs actually wrap (~55-80) but well above any
+// realistic "<intro phrase>\n<url>" prose pattern.
+const SOFT_WRAP_MIN_LINE_LEN = 40
 
 export function extractURLs(text: string): string[] {
-  const matches = text.match(URL_REGEX)
-  if (!matches) return []
-  return matches.map(trimTrailingPunctuation).filter((u) => u.length > 0)
+  const results = new Set<string>()
+  // Reset lastIndex on a fresh regex object so the walker doesn't
+  // accidentally pick up state from a sibling exec elsewhere.
+  URL_START_REGEX.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = URL_START_REGEX.exec(text)) !== null) {
+    const start = match.index
+    let i = start + match[0].length // skip past `https://` so we don't immediately re-match
+    while (i < text.length) {
+      const ch = text[i]
+      const code = ch.charCodeAt(0)
+
+      // Hard terminators — these never appear inside URLs.
+      if (
+        ch === ' ' ||
+        ch === '\t' ||
+        ch === '<' ||
+        ch === '>' ||
+        ch === '"' ||
+        ch === "'"
+      ) {
+        break
+      }
+
+      // Newlines: allow up to one INTERNAL newline as a CLI soft-wrap;
+      // two consecutive newlines = paragraph break and the URL is done.
+      if (ch === '\n' || ch === '\r') {
+        let j = i + 1
+        let nlCount = ch === '\n' ? 1 : 0
+        // Sweep through the CR/LF run so `\r\n` counts as ONE newline.
+        while (j < text.length && (text[j] === '\n' || text[j] === '\r')) {
+          if (text[j] === '\n') nlCount++
+          j++
+        }
+        if (nlCount >= 2) break // paragraph break terminates
+        if (j >= text.length) break // trailing newline at end of buffer
+        if (!URL_BODY_CHAR.test(text[j])) break // followed by non-URL prose
+
+        // Heuristic — distinguish a CLI soft-wrap (continue) from a real
+        // paragraph break that happens to be followed by URL-body chars
+        // (stop). claude-code / codex / gemini wrap long URLs at the
+        // terminal column width (~55-80); prose lines like "see\nhttps://x"
+        // are usually < 40 chars before the break. If the CURRENT line is
+        // shorter than the wrap-width floor, treat the `\n` as real and
+        // stop the URL there.
+        const prevNlIdx = text.lastIndexOf('\n', i - 1)
+        const currentLineStart = prevNlIdx === -1 ? 0 : prevNlIdx + 1
+        const currentLineLen = i - currentLineStart
+        if (currentLineLen < SOFT_WRAP_MIN_LINE_LEN) break
+
+        // Single newline with URL-body chars on both sides + a "long"
+        // current line: CLI soft-wrap. Skip the newline, continue.
+        i = j
+        continue
+      }
+
+      // Other control chars terminate.
+      if (code < 0x20) break
+
+      i++
+    }
+
+    const raw = text.slice(start, i).replace(/[\r\n]+/g, '')
+    const cleaned = trimTrailingPunctuation(raw)
+    if (cleaned.length > 0) {
+      results.add(cleaned)
+    }
+
+    // Advance the start regex past the URL we just consumed so we
+    // don't try to start a new match inside it (where a URL-encoded
+    // `https%3A%2F%2F` lives, for instance).
+    URL_START_REGEX.lastIndex = i
+  }
+  return Array.from(results)
 }
 
 /**
@@ -54,18 +166,4 @@ function trimTrailingPunctuation(url: string): string {
     }
   }
   return url.slice(0, end)
-}
-
-/**
- * Strip ANSI CSI escape sequences from text so URL extraction isn't
- * confused by colour resets or cursor moves embedded in the stream.
- * Covers the only form we see in PTY output: ESC `[` followed by
- * parameter bytes (digits / `;` / `?`) and a final letter — SGR
- * (colours), DEC private modes, cursor positioning, etc.
- */
-// eslint-disable-next-line no-control-regex -- \x1b is the literal ESC byte
-const ANSI_CSI_REGEX = /\x1b\[[0-9;?]*[a-zA-Z]/g
-
-export function stripANSI(text: string): string {
-  return text.replace(ANSI_CSI_REGEX, '')
 }


### PR DESCRIPTION
## The real bug

v2.0.3 made the badge a direct anchor. But the **anchor target was
wrong** — it pointed at a truncated URL. From the reporter's
screenshot:

```
Detected:  https://claude.com/cai/oauth/authorize?code=true&client_
Detected:  https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c2
Real URL:  https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-...&state=oJ-...T1bc  (450 chars)
```

The badge "worked" — the anchor navigated — but landed on a URL the
OAuth provider rejected, so the operator still couldn't auth. Two
truncated entries got captured because the PTY bytes arrived in two
chunks and each chunk's snapshot of the URL ended at a different
soft-wrap.

## Why the regex was wrong

AI CLIs (claude-code, codex, gemini) **hard-wrap** long URLs by
emitting literal `\n` every ~55 chars. The PTY byte stream
contains:

```
https://claude.com/cai/oauth/authorize?code=true&client_
id=9d1c250a-e61b-44d9-88ed-5944d1962f5e&response_type=co
de&redirect_uri=https%3A%2F%2Fplatform.claude.com%2Foaut
...
```

The old extractor regex was `/\bhttps?:\/\/[^\s<>"'\x00-\x1f]+/g`,
which stops at `\n` (it's in `\s`). So it captured only
`https://...&client_` — a 50-char prefix that won't authenticate.

## Fix — state-machine walker

Replace the regex with a small state machine that:

1. Anchors on `https?://`.
2. Greedy consumes URL-body characters (RFC 3986 set).
3. On `\n` / `\r`:
   - 2+ consecutive newlines → STOP (paragraph break).
   - Single newline followed by non-URL char → STOP (prose continuation).
   - Single newline followed by URL char + current line ≥ 40 chars → CONTINUE (CLI soft-wrap).
   - Single newline followed by URL char + current line < 40 chars → STOP (short prose line).
4. Other terminators (space, tab, `<`, `>`, `"`, `'`, control chars) stop normally.
5. Strip captured embedded `\r`/`\n` before returning.

Why **40 chars**: CLIs wrap URLs at the terminal column width
(~55-80), always above 40. Realistic prose patterns like
`"see\nhttps://x"` or `"end of sentence.\nNext"` are virtually
always < 40 chars on the intro line. The line-length check is what
keeps `"see\nhttps://x.com"` from being glued into one URL.

## Verified

Real claude-code OAuth output (the one from the reporter's
screenshot, 450 chars when reassembled):

```
input  → 8 wrapped lines, ending in '...Sa3T1\nbc\n\nPaste code...'
output → 1 URL, 450 chars, ending in '...Sa3T1bc'
```

Edge-case sweep (Node.js smoke):

| Case | Result |
|---|---|
| Soft-wrapped 450-char OAuth URL | ✓ one full URL |
| `see\nhttps://x.com\nMore` (prose intro < 40 chars) | ✓ no glue |
| URL with trailing sentence period | ✓ trimmed |
| Two distinct URLs on same line | ✓ both |
| URL with parens in path | ✓ |
| URL inside quotes | ✓ |
| No URL | ✓ empty |
| URL at end-of-buffer no newline | ✓ |

`pnpm exec tsc -b` / `pnpm exec eslint <touched>` / `pnpm exec vite build` all clean.

## Test plan

- [ ] Mobile browser: spawn Claude session, run `claude login`,
      verify the badge appears as **"🔗 1 link"** (not 2), tap it,
      mobile browser opens the **full** OAuth URL and Claude's auth
      screen renders.
- [ ] Repeat with `gemini auth login` and `codex login`.
- [ ] Confirm that a normal short URL in prose still gets detected
      (`"see https://example.com for more"`).
- [ ] Multi-URL session (e.g. several distinct links in scrollback)
      still works — the `⋯` button still opens the dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)