### PR TITLE
feat(install/windows): true one-liner — auto-install WSL2+Ubuntu, run installer, persist gateway

### DIFF
--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -1,131 +1,145 @@
 # scripts/install-windows.ps1
 # Windows entry point for the opendray installer.
 #
-# opendray does NOT support native Windows. The session subsystem
-# spawns AI CLIs through PTYs (creack/pty), and PTYs only exist on
-# Unix kernels. ConPTY exists on Windows but is not wired into
-# opendray and there are no plans to support it in V1.
+# opendray does NOT run as a native Windows process — the session
+# subsystem spawns AI CLIs through Unix PTYs, which the Windows kernel
+# doesn't expose to opendray. So the Windows install is: set up WSL2 +
+# Ubuntu, then run the Linux installer inside it.
 #
-# Recommended path: install WSL2 + Ubuntu, then run install-linux.sh
-# inside the WSL distribution. This script:
-#   1) Detects whether WSL is already installed.
-#   2) Offers to install WSL2 + Ubuntu (one-time, needs admin + reboot).
-#   3) Once WSL is up, prints the exact commands to clone the repo
-#      and run the Linux installer inside Ubuntu.
+# Unlike a manual guide, this script does the whole thing for you:
+#   1) Ensures the WSL2 feature is present (enables it if missing —
+#      that one path needs admin + a reboot, then re-run).
+#   2) Ensures a usable Ubuntu/Debian distro exists (installs
+#      Ubuntu-24.04 if there isn't one — a Docker/Podman WSL distro
+#      does NOT count).
+#   3) Ensures systemd is enabled inside the distro (opendray runs as a
+#      systemd service).
+#   4) Runs the opendray Linux installer inside WSL.
+#   5) Registers a logon task so the distro (and the gateway) comes back
+#      up after idle/reboot — WSL stops idle distros otherwise.
 #
-# Usage (from an elevated PowerShell):
-#   pwsh -ExecutionPolicy Bypass -File scripts/install-windows.ps1
+# Usage (from PowerShell; elevate if WSL isn't installed yet):
+#   irm https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-windows.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 
-function Write-Banner {
-    Write-Host ""
-    Write-Host "━━━ opendray installer — Windows entry ━━━" -ForegroundColor Cyan
-    Write-Host ""
-}
+$Distro    = "Ubuntu-24.04"
+$InstallSh = "https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh"
+$TaskName  = "opendray-wsl-keepalive"
 
-function Write-Info  { param([string]$m) Write-Host "[*] $m" -ForegroundColor Blue }
-function Write-Ok    { param([string]$m) Write-Host "[✓] $m" -ForegroundColor Green }
-function Write-Warn  { param([string]$m) Write-Host "[!] $m" -ForegroundColor Yellow }
-function Write-Err   { param([string]$m) Write-Host "[✗] $m" -ForegroundColor Red }
+function Write-Banner { Write-Host ""; Write-Host "+-- opendray installer - Windows entry --+" -ForegroundColor Cyan; Write-Host "" }
+function Write-Info { param([string]$m) Write-Host "[*] $m" -ForegroundColor Blue }
+function Write-Ok   { param([string]$m) Write-Host "[OK] $m" -ForegroundColor Green }
+function Write-Warn { param([string]$m) Write-Host "[!] $m" -ForegroundColor Yellow }
+function Write-Err  { param([string]$m) Write-Host "[X] $m" -ForegroundColor Red }
 
 function Test-IsAdmin {
-    $id  = [System.Security.Principal.WindowsIdentity]::GetCurrent()
-    $win = New-Object System.Security.Principal.WindowsPrincipal($id)
-    return $win.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+    $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    return (New-Object System.Security.Principal.WindowsPrincipal($id)).IsInRole(
+        [System.Security.Principal.WindowsBuiltInRole]::Administrator)
 }
+
+# WSL emits UTF-16; WSL_UTF8 makes its output parseable.
+$env:WSL_UTF8 = "1"
 
 Write-Banner
 
-Write-Host @"
-opendray cannot run as a native Windows process. The AI-CLI session
-subsystem uses Unix PTYs, which Windows does not expose to opendray.
-This wizard helps you set up WSL2 + Ubuntu so you can run the Linux
-installer inside it.
+# -- Step 1: ensure the WSL2 feature ---------------------------------
+$wslReady = $false
+try { $null = & wsl.exe --status 2>&1; if ($LASTEXITCODE -eq 0) { $wslReady = $true } } catch { $wslReady = $false }
 
-"@
-
-# ── Step 1: detect existing WSL ─────────────────────────────────────
-$wslAvailable = $false
-try {
-    $null = & wsl.exe --status 2>&1
-    if ($LASTEXITCODE -eq 0) { $wslAvailable = $true }
-} catch {
-    $wslAvailable = $false
-}
-
-if ($wslAvailable) {
-    Write-Ok "WSL is already enabled."
-    Write-Host ""
-    Write-Host "Available distributions:"
-    & wsl.exe --list --verbose 2>&1 | ForEach-Object { "    $_" }
-    Write-Host ""
-} else {
-    Write-Warn "WSL is not enabled on this machine."
-    Write-Host ""
-    Write-Host "To install WSL2 + Ubuntu (Windows 10 2004+ / Windows 11):"
-    Write-Host ""
-    Write-Host "  1) Open PowerShell as Administrator." -ForegroundColor Yellow
-    Write-Host "  2) Run:" -ForegroundColor Yellow
-    Write-Host "       wsl --install -d Ubuntu" -ForegroundColor Green
-    Write-Host "  3) Reboot when prompted." -ForegroundColor Yellow
-    Write-Host "  4) On first launch, Ubuntu asks for a Linux username/password." -ForegroundColor Yellow
-    Write-Host "  5) After Ubuntu's prompt, rerun this script in normal PowerShell" -ForegroundColor Yellow
-    Write-Host "     to get the inside-WSL command to install opendray." -ForegroundColor Yellow
-    Write-Host ""
-
+if (-not $wslReady) {
+    Write-Warn "WSL2 is not enabled on this machine."
     if (-not (Test-IsAdmin)) {
-        Write-Warn "This PowerShell is NOT elevated. 'wsl --install' needs admin."
-        Write-Host "Right-click PowerShell → Run as administrator, then rerun."
+        Write-Err "Enabling WSL2 needs an elevated PowerShell."
+        Write-Host "  Right-click PowerShell -> Run as administrator, then re-run this command."
         exit 1
     }
-
-    $answer = Read-Host "Run 'wsl --install -d Ubuntu' now? [y/N]"
-    if ($answer -match '^[yY]') {
-        Write-Info "Running 'wsl --install -d Ubuntu' ..."
-        & wsl.exe --install -d Ubuntu
-        Write-Ok "Install initiated. Reboot when prompted, then rerun this script."
-    }
+    Write-Info "Enabling WSL2 (this is a one-time step)..."
+    & wsl.exe --install --no-distribution
+    Write-Ok "WSL2 enabled. REBOOT, then re-run this same command to finish."
     exit 0
 }
+Write-Ok "WSL2 is available."
 
-# ── Step 2: WSL is up — print the cross-over command ────────────────
+# -- Step 2: ensure a usable Ubuntu/Debian distro --------------------
+# Bug this replaces: the old script treated ANY WSL distro (e.g. a
+# Docker/Podman helper) as 'ready' and pointed users at an Ubuntu that
+# wasn't installed. Match only real Debian-family distros.
+$installed = @()
+try { $installed = (& wsl.exe --list --quiet 2>$null) | ForEach-Object { ($_ -replace '\0','').Trim() } | Where-Object { $_ } } catch {}
+$usable = $installed | Where-Object { $_ -match '^(Ubuntu|Debian)' }
+
+if (-not $usable) {
+    Write-Warn "No Ubuntu/Debian WSL distro found (installed: $([string]::Join(', ', $installed)))."
+    Write-Info "Installing $Distro ..."
+    & wsl.exe --install -d $Distro --no-launch
+    if ($LASTEXITCODE -ne 0) { Write-Err "Failed to install $Distro."; exit 1 }
+    Write-Ok "$Distro installed."
+} else {
+    $Distro = ($usable | Select-Object -First 1)
+    Write-Ok "Using existing distro: $Distro"
+}
+
+# -- Step 3: ensure systemd is enabled inside the distro -------------
+# opendray installs a systemd service; default WSL has systemd off.
+$wantConf = "[boot]`nsystemd=true`n"
+$b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($wantConf))
+$needsRestart = $false
+$current = (& wsl.exe -d $Distro -u root -- sh -c "cat /etc/wsl.conf 2>/dev/null") -join "`n"
+if ($current -notmatch 'systemd\s*=\s*true') {
+    Write-Info "Enabling systemd in $Distro ..."
+    & wsl.exe -d $Distro -u root -- sh -c "echo $b64 | base64 -d > /etc/wsl.conf"
+    $needsRestart = $true
+}
+if ($needsRestart) {
+    & wsl.exe --terminate $Distro 2>&1 | Out-Null
+    Start-Sleep -Seconds 3
+}
+# wait for systemd to come up
+$ok = $false
+foreach ($i in 1..20) {
+    $st = (& wsl.exe -d $Distro -u root -- sh -c "systemctl is-system-running 2>/dev/null") -join ""
+    if ($st -match 'running|degraded|starting') { $ok = $true; break }
+    Start-Sleep -Seconds 2
+}
+if ($ok) { Write-Ok "systemd is active in $Distro." } else { Write-Warn "systemd may not be fully up; continuing." }
+
+# -- Step 4: run the opendray Linux installer inside WSL -------------
 Write-Host ""
-Write-Host "━━━ Next step: inside Ubuntu ━━━" -ForegroundColor Cyan
+Write-Host "+-- Running the opendray installer inside $Distro --+" -ForegroundColor Cyan
+Write-Host "You'll answer a few prompts (Postgres, admin password, listen address)." -ForegroundColor Yellow
+Write-Host "Tip: choose 0.0.0.0:8770 for the listen address to reach it from other LAN devices." -ForegroundColor Yellow
 Write-Host ""
-Write-Host @"
-Open your Ubuntu (or other WSL distribution) shell — either via
-Windows Terminal, the 'Ubuntu' Start menu entry, or:
+& wsl.exe -d $Distro -u root -- bash -c "curl -fsSL $InstallSh | bash"
+$installRc = $LASTEXITCODE
+if ($installRc -ne 0) { Write-Err "The Linux installer exited with code $installRc. See output above."; exit $installRc }
 
-    wsl -d Ubuntu
+# -- Step 5: persistence - keep the distro (and gateway) up ----------
+# WSL stops idle distros, which would stop the systemd service. A hidden
+# logon task boots the distro and holds it open with `sleep infinity`,
+# so the gateway stays reachable at http://localhost:8770/.
+Write-Info "Registering logon task '$TaskName' to keep the gateway running..."
+try {
+    $action  = New-ScheduledTaskAction -Execute "wsl.exe" `
+        -Argument "-d $Distro -u root --exec /bin/sh -c `"exec sleep infinity`""
+    $trigger = New-ScheduledTaskTrigger -AtLogOn
+    $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries -StartWhenAvailable -ExecutionTimeLimit ([TimeSpan]::Zero)
+    $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
+    Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger `
+        -Settings $settings -Principal $principal -Force | Out-Null
+    Start-ScheduledTask -TaskName $TaskName
+    Write-Ok "Keep-alive task registered and started."
+} catch {
+    Write-Warn "Could not register the keep-alive task: $($_.Exception.Message)"
+    Write-Warn "The gateway will still run while a WSL session is open; to make it persistent,"
+    Write-Warn "create a logon task that runs: wsl -d $Distro -u root --exec /bin/sh -c 'exec sleep infinity'"
+}
 
-Then run:
-
-"@
-
-Write-Host "    sudo apt update && sudo apt install -y git" -ForegroundColor Green
-Write-Host "    git clone https://github.com/Opendray/opendray_v2.git" -ForegroundColor Green
-Write-Host "    cd opendray_v2" -ForegroundColor Green
-Write-Host "    bash scripts/install-linux.sh" -ForegroundColor Green
 Write-Host ""
-
-Write-Host @"
-The Linux installer will walk you through Postgres, AI CLI install,
-opendray credentials, and systemd registration — inside the WSL2
-Ubuntu environment. Once it finishes, the admin UI is reachable from
-the Windows host at http://localhost:8770/admin/ (WSL2 forwards
-loopback ports to the host automatically).
-
-If the gateway needs to be reachable from other LAN devices, pick
-0.0.0.0:8770 when the wizard asks for the listen address — and
-remember WSL2 NAT means LAN hosts hit the Windows machine's IP, not
-the WSL distribution's IP.
-
-"@
-
-Write-Host "Heads up:" -ForegroundColor Yellow
-Write-Host "  - WSL2 Ubuntu does not auto-start systemd in default installs"
-Write-Host "    older than Win11 22H2. If 'systemctl' refuses to run, add"
-Write-Host "    'systemd=true' under [boot] in /etc/wsl.conf and 'wsl --shutdown'"
-Write-Host "    from PowerShell once before retrying."
+Write-Ok "Done. Open the admin UI from Windows:  http://localhost:8770/admin/"
+Write-Host "  (WSL forwards loopback to the Windows host. For LAN access from other"
+Write-Host "   devices, they reach the Windows machine's IP - and you must have picked"
+Write-Host "   0.0.0.0:8770 as the listen address during install.)"
 Write-Host ""


### PR DESCRIPTION
## Problem

The Windows path was advertised as a one-liner (`irm … | iex`) but `install-windows.ps1` was actually a **guided helper**: it printed manual commands (`wsl -d Ubuntu`, `apt install git`, `git clone`, `bash install-linux.sh`) and **installed nothing**. Worse, it treated **any** WSL distro as "ready" — so on a machine whose only WSL distro is a Docker/Podman helper, it announced "WSL is already enabled" and pointed the user at an **Ubuntu that isn't installed**, so the printed steps fail.

Reproduced on **Windows Server 2025** (WSL2 enabled, only a `podman-machine-default` distro): the one-liner declared success and handed over instructions for a non-existent Ubuntu.

There's also an operational gap: opendray runs as a **systemd service** inside WSL, but (a) WSL needs `systemd=true` set, and (b) **WSL stops idle distros**, so the gateway silently disappears after idle/reboot.

## Change — make it a real one-liner

Rewrites `install-windows.ps1` to actually set everything up, end to end:

1. **WSL2 feature** — enable it (`wsl --install --no-distribution`) if missing; that path needs admin + a reboot, after which re-running finishes.
2. **Usable distro** — detect a real Debian-family distro (`^(Ubuntu|Debian)`, *excluding* docker/podman helpers — the bug fix) and install **Ubuntu-24.04** if none exists.
3. **systemd** — set `/etc/wsl.conf [boot] systemd=true` and apply it.
4. **Run the installer** — `install-linux.sh` inside WSL (the existing, tested Linux path).
5. **Persistence** — register a logon Scheduled Task that boots + holds the distro (`sleep infinity`), so the systemd service (and `http://localhost:8770`) survives WSL's idle-stop and reboots.

Matches the project's bar: a single command that checks for and installs all required components, securely (the inner Linux installer keeps its checksum-verified download, least-priv DB user, 0600 secrets).

## Validated on real hardware (Windows Server 2025, WSL 2.5.10, over WinRM)

- **Distro detection:** installed = `{podman-machine-default, Ubuntu-24.04}` → correctly **excludes podman**, picks `Ubuntu-24.04`.
- **systemd:** enabled + `is-system-running` reports active.
- **Linux installer inside WSL:** ran end-to-end — Postgres + pgvector via apt, DB/role bootstrap, **33 migrations**, systemd `opendray.service` active+enabled.
- **Reachability:** `http://localhost:8770/api/v1/health` from the **Windows host** → `{"status":"ok","db_ok":true}` (WSL loopback forwarding).
- **Persistence:** terminated the distro (idle simulation) → keep-alive task booted it → gateway reachable again on the Windows host.
- **Parse:** `Parser::ParseFile` on the shipped script → no syntax errors.

## Test plan

- [x] PowerShell parse check
- [x] Distro detection excludes docker/podman, installs/uses Ubuntu
- [x] systemd enablement in WSL
- [x] `install-linux.sh` e2e inside WSL → healthy gateway
- [x] Windows `localhost:8770` reaches the WSL gateway
- [x] Keep-alive task boots an idle-stopped distro
- [ ] Full cold path on a box with **WSL not yet enabled** (the reboot branch) — not exercised here (test box already had WSL2)