### PR TITLE
chore(repo): finish opendray_v2 → opendray rename across code/config/docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,9 +10,9 @@ body:
         reproduce the issue without a back-and-forth.
 
         Before filing:
-        - Check the [open Issues](https://github.com/Opendray/opendray_v2/issues) for a duplicate.
+        - Check the [open Issues](https://github.com/Opendray/opendray/issues) for a duplicate.
         - For "how do I..." or "is this expected" questions, use
-          [Discussions](https://github.com/Opendray/opendray_v2/discussions) instead.
+          [Discussions](https://github.com/Opendray/opendray/discussions) instead.
 
   - type: textarea
     id: summary

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,18 +1,18 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 Questions & how-do-I (Discussions)
-    url: https://github.com/Opendray/opendray_v2/discussions
+    url: https://github.com/Opendray/opendray/discussions
     about: |
       Questions about how to use opendray, deployment troubleshooting, or "is this
       expected behaviour?" belong in Discussions — Issues are for confirmed bugs
       and concrete feature proposals.
   - name: 🔒 Security disclosure
-    url: https://github.com/Opendray/opendray_v2/blob/main/SECURITY.md
+    url: https://github.com/Opendray/opendray/blob/main/SECURITY.md
     about: |
       Report security vulnerabilities privately — do not file a public issue.
       See SECURITY.md for the disclosure flow.
   - name: 📖 Documentation (English / 简体中文)
-    url: https://github.com/Opendray/opendray_v2#install
+    url: https://github.com/Opendray/opendray#install
     about: |
       Install paths (Docker Compose / systemd / launchd / direct binary), quickstart,
       operator guide, API reference, and architecture decision records.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,9 +7,9 @@ body:
     attributes:
       value: |
         Before filing:
-        - Check the [open Issues](https://github.com/Opendray/opendray_v2/issues?q=is%3Aissue+label%3Aenhancement) for a duplicate.
+        - Check the [open Issues](https://github.com/Opendray/opendray/issues?q=is%3Aissue+label%3Aenhancement) for a duplicate.
         - For early-stage "what if we..." ideas, prefer
-          [Discussions → Ideas](https://github.com/Opendray/opendray_v2/discussions) —
+          [Discussions → Ideas](https://github.com/Opendray/opendray/discussions) —
           formal issues are for ideas that already feel concrete.
 
   - type: textarea

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,4 +67,4 @@ release:
   prerelease: auto
   name_template: "v{{ .Version }}"
   header: |
-    See [CHANGELOG.md](https://github.com/Opendray/opendray_v2/blob/main/CHANGELOG.md) for the full release notes.
+    See [CHANGELOG.md](https://github.com/Opendray/opendray/blob/main/CHANGELOG.md) for the full release notes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ this release ships.
 
 
 ```bash
-git clone https://github.com/Opendray/opendray_v2.git
-cd opendray_v2
+git clone https://github.com/Opendray/opendray.git
+cd opendray
 
 # 1. Postgres reachable; credentials in your secret manager.
 cp config.example.toml config.toml

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,7 +54,7 @@ every login attempt** rather than booting with no auth.
 If you discover a security vulnerability in OpenDray, please report it
 privately. Do **not** open a public GitHub issue.
 
-- **GitHub Security Advisories:** [Open a private advisory](https://github.com/Opendray/opendray_v2/security/advisories)
+- **GitHub Security Advisories:** [Open a private advisory](https://github.com/Opendray/opendray/security/advisories)
 - **Email:** security@opendray.dev
 
 We aim to acknowledge reports within 48 hours and ship fixes for critical

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -9,7 +9,7 @@ release-pipeline behaviour.
 
 - **Major version = product generation.** v1 is the legacy
   `Opendray/opendray` codebase (archived). v2 is this codebase
-  (`Opendray/opendray_v2`). v3 is reserved for a future cross-
+  (`Opendray/opendray`). v3 is reserved for a future cross-
   architecture rewrite.
 - **Minor version = feature iteration.** New channels, new providers,
   new memory subsystems, new API endpoints — anything additive within

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -3751,7 +3751,7 @@
       "version": "version",
       "serverUrl": "server URL"
     },
-    "tagline": "opendray mobile — multi-CLI gateway control.\nSource: github.com/Opendray/opendray_v2"
+    "tagline": "opendray mobile — multi-CLI gateway control.\nSource: github.com/Opendray/opendray"
   },
   "settings": {
     "title": "Settings",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -3750,7 +3750,7 @@
       "version": "版本",
       "serverUrl": "服务器 URL"
     },
-    "tagline": "opendray mobile — 多 CLI 网关控制。\n源码：github.com/Opendray/opendray_v2"
+    "tagline": "opendray mobile — 多 CLI 网关控制。\n源码：github.com/Opendray/opendray"
   },
   "settings": {
     "title": "设置",

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -1800,8 +1800,8 @@ class TranslationsAboutEn {
 
 	late final TranslationsAboutCopyLabelsEn copyLabels = TranslationsAboutCopyLabelsEn.internal(_root);
 
-	/// en: 'opendray mobile — multi-CLI gateway control. Source: github.com/Opendray/opendray_v2'
-	String get tagline => 'opendray mobile — multi-CLI gateway control.\nSource: github.com/Opendray/opendray_v2';
+	/// en: 'opendray mobile — multi-CLI gateway control. Source: github.com/Opendray/opendray'
+	String get tagline => 'opendray mobile — multi-CLI gateway control.\nSource: github.com/Opendray/opendray';
 }
 
 // Path: settings
@@ -16357,7 +16357,7 @@ extension on Translations {
 			'about.copyTooltip' => 'Copy',
 			'about.copyLabels.version' => 'version',
 			'about.copyLabels.serverUrl' => 'server URL',
-			'about.tagline' => 'opendray mobile — multi-CLI gateway control.\nSource: github.com/Opendray/opendray_v2',
+			'about.tagline' => 'opendray mobile — multi-CLI gateway control.\nSource: github.com/Opendray/opendray',
 			'settings.title' => 'Settings',
 			'settings.language.section' => 'Language',
 			'settings.language.system' => 'System',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -840,7 +840,7 @@ class _TranslationsAboutZh extends TranslationsAboutEn {
 	@override String copied({required Object label}) => '已复制 ${label}';
 	@override String get copyTooltip => '复制';
 	@override late final _TranslationsAboutCopyLabelsZh copyLabels = _TranslationsAboutCopyLabelsZh._(_root);
-	@override String get tagline => 'opendray mobile — 多 CLI 网关控制。\n源码：github.com/Opendray/opendray_v2';
+	@override String get tagline => 'opendray mobile — 多 CLI 网关控制。\n源码：github.com/Opendray/opendray';
 }
 
 // Path: settings
@@ -10154,7 +10154,7 @@ extension on TranslationsZh {
 			'about.copyTooltip' => '复制',
 			'about.copyLabels.version' => '版本',
 			'about.copyLabels.serverUrl' => '服务器 URL',
-			'about.tagline' => 'opendray mobile — 多 CLI 网关控制。\n源码：github.com/Opendray/opendray_v2',
+			'about.tagline' => 'opendray mobile — 多 CLI 网关控制。\n源码：github.com/Opendray/opendray',
 			'settings.title' => '设置',
 			'settings.language.section' => '语言',
 			'settings.language.system' => '跟随系统',

--- a/cmd/opendray/update.go
+++ b/cmd/opendray/update.go
@@ -42,7 +42,7 @@ import (
 	"github.com/opendray/opendray-v2/internal/version"
 )
 
-const updateReleasesAPI = "https://api.github.com/repos/Opendray/opendray_v2/releases/latest"
+const updateReleasesAPI = "https://api.github.com/repos/Opendray/opendray/releases/latest"
 
 type ghReleaseAsset struct {
 	Name        string `json:"name"`

--- a/deploy/systemd/opendray.service
+++ b/deploy/systemd/opendray.service
@@ -26,7 +26,7 @@
 
 [Unit]
 Description=opendray v2 — multiplexer + integration gateway for AI agent CLIs
-Documentation=https://github.com/Opendray/opendray_v2/blob/main/docs/operator-guide.md
+Documentation=https://github.com/Opendray/opendray/blob/main/docs/operator-guide.md
 After=network-online.target
 Wants=network-online.target
 


### PR DESCRIPTION
Follow-up to #237 (install URLs). Updates the remaining `Opendray/opendray_v2` references left after the repo was renamed to **`Opendray/opendray`** — these worked via GitHub's redirect, but the canonical name is cleaner and avoids any redirect-reliance.

**Functional**
- `cmd/opendray/update.go` — the self-updater's releases API URL (`api.github.com/repos/Opendray/opendray_v2/releases/latest` → `…/opendray/…`). Built clean.
- `deploy/systemd/opendray.service` — `Documentation=` URL.

**i18n**
- `app/i18n/{en,zh}.json` — the "Source: github.com/…" tagline, plus the generated Flutter `strings_{en,zh}.g.dart` (kept in sync with the JSON source).

**Docs / meta**
- `CONTRIBUTING.md` (incl. `cd opendray_v2` → `cd opendray`), `SECURITY.md`, `VERSIONING.md`, `.goreleaser.yml` (CHANGELOG link), and the three issue templates.

**Intentionally left unchanged**
- The Go module path `github.com/opendray/opendray-v2` (import path, not a repo URL).
- The CHANGELOG entry that names the old product `opendray_v2` (history).

No behavior change beyond the canonical URLs; `go build ./cmd/opendray` clean.