### PR TITLE
fix(channel): show session names in /list instead of bare ids

### DIFF
--- a/internal/app/channel_commands.go
+++ b/internal/app/channel_commands.go
@@ -110,17 +110,24 @@ func listSessionsCardHandler(mgr sessionOps) channel.CommandCardHandler {
 			}
 		}
 
-		// Body: numbered list. The full id is shown so operators
-		// who want to type /end <full> can still copy it; the
-		// buttons below carry the full id in their callback data.
+		// Body: numbered list. We lead with the human-given name
+		// when one exists — operators think in names, not nano ids —
+		// and keep the full id on the line so it stays copyable for
+		// `/end <full>`. The buttons below also carry the full id in
+		// their callback data. Sessions started without a name fall
+		// back to the bare id (there's nothing friendlier to show).
 		var b strings.Builder
 		fmt.Fprintf(&b, "%d session%s (showing %d):\n",
 			liveCount, plural(liveCount), len(all))
 		now := time.Now().UTC()
 		for i, s := range all {
+			label := s.ID
+			if s.Name != "" {
+				label = fmt.Sprintf("%s (%s)", s.Name, s.ID)
+			}
 			fmt.Fprintf(&b, "%d. %s — %s — %s — %s\n",
 				i+1,
-				s.ID,
+				label,
 				s.ProviderID,
 				s.State,
 				relativeAge(sessionActivityTime(s), now),

--- a/internal/app/channel_commands_test.go
+++ b/internal/app/channel_commands_test.go
@@ -128,6 +128,30 @@ func TestListSessionsCardHandler_LiveFirstThenTerminated(t *testing.T) {
 	}
 }
 
+func TestListSessionsCardHandler_LeadsWithName(t *testing.T) {
+	now := time.Now().UTC()
+	sessions := []session.Session{
+		{ID: "ses_named01", Name: "deploy-bot", ProviderID: "claude",
+			State: session.StateIdle, StartedAt: now.Add(-time.Minute)},
+		{ID: "ses_unnamed1", ProviderID: "gemini",
+			State: session.StateIdle, StartedAt: now.Add(-2 * time.Minute)},
+	}
+	h := listSessionsCardHandler(&fakeSessionOps{sessions: sessions})
+	got, err := h(context.Background(), channel.CommandContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := cardText(t, got)
+	// Named session: name leads, full id retained in parens for copy.
+	if !strings.Contains(body, "deploy-bot (ses_named01)") {
+		t.Errorf("named session should render \"name (id)\":\n%s", body)
+	}
+	// Unnamed session: bare id, no empty parens.
+	if !strings.Contains(body, "ses_unnamed1 —") || strings.Contains(body, "()") {
+		t.Errorf("unnamed session should render the bare id:\n%s", body)
+	}
+}
+
 func TestListSessionsCardHandler_CapsAtMax(t *testing.T) {
 	now := time.Now().UTC()
 	sessions := make([]session.Session, 0, listSessionsMax+5)

--- a/internal/session/default_name_test.go
+++ b/internal/session/default_name_test.go
@@ -1,0 +1,26 @@
+package session
+
+import "testing"
+
+func TestDefaultSessionName(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider string
+		cwd      string
+		want     string
+	}{
+		{"cwd basename", "claude", "/home/navid/projects/opendray", "opendray"},
+		{"trailing slash", "gemini", "/home/navid/projects/opendray/", "opendray"},
+		{"root falls back to provider", "claude", "/", "claude"},
+		{"empty falls back to provider", "codex", "", "codex"},
+		{"dot falls back to provider", "gemini", ".", "gemini"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := defaultSessionName(tc.provider, tc.cwd); got != tc.want {
+				t.Errorf("defaultSessionName(%q, %q) = %q, want %q",
+					tc.provider, tc.cwd, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -218,6 +218,21 @@ func (m *Manager) ReconcileStartup(ctx context.Context) error {
 	return nil
 }
 
+// defaultSessionName derives a friendly label for sessions created
+// without an explicit name, so channel surfaces (/list, idle cards)
+// show something operators recognise instead of a bare nano id. The
+// working-directory basename is the most meaningful default; we fall
+// back to the provider id when the cwd has no usable basename (root,
+// empty, ".").
+func defaultSessionName(providerID, cwd string) string {
+	base := filepath.Base(strings.TrimRight(cwd, string(filepath.Separator)))
+	switch base {
+	case "", ".", string(filepath.Separator):
+		return providerID
+	}
+	return base
+}
+
 // Create resolves the provider, spawns a PTY, persists the row, and
 // starts the stdout pump + exit detector goroutines. Returns the
 // persisted Session view.
@@ -234,9 +249,13 @@ func (m *Manager) Create(ctx context.Context, req CreateRequest) (Session, error
 	m.mu.RUnlock()
 
 	sessID := newID()
+	name := req.Name
+	if name == "" {
+		name = defaultSessionName(req.ProviderID, req.Cwd)
+	}
 	sess := Session{
 		ID:              sessID,
-		Name:            req.Name,
+		Name:            name,
 		ProviderID:      req.ProviderID,
 		Cwd:             req.Cwd,
 		Args:            req.Args,


### PR DESCRIPTION
## Problem

`/list` in chat channels (Telegram, etc.) renders every session by its raw nano id and never looks at the session's name:

```
4 sessions (showing 4):
1. ses_el0bkKP-O3cN — claude — idle — 12m ago
2. ses_4ag4ZIRIW2E0 — shell — idle — 13m ago
3. ses_45mw7yeKLyg5 — gemini — running — 13m ago
4. ses_ZOHVgF2b-IOO — codex — idle — 8h ago
```

Operators can't tell sessions apart at a glance. Reported in #220.

## Fix

Two parts:

1. **`internal/app/channel_commands.go`** — lead with the session name when one exists, keeping the full id in parens (`deploy-bot (ses_el0bkKP-O3cN) — claude — idle — 12m ago`). The full id stays on the line because `/end`/`/resume` resolve by exact id and the End/Resume buttons carry the full id in their callback data, so copy-paste and button taps both keep working.

2. **`internal/session/manager.go`** — auto-name sessions created without an explicit name from the working-directory basename (falling back to the provider id for root/empty cwd). Sessions started without `--name` were the common case where there was no name to show; now they get a readable default.

## Tests

- `TestListSessionsCardHandler_LeadsWithName` — named session renders `name (id)`, unnamed renders the bare id with no empty parens.
- `TestDefaultSessionName` — cwd-basename derivation incl. trailing-slash and root/empty/`.` fallbacks.
- Existing `/list` sort/cap tests still pass (full ids remain present in the body).

Closes #220.