### PR TITLE
feat(catalog): warn + confirm before in-app CLI upgrade when sessions are using it

### DIFF
--- a/app/shared/src/lib/types.ts
+++ b/app/shared/src/lib/types.ts
@@ -134,6 +134,10 @@ export interface ProviderRuntime {
   latestVersion?: string
   updateAvailable: boolean
   checkedAt?: string
+  // Non-terminal sessions currently using this provider's CLI. Used by
+  // the Providers page to warn before upgrading a CLI that running
+  // sessions are on it. 0 when the server didn't populate the counter.
+  activeSessions: number
 }
 
 export interface Provider {

--- a/app/web/src/pages/Providers.tsx
+++ b/app/web/src/pages/Providers.tsx
@@ -14,6 +14,7 @@ import { ProviderModelsSection } from '@/components/providers/ProviderModelsSect
 import { BrandAvatar } from '@/components/BrandAvatar'
 import { providerIconKey } from '@/lib/providerIcons'
 import { ClaudeAccountsPanel } from '@/components/providers/ClaudeAccountsPanel'
+import { useConfirmDialog } from '@/components/ConfirmDialog'
 import {
   listProviders,
   toggleProvider,
@@ -180,13 +181,19 @@ function ProviderDetail({
   const m = provider.manifest
   const rt = provider.runtime
   // Latest-version check is a network (npm) call, so it runs on its own
-  // endpoint and only for installed CLI providers.
+  // endpoint and only for installed CLI providers. staleTime aligns with
+  // the server-side npm cache (1h) and refetch-on-focus/mount is off so
+  // toggling between tabs doesn't keep round-tripping for data the
+  // backend would just return from cache anyway.
   const { data: upd } = useQuery({
     queryKey: ['provider-update', m.id],
     queryFn: () => checkProviderUpdate(m.id),
     enabled: m.kind === 'cli' && !!rt?.installed,
-    staleTime: 60_000,
+    staleTime: 60 * 60_000,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
   })
+  const { confirm, dialog: confirmDialog } = useConfirmDialog()
   const updateMut = useMutation({
     mutationFn: () => updateProvider(m.id),
     onSuccess: (res) => {
@@ -265,7 +272,22 @@ function ProviderDetail({
                   variant="outline"
                   className="h-6 px-2 text-[11px]"
                   disabled={updateMut.isPending}
-                  onClick={() => updateMut.mutate()}
+                  onClick={async () => {
+                    const n = upd?.activeSessions ?? 0
+                    if (n > 0) {
+                      const label = m.displayName ?? m.id
+                      const ok = await confirm({
+                        title: `Upgrade ${label} CLI?`,
+                        description:
+                          `${n} session${n === 1 ? '' : 's'} currently running on ${m.id}. ` +
+                          `${n === 1 ? "It'll" : "They'll"} keep using the old version in memory — new sessions (and any on-demand code loads) pick up the new one. Continue?`,
+                        confirmLabel: 'Upgrade',
+                        cancelLabel: 'Cancel',
+                      })
+                      if (!ok) return
+                    }
+                    updateMut.mutate()
+                  }}
                 >
                   {updateMut.isPending ? (
                     <Loader2 className="h-3 w-3 animate-spin" />
@@ -375,6 +397,7 @@ function ProviderDetail({
             : t('web.providers.detail.save')}
         </Button>
       </div>
+      {confirmDialog}
     </main>
   )
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -180,6 +180,11 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		log.Warn("session reconcile on startup failed", "err", err)
 	}
 	sessionHandlers := session.NewHandlers(sessionMgr, log)
+	// Now that the session manager exists, let the catalog handler
+	// populate RuntimeInfo.ActiveSessions on update-check responses so
+	// the UI can warn the operator before upgrading a CLI that running
+	// sessions are using.
+	catalogHandlers.WithSessionCounter(sessionMgr.ActiveCountByProvider)
 
 	channelHub := channel.NewHub(st.Pool(), bus, log)
 	// Plain-text inbound from a channel (e.g. a Telegram reply that

--- a/internal/catalog/handler.go
+++ b/internal/catalog/handler.go
@@ -48,6 +48,10 @@ type Handlers struct {
 	prober *Prober
 	bus    *eventbus.Hub
 	log    *slog.Logger
+	// activeCountFor returns the count of currently non-terminal
+	// sessions on a provider, used to populate RuntimeInfo.ActiveSessions
+	// for the upgrade UI. Optional; nil → ActiveSessions is left at 0.
+	activeCountFor func(providerID string) int
 }
 
 func NewHandlers(cat *Catalog, bus *eventbus.Hub, log *slog.Logger) *Handlers {
@@ -55,6 +59,14 @@ func NewHandlers(cat *Catalog, bus *eventbus.Hub, log *slog.Logger) *Handlers {
 		log = slog.Default()
 	}
 	return &Handlers{cat: cat, prober: NewProber(), bus: bus, log: log.With("component", "catalog.http")}
+}
+
+// WithSessionCounter wires in a per-provider active-session counter so
+// the update-check response includes how many live sessions are using
+// the provider's CLI. Returns the receiver so it chains off the ctor.
+func (h *Handlers) WithSessionCounter(f func(providerID string) int) *Handlers {
+	h.activeCountFor = f
+	return h
 }
 
 func (h *Handlers) Mount(r chi.Router) {
@@ -119,6 +131,9 @@ func (h *Handlers) updateCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	info := h.prober.CheckUpdate(r.Context(), p.Manifest)
+	if h.activeCountFor != nil {
+		info.ActiveSessions = h.activeCountFor(id)
+	}
 	writeJSON(w, http.StatusOK, info)
 }
 

--- a/internal/catalog/probe.go
+++ b/internal/catalog/probe.go
@@ -26,6 +26,12 @@ type RuntimeInfo struct {
 	LatestVersion    string `json:"latestVersion,omitempty"`
 	UpdateAvailable  bool   `json:"updateAvailable"`
 	CheckedAt        string `json:"checkedAt,omitempty"` // RFC3339; when LatestVersion was fetched
+	// ActiveSessions is the number of non-terminal sessions currently
+	// using this provider's CLI. Populated by the handler from the
+	// session manager (0 when the counter isn't wired). Surfaced so the
+	// dashboard can warn before upgrading a CLI that running sessions
+	// are using.
+	ActiveSessions int `json:"activeSessions"`
 }
 
 // Cache TTLs: installed state is cheap (local exec) so a short TTL keeps

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -675,6 +675,29 @@ func (m *Manager) List(ctx context.Context) ([]Session, error) {
 	return list, nil
 }
 
+// ActiveCountByProvider returns the number of currently non-terminal
+// sessions backed by providerID. Iterates the in-memory live map only,
+// so it's O(live sessions) and lock-cheap — designed for the catalog
+// update-check path that surfaces "N session(s) running on claude" so
+// the operator can confirm before swapping the CLI binary underneath
+// them.
+func (m *Manager) ActiveCountByProvider(providerID string) int {
+	if providerID == "" {
+		return 0
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	n := 0
+	for _, rs := range m.sessions {
+		rs.sessMu.RLock()
+		if rs.sess.ProviderID == providerID && !rs.sess.State.IsTerminal() {
+			n++
+		}
+		rs.sessMu.RUnlock()
+	}
+	return n
+}
+
 // Stop terminates the running process for a session but preserves
 // the DB row. The user can subsequently call Start to re-spawn.
 // For an already-terminal session it succeeds as a no-op.


### PR DESCRIPTION
## What this adds

A confirmation dialog on the Providers page **only when** an in-app CLI upgrade would land on a provider that has live sessions running on it. If no sessions are using the provider, the Update button still fires immediately — same one-tap UX as today.

### The reasoning behind a confirm (not a hard block)

`Prober.Update` swaps the CLI binary via `npm install -g`. Linux file-replacement semantics mean a *running* session keeps using the old version it has loaded in RAM, so most of the time this is benign — but a long session with lazy/dynamic imports or in-flight subprocess work *can* pick up new code mid-run. The dialog copy explicitly says that:

> *N sessions currently running on `<id>`. They'll keep using the old version in memory — new sessions (and any on-demand code loads) pick up the new one. Continue?*

So it's framing, not a fake warning about an interrupt that doesn't really happen.

## Implementation

Intentionally small footprint:

- **`session.Manager.ActiveCountByProvider(providerID)`** — O(live sessions) walk of the in-memory map, counting non-terminal sessions whose `ProviderID == id`. Lock-cheap; lives alongside `Stop` for review locality.
- **`catalog.RuntimeInfo.ActiveSessions`** — new int field. Populated by the handler.
- **`catalog.Handlers.WithSessionCounter(f func(string) int)`** — optional setter, chained off the ctor. Keeps the `catalog` package independent of the `session` package (no import added) and avoids changing `NewHandlers`'s signature. When unset, `ActiveSessions` stays `0` and the dialog never fires — fully backward-compatible.
- **`app.go`** wires the setter once `sessionMgr` is constructed.
- **`Providers.tsx`** — `useConfirmDialog` (already in the repo) gates the Update click when `upd.activeSessions > 0`. Uses `m.displayName ?? m.id` for the title.
- **React-Query tuning on the update-check query** — `staleTime` bumped to 1h (matches `Prober.latestTTL`), `refetchOnWindowFocus` / `refetchOnMount` disabled. Switching dashboard tabs no longer round-trips for data the backend would just return from cache. (Independent of the dialog; included here because it touches the same hook block.)

## Files changed

| File | Net lines |
|---|---|
| `internal/session/manager.go` | +23 / 0 |
| `internal/catalog/probe.go` | +6 / 0 |
| `internal/catalog/handler.go` | +15 / 0 |
| `internal/app/app.go` | +5 / 0 |
| `app/shared/src/lib/types.ts` | +4 / 0 |
| `app/web/src/pages/Providers.tsx` | +29 / -3 |

No new dependencies.

## How to try it

1. Spawn a Claude / Gemini / Codex session.
2. Force the provider one minor behind:
   ```bash
   sudo -u opendray -H npm install -g @google/gemini-cli@0.44.0
   ```
3. Providers → Gemini CLI → Update — dialog appears with the count + explanation. Cancel keeps the session intact; Upgrade runs the install.
4. With **no** sessions on the provider, Update fires immediately as today.

## Out of scope

This PR is just the in-flow warning. The "in-app updates aren't available — npm prefix isn't writable" path (`ErrUpdatePrefixReadonly`) is untouched. There's a separate issue (#262) proposing a helper for the non-root-prefix setup — happy to keep these orthogonal.

The deprecated dialog copy on the fork went through `'Upgrade anyway' / destructive` styling at first — settled on plain `'Upgrade'` because we walked back the implicit "may interrupt" promise after looking at how Linux actually replaces a running binary.