### PR TITLE
fix(i18n): use {var} interpolation in 9 strings (was {{var}} = literal templates)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -964,11 +964,11 @@
           "mcp": "mcp"
         },
         "notInstalled": "not installed",
-        "updateAvailable": "update available → {{version}}",
+        "updateAvailable": "update available → {version}",
         "upToDate": "up to date",
-        "update": "Update to {{version}}",
+        "update": "Update to {version}",
         "updating": "Updating…",
-        "updatedToast": "Updated {{from}} → {{to}}",
+        "updatedToast": "Updated {from} → {to}",
         "alreadyLatestToast": "Already up to date",
         "updateFailedToast": "Update failed",
         "updateUnavailable": "In-app update not available here"
@@ -1011,11 +1011,11 @@
         "empty": "No models configured yet.",
         "add": "Add",
         "addPlaceholder": "model id (e.g. sonnet)",
-        "suggested": "Suggested ({{count}})",
+        "suggested": "Suggested ({count})",
         "default": "default",
         "makeDefault": "set default",
         "setDefault": "Use as the default model",
-        "remove": "Remove {{model}}"
+        "remove": "Remove {model}"
       }
     },
     "channels": {
@@ -1313,7 +1313,7 @@
         "test": {
           "button": "Test",
           "title": "Validate this MCP server from the daemon",
-          "connected": "connected · {{count}} tools",
+          "connected": "connected · {count} tools",
           "reachable": "reachable",
           "failed": "test failed"
         }
@@ -2125,14 +2125,14 @@
         "description": "opendray v2 — the multiplexer + integration gateway for AI agent CLIs. Source under Apache 2.0.",
         "version": "Version",
         "commit": "Commit",
-        "updateAvailable": "Update available: {{version}}",
+        "updateAvailable": "Update available: {version}",
         "releaseNotes": "Release notes ↗",
         "updateNow": "Update now",
         "upgradingShort": "Upgrading…",
         "confirmRestart": "This restarts the service; running sessions reconnect.",
         "confirmUpgrade": "Upgrade & restart",
-        "upgrading": "Upgrading to {{version}}…",
-        "upgraded": "Updated to {{version}}.",
+        "upgrading": "Upgrading to {version}…",
+        "upgraded": "Updated to {version}.",
         "upgradeSlow": "Upgrade is taking a while — check the service logs if it doesn't come back.",
         "guidedHint": "In-app upgrade isn't available here. Run on the server:",
         "checkFailed": "Couldn't check for updates (offline or rate-limited).",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -964,11 +964,11 @@
           "mcp": "mcp"
         },
         "notInstalled": "未安装",
-        "updateAvailable": "有可用更新 → {{version}}",
+        "updateAvailable": "有可用更新 → {version}",
         "upToDate": "已是最新",
-        "update": "更新到 {{version}}",
+        "update": "更新到 {version}",
         "updating": "更新中…",
-        "updatedToast": "已更新 {{from}} → {{to}}",
+        "updatedToast": "已更新 {from} → {to}",
         "alreadyLatestToast": "已是最新",
         "updateFailedToast": "更新失败",
         "updateUnavailable": "此处无法在应用内更新"
@@ -1010,11 +1010,11 @@
         "empty": "尚未配置任何模型。",
         "add": "添加",
         "addPlaceholder": "模型 ID（如 sonnet）",
-        "suggested": "建议（{{count}}）",
+        "suggested": "建议（{count}）",
         "default": "默认",
         "makeDefault": "设为默认",
         "setDefault": "用作默认模型",
-        "remove": "移除 {{model}}"
+        "remove": "移除 {model}"
       }
     },
     "channels": {
@@ -1312,7 +1312,7 @@
         "test": {
           "button": "测试",
           "title": "从守护进程验证此 MCP 服务器",
-          "connected": "已连接 · {{count}} 个工具",
+          "connected": "已连接 · {count} 个工具",
           "reachable": "可达",
           "failed": "测试失败"
         }
@@ -2124,14 +2124,14 @@
         "description": "opendray v2 — 面向 AI agent CLI 的多路复用 + 集成网关。源码采用 Apache 2.0 协议。",
         "version": "版本",
         "commit": "提交",
-        "updateAvailable": "有可用更新：{{version}}",
+        "updateAvailable": "有可用更新：{version}",
         "releaseNotes": "发行说明 ↗",
         "updateNow": "立即更新",
         "upgradingShort": "更新中…",
         "confirmRestart": "这将重启服务，正在运行的会话会重新连接。",
         "confirmUpgrade": "升级并重启",
-        "upgrading": "正在升级到 {{version}}…",
-        "upgraded": "已更新到 {{version}}。",
+        "upgrading": "正在升级到 {version}…",
+        "upgraded": "已更新到 {version}。",
         "upgradeSlow": "升级耗时较长——如果服务未恢复，请检查日志。",
         "guidedHint": "此处不支持应用内升级。请在服务器上运行：",
         "checkFailed": "无法检查更新（离线或受限）。",


### PR DESCRIPTION
The i18next init at `app/web/src/i18n.ts` overrides the interpolation syntax to single braces:

```js
interpolation: { prefix: '{', suffix: '}' }
```

Most strings in `en.json` / `zh.json` follow that (`{error}`, `{count}`, `{kbd}`, …) but **9 strings** were authored with the i18next default `{{var}}` and render literally — users see e.g.

- `update available → {{version}}`
- `Update to {{version}}`
- `Updated {{from}} → {{to}}`
- `Suggested ({{count}})`
- `Remove {{model}}`
- `connected · {{count}} tools`
- The three version-toaster lines under `web.about`

instead of the substituted values.

### The fix

One-line `sed` across both locales — swaps `{{var}}` → `{var}` for the affected keys only. No UI, behaviour, or other content changes; the substituted values were already being passed to `t(...)` correctly, the templates just couldn't find them.

```bash
sed -i -E 's/\{\{([a-zA-Z_]+)\}\}/{\1}/g' app/i18n/en.json app/i18n/zh.json
```

### How to verify

- Open Providers → any CLI provider with an update available → the `update available → 0.44.1` badge / `Update to 0.44.1` button / `Updated 0.44.0 → 0.44.1` toast all render with substituted values.
- Open MCP panel → connected status now reads `connected · 5 tools` instead of `connected · {{count}} tools`.
- About → version update flow renders the version strings correctly.

### Scope

`app/i18n/en.json` + `app/i18n/zh.json` only. 18 lines changed in each file (the 9 keys × 2 sides of the diff). No code changes.