### PR TITLE
fix(channels): distinguish notify_on=[] (all) from notify_on=__none__ (muted)

### DIFF
--- a/app/web/src/pages/Channels.tsx
+++ b/app/web/src/pages/Channels.tsx
@@ -294,7 +294,10 @@ function ChannelCard({
             {Array.isArray(cfg.notify_on) && (cfg.notify_on as string[]).length > 0 && (
               <span>
                 {t('web.channels.card.notifyOnLabel')}{' '}
-                {(cfg.notify_on as string[]).join(', ')}
+                {(cfg.notify_on as string[]).length === 1 &&
+                (cfg.notify_on as string[])[0] === NOTIFY_TOPIC_NONE
+                  ? t('web.channels.notifications.hintNone')
+                  : (cfg.notify_on as string[]).join(', ')}
               </span>
             )}
           </div>
@@ -701,10 +704,16 @@ function valuesFromConfig(
   // as a string array (or absent); cooldown as a number (or absent
   // → DEFAULT_COOLDOWN).
   if (Array.isArray(config.notify_on)) {
-    out.notify_on = (config.notify_on as unknown[])
+    const arr = (config.notify_on as unknown[])
       .map((v) => String(v))
       .filter((s) => s.length > 0)
-      .join(',')
+    if (arr.length === 1 && arr[0] === NOTIFY_TOPIC_NONE) {
+      // Round-trip the explicit-mute state back into the form so the
+      // checkboxes render "all unchecked" instead of "all checked".
+      out.notify_on = NOTIFY_TOPIC_NONE
+    } else {
+      out.notify_on = arr.join(',')
+    }
   } else {
     out.notify_on = ''
   }
@@ -736,6 +745,13 @@ function valuesFromConfig(
 // Order matches the order they're rendered as checkboxes.
 const SESSION_TOPICS = ['session.started', 'session.idle', 'session.ended'] as const
 
+// Sentinel stored in notify_on to express "explicitly opt out of every
+// topic". Distinct from notify_on=[], which means "no filter, match
+// all" — that ambiguity was the source of issues #222 and #223 (last
+// deselected topic silently re-enabled all three on the next render).
+// Mirrors NotifyTopicNone in internal/channel/hub.go — keep in sync.
+const NOTIFY_TOPIC_NONE = '__none__'
+
 const NOTIFY_MODE_VALUES = ['once', 'cooldown', 'every'] as const
 const COOLDOWN_VALUES = ['60', '300', '900', '1800', '3600'] as const
 const SNIPPET_CAP_VALUES = ['0', '1000', '3000', '6000', '12000'] as const
@@ -757,10 +773,20 @@ function NotificationFields({
   setValue: (name: string, val: string) => void
 }) {
   const { t } = useTranslation()
-  // Stored as comma-separated topics. Empty string = all topics
-  // (matches the backend's notify_on=[] = "any" semantics).
-  const selected = parseTopicList(values.notify_on ?? '')
-  const isAllSelected = selected.length === 0 || selected.length === SESSION_TOPICS.length
+  // Three-state encoding for notify_on, kept in sync with the backend:
+  //   ''               → "all topics" (no filter, the default for new
+  //                      channels and the historical empty-array value)
+  //   NOTIFY_TOPIC_NONE→ explicit opt-out of every topic (muted via
+  //                      the topic filter, without disabling the channel)
+  //   'a,b'            → only the listed topics
+  // Pre-fix this row collapsed states 1 and 2, so deselecting the last
+  // badge silently re-enabled all three (#223) and made the configured
+  // value drift in ways that masked #222.
+  const rawNotify = (values.notify_on ?? '').trim()
+  const isExplicitNone = rawNotify === NOTIFY_TOPIC_NONE
+  const selected = isExplicitNone ? [] : parseTopicList(rawNotify)
+  const isAllSelected =
+    !isExplicitNone && (rawNotify === '' || selected.length === SESSION_TOPICS.length)
 
   const mode = values.notify_mode ?? DEFAULT_NOTIFY_MODE
   const cooldown = values.notify_cooldown_s ?? DEFAULT_COOLDOWN
@@ -782,15 +808,21 @@ function NotificationFields({
   const modeHint = modeHintMap[mode] ?? ''
 
   const toggleTopic = (topic: string) => {
-    // First click: convert "all" → explicit list of remaining ones.
+    // First click on a default-state channel: materialise the implicit
+    // "all" into an explicit list so we can subtract from it.
     const base = isAllSelected ? [...SESSION_TOPICS] : selected
     const next = base.includes(topic)
       ? base.filter((t) => t !== topic)
       : [...base, topic]
-    // If the result is "all three", store as empty (= match all)
-    // so the channel keeps receiving any topics added in future.
     if (next.length === SESSION_TOPICS.length) {
+      // All three selected → collapse back to "match all" so future
+      // topics added to SESSION_TOPICS keep flowing without re-edits.
       setValue('notify_on', '')
+    } else if (next.length === 0) {
+      // Zero selected → the explicit-mute state. Storing the sentinel
+      // (instead of '') preserves the user's intent across renders;
+      // backend dispatch drops every event for channels in this state.
+      setValue('notify_on', NOTIFY_TOPIC_NONE)
     } else {
       setValue('notify_on', next.join(','))
     }
@@ -1062,11 +1094,18 @@ function buildConfigFromValues(
   }
   // Synthetic notification fields — every non-bridge channel receives
   // these, regardless of whether they're declared in def.fields.
-  const topics = parseTopicList(values.notify_on ?? '')
-  if (topics.length > 0 && topics.length < SESSION_TOPICS.length) {
-    // Persist explicit selection. All-three-selected is omitted to
-    // mean "any topic" (matches the backend default).
-    cfg.notify_on = topics
+  const rawNotify = (values.notify_on ?? '').trim()
+  if (rawNotify === NOTIFY_TOPIC_NONE) {
+    // Explicit opt-out: persist the sentinel so dispatch drops every
+    // event for this channel (issue #223 fix).
+    cfg.notify_on = [NOTIFY_TOPIC_NONE]
+  } else {
+    const topics = parseTopicList(rawNotify)
+    if (topics.length > 0 && topics.length < SESSION_TOPICS.length) {
+      // Persist explicit selection. All-three-selected is omitted to
+      // mean "any topic" (matches the backend default).
+      cfg.notify_on = topics
+    }
   }
   // Repeat policy: persist mode unless it's the default ("once" = no
   // emit so existing channels picked up by the new code keep their

--- a/internal/channel/hub.go
+++ b/internal/channel/hub.go
@@ -736,7 +736,7 @@ func (h *Hub) dispatch(ctx context.Context, ev eventbus.Event) {
 		if err != nil {
 			continue
 		}
-		if len(topics) > 0 && !contains(topics, ev.Topic) {
+		if !shouldDispatchTopic(topics, ev.Topic) {
 			continue
 		}
 		if h.suppressByPolicy(ctx, c.ID(), ev.Topic, sessionID) {
@@ -980,6 +980,28 @@ func (h *Hub) notifyTopicsFor(ctx context.Context, channelID string) ([]string, 
 	}
 	_ = json.Unmarshal(row.Config, &cfg)
 	return cfg.NotifyOn, nil
+}
+
+// NotifyTopicNone is the sentinel that, when stored as the sole entry of
+// notify_on, marks an *explicit* opt-out of every topic — distinct from
+// notify_on=[] (the historical "match all" default). The UI needs this
+// to express "no topics selected" without rendering as "everything
+// selected" on the next read, see [shouldDispatchTopic].
+const NotifyTopicNone = "__none__"
+
+// shouldDispatchTopic decides whether a dispatched event passes a
+// channel's notify_on filter. Semantics:
+//   - len==0           → match all (no filter configured)
+//   - == [NotifyTopicNone] → match none (explicit opt-out)
+//   - otherwise        → match only the listed topics
+func shouldDispatchTopic(topics []string, eventTopic string) bool {
+	if len(topics) == 0 {
+		return true
+	}
+	if len(topics) == 1 && topics[0] == NotifyTopicNone {
+		return false
+	}
+	return contains(topics, eventTopic)
 }
 
 // CreateChannel registers a new channel and starts it if enabled.

--- a/internal/channel/hub_dispatch_test.go
+++ b/internal/channel/hub_dispatch_test.go
@@ -1,0 +1,42 @@
+package channel
+
+import "testing"
+
+// shouldDispatchTopic is the pure topic-filter predicate used inside
+// (*Hub).dispatch. The bug fixed alongside issues #222/#223 added the
+// NotifyTopicNone sentinel so the UI can express "explicitly muted by
+// topic filter" without colliding with the historical "notify_on=[] =
+// match all" default. These cases pin every branch.
+func TestShouldDispatchTopic(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		topics []string
+		topic  string
+		want   bool
+	}{
+		{"nil filter matches all", nil, "session.idle", true},
+		{"empty filter matches all", []string{}, "session.idle", true},
+		{"empty filter matches ended too", []string{}, "session.ended", true},
+		{"sentinel none drops idle", []string{NotifyTopicNone}, "session.idle", false},
+		{"sentinel none drops ended", []string{NotifyTopicNone}, "session.ended", false},
+		{"sentinel none drops started", []string{NotifyTopicNone}, "session.started", false},
+		{"single topic match", []string{"session.idle"}, "session.idle", true},
+		{"single topic miss", []string{"session.idle"}, "session.ended", false},
+		{"multi topic match first", []string{"session.idle", "session.ended"}, "session.idle", true},
+		{"multi topic match last", []string{"session.idle", "session.ended"}, "session.ended", true},
+		{"multi topic miss", []string{"session.idle", "session.ended"}, "session.started", false},
+		{"sentinel mixed with real topic stays a match", []string{NotifyTopicNone, "session.idle"}, "session.idle", true},
+		{"sentinel mixed treats sentinel as ordinary string when not sole entry", []string{NotifyTopicNone, "session.idle"}, "session.ended", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldDispatchTopic(tc.topics, tc.topic); got != tc.want {
+				t.Errorf("shouldDispatchTopic(%v, %q) = %v, want %v", tc.topics, tc.topic, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #222.
Closes #223.

## Problem

The notification topic filter conflated two distinct states:

| stored `notify_on` | intended meaning | how the UI rendered |
|---|---|---|
| `[]` (new channel) | "match all topics" | all three badges checked |
| `[]` (user deselected the last topic) | "match none" | all three badges checked _again_ |

The frontend `isAllSelected` predicate treated `selected.length === 0`
the same as `selected.length === SESSION_TOPICS.length`. Toggling the
last selected badge wrote `notify_on = ""`, so on the next render every
badge reappeared as checked and the `hintNone` branch was dead code.

That in turn produced the configurations behind #222: channels stuck at
`notify_on=["session.ended"]` because operators could not cleanly reach
a "none" state — so the model's `session.idle` replies were silently
filtered out and the chat felt one-way.

## Fix

Introduce a sentinel `__none__` to mark _explicit opt-out_:

**Backend** (`internal/channel/hub.go`)
- Export `NotifyTopicNone = "__none__"`.
- Extract `shouldDispatchTopic(topics, eventTopic)` so the predicate is
  independently testable.
- `dispatch` treats `[NotifyTopicNone]` as "drop everything", while
  `[]` continues to mean "match all" — no data migration needed.

**Frontend** (`app/web/src/pages/Channels.tsx`)
- `NOTIFY_TOPIC_NONE` mirrors the Go constant.
- `isExplicitNone` breaks the 0-vs-N collision in `isAllSelected`.
- `toggleTopic` writes the sentinel when the user clears the last
  topic instead of falling back to `""` (which previously re-enabled
  every topic).
- `valuesFromConfig` and `buildConfigFromValues` round-trip the sentinel.
- The card list and the `hintNone` string render correctly in the
  muted state (`hintNone` was previously unreachable dead code).

## Tests

- `internal/channel/hub_dispatch_test.go`: 13 table cases covering
  nil / empty / sentinel / single-topic / multi-topic / sentinel-mixed
  paths.
- `go test ./internal/channel/... -race` ✅
- `pnpm tsc --noEmit` ✅
- `pnpm build` ✅
- `pnpm lint` baseline unchanged (3 pre-existing errors in untouched
  code at lines 424/454/463, same on `main`).

## Manual test plan

1. Create a new Telegram channel → all 3 topic badges checked
   ("Receiving every session event"). Save and verify
   `SELECT config FROM channels`: no `notify_on` key written.
2. Deselect `session.started` → "1 of 3" hint,
   `notify_on=["session.idle","session.ended"]`.
3. Deselect `session.idle` → "1 of 3" hint, `notify_on=["session.ended"]`.
4. Deselect `session.ended` → **all 3 badges turn outline** (not all
   re-checked), hint reads `No events selected — outbound notifications
   muted`, `notify_on=["__none__"]`.
5. Reopen the channel → still shows the muted state, not "all selected".
6. Click any badge → exits muted mode back into a 1-of-3 selection.

## Migration note

Existing channels that already store `notify_on=["session.ended"]` — the
exact state described in the #222 report — are unaffected by this PR.
That value is still a valid storage shape and will continue to filter
only `session.ended`. To clear it, either re-edit the channel in the
UI (the Notify-on row now shows all-checked → click each unwanted topic
or reset by ticking the rest) or run:

```sql
UPDATE channels
   SET config = config - 'notify_on'
 WHERE kind IN ('telegram','slack','discord','feishu','dingtalk','wecom')
   AND config->'notify_on' IS NOT NULL;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)