### PR TITLE
fix(install): make installer work on macOS bash 3.2 out of the box

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,6 +15,15 @@
 # from a real checkout — the bootstrap path just adds one git clone in
 # front.
 
+# Must run under bash (not sh/dash/zsh) — we use BASH_SOURCE, arrays,
+# [[ ]], and printf -v downstream. No version floor: bash 3.2 (macOS
+# /bin/bash) is supported. This only catches `curl ... | sh` mistakes.
+if [ -z "${BASH_VERSION:-}" ]; then
+    echo "[!] opendray installer must be run with bash, not sh. Re-run with:" >&2
+    echo "    curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash" >&2
+    exit 1
+fi
+
 set -euo pipefail
 
 # ── Locate ourselves on disk (or detect we're piped) ──────────────────

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -2,7 +2,9 @@
 # scripts/lib/common.sh
 # Shared shell helpers for the opendray installer wizards.
 # Sourced by install-linux.sh and install-macos.sh.
-# Requires bash 4+ (for `printf -v`, `read -ra`, parameter expansion).
+# Compatible with bash 3.2+ (macOS ships 3.2 as /bin/bash). `printf -v`
+# (bash 3.1+) and `read -ra` (bash 3.x) are fine; the only 4.0-only
+# construct was ${var,,} case-conversion, replaced with tr.
 
 # Detect colour-capable terminal once.
 # Use $'…' (ANSI-C quoting) so the vars hold *real* ESC bytes — that
@@ -81,7 +83,9 @@ ask_yes_no() {
         response=""
         read -r response || response=""
         response="${response:-$default}"
-        case "${response,,}" in
+        # tr instead of ${response,,} — the latter is bash 4.0+ and macOS
+        # ships bash 3.2 as /bin/bash.
+        case "$(printf '%s' "$response" | tr '[:upper:]' '[:lower:]')" in
             y|yes) printf -v "$var_name" '%s' 'y'; return 0 ;;
             n|no)  printf -v "$var_name" '%s' 'n'; return 0 ;;
             *) log_warn "Please answer y or n" ;;
@@ -269,6 +273,11 @@ _cleanup_files=()
 register_cleanup_file() { _cleanup_files+=("$1"); }
 _run_cleanup() {
     local f
+    # Guard the expansion: under `set -u`, bash 3.2 (macOS /bin/bash)
+    # errors on "${arr[@]}" when the array is empty — which it usually
+    # is here, since most runs register no cleanup files. ${#arr[@]} is
+    # safe to read when empty; only iterate when there's something.
+    [ "${#_cleanup_files[@]}" -gt 0 ] || return 0
     for f in "${_cleanup_files[@]}"; do
         [ -f "$f" ] && rm -f -- "$f"
     done


### PR DESCRIPTION
## Problem

The documented one-liner

```sh
curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash
```

runs on macOS `/bin/bash`, which is **3.2** — the last GPL2 release Apple ships. The wizard dies several screens deep with cryptic errors:

```
common.sh: line 84: ${response,,}: bad substitution
common.sh: line 270: _cleanup_files[@]: unbound variable
```

## Root cause (narrower than the header claimed)

`scripts/lib/common.sh` carried `# Requires bash 4+ (for printf -v, read -ra, parameter expansion)`. Two of those three are actually fine on 3.2:

- `printf -v` — added in **bash 3.1**
- `read -ra` — `-r` and `-a` both exist in **bash 3.x**

The only genuine incompatibilities:

1. **`${response,,}`** (line 84) — lowercase parameter expansion, **bash 4.0+**.
2. **`"${_cleanup_files[@]}"`** (line ~272) expanded under `set -u` while the array is **empty** — bash 3.2 raises `unbound variable` here (a wart fixed in 4.4). The array is empty on most runs because no cleanup files get registered.

## Fix — works on stock macOS, no Homebrew-bash prerequisite

```diff
-        case "${response,,}" in
+        # tr instead of ${response,,} — the latter is bash 4.0+ and macOS
+        # ships bash 3.2 as /bin/bash.
+        case "$(printf '%s' "$response" | tr '[:upper:]' '[:lower:]')" in
```

```diff
 _run_cleanup() {
     local f
+    [ "${#_cleanup_files[@]}" -gt 0 ] || return 0
     for f in "${_cleanup_files[@]}"; do
         [ -f "$f" ] && rm -f -- "$f"
     done
 }
```

`${#arr[@]}` is safe to read when empty even on 3.2; we only iterate when there's something to clean.

Header comment in `common.sh` updated to reflect actual **3.2+** compatibility.

Plus a minimal entry-point guard in `install.sh` — if `BASH_VERSION` is unset (someone ran `curl ... | sh`), print a clear "run with bash" message instead of failing on the first bashism. **No version floor — 3.2 is supported.**

## Why this approach over a preflight that requires bash 4+

I opened #206 first with a preflight that detected bash <4 and told the user to `brew install bash`. On reflection that's the wrong trade for a one-liner installer whose whole value is "just works" — it pushes a manual prerequisite onto every stock-Mac user. This PR instead makes the scripts genuinely 3.2-compatible (the incompatible surface turned out to be tiny), so the one-liner works as advertised. **Closing #206 in favour of this.**

## Verified

On a simulated bash 3.2 environment (`set -euo pipefail`, sourced `common.sh`):

- `ask_yes_no` lowercases `YES`/`N`/empty-default correctly → `y` / `n` / `y`
- `_run_cleanup` with an empty `_cleanup_files` array no longer errors under `set -u`
- `_run_cleanup` with one registered file removes it
- `install.sh` run under `sh` (no `BASH_VERSION`) prints the bash-required message and exits 1
- `bash -n` clean on `install.sh`, `install-macos.sh`, `common.sh`

## Test plan

- [x] `bash -n` on all three touched/adjacent scripts
- [x] Functional test of `ask_yes_no` + `_run_cleanup` under `set -u`
- [x] `curl | sh` guard fires
- [ ] End-to-end on a real macOS (Intel + Apple Silicon) with stock `/bin/bash` 3.2, no Homebrew bash installed
- [ ] Regression check on Linux (bash 5.x) — behavior unchanged