### PR TITLE
ci: notify opendray.dev when a release is published

### DIFF
--- a/.github/workflows/notify-site-on-release.yml
+++ b/.github/workflows/notify-site-on-release.yml
@@ -1,0 +1,39 @@
+name: Notify site on release
+
+# When a GitHub release is flipped from draft to published, ping
+# Opendray/opendray.dev so it rebuilds and the changelog/version card
+# updates immediately. Without this, opendray.dev only rebuilds on its
+# own push-to-main, so new releases can sit unseen on the site for days.
+#
+# Required secret:
+#   ODSITE_DISPATCH_PAT — fine-grained PAT scoped to Opendray/opendray.dev
+#                         with `Actions: read & write` (Repository permission)
+#                         and nothing else. Rotate annually.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger opendray.dev rebuild
+        env:
+          PAT: ${{ secrets.ODSITE_DISPATCH_PAT }}
+          TAG: ${{ github.event.release.tag_name || 'manual' }}
+        run: |
+          if [ -z "$PAT" ]; then
+            echo "ODSITE_DISPATCH_PAT not set — skipping dispatch."
+            echo "Add a fine-grained PAT (Opendray/opendray.dev, Actions: read & write)."
+            exit 0
+          fi
+          curl -sSf -X POST \
+            -H "Authorization: token $PAT" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/Opendray/opendray.dev/dispatches" \
+            -d "{\"event_type\":\"opendray-release\",\"client_payload\":{\"tag\":\"$TAG\"}}"
+          echo "Dispatched opendray-release for $TAG"


### PR DESCRIPTION
## Why

`opendray.dev` only rebuilds on its own push-to-`main`, so a brand-new release sits on the site as "previous release" until someone touches the site repo. v2.3.4 published today still shows v2.3.3 on the changelog page as a result.

## What changes

Adds `.github/workflows/notify-site-on-release.yml` — a 40-line workflow that:

1. Triggers on `release: {types: [published]}` (i.e. when a human flips a draft release to public — goreleaser drafts by default per `.goreleaser.yml`).
2. POSTs a `repository_dispatch` event of type `opendray-release` to `Opendray/opendray.dev`.

That trigger is wired up on the site side (companion PR `Opendray/opendray.dev#3`) to kick a Cloudflare Pages deploy within ~30s of the release going public.

## Required follow-up before this works

Add a repo secret on `Opendray/opendray`:

- **Name:** `ODSITE_DISPATCH_PAT`
- **Type:** Fine-grained PAT
- **Resource owner:** `Opendray`
- **Repository access:** Only `Opendray/opendray.dev`
- **Permissions:** `Actions: Read and write` (and nothing else)
- **Expiry:** 1 year, set a calendar reminder to rotate

If the secret is missing, the dispatch step logs a notice and exits 0 — it does **not** break the release pipeline. Daily cron on the site repo is the seatbelt in that case.

## Risk

Net-new workflow file. Permissions block is `{}`, the step has no checkout, no code execution beyond a single `curl` call to GitHub's REST API.
