### PR TITLE
feat(channel): interactive session switching via /select + Talk-to buttons

### DIFF
--- a/internal/app/channel_commands.go
+++ b/internal/app/channel_commands.go
@@ -59,6 +59,13 @@ func registerChannelCommands(hub *channel.Hub, mgr sessionOps) {
 		Source:      "builtin",
 		Handler:     resumeSessionHandler(mgr),
 	})
+	hub.RegisterCommand(channel.Command{
+		Name: "select",
+		Description: "Talk to a session: /select <session_id> " +
+			"(pin where your messages go; /select off to clear)",
+		Source:  "builtin",
+		Handler: selectSessionHandler(mgr),
+	})
 }
 
 // listSessionsMax caps how many rows /list returns. Telegram's
@@ -134,13 +141,20 @@ func listSessionsCardHandler(mgr sessionOps) channel.CommandCardHandler {
 			)
 		}
 
-		// Buttons: live sessions get an End row, terminated ones a
-		// Resume row. Two per row keeps tap targets large on mobile
-		// without forcing the keyboard taller than the screen.
-		var endRow, resumeRow []channel.ButtonOption
+		// Buttons: live sessions get a "Talk to" row (pins this chat's
+		// active session so plain messages route there) and an End
+		// row; terminated ones get a Resume row. Two per row keeps tap
+		// targets large on mobile without forcing the keyboard taller
+		// than the screen.
+		var talkRow, endRow, resumeRow []channel.ButtonOption
 		for i, s := range all {
 			label := fmt.Sprintf("%d %s", i+1, sessionShortID(s.ID))
 			if isLiveState(s.State) {
+				talkRow = append(talkRow, channel.ButtonOption{
+					Text:  "💬 Talk to " + label,
+					Value: "cmd:/select " + s.ID,
+					Style: "primary",
+				})
 				endRow = append(endRow, channel.ButtonOption{
 					Text:  "End " + label,
 					Value: "cmd:/end " + s.ID,
@@ -154,7 +168,8 @@ func listSessionsCardHandler(mgr sessionOps) channel.CommandCardHandler {
 				})
 			}
 		}
-		buttons := make([][]channel.ButtonOption, 0, 4)
+		buttons := make([][]channel.ButtonOption, 0, 6)
+		buttons = append(buttons, chunkButtons(talkRow, 2)...)
 		buttons = append(buttons, chunkButtons(endRow, 2)...)
 		buttons = append(buttons, chunkButtons(resumeRow, 2)...)
 
@@ -226,6 +241,89 @@ func resumeSessionHandler(mgr sessionOps) channel.CommandHandler {
 		}
 		return fmt.Sprintf("Session %s resumed (state=%s).", sid, s.State), nil
 	}
+}
+
+// selectSessionHandler pins the chat's active session so plain
+// (non-reply) messages route to it — the interactive way to switch
+// between sessions. Backs the /select command and the "💬 Talk to"
+// buttons on /list. No argument reports the current pin; "off"
+// (or clear/none) removes it.
+func selectSessionHandler(mgr sessionOps) channel.CommandHandler {
+	return func(ctx context.Context, cc channel.CommandContext) (string, error) {
+		chID := ""
+		if cc.Channel != nil {
+			chID = cc.Channel.ID()
+		}
+		if cc.Hub == nil || chID == "" {
+			return "Session selection isn't available on this channel.", nil
+		}
+
+		arg, ok := singleSessionArg(cc.Args)
+		if !ok {
+			cur := cc.Hub.ActiveSession(chID)
+			if cur == "" {
+				return "No session selected. Use /list and tap “💬 Talk to”, or /select <session_id>.", nil
+			}
+			return fmt.Sprintf("Currently talking to %s. Send /select off to clear.",
+				sessionDisplay(ctx, mgr, cur)), nil
+		}
+
+		switch strings.ToLower(arg) {
+		case "off", "clear", "none":
+			cc.Hub.SetActiveSession(chID, "")
+			return "Cleared — messages now follow the most recent session again.", nil
+		}
+
+		// Validate against the live set so we never pin a stale/typo'd id
+		// that would silently swallow the chat's messages.
+		sess, found, err := findSession(ctx, mgr, arg)
+		if err != nil {
+			return "", fmt.Errorf("select %s: %w", arg, err)
+		}
+		if !found {
+			return "Session " + arg + " not found — /list shows current sessions.", nil
+		}
+		if !isLiveState(sess.State) {
+			return fmt.Sprintf("Session %s is %s — /resume it first.",
+				sessionLabel(sess), sess.State), nil
+		}
+		cc.Hub.SetActiveSession(chID, sess.ID)
+		return fmt.Sprintf("✅ Now talking to %s. Your messages go here until you /select another (or /select off).",
+			sessionLabel(sess)), nil
+	}
+}
+
+// findSession returns the session with the given id from the manager's
+// current list.
+func findSession(ctx context.Context, mgr sessionOps, id string) (session.Session, bool, error) {
+	all, err := mgr.List(ctx)
+	if err != nil {
+		return session.Session{}, false, err
+	}
+	for _, s := range all {
+		if s.ID == id {
+			return s, true, nil
+		}
+	}
+	return session.Session{}, false, nil
+}
+
+// sessionLabel renders a session as "name (id)", or the bare id when
+// it has no name — matching how /list presents sessions.
+func sessionLabel(s session.Session) string {
+	if s.Name != "" {
+		return fmt.Sprintf("%s (%s)", s.Name, s.ID)
+	}
+	return s.ID
+}
+
+// sessionDisplay looks a session up by id for display, falling back to
+// the bare id when it's no longer listed.
+func sessionDisplay(ctx context.Context, mgr sessionOps, id string) string {
+	if s, ok, err := findSession(ctx, mgr, id); err == nil && ok {
+		return sessionLabel(s)
+	}
+	return id
 }
 
 // ── helpers ──────────────────────────────────────────────────────

--- a/internal/app/channel_commands_test.go
+++ b/internal/app/channel_commands_test.go
@@ -175,16 +175,17 @@ func TestListSessionsCardHandler_CapsAtMax(t *testing.T) {
 		t.Errorf("want %d lines (cap + header), got %d\n%s",
 			listSessionsMax+1, lines, body)
 	}
-	// Every shown session contributed exactly one button.
-	if got := len(cardButtonValues(got)); got != listSessionsMax {
-		t.Errorf("want %d buttons (one per shown session), got %d",
-			listSessionsMax, got)
+	// Every shown session is live here, so each contributes two
+	// buttons: "Talk to" + End.
+	if got := len(cardButtonValues(got)); got != listSessionsMax*2 {
+		t.Errorf("want %d buttons (Talk+End per live session), got %d",
+			listSessionsMax*2, got)
 	}
 }
 
-// The whole point of this PR: each session row in /list produces a
-// tappable button whose callback value carries the FULL session id,
-// so the operator never has to type it. Live sessions get an /end
+// Each session row in /list produces tappable buttons whose callback
+// value carries the FULL session id, so the operator never has to type
+// it. Live sessions get a "Talk to" (/select) button and an /end
 // button; terminated ones get /resume.
 func TestListSessionsCardHandler_ButtonsCarryFullIdAndCorrectVerb(t *testing.T) {
 	now := time.Now().UTC()
@@ -206,6 +207,8 @@ func TestListSessionsCardHandler_ButtonsCarryFullIdAndCorrectVerb(t *testing.T) 
 	}
 	values := cardButtonValues(got)
 	want := []string{
+		"cmd:/select ses_running1",
+		"cmd:/select ses_idle1",
 		"cmd:/end ses_running1",
 		"cmd:/end ses_idle1",
 		"cmd:/resume ses_ended1",
@@ -214,8 +217,8 @@ func TestListSessionsCardHandler_ButtonsCarryFullIdAndCorrectVerb(t *testing.T) 
 	if len(values) != len(want) {
 		t.Fatalf("got %d buttons, want %d\nvalues: %v", len(values), len(want), values)
 	}
-	// Order: end buttons first (live sessions, in input recency
-	// order), then resume buttons (terminated sessions).
+	// Order: Talk-to (live) first, then End (live), then Resume
+	// (terminated) — each group in input recency order.
 	for i, w := range want {
 		if values[i] != w {
 			t.Errorf("button[%d] = %q, want %q\nall: %v", i, values[i], w, values)
@@ -378,5 +381,64 @@ func TestRelativeAge_Buckets(t *testing.T) {
 		if got := relativeAge(c.ts, base); got != c.want {
 			t.Errorf("ts=%v got %q want %q", c.ts, got, c.want)
 		}
+	}
+}
+
+// fakeChannel is a minimal channel.Channel for exercising command
+// handlers that only need Channel.ID().
+type fakeChannel struct{ id string }
+
+func (f *fakeChannel) Kind() string                                       { return "test" }
+func (f *fakeChannel) ID() string                                         { return f.id }
+func (f *fakeChannel) Start(context.Context, channel.InboundFunc) error   { return nil }
+func (f *fakeChannel) Stop(context.Context) error                         { return nil }
+func (f *fakeChannel) Send(context.Context, channel.ChannelMessage) error { return nil }
+
+func TestSelectSessionHandler(t *testing.T) {
+	hub := channel.NewHub(nil, nil, nil)
+	ch := &fakeChannel{id: "ch_test"}
+	mgr := &fakeSessionOps{sessions: []session.Session{
+		{ID: "ses_live1", Name: "deploy", ProviderID: "claude", State: session.StateRunning},
+		{ID: "ses_dead1", ProviderID: "gemini", State: session.StateEnded},
+	}}
+	h := selectSessionHandler(mgr)
+	mk := func(args ...string) channel.CommandContext {
+		return channel.CommandContext{Channel: ch, Hub: hub, Args: args}
+	}
+
+	// Pin a live session — confirmation names it, routing is set.
+	resp, err := h(context.Background(), mk("ses_live1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(resp, "deploy (ses_live1)") {
+		t.Errorf("expected confirmation naming the session, got %q", resp)
+	}
+	if got := hub.ActiveSession("ch_test"); got != "ses_live1" {
+		t.Errorf("active session = %q, want ses_live1", got)
+	}
+
+	// No-arg reports the current pin.
+	if resp, _ = h(context.Background(), mk()); !strings.Contains(resp, "ses_live1") {
+		t.Errorf("no-arg should report current pin, got %q", resp)
+	}
+
+	// "off" clears the pin.
+	if _, _ = h(context.Background(), mk("off")); hub.ActiveSession("ch_test") != "" {
+		t.Errorf("/select off should clear the active session")
+	}
+
+	// Unknown id is rejected and must not change an existing pin.
+	hub.SetActiveSession("ch_test", "ses_live1")
+	if resp, _ = h(context.Background(), mk("ses_nope")); !strings.Contains(resp, "not found") {
+		t.Errorf("unknown id should report not found, got %q", resp)
+	}
+	if hub.ActiveSession("ch_test") != "ses_live1" {
+		t.Errorf("unknown id must not change the pin")
+	}
+
+	// A terminated session is rejected with a resume hint.
+	if resp, _ = h(context.Background(), mk("ses_dead1")); !strings.Contains(resp, "resume") {
+		t.Errorf("terminated session should suggest /resume, got %q", resp)
 	}
 }

--- a/internal/channel/hub.go
+++ b/internal/channel/hub.go
@@ -162,9 +162,9 @@ func (h *Hub) RegisterCommand(c Command) { h.cmds.Register(c) }
 //     operators who expected /sessions == /list.
 //
 // The pinned-session machinery (activeSess + lookupActiveSession +
-// setActiveSession) is retained as dead-code-but-load-bearing — if
-// we ever bring /select back the routing is already wired. Cheap
-// to keep; ripping it out would expand the diff for no gain.
+// setActiveSession) is driven by the /select command and the "Talk
+// to" buttons on /list (registered in internal/app), via the public
+// SetActiveSession / ActiveSession methods below.
 func (h *Hub) registerBuiltinCommands() {
 	h.cmds.Register(Command{
 		Name:        "notify",
@@ -860,6 +860,20 @@ func (h *Hub) setActiveSession(channelID, sessionID string) {
 		return
 	}
 	h.activeSess[channelID] = sessionID
+}
+
+// SetActiveSession pins (or clears, when sessionID is "") the session
+// that non-reply inbound messages from this channel route to. This is
+// the public entry point for the /select command and the "Talk to"
+// buttons on /list; routing precedence stays reply-to > active > last.
+func (h *Hub) SetActiveSession(channelID, sessionID string) {
+	h.setActiveSession(channelID, sessionID)
+}
+
+// ActiveSession returns the session currently pinned for a channel, or
+// "" when none is set.
+func (h *Hub) ActiveSession(channelID string) string {
+	return h.lookupActiveSession(channelID)
 }
 
 // submitToSession types `text` into a session's PTY rune-by-rune,


### PR DESCRIPTION
## Problem

In chat channels (Telegram, etc.) there's no way to choose **which session** your messages go to — you can only reply to a specific notification message. If no notification is handy, messages fall through to "the most recent session", which is confusing when several sessions are live.

The hub already had the routing override for a pinned "active session" (`activeSess`, precedence `reply-to > active > last`), but **nothing set it** — the `/select` command had been removed, leaving `setActiveSession` as dead code with a comment noting the routing was "already wired if we ever bring /select back".

## Change

Bring it back, button-first:

- **hub**: expose `SetActiveSession` / `ActiveSession` as the public entry points.
- **/list**: each live session row now renders a **"💬 Talk to"** button (`cmd:/select <id>`) next to End. Tapping it pins that session — the intended phone-friendly path, since nano-ids are too long to type.
- **/select `<id>`**: pin the chat's active session so plain (non-reply) messages route there. The id is validated against the live session set, so a stale or mistyped id can't silently swallow the chat's messages. `/select` with no arg reports the current pin; `/select off` clears it.

Routing precedence is unchanged: an explicit reply-to still wins over the pin.

## Tests

- `TestSelectSessionHandler`: pin a live session (confirmation names it + routing set), no-arg reports current, `off` clears, unknown id rejected without changing the pin, terminated session rejected with a resume hint.
- Updated the `/list` button-count/verb tests for the new Talk-to buttons.

Builds on the `/list` name-rendering change (#224).