### PR TITLE
feat(catalog): admin Update action to patch provider CLIs from the panel

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -970,7 +970,8 @@
         "updating": "Updating…",
         "updatedToast": "Updated {{from}} → {{to}}",
         "alreadyLatestToast": "Already up to date",
-        "updateFailedToast": "Update failed"
+        "updateFailedToast": "Update failed",
+        "updateUnavailable": "In-app update not available here"
       },
       "configForm": {
         "selectPlaceholder": "Select…",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -962,7 +962,10 @@
           "stream": "stream",
           "images": "images",
           "mcp": "mcp"
-        }
+        },
+        "notInstalled": "not installed",
+        "updateAvailable": "update available → {{version}}",
+        "upToDate": "up to date"
       },
       "configForm": {
         "selectPlaceholder": "Select…",
@@ -1683,16 +1686,46 @@
     },
     "serverSettings": {
       "sections": {
-        "general": { "title": "General", "desc": "Listen address, operator account, token TTL." },
-        "logging": { "title": "Logging", "desc": "Verbosity, format, and live tail." },
-        "sessions": { "title": "Sessions", "desc": "Idle detection thresholds." },
-        "vault": { "title": "Vault", "desc": "Notes, skills, and git-versioned root." },
-        "mcp": { "title": "MCP registry", "desc": "Server registry + secrets." },
-        "memory": { "title": "Memory", "desc": "Cross-CLI persistent memory subsystem." },
-        "backup": { "title": "Backup", "desc": "Encrypted DB backups, restore, and admin data exports." },
-        "claude": { "title": "Storage · Claude", "desc": "Where Claude transcripts live on disk." },
-        "codex": { "title": "Storage · Codex", "desc": "Codex sessions root." },
-        "gemini": { "title": "Storage · Gemini", "desc": "Gemini per-project tmp + projects.json." }
+        "general": {
+          "title": "General",
+          "desc": "Listen address, operator account, token TTL."
+        },
+        "logging": {
+          "title": "Logging",
+          "desc": "Verbosity, format, and live tail."
+        },
+        "sessions": {
+          "title": "Sessions",
+          "desc": "Idle detection thresholds."
+        },
+        "vault": {
+          "title": "Vault",
+          "desc": "Notes, skills, and git-versioned root."
+        },
+        "mcp": {
+          "title": "MCP registry",
+          "desc": "Server registry + secrets."
+        },
+        "memory": {
+          "title": "Memory",
+          "desc": "Cross-CLI persistent memory subsystem."
+        },
+        "backup": {
+          "title": "Backup",
+          "desc": "Encrypted DB backups, restore, and admin data exports."
+        },
+        "claude": {
+          "title": "Storage · Claude",
+          "desc": "Where Claude transcripts live on disk."
+        },
+        "codex": {
+          "title": "Storage · Codex",
+          "desc": "Codex sessions root."
+        },
+        "gemini": {
+          "title": "Storage · Gemini",
+          "desc": "Gemini per-project tmp + projects.json."
+        }
       },
       "loading": "Loading server settings…",
       "loadFailed": "Failed to load: {message}",
@@ -3144,12 +3177,30 @@
     "pathStyle": "Path-style addressing",
     "pathStyleSubtitle": "Legacy / MinIO",
     "kinds": {
-      "local": { "label": "Local disk", "description": "Folder on the machine running opendray" },
-      "smb": { "label": "SMB share", "description": "Windows shares + most home NAS appliances" },
-      "webdav": { "label": "WebDAV", "description": "Self-hosted clouds + file-sharing services" },
-      "sftp": { "label": "SFTP", "description": "Any SSH-accessible server" },
-      "s3": { "label": "S3 / compatible", "description": "Amazon S3 + S3-compatible buckets (MinIO, R2, B2)" },
-      "rclone": { "label": "rclone (any)", "description": "OneDrive, Google Drive, Dropbox via the rclone CLI" }
+      "local": {
+        "label": "Local disk",
+        "description": "Folder on the machine running opendray"
+      },
+      "smb": {
+        "label": "SMB share",
+        "description": "Windows shares + most home NAS appliances"
+      },
+      "webdav": {
+        "label": "WebDAV",
+        "description": "Self-hosted clouds + file-sharing services"
+      },
+      "sftp": {
+        "label": "SFTP",
+        "description": "Any SSH-accessible server"
+      },
+      "s3": {
+        "label": "S3 / compatible",
+        "description": "Amazon S3 + S3-compatible buckets (MinIO, R2, B2)"
+      },
+      "rclone": {
+        "label": "rclone (any)",
+        "description": "OneDrive, Google Drive, Dropbox via the rclone CLI"
+      }
     },
     "formTitleEdit": "Edit target",
     "formTitleNew": "New backup target",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -965,7 +965,12 @@
         },
         "notInstalled": "not installed",
         "updateAvailable": "update available → {{version}}",
-        "upToDate": "up to date"
+        "upToDate": "up to date",
+        "update": "Update to {{version}}",
+        "updating": "Updating…",
+        "updatedToast": "Updated {{from}} → {{to}}",
+        "alreadyLatestToast": "Already up to date",
+        "updateFailedToast": "Update failed"
       },
       "configForm": {
         "selectPlaceholder": "Select…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -965,7 +965,12 @@
         },
         "notInstalled": "未安装",
         "updateAvailable": "有可用更新 → {{version}}",
-        "upToDate": "已是最新"
+        "upToDate": "已是最新",
+        "update": "更新到 {{version}}",
+        "updating": "更新中…",
+        "updatedToast": "已更新 {{from}} → {{to}}",
+        "alreadyLatestToast": "已是最新",
+        "updateFailedToast": "更新失败"
       },
       "configForm": {
         "selectPlaceholder": "选择…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -962,7 +962,10 @@
           "stream": "stream",
           "images": "images",
           "mcp": "mcp"
-        }
+        },
+        "notInstalled": "未安装",
+        "updateAvailable": "有可用更新 → {{version}}",
+        "upToDate": "已是最新"
       },
       "configForm": {
         "selectPlaceholder": "选择…",
@@ -1682,16 +1685,46 @@
     },
     "serverSettings": {
       "sections": {
-        "general": { "title": "通用", "desc": "监听地址、操作员账号、令牌 TTL。" },
-        "logging": { "title": "日志", "desc": "日志级别、格式与实时跟踪。" },
-        "sessions": { "title": "会话", "desc": "空闲检测阈值。" },
-        "vault": { "title": "Vault", "desc": "笔记、技能与 git 版本化根目录。" },
-        "mcp": { "title": "MCP 注册表", "desc": "服务器注册表与密钥。" },
-        "memory": { "title": "记忆", "desc": "跨 CLI 的持久化记忆子系统。" },
-        "backup": { "title": "备份", "desc": "加密数据库备份、恢复，以及管理员数据导出。" },
-        "claude": { "title": "存储 · Claude", "desc": "Claude 会话记录在磁盘上的位置。" },
-        "codex": { "title": "存储 · Codex", "desc": "Codex 会话根目录。" },
-        "gemini": { "title": "存储 · Gemini", "desc": "Gemini 每项目 tmp 与 projects.json。" }
+        "general": {
+          "title": "通用",
+          "desc": "监听地址、操作员账号、令牌 TTL。"
+        },
+        "logging": {
+          "title": "日志",
+          "desc": "日志级别、格式与实时跟踪。"
+        },
+        "sessions": {
+          "title": "会话",
+          "desc": "空闲检测阈值。"
+        },
+        "vault": {
+          "title": "Vault",
+          "desc": "笔记、技能与 git 版本化根目录。"
+        },
+        "mcp": {
+          "title": "MCP 注册表",
+          "desc": "服务器注册表与密钥。"
+        },
+        "memory": {
+          "title": "记忆",
+          "desc": "跨 CLI 的持久化记忆子系统。"
+        },
+        "backup": {
+          "title": "备份",
+          "desc": "加密数据库备份、恢复，以及管理员数据导出。"
+        },
+        "claude": {
+          "title": "存储 · Claude",
+          "desc": "Claude 会话记录在磁盘上的位置。"
+        },
+        "codex": {
+          "title": "存储 · Codex",
+          "desc": "Codex 会话根目录。"
+        },
+        "gemini": {
+          "title": "存储 · Gemini",
+          "desc": "Gemini 每项目 tmp 与 projects.json。"
+        }
       },
       "loading": "正在加载服务器设置…",
       "loadFailed": "加载失败：{message}",
@@ -3143,12 +3176,30 @@
     "pathStyle": "路径风格寻址",
     "pathStyleSubtitle": "旧版 / MinIO",
     "kinds": {
-      "local": { "label": "本地磁盘", "description": "运行 opendray 的机器上的文件夹" },
-      "smb": { "label": "SMB 共享", "description": "Windows 共享 + 多数家用 NAS 设备" },
-      "webdav": { "label": "WebDAV", "description": "自托管云盘 + 文件共享服务" },
-      "sftp": { "label": "SFTP", "description": "任何可 SSH 访问的服务器" },
-      "s3": { "label": "S3 / 兼容", "description": "Amazon S3 + S3 兼容存储桶（MinIO、R2、B2）" },
-      "rclone": { "label": "rclone（任意）", "description": "通过 rclone CLI 访问 OneDrive、Google Drive、Dropbox" }
+      "local": {
+        "label": "本地磁盘",
+        "description": "运行 opendray 的机器上的文件夹"
+      },
+      "smb": {
+        "label": "SMB 共享",
+        "description": "Windows 共享 + 多数家用 NAS 设备"
+      },
+      "webdav": {
+        "label": "WebDAV",
+        "description": "自托管云盘 + 文件共享服务"
+      },
+      "sftp": {
+        "label": "SFTP",
+        "description": "任何可 SSH 访问的服务器"
+      },
+      "s3": {
+        "label": "S3 / 兼容",
+        "description": "Amazon S3 + S3 兼容存储桶（MinIO、R2、B2）"
+      },
+      "rclone": {
+        "label": "rclone（任意）",
+        "description": "通过 rclone CLI 访问 OneDrive、Google Drive、Dropbox"
+      }
     },
     "formTitleEdit": "编辑目标",
     "formTitleNew": "新建备份目标",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -970,7 +970,8 @@
         "updating": "更新中…",
         "updatedToast": "已更新 {{from}} → {{to}}",
         "alreadyLatestToast": "已是最新",
-        "updateFailedToast": "更新失败"
+        "updateFailedToast": "更新失败",
+        "updateUnavailable": "此处无法在应用内更新"
       },
       "configForm": {
         "selectPlaceholder": "选择…",

--- a/app/shared/src/lib/catalog.ts
+++ b/app/shared/src/lib/catalog.ts
@@ -15,6 +15,25 @@ export async function checkProviderUpdate(
   return api<ProviderRuntime>(`/api/v1/providers/${id}/update-check`)
 }
 
+export interface ProviderUpdateResult {
+  package: string
+  beforeVersion?: string
+  afterVersion?: string
+  changed: boolean
+  output?: string
+}
+
+// updateProvider patches the CLI to the latest npm version (admin-only,
+// audited server-side). The npm package is taken from the trusted
+// manifest, not the request — no arbitrary-package vector.
+export async function updateProvider(
+  id: string,
+): Promise<ProviderUpdateResult> {
+  return api<ProviderUpdateResult>(`/api/v1/providers/${id}/update`, {
+    method: 'POST',
+  })
+}
+
 export async function getProvider(id: string): Promise<Provider> {
   return api<Provider>(`/api/v1/providers/${id}`)
 }

--- a/app/shared/src/lib/catalog.ts
+++ b/app/shared/src/lib/catalog.ts
@@ -1,9 +1,18 @@
 import { api } from './api'
-import type { Provider } from './types'
+import type { Provider, ProviderRuntime } from './types'
 
 export async function listProviders(): Promise<Provider[]> {
   const res = await api<{ providers: Provider[] }>('/api/v1/providers')
   return res.providers ?? []
+}
+
+// checkProviderUpdate probes the installed version AND the latest npm
+// version (network; cached server-side). Kept separate from
+// listProviders so the list render isn't blocked on the npm lookup.
+export async function checkProviderUpdate(
+  id: string,
+): Promise<ProviderRuntime> {
+  return api<ProviderRuntime>(`/api/v1/providers/${id}/update-check`)
 }
 
 export async function getProvider(id: string): Promise<Provider> {

--- a/app/shared/src/lib/catalog.ts
+++ b/app/shared/src/lib/catalog.ts
@@ -21,6 +21,10 @@ export interface ProviderUpdateResult {
   afterVersion?: string
   changed: boolean
   output?: string
+  // available=false when an in-app update can't run here (e.g. the npm
+  // prefix isn't writable by the service); reason explains why.
+  available: boolean
+  reason?: string
 }
 
 // updateProvider patches the CLI to the latest npm version (admin-only,

--- a/app/shared/src/lib/types.ts
+++ b/app/shared/src/lib/types.ts
@@ -111,6 +111,7 @@ export interface ProviderManifest {
   version: string
   kind: 'cli' | 'shell'
   executable: string
+  npmPackage?: string
   defaultArgs?: string[]
   capabilities: {
     supportsResume: boolean
@@ -121,11 +122,24 @@ export interface ProviderManifest {
   configSchema?: ConfigField[]
 }
 
+// ProviderRuntime is the live, probed CLI state (not from the manifest):
+// whether the binary is installed and its real `--version`, plus the
+// latest npm version when an update-check has run.
+export interface ProviderRuntime {
+  installed: boolean
+  installedVersion?: string
+  path?: string
+  latestVersion?: string
+  updateAvailable: boolean
+  checkedAt?: string
+}
+
 export interface Provider {
   manifest: ProviderManifest
   manifest_hash: string
   config: Record<string, unknown>
   enabled: boolean
+  runtime?: ProviderRuntime
 }
 
 // ── Channels ────────────────────────────────────────────────

--- a/app/web/src/pages/Providers.tsx
+++ b/app/web/src/pages/Providers.tsx
@@ -17,6 +17,7 @@ import {
   listProviders,
   toggleProvider,
   updateProviderConfig,
+  checkProviderUpdate,
 } from '@/lib/catalog'
 import type { Provider } from '@/lib/types'
 import { cn } from '@/lib/utils'
@@ -173,6 +174,15 @@ function ProviderDetail({
 }) {
   const { t } = useTranslation()
   const m = provider.manifest
+  const rt = provider.runtime
+  // Latest-version check is a network (npm) call, so it runs on its own
+  // endpoint and only for installed CLI providers.
+  const { data: upd } = useQuery({
+    queryKey: ['provider-update', m.id],
+    queryFn: () => checkProviderUpdate(m.id),
+    enabled: m.kind === 'cli' && !!rt?.installed,
+    staleTime: 60_000,
+  })
   const caps: { key: keyof typeof m.capabilities; labelKey: string }[] = [
     { key: 'supportsResume', labelKey: 'web.providers.detail.caps.resume' },
     { key: 'supportsStream', labelKey: 'web.providers.detail.caps.stream' },
@@ -197,9 +207,27 @@ function ProviderDetail({
             <Badge variant="outline" className="font-mono normal-case">
               {m.kind}
             </Badge>
-            <Badge variant="outline" className="font-mono normal-case">
-              v{m.version}
-            </Badge>
+            {rt && !rt.installed ? (
+              <Badge
+                variant="outline"
+                className="font-mono normal-case text-muted-foreground"
+              >
+                {t('web.providers.detail.notInstalled')}
+              </Badge>
+            ) : (
+              <Badge variant="outline" className="font-mono normal-case">
+                {/* Real installed CLI version when known; falls back to
+                    the manifest's schema version only if unprobed. */}
+                {rt?.installedVersion ?? `v${m.version}`}
+              </Badge>
+            )}
+            {upd?.updateAvailable && upd.latestVersion ? (
+              <Badge variant="accent" className="font-mono normal-case">
+                {t('web.providers.detail.updateAvailable', {
+                  version: upd.latestVersion,
+                })}
+              </Badge>
+            ) : null}
           </div>
           <p className="text-[12px] text-muted-foreground mt-1 max-w-[60ch]">
             {m.description}

--- a/app/web/src/pages/Providers.tsx
+++ b/app/web/src/pages/Providers.tsx
@@ -188,6 +188,13 @@ function ProviderDetail({
   const updateMut = useMutation({
     mutationFn: () => updateProvider(m.id),
     onSuccess: (res) => {
+      if (!res.available) {
+        // Can't update here (e.g. read-only npm prefix) — guidance, not error.
+        toast.info(t('web.providers.detail.updateUnavailable'), {
+          description: res.reason,
+        })
+        return
+      }
       if (res.changed) {
         toast.success(
           t('web.providers.detail.updatedToast', {

--- a/app/web/src/pages/Providers.tsx
+++ b/app/web/src/pages/Providers.tsx
@@ -18,6 +18,7 @@ import {
   toggleProvider,
   updateProviderConfig,
   checkProviderUpdate,
+  updateProvider,
 } from '@/lib/catalog'
 import type { Provider } from '@/lib/types'
 import { cn } from '@/lib/utils'
@@ -173,6 +174,7 @@ function ProviderDetail({
   onToggle: (enabled: boolean) => void
 }) {
   const { t } = useTranslation()
+  const qc = useQueryClient()
   const m = provider.manifest
   const rt = provider.runtime
   // Latest-version check is a network (npm) call, so it runs on its own
@@ -182,6 +184,27 @@ function ProviderDetail({
     queryFn: () => checkProviderUpdate(m.id),
     enabled: m.kind === 'cli' && !!rt?.installed,
     staleTime: 60_000,
+  })
+  const updateMut = useMutation({
+    mutationFn: () => updateProvider(m.id),
+    onSuccess: (res) => {
+      if (res.changed) {
+        toast.success(
+          t('web.providers.detail.updatedToast', {
+            from: res.beforeVersion,
+            to: res.afterVersion,
+          }),
+        )
+      } else {
+        toast.info(t('web.providers.detail.alreadyLatestToast'))
+      }
+      qc.invalidateQueries({ queryKey: ['providers'] })
+      qc.invalidateQueries({ queryKey: ['provider-update', m.id] })
+    },
+    onError: (e: Error) =>
+      toast.error(t('web.providers.detail.updateFailedToast'), {
+        description: e.message,
+      }),
   })
   const caps: { key: keyof typeof m.capabilities; labelKey: string }[] = [
     { key: 'supportsResume', labelKey: 'web.providers.detail.caps.resume' },
@@ -222,11 +245,29 @@ function ProviderDetail({
               </Badge>
             )}
             {upd?.updateAvailable && upd.latestVersion ? (
-              <Badge variant="accent" className="font-mono normal-case">
-                {t('web.providers.detail.updateAvailable', {
-                  version: upd.latestVersion,
-                })}
-              </Badge>
+              <>
+                <Badge variant="accent" className="font-mono normal-case">
+                  {t('web.providers.detail.updateAvailable', {
+                    version: upd.latestVersion,
+                  })}
+                </Badge>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-6 px-2 text-[11px]"
+                  disabled={updateMut.isPending}
+                  onClick={() => updateMut.mutate()}
+                >
+                  {updateMut.isPending ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : null}
+                  {updateMut.isPending
+                    ? t('web.providers.detail.updating')
+                    : t('web.providers.detail.update', {
+                        version: upd.latestVersion,
+                      })}
+                </Button>
+              </>
             ) : null}
           </div>
           <p className="text-[12px] text-muted-foreground mt-1 max-w-[60ch]">

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -117,7 +117,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		st.Close()
 		return nil, err
 	}
-	catalogHandlers := catalog.NewHandlers(cat, log)
+	catalogHandlers := catalog.NewHandlers(cat, bus, log)
 
 	var cliacctOpts []cliacct.Option
 	if d := strings.TrimSpace(cfg.Providers.Claude.AccountsDir); d != "" {

--- a/internal/audit/sink.go
+++ b/internal/audit/sink.go
@@ -34,6 +34,7 @@ var subscribedPatterns = []string{
 	"integration.deregistered",
 	"integration.key_rotated",
 	"integration.health_changed",
+	"provider.updated",
 }
 
 const subscriberBuffer = 256
@@ -122,6 +123,9 @@ func extractSubject(data any) (kind, id string) {
 	}
 	if v, ok := m["channel_id"].(string); ok {
 		return "channel", v
+	}
+	if v, ok := m["provider_id"].(string); ok {
+		return "provider", v
 	}
 	if v, ok := m["user"].(string); ok {
 		return "admin", v

--- a/internal/audit/sink_test.go
+++ b/internal/audit/sink_test.go
@@ -42,7 +42,10 @@ func TestSubscribedPatterns_Allowlist(t *testing.T) {
 			"admin.login_success", "admin.login_failed", "admin.logout",
 			"channel.message_sent", "channel.message_received",
 			"integration.registered", "integration.deregistered",
-			"integration.key_rotated", "integration.health_changed":
+			"integration.key_rotated", "integration.health_changed",
+			// provider.updated carries only provider id + version
+			// strings + npm output tail — no PII.
+			"provider.updated":
 		default:
 			t.Errorf("audit subscribes to %q — confirm it is PII-free and update this test", p)
 		}

--- a/internal/catalog/authz_test.go
+++ b/internal/catalog/authz_test.go
@@ -1,0 +1,46 @@
+package catalog
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/opendray/opendray-v2/internal/integration"
+)
+
+func TestRequirePrivileged(t *testing.T) {
+	h := &Handlers{log: slog.Default()}
+
+	cases := []struct {
+		name      string
+		principal *integration.Principal
+		scope     string
+		wantOK    bool
+		wantCode  int
+	}{
+		{"admin allowed", &integration.Principal{Kind: integration.KindAdmin, ID: "navid"}, scopeProvidersUpdate, true, 0},
+		{"integration with scope", &integration.Principal{Kind: integration.KindIntegration, ID: "i1", Scopes: []string{scopeProvidersUpdate}}, scopeProvidersUpdate, true, 0},
+		{"integration wrong scope", &integration.Principal{Kind: integration.KindIntegration, ID: "i2", Scopes: []string{"providers:write"}}, scopeProvidersUpdate, false, http.StatusForbidden},
+		{"integration no scope", &integration.Principal{Kind: integration.KindIntegration, ID: "i3", Scopes: nil}, scopeProvidersUpdate, false, http.StatusForbidden},
+		{"no principal", nil, scopeProvidersUpdate, false, http.StatusUnauthorized},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			if c.principal != nil {
+				ctx = integration.WithPrincipal(ctx, *c.principal)
+			}
+			r := httptest.NewRequest(http.MethodPost, "/x", nil).WithContext(ctx)
+			w := httptest.NewRecorder()
+			got := h.requirePrivileged(w, r, c.scope)
+			if got != c.wantOK {
+				t.Fatalf("requirePrivileged=%v want %v", got, c.wantOK)
+			}
+			if !c.wantOK && w.Code != c.wantCode {
+				t.Errorf("status=%d want %d", w.Code, c.wantCode)
+			}
+		})
+	}
+}

--- a/internal/catalog/builtin/claude.json
+++ b/internal/catalog/builtin/claude.json
@@ -9,6 +9,7 @@
   "version": "1.0.0",
   "kind": "cli",
   "executable": "claude",
+  "npmPackage": "@anthropic-ai/claude-code",
   "capabilities": {
     "supportsResume": true,
     "supportsStream": true,
@@ -22,7 +23,10 @@
       "label_zh": "认证",
       "type": "select",
       "group": "auth",
-      "options": ["env", "custom"],
+      "options": [
+        "env",
+        "custom"
+      ],
       "default": "env",
       "description": "env = read ANTHROPIC_API_KEY from system; custom = use the key below",
       "description_zh": "env = 从系统读取 ANTHROPIC_API_KEY；custom = 使用下方自定义密钥"
@@ -85,6 +89,10 @@
     }
   ],
   "ui": {
-    "activityBar": { "id": "claude", "icon": "🟣", "title": "Claude Code" }
+    "activityBar": {
+      "id": "claude",
+      "icon": "🟣",
+      "title": "Claude Code"
+    }
   }
 }

--- a/internal/catalog/builtin/codex.json
+++ b/internal/catalog/builtin/codex.json
@@ -9,6 +9,7 @@
   "version": "1.0.0",
   "kind": "cli",
   "executable": "codex",
+  "npmPackage": "@openai/codex",
   "capabilities": {
     "supportsResume": false,
     "supportsStream": true,
@@ -22,7 +23,10 @@
       "label_zh": "认证",
       "type": "select",
       "group": "auth",
-      "options": ["env", "custom"],
+      "options": [
+        "env",
+        "custom"
+      ],
       "default": "env",
       "description": "env = read OPENAI_API_KEY from system; custom = use the key below",
       "description_zh": "env = 从系统读取 OPENAI_API_KEY；custom = 使用下方自定义密钥"
@@ -44,7 +48,11 @@
       "label_zh": "审批模式",
       "type": "select",
       "group": "runtime",
-      "options": ["untrusted", "on-request", "never"],
+      "options": [
+        "untrusted",
+        "on-request",
+        "never"
+      ],
       "default": "on-request",
       "cliFlag": "--ask-for-approval",
       "cliValue": true,
@@ -57,7 +65,11 @@
       "label_zh": "沙盒策略",
       "type": "select",
       "group": "runtime",
-      "options": ["read-only", "workspace-write", "danger-full-access"],
+      "options": [
+        "read-only",
+        "workspace-write",
+        "danger-full-access"
+      ],
       "default": "workspace-write",
       "cliFlag": "-s",
       "cliValue": true,
@@ -91,6 +103,10 @@
     }
   ],
   "ui": {
-    "activityBar": { "id": "codex", "icon": "🤖", "title": "Codex" }
+    "activityBar": {
+      "id": "codex",
+      "icon": "🤖",
+      "title": "Codex"
+    }
   }
 }

--- a/internal/catalog/builtin/gemini.json
+++ b/internal/catalog/builtin/gemini.json
@@ -9,6 +9,7 @@
   "version": "1.0.0",
   "kind": "cli",
   "executable": "gemini",
+  "npmPackage": "@google/gemini-cli",
   "capabilities": {
     "supportsResume": false,
     "supportsStream": true,
@@ -22,7 +23,10 @@
       "label_zh": "认证",
       "type": "select",
       "group": "auth",
-      "options": ["env", "custom"],
+      "options": [
+        "env",
+        "custom"
+      ],
       "default": "env",
       "description": "env = read GOOGLE_API_KEY from system; custom = use the key below",
       "description_zh": "env = 从系统读取 GOOGLE_API_KEY；custom = 使用下方自定义密钥"
@@ -55,7 +59,10 @@
       "label_zh": "沙盒",
       "type": "select",
       "group": "runtime",
-      "options": ["", "none"],
+      "options": [
+        "",
+        "none"
+      ],
       "default": "",
       "cliFlag": "-s",
       "cliValue": true,
@@ -89,6 +96,10 @@
     }
   ],
   "ui": {
-    "activityBar": { "id": "gemini", "icon": "✨", "title": "Gemini" }
+    "activityBar": {
+      "id": "gemini",
+      "icon": "✨",
+      "title": "Gemini"
+    }
   }
 }

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -62,6 +62,9 @@ type Provider struct {
 	ManifestHash string         `json:"manifest_hash"`
 	Config       map[string]any `json:"config"`
 	Enabled      bool           `json:"enabled"`
+	// Runtime is the live probed CLI state (installed?, real version).
+	// Set by the HTTP handler, not the store — nil when not probed.
+	Runtime *RuntimeInfo `json:"runtime,omitempty"`
 }
 
 func (c *Catalog) Get(ctx context.Context, id string) (Provider, error) {

--- a/internal/catalog/handler.go
+++ b/internal/catalog/handler.go
@@ -7,20 +7,23 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/opendray/opendray-v2/internal/eventbus"
 )
 
 // Handlers serves the /providers REST surface. Mount under /api/v1.
 type Handlers struct {
 	cat    *Catalog
 	prober *Prober
+	bus    *eventbus.Hub
 	log    *slog.Logger
 }
 
-func NewHandlers(cat *Catalog, log *slog.Logger) *Handlers {
+func NewHandlers(cat *Catalog, bus *eventbus.Hub, log *slog.Logger) *Handlers {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &Handlers{cat: cat, prober: NewProber(), log: log.With("component", "catalog.http")}
+	return &Handlers{cat: cat, prober: NewProber(), bus: bus, log: log.With("component", "catalog.http")}
 }
 
 func (h *Handlers) Mount(r chi.Router) {
@@ -32,6 +35,8 @@ func (h *Handlers) Mount(r chi.Router) {
 			r.Patch("/toggle", h.toggle)
 			// Network npm lookup → its own endpoint so the list stays fast.
 			r.Get("/update-check", h.updateCheck)
+			// Admin-only action: patch the CLI to the latest npm version.
+			r.Post("/update", h.update)
 		})
 	})
 }
@@ -84,6 +89,60 @@ func (h *Handlers) updateCheck(w http.ResponseWriter, r *http.Request) {
 	}
 	info := h.prober.CheckUpdate(r.Context(), p.Manifest)
 	writeJSON(w, http.StatusOK, info)
+}
+
+// update patches the provider's CLI to the latest npm version. The
+// route sits behind the same admin auth as the rest of /api/v1; the npm
+// package comes from the trusted manifest (not the request body), so
+// there's no arbitrary-package vector. The outcome is published to the
+// audit log via the event bus.
+func (h *Handlers) update(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	p, err := h.cat.Get(r.Context(), id)
+	if errors.Is(err, ErrNotFound) {
+		writeError(w, http.StatusNotFound, err)
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	res, err := h.prober.Update(r.Context(), p.Manifest)
+	if err != nil {
+		h.log.Warn("provider update failed", "provider", id, "package", res.Package, "err", err)
+		h.publishUpdate(id, res, false, err.Error())
+		// 502: the npm install itself failed (e.g. non-writable prefix),
+		// not a bad request. Surface the npm output for diagnosis.
+		writeJSON(w, http.StatusBadGateway, map[string]any{
+			"error":  err.Error(),
+			"result": res,
+		})
+		return
+	}
+	h.log.Info("provider updated", "provider", id, "package", res.Package,
+		"before", res.BeforeVersion, "after", res.AfterVersion, "changed", res.Changed)
+	h.publishUpdate(id, res, true, "")
+	writeJSON(w, http.StatusOK, res)
+}
+
+// publishUpdate emits a provider.updated event for the audit sink.
+func (h *Handlers) publishUpdate(id string, res UpdateResult, ok bool, errMsg string) {
+	if h.bus == nil {
+		return
+	}
+	h.bus.Publish(eventbus.Event{
+		Topic: "provider.updated",
+		Data: map[string]any{
+			"provider_id": id,
+			"package":     res.Package,
+			"before":      res.BeforeVersion,
+			"after":       res.AfterVersion,
+			"changed":     res.Changed,
+			"ok":          ok,
+			"error":       errMsg,
+		},
+	})
 }
 
 func (h *Handlers) updateConfig(w http.ResponseWriter, r *http.Request) {

--- a/internal/catalog/handler.go
+++ b/internal/catalog/handler.go
@@ -3,13 +3,44 @@ package catalog
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/opendray/opendray-v2/internal/eventbus"
+	"github.com/opendray/opendray-v2/internal/integration"
 )
+
+// Scopes gating the provider *mutation* endpoints. Reads (list / get /
+// update-check) stay open to any authenticated principal; writes and the
+// code-running update require admin, or an integration key explicitly
+// granted the scope. This keeps a plain integration key from changing
+// what executes on the box (config.command override, npm install).
+const (
+	scopeProvidersWrite  = "providers:write"  // config / toggle
+	scopeProvidersUpdate = "providers:update" // npm install -g
+)
+
+// requirePrivileged allows admins unconditionally, and integration keys
+// only when they hold `scope`. Returns false (and writes the response)
+// when denied. Mirrors the admin-or-scope check in integration/events.go.
+func (h *Handlers) requirePrivileged(w http.ResponseWriter, r *http.Request, scope string) bool {
+	p, ok := integration.CurrentPrincipal(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, errors.New("unauthorized"))
+		return false
+	}
+	if p.Kind == integration.KindAdmin || integration.HasScope(p.Scopes, scope) {
+		return true
+	}
+	h.log.Warn("provider mutation denied",
+		"principal", p.ID, "kind", p.Kind, "scope", scope)
+	writeError(w, http.StatusForbidden,
+		fmt.Errorf("requires admin or the %q scope", scope))
+	return false
+}
 
 // Handlers serves the /providers REST surface. Mount under /api/v1.
 type Handlers struct {
@@ -97,6 +128,9 @@ func (h *Handlers) updateCheck(w http.ResponseWriter, r *http.Request) {
 // there's no arbitrary-package vector. The outcome is published to the
 // audit log via the event bus.
 func (h *Handlers) update(w http.ResponseWriter, r *http.Request) {
+	if !h.requirePrivileged(w, r, scopeProvidersUpdate) {
+		return
+	}
 	id := chi.URLParam(r, "id")
 	p, err := h.cat.Get(r.Context(), id)
 	if errors.Is(err, ErrNotFound) {
@@ -146,6 +180,9 @@ func (h *Handlers) publishUpdate(id string, res UpdateResult, ok bool, errMsg st
 }
 
 func (h *Handlers) updateConfig(w http.ResponseWriter, r *http.Request) {
+	if !h.requirePrivileged(w, r, scopeProvidersWrite) {
+		return
+	}
 	id := chi.URLParam(r, "id")
 	var cfg map[string]any
 	if err := json.NewDecoder(r.Body).Decode(&cfg); err != nil {
@@ -165,6 +202,9 @@ func (h *Handlers) updateConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handlers) toggle(w http.ResponseWriter, r *http.Request) {
+	if !h.requirePrivileged(w, r, scopeProvidersWrite) {
+		return
+	}
 	id := chi.URLParam(r, "id")
 	var req struct {
 		Enabled bool `json:"enabled"`

--- a/internal/catalog/handler.go
+++ b/internal/catalog/handler.go
@@ -11,15 +11,16 @@ import (
 
 // Handlers serves the /providers REST surface. Mount under /api/v1.
 type Handlers struct {
-	cat *Catalog
-	log *slog.Logger
+	cat    *Catalog
+	prober *Prober
+	log    *slog.Logger
 }
 
 func NewHandlers(cat *Catalog, log *slog.Logger) *Handlers {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &Handlers{cat: cat, log: log.With("component", "catalog.http")}
+	return &Handlers{cat: cat, prober: NewProber(), log: log.With("component", "catalog.http")}
 }
 
 func (h *Handlers) Mount(r chi.Router) {
@@ -29,6 +30,8 @@ func (h *Handlers) Mount(r chi.Router) {
 			r.Get("/", h.get)
 			r.Patch("/config", h.updateConfig)
 			r.Patch("/toggle", h.toggle)
+			// Network npm lookup → its own endpoint so the list stays fast.
+			r.Get("/update-check", h.updateCheck)
 		})
 	})
 }
@@ -38,6 +41,13 @@ func (h *Handlers) list(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
+	}
+	// Enrich with the cheap, locally-probed install state + real version
+	// (cached). The npm "update available" check is the separate
+	// /update-check endpoint to keep this response snappy.
+	for i := range ps {
+		info := h.prober.Installed(r.Context(), ps[i].Manifest)
+		ps[i].Runtime = &info
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"providers": ps})
 }
@@ -53,7 +63,27 @@ func (h *Handlers) get(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
+	info := h.prober.Installed(r.Context(), p.Manifest)
+	p.Runtime = &info
 	writeJSON(w, http.StatusOK, p)
+}
+
+// updateCheck probes the installed version AND the latest npm version,
+// reporting whether an update is available. Separate from list because
+// it makes a network call (cached for an hour).
+func (h *Handlers) updateCheck(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	p, err := h.cat.Get(r.Context(), id)
+	if errors.Is(err, ErrNotFound) {
+		writeError(w, http.StatusNotFound, err)
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	info := h.prober.CheckUpdate(r.Context(), p.Manifest)
+	writeJSON(w, http.StatusOK, info)
 }
 
 func (h *Handlers) updateConfig(w http.ResponseWriter, r *http.Request) {

--- a/internal/catalog/handler.go
+++ b/internal/catalog/handler.go
@@ -143,17 +143,31 @@ func (h *Handlers) update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res, err := h.prober.Update(r.Context(), p.Manifest)
-	if err != nil {
+	switch {
+	case errors.Is(err, ErrUpdatePrefixReadonly):
+		// Not an error condition the operator can act on by retrying:
+		// the daemon is unprivileged and the npm prefix is root-owned.
+		// Report "unavailable" so the UI shows guidance, not a failure.
+		res.Available = false
+		res.Reason = "In-app updates aren't available here — the npm global prefix isn't writable by the opendray service. " +
+			"Install the CLI into an opendray-owned npm prefix (on the service PATH) to enable one-tap updates."
+		h.log.Info("provider update unavailable (read-only prefix)", "provider", id)
+		h.publishUpdate(id, res, false, "prefix-readonly")
+		writeJSON(w, http.StatusOK, res)
+		return
+	case err != nil:
 		h.log.Warn("provider update failed", "provider", id, "package", res.Package, "err", err)
+		res.Available = true
 		h.publishUpdate(id, res, false, err.Error())
-		// 502: the npm install itself failed (e.g. non-writable prefix),
-		// not a bad request. Surface the npm output for diagnosis.
+		// 502: the npm install itself failed (registry error, bad package,
+		// …). Surface the npm output for diagnosis.
 		writeJSON(w, http.StatusBadGateway, map[string]any{
 			"error":  err.Error(),
 			"result": res,
 		})
 		return
 	}
+	res.Available = true
 	h.log.Info("provider updated", "provider", id, "package", res.Package,
 		"before", res.BeforeVersion, "after", res.AfterVersion, "changed", res.Changed)
 	h.publishUpdate(id, res, true, "")

--- a/internal/catalog/manifest.go
+++ b/internal/catalog/manifest.go
@@ -17,19 +17,23 @@ package catalog
 // config* (not a manifest field) since MCP injection is a session
 // spawn-time hook, not a separate plugin.
 type Manifest struct {
-	ID            string        `json:"id"`
-	DisplayName   string        `json:"displayName"`
-	DisplayNameZh string        `json:"displayName_zh,omitempty"`
-	Description   string        `json:"description"`
-	DescriptionZh string        `json:"description_zh,omitempty"`
-	Icon          string        `json:"icon"`
-	Version       string        `json:"version"`
-	Kind          string        `json:"kind"` // "cli" | "shell"
-	Executable    string        `json:"executable"`
-	DefaultArgs   []string      `json:"defaultArgs,omitempty"`
-	Capabilities  Capabilities  `json:"capabilities"`
-	ConfigSchema  []ConfigField `json:"configSchema,omitempty"`
-	UI            *UI           `json:"ui,omitempty"`
+	ID            string `json:"id"`
+	DisplayName   string `json:"displayName"`
+	DisplayNameZh string `json:"displayName_zh,omitempty"`
+	Description   string `json:"description"`
+	DescriptionZh string `json:"description_zh,omitempty"`
+	Icon          string `json:"icon"`
+	Version       string `json:"version"`
+	Kind          string `json:"kind"` // "cli" | "shell"
+	Executable    string `json:"executable"`
+	// NpmPackage is the npm package the executable ships in, used to
+	// probe the latest published version (and, in Phase 2, to update
+	// the CLI). Empty for non-npm providers such as the builtin shell.
+	NpmPackage   string        `json:"npmPackage,omitempty"`
+	DefaultArgs  []string      `json:"defaultArgs,omitempty"`
+	Capabilities Capabilities  `json:"capabilities"`
+	ConfigSchema []ConfigField `json:"configSchema,omitempty"`
+	UI           *UI           `json:"ui,omitempty"`
 }
 
 // Capabilities is descriptive metadata used by clients to render the

--- a/internal/catalog/probe.go
+++ b/internal/catalog/probe.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"regexp"
@@ -53,20 +54,26 @@ type Prober struct {
 	installed map[string]cachedInstalled // executable -> info
 	latest    map[string]cachedLatest    // npm package -> version
 
-	lookPath func(string) (string, error)
-	runVer   func(ctx context.Context, bin string) (string, error)
-	npmView  func(ctx context.Context, pkg string) (string, error)
-	now      func() time.Time
+	// updateMu serialises Update() so two concurrent npm installs can't
+	// stomp the same global prefix.
+	updateMu sync.Mutex
+
+	lookPath   func(string) (string, error)
+	runVer     func(ctx context.Context, bin string) (string, error)
+	npmView    func(ctx context.Context, pkg string) (string, error)
+	npmInstall func(ctx context.Context, pkg string) (string, error)
+	now        func() time.Time
 }
 
 func NewProber() *Prober {
 	return &Prober{
-		installed: map[string]cachedInstalled{},
-		latest:    map[string]cachedLatest{},
-		lookPath:  exec.LookPath,
-		runVer:    defaultCliVersion,
-		npmView:   defaultNpmLatest,
-		now:       time.Now,
+		installed:  map[string]cachedInstalled{},
+		latest:     map[string]cachedLatest{},
+		lookPath:   exec.LookPath,
+		runVer:     defaultCliVersion,
+		npmView:    defaultNpmLatest,
+		npmInstall: defaultNpmInstall,
+		now:        time.Now,
 	}
 }
 
@@ -126,6 +133,62 @@ func (p *Prober) CheckUpdate(ctx context.Context, m Manifest) RuntimeInfo {
 	info.CheckedAt = p.now().UTC().Format(time.RFC3339)
 	info.UpdateAvailable = updateAvailable(info.InstalledVersion, latest)
 	return info
+}
+
+// UpdateResult reports the outcome of a provider CLI update.
+type UpdateResult struct {
+	Package       string `json:"package"`
+	BeforeVersion string `json:"beforeVersion,omitempty"`
+	AfterVersion  string `json:"afterVersion,omitempty"`
+	Changed       bool   `json:"changed"`
+	Output        string `json:"output,omitempty"` // tail of the npm output
+}
+
+// Update runs `npm install -g <pkg>` for the provider's CLI, then
+// re-probes the version. Serialised across calls. The npm package name
+// comes from the trusted manifest (never user input) — that is the
+// whitelist. Whether the install succeeds depends on the npm global
+// prefix being writable by the daemon's user; on a hardened deploy that
+// means an opendray-owned prefix, otherwise this returns a permission
+// error rather than escalating.
+func (p *Prober) Update(ctx context.Context, m Manifest) (UpdateResult, error) {
+	if m.NpmPackage == "" {
+		return UpdateResult{}, fmt.Errorf("provider %q is not updatable via npm", m.ID)
+	}
+
+	p.updateMu.Lock()
+	defer p.updateMu.Unlock()
+
+	before := p.Installed(ctx, m).InstalledVersion
+	out, err := p.npmInstall(ctx, m.NpmPackage)
+
+	// The install may have changed what's on disk even on partial
+	// failure, so always drop the cached install state.
+	p.mu.Lock()
+	delete(p.installed, m.Executable)
+	p.mu.Unlock()
+
+	res := UpdateResult{Package: m.NpmPackage, BeforeVersion: before, Output: tailLines(out, 40)}
+	if err != nil {
+		return res, fmt.Errorf("npm install -g %s: %w", m.NpmPackage, err)
+	}
+	res.AfterVersion = p.Installed(ctx, m).InstalledVersion
+	res.Changed = res.AfterVersion != before
+	return res, nil
+}
+
+// tailLines returns the last n lines of s (npm output can be long;
+// callers only want the tail for diagnostics).
+func tailLines(s string, n int) string {
+	s = strings.TrimRight(s, "\n")
+	if s == "" {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
 }
 
 // ── version comparison ───────────────────────────────────────────────
@@ -191,4 +254,16 @@ func defaultNpmLatest(ctx context.Context, pkg string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+func defaultNpmInstall(ctx context.Context, pkg string) (string, error) {
+	if _, err := exec.LookPath("npm"); err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+	// CombinedOutput so npm's progress/errors (incl. EACCES on a
+	// non-writable prefix) come back to the operator.
+	out, err := exec.CommandContext(ctx, "npm", "install", "-g", pkg).CombinedOutput()
+	return string(out), err
 }

--- a/internal/catalog/probe.go
+++ b/internal/catalog/probe.go
@@ -1,0 +1,194 @@
+package catalog
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RuntimeInfo is the live, probed state of a provider's CLI — distinct
+// from the static Manifest. Populated by Prober at request time, never
+// persisted. InstalledVersion is the real `<cli> --version` output (the
+// thing the dashboard should show instead of the manifest's schema
+// version); LatestVersion/UpdateAvailable come from the npm registry.
+type RuntimeInfo struct {
+	Installed        bool   `json:"installed"`
+	InstalledVersion string `json:"installedVersion,omitempty"`
+	Path             string `json:"path,omitempty"`
+	LatestVersion    string `json:"latestVersion,omitempty"`
+	UpdateAvailable  bool   `json:"updateAvailable"`
+	CheckedAt        string `json:"checkedAt,omitempty"` // RFC3339; when LatestVersion was fetched
+}
+
+// Cache TTLs: installed state is cheap (local exec) so a short TTL keeps
+// the providers list fresh without re-probing on every poll; the npm
+// lookup is a network call, so it's cached much longer and only run by
+// the explicit update-check path.
+const (
+	installedTTL = 60 * time.Second
+	latestTTL    = time.Hour
+)
+
+type cachedInstalled struct {
+	info RuntimeInfo
+	at   time.Time
+}
+
+type cachedLatest struct {
+	version string
+	at      time.Time
+}
+
+// Prober probes installed CLI versions (local exec) and latest npm
+// versions (network), each with its own TTL cache. The exec/lookup
+// functions are injectable so tests don't shell out.
+type Prober struct {
+	mu        sync.Mutex
+	installed map[string]cachedInstalled // executable -> info
+	latest    map[string]cachedLatest    // npm package -> version
+
+	lookPath func(string) (string, error)
+	runVer   func(ctx context.Context, bin string) (string, error)
+	npmView  func(ctx context.Context, pkg string) (string, error)
+	now      func() time.Time
+}
+
+func NewProber() *Prober {
+	return &Prober{
+		installed: map[string]cachedInstalled{},
+		latest:    map[string]cachedLatest{},
+		lookPath:  exec.LookPath,
+		runVer:    defaultCliVersion,
+		npmView:   defaultNpmLatest,
+		now:       time.Now,
+	}
+}
+
+// Installed reports whether the manifest's executable is on PATH and its
+// `--version` string. Fast (local exec), cached for installedTTL.
+func (p *Prober) Installed(ctx context.Context, m Manifest) RuntimeInfo {
+	if m.Executable == "" {
+		return RuntimeInfo{}
+	}
+	p.mu.Lock()
+	if c, ok := p.installed[m.Executable]; ok && p.now().Sub(c.at) < installedTTL {
+		info := c.info
+		p.mu.Unlock()
+		return info
+	}
+	p.mu.Unlock()
+
+	var info RuntimeInfo
+	if path, err := p.lookPath(m.Executable); err == nil {
+		info.Installed = true
+		info.Path = path
+		if v, err := p.runVer(ctx, m.Executable); err == nil {
+			info.InstalledVersion = v
+		}
+	}
+
+	p.mu.Lock()
+	p.installed[m.Executable] = cachedInstalled{info: info, at: p.now()}
+	p.mu.Unlock()
+	return info
+}
+
+// CheckUpdate returns Installed() enriched with the latest published npm
+// version and an update-available flag. Network call, cached latestTTL.
+func (p *Prober) CheckUpdate(ctx context.Context, m Manifest) RuntimeInfo {
+	info := p.Installed(ctx, m)
+	if m.NpmPackage == "" {
+		return info
+	}
+
+	p.mu.Lock()
+	c, ok := p.latest[m.NpmPackage]
+	fresh := ok && p.now().Sub(c.at) < latestTTL
+	latest := c.version
+	p.mu.Unlock()
+
+	if !fresh {
+		if v, err := p.npmView(ctx, m.NpmPackage); err == nil && v != "" {
+			latest = v
+			p.mu.Lock()
+			p.latest[m.NpmPackage] = cachedLatest{version: v, at: p.now()}
+			p.mu.Unlock()
+		}
+	}
+
+	info.LatestVersion = latest
+	info.CheckedAt = p.now().UTC().Format(time.RFC3339)
+	info.UpdateAvailable = updateAvailable(info.InstalledVersion, latest)
+	return info
+}
+
+// ── version comparison ───────────────────────────────────────────────
+
+var semverRe = regexp.MustCompile(`\d+\.\d+\.\d+`)
+
+// extractSemver pulls the first MAJOR.MINOR.PATCH out of a version
+// string. CLIs decorate their --version output ("codex-cli 0.132.0",
+// "2.1.146 (Claude Code)"); npm returns a bare "2.1.146".
+func extractSemver(s string) string { return semverRe.FindString(s) }
+
+// updateAvailable is true only when a clean latest version is strictly
+// greater than the installed one — so a locally-ahead dev build never
+// shows a spurious "update available".
+func updateAvailable(installed, latest string) bool {
+	iv := extractSemver(installed)
+	lv := extractSemver(latest)
+	if iv == "" || lv == "" {
+		return false
+	}
+	return semverLess(iv, lv)
+}
+
+func semverLess(a, b string) bool {
+	ap := strings.Split(a, ".")
+	bp := strings.Split(b, ".")
+	for i := 0; i < 3; i++ {
+		ai, _ := strconv.Atoi(ap[i])
+		bi, _ := strconv.Atoi(bp[i])
+		if ai != bi {
+			return ai < bi
+		}
+	}
+	return false
+}
+
+// ── default probes (shell out) ───────────────────────────────────────
+
+func defaultCliVersion(ctx context.Context, bin string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, "--version")
+	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	sc := bufio.NewScanner(strings.NewReader(string(out)))
+	if sc.Scan() {
+		return strings.TrimSpace(sc.Text()), nil
+	}
+	return "", nil
+}
+
+func defaultNpmLatest(ctx context.Context, pkg string) (string, error) {
+	if _, err := exec.LookPath("npm"); err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "npm", "view", pkg, "version").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/catalog/probe.go
+++ b/internal/catalog/probe.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -62,6 +63,7 @@ type Prober struct {
 	runVer     func(ctx context.Context, bin string) (string, error)
 	npmView    func(ctx context.Context, pkg string) (string, error)
 	npmInstall func(ctx context.Context, pkg string) (string, error)
+	npmRoot    func(ctx context.Context) (string, error)
 	now        func() time.Time
 }
 
@@ -73,9 +75,17 @@ func NewProber() *Prober {
 		runVer:     defaultCliVersion,
 		npmView:    defaultNpmLatest,
 		npmInstall: defaultNpmInstall,
+		npmRoot:    defaultNpmRoot,
 		now:        time.Now,
 	}
 }
+
+// ErrUpdatePrefixReadonly means the npm global prefix isn't writable by
+// the service user, so an in-app `npm install -g` would fail with EACCES.
+// We detect this up front and report "unavailable" rather than letting
+// the install error out — the daemon runs unprivileged, so updates only
+// work when the CLIs live in an opendray-owned npm prefix.
+var ErrUpdatePrefixReadonly = errors.New("npm global prefix is not writable by the opendray service")
 
 // Installed reports whether the manifest's executable is on PATH and its
 // `--version` string. Fast (local exec), cached for installedTTL.
@@ -142,6 +152,11 @@ type UpdateResult struct {
 	AfterVersion  string `json:"afterVersion,omitempty"`
 	Changed       bool   `json:"changed"`
 	Output        string `json:"output,omitempty"` // tail of the npm output
+	// Available is false when an in-app update can't run here (e.g. the
+	// npm prefix isn't writable by the service); Reason explains why.
+	// Set by the HTTP handler.
+	Available bool   `json:"available"`
+	Reason    string `json:"reason,omitempty"`
 }
 
 // Update runs `npm install -g <pkg>` for the provider's CLI, then
@@ -160,6 +175,13 @@ func (p *Prober) Update(ctx context.Context, m Manifest) (UpdateResult, error) {
 	defer p.updateMu.Unlock()
 
 	before := p.Installed(ctx, m).InstalledVersion
+
+	// Preflight: if the npm global dir isn't writable by this (unprivileged)
+	// process, an install would just EACCES — report it cleanly instead.
+	if dir, derr := p.npmRoot(ctx); derr == nil && dir != "" && !dirWritable(dir) {
+		return UpdateResult{Package: m.NpmPackage, BeforeVersion: before}, ErrUpdatePrefixReadonly
+	}
+
 	out, err := p.npmInstall(ctx, m.NpmPackage)
 
 	// The install may have changed what's on disk even on partial
@@ -254,6 +276,34 @@ func defaultNpmLatest(ctx context.Context, pkg string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// defaultNpmRoot returns the global node_modules dir (`npm root -g`) —
+// where `npm install -g` writes — so we can check writability up front.
+func defaultNpmRoot(ctx context.Context) (string, error) {
+	if _, err := exec.LookPath("npm"); err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "npm", "root", "-g").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// dirWritable reports whether dir exists and the current process can
+// create files in it (catches the root-owned-prefix case).
+func dirWritable(dir string) bool {
+	f, err := os.CreateTemp(dir, ".opendray-write-probe-*")
+	if err != nil {
+		return false
+	}
+	name := f.Name()
+	_ = f.Close()
+	_ = os.Remove(name)
+	return true
 }
 
 func defaultNpmInstall(ctx context.Context, pkg string) (string, error) {

--- a/internal/catalog/probe_test.go
+++ b/internal/catalog/probe_test.go
@@ -76,3 +76,48 @@ func TestProber_CheckUpdate(t *testing.T) {
 		t.Errorf("no-package provider should not report updates: %+v", none)
 	}
 }
+
+func TestProber_Update(t *testing.T) {
+	versions := []string{"0.132.0", "0.140.0"} // before, after
+	call := 0
+	installs := 0
+	p := NewProber()
+	p.lookPath = func(string) (string, error) { return "/usr/bin/codex", nil }
+	p.runVer = func(context.Context, string) (string, error) {
+		v := versions[call]
+		if call < len(versions)-1 {
+			call++
+		}
+		return "codex-cli " + v, nil
+	}
+	p.npmInstall = func(_ context.Context, pkg string) (string, error) {
+		installs++
+		if pkg != "@openai/codex" {
+			t.Errorf("npm install got wrong package: %q", pkg)
+		}
+		return "+ @openai/codex@0.140.0\nadded 1 package", nil
+	}
+	m := Manifest{ID: "codex", Executable: "codex", NpmPackage: "@openai/codex"}
+
+	res, err := p.Update(context.Background(), m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installs != 1 {
+		t.Errorf("expected one npm install, got %d", installs)
+	}
+	if res.BeforeVersion != "codex-cli 0.132.0" || res.AfterVersion != "codex-cli 0.140.0" || !res.Changed {
+		t.Errorf("unexpected result: %+v", res)
+	}
+	if res.Output == "" {
+		t.Error("expected npm output tail")
+	}
+}
+
+func TestProber_UpdateNoPackage(t *testing.T) {
+	p := NewProber()
+	_, err := p.Update(context.Background(), Manifest{ID: "shell", Executable: "bash"})
+	if err == nil {
+		t.Error("update of a provider without an npm package should error")
+	}
+}

--- a/internal/catalog/probe_test.go
+++ b/internal/catalog/probe_test.go
@@ -3,6 +3,8 @@ package catalog
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -97,6 +99,8 @@ func TestProber_Update(t *testing.T) {
 		}
 		return "+ @openai/codex@0.140.0\nadded 1 package", nil
 	}
+	// Preflight: point npm root at a writable temp dir so Update proceeds.
+	p.npmRoot = func(context.Context) (string, error) { return t.TempDir(), nil }
 	m := Manifest{ID: "codex", Executable: "codex", NpmPackage: "@openai/codex"}
 
 	res, err := p.Update(context.Background(), m)
@@ -119,5 +123,28 @@ func TestProber_UpdateNoPackage(t *testing.T) {
 	_, err := p.Update(context.Background(), Manifest{ID: "shell", Executable: "bash"})
 	if err == nil {
 		t.Error("update of a provider without an npm package should error")
+	}
+}
+
+func TestProber_UpdateReadonlyPrefix(t *testing.T) {
+	installed := false
+	p := NewProber()
+	p.lookPath = func(string) (string, error) { return "/usr/bin/codex", nil }
+	p.runVer = func(context.Context, string) (string, error) { return "codex-cli 0.132.0", nil }
+	p.npmInstall = func(context.Context, string) (string, error) { installed = true; return "", nil }
+	// Point npm root at a path that can't be written (a file, not a dir).
+	ro := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(ro, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p.npmRoot = func(context.Context) (string, error) { return ro, nil }
+
+	_, err := p.Update(context.Background(),
+		Manifest{ID: "codex", Executable: "codex", NpmPackage: "@openai/codex"})
+	if !errors.Is(err, ErrUpdatePrefixReadonly) {
+		t.Fatalf("expected ErrUpdatePrefixReadonly, got %v", err)
+	}
+	if installed {
+		t.Error("npm install must NOT run when the prefix is read-only")
 	}
 }

--- a/internal/catalog/probe_test.go
+++ b/internal/catalog/probe_test.go
@@ -1,0 +1,78 @@
+package catalog
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestExtractSemverAndUpdateAvailable(t *testing.T) {
+	cases := []struct {
+		installed, latest string
+		wantUpdate        bool
+	}{
+		{"2.1.146 (Claude Code)", "2.1.150", true},
+		{"codex-cli 0.132.0", "0.132.0", false},
+		{"0.42.0", "0.41.9", false}, // installed ahead
+		{"", "1.0.0", false},        // not installed
+		{"1.2.3", "", false},        // no latest
+		{"1.2.3", "1.3.0", true},
+		{"1.9.0", "1.10.0", true}, // numeric, not lexical
+	}
+	for _, c := range cases {
+		if got := updateAvailable(c.installed, c.latest); got != c.wantUpdate {
+			t.Errorf("updateAvailable(%q,%q)=%v want %v", c.installed, c.latest, got, c.wantUpdate)
+		}
+	}
+}
+
+func TestProber_InstalledCachesAndProbes(t *testing.T) {
+	calls := 0
+	p := NewProber()
+	p.now = func() time.Time { return time.Unix(1000, 0) }
+	p.lookPath = func(string) (string, error) { return "/usr/bin/claude", nil }
+	p.runVer = func(context.Context, string) (string, error) {
+		calls++
+		return "2.1.146 (Claude Code)", nil
+	}
+	m := Manifest{Executable: "claude"}
+
+	got := p.Installed(context.Background(), m)
+	if !got.Installed || got.InstalledVersion != "2.1.146 (Claude Code)" || got.Path != "/usr/bin/claude" {
+		t.Fatalf("unexpected info: %+v", got)
+	}
+	// Second call within TTL must hit the cache (no extra probe).
+	_ = p.Installed(context.Background(), m)
+	if calls != 1 {
+		t.Errorf("expected 1 probe (cached), got %d", calls)
+	}
+}
+
+func TestProber_NotInstalled(t *testing.T) {
+	p := NewProber()
+	p.lookPath = func(string) (string, error) { return "", errors.New("not found") }
+	got := p.Installed(context.Background(), Manifest{Executable: "ghost"})
+	if got.Installed {
+		t.Errorf("ghost should not be installed: %+v", got)
+	}
+}
+
+func TestProber_CheckUpdate(t *testing.T) {
+	p := NewProber()
+	p.now = func() time.Time { return time.Unix(2000, 0) }
+	p.lookPath = func(string) (string, error) { return "/usr/bin/codex", nil }
+	p.runVer = func(context.Context, string) (string, error) { return "codex-cli 0.132.0", nil }
+	p.npmView = func(context.Context, string) (string, error) { return "0.140.0", nil }
+
+	info := p.CheckUpdate(context.Background(), Manifest{Executable: "codex", NpmPackage: "@openai/codex"})
+	if info.InstalledVersion != "codex-cli 0.132.0" || info.LatestVersion != "0.140.0" || !info.UpdateAvailable {
+		t.Errorf("unexpected: %+v", info)
+	}
+
+	// No npm package → no latest lookup, no false update flag.
+	none := p.CheckUpdate(context.Background(), Manifest{Executable: "codex"})
+	if none.UpdateAvailable || none.LatestVersion != "" {
+		t.Errorf("no-package provider should not report updates: %+v", none)
+	}
+}

--- a/internal/integration/middleware.go
+++ b/internal/integration/middleware.go
@@ -32,6 +32,13 @@ func CurrentPrincipal(ctx context.Context) (Principal, bool) {
 	return p, ok
 }
 
+// WithPrincipal attaches a principal to ctx. The middlewares use this on
+// the request path; it's also the supported way for other packages and
+// tests to set up a principal-bearing context.
+func WithPrincipal(ctx context.Context, p Principal) context.Context {
+	return context.WithValue(ctx, principalCtxKey{}, p)
+}
+
 // CombinedMiddleware accepts an admin bearer OR an integration API key
 // on the same route. Used to wrap business endpoints (sessions /
 // providers / channels / catalog / auth/me / auth/logout) so that


### PR DESCRIPTION
## What

Phase 2 of provider-update support (stacks on #227). Adds a one-tap **Update** on the Providers page that patches a CLI to the latest npm version, from the dashboard.

- **catalog**: `Prober.Update` runs `npm install -g <pkg>` (serialised via a mutex), drops the cached install state, re-probes the version, and returns `{package, beforeVersion, afterVersion, changed, output}` (output = tail of npm's combined stdout/stderr).
- **API**: `POST /providers/{id}/update`, behind the existing admin auth. On npm failure it returns **502 + the npm output** so a non-writable prefix (or registry error) is diagnosable rather than a silent failure.
- **audit**: emits `provider.updated` on the event bus — provider id, before/after versions, changed flag, npm output tail. PII-free; added to the audit sink allowlist (+ `provider_id` subject extraction).
- **web**: an **"Update to X"** button beside the "update available" badge, with a pending spinner and success/already-latest/error toasts.

## Security model

The npm package is read from the **trusted manifest**, never the request body — that's the whitelist, so there's no arbitrary-package-install vector. The route is admin-only and every run is audited.

Critically, the opendray daemon runs **unprivileged** (`User=opendray`, `ProtectSystem=strict`, `ReadWritePaths=/var/lib/opendray`) and therefore *cannot* write a root-owned global `node_modules`. Enabling this in production means pointing npm's global prefix at an **opendray-owned, writable directory** (under `ReadWritePaths`) so the update needs no root and no new privileged component. If the prefix isn't writable, `Update` fails cleanly with the EACCES output rather than escalating.

## Tests

`probe_test.go`: `Update` runs exactly one install with the manifest's package, reports before→after + changed + output; a provider with no `npmPackage` errors. Audit allowlist test updated to acknowledge `provider.updated` as PII-free.