### PR TITLE
fix(install-macos): launchd service PATH misses CLIs outside the brew bin

### DIFF
--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -602,6 +602,22 @@ else
     USER_KV=""
 fi
 
+# Build the service PATH. launchd does NOT read shell rc files, so the
+# daemon only sees this PATH — if an AI CLI lives somewhere else (e.g.
+# Claude Code's native installer puts `claude` in ~/.local/bin, not the
+# brew bin), opendray can't spawn it and sessions fail with the CLI "not
+# found". Seed the standard dirs, then prepend wherever each installed
+# CLI actually resolves right now, plus the native-installer location.
+SVC_PATH="${BREW_PREFIX}/bin:/usr/local/bin:/usr/bin:/bin"
+for _cli in claude gemini codex; do
+    _clipath="$(command -v "$_cli" 2>/dev/null || true)"
+    [ -n "$_clipath" ] || continue
+    _clidir="$(cd "$(dirname "$_clipath")" 2>/dev/null && pwd || true)"
+    [ -n "$_clidir" ] || continue
+    case ":$SVC_PATH:" in *":$_clidir:"*) ;; *) SVC_PATH="$_clidir:$SVC_PATH" ;; esac
+done
+case ":$SVC_PATH:" in *":$HOME/.local/bin:"*) ;; *) SVC_PATH="$HOME/.local/bin:$SVC_PATH" ;; esac
+
 # Render plist via a tmp file (Daemon path writes via run_priv).
 TMP_PLIST="$(mktemp -t opendray-plist.XXXXXX)"
 register_cleanup_file "$TMP_PLIST"
@@ -634,7 +650,7 @@ cat > "$TMP_PLIST" <<EOF
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>${BREW_PREFIX}/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>${SVC_PATH}</string>
         <key>HOME</key>
         <string>${HOME}</string>
     </dict>


### PR DESCRIPTION
## Symptom

macOS install completes, but **spawning a session fails** because opendray (running as the launchd agent) can't find the AI CLI.

## Root cause

The generated plist hardcodes:
```xml
<key>PATH</key>
<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
```
launchd **does not read shell rc files**, so the daemon only sees this PATH. If a CLI lives elsewhere, `exec.LookPath` fails at spawn.

The common trigger: `claude` installed via **Claude Code's native installer** lands in `~/.local/bin/claude`, not the brew bin. The installer's own `have_cmd claude` check passes (it sees the user's *interactive* PATH, which includes `~/.local/bin`), so it skips the npm install — leaving `claude` in `~/.local/bin`, which the service PATH then excludes. Result: `which claude` works in the user's terminal, but opendray's service can't spawn it. (Editing `~/.zshrc`/`~/.bashrc` doesn't help — launchd ignores them.)

## Fix

Build the service PATH dynamically before rendering the plist: seed the standard dirs, then prepend the directory where each installed CLI (`claude`/`gemini`/`codex`) actually resolves via `command -v`, plus `~/.local/bin`. opendray then finds the CLIs regardless of install method.

## Verified

`bash -n` clean; unit-tested the builder — a `claude` placed in a native-installer-style dir on PATH gets its directory prepended to `SVC_PATH`, and `~/.local/bin` is always included.

Immediate workaround for an already-installed user: `ln -sf ~/.local/bin/claude /opt/homebrew/bin/claude`, or set the Claude provider's Command Path to the full path in the dashboard.