### PR TITLE
feat(web): always-visible Check-for-updates + re-install in Settings → About

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -2129,7 +2129,10 @@
         "upgradeSlow": "Upgrade is taking a while — check the service logs if it doesn't come back.",
         "guidedHint": "In-app upgrade isn't available here. Run on the server:",
         "checkFailed": "Couldn't check for updates (offline or rate-limited).",
-        "upToDate": "You're on the latest release."
+        "upToDate": "You're on the latest release.",
+        "checkUpdates": "Check for updates",
+        "checking": "Checking…",
+        "reinstall": "Re-install"
       }
     },
     "logViewer": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -2128,7 +2128,10 @@
         "upgradeSlow": "升级耗时较长——如果服务未恢复，请检查日志。",
         "guidedHint": "此处不支持应用内升级。请在服务器上运行：",
         "checkFailed": "无法检查更新（离线或受限）。",
-        "upToDate": "已是最新版本。"
+        "upToDate": "已是最新版本。",
+        "checkUpdates": "检查更新",
+        "checking": "检查中…",
+        "reinstall": "重新安装"
       }
     },
     "logViewer": {

--- a/app/shared/src/lib/version.ts
+++ b/app/shared/src/lib/version.ts
@@ -30,6 +30,9 @@ export async function getVersionInfo(): Promise<VersionInfo> {
   return api<VersionInfo>('/version')
 }
 
-export async function requestSelfUpdate(): Promise<SelfUpdateResponse> {
-  return api<SelfUpdateResponse>('/version/update', { method: 'POST' })
+export async function requestSelfUpdate(
+  force = false,
+): Promise<SelfUpdateResponse> {
+  const q = force ? '?force=true' : ''
+  return api<SelfUpdateResponse>(`/version/update${q}`, { method: 'POST' })
 }

--- a/app/web/src/pages/Settings.tsx
+++ b/app/web/src/pages/Settings.tsx
@@ -754,9 +754,28 @@ function AboutSection() {
     return () => clearInterval(id)
   }, [phase, data?.latest, refetch, t])
 
-  async function startUpgrade() {
+  const [checking, setChecking] = useState(false)
+  // confirmForce distinguishes a normal upgrade from a force re-install
+  // (the "Re-install" action shown when already on the latest).
+  const [confirmForce, setConfirmForce] = useState(false)
+
+  async function checkNow() {
+    setChecking(true)
     try {
-      const res = await requestSelfUpdate()
+      const r = await refetch()
+      const info = r.data
+      if (info?.checkError) toast.error(t('web.settings.about.checkFailed'))
+      else if (info?.updateAvailable)
+        toast.success(t('web.settings.about.updateAvailable', { version: info.latest }))
+      else toast.message(t('web.settings.about.upToDate'))
+    } finally {
+      setChecking(false)
+    }
+  }
+
+  async function startUpgrade(force = false) {
+    try {
+      const res = await requestSelfUpdate(force)
       if (res.error) {
         toast.error(res.error)
         setPhase('idle')
@@ -772,7 +791,8 @@ function AboutSection() {
     }
   }
 
-  const busy = phase === 'upgrading' || data?.pending
+  const busy = phase === 'upgrading' || !!data?.pending
+  const canSelfUpdate = !!data?.selfUpdate
   return (
     <div>
       <SectionHeader title={t('web.settings.about.title')} />
@@ -785,69 +805,102 @@ function AboutSection() {
         <Field label={t('web.settings.about.commit')} value={data.commit} monospace />
       )}
 
-      {data?.updateAvailable ? (
-        <div className="mt-3 rounded-md border border-primary/40 bg-primary/5 p-3">
-          <div className="text-[12px] font-medium">
-            {t('web.settings.about.updateAvailable', { version: data.latest })}
-          </div>
-          {data.notesUrl && (
-            <a
-              href={data.notesUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="text-[11px] text-primary underline"
-            >
-              {t('web.settings.about.releaseNotes')}
-            </a>
-          )}
-          <div className="mt-2">
-            {data.selfUpdate ? (
-              phase === 'confirming' ? (
-                <div className="flex items-center gap-2">
-                  <span className="text-[11px] text-muted-foreground">
-                    {t('web.settings.about.confirmRestart')}
-                  </span>
-                  <button
-                    onClick={startUpgrade}
-                    className="rounded bg-primary px-2.5 py-1 text-[11px] font-medium text-primary-foreground"
-                  >
-                    {t('web.settings.about.confirmUpgrade')}
-                  </button>
-                  <button
-                    onClick={() => setPhase('idle')}
-                    className="rounded border border-border px-2.5 py-1 text-[11px]"
-                  >
-                    {t('common.cancel')}
-                  </button>
-                </div>
-              ) : (
-                <button
-                  onClick={() => setPhase('confirming')}
-                  disabled={!!busy}
-                  className="rounded bg-primary px-2.5 py-1 text-[11px] font-medium text-primary-foreground disabled:opacity-50"
-                >
-                  {busy
-                    ? t('web.settings.about.upgradingShort')
-                    : t('web.settings.about.updateNow')}
-                </button>
-              )
-            ) : (
-              <div className="text-[11px] text-muted-foreground">
-                {t('web.settings.about.guidedHint')}
-                <code className="ml-1 font-mono text-foreground">opendray update</code>
-              </div>
+      {/* Status line — always shown */}
+      <div className="mt-3 text-[12px]">
+        {data?.updateAvailable ? (
+          <span className="font-medium">
+            {t('web.settings.about.updateAvailable', { version: data.latest })}{' '}
+            {data.notesUrl && (
+              <a
+                href={data.notesUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="text-[11px] text-primary underline"
+              >
+                {t('web.settings.about.releaseNotes')}
+              </a>
             )}
-          </div>
+          </span>
+        ) : data?.checkError ? (
+          <span className="text-muted-foreground">
+            {t('web.settings.about.checkFailed')}
+          </span>
+        ) : (
+          <span className="text-muted-foreground">
+            {t('web.settings.about.upToDate')}
+          </span>
+        )}
+      </div>
+
+      {/* Controls — always visible */}
+      {phase === 'confirming' ? (
+        <div className="mt-2 flex items-center gap-2">
+          <span className="text-[11px] text-muted-foreground">
+            {t('web.settings.about.confirmRestart')}
+          </span>
+          <button
+            onClick={() => startUpgrade(confirmForce)}
+            className="rounded bg-primary px-2.5 py-1 text-[11px] font-medium text-primary-foreground"
+          >
+            {t('web.settings.about.confirmUpgrade')}
+          </button>
+          <button
+            onClick={() => setPhase('idle')}
+            className="rounded border border-border px-2.5 py-1 text-[11px]"
+          >
+            {t('common.cancel')}
+          </button>
         </div>
-      ) : data?.checkError ? (
-        <p className="mt-3 text-[11px] text-muted-foreground">
-          {t('web.settings.about.checkFailed')}
-        </p>
-      ) : data?.latest ? (
-        <p className="mt-3 text-[11px] text-muted-foreground">
-          {t('web.settings.about.upToDate')}
-        </p>
-      ) : null}
+      ) : (
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <button
+            onClick={checkNow}
+            disabled={checking || busy}
+            className="rounded border border-border px-2.5 py-1 text-[11px] disabled:opacity-50"
+          >
+            {checking
+              ? t('web.settings.about.checking')
+              : t('web.settings.about.checkUpdates')}
+          </button>
+
+          {data?.updateAvailable && canSelfUpdate && (
+            <button
+              onClick={() => {
+                setConfirmForce(false)
+                setPhase('confirming')
+              }}
+              disabled={busy}
+              className="rounded bg-primary px-2.5 py-1 text-[11px] font-medium text-primary-foreground disabled:opacity-50"
+            >
+              {busy
+                ? t('web.settings.about.upgradingShort')
+                : t('web.settings.about.updateNow')}
+            </button>
+          )}
+
+          {!data?.updateAvailable && !data?.checkError && canSelfUpdate && (
+            <button
+              onClick={() => {
+                setConfirmForce(true)
+                setPhase('confirming')
+              }}
+              disabled={busy}
+              className="rounded border border-border px-2.5 py-1 text-[11px] disabled:opacity-50"
+            >
+              {busy
+                ? t('web.settings.about.upgradingShort')
+                : t('web.settings.about.reinstall')}
+            </button>
+          )}
+
+          {data?.updateAvailable && !canSelfUpdate && (
+            <span className="text-[11px] text-muted-foreground">
+              {t('web.settings.about.guidedHint')}
+              <code className="ml-1 font-mono text-foreground">opendray update</code>
+            </span>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/cmd/opendray/selfupdate.go
+++ b/cmd/opendray/selfupdate.go
@@ -61,7 +61,11 @@ func runSelfUpdate(args []string) int {
 	// root (the oneshot) the /usr/local/bin write and systemctl restart
 	// both succeed. It re-resolves "latest" from the canonical repo and
 	// verifies the download, so the request can't redirect it elsewhere.
-	return runUpdate([]string{"--yes", "--restart"})
+	updateArgs := []string{"--yes", "--restart"}
+	if req.Force {
+		updateArgs = append(updateArgs, "--force") // re-install even when current
+	}
+	return runUpdate(updateArgs)
 }
 
 // ensureNoMdwxDropIn writes the W^X override if absent (idempotent;

--- a/internal/app/version_handler.go
+++ b/internal/app/version_handler.go
@@ -102,12 +102,14 @@ func (h *versionHandlers) requestUpdate(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	force := r.URL.Query().Get("force") == "true" || r.URL.Query().Get("force") == "1"
+
 	st, err := selfupdate.Check(r.Context(), version.Version)
 	if err != nil {
 		writeVersionJSON(w, http.StatusBadGateway, map[string]any{"error": "couldn't reach the release feed: " + err.Error()})
 		return
 	}
-	if !st.Available {
+	if !st.Available && !force {
 		writeVersionJSON(w, http.StatusOK, map[string]any{"error": "already on the latest release.", "current": st.Current})
 		return
 	}
@@ -116,23 +118,23 @@ func (h *versionHandlers) requestUpdate(w http.ResponseWriter, r *http.Request) 
 	if p, ok := integration.CurrentPrincipal(r.Context()); ok && p.ID != "" {
 		by = p.ID
 	}
-	req := selfupdate.Request{Version: st.Latest, RequestedBy: by, RequestedAt: time.Now().UTC()}
+	req := selfupdate.Request{Version: st.Latest, RequestedBy: by, RequestedAt: time.Now().UTC(), Force: force}
 	if err := selfupdate.WriteRequest(h.dataDir, req); err != nil {
 		writeVersionJSON(w, http.StatusInternalServerError, map[string]any{"error": "couldn't queue the upgrade: " + err.Error()})
 		return
 	}
 	// Privileged action — leave a loud trail in the journal + audit bus.
-	h.log.Warn("self-update requested", "from", st.Current, "to", st.Latest, "by", by)
+	h.log.Warn("self-update requested", "from", st.Current, "to", st.Latest, "force", force, "by", by)
 	if h.bus != nil {
 		h.bus.Publish(eventbus.Event{Topic: "selfupdate.requested", Data: map[string]any{
-			"from": st.Current, "to": st.Latest, "requestedBy": by,
+			"from": st.Current, "to": st.Latest, "force": force, "requestedBy": by,
 		}})
 	}
 	// 202: the root oneshot will pick up the request, upgrade, and restart
 	// the daemon — so the client should poll GET /version afterward and
 	// expect the connection to drop during the restart.
 	writeVersionJSON(w, http.StatusAccepted, map[string]any{
-		"queued": true, "from": st.Current, "to": st.Latest,
+		"queued": true, "from": st.Current, "to": st.Latest, "force": force,
 		"note": "Upgrading in the background; the service will restart and running sessions will reconnect.",
 	})
 }

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -51,6 +51,9 @@ type Request struct {
 	Version     string    `json:"version"`
 	RequestedBy string    `json:"requestedBy"`
 	RequestedAt time.Time `json:"requestedAt"`
+	// Force re-installs the latest even when already current (the
+	// dashboard's "Re-install" action). Maps to `opendray update --force`.
+	Force bool `json:"force,omitempty"`
 }
 
 type ghRelease struct {


### PR DESCRIPTION
Follow-up to #241. The update control only rendered when the install was behind, so on a current box (e.g. just after a release) Settings → About showed the version but **no button** — which reads as "the feature is missing."

## Change
About now always shows actionable controls:
- **Check for updates** — always visible; re-queries the release feed and toasts the result.
- **Update now** — when an update is available (unchanged one-click background upgrade).
- **Re-install** — when already on the latest; forces a fresh install of the current release (`POST /version/update?force=true` → request `Force:true` → `opendray update --force` in the oneshot).
- A status line: *update available · vX.Y.Z (release notes)* / *up to date* / *couldn't check*.

`Request.Force` is threaded end-to-end (handler → request file → self-update oneshot). Non-Linux / non-capable hosts still show the guided `opendray update` command.

## Checks
`go build`, `go test`, `gofmt`, `tsc -b` clean. Ships in 2.2.1.