### PR TITLE
fix(install): point install/uninstall URLs at the renamed repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Opendray/opendray_v2/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/Opendray/opendray_v2?label=release&color=4f46e5"></a>
-  <a href="LICENSE"><img alt="License Apache 2.0" src="https://img.shields.io/github/license/Opendray/opendray_v2?color=blue"></a>
-  <a href="https://github.com/Opendray/opendray_v2/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/Opendray/opendray_v2/ci.yml?branch=main&label=CI"></a>
-  <a href="https://github.com/Opendray/opendray_v2/discussions"><img alt="Discussions" src="https://img.shields.io/github/discussions/Opendray/opendray_v2?color=ec4899"></a>
+  <a href="https://github.com/Opendray/opendray/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/Opendray/opendray?label=release&color=4f46e5"></a>
+  <a href="LICENSE"><img alt="License Apache 2.0" src="https://img.shields.io/github/license/Opendray/opendray?color=blue"></a>
+  <a href="https://github.com/Opendray/opendray/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/Opendray/opendray/ci.yml?branch=main&label=CI"></a>
+  <a href="https://github.com/Opendray/opendray/discussions"><img alt="Discussions" src="https://img.shields.io/github/discussions/Opendray/opendray?color=ec4899"></a>
   <br/>
   <img alt="Go" src="https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white">
   <img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black">
@@ -66,13 +66,13 @@ This generation ships:
 **Linux / macOS / WSL2**
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh | bash
 ```
 
 **Windows** — sets up WSL2 first, then runs the Linux installer inside it. [details →](scripts/README.md#windows)
 
 ```powershell
-irm https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-windows.ps1 | iex
+irm https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install-windows.ps1 | iex
 ```
 
 Walks through Postgres setup, AI-CLI install, admin credentials, and service registration — landing a running gateway in ~5–10 minutes. See [**`scripts/README.md`**](scripts/README.md) for what the wizard does, the file layout it creates, options, and troubleshooting.
@@ -84,13 +84,13 @@ Walks through Postgres setup, AI-CLI install, admin credentials, and service reg
 **Default** — stops the gateway and removes the binary, but **keeps** your `config.toml`, data directory (bcrypt keyfile, sessions, notes, vault), logs, and the PostgreSQL database so a re-install resumes where you left off:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | bash
 ```
 
 **Full purge** — also drops the PG database + role, deletes config / data / logs, removes the service user. Includes a post-delete verification step that bails loudly if anything survived:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
 ```
 
 ### Day-to-day commands
@@ -121,7 +121,7 @@ Every supported path includes session spawn, AI-CLI access, encrypted backups, a
 
 | Path | Best for | Jump to |
 |---|---|---|
-| 📦 **Pre-built binary** | "Just run it" — Linux / macOS, any supervisor | [Releases page](https://github.com/Opendray/opendray_v2/releases) → see [Production deploy](#production-deploy) |
+| 📦 **Pre-built binary** | "Just run it" — Linux / macOS, any supervisor | [Releases page](https://github.com/Opendray/opendray/releases) → see [Production deploy](#production-deploy) |
 | 🐧 **systemd unit** | Bare-metal / VM / LXC Linux box | [Production deploy §A](#option-a--systemd-bare-metal--vm--lxc) |
 | 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio as home server | [Production deploy §B](#option-b--macos-launchd-mac-mini--studio-as-home-server) |
 | 🛠 **Build from source** | Dev / contributing / custom builds | [Quickstart](#quickstart-5-minute-dev-path) below |
@@ -169,7 +169,7 @@ with sandboxing (`ProtectSystem=strict`, `NoNewPrivileges`,
 boot, and a 20s graceful-stop window.
 
 **Get a binary first.** Either grab a pre-built archive from the
-[Releases page](https://github.com/Opendray/opendray_v2/releases)
+[Releases page](https://github.com/Opendray/opendray/releases)
 (`opendray_*_linux_<arch>.tar.gz` — unpacks to a single `opendray`
 binary), or build from source via the [Quickstart](#quickstart-5-minute-dev-path)
 above (`go build ./cmd/opendray`).
@@ -213,7 +213,7 @@ goreleaser release --clean --snapshot
 ls dist/                  # opendray_*_linux_amd64.tar.gz etc.
 
 # Or grab a published release artefact:
-# https://github.com/Opendray/opendray_v2/releases
+# https://github.com/Opendray/opendray/releases
 ```
 
 Then point your supervisor (s6, runit, supervisord, runwhen) at:

--- a/README.zh.md
+++ b/README.zh.md
@@ -11,10 +11,10 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Opendray/opendray_v2/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/Opendray/opendray_v2?label=release&color=4f46e5"></a>
-  <a href="LICENSE"><img alt="License Apache 2.0" src="https://img.shields.io/github/license/Opendray/opendray_v2?color=blue"></a>
-  <a href="https://github.com/Opendray/opendray_v2/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/Opendray/opendray_v2/ci.yml?branch=main&label=CI"></a>
-  <a href="https://github.com/Opendray/opendray_v2/discussions"><img alt="Discussions" src="https://img.shields.io/github/discussions/Opendray/opendray_v2?color=ec4899"></a>
+  <a href="https://github.com/Opendray/opendray/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/Opendray/opendray?label=release&color=4f46e5"></a>
+  <a href="LICENSE"><img alt="License Apache 2.0" src="https://img.shields.io/github/license/Opendray/opendray?color=blue"></a>
+  <a href="https://github.com/Opendray/opendray/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/Opendray/opendray/ci.yml?branch=main&label=CI"></a>
+  <a href="https://github.com/Opendray/opendray/discussions"><img alt="Discussions" src="https://img.shields.io/github/discussions/Opendray/opendray?color=ec4899"></a>
   <br/>
   <img alt="Go" src="https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white">
   <img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black">
@@ -64,13 +64,13 @@
 **Linux / macOS / WSL2**
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh | bash
 ```
 
 **Windows** —— 先设置 WSL2,然后在 WSL2 里跑 Linux 安装器。[详情 →](scripts/README.md#windows)
 
 ```powershell
-irm https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-windows.ps1 | iex
+irm https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install-windows.ps1 | iex
 ```
 
 引导你完成 Postgres 设置、AI CLI 安装、admin 凭据、服务注册,5–10 分钟拉起一个运行中的网关。详见 [**`scripts/README.md`**](scripts/README.md):wizard 做什么、生成的文件布局、参数、排错。
@@ -82,13 +82,13 @@ irm https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-
 **默认模式** —— 停掉网关、删 binary,但**保留** `config.toml`、数据目录(bcrypt keyfile、sessions、notes、vault)、日志、PostgreSQL 数据库。重装时直接接上,数据不丢:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | bash
 ```
 
 **完整 purge** —— 还会 drop 数据库 + role、删 config / 数据 / 日志、移除服务用户。最后有 verification 步骤,有残留会大声报错:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
 ```
 
 ### 日常运维命令
@@ -119,7 +119,7 @@ sudo opendray start              # start | stop | restart | status —— 封装
 
 | 方式 | 适合 | 跳转到 |
 |---|---|---|
-| 📦 **预构建二进制** | "拿来就跑" — Linux / macOS,搭配任意进程管理器 | [Releases 页](https://github.com/Opendray/opendray_v2/releases) → 见下方 [生产部署](#生产部署) |
+| 📦 **预构建二进制** | "拿来就跑" — Linux / macOS,搭配任意进程管理器 | [Releases 页](https://github.com/Opendray/opendray/releases) → 见下方 [生产部署](#生产部署) |
 | 🐧 **systemd unit** | 裸机 / VM / Linux LXC | [生产部署 §A](#方案-a--systemd裸机--vm--lxc) |
 | 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio 当家用 server | [生产部署 §B](#方案-b--macos-launchdmac-mini--studio-当家用-server) |
 | 🛠 **从源码构建** | 开发 / 贡献代码 / 定制构建 | [快速开始](#快速开始5-分钟开发版) |
@@ -167,7 +167,7 @@ Linux 推荐部署路径。
 的启动顺序、20 秒优雅退出窗口。
 
 **先拿一个二进制。** 要么从
-[Releases 页](https://github.com/Opendray/opendray_v2/releases)
+[Releases 页](https://github.com/Opendray/opendray/releases)
 下载预构建归档(`opendray_*_linux_<arch>.tar.gz` — 解压就是
 单一 `opendray` 二进制),要么按上面 [快速开始](#快速开始5-分钟开发版)
 从源码 build(`go build ./cmd/opendray`)。
@@ -211,7 +211,7 @@ goreleaser release --clean --snapshot
 ls dist/                  # opendray_*_linux_amd64.tar.gz 等
 
 # 或者从已发布的 release 拿 artifact:
-# https://github.com/Opendray/opendray_v2/releases
+# https://github.com/Opendray/opendray/releases
 ```
 
 让你的进程管理器(s6、runit、supervisord、runwhen)指向:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ condensed paths in README Production deploy are a better fit.
 |---|---|---|
 | At least one of: Claude Code / Codex CLI / Gemini CLI | opendray is a **wrapper**, not a model — it spawns a CLI on your host | Step 1 below |
 | PostgreSQL 15 / 16 / 17 + **pgvector** extension | State, sessions, memory vectors | Step 2 below |
-| `go` 1.25+ and `pnpm` 10+ — *only* if you build from source | Skip if you grab a release binary | [Releases page](https://github.com/Opendray/opendray_v2/releases) |
+| `go` 1.25+ and `pnpm` 10+ — *only* if you build from source | Skip if you grab a release binary | [Releases page](https://github.com/Opendray/opendray/releases) |
 | A reachable network port (default `:8770`) for the web admin | UI + API + WebSockets | Bind to `127.0.0.1` unless behind a reverse proxy |
 
 ---

--- a/docs/getting-started.zh.md
+++ b/docs/getting-started.zh.md
@@ -20,7 +20,7 @@ wrap 的 CLI、bootstrap Postgres)跟 README 里的部署路径串到一起。
 |---|---|---|
 | 至少一个:Claude Code / Codex CLI / Gemini CLI | opendray 是 **wrapper**,不是模型 —— 它在 host 上 spawn 你装好的 CLI | 第 1 步 |
 | PostgreSQL 15 / 16 / 17 + **pgvector** 扩展 | 状态、会话、记忆向量 | 第 2 步 |
-| `go` 1.25+ 和 `pnpm` 10+ —— *只在* 从源码 build 时需要 | 用 release binary 的话跳过 | [Releases 页](https://github.com/Opendray/opendray_v2/releases) |
+| `go` 1.25+ 和 `pnpm` 10+ —— *只在* 从源码 build 时需要 | 用 release binary 的话跳过 | [Releases 页](https://github.com/Opendray/opendray/releases) |
 | 一个可达的端口(默认 `:8770`)给 Web 后台 | UI + API + WebSocket | 没反向代理就绑 `127.0.0.1` |
 
 ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,8 +23,8 @@ docker --version        # 24.x or newer
 ## 5-minute path
 
 ```bash
-git clone https://github.com/Opendray/opendray_v2.git
-cd opendray_v2
+git clone https://github.com/Opendray/opendray.git
+cd opendray
 
 # 1. Start the bundled Postgres (or skip and use your own — see below).
 apt install -y postgresql-16 postgresql-16-pgvector  # or brew install postgresql pgvector

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,9 +5,9 @@ Windows (WSL2 setup helper).
 
 | Script | What it does | One-liner |
 |---|---|---|
-| `install.sh` | Install everything (Postgres, AI CLIs, admin creds, service). | `curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh \| bash` |
-| `uninstall.sh` | Remove the gateway. Keeps DB + data by default. | `curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh \| bash` |
-| `uninstall.sh --purge` | Remove everything: DB, role, config, data, logs. | `curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh \| bash -s -- --purge` |
+| `install.sh` | Install everything (Postgres, AI CLIs, admin creds, service). | `curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh \| bash` |
+| `uninstall.sh` | Remove the gateway. Keeps DB + data by default. | `curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh \| bash` |
+| `uninstall.sh --purge` | Remove everything: DB, role, config, data, logs. | `curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh \| bash -s -- --purge` |
 
 > Want the manual deploy paths instead?
 > See [`docs/getting-started.md`](../docs/getting-started.md) and
@@ -44,13 +44,13 @@ Those happen after the wizard, in the admin UI.
 ### Linux / macOS / WSL2 — one-liner
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh | bash
 ```
 
 `install.sh` is dual-mode:
 
 - **Piped from curl** (no local checkout): it shallow-clones
-  `Opendray/opendray_v2` to `${TMPDIR:-/tmp}/opendray-install-$$`,
+  `Opendray/opendray` to `${TMPDIR:-/tmp}/opendray-install-$$`,
   installs `git` first via `apt` / `brew` if it's missing, then
   re-execs itself from the clone so the rest of the wizard sees a
   real working directory.
@@ -67,8 +67,8 @@ walking through the same wizard. The one-liner just removes the
 If you'd rather inspect the code before running anything:
 
 ```sh
-git clone https://github.com/Opendray/opendray_v2.git
-cd opendray_v2
+git clone https://github.com/Opendray/opendray.git
+cd opendray
 bash scripts/install-linux.sh          # Linux (Ubuntu/Debian)
 # or:
 bash scripts/install-macos.sh          # macOS (Intel + Apple Silicon)
@@ -87,7 +87,7 @@ spawns AI CLIs via Unix PTYs, which Windows does not expose to
 opendray. The PowerShell helper sets up WSL2 + Ubuntu for you:
 
 ```powershell
-irm https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-windows.ps1 | iex
+irm https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install-windows.ps1 | iex
 ```
 
 Or, from a local checkout:
@@ -218,7 +218,7 @@ service — no `config.toml` touch required.
 
 ```sh
 # Linux / macOS — stops + removes the gateway, KEEPS DB + data
-curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | bash
 
 # Or from a checkout:
 bash scripts/uninstall.sh
@@ -234,10 +234,10 @@ installer later picks up where you left off.
 
 ```sh
 # Method 1: env var (safer for copy-paste — survives accidental newlines)
-curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
 
 # Method 2: flag via bash -s (must be one line, no manual line break!)
-curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | bash -s -- --purge
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | bash -s -- --purge
 
 # From a checkout:
 bash scripts/uninstall.sh --purge

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -31,7 +31,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/common.sh"
 
 # ── Defaults (can be overridden by env or prompts) ───────────────────
-: "${OPENDRAY_REPO:=Opendray/opendray_v2}"
+: "${OPENDRAY_REPO:=Opendray/opendray}"
 : "${OPENDRAY_PREFIX:=/usr/local}"             # binary install prefix
 : "${OPENDRAY_CONFIG_DIR:=/etc/opendray}"
 : "${OPENDRAY_DATA_DIR:=/var/lib/opendray}"

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -20,7 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/common.sh"
 
 # ── Defaults ─────────────────────────────────────────────────────────
-: "${OPENDRAY_REPO:=Opendray/opendray_v2}"
+: "${OPENDRAY_REPO:=Opendray/opendray}"
 : "${OPENDRAY_HOME:=$HOME/.opendray}"
 
 LAUNCHD_SCOPE="agent"     # "agent" (user) or "daemon" (system)

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -19,12 +19,12 @@
 #      up after idle/reboot -- WSL stops idle distros otherwise.
 #
 # Usage (from PowerShell; elevate if WSL isn't installed yet):
-#   irm https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-windows.ps1 | iex
+#   irm https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install-windows.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 
 $Distro    = "Ubuntu-24.04"
-$InstallSh = "https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh"
+$InstallSh = "https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh"
 $TaskName  = "opendray-wsl-keepalive"
 
 function Write-Banner { Write-Host ""; Write-Host "+-- opendray installer - Windows entry --+" -ForegroundColor Cyan; Write-Host "" }
@@ -43,7 +43,7 @@ function Test-IsAdmin {
 $env:WSL_UTF8 = "1"
 
 # Self URL -- used to auto-resume the install after the WSL-enable reboot.
-$SelfUrl = "https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install-windows.ps1"
+$SelfUrl = "https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install-windows.ps1"
 
 Write-Banner
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@
 #
 # Mode 2: curl | bash bootstrap
 #   Invoked over a pipe with no on-disk script directory:
-#     curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash
+#     curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh | bash
 #   We install git if missing, shallow-clone the repo to a working
 #   directory, then re-execute scripts/install.sh from the clone.
 #
@@ -20,7 +20,7 @@
 # /bin/bash) is supported. This only catches `curl ... | sh` mistakes.
 if [ -z "${BASH_VERSION:-}" ]; then
     echo "[!] opendray installer must be run with bash, not sh. Re-run with:" >&2
-    echo "    curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash" >&2
+    echo "    curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh | bash" >&2
     exit 1
 fi
 
@@ -70,7 +70,7 @@ ok()   { printf "${C_GRN}[✓]${C_NC} %s\n" "$*"; }
 warn() { printf "${C_YEL}[!]${C_NC} %s\n" "$*"; }
 die()  { printf "${C_RED}[✗]${C_NC} %s\n" "$*" >&2; exit 1; }
 
-REPO_URL="${OPENDRAY_INSTALL_REPO:-https://github.com/Opendray/opendray_v2.git}"
+REPO_URL="${OPENDRAY_INSTALL_REPO:-https://github.com/Opendray/opendray.git}"
 REF="${OPENDRAY_INSTALL_REF:-main}"
 INSTALL_DIR="${OPENDRAY_INSTALL_DIR:-${TMPDIR:-/tmp}/opendray-install-$$}"
 
@@ -82,7 +82,7 @@ ${C_BLU}━━━ opendray installer — bootstrap ━━━${C_NC}
 
 This bootstrap step:
   1. Ensures git is installed (apt / brew if missing — needs sudo).
-  2. Shallow-clones opendray_v2 to the workdir above.
+  2. Shallow-clones opendray to the workdir above.
   3. Hands off to scripts/install-<os>.sh, which is the real wizard.
 
 After the wizard completes, the workdir is left on disk for re-runs.

--- a/scripts/uninstall-linux.sh
+++ b/scripts/uninstall-linux.sh
@@ -371,5 +371,5 @@ cat <<EOF
     · apt packages
 
   Re-install any time with:
-    curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash
+    curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh | bash
 EOF

--- a/scripts/uninstall-macos.sh
+++ b/scripts/uninstall-macos.sh
@@ -304,5 +304,5 @@ cat <<EOF
     · PostgreSQL server itself + any other databases
 
   Re-install any time with:
-    curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash
+    curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh | bash
 EOF

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -5,8 +5,8 @@
 #   bash scripts/uninstall.sh [--purge]
 #
 # Mode 2: curl | bash
-#   curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | bash
-#   curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/uninstall.sh | bash -s -- --purge
+#   curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | bash -s -- --purge
 #
 # Default (no --purge):
 #   Stops + removes the running gateway (binary, systemd unit / launchd
@@ -44,7 +44,7 @@ fi
 say() { printf "${C_BLU}[*]${C_NC} %s\n" "$*"; }
 die() { printf "${C_RED}[✗]${C_NC} %s\n" "$*" >&2; exit 1; }
 
-REPO_URL="${OPENDRAY_INSTALL_REPO:-https://github.com/Opendray/opendray_v2.git}"
+REPO_URL="${OPENDRAY_INSTALL_REPO:-https://github.com/Opendray/opendray.git}"
 REF="${OPENDRAY_INSTALL_REF:-main}"
 INSTALL_DIR="${OPENDRAY_INSTALL_DIR:-${TMPDIR:-/tmp}/opendray-uninstall-$$}"
 


### PR DESCRIPTION
## Why

`Opendray/opendray_v2` was renamed to **`Opendray/opendray`**. Git, web, and API requests redirect from the old name — **but `raw.githubusercontent.com` does not reliably follow repo renames**, so the documented install/uninstall one-liners:

```
curl -fsSL https://raw.githubusercontent.com/Opendray/opendray_v2/main/scripts/install.sh | bash
```

would 404. The `git clone` defaults work via redirect but should still point at the canonical name.

## Change

Replace `Opendray/opendray_v2` → `Opendray/opendray` across:
- **install/uninstall scripts** — raw URLs, `OPENDRAY_INSTALL_REPO`/`REPO_URL` clone defaults (`install.sh`, `install-linux.sh`, `install-macos.sh`, `install-windows.ps1`, `uninstall*.sh`, `scripts/README.md`)
- **README / docs** — install one-liners, badges, releases links, and `cd opendray_v2` → `cd opendray` after clone (`README.md`, `README.zh.md`, `docs/quickstart.md`, `docs/getting-started*.md`)

The Go module path (`github.com/opendray/opendray-v2`, hyphenated) is **intentionally left unchanged** — that's the import path, not a repo URL.

Out of scope (left for a separate pass since they redirect / use git context, not raw URLs): CHANGELOG history, CONTRIBUTING/SECURITY links, issue templates, `.goreleaser.yml`, workflows.

`bash -n` clean on all modified scripts.