### PR TITLE
fix(install/macos): idempotent launchd (re)load — fixes Bootstrap failed: 5 on re-install

### DIFF
--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -630,18 +630,36 @@ cat > "$TMP_PLIST" <<EOF
 </plist>
 EOF
 
+# (Re)load a launchd unit, tolerant of an already-loaded label.
+# `launchctl bootout` is asynchronous: a naive `bootout || true; bootstrap`
+# races on a re-install — the old instance is still draining when bootstrap
+# runs, which fails with "Bootstrap failed: 5: Input/output error". Wait for
+# the old instance to actually disappear, then bootstrap; if it still won't
+# load (already-loaded / transient EIO), bootout + retry once. A genuinely
+# broken load is caught by the health check that follows.
+reload_launchd_unit() {
+    local domain="$1" label="$2" plist="$3" priv="${4:-}"
+    local i
+    $priv launchctl bootout "$domain/$label" 2>/dev/null || true
+    for i in 1 2 3 4 5 6 7 8 9 10; do
+        $priv launchctl print "$domain/$label" >/dev/null 2>&1 || break
+        sleep 1
+    done
+    if ! $priv launchctl bootstrap "$domain" "$plist" 2>/dev/null; then
+        $priv launchctl bootout "$domain/$label" 2>/dev/null || true
+        sleep 2
+        $priv launchctl bootstrap "$domain" "$plist" 2>/dev/null || true
+    fi
+    $priv launchctl enable    "$domain/$label" 2>/dev/null || true
+    $priv launchctl kickstart -k "$domain/$label" 2>/dev/null || true
+}
+
 if [ "$LAUNCHD_SCOPE" = "daemon" ]; then
     run_priv install -m 0644 -o root -g wheel "$TMP_PLIST" "$PLIST_PATH"
-    run_priv launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null || true
-    run_priv launchctl bootstrap "$DOMAIN" "$PLIST_PATH"
-    run_priv launchctl enable    "$DOMAIN/$LABEL"
-    run_priv launchctl kickstart -k "$DOMAIN/$LABEL"
+    reload_launchd_unit "$DOMAIN" "$LABEL" "$PLIST_PATH" run_priv
 else
     install -m 0644 "$TMP_PLIST" "$PLIST_PATH"
-    launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null || true
-    launchctl bootstrap "$DOMAIN" "$PLIST_PATH"
-    launchctl enable    "$DOMAIN/$LABEL"
-    launchctl kickstart -k "$DOMAIN/$LABEL"
+    reload_launchd_unit "$DOMAIN" "$LABEL" "$PLIST_PATH"
 fi
 log_ok "launchd unit loaded: $PLIST_PATH"
 


### PR DESCRIPTION
## Problem

Re-running the macOS installer on a machine where opendray is already installed fails at the **final step** with:

```
┌── Step 9 ── Install launchd unit
Bootstrap failed: 5: Input/output error
```

Everything before it succeeded (Postgres provisioned, DB bootstrapped, binary installed, 33 migrations applied) — only the LaunchAgent load fails, leaving the gateway not running.

Phase 10 did:

```sh
launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null || true
launchctl bootstrap "$DOMAIN" "$PLIST_PATH"
```

`launchctl bootout` is **asynchronous**. When the unit is already loaded (a re-install), the old instance is still draining when `bootstrap` runs immediately after, so bootstrap hits the still-present label and returns EIO 5. (First installs onto a clean slot worked, which is why this only shows on a second run.)

## Fix

`reload_launchd_unit()` — bootout, **poll until the label actually disappears**, then bootstrap; if it still won't load, bootout + retry once. Used for both the daemon and agent paths. A genuinely broken load is still caught by the health check that follows, so we don't mask real failures.

```sh
reload_launchd_unit() {
    local domain="$1" label="$2" plist="$3" priv="${4:-}"
    $priv launchctl bootout "$domain/$label" 2>/dev/null || true
    for i in 1 2 3 4 5 6 7 8 9 10; do
        $priv launchctl print "$domain/$label" >/dev/null 2>&1 || break
        sleep 1
    done
    if ! $priv launchctl bootstrap "$domain" "$plist" 2>/dev/null; then
        $priv launchctl bootout "$domain/$label" 2>/dev/null || true
        sleep 2
        $priv launchctl bootstrap "$domain" "$plist" 2>/dev/null || true
    fi
    $priv launchctl enable    "$domain/$label" 2>/dev/null || true
    $priv launchctl kickstart -k "$domain/$label" 2>/dev/null || true
}
```

## Verified on real hardware

macOS 26.4 / Apple Silicon, against a **live already-loaded agent** (the exact state that triggers the bug): the naive `bootout;bootstrap` returns `Bootstrap failed: 5`, while `reload_launchd_unit` returns 0, the unit ends in `state = running`, and the gateway health endpoint returns `{"status":"ok","db_ok":true}`.

## Test plan

- [x] `bash -n scripts/install-macos.sh`
- [x] Run `reload_launchd_unit` against a loaded agent → clean reload, healthy gateway
- [ ] Full re-install e2e (was failing at Step 9; should now complete)