### PR TITLE
chore(repo): add CODEOWNERS + update SECURITY.md (v1 archived)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# CODEOWNERS auto-assigns reviewers when a PR touches matching paths.
+# The LAST matching pattern wins, so put broad patterns first and
+# narrower ones below.
+
+# Default reviewer for any change.
+*                          @linivek
+
+# Installers + service units — the installer pass added a lot here and is
+# co-owned. Anything that affects how the gateway gets onto a machine.
+/install.sh                @linivek @navidrast
+/scripts/                  @linivek @navidrast
+/deploy/                   @linivek @navidrast
+/uninstall.sh              @linivek @navidrast
+
+# Release / packaging surfaces.
+/.goreleaser.yaml          @linivek
+/.goreleaser.yml           @linivek
+/Dockerfile                @linivek
+
+# Repo meta / governance.
+/.github/                  @linivek
+/CONTRIBUTING.md           @linivek
+/SECURITY.md               @linivek
+/LICENSE                   @linivek

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,7 +65,7 @@ issues within 7 days.
 | Version | Supported |
 |---|---|
 | v1.0-rc onward | ✅ |
-| v1 (`Opendray/opendray`) | Maintenance only — security fixes for the cutover quarter, then archived per ADR 0001. |
+| v1 (`Opendray/opendray`) | Archived — no further fixes. Migrate to v2. |
 
 ## CVE History
 


### PR DESCRIPTION
Small repo-hygiene PR.

## CODEOWNERS (`.github/CODEOWNERS`)
Auto-assigns reviewers on PRs.

- Default reviewer: `@linivek`.
- Installer / deploy / uninstall paths: `@linivek @navidrast` (after the install path co-ownership during #208–#214).
- Release / packaging files + repo governance: `@linivek`.

## SECURITY.md
The Supported Versions table said v1 would be "archived per ADR 0001 after the cutover quarter." That archive happened (Opendray/opendray is now archived with a `[Archived] Superseded by opendray_v2 …` description). Replaced the forward-looking entry with the current state: v1 is archived, no further fixes, migrate to v2.

No behavioural changes; purely metadata + governance.