### PR TITLE
fix(web): version + self-update API called at wrong path (missing /api/v1)

### DIFF
--- a/app/shared/src/lib/version.ts
+++ b/app/shared/src/lib/version.ts
@@ -27,12 +27,12 @@ export interface SelfUpdateResponse {
 }
 
 export async function getVersionInfo(): Promise<VersionInfo> {
-  return api<VersionInfo>('/version')
+  return api<VersionInfo>('/api/v1/version')
 }
 
 export async function requestSelfUpdate(
   force = false,
 ): Promise<SelfUpdateResponse> {
   const q = force ? '?force=true' : ''
-  return api<SelfUpdateResponse>(`/version/update${q}`, { method: 'POST' })
+  return api<SelfUpdateResponse>(`/api/v1/version/update${q}`, { method: 'POST' })
 }


### PR DESCRIPTION
## Problem
The Settings → About version display is blank/`—` and the self-update button does nothing, on every install.

`version.ts` calls `api('/version')` and `api('/version/update')`, but `api()` does **not** prepend `/api/v1` — every other caller passes the full path (e.g. `api('/api/v1/sessions')`). So these requests hit `/version`, which 404s (or returns the SPA), the About version query errors out, and the self-update POST never reaches the handler.

## Fix
Prefix both with `/api/v1` to match the rest of the client:
- `getVersionInfo` → `/api/v1/version`
- `requestSelfUpdate` → `/api/v1/version/update`

One-line client fix; no backend or behavior change beyond the calls now reaching their handlers. `tsc -b` + `vite build` pass.
