### PR TITLE
fix(web): 401 redirect respects the base path (fixes 404 on restart)

### DIFF
--- a/app/shared/src/env.d.ts
+++ b/app/shared/src/env.d.ts
@@ -1,0 +1,11 @@
+// Minimal Vite env typing for the shared package, which doesn't pull in
+// vite/client. Only BASE_URL is needed here — Vite replaces
+// `import.meta.env.BASE_URL` with the configured base (e.g. "/admin/")
+// at build time. (Interface-merges harmlessly with vite/client in the
+// web app's own compilation.)
+interface ImportMetaEnv {
+  readonly BASE_URL: string
+}
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/app/shared/src/lib/api.ts
+++ b/app/shared/src/lib/api.ts
@@ -49,10 +49,16 @@ export async function api<T = unknown>(
           description: 'Please sign in again.',
         })
       }
-      const next = encodeURIComponent(
-        window.location.pathname + window.location.search,
-      )
-      window.location.assign(`/login?next=${next}`)
+      // The SPA is mounted under Vite's base path (e.g. "/admin/"), so a
+      // bare "/login" hits the server's 404 instead of the login route.
+      // Build the redirect under the base, and make `next` router-relative
+      // (strip the base) so post-login restore doesn't double-prefix it.
+      const base = import.meta.env.BASE_URL.replace(/\/$/, '') // "" dev, "/admin" prod
+      const path = window.location.pathname
+      const rel =
+        base && path.startsWith(base) ? path.slice(base.length) || '/' : path
+      const next = encodeURIComponent(rel + window.location.search)
+      window.location.assign(`${base}/login?next=${next}`)
     }
   }
 


### PR DESCRIPTION
## Problem
After a gateway restart, opening the dashboard shows a plain **"404 page not found"** instead of the login page.

## Root cause
1. Auth tokens live in an in-memory map (`internal/auth/auth.go`), so a restart invalidates them — the next request 401s.
2. The api client's 401 handler did a hard `window.location.assign('/login')`, but the SPA is mounted under Vite's base path (e.g. `/admin/`). A bare `/login` hits the Go server's 404, not the SPA's login route. (Verified: `/admin/login` → 200, `/login` → 404.)

## Fix
- Redirect under `import.meta.env.BASE_URL` → `/admin/login`.
- Make the `next` param router-relative (strip the base) so post-login restore doesn't double-prefix.
- Add a minimal `ImportMetaEnv` typing for the `shared` package (it doesn't pull in `vite/client`).

## Out of scope (related)
Tokens being in-memory means a restart logs you out entirely; persisting them is a sensible follow-up but touches auth, left separate.

`pnpm -C app/web exec tsc -b` and `pnpm -C app/web build` pass.
