### PR TITLE
feat(web/mcp): transport-aware editor template + codex unsupported badge

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1289,6 +1289,8 @@
         "removedToast": "MCP server removed",
         "deleteFailedToast": "Delete failed",
         "toggleFailedToast": "Toggle failed",
+        "codexUnsupportedBadge": "Codex: unsupported",
+        "codexUnsupportedTooltip": "The codex CLI supports stdio transport only. This server will be skipped for codex sessions; claude and gemini will still use it.",
         "editor": {
           "createTitle": "New MCP server",
           "editTitle": "Edit MCP: {id}",
@@ -1301,7 +1303,12 @@
           "createdToast": "MCP server created",
           "savedToast": "MCP server saved",
           "createFailedToast": "Create failed",
-          "saveFailedToast": "Save failed"
+          "saveFailedToast": "Save failed",
+          "transportLabel": "Transport",
+          "transportHint": "Switching transport replaces the JSON template with a starter shape appropriate for the new transport.",
+          "transportStdio": "stdio (local subprocess)",
+          "transportSse": "sse (remote server)",
+          "transportHttp": "http (remote server)"
         },
         "test": {
           "button": "Test",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -1288,6 +1288,8 @@
         "removedToast": "MCP 服务器已移除",
         "deleteFailedToast": "删除失败",
         "toggleFailedToast": "切换失败",
+        "codexUnsupportedBadge": "Codex: 不支持",
+        "codexUnsupportedTooltip": "Codex CLI 仅支持 stdio 传输方式。Codex 会话将跳过此服务器；claude 和 gemini 仍会使用。",
         "editor": {
           "createTitle": "新建 MCP 服务器",
           "editTitle": "编辑 MCP: {id}",
@@ -1300,7 +1302,12 @@
           "createdToast": "MCP 服务器已创建",
           "savedToast": "MCP 服务器已保存",
           "createFailedToast": "创建失败",
-          "saveFailedToast": "保存失败"
+          "saveFailedToast": "保存失败",
+          "transportLabel": "传输方式",
+          "transportHint": "切换传输方式会将 JSON 模板替换为对应的新模板。",
+          "transportStdio": "stdio (本地子进程)",
+          "transportSse": "sse (远程服务器)",
+          "transportHttp": "http (远程服务器)"
         },
         "test": {
           "button": "测试",

--- a/app/shared/src/lib/mcps.ts
+++ b/app/shared/src/lib/mcps.ts
@@ -113,18 +113,35 @@ export async function testMcp(id: string): Promise<McpTestResult> {
   return api<McpTestResult>(`/api/v1/mcps/${id}/test`, { method: 'POST' })
 }
 
-// defaultMcpServer returns a starter template for the New dialog —
-// stdio transport with a placeholder command so the user has the
-// shape in front of them.
-export function defaultMcpServer(): McpServer {
-  return {
+// McpTransport mirrors McpServer.transport. Exported so the Plugins
+// editor can drive the transport selector that picks which template
+// shape defaultMcpServer returns.
+export type McpTransport = NonNullable<McpServer['transport']>
+
+// defaultMcpServer returns a starter template for the New dialog.
+// The shape depends on transport: stdio servers need command/args/env,
+// while sse/http remote servers need url/headers — the backend rejects
+// sse/http without a url (see internal/mcp/handler.go,
+// prepareServerForWrite, added in #230).
+export function defaultMcpServer(transport: McpTransport = 'stdio'): McpServer {
+  const base: McpServer = {
     id: '',
     name: '',
     description: '',
-    transport: 'stdio',
+    transport,
+    enabled: true,
+  }
+  if (transport === 'sse' || transport === 'http') {
+    return {
+      ...base,
+      url: 'https://example.com/mcp',
+      headers: {},
+    }
+  }
+  return {
+    ...base,
     command: 'npx',
     args: ['-y', '@modelcontextprotocol/server-filesystem', '/path/to/expose'],
     env: {},
-    enabled: true,
   }
 }

--- a/app/web/src/pages/Plugins.tsx
+++ b/app/web/src/pages/Plugins.tsx
@@ -72,6 +72,7 @@ import {
   deleteMcpSecret,
   defaultMcpServer,
   type McpServer,
+  type McpTransport,
 } from '@/lib/mcps'
 import { cn } from '@/lib/utils'
 
@@ -304,6 +305,14 @@ function McpSection() {
                   </td>
                   <td className="px-3 py-2 font-mono text-[10.5px]">
                     {s.transport ?? 'stdio'}
+                    {(s.transport === 'sse' || s.transport === 'http') && (
+                      <div
+                        className="mt-1 inline-flex items-center text-[9.5px] px-1.5 py-px rounded bg-amber-500/15 text-amber-300 border border-amber-500/30 font-sans"
+                        title={t('web.plugins.mcp.codexUnsupportedTooltip')}
+                      >
+                        {t('web.plugins.mcp.codexUnsupportedBadge')}
+                      </div>
+                    )}
                   </td>
                   <td className="px-3 py-2 font-mono text-[10.5px] break-all max-w-[260px]">
                     {s.transport === 'sse' || s.transport === 'http'
@@ -406,6 +415,7 @@ function McpEditor({ open, onOpenChange, mode, editingId }: McpEditorProps) {
   const [id, setId] = useState('')
   const [body, setBody] = useState('')
   const [parseError, setParseError] = useState<string | null>(null)
+  const [transport, setTransport] = useState<McpTransport>('stdio')
 
   const { data: existing, isLoading } = useQuery({
     queryKey: ['mcp', editingId],
@@ -416,15 +426,30 @@ function McpEditor({ open, onOpenChange, mode, editingId }: McpEditorProps) {
   useEffect(() => {
     if (mode === 'create' && open) {
       setId('')
-      setBody(prettyMcp(defaultMcpServer()))
+      setTransport('stdio')
+      setBody(prettyMcp(defaultMcpServer('stdio')))
       setParseError(null)
     } else if (mode === 'edit' && existing) {
       setId(existing.id)
+      setTransport((existing.transport ?? 'stdio') as McpTransport)
       setBody(prettyMcp(existing))
       setParseError(null)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, existing?.id, open])
+
+  // Switching transport in create mode swaps the JSON template so the
+  // user sees fields appropriate for the chosen transport — sse/http
+  // need url/headers, stdio needs command/args/env. Edit mode keeps
+  // the user's hand-tuned body intact; changing transport there is a
+  // raw-JSON edit by design.
+  const handleTransportChange = (next: McpTransport) => {
+    setTransport(next)
+    if (mode === 'create') {
+      setBody(prettyMcp(defaultMcpServer(next)))
+      setParseError(null)
+    }
+  }
 
   const create = useMutation({
     mutationFn: async () => {
@@ -523,6 +548,37 @@ function McpEditor({ open, onOpenChange, mode, editingId }: McpEditorProps) {
                     i18nKey="web.plugins.mcp.editor.idHint"
                     components={{ 1: <code /> }}
                   />
+                </p>
+              </div>
+            )}
+            {mode === 'create' && (
+              <div className="space-y-1.5">
+                <Label htmlFor="mcp-transport">
+                  {t('web.plugins.mcp.editor.transportLabel')}
+                </Label>
+                <Select
+                  value={transport}
+                  onValueChange={(v) =>
+                    handleTransportChange(v as McpTransport)
+                  }
+                >
+                  <SelectTrigger id="mcp-transport">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="stdio">
+                      {t('web.plugins.mcp.editor.transportStdio')}
+                    </SelectItem>
+                    <SelectItem value="sse">
+                      {t('web.plugins.mcp.editor.transportSse')}
+                    </SelectItem>
+                    <SelectItem value="http">
+                      {t('web.plugins.mcp.editor.transportHttp')}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-[10.5px] text-muted-foreground/80">
+                  {t('web.plugins.mcp.editor.transportHint')}
                 </p>
               </div>
             )}


### PR DESCRIPTION
Follow-up to #230 — closes the remaining two pieces of #221.

## Background

#230 wired the backend so that an `sse`/`http` MCP server with the URL accidentally placed in `command` gets normalized to `url` on read/write, and rejected with a 400 on create/update if it has no URL. That fixed the *symptom* operators saw ("my remote servers silently disappear"), but the UI that *caused* the mistake didn't change:

1. The MCP editor is a raw-JSON textarea seeded by `defaultMcpServer()`, which always returns the stdio shape (`command` + `args` + `env`). Users switching to `transport: 'sse'` had no template guidance — they kept the `command` field and never added `url`. The backend now rejects that, but the UI still doesn't help them get it right.
2. `internal/catalog/mcp.go` (`renderCodexMCP`) silently skips non-stdio entries for codex sessions. Operators get no UI signal that a server they added won't be loaded for codex (claude / gemini still load it).

## Changes

**`app/shared/src/lib/mcps.ts`**
- New exported `McpTransport` type alias (used by the editor).
- `defaultMcpServer(transport: McpTransport = 'stdio')` returns a transport-appropriate template:
  - `stdio` → `command` + `args` + `env` (unchanged starter).
  - `sse` / `http` → `url` + `headers`, with a placeholder URL so the user sees the shape.

**`app/web/src/pages/Plugins.tsx`**
- `McpEditor` adds a `transport` state synced from the existing server on edit-open and reset to `stdio` on create-open.
- New transport `<Select>` shown in **create mode only**. Switching it calls `handleTransportChange`, which swaps the JSON textarea to the matching `defaultMcpServer(next)` template and clears any parse error.
- Edit mode intentionally does **not** show the selector — the user's hand-tuned JSON stays intact; changing transport there remains a raw-JSON edit (advanced path).
- The MCP table's transport column now shows an amber `Codex: unsupported` badge under the transport name when `transport === 'sse' || transport === 'http'`. Tooltip explains: codex CLI is stdio-only, this row will be skipped for codex sessions, claude and gemini still use it.

**`app/i18n/{en,zh}.json`**
- 7 new strings under `web.plugins.mcp`:
  - `editor.transportLabel`, `editor.transportHint`
  - `editor.transportStdio`, `editor.transportSse`, `editor.transportHttp`
  - `codexUnsupportedBadge`, `codexUnsupportedTooltip`

## What's out of scope

- No backend change. The codex stdio-only constraint in `internal/catalog/mcp.go` is correct (the codex CLI doesn't support sse/http); the UI just surfaces it. If codex ever adds remote-MCP support, the badge becomes a one-line removal.
- No structured form. Keeping the textarea as the editor body — only the *template* it's seeded with becomes transport-aware. A full structured form is a bigger UX change and a separate PR if appetite emerges.

## Test plan

- [ ] New MCP dialog: default transport is `stdio`, body shows `command` / `args` / `env`.
- [ ] Switch transport selector to `sse` → body resets to `url` + `headers` placeholder.
- [ ] Switch back to `stdio` → body resets to the stdio starter.
- [ ] Create an sse server with the new template, save, reload — entry persists with `url` populated.
- [ ] Edit an existing server: transport selector is hidden; JSON body is the existing content untouched.
- [ ] Plugins table: sse/http rows show the amber `Codex: unsupported` badge; stdio rows don't.
- [ ] Hover the badge → tooltip says codex skips it, claude/gemini still use it.
- [ ] Both `en` and `zh` locales render the new strings correctly.
- [x] `pnpm --filter web build` (tsc -b + vite build) — green
- [x] JSON syntax of both i18n files valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)