### PR TITLE
fix(install-linux): correct post-install AI CLI login instructions

### DIFF
--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -234,14 +234,19 @@ cat <<'EOF'
 
   ┌─ Heads up ──────────────────────────────────────────────────────┐
   │ The CLIs are installed but NOT logged in. After this wizard,    │
-  │ run their login command interactively at least once:            │
+  │ run each login command as the opendray service user so the      │
+  │ daemon can read the resulting credentials:                      │
   │                                                                 │
-  │   claude login    # opens browser OAuth                         │
-  │   gemini auth login                                             │
-  │   codex login     # check CLI's own docs                        │
+  │   sudo -u opendray -H claude auth login                         │
+  │   sudo -u opendray -H codex login --device-auth                 │
+  │   sudo -u opendray -H GEMINI_CLI_NO_BROWSER=true gemini         │
+  │     (gemini has no `login` subcommand; run it once,             │
+  │      paste the device code from codeassist.google.com/          │
+  │      authcode at the prompt, then ^C to exit)                   │
   │                                                                 │
-  │ Credentials live in your user homedir and opendray picks them   │
-  │ up automatically when it spawns sessions.                       │
+  │ Credentials are written under                                   │
+  │   /var/lib/opendray/.{codex,gemini,claude}/                     │
+  │ which is where the daemon reads them at session spawn time.     │
   └─────────────────────────────────────────────────────────────────┘
 EOF
 
@@ -776,7 +781,15 @@ cat <<EOF
   Next:
     1. Open the admin UI (link above is clickable in most terminals),
        log in as ${OD_ADMIN_USER}, rotate the admin password.
-    2. Finish logging your AI CLI(s) in (claude login / gemini auth login / codex login).
+    2. Finish logging your AI CLI(s) in as the opendray service user so
+       the daemon can read the resulting credentials under
+       /var/lib/opendray/.{codex,gemini,claude}/ :
+         sudo -u opendray -H claude auth login
+         sudo -u opendray -H codex login --device-auth
+         sudo -u opendray -H GEMINI_CLI_NO_BROWSER=true gemini
+       (gemini has no 'login' subcommand — run it once interactively,
+        paste the device code from codeassist.google.com/authcode at
+        the prompt, then ^C to exit.)
     3. Providers → register the CLI binary path (e.g. \$(which claude)).
     4. Sessions → New session → spawn your first session.
 


### PR DESCRIPTION
Closes #219.

## Problem

The post-install **Heads up** banner and the trailing **Next steps**
checklist printed three login commands that do not work as written for
the typical opendray service-user install. Operators copy-paste them,
see no immediate errors, and then later hit "the daemon can't see any
credentials" with no useful diagnostic.

| Old | What's wrong |
|---|---|
| `gemini auth login` | gemini-cli 0.42.0 has no `auth` and no `login` subcommand — copy-pasting it returns `Unknown command`. |
| `codex login` | Without `--device-auth`, opens a local OAuth callback on `localhost:1455`; on a remote CT/VM accessed via SSH the operator's browser can't reach it. |
| `claude login` | Claude Code 2.x removed the top-level alias; the working invocation is `claude auth login`. |
| "Credentials live in your user homedir…" | The systemd unit runs as `User=opendray` with `HOME=/var/lib/opendray`. A login run as root (typical pct enter / fresh SSH) writes to `/root/.codex/auth.json` etc., never read by the daemon. Symptom is a delayed session-spawn failure with no useful message. |

## Fix

Rewrite both surfaces so the printed commands actually work:

- Every login is wrapped in `sudo -u opendray -H <cmd>` so the
  resulting credential files land in the daemon's `HOME`
  (`/var/lib/opendray`), where it actually reads them.
- Use the current, working CLI invocation for each tool:
  - `claude auth login`
  - `codex login --device-auth`
  - `GEMINI_CLI_NO_BROWSER=true gemini` (interactive paste-the-code flow)
- Spell out the gemini-cli "no login subcommand" quirk inline so the
  operator isn't surprised by the prompt-then-exit pattern.
- State the credential destination explicitly:
  `/var/lib/opendray/.{codex,gemini,claude}/`.

## Verification

- `bash -n scripts/install-linux.sh` ✅
- Banner box-drawing re-aligned to 73 bytes per line (verified with `awk '{print length}'`).
- `gemini --help` (0.42.0): confirmed no `auth` or `login` subcommand exists.
- `codex login --help` (0.130.0): confirmed `--device-auth` flag exists.
- `claude --help` (2.1.142): confirmed `auth` subcommand replaces the
  old top-level `login`.

## Not in scope

The issue's "out of scope / follow-up ideas" section mentions
auto-driving the logins from the wizard and adding `--skip-trust` to
`internal/catalog/builtin/gemini.json`. Those are separate
enhancements; this PR only fixes the wrong instructions that operators
follow today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)