### PR TITLE
fix(web): make language toggle actually switch UI strings

### DIFF
--- a/app/web/src/components/LocaleSync.tsx
+++ b/app/web/src/components/LocaleSync.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useLocale } from '@/stores/locale'
+
+// Bridges the zustand locale store → i18next.changeLanguage.
+//
+// Previously this lived as a module-level useLocale.subscribe(...) in
+// i18n.ts, which fired before React mounted and could miss updates in
+// React 19 StrictMode / Vite HMR — the dropdown's checkmark moved but
+// the rendered translations didn't. Running the bridge as a React
+// effect uses the same lifecycle as every other useTranslation()
+// consumer, so they update in lockstep.
+export function LocaleSync() {
+  const locale = useLocale((s) => s.locale)
+  const { i18n } = useTranslation()
+
+  useEffect(() => {
+    if (i18n.language !== locale) {
+      void i18n.changeLanguage(locale)
+    }
+  }, [locale, i18n])
+
+  return null
+}

--- a/app/web/src/i18n.ts
+++ b/app/web/src/i18n.ts
@@ -3,8 +3,12 @@ import { initReactI18next } from 'react-i18next'
 
 import en from '../../i18n/en.json'
 import zh from '../../i18n/zh.json'
-import { useLocale, type Locale } from '@/stores/locale'
+import { useLocale } from '@/stores/locale'
 
+// Initialise with the persisted (or detected) locale. After this point
+// the running language is owned by i18next and kept in sync with the
+// zustand store through <LocaleSync /> in the React tree — see
+// components/LocaleSync.tsx for the rationale.
 void i18n
   .use(initReactI18next)
   .init({
@@ -21,15 +25,5 @@ void i18n
     },
     returnNull: false,
   })
-
-useLocale.subscribe((s) => {
-  if (i18n.language !== s.locale) {
-    void i18n.changeLanguage(s.locale)
-  }
-})
-
-export function setLocale(l: Locale) {
-  useLocale.getState().setLocale(l)
-}
 
 export default i18n

--- a/app/web/src/main.tsx
+++ b/app/web/src/main.tsx
@@ -6,6 +6,7 @@ import { RouterProvider } from '@tanstack/react-router'
 import './index.css'
 import './i18n' // side-effect: initialise i18next before render
 import { router } from './router'
+import { LocaleSync } from '@/components/LocaleSync'
 import { Toaster } from '@/components/ui/sonner'
 import '@/stores/theme' // side-effect: apply persisted theme
 
@@ -32,6 +33,7 @@ const queryClient = new QueryClient({
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
+      <LocaleSync />
       <RouterProvider router={router} />
       <Toaster />
     </QueryClientProvider>


### PR DESCRIPTION
## Summary

The web Topbar language dropdown moved its checkmark when the user picked **Chinese / English**, but the rendered translations stayed on whatever was loaded at boot. Closing the dropdown showed the same language as before.

## Root cause

The zustand → i18next bridge lived as a **module-level** `useLocale.subscribe(...)` in `i18n.ts`:

```ts
useLocale.subscribe((s) => {
  if (i18n.language !== s.locale) {
    void i18n.changeLanguage(s.locale)
  }
})
```

This mounts before React takes over. Under React 19 StrictMode + Vite HMR + zustand persist hydration, that subscription could be registered against a store snapshot that React never re-reconciled with — so `setLocale()` updated the store (moving the dropdown checkmark, which reads from the store) without the listener ever calling `i18n.changeLanguage()`. The Topbar updated; nothing else did.

## Fix

Move the bridge into a small `<LocaleSync />` React component mounted under `QueryClientProvider`:

```tsx
export function LocaleSync() {
  const locale = useLocale((s) => s.locale)
  const { i18n } = useTranslation()
  useEffect(() => {
    if (i18n.language !== locale) {
      void i18n.changeLanguage(locale)
    }
  }, [locale, i18n])
  return null
}
```

It shares the same React lifecycle as every other `useTranslation()` consumer, so when locale changes the effect fires, `i18n.changeLanguage()` runs, react-i18next emits `languageChanged`, and every page re-renders in lockstep.

Drop the now-dead `useLocale.subscribe(...)` block and the unused exported `setLocale()` helper from `i18n.ts` while we're here (the only caller — Topbar — talks to the zustand store directly).

## Test plan

- [x] `pnpm tsc --noEmit` clean.
- [x] `pnpm dev` boots without errors.
- [ ] In the running app: open the Topbar → Languages dropdown → pick the *other* language → every visible string (sidebar, topbar, current page) switches immediately. Reload — choice persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)