### PR TITLE
docs(readme): split uninstall blocks, refresh status, surface day-to-day commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,32 +40,24 @@
 
 ## Status
 
-**v2.0.0** — first release of the opendray v2 generation (2026-05-17).
-See [`VERSIONING.md`](VERSIONING.md) for the major-as-generation policy
-(major = product generation, not strict SemVer "breaking change").
+**v2.0.5** (latest) — the v2 generation is feature-complete and shipping
+patch releases as operators report polish items. See
+[`VERSIONING.md`](VERSIONING.md) for the major-as-generation policy
+(major = product generation, not strict SemVer "breaking change") and
+[`CHANGELOG.md`](CHANGELOG.md) for the full release history.
 
-What's in this generation:
+This generation ships:
 
-- **Backend (Go)** — sessions, channels, providers, memory, backup,
-  integration API. Single static binary with the React SPA embedded
-  via `go:embed`.
-- **Web admin** (React 19 + Vite + Tailwind v4 + shadcn/ui + TanStack
-  Router/Query + Zustand + xterm.js)
-- **Mobile app** (Flutter, iOS + Android, in `app/mobile/`) — parity
-  with web on session control, channel management, memory, backups,
-  notes, and the integration API
-- **Six bidirectional channels** — Telegram · Slack · Discord ·
-  Feishu (飞书) · DingTalk (钉钉) · WeCom (企业微信) — plus
-  **Bridge** for custom WebSocket-bound platforms
-- **Local-first memory** — ONNX / Ollama / LM Studio embedding;
-  cross-layer retrieval (user · project · session) with smart ranking
-  and conflict detection; no data leaves your network
-- **Automated release pipeline** — goreleaser cross-compile
+- **One-line installer + uninstaller wizards** (Linux + macOS;
+  Windows funnels through WSL2). Walks the operator through Postgres
+  bootstrap, AI-CLI install, admin credentials, listen address,
+  binary install, schema migration, and service registration.
+- **Self-managing binary** — `opendray update / start / stop /
+  restart / status / providers list / providers update` so operators
+  don't touch `systemctl` / `launchctl` for routine ops.
+- **Goreleaser release pipeline** — cross-compiled binaries
   (linux/darwin × amd64/arm64), cosign keyless signing (Sigstore),
-  SPDX SBOM
-
-See [`CHANGELOG.md`](CHANGELOG.md) for the v2.0.0 entry and the
-rolling Unreleased section for what's landing next.
+  SPDX SBOM, atomically verified self-update.
 
 ## Install
 
@@ -85,15 +77,43 @@ irm https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-
 
 Walks through Postgres setup, AI-CLI install, admin credentials, and service registration — landing a running gateway in ~5–10 minutes. See [**`scripts/README.md`**](scripts/README.md) for what the wizard does, the file layout it creates, options, and troubleshooting.
 
-**Uninstall** (Linux / macOS) — keeps DB + data by default; pass `OPENDRAY_PURGE=1` to drop everything:
+> **Want the manual walkthrough?** Read [**docs/getting-started.md**](docs/getting-started.md) — a 15-minute end-to-end guide that mirrors what the wizard does so you can verify each step yourself.
+
+### Uninstall (Linux / macOS)
+
+**Default** — stops the gateway and removes the binary, but **keeps** your `config.toml`, data directory (bcrypt keyfile, sessions, notes, vault), logs, and the PostgreSQL database so a re-install resumes where you left off:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | bash
-# or, full purge (DB, role, config, data, logs):
+```
+
+**Full purge** — also drops the PG database + role, deletes config / data / logs, removes the service user. Includes a post-delete verification step that bails loudly if anything survived:
+
+```sh
 curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
 ```
 
-> **Want the manual walkthrough?** Read [**docs/getting-started.md**](docs/getting-started.md) — a 15-minute end-to-end guide that mirrors what the wizard does so you can verify each step yourself.
+### Day-to-day commands
+
+After install, the `opendray` binary handles its own lifecycle — no need to remember `systemctl` / `launchctl` incantations:
+
+```sh
+sudo opendray update --restart   # download latest release, verify SHA, atomic replace + restart
+```
+
+```sh
+sudo opendray providers update   # bump installed AI CLIs (claude / codex / gemini) to npm-latest
+```
+
+```sh
+opendray providers list          # see which AI CLIs are installed + their versions
+```
+
+```sh
+sudo opendray start              # start | stop | restart | status — wraps systemd / launchd
+```
+
+`opendray --help` lists the full subcommand set.
 
 ### Deploy path picker
 
@@ -192,7 +212,7 @@ Build once, run with whatever supervisor you already use:
 goreleaser release --clean --snapshot
 ls dist/                  # opendray_*_linux_amd64.tar.gz etc.
 
-# Or grab a published release artefact (after v2.0.0 ships):
+# Or grab a published release artefact:
 # https://github.com/Opendray/opendray_v2/releases
 ```
 
@@ -270,8 +290,7 @@ export OPENDRAY_BACKUP_PG_RESTORE_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_re
 
 Restart opendray; the sidebar grows a Backups page (`/backups`)
 for encrypted PostgreSQL dumps + restore, and `/export` for
-zip-bundle data exports + import. ADR 0012 + the in-app
-Tutorial → Backups section have the full lifecycle.
+zip-bundle data exports + import. ADR 0012 has the full lifecycle.
 
 A single Go binary carries the whole web bundle — no Node runtime
 required at runtime, no separate static-file server, no Caddy/nginx

--- a/README.zh.md
+++ b/README.zh.md
@@ -40,29 +40,22 @@
 
 ## 当前状态
 
-**v2.0.0** — opendray v2 这一代产品的首次发布(2026-05-17)。
+**v2.0.5**(最新)—— v2 代功能已完整,目前在按运维反馈滚动 patch 版本。
 参见 [`VERSIONING.md`](VERSIONING.md) 了解 major-as-generation 版本策略
-(major = 产品代号,而不是严格的 SemVer "破坏性变更" 标记)。
+(major = 产品代号,而不是严格的 SemVer "破坏性变更" 标记),
+[`CHANGELOG.md`](CHANGELOG.md) 有完整 release 历史。
 
 这一代产品包含:
 
-- **后端(Go)** — sessions、channels、providers、memory、backup、
-  集成 API。单一静态二进制,React SPA 通过 `go:embed` 嵌入。
-- **Web admin**(React 19 + Vite + Tailwind v4 + shadcn/ui + TanStack
-  Router/Query + Zustand + xterm.js)
-- **移动端**(Flutter,iOS + Android,在 `app/mobile/`)— 在会话控制、
-  频道管理、记忆、备份、笔记和集成 API 上跟 Web 完全对等
-- **六大双向频道** — Telegram · Slack · Discord · 飞书(Feishu)·
-  钉钉(DingTalk)· 企业微信(WeCom)— 外加 **Bridge** 用 WebSocket
-  接入自定义平台
-- **本地优先的记忆系统** — ONNX / Ollama / LM Studio 嵌入向量;
-  跨层检索(用户 · 项目 · 会话)+ 智能排序 + 冲突检测;
-  数据不出你的内网
-- **自动化 release 流水线** — goreleaser 交叉编译(linux/darwin ×
-  amd64/arm64)、cosign 无密钥签名(Sigstore)、SPDX SBOM
-
-查看 [`CHANGELOG.md`](CHANGELOG.md) 了解 v2.0.0 详情和后续 Unreleased
-段中即将落地的内容。
+- **一行命令安装/卸载 wizard**(Linux + macOS;Windows 经 WSL2)——
+  引导操作者完成 Postgres bootstrap、AI CLI 安装、admin 凭据、监听地址、
+  binary 安装、schema migration、service 注册。
+- **可自管理的 binary** —— `opendray update / start / stop /
+  restart / status / providers list / providers update`,日常运维
+  不用碰 `systemctl` / `launchctl`。
+- **goreleaser release 流水线** —— 交叉编译(linux/darwin ×
+  amd64/arm64)、cosign 无密钥签名(Sigstore)、SPDX SBOM、原子校验
+  自更新。
 
 ## 安装
 
@@ -82,15 +75,43 @@ irm https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-
 
 引导你完成 Postgres 设置、AI CLI 安装、admin 凭据、服务注册,5–10 分钟拉起一个运行中的网关。详见 [**`scripts/README.md`**](scripts/README.md):wizard 做什么、生成的文件布局、参数、排错。
 
-**卸载**(Linux / macOS)—— 默认保留 DB + 数据;加 `OPENDRAY_PURGE=1` 全部清除:
+> **想自己一步步来?** 看 [**docs/getting-started.zh.md**](docs/getting-started.zh.md) —— 15 分钟端到端 walkthrough,跟 wizard 做的是同样的事,但每一步你都自己确认。
+
+### 卸载(Linux / macOS)
+
+**默认模式** —— 停掉网关、删 binary,但**保留** `config.toml`、数据目录(bcrypt keyfile、sessions、notes、vault)、日志、PostgreSQL 数据库。重装时直接接上,数据不丢:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | bash
-# 或者完整 purge(DB / role / config / 数据 / 日志):
+```
+
+**完整 purge** —— 还会 drop 数据库 + role、删 config / 数据 / 日志、移除服务用户。最后有 verification 步骤,有残留会大声报错:
+
+```sh
 curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
 ```
 
-> **想自己一步步来?** 看 [**docs/getting-started.zh.md**](docs/getting-started.zh.md) —— 15 分钟端到端 walkthrough,跟 wizard 做的是同样的事,但每一步你都自己确认。
+### 日常运维命令
+
+装完之后,`opendray` 二进制自己管自己的生命周期 —— 不用记 `systemctl` / `launchctl`:
+
+```sh
+sudo opendray update --restart   # 拉最新 release、SHA-256 校验、原子替换 + 重启
+```
+
+```sh
+sudo opendray providers update   # 升级 AI CLIs(claude / codex / gemini)到 npm 最新版
+```
+
+```sh
+opendray providers list          # 看装了哪些 AI CLI、各自版本
+```
+
+```sh
+sudo opendray start              # start | stop | restart | status —— 封装 systemd / launchd
+```
+
+完整子命令列表:`opendray --help`。
 
 ### 选部署路径
 
@@ -189,7 +210,7 @@ Unit 在 `ExecStartPre` 阶段跑 `opendray migrate`,首次启动会先把
 goreleaser release --clean --snapshot
 ls dist/                  # opendray_*_linux_amd64.tar.gz 等
 
-# 或者从已发布的 release 拿 artifact(v2.0.0 发布之后):
+# 或者从已发布的 release 拿 artifact:
 # https://github.com/Opendray/opendray_v2/releases
 ```
 
@@ -264,7 +285,7 @@ export OPENDRAY_BACKUP_PG_RESTORE_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_re
 
 重启 opendray,侧栏会出现 Backups 页(`/backups`)用于加密的
 PostgreSQL 备份 + 恢复,以及 `/export` 用于 zip 包数据导出 + 导入。
-ADR 0012 和应用内的 **Tutorial → Backups** 章节有完整生命周期说明。
+ADR 0012 有完整生命周期说明。
 
 一个 Go 二进制装着整个 web bundle —— 运行时不需要 Node,不需要单独的
 静态文件服务器,不需要 Caddy/nginx。Cloudflare Tunnel 在 `:8770`


### PR DESCRIPTION
## Operator audit + the copy-paste trap

Reported issue first: the README had **both** uninstall commands in
one fenced code block:

````markdown
```sh
curl -fsSL .../uninstall.sh | bash
# or, full purge (DB, role, config, data, logs):
curl -fsSL .../uninstall.sh | OPENDRAY_PURGE=1 bash
```
````

GitHub's "copy" button on a code block copies the **whole block**.
An operator wanting just the safe "remove gateway, keep data" path
ends up copying two commands. Pasting into a shell runs the default
uninstall AND then immediately reruns it with `--purge` — data the
operator thought was safe just got dropped. Bug.

Fix: split into two separate code blocks under explicit headings:

```markdown
### Uninstall (Linux / macOS)

**Default** — stops the gateway, keeps DB + data:

```sh
curl -fsSL .../uninstall.sh | bash
```

**Full purge** — also drops DB / role / config / data / logs:

```sh
curl -fsSL .../uninstall.sh | OPENDRAY_PURGE=1 bash
```
```

The copy button now copies one and only one command.

## Other fixes from the same audit pass

| Stale text | What was wrong | Now |
|---|---|---|
| Status section: "v2.0.0 — first release" | Six releases out of date | "v2.0.5 (latest)" + pointer at CHANGELOG.md |
| Status bullet list | Duplicated "What is opendray?" stack rundown | Rewrote to highlight v2.0.x distinctives — one-line installer, self-managing binary, signed release pipeline |
| "ADR 0012 + the in-app Tutorial → Backups section" | In-app tutorial was deleted in v2.0.1 | "ADR 0012 has the full lifecycle" |
| "after v2.0.0 ships" comment | v2.0.5 is shipped | Removed |
| No mention of `opendray update / start / stop / status / providers` anywhere | Operators only discover them via `opendray --help` | New **Day-to-day commands** subsection right below uninstall, one copy-able code block per command |

The Day-to-day commands section addresses an operator complaint earlier
tonight ("我们的opendray指令中,没有提供stop或start opendray的指令")
that was actually already shipped in v2.0.2 — they just weren't
documented in the README.

## What's NOT in this PR

- No code changes — this is README-only.
- CHANGELOG untouched (docs-only nits don't get a release entry).
- README.zh.md mirrors every change.

## Test plan

- [ ] Render the README on GitHub. Click the copy button on the
      Default uninstall block — clipboard should contain exactly
      that one curl line.
- [ ] Same for the Full purge block.
- [ ] Same for each of the four Day-to-day commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)