### PR TITLE
fix(install): put `opendray` on PATH on macOS

### DIFF
--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -493,6 +493,28 @@ fi
 log_ok "Installed: $OPENDRAY_BIN"
 "$OPENDRAY_BIN" version
 
+# ── Put `opendray` on the interactive PATH ───────────────────────────
+# The binary lives under $OPENDRAY_HOME/bin (default ~/.opendray/bin),
+# which is NOT on the default macOS PATH — the launchd service runs via
+# the absolute path, but an interactive `opendray …` wouldn't resolve.
+# Link it into Homebrew's bin: it's already on PATH for any working brew
+# setup and user-writable (no sudo), and resolves on both Intel
+# (/usr/local/bin) and Apple Silicon (/opt/homebrew/bin).
+OD_PATH_NOTE=""
+if [ "$(command -v opendray 2>/dev/null || true)" = "$OPENDRAY_BIN" ]; then
+    log_ok "opendray already on PATH"
+else
+    OD_LINK_DIR="$BREW_PREFIX/bin"
+    if mkdir -p "$OD_LINK_DIR" 2>/dev/null && [ -w "$OD_LINK_DIR" ]; then
+        ln -sf "$OPENDRAY_BIN" "$OD_LINK_DIR/opendray"
+        log_ok "Linked opendray → $OD_LINK_DIR/opendray (on PATH)"
+    else
+        OD_PATH_NOTE="$OPENDRAY_HOME/bin"
+        log_warn "Could not link into $OD_LINK_DIR — add opendray to PATH yourself:"
+        log_warn "    echo 'export PATH=\"$OD_PATH_NOTE:\$PATH\"' >> ~/.zshrc && source ~/.zshrc"
+    fi
+fi
+
 # ───────────────────────────────────────────────────────────────────────
 # Phase 9 — Config + migrate
 # ───────────────────────────────────────────────────────────────────────
@@ -737,11 +759,18 @@ case "$HOST_PART" in
         ;;
 esac
 
+if [ -n "$OD_PATH_NOTE" ]; then
+    OD_CLI_LINE="opendray   ${C_YEL}← add ${OD_PATH_NOTE} to PATH first (see above)${C_NC}"
+else
+    OD_CLI_LINE="opendray version"
+fi
+
 cat <<EOF
   ${C_BLU}Admin UI${C_NC}        ${WEB_URL}${WEB_URL_NOTE}
   ${C_BLU}Username${C_NC}        ${OD_ADMIN_USER}
   ${C_BLU}Password${C_NC}        ${OD_ADMIN_PW}   ${C_YEL}← rotate via Settings → Admin on first login${C_NC}
 
+  ${C_BLU}CLI${C_NC}             ${OD_CLI_LINE}
   ${C_BLU}Config${C_NC}          ${OD_CONFIG_PATH}
   ${C_BLU}Logs${C_NC}            ${OPENDRAY_HOME}/logs/opendray.{log,err}
   ${C_BLU}Service${C_NC}         launchctl kickstart -k ${DOMAIN}/${LABEL}     # restart

--- a/scripts/uninstall-macos.sh
+++ b/scripts/uninstall-macos.sh
@@ -148,6 +148,20 @@ if [ "$HAS_BIN" = "1" ]; then
     log_ok "Removed $OPENDRAY_HOME/bin/opendray"
 fi
 
+# Remove the PATH symlink the installer created in Homebrew's bin
+# (either arch). Only unlink when it points back into our install, so
+# an unrelated `opendray` on PATH is never touched. readlink still
+# returns the stored target even after the binary above is gone.
+for _link in "/usr/local/bin/opendray" "/opt/homebrew/bin/opendray"; do
+    if [ -L "$_link" ]; then
+        case "$(readlink "$_link" 2>/dev/null || true)" in
+            "$OPENDRAY_HOME"/*)
+                rm -f "$_link" && log_ok "Removed PATH symlink $_link"
+                ;;
+        esac
+    fi
+done
+
 # ───────────────────────────────────────────────────────────────────────
 # Phase 3 — Purge
 # ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The macOS installer drops the binary in `~/.opendray/bin`, which is **not on the default macOS PATH**. The launchd service uses the absolute path, so the gateway runs fine — but an interactive `opendray …` (e.g. `opendray version`, `opendray migrate`) doesn't resolve after a fresh install. Linux already installs to `/usr/local/bin` (on PATH); only macOS had the gap.

## Fix

`scripts/install-macos.sh`: after installing the binary, symlink it into Homebrew's `bin`:
- Already on PATH for any working brew setup, and user-writable, so **no sudo**.
- Resolves on both Intel (`/usr/local/bin`) and Apple Silicon (`/opt/homebrew/bin`) via `$BREW_PREFIX`.
- Skips silently if `opendray` already resolves to our binary; falls back to printing the `export PATH …` line if the dir isn't writable.
- Final summary gains a **CLI** line reflecting the outcome.

`scripts/uninstall-macos.sh`: removes the symlink too — but **only when it points back into `~/.opendray`**, so an unrelated `opendray` on PATH is never touched.

## Notes

- No changes outside the two macOS scripts; no workflow/CI files touched.
- Shell logic + symlink guard validated locally; the live `brew --prefix` resolution is worth a real run on a Mac with Homebrew.