### PR TITLE
fix(memory): injection banner renders frontmatter memories as '- ---'

### DIFF
--- a/internal/memory/injector/inject.go
+++ b/internal/memory/injector/inject.go
@@ -190,21 +190,69 @@ func renderTopKPreface(mems []memory.Memory) string {
 	b.WriteString("\n## Recent project memory\n\n")
 	b.WriteString("opendray injected the following durable facts from prior sessions in this project:\n\n")
 	for _, m := range mems {
-		text := strings.TrimSpace(m.Text)
-		if text == "" {
+		line := bulletFor(m.Text)
+		if line == "" {
 			continue
 		}
-		// Take only the first line of multi-line memories — keeps
-		// the prefix compact even if a memory was a fenced block.
-		if i := strings.IndexByte(text, '\n'); i >= 0 {
-			text = text[:i]
-		}
 		b.WriteString("- ")
-		b.WriteString(text)
+		b.WriteString(line)
 		b.WriteString("\n")
 	}
 	b.WriteString("\nEnd of memory preface.\n")
 	return b.String()
+}
+
+const maxBulletLen = 200
+
+// bulletFor extracts a compact one-line summary of a memory for the
+// injection banner. Memories are commonly authored with YAML
+// frontmatter (---\n…\n---\n<body>); naively taking the first line then
+// yields the bare "---" delimiter (every bullet renders as "- ---"), so
+// we strip the frontmatter and prefer its `description:` field, falling
+// back to the first non-empty body line. Frontmatter-less memories keep
+// the original behaviour: their first non-empty line.
+func bulletFor(text string) string {
+	text = strings.TrimSpace(text)
+	body := text
+	if strings.HasPrefix(text, "---") {
+		rest := text[len("---"):]
+		if end := strings.Index(rest, "\n---"); end >= 0 {
+			front := rest[:end]
+			if d := yamlScalar(front, "description"); d != "" {
+				return clip(d)
+			}
+			body = strings.TrimSpace(rest[end+len("\n---"):])
+		}
+	}
+	return clip(firstNonEmptyLine(body))
+}
+
+func firstNonEmptyLine(s string) string {
+	for _, ln := range strings.Split(s, "\n") {
+		if t := strings.TrimSpace(ln); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+// yamlScalar pulls a top-level "key: value" scalar out of a frontmatter
+// block, trimming surrounding quotes. Deliberately avoids a YAML
+// dependency for a single field.
+func yamlScalar(front, key string) string {
+	for _, ln := range strings.Split(front, "\n") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(ln), key+":"); ok {
+			return strings.Trim(strings.TrimSpace(rest), `"'`)
+		}
+	}
+	return ""
+}
+
+func clip(s string) string {
+	if len(s) > maxBulletLen {
+		return strings.TrimSpace(s[:maxBulletLen]) + "…"
+	}
+	return s
 }
 
 // silence unused import

--- a/internal/memory/injector/inject_test.go
+++ b/internal/memory/injector/inject_test.go
@@ -101,6 +101,35 @@ func TestRender_TopKRecent_Renders(t *testing.T) {
 	}
 }
 
+func TestRender_TopKRecent_StripsFrontmatter(t *testing.T) {
+	// Memories authored with YAML frontmatter must not render their
+	// "---" delimiter as the bullet (the 2026-05-23 bug: every bullet
+	// came out as "- ---"). Prefer the description; fall back to the
+	// first body line.
+	mem := &fakeMemoryReader{
+		mems: []memory.Memory{
+			{ID: "1", Text: "---\nname: ct128-guard\ndescription: \"CT128 self-update disabled\"\nmetadata:\n  type: project\n---\n\nLong body that must NOT be the bullet."},
+			{ID: "2", Text: "---\nname: no-desc\n---\n\nBody first line is the bullet."},
+		},
+	}
+	inj := &Injector{memory: mem, log: silentLog()}
+	out, err := inj.renderTopKRecent(context.Background(),
+		Profile{StrategyKind: "top_k_recent", Config: map[string]any{"k": float64(2)}},
+		"/proj")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "- ---") {
+		t.Errorf("frontmatter delimiter leaked as a bullet: %q", out)
+	}
+	if !strings.Contains(out, "CT128 self-update disabled") {
+		t.Errorf("description not surfaced: %q", out)
+	}
+	if !strings.Contains(out, "Body first line is the bullet.") {
+		t.Errorf("body fallback not surfaced: %q", out)
+	}
+}
+
 func TestRender_TopKRecent_EmptyMemoriesReturnsEmpty(t *testing.T) {
 	mem := &fakeMemoryReader{mems: nil}
 	inj := &Injector{memory: mem, log: silentLog()}


### PR DESCRIPTION
## Problem
The per-session "Recent project memory" injection banner renders every fact as **`- ---`**, so a new session inherits a useless preface even though the memories are stored fine.

Cause: `renderTopKPreface` takes the **first line** of each memory's text as the bullet. Memories authored with YAML frontmatter (`---\nname: …\ndescription: …\n---\n\n<body>`) have `---` as their first line → every bullet becomes `- ---`.

This is **embedder-independent** — the injector uses `memory.List` (recency), not `Search` — so it's broken regardless of the embedder backend (bm25/http/etc.).

## Fix
`bulletFor()`: strip a leading YAML frontmatter block and prefer its `description:` field; fall back to the first non-empty body line. Frontmatter-less memories keep the original first-line behaviour. Bullets clipped to 200 chars.

## Test
New `TestRender_TopKRecent_StripsFrontmatter` (uses the real frontmatter shape; asserts no `- ---` leak, description surfaced, body fallback works). Existing render tests still pass. gofmt/vet clean.
