### PR TITLE
feat(update): in-dashboard update notification + one-click background upgrade

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -2115,7 +2115,21 @@
       },
       "about": {
         "title": "About",
-        "description": "opendray v2 — the multiplexer + integration gateway for AI agent CLIs. Source under Apache 2.0."
+        "description": "opendray v2 — the multiplexer + integration gateway for AI agent CLIs. Source under Apache 2.0.",
+        "version": "Version",
+        "commit": "Commit",
+        "updateAvailable": "Update available: {{version}}",
+        "releaseNotes": "Release notes ↗",
+        "updateNow": "Update now",
+        "upgradingShort": "Upgrading…",
+        "confirmRestart": "This restarts the service; running sessions reconnect.",
+        "confirmUpgrade": "Upgrade & restart",
+        "upgrading": "Upgrading to {{version}}…",
+        "upgraded": "Updated to {{version}}.",
+        "upgradeSlow": "Upgrade is taking a while — check the service logs if it doesn't come back.",
+        "guidedHint": "In-app upgrade isn't available here. Run on the server:",
+        "checkFailed": "Couldn't check for updates (offline or rate-limited).",
+        "upToDate": "You're on the latest release."
       }
     },
     "logViewer": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -2114,7 +2114,21 @@
       },
       "about": {
         "title": "关于",
-        "description": "opendray v2 — 面向 AI agent CLI 的多路复用 + 集成网关。源码采用 Apache 2.0 协议。"
+        "description": "opendray v2 — 面向 AI agent CLI 的多路复用 + 集成网关。源码采用 Apache 2.0 协议。",
+        "version": "版本",
+        "commit": "提交",
+        "updateAvailable": "有可用更新：{{version}}",
+        "releaseNotes": "发行说明 ↗",
+        "updateNow": "立即更新",
+        "upgradingShort": "更新中…",
+        "confirmRestart": "这将重启服务，正在运行的会话会重新连接。",
+        "confirmUpgrade": "升级并重启",
+        "upgrading": "正在升级到 {{version}}…",
+        "upgraded": "已更新到 {{version}}。",
+        "upgradeSlow": "升级耗时较长——如果服务未恢复，请检查日志。",
+        "guidedHint": "此处不支持应用内升级。请在服务器上运行：",
+        "checkFailed": "无法检查更新（离线或受限）。",
+        "upToDate": "已是最新版本。"
       }
     },
     "logViewer": {

--- a/app/shared/src/lib/version.ts
+++ b/app/shared/src/lib/version.ts
@@ -1,0 +1,35 @@
+import { api } from './api'
+
+export interface VersionInfo {
+  current: string
+  commit?: string
+  latest?: string
+  updateAvailable: boolean
+  notesUrl?: string
+  // selfUpdate: this host can apply a one-click background upgrade (Linux
+  // with the privileged self-update units installed). When false the UI
+  // falls back to showing the manual `opendray update` command.
+  selfUpdate: boolean
+  // pending: an upgrade request is already queued.
+  pending: boolean
+  // checkError: set when the release feed couldn't be reached (offline /
+  // rate-limited); `latest` is then absent and only `current` is known.
+  checkError?: string
+}
+
+export interface SelfUpdateResponse {
+  queued?: boolean
+  from?: string
+  to?: string
+  note?: string
+  error?: string
+  pending?: boolean
+}
+
+export async function getVersionInfo(): Promise<VersionInfo> {
+  return api<VersionInfo>('/version')
+}
+
+export async function requestSelfUpdate(): Promise<SelfUpdateResponse> {
+  return api<SelfUpdateResponse>('/version/update', { method: 'POST' })
+}

--- a/app/web/src/pages/Settings.tsx
+++ b/app/web/src/pages/Settings.tsx
@@ -17,7 +17,10 @@ import {
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
+import { toast } from 'sonner'
+
 import { api } from '@/lib/api'
+import { getVersionInfo, requestSelfUpdate, type VersionInfo } from '@/lib/version'
 import { useTheme, type ThemeMode } from '@/stores/theme'
 import { useAuth } from '@/stores/auth'
 import { useLayout } from '@/stores/layout'
@@ -713,12 +716,138 @@ function SystemSection({ health }: { health: HealthResponse | undefined }) {
 
 function AboutSection() {
   const { t } = useTranslation()
+  const { data, refetch } = useQuery<VersionInfo>({
+    queryKey: ['version'],
+    queryFn: getVersionInfo,
+  })
+  // phase: idle → confirming (inline confirm) → upgrading (polling for the
+  // restarted daemon to come back on the new version).
+  const [phase, setPhase] = useState<'idle' | 'confirming' | 'upgrading'>('idle')
+
+  // While upgrading, the daemon downloads + swaps + restarts, so requests
+  // fail mid-flight. Poll until `current` reaches `latest` (or give up).
+  useEffect(() => {
+    if (phase !== 'upgrading') return
+    const target = data?.latest
+    let tries = 0
+    const id = setInterval(async () => {
+      tries++
+      try {
+        const v = await getVersionInfo()
+        if (!v.updateAvailable || (target && v.current === target)) {
+          clearInterval(id)
+          setPhase('idle')
+          toast.success(t('web.settings.about.upgraded', { version: v.current }))
+          void refetch()
+          return
+        }
+      } catch {
+        /* expected during the restart window — keep polling */
+      }
+      if (tries > 30) {
+        clearInterval(id)
+        setPhase('idle')
+        toast.message(t('web.settings.about.upgradeSlow'))
+        void refetch()
+      }
+    }, 4000)
+    return () => clearInterval(id)
+  }, [phase, data?.latest, refetch, t])
+
+  async function startUpgrade() {
+    try {
+      const res = await requestSelfUpdate()
+      if (res.error) {
+        toast.error(res.error)
+        setPhase('idle')
+        return
+      }
+      toast.success(t('web.settings.about.upgrading', { version: res.to ?? '' }), {
+        description: res.note,
+      })
+      setPhase('upgrading')
+    } catch (e) {
+      toast.error(String(e))
+      setPhase('idle')
+    }
+  }
+
+  const busy = phase === 'upgrading' || data?.pending
   return (
     <div>
       <SectionHeader title={t('web.settings.about.title')} />
-      <p className="text-[12px] text-muted-foreground leading-relaxed">
+      <p className="text-[12px] text-muted-foreground leading-relaxed mb-3">
         {t('web.settings.about.description')}
       </p>
+
+      <Field label={t('web.settings.about.version')} value={data?.current ?? '…'} monospace />
+      {data?.commit && (
+        <Field label={t('web.settings.about.commit')} value={data.commit} monospace />
+      )}
+
+      {data?.updateAvailable ? (
+        <div className="mt-3 rounded-md border border-primary/40 bg-primary/5 p-3">
+          <div className="text-[12px] font-medium">
+            {t('web.settings.about.updateAvailable', { version: data.latest })}
+          </div>
+          {data.notesUrl && (
+            <a
+              href={data.notesUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="text-[11px] text-primary underline"
+            >
+              {t('web.settings.about.releaseNotes')}
+            </a>
+          )}
+          <div className="mt-2">
+            {data.selfUpdate ? (
+              phase === 'confirming' ? (
+                <div className="flex items-center gap-2">
+                  <span className="text-[11px] text-muted-foreground">
+                    {t('web.settings.about.confirmRestart')}
+                  </span>
+                  <button
+                    onClick={startUpgrade}
+                    className="rounded bg-primary px-2.5 py-1 text-[11px] font-medium text-primary-foreground"
+                  >
+                    {t('web.settings.about.confirmUpgrade')}
+                  </button>
+                  <button
+                    onClick={() => setPhase('idle')}
+                    className="rounded border border-border px-2.5 py-1 text-[11px]"
+                  >
+                    {t('common.cancel')}
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setPhase('confirming')}
+                  disabled={!!busy}
+                  className="rounded bg-primary px-2.5 py-1 text-[11px] font-medium text-primary-foreground disabled:opacity-50"
+                >
+                  {busy
+                    ? t('web.settings.about.upgradingShort')
+                    : t('web.settings.about.updateNow')}
+                </button>
+              )
+            ) : (
+              <div className="text-[11px] text-muted-foreground">
+                {t('web.settings.about.guidedHint')}
+                <code className="ml-1 font-mono text-foreground">opendray update</code>
+              </div>
+            )}
+          </div>
+        </div>
+      ) : data?.checkError ? (
+        <p className="mt-3 text-[11px] text-muted-foreground">
+          {t('web.settings.about.checkFailed')}
+        </p>
+      ) : data?.latest ? (
+        <p className="mt-3 text-[11px] text-muted-foreground">
+          {t('web.settings.about.upToDate')}
+        </p>
+      ) : null}
     </div>
   )
 }

--- a/cmd/opendray/main.go
+++ b/cmd/opendray/main.go
@@ -49,6 +49,8 @@ func main() {
 		os.Exit(runMigrate(args))
 	case "update":
 		os.Exit(runUpdate(args))
+	case "self-update":
+		os.Exit(runSelfUpdate(args))
 	case "providers":
 		os.Exit(runProviders(args))
 	case "start":

--- a/cmd/opendray/selfupdate.go
+++ b/cmd/opendray/selfupdate.go
@@ -1,0 +1,88 @@
+// `opendray self-update --apply` is the privileged half of the
+// in-dashboard upgrade. It is NOT meant to be run by hand — the
+// opendray-selfupdate.service oneshot (root) runs it when the
+// opendray-selfupdate.path unit sees the daemon drop a request file.
+//
+// The unprivileged daemon can't replace /usr/local/bin/opendray or restart
+// the unit, so the dashboard only queues a request; this command, running
+// as root, applies the official latest release (checksum-verified, via the
+// same path as `opendray update`), ensures the W^X drop-in so the upgraded
+// daemon doesn't relapse into the codex/gemini JIT crash (#239), restarts,
+// and clears the request.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/opendray/opendray-v2/internal/selfupdate"
+)
+
+const noMdwxDropIn = "/etc/systemd/system/opendray.service.d/no-mdwx.conf"
+
+func selfUpdateStateDir() string {
+	if d := strings.TrimSpace(os.Getenv("OPENDRAY_STATE_DIR")); d != "" {
+		return d
+	}
+	return "/var/lib/opendray"
+}
+
+func runSelfUpdate(args []string) int {
+	fs := flag.NewFlagSet("self-update", flag.ExitOnError)
+	apply := fs.Bool("apply", false, "apply a queued upgrade request (run as root by the systemd oneshot)")
+	_ = fs.Parse(args)
+	if !*apply {
+		fmt.Fprintln(os.Stderr, "usage: opendray self-update --apply  (invoked by opendray-selfupdate.service; not for manual use)")
+		return 2
+	}
+
+	reqPath := selfupdate.RequestPath(selfUpdateStateDir())
+	req, err := selfupdate.ReadRequest(reqPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "no/invalid self-update request at %s: %v\n", reqPath, err)
+		return 1
+	}
+	// Always clear the trigger so the path unit doesn't re-fire, even if
+	// the upgrade fails below.
+	defer os.Remove(reqPath)
+	fmt.Printf("self-update: queued upgrade to %s by %s at %s\n",
+		req.Version, req.RequestedBy, req.RequestedAt.Format(time.RFC3339))
+
+	// Ensure the W^X drop-in so the upgraded daemon doesn't relapse into the
+	// codex/gemini JIT crash — `update` alone never touches the unit (#239).
+	ensureNoMdwxDropIn()
+
+	// Binary swap + restart via the existing checksum-verified path. As
+	// root (the oneshot) the /usr/local/bin write and systemctl restart
+	// both succeed. It re-resolves "latest" from the canonical repo and
+	// verifies the download, so the request can't redirect it elsewhere.
+	return runUpdate([]string{"--yes", "--restart"})
+}
+
+// ensureNoMdwxDropIn writes the W^X override if absent (idempotent;
+// preserves an existing drop-in) and reloads systemd to pick it up.
+func ensureNoMdwxDropIn() {
+	if _, err := os.Stat(noMdwxDropIn); err == nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(noMdwxDropIn), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "[!] couldn't create drop-in dir: %v\n", err)
+		return
+	}
+	const content = "# Added by `opendray self-update`: V8/Node JIT (codex, gemini) needs\n" +
+		"# W^X (RW->RX mprotect), which MemoryDenyWriteExecute blocks.\n" +
+		"[Service]\nMemoryDenyWriteExecute=false\n"
+	if err := os.WriteFile(noMdwxDropIn, []byte(content), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "[!] couldn't write %s: %v\n", noMdwxDropIn, err)
+		return
+	}
+	fmt.Printf("[✓] ensured %s\n", noMdwxDropIn)
+	if err := exec.Command("systemctl", "daemon-reload").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "[!] daemon-reload failed: %v\n", err)
+	}
+}

--- a/deploy/systemd/opendray-selfupdate.path
+++ b/deploy/systemd/opendray-selfupdate.path
@@ -1,0 +1,17 @@
+# Watches for an in-dashboard upgrade request. The unprivileged opendray
+# daemon (uid 999) can't replace its own binary or restart the unit, so the
+# dashboard's "Update now" only drops a request file here; this path unit
+# activates the privileged opendray-selfupdate.service oneshot in response.
+#
+# Install: place alongside opendray.service, then
+#   systemctl daemon-reload && systemctl enable --now opendray-selfupdate.path
+[Unit]
+Description=Watch for an opendray in-dashboard upgrade request
+
+[Path]
+# Must match the daemon's OPENDRAY_STATE_DIR (default /var/lib/opendray).
+PathExists=/var/lib/opendray/selfupdate.request
+Unit=opendray-selfupdate.service
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/opendray-selfupdate.service
+++ b/deploy/systemd/opendray-selfupdate.service
@@ -1,0 +1,21 @@
+# Privileged oneshot that applies a queued opendray upgrade. Activated by
+# opendray-selfupdate.path when the daemon drops a request file — NOT
+# enabled to run on its own. Runs as root because it replaces
+# /usr/local/bin/opendray, refreshes the unit's W^X drop-in, and restarts
+# the service. It re-resolves "latest" from the canonical repo and verifies
+# the download, so the request file can't point it at arbitrary code.
+[Unit]
+Description=Apply a queued opendray upgrade (privileged)
+After=network-online.target opendray.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/opendray self-update --apply
+# If the daemon uses a non-default state dir, set it here too so this
+# oneshot reads the request from the same place:
+# Environment=OPENDRAY_STATE_DIR=/var/lib/opendray
+
+# Minimal hardening — this is short-lived and must write /usr/local/bin
+# and /etc/systemd/system, so it can't be locked down like the daemon.
+ProtectHome=yes

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -637,6 +637,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 				auditHandlers.Mount(r)
 				intgrCallLogHandlers.Mount(r)
 				settingsHandlers.Mount(r)
+				newVersionHandlers(selfUpdateStateDir(), bus, log).Mount(r)
 				// SetupHandlers (status + setup + disable) is always
 				// mounted — that's the whole point of PR #49 / #50.
 				// Handlers (the data routes) is also always mounted

--- a/internal/app/version_handler.go
+++ b/internal/app/version_handler.go
@@ -1,0 +1,144 @@
+package app
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/opendray/opendray-v2/internal/eventbus"
+	"github.com/opendray/opendray-v2/internal/integration"
+	"github.com/opendray/opendray-v2/internal/selfupdate"
+	"github.com/opendray/opendray-v2/internal/version"
+)
+
+// unitFile is present only when the install shipped the privileged
+// self-update units (path + oneshot). Its absence means the install
+// predates the feature → in-app upgrade can't be triggered, so the API
+// reports capable=false and the UI falls back to a guided command.
+const selfUpdatePathUnit = "/etc/systemd/system/opendray-selfupdate.path"
+
+// versionHandlers serves the dashboard's About/version surface: a
+// read-only release check and the admin-only "request a background
+// upgrade" trigger. Mounted in the admin-session-only group.
+type versionHandlers struct {
+	dataDir string // daemon-writable dir the privileged oneshot watches
+	bus     *eventbus.Hub
+	log     *slog.Logger
+}
+
+func newVersionHandlers(dataDir string, bus *eventbus.Hub, log *slog.Logger) *versionHandlers {
+	return &versionHandlers{dataDir: dataDir, bus: bus, log: log.With("component", "version.http")}
+}
+
+// selfUpdateStateDir is the daemon-writable directory the privileged
+// self-update oneshot watches for a request file. Matches the unit's
+// WorkingDirectory/ReadWritePaths; overridable for non-standard installs.
+func selfUpdateStateDir() string {
+	if d := strings.TrimSpace(os.Getenv("OPENDRAY_STATE_DIR")); d != "" {
+		return d
+	}
+	return "/var/lib/opendray"
+}
+
+func (h *versionHandlers) Mount(r chi.Router) {
+	r.Get("/version", h.get)
+	r.Post("/version/update", h.requestUpdate)
+}
+
+// selfUpdateCapable reports whether a one-click background upgrade can be
+// triggered on this host: Linux, the privileged units are installed, and
+// the watched dir is writable by the daemon.
+func (h *versionHandlers) selfUpdateCapable() bool {
+	if runtime.GOOS != "linux" || h.dataDir == "" {
+		return false
+	}
+	if _, err := os.Stat(selfUpdatePathUnit); err != nil {
+		return false
+	}
+	return true
+}
+
+func (h *versionHandlers) get(w http.ResponseWriter, r *http.Request) {
+	resp := map[string]any{
+		"current":         selfupdate.NormalizeVersion(version.Version),
+		"commit":          version.Commit,
+		"updateAvailable": false,
+		"selfUpdate":      h.selfUpdateCapable(),
+		"pending":         selfupdate.PendingRequest(h.dataDir),
+	}
+	st, err := selfupdate.Check(r.Context(), version.Version)
+	if err != nil {
+		// Soft-fail: still report the current version + capability, just
+		// no "latest" (offline / rate-limited). The UI shows current only.
+		resp["checkError"] = err.Error()
+		writeVersionJSON(w, http.StatusOK, resp)
+		return
+	}
+	resp["latest"] = st.Latest
+	resp["updateAvailable"] = st.Available
+	resp["notesUrl"] = st.NotesURL
+	writeVersionJSON(w, http.StatusOK, resp)
+}
+
+func (h *versionHandlers) requestUpdate(w http.ResponseWriter, r *http.Request) {
+	if !h.selfUpdateCapable() {
+		writeVersionJSON(w, http.StatusConflict, map[string]any{
+			"error": "in-app upgrade isn't available on this install. " +
+				"Run `opendray update` (Linux: re-run the installer first to add the self-update units), or upgrade manually.",
+			"selfUpdate": false,
+		})
+		return
+	}
+	if selfupdate.PendingRequest(h.dataDir) {
+		writeVersionJSON(w, http.StatusConflict, map[string]any{
+			"error": "an upgrade is already in progress.", "pending": true,
+		})
+		return
+	}
+
+	st, err := selfupdate.Check(r.Context(), version.Version)
+	if err != nil {
+		writeVersionJSON(w, http.StatusBadGateway, map[string]any{"error": "couldn't reach the release feed: " + err.Error()})
+		return
+	}
+	if !st.Available {
+		writeVersionJSON(w, http.StatusOK, map[string]any{"error": "already on the latest release.", "current": st.Current})
+		return
+	}
+
+	by := "admin"
+	if p, ok := integration.CurrentPrincipal(r.Context()); ok && p.ID != "" {
+		by = p.ID
+	}
+	req := selfupdate.Request{Version: st.Latest, RequestedBy: by, RequestedAt: time.Now().UTC()}
+	if err := selfupdate.WriteRequest(h.dataDir, req); err != nil {
+		writeVersionJSON(w, http.StatusInternalServerError, map[string]any{"error": "couldn't queue the upgrade: " + err.Error()})
+		return
+	}
+	// Privileged action — leave a loud trail in the journal + audit bus.
+	h.log.Warn("self-update requested", "from", st.Current, "to", st.Latest, "by", by)
+	if h.bus != nil {
+		h.bus.Publish(eventbus.Event{Topic: "selfupdate.requested", Data: map[string]any{
+			"from": st.Current, "to": st.Latest, "requestedBy": by,
+		}})
+	}
+	// 202: the root oneshot will pick up the request, upgrade, and restart
+	// the daemon — so the client should poll GET /version afterward and
+	// expect the connection to drop during the restart.
+	writeVersionJSON(w, http.StatusAccepted, map[string]any{
+		"queued": true, "from": st.Current, "to": st.Latest,
+		"note": "Upgrading in the background; the service will restart and running sessions will reconnect.",
+	})
+}
+
+func writeVersionJSON(w http.ResponseWriter, code int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -1,0 +1,167 @@
+// Package selfupdate is the shared core for opendray's self-update:
+// the read-only "what's the latest release" check (used by the CLI and the
+// dashboard's About panel) and the on-disk update *request* that the
+// unprivileged daemon drops for a privileged systemd oneshot to act on.
+//
+// Privilege model: the daemon runs as the unprivileged `opendray` user and
+// cannot replace /usr/local/bin/opendray, restart the unit, or refresh the
+// unit file. So an in-dashboard "Update now" does NOT update anything
+// directly — it writes a request file into a daemon-owned directory. A
+// root systemd path unit (opendray-selfupdate.path) watches that file and
+// activates a root oneshot (opendray-selfupdate.service →
+// `opendray self-update --apply`) which downloads the *official* signed
+// release, verifies it, swaps the binary, refreshes the unit, and restarts.
+// The request's only power is "trigger an upgrade to the official latest" —
+// it cannot point the installer at arbitrary code.
+package selfupdate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ReleasesAPI is the GitHub releases-latest endpoint for the canonical
+// repo. Kept here so the CLI and server agree on the source of truth.
+const ReleasesAPI = "https://api.github.com/repos/Opendray/opendray/releases/latest"
+
+// RequestFile is the daemon-owned trigger the privileged oneshot watches.
+// It lives under the daemon's writable data dir (ReadWritePaths).
+const RequestFile = "selfupdate.request"
+
+// Status is the result of a release check.
+type Status struct {
+	Current   string `json:"current"`
+	Latest    string `json:"latest"`
+	Available bool   `json:"updateAvailable"`
+	NotesURL  string `json:"notesUrl"`
+}
+
+// Request is the on-disk upgrade trigger written by the daemon and consumed
+// by the root oneshot. Version is advisory/audit only — the oneshot always
+// installs the official latest and verifies it, so a tampered request can
+// at most force an upgrade-to-latest, never arbitrary code.
+type Request struct {
+	Version     string    `json:"version"`
+	RequestedBy string    `json:"requestedBy"`
+	RequestedAt time.Time `json:"requestedAt"`
+}
+
+type ghRelease struct {
+	TagName string `json:"tag_name"`
+	HTMLURL string `json:"html_url"`
+}
+
+// NormalizeVersion strips a leading "v" so "v2.1.1" and "2.1.1" compare
+// equal, and trims any "+build" metadata (custom CT builds like
+// "2.1.1+ct128.abc" compare against the release base).
+func NormalizeVersion(v string) string {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if i := strings.IndexByte(v, '+'); i >= 0 {
+		v = v[:i]
+	}
+	return v
+}
+
+// Check fetches the latest release and compares it to current.
+func Check(ctx context.Context, current string) (Status, error) {
+	rel, err := fetchLatest(ctx)
+	if err != nil {
+		return Status{}, err
+	}
+	cur := NormalizeVersion(current)
+	latest := NormalizeVersion(rel.TagName)
+	return Status{
+		Current:   cur,
+		Latest:    latest,
+		Available: latest != "" && latest != cur,
+		NotesURL:  rel.HTMLURL,
+	}, nil
+}
+
+func fetchLatest(ctx context.Context) (*ghRelease, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ReleasesAPI, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "opendray-selfupdate")
+
+	resp, err := (&http.Client{Timeout: 20 * time.Second}).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("github API returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var rel ghRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, fmt.Errorf("decode release JSON: %w", err)
+	}
+	if rel.TagName == "" {
+		return nil, fmt.Errorf("github returned an empty tag_name (rate-limited?)")
+	}
+	return &rel, nil
+}
+
+// RequestPath returns the trigger-file path inside dataDir.
+func RequestPath(dataDir string) string {
+	return filepath.Join(dataDir, RequestFile)
+}
+
+// WriteRequest atomically writes the upgrade trigger (temp + rename) so the
+// watching path unit never sees a half-written file.
+func WriteRequest(dataDir string, r Request) error {
+	if r.RequestedAt.IsZero() {
+		r.RequestedAt = time.Now().UTC()
+	}
+	b, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := RequestPath(dataDir)
+	tmp, err := os.CreateTemp(dataDir, RequestFile+".*")
+	if err != nil {
+		return fmt.Errorf("create temp request: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// ReadRequest loads and removes the trigger file. Removal is best-effort
+// but logged by the caller; the oneshot also rm's it so the path unit
+// doesn't re-fire.
+func ReadRequest(path string) (Request, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Request{}, err
+	}
+	var r Request
+	if err := json.Unmarshal(b, &r); err != nil {
+		return Request{}, fmt.Errorf("parse request: %w", err)
+	}
+	return r, nil
+}
+
+// PendingRequest reports whether a trigger file is already present (so the
+// API can avoid stacking duplicate requests).
+func PendingRequest(dataDir string) bool {
+	_, err := os.Stat(RequestPath(dataDir))
+	return err == nil
+}

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -1,0 +1,56 @@
+package selfupdate
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNormalizeVersion(t *testing.T) {
+	cases := map[string]string{
+		"v2.1.1":           "2.1.1",
+		"2.1.1":            "2.1.1",
+		"  v2.1.1 ":        "2.1.1",
+		"2.1.1+ct128.abc1": "2.1.1", // custom build compares against base
+		"v2.1.0+build":     "2.1.0",
+	}
+	for in, want := range cases {
+		if got := NormalizeVersion(in); got != want {
+			t.Errorf("NormalizeVersion(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+func TestRequestRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	if PendingRequest(dir) {
+		t.Fatal("PendingRequest = true on empty dir")
+	}
+	in := Request{Version: "2.1.2", RequestedBy: "admin", RequestedAt: time.Now().UTC().Truncate(time.Second)}
+	if err := WriteRequest(dir, in); err != nil {
+		t.Fatalf("WriteRequest: %v", err)
+	}
+	if !PendingRequest(dir) {
+		t.Fatal("PendingRequest = false after write")
+	}
+	got, err := ReadRequest(RequestPath(dir))
+	if err != nil {
+		t.Fatalf("ReadRequest: %v", err)
+	}
+	if got.Version != in.Version || got.RequestedBy != in.RequestedBy || !got.RequestedAt.Equal(in.RequestedAt) {
+		t.Errorf("round-trip mismatch: got %+v want %+v", got, in)
+	}
+}
+
+func TestWriteRequestDefaultsTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteRequest(dir, Request{Version: "2.1.2", RequestedBy: "admin"}); err != nil {
+		t.Fatalf("WriteRequest: %v", err)
+	}
+	got, err := ReadRequest(RequestPath(dir))
+	if err != nil {
+		t.Fatalf("ReadRequest: %v", err)
+	}
+	if got.RequestedAt.IsZero() {
+		t.Error("RequestedAt was not defaulted")
+	}
+}

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -635,6 +635,9 @@ Group=$OPENDRAY_SERVICE_USER
 # the database URL and admin bootstrap password never appear in
 # config.toml on disk or in 'ps aux' / journalctl output.
 EnvironmentFile=$OD_ENV_PATH
+# Where the dashboard's "Update now" drops its request file for the
+# privileged self-update oneshot to act on (must match the .path unit).
+Environment=OPENDRAY_STATE_DIR=$OPENDRAY_DATA_DIR
 ExecStart=$OPENDRAY_PREFIX/bin/opendray serve -config $OD_CONFIG_PATH
 Restart=on-failure
 RestartSec=5s
@@ -654,16 +657,58 @@ ProtectControlGroups=true
 RestrictNamespaces=true
 RestrictRealtime=true
 LockPersonality=true
-MemoryDenyWriteExecute=true
+# MemoryDenyWriteExecute is intentionally NOT enabled: the V8/Node-based
+# CLIs (codex, gemini) JIT-compile and must flip pages RW->RX via mprotect,
+# which a W^X filter blocks (SIGSYS → the child dies on spawn). Claude
+# survives via an interpreter-only fallback; codex/gemini do not. The
+# blast radius without it is the unprivileged $OPENDRAY_SERVICE_USER user.
 
 [Install]
 WantedBy=multi-user.target
 EOF
 
 run_priv install -m 0644 "$TMP_UNIT" "$UNIT_PATH"
+
+# ── Self-update units (in-dashboard "Update now") ────────────────────
+# The daemon is unprivileged and can't replace its own binary or restart
+# the unit, so "Update now" only drops a request file; this root oneshot,
+# activated by the path unit when the file appears, does the privileged
+# work. It installs the official latest (checksum-verified) and clears the
+# request.
+TMP_SU_SVC="$(mktemp)"; register_cleanup_file "$TMP_SU_SVC"
+cat > "$TMP_SU_SVC" <<EOF
+[Unit]
+Description=Apply a queued opendray upgrade (privileged)
+After=network-online.target ${OPENDRAY_SERVICE_NAME}.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+Environment=OPENDRAY_STATE_DIR=$OPENDRAY_DATA_DIR
+ExecStart=$OPENDRAY_PREFIX/bin/opendray self-update --apply
+ProtectHome=yes
+EOF
+
+TMP_SU_PATH="$(mktemp)"; register_cleanup_file "$TMP_SU_PATH"
+cat > "$TMP_SU_PATH" <<EOF
+[Unit]
+Description=Watch for an opendray in-dashboard upgrade request
+
+[Path]
+PathExists=$OPENDRAY_DATA_DIR/selfupdate.request
+Unit=opendray-selfupdate.service
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+run_priv install -m 0644 "$TMP_SU_SVC" "/etc/systemd/system/opendray-selfupdate.service"
+run_priv install -m 0644 "$TMP_SU_PATH" "/etc/systemd/system/opendray-selfupdate.path"
+
 run_priv systemctl daemon-reload
 run_priv systemctl enable --now "$OPENDRAY_SERVICE_NAME"
-log_ok "Service '$OPENDRAY_SERVICE_NAME' enabled and started"
+run_priv systemctl enable --now opendray-selfupdate.path
+log_ok "Service '$OPENDRAY_SERVICE_NAME' enabled and started (+ self-update watcher)"
 
 # Health check loop.
 log_info "Waiting for the gateway to respond..."


### PR DESCRIPTION
Implements the in-dashboard update notification + one-click background upgrade (Settings → About). Builds on #239 (upgrade-path gap) and #240 (startup W^X probe).

## Privilege model (signed off: path-activated root oneshot)
The daemon is unprivileged (uid 999) and **cannot** replace `/usr/local/bin/opendray`, restart the unit, or refresh it. So:
- **`GET /api/v1/version`** (admin group) — current / latest / `updateAvailable` + `selfUpdate` capability + `pending`. Read-only release check (new `internal/selfupdate`).
- **`POST /api/v1/version/update`** (admin-only) — drops a request file in the daemon-owned state dir, returns `202`. Updates nothing itself.
- **`opendray-selfupdate.path`** watches that file → activates the root **`opendray-selfupdate.service`** oneshot → **`opendray self-update --apply`**, which installs the **official latest** (checksum-verified, reusing the `opendray update` path), ensures the W^X drop-in, restarts, and clears the request. The request is advisory — the oneshot re-resolves latest from the canonical repo and verifies the download, so a tampered request can at most force an upgrade-to-latest, never arbitrary code.
- **UI:** confirm (warns the service restarts), then polls `/version` until the restarted daemon reports the new version. Hosts without the privileged units show a guided `opendray update` command instead.

## Also fixes the W^X regression at its source
`install-linux.sh` generated its **own inline unit that still set `MemoryDenyWriteExecute=true`** — #218 only fixed the standalone reference unit, so **fresh installs kept crashing codex/gemini**. The installer now omits it (with the documented reason), installs the two self-update units, and sets `OPENDRAY_STATE_DIR`.

## Tests / checks
- `internal/selfupdate` unit tests (version normalize incl. `+build` metadata; request round-trip; pending detection).
- `go build ./...`, `go test`, `gofmt`, `tsc -b`, full `pnpm --filter web build`, `bash -n` installer — all clean.
- Note: the systemd path→oneshot wiring can't be exercised in CI; needs a real-host smoke test (I can validate on CT 128).

## Scoped follow-ups
- **cosign signature verification** in the apply path (releases ship `.sig`/`.pem`; today it reuses `opendray update`'s checksum-against-official-release verification). 
- **macOS:** launchd runs as the user (can write a user-owned binary), so the root-oneshot model is Linux-only here; macOS shows the guided command for now.