### PR TITLE
feat(catalog): per-provider model management from the dashboard

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -965,7 +965,12 @@
         },
         "notInstalled": "not installed",
         "updateAvailable": "update available → {{version}}",
-        "upToDate": "up to date"
+        "upToDate": "up to date",
+        "update": "Update to {{version}}",
+        "updating": "Updating…",
+        "updatedToast": "Updated {{from}} → {{to}}",
+        "alreadyLatestToast": "Already up to date",
+        "updateFailedToast": "Update failed"
       },
       "configForm": {
         "selectPlaceholder": "Select…",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1003,6 +1003,18 @@
         "removeFailedToast": "Remove failed",
         "toggleAria": "Toggle {name}",
         "removeAria": "Remove {name}"
+      },
+      "models": {
+        "title": "Models",
+        "help": "Models offered for this provider. The default is passed to every session via the model flag; sessions can still override it.",
+        "empty": "No models configured yet.",
+        "add": "Add",
+        "addPlaceholder": "model id (e.g. sonnet)",
+        "suggested": "Suggested ({{count}})",
+        "default": "default",
+        "makeDefault": "set default",
+        "setDefault": "Use as the default model",
+        "remove": "Remove {{model}}"
       }
     },
     "channels": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -965,7 +965,12 @@
         },
         "notInstalled": "未安装",
         "updateAvailable": "有可用更新 → {{version}}",
-        "upToDate": "已是最新"
+        "upToDate": "已是最新",
+        "update": "更新到 {{version}}",
+        "updating": "更新中…",
+        "updatedToast": "已更新 {{from}} → {{to}}",
+        "alreadyLatestToast": "已是最新",
+        "updateFailedToast": "更新失败"
       },
       "configForm": {
         "selectPlaceholder": "选择…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -1002,6 +1002,18 @@
         "removeFailedToast": "移除失败",
         "toggleAria": "切换 {name}",
         "removeAria": "移除 {name}"
+      },
+      "models": {
+        "title": "模型",
+        "help": "该提供方可用的模型。默认模型会通过 model 参数传给每个会话；会话仍可覆盖。",
+        "empty": "尚未配置任何模型。",
+        "add": "添加",
+        "addPlaceholder": "模型 ID（如 sonnet）",
+        "suggested": "建议（{{count}}）",
+        "default": "默认",
+        "makeDefault": "设为默认",
+        "setDefault": "用作默认模型",
+        "remove": "移除 {{model}}"
       }
     },
     "channels": {

--- a/app/shared/src/lib/catalog.ts
+++ b/app/shared/src/lib/catalog.ts
@@ -15,6 +15,25 @@ export async function checkProviderUpdate(
   return api<ProviderRuntime>(`/api/v1/providers/${id}/update-check`)
 }
 
+export interface ProviderUpdateResult {
+  package: string
+  beforeVersion?: string
+  afterVersion?: string
+  changed: boolean
+  output?: string
+}
+
+// updateProvider patches the CLI to the latest npm version (admin-only,
+// audited server-side). The npm package is taken from the trusted
+// manifest, not the request — no arbitrary-package vector.
+export async function updateProvider(
+  id: string,
+): Promise<ProviderUpdateResult> {
+  return api<ProviderUpdateResult>(`/api/v1/providers/${id}/update`, {
+    method: 'POST',
+  })
+}
+
 export async function getProvider(id: string): Promise<Provider> {
   return api<Provider>(`/api/v1/providers/${id}`)
 }

--- a/app/shared/src/lib/types.ts
+++ b/app/shared/src/lib/types.ts
@@ -112,6 +112,8 @@ export interface ProviderManifest {
   kind: 'cli' | 'shell'
   executable: string
   npmPackage?: string
+  modelFlag?: string
+  knownModels?: string[]
   defaultArgs?: string[]
   capabilities: {
     supportsResume: boolean

--- a/app/web/src/components/providers/ProviderModelsSection.tsx
+++ b/app/web/src/components/providers/ProviderModelsSection.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Plus, X, Sparkles } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import type { ProviderManifest } from '@/lib/types'
+import { cn } from '@/lib/utils'
+
+// ProviderModelsSection edits the operator-managed model list + default
+// for a provider. The list lives in provider config `models` (string[])
+// and the default in `model` (string); the backend passes the default
+// to every spawn via the manifest's modelFlag. "Suggested" pulls the
+// manifest's knownModels (the CLIs expose no live model list).
+export function ProviderModelsSection({
+  manifest,
+  value,
+  onChange,
+}: {
+  manifest: ProviderManifest
+  value: Record<string, unknown>
+  onChange: (v: Record<string, unknown>) => void
+}) {
+  const { t } = useTranslation()
+  const [draftModel, setDraftModel] = useState('')
+
+  const models = Array.isArray(value.models) ? (value.models as string[]) : []
+  const defaultModel = typeof value.model === 'string' ? value.model : ''
+  const known = manifest.knownModels ?? []
+  const suggestable = known.filter((k) => !models.includes(k))
+
+  function commit(next: { models?: string[]; model?: string }) {
+    onChange({
+      ...value,
+      models: next.models ?? models,
+      model: next.model ?? defaultModel,
+    })
+  }
+
+  function add(id: string) {
+    const m = id.trim()
+    if (!m || models.includes(m)) return
+    commit({ models: [...models, m] })
+    setDraftModel('')
+  }
+
+  function remove(id: string) {
+    commit({
+      models: models.filter((x) => x !== id),
+      // Clear the default if we just removed it.
+      model: defaultModel === id ? '' : defaultModel,
+    })
+  }
+
+  return (
+    <div>
+      <h2 className="text-[12px] font-semibold uppercase tracking-wider text-muted-foreground/80 mb-1">
+        {t('web.providers.models.title')}
+      </h2>
+      <p className="text-[12px] text-muted-foreground mb-3 max-w-[60ch]">
+        {t('web.providers.models.help')}
+      </p>
+
+      {models.length === 0 ? (
+        <p className="text-[12px] text-muted-foreground italic mb-3">
+          {t('web.providers.models.empty')}
+        </p>
+      ) : (
+        <ul className="space-y-1.5 mb-3">
+          {models.map((id) => {
+            const isDefault = id === defaultModel
+            return (
+              <li key={id} className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => commit({ model: isDefault ? '' : id })}
+                  className={cn(
+                    'text-[11px] px-2 py-0.5 rounded border font-mono',
+                    isDefault
+                      ? 'border-primary text-primary'
+                      : 'border-border text-muted-foreground hover:text-foreground',
+                  )}
+                  title={t('web.providers.models.setDefault')}
+                >
+                  {isDefault
+                    ? t('web.providers.models.default')
+                    : t('web.providers.models.makeDefault')}
+                </button>
+                <span className="font-mono text-[13px] flex-1">{id}</span>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-6 w-6 p-0"
+                  onClick={() => remove(id)}
+                  aria-label={t('web.providers.models.remove', { model: id })}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </Button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+
+      <div className="flex items-center gap-2">
+        <Input
+          value={draftModel}
+          onChange={(e) => setDraftModel(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              add(draftModel)
+            }
+          }}
+          placeholder={t('web.providers.models.addPlaceholder')}
+          className="h-8 text-[13px] font-mono"
+        />
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-8 shrink-0"
+          onClick={() => add(draftModel)}
+          disabled={!draftModel.trim()}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          {t('web.providers.models.add')}
+        </Button>
+        {suggestable.length > 0 ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-8 shrink-0"
+            onClick={() => commit({ models: [...models, ...suggestable] })}
+            title={suggestable.join(', ')}
+          >
+            <Sparkles className="h-3.5 w-3.5" />
+            {t('web.providers.models.suggested', { count: suggestable.length })}
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/app/web/src/pages/Providers.tsx
+++ b/app/web/src/pages/Providers.tsx
@@ -18,6 +18,7 @@ import {
   toggleProvider,
   updateProviderConfig,
   checkProviderUpdate,
+  updateProvider,
 } from '@/lib/catalog'
 import type { Provider } from '@/lib/types'
 import { cn } from '@/lib/utils'
@@ -173,6 +174,7 @@ function ProviderDetail({
   onToggle: (enabled: boolean) => void
 }) {
   const { t } = useTranslation()
+  const qc = useQueryClient()
   const m = provider.manifest
   const rt = provider.runtime
   // Latest-version check is a network (npm) call, so it runs on its own
@@ -182,6 +184,27 @@ function ProviderDetail({
     queryFn: () => checkProviderUpdate(m.id),
     enabled: m.kind === 'cli' && !!rt?.installed,
     staleTime: 60_000,
+  })
+  const updateMut = useMutation({
+    mutationFn: () => updateProvider(m.id),
+    onSuccess: (res) => {
+      if (res.changed) {
+        toast.success(
+          t('web.providers.detail.updatedToast', {
+            from: res.beforeVersion,
+            to: res.afterVersion,
+          }),
+        )
+      } else {
+        toast.info(t('web.providers.detail.alreadyLatestToast'))
+      }
+      qc.invalidateQueries({ queryKey: ['providers'] })
+      qc.invalidateQueries({ queryKey: ['provider-update', m.id] })
+    },
+    onError: (e: Error) =>
+      toast.error(t('web.providers.detail.updateFailedToast'), {
+        description: e.message,
+      }),
   })
   const caps: { key: keyof typeof m.capabilities; labelKey: string }[] = [
     { key: 'supportsResume', labelKey: 'web.providers.detail.caps.resume' },
@@ -222,11 +245,29 @@ function ProviderDetail({
               </Badge>
             )}
             {upd?.updateAvailable && upd.latestVersion ? (
-              <Badge variant="accent" className="font-mono normal-case">
-                {t('web.providers.detail.updateAvailable', {
-                  version: upd.latestVersion,
-                })}
-              </Badge>
+              <>
+                <Badge variant="accent" className="font-mono normal-case">
+                  {t('web.providers.detail.updateAvailable', {
+                    version: upd.latestVersion,
+                  })}
+                </Badge>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-6 px-2 text-[11px]"
+                  disabled={updateMut.isPending}
+                  onClick={() => updateMut.mutate()}
+                >
+                  {updateMut.isPending ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : null}
+                  {updateMut.isPending
+                    ? t('web.providers.detail.updating')
+                    : t('web.providers.detail.update', {
+                        version: upd.latestVersion,
+                      })}
+                </Button>
+              </>
             ) : null}
           </div>
           <p className="text-[12px] text-muted-foreground mt-1 max-w-[60ch]">

--- a/app/web/src/pages/Providers.tsx
+++ b/app/web/src/pages/Providers.tsx
@@ -10,6 +10,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
 import { ConfigForm } from '@/components/providers/ConfigForm'
+import { ProviderModelsSection } from '@/components/providers/ProviderModelsSection'
 import { BrandAvatar } from '@/components/BrandAvatar'
 import { providerIconKey } from '@/lib/providerIcons'
 import { ClaudeAccountsPanel } from '@/components/providers/ClaudeAccountsPanel'
@@ -157,6 +158,7 @@ export function ProvidersPage() {
 
 function ProviderDetail({
   provider,
+  draft,
   onChange,
   dirty,
   saving,
@@ -315,6 +317,16 @@ function ProviderDetail({
               {t('web.providers.detail.noConfig')}
             </p>
           )}
+          {m.modelFlag ? (
+            <>
+              <Separator className="my-6" />
+              <ProviderModelsSection
+                manifest={m}
+                value={draft}
+                onChange={onChange}
+              />
+            </>
+          ) : null}
           {m.id === 'claude' && (
             <>
               <Separator className="my-6" />

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -117,7 +117,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		st.Close()
 		return nil, err
 	}
-	catalogHandlers := catalog.NewHandlers(cat, log)
+	catalogHandlers := catalog.NewHandlers(cat, bus, log)
 
 	var cliacctOpts []cliacct.Option
 	if d := strings.TrimSpace(cfg.Providers.Claude.AccountsDir); d != "" {

--- a/internal/audit/sink.go
+++ b/internal/audit/sink.go
@@ -34,6 +34,7 @@ var subscribedPatterns = []string{
 	"integration.deregistered",
 	"integration.key_rotated",
 	"integration.health_changed",
+	"provider.updated",
 }
 
 const subscriberBuffer = 256
@@ -122,6 +123,9 @@ func extractSubject(data any) (kind, id string) {
 	}
 	if v, ok := m["channel_id"].(string); ok {
 		return "channel", v
+	}
+	if v, ok := m["provider_id"].(string); ok {
+		return "provider", v
 	}
 	if v, ok := m["user"].(string); ok {
 		return "admin", v

--- a/internal/audit/sink_test.go
+++ b/internal/audit/sink_test.go
@@ -42,7 +42,10 @@ func TestSubscribedPatterns_Allowlist(t *testing.T) {
 			"admin.login_success", "admin.login_failed", "admin.logout",
 			"channel.message_sent", "channel.message_received",
 			"integration.registered", "integration.deregistered",
-			"integration.key_rotated", "integration.health_changed":
+			"integration.key_rotated", "integration.health_changed",
+			// provider.updated carries only provider id + version
+			// strings + npm output tail — no PII.
+			"provider.updated":
 		default:
 			t.Errorf("audit subscribes to %q — confirm it is PII-free and update this test", p)
 		}

--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -294,6 +294,8 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 	// manifest, which keeps spawn args reproducible across restarts.
 	configArgs, configEnv := applyConfigSchema(p.Manifest.ConfigSchema, p.Config)
 	args = append(args, configArgs...)
+	// Per-provider default model (operator-managed) → e.g. `--model X`.
+	args = append(args, modelArgs(p.Manifest, p.Config)...)
 	if p.Manifest.ID == "codex" {
 		if approval, ok := p.Config["approval"].(string); ok && approval != "" {
 			args = append(args, "-c", "approval_policy="+tomlString(approval))

--- a/internal/catalog/builtin/claude.json
+++ b/internal/catalog/builtin/claude.json
@@ -10,6 +10,12 @@
   "kind": "cli",
   "executable": "claude",
   "npmPackage": "@anthropic-ai/claude-code",
+  "modelFlag": "--model",
+  "knownModels": [
+    "opus",
+    "sonnet",
+    "haiku"
+  ],
   "capabilities": {
     "supportsResume": true,
     "supportsStream": true,

--- a/internal/catalog/builtin/codex.json
+++ b/internal/catalog/builtin/codex.json
@@ -10,6 +10,12 @@
   "kind": "cli",
   "executable": "codex",
   "npmPackage": "@openai/codex",
+  "modelFlag": "--model",
+  "knownModels": [
+    "gpt-5-codex",
+    "o3",
+    "o4-mini"
+  ],
   "capabilities": {
     "supportsResume": false,
     "supportsStream": true,

--- a/internal/catalog/builtin/gemini.json
+++ b/internal/catalog/builtin/gemini.json
@@ -10,6 +10,12 @@
   "kind": "cli",
   "executable": "gemini",
   "npmPackage": "@google/gemini-cli",
+  "modelFlag": "--model",
+  "knownModels": [
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-2.5-flash-lite"
+  ],
   "capabilities": {
     "supportsResume": false,
     "supportsStream": true,

--- a/internal/catalog/configargs.go
+++ b/internal/catalog/configargs.go
@@ -26,6 +26,22 @@ import (
 // dependsOn / dependsVal: a field is skipped when cfg[dependsOn] is
 // missing or unequal to dependsVal — lets fields like apiKey only apply
 // when authType=="custom".
+//
+// modelArgs renders the per-provider default model into CLI args when
+// the operator has set one (config["model"]) and the manifest declares a
+// model flag. A per-session --model in the spawn args still wins — the
+// session manager drops provider-derived flags the user re-specifies.
+func modelArgs(m Manifest, cfg map[string]any) []string {
+	if m.ModelFlag == "" {
+		return nil
+	}
+	model, _ := cfg["model"].(string)
+	if model == "" {
+		return nil
+	}
+	return []string{m.ModelFlag, model}
+}
+
 func applyConfigSchema(schema []ConfigField, cfg map[string]any) ([]string, map[string]string) {
 	if len(schema) == 0 || len(cfg) == 0 {
 		return nil, nil

--- a/internal/catalog/configargs_test.go
+++ b/internal/catalog/configargs_test.go
@@ -287,3 +287,32 @@ func TestApplyConfigSchema_RealManifests(t *testing.T) {
 		}
 	})
 }
+
+func TestModelArgs(t *testing.T) {
+	cli := Manifest{ModelFlag: "--model"}
+	cases := []struct {
+		name string
+		m    Manifest
+		cfg  map[string]any
+		want []string
+	}{
+		{"default set", cli, map[string]any{"model": "opus"}, []string{"--model", "opus"}},
+		{"no default", cli, map[string]any{}, nil},
+		{"empty default", cli, map[string]any{"model": ""}, nil},
+		{"non-string default", cli, map[string]any{"model": 3}, nil},
+		{"no model flag", Manifest{}, map[string]any{"model": "opus"}, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := modelArgs(c.m, c.cfg)
+			if len(got) != len(c.want) {
+				t.Fatalf("modelArgs=%v want %v", got, c.want)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Errorf("modelArgs[%d]=%q want %q", i, got[i], c.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/catalog/handler.go
+++ b/internal/catalog/handler.go
@@ -7,20 +7,23 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/opendray/opendray-v2/internal/eventbus"
 )
 
 // Handlers serves the /providers REST surface. Mount under /api/v1.
 type Handlers struct {
 	cat    *Catalog
 	prober *Prober
+	bus    *eventbus.Hub
 	log    *slog.Logger
 }
 
-func NewHandlers(cat *Catalog, log *slog.Logger) *Handlers {
+func NewHandlers(cat *Catalog, bus *eventbus.Hub, log *slog.Logger) *Handlers {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &Handlers{cat: cat, prober: NewProber(), log: log.With("component", "catalog.http")}
+	return &Handlers{cat: cat, prober: NewProber(), bus: bus, log: log.With("component", "catalog.http")}
 }
 
 func (h *Handlers) Mount(r chi.Router) {
@@ -32,6 +35,8 @@ func (h *Handlers) Mount(r chi.Router) {
 			r.Patch("/toggle", h.toggle)
 			// Network npm lookup → its own endpoint so the list stays fast.
 			r.Get("/update-check", h.updateCheck)
+			// Admin-only action: patch the CLI to the latest npm version.
+			r.Post("/update", h.update)
 		})
 	})
 }
@@ -84,6 +89,60 @@ func (h *Handlers) updateCheck(w http.ResponseWriter, r *http.Request) {
 	}
 	info := h.prober.CheckUpdate(r.Context(), p.Manifest)
 	writeJSON(w, http.StatusOK, info)
+}
+
+// update patches the provider's CLI to the latest npm version. The
+// route sits behind the same admin auth as the rest of /api/v1; the npm
+// package comes from the trusted manifest (not the request body), so
+// there's no arbitrary-package vector. The outcome is published to the
+// audit log via the event bus.
+func (h *Handlers) update(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	p, err := h.cat.Get(r.Context(), id)
+	if errors.Is(err, ErrNotFound) {
+		writeError(w, http.StatusNotFound, err)
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	res, err := h.prober.Update(r.Context(), p.Manifest)
+	if err != nil {
+		h.log.Warn("provider update failed", "provider", id, "package", res.Package, "err", err)
+		h.publishUpdate(id, res, false, err.Error())
+		// 502: the npm install itself failed (e.g. non-writable prefix),
+		// not a bad request. Surface the npm output for diagnosis.
+		writeJSON(w, http.StatusBadGateway, map[string]any{
+			"error":  err.Error(),
+			"result": res,
+		})
+		return
+	}
+	h.log.Info("provider updated", "provider", id, "package", res.Package,
+		"before", res.BeforeVersion, "after", res.AfterVersion, "changed", res.Changed)
+	h.publishUpdate(id, res, true, "")
+	writeJSON(w, http.StatusOK, res)
+}
+
+// publishUpdate emits a provider.updated event for the audit sink.
+func (h *Handlers) publishUpdate(id string, res UpdateResult, ok bool, errMsg string) {
+	if h.bus == nil {
+		return
+	}
+	h.bus.Publish(eventbus.Event{
+		Topic: "provider.updated",
+		Data: map[string]any{
+			"provider_id": id,
+			"package":     res.Package,
+			"before":      res.BeforeVersion,
+			"after":       res.AfterVersion,
+			"changed":     res.Changed,
+			"ok":          ok,
+			"error":       errMsg,
+		},
+	})
 }
 
 func (h *Handlers) updateConfig(w http.ResponseWriter, r *http.Request) {

--- a/internal/catalog/manifest.go
+++ b/internal/catalog/manifest.go
@@ -29,7 +29,16 @@ type Manifest struct {
 	// NpmPackage is the npm package the executable ships in, used to
 	// probe the latest published version (and, in Phase 2, to update
 	// the CLI). Empty for non-npm providers such as the builtin shell.
-	NpmPackage   string        `json:"npmPackage,omitempty"`
+	NpmPackage string `json:"npmPackage,omitempty"`
+	// ModelFlag is the CLI flag used to select a model (e.g. "--model").
+	// When set and the operator has configured a default `model`, it is
+	// passed on every spawn. Empty for providers with no model concept.
+	ModelFlag string `json:"modelFlag,omitempty"`
+	// KnownModels is a maintained suggestion list (kept current per
+	// release) the UI offers as "Suggested" — the CLIs expose no live
+	// model-list command, so this is the auto-populate source. Operators
+	// edit the actual list (provider config `models`) on top.
+	KnownModels  []string      `json:"knownModels,omitempty"`
 	DefaultArgs  []string      `json:"defaultArgs,omitempty"`
 	Capabilities Capabilities  `json:"capabilities"`
 	ConfigSchema []ConfigField `json:"configSchema,omitempty"`

--- a/internal/catalog/probe.go
+++ b/internal/catalog/probe.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"regexp"
@@ -53,20 +54,26 @@ type Prober struct {
 	installed map[string]cachedInstalled // executable -> info
 	latest    map[string]cachedLatest    // npm package -> version
 
-	lookPath func(string) (string, error)
-	runVer   func(ctx context.Context, bin string) (string, error)
-	npmView  func(ctx context.Context, pkg string) (string, error)
-	now      func() time.Time
+	// updateMu serialises Update() so two concurrent npm installs can't
+	// stomp the same global prefix.
+	updateMu sync.Mutex
+
+	lookPath   func(string) (string, error)
+	runVer     func(ctx context.Context, bin string) (string, error)
+	npmView    func(ctx context.Context, pkg string) (string, error)
+	npmInstall func(ctx context.Context, pkg string) (string, error)
+	now        func() time.Time
 }
 
 func NewProber() *Prober {
 	return &Prober{
-		installed: map[string]cachedInstalled{},
-		latest:    map[string]cachedLatest{},
-		lookPath:  exec.LookPath,
-		runVer:    defaultCliVersion,
-		npmView:   defaultNpmLatest,
-		now:       time.Now,
+		installed:  map[string]cachedInstalled{},
+		latest:     map[string]cachedLatest{},
+		lookPath:   exec.LookPath,
+		runVer:     defaultCliVersion,
+		npmView:    defaultNpmLatest,
+		npmInstall: defaultNpmInstall,
+		now:        time.Now,
 	}
 }
 
@@ -126,6 +133,62 @@ func (p *Prober) CheckUpdate(ctx context.Context, m Manifest) RuntimeInfo {
 	info.CheckedAt = p.now().UTC().Format(time.RFC3339)
 	info.UpdateAvailable = updateAvailable(info.InstalledVersion, latest)
 	return info
+}
+
+// UpdateResult reports the outcome of a provider CLI update.
+type UpdateResult struct {
+	Package       string `json:"package"`
+	BeforeVersion string `json:"beforeVersion,omitempty"`
+	AfterVersion  string `json:"afterVersion,omitempty"`
+	Changed       bool   `json:"changed"`
+	Output        string `json:"output,omitempty"` // tail of the npm output
+}
+
+// Update runs `npm install -g <pkg>` for the provider's CLI, then
+// re-probes the version. Serialised across calls. The npm package name
+// comes from the trusted manifest (never user input) — that is the
+// whitelist. Whether the install succeeds depends on the npm global
+// prefix being writable by the daemon's user; on a hardened deploy that
+// means an opendray-owned prefix, otherwise this returns a permission
+// error rather than escalating.
+func (p *Prober) Update(ctx context.Context, m Manifest) (UpdateResult, error) {
+	if m.NpmPackage == "" {
+		return UpdateResult{}, fmt.Errorf("provider %q is not updatable via npm", m.ID)
+	}
+
+	p.updateMu.Lock()
+	defer p.updateMu.Unlock()
+
+	before := p.Installed(ctx, m).InstalledVersion
+	out, err := p.npmInstall(ctx, m.NpmPackage)
+
+	// The install may have changed what's on disk even on partial
+	// failure, so always drop the cached install state.
+	p.mu.Lock()
+	delete(p.installed, m.Executable)
+	p.mu.Unlock()
+
+	res := UpdateResult{Package: m.NpmPackage, BeforeVersion: before, Output: tailLines(out, 40)}
+	if err != nil {
+		return res, fmt.Errorf("npm install -g %s: %w", m.NpmPackage, err)
+	}
+	res.AfterVersion = p.Installed(ctx, m).InstalledVersion
+	res.Changed = res.AfterVersion != before
+	return res, nil
+}
+
+// tailLines returns the last n lines of s (npm output can be long;
+// callers only want the tail for diagnostics).
+func tailLines(s string, n int) string {
+	s = strings.TrimRight(s, "\n")
+	if s == "" {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
 }
 
 // ── version comparison ───────────────────────────────────────────────
@@ -191,4 +254,16 @@ func defaultNpmLatest(ctx context.Context, pkg string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+func defaultNpmInstall(ctx context.Context, pkg string) (string, error) {
+	if _, err := exec.LookPath("npm"); err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+	// CombinedOutput so npm's progress/errors (incl. EACCES on a
+	// non-writable prefix) come back to the operator.
+	out, err := exec.CommandContext(ctx, "npm", "install", "-g", pkg).CombinedOutput()
+	return string(out), err
 }

--- a/internal/catalog/probe_test.go
+++ b/internal/catalog/probe_test.go
@@ -76,3 +76,48 @@ func TestProber_CheckUpdate(t *testing.T) {
 		t.Errorf("no-package provider should not report updates: %+v", none)
 	}
 }
+
+func TestProber_Update(t *testing.T) {
+	versions := []string{"0.132.0", "0.140.0"} // before, after
+	call := 0
+	installs := 0
+	p := NewProber()
+	p.lookPath = func(string) (string, error) { return "/usr/bin/codex", nil }
+	p.runVer = func(context.Context, string) (string, error) {
+		v := versions[call]
+		if call < len(versions)-1 {
+			call++
+		}
+		return "codex-cli " + v, nil
+	}
+	p.npmInstall = func(_ context.Context, pkg string) (string, error) {
+		installs++
+		if pkg != "@openai/codex" {
+			t.Errorf("npm install got wrong package: %q", pkg)
+		}
+		return "+ @openai/codex@0.140.0\nadded 1 package", nil
+	}
+	m := Manifest{ID: "codex", Executable: "codex", NpmPackage: "@openai/codex"}
+
+	res, err := p.Update(context.Background(), m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installs != 1 {
+		t.Errorf("expected one npm install, got %d", installs)
+	}
+	if res.BeforeVersion != "codex-cli 0.132.0" || res.AfterVersion != "codex-cli 0.140.0" || !res.Changed {
+		t.Errorf("unexpected result: %+v", res)
+	}
+	if res.Output == "" {
+		t.Error("expected npm output tail")
+	}
+}
+
+func TestProber_UpdateNoPackage(t *testing.T) {
+	p := NewProber()
+	_, err := p.Update(context.Background(), Manifest{ID: "shell", Executable: "bash"})
+	if err == nil {
+		t.Error("update of a provider without an npm package should error")
+	}
+}


### PR DESCRIPTION
## What

opendray had **no model concept** — a model only reached a CLI if you hand-typed `--model X` into spawn args. This adds an operator-managed **model list + default per provider**, editable in the Providers page, applied to every session.

- **manifest**: `modelFlag` (the CLI flag, e.g. `--model`) + `knownModels` (a maintained suggestion list). Filled for claude/codex/gemini (all use `--model`). *None of the three CLIs expose a live "list models" command, so `knownModels` is the auto-populate source — operators edit the real list on top.*
- **spawn**: `modelArgs()` passes the configured default (`config.model`) via the manifest's `modelFlag` on every spawn. A per-session `--model` still wins, since the session manager drops provider-derived flags the user re-specifies.
- **web**: a **Models** section in the Providers detail — add/remove model ids, mark one as **default**, and a one-tap **"Suggested (N)"** to import the manifest's `knownModels`. Edits ride the existing config draft/save (stored in provider config `models`; default in `model`).

## Why this shape

Reuses the existing per-provider config + the config→CLI-args path, so there's no new storage and no spawn-path special-casing beyond one helper. Model selection stays advisory/whitelisted by the operator — nothing is auto-installed or executed.

## Tests

`TestModelArgs`: renders `--model <default>` when set, nothing when unset/empty/non-string, and nothing when the manifest declares no model flag.

Builds on #227 (provider runtime/version surface).