### PR TITLE
fix(systemd): restart on SIGHUP/SIGPIPE + raise nofile/tasks limits

### DIFF
--- a/deploy/launchd/com.opendray.opendray.plist
+++ b/deploy/launchd/com.opendray.opendray.plist
@@ -63,12 +63,17 @@
   <true/>
 
   <!-- Restart on failure (analogous to systemd Restart=on-failure).
+       Crashed=true makes restart-on-signal explicit so a SIGHUP-killed
+       daemon is reliably treated as a crash and restarted, regardless
+       of how a given launchd version interprets the exit.
        NetworkState=true delays restart until the network is up,
        matching the systemd unit's After=network-online.target. -->
   <key>KeepAlive</key>
   <dict>
     <key>SuccessfulExit</key>
     <false/>
+    <key>Crashed</key>
+    <true/>
     <key>NetworkState</key>
     <true/>
   </dict>

--- a/deploy/systemd/opendray.service
+++ b/deploy/systemd/opendray.service
@@ -51,10 +51,23 @@ ExecStart=/usr/local/bin/opendray serve -config /etc/opendray/config.toml
 # Restart policy — opendray returns non-zero on fatal errors, never
 # on graceful shutdown. on-failure restarts only when something
 # actually broke; SIGTERM/SIGINT exits cleanly with status 0.
+#
+# RestartForceExitStatus adds SIGHUP/SIGPIPE to the restart set.
+# systemd treats SIGHUP/SIGINT/SIGTERM/SIGPIPE as "clean exit" by
+# default — opendray catches SIGTERM/SIGINT for graceful shutdown,
+# but HUP/PIPE arriving unhandled means something killed us we
+# didn't expect (rogue cleanup script, parent shell on logout,
+# misconfigured tool). Treat those as failures and restart.
 Restart=on-failure
 RestartSec=5s
+RestartForceExitStatus=SIGHUP SIGPIPE
 StartLimitIntervalSec=60
 StartLimitBurst=5
+
+# Resource ceilings — the default ulimit (1024 fds) is easy to
+# exhaust with concurrent PTY sessions + DB pool + WS clients.
+LimitNOFILE=65536
+TasksMax=4096
 
 # Graceful shutdown window — opendray's internal supervisor budgets
 # 15s for HTTP drain + subsystem stop. Give systemd 20s before


### PR DESCRIPTION
## Problem

`deploy/systemd/opendray.service` ships `Restart=on-failure`. Per systemd semantics that *excludes* the four "clean shutdown" signals — **SIGHUP, SIGINT, SIGTERM, SIGPIPE**. opendray catches SIGTERM/SIGINT for graceful shutdown (correct), but HUP/PIPE arriving unhandled today silently terminates the service with no restart attempt. The service appears stopped cleanly: `systemctl list-units --failed` shows nothing, `systemctl status opendray` reports `Active: inactive (dead)`, and no alert fires.

Triggers seen in the wild:

- a cleanup script doing `pkill -HUP <something>` with a too-broad name match
- a parent shell sending HUP on logout when the unit was somehow started in user scope
- `SIGPIPE` from a closed downstream during heavy output (less common but real)

## Change

`deploy/systemd/opendray.service`:

```diff
 Restart=on-failure
 RestartSec=5s
+RestartForceExitStatus=SIGHUP SIGPIPE
 StartLimitIntervalSec=60
 StartLimitBurst=5

+# Resource ceilings — the default ulimit (1024 fds) is easy to
+# exhaust with concurrent PTY sessions + DB pool + WS clients.
+LimitNOFILE=65536
+TasksMax=4096
```

Preserves the maintainer's stated intent (`SIGTERM/SIGINT exits cleanly with status 0`) and adds coverage for the two clean-shutdown signals opendray does not deliberately handle. `LimitNOFILE` + `TasksMax` are unrelated but tiny — happy to split them out into a separate PR if preferred.

`deploy/launchd/com.opendray.opendray.plist`:

```diff
   <key>KeepAlive</key>
   <dict>
     <key>SuccessfulExit</key>
     <false/>
+    <key>Crashed</key>
+    <true/>
     <key>NetworkState</key>
     <true/>
   </dict>
```

launchd's `KeepAlive.SuccessfulExit=false` *usually* restarts on signal-based termination, but `Crashed=true` makes the intent explicit and survives future launchd behaviour changes.

## Forensic visibility preserved

`journalctl -u opendray` still shows the underlying cause — `code=killed, signal=HUP` — followed by the start line of the restarted instance. When restarts happen the cause is traceable. The change only affects *whether* the restart is scheduled.

## What this PR is not

Not adding `Restart=always` (would mask real crash loops, would restart after `systemctl stop` if not careful with `Type=`). Not adding `WatchdogSec` (that would need a Go-side `sd_notify` integration — happy to discuss in a follow-up issue if there's appetite). Not changing opendray's own signal handling — though "install a Go handler for SIGHUP that either reloads config or exits 1" is the right defense-in-depth fix, and I'd open that as a separate discussion if you'd find it useful.

## Test plan

- [x] `systemd-analyze verify deploy/systemd/opendray.service` clean
- [x] `plutil -lint deploy/launchd/com.opendray.opendray.plist` clean (parser accepts the addition)
- [ ] `sudo systemctl start opendray && pkill -HUP opendray` → unit restarts within ~5s; journal shows `code=killed, signal=HUP` then `Started opendray ...`
- [ ] `sudo systemctl stop opendray` → exits cleanly via SIGTERM, no restart (intent preserved)
- [ ] Force 6 restarts in <60s → `StartLimitBurst` fires, unit enters `failed` state (crash-loop protection intact)
- [ ] Inside the running process: `cat /proc/$(pgrep opendray)/limits | grep "Max open files"` reads `65536`
- [ ] macOS: `sudo launchctl kill HUP system/com.opendray.opendray` → daemon restarts within `ThrottleInterval` (5s)