### PR TITLE
docs(changelog): add v2.5.0 entry + bump README status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,79 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+## [v2.5.0] — 2026-05-31
+
+Phase 2 Tier A of the multi-Claude-account work: rate-limit-aware
+auto-failover. A Claude session that hits its account quota can now
+automatically switch itself to the next non-throttled enabled account,
+with the conversation continuing seamlessly on the new identity. Plus
+documentation polish around the release ceremony so the next operator
+cutting a release doesn't have to re-discover today's gotchas.
+
+### Added
+
+- **Rate-limit auto-failover for Claude sessions** ([providers.claude]
+  `auto_failover_enabled`, default false). `pumpStdout` scans each
+  Claude session's PTY for the `You've hit your session limit · resets
+  HH:MM (UTC)` banner. On a match:
+  1. The current account is marked throttled-until-reset in an
+     in-memory `ThrottleStore` (lazy GC of expired entries).
+  2. `PickFailoverClaudeAccount` picks the next enabled non-throttled
+     account by the same least-loaded heuristic auto-assign already
+     uses.
+  3. `SwitchClaudeAccount` runs end-to-end — transcript JSONL
+     hard-linked, PTY respawned with `--resume`, conversation
+     continues on the new identity.
+  4. Bus events for observability: `session.auto_switched` on
+     success, `session.auto_failover_no_target` when the fleet is
+     exhausted, `session.auto_failover_failed` when the switch
+     itself errors.
+  5s cooldown per session + 4 KiB rolling window so a persistent
+  banner can't drive the regex on every chunk. Opt-in by design —
+  defaults off so existing operators aren't surprised by silent
+  account switches.
+- **`RELEASING.md` runbook at the repo root** documenting the release
+  ceremony end-to-end: the chain diagram, the "tag-after-changelog-
+  merges" gotcha, recovery procedures (empty release body, pulled-
+  back release), pre/post-release checklists, roadmap to
+  release-please automation and pre-release `-rc.N` channels.
+
+### Tests
+
+- **Pinned contract: disabled accounts are excluded from auto-assign.**
+  A regression-safety unit test for the `enabled<2` guard in
+  `PickAutoAssignClaudeAccount`. The SQL filter
+  (`WHERE ca.enabled = true`) and the explicit-pin validation path
+  were already covered by live integration + handler tests; this
+  closes the last gap.
+
+### Internal
+
+- New `ClaudeAccountResolver` interface methods:
+  `MarkClaudeAccountThrottled`, `IsClaudeAccountThrottled`,
+  `PickFailoverClaudeAccount`. `pickLeastLoaded` SQL gains variadic
+  `exclude ...string` (parameterized via `NOT (ca.id = ANY($1::text[]))`).
+
+### Config
+
+- New: `[providers.claude] auto_failover_enabled` (default false).
+  Opt-in for the runtime rate-limit-driven account switching.
+
+### Honest limitations of Tier A
+
+- Banner-text fragile — if Claude rephrases the limit message, the
+  regex needs updating. Fallback separators (`-`, `|`) for the middle
+  bullet are already covered.
+- No predictive load spread — only reacts to hard limits. Tiers B
+  (active probing) and C (local HTTPS proxy) from the design
+  discussion remain available as upgrades.
+- Sessions running on the empty-id default (`~/.claude`) are skipped
+  by the failover path for the MVP — mapping the default to a real
+  account row needs a resolver round-trip we haven't exposed yet.
+  After auto-assign kicks in for ≥2 enabled accounts, most new
+  sessions are pinned to a named account anyway, so this gap shrinks
+  to zero in practice.
+
 ## [v2.4.0] — 2026-05-31
 
 Multi-Claude-account UX, two-way Telegram channel, and a clutch of

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 ## Status
 
-**v2.4.0** (latest) — the v2 generation continues to iterate. See
+**v2.5.0** (latest) — the v2 generation continues to iterate. See
 [`VERSIONING.md`](VERSIONING.md) for the major-as-generation policy
 (major = product generation, not strict SemVer "breaking change") and
 [`CHANGELOG.md`](CHANGELOG.md) for the full release history.

--- a/README.zh.md
+++ b/README.zh.md
@@ -46,7 +46,7 @@
 
 ## 当前状态
 
-**v2.4.0**(最新)—— v2 代持续迭代。
+**v2.5.0**(最新)—— v2 代持续迭代。
 参见 [`VERSIONING.md`](VERSIONING.md) 了解 major-as-generation 版本策略
 (major = 产品代号,而不是严格的 SemVer "破坏性变更" 标记),
 [`CHANGELOG.md`](CHANGELOG.md) 有完整 release 历史。


### PR DESCRIPTION
## Summary

v2.5.0 docs. Per `RELEASING.md`, the changelog PR must merge into `main` BEFORE the tag is pushed so goreleaser sees the CHANGELOG section at the tagged commit (and the release body comes out populated rather than empty).

## What's in v2.5.0

- **Phase 2 Tier A rate-limit auto-failover** (#276) — opt-in via `[providers.claude] auto_failover_enabled`
- **`RELEASING.md` release-ceremony runbook** at the repo root (#275)
- **Pinned regression test** for "disabled accounts excluded from auto-assign" (#274)

CHANGELOG.md has the full breakdown including the honest limitations of Tier A so operators evaluating the feature know what's not covered yet.

## Test plan

- [x] Markdown renders cleanly in GitHub preview
- [x] README Status line + README.zh.md Status line match (`v2.4.0` → `v2.5.0`)
- [x] No code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
