### PR TITLE
feat(catalog): real CLI version + update-available in providers API/UI

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -962,7 +962,10 @@
           "stream": "stream",
           "images": "images",
           "mcp": "mcp"
-        }
+        },
+        "notInstalled": "not installed",
+        "updateAvailable": "update available → {{version}}",
+        "upToDate": "up to date"
       },
       "configForm": {
         "selectPlaceholder": "Select…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -962,7 +962,10 @@
           "stream": "stream",
           "images": "images",
           "mcp": "mcp"
-        }
+        },
+        "notInstalled": "未安装",
+        "updateAvailable": "有可用更新 → {{version}}",
+        "upToDate": "已是最新"
       },
       "configForm": {
         "selectPlaceholder": "选择…",

--- a/app/shared/src/lib/catalog.ts
+++ b/app/shared/src/lib/catalog.ts
@@ -1,9 +1,18 @@
 import { api } from './api'
-import type { Provider } from './types'
+import type { Provider, ProviderRuntime } from './types'
 
 export async function listProviders(): Promise<Provider[]> {
   const res = await api<{ providers: Provider[] }>('/api/v1/providers')
   return res.providers ?? []
+}
+
+// checkProviderUpdate probes the installed version AND the latest npm
+// version (network; cached server-side). Kept separate from
+// listProviders so the list render isn't blocked on the npm lookup.
+export async function checkProviderUpdate(
+  id: string,
+): Promise<ProviderRuntime> {
+  return api<ProviderRuntime>(`/api/v1/providers/${id}/update-check`)
 }
 
 export async function getProvider(id: string): Promise<Provider> {

--- a/app/shared/src/lib/types.ts
+++ b/app/shared/src/lib/types.ts
@@ -111,6 +111,7 @@ export interface ProviderManifest {
   version: string
   kind: 'cli' | 'shell'
   executable: string
+  npmPackage?: string
   defaultArgs?: string[]
   capabilities: {
     supportsResume: boolean
@@ -121,11 +122,24 @@ export interface ProviderManifest {
   configSchema?: ConfigField[]
 }
 
+// ProviderRuntime is the live, probed CLI state (not from the manifest):
+// whether the binary is installed and its real `--version`, plus the
+// latest npm version when an update-check has run.
+export interface ProviderRuntime {
+  installed: boolean
+  installedVersion?: string
+  path?: string
+  latestVersion?: string
+  updateAvailable: boolean
+  checkedAt?: string
+}
+
 export interface Provider {
   manifest: ProviderManifest
   manifest_hash: string
   config: Record<string, unknown>
   enabled: boolean
+  runtime?: ProviderRuntime
 }
 
 // ── Channels ────────────────────────────────────────────────

--- a/app/web/src/pages/Providers.tsx
+++ b/app/web/src/pages/Providers.tsx
@@ -17,6 +17,7 @@ import {
   listProviders,
   toggleProvider,
   updateProviderConfig,
+  checkProviderUpdate,
 } from '@/lib/catalog'
 import type { Provider } from '@/lib/types'
 import { cn } from '@/lib/utils'
@@ -173,6 +174,15 @@ function ProviderDetail({
 }) {
   const { t } = useTranslation()
   const m = provider.manifest
+  const rt = provider.runtime
+  // Latest-version check is a network (npm) call, so it runs on its own
+  // endpoint and only for installed CLI providers.
+  const { data: upd } = useQuery({
+    queryKey: ['provider-update', m.id],
+    queryFn: () => checkProviderUpdate(m.id),
+    enabled: m.kind === 'cli' && !!rt?.installed,
+    staleTime: 60_000,
+  })
   const caps: { key: keyof typeof m.capabilities; labelKey: string }[] = [
     { key: 'supportsResume', labelKey: 'web.providers.detail.caps.resume' },
     { key: 'supportsStream', labelKey: 'web.providers.detail.caps.stream' },
@@ -197,9 +207,27 @@ function ProviderDetail({
             <Badge variant="outline" className="font-mono normal-case">
               {m.kind}
             </Badge>
-            <Badge variant="outline" className="font-mono normal-case">
-              v{m.version}
-            </Badge>
+            {rt && !rt.installed ? (
+              <Badge
+                variant="outline"
+                className="font-mono normal-case text-muted-foreground"
+              >
+                {t('web.providers.detail.notInstalled')}
+              </Badge>
+            ) : (
+              <Badge variant="outline" className="font-mono normal-case">
+                {/* Real installed CLI version when known; falls back to
+                    the manifest's schema version only if unprobed. */}
+                {rt?.installedVersion ?? `v${m.version}`}
+              </Badge>
+            )}
+            {upd?.updateAvailable && upd.latestVersion ? (
+              <Badge variant="accent" className="font-mono normal-case">
+                {t('web.providers.detail.updateAvailable', {
+                  version: upd.latestVersion,
+                })}
+              </Badge>
+            ) : null}
           </div>
           <p className="text-[12px] text-muted-foreground mt-1 max-w-[60ch]">
             {m.description}

--- a/internal/catalog/builtin/claude.json
+++ b/internal/catalog/builtin/claude.json
@@ -9,6 +9,7 @@
   "version": "1.0.0",
   "kind": "cli",
   "executable": "claude",
+  "npmPackage": "@anthropic-ai/claude-code",
   "capabilities": {
     "supportsResume": true,
     "supportsStream": true,
@@ -22,7 +23,10 @@
       "label_zh": "认证",
       "type": "select",
       "group": "auth",
-      "options": ["env", "custom"],
+      "options": [
+        "env",
+        "custom"
+      ],
       "default": "env",
       "description": "env = read ANTHROPIC_API_KEY from system; custom = use the key below",
       "description_zh": "env = 从系统读取 ANTHROPIC_API_KEY；custom = 使用下方自定义密钥"
@@ -85,6 +89,10 @@
     }
   ],
   "ui": {
-    "activityBar": { "id": "claude", "icon": "🟣", "title": "Claude Code" }
+    "activityBar": {
+      "id": "claude",
+      "icon": "🟣",
+      "title": "Claude Code"
+    }
   }
 }

--- a/internal/catalog/builtin/codex.json
+++ b/internal/catalog/builtin/codex.json
@@ -9,6 +9,7 @@
   "version": "1.0.0",
   "kind": "cli",
   "executable": "codex",
+  "npmPackage": "@openai/codex",
   "capabilities": {
     "supportsResume": false,
     "supportsStream": true,
@@ -22,7 +23,10 @@
       "label_zh": "认证",
       "type": "select",
       "group": "auth",
-      "options": ["env", "custom"],
+      "options": [
+        "env",
+        "custom"
+      ],
       "default": "env",
       "description": "env = read OPENAI_API_KEY from system; custom = use the key below",
       "description_zh": "env = 从系统读取 OPENAI_API_KEY；custom = 使用下方自定义密钥"
@@ -44,7 +48,11 @@
       "label_zh": "审批模式",
       "type": "select",
       "group": "runtime",
-      "options": ["untrusted", "on-request", "never"],
+      "options": [
+        "untrusted",
+        "on-request",
+        "never"
+      ],
       "default": "on-request",
       "cliFlag": "--ask-for-approval",
       "cliValue": true,
@@ -57,7 +65,11 @@
       "label_zh": "沙盒策略",
       "type": "select",
       "group": "runtime",
-      "options": ["read-only", "workspace-write", "danger-full-access"],
+      "options": [
+        "read-only",
+        "workspace-write",
+        "danger-full-access"
+      ],
       "default": "workspace-write",
       "cliFlag": "-s",
       "cliValue": true,
@@ -91,6 +103,10 @@
     }
   ],
   "ui": {
-    "activityBar": { "id": "codex", "icon": "🤖", "title": "Codex" }
+    "activityBar": {
+      "id": "codex",
+      "icon": "🤖",
+      "title": "Codex"
+    }
   }
 }

--- a/internal/catalog/builtin/gemini.json
+++ b/internal/catalog/builtin/gemini.json
@@ -9,6 +9,7 @@
   "version": "1.0.0",
   "kind": "cli",
   "executable": "gemini",
+  "npmPackage": "@google/gemini-cli",
   "capabilities": {
     "supportsResume": false,
     "supportsStream": true,
@@ -22,7 +23,10 @@
       "label_zh": "认证",
       "type": "select",
       "group": "auth",
-      "options": ["env", "custom"],
+      "options": [
+        "env",
+        "custom"
+      ],
       "default": "env",
       "description": "env = read GOOGLE_API_KEY from system; custom = use the key below",
       "description_zh": "env = 从系统读取 GOOGLE_API_KEY；custom = 使用下方自定义密钥"
@@ -55,7 +59,10 @@
       "label_zh": "沙盒",
       "type": "select",
       "group": "runtime",
-      "options": ["", "none"],
+      "options": [
+        "",
+        "none"
+      ],
       "default": "",
       "cliFlag": "-s",
       "cliValue": true,
@@ -89,6 +96,10 @@
     }
   ],
   "ui": {
-    "activityBar": { "id": "gemini", "icon": "✨", "title": "Gemini" }
+    "activityBar": {
+      "id": "gemini",
+      "icon": "✨",
+      "title": "Gemini"
+    }
   }
 }

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -62,6 +62,9 @@ type Provider struct {
 	ManifestHash string         `json:"manifest_hash"`
 	Config       map[string]any `json:"config"`
 	Enabled      bool           `json:"enabled"`
+	// Runtime is the live probed CLI state (installed?, real version).
+	// Set by the HTTP handler, not the store — nil when not probed.
+	Runtime *RuntimeInfo `json:"runtime,omitempty"`
 }
 
 func (c *Catalog) Get(ctx context.Context, id string) (Provider, error) {

--- a/internal/catalog/handler.go
+++ b/internal/catalog/handler.go
@@ -11,15 +11,16 @@ import (
 
 // Handlers serves the /providers REST surface. Mount under /api/v1.
 type Handlers struct {
-	cat *Catalog
-	log *slog.Logger
+	cat    *Catalog
+	prober *Prober
+	log    *slog.Logger
 }
 
 func NewHandlers(cat *Catalog, log *slog.Logger) *Handlers {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &Handlers{cat: cat, log: log.With("component", "catalog.http")}
+	return &Handlers{cat: cat, prober: NewProber(), log: log.With("component", "catalog.http")}
 }
 
 func (h *Handlers) Mount(r chi.Router) {
@@ -29,6 +30,8 @@ func (h *Handlers) Mount(r chi.Router) {
 			r.Get("/", h.get)
 			r.Patch("/config", h.updateConfig)
 			r.Patch("/toggle", h.toggle)
+			// Network npm lookup → its own endpoint so the list stays fast.
+			r.Get("/update-check", h.updateCheck)
 		})
 	})
 }
@@ -38,6 +41,13 @@ func (h *Handlers) list(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
+	}
+	// Enrich with the cheap, locally-probed install state + real version
+	// (cached). The npm "update available" check is the separate
+	// /update-check endpoint to keep this response snappy.
+	for i := range ps {
+		info := h.prober.Installed(r.Context(), ps[i].Manifest)
+		ps[i].Runtime = &info
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"providers": ps})
 }
@@ -53,7 +63,27 @@ func (h *Handlers) get(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
+	info := h.prober.Installed(r.Context(), p.Manifest)
+	p.Runtime = &info
 	writeJSON(w, http.StatusOK, p)
+}
+
+// updateCheck probes the installed version AND the latest npm version,
+// reporting whether an update is available. Separate from list because
+// it makes a network call (cached for an hour).
+func (h *Handlers) updateCheck(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	p, err := h.cat.Get(r.Context(), id)
+	if errors.Is(err, ErrNotFound) {
+		writeError(w, http.StatusNotFound, err)
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	info := h.prober.CheckUpdate(r.Context(), p.Manifest)
+	writeJSON(w, http.StatusOK, info)
 }
 
 func (h *Handlers) updateConfig(w http.ResponseWriter, r *http.Request) {

--- a/internal/catalog/manifest.go
+++ b/internal/catalog/manifest.go
@@ -17,19 +17,23 @@ package catalog
 // config* (not a manifest field) since MCP injection is a session
 // spawn-time hook, not a separate plugin.
 type Manifest struct {
-	ID            string        `json:"id"`
-	DisplayName   string        `json:"displayName"`
-	DisplayNameZh string        `json:"displayName_zh,omitempty"`
-	Description   string        `json:"description"`
-	DescriptionZh string        `json:"description_zh,omitempty"`
-	Icon          string        `json:"icon"`
-	Version       string        `json:"version"`
-	Kind          string        `json:"kind"` // "cli" | "shell"
-	Executable    string        `json:"executable"`
-	DefaultArgs   []string      `json:"defaultArgs,omitempty"`
-	Capabilities  Capabilities  `json:"capabilities"`
-	ConfigSchema  []ConfigField `json:"configSchema,omitempty"`
-	UI            *UI           `json:"ui,omitempty"`
+	ID            string `json:"id"`
+	DisplayName   string `json:"displayName"`
+	DisplayNameZh string `json:"displayName_zh,omitempty"`
+	Description   string `json:"description"`
+	DescriptionZh string `json:"description_zh,omitempty"`
+	Icon          string `json:"icon"`
+	Version       string `json:"version"`
+	Kind          string `json:"kind"` // "cli" | "shell"
+	Executable    string `json:"executable"`
+	// NpmPackage is the npm package the executable ships in, used to
+	// probe the latest published version (and, in Phase 2, to update
+	// the CLI). Empty for non-npm providers such as the builtin shell.
+	NpmPackage   string        `json:"npmPackage,omitempty"`
+	DefaultArgs  []string      `json:"defaultArgs,omitempty"`
+	Capabilities Capabilities  `json:"capabilities"`
+	ConfigSchema []ConfigField `json:"configSchema,omitempty"`
+	UI           *UI           `json:"ui,omitempty"`
 }
 
 // Capabilities is descriptive metadata used by clients to render the

--- a/internal/catalog/probe.go
+++ b/internal/catalog/probe.go
@@ -1,0 +1,194 @@
+package catalog
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RuntimeInfo is the live, probed state of a provider's CLI — distinct
+// from the static Manifest. Populated by Prober at request time, never
+// persisted. InstalledVersion is the real `<cli> --version` output (the
+// thing the dashboard should show instead of the manifest's schema
+// version); LatestVersion/UpdateAvailable come from the npm registry.
+type RuntimeInfo struct {
+	Installed        bool   `json:"installed"`
+	InstalledVersion string `json:"installedVersion,omitempty"`
+	Path             string `json:"path,omitempty"`
+	LatestVersion    string `json:"latestVersion,omitempty"`
+	UpdateAvailable  bool   `json:"updateAvailable"`
+	CheckedAt        string `json:"checkedAt,omitempty"` // RFC3339; when LatestVersion was fetched
+}
+
+// Cache TTLs: installed state is cheap (local exec) so a short TTL keeps
+// the providers list fresh without re-probing on every poll; the npm
+// lookup is a network call, so it's cached much longer and only run by
+// the explicit update-check path.
+const (
+	installedTTL = 60 * time.Second
+	latestTTL    = time.Hour
+)
+
+type cachedInstalled struct {
+	info RuntimeInfo
+	at   time.Time
+}
+
+type cachedLatest struct {
+	version string
+	at      time.Time
+}
+
+// Prober probes installed CLI versions (local exec) and latest npm
+// versions (network), each with its own TTL cache. The exec/lookup
+// functions are injectable so tests don't shell out.
+type Prober struct {
+	mu        sync.Mutex
+	installed map[string]cachedInstalled // executable -> info
+	latest    map[string]cachedLatest    // npm package -> version
+
+	lookPath func(string) (string, error)
+	runVer   func(ctx context.Context, bin string) (string, error)
+	npmView  func(ctx context.Context, pkg string) (string, error)
+	now      func() time.Time
+}
+
+func NewProber() *Prober {
+	return &Prober{
+		installed: map[string]cachedInstalled{},
+		latest:    map[string]cachedLatest{},
+		lookPath:  exec.LookPath,
+		runVer:    defaultCliVersion,
+		npmView:   defaultNpmLatest,
+		now:       time.Now,
+	}
+}
+
+// Installed reports whether the manifest's executable is on PATH and its
+// `--version` string. Fast (local exec), cached for installedTTL.
+func (p *Prober) Installed(ctx context.Context, m Manifest) RuntimeInfo {
+	if m.Executable == "" {
+		return RuntimeInfo{}
+	}
+	p.mu.Lock()
+	if c, ok := p.installed[m.Executable]; ok && p.now().Sub(c.at) < installedTTL {
+		info := c.info
+		p.mu.Unlock()
+		return info
+	}
+	p.mu.Unlock()
+
+	var info RuntimeInfo
+	if path, err := p.lookPath(m.Executable); err == nil {
+		info.Installed = true
+		info.Path = path
+		if v, err := p.runVer(ctx, m.Executable); err == nil {
+			info.InstalledVersion = v
+		}
+	}
+
+	p.mu.Lock()
+	p.installed[m.Executable] = cachedInstalled{info: info, at: p.now()}
+	p.mu.Unlock()
+	return info
+}
+
+// CheckUpdate returns Installed() enriched with the latest published npm
+// version and an update-available flag. Network call, cached latestTTL.
+func (p *Prober) CheckUpdate(ctx context.Context, m Manifest) RuntimeInfo {
+	info := p.Installed(ctx, m)
+	if m.NpmPackage == "" {
+		return info
+	}
+
+	p.mu.Lock()
+	c, ok := p.latest[m.NpmPackage]
+	fresh := ok && p.now().Sub(c.at) < latestTTL
+	latest := c.version
+	p.mu.Unlock()
+
+	if !fresh {
+		if v, err := p.npmView(ctx, m.NpmPackage); err == nil && v != "" {
+			latest = v
+			p.mu.Lock()
+			p.latest[m.NpmPackage] = cachedLatest{version: v, at: p.now()}
+			p.mu.Unlock()
+		}
+	}
+
+	info.LatestVersion = latest
+	info.CheckedAt = p.now().UTC().Format(time.RFC3339)
+	info.UpdateAvailable = updateAvailable(info.InstalledVersion, latest)
+	return info
+}
+
+// ── version comparison ───────────────────────────────────────────────
+
+var semverRe = regexp.MustCompile(`\d+\.\d+\.\d+`)
+
+// extractSemver pulls the first MAJOR.MINOR.PATCH out of a version
+// string. CLIs decorate their --version output ("codex-cli 0.132.0",
+// "2.1.146 (Claude Code)"); npm returns a bare "2.1.146".
+func extractSemver(s string) string { return semverRe.FindString(s) }
+
+// updateAvailable is true only when a clean latest version is strictly
+// greater than the installed one — so a locally-ahead dev build never
+// shows a spurious "update available".
+func updateAvailable(installed, latest string) bool {
+	iv := extractSemver(installed)
+	lv := extractSemver(latest)
+	if iv == "" || lv == "" {
+		return false
+	}
+	return semverLess(iv, lv)
+}
+
+func semverLess(a, b string) bool {
+	ap := strings.Split(a, ".")
+	bp := strings.Split(b, ".")
+	for i := 0; i < 3; i++ {
+		ai, _ := strconv.Atoi(ap[i])
+		bi, _ := strconv.Atoi(bp[i])
+		if ai != bi {
+			return ai < bi
+		}
+	}
+	return false
+}
+
+// ── default probes (shell out) ───────────────────────────────────────
+
+func defaultCliVersion(ctx context.Context, bin string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, "--version")
+	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	sc := bufio.NewScanner(strings.NewReader(string(out)))
+	if sc.Scan() {
+		return strings.TrimSpace(sc.Text()), nil
+	}
+	return "", nil
+}
+
+func defaultNpmLatest(ctx context.Context, pkg string) (string, error) {
+	if _, err := exec.LookPath("npm"); err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "npm", "view", pkg, "version").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/catalog/probe_test.go
+++ b/internal/catalog/probe_test.go
@@ -1,0 +1,78 @@
+package catalog
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestExtractSemverAndUpdateAvailable(t *testing.T) {
+	cases := []struct {
+		installed, latest string
+		wantUpdate        bool
+	}{
+		{"2.1.146 (Claude Code)", "2.1.150", true},
+		{"codex-cli 0.132.0", "0.132.0", false},
+		{"0.42.0", "0.41.9", false}, // installed ahead
+		{"", "1.0.0", false},        // not installed
+		{"1.2.3", "", false},        // no latest
+		{"1.2.3", "1.3.0", true},
+		{"1.9.0", "1.10.0", true}, // numeric, not lexical
+	}
+	for _, c := range cases {
+		if got := updateAvailable(c.installed, c.latest); got != c.wantUpdate {
+			t.Errorf("updateAvailable(%q,%q)=%v want %v", c.installed, c.latest, got, c.wantUpdate)
+		}
+	}
+}
+
+func TestProber_InstalledCachesAndProbes(t *testing.T) {
+	calls := 0
+	p := NewProber()
+	p.now = func() time.Time { return time.Unix(1000, 0) }
+	p.lookPath = func(string) (string, error) { return "/usr/bin/claude", nil }
+	p.runVer = func(context.Context, string) (string, error) {
+		calls++
+		return "2.1.146 (Claude Code)", nil
+	}
+	m := Manifest{Executable: "claude"}
+
+	got := p.Installed(context.Background(), m)
+	if !got.Installed || got.InstalledVersion != "2.1.146 (Claude Code)" || got.Path != "/usr/bin/claude" {
+		t.Fatalf("unexpected info: %+v", got)
+	}
+	// Second call within TTL must hit the cache (no extra probe).
+	_ = p.Installed(context.Background(), m)
+	if calls != 1 {
+		t.Errorf("expected 1 probe (cached), got %d", calls)
+	}
+}
+
+func TestProber_NotInstalled(t *testing.T) {
+	p := NewProber()
+	p.lookPath = func(string) (string, error) { return "", errors.New("not found") }
+	got := p.Installed(context.Background(), Manifest{Executable: "ghost"})
+	if got.Installed {
+		t.Errorf("ghost should not be installed: %+v", got)
+	}
+}
+
+func TestProber_CheckUpdate(t *testing.T) {
+	p := NewProber()
+	p.now = func() time.Time { return time.Unix(2000, 0) }
+	p.lookPath = func(string) (string, error) { return "/usr/bin/codex", nil }
+	p.runVer = func(context.Context, string) (string, error) { return "codex-cli 0.132.0", nil }
+	p.npmView = func(context.Context, string) (string, error) { return "0.140.0", nil }
+
+	info := p.CheckUpdate(context.Background(), Manifest{Executable: "codex", NpmPackage: "@openai/codex"})
+	if info.InstalledVersion != "codex-cli 0.132.0" || info.LatestVersion != "0.140.0" || !info.UpdateAvailable {
+		t.Errorf("unexpected: %+v", info)
+	}
+
+	// No npm package → no latest lookup, no false update flag.
+	none := p.CheckUpdate(context.Background(), Manifest{Executable: "codex"})
+	if none.UpdateAvailable || none.LatestVersion != "" {
+		t.Errorf("no-package provider should not report updates: %+v", none)
+	}
+}


### PR DESCRIPTION
## Problem

The Providers dashboard shows every CLI as **`v1.0.0`** — that's the manifest *schema* version (`Manifest.Version`), not the installed CLI version. The real versions differ a lot (e.g. Claude Code `2.1.146`, Codex `0.132.0`, Gemini `0.42.0`). opendray already knows the real value (`cliVersion` in `cmd/opendray/providers.go`) but never surfaces it to the API/UI, so operators can't tell what's actually installed or whether an update exists.

## Change (Phase 1 — read-only, no privilege change)

- **manifest**: add `npmPackage` (the npm package each CLI ships in); filled for claude/codex/gemini. (`shell` has none.)
- **catalog**: new cached `Prober`:
  - `Installed()` probes `<cli> --version` locally — cheap, 60s TTL.
  - `CheckUpdate()` also fetches the latest npm version (`npm view`) — network, 1h TTL — and sets `updateAvailable` via a **numeric** semver compare, so a locally-ahead build never shows a spurious update.
- **API**:
  - `GET /providers` and `GET /providers/{id}` now include a `runtime` block: `{installed, installedVersion, path}`.
  - new `GET /providers/{id}/update-check` → `{installedVersion, latestVersion, updateAvailable, checkedAt}`. Split out so the list render isn't blocked on the npm call.
- **web**: Providers page shows the **real installed version** (or "not installed"), plus an **"update available → X"** badge driven by `update-check`. New i18n keys in en/zh.

## Tests

`probe_test.go`: semver extraction + numeric `updateAvailable` (incl. installed-ahead and 1.9→1.10), install caching (one probe within TTL), not-installed, and the no-npm-package path.

## Follow-up

Phase 2 adds an admin-only, whitelisted, audited **Update** action (the daemon is sandboxed and can't `npm -g` today — that'll use an opendray-owned npm prefix so no privilege escalation is needed).