### PR TITLE
fix(install): validate DB identifiers + don't abort on a free port

### DIFF
--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -331,8 +331,8 @@ fi
 
 log_step 5 "Bootstrap opendray database"
 
-ask_with_default "Database name"                    "opendray"        OD_DB_NAME
-ask_with_default "Application DB user (CRUD only)"  "opendray_user"   OD_DB_USER
+ask_pg_identifier "Database name"                    "opendray"        OD_DB_NAME
+ask_pg_identifier "Application DB user (CRUD only)"  "opendray_user"   OD_DB_USER
 
 DEFAULT_DB_PW="$(gen_password 24)"
 ask_with_default "App DB password (Enter = random)" "$DEFAULT_DB_PW" OD_DB_PW

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -241,7 +241,7 @@ if [ "$PG_MODE" = "local" ]; then
     if [ -n "$PG_VER" ]; then
         log_info "Reusing already-installed, pgvector-supported PostgreSQL $PG_VER"
     else
-        PG_VER="$(printf '%s\n' $_supported | sort -rn | uniq | head -1)"
+        PG_VER="$(printf '%s\n' $_supported | sort -rn | uniq | head -1 || true)"
         log_info "pgvector supports PostgreSQL $PG_VER — installing postgresql@$PG_VER"
     fi
     PG_FORMULA="postgresql@$PG_VER"
@@ -257,7 +257,10 @@ if [ "$PG_MODE" = "local" ]; then
     # a leftover cluster), don't let the new server crash-loop on a bind
     # conflict. Offer an alternate port and write it into postgresql.conf.
     PG_SUPER_PORT=5432
-    _busy_pid="$(lsof -nP -iTCP:5432 -sTCP:LISTEN -t 2>/dev/null | head -1)"
+    # `|| true`: lsof exits non-zero when nothing is listening (the common
+    # fresh-install case). Without it, `set -o pipefail` + `set -e` would
+    # abort the installer right here on a free port.
+    _busy_pid="$(lsof -nP -iTCP:5432 -sTCP:LISTEN -t 2>/dev/null | head -1 || true)"
     if [ -n "$_busy_pid" ]; then
         log_warn "Port 5432 is already in use by PID $_busy_pid ($(ps -p "$_busy_pid" -o comm= 2>/dev/null | tail -1))."
         ask_with_default "Port for opendray's PostgreSQL ($PG_FORMULA)" "5433" PG_SUPER_PORT

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -337,8 +337,8 @@ fi
 
 log_step 5 "Bootstrap opendray database"
 
-ask_with_default "Database name"                   "opendray"      OD_DB_NAME
-ask_with_default "App DB user (CRUD only)"         "opendray_user" OD_DB_USER
+ask_pg_identifier "Database name"                   "opendray"      OD_DB_NAME
+ask_pg_identifier "App DB user (CRUD only)"         "opendray_user" OD_DB_USER
 
 DEFAULT_DB_PW="$(gen_password 24)"
 ask_with_default "App DB password (Enter = random)" "$DEFAULT_DB_PW" OD_DB_PW

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -60,6 +60,28 @@ ask_with_default() {
     printf -v "$var_name" '%s' "${response:-$default}"
 }
 
+# ask_pg_identifier <prompt> <default> <out-var-name>
+# Like ask_with_default, but only accepts a safe, unquoted PostgreSQL
+# identifier: a letter or underscore, then letters/digits/underscores,
+# 1–63 chars. Re-prompts on anything else. This is what keeps a stray
+# quote or space out of the bootstrap SQL (the DB name / role name are
+# interpolated into CREATE DATABASE / CREATE USER), so a value like `'`
+# can never break or inject into those statements.
+ask_pg_identifier() {
+    local prompt="$1" default="$2" var_name="$3" _val=""
+    while true; do
+        ask_with_default "$prompt" "$default" _val
+        case "$_val" in
+            [A-Za-z_]*)
+                if printf '%s' "$_val" | LC_ALL=C grep -Eq '^[A-Za-z_][A-Za-z0-9_]{0,62}$'; then
+                    printf -v "$var_name" '%s' "$_val"
+                    return 0
+                fi ;;
+        esac
+        log_warn "Invalid name '$_val' — use letters, digits and underscores only, starting with a letter or underscore (max 63 chars)."
+    done
+}
+
 # ask_password <prompt> <out-var-name>
 ask_password() {
     local prompt="$1"


### PR DESCRIPTION
Two installer bugs found by driving the macOS wizard **end-to-end on real hardware** (macOS 26.4 / Apple Silicon), past the Postgres-provisioning step that earlier failures never cleared.

## Bug 1 — DB name / user interpolated raw into SQL (injection + breakage)

`install-{macos,linux}.sh` Phase 6 took the answers straight into SQL:

```sh
ask_with_default "App DB user (CRUD only)" "opendray_user" OD_DB_USER
...
run_psql_super "SELECT 1 FROM pg_roles WHERE rolname = '$OD_DB_USER'"
run_psql_super "CREATE USER \"$OD_DB_USER\" WITH ENCRYPTED PASSWORD '...'"
```

A single quote in the answer (a fat-fingered or typed-ahead `'` at the prompt) produced:

```
ERROR:  unterminated quoted string at or near "'''"
```

…then created a **garbage role literally named `'`**, wired the app DSN to connect as it, and the install died at migrate with `permission denied for table schema_migrations` (that role didn't own the schema). Injection-class on top of the breakage.

**Fix:** new `ask_pg_identifier` helper in `lib/common.sh` — prompts like `ask_with_default` but only accepts a safe unquoted identifier (`^[A-Za-z_][A-Za-z0-9_]{0,62}$`), re-prompting otherwise. Used for the Database-name and App-DB-user prompts in both installers. With the value constrained to `[A-Za-z0-9_]`, the existing `CREATE DATABASE` / `CREATE USER` interpolation can no longer break or inject.

## Bug 2 — installer aborts on a *free* port under `set -e` (regression from #209)

The robust-Postgres block added in #209 detected a busy 5432 with:

```sh
_busy_pid="$(lsof -nP -iTCP:5432 -sTCP:LISTEN -t 2>/dev/null | head -1)"
```

When **nothing** is listening on 5432 — the *common fresh-install case* — `lsof` exits non-zero, `set -o pipefail` propagates it, and `set -e` aborts the installer silently, right before Postgres is started. It only worked on machines where 5432 was already occupied. (My #209 validation ran the snippets standalone, not under `set -e`, so it slipped through.)

**Fix:** `|| true` on the `lsof` substitution (free port → empty pid, not a fatal exit) and on the newest-supported `head -1` fallback (can take a SIGPIPE).

## Verified end-to-end on real hardware

Clean baseline (5432 free, no opendray DB/role, no `~/.opendray`), then drove the full wizard via `expect` choosing the **local-Postgres** path, and deliberately **typed a `'` at the App DB user prompt**:

- `'` was **rejected with a re-prompt**; final role came out as `opendray_user`, not `'`.
- Postgres provisioned on the free 5432 with **no `set -e` abort**.
- DB + role bootstrap → **33 migrations applied, no permission error**.
- LaunchAgent loaded; **health endpoint OK on both loopback and LAN**.
- Post-run DB state: roles = `{navid, opendray_user}` (no `'`), `schema_migrations` owned by `opendray_user`, 33 rows.

## Test plan

- [x] `bash -n` on all three touched scripts
- [x] Unit test of `ask_pg_identifier`: empty→default, valid→accepted, `'`/space→rejected+re-prompt
- [x] Full macOS e2e on a free-port baseline with a `'` injected → rejected, install completes, gateway healthy (33 migrations, LAN health OK)
- [ ] Linux e2e (same shared helper; not run here)