### PR TITLE
fix(install-macos): installer aborts on fresh local Postgres (commented port line)

### DIFF
--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -260,7 +260,13 @@ if [ "$PG_MODE" = "local" ]; then
     # must probe the same port we'll actually bind (otherwise the
     # readiness check below waits on the wrong port and times out).
     _pgconf="$BREW_PREFIX/var/$PG_FORMULA/postgresql.conf"
-    PG_SUPER_PORT="$(grep -E '^[[:space:]]*port[[:space:]]*=' "$_pgconf" 2>/dev/null | tail -1 | sed -E 's/^[^=]*=[[:space:]]*([0-9]+).*/\1/')"
+    # A fresh postgresql.conf ships the port line COMMENTED ("#port = 5432"),
+    # so this grep finds no match and exits 1. Under `set -euo pipefail`
+    # that aborts the whole installer right after the Postgres install —
+    # before the `${PG_SUPER_PORT:-5432}` fallback below can apply. The
+    # `|| true` keeps the no-match case from tripping errexit (same guard
+    # the lsof probe just below already uses).
+    PG_SUPER_PORT="$(grep -E '^[[:space:]]*port[[:space:]]*=' "$_pgconf" 2>/dev/null | tail -1 | sed -E 's/^[^=]*=[[:space:]]*([0-9]+).*/\1/' || true)"
     PG_SUPER_PORT="${PG_SUPER_PORT:-5432}"
 
     # A conflict only if that port is held by a process that ISN'T this


### PR DESCRIPTION
## Symptom

On macOS, choosing **"Install PostgreSQL locally via brew"**, the installer prints the `postgresql@18` brew output and then **silently drops back to the shell** — no further log lines, no error. Real user report: it stops right after the Postgres `Summary 🍺` / caveats, at the prompt.

## Root cause

`install-macos.sh` runs under `set -euo pipefail`. The port-detection line:

```bash
PG_SUPER_PORT="$(grep -E '^[[:space:]]*port[[:space:]]*=' "$_pgconf" 2>/dev/null | tail -1 | sed -E '...')"
PG_SUPER_PORT="${PG_SUPER_PORT:-5432}"
```

matches an **uncommented** `port =` line. A freshly `initdb`'d `postgresql.conf` ships it **commented** (`#port = 5432`), so the grep matches nothing and exits 1 → with `pipefail` the pipeline exits 1 → the command substitution makes the assignment return non-zero → **`errexit` aborts the installer** before the `${PG_SUPER_PORT:-5432}` fallback on the very next line can apply.

It only bites the **fresh local-install** path. Existing-host installs (option 1) and machines whose conf already has an uncommented `port =` (e.g. from a prior run that hit a port conflict) are unaffected — which is why it reproduces on one Mac but not another. The author already guards the identical footgun on the `lsof` probe a few lines below (`|| true` with a comment explaining errexit+pipefail) — this line just missed it.

## Fix

Add `|| true` to the pipeline so a no-match falls through to the `:-5432` default, matching the existing guard below it.

## Verified

Under `set -euo pipefail` against a conf with only `#port = 5432`: pre-fix aborts at the assignment; post-fix survives and `PG_SUPER_PORT=5432`. `bash -n` clean.