### PR TITLE
chore(gitignore): ignore app/releases/ APK output dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ app/mobile/android/local.properties
 app/mobile/coverage/
 app/mobile/pubspec.lock
 
+# Mobile release artefacts produced by app/mobile/build_android.sh
+app/releases/
+
 # ── Web (apps/web/) ──────────────────────────────────────────
 app/web/node_modules/
 app/web/dist/


### PR DESCRIPTION
## Summary

Add `app/releases/` to root `.gitignore`. The local mobile release helper writes signed APKs there before uploading to UNAS / TestFlight; the directory only ever holds per-build artefacts that shouldn't land in git.

## Test plan

- [x] `git status` no longer surfaces `app/releases/*.apk` after a local release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)