### PR TITLE
fix(catalog): gate provider mutations + graceful Update (harden the merged Update action)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -970,7 +970,8 @@
         "updating": "Updating…",
         "updatedToast": "Updated {{from}} → {{to}}",
         "alreadyLatestToast": "Already up to date",
-        "updateFailedToast": "Update failed"
+        "updateFailedToast": "Update failed",
+        "updateUnavailable": "In-app update not available here"
       },
       "configForm": {
         "selectPlaceholder": "Select…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -970,7 +970,8 @@
         "updating": "更新中…",
         "updatedToast": "已更新 {{from}} → {{to}}",
         "alreadyLatestToast": "已是最新",
-        "updateFailedToast": "更新失败"
+        "updateFailedToast": "更新失败",
+        "updateUnavailable": "此处无法在应用内更新"
       },
       "configForm": {
         "selectPlaceholder": "选择…",

--- a/app/shared/src/lib/catalog.ts
+++ b/app/shared/src/lib/catalog.ts
@@ -21,6 +21,10 @@ export interface ProviderUpdateResult {
   afterVersion?: string
   changed: boolean
   output?: string
+  // available=false when an in-app update can't run here (e.g. the npm
+  // prefix isn't writable by the service); reason explains why.
+  available: boolean
+  reason?: string
 }
 
 // updateProvider patches the CLI to the latest npm version (admin-only,

--- a/app/web/src/pages/Providers.tsx
+++ b/app/web/src/pages/Providers.tsx
@@ -190,6 +190,13 @@ function ProviderDetail({
   const updateMut = useMutation({
     mutationFn: () => updateProvider(m.id),
     onSuccess: (res) => {
+      if (!res.available) {
+        // Can't update here (e.g. read-only npm prefix) — guidance, not error.
+        toast.info(t('web.providers.detail.updateUnavailable'), {
+          description: res.reason,
+        })
+        return
+      }
       if (res.changed) {
         toast.success(
           t('web.providers.detail.updatedToast', {

--- a/internal/catalog/authz_test.go
+++ b/internal/catalog/authz_test.go
@@ -1,0 +1,46 @@
+package catalog
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/opendray/opendray-v2/internal/integration"
+)
+
+func TestRequirePrivileged(t *testing.T) {
+	h := &Handlers{log: slog.Default()}
+
+	cases := []struct {
+		name      string
+		principal *integration.Principal
+		scope     string
+		wantOK    bool
+		wantCode  int
+	}{
+		{"admin allowed", &integration.Principal{Kind: integration.KindAdmin, ID: "navid"}, scopeProvidersUpdate, true, 0},
+		{"integration with scope", &integration.Principal{Kind: integration.KindIntegration, ID: "i1", Scopes: []string{scopeProvidersUpdate}}, scopeProvidersUpdate, true, 0},
+		{"integration wrong scope", &integration.Principal{Kind: integration.KindIntegration, ID: "i2", Scopes: []string{"providers:write"}}, scopeProvidersUpdate, false, http.StatusForbidden},
+		{"integration no scope", &integration.Principal{Kind: integration.KindIntegration, ID: "i3", Scopes: nil}, scopeProvidersUpdate, false, http.StatusForbidden},
+		{"no principal", nil, scopeProvidersUpdate, false, http.StatusUnauthorized},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			if c.principal != nil {
+				ctx = integration.WithPrincipal(ctx, *c.principal)
+			}
+			r := httptest.NewRequest(http.MethodPost, "/x", nil).WithContext(ctx)
+			w := httptest.NewRecorder()
+			got := h.requirePrivileged(w, r, c.scope)
+			if got != c.wantOK {
+				t.Fatalf("requirePrivileged=%v want %v", got, c.wantOK)
+			}
+			if !c.wantOK && w.Code != c.wantCode {
+				t.Errorf("status=%d want %d", w.Code, c.wantCode)
+			}
+		})
+	}
+}

--- a/internal/catalog/handler.go
+++ b/internal/catalog/handler.go
@@ -3,13 +3,44 @@ package catalog
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/opendray/opendray-v2/internal/eventbus"
+	"github.com/opendray/opendray-v2/internal/integration"
 )
+
+// Scopes gating the provider *mutation* endpoints. Reads (list / get /
+// update-check) stay open to any authenticated principal; writes and the
+// code-running update require admin, or an integration key explicitly
+// granted the scope. This keeps a plain integration key from changing
+// what executes on the box (config.command override, npm install).
+const (
+	scopeProvidersWrite  = "providers:write"  // config / toggle
+	scopeProvidersUpdate = "providers:update" // npm install -g
+)
+
+// requirePrivileged allows admins unconditionally, and integration keys
+// only when they hold `scope`. Returns false (and writes the response)
+// when denied. Mirrors the admin-or-scope check in integration/events.go.
+func (h *Handlers) requirePrivileged(w http.ResponseWriter, r *http.Request, scope string) bool {
+	p, ok := integration.CurrentPrincipal(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, errors.New("unauthorized"))
+		return false
+	}
+	if p.Kind == integration.KindAdmin || integration.HasScope(p.Scopes, scope) {
+		return true
+	}
+	h.log.Warn("provider mutation denied",
+		"principal", p.ID, "kind", p.Kind, "scope", scope)
+	writeError(w, http.StatusForbidden,
+		fmt.Errorf("requires admin or the %q scope", scope))
+	return false
+}
 
 // Handlers serves the /providers REST surface. Mount under /api/v1.
 type Handlers struct {
@@ -97,6 +128,9 @@ func (h *Handlers) updateCheck(w http.ResponseWriter, r *http.Request) {
 // there's no arbitrary-package vector. The outcome is published to the
 // audit log via the event bus.
 func (h *Handlers) update(w http.ResponseWriter, r *http.Request) {
+	if !h.requirePrivileged(w, r, scopeProvidersUpdate) {
+		return
+	}
 	id := chi.URLParam(r, "id")
 	p, err := h.cat.Get(r.Context(), id)
 	if errors.Is(err, ErrNotFound) {
@@ -146,6 +180,9 @@ func (h *Handlers) publishUpdate(id string, res UpdateResult, ok bool, errMsg st
 }
 
 func (h *Handlers) updateConfig(w http.ResponseWriter, r *http.Request) {
+	if !h.requirePrivileged(w, r, scopeProvidersWrite) {
+		return
+	}
 	id := chi.URLParam(r, "id")
 	var cfg map[string]any
 	if err := json.NewDecoder(r.Body).Decode(&cfg); err != nil {
@@ -165,6 +202,9 @@ func (h *Handlers) updateConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handlers) toggle(w http.ResponseWriter, r *http.Request) {
+	if !h.requirePrivileged(w, r, scopeProvidersWrite) {
+		return
+	}
 	id := chi.URLParam(r, "id")
 	var req struct {
 		Enabled bool `json:"enabled"`

--- a/internal/catalog/handler.go
+++ b/internal/catalog/handler.go
@@ -143,17 +143,31 @@ func (h *Handlers) update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res, err := h.prober.Update(r.Context(), p.Manifest)
-	if err != nil {
+	switch {
+	case errors.Is(err, ErrUpdatePrefixReadonly):
+		// Not an error condition the operator can act on by retrying:
+		// the daemon is unprivileged and the npm prefix is root-owned.
+		// Report "unavailable" so the UI shows guidance, not a failure.
+		res.Available = false
+		res.Reason = "In-app updates aren't available here — the npm global prefix isn't writable by the opendray service. " +
+			"Install the CLI into an opendray-owned npm prefix (on the service PATH) to enable one-tap updates."
+		h.log.Info("provider update unavailable (read-only prefix)", "provider", id)
+		h.publishUpdate(id, res, false, "prefix-readonly")
+		writeJSON(w, http.StatusOK, res)
+		return
+	case err != nil:
 		h.log.Warn("provider update failed", "provider", id, "package", res.Package, "err", err)
+		res.Available = true
 		h.publishUpdate(id, res, false, err.Error())
-		// 502: the npm install itself failed (e.g. non-writable prefix),
-		// not a bad request. Surface the npm output for diagnosis.
+		// 502: the npm install itself failed (registry error, bad package,
+		// …). Surface the npm output for diagnosis.
 		writeJSON(w, http.StatusBadGateway, map[string]any{
 			"error":  err.Error(),
 			"result": res,
 		})
 		return
 	}
+	res.Available = true
 	h.log.Info("provider updated", "provider", id, "package", res.Package,
 		"before", res.BeforeVersion, "after", res.AfterVersion, "changed", res.Changed)
 	h.publishUpdate(id, res, true, "")

--- a/internal/catalog/probe.go
+++ b/internal/catalog/probe.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -62,6 +63,7 @@ type Prober struct {
 	runVer     func(ctx context.Context, bin string) (string, error)
 	npmView    func(ctx context.Context, pkg string) (string, error)
 	npmInstall func(ctx context.Context, pkg string) (string, error)
+	npmRoot    func(ctx context.Context) (string, error)
 	now        func() time.Time
 }
 
@@ -73,9 +75,17 @@ func NewProber() *Prober {
 		runVer:     defaultCliVersion,
 		npmView:    defaultNpmLatest,
 		npmInstall: defaultNpmInstall,
+		npmRoot:    defaultNpmRoot,
 		now:        time.Now,
 	}
 }
+
+// ErrUpdatePrefixReadonly means the npm global prefix isn't writable by
+// the service user, so an in-app `npm install -g` would fail with EACCES.
+// We detect this up front and report "unavailable" rather than letting
+// the install error out — the daemon runs unprivileged, so updates only
+// work when the CLIs live in an opendray-owned npm prefix.
+var ErrUpdatePrefixReadonly = errors.New("npm global prefix is not writable by the opendray service")
 
 // Installed reports whether the manifest's executable is on PATH and its
 // `--version` string. Fast (local exec), cached for installedTTL.
@@ -142,6 +152,11 @@ type UpdateResult struct {
 	AfterVersion  string `json:"afterVersion,omitempty"`
 	Changed       bool   `json:"changed"`
 	Output        string `json:"output,omitempty"` // tail of the npm output
+	// Available is false when an in-app update can't run here (e.g. the
+	// npm prefix isn't writable by the service); Reason explains why.
+	// Set by the HTTP handler.
+	Available bool   `json:"available"`
+	Reason    string `json:"reason,omitempty"`
 }
 
 // Update runs `npm install -g <pkg>` for the provider's CLI, then
@@ -160,6 +175,13 @@ func (p *Prober) Update(ctx context.Context, m Manifest) (UpdateResult, error) {
 	defer p.updateMu.Unlock()
 
 	before := p.Installed(ctx, m).InstalledVersion
+
+	// Preflight: if the npm global dir isn't writable by this (unprivileged)
+	// process, an install would just EACCES — report it cleanly instead.
+	if dir, derr := p.npmRoot(ctx); derr == nil && dir != "" && !dirWritable(dir) {
+		return UpdateResult{Package: m.NpmPackage, BeforeVersion: before}, ErrUpdatePrefixReadonly
+	}
+
 	out, err := p.npmInstall(ctx, m.NpmPackage)
 
 	// The install may have changed what's on disk even on partial
@@ -254,6 +276,34 @@ func defaultNpmLatest(ctx context.Context, pkg string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// defaultNpmRoot returns the global node_modules dir (`npm root -g`) —
+// where `npm install -g` writes — so we can check writability up front.
+func defaultNpmRoot(ctx context.Context) (string, error) {
+	if _, err := exec.LookPath("npm"); err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "npm", "root", "-g").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// dirWritable reports whether dir exists and the current process can
+// create files in it (catches the root-owned-prefix case).
+func dirWritable(dir string) bool {
+	f, err := os.CreateTemp(dir, ".opendray-write-probe-*")
+	if err != nil {
+		return false
+	}
+	name := f.Name()
+	_ = f.Close()
+	_ = os.Remove(name)
+	return true
 }
 
 func defaultNpmInstall(ctx context.Context, pkg string) (string, error) {

--- a/internal/catalog/probe_test.go
+++ b/internal/catalog/probe_test.go
@@ -3,6 +3,8 @@ package catalog
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -97,6 +99,8 @@ func TestProber_Update(t *testing.T) {
 		}
 		return "+ @openai/codex@0.140.0\nadded 1 package", nil
 	}
+	// Preflight: point npm root at a writable temp dir so Update proceeds.
+	p.npmRoot = func(context.Context) (string, error) { return t.TempDir(), nil }
 	m := Manifest{ID: "codex", Executable: "codex", NpmPackage: "@openai/codex"}
 
 	res, err := p.Update(context.Background(), m)
@@ -119,5 +123,28 @@ func TestProber_UpdateNoPackage(t *testing.T) {
 	_, err := p.Update(context.Background(), Manifest{ID: "shell", Executable: "bash"})
 	if err == nil {
 		t.Error("update of a provider without an npm package should error")
+	}
+}
+
+func TestProber_UpdateReadonlyPrefix(t *testing.T) {
+	installed := false
+	p := NewProber()
+	p.lookPath = func(string) (string, error) { return "/usr/bin/codex", nil }
+	p.runVer = func(context.Context, string) (string, error) { return "codex-cli 0.132.0", nil }
+	p.npmInstall = func(context.Context, string) (string, error) { installed = true; return "", nil }
+	// Point npm root at a path that can't be written (a file, not a dir).
+	ro := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(ro, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p.npmRoot = func(context.Context) (string, error) { return ro, nil }
+
+	_, err := p.Update(context.Background(),
+		Manifest{ID: "codex", Executable: "codex", NpmPackage: "@openai/codex"})
+	if !errors.Is(err, ErrUpdatePrefixReadonly) {
+		t.Fatalf("expected ErrUpdatePrefixReadonly, got %v", err)
+	}
+	if installed {
+		t.Error("npm install must NOT run when the prefix is read-only")
 	}
 }

--- a/internal/integration/middleware.go
+++ b/internal/integration/middleware.go
@@ -32,6 +32,13 @@ func CurrentPrincipal(ctx context.Context) (Principal, bool) {
 	return p, ok
 }
 
+// WithPrincipal attaches a principal to ctx. The middlewares use this on
+// the request path; it's also the supported way for other packages and
+// tests to set up a principal-bearing context.
+func WithPrincipal(ctx context.Context, p Principal) context.Context {
+	return context.WithValue(ctx, principalCtxKey{}, p)
+}
+
 // CombinedMiddleware accepts an admin bearer OR an integration API key
 // on the same route. Used to wrap business endpoints (sessions /
 // providers / channels / catalog / auth/me / auth/logout) so that


### PR DESCRIPTION
## Security fix — closes an ungated code-exec path on main

The provider **Update** action (`POST /providers/{id}/update`, which runs `npm install -g`) landed on main via #227 **ungated**: the catalog routes accept integration API keys (via `integration.CombinedMiddleware`), so any valid integration key — not just an admin — can trigger an npm install (code execution as the service user). `PATCH /config` (which can set a `command` override) and `/toggle` have the same exposure.

This PR adds the gate that was meant to ship with it:

- **`requirePrivileged`**: config/toggle require admin or scope `providers:write`; update requires admin or `providers:update`. Mirrors the admin-or-scope check in `integration/events.go`. Reads (list/get/update-check) stay open. The web dashboard authenticates as admin, so it's unaffected.
- Adds `integration.WithPrincipal` for handler/test contexts.
- **Graceful read-only prefix**: the daemon is unprivileged; on a default install the CLIs sit in a root-owned npm prefix it can't write, so an update would `EACCES`. Preflight `npm root -g` writability and return a clean "update unavailable here — install into an opendray-owned prefix" result (HTTP 200, `available:false`) instead of a 502. The UI shows guidance, not a failure.

## Tests
`authz_test.go` (admin allowed / scoped integration allowed / wrong-or-no-scope 403 / no-principal 401) and `probe_test.go` (read-only prefix → `ErrUpdatePrefixReadonly`, no install attempted; writable prefix → install proceeds).