### PR TITLE
fix(install/windows): OS-build guard, auto-resume after WSL reboot, PS 5.1 compat

### DIFF
--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -42,7 +42,23 @@ function Test-IsAdmin {
 # WSL emits UTF-16; WSL_UTF8 makes its output parseable.
 $env:WSL_UTF8 = "1"
 
+# Self URL — used to auto-resume the install after the WSL-enable reboot.
+$SelfUrl = "https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-windows.ps1"
+
 Write-Banner
+
+# -- Step 0: Windows build supports `wsl --install` ------------------
+# `wsl --install` (the modern in-box installer) requires Windows 10
+# version 2004 (build 19041) or newer, Windows 11, or Server 2022+.
+# Older builds need the legacy "Enable feature + download distro from
+# Store" dance, which this script does not implement.
+$build = [int]([System.Environment]::OSVersion.Version.Build)
+if ($build -lt 19041) {
+    Write-Err "This Windows build ($build) is too old for `wsl --install`."
+    Write-Host "  Required: Windows 10 build 19041 (version 2004) or newer, Windows 11, or Server 2022+."
+    Write-Host "  Update Windows, or follow the manual WSL2 setup at https://learn.microsoft.com/windows/wsl/install-manual"
+    exit 1
+}
 
 # -- Step 1: ensure the WSL2 feature ---------------------------------
 $wslReady = $false
@@ -57,7 +73,19 @@ if (-not $wslReady) {
     }
     Write-Info "Enabling WSL2 (this is a one-time step)..."
     & wsl.exe --install --no-distribution
-    Write-Ok "WSL2 enabled. REBOOT, then re-run this same command to finish."
+    # Auto-resume after the reboot: a RunOnce entry re-runs the same
+    # one-liner at next logon, so the user reboots once and the install
+    # continues by itself — closing the "one command, walk away" gap.
+    try {
+        $runOnceCmd = "powershell -NoProfile -ExecutionPolicy Bypass -Command `"irm $SelfUrl | iex`""
+        New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\RunOnce' -Force | Out-Null
+        Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\RunOnce' `
+            -Name 'opendray-resume-install' -Value $runOnceCmd
+        Write-Ok "WSL2 enabled. REBOOT now — the install will resume automatically when you log back in."
+    } catch {
+        Write-Warn "Could not register auto-resume ($($_.Exception.Message))."
+        Write-Ok "WSL2 enabled. REBOOT, then re-run this same command to finish."
+    }
     exit 0
 }
 Write-Ok "WSL2 is available."

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -1,22 +1,22 @@
 # scripts/install-windows.ps1
 # Windows entry point for the opendray installer.
 #
-# opendray does NOT run as a native Windows process — the session
+# opendray does NOT run as a native Windows process -- the session
 # subsystem spawns AI CLIs through Unix PTYs, which the Windows kernel
 # doesn't expose to opendray. So the Windows install is: set up WSL2 +
 # Ubuntu, then run the Linux installer inside it.
 #
 # Unlike a manual guide, this script does the whole thing for you:
-#   1) Ensures the WSL2 feature is present (enables it if missing —
+#   1) Ensures the WSL2 feature is present (enables it if missing --
 #      that one path needs admin + a reboot, then re-run).
 #   2) Ensures a usable Ubuntu/Debian distro exists (installs
-#      Ubuntu-24.04 if there isn't one — a Docker/Podman WSL distro
+#      Ubuntu-24.04 if there isn't one -- a Docker/Podman WSL distro
 #      does NOT count).
 #   3) Ensures systemd is enabled inside the distro (opendray runs as a
 #      systemd service).
 #   4) Runs the opendray Linux installer inside WSL.
 #   5) Registers a logon task so the distro (and the gateway) comes back
-#      up after idle/reboot — WSL stops idle distros otherwise.
+#      up after idle/reboot -- WSL stops idle distros otherwise.
 #
 # Usage (from PowerShell; elevate if WSL isn't installed yet):
 #   irm https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-windows.ps1 | iex
@@ -42,7 +42,7 @@ function Test-IsAdmin {
 # WSL emits UTF-16; WSL_UTF8 makes its output parseable.
 $env:WSL_UTF8 = "1"
 
-# Self URL — used to auto-resume the install after the WSL-enable reboot.
+# Self URL -- used to auto-resume the install after the WSL-enable reboot.
 $SelfUrl = "https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-windows.ps1"
 
 Write-Banner
@@ -75,14 +75,14 @@ if (-not $wslReady) {
     & wsl.exe --install --no-distribution
     # Auto-resume after the reboot: a RunOnce entry re-runs the same
     # one-liner at next logon, so the user reboots once and the install
-    # continues by itself — closing the "one command, walk away" gap.
+    # continues by itself -- closing the "one command, walk away" gap.
     try {
         $tmpl = 'powershell -NoProfile -ExecutionPolicy Bypass -Command "irm {0} | iex"'
         $runOnceCmd = $tmpl -f $SelfUrl
         New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\RunOnce' -Force | Out-Null
         Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\RunOnce' `
             -Name 'opendray-resume-install' -Value $runOnceCmd
-        Write-Ok "WSL2 enabled. REBOOT now — the install will resume automatically when you log back in."
+        Write-Ok "WSL2 enabled. REBOOT now -- the install will resume automatically when you log back in."
     } catch {
         Write-Warn "Could not register auto-resume ($($_.Exception.Message))."
         Write-Ok "WSL2 enabled. REBOOT, then re-run this same command to finish."

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -54,7 +54,7 @@ Write-Banner
 # Store" dance, which this script does not implement.
 $build = [int]([System.Environment]::OSVersion.Version.Build)
 if ($build -lt 19041) {
-    Write-Err "This Windows build ($build) is too old for `wsl --install`."
+    Write-Err ("This Windows build ($build) is too old for 'wsl --install'.")
     Write-Host "  Required: Windows 10 build 19041 (version 2004) or newer, Windows 11, or Server 2022+."
     Write-Host "  Update Windows, or follow the manual WSL2 setup at https://learn.microsoft.com/windows/wsl/install-manual"
     exit 1

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -77,7 +77,8 @@ if (-not $wslReady) {
     # one-liner at next logon, so the user reboots once and the install
     # continues by itself — closing the "one command, walk away" gap.
     try {
-        $runOnceCmd = "powershell -NoProfile -ExecutionPolicy Bypass -Command `"irm $SelfUrl | iex`""
+        $tmpl = 'powershell -NoProfile -ExecutionPolicy Bypass -Command "irm {0} | iex"'
+        $runOnceCmd = $tmpl -f $SelfUrl
         New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\RunOnce' -Force | Out-Null
         Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\RunOnce' `
             -Name 'opendray-resume-install' -Value $runOnceCmd


### PR DESCRIPTION
Three follow-ups to #213 so the Windows installer's cold path (no WSL installed) is genuinely a single user command — and so the script parses cleanly under Windows PowerShell 5.1.

## 1. Pre-flight Windows-build check

`wsl --install` requires Windows 10 version 2004 (build 19041) or newer, Windows 11, or Server 2022+. On older builds it now fails with an actionable message instead of letting `wsl.exe` produce a cryptic error.

```powershell
$build = [int]([System.Environment]::OSVersion.Version.Build)
if ($build -lt 19041) {
    Write-Err ("This Windows build ($build) is too old for 'wsl --install'.")
    ...
    exit 1
}
```

## 2. RunOnce auto-resume after the WSL-enable reboot

Enabling the WSL2 feature requires a reboot, but the installer was telling users to re-run the one-liner by hand after. Now it registers `HKCU\…\RunOnce\opendray-resume-install` to re-invoke the same `irm … | iex` at next logon — the user reboots once and the install picks up by itself (proceeds into Ubuntu install + `install-linux.sh` + the persistence task).

```powershell
$tmpl = 'powershell -NoProfile -ExecutionPolicy Bypass -Command "irm {0} | iex"'
$runOnceCmd = $tmpl -f $SelfUrl
New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\RunOnce' -Force | Out-Null
Set-ItemProperty -Path 'HKCU:\…\RunOnce' -Name 'opendray-resume-install' -Value $runOnceCmd
```

If the RunOnce write fails, we fall back to telling the user to re-run manually — never worse than before.

## 3. PS 5.1 / CP1252 compat — pure ASCII

#213 used em-dashes (`—`) in the script. Windows PowerShell 5.1 reads scripts as **Windows-1252** (the system codepage) when there's no BOM — and in CP1252 the third UTF-8 byte of `—` (`0x94`) maps to `"`. So a `"…before the — install…"` string was getting silently closed mid-content by the parser, cascading "missing closing }" / "string missing terminator" errors. Replaced all em-dashes with ASCII `--`. The script now parses cleanly on PS 5.1.

(PS 7+ defaults to UTF-8 so this wasn't visible there.)

## Validated on Windows Server 2025

- **Parse:** `Parser::ParseFile` on the shipped script → **PARSE OK** (no syntax errors).
- **Build guard:** correctly reports `passes(>=19041): True` on build 26100.
- **RunOnce write:** registers under `HKCU\…\RunOnce`, readback returns the exact command; removable cleanly.

The interactive cold path (WSL feature actually missing) still can't be exercised without uninstalling WSL on the test box (which breaks the existing podman-machine-default distro), so that branch remains code-reviewed only.

## Test plan

- [x] Parse-check via `Parser::ParseFile` on the actual shipped file (fetched fresh, bypassing the raw CDN)
- [x] Build-guard threshold logic on a real Server 2025 box
- [x] RunOnce key write/readback/remove
- [ ] Cold path on a box with WSL2 truly not enabled (requires a WSL-free Windows VM)