### PR TITLE
fix(channel): handle /start + clearer /list header for terminated sessions

### DIFF
--- a/internal/app/channel_commands.go
+++ b/internal/app/channel_commands.go
@@ -124,8 +124,15 @@ func listSessionsCardHandler(mgr sessionOps) channel.CommandCardHandler {
 		// their callback data. Sessions started without a name fall
 		// back to the bare id (there's nothing friendlier to show).
 		var b strings.Builder
-		fmt.Fprintf(&b, "%d session%s (showing %d):\n",
-			liveCount, plural(liveCount), len(all))
+		// Header reads naturally whether or not terminated sessions are
+		// mixed in: "3 sessions:" when all shown are live, otherwise
+		// "0 active · 4 shown (incl. ended):" so "0 ... showing 4" can't
+		// look like a contradiction.
+		if liveCount == len(all) {
+			fmt.Fprintf(&b, "%d session%s:\n", liveCount, plural(liveCount))
+		} else {
+			fmt.Fprintf(&b, "%d active · %d shown (incl. ended):\n", liveCount, len(all))
+		}
 		now := time.Now().UTC()
 		for i, s := range all {
 			label := s.ID

--- a/internal/app/channel_commands_test.go
+++ b/internal/app/channel_commands_test.go
@@ -109,8 +109,8 @@ func TestListSessionsCardHandler_LiveFirstThenTerminated(t *testing.T) {
 		t.Fatal(err)
 	}
 	body := cardText(t, got)
-	// Header counts active sessions only.
-	if !strings.HasPrefix(body, "2 sessions") {
+	// Mixed live + terminated: header leads with the active count.
+	if !strings.HasPrefix(body, "2 active · 3 shown") {
 		t.Errorf("header wrong:\n%s", body)
 	}
 	// Live first (sorted by recency), terminated last.

--- a/internal/channel/command.go
+++ b/internal/channel/command.go
@@ -66,6 +66,16 @@ func NewCommandRegistry() *CommandRegistry {
 		Source:      "builtin",
 		Handler:     helpHandler(r),
 	})
+	// /start is what Telegram (and most chat platforms) send when a
+	// user first opens the bot, so it must resolve to something
+	// friendly instead of "Unknown command". It greets, then prints
+	// the same command list as /help.
+	r.Register(Command{
+		Name:        "start",
+		Description: "Welcome message + command list",
+		Source:      "builtin",
+		Handler:     startHandler(r),
+	})
 	return r
 }
 
@@ -138,5 +148,19 @@ func helpHandler(r *CommandRegistry) CommandHandler {
 			fmt.Fprintf(&b, "  /%s — %s\n", c.Name, c.Description)
 		}
 		return strings.TrimRight(b.String(), "\n"), nil
+	}
+}
+
+// startHandler greets the user and appends the /help command list.
+// Wired to /start so the bot's first-contact command is never an
+// "Unknown command" error.
+func startHandler(r *CommandRegistry) CommandHandler {
+	help := helpHandler(r)
+	return func(ctx context.Context, cc CommandContext) (string, error) {
+		body, err := help(ctx, cc)
+		if err != nil {
+			return "", err
+		}
+		return "👋 opendray is connected. Use /list to see sessions, then tap “💬 Talk to” to pick one.\n\n" + body, nil
 	}
 }

--- a/internal/channel/command_test.go
+++ b/internal/channel/command_test.go
@@ -66,7 +66,7 @@ func TestRegistry_RegisterLookupList(t *testing.T) {
 		names = append(names, c.Name)
 	}
 	got := strings.Join(names, ",")
-	if got != "cancel,help" {
+	if got != "cancel,help,start" {
 		t.Errorf("List sorted: %s", got)
 	}
 }
@@ -84,6 +84,24 @@ func TestHelpHandler_ListsCommands(t *testing.T) {
 	for _, want := range []string{"/help", "/cancel — End a session", "/status — Show session status"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("help output missing %q\n--full--\n%s", want, out)
+		}
+	}
+}
+
+func TestStartHandler_GreetsAndListsCommands(t *testing.T) {
+	r := NewCommandRegistry()
+	cmd, ok := r.Lookup("start")
+	if !ok {
+		t.Fatal("/start should be registered by default")
+	}
+	out, err := cmd.Handler(context.Background(), CommandContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Greeting up top, then the same command list as /help (incl. itself).
+	for _, want := range []string{"opendray is connected", "/help", "/start"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("/start output missing %q\n--full--\n%s", want, out)
 		}
 	}
 }


### PR DESCRIPTION
Two small chat-channel UX fixes (running on a live deploy since the 2.1.0 work, not yet in a release):

- **/start**: Telegram (and most chat platforms) send `/start` when a user first opens the bot. It returned "Unknown command" — now it's a builtin that greets and prints the `/help` command list.
- **/list header**: "0 sessions (showing 4)" read like a contradiction when all shown sessions were ended. Now: "N sessions:" when all shown are live, else "N active · M shown (incl. ended):".

Tests updated in `internal/channel/command_test.go` and `internal/app/channel_commands_test.go`.