### PR TITLE
feat(mcp): validate MCP servers from the Plugins page

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1281,6 +1281,13 @@
           "savedToast": "MCP server saved",
           "createFailedToast": "Create failed",
           "saveFailedToast": "Save failed"
+        },
+        "test": {
+          "button": "Test",
+          "title": "Validate this MCP server from the daemon",
+          "connected": "connected · {{count}} tools",
+          "reachable": "reachable",
+          "failed": "test failed"
         }
       },
       "mcpSecrets": {
@@ -1683,16 +1690,46 @@
     },
     "serverSettings": {
       "sections": {
-        "general": { "title": "General", "desc": "Listen address, operator account, token TTL." },
-        "logging": { "title": "Logging", "desc": "Verbosity, format, and live tail." },
-        "sessions": { "title": "Sessions", "desc": "Idle detection thresholds." },
-        "vault": { "title": "Vault", "desc": "Notes, skills, and git-versioned root." },
-        "mcp": { "title": "MCP registry", "desc": "Server registry + secrets." },
-        "memory": { "title": "Memory", "desc": "Cross-CLI persistent memory subsystem." },
-        "backup": { "title": "Backup", "desc": "Encrypted DB backups, restore, and admin data exports." },
-        "claude": { "title": "Storage · Claude", "desc": "Where Claude transcripts live on disk." },
-        "codex": { "title": "Storage · Codex", "desc": "Codex sessions root." },
-        "gemini": { "title": "Storage · Gemini", "desc": "Gemini per-project tmp + projects.json." }
+        "general": {
+          "title": "General",
+          "desc": "Listen address, operator account, token TTL."
+        },
+        "logging": {
+          "title": "Logging",
+          "desc": "Verbosity, format, and live tail."
+        },
+        "sessions": {
+          "title": "Sessions",
+          "desc": "Idle detection thresholds."
+        },
+        "vault": {
+          "title": "Vault",
+          "desc": "Notes, skills, and git-versioned root."
+        },
+        "mcp": {
+          "title": "MCP registry",
+          "desc": "Server registry + secrets."
+        },
+        "memory": {
+          "title": "Memory",
+          "desc": "Cross-CLI persistent memory subsystem."
+        },
+        "backup": {
+          "title": "Backup",
+          "desc": "Encrypted DB backups, restore, and admin data exports."
+        },
+        "claude": {
+          "title": "Storage · Claude",
+          "desc": "Where Claude transcripts live on disk."
+        },
+        "codex": {
+          "title": "Storage · Codex",
+          "desc": "Codex sessions root."
+        },
+        "gemini": {
+          "title": "Storage · Gemini",
+          "desc": "Gemini per-project tmp + projects.json."
+        }
       },
       "loading": "Loading server settings…",
       "loadFailed": "Failed to load: {message}",
@@ -3144,12 +3181,30 @@
     "pathStyle": "Path-style addressing",
     "pathStyleSubtitle": "Legacy / MinIO",
     "kinds": {
-      "local": { "label": "Local disk", "description": "Folder on the machine running opendray" },
-      "smb": { "label": "SMB share", "description": "Windows shares + most home NAS appliances" },
-      "webdav": { "label": "WebDAV", "description": "Self-hosted clouds + file-sharing services" },
-      "sftp": { "label": "SFTP", "description": "Any SSH-accessible server" },
-      "s3": { "label": "S3 / compatible", "description": "Amazon S3 + S3-compatible buckets (MinIO, R2, B2)" },
-      "rclone": { "label": "rclone (any)", "description": "OneDrive, Google Drive, Dropbox via the rclone CLI" }
+      "local": {
+        "label": "Local disk",
+        "description": "Folder on the machine running opendray"
+      },
+      "smb": {
+        "label": "SMB share",
+        "description": "Windows shares + most home NAS appliances"
+      },
+      "webdav": {
+        "label": "WebDAV",
+        "description": "Self-hosted clouds + file-sharing services"
+      },
+      "sftp": {
+        "label": "SFTP",
+        "description": "Any SSH-accessible server"
+      },
+      "s3": {
+        "label": "S3 / compatible",
+        "description": "Amazon S3 + S3-compatible buckets (MinIO, R2, B2)"
+      },
+      "rclone": {
+        "label": "rclone (any)",
+        "description": "OneDrive, Google Drive, Dropbox via the rclone CLI"
+      }
     },
     "formTitleEdit": "Edit target",
     "formTitleNew": "New backup target",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -1280,6 +1280,13 @@
           "savedToast": "MCP 服务器已保存",
           "createFailedToast": "创建失败",
           "saveFailedToast": "保存失败"
+        },
+        "test": {
+          "button": "测试",
+          "title": "从守护进程验证此 MCP 服务器",
+          "connected": "已连接 · {{count}} 个工具",
+          "reachable": "可达",
+          "failed": "测试失败"
         }
       },
       "mcpSecrets": {
@@ -1682,16 +1689,46 @@
     },
     "serverSettings": {
       "sections": {
-        "general": { "title": "通用", "desc": "监听地址、操作员账号、令牌 TTL。" },
-        "logging": { "title": "日志", "desc": "日志级别、格式与实时跟踪。" },
-        "sessions": { "title": "会话", "desc": "空闲检测阈值。" },
-        "vault": { "title": "Vault", "desc": "笔记、技能与 git 版本化根目录。" },
-        "mcp": { "title": "MCP 注册表", "desc": "服务器注册表与密钥。" },
-        "memory": { "title": "记忆", "desc": "跨 CLI 的持久化记忆子系统。" },
-        "backup": { "title": "备份", "desc": "加密数据库备份、恢复，以及管理员数据导出。" },
-        "claude": { "title": "存储 · Claude", "desc": "Claude 会话记录在磁盘上的位置。" },
-        "codex": { "title": "存储 · Codex", "desc": "Codex 会话根目录。" },
-        "gemini": { "title": "存储 · Gemini", "desc": "Gemini 每项目 tmp 与 projects.json。" }
+        "general": {
+          "title": "通用",
+          "desc": "监听地址、操作员账号、令牌 TTL。"
+        },
+        "logging": {
+          "title": "日志",
+          "desc": "日志级别、格式与实时跟踪。"
+        },
+        "sessions": {
+          "title": "会话",
+          "desc": "空闲检测阈值。"
+        },
+        "vault": {
+          "title": "Vault",
+          "desc": "笔记、技能与 git 版本化根目录。"
+        },
+        "mcp": {
+          "title": "MCP 注册表",
+          "desc": "服务器注册表与密钥。"
+        },
+        "memory": {
+          "title": "记忆",
+          "desc": "跨 CLI 的持久化记忆子系统。"
+        },
+        "backup": {
+          "title": "备份",
+          "desc": "加密数据库备份、恢复，以及管理员数据导出。"
+        },
+        "claude": {
+          "title": "存储 · Claude",
+          "desc": "Claude 会话记录在磁盘上的位置。"
+        },
+        "codex": {
+          "title": "存储 · Codex",
+          "desc": "Codex 会话根目录。"
+        },
+        "gemini": {
+          "title": "存储 · Gemini",
+          "desc": "Gemini 每项目 tmp 与 projects.json。"
+        }
       },
       "loading": "正在加载服务器设置…",
       "loadFailed": "加载失败：{message}",
@@ -3143,12 +3180,30 @@
     "pathStyle": "路径风格寻址",
     "pathStyleSubtitle": "旧版 / MinIO",
     "kinds": {
-      "local": { "label": "本地磁盘", "description": "运行 opendray 的机器上的文件夹" },
-      "smb": { "label": "SMB 共享", "description": "Windows 共享 + 多数家用 NAS 设备" },
-      "webdav": { "label": "WebDAV", "description": "自托管云盘 + 文件共享服务" },
-      "sftp": { "label": "SFTP", "description": "任何可 SSH 访问的服务器" },
-      "s3": { "label": "S3 / 兼容", "description": "Amazon S3 + S3 兼容存储桶（MinIO、R2、B2）" },
-      "rclone": { "label": "rclone（任意）", "description": "通过 rclone CLI 访问 OneDrive、Google Drive、Dropbox" }
+      "local": {
+        "label": "本地磁盘",
+        "description": "运行 opendray 的机器上的文件夹"
+      },
+      "smb": {
+        "label": "SMB 共享",
+        "description": "Windows 共享 + 多数家用 NAS 设备"
+      },
+      "webdav": {
+        "label": "WebDAV",
+        "description": "自托管云盘 + 文件共享服务"
+      },
+      "sftp": {
+        "label": "SFTP",
+        "description": "任何可 SSH 访问的服务器"
+      },
+      "s3": {
+        "label": "S3 / 兼容",
+        "description": "Amazon S3 + S3 兼容存储桶（MinIO、R2、B2）"
+      },
+      "rclone": {
+        "label": "rclone（任意）",
+        "description": "通过 rclone CLI 访问 OneDrive、Google Drive、Dropbox"
+      }
     },
     "formTitleEdit": "编辑目标",
     "formTitleNew": "新建备份目标",

--- a/app/shared/src/lib/mcps.ts
+++ b/app/shared/src/lib/mcps.ts
@@ -86,6 +86,33 @@ export async function deleteMcpSecret(key: string): Promise<void> {
   })
 }
 
+// McpCheck is one validation step; McpTestResult is the whole outcome
+// of POST /mcps/{id}/test (mirrors internal/mcp/validate.go).
+export interface McpCheck {
+  name: string
+  ok: boolean
+  detail?: string
+}
+
+export interface McpTestResult {
+  ok: boolean
+  transport: string
+  checks: McpCheck[]
+  toolCount?: number
+  tools?: string[]
+  serverName?: string
+  serverVersion?: string
+  note?: string
+  missingEnv?: string[]
+  latencyMs?: number
+}
+
+// testMcp validates a server from the daemon: stdio → live MCP
+// handshake (real tool count); sse/http → config-sanity + reachability.
+export async function testMcp(id: string): Promise<McpTestResult> {
+  return api<McpTestResult>(`/api/v1/mcps/${id}/test`, { method: 'POST' })
+}
+
 // defaultMcpServer returns a starter template for the New dialog —
 // stdio transport with a placeholder command so the user has the
 // shape in front of them.

--- a/app/web/src/pages/Plugins.tsx
+++ b/app/web/src/pages/Plugins.tsx
@@ -66,6 +66,7 @@ import {
   createMcp,
   updateMcp,
   deleteMcp,
+  testMcp,
   getMcpSecrets,
   setMcpSecret,
   deleteMcpSecret,
@@ -196,6 +197,33 @@ function McpSection() {
       }),
   })
 
+  const test = useMutation({
+    mutationFn: (id: string) => testMcp(id),
+    onSuccess: (res, id) => {
+      if (res.ok) {
+        const summary =
+          res.transport === 'stdio'
+            ? t('web.plugins.mcp.test.connected', { count: res.toolCount ?? 0 })
+            : t('web.plugins.mcp.test.reachable')
+        toast.success(`${id}: ${summary}`, {
+          description:
+            (res.tools?.length ? res.tools.join(', ') : res.note) || undefined,
+        })
+      } else {
+        const failed = res.checks.find((c) => !c.ok)
+        toast.error(`${id}: ${t('web.plugins.mcp.test.failed')}`, {
+          description: failed
+            ? `${failed.name}: ${failed.detail ?? ''}`
+            : res.note,
+        })
+      }
+    },
+    onError: (err: Error, id) =>
+      toast.error(`${id}: ${t('web.plugins.mcp.test.failed')}`, {
+        description: err.message,
+      }),
+  })
+
   const toggle = useMutation({
     mutationFn: async (s: McpServer) =>
       updateMcp(s.id, { ...s, enabled: !s.enabled }),
@@ -301,6 +329,21 @@ function McpSection() {
                   </td>
                   <td className="px-3 py-2 text-right">
                     <div className="flex items-center justify-end gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => test.mutate(s.id)}
+                        disabled={test.isPending && test.variables === s.id}
+                        className="h-7 px-2 text-[11px] gap-1"
+                        title={t('web.plugins.mcp.test.title')}
+                      >
+                        {test.isPending && test.variables === s.id ? (
+                          <Loader2 className="size-3 animate-spin" />
+                        ) : (
+                          <Plug className="size-3" />
+                        )}
+                        {t('web.plugins.mcp.test.button')}
+                      </Button>
                       <Button
                         variant="ghost"
                         size="sm"

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -49,6 +49,9 @@ func (h *Handlers) Mount(r chi.Router) {
 			r.Get("/", h.get)
 			r.Put("/", h.update)
 			r.Delete("/", h.delete)
+			// Validate the server from the daemon: stdio → live MCP
+			// handshake; sse/http → config-sanity + reachability.
+			r.Post("/test", h.test)
 		})
 	})
 }
@@ -91,6 +94,31 @@ func (h *Handlers) get(w http.ResponseWriter, r *http.Request) {
 	}
 	s.SourcePath = ""
 	writeJSON(w, http.StatusOK, s)
+}
+
+// test validates one MCP server from the daemon. ${SECRET} placeholders
+// are resolved (best-effort) so the handshake uses real credentials.
+// Admin-only via the route group it's mounted under.
+func (h *Handlers) test(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if !ValidID(id) {
+		writeError(w, http.StatusBadRequest, errors.New("invalid id"))
+		return
+	}
+	s, err := h.loader.Get(id)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			writeError(w, http.StatusNotFound, err)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	var missing []string
+	if sec, serr := LoadSecrets(h.secretsPath); serr == nil {
+		s, missing = sec.Resolve(s)
+	}
+	writeJSON(w, http.StatusOK, Validate(r.Context(), s, missing))
 }
 
 func (h *Handlers) create(w http.ResponseWriter, r *http.Request) {

--- a/internal/mcp/validate.go
+++ b/internal/mcp/validate.go
@@ -1,0 +1,244 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Check is one validation step (config sanity, reachability, handshake).
+type Check struct {
+	Name   string `json:"name"`
+	OK     bool   `json:"ok"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// ValidationResult is the outcome of testing one MCP server — rendered
+// by the Plugins UI as a Cursor-style "✓ connected · N tools" / "✗ …".
+type ValidationResult struct {
+	OK            bool     `json:"ok"`
+	Transport     string   `json:"transport"`
+	Checks        []Check  `json:"checks"`
+	ToolCount     int      `json:"toolCount,omitempty"`
+	Tools         []string `json:"tools,omitempty"`
+	ServerName    string   `json:"serverName,omitempty"`
+	ServerVersion string   `json:"serverVersion,omitempty"`
+	Note          string   `json:"note,omitempty"`
+	MissingEnv    []string `json:"missingEnv,omitempty"`
+	LatencyMs     int64    `json:"latencyMs,omitempty"`
+}
+
+// Validate checks one MCP server from the daemon's vantage point (so it
+// sees the same PATH + network a real session spawn would). stdio
+// servers get a full MCP handshake (initialize + tools/list); sse/http
+// servers get config-sanity + URL reachability (a full remote handshake
+// is a later addition). `missing` is the set of unresolved ${SECRET}
+// placeholders from Secrets.Resolve.
+func Validate(ctx context.Context, srv Server, missing []string) ValidationResult {
+	transport := strings.TrimSpace(srv.Transport)
+	if transport == "" {
+		transport = "stdio"
+	}
+	res := ValidationResult{Transport: transport, MissingEnv: missing}
+	add := func(name string, ok bool, detail string) { res.Checks = append(res.Checks, Check{name, ok, detail}) }
+
+	switch transport {
+	case "sse", "http":
+		// Config sanity — the #221 trap: address belongs in `url`.
+		if strings.TrimSpace(srv.URL) == "" {
+			detail := "sse/http transport needs a `url`"
+			if strings.TrimSpace(srv.Command) != "" {
+				detail = "address looks like it's in the `command` field — move it to `url`"
+			}
+			add("config", false, detail)
+			res.OK = false
+			return res
+		}
+		add("config", true, "url set")
+		if len(missing) > 0 {
+			add("secrets", false, "unresolved placeholders: "+strings.Join(missing, ", "))
+		}
+		// Reachability.
+		start := time.Now()
+		status, err := urlReachable(ctx, srv.URL)
+		res.LatencyMs = time.Since(start).Milliseconds()
+		if err != nil {
+			add("reachable", false, err.Error())
+			res.OK = false
+		} else {
+			add("reachable", true, fmt.Sprintf("HTTP %d", status))
+			res.OK = len(missing) == 0
+		}
+		res.Note = "Reachability only (no live handshake for sse/http yet). " +
+			"Note: codex is stdio-only and won't see this server."
+		return res
+
+	default: // stdio
+		if strings.TrimSpace(srv.Command) == "" {
+			add("config", false, "stdio transport needs a `command`")
+			res.OK = false
+			return res
+		}
+		add("config", true, "command set")
+		// Command resolvable on the daemon's PATH?
+		path, err := exec.LookPath(srv.Command)
+		if err != nil {
+			add("command", false, fmt.Sprintf("%q not found on the service PATH", srv.Command))
+			res.OK = false
+			return res
+		}
+		add("command", true, path)
+		if len(missing) > 0 {
+			add("secrets", false, "unresolved placeholders: "+strings.Join(missing, ", "))
+		}
+		// Full MCP handshake.
+		start := time.Now()
+		hs, err := stdioHandshake(ctx, srv)
+		res.LatencyMs = time.Since(start).Milliseconds()
+		if err != nil {
+			add("handshake", false, err.Error())
+			res.OK = false
+			return res
+		}
+		res.ToolCount = len(hs.tools)
+		res.Tools = hs.tools
+		res.ServerName = hs.name
+		res.ServerVersion = hs.version
+		add("handshake", true, fmt.Sprintf("connected, %d tools", len(hs.tools)))
+		res.OK = len(missing) == 0
+		return res
+	}
+}
+
+type handshakeResult struct {
+	tools         []string
+	name, version string
+}
+
+// stdioHandshake spawns the server and runs initialize + tools/list over
+// stdio, returning the advertised tools. The process is always killed.
+func stdioHandshake(ctx context.Context, srv Server) (handshakeResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, srv.Command, srv.Args...)
+	cmd.Env = append(os.Environ(), envSlice(srv.Env)...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return handshakeResult{}, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return handshakeResult{}, err
+	}
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return handshakeResult{}, fmt.Errorf("start: %w", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	// stdout is the MCP channel; logs go to stderr (we keep it for errors).
+	for _, msg := range []string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"opendray-validator","version":"1"}}}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`,
+	} {
+		if _, err := io.WriteString(stdin, msg+"\n"); err != nil {
+			return handshakeResult{}, fmt.Errorf("write request: %w", err)
+		}
+	}
+
+	var out handshakeResult
+	sc := bufio.NewScanner(stdout)
+	sc.Buffer(make([]byte, 1<<20), 8<<20) // tool lists can be large
+	for sc.Scan() {
+		var msg struct {
+			ID     *int            `json:"id"`
+			Result json.RawMessage `json:"result"`
+			Error  *struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if json.Unmarshal(sc.Bytes(), &msg) != nil || msg.ID == nil {
+			continue // notifications / log lines / partial frames
+		}
+		switch *msg.ID {
+		case 1:
+			var init struct {
+				ServerInfo struct{ Name, Version string } `json:"serverInfo"`
+			}
+			_ = json.Unmarshal(msg.Result, &init)
+			out.name, out.version = init.ServerInfo.Name, init.ServerInfo.Version
+		case 2:
+			if msg.Error != nil {
+				return out, errors.New(msg.Error.Message)
+			}
+			var tl struct {
+				Tools []struct {
+					Name string `json:"name"`
+				} `json:"tools"`
+			}
+			if err := json.Unmarshal(msg.Result, &tl); err != nil {
+				return out, fmt.Errorf("parse tools/list: %w", err)
+			}
+			for _, t := range tl.Tools {
+				out.tools = append(out.tools, t.Name)
+			}
+			return out, nil
+		}
+	}
+	if ctx.Err() != nil {
+		return out, fmt.Errorf("timed out waiting for MCP response%s", stderrHint(stderr.String()))
+	}
+	return out, fmt.Errorf("server exited before answering tools/list%s", stderrHint(stderr.String()))
+}
+
+// urlReachable does a GET with a short timeout. http.Client returns once
+// headers arrive, so an SSE endpoint that streams forever still reports
+// promptly. Any status is "reachable"; a transport error is not.
+func urlReachable(ctx context.Context, rawurl string) (int, error) {
+	ctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawurl, nil)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	_ = resp.Body.Close()
+	return resp.StatusCode, nil
+}
+
+func envSlice(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k, v := range m {
+		out = append(out, k+"="+v)
+	}
+	return out
+}
+
+func stderrHint(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	if len(lines) > 3 {
+		lines = lines[len(lines)-3:]
+	}
+	return " — stderr: " + strings.Join(lines, " | ")
+}

--- a/internal/mcp/validate_test.go
+++ b/internal/mcp/validate_test.go
@@ -1,0 +1,94 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func checkByName(res ValidationResult, name string) (Check, bool) {
+	for _, c := range res.Checks {
+		if c.Name == name {
+			return c, true
+		}
+	}
+	return Check{}, false
+}
+
+func TestValidate_ConfigSanity(t *testing.T) {
+	// sse with the address mistakenly in `command` (the #221 trap).
+	res := Validate(context.Background(),
+		Server{Transport: "sse", Command: "http://host:3100/sse"}, nil)
+	if res.OK {
+		t.Error("sse with no url should fail")
+	}
+	if c, ok := checkByName(res, "config"); !ok || c.OK || !strings.Contains(c.Detail, "command") {
+		t.Errorf("expected config check pointing at the command field, got %+v", res.Checks)
+	}
+
+	// stdio with no command.
+	res = Validate(context.Background(), Server{Transport: "stdio"}, nil)
+	if res.OK {
+		t.Error("stdio with no command should fail")
+	}
+}
+
+func TestValidate_SSEReachability_Unreachable(t *testing.T) {
+	// Nothing listening here → reachability fails, but config passes.
+	res := Validate(context.Background(),
+		Server{Transport: "sse", URL: "http://127.0.0.1:1/sse"}, nil)
+	if c, ok := checkByName(res, "config"); !ok || !c.OK {
+		t.Errorf("config should pass when url is set: %+v", res.Checks)
+	}
+	if res.OK {
+		t.Error("unreachable endpoint should not be OK")
+	}
+	if !strings.Contains(res.Note, "codex") {
+		t.Errorf("sse note should mention the codex caveat: %q", res.Note)
+	}
+}
+
+func TestValidate_StdioHandshake(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fakemcp.sh")
+	// Minimal MCP server: the validator writes initialize, then the
+	// initialized notification, then tools/list — in that order. Reply
+	// to the two requests with canned JSON-RPC results.
+	body := `#!/bin/sh
+read _init
+printf '{"jsonrpc":"2.0","id":1,"result":{"serverInfo":{"name":"fake-vault","version":"9.9"},"capabilities":{}}}\n'
+read _initialized
+read _toolslist
+printf '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"read_secret"},{"name":"list_mounts"}]}}\n'
+`
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Validate(context.Background(), Server{Transport: "stdio", Command: script}, nil)
+	if !res.OK {
+		t.Fatalf("handshake should succeed: %+v", res.Checks)
+	}
+	if res.ToolCount != 2 {
+		t.Errorf("toolCount = %d, want 2 (%v)", res.ToolCount, res.Tools)
+	}
+	if res.ServerName != "fake-vault" || res.ServerVersion != "9.9" {
+		t.Errorf("serverInfo = %q %q", res.ServerName, res.ServerVersion)
+	}
+	if c, ok := checkByName(res, "handshake"); !ok || !c.OK {
+		t.Errorf("handshake check missing/failed: %+v", res.Checks)
+	}
+}
+
+func TestValidate_StdioCommandNotFound(t *testing.T) {
+	res := Validate(context.Background(),
+		Server{Transport: "stdio", Command: "definitely-not-a-real-binary-xyz"}, nil)
+	if res.OK {
+		t.Error("missing command should fail")
+	}
+	if c, ok := checkByName(res, "command"); !ok || c.OK {
+		t.Errorf("expected failing command check: %+v", res.Checks)
+	}
+}


### PR DESCRIPTION
## Why

There was no way to tell whether an MCP server actually works — you found out only by spawning a session and running `/mcp` in the CLI. The common misconfigs all fail **silently**: the address typed into the `command` field instead of `url`, an unreachable host/port, or a binary that isn't on the daemon's PATH.

## What

A **Test** action (Plugins page, per server) that validates from the **daemon's** vantage point — the same PATH + network a real session spawn sees, so it catches things the browser can't:

- **stdio** → a full MCP handshake (`initialize` + `tools/list`) → reports the real **tool count + names** (Cursor-style), or the actual error with an stderr tail.
- **sse/http** → config-sanity + URL **reachability**, and a note that **codex** (stdio-only) won't see remote servers. (A live remote handshake is a follow-up.)
- **config-sanity** catches the frequent trap: `transport: sse/http` with the address left in `command` instead of `url`.

`${SECRET}` placeholders are resolved (via `Secrets.Resolve`) before the handshake, so it runs with real credentials.

- **API:** `POST /api/v1/mcps/{id}/test` — admin-only (the MCP routes sit under the admin middleware group).
- **UI:** a Test button per server; result shown as a toast (`✓ connected · N tools` / `✗ <failed check>`).

## Tests

`internal/mcp/validate_test.go`: config-sanity (sse-without-url flags the command-field mistake; stdio-without-command), SSE unreachable (config passes, reachability fails, codex note present), command-not-found, and a **real stdio handshake** against a hermetic `sh` fake MCP server (asserts tool count + serverInfo). `bash`-free, no external deps.