### PR TITLE
feat(web): responsive mobile layout — slide-over nav + inspector with edge handles

### DIFF
--- a/app/shared/src/stores/layout.ts
+++ b/app/shared/src/stores/layout.ts
@@ -17,6 +17,9 @@ interface LayoutState {
   toggleSidebar: () => void
   toggleSessionList: () => void
   toggleInspector: () => void
+  setSidebarCollapsed: (v: boolean) => void
+  setSessionListCollapsed: (v: boolean) => void
+  setInspectorOpen: (v: boolean) => void
   setInspectorWidth: (v: number) => void
   setFontScale: (v: number) => void
 }
@@ -68,6 +71,9 @@ export const useLayout = create<LayoutState>()(
         set({ sessionListCollapsed: !get().sessionListCollapsed }),
       toggleInspector: () =>
         set({ inspectorOpen: !get().inspectorOpen }),
+      setSidebarCollapsed: (v) => set({ sidebarCollapsed: v }),
+      setSessionListCollapsed: (v) => set({ sessionListCollapsed: v }),
+      setInspectorOpen: (v) => set({ inspectorOpen: v }),
       setInspectorWidth: (v) =>
         set({ inspectorWidth: clampInspectorWidth(v) }),
       setFontScale: (v) => {

--- a/app/web/src/components/AppShell.tsx
+++ b/app/web/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
-import { Suspense, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import { Outlet } from '@tanstack/react-router'
-import { Loader2 } from 'lucide-react'
+import { Loader2, ChevronRight } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { SidebarNav } from './SidebarNav'
@@ -8,18 +8,66 @@ import { Topbar } from './Topbar'
 import { CommandPalette, useCommandPaletteHotkey } from './CommandPalette'
 import { HealthBanner } from './HealthBanner'
 import { TooltipProvider } from '@/components/ui/tooltip'
+import { useLayout } from '@/stores/layout'
+import { useIsMobile } from '@/lib/useIsMobile'
+import { cn } from '@/lib/utils'
 
 export function AppShell() {
   const [paletteOpen, setPaletteOpen] = useState(false)
   useCommandPaletteHotkey(setPaletteOpen)
+
+  const isMobile = useIsMobile()
+  const sidebarCollapsed = useLayout((s) => s.sidebarCollapsed)
+  const setSidebarCollapsed = useLayout((s) => s.setSidebarCollapsed)
+
+  // Entering mobile collapses the nav so the workbench gets full width;
+  // the user re-opens it as a slide-over via the edge arrow / topbar.
+  useEffect(() => {
+    if (isMobile) setSidebarCollapsed(true)
+  }, [isMobile, setSidebarCollapsed])
+
+  const navOpen = !sidebarCollapsed
 
   return (
     <TooltipProvider delayDuration={200}>
       <div className="h-svh flex flex-col bg-background text-foreground">
         <Topbar onOpenPalette={() => setPaletteOpen(true)} />
         <HealthBanner />
-        <div className="flex-1 flex overflow-hidden min-h-0">
-          <SidebarNav />
+        <div className="flex-1 flex overflow-hidden min-h-0 relative">
+          {isMobile ? (
+            <>
+              {/* Slide-over nav drawer */}
+              <div
+                className={cn(
+                  'fixed inset-y-0 left-0 z-50 flex transition-transform duration-200 ease-out',
+                  navOpen ? 'translate-x-0' : '-translate-x-full',
+                )}
+              >
+                <SidebarNav />
+              </div>
+              {/* Backdrop (tap to close) */}
+              {navOpen && (
+                <div
+                  className="fixed inset-0 z-40 bg-black/50"
+                  onClick={() => setSidebarCollapsed(true)}
+                  aria-hidden
+                />
+              )}
+              {/* Edge handle to pull the nav in when closed */}
+              {!navOpen && (
+                <button
+                  type="button"
+                  onClick={() => setSidebarCollapsed(false)}
+                  aria-label="Open navigation"
+                  className="fixed left-0 top-1/2 -translate-y-1/2 z-30 h-12 w-5 rounded-r-md border border-l-0 border-border bg-card/90 text-muted-foreground flex items-center justify-center shadow-sm active:bg-card"
+                >
+                  <ChevronRight className="size-3.5" />
+                </button>
+              )}
+            </>
+          ) : (
+            <SidebarNav />
+          )}
           <main className="flex-1 overflow-auto min-w-0">
             <Suspense fallback={<RouteFallback />}>
               <Outlet />

--- a/app/web/src/components/AppShell.tsx
+++ b/app/web/src/components/AppShell.tsx
@@ -9,7 +9,7 @@ import { CommandPalette, useCommandPaletteHotkey } from './CommandPalette'
 import { HealthBanner } from './HealthBanner'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { useLayout } from '@/stores/layout'
-import { useIsMobile } from '@/lib/useIsMobile'
+import { useIsMobile } from '../lib/useIsMobile'
 import { cn } from '@/lib/utils'
 
 export function AppShell() {

--- a/app/web/src/components/SidebarNav.tsx
+++ b/app/web/src/components/SidebarNav.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from 'react-i18next'
 
 import { cn } from '@/lib/utils'
 import { useLayout } from '@/stores/layout'
+import { useIsMobile } from '@/lib/useIsMobile'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
 interface NavItem {
@@ -52,7 +53,11 @@ const groups: NavItem[][] = [
 export function SidebarNav() {
   const { t } = useTranslation()
   const { location } = useRouterState()
-  const collapsed = useLayout((s) => s.sidebarCollapsed)
+  const collapsedState = useLayout((s) => s.sidebarCollapsed)
+  const isMobile = useIsMobile()
+  // On mobile the nav is a full-width slide-over (positioned by AppShell),
+  // so never collapse it to the icon rail there.
+  const collapsed = collapsedState && !isMobile
   return (
     <nav
       className={cn(

--- a/app/web/src/components/SidebarNav.tsx
+++ b/app/web/src/components/SidebarNav.tsx
@@ -17,7 +17,7 @@ import { useTranslation } from 'react-i18next'
 
 import { cn } from '@/lib/utils'
 import { useLayout } from '@/stores/layout'
-import { useIsMobile } from '@/lib/useIsMobile'
+import { useIsMobile } from '../lib/useIsMobile'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
 interface NavItem {

--- a/app/web/src/lib/useIsMobile.ts
+++ b/app/web/src/lib/useIsMobile.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+
+// Phone breakpoint. Below this the 3-pane workbench renders the side
+// panels (nav, inspector) as slide-over drawers instead of inline
+// columns, so the middle workbench keeps full width.
+const MOBILE_QUERY = '(max-width: 767px)'
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== 'undefined' ? window.matchMedia(MOBILE_QUERY).matches : false,
+  )
+  useEffect(() => {
+    const mql = window.matchMedia(MOBILE_QUERY)
+    const onChange = () => setIsMobile(mql.matches)
+    onChange()
+    mql.addEventListener('change', onChange)
+    return () => mql.removeEventListener('change', onChange)
+  }, [])
+  return isMobile
+}

--- a/app/web/src/pages/Sessions.tsx
+++ b/app/web/src/pages/Sessions.tsx
@@ -12,6 +12,7 @@ import {
   PanelLeftOpen,
   PanelRightClose,
   PanelRightOpen,
+  ChevronLeft,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Trans, useTranslation } from 'react-i18next'
@@ -41,6 +42,7 @@ import {
 } from '@/lib/sessions'
 import { useSessionTabs } from '@/stores/sessionTabs'
 import { useLayout } from '@/stores/layout'
+import { useIsMobile } from '@/lib/useIsMobile'
 import { cn } from '@/lib/utils'
 import { isTerminalSessionState, type Session } from '@/lib/types'
 
@@ -173,6 +175,18 @@ export function SessionsPage() {
   const toggleList = useLayout((s) => s.toggleSessionList)
   const inspectorOpen = useLayout((s) => s.inspectorOpen)
   const toggleInspector = useLayout((s) => s.toggleInspector)
+  const setListCollapsed = useLayout((s) => s.setSessionListCollapsed)
+  const setInspectorOpen = useLayout((s) => s.setInspectorOpen)
+
+  const isMobile = useIsMobile()
+  // On phones the list + inspector are slide-overs; collapse both on
+  // entry so the terminal/workbench gets the full, usable width.
+  useEffect(() => {
+    if (isMobile) {
+      setListCollapsed(true)
+      setInspectorOpen(false)
+    }
+  }, [isMobile, setListCollapsed, setInspectorOpen])
 
   const termRef = useRef<TerminalHandle>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -264,9 +278,39 @@ export function SessionsPage() {
         )}
       </div>
 
-      {inspectorOpen && currentSession && (
-        <InspectorPanel session={currentSession} />
-      )}
+      {/* Inspector: inline column on desktop, slide-over drawer on mobile. */}
+      {currentSession &&
+        (isMobile ? (
+          <>
+            <div
+              className={cn(
+                'fixed inset-y-0 right-0 z-50 flex transition-transform duration-200 ease-out',
+                inspectorOpen ? 'translate-x-0' : 'translate-x-full',
+              )}
+            >
+              <InspectorPanel session={currentSession} />
+            </div>
+            {inspectorOpen && (
+              <div
+                className="fixed inset-0 z-40 bg-black/50"
+                onClick={() => setInspectorOpen(false)}
+                aria-hidden
+              />
+            )}
+            {!inspectorOpen && (
+              <button
+                type="button"
+                onClick={() => setInspectorOpen(true)}
+                aria-label="Open inspector"
+                className="fixed right-0 top-1/2 -translate-y-1/2 z-30 h-12 w-5 rounded-l-md border border-r-0 border-border bg-card/90 text-muted-foreground flex items-center justify-center shadow-sm active:bg-card"
+              >
+                <ChevronLeft className="size-3.5" />
+              </button>
+            )}
+          </>
+        ) : (
+          inspectorOpen && <InspectorPanel session={currentSession} />
+        ))}
 
       <input
         ref={fileInputRef}

--- a/app/web/src/pages/Sessions.tsx
+++ b/app/web/src/pages/Sessions.tsx
@@ -42,7 +42,7 @@ import {
 } from '@/lib/sessions'
 import { useSessionTabs } from '@/stores/sessionTabs'
 import { useLayout } from '@/stores/layout'
-import { useIsMobile } from '@/lib/useIsMobile'
+import { useIsMobile } from '../lib/useIsMobile'
 import { cn } from '@/lib/utils'
 import { isTerminalSessionState, type Session } from '@/lib/types'
 


### PR DESCRIPTION
## Problem

On a phone, the dashboard's 3-pane workbench (left nav · sessions/workbench · right inspector) renders as fixed-width columns. They push each other, so the middle (terminal/coding area) is squeezed to a sliver — not usable for coding. The collapse toggles existed in the layout store, but nothing was viewport-aware, so it never adapted.

## Change

- **`useIsMobile()`** hook (`matchMedia(max-width: 767px)`).
- On mobile, the **left nav** and the **right inspector** render as **slide-over drawers** (fixed position, `translate-x`, dimmed backdrop) instead of inline columns — so the workbench keeps full width and panels overlay rather than squeeze.
- **Auto-collapse** the nav, session list, and inspector when entering mobile.
- **Edge arrow handles** (chevrons pinned to the left/right screen edges) to pull each side panel in when it's closed; tap the backdrop to dismiss.
- Desktop layout is unchanged (`useIsMobile` false → original inline columns).

Adds `setSidebarCollapsed` / `setSessionListCollapsed` / `setInspectorOpen` to the layout store.

## Notes
`tsc` clean. This is a first responsive cut; the breakpoint (767px) and drawer widths can be tuned. Inspector drawer uses the existing `inspectorWidth` (≥320px), which is near-full-width on a typical phone.