### PR TITLE
feat(memory): global-scope injection fallback + recency default

### DIFF
--- a/internal/memory/injector/inject.go
+++ b/internal/memory/injector/inject.go
@@ -154,14 +154,26 @@ func readK(cfg map[string]any, fallback, max int) int {
 // list returns "" (no banner is better than a blank one).
 func (i *Injector) renderTopKRecent(ctx context.Context, profile Profile, cwd string) (string, error) {
 	k := readK(profile.Config, 5, 50)
-	if cwd == "" {
-		i.log.Debug("injector: empty cwd, skipping top_k_recent")
-		return "", nil
+	var mems []memory.Memory
+	if cwd != "" {
+		m, err := i.memory.List(ctx, memory.ScopeProject, cwd, k)
+		if err != nil {
+			i.log.Warn("injector: list memories failed", "cwd", cwd, "err", err)
+		} else {
+			mems = m
+		}
 	}
-	mems, err := i.memory.List(ctx, memory.ScopeProject, cwd, k)
-	if err != nil {
-		i.log.Warn("injector: list memories failed", "cwd", cwd, "err", err)
-		return "", nil // non-fatal — skip injection rather than block spawn
+	// Cross-session fallback: a session in a fresh cwd has no project-scoped
+	// memories, but global-scope memories (e.g. stored via the memory MCP at
+	// OPENDRAY_MEMORY_SCOPE=global) should still surface so "told one
+	// session, recalled in another" works regardless of cwd.
+	if len(mems) == 0 {
+		g, err := i.memory.List(ctx, memory.ScopeGlobal, "", k)
+		if err != nil {
+			i.log.Warn("injector: global list failed", "err", err)
+			return "", nil // non-fatal — skip injection rather than block spawn
+		}
+		mems = g
 	}
 	if len(mems) == 0 {
 		return "", nil

--- a/internal/memory/injector/inject_test.go
+++ b/internal/memory/injector/inject_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 type fakeMemoryReader struct {
-	mems       []memory.Memory
+	mems       []memory.Memory // returned for project scope
+	globalMems []memory.Memory // returned for global scope (fallback)
 	searchHits []memory.SearchHit
 	err        error
 }
@@ -21,10 +22,14 @@ func (f *fakeMemoryReader) List(ctx context.Context, scope memory.Scope, scopeKe
 	if f.err != nil {
 		return nil, f.err
 	}
-	if len(f.mems) > limit {
-		return f.mems[:limit], nil
+	out := f.mems
+	if scope == memory.ScopeGlobal {
+		out = f.globalMems
 	}
-	return f.mems, nil
+	if len(out) > limit {
+		return out[:limit], nil
+	}
+	return out, nil
 }
 
 func (f *fakeMemoryReader) Search(ctx context.Context, req memory.SearchRequest) ([]memory.SearchHit, error) {
@@ -140,13 +145,28 @@ func TestRender_TopKRecent_ListErrorSkipsGracefully(t *testing.T) {
 	}
 }
 
-func TestRender_TopKRecent_EmptyCwdReturnsEmpty(t *testing.T) {
-	mem := &fakeMemoryReader{mems: []memory.Memory{{ID: "1", Text: "x"}}}
+func TestRender_TopKRecent_EmptyEverywhereReturnsEmpty(t *testing.T) {
+	mem := &fakeMemoryReader{} // no project, no global
 	inj := &Injector{memory: mem, log: silentLog()}
 	out, _ := inj.renderTopKRecent(context.Background(),
 		Profile{StrategyKind: "top_k_recent"}, "")
 	if out != "" {
-		t.Errorf("empty cwd should yield empty preface, got %q", out)
+		t.Errorf("no memories anywhere should yield empty preface, got %q", out)
+	}
+}
+
+func TestRender_TopKRecent_FallsBackToGlobal(t *testing.T) {
+	// No project memories for this cwd, but a global memory exists — it
+	// should surface (cross-session recall regardless of cwd).
+	mem := &fakeMemoryReader{
+		mems:       nil,
+		globalMems: []memory.Memory{{ID: "g1", Text: "global fact"}},
+	}
+	inj := &Injector{memory: mem, log: silentLog()}
+	out, _ := inj.renderTopKRecent(context.Background(),
+		Profile{StrategyKind: "top_k_recent"}, "/some/fresh/cwd")
+	if !strings.Contains(out, "global fact") {
+		t.Errorf("expected global memory in preface, got %q", out)
 	}
 }
 

--- a/internal/memory/injector/profile.go
+++ b/internal/memory/injector/profile.go
@@ -148,9 +148,13 @@ func (s *ProfileStore) Resolve(ctx context.Context, sessionID string) Profile {
 	if p, err := scanProfile(row); err == nil {
 		return p
 	}
+	// Default to top_k_recent (not top_k_relevant): recency is less
+	// cwd-dependent, and renderTopKRecent falls back to global scope when
+	// the cwd has no project memories — so cross-session recall works out
+	// of the box without an operator configuring a profile.
 	return Profile{
-		ID:           "synthetic-default-top-k-relevant",
-		StrategyKind: "top_k_relevant",
+		ID:           "synthetic-default-top-k-recent",
+		StrategyKind: "top_k_recent",
 		Config:       map[string]any{"k": float64(5)},
 	}
 }


### PR DESCRIPTION
Part 1 of making cross-session memory recall work. Spawn-time injection was cwd/project-scoped, so a session in a different cwd than where memories were captured got **nothing** — which is why a fact told to one session wasn't recalled in another.

- `renderTopKRecent` falls back to **global-scope** memories when the cwd has no project-scoped ones (works with empty cwd too).
- The **synthetic default profile** (no profile configured) is now `top_k_recent` (recency, less cwd-dependent) instead of `top_k_relevant` (cwd-query), pairing with the global fallback so it works out of the box.

Tests added for empty-everywhere and global-fallback. Part 2 (separate PR) opens the memory recall endpoints to an integration key so the `opendray mcp-memory` server can be wired durably for live recall.