### PR TITLE
chore(deps): sync demo-client lockfile with package.json (ws 8.21.0)

### DIFF
--- a/examples/integrations/demo-client/pnpm-lock.yaml
+++ b/examples/integrations/demo-client/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^16.4.5
         version: 16.6.1
       ws:
-        specifier: ^8.18.0
-        version: 8.20.0
+        specifier: ^8.20.1
+        version: 8.21.0
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -225,8 +225,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -376,4 +376,4 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  ws@8.20.0: {}
+  ws@8.21.0: {}


### PR DESCRIPTION
## Summary

- PR #255 bumped the `ws` range to `^8.20.1` in `examples/integrations/demo-client/package.json` but left the lockfile pinned at `8.20.0`.
- Dependabot does not run a lockfile-only install for this example because it sits under `examples/integrations/` and is excluded from `pnpm-workspace.yaml` (which only includes `app/*`).
- Resolved by running `pnpm install --lockfile-only --ignore-workspace` inside the demo. pnpm picked `ws@8.21.0`, which satisfies the new caret range and contains the `websocket.close()` uninitialised-memory disclosure fix originally shipped in 8.20.1.

## Scope

- Only touches `examples/integrations/demo-client/pnpm-lock.yaml`.
- Main workspace (`app/*`) is unaffected.

## Test plan

- [x] `pnpm install --lockfile-only --ignore-workspace` runs cleanly inside `examples/integrations/demo-client/`.
- [x] Lockfile now records `ws@8.21.0`, matching the `^8.20.1` specifier from PR #255.
- [ ] CI passes (Backend Go / Frontend web / Lint Go).

🤖 Generated with [Claude Code](https://claude.com/claude-code)