### PR TITLE
fix(session): give spawned CLIs a color-capable TERM

### DIFF
--- a/internal/session/color_term_test.go
+++ b/internal/session/color_term_test.go
@@ -1,0 +1,36 @@
+package session
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestEnsureColorTerm(t *testing.T) {
+	t.Run("injects defaults when absent", func(t *testing.T) {
+		got := ensureColorTerm([]string{"PATH=/usr/bin", "HOME=/var/lib/opendray"})
+		if !slices.Contains(got, "TERM=xterm-256color") {
+			t.Errorf("TERM not injected: %v", got)
+		}
+		if !slices.Contains(got, "COLORTERM=truecolor") {
+			t.Errorf("COLORTERM not injected: %v", got)
+		}
+	})
+
+	t.Run("respects existing TERM and COLORTERM", func(t *testing.T) {
+		in := []string{"TERM=screen-256color", "COLORTERM=24bit"}
+		got := ensureColorTerm(slices.Clone(in))
+		if !slices.Equal(got, in) {
+			t.Errorf("should not override existing values: %v", got)
+		}
+	})
+
+	t.Run("fills only the missing one", func(t *testing.T) {
+		got := ensureColorTerm([]string{"TERM=vt100"})
+		if slices.Contains(got, "TERM=xterm-256color") {
+			t.Errorf("should not override existing TERM: %v", got)
+		}
+		if !slices.Contains(got, "COLORTERM=truecolor") {
+			t.Errorf("COLORTERM should be injected: %v", got)
+		}
+	})
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -376,7 +376,7 @@ func (m *Manager) spawn(ctx context.Context, sess Session, reactivate bool) (*ru
 
 	cmd := exec.Command(p.Executable, args...)
 	cmd.Dir = sess.Cwd
-	cmd.Env = mergeEnv(os.Environ(), extraEnv)
+	cmd.Env = mergeEnv(ensureColorTerm(os.Environ()), extraEnv)
 
 	ptmx, err := pty.Start(cmd)
 	if err != nil {
@@ -464,6 +464,34 @@ func (m *Manager) RecentScreen(id string) string {
 // mergeEnv overlays `overrides` onto a base "K=V" slice. Keys present
 // in both win for `overrides`. Used so PrepareFunc can inject env vars
 // like CODEX_HOME without losing the inherited environment.
+// ensureColorTerm guarantees child CLIs see a color-capable terminal.
+// opendray always allocates a real PTY (pty.Start), so the CLIs'
+// isatty() check passes — but systemd starts the daemon with no TERM,
+// and Node/ink-based CLIs (claude, codex, gemini) fall back to
+// monochrome output when TERM is unset. We inject xterm-256color +
+// truecolor as defaults only; an explicit TERM/COLORTERM already in
+// the environment (or set later by provider config, which mergeEnv
+// applies as an override) still wins, and we never touch NO_COLOR so
+// an operator who opted out stays opted out.
+func ensureColorTerm(env []string) []string {
+	var hasTERM, hasCOLORTERM bool
+	for _, kv := range env {
+		switch {
+		case strings.HasPrefix(kv, "TERM="):
+			hasTERM = true
+		case strings.HasPrefix(kv, "COLORTERM="):
+			hasCOLORTERM = true
+		}
+	}
+	if !hasTERM {
+		env = append(env, "TERM=xterm-256color")
+	}
+	if !hasCOLORTERM {
+		env = append(env, "COLORTERM=truecolor")
+	}
+	return env
+}
+
 func mergeEnv(base []string, overrides map[string]string) []string {
 	if len(overrides) == 0 {
 		return base


### PR DESCRIPTION
## Problem

Every spawned session renders in black & white — no ANSI color or styling from claude / codex / gemini, even though the web terminal (xterm.js / Dart xterm) is fully capable of rendering color.

Root cause: the spawn builds the child environment as `mergeEnv(os.Environ(), extraEnv)` and never sets `TERM`. systemd starts the daemon with **no `TERM`** in its environment, so the child inherits none. claude/codex/gemini are Node/ink-based TUIs whose color detection (`supports-color`) disables color when `TERM` is unset. opendray does allocate a real PTY, so `isatty()` passes — but that isn't enough on its own.

Verified on a live deploy: the daemon and all three child CLIs had no `TERM`/`COLORTERM` in their environment.

## Fix

`ensureColorTerm` injects `TERM=xterm-256color` + `COLORTERM=truecolor` as **defaults** at spawn:

```go
cmd.Env = mergeEnv(ensureColorTerm(os.Environ()), extraEnv)
```

- Only fills what's missing — an explicit `TERM`/`COLORTERM` already in the environment, or one set by provider config (which `mergeEnv` applies as an override afterwards), still wins.
- `NO_COLOR` is left untouched, so an operator who opted out of color stays opted out.

## Tests

`TestEnsureColorTerm` covers: inject-when-absent, respect-existing, and fill-only-the-missing-one.