### PR TITLE
fix(install): preflight bash version + actionable macOS message

### DIFF
--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -6,6 +6,22 @@
 # for a personal Mac or a Mac mini home server. Re-run with --launchd-daemon to
 # install a system-wide LaunchDaemon instead.
 
+# lib/common.sh requires bash 4+ (uses ${var,,}, printf -v, read -ra).
+# When this script is invoked directly (e.g. from a checkout) macOS
+# users with /bin/bash 3.2 would otherwise die deep inside common.sh
+# with "bad substitution". Guard the entry point too — install.sh has
+# the same check for the curl|bash path.
+if [ -z "${BASH_VERSION:-}" ] || [ "${BASH_VERSION%%.*}" -lt 4 ]; then
+    cat >&2 <<EOF
+[!] install-macos.sh requires bash 4+ (detected: ${BASH_VERSION:-unknown}).
+    macOS ships /bin/bash 3.2; install a current bash and re-invoke:
+      brew install bash
+      /opt/homebrew/bin/bash scripts/install-macos.sh "\$@"
+    (Intel Mac: /usr/local/bin/bash)
+EOF
+    exit 1
+fi
+
 set -euo pipefail
 
 # Reattach stdin to the controlling terminal so prompts work even when

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,6 +15,44 @@
 # from a real checkout — the bootstrap path just adds one git clone in
 # front.
 
+# ── bash 4+ preflight ────────────────────────────────────────────────
+# lib/common.sh uses ${var,,}, printf -v, read -ra and other bash 4+
+# features (see the `# Requires bash 4+` note at the top of that file).
+# macOS still ships bash 3.2 as /bin/bash — the last GPL2 release Apple
+# will ever ship — so `curl ... | bash` on macOS lands in 3.2 and
+# downstream scripts die with cryptic "bad substitution" / "unbound
+# variable" errors halfway through. Fail fast with an actionable
+# message instead.
+if [ -z "${BASH_VERSION:-}" ]; then
+    printf '[!] opendray installer must be run with bash, not %s.\n' \
+        "$(ps -p $$ -o comm= 2>/dev/null | tail -1 || echo sh)" >&2
+    exit 1
+fi
+_bash_major="${BASH_VERSION%%.*}"
+if [ "${_bash_major:-0}" -lt 4 ]; then
+    cat >&2 <<EOF
+[!] opendray installer requires bash 4.0 or newer.
+    Detected: bash ${BASH_VERSION}
+
+    macOS ships bash 3.2 as /bin/bash (Apple has not updated past
+    the last GPL2 release). Install a current bash and re-run via it:
+
+      Apple Silicon (M1/M2/M3/M4):
+        brew install bash
+        /opt/homebrew/bin/bash -c "\$(curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh)"
+
+      Intel Mac:
+        brew install bash
+        /usr/local/bin/bash -c "\$(curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh)"
+
+    On Linux: every supported distro ships bash 4+ already; if you
+    are still hitting this, your invocation is being downgraded to a
+    non-bash shell — re-run with: bash scripts/install.sh
+EOF
+    exit 1
+fi
+unset _bash_major
+
 set -euo pipefail
 
 # ── Locate ourselves on disk (or detect we're piped) ──────────────────


### PR DESCRIPTION
## Problem

`scripts/lib/common.sh` declares `# Requires bash 4+` at the top and uses `${var,,}`, `printf -v`, `read -ra`, and other bash 4+ features. Examples currently in the file:

- **Line 84** (`ask_yn`): `case "${response,,}" in` — bash 4+ lowercase parameter expansion
- **Line 270** (`_run_cleanup`): `for f in "${_cleanup_files[@]}"; do` — bash 3.2 throws `unbound variable` here under `set -u` even though the array is declared (a long-standing bash 3.2 wart fixed in 4.4)

The documented one-liner

```sh
curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash
```

runs on whichever `bash` is first in PATH. On macOS that's **`/bin/bash` 3.2** — the last GPL2 release Apple will ever ship. The shebang `#!/usr/bin/env bash` doesn't help: the pipe form invokes `... | bash` directly, and even running `bash scripts/install.sh` from a checkout picks up `/bin/bash` first.

Result on a stock macOS install: the wizard dies several screens deep with cryptic errors like:

```
/var/folders/v7/.../opendray-install-10822/scripts/lib/common.sh: line 84: ${response,,}: bad substitution
/var/folders/v7/.../opendray-install-10822/scripts/lib/common.sh: line 270: _cleanup_files[@]: unbound variable
```

The user has no idea this is a bash-version issue. There's no actionable next step in the output.

## Fix

Preserve the maintainer's stated design ("requires bash 4+") and fail fast at the entry point with a clear, actionable message that lists the exact Homebrew install + re-invocation command for both Apple Silicon and Intel.

`scripts/install.sh`:

```diff
+# ── bash 4+ preflight ────────────────────────────────────────────────
+if [ -z "${BASH_VERSION:-}" ]; then
+    printf '[!] opendray installer must be run with bash, not %s.\n' \
+        "$(ps -p $$ -o comm= 2>/dev/null | tail -1 || echo sh)" >&2
+    exit 1
+fi
+_bash_major="${BASH_VERSION%%.*}"
+if [ "${_bash_major:-0}" -lt 4 ]; then
+    cat >&2 <<EOF
+[!] opendray installer requires bash 4.0 or newer.
+    Detected: bash ${BASH_VERSION}
+    …
+EOF
+    exit 1
+fi
+
 set -euo pipefail
```

Same guard at the top of `scripts/install-macos.sh` for the case where the operator runs the OS-specific wizard directly from a checkout.

## Verified

```text
$ bash --version
GNU bash, version 3.2.57(1)-release  # simulated

$ bash scripts/install.sh
[!] opendray installer requires bash 4.0 or newer.
    Detected: bash 3.2.57

    macOS ships bash 3.2 as /bin/bash (Apple has not updated past
    the last GPL2 release). Install a current bash and re-run via it:

      Apple Silicon (M1/M2/M3/M4):
        brew install bash
        /opt/homebrew/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh)"
      …
```

Bash 4+ → preflight passes silently, script continues normally.

## Alternative considered

Backporting `common.sh` to bash 3.2 (replace `${,,}` with `tr '[:upper:]' '[:lower:]'`, replace `printf -v` with subshell + `eval`, fix the empty-array trap). Rejected because it contradicts the explicit `# Requires bash 4+` design note and loses the readability the maintainer chose those features for. Happy to take that alternative if preferred — just say the word and I'll redo the PR that way.

## What this PR is not

Doesn't change any installer behavior on Linux (every supported distro ships bash 4+) or on macOS with Homebrew bash. Doesn't auto-relaunch via Homebrew bash if found — that would add magic that surprises users; a clear actionable message is more predictable.

## Test plan

- [x] `bash -n scripts/install.sh` clean
- [x] `bash -n scripts/install-macos.sh` clean
- [x] Forced `BASH_VERSION=3.2.57` → preflight fires, exits 1, prints actionable message
- [x] Real bash 5.2 → preflight passes silently, normal flow continues
- [ ] On a fresh macOS without Homebrew bash: confirm the message is what the operator sees (vs. the current cryptic mid-install failure)
- [ ] With Homebrew bash installed + invoked explicitly: full install completes