### PR TITLE
fix(memory): scope-gate memory endpoints (admin or memory:read/write)

### DIFF
--- a/app/shared/src/lib/scopes.ts
+++ b/app/shared/src/lib/scopes.ts
@@ -75,6 +75,18 @@ const RAW: Record<string, Omit<ScopeInfo, 'id'>> = {
       'List installed agent providers (claude, codex, gemini, shell) and their catalog metadata.',
     group: 'misc',
   },
+  'memory:read': {
+    title: 'Read memory',
+    description:
+      'Search, list, and read stored memories. Used by the memory MCP for live cross-session recall. Does not grant delete/re-embed (admin only).',
+    group: 'misc',
+  },
+  'memory:write': {
+    title: 'Write memory',
+    description:
+      'Store new memories. Used by the memory MCP so agents can persist durable facts. Does not grant delete/re-embed (admin only).',
+    group: 'misc',
+  },
 }
 
 export const SCOPE_INFO: ScopeInfo[] = ALL_SCOPES.map((id) => {

--- a/app/shared/src/lib/types.ts
+++ b/app/shared/src/lib/types.ts
@@ -211,6 +211,8 @@ export const ALL_SCOPES = [
   'event:subscribe:channel.*',
   'event:subscribe:integration.*',
   'provider:read',
+  'memory:read',
+  'memory:write',
 ] as const
 
 export type Scope = (typeof ALL_SCOPES)[number] | string

--- a/internal/memory/handler.go
+++ b/internal/memory/handler.go
@@ -3,12 +3,55 @@ package memory
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/opendray/opendray-v2/internal/integration"
 )
+
+// Memory scopes for integration keys. Reads (search/list/get/scope-keys/
+// status) need ScopeMemoryRead; store needs ScopeMemoryWrite. Admins pass
+// either unconditionally. The destructive/management endpoints stay
+// admin-only regardless of scope.
+const (
+	ScopeMemoryRead  = "memory:read"
+	ScopeMemoryWrite = "memory:write"
+)
+
+// requireScope allows admins, and integration keys holding `scope`.
+// Mounted under integration.CombinedMiddleware, which sets the principal.
+func (h *Handlers) requireScope(scope string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			p, ok := integration.CurrentPrincipal(r.Context())
+			if !ok {
+				writeError(w, http.StatusUnauthorized, errors.New("unauthorized"))
+				return
+			}
+			if p.Kind == integration.KindAdmin || integration.HasScope(p.Scopes, scope) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			writeError(w, http.StatusForbidden, fmt.Errorf("requires admin or the %q scope", scope))
+		})
+	}
+}
+
+// requireAdmin allows only admin principals (integration keys are rejected
+// regardless of scope) — for the destructive / management memory endpoints.
+func (h *Handlers) requireAdmin(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if p, ok := integration.CurrentPrincipal(r.Context()); !ok || p.Kind != integration.KindAdmin {
+			writeError(w, http.StatusForbidden, errors.New("requires admin"))
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
 
 // Handlers exposes the memory subsystem over HTTP under /memory/*.
 // Mount under the dual-auth route group (admin OR integration) so
@@ -43,20 +86,26 @@ func NewHandlers(svc *Service, log *slog.Logger) *Handlers {
 // dual-auth middleware (admin OR integration) applied.
 func (h *Handlers) Mount(r chi.Router) {
 	r.Route("/memory", func(r chi.Router) {
-		r.Get("/status", h.status)
-		r.Post("/store", h.store)
-		r.Post("/search", h.search)
-		r.Get("/list", h.list)
-		r.Get("/scope-keys", h.scopeKeys)
-		r.Get("/{id}", h.getOne)
-		r.Patch("/{id}", h.update)
-		r.Delete("/{id}", h.delete)
-		r.Post("/delete-by-scope", h.deleteByScope)
-		r.Post("/test", h.test)
-		r.Post("/probe", h.probe)
-		r.Get("/embedder-stats", h.embedderStats)
-		r.Post("/reembed", h.reembed)
-		r.Post("/mirror", h.mirror)
+		// Recall surface — admin OR integration key with the scope. This is
+		// what `opendray mcp-memory` calls, so a long-lived integration key
+		// can drive live cross-session recall.
+		read := h.requireScope(ScopeMemoryRead)
+		r.With(read).Get("/status", h.status)
+		r.With(read).Post("/search", h.search)
+		r.With(read).Get("/list", h.list)
+		r.With(read).Get("/scope-keys", h.scopeKeys)
+		r.With(read).Get("/{id}", h.getOne)
+		r.With(h.requireScope(ScopeMemoryWrite)).Post("/store", h.store)
+
+		// Management / destructive — admin only, never an integration key.
+		r.With(h.requireAdmin).Patch("/{id}", h.update)
+		r.With(h.requireAdmin).Delete("/{id}", h.delete)
+		r.With(h.requireAdmin).Post("/delete-by-scope", h.deleteByScope)
+		r.With(h.requireAdmin).Post("/test", h.test)
+		r.With(h.requireAdmin).Post("/probe", h.probe)
+		r.With(h.requireAdmin).Get("/embedder-stats", h.embedderStats)
+		r.With(h.requireAdmin).Post("/reembed", h.reembed)
+		r.With(h.requireAdmin).Post("/mirror", h.mirror)
 	})
 }
 

--- a/internal/memory/handler_authz_test.go
+++ b/internal/memory/handler_authz_test.go
@@ -1,0 +1,70 @@
+package memory
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/opendray/opendray-v2/internal/integration"
+)
+
+// The guards don't touch other Handlers fields, so a zero value is fine.
+func guardNext() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+}
+
+func reqWithPrincipal(p *integration.Principal) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/memory/list", nil)
+	if p != nil {
+		r = r.WithContext(integration.WithPrincipal(r.Context(), *p))
+	}
+	return r
+}
+
+func TestRequireScope(t *testing.T) {
+	h := &Handlers{}
+	mw := h.requireScope(ScopeMemoryRead)
+	cases := []struct {
+		name string
+		p    *integration.Principal
+		want int
+	}{
+		{"admin allowed", &integration.Principal{Kind: integration.KindAdmin}, http.StatusOK},
+		{"integration with scope", &integration.Principal{Kind: integration.KindIntegration, Scopes: []string{ScopeMemoryRead}}, http.StatusOK},
+		{"integration wrong scope", &integration.Principal{Kind: integration.KindIntegration, Scopes: []string{ScopeMemoryWrite}}, http.StatusForbidden},
+		{"integration no scope", &integration.Principal{Kind: integration.KindIntegration}, http.StatusForbidden},
+		{"no principal", nil, http.StatusUnauthorized},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			mw(guardNext()).ServeHTTP(rec, reqWithPrincipal(c.p))
+			if rec.Code != c.want {
+				t.Errorf("got %d, want %d", rec.Code, c.want)
+			}
+		})
+	}
+}
+
+func TestRequireAdmin(t *testing.T) {
+	h := &Handlers{}
+	cases := []struct {
+		name string
+		p    *integration.Principal
+		want int
+	}{
+		{"admin allowed", &integration.Principal{Kind: integration.KindAdmin}, http.StatusOK},
+		// A scoped integration key must NOT reach destructive endpoints.
+		{"integration rejected", &integration.Principal{Kind: integration.KindIntegration, Scopes: []string{ScopeMemoryRead, ScopeMemoryWrite}}, http.StatusForbidden},
+		{"no principal", nil, http.StatusForbidden},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.requireAdmin(guardNext()).ServeHTTP(rec, reqWithPrincipal(c.p))
+			if rec.Code != c.want {
+				t.Errorf("got %d, want %d", rec.Code, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part 2 of making cross-session memory recall work — and a security fix.

The memory routes are mounted under `CombinedMiddleware`, so **any valid integration key already reached them with no scope check** — including destructive ops (delete, delete-by-scope, reembed, mirror). Same latent hole #234 closed for providers.

- **Recall** (search/list/get/scope-keys/status) → admin OR `memory:read`
- **store** → admin OR `memory:write`
- **destructive/management** → admin only (integration keys rejected regardless of scope)

This also makes `opendray mcp-memory` properly scopable: wire it with a long-lived integration key granted `memory:read`+`memory:write` for live cross-session recall, without handing it admin or delete rights. Adds the two scopes to the registry/picker.

Guard unit tests cover admin/scoped/wrong-scope/no-scope/no-principal for both read and admin-only paths.