### PR TITLE
feat(app): warn at startup when W^X blocks executable memory (codex/gemini)

### DIFF
--- a/cmd/opendray/update.go
+++ b/cmd/opendray/update.go
@@ -185,6 +185,16 @@ func runUpdate(args []string) int {
 		fmt.Println("  opendray migrate -config ~/.opendray/config.toml                       # macOS")
 	}
 
+	// `opendray update` swaps only the binary — it does not regenerate the
+	// service unit. Releases that change the unit (e.g. the W^X /
+	// MemoryDenyWriteExecute fix) won't take effect until the unit is
+	// refreshed, which silently re-breaks codex/gemini on upgraders.
+	if runtime.GOOS == "linux" {
+		fmt.Println("\nNote: this updates the binary only, not the systemd unit. If a release")
+		fmt.Println("changed the unit and codex/gemini sessions crash, refresh it by re-running")
+		fmt.Println("the installer, then `sudo systemctl daemon-reload && sudo systemctl restart opendray`.")
+	}
+
 	return 0
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -729,6 +729,21 @@ func (a *App) Run(ctx context.Context) error {
 		"version", version.Version,
 		"commit", version.Commit)
 
+	// W^X preflight: if executable memory can't be mapped, the V8-based
+	// CLIs (codex, gemini) will crash with a fatal SetPermissions error on
+	// spawn while Claude keeps working. Surface it loudly here instead of
+	// leaving operators to decode a V8 stack trace inside a dead session.
+	// Common cause after an in-place `opendray update`: the systemd unit
+	// still carries MemoryDenyWriteExecute=true (the unit isn't refreshed
+	// by a binary update).
+	if err := canMapExecutable(); err != nil {
+		a.log.Warn("executable memory mapping is blocked — codex/gemini sessions will crash on spawn (Claude is unaffected). "+
+			"Likely MemoryDenyWriteExecute=true on the opendray systemd unit, or an exhausted vm.max_map_count. "+
+			"Fix: drop MemoryDenyWriteExecute (e.g. a no-mdwx.conf drop-in or re-run the installer), then `systemctl daemon-reload && systemctl restart opendray`; "+
+			"if it's already off, raise vm.max_map_count.",
+			"err", err)
+	}
+
 	if err := a.channels.Start(ctx); err != nil {
 		a.log.Error("channel hub start", "err", err)
 	}

--- a/internal/app/wxcheck_linux.go
+++ b/internal/app/wxcheck_linux.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package app
+
+import "syscall"
+
+// canMapExecutable reports whether the process can flip a freshly-written
+// (writable) page to executable — the operation V8/Node's JIT performs at
+// runtime. codex and gemini are V8-based and crash with a fatal
+// SetPermissions error the moment this is blocked; Claude survives via an
+// interpreter-only fallback, which is why "codex/gemini die, Claude works"
+// is the tell-tale signature.
+//
+// Two things break it, both inherited by the CLIs we spawn:
+//   - systemd MemoryDenyWriteExecute=true (W^X seccomp filter → EPERM)
+//   - an exhausted vm.max_map_count or a tight memory cgroup (→ ENOMEM)
+//
+// The opendray daemon itself is AOT-compiled Go and never needs this, so it
+// runs fine under the restriction and can detect+warn on behalf of the
+// children it spawns.
+func canMapExecutable() error {
+	const size = 4096
+	p, err := syscall.Mmap(-1, 0, size,
+		syscall.PROT_READ|syscall.PROT_WRITE,
+		syscall.MAP_PRIVATE|syscall.MAP_ANONYMOUS)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = syscall.Munmap(p) }()
+	p[0] = 0xc3 // x86 RET — make the page look like real code
+	return syscall.Mprotect(p, syscall.PROT_READ|syscall.PROT_EXEC)
+}

--- a/internal/app/wxcheck_other.go
+++ b/internal/app/wxcheck_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package app
+
+// canMapExecutable is a no-op off Linux: MemoryDenyWriteExecute is a
+// systemd/Linux concern, and macOS (launchd) has no equivalent that
+// would block the spawned CLIs' JIT.
+func canMapExecutable() error { return nil }

--- a/internal/app/wxcheck_test.go
+++ b/internal/app/wxcheck_test.go
@@ -1,0 +1,14 @@
+package app
+
+import "testing"
+
+// In an unrestricted environment (normal CI/dev, no MemoryDenyWriteExecute)
+// the probe must succeed. The negative case (W^X active) can't be set up
+// from a plain unit test, but asserting the positive case guards against a
+// broken probe — e.g. wrong mmap flags — that would false-alarm every
+// operator on every start.
+func TestCanMapExecutable(t *testing.T) {
+	if err := canMapExecutable(); err != nil {
+		t.Fatalf("canMapExecutable() = %v; want nil in an unrestricted environment", err)
+	}
+}


### PR DESCRIPTION
Closes the silent-failure half of #239.

## Problem
codex/gemini (V8/Node) crash on spawn with a fatal `SetPermissions` error when the process can't flip pages RW→RX — but operators only see a V8 stack trace inside a dead session, with no hint of the cause. Claude survives (interpreter fallback), so the signature is "codex/gemini die, Claude works." Worst case: after an in-place `opendray update`, the systemd unit still has `MemoryDenyWriteExecute=true` (the binary update doesn't refresh the unit), so #218's fix never lands and it keeps crashing on a current release.

## Change
- **Startup W^X probe** (`internal/app/wxcheck_linux.go`): at `opendray serve` start, `mmap` a RW page and `mprotect` it RX. On failure, log a loud, actionable `Warn` naming both causes (MemoryDenyWriteExecute → EPERM; exhausted `vm.max_map_count` / memory cgroup → ENOMEM) and the fix. Linux-only; no-op elsewhere (`wxcheck_other.go`). The daemon is AOT Go and runs fine under the restriction, so it detects+warns on behalf of the CLIs it spawns.
- **`opendray update`** now prints a note that it swaps the binary only, not the systemd unit — and how to refresh the unit.

## Test
`TestCanMapExecutable` asserts the probe succeeds in an unrestricted env (guards against a broken probe false-alarming every operator). The negative path can't be exercised from a plain unit test (needs the seccomp filter), but the binary detecting+warning is verifiable on an MDWX box.

## Not in scope (open question in #239)
Actively reconciling the unit on update needs root + risks clobbering local overrides, so this takes the detect-and-warn approach first.