### PR TITLE
feat(v2.0.5): Flutter mobile URL detector + remove web login "admin" default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+## [v2.0.5] — 2026-05-18
+
+### Added
+
+- **Flutter mobile session terminal now has the URL detector
+  badge.** Same model as the web admin: the PTY byte stream is
+  scanned for http(s) URLs with the same state-machine extractor
+  that re-assembles CLI-soft-wrapped OAuth URLs. A floating pill
+  in the top-right corner of the terminal — primary tap opens the
+  most recent URL in the OS browser via `url_launcher`, secondary
+  `⋯` button opens a bottom-sheet with every URL (newest first)
+  for picking older ones. Closes the OAuth-on-Flutter-app gap
+  reported alongside the web fix.
+
+### Changed
+
+- **Web login no longer pre-fills the username with "admin".** The
+  install wizard lets operators pick any username, so seeding the
+  field forced everyone-who-didn't-keep-the-default to backspace
+  before typing. The field is now empty by default and autofocused.
+
 ## [v2.0.4] — 2026-05-18
 
 ### Fixed

--- a/app/mobile/lib/features/sessions/session_terminal_view.dart
+++ b/app/mobile/lib/features/sessions/session_terminal_view.dart
@@ -11,6 +11,8 @@ import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/sessions_api.dart';
 import 'package:opendray/core/auth/auth_state.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/sessions/url_extractor.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:xterm/xterm.dart';
 
@@ -50,6 +52,19 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
   // identical payloads on every layout pass.
   int _lastCols = 0;
   int _lastRows = 0;
+
+  // URL detector state — same model as the web admin's badge:
+  //   - Scan PTY bytes for http(s) URLs as they stream in.
+  //   - Keep the most recent ones in insertion order (dedup'd).
+  //   - Surface a floating "Open latest link" button (Stack overlay)
+  //     so OAuth flows on mobile aren't gated behind manual
+  //     copy-paste of a hard-wrapped URL.
+  // The 4 KB tail handles URLs spanning a WS frame boundary
+  // (a single OAuth URL is ~450 chars, well under 4 KB).
+  static const _urlScanTailBytes = 4096;
+  static const _maxDetectedUrls = 50;
+  final List<String> _detectedUrls = <String>[];
+  String _urlScanTail = '';
 
   @override
   void initState() {
@@ -193,9 +208,13 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
       setState(() => _state = _ConnState.connected);
     }
     if (msg is Uint8List) {
-      _terminal.write(_decode(msg));
+      final decoded = _decode(msg);
+      _terminal.write(decoded);
+      _scanForUrls(decoded);
     } else if (msg is List<int>) {
-      _terminal.write(_decode(Uint8List.fromList(msg)));
+      final decoded = _decode(Uint8List.fromList(msg));
+      _terminal.write(decoded);
+      _scanForUrls(decoded);
     } else if (msg is String) {
       // Server sends control frames (e.g. {"type":"ended"}) as text.
       // We don't render them on the terminal; flip state instead.
@@ -205,6 +224,169 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
         }
       }
     }
+  }
+
+  void _scanForUrls(String chunk) {
+    try {
+      final combined = _urlScanTail + stripAnsi(chunk);
+      final found = extractUrls(combined);
+      if (found.isNotEmpty) {
+        var changed = false;
+        final seen = _detectedUrls.toSet();
+        for (final u in found) {
+          if (!seen.contains(u)) {
+            seen.add(u);
+            _detectedUrls.add(u);
+            changed = true;
+          }
+        }
+        // Cap the list at MAX_DETECTED_URLS — newest stay, oldest go.
+        if (_detectedUrls.length > _maxDetectedUrls) {
+          _detectedUrls.removeRange(
+            0,
+            _detectedUrls.length - _maxDetectedUrls,
+          );
+          changed = true;
+        }
+        if (changed && mounted) setState(() {});
+      }
+      _urlScanTail = combined.length > _urlScanTailBytes
+          ? combined.substring(combined.length - _urlScanTailBytes)
+          : combined;
+    } on Object catch (_) {
+      // URL extraction is best-effort. If anything throws (malformed
+      // UTF-8 cluster, etc.), drop this chunk's scan and keep the
+      // terminal flowing.
+    }
+  }
+
+  Future<void> _openDetectedUrl(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    try {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } on Object catch (_) {
+      // If the launcher rejects the URL (sandbox / unsupported
+      // scheme) we silently no-op — the operator can fall back to
+      // long-pressing the URL in the terminal.
+    }
+  }
+
+  Future<void> _showDetectedUrlsSheet(BuildContext context) async {
+    // Newest first — matches the badge's primary-tap target and the
+    // most likely thing the operator wants to act on.
+    final ordered = _detectedUrls.reversed.toList(growable: false);
+    await showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: const Color(0xFF1A1A1F),
+      isScrollControlled: true,
+      builder: (sheetCtx) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const Text(
+                  'Detected links',
+                  style: TextStyle(
+                    color: Color(0xFFE7E7EA),
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                const Text(
+                  'URLs printed in this session’s output. Tap Open '
+                  'to launch in your default browser.',
+                  style: TextStyle(
+                    color: Color(0xFF9999A0),
+                    fontSize: 12,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Flexible(
+                  child: ListView.separated(
+                    shrinkWrap: true,
+                    itemCount: ordered.length,
+                    separatorBuilder: (_, __) =>
+                        const SizedBox(height: 10),
+                    itemBuilder: (_, idx) {
+                      final url = ordered[idx];
+                      return Container(
+                        padding: const EdgeInsets.all(10),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFF222227),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Column(
+                          crossAxisAlignment:
+                              CrossAxisAlignment.stretch,
+                          children: [
+                            SelectableText(
+                              url,
+                              style: const TextStyle(
+                                color: Color(0xFFE7E7EA),
+                                fontSize: 11,
+                                fontFamily: 'monospace',
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            Row(
+                              children: [
+                                Expanded(
+                                  child: FilledButton.icon(
+                                    icon: const Icon(
+                                      Icons.open_in_new,
+                                      size: 16,
+                                    ),
+                                    label: const Text('Open'),
+                                    onPressed: () {
+                                      Navigator.of(sheetCtx).pop();
+                                      _openDetectedUrl(url);
+                                    },
+                                  ),
+                                ),
+                                const SizedBox(width: 8),
+                                Expanded(
+                                  child: OutlinedButton.icon(
+                                    icon: const Icon(
+                                      Icons.copy,
+                                      size: 16,
+                                    ),
+                                    label: const Text('Copy'),
+                                    onPressed: () async {
+                                      await Clipboard.setData(
+                                        ClipboardData(text: url),
+                                      );
+                                      if (sheetCtx.mounted) {
+                                        ScaffoldMessenger.of(sheetCtx)
+                                            .showSnackBar(
+                                          const SnackBar(
+                                            content: Text(
+                                              'URL copied',
+                                            ),
+                                          ),
+                                        );
+                                      }
+                                    },
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
   }
 
   String _decode(Uint8List bytes) {
@@ -446,39 +628,54 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
             onRetry: _state == _ConnState.error ? _retryNow : null,
           ),
         Expanded(
-          child: ColoredBox(
-            color: const Color(0xFF101012),
-            child: TerminalView(
-              _terminal,
-              controller: _controller,
-              autofocus: true,
-              backgroundOpacity: 1,
-              theme: const TerminalTheme(
-                cursor: Color(0xFFE6AE57),
-                selection: Color(0x66E6AE57),
-                foreground: Color(0xFFE7E7EA),
-                background: Color(0xFF101012),
-                black: Color(0xFF000000),
-                red: Color(0xFFE07A5F),
-                green: Color(0xFF8AD18A),
-                yellow: Color(0xFFE6AE57),
-                blue: Color(0xFF7AA9DA),
-                magenta: Color(0xFFC678DD),
-                cyan: Color(0xFF6FBFC4),
-                white: Color(0xFFE7E7EA),
-                brightBlack: Color(0xFF555555),
-                brightRed: Color(0xFFFF8C72),
-                brightGreen: Color(0xFFA8E1A8),
-                brightYellow: Color(0xFFFFD08A),
-                brightBlue: Color(0xFF8FBEEF),
-                brightMagenta: Color(0xFFD79DEC),
-                brightCyan: Color(0xFF8BD5DA),
-                brightWhite: Color(0xFFFFFFFF),
-                searchHitBackground: Color(0xFF66492A),
-                searchHitBackgroundCurrent: Color(0xFF8C5C2E),
-                searchHitForeground: Color(0xFFFFFFFF),
+          child: Stack(
+            children: [
+              ColoredBox(
+                color: const Color(0xFF101012),
+                child: TerminalView(
+                  _terminal,
+                  controller: _controller,
+                  autofocus: true,
+                  backgroundOpacity: 1,
+                  theme: const TerminalTheme(
+                    cursor: Color(0xFFE6AE57),
+                    selection: Color(0x66E6AE57),
+                    foreground: Color(0xFFE7E7EA),
+                    background: Color(0xFF101012),
+                    black: Color(0xFF000000),
+                    red: Color(0xFFE07A5F),
+                    green: Color(0xFF8AD18A),
+                    yellow: Color(0xFFE6AE57),
+                    blue: Color(0xFF7AA9DA),
+                    magenta: Color(0xFFC678DD),
+                    cyan: Color(0xFF6FBFC4),
+                    white: Color(0xFFE7E7EA),
+                    brightBlack: Color(0xFF555555),
+                    brightRed: Color(0xFFFF8C72),
+                    brightGreen: Color(0xFFA8E1A8),
+                    brightYellow: Color(0xFFFFD08A),
+                    brightBlue: Color(0xFF8FBEEF),
+                    brightMagenta: Color(0xFFD79DEC),
+                    brightCyan: Color(0xFF8BD5DA),
+                    brightWhite: Color(0xFFFFFFFF),
+                    searchHitBackground: Color(0xFF66492A),
+                    searchHitBackgroundCurrent: Color(0xFF8C5C2E),
+                    searchHitForeground: Color(0xFFFFFFFF),
+                  ),
+                ),
               ),
-            ),
+              if (_detectedUrls.isNotEmpty)
+                Positioned(
+                  top: 8,
+                  right: 8,
+                  child: _DetectedUrlBadge(
+                    urls: _detectedUrls,
+                    onTapLatest: () =>
+                        _openDetectedUrl(_detectedUrls.last),
+                    onOpenList: () => _showDetectedUrlsSheet(context),
+                  ),
+                ),
+            ],
           ),
         ),
         _MobileKeyboardBar(
@@ -831,5 +1028,121 @@ class _Key extends StatelessWidget {
     );
     final t = tooltip;
     return t != null ? Tooltip(message: t, child: body) : body;
+  }
+}
+
+class _DetectedUrlBadge extends StatelessWidget {
+  const _DetectedUrlBadge({
+    required this.urls,
+    required this.onTapLatest,
+    required this.onOpenList,
+  });
+
+  final List<String> urls;
+  final VoidCallback onTapLatest;
+  final VoidCallback onOpenList;
+
+  @override
+  Widget build(BuildContext context) {
+    final count = urls.length;
+    final label = count == 1 ? '$count link' : '$count links';
+
+    // N = 1: single tappable pill.
+    if (count == 1) {
+      return Material(
+        color: const Color(0xFF222227),
+        borderRadius: BorderRadius.circular(8),
+        elevation: 2,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(8),
+          onTap: onTapLatest,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(
+                  Icons.open_in_new,
+                  size: 14,
+                  color: Color(0xFFE7E7EA),
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  label,
+                  style: const TextStyle(
+                    color: Color(0xFFE7E7EA),
+                    fontSize: 12,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    // N ≥ 2: split pill — left tap opens the latest URL, right
+    // tap opens the multi-URL sheet for picking older ones.
+    return Material(
+      color: const Color(0xFF222227),
+      borderRadius: BorderRadius.circular(8),
+      elevation: 2,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          InkWell(
+            borderRadius: const BorderRadius.only(
+              topLeft: Radius.circular(8),
+              bottomLeft: Radius.circular(8),
+            ),
+            onTap: onTapLatest,
+            child: Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(
+                    Icons.open_in_new,
+                    size: 14,
+                    color: Color(0xFFE7E7EA),
+                  ),
+                  const SizedBox(width: 6),
+                  Text(
+                    label,
+                    style: const TextStyle(
+                      color: Color(0xFFE7E7EA),
+                      fontSize: 12,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Container(
+            width: 1,
+            height: 20,
+            color: const Color(0xFF3A3A40),
+          ),
+          InkWell(
+            borderRadius: const BorderRadius.only(
+              topRight: Radius.circular(8),
+              bottomRight: Radius.circular(8),
+            ),
+            onTap: onOpenList,
+            child: const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              child: Icon(
+                Icons.more_horiz,
+                size: 16,
+                color: Color(0xFFE7E7EA),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/app/mobile/lib/features/sessions/url_extractor.dart
+++ b/app/mobile/lib/features/sessions/url_extractor.dart
@@ -1,0 +1,140 @@
+// URL extraction for the Flutter mobile session terminal.
+//
+// Mirrors the algorithm in
+// app/web/src/components/sessions/url-extractor.ts — anchor on
+// `https?://`, walk char-by-char, allow ONE intermediate `\n` as a
+// CLI soft-wrap when the current line is long enough that wrapping
+// was plausible.
+//
+// Why a state machine and not a plain regex: AI CLIs (claude-code,
+// codex, gemini) hard-wrap long OAuth URLs at the terminal column
+// width by emitting literal `\n` characters every ~55 chars. A
+// `\bhttps?://[^\s]+` regex stops at the first `\n` and captures
+// only the first wrapped segment. The user ends up tapping a
+// truncated URL and OAuth fails. See the web extractor's docstring
+// for the long version.
+
+import 'dart:convert';
+
+/// Strip ANSI CSI escape sequences (colour resets, cursor moves)
+/// so the URL extractor isn't confused by them.
+final _ansiCsiRegex = RegExp(r'\x1B\[[0-9;?]*[a-zA-Z]');
+String stripAnsi(String text) => text.replaceAll(_ansiCsiRegex, '');
+
+/// URL syntax characters per RFC 3986 — the body of an http(s) URL
+/// is any of these. Used by the state machine to decide whether a
+/// `\n` mid-URL is a CLI soft-wrap (continue) or a real terminator
+/// (stop).
+bool _isUrlBodyChar(String ch) {
+  final c = ch.codeUnitAt(0);
+  // A-Z, a-z, 0-9
+  if (c >= 0x30 && c <= 0x39) return true;
+  if (c >= 0x41 && c <= 0x5A) return true;
+  if (c >= 0x61 && c <= 0x7A) return true;
+  // ! $ & ' ( ) * + , - . / : ; = ? @ _ ~ % # [ ]
+  const others = {
+    0x21, 0x24, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D,
+    0x2E, 0x2F, 0x3A, 0x3B, 0x3D, 0x3F, 0x40, 0x5B, 0x5D, 0x5F,
+    0x7E, 0x25, 0x23,
+  };
+  return others.contains(c);
+}
+
+// Same rationale + value as the web extractor: minimum length of the
+// "current line" for a single `\n` to be treated as a soft-wrap.
+const _softWrapMinLineLen = 40;
+
+final _urlStartRegex = RegExp('https?://');
+
+/// Extract http(s) URLs from text, including those the CLI has
+/// hard-wrapped onto multiple lines. Returns URLs in the order
+/// they were encountered, deduped.
+List<String> extractUrls(String text) {
+  final results = <String>{};
+  for (final match in _urlStartRegex.allMatches(text)) {
+    final start = match.start;
+    var i = start + match.group(0)!.length;
+
+    while (i < text.length) {
+      final ch = text[i];
+      final code = ch.codeUnitAt(0);
+
+      // Hard terminators — never appear inside URLs.
+      if (ch == ' ' ||
+          ch == '\t' ||
+          ch == '<' ||
+          ch == '>' ||
+          ch == '"' ||
+          ch == "'") {
+        break;
+      }
+
+      // Newlines — allow ONE as CLI soft-wrap when conditions match.
+      if (ch == '\n' || ch == '\r') {
+        var j = i + 1;
+        var nlCount = ch == '\n' ? 1 : 0;
+        while (j < text.length &&
+            (text[j] == '\n' || text[j] == '\r')) {
+          if (text[j] == '\n') nlCount++;
+          j++;
+        }
+        if (nlCount >= 2) break; // paragraph break terminates
+        if (j >= text.length) break; // trailing newline
+        if (!_isUrlBodyChar(text[j])) break; // followed by non-URL
+
+        // Heuristic: only treat as soft-wrap when the current line
+        // is plausibly wrap-width (≥ 40 chars). Short prose lines
+        // like "see\nhttps://..." stay separate.
+        final prevNlIdx = text.lastIndexOf('\n', i - 1);
+        final lineStart = prevNlIdx == -1 ? 0 : prevNlIdx + 1;
+        final lineLen = i - lineStart;
+        if (lineLen < _softWrapMinLineLen) break;
+
+        i = j;
+        continue;
+      }
+
+      // Other ASCII control chars terminate.
+      if (code < 0x20) break;
+
+      i++;
+    }
+
+    final raw = text
+        .substring(start, i)
+        .replaceAll(RegExp(r'[\r\n]+'), '');
+    final cleaned = _trimTrailingPunctuation(raw);
+    if (cleaned.isNotEmpty) results.add(cleaned);
+  }
+  return results.toList();
+}
+
+String _trimTrailingPunctuation(String url) {
+  var end = url.length;
+  while (end > 0) {
+    final ch = url[end - 1];
+    final isStripChar = ch == '.' ||
+        ch == ',' ||
+        ch == ';' ||
+        ch == ':' ||
+        ch == '!' ||
+        ch == '?' ||
+        ch == "'";
+    final isUnpairedClose = (ch == ')' &&
+            !url.substring(0, end - 1).contains('(')) ||
+        (ch == ']' &&
+            !url.substring(0, end - 1).contains('['));
+    if (isStripChar || isUnpairedClose) {
+      end -= 1;
+    } else {
+      break;
+    }
+  }
+  return url.substring(0, end);
+}
+
+/// Decode UTF-8 bytes leniently (matches the terminal's `_decode`
+/// behaviour — never throws on invalid sequences mid-stream).
+String decodeForUrlScan(List<int> bytes) {
+  return const Utf8Decoder(allowMalformed: true).convert(bytes);
+}

--- a/app/mobile/pubspec.yaml
+++ b/app/mobile/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   shared_preferences: ^2.3.4
   slang: ^4.14.0
   slang_flutter: ^4.14.0
+  url_launcher: ^6.3.1
   web_socket_channel: ^3.0.1
   xterm: ^4.0.0
   yaml: ^3.1.2

--- a/app/web/src/pages/Login.tsx
+++ b/app/web/src/pages/Login.tsx
@@ -21,7 +21,10 @@ export function LoginPage() {
   const navigate = useNavigate()
   const search = useSearch({ strict: false }) as { next?: string }
   const setSession = useAuth((s) => s.setSession)
-  const [username, setUsername] = useState('admin')
+  // Start empty — the wizard lets operators pick any username during
+  // install, so seeding "admin" is misleading and forces an extra
+  // backspace for everyone who didn't keep the default.
+  const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)


### PR DESCRIPTION
## Two polishes after v2.0.4

### 1. Flutter mobile session terminal had no URL detection at all

Operator screenshot showed the OAuth URL printed on-screen in the
Flutter app but no tap-to-open affordance. Manual long-press
selection fails on CLI-soft-wrapped URLs (each visual row is its
own selection target → user grabs a partial URL → OAuth rejects).

Now ships URL detection on the mobile side too, parity with web:

```
┌─────────────────────────────┐
│ Terminal output ...         │
│ https://claude.com/cai/...  │  ← floating pill in top-right
│                       ┌───┐ │     (when N ≥ 1)
│                       │🔗 1│ │
│                       └───┘ │
└─────────────────────────────┘
```

Tap the pill → `url_launcher` opens the most recent URL in the OS
browser (no in-app webview). When N ≥ 2 the pill splits — primary
tap opens the latest URL, `⋯` button opens a bottom-sheet listing
every URL newest-first with Open + Copy buttons each.

**Files:**

- `app/mobile/lib/features/sessions/url_extractor.dart` — port of the
  web state-machine extractor. Same 40-char soft-wrap heuristic,
  same RFC 3986 URL-body char set, same trailing-punctuation rules.
- `app/mobile/lib/features/sessions/session_terminal_view.dart`:
  - `_detectedUrls` + `_urlScanTail` state (4 KB tail for WS frame
    boundaries, capped at 50, dedup'd insertion order).
  - `_scanForUrls(decoded)` called from `_onWsMessage` after
    `_terminal.write`.
  - `TerminalView` wrapped in `Stack` with a `Positioned` overlay
    for the new `_DetectedUrlBadge` widget.
  - `_openDetectedUrl` calls `launchUrl(uri, mode:
    LaunchMode.externalApplication)`.
  - `_showDetectedUrlsSheet` renders the multi-URL bottom-sheet.
- `app/mobile/pubspec.yaml` — `url_launcher: ^6.3.1` (only new dep).

**Verified:** `dart analyze lib` — no issues.

### 2. Web login no longer pre-fills "admin"

`useState('admin')` → `useState('')`. The install wizard lets
operators pick any username, so seeding "admin" was misleading
and forced backspacing for everyone who chose a different name.
`autoFocus` is preserved so the keyboard still lands on the field
immediately.

## Out of scope (intentional)

- Mobile bottom-sheet strings are hardcoded English for this
  release. Adding them to the slang JSON source + regenerating
  `strings_*.g.dart` would have ballooned the PR. Folded in a
  follow-up.
- Web admin behaviour is unchanged in this PR (v2.0.4 already
  fixed it).

## Test plan

- [ ] Open the Flutter mobile app, spawn a Claude session, run
      `claude login`. Verify the pill appears in the top-right,
      single tap opens the OAuth URL in Mobile Safari / Chrome.
- [ ] Same with `codex login` / `gemini auth login`.
- [ ] In a session with multiple detected URLs, tap the `⋯` button
      → bottom-sheet appears with each URL + Open / Copy. Open
      from the sheet works; Copy puts the URL in clipboard.
- [ ] Web login page: field is empty on first render; cursor in
      it; type a name + password and submit normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)