### PR TITLE
fix(web): clipboard copy works over plain-http (not just HTTPS)

### DIFF
--- a/app/shared/src/lib/clipboard.ts
+++ b/app/shared/src/lib/clipboard.ts
@@ -1,0 +1,77 @@
+// copyText writes `text` to the clipboard, returning whether it
+// succeeded.
+//
+// The async Clipboard API (navigator.clipboard.writeText) is only
+// exposed in a *secure context* — https, or http on localhost. The
+// opendray dashboard is frequently reached over plain http on a LAN
+// IP (e.g. http://192.168.x.x:8770 from an iPad), where
+// navigator.clipboard is `undefined` and every writeText call throws
+// or no-ops. That's why "Copy" buttons silently fail on mobile.
+//
+// So we try the modern API when it's actually available, then fall
+// back to the legacy execCommand('copy') path, which works in
+// non-secure contexts (incl. iOS Safari) as long as it runs inside a
+// user gesture — which every caller here does (a tap/click handler).
+export async function copyText(text: string): Promise<boolean> {
+  if (
+    typeof navigator !== 'undefined' &&
+    navigator.clipboard &&
+    typeof window !== 'undefined' &&
+    window.isSecureContext
+  ) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch {
+      // Permission denied / transient failure — fall through to legacy.
+    }
+  }
+  return legacyCopy(text)
+}
+
+// legacyCopy stages the text in an off-screen <textarea>, selects it,
+// and runs document.execCommand('copy'). iOS Safari needs the node to
+// be actually rendered (not display:none) and needs an explicit
+// setSelectionRange — a bare .select() doesn't take on iOS.
+function legacyCopy(text: string): boolean {
+  if (typeof document === 'undefined') return false
+  const ta = document.createElement('textarea')
+  ta.value = text
+  ta.setAttribute('readonly', '')
+  // Keep it in the layout but invisible and inert.
+  ta.style.position = 'fixed'
+  ta.style.top = '0'
+  ta.style.left = '0'
+  ta.style.width = '1px'
+  ta.style.height = '1px'
+  ta.style.padding = '0'
+  ta.style.border = 'none'
+  ta.style.outline = 'none'
+  ta.style.boxShadow = 'none'
+  ta.style.background = 'transparent'
+  ta.style.opacity = '0'
+  document.body.appendChild(ta)
+
+  // Preserve whatever the user had selected so a programmatic copy
+  // doesn't clobber their selection.
+  const selection = document.getSelection()
+  const saved =
+    selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null
+
+  let ok = false
+  try {
+    ta.focus()
+    ta.select()
+    ta.setSelectionRange(0, text.length)
+    ok = document.execCommand('copy')
+  } catch {
+    ok = false
+  } finally {
+    document.body.removeChild(ta)
+    if (saved && selection) {
+      selection.removeAllRanges()
+      selection.addRange(saved)
+    }
+  }
+  return ok
+}

--- a/app/web/src/components/backup/BackupsView.tsx
+++ b/app/web/src/components/backup/BackupsView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Trans, useTranslation } from 'react-i18next'
+import { copyText } from '@/lib/clipboard'
 import {
   ChevronDown,
   ChevronRight,
@@ -456,7 +457,7 @@ function GeneratedPassphrasePanel({
   const pass = result.passphrase ?? ''
   async function copy() {
     try {
-      await navigator.clipboard.writeText(pass)
+      if (!(await copyText(pass))) throw new Error('clipboard unavailable')
       toast.success(t('web.backups.generated.copiedToast'))
     } catch {
       toast.error(t('web.backups.generated.copyFailedToast'))

--- a/app/web/src/components/integrations/APIKeyRevealDialog.tsx
+++ b/app/web/src/components/integrations/APIKeyRevealDialog.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import { Copy, AlertTriangle, Check, X } from 'lucide-react'
 import { Trans, useTranslation } from 'react-i18next'
 
+import { copyText } from '@/lib/clipboard'
+
 import {
   Dialog,
   DialogContent,
@@ -64,7 +66,7 @@ export function APIKeyRevealDialog({
 
   const copy = async () => {
     try {
-      await navigator.clipboard.writeText(apiKey)
+      if (!(await copyText(apiKey))) throw new Error('clipboard unavailable')
       setCopied(true)
       // Successful copy implies the operator has the key. Auto-ack
       // so they don't also need to click the checkbox.

--- a/app/web/src/components/sessions/DetectedURLs.tsx
+++ b/app/web/src/components/sessions/DetectedURLs.tsx
@@ -27,6 +27,7 @@ import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
 import { Button } from 'shared-ui/primitives/button'
+import { copyText } from '@/lib/clipboard'
 import {
   Dialog,
   DialogContent,
@@ -90,7 +91,7 @@ export function DetectedURLs({ urls }: DetectedURLsProps) {
   // ── N ≥ 2: primary anchor (open latest) + secondary ⋯ (open dialog) ──
   const handleCopy = async (url: string) => {
     try {
-      await navigator.clipboard.writeText(url)
+      if (!(await copyText(url))) throw new Error('clipboard unavailable')
       toast.success(t('web.sessions.terminal.urls.copiedToast'))
     } catch {
       toast.error(t('web.sessions.terminal.urls.copyFailedToast'))

--- a/app/web/src/components/sessions/inspector/DiffViewer.tsx
+++ b/app/web/src/components/sessions/inspector/DiffViewer.tsx
@@ -17,6 +17,7 @@ import {
   type DiffScope,
 } from '@/lib/git'
 import { cn } from '@/lib/utils'
+import { copyText } from '@/lib/clipboard'
 
 interface DiffViewerProps {
   open: boolean
@@ -59,7 +60,7 @@ export function DiffViewer({ open, onOpenChange, target }: DiffViewerProps) {
   const copy = async () => {
     if (!data) return
     try {
-      await navigator.clipboard.writeText(data)
+      if (!(await copyText(data))) throw new Error('clipboard unavailable')
       toast.success('Diff copied')
     } catch (e) {
       toast.error('Copy failed', { description: (e as Error).message })

--- a/app/web/src/components/sessions/inspector/FileViewerDialog.tsx
+++ b/app/web/src/components/sessions/inspector/FileViewerDialog.tsx
@@ -19,6 +19,7 @@ import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { readFile } from '@/lib/fs'
 import { cn } from '@/lib/utils'
+import { copyText } from '@/lib/clipboard'
 
 interface FileViewerDialogProps {
   path: string | null
@@ -57,7 +58,7 @@ export function FileViewerDialog({
   const copy = async () => {
     if (!data) return
     try {
-      await navigator.clipboard.writeText(data)
+      if (!(await copyText(data))) throw new Error('clipboard unavailable')
       toast.success('Copied to clipboard')
     } catch (e) {
       toast.error('Copy failed', { description: (e as Error).message })

--- a/app/web/src/components/sessions/inspector/HistoryPanel.tsx
+++ b/app/web/src/components/sessions/inspector/HistoryPanel.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { fetchSessionHistory, resendInput, type HistoryEntry } from '@/lib/sessions'
 import type { Session } from '@/lib/types'
+import { copyText } from '@/lib/clipboard'
 
 // HistoryPanel — Inspector tab. Lists every prompt the operator has
 // sent in this *project* (cwd), pooled across every Claude session
@@ -112,7 +113,7 @@ function HistoryRow({ entry, sessionID }: RowProps) {
 
   const copy = async () => {
     try {
-      await navigator.clipboard.writeText(entry.text)
+      if (!(await copyText(entry.text))) throw new Error('clipboard unavailable')
       toast.success('Copied prompt to clipboard')
     } catch (err) {
       toast.error('Copy failed', {

--- a/app/web/src/pages/Channels.tsx
+++ b/app/web/src/pages/Channels.tsx
@@ -13,6 +13,7 @@ import {
   Pencil,
 } from 'lucide-react'
 import { toast } from 'sonner'
+import { copyText } from '@/lib/clipboard'
 import { Trans, useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 
@@ -308,8 +309,10 @@ function ChannelCard({
                 size="sm"
                 className="h-6 px-2 text-[11px]"
                 onClick={() => {
-                  navigator.clipboard.writeText(webhookURL)
-                  toast.success(t('web.channels.card.webhookCopiedToast'))
+                  void copyText(webhookURL).then((ok) => {
+                    if (ok) toast.success(t('web.channels.card.webhookCopiedToast'))
+                    else toast.error(t('web.sessions.terminal.copyFailedToast'))
+                  })
                 }}
                 title={t('web.channels.card.copyWebhookTooltip')}
               >
@@ -1189,8 +1192,10 @@ function BridgeFields({
             variant="outline"
             size="sm"
             onClick={() => {
-              navigator.clipboard.writeText(token)
-              toast.success(t('web.channels.bridge.tokenCopiedToast'))
+              void copyText(token).then((ok) => {
+                if (ok) toast.success(t('web.channels.bridge.tokenCopiedToast'))
+                else toast.error(t('web.sessions.terminal.copyFailedToast'))
+              })
             }}
             title={t('web.channels.bridge.copyTooltip')}
           >
@@ -1401,10 +1406,15 @@ function CopyRow({
           variant="outline"
           size="sm"
           onClick={() => {
-            navigator.clipboard.writeText(value)
-            setCopied(true)
-            setTimeout(() => setCopied(false), 1500)
-            toast.success(t('web.channels.setup.copyLabelToast', { label }))
+            void copyText(value).then((ok) => {
+              if (!ok) {
+                toast.error(t('web.sessions.terminal.copyFailedToast'))
+                return
+              }
+              setCopied(true)
+              setTimeout(() => setCopied(false), 1500)
+              toast.success(t('web.channels.setup.copyLabelToast', { label }))
+            })
           }}
         >
           {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
@@ -1429,10 +1439,15 @@ function CodeBlock({ filename, code }: { filename: string; code: string }) {
           size="sm"
           className="h-7 text-[11px]"
           onClick={() => {
-            navigator.clipboard.writeText(code)
-            setCopied(true)
-            setTimeout(() => setCopied(false), 1500)
-            toast.success(t('web.channels.setup.codeCopiedToast'))
+            void copyText(code).then((ok) => {
+              if (!ok) {
+                toast.error(t('web.sessions.terminal.copyFailedToast'))
+                return
+              }
+              setCopied(true)
+              setTimeout(() => setCopied(false), 1500)
+              toast.success(t('web.channels.setup.codeCopiedToast'))
+            })
           }}
         >
           {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}


### PR DESCRIPTION
## Problem
Copy buttons silently do nothing on any **non-secure-context** origin — most commonly the dashboard served over **plain http on a LAN IP** (typical on mobile / iPad). `navigator.clipboard` is only exposed in a secure context (https or localhost), so every `writeText()` call is a no-op there.

## Fix
Add a shared `copyText()` helper (`app/shared/src/lib/clipboard.ts`): use the async Clipboard API when it's genuinely available (`navigator.clipboard && window.isSecureContext`), otherwise fall back to a staged off-screen `<textarea>` + `document.execCommand('copy')` — which works over plain http and in iOS Safari inside a user gesture (every caller is a tap handler).

Route the existing copy callsites through it: channels (webhook/token/label/code), API-key reveal, backup passphrase, file viewer, diff viewer, history panel, detected URLs.

**Pure bugfix** — no new UI, no behavior change beyond "copy now actually works." `tsc -b` + `vite build` pass.
