### PR TITLE
fix(session): preserve and resume sessions across a daemon restart

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -637,7 +637,19 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 				auditHandlers.Mount(r)
 				intgrCallLogHandlers.Mount(r)
 				settingsHandlers.Mount(r)
-				newVersionHandlers(selfUpdateStateDir(), bus, log).Mount(r)
+				newVersionHandlers(selfUpdateStateDir(), bus, log, func() int {
+					rows, err := sessionMgr.List(context.Background())
+					if err != nil {
+						return 0
+					}
+					live := 0
+					for _, s := range rows {
+						if !s.State.IsTerminal() {
+							live++
+						}
+					}
+					return live
+				}).Mount(r)
 				// SetupHandlers (status + setup + disable) is always
 				// mounted — that's the whole point of PR #49 / #50.
 				// Handlers (the data routes) is also always mounted

--- a/internal/app/version_handler.go
+++ b/internal/app/version_handler.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -30,10 +31,15 @@ type versionHandlers struct {
 	dataDir string // daemon-writable dir the privileged oneshot watches
 	bus     *eventbus.Hub
 	log     *slog.Logger
+	// liveSessions reports how many sessions are currently live. When
+	// >0, a self-update is gated behind force=true so the operator
+	// confirms the restart (sessions auto-resume, but the connection
+	// drops). nil disables the gate.
+	liveSessions func() int
 }
 
-func newVersionHandlers(dataDir string, bus *eventbus.Hub, log *slog.Logger) *versionHandlers {
-	return &versionHandlers{dataDir: dataDir, bus: bus, log: log.With("component", "version.http")}
+func newVersionHandlers(dataDir string, bus *eventbus.Hub, log *slog.Logger, liveSessions func() int) *versionHandlers {
+	return &versionHandlers{dataDir: dataDir, bus: bus, log: log.With("component", "version.http"), liveSessions: liveSessions}
 }
 
 // selfUpdateStateDir is the daemon-writable directory the privileged
@@ -104,6 +110,20 @@ func (h *versionHandlers) requestUpdate(w http.ResponseWriter, r *http.Request) 
 
 	force := r.URL.Query().Get("force") == "true" || r.URL.Query().Get("force") == "1"
 
+	// Drain gate: the upgrade restarts the daemon, dropping every live
+	// PTY. Sessions auto-resume on restart, but the operator should
+	// confirm rather than have running work interrupted silently.
+	if !force && h.liveSessions != nil {
+		if n := h.liveSessions(); n > 0 {
+			writeVersionJSON(w, http.StatusConflict, map[string]any{
+				"error": fmt.Sprintf("%d live session(s) would be interrupted by the upgrade restart "+
+					"(they auto-resume afterward). Re-request with force=true to proceed.", n),
+				"liveSessions": n, "needsForce": true,
+			})
+			return
+		}
+	}
+
 	st, err := selfupdate.Check(r.Context(), version.Version)
 	if err != nil {
 		writeVersionJSON(w, http.StatusBadGateway, map[string]any{"error": "couldn't reach the release feed: " + err.Error()})
@@ -135,7 +155,7 @@ func (h *versionHandlers) requestUpdate(w http.ResponseWriter, r *http.Request) 
 	// expect the connection to drop during the restart.
 	writeVersionJSON(w, http.StatusAccepted, map[string]any{
 		"queued": true, "from": st.Current, "to": st.Latest, "force": force,
-		"note": "Upgrading in the background; the service will restart and running sessions will reconnect.",
+		"note": "Upgrading in the background; the service will restart and interrupted sessions will auto-resume.",
 	})
 }
 

--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -377,8 +377,10 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 		// Gemini both accept `--session-id <uuid>`; Codex does not,
 		// so it stays on the cwd-based reader path. injectSessionIDFor
 		// mutates out.Args + out.ClaudeSessionID directly, and the
-		// session manager picks up the UUID for persistence.
-		injectSessionIDFor(providerID, &out)
+		// session manager picks up the UUID for persistence. When this
+		// is a reactivation carrying an existing agent UUID, it emits
+		// `--resume <id>` instead so the prior transcript continues.
+		injectSessionIDFor(prepareCtx, providerID, &out)
 
 		if wantClaudeAccount {
 			acct, token, err := sp.accounts.ReadToken(prepareCtx, claudeAccountID)
@@ -1089,9 +1091,28 @@ sessions will still want to retrieve months from now.
 // (Args ordering puts provider-baseline → out.Args → sess.Args, so
 // a user-supplied flag wins anyway, but we skip injection too to
 // avoid emitting a duplicate flag.)
-func injectSessionIDFor(providerID string, out *session.PrepareOutput) bool {
+//
+// Resume path: when ctx carries a resume UUID (set by the session
+// manager on reactivation), claude continues that conversation via
+// `--resume <id>` rather than starting a fresh `--session-id`. We
+// preserve the original UUID on out.ClaudeSessionID so the row keeps
+// pointing at the same transcript. Gemini has no verified resume flag,
+// so it falls back to a fresh session-id (a new turn, history intact
+// on disk) until that's confirmed.
+func injectSessionIDFor(ctx context.Context, providerID string, out *session.PrepareOutput) bool {
+	resumeID := session.ResumeClaudeSessionIDFromContext(ctx)
 	switch providerID {
-	case "claude", "gemini":
+	case "claude":
+		if resumeID != "" {
+			out.Args = append(out.Args, "--resume", resumeID)
+			out.ClaudeSessionID = resumeID
+			return true
+		}
+		id := uuid.NewString()
+		out.Args = append(out.Args, "--session-id", id)
+		out.ClaudeSessionID = id
+		return true
+	case "gemini":
 		id := uuid.NewString()
 		out.Args = append(out.Args, "--session-id", id)
 		out.ClaudeSessionID = id

--- a/internal/catalog/inject_test.go
+++ b/internal/catalog/inject_test.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -125,7 +126,7 @@ func TestInjectAmbientMemory_UnknownProviderSilent(t *testing.T) {
 
 func TestInjectSessionID_Claude(t *testing.T) {
 	out := &session.PrepareOutput{}
-	if !injectSessionIDFor("claude", out) {
+	if !injectSessionIDFor(context.Background(), "claude", out) {
 		t.Fatal("expected injection to fire for claude")
 	}
 	if out.ClaudeSessionID == "" {
@@ -136,9 +137,28 @@ func TestInjectSessionID_Claude(t *testing.T) {
 	}
 }
 
+func TestInjectSessionID_ClaudeResume(t *testing.T) {
+	// On reactivation the manager threads the existing agent UUID via
+	// ctx; claude must continue it with --resume, NOT mint a fresh
+	// --session-id (which would start a blank conversation and orphan
+	// the original transcript). Regression for the 2026-05-23 incident.
+	const prior = "d3cca926-5e55-4d6b-8920-392e990347a1"
+	out := &session.PrepareOutput{}
+	ctx := session.WithResumeClaudeSessionID(context.Background(), prior)
+	if !injectSessionIDFor(ctx, "claude", out) {
+		t.Fatal("expected injection to fire for claude resume")
+	}
+	if out.ClaudeSessionID != prior {
+		t.Errorf("resume: ClaudeSessionID = %q, want preserved %q", out.ClaudeSessionID, prior)
+	}
+	if len(out.Args) != 2 || out.Args[0] != "--resume" || out.Args[1] != prior {
+		t.Errorf("resume: expected --resume %s, got %+v", prior, out.Args)
+	}
+}
+
 func TestInjectSessionID_Gemini(t *testing.T) {
 	out := &session.PrepareOutput{}
-	if !injectSessionIDFor("gemini", out) {
+	if !injectSessionIDFor(context.Background(), "gemini", out) {
 		t.Fatal("expected injection to fire for gemini")
 	}
 	if out.ClaudeSessionID == "" {
@@ -153,7 +173,7 @@ func TestInjectSessionID_CodexSkipped(t *testing.T) {
 	// Codex has no --session-id flag — must skip rather than emit a
 	// bogus arg that codex would reject.
 	out := &session.PrepareOutput{}
-	if injectSessionIDFor("codex", out) {
+	if injectSessionIDFor(context.Background(), "codex", out) {
 		t.Errorf("codex: injection should not fire (no --session-id support)")
 	}
 	if len(out.Args) != 0 || out.ClaudeSessionID != "" {
@@ -166,8 +186,8 @@ func TestInjectSessionID_FreshUUIDsAcrossSpawns(t *testing.T) {
 	// Claude sessions would race for the same *.jsonl.
 	out1 := &session.PrepareOutput{}
 	out2 := &session.PrepareOutput{}
-	injectSessionIDFor("claude", out1)
-	injectSessionIDFor("claude", out2)
+	injectSessionIDFor(context.Background(), "claude", out1)
+	injectSessionIDFor(context.Background(), "claude", out2)
 	if out1.ClaudeSessionID == out2.ClaudeSessionID {
 		t.Errorf("expected distinct UUIDs across spawns, got %q twice", out1.ClaudeSessionID)
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -362,7 +362,15 @@ func (m *Manager) spawn(ctx context.Context, sess Session, reactivate bool) (*ru
 	)
 	var preparedClaudeSessionID string
 	if p.Prepare != nil {
-		out, err := p.Prepare(WithSessionID(WithCwd(ctx, sess.Cwd), sess.ID), sess.ID, tempDir)
+		// On reactivation (Start/resume) carry the existing agent-side
+		// UUID into Prepare so the provider emits `--resume <id>` and
+		// the prior transcript continues, instead of minting a fresh
+		// session and orphaning history.
+		prepareCtx := WithSessionID(WithCwd(ctx, sess.Cwd), sess.ID)
+		if reactivate {
+			prepareCtx = WithResumeClaudeSessionID(prepareCtx, sess.ClaudeSessionID)
+		}
+		out, err := p.Prepare(prepareCtx, sess.ID, tempDir)
 		if err != nil {
 			_ = os.RemoveAll(tempDir)
 			return nil, fmt.Errorf("provider prepare: %w", err)

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -29,6 +30,14 @@ const (
 
 	defaultIdleThreshold = 30 * time.Second
 	defaultIdleInterval  = 5 * time.Second
+
+	// autoResumeConcurrency bounds how many interrupted sessions are
+	// re-spawned in parallel at startup. Each resume runs a provider
+	// Prepare (token reads, MCP config) + pty.Start, so we throttle to
+	// avoid a thundering herd on a box that just (re)booted. The total
+	// count is unbounded by default — the throttle, not a cap, keeps the
+	// spike bounded; OPENDRAY_AUTO_RESUME_MAX adds an optional hard cap.
+	autoResumeConcurrency = 4
 
 	// defaultVTCols / defaultVTRows seed the virtual terminal we keep
 	// for screen snapshots. Most modern CLIs query the real PTY size on
@@ -241,20 +250,69 @@ func (m *Manager) ReconcileStartup(ctx context.Context) error {
 			"count", len(ids), "reason", "OPENDRAY_NO_AUTO_RESUME set")
 		return nil
 	}
-	m.log.Info("resuming sessions interrupted by a prior gateway exit",
-		"count", len(ids))
+
+	// Optional hard cap. ids are newest-first, so a cap keeps the most
+	// recent and leaves the rest 'interrupted' (recoverable via an
+	// explicit Start). 0 / unset = no cap.
+	var skipped int
+	if max := autoResumeMaxFromEnv(); max > 0 && len(ids) > max {
+		skipped = len(ids) - max
+		ids = ids[:max]
+	}
+
+	// Resume in the background with bounded concurrency: startup must
+	// not block on N PTY spawns, and we must not fan out an unbounded
+	// burst at boot. Per-session failures are logged and leave the row
+	// 'interrupted' for a later manual / next-boot resume.
+	m.log.Info("auto-resuming interrupted sessions in background",
+		"count", len(ids), "skipped_over_cap", skipped,
+		"concurrency", autoResumeConcurrency)
+	go m.resumeInterrupted(ctx, ids)
+	return nil
+}
+
+// resumeInterrupted re-spawns the given sessions, at most
+// autoResumeConcurrency at a time, stopping early if ctx is cancelled
+// (gateway shutting down). Runs in its own goroutine off ReconcileStartup.
+func (m *Manager) resumeInterrupted(ctx context.Context, ids []string) {
+	sem := make(chan struct{}, autoResumeConcurrency)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
 	var resumed, failed int
 	for _, id := range ids {
-		if _, err := m.Start(ctx, id); err != nil {
-			m.log.Warn("startup auto-resume failed; session left interrupted",
-				"session_id", id, "err", err)
-			failed++
-			continue
+		if ctx.Err() != nil {
+			break // shutting down — stop launching more resumes
 		}
-		resumed++
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			if _, err := m.Start(ctx, id); err != nil {
+				m.log.Warn("startup auto-resume failed; session left interrupted",
+					"session_id", id, "err", err)
+				mu.Lock()
+				failed++
+				mu.Unlock()
+				return
+			}
+			mu.Lock()
+			resumed++
+			mu.Unlock()
+		}(id)
 	}
+	wg.Wait()
 	m.log.Info("startup auto-resume complete", "resumed", resumed, "failed", failed)
-	return nil
+}
+
+// autoResumeMaxFromEnv reads OPENDRAY_AUTO_RESUME_MAX; 0/unset/invalid
+// means no cap.
+func autoResumeMaxFromEnv() int {
+	n, err := strconv.Atoi(strings.TrimSpace(os.Getenv("OPENDRAY_AUTO_RESUME_MAX")))
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
 }
 
 // defaultSessionName derives a friendly label for sessions created

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -124,6 +124,15 @@ func (m *Manager) consumeStopRequest(id string) bool {
 	return v
 }
 
+// isClosing reports whether Shutdown has begun. waitExit uses it to
+// record a daemon-driven exit as 'interrupted' (resume on next start)
+// rather than 'ended' (a real, agent-initiated exit).
+func (m *Manager) isClosing() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.closed
+}
+
 // runningSession holds the runtime state for one active PTY-backed
 // session. The exported view (Manager.Get returns Session) snapshots
 // `sess` under sessMu.
@@ -210,7 +219,17 @@ func NewManager(pool *pgxpool.Pool, bus *eventbus.Hub, providers ProviderResolve
 // after NewManager and before serving traffic; failures to resume a
 // single session are logged and skipped, never fatal.
 func (m *Manager) ReconcileStartup(ctx context.Context) error {
-	ids, err := m.store.MarkRunningAsInterrupted(ctx)
+	// Crash path: a daemon that was SIGKILLed (or died hard) never ran
+	// waitExit, so its sessions are still 'running'/'idle'/'pending'.
+	// Flip them to 'interrupted'. A clean shutdown already marked its
+	// sessions 'interrupted' from waitExit, so nothing to flip there.
+	if _, err := m.store.MarkRunningAsInterrupted(ctx); err != nil {
+		return err
+	}
+	// Resume everything left in 'interrupted' — both the rows just
+	// flipped above (crash) and those recorded by waitExit during a
+	// graceful restart. This is the set that must come back live.
+	ids, err := m.store.ListInterrupted(ctx)
 	if err != nil {
 		return err
 	}
@@ -218,7 +237,7 @@ func (m *Manager) ReconcileStartup(ctx context.Context) error {
 		return nil
 	}
 	if os.Getenv("OPENDRAY_NO_AUTO_RESUME") != "" {
-		m.log.Info("marked interrupted sessions on startup; auto-resume disabled",
+		m.log.Info("interrupted sessions present on startup; auto-resume disabled",
 			"count", len(ids), "reason", "OPENDRAY_NO_AUTO_RESUME set")
 		return nil
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -201,20 +201,40 @@ func NewManager(pool *pgxpool.Pool, bus *eventbus.Hub, providers ProviderResolve
 	return m
 }
 
-// ReconcileStartup marks any DB rows in non-terminal states as
-// 'ended' (exit_code=-1). Call once after NewManager and before
-// serving traffic — otherwise WS clients reconnect forever to
-// sessions whose PTYs died with the old gateway process.
+// ReconcileStartup reconciles DB rows left non-terminal by a prior
+// gateway process (their PTYs died with it). Each such row is marked
+// 'interrupted', then — unless OPENDRAY_NO_AUTO_RESUME is set — the
+// session is re-spawned via Start, which for claude resumes the
+// original transcript (--resume <claude_session_id>) so a daemon
+// restart (e.g. a self-update) no longer destroys live work. Call once
+// after NewManager and before serving traffic; failures to resume a
+// single session are logged and skipped, never fatal.
 func (m *Manager) ReconcileStartup(ctx context.Context) error {
-	n, err := m.store.MarkAllRunningAsEnded(ctx)
+	ids, err := m.store.MarkRunningAsInterrupted(ctx)
 	if err != nil {
 		return err
 	}
-	if n > 0 {
-		m.log.Info("reconciled stale sessions on startup",
-			"count", n,
-			"reason", "previous gateway process exited; PTYs gone")
+	if len(ids) == 0 {
+		return nil
 	}
+	if os.Getenv("OPENDRAY_NO_AUTO_RESUME") != "" {
+		m.log.Info("marked interrupted sessions on startup; auto-resume disabled",
+			"count", len(ids), "reason", "OPENDRAY_NO_AUTO_RESUME set")
+		return nil
+	}
+	m.log.Info("resuming sessions interrupted by a prior gateway exit",
+		"count", len(ids))
+	var resumed, failed int
+	for _, id := range ids {
+		if _, err := m.Start(ctx, id); err != nil {
+			m.log.Warn("startup auto-resume failed; session left interrupted",
+				"session_id", id, "err", err)
+			failed++
+			continue
+		}
+		resumed++
+	}
+	m.log.Info("startup auto-resume complete", "resumed", resumed, "failed", failed)
 	return nil
 }
 

--- a/internal/session/provider.go
+++ b/internal/session/provider.go
@@ -128,3 +128,29 @@ func SessionIDFromContext(ctx context.Context) string {
 	}
 	return ""
 }
+
+// resumeClaudeSessionIDCtxKey carries the agent-side session UUID that
+// a reactivated (resumed) session should continue, so the provider's
+// Prepare emits `--resume <id>` instead of minting a fresh
+// `--session-id`. Without this, "resuming" a session spawned a brand
+// new agent conversation and orphaned the original transcript.
+type resumeClaudeSessionIDCtxKey struct{}
+
+// WithResumeClaudeSessionID returns a derived context carrying the
+// agent-side session UUID to resume. Empty is a no-op so call sites
+// (fresh spawns) needn't guard.
+func WithResumeClaudeSessionID(ctx context.Context, id string) context.Context {
+	if id == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, resumeClaudeSessionIDCtxKey{}, id)
+}
+
+// ResumeClaudeSessionIDFromContext returns the UUID set by
+// WithResumeClaudeSessionID, or "" when this is a fresh spawn.
+func ResumeClaudeSessionIDFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(resumeClaudeSessionIDCtxKey{}).(string); ok {
+		return v
+	}
+	return ""
+}

--- a/internal/session/pump.go
+++ b/internal/session/pump.go
@@ -156,12 +156,17 @@ func (m *Manager) waitExit(rs *runningSession) {
 	}
 
 	rs.endOnce.Do(func() {
-		// Distinguish user-initiated stops (Manager.Stop set
-		// stopRequested) from spontaneous exits. The DB row
-		// persists either way so the user can Restart.
+		// Classify the exit:
+		//   - user-initiated stop (Manager.Stop set stopRequested) → stopped
+		//   - daemon shutting down (Shutdown SIGTERMed us) → interrupted,
+		//     so startup reconciliation resumes it via claude_session_id
+		//   - otherwise the agent exited on its own → ended
+		// The DB row persists in every case so the user can Restart.
 		state := StateEnded
 		if m.consumeStopRequest(rs.sess.ID) {
 			state = StateStopped
+		} else if m.isClosing() {
+			state = StateInterrupted
 		}
 
 		dbCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -194,8 +199,11 @@ func (m *Manager) waitExit(rs *runningSession) {
 		m.mu.Unlock()
 
 		topic := "session.ended"
-		if state == StateStopped {
+		switch state {
+		case StateStopped:
 			topic = "session.stopped"
+		case StateInterrupted:
+			topic = "session.interrupted"
 		}
 		m.bus.Publish(eventbus.Event{
 			Topic: topic,

--- a/internal/session/pump.go
+++ b/internal/session/pump.go
@@ -156,18 +156,11 @@ func (m *Manager) waitExit(rs *runningSession) {
 	}
 
 	rs.endOnce.Do(func() {
-		// Classify the exit:
-		//   - user-initiated stop (Manager.Stop set stopRequested) → stopped
-		//   - daemon shutting down (Shutdown SIGTERMed us) → interrupted,
-		//     so startup reconciliation resumes it via claude_session_id
-		//   - otherwise the agent exited on its own → ended
-		// The DB row persists in every case so the user can Restart.
-		state := StateEnded
-		if m.consumeStopRequest(rs.sess.ID) {
-			state = StateStopped
-		} else if m.isClosing() {
-			state = StateInterrupted
-		}
+		// Classify the exit (see classifyExitState): a user stop wins,
+		// else a gateway shutdown is an interruption to auto-resume, else
+		// a normal end. The DB row persists in every case so the user can
+		// Restart. consumeStopRequest must run regardless to clear the flag.
+		state := classifyExitState(m.consumeStopRequest(rs.sess.ID), m.isClosing())
 
 		dbCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/internal/session/reconcile_test.go
+++ b/internal/session/reconcile_test.go
@@ -45,6 +45,26 @@ func TestStateIsTerminal(t *testing.T) {
 	}
 }
 
+func TestAutoResumeMaxFromEnv(t *testing.T) {
+	cases := []struct {
+		val  string
+		want int
+	}{
+		{"", 0},      // unset -> no cap
+		{"0", 0},     // explicit 0 -> no cap
+		{"5", 5},     // positive cap
+		{"  12 ", 12}, // trimmed
+		{"-3", 0},    // negative -> no cap
+		{"abc", 0},   // garbage -> no cap
+	}
+	for _, c := range cases {
+		t.Setenv("OPENDRAY_AUTO_RESUME_MAX", c.val)
+		if got := autoResumeMaxFromEnv(); got != c.want {
+			t.Errorf("OPENDRAY_AUTO_RESUME_MAX=%q -> %d, want %d", c.val, got, c.want)
+		}
+	}
+}
+
 // devDB returns a pool against OPENDRAY_DEV_DB_URL, skipping when unset
 // or unreachable (CI default until a Postgres service lands). Mirrors
 // internal/githost's helper.

--- a/internal/session/reconcile_test.go
+++ b/internal/session/reconcile_test.go
@@ -50,12 +50,12 @@ func TestAutoResumeMaxFromEnv(t *testing.T) {
 		val  string
 		want int
 	}{
-		{"", 0},      // unset -> no cap
-		{"0", 0},     // explicit 0 -> no cap
-		{"5", 5},     // positive cap
+		{"", 0},       // unset -> no cap
+		{"0", 0},      // explicit 0 -> no cap
+		{"5", 5},      // positive cap
 		{"  12 ", 12}, // trimmed
-		{"-3", 0},    // negative -> no cap
-		{"abc", 0},   // garbage -> no cap
+		{"-3", 0},     // negative -> no cap
+		{"abc", 0},    // garbage -> no cap
 	}
 	for _, c := range cases {
 		t.Setenv("OPENDRAY_AUTO_RESUME_MAX", c.val)

--- a/internal/session/reconcile_test.go
+++ b/internal/session/reconcile_test.go
@@ -1,0 +1,157 @@
+package session
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestClassifyExitState pins the precedence used by waitExit: a user
+// stop wins, a gateway shutdown is an interruption (auto-resumed on
+// next start), and anything else is a normal end. This is the core of
+// the 2026-05-23 fix that made graceful restarts preserve sessions.
+func TestClassifyExitState(t *testing.T) {
+	cases := []struct {
+		name          string
+		stop, closing bool
+		want          State
+	}{
+		{"user stop beats shutdown", true, true, StateStopped},
+		{"user stop", true, false, StateStopped},
+		{"shutdown -> interrupted", false, true, StateInterrupted},
+		{"spontaneous exit -> ended", false, false, StateEnded},
+	}
+	for _, c := range cases {
+		if got := classifyExitState(c.stop, c.closing); got != c.want {
+			t.Errorf("%s: classifyExitState(%v, %v) = %q, want %q",
+				c.name, c.stop, c.closing, got, c.want)
+		}
+	}
+}
+
+func TestStateIsTerminal(t *testing.T) {
+	for _, s := range []State{StateStopped, StateEnded, StateInterrupted} {
+		if !s.IsTerminal() {
+			t.Errorf("%q should be terminal", s)
+		}
+	}
+	for _, s := range []State{StatePending, StateRunning, StateIdle} {
+		if s.IsTerminal() {
+			t.Errorf("%q should not be terminal", s)
+		}
+	}
+}
+
+// devDB returns a pool against OPENDRAY_DEV_DB_URL, skipping when unset
+// or unreachable (CI default until a Postgres service lands). Mirrors
+// internal/githost's helper.
+//
+// WARNING: TestReconcileStoreInterrupted calls MarkRunningAsInterrupted,
+// which flips EVERY non-terminal row in the target database. Point this
+// at a DISPOSABLE dev database, never production.
+func devDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	url := os.Getenv("OPENDRAY_DEV_DB_URL")
+	if url == "" {
+		t.Skip("OPENDRAY_DEV_DB_URL not set; export a writable Postgres DSN to run this test")
+	}
+	pool, err := pgxpool.New(context.Background(), url)
+	if err != nil {
+		t.Skipf("dev DB unreachable, skipping: %v", err)
+	}
+	if err := pool.Ping(context.Background()); err != nil {
+		t.Skipf("dev DB ping failed, skipping: %v", err)
+	}
+	return pool
+}
+
+// TestReconcileStoreInterrupted verifies the store half of the restart-
+// preservation fix: MarkRunningAsInterrupted flips only non-terminal
+// rows (and returns them), and ListInterrupted enumerates them — while
+// rows the user explicitly stopped/ended stay put.
+func TestReconcileStoreInterrupted(t *testing.T) {
+	pool := devDB(t)
+	defer pool.Close()
+	st := newStore(pool)
+	ctx := context.Background()
+
+	mk := func(target State) string {
+		id := newID()
+		if err := st.Insert(ctx, Session{
+			ID: id, Name: "reconcile-test", ProviderID: "claude",
+			Cwd: "/tmp", Args: []string{}, State: StateRunning,
+			StartedAt: time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("insert %s: %v", target, err)
+		}
+		switch target {
+		case StateRunning:
+			// already running
+		case StateStopped, StateEnded:
+			if err := st.MarkTerminal(ctx, id, target, 0); err != nil {
+				t.Fatalf("mark %s: %v", target, err)
+			}
+		default: // idle / pending
+			if _, err := pool.Exec(ctx, `UPDATE sessions SET state=$1 WHERE id=$2`, string(target), id); err != nil {
+				t.Fatalf("set %s: %v", target, err)
+			}
+		}
+		return id
+	}
+
+	running, idle, pending := mk(StateRunning), mk(StateIdle), mk(StatePending)
+	stopped, ended := mk(StateStopped), mk(StateEnded)
+	all := []string{running, idle, pending, stopped, ended}
+	t.Cleanup(func() {
+		for _, id := range all {
+			_, _ = pool.Exec(ctx, `DELETE FROM sessions WHERE id=$1`, id)
+		}
+	})
+
+	flipped, err := st.MarkRunningAsInterrupted(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	set := func(ids []string) map[string]bool {
+		m := make(map[string]bool, len(ids))
+		for _, id := range ids {
+			m[id] = true
+		}
+		return m
+	}
+	got := set(flipped)
+	for _, id := range []string{running, idle, pending} {
+		if !got[id] {
+			t.Errorf("non-terminal session %s should have been flipped to interrupted", id)
+		}
+	}
+	for _, id := range []string{stopped, ended} {
+		if got[id] {
+			t.Errorf("terminal session %s must not be flipped", id)
+		}
+	}
+
+	listed := set(mustListInterrupted(t, st, ctx))
+	for _, id := range []string{running, idle, pending} {
+		if !listed[id] {
+			t.Errorf("ListInterrupted missing %s", id)
+		}
+	}
+	for _, id := range []string{stopped, ended} {
+		if listed[id] {
+			t.Errorf("ListInterrupted must not include terminal %s", id)
+		}
+	}
+}
+
+func mustListInterrupted(t *testing.T, st *sessionStore, ctx context.Context) []string {
+	t.Helper()
+	ids, err := st.ListInterrupted(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ids
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -22,12 +22,19 @@ const (
 	// StateEnded — process exited on its own (clean exit or crash).
 	// Row preserved; user can Restart or Remove.
 	StateEnded State = "ended"
+	// StateInterrupted — the session was live when the gateway process
+	// exited (e.g. a self-update restart), so its PTY died with no
+	// clean exit of its own. Distinct from 'ended' so startup
+	// reconciliation can tell "the daemon killed this" apart from "the
+	// agent exited", and auto-resume it. Terminal for Restart/resume.
+	StateInterrupted State = "interrupted"
 )
 
-// IsTerminal reports whether the session is no longer running. Both
-// stopped and ended are terminal.
+// IsTerminal reports whether the session is no longer running. Stopped,
+// ended, and interrupted are all terminal (the PTY is gone); each can
+// be re-spawned via Start.
 func (s State) IsTerminal() bool {
-	return s == StateStopped || s == StateEnded
+	return s == StateStopped || s == StateEnded || s == StateInterrupted
 }
 
 // Session is the public view of a PTY-backed CLI session. Runtime

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -37,6 +37,21 @@ func (s State) IsTerminal() bool {
 	return s == StateStopped || s == StateEnded || s == StateInterrupted
 }
 
+// classifyExitState decides which terminal state to record for a session
+// whose process just exited. Precedence: an explicit user stop wins;
+// otherwise a gateway shutdown makes it 'interrupted' (so startup
+// reconciliation resumes it); a spontaneous exit is a normal 'ended'.
+func classifyExitState(stopRequested, closing bool) State {
+	switch {
+	case stopRequested:
+		return StateStopped
+	case closing:
+		return StateInterrupted
+	default:
+		return StateEnded
+	}
+}
+
 // Session is the public view of a PTY-backed CLI session. Runtime
 // resources (PTY fd, ring buffer, subscribers) live on the Manager's
 // internal struct, not here.

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -162,6 +162,33 @@ func (s *sessionStore) MarkRunningAsInterrupted(ctx context.Context) ([]string, 
 	return ids, rows.Err()
 }
 
+// ListInterrupted returns the ids of every row currently in the
+// 'interrupted' state, newest first. These are sessions a prior gateway
+// left for resume: either flipped by MarkRunningAsInterrupted (the
+// daemon crashed before the exit detector ran) or recorded directly by
+// waitExit during a clean shutdown. Startup reconciliation re-spawns
+// them; once resumed they leave this state, so the set only ever holds
+// sessions still awaiting a successful resume.
+func (s *sessionStore) ListInterrupted(ctx context.Context) ([]string, error) {
+	rows, err := s.pool.Query(ctx, `
+        SELECT id FROM sessions
+        WHERE state='interrupted'
+        ORDER BY started_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("list interrupted: %w", err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan interrupted id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 // UpdateClaudeAccount rebinds the session's claude_account_id without
 // touching state/pid/etc. Used by Manager.SwitchClaudeAccount after a
 // successful respawn under a new credential.

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -134,6 +134,34 @@ func (s *sessionStore) MarkAllRunningAsEnded(ctx context.Context) (int64, error)
 	return res.RowsAffected(), nil
 }
 
+// MarkRunningAsInterrupted flips every non-terminal row to
+// 'interrupted' (exit_code=-1) and returns the affected session ids,
+// newest first. Unlike MarkAllRunningAsEnded it records that the
+// gateway — not the agent — killed these PTYs, so startup
+// reconciliation can auto-resume them via their preserved
+// claude_session_id. Rows that the user explicitly stopped/ended are
+// already terminal and untouched.
+func (s *sessionStore) MarkRunningAsInterrupted(ctx context.Context) ([]string, error) {
+	rows, err := s.pool.Query(ctx, `
+        UPDATE sessions
+        SET state='interrupted', ended_at=NOW(), exit_code=-1
+        WHERE state IN ('pending', 'running', 'idle')
+        RETURNING id`)
+	if err != nil {
+		return nil, fmt.Errorf("mark interrupted: %w", err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan interrupted id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 // UpdateClaudeAccount rebinds the session's claude_account_id without
 // touching state/pid/etc. Used by Manager.SwitchClaudeAccount after a
 // successful respawn under a new credential.


### PR DESCRIPTION
## Problem
A graceful `systemctl restart` (or a self-update) tears down every live session and they never come back. The CLI transcripts survive on disk, but the gateway can't reattach them — so a restart effectively destroys in-flight agent work.

## Root cause (two bugs)
1. **Resume never resumed.** `injectSessionIDFor` minted a *fresh* `--session-id` on every spawn — including the reactivate/`Start` path — then overwrote the row's `claude_session_id`. So "resuming" started a blank conversation and orphaned the original transcript.
2. **Restart marked sessions ended.** `Shutdown` SIGTERMs each session and `waitExit` recorded the exit as `ended` (143); `ReconcileStartup` only flipped `running → ended`. After a clean restart everything was already terminal, so nothing resumed (auto-resume only ever fired after a hard crash).

## Fix
- On reactivation, thread the existing agent UUID into `Prepare`; claude spawns with `--resume <id>` and the row's `claude_session_id` is preserved.
- New `StateInterrupted` (terminal, resumable). `waitExit` records `interrupted` when the daemon is closing (not a user stop) via `isClosing()`; distinct `session.interrupted` bus topic so restarts don't fire "ended" notifications.
- `ReconcileStartup` flips still-`running` rows (crash path) **and** resumes every `interrupted` row (clean-shutdown path). `OPENDRAY_NO_AUTO_RESUME` opts out.
- `POST /version/update` returns **409 `needsForce`** when sessions are live, so a self-update can't silently interrupt running work.

## Tests
`classifyExitState` precedence + `IsTerminal` (pure, always run); `TestReconcileStoreInterrupted` (DB-backed, skips without `OPENDRAY_DEV_DB_URL`, matching the existing githost/summarizer tests).

`go build ./... ` / `go vet` / `go test ./internal/session/... ./internal/catalog/... ./internal/app/...` all pass.
