### PR TITLE
fix(systemd): drop MemoryDenyWriteExecute — breaks codex/gemini sessions

### DIFF
--- a/deploy/systemd/opendray.service
+++ b/deploy/systemd/opendray.service
@@ -78,7 +78,21 @@ ProtectControlGroups=true
 RestrictRealtime=true
 RestrictSUIDSGID=true
 LockPersonality=true
-MemoryDenyWriteExecute=true
+# NOTE: MemoryDenyWriteExecute is intentionally NOT enabled.
+#
+# It enforces W^X on the process AND all its children via seccomp.
+# Codex and Gemini are V8/Node.js-based CLIs whose JIT needs to flip
+# JIT pages from RW→RX via mprotect, which the W^X filter blocks
+# (SIGSYS). The child dies within ~50 ms of pty.Start and the user
+# sees a "[session ended — read-only buffer]" banner with no other
+# diagnostic.
+#
+# (Claude survives because anthropic-ai/claude-code falls back to an
+# interpreter-only path when it detects the constraint; codex and
+# gemini don't have that fallback.)
+#
+# If you want this hardening back, you'd have to spawn child CLIs in
+# a different unit/cgroup so the seccomp filter doesn't inherit.
 SystemCallArchitectures=native
 ReadWritePaths=/var/lib/opendray
 


### PR DESCRIPTION
Fixes #217.

## Summary

`MemoryDenyWriteExecute=true` enforces W^X on the opendray daemon **and inherits to spawned child processes via seccomp**. V8 (Codex and Gemini's runtime) needs an `mprotect RW→RX` transition for JIT code pages, which the W^X filter blocks → `SIGSYS` → child dies within ~50 ms of `pty.Start`, surfacing as the `[session ended — read-only buffer]` banner in the UI.

## Changes

- Remove `MemoryDenyWriteExecute=true` from `deploy/systemd/opendray.service`.
- Add an inline comment explaining the trade-off so a future hardening sweep doesn't re-introduce it without solving the child-spawn issue first.

All other hardening (`NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome=read-only`, `LockPersonality`, `RestrictNamespaces`, `CapabilityBoundingSet=`, …) is preserved.

## Verification

- Reproduced the issue on a fresh install (Debian 12 LXC, opendray 2.0.5, `@openai/codex` 0.132.0, `@google/gemini-cli` 0.42.0). Sessions ended in 50–65 ms with `exit_code = -1`.
- Applied the equivalent of this diff via a `/etc/systemd/system/opendray.service.d/no-mdwx.conf` drop-in. Same opendray binary, only the seccomp filter changed. Codex and Gemini sessions then stayed alive indefinitely (5+ min verified).
- Claude sessions are unaffected either way (it has an interpreter-only fallback that survives W^X).

See issue #217 for the full diagnostic trail (DB snapshots, signal-exit-code analysis, isolated systemd drop-in test).

## Test plan

- [ ] Operator can install via `install-linux.sh` and spawn a Codex session that survives past the first frame
- [ ] Same for Gemini (note: gemini will stop at its trusted-folders prompt — separate small follow-up, see issue's side-note)
- [ ] Existing Claude sessions continue to work