### PR TITLE
Fix remote MCP URL normalization

### DIFF
--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -120,14 +120,18 @@ func (h *Handlers) create(w http.ResponseWriter, r *http.Request) {
 			fmt.Errorf("MCP server %s already exists", id))
 		return
 	}
-	if err := os.MkdirAll(dest, 0o700); err != nil {
-		writeError(w, http.StatusInternalServerError, err)
-		return
-	}
 	srv := *req.Server
 	srv.ID = id
 	if strings.TrimSpace(srv.Name) == "" {
 		srv.Name = id
+	}
+	if err := prepareServerForWrite(&srv); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if err := os.MkdirAll(dest, 0o700); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
 	}
 	if err := writeServer(dest, srv); err != nil {
 		writeError(w, http.StatusInternalServerError, err)
@@ -162,14 +166,18 @@ func (h *Handlers) update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	dest := filepath.Join(h.loader.VaultRoot(), id)
-	if err := os.MkdirAll(dest, 0o700); err != nil {
-		writeError(w, http.StatusInternalServerError, err)
-		return
-	}
 	srv := *req.Server
 	srv.ID = id
 	if strings.TrimSpace(srv.Name) == "" {
 		srv.Name = id
+	}
+	if err := prepareServerForWrite(&srv); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if err := os.MkdirAll(dest, 0o700); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
 	}
 	if err := writeServer(dest, srv); err != nil {
 		writeError(w, http.StatusInternalServerError, err)
@@ -331,6 +339,14 @@ func (h *Handlers) loadState() (secretsState, error) {
 	state.Encrypted = secrets.Encrypted()
 	state.Keys = secrets.Keys()
 	return state, nil
+}
+
+func prepareServerForWrite(s *Server) error {
+	normalizeServer(s)
+	if (s.Transport == "sse" || s.Transport == "http") && strings.TrimSpace(s.URL) == "" {
+		return errors.New("remote MCP servers require url for sse/http transport")
+	}
+	return nil
 }
 
 func writeServer(dir string, s Server) error {

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -144,8 +145,31 @@ func loadOne(root, id string) (Server, error) {
 	if s.Transport == "" {
 		s.Transport = "stdio"
 	}
+	normalizeServer(&s)
 	s.SourcePath = filepath.Join(root, id)
 	return s, nil
+}
+
+func normalizeServer(s *Server) {
+	s.Transport = strings.TrimSpace(s.Transport)
+	if s.Transport == "" {
+		s.Transport = "stdio"
+	}
+	if s.Transport != "sse" && s.Transport != "http" {
+		return
+	}
+
+	s.URL = strings.TrimSpace(s.URL)
+	command := strings.TrimSpace(s.Command)
+	if s.URL == "" && isHTTPURL(command) {
+		s.URL = command
+		s.Command = ""
+	}
+}
+
+func isHTTPURL(raw string) bool {
+	u, err := url.Parse(raw)
+	return err == nil && u.Host != "" && (u.Scheme == "http" || u.Scheme == "https")
 }
 
 // ValidID enforces the directory naming rules: lowercase alphanumeric,
@@ -171,6 +195,7 @@ func Marshal(s Server) ([]byte, error) {
 	// Strip computed / non-persisted fields before writing so the file
 	// only contains user-authored content.
 	clean := s
+	normalizeServer(&clean)
 	clean.SourcePath = ""
 	if strings.TrimSpace(clean.Transport) == "stdio" {
 		clean.Transport = ""

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -1,0 +1,72 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadOneNormalizesRemoteCommandURL(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "remote")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "mcp.json"), []byte(`{
+  "name": "remote",
+  "transport": "sse",
+  "command": "https://example.com/sse",
+  "enabled": true
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := loadOne(root, "remote")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.URL != "https://example.com/sse" {
+		t.Fatalf("URL=%q, want remote endpoint", got.URL)
+	}
+	if got.Command != "" {
+		t.Fatalf("Command=%q, want cleared after URL migration", got.Command)
+	}
+}
+
+func TestMarshalNormalizesRemoteCommandURL(t *testing.T) {
+	body, err := Marshal(Server{
+		ID:        "remote",
+		Name:      "remote",
+		Transport: "http",
+		Command:   "https://example.com/mcp",
+		Enabled:   true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got Server
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.URL != "https://example.com/mcp" {
+		t.Fatalf("URL=%q, want remote endpoint", got.URL)
+	}
+	if got.Command != "" {
+		t.Fatalf("Command=%q, want omitted after URL migration", got.Command)
+	}
+}
+
+func TestPrepareServerForWriteRejectsRemoteCommand(t *testing.T) {
+	srv := Server{
+		ID:        "remote",
+		Name:      "remote",
+		Transport: "http",
+		Command:   "node server.js",
+		Enabled:   true,
+	}
+	if err := prepareServerForWrite(&srv); err == nil {
+		t.Fatal("expected remote server without URL to be rejected")
+	}
+}


### PR DESCRIPTION
## Summary
- normalize legacy remote MCP entries that stored an HTTP(S) endpoint in `command` instead of `url`
- apply the same normalization before create/update writes so API/UI payloads persist a usable `url` field
- reject non-normalizable `sse`/`http` entries without a URL with a 400 instead of saving a config that the renderer silently drops
- add MCP registry regression tests for loader migration, marshal normalization, and invalid remote writes

Fixes #221.

## Testing
- `git diff --check`
- Not run: `go test ./internal/mcp ./internal/catalog` (`go`/`gofmt` are not installed in this Codex environment)
