### PR TITLE
feat(git): PR detail surface — description, status & CI on web + mobile

### DIFF
--- a/app/mobile/lib/core/api/git_api.dart
+++ b/app/mobile/lib/core/api/git_api.dart
@@ -279,6 +279,91 @@ class GitCheckRun {
           conclusion == 'action_required');
 }
 
+// One commit in a pull request (Commits tab).
+class GitPRCommit {
+  GitPRCommit({
+    required this.sha,
+    required this.shortSha,
+    required this.message,
+    required this.author,
+    required this.date,
+    required this.url,
+  });
+
+  factory GitPRCommit.fromJson(Map<String, dynamic> json) => GitPRCommit(
+    sha: json['sha'] as String? ?? '',
+    shortSha: json['short_sha'] as String? ?? '',
+    message: json['message'] as String? ?? '',
+    author: json['author'] as String? ?? '',
+    date: json['date'] as String? ?? '',
+    url: json['url'] as String? ?? '',
+  );
+
+  final String sha;
+  final String shortSha;
+  final String message;
+  final String author;
+  final String date;
+  final String url;
+
+  // First line of the commit message — shown as the subject.
+  String get subject => message.split('\n').first;
+}
+
+// One changed file in a pull request (Files changed tab). Patch may be
+// empty when the host doesn't return it inline.
+class GitPRFile {
+  GitPRFile({
+    required this.filename,
+    required this.status,
+    required this.additions,
+    required this.deletions,
+    required this.patch,
+  });
+
+  factory GitPRFile.fromJson(Map<String, dynamic> json) => GitPRFile(
+    filename: json['filename'] as String? ?? '',
+    status: json['status'] as String? ?? '',
+    additions: (json['additions'] as num?)?.toInt() ?? 0,
+    deletions: (json['deletions'] as num?)?.toInt() ?? 0,
+    patch: json['patch'] as String? ?? '',
+  );
+
+  final String filename;
+  // added | modified | removed | renamed
+  final String status;
+  final int additions;
+  final int deletions;
+  final String patch;
+}
+
+// One conversation entry: an issue/MR comment or a review summary
+// (Conversation tab). State is set only for review summaries.
+class GitPRComment {
+  GitPRComment({
+    required this.author,
+    required this.body,
+    required this.createdAt,
+    required this.state,
+    required this.url,
+  });
+
+  factory GitPRComment.fromJson(Map<String, dynamic> json) => GitPRComment(
+    author: json['author'] as String? ?? '',
+    body: json['body'] as String? ?? '',
+    createdAt: json['created_at'] as String? ?? '',
+    state: json['state'] as String? ?? '',
+    url: json['url'] as String? ?? '',
+  );
+
+  final String author;
+  final String body;
+  final String createdAt;
+  // approved | changes_requested | commented (reviews only; else empty)
+  final String state;
+  final String url;
+}
+
 class GitApi {
   GitApi(this._dio);
   final Dio _dio;
@@ -428,6 +513,69 @@ class GitApi {
       return raw
           .whereType<Map<String, dynamic>>()
           .map(GitCheckRun.fromJson)
+          .toList();
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // GET /git/prs/{n}/commits — commits in the PR (Commits tab).
+  Future<List<GitPRCommit>> prCommits({
+    required String dir,
+    required int number,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/git/prs/$number/commits',
+        queryParameters: {'path': dir},
+      );
+      final raw = res.data?['commits'];
+      if (raw is! List) return const [];
+      return raw
+          .whereType<Map<String, dynamic>>()
+          .map(GitPRCommit.fromJson)
+          .toList();
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // GET /git/prs/{n}/files — changed files + patches (Files tab).
+  Future<List<GitPRFile>> prFiles({
+    required String dir,
+    required int number,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/git/prs/$number/files',
+        queryParameters: {'path': dir},
+      );
+      final raw = res.data?['files'];
+      if (raw is! List) return const [];
+      return raw
+          .whereType<Map<String, dynamic>>()
+          .map(GitPRFile.fromJson)
+          .toList();
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // GET /git/prs/{n}/comments — conversation (Conversation tab).
+  Future<List<GitPRComment>> prComments({
+    required String dir,
+    required int number,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/git/prs/$number/comments',
+        queryParameters: {'path': dir},
+      );
+      final raw = res.data?['comments'];
+      if (raw is! List) return const [];
+      return raw
+          .whereType<Map<String, dynamic>>()
+          .map(GitPRComment.fromJson)
           .toList();
     } on Object catch (e) {
       throw toApiException(e);

--- a/app/mobile/lib/core/api/git_api.dart
+++ b/app/mobile/lib/core/api/git_api.dart
@@ -120,6 +120,7 @@ class GitPullRequest {
     required this.url,
     required this.draft,
     required this.updatedAt,
+    this.body = '',
   });
 
   factory GitPullRequest.fromJson(Map<String, dynamic> json) => GitPullRequest(
@@ -132,6 +133,7 @@ class GitPullRequest {
     url: json['url'] as String? ?? '',
     draft: json['draft'] as bool? ?? false,
     updatedAt: json['updated_at'] as String? ?? '',
+    body: json['body'] as String? ?? '',
   );
 
   final int number;
@@ -144,6 +146,9 @@ class GitPullRequest {
   final String url;
   final bool draft;
   final String updatedAt;
+  // PR description (markdown). Empty on list responses — only the
+  // single-PR detail fetch (getPullRequest) populates it.
+  final String body;
 }
 
 // Container for the /git/prs response: PRs plus repo metadata so
@@ -443,6 +448,24 @@ class GitApi {
         queryParameters: {'path': dir, 'state': state},
       );
       return GitPullRequestList.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // GET /git/prs/{n}?path=<dir> — a single PR including its
+  // body/description. The list endpoint omits body to stay lean, so
+  // the detail screen calls this to render the description.
+  Future<GitPullRequest> getPullRequest({
+    required String dir,
+    required int number,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/git/prs/$number',
+        queryParameters: {'path': dir},
+      );
+      return GitPullRequest.fromJson(res.data ?? {});
     } on Object catch (e) {
       throw toApiException(e);
     }

--- a/app/mobile/lib/features/sessions/inspector/git_pr_section.dart
+++ b/app/mobile/lib/features/sessions/inspector/git_pr_section.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/git_api.dart';
+import 'package:opendray/features/sessions/inspector/pr_detail_screen.dart';
 
 // GitPRSection sits at the bottom of the status pane and exposes
 // the PR command-center surface on mobile. Mirrors the web's
@@ -25,7 +26,6 @@ class _GitPRSectionState extends ConsumerState<GitPRSection> {
   GitPullRequestList? _list;
   bool _loading = true;
   Object? _error;
-  int? _expandedPR;
   Timer? _refreshTimer;
 
   @override
@@ -153,329 +153,83 @@ class _GitPRSectionState extends ConsumerState<GitPRSection> {
             )
           else
             for (final pr in _list!.prs)
-              _PRRow(
-                pr: pr,
-                cwd: widget.cwd,
-                expanded: _expandedPR == pr.number,
-                onToggle: () => setState(
-                  () =>
-                      _expandedPR = _expandedPR == pr.number ? null : pr.number,
-                ),
-                onMerged: () {
-                  setState(() => _expandedPR = null);
-                  unawaited(_load());
-                },
-              ),
+              _PRRow(pr: pr, onTap: () => unawaited(_openDetail(pr))),
         ],
       ),
     );
   }
+
+  Future<void> _openDetail(GitPullRequest pr) async {
+    final merged = await Navigator.of(context).push<bool>(
+      MaterialPageRoute(
+        builder: (_) => PRDetailScreen(cwd: widget.cwd, pr: pr),
+      ),
+    );
+    // The detail screen pops `true` after a successful merge; refresh
+    // the list so the merged PR drops out of the open view.
+    if ((merged ?? false) && mounted) {
+      await _load();
+    }
+  }
 }
 
-class _PRRow extends ConsumerWidget {
-  const _PRRow({
-    required this.pr,
-    required this.cwd,
-    required this.expanded,
-    required this.onToggle,
-    required this.onMerged,
-  });
+class _PRRow extends StatelessWidget {
+  const _PRRow({required this.pr, required this.onTap});
 
   final GitPullRequest pr;
-  final String cwd;
-  final bool expanded;
-  final VoidCallback onToggle;
-  final VoidCallback onMerged;
+  final VoidCallback onTap;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final stateColor = switch (pr.state) {
-      'merged' => Colors.purple,
-      'closed' => theme.colorScheme.error,
-      _ => Colors.green,
-    };
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        InkWell(
-          onTap: onToggle,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
-            child: Row(
-              children: [
-                Icon(Icons.merge, size: 14, color: stateColor),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        pr.title,
-                        style: theme.textTheme.bodyMedium,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      Text(
-                        '#${pr.number} · ${pr.author} · ${pr.head} → ${pr.base}',
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.outline,
-                          fontFamily: 'monospace',
-                          fontSize: 10,
-                        ),
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ],
-                  ),
-                ),
-              ],
+    final stateColor = pr.draft
+        ? theme.colorScheme.outline
+        : switch (pr.state) {
+            'merged' => Colors.purple,
+            'closed' => theme.colorScheme.error,
+            _ => Colors.green,
+          };
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+        child: Row(
+          children: [
+            Icon(
+              pr.draft ? Icons.merge_outlined : Icons.merge,
+              size: 14,
+              color: stateColor,
             ),
-          ),
-        ),
-        if (expanded && pr.state == 'open')
-          _PRExpandedPanel(pr: pr, cwd: cwd, onMerged: onMerged),
-      ],
-    );
-  }
-}
-
-class _PRExpandedPanel extends ConsumerStatefulWidget {
-  const _PRExpandedPanel({
-    required this.pr,
-    required this.cwd,
-    required this.onMerged,
-  });
-
-  final GitPullRequest pr;
-  final String cwd;
-  final VoidCallback onMerged;
-
-  @override
-  ConsumerState<_PRExpandedPanel> createState() => _PRExpandedPanelState();
-}
-
-class _PRExpandedPanelState extends ConsumerState<_PRExpandedPanel> {
-  List<GitCheckRun>? _checks;
-  Object? _checksError;
-  bool _busy = false;
-  String _method = 'squash';
-  bool _deleteBranch = true;
-  Timer? _refreshTimer;
-
-  @override
-  void initState() {
-    super.initState();
-    unawaited(_loadChecks());
-    _refreshTimer = Timer.periodic(
-      const Duration(seconds: 30),
-      (_) => unawaited(_loadChecks()),
-    );
-  }
-
-  @override
-  void dispose() {
-    _refreshTimer?.cancel();
-    super.dispose();
-  }
-
-  Future<void> _loadChecks() async {
-    try {
-      final c = await ref
-          .read(gitApiProvider)
-          .prChecks(dir: widget.cwd, number: widget.pr.number);
-      if (!mounted) return;
-      setState(() {
-        _checks = c;
-        _checksError = null;
-      });
-    } on Object catch (e) {
-      if (!mounted) return;
-      setState(() => _checksError = e);
-    }
-  }
-
-  Future<void> _merge() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text('Merge PR #${widget.pr.number}?'),
-        content: Text(
-          '$_method${_deleteBranch ? " · delete branch" : ""}\n\n${widget.pr.title}',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: const Text('Merge'),
-          ),
-        ],
-      ),
-    );
-    if (confirmed != true || !mounted) return;
-    setState(() => _busy = true);
-    final messenger = ScaffoldMessenger.of(context);
-    final errorColor = Theme.of(context).colorScheme.error;
-    try {
-      await ref
-          .read(gitApiProvider)
-          .mergePullRequest(
-            dir: widget.cwd,
-            number: widget.pr.number,
-            method: _method,
-            deleteBranch: _deleteBranch,
-          );
-      if (!mounted) return;
-      messenger.showSnackBar(
-        SnackBar(content: Text('Merged PR #${widget.pr.number}')),
-      );
-      widget.onMerged();
-    } on ApiException catch (e) {
-      if (!mounted) return;
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text('Merge failed: ${e.message}'),
-          backgroundColor: errorColor,
-        ),
-      );
-    } finally {
-      if (mounted) setState(() => _busy = false);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Container(
-      margin: const EdgeInsets.only(left: 22, right: 4, bottom: 6),
-      padding: const EdgeInsets.all(8),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (_checksError != null)
-            Text(
-              'Checks unavailable',
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.outline,
-              ),
-            )
-          else if (_checks == null)
-            const SizedBox(
-              height: 18,
-              child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
-            )
-          else if (_checks!.isEmpty)
-            Text(
-              'No checks configured.',
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.outline,
-              ),
-            )
-          else
-            _ChecksSummary(checks: _checks!),
-          const Divider(height: 16),
-          Row(
-            children: [
-              DropdownButton<String>(
-                value: _method,
-                isDense: true,
-                items: const [
-                  DropdownMenuItem(value: 'squash', child: Text('squash')),
-                  DropdownMenuItem(value: 'merge', child: Text('merge')),
-                  DropdownMenuItem(value: 'rebase', child: Text('rebase')),
-                ],
-                onChanged: _busy
-                    ? null
-                    : (v) {
-                        if (v != null) setState(() => _method = v);
-                      },
-              ),
-              const SizedBox(width: 8),
-              Row(
-                mainAxisSize: MainAxisSize.min,
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Checkbox(
-                    value: _deleteBranch,
-                    onChanged: _busy
-                        ? null
-                        : (v) => setState(() => _deleteBranch = v ?? false),
-                    visualDensity: VisualDensity.compact,
+                  Text(
+                    pr.title,
+                    style: theme.textTheme.bodyMedium,
+                    overflow: TextOverflow.ellipsis,
                   ),
-                  Text('Delete branch', style: theme.textTheme.bodySmall),
+                  Text(
+                    '#${pr.number} · ${pr.author} · ${pr.head} → ${pr.base}',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.outline,
+                      fontFamily: 'monospace',
+                      fontSize: 10,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
                 ],
               ),
-              const Spacer(),
-              FilledButton.icon(
-                onPressed: _busy ? null : _merge,
-                icon: _busy
-                    ? const SizedBox(
-                        width: 14,
-                        height: 14,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : const Icon(Icons.merge, size: 16),
-                label: const Text('Merge'),
-              ),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _ChecksSummary extends StatelessWidget {
-  const _ChecksSummary({required this.checks});
-  final List<GitCheckRun> checks;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    var pending = 0;
-    var passed = 0;
-    var failed = 0;
-    for (final c in checks) {
-      if (c.passing) {
-        passed++;
-      } else if (c.failing) {
-        failed++;
-      } else {
-        pending++;
-      }
-    }
-    IconData icon;
-    Color color;
-    String label;
-    if (pending > 0) {
-      icon = Icons.circle_outlined;
-      color = theme.colorScheme.outline;
-      label =
-          '$pending pending · $passed passed${failed > 0 ? " · $failed failed" : ""}';
-    } else if (failed > 0) {
-      icon = Icons.cancel_outlined;
-      color = theme.colorScheme.error;
-      label = '$failed failed · $passed passed';
-    } else {
-      icon = Icons.check_circle_outlined;
-      color = Colors.green;
-      label = 'All $passed passed';
-    }
-    return Row(
-      children: [
-        Icon(icon, size: 16, color: color),
-        const SizedBox(width: 6),
-        Expanded(
-          child: Text(
-            label,
-            style: theme.textTheme.bodySmall?.copyWith(color: color),
-          ),
+            ),
+            Icon(
+              Icons.chevron_right,
+              size: 16,
+              color: theme.colorScheme.outline,
+            ),
+          ],
         ),
-      ],
+      ),
     );
   }
 }

--- a/app/mobile/lib/features/sessions/inspector/pr_detail_screen.dart
+++ b/app/mobile/lib/features/sessions/inspector/pr_detail_screen.dart
@@ -7,14 +7,13 @@ import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/git_api.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-// PRDetailScreen is the full-screen surface opened when a PR row is
-// tapped (any state). It mirrors the web detail drawer: a status
-// badge, the description (the list endpoint omits body, so we re-fetch
-// the single PR here), CI checks for every state, and — only while the
-// PR is open — merge controls.
+// PRDetailScreen is the full-screen, GitHub-style PR view opened when a
+// row is tapped (any state). Four tabs — Conversation / Commits /
+// Checks / Files changed — all read-only; the merge action (open PRs
+// only) sits in a footer below the tabs.
 //
-// Returns `true` via Navigator.pop when the PR was merged so the
-// caller can refresh its list.
+// Returns `true` via Navigator.pop when the PR was merged so the caller
+// can refresh its list.
 class PRDetailScreen extends ConsumerStatefulWidget {
   const PRDetailScreen({required this.cwd, required this.pr, super.key});
 
@@ -32,31 +31,15 @@ class _PRDetailScreenState extends ConsumerState<PRDetailScreen> {
   bool _detailLoading = true;
   Object? _detailError;
 
-  List<GitCheckRun>? _checks;
-  Object? _checksError;
-
   String _method = 'squash';
   bool _deleteBranch = true;
   bool _busy = false;
-
-  Timer? _checksTimer;
 
   @override
   void initState() {
     super.initState();
     _pr = widget.pr;
     unawaited(_loadDetail());
-    unawaited(_loadChecks());
-    _checksTimer = Timer.periodic(
-      const Duration(seconds: 30),
-      (_) => unawaited(_loadChecks()),
-    );
-  }
-
-  @override
-  void dispose() {
-    _checksTimer?.cancel();
-    super.dispose();
   }
 
   Future<void> _loadDetail() async {
@@ -79,36 +62,14 @@ class _PRDetailScreenState extends ConsumerState<PRDetailScreen> {
     }
   }
 
-  Future<void> _loadChecks() async {
-    try {
-      final c = await ref
-          .read(gitApiProvider)
-          .prChecks(dir: widget.cwd, number: widget.pr.number);
-      if (!mounted) return;
-      setState(() {
-        _checks = c;
-        _checksError = null;
-      });
-    } on Object catch (e) {
-      if (!mounted) return;
-      setState(() => _checksError = e);
-    }
-  }
-
   Future<void> _openInBrowser() async {
     final uri = Uri.tryParse(_pr.url);
     if (uri == null) return;
     try {
       await launchUrl(uri, mode: LaunchMode.externalApplication);
     } on Object {
-      // Best-effort: a missing browser / malformed URL shouldn't crash
-      // the screen. The host link is a convenience, not load-bearing.
+      // Best-effort convenience link; never crash the screen.
     }
-  }
-
-  String _errorMessage(Object? e) {
-    if (e is ApiException) return e.message;
-    return '$e';
   }
 
   Future<void> _merge() async {
@@ -166,20 +127,63 @@ class _PRDetailScreenState extends ConsumerState<PRDetailScreen> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Scaffold(
-      appBar: AppBar(
-        title: Text('PR #${_pr.number}'),
-        actions: [
-          if (_pr.url.isNotEmpty)
-            IconButton(
-              tooltip: 'Open on host',
-              icon: const Icon(Icons.open_in_new),
-              onPressed: _openInBrowser,
+    final detailError = _detailError == null ? null : _errMsg(_detailError);
+    return DefaultTabController(
+      length: 4,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text('PR #${_pr.number}'),
+          actions: [
+            if (_pr.url.isNotEmpty)
+              IconButton(
+                tooltip: 'Open on host',
+                icon: const Icon(Icons.open_in_new),
+                onPressed: _openInBrowser,
+              ),
+          ],
+        ),
+        body: Column(
+          children: [
+            _header(theme),
+            const TabBar(
+              isScrollable: true,
+              tabAlignment: TabAlignment.start,
+              tabs: [
+                Tab(text: 'Conversation'),
+                Tab(text: 'Commits'),
+                Tab(text: 'Checks'),
+                Tab(text: 'Files'),
+              ],
             ),
-        ],
+            Expanded(
+              child: TabBarView(
+                children: [
+                  _ConversationTab(
+                    cwd: widget.cwd,
+                    number: _pr.number,
+                    author: _pr.author,
+                    body: _pr.body,
+                    detailLoading: _detailLoading,
+                    detailError: detailError,
+                  ),
+                  _CommitsTab(cwd: widget.cwd, number: _pr.number),
+                  _ChecksTab(cwd: widget.cwd, number: _pr.number),
+                  _FilesTab(cwd: widget.cwd, number: _pr.number),
+                ],
+              ),
+            ),
+          ],
+        ),
+        bottomNavigationBar: _pr.state == 'open' ? _mergeBar(theme) : null,
       ),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
+    );
+  }
+
+  Widget _header(ThemeData theme) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(_pr.title, style: theme.textTheme.titleMedium),
           const SizedBox(height: 8),
@@ -196,53 +200,186 @@ class _PRDetailScreenState extends ConsumerState<PRDetailScreen> {
                   color: theme.colorScheme.outline,
                 ),
               ),
+              Text(
+                '#${_pr.number} · ${_pr.author}',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.outline,
+                ),
+              ),
             ],
           ),
-          const SizedBox(height: 4),
-          Text(
-            '#${_pr.number} · ${_pr.author}',
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.outline,
-            ),
-          ),
-          const Divider(height: 32),
-          Text('Description', style: theme.textTheme.labelLarge),
-          const SizedBox(height: 8),
-          _buildDescription(theme),
-          const Divider(height: 32),
-          Text('Checks', style: theme.textTheme.labelLarge),
-          const SizedBox(height: 8),
-          _buildChecks(theme),
-          if (_pr.state == 'open') ...[
-            const Divider(height: 32),
-            Text('Merge', style: theme.textTheme.labelLarge),
-            const SizedBox(height: 8),
-            _buildMergeControls(theme),
-          ],
         ],
       ),
     );
   }
 
-  Widget _buildDescription(ThemeData theme) {
-    if (_detailLoading && _pr.body.isEmpty) {
+  Widget _mergeBar(ThemeData theme) {
+    return SafeArea(
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(12, 6, 12, 6),
+        decoration: BoxDecoration(
+          border: Border(top: BorderSide(color: theme.dividerColor)),
+        ),
+        child: Row(
+          children: [
+            DropdownButton<String>(
+              value: _method,
+              isDense: true,
+              items: const [
+                DropdownMenuItem(value: 'squash', child: Text('squash')),
+                DropdownMenuItem(value: 'merge', child: Text('merge')),
+                DropdownMenuItem(value: 'rebase', child: Text('rebase')),
+              ],
+              onChanged: _busy
+                  ? null
+                  : (v) {
+                      if (v != null) setState(() => _method = v);
+                    },
+            ),
+            const SizedBox(width: 8),
+            Checkbox(
+              value: _deleteBranch,
+              onChanged: _busy
+                  ? null
+                  : (v) => setState(() => _deleteBranch = v ?? false),
+              visualDensity: VisualDensity.compact,
+            ),
+            Text('Delete branch', style: theme.textTheme.bodySmall),
+            const Spacer(),
+            FilledButton.icon(
+              onPressed: _busy ? null : _merge,
+              icon: _busy
+                  ? const SizedBox(
+                      width: 14,
+                      height: 14,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.merge, size: 16),
+              label: const Text('Merge'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Conversation tab ──────────────────────────────────────────────
+
+class _ConversationTab extends ConsumerStatefulWidget {
+  const _ConversationTab({
+    required this.cwd,
+    required this.number,
+    required this.author,
+    required this.body,
+    required this.detailLoading,
+    required this.detailError,
+  });
+
+  final String cwd;
+  final int number;
+  final String author;
+  final String body; // PR description (from the parent detail fetch)
+  final bool detailLoading;
+  final String? detailError;
+
+  @override
+  ConsumerState<_ConversationTab> createState() => _ConversationTabState();
+}
+
+class _ConversationTabState extends ConsumerState<_ConversationTab> {
+  List<GitPRComment>? _comments;
+  Object? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
+  }
+
+  Future<void> _load() async {
+    try {
+      final c = await ref
+          .read(gitApiProvider)
+          .prComments(dir: widget.cwd, number: widget.number);
+      if (!mounted) return;
+      setState(() {
+        _comments = c;
+        _error = null;
+      });
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() => _error = e);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final comments = _comments ?? const <GitPRComment>[];
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        // Description
+        _CommentCard(
+          author: widget.author,
+          when: '',
+          child: _descriptionBody(theme),
+        ),
+        const SizedBox(height: 8),
+        // Comments
+        if (_error != null)
+          Text(
+            'Comments unavailable: ${_errMsg(_error)}',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.outline,
+            ),
+          )
+        else if (_comments == null)
+          const Padding(
+            padding: EdgeInsets.symmetric(vertical: 8),
+            child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+          )
+        else if (comments.isEmpty)
+          Text(
+            'No comments yet.',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.outline,
+            ),
+          )
+        else
+          for (final c in comments) ...[
+            _CommentCard(
+              author: c.author,
+              when: _relTime(c.createdAt),
+              state: c.state.isEmpty ? null : c.state,
+              child: SelectableText(c.body, style: theme.textTheme.bodyMedium),
+            ),
+            const SizedBox(height: 8),
+          ],
+      ],
+    );
+  }
+
+  Widget _descriptionBody(ThemeData theme) {
+    if (widget.detailLoading && widget.body.isEmpty) {
       return const Padding(
-        padding: EdgeInsets.symmetric(vertical: 8),
+        padding: EdgeInsets.symmetric(vertical: 4),
         child: SizedBox(
-          height: 18,
+          height: 16,
           child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
         ),
       );
     }
-    if (_detailError != null && _pr.body.isEmpty) {
+    if (widget.detailError != null && widget.body.isEmpty) {
       return Text(
-        "Couldn't load details: ${_errorMessage(_detailError)}",
+        "Couldn't load details: ${widget.detailError}",
         style: theme.textTheme.bodySmall?.copyWith(
           color: theme.colorScheme.error,
         ),
       );
     }
-    if (_pr.body.trim().isEmpty) {
+    if (widget.body.trim().isEmpty) {
       return Text(
         'No description provided.',
         style: theme.textTheme.bodySmall?.copyWith(
@@ -251,43 +388,270 @@ class _PRDetailScreenState extends ConsumerState<PRDetailScreen> {
         ),
       );
     }
-    // Plain-text rendering preserving newlines. Mobile carries no
-    // markdown renderer dependency (the web drawer renders markdown);
-    // this keeps the description readable without pulling in a package.
-    return SelectableText(_pr.body.trim(), style: theme.textTheme.bodyMedium);
+    return SelectableText(
+      widget.body.trim(),
+      style: theme.textTheme.bodyMedium,
+    );
+  }
+}
+
+class _CommentCard extends StatelessWidget {
+  const _CommentCard({
+    required this.author,
+    required this.when,
+    required this.child,
+    this.state,
+  });
+
+  final String author;
+  final String when;
+  final String? state;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: theme.dividerColor),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            decoration: BoxDecoration(
+              color: theme.colorScheme.surfaceContainerHighest,
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
+            ),
+            child: Row(
+              children: [
+                Text(
+                  author,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    fontFamily: 'monospace',
+                  ),
+                ),
+                if (state != null) ...[
+                  const SizedBox(width: 6),
+                  _ReviewStateBadge(state: state!),
+                ],
+                const Spacer(),
+                if (when.isNotEmpty)
+                  Text(
+                    when,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.outline,
+                      fontSize: 10,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(10),
+            child: SizedBox(width: double.infinity, child: child),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ReviewStateBadge extends StatelessWidget {
+  const _ReviewStateBadge({required this.state});
+  final String state;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = switch (state) {
+      'approved' => Colors.green,
+      'changes_requested' => theme.colorScheme.error,
+      _ => theme.colorScheme.outline,
+    };
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      decoration: BoxDecoration(
+        border: Border.all(color: color),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        state.replaceAll('_', ' '),
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: color,
+          fontSize: 9,
+        ),
+      ),
+    );
+  }
+}
+
+// ── Commits tab ───────────────────────────────────────────────────
+
+class _CommitsTab extends ConsumerStatefulWidget {
+  const _CommitsTab({required this.cwd, required this.number});
+  final String cwd;
+  final int number;
+
+  @override
+  ConsumerState<_CommitsTab> createState() => _CommitsTabState();
+}
+
+class _CommitsTabState extends ConsumerState<_CommitsTab> {
+  List<GitPRCommit>? _commits;
+  Object? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
   }
 
-  Widget _buildChecks(ThemeData theme) {
-    if (_checksError != null) {
-      return Text(
-        'Checks unavailable: ${_errorMessage(_checksError)}',
-        style: theme.textTheme.bodySmall?.copyWith(
-          color: theme.colorScheme.outline,
-        ),
-      );
+  Future<void> _load() async {
+    try {
+      final c = await ref
+          .read(gitApiProvider)
+          .prCommits(dir: widget.cwd, number: widget.number);
+      if (!mounted) return;
+      setState(() {
+        _commits = c;
+        _error = null;
+      });
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() => _error = e);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (_error != null) {
+      return _TabMessage(text: 'Commits unavailable: ${_errMsg(_error)}');
+    }
+    if (_commits == null) {
+      return const Center(child: CircularProgressIndicator(strokeWidth: 2));
+    }
+    if (_commits!.isEmpty) {
+      return const _TabMessage(text: 'No commits.');
+    }
+    return ListView.separated(
+      padding: const EdgeInsets.all(16),
+      itemCount: _commits!.length,
+      separatorBuilder: (_, __) => Divider(height: 14, color: theme.dividerColor),
+      itemBuilder: (context, i) {
+        final c = _commits![i];
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(Icons.commit, size: 16, color: theme.colorScheme.outline),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    c.subject,
+                    style: theme.textTheme.bodyMedium,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text(
+                    '${c.author} · ${_relTime(c.date)}',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.outline,
+                      fontFamily: 'monospace',
+                      fontSize: 10,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            Text(
+              c.shortSha,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.outline,
+                fontFamily: 'monospace',
+                fontSize: 10,
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+// ── Checks tab ────────────────────────────────────────────────────
+
+class _ChecksTab extends ConsumerStatefulWidget {
+  const _ChecksTab({required this.cwd, required this.number});
+  final String cwd;
+  final int number;
+
+  @override
+  ConsumerState<_ChecksTab> createState() => _ChecksTabState();
+}
+
+class _ChecksTabState extends ConsumerState<_ChecksTab> {
+  List<GitCheckRun>? _checks;
+  Object? _error;
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
+    _timer = Timer.periodic(
+      const Duration(seconds: 30),
+      (_) => unawaited(_load()),
+    );
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    try {
+      final c = await ref
+          .read(gitApiProvider)
+          .prChecks(dir: widget.cwd, number: widget.number);
+      if (!mounted) return;
+      setState(() {
+        _checks = c;
+        _error = null;
+      });
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() => _error = e);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (_error != null) {
+      return _TabMessage(text: 'Checks unavailable: ${_errMsg(_error)}');
     }
     if (_checks == null) {
-      return const SizedBox(
-        height: 18,
-        child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
-      );
+      return const Center(child: CircularProgressIndicator(strokeWidth: 2));
     }
     if (_checks!.isEmpty) {
-      return Text(
-        'No checks configured for this PR.',
-        style: theme.textTheme.bodySmall?.copyWith(
-          color: theme.colorScheme.outline,
-        ),
-      );
+      return const _TabMessage(text: 'No checks configured for this PR.');
     }
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+    return ListView(
+      padding: const EdgeInsets.all(16),
       children: [
         _ChecksSummary(checks: _checks!),
         const SizedBox(height: 8),
         for (final c in _checks!)
           Padding(
-            padding: const EdgeInsets.symmetric(vertical: 2),
+            padding: const EdgeInsets.symmetric(vertical: 3),
             child: Row(
               children: [
                 Icon(_checkIcon(c), size: 14, color: _checkColor(theme, c)),
@@ -305,53 +669,263 @@ class _PRDetailScreenState extends ConsumerState<PRDetailScreen> {
       ],
     );
   }
+}
 
-  Widget _buildMergeControls(ThemeData theme) {
-    return Row(
-      children: [
-        DropdownButton<String>(
-          value: _method,
-          isDense: true,
-          items: const [
-            DropdownMenuItem(value: 'squash', child: Text('squash')),
-            DropdownMenuItem(value: 'merge', child: Text('merge')),
-            DropdownMenuItem(value: 'rebase', child: Text('rebase')),
-          ],
-          onChanged: _busy
-              ? null
-              : (v) {
-                  if (v != null) setState(() => _method = v);
-                },
-        ),
-        const SizedBox(width: 8),
-        Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Checkbox(
-              value: _deleteBranch,
-              onChanged: _busy
-                  ? null
-                  : (v) => setState(() => _deleteBranch = v ?? false),
-              visualDensity: VisualDensity.compact,
-            ),
-            Text('Delete branch', style: theme.textTheme.bodySmall),
-          ],
-        ),
-        const Spacer(),
-        FilledButton.icon(
-          onPressed: _busy ? null : _merge,
-          icon: _busy
-              ? const SizedBox(
-                  width: 14,
-                  height: 14,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                )
-              : const Icon(Icons.merge, size: 16),
-          label: const Text('Merge'),
-        ),
-      ],
+// ── Files changed tab ─────────────────────────────────────────────
+
+class _FilesTab extends ConsumerStatefulWidget {
+  const _FilesTab({required this.cwd, required this.number});
+  final String cwd;
+  final int number;
+
+  @override
+  ConsumerState<_FilesTab> createState() => _FilesTabState();
+}
+
+class _FilesTabState extends ConsumerState<_FilesTab> {
+  List<GitPRFile>? _files;
+  Object? _error;
+  Set<String> _expanded = {};
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
+  }
+
+  Future<void> _load() async {
+    try {
+      final f = await ref
+          .read(gitApiProvider)
+          .prFiles(dir: widget.cwd, number: widget.number);
+      if (!mounted) return;
+      setState(() {
+        _files = f;
+        _error = null;
+      });
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() => _error = e);
+    }
+  }
+
+  void _toggle(String name) {
+    final next = Set<String>.from(_expanded);
+    if (next.contains(name)) {
+      next.remove(name);
+    } else {
+      next.add(name);
+    }
+    setState(() => _expanded = next);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (_error != null) {
+      return _TabMessage(text: 'Files unavailable: ${_errMsg(_error)}');
+    }
+    if (_files == null) {
+      return const Center(child: CircularProgressIndicator(strokeWidth: 2));
+    }
+    if (_files!.isEmpty) {
+      return const _TabMessage(text: 'No changed files.');
+    }
+    return ListView.separated(
+      padding: const EdgeInsets.all(16),
+      itemCount: _files!.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 6),
+      itemBuilder: (context, i) {
+        final f = _files![i];
+        final isOpen = _expanded.contains(f.filename);
+        return Container(
+          decoration: BoxDecoration(
+            border: Border.all(color: theme.dividerColor),
+            borderRadius: BorderRadius.circular(6),
+          ),
+          clipBehavior: Clip.antiAlias,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              InkWell(
+                onTap: () => _toggle(f.filename),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 8,
+                  ),
+                  child: Row(
+                    children: [
+                      _StatusLetter(status: f.status),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          f.filename,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            fontFamily: 'monospace',
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        '+${f.additions}',
+                        style: const TextStyle(
+                          color: Colors.green,
+                          fontSize: 11,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        '-${f.deletions}',
+                        style: TextStyle(
+                          color: theme.colorScheme.error,
+                          fontSize: 11,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              if (isOpen)
+                f.patch.isEmpty
+                    ? Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 8,
+                        ),
+                        child: Text(
+                          'No inline diff available.',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.outline,
+                          ),
+                        ),
+                      )
+                    : _DiffView(patch: f.patch),
+            ],
+          ),
+        );
+      },
     );
   }
+}
+
+class _DiffView extends StatelessWidget {
+  const _DiffView({required this.patch});
+  final String patch;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final lines = patch.split('\n');
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        border: Border(top: BorderSide(color: theme.dividerColor)),
+      ),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            for (final line in lines) _diffLine(theme, line),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _diffLine(ThemeData theme, String line) {
+    final isAdd = line.startsWith('+') && !line.startsWith('+++');
+    final isDel = line.startsWith('-') && !line.startsWith('---');
+    final isHunk = line.startsWith('@@');
+    Color? bg;
+    var fg = theme.colorScheme.onSurface;
+    if (isAdd) {
+      bg = Colors.green.withValues(alpha: 0.12);
+      fg = Colors.green.shade400;
+    } else if (isDel) {
+      bg = theme.colorScheme.error.withValues(alpha: 0.12);
+      fg = theme.colorScheme.error;
+    } else if (isHunk) {
+      fg = theme.colorScheme.outline;
+    }
+    return Container(
+      color: bg,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 1),
+      child: Text(
+        line.isEmpty ? ' ' : line,
+        style: TextStyle(fontFamily: 'monospace', fontSize: 11, color: fg),
+      ),
+    );
+  }
+}
+
+class _StatusLetter extends StatelessWidget {
+  const _StatusLetter({required this.status});
+  final String status;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (String ch, Color color) = switch (status) {
+      'added' => ('A', Colors.green),
+      'removed' => ('D', theme.colorScheme.error),
+      'renamed' => ('R', Colors.purple),
+      _ => ('M', theme.colorScheme.outline),
+    };
+    return SizedBox(
+      width: 14,
+      child: Text(
+        ch,
+        textAlign: TextAlign.center,
+        style: TextStyle(
+          fontFamily: 'monospace',
+          fontSize: 11,
+          color: color,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+// ── shared bits ───────────────────────────────────────────────────
+
+class _TabMessage extends StatelessWidget {
+  const _TabMessage({required this.text});
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Text(
+        text,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.outline,
+        ),
+      ),
+    );
+  }
+}
+
+String _errMsg(Object? e) {
+  if (e is ApiException) return e.message;
+  return '$e';
+}
+
+String _relTime(String iso) {
+  final t = DateTime.tryParse(iso);
+  if (t == null) return iso;
+  final d = DateTime.now().difference(t);
+  if (d.inDays > 365) return '${(d.inDays / 365).floor()}y ago';
+  if (d.inDays > 30) return '${(d.inDays / 30).floor()}mo ago';
+  if (d.inDays > 0) return '${d.inDays}d ago';
+  if (d.inHours > 0) return '${d.inHours}h ago';
+  if (d.inMinutes > 0) return '${d.inMinutes}m ago';
+  return 'just now';
 }
 
 IconData _checkIcon(GitCheckRun c) {
@@ -400,9 +974,7 @@ class _StateBadge extends StatelessWidget {
   }
 }
 
-// _ChecksSummary aggregates the check runs into a single headline row
-// (moved here from git_pr_section.dart when the inline expand panel
-// was replaced by this screen).
+// _ChecksSummary aggregates the check runs into a single headline row.
 class _ChecksSummary extends StatelessWidget {
   const _ChecksSummary({required this.checks});
 

--- a/app/mobile/lib/features/sessions/inspector/pr_detail_screen.dart
+++ b/app/mobile/lib/features/sessions/inspector/pr_detail_screen.dart
@@ -1,0 +1,456 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/api/api_exception.dart';
+import 'package:opendray/core/api/git_api.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+// PRDetailScreen is the full-screen surface opened when a PR row is
+// tapped (any state). It mirrors the web detail drawer: a status
+// badge, the description (the list endpoint omits body, so we re-fetch
+// the single PR here), CI checks for every state, and — only while the
+// PR is open — merge controls.
+//
+// Returns `true` via Navigator.pop when the PR was merged so the
+// caller can refresh its list.
+class PRDetailScreen extends ConsumerStatefulWidget {
+  const PRDetailScreen({required this.cwd, required this.pr, super.key});
+
+  final String cwd;
+  final GitPullRequest pr;
+
+  @override
+  ConsumerState<PRDetailScreen> createState() => _PRDetailScreenState();
+}
+
+class _PRDetailScreenState extends ConsumerState<PRDetailScreen> {
+  // Seeded from the list row so the header paints instantly; replaced
+  // by the detail fetch (which carries the body) once it resolves.
+  late GitPullRequest _pr;
+  bool _detailLoading = true;
+  Object? _detailError;
+
+  List<GitCheckRun>? _checks;
+  Object? _checksError;
+
+  String _method = 'squash';
+  bool _deleteBranch = true;
+  bool _busy = false;
+
+  Timer? _checksTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _pr = widget.pr;
+    unawaited(_loadDetail());
+    unawaited(_loadChecks());
+    _checksTimer = Timer.periodic(
+      const Duration(seconds: 30),
+      (_) => unawaited(_loadChecks()),
+    );
+  }
+
+  @override
+  void dispose() {
+    _checksTimer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _loadDetail() async {
+    try {
+      final full = await ref
+          .read(gitApiProvider)
+          .getPullRequest(dir: widget.cwd, number: widget.pr.number);
+      if (!mounted) return;
+      setState(() {
+        _pr = full;
+        _detailLoading = false;
+        _detailError = null;
+      });
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _detailError = e;
+        _detailLoading = false;
+      });
+    }
+  }
+
+  Future<void> _loadChecks() async {
+    try {
+      final c = await ref
+          .read(gitApiProvider)
+          .prChecks(dir: widget.cwd, number: widget.pr.number);
+      if (!mounted) return;
+      setState(() {
+        _checks = c;
+        _checksError = null;
+      });
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() => _checksError = e);
+    }
+  }
+
+  Future<void> _openInBrowser() async {
+    final uri = Uri.tryParse(_pr.url);
+    if (uri == null) return;
+    try {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } on Object {
+      // Best-effort: a missing browser / malformed URL shouldn't crash
+      // the screen. The host link is a convenience, not load-bearing.
+    }
+  }
+
+  String _errorMessage(Object? e) {
+    if (e is ApiException) return e.message;
+    return '$e';
+  }
+
+  Future<void> _merge() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('Merge PR #${_pr.number}?'),
+        content: Text(
+          '$_method${_deleteBranch ? " · delete branch" : ""}\n\n${_pr.title}',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Merge'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    setState(() => _busy = true);
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+    final errorColor = Theme.of(context).colorScheme.error;
+    try {
+      await ref
+          .read(gitApiProvider)
+          .mergePullRequest(
+            dir: widget.cwd,
+            number: _pr.number,
+            method: _method,
+            deleteBranch: _deleteBranch,
+          );
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(content: Text('Merged PR #${_pr.number}')),
+      );
+      navigator.pop(true); // tell the caller to refresh its list
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('Merge failed: ${e.message}'),
+          backgroundColor: errorColor,
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('PR #${_pr.number}'),
+        actions: [
+          if (_pr.url.isNotEmpty)
+            IconButton(
+              tooltip: 'Open on host',
+              icon: const Icon(Icons.open_in_new),
+              onPressed: _openInBrowser,
+            ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(_pr.title, style: theme.textTheme.titleMedium),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 4,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              _StateBadge(pr: _pr),
+              Text(
+                '${_pr.head} → ${_pr.base}',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontFamily: 'monospace',
+                  color: theme.colorScheme.outline,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '#${_pr.number} · ${_pr.author}',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.outline,
+            ),
+          ),
+          const Divider(height: 32),
+          Text('Description', style: theme.textTheme.labelLarge),
+          const SizedBox(height: 8),
+          _buildDescription(theme),
+          const Divider(height: 32),
+          Text('Checks', style: theme.textTheme.labelLarge),
+          const SizedBox(height: 8),
+          _buildChecks(theme),
+          if (_pr.state == 'open') ...[
+            const Divider(height: 32),
+            Text('Merge', style: theme.textTheme.labelLarge),
+            const SizedBox(height: 8),
+            _buildMergeControls(theme),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDescription(ThemeData theme) {
+    if (_detailLoading && _pr.body.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 8),
+        child: SizedBox(
+          height: 18,
+          child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+        ),
+      );
+    }
+    if (_detailError != null && _pr.body.isEmpty) {
+      return Text(
+        "Couldn't load details: ${_errorMessage(_detailError)}",
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.error,
+        ),
+      );
+    }
+    if (_pr.body.trim().isEmpty) {
+      return Text(
+        'No description provided.',
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.outline,
+          fontStyle: FontStyle.italic,
+        ),
+      );
+    }
+    // Plain-text rendering preserving newlines. Mobile carries no
+    // markdown renderer dependency (the web drawer renders markdown);
+    // this keeps the description readable without pulling in a package.
+    return SelectableText(_pr.body.trim(), style: theme.textTheme.bodyMedium);
+  }
+
+  Widget _buildChecks(ThemeData theme) {
+    if (_checksError != null) {
+      return Text(
+        'Checks unavailable: ${_errorMessage(_checksError)}',
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.outline,
+        ),
+      );
+    }
+    if (_checks == null) {
+      return const SizedBox(
+        height: 18,
+        child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+      );
+    }
+    if (_checks!.isEmpty) {
+      return Text(
+        'No checks configured for this PR.',
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.outline,
+        ),
+      );
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _ChecksSummary(checks: _checks!),
+        const SizedBox(height: 8),
+        for (final c in _checks!)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 2),
+            child: Row(
+              children: [
+                Icon(_checkIcon(c), size: 14, color: _checkColor(theme, c)),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    c.name,
+                    style: theme.textTheme.bodySmall,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildMergeControls(ThemeData theme) {
+    return Row(
+      children: [
+        DropdownButton<String>(
+          value: _method,
+          isDense: true,
+          items: const [
+            DropdownMenuItem(value: 'squash', child: Text('squash')),
+            DropdownMenuItem(value: 'merge', child: Text('merge')),
+            DropdownMenuItem(value: 'rebase', child: Text('rebase')),
+          ],
+          onChanged: _busy
+              ? null
+              : (v) {
+                  if (v != null) setState(() => _method = v);
+                },
+        ),
+        const SizedBox(width: 8),
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Checkbox(
+              value: _deleteBranch,
+              onChanged: _busy
+                  ? null
+                  : (v) => setState(() => _deleteBranch = v ?? false),
+              visualDensity: VisualDensity.compact,
+            ),
+            Text('Delete branch', style: theme.textTheme.bodySmall),
+          ],
+        ),
+        const Spacer(),
+        FilledButton.icon(
+          onPressed: _busy ? null : _merge,
+          icon: _busy
+              ? const SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.merge, size: 16),
+          label: const Text('Merge'),
+        ),
+      ],
+    );
+  }
+}
+
+IconData _checkIcon(GitCheckRun c) {
+  if (c.passing) return Icons.check_circle_outlined;
+  if (c.failing) return Icons.cancel_outlined;
+  return Icons.circle_outlined;
+}
+
+Color _checkColor(ThemeData theme, GitCheckRun c) {
+  if (c.passing) return Colors.green;
+  if (c.failing) return theme.colorScheme.error;
+  return theme.colorScheme.outline;
+}
+
+// _StateBadge is the textual status pill in the detail header. Draft
+// wins over the open/closed/merged state since a draft is always open.
+class _StateBadge extends StatelessWidget {
+  const _StateBadge({required this.pr});
+
+  final GitPullRequest pr;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (String label, Color color) = pr.draft
+        ? ('DRAFT', theme.colorScheme.outline)
+        : switch (pr.state) {
+            'merged' => ('MERGED', Colors.purple),
+            'closed' => ('CLOSED', theme.colorScheme.error),
+            _ => ('OPEN', Colors.green),
+          };
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        border: Border.all(color: color),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: color,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+// _ChecksSummary aggregates the check runs into a single headline row
+// (moved here from git_pr_section.dart when the inline expand panel
+// was replaced by this screen).
+class _ChecksSummary extends StatelessWidget {
+  const _ChecksSummary({required this.checks});
+
+  final List<GitCheckRun> checks;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    var pending = 0;
+    var passed = 0;
+    var failed = 0;
+    for (final c in checks) {
+      if (c.passing) {
+        passed++;
+      } else if (c.failing) {
+        failed++;
+      } else {
+        pending++;
+      }
+    }
+    IconData icon;
+    Color color;
+    String label;
+    if (pending > 0) {
+      icon = Icons.circle_outlined;
+      color = theme.colorScheme.outline;
+      label =
+          '$pending pending · $passed passed${failed > 0 ? " · $failed failed" : ""}';
+    } else if (failed > 0) {
+      icon = Icons.cancel_outlined;
+      color = theme.colorScheme.error;
+      label = '$failed failed · $passed passed';
+    } else {
+      icon = Icons.check_circle_outlined;
+      color = Colors.green;
+      label = 'All $passed passed';
+    }
+    return Row(
+      children: [
+        Icon(icon, size: 16, color: color),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            label,
+            style: theme.textTheme.bodySmall?.copyWith(color: color),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/app/shared/src/lib/githost.ts
+++ b/app/shared/src/lib/githost.ts
@@ -171,3 +171,66 @@ export async function getPRChecks(
   )
   return res.checks ?? []
 }
+
+// ── PR detail tabs: commits / files / conversation ─────────────
+
+export interface PRCommit {
+  sha: string
+  short_sha: string
+  message: string // full message; UI shows the first line
+  author: string
+  date: string
+  url: string
+}
+
+export interface PRFile {
+  filename: string
+  // added | modified | removed | renamed
+  status: string
+  additions: number
+  deletions: number
+  // Unified diff; absent when the host doesn't return it inline.
+  patch?: string
+}
+
+export interface PRComment {
+  author: string
+  body: string
+  created_at: string
+  // Set only for review summaries: approved | changes_requested | commented
+  state?: string
+  url?: string
+}
+
+export async function getPRCommits(
+  path: string,
+  number: number,
+): Promise<PRCommit[]> {
+  const params = new URLSearchParams({ path })
+  const res = await api<{ commits: PRCommit[] }>(
+    `/api/v1/git/prs/${number}/commits?${params.toString()}`,
+  )
+  return res.commits ?? []
+}
+
+export async function getPRFiles(
+  path: string,
+  number: number,
+): Promise<PRFile[]> {
+  const params = new URLSearchParams({ path })
+  const res = await api<{ files: PRFile[] }>(
+    `/api/v1/git/prs/${number}/files?${params.toString()}`,
+  )
+  return res.files ?? []
+}
+
+export async function getPRComments(
+  path: string,
+  number: number,
+): Promise<PRComment[]> {
+  const params = new URLSearchParams({ path })
+  const res = await api<{ comments: PRComment[] }>(
+    `/api/v1/git/prs/${number}/comments?${params.toString()}`,
+  )
+  return res.comments ?? []
+}

--- a/app/shared/src/lib/githost.ts
+++ b/app/shared/src/lib/githost.ts
@@ -74,6 +74,9 @@ export interface GitPullRequest {
   base: string
   url: string
   draft: boolean
+  // Description (markdown). Only populated by getGitPR (the single-PR
+  // detail fetch); the list endpoint omits it to stay lean.
+  body?: string
   updated_at: string
 }
 
@@ -94,6 +97,18 @@ export async function listGitPRs(
 ): Promise<GitPullRequestsResponse> {
   const params = new URLSearchParams({ path, state })
   return api<GitPullRequestsResponse>(`/api/v1/git/prs?${params.toString()}`)
+}
+
+// getGitPR fetches a single PR including its body/description. Use this
+// for the detail surface; listGitPRs leaves body empty.
+export async function getGitPR(
+  path: string,
+  number: number,
+): Promise<GitPullRequest> {
+  const params = new URLSearchParams({ path })
+  return api<GitPullRequest>(
+    `/api/v1/git/prs/${number}?${params.toString()}`,
+  )
 }
 
 // ── PR write ops ───────────────────────────────────────────────

--- a/app/web/src/components/sessions/inspector/PullRequestsSection.tsx
+++ b/app/web/src/components/sessions/inspector/PullRequestsSection.tsx
@@ -13,6 +13,7 @@ import {
   CircleDashed,
   Plus,
   GitMerge,
+  GitCommit,
   X,
 } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
@@ -23,9 +24,13 @@ import remarkGfm from 'remark-gfm'
 import {
   type CheckRun,
   type GitPullRequest as PR,
+  type PRComment,
   createGitPR,
   getGitPR,
   getPRChecks,
+  getPRComments,
+  getPRCommits,
+  getPRFiles,
   listGitPRs,
   mergeGitPR,
 } from '@/lib/githost'
@@ -376,6 +381,7 @@ function PRDetailDrawer({
   onClose: () => void
   onMerged: () => void
 }) {
+  const [tab, setTab] = useState<DetailTab>('conversation')
   const [method, setMethod] = useState<'squash' | 'merge' | 'rebase'>('squash')
   const [deleteBranch, setDeleteBranch] = useState(true)
 
@@ -402,12 +408,6 @@ function PRDetailDrawer({
   })
   const full = detail.data ?? pr
 
-  const checks = useQuery({
-    queryKey: ['git-pr-checks', cwd, pr.number],
-    queryFn: () => getPRChecks(cwd, pr.number),
-    refetchInterval: 30_000,
-  })
-
   const merge = useMutation({
     mutationFn: () =>
       mergeGitPR({
@@ -429,16 +429,12 @@ function PRDetailDrawer({
     },
   })
 
-  // Aggregate check status for the headline summary. Pending while any
-  // check is still queued / in_progress; failed if any concluded with
-  // anything other than success / neutral / skipped.
-  const checkSummary = aggregateChecks(checks.data ?? [])
   // body is undefined until the detail fetch resolves; '' means the PR
-  // genuinely has no description.
+  // genuinely has no description. While the query still serves the
+  // seeded list row (isPlaceholderData), the body fetch is in flight.
   const body = full.body?.trim() ?? ''
-  // While the query is still serving the seeded list row, the body
-  // hasn't been fetched yet — drives the description loading state.
   const bodyPending = detail.isPlaceholderData
+  const detailError = detail.isError ? (detail.error as Error).message : null
 
   return createPortal(
     <div className="fixed inset-0 z-[60] flex justify-end">
@@ -450,7 +446,7 @@ function PRDetailDrawer({
       <div
         role="dialog"
         aria-modal="true"
-        className="relative h-full w-full max-w-md bg-background border-l border-border shadow-2xl flex flex-col"
+        className="relative h-full w-full max-w-2xl bg-background border-l border-border shadow-2xl flex flex-col"
       >
         {/* Header */}
         <div className="flex items-start gap-2 px-3 py-2.5 border-b border-border">
@@ -493,161 +489,443 @@ function PRDetailDrawer({
           </span>
         </div>
 
-        {/* Scrollable content */}
-        <div className="flex-1 overflow-y-auto px-3 py-3 flex flex-col gap-4">
-          {/* Description */}
-          <section className="flex flex-col gap-1.5">
-            <h3 className="text-[10px] uppercase tracking-wider text-muted-foreground/70 font-medium">
-              Description
-            </h3>
-            {detail.isError ? (
-              <div className="text-[11px] text-state-failed">
-                Couldn't load details: {(detail.error as Error).message}
-              </div>
-            ) : bodyPending ? (
-              <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-                <Loader2 className="size-3 animate-spin" />
-                Loading…
-              </div>
-            ) : body ? (
-              <div className="prose-md text-[12px] leading-relaxed break-words">
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
-                  components={mdComponents}
-                >
-                  {body}
-                </ReactMarkdown>
-              </div>
-            ) : (
-              <div className="text-[11px] text-muted-foreground/60 italic">
-                No description provided.
-              </div>
-            )}
-          </section>
-
-          {/* Checks — shown for every state, not just open */}
-          <section className="flex flex-col gap-1.5">
-            <h3 className="text-[10px] uppercase tracking-wider text-muted-foreground/70 font-medium">
-              Checks
-            </h3>
-            {checks.isLoading && (
-              <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-                <Loader2 className="size-3 animate-spin" />
-                Loading checks…
-              </div>
-            )}
-            {checks.error && (
-              <div className="text-[11px] text-state-failed">
-                checks unavailable: {(checks.error as Error).message}
-              </div>
-            )}
-            {!checks.isLoading && !checks.error && (
-              <div className="flex flex-col gap-0.5 text-[11px]">
-                {(checks.data ?? []).length === 0 ? (
-                  <div className="text-muted-foreground/60">
-                    No checks configured for this PR.
-                  </div>
-                ) : (
-                  <>
-                    <div
-                      className={cn(
-                        'flex items-center gap-1.5',
-                        checkSummary.allPassing && 'text-state-running',
-                        checkSummary.anyFailed && 'text-state-failed',
-                        checkSummary.pending && 'text-muted-foreground',
-                      )}
-                    >
-                      {checkSummary.allPassing && (
-                        <CheckCircle2 className="size-3" />
-                      )}
-                      {checkSummary.anyFailed && <XCircle className="size-3" />}
-                      {checkSummary.pending && (
-                        <CircleDashed className="size-3 animate-spin" />
-                      )}
-                      <span>{checkSummary.label}</span>
-                    </div>
-                    <div className="pl-4 flex flex-col gap-0.5 text-muted-foreground/80">
-                      {(checks.data ?? []).map((c) => (
-                        <a
-                          key={c.name + c.url}
-                          href={c.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="flex items-center gap-1.5 hover:text-foreground"
-                        >
-                          <CheckIcon check={c} />
-                          <span className="truncate">{c.name}</span>
-                        </a>
-                      ))}
-                    </div>
-                  </>
-                )}
-              </div>
-            )}
-          </section>
-
-          {/* Merge — only while the PR is open */}
-          {full.state === 'open' && (
-            <section className="flex flex-col gap-1.5">
-              <h3 className="text-[10px] uppercase tracking-wider text-muted-foreground/70 font-medium">
-                Merge
-              </h3>
-              <div className="flex flex-wrap items-center gap-2 text-[11px]">
-                <select
-                  value={method}
-                  onChange={(e) =>
-                    setMethod(e.target.value as 'squash' | 'merge' | 'rebase')
-                  }
-                  className="text-[11px] bg-transparent border border-border rounded px-1.5 py-0.5"
-                >
-                  <option value="squash">squash</option>
-                  <option value="merge">merge</option>
-                  <option value="rebase">rebase</option>
-                </select>
-                <label className="flex items-center gap-1 text-muted-foreground">
-                  <input
-                    type="checkbox"
-                    checked={deleteBranch}
-                    onChange={(e) => setDeleteBranch(e.target.checked)}
-                  />
-                  Delete branch
-                </label>
-                <button
-                  type="button"
-                  disabled={merge.isPending}
-                  onClick={() => {
-                    if (
-                      !window.confirm(
-                        `Merge PR #${full.number} (${method})${
-                          deleteBranch ? ' and delete branch' : ''
-                        }?`,
-                      )
-                    ) {
-                      return
-                    }
-                    merge.mutate()
-                  }}
-                  className={cn(
-                    'ml-auto text-[11px] px-2 py-0.5 rounded transition-colors flex items-center gap-1',
-                    merge.isPending
-                      ? 'bg-muted/30 text-muted-foreground/50'
-                      : 'bg-purple-500/80 text-background hover:bg-purple-500',
-                  )}
-                >
-                  {merge.isPending ? (
-                    <Loader2 className="size-3 animate-spin" />
-                  ) : (
-                    <GitMerge className="size-3" />
-                  )}
-                  Merge
-                </button>
-              </div>
-            </section>
-          )}
+        {/* Tabs */}
+        <div className="flex items-center gap-1 px-2 border-b border-border text-[11px]">
+          {DETAIL_TABS.map((t) => (
+            <button
+              key={t.key}
+              type="button"
+              onClick={() => setTab(t.key)}
+              className={cn(
+                'px-2.5 py-1.5 -mb-px border-b-2 transition-colors',
+                tab === t.key
+                  ? 'border-state-running text-foreground'
+                  : 'border-transparent text-muted-foreground/60 hover:text-foreground',
+              )}
+            >
+              {t.label}
+            </button>
+          ))}
         </div>
+
+        {/* Active tab — each tab fetches lazily on first view (react-query
+            caches by key, so switching back is instant). */}
+        <div className="flex-1 overflow-y-auto px-3 py-3">
+          {tab === 'conversation' && (
+            <ConversationTab
+              cwd={cwd}
+              number={full.number}
+              author={full.author}
+              body={body}
+              bodyPending={bodyPending}
+              detailError={detailError}
+            />
+          )}
+          {tab === 'commits' && <CommitsTab cwd={cwd} number={full.number} />}
+          {tab === 'checks' && <ChecksTab cwd={cwd} number={full.number} />}
+          {tab === 'files' && <FilesTab cwd={cwd} number={full.number} />}
+        </div>
+
+        {/* Merge — footer, only while the PR is open (visible on any tab) */}
+        {full.state === 'open' && (
+          <div className="border-t border-border px-3 py-2 flex flex-wrap items-center gap-2 text-[11px]">
+            <select
+              value={method}
+              onChange={(e) =>
+                setMethod(e.target.value as 'squash' | 'merge' | 'rebase')
+              }
+              className="text-[11px] bg-transparent border border-border rounded px-1.5 py-0.5"
+            >
+              <option value="squash">squash</option>
+              <option value="merge">merge</option>
+              <option value="rebase">rebase</option>
+            </select>
+            <label className="flex items-center gap-1 text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={deleteBranch}
+                onChange={(e) => setDeleteBranch(e.target.checked)}
+              />
+              Delete branch
+            </label>
+            <button
+              type="button"
+              disabled={merge.isPending}
+              onClick={() => {
+                if (
+                  !window.confirm(
+                    `Merge PR #${full.number} (${method})${
+                      deleteBranch ? ' and delete branch' : ''
+                    }?`,
+                  )
+                ) {
+                  return
+                }
+                merge.mutate()
+              }}
+              className={cn(
+                'ml-auto text-[11px] px-2 py-0.5 rounded transition-colors flex items-center gap-1',
+                merge.isPending
+                  ? 'bg-muted/30 text-muted-foreground/50'
+                  : 'bg-purple-500/80 text-background hover:bg-purple-500',
+              )}
+            >
+              {merge.isPending ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <GitMerge className="size-3" />
+              )}
+              Merge
+            </button>
+          </div>
+        )}
       </div>
     </div>,
     document.body,
+  )
+}
+
+type DetailTab = 'conversation' | 'commits' | 'checks' | 'files'
+
+const DETAIL_TABS: { key: DetailTab; label: string }[] = [
+  { key: 'conversation', label: 'Conversation' },
+  { key: 'commits', label: 'Commits' },
+  { key: 'checks', label: 'Checks' },
+  { key: 'files', label: 'Files changed' },
+]
+
+function firstLine(s: string): string {
+  return s.split('\n', 1)[0]
+}
+
+function TabLoading({ text = 'Loading…' }: { text?: string }) {
+  return (
+    <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground py-2">
+      <Loader2 className="size-3 animate-spin" />
+      {text}
+    </div>
+  )
+}
+
+function TabError({ message }: { message: string }) {
+  return (
+    <div className="text-[11px] text-state-failed py-2 break-words">{message}</div>
+  )
+}
+
+function TabEmpty({ text }: { text: string }) {
+  return <div className="text-[11px] text-muted-foreground/60 py-2">{text}</div>
+}
+
+// ConversationTab: the PR description followed by the comment thread.
+function ConversationTab({
+  cwd,
+  number,
+  author,
+  body,
+  bodyPending,
+  detailError,
+}: {
+  cwd: string
+  number: number
+  author: string
+  body: string
+  bodyPending: boolean
+  detailError: string | null
+}) {
+  const comments = useQuery({
+    queryKey: ['git-pr-comments', cwd, number],
+    queryFn: () => getPRComments(cwd, number),
+    // Tabs unmount on switch; treat the conversation as fresh for a few
+    // minutes so flipping back doesn't refetch every time.
+    staleTime: 5 * 60 * 1000,
+  })
+  const list = comments.data ?? []
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="rounded border border-border/50 bg-card/30">
+        <div className="px-2.5 py-1.5 border-b border-border/40 text-[10px] text-muted-foreground/80">
+          <span className="font-mono text-foreground/90">{author}</span> opened
+          this pull request
+        </div>
+        <div className="px-2.5 py-2">
+          {detailError ? (
+            <div className="text-[11px] text-state-failed">
+              Couldn't load details: {detailError}
+            </div>
+          ) : bodyPending ? (
+            <TabLoading />
+          ) : body ? (
+            <div className="prose-md text-[12px] leading-relaxed break-words">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={mdComponents}
+              >
+                {body}
+              </ReactMarkdown>
+            </div>
+          ) : (
+            <div className="text-[11px] text-muted-foreground/60 italic">
+              No description provided.
+            </div>
+          )}
+        </div>
+      </div>
+
+      {comments.isLoading && <TabLoading text="Loading comments…" />}
+      {comments.error && (
+        <TabError
+          message={`comments unavailable: ${(comments.error as Error).message}`}
+        />
+      )}
+      {!comments.isLoading && !comments.error && list.length === 0 && (
+        <TabEmpty text="No comments yet." />
+      )}
+      {list.map((c, i) => (
+        <CommentItem key={c.url ?? `${c.author}-${c.created_at}-${i}`} c={c} />
+      ))}
+    </div>
+  )
+}
+
+function CommentItem({ c }: { c: PRComment }) {
+  return (
+    <div className="rounded border border-border/50 bg-card/30">
+      <div className="flex items-center gap-2 px-2.5 py-1.5 border-b border-border/40 text-[10px] text-muted-foreground/80">
+        <span className="font-mono text-foreground/90">{c.author}</span>
+        {c.state && <ReviewStateBadge state={c.state} />}
+        <span className="ml-auto">{relTime(c.created_at)}</span>
+      </div>
+      <div className="prose-md text-[12px] leading-relaxed break-words px-2.5 py-2">
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
+          {c.body}
+        </ReactMarkdown>
+      </div>
+    </div>
+  )
+}
+
+function ReviewStateBadge({ state }: { state: string }) {
+  const cls =
+    state === 'approved'
+      ? 'text-state-running border-state-running/40'
+      : state === 'changes_requested'
+        ? 'text-state-failed border-state-failed/40'
+        : 'text-muted-foreground/70 border-border'
+  return (
+    <span
+      className={cn(
+        'text-[9px] uppercase tracking-wide px-1 py-px rounded border',
+        cls,
+      )}
+    >
+      {state.replaceAll('_', ' ')}
+    </span>
+  )
+}
+
+function CommitsTab({ cwd, number }: { cwd: string; number: number }) {
+  const q = useQuery({
+    queryKey: ['git-pr-commits', cwd, number],
+    queryFn: () => getPRCommits(cwd, number),
+    staleTime: 5 * 60 * 1000,
+  })
+  if (q.isLoading) return <TabLoading text="Loading commits…" />
+  if (q.error)
+    return (
+      <TabError message={`commits unavailable: ${(q.error as Error).message}`} />
+    )
+  const commits = q.data ?? []
+  if (commits.length === 0) return <TabEmpty text="No commits." />
+  return (
+    <div className="flex flex-col">
+      {commits.map((c, i) => (
+        <div
+          key={c.sha || `commit-${i}`}
+          className="flex items-start gap-2 py-1.5 border-b border-border/30 last:border-b-0"
+        >
+          <GitCommit className="size-3.5 mt-0.5 text-muted-foreground/60 shrink-0" />
+          <div className="min-w-0 flex-1">
+            <div className="text-[12px] truncate">{firstLine(c.message)}</div>
+            <div className="text-[10px] text-muted-foreground/60 font-mono">
+              {c.author} · {relTime(c.date)}
+            </div>
+          </div>
+          {c.url ? (
+            <a
+              href={c.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono text-[10px] text-muted-foreground/60 hover:text-foreground mt-0.5 shrink-0"
+            >
+              {c.short_sha}
+            </a>
+          ) : (
+            <span className="font-mono text-[10px] text-muted-foreground/40 mt-0.5 shrink-0">
+              {c.short_sha}
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ChecksTab owns the checks query (was inline in the drawer before the
+// tab split). Polls every 30s while the tab is mounted.
+function ChecksTab({ cwd, number }: { cwd: string; number: number }) {
+  const checks = useQuery({
+    queryKey: ['git-pr-checks', cwd, number],
+    queryFn: () => getPRChecks(cwd, number),
+    refetchInterval: 30_000,
+  })
+  if (checks.isLoading) return <TabLoading text="Loading checks…" />
+  if (checks.error)
+    return (
+      <TabError
+        message={`checks unavailable: ${(checks.error as Error).message}`}
+      />
+    )
+  const data = checks.data ?? []
+  if (data.length === 0)
+    return <TabEmpty text="No checks configured for this PR." />
+  const summary = aggregateChecks(data)
+  return (
+    <div className="flex flex-col gap-0.5 text-[11px]">
+      <div
+        className={cn(
+          'flex items-center gap-1.5',
+          summary.allPassing && 'text-state-running',
+          summary.anyFailed && 'text-state-failed',
+          summary.pending && 'text-muted-foreground',
+        )}
+      >
+        {summary.allPassing && <CheckCircle2 className="size-3" />}
+        {summary.anyFailed && <XCircle className="size-3" />}
+        {summary.pending && <CircleDashed className="size-3 animate-spin" />}
+        <span>{summary.label}</span>
+      </div>
+      <div className="pl-4 flex flex-col gap-0.5 text-muted-foreground/80">
+        {data.map((c) => (
+          <a
+            key={c.name + c.url}
+            href={c.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 hover:text-foreground"
+          >
+            <CheckIcon check={c} />
+            <span className="truncate">{c.name}</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function FilesTab({ cwd, number }: { cwd: string; number: number }) {
+  const q = useQuery({
+    queryKey: ['git-pr-files', cwd, number],
+    queryFn: () => getPRFiles(cwd, number),
+    staleTime: 5 * 60 * 1000,
+  })
+  const [open, setOpen] = useState<Set<string>>(() => new Set())
+  if (q.isLoading) return <TabLoading text="Loading files…" />
+  if (q.error)
+    return <TabError message={`files unavailable: ${(q.error as Error).message}`} />
+  const files = q.data ?? []
+  if (files.length === 0) return <TabEmpty text="No changed files." />
+  const toggle = (name: string) => {
+    // Functional updater so rapid taps don't read a stale `open`.
+    setOpen((prev) => {
+      const next = new Set(prev)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return next
+    })
+  }
+  return (
+    <div className="flex flex-col gap-1">
+      {files.map((f) => {
+        const isOpen = open.has(f.filename)
+        return (
+          <div
+            key={f.filename}
+            className="border border-border/40 rounded overflow-hidden"
+          >
+            <button
+              type="button"
+              onClick={() => toggle(f.filename)}
+              className="w-full flex items-center gap-2 px-2 py-1.5 text-left hover:bg-card"
+            >
+              <FileStatusIcon status={f.status} />
+              <span className="text-[11px] font-mono truncate flex-1">
+                {f.filename}
+              </span>
+              <span className="text-[10px] text-state-running shrink-0">
+                +{f.additions}
+              </span>
+              <span className="text-[10px] text-state-failed shrink-0">
+                -{f.deletions}
+              </span>
+            </button>
+            {isOpen &&
+              (f.patch ? (
+                <DiffView patch={f.patch} />
+              ) : (
+                <div className="px-2 py-1.5 text-[10px] text-muted-foreground/50 border-t border-border/40">
+                  No inline diff available.
+                </div>
+              ))}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function FileStatusIcon({ status }: { status: string }) {
+  const { ch, cls } =
+    status === 'added'
+      ? { ch: 'A', cls: 'text-state-running' }
+      : status === 'removed'
+        ? { ch: 'D', cls: 'text-state-failed' }
+        : status === 'renamed'
+          ? { ch: 'R', cls: 'text-purple-400' }
+          : { ch: 'M', cls: 'text-muted-foreground/70' }
+  return (
+    <span className={cn('font-mono text-[10px] w-3 text-center shrink-0', cls)}>
+      {ch}
+    </span>
+  )
+}
+
+// DiffView renders a unified-diff patch with +/- line coloring.
+// Intentionally light — no syntax highlighting (see PR scope).
+function DiffView({ patch }: { patch: string }) {
+  return (
+    <div className="overflow-x-auto border-t border-border/40 bg-card/30">
+      <pre className="text-[10px] leading-relaxed font-mono w-max min-w-full">
+        {patch.split('\n').map((line, i) => {
+          const add = line.startsWith('+') && !line.startsWith('+++')
+          const del = line.startsWith('-') && !line.startsWith('---')
+          const hunk = line.startsWith('@@')
+          return (
+            <div
+              key={`${i}:${line}`}
+              className={cn(
+                'px-2',
+                add && 'bg-state-running/10 text-state-running',
+                del && 'bg-state-failed/10 text-state-failed',
+                hunk && 'bg-card/60 text-muted-foreground/70',
+              )}
+            >
+              {line || ' '}
+            </div>
+          )
+        })}
+      </pre>
+    </div>
   )
 }
 

--- a/app/web/src/components/sessions/inspector/PullRequestsSection.tsx
+++ b/app/web/src/components/sessions/inspector/PullRequestsSection.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { type ComponentPropsWithoutRef, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { Link } from '@tanstack/react-router'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
@@ -12,14 +13,18 @@ import {
   CircleDashed,
   Plus,
   GitMerge,
+  X,
 } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
 import { toast } from 'sonner'
+import ReactMarkdown, { type Components } from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 
 import {
   type CheckRun,
   type GitPullRequest as PR,
   createGitPR,
+  getGitPR,
   getPRChecks,
   listGitPRs,
   mergeGitPR,
@@ -35,7 +40,8 @@ interface PullRequestsSectionProps {
 // returns PRs from the matching git_hosts row or `need_token: true`,
 // which we render as a deep link to /plugins.
 //
-// Each row expands on click to show CI checks + a Merge button. The
+// Each row opens a right-side detail drawer (description, status, CI
+// checks for any state, and a Merge action when the PR is open). The
 // "Create PR" button at the top of the section opens a small inline
 // form (no modal) that defaults the title from a placeholder hint
 // since we don't have easy access to the latest commit message from
@@ -43,7 +49,11 @@ interface PullRequestsSectionProps {
 export function PullRequestsSection({ cwd }: PullRequestsSectionProps) {
   const [state, setState] = useState<'open' | 'closed' | 'all'>('open')
   const [creating, setCreating] = useState(false)
-  const [expandedPR, setExpandedPR] = useState<number | null>(null)
+  // The PR the detail drawer is showing. We hold the row object itself
+  // (not just its number) so the drawer survives the 60s list refetch
+  // — otherwise a PR that gets merged/closed elsewhere, or drops off
+  // the 20-item window, would yank the drawer shut mid-read.
+  const [detailPR, setDetailPR] = useState<PR | null>(null)
   const qc = useQueryClient()
 
   const { data, isLoading, error } = useQuery({
@@ -126,21 +136,21 @@ export function PullRequestsSection({ cwd }: PullRequestsSectionProps) {
       {data && !data.need_token && (
         <div className="flex flex-col">
           {data.prs.map((p) => (
-            <PRRow
-              key={p.number}
-              pr={p}
-              cwd={cwd}
-              expanded={expandedPR === p.number}
-              onToggle={() =>
-                setExpandedPR((cur) => (cur === p.number ? null : p.number))
-              }
-              onMerged={() => {
-                setExpandedPR(null)
-                qc.invalidateQueries({ queryKey: ['git-prs', cwd] })
-              }}
-            />
+            <PRRow key={p.number} pr={p} onOpen={() => setDetailPR(p)} />
           ))}
         </div>
+      )}
+
+      {detailPR && (
+        <PRDetailDrawer
+          cwd={cwd}
+          pr={detailPR}
+          onClose={() => setDetailPR(null)}
+          onMerged={() => {
+            setDetailPR(null)
+            qc.invalidateQueries({ queryKey: ['git-prs', cwd] })
+          }}
+        />
       )}
     </section>
   )
@@ -242,43 +252,18 @@ function CreatePRForm({
   )
 }
 
-// PRRow is the per-PR card. Click toggles checks/merge expansion;
-// the external-link icon still jumps to the host's web view.
-function PRRow({
-  pr,
-  cwd,
-  expanded,
-  onToggle,
-  onMerged,
-}: {
-  pr: PR
-  cwd: string
-  expanded: boolean
-  onToggle: () => void
-  onMerged: () => void
-}) {
+// PRRow is the per-PR card. Click opens the detail drawer; the
+// external-link icon still jumps to the host's web view.
+function PRRow({ pr, onOpen }: { pr: PR; onOpen: () => void }) {
   return (
     <div className="border-b border-border/30 last:border-b-0">
       <button
         type="button"
-        onClick={onToggle}
+        onClick={onOpen}
         className="w-full px-1 py-1.5 flex items-start gap-2 hover:bg-card rounded-sm group text-left"
         title={`#${pr.number} · ${pr.author} · ${pr.head} → ${pr.base}`}
       >
-        {pr.draft ? (
-          <GitPullRequestDraft className="size-3 mt-0.5 text-muted-foreground/60 shrink-0" />
-        ) : (
-          <GitPullRequest
-            className={cn(
-              'size-3 mt-0.5 shrink-0',
-              pr.state === 'merged'
-                ? 'text-purple-400'
-                : pr.state === 'closed'
-                  ? 'text-state-failed'
-                  : 'text-state-running',
-            )}
-          />
-        )}
+        <PRStateIcon pr={pr} className="mt-0.5" />
         <div className="flex flex-col min-w-0 flex-1">
           <span className="text-[12px] truncate group-hover:text-foreground">
             {pr.title}
@@ -299,27 +284,123 @@ function PRRow({
           <ExternalLink className="size-3 mt-0.5" />
         </a>
       </button>
-      {expanded && pr.state === 'open' && (
-        <PRExpandedPanel pr={pr} cwd={cwd} onMerged={onMerged} />
-      )}
     </div>
   )
 }
 
-// PRExpandedPanel renders CI checks + merge action when a PR is
-// open. Closed / merged PRs hide the panel entirely (no useful
-// actions). Checks are loaded lazily on first expand.
-function PRExpandedPanel({
-  pr,
+// PRStateIcon renders the PR glyph coloured by state (draft / merged /
+// closed / open). Shared between the row and the drawer header.
+function PRStateIcon({ pr, className }: { pr: PR; className?: string }) {
+  if (pr.draft) {
+    return (
+      <GitPullRequestDraft
+        className={cn('size-3 text-muted-foreground/60 shrink-0', className)}
+      />
+    )
+  }
+  return (
+    <GitPullRequest
+      className={cn(
+        'size-3 shrink-0',
+        pr.state === 'merged'
+          ? 'text-purple-400'
+          : pr.state === 'closed'
+            ? 'text-state-failed'
+            : 'text-state-running',
+        className,
+      )}
+    />
+  )
+}
+
+// StateBadge is the textual status pill in the drawer header.
+function StateBadge({ pr }: { pr: PR }) {
+  const { label, cls } = pr.draft
+    ? { label: 'Draft', cls: 'text-muted-foreground/80 border-border' }
+    : pr.state === 'merged'
+      ? { label: 'Merged', cls: 'text-purple-400 border-purple-400/40' }
+      : pr.state === 'closed'
+        ? { label: 'Closed', cls: 'text-state-failed border-state-failed/40' }
+        : { label: 'Open', cls: 'text-state-running border-state-running/40' }
+  return (
+    <span
+      className={cn(
+        'text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded border shrink-0',
+        cls,
+      )}
+    >
+      {label}
+    </span>
+  )
+}
+
+// mdComponents keeps the rendered PR body inside the panel: links open
+// in a new tab, code blocks scroll instead of overflowing the narrow
+// drawer, and images are width-constrained. The `any` props mirror the
+// codebase's other react-markdown overrides (see NoteEditor).
+const mdComponents: Components = {
+  a: (props: ComponentPropsWithoutRef<'a'>) => (
+    <a
+      {...props}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-state-running hover:underline break-words"
+    />
+  ),
+  pre: (props: ComponentPropsWithoutRef<'pre'>) => (
+    <pre
+      {...props}
+      className="overflow-x-auto rounded bg-card/60 p-2 text-[11px]"
+    />
+  ),
+  img: (props: ComponentPropsWithoutRef<'img'>) => (
+    <img {...props} alt={props.alt ?? ''} className="max-w-full rounded" />
+  ),
+}
+
+// PRDetailDrawer is the right-side panel shown when a PR row is
+// clicked. It works for every PR state: the description (markdown), a
+// status badge, and CI checks render for open / closed / merged
+// alike; the Merge action is only offered while the PR is open.
+//
+// Mounted into a portal on document.body so it overlays the whole
+// viewport rather than being clipped by the inspector sidebar.
+function PRDetailDrawer({
   cwd,
+  pr,
+  onClose,
   onMerged,
 }: {
-  pr: PR
   cwd: string
+  pr: PR
+  onClose: () => void
   onMerged: () => void
 }) {
   const [method, setMethod] = useState<'squash' | 'merge' | 'rebase'>('squash')
   const [deleteBranch, setDeleteBranch] = useState(true)
+
+  // Close on Escape.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  // Full PR incl. body. Seeded from the list row so the header paints
+  // instantly; the body fills in when the single-PR fetch resolves
+  // (the list endpoint omits body to stay lean).
+  const detail = useQuery({
+    queryKey: ['git-pr', cwd, pr.number],
+    queryFn: () => getGitPR(cwd, pr.number),
+    // placeholderData (not initialData) seeds the header instantly from
+    // the list row while still flagging the body fetch as in-flight via
+    // isPlaceholderData. initialData would mark the query "fresh" and
+    // suppress the loading state, flashing "no description" first.
+    placeholderData: pr,
+  })
+  const full = detail.data ?? pr
 
   const checks = useQuery({
     queryKey: ['git-pr-checks', cwd, pr.number],
@@ -348,117 +429,225 @@ function PRExpandedPanel({
     },
   })
 
-  // Aggregate check status for the headline summary. Pending while
-  // any check is still queued / in_progress; failed if any concluded
-  // with anything other than success / neutral / skipped.
+  // Aggregate check status for the headline summary. Pending while any
+  // check is still queued / in_progress; failed if any concluded with
+  // anything other than success / neutral / skipped.
   const checkSummary = aggregateChecks(checks.data ?? [])
+  // body is undefined until the detail fetch resolves; '' means the PR
+  // genuinely has no description.
+  const body = full.body?.trim() ?? ''
+  // While the query is still serving the seeded list row, the body
+  // hasn't been fetched yet — drives the description loading state.
+  const bodyPending = detail.isPlaceholderData
 
-  return (
-    <div className="px-2 py-2 bg-card/40 border-l-2 border-state-running/40 ml-3 mb-1 flex flex-col gap-2 text-[11px]">
-      {checks.isLoading && (
-        <div className="flex items-center gap-1.5 text-muted-foreground">
-          <Loader2 className="size-3 animate-spin" />
-          Loading checks…
-        </div>
-      )}
-      {checks.error && (
-        <div className="text-state-failed">
-          checks unavailable: {(checks.error as Error).message}
-        </div>
-      )}
-      {!checks.isLoading && !checks.error && (
-        <div className="flex flex-col gap-0.5">
-          {(checks.data ?? []).length === 0 ? (
-            <div className="text-muted-foreground/60">
-              No checks configured for this PR.
+  return createPortal(
+    <div className="fixed inset-0 z-[60] flex justify-end">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-black/40 backdrop-blur-[1px]"
+        onClick={onClose}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="relative h-full w-full max-w-md bg-background border-l border-border shadow-2xl flex flex-col"
+      >
+        {/* Header */}
+        <div className="flex items-start gap-2 px-3 py-2.5 border-b border-border">
+          <PRStateIcon pr={full} className="mt-1" />
+          <div className="min-w-0 flex-1">
+            <div className="text-[13px] font-medium leading-snug break-words">
+              {full.title}
             </div>
-          ) : (
-            <>
-              <div
-                className={cn(
-                  'flex items-center gap-1.5',
-                  checkSummary.allPassing && 'text-state-running',
-                  checkSummary.anyFailed && 'text-state-failed',
-                  checkSummary.pending && 'text-muted-foreground',
-                )}
-              >
-                {checkSummary.allPassing && <CheckCircle2 className="size-3" />}
-                {checkSummary.anyFailed && <XCircle className="size-3" />}
-                {checkSummary.pending && (
-                  <CircleDashed className="size-3 animate-spin" />
-                )}
-                <span>{checkSummary.label}</span>
+            <div className="text-[10px] text-muted-foreground/70 font-mono mt-0.5">
+              #{full.number} · {full.author}
+            </div>
+          </div>
+          <a
+            href={full.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground/50 hover:text-foreground p-0.5"
+            title="Open on host"
+          >
+            <ExternalLink className="size-3.5" />
+          </a>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="text-muted-foreground/50 hover:text-foreground p-0.5"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        {/* Meta row */}
+        <div className="px-3 py-2 border-b border-border/50 flex items-center gap-2 flex-wrap text-[11px]">
+          <StateBadge pr={full} />
+          <span className="font-mono text-muted-foreground/80 truncate">
+            {full.head} → {full.base}
+          </span>
+          <span className="text-muted-foreground/50">
+            · {relTime(full.updated_at)}
+          </span>
+        </div>
+
+        {/* Scrollable content */}
+        <div className="flex-1 overflow-y-auto px-3 py-3 flex flex-col gap-4">
+          {/* Description */}
+          <section className="flex flex-col gap-1.5">
+            <h3 className="text-[10px] uppercase tracking-wider text-muted-foreground/70 font-medium">
+              Description
+            </h3>
+            {detail.isError ? (
+              <div className="text-[11px] text-state-failed">
+                Couldn't load details: {(detail.error as Error).message}
               </div>
-              <div className="pl-4 flex flex-col gap-0.5 text-muted-foreground/80">
-                {(checks.data ?? []).map((c) => (
-                  <a
-                    key={c.name + c.url}
-                    href={c.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-1.5 hover:text-foreground"
-                  >
-                    <CheckIcon check={c} />
-                    <span className="truncate">{c.name}</span>
-                  </a>
-                ))}
+            ) : bodyPending ? (
+              <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                <Loader2 className="size-3 animate-spin" />
+                Loading…
               </div>
-            </>
+            ) : body ? (
+              <div className="prose-md text-[12px] leading-relaxed break-words">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={mdComponents}
+                >
+                  {body}
+                </ReactMarkdown>
+              </div>
+            ) : (
+              <div className="text-[11px] text-muted-foreground/60 italic">
+                No description provided.
+              </div>
+            )}
+          </section>
+
+          {/* Checks — shown for every state, not just open */}
+          <section className="flex flex-col gap-1.5">
+            <h3 className="text-[10px] uppercase tracking-wider text-muted-foreground/70 font-medium">
+              Checks
+            </h3>
+            {checks.isLoading && (
+              <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                <Loader2 className="size-3 animate-spin" />
+                Loading checks…
+              </div>
+            )}
+            {checks.error && (
+              <div className="text-[11px] text-state-failed">
+                checks unavailable: {(checks.error as Error).message}
+              </div>
+            )}
+            {!checks.isLoading && !checks.error && (
+              <div className="flex flex-col gap-0.5 text-[11px]">
+                {(checks.data ?? []).length === 0 ? (
+                  <div className="text-muted-foreground/60">
+                    No checks configured for this PR.
+                  </div>
+                ) : (
+                  <>
+                    <div
+                      className={cn(
+                        'flex items-center gap-1.5',
+                        checkSummary.allPassing && 'text-state-running',
+                        checkSummary.anyFailed && 'text-state-failed',
+                        checkSummary.pending && 'text-muted-foreground',
+                      )}
+                    >
+                      {checkSummary.allPassing && (
+                        <CheckCircle2 className="size-3" />
+                      )}
+                      {checkSummary.anyFailed && <XCircle className="size-3" />}
+                      {checkSummary.pending && (
+                        <CircleDashed className="size-3 animate-spin" />
+                      )}
+                      <span>{checkSummary.label}</span>
+                    </div>
+                    <div className="pl-4 flex flex-col gap-0.5 text-muted-foreground/80">
+                      {(checks.data ?? []).map((c) => (
+                        <a
+                          key={c.name + c.url}
+                          href={c.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center gap-1.5 hover:text-foreground"
+                        >
+                          <CheckIcon check={c} />
+                          <span className="truncate">{c.name}</span>
+                        </a>
+                      ))}
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+          </section>
+
+          {/* Merge — only while the PR is open */}
+          {full.state === 'open' && (
+            <section className="flex flex-col gap-1.5">
+              <h3 className="text-[10px] uppercase tracking-wider text-muted-foreground/70 font-medium">
+                Merge
+              </h3>
+              <div className="flex flex-wrap items-center gap-2 text-[11px]">
+                <select
+                  value={method}
+                  onChange={(e) =>
+                    setMethod(e.target.value as 'squash' | 'merge' | 'rebase')
+                  }
+                  className="text-[11px] bg-transparent border border-border rounded px-1.5 py-0.5"
+                >
+                  <option value="squash">squash</option>
+                  <option value="merge">merge</option>
+                  <option value="rebase">rebase</option>
+                </select>
+                <label className="flex items-center gap-1 text-muted-foreground">
+                  <input
+                    type="checkbox"
+                    checked={deleteBranch}
+                    onChange={(e) => setDeleteBranch(e.target.checked)}
+                  />
+                  Delete branch
+                </label>
+                <button
+                  type="button"
+                  disabled={merge.isPending}
+                  onClick={() => {
+                    if (
+                      !window.confirm(
+                        `Merge PR #${full.number} (${method})${
+                          deleteBranch ? ' and delete branch' : ''
+                        }?`,
+                      )
+                    ) {
+                      return
+                    }
+                    merge.mutate()
+                  }}
+                  className={cn(
+                    'ml-auto text-[11px] px-2 py-0.5 rounded transition-colors flex items-center gap-1',
+                    merge.isPending
+                      ? 'bg-muted/30 text-muted-foreground/50'
+                      : 'bg-purple-500/80 text-background hover:bg-purple-500',
+                  )}
+                >
+                  {merge.isPending ? (
+                    <Loader2 className="size-3 animate-spin" />
+                  ) : (
+                    <GitMerge className="size-3" />
+                  )}
+                  Merge
+                </button>
+              </div>
+            </section>
           )}
         </div>
-      )}
-
-      <div className="flex flex-wrap items-center gap-2 border-t border-border/40 pt-2">
-        <select
-          value={method}
-          onChange={(e) =>
-            setMethod(e.target.value as 'squash' | 'merge' | 'rebase')
-          }
-          className="text-[11px] bg-transparent border border-border rounded px-1.5 py-0.5"
-        >
-          <option value="squash">squash</option>
-          <option value="merge">merge</option>
-          <option value="rebase">rebase</option>
-        </select>
-        <label className="flex items-center gap-1 text-muted-foreground">
-          <input
-            type="checkbox"
-            checked={deleteBranch}
-            onChange={(e) => setDeleteBranch(e.target.checked)}
-          />
-          Delete branch
-        </label>
-        <button
-          type="button"
-          disabled={merge.isPending}
-          onClick={() => {
-            if (
-              !window.confirm(
-                `Merge PR #${pr.number} (${method})${
-                  deleteBranch ? ' and delete branch' : ''
-                }?`,
-              )
-            ) {
-              return
-            }
-            merge.mutate()
-          }}
-          className={cn(
-            'ml-auto text-[11px] px-2 py-0.5 rounded transition-colors flex items-center gap-1',
-            merge.isPending
-              ? 'bg-muted/30 text-muted-foreground/50'
-              : 'bg-purple-500/80 text-background hover:bg-purple-500',
-          )}
-        >
-          {merge.isPending ? (
-            <Loader2 className="size-3 animate-spin" />
-          ) : (
-            <GitMerge className="size-3" />
-          )}
-          Merge
-        </button>
       </div>
-    </div>
+    </div>,
+    document.body,
   )
 }
 

--- a/internal/githost/githost.go
+++ b/internal/githost/githost.go
@@ -361,6 +361,10 @@ func splitOwnerRepo(path string) (string, string, error) {
 // ── Pull request listing ────────────────────────────────────────
 
 // PullRequest is the trimmed-down view we surface in the panel.
+//
+// Body is the PR description (markdown). It is only populated by the
+// single-PR detail fetch (GetPullRequest); the list endpoints leave
+// it empty to keep their payloads lean, hence omitempty.
 type PullRequest struct {
 	Number    int       `json:"number"`
 	Title     string    `json:"title"`
@@ -370,6 +374,7 @@ type PullRequest struct {
 	Base      string    `json:"base"` // target branch
 	URL       string    `json:"url"`  // web URL
 	Draft     bool      `json:"draft"`
+	Body      string    `json:"body,omitempty"` // description (detail fetch only)
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
@@ -400,6 +405,30 @@ func (s *Service) ListPullRequests(ctx context.Context, dir, state string) (Remo
 		return rem, prs, err
 	default:
 		return rem, nil, fmt.Errorf("unsupported host kind: %s", hostRow.Kind)
+	}
+}
+
+// GetPullRequest fetches a single PR — including its body/description —
+// from the host that owns dir's remote. Unlike ListPullRequests this
+// populates PullRequest.Body, so the detail surface (web drawer /
+// mobile screen) can render the description for any PR state.
+func (s *Service) GetPullRequest(ctx context.Context, dir string, number int) (PullRequest, error) {
+	rem, hostRow, err := s.resolveHost(ctx, dir)
+	if err != nil {
+		return PullRequest{}, err
+	}
+	if number <= 0 {
+		return PullRequest{}, errors.New("number required")
+	}
+	switch hostRow.Kind {
+	case KindGitHub:
+		return s.getGitHubPR(ctx, hostRow, rem, number)
+	case KindGitea:
+		return s.getGiteaPR(ctx, hostRow, rem, number)
+	case KindGitLab:
+		return s.getGitLabMR(ctx, hostRow, rem, number)
+	default:
+		return PullRequest{}, fmt.Errorf("unsupported host kind: %s", hostRow.Kind)
 	}
 }
 
@@ -723,6 +752,7 @@ type githubPRResponse struct {
 	Base struct {
 		Ref string `json:"ref"`
 	} `json:"base"`
+	Body     string     `json:"body"`
 	MergedAt *time.Time `json:"merged_at"`
 }
 
@@ -740,6 +770,7 @@ func (p githubPRResponse) toPullRequest() PullRequest {
 		Base:      p.Base.Ref,
 		URL:       p.HTMLURL,
 		Draft:     p.Draft,
+		Body:      p.Body,
 		UpdatedAt: p.UpdatedAt,
 	}
 }
@@ -839,6 +870,21 @@ func (s *Service) githubDefaultBranch(ctx context.Context, h Host, rem Remote) (
 		return "", errors.New("repo has no default_branch")
 	}
 	return raw.DefaultBranch, nil
+}
+
+// getGitHubPR fetches a single PR (incl. body) for the detail view.
+func (s *Service) getGitHubPR(ctx context.Context, h Host, rem Remote, number int) (PullRequest, error) {
+	u := fmt.Sprintf("%s/repos/%s/%s/pulls/%d",
+		githubAPIBase(h.Host), rem.Owner, rem.Repo, number)
+	body, err := s.do(ctx, http.MethodGet, u, "Bearer "+h.Token, "application/vnd.github+json", nil)
+	if err != nil {
+		return PullRequest{}, err
+	}
+	var raw githubPRResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return PullRequest{}, fmt.Errorf("github decode: %w", err)
+	}
+	return raw.toPullRequest(), nil
 }
 
 func (s *Service) githubChecks(ctx context.Context, h Host, rem Remote, number int) ([]CheckRun, error) {
@@ -1004,7 +1050,8 @@ func decodeGiteaPR(body []byte) (PullRequest, error) {
 		Base struct {
 			Ref string `json:"ref"`
 		} `json:"base"`
-		Merged bool `json:"merged"`
+		Body   string `json:"body"`
+		Merged bool   `json:"merged"`
 	}
 	if err := json.Unmarshal(body, &p); err != nil {
 		return PullRequest{}, fmt.Errorf("gitea decode: %w", err)
@@ -1021,8 +1068,20 @@ func decodeGiteaPR(body []byte) (PullRequest, error) {
 		Head:      p.Head.Ref,
 		Base:      p.Base.Ref,
 		URL:       p.HTMLURL,
+		Body:      p.Body,
 		UpdatedAt: p.UpdatedAt,
 	}, nil
+}
+
+// getGiteaPR fetches a single PR (incl. body) for the detail view.
+func (s *Service) getGiteaPR(ctx context.Context, h Host, rem Remote, number int) (PullRequest, error) {
+	u := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/pulls/%d",
+		h.Host, rem.Owner, rem.Repo, number)
+	body, err := s.do(ctx, http.MethodGet, u, "token "+h.Token, "application/json", nil)
+	if err != nil {
+		return PullRequest{}, err
+	}
+	return decodeGiteaPR(body)
 }
 
 // ── GitLab: create / merge (merge requests) ───────────────────────
@@ -1112,6 +1171,7 @@ func decodeGitLabMR(body []byte) (PullRequest, error) {
 		} `json:"author"`
 		SourceBranch string `json:"source_branch"`
 		TargetBranch string `json:"target_branch"`
+		Description  string `json:"description"`
 		Draft        bool   `json:"draft"`
 	}
 	if err := json.Unmarshal(body, &p); err != nil {
@@ -1126,8 +1186,21 @@ func decodeGitLabMR(body []byte) (PullRequest, error) {
 		Base:      p.TargetBranch,
 		URL:       p.WebURL,
 		Draft:     p.Draft,
+		Body:      p.Description,
 		UpdatedAt: p.UpdatedAt,
 	}, nil
+}
+
+// getGitLabMR fetches a single MR (incl. description) for the detail view.
+func (s *Service) getGitLabMR(ctx context.Context, h Host, rem Remote, number int) (PullRequest, error) {
+	projectID := url.PathEscape(rem.Owner + "/" + rem.Repo)
+	u := fmt.Sprintf("https://%s/api/v4/projects/%s/merge_requests/%d",
+		h.Host, projectID, number)
+	body, err := s.do(ctx, http.MethodGet, u, "Bearer "+h.Token, "application/json", nil)
+	if err != nil {
+		return PullRequest{}, err
+	}
+	return decodeGitLabMR(body)
 }
 
 // ── Cross-platform commit status mapping ──────────────────────────
@@ -1377,6 +1450,7 @@ func (h *Handlers) Mount(r chi.Router) {
 	r.Get("/git/remote", h.remote)
 	r.Get("/git/prs", h.prs)
 	r.Post("/git/prs", h.createPR)
+	r.Get("/git/prs/{number}", h.prDetail)
 	r.Post("/git/prs/{number}/merge", h.mergePR)
 	r.Get("/git/prs/{number}/checks", h.prChecks)
 }
@@ -1448,6 +1522,28 @@ func (h *Handlers) prChecks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"checks": checks})
+}
+
+// prDetail mounts GET /git/prs/{number}?path=<dir>. Returns the full
+// PullRequest envelope — including body — for the detail surface.
+func (h *Handlers) prDetail(w http.ResponseWriter, r *http.Request) {
+	dir := strings.TrimSpace(r.URL.Query().Get("path"))
+	if dir == "" {
+		writeError(w, http.StatusBadRequest, errors.New("path required"))
+		return
+	}
+	num := chi.URLParam(r, "number")
+	n, err := strconv.Atoi(num)
+	if err != nil || n <= 0 {
+		writeError(w, http.StatusBadRequest, errors.New("invalid number"))
+		return
+	}
+	pr, err := h.svc.GetPullRequest(r.Context(), dir, n)
+	if err != nil {
+		writeError(w, statusFromGitErr(err), err)
+		return
+	}
+	writeJSON(w, http.StatusOK, pr)
 }
 
 // statusFromGitErr maps the common sentinel errors to HTTP codes so

--- a/internal/githost/githost.go
+++ b/internal/githost/githost.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -462,6 +463,40 @@ type CheckRun struct {
 	Conclusion string    `json:"conclusion"` // success | failure | neutral | cancelled | skipped | timed_out | action_required
 	URL        string    `json:"url"`
 	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// PRCommit is one commit belonging to a pull request. Message is the
+// full commit message; the UI shows its first line as the subject.
+type PRCommit struct {
+	SHA      string    `json:"sha"`
+	ShortSHA string    `json:"short_sha"`
+	Message  string    `json:"message"`
+	Author   string    `json:"author"`
+	Date     time.Time `json:"date"`
+	URL      string    `json:"url"`
+}
+
+// PRFile is one changed file in a pull request. Patch is the unified
+// diff for the file; it may be empty when the host doesn't return
+// per-file patches inline (some Gitea versions), in which case the UI
+// shows the +/- counts without an expandable diff.
+type PRFile struct {
+	Filename  string `json:"filename"`
+	Status    string `json:"status"` // added | modified | removed | renamed
+	Additions int    `json:"additions"`
+	Deletions int    `json:"deletions"`
+	Patch     string `json:"patch,omitempty"`
+}
+
+// PRComment is one conversation entry: an issue/MR comment or a review
+// summary. State is set only for review summaries (approved |
+// changes_requested | commented).
+type PRComment struct {
+	Author    string    `json:"author"`
+	Body      string    `json:"body"`
+	CreatedAt time.Time `json:"created_at"`
+	State     string    `json:"state,omitempty"`
+	URL       string    `json:"url,omitempty"`
 }
 
 // CreatePullRequest opens a PR on the host that owns dir's remote.
@@ -1381,6 +1416,506 @@ func (s *Service) gitlabChecks(ctx context.Context, h Host, rem Remote, number i
 	return out, nil
 }
 
+// ── PR commits / files / comments (read-only detail tabs) ─────────
+
+// PRCommits returns the commits in a pull request, oldest first.
+func (s *Service) PRCommits(ctx context.Context, dir string, number int) ([]PRCommit, error) {
+	rem, hostRow, err := s.resolveHost(ctx, dir)
+	if err != nil {
+		return nil, err
+	}
+	if number <= 0 {
+		return nil, errors.New("number required")
+	}
+	switch hostRow.Kind {
+	case KindGitHub:
+		return s.githubPRCommits(ctx, hostRow, rem, number)
+	case KindGitea:
+		return s.giteaPRCommits(ctx, hostRow, rem, number)
+	case KindGitLab:
+		return s.gitlabPRCommits(ctx, hostRow, rem, number)
+	default:
+		return []PRCommit{}, nil
+	}
+}
+
+// PRFiles returns the changed files, with per-file patches where the
+// host provides them inline. Capped at the host's first ~100 files (no
+// pagination follow-up), consistent with the other PR endpoints.
+func (s *Service) PRFiles(ctx context.Context, dir string, number int) ([]PRFile, error) {
+	rem, hostRow, err := s.resolveHost(ctx, dir)
+	if err != nil {
+		return nil, err
+	}
+	if number <= 0 {
+		return nil, errors.New("number required")
+	}
+	switch hostRow.Kind {
+	case KindGitHub:
+		return s.githubPRFiles(ctx, hostRow, rem, number)
+	case KindGitea:
+		return s.giteaPRFiles(ctx, hostRow, rem, number)
+	case KindGitLab:
+		return s.gitlabPRFiles(ctx, hostRow, rem, number)
+	default:
+		return []PRFile{}, nil
+	}
+}
+
+// PRComments returns the conversation — issue/MR comments plus review
+// summaries — oldest first.
+func (s *Service) PRComments(ctx context.Context, dir string, number int) ([]PRComment, error) {
+	rem, hostRow, err := s.resolveHost(ctx, dir)
+	if err != nil {
+		return nil, err
+	}
+	if number <= 0 {
+		return nil, errors.New("number required")
+	}
+	switch hostRow.Kind {
+	case KindGitHub:
+		return s.githubPRComments(ctx, hostRow, rem, number)
+	case KindGitea:
+		return s.giteaPRComments(ctx, hostRow, rem, number)
+	case KindGitLab:
+		return s.gitlabPRComments(ctx, hostRow, rem, number)
+	default:
+		return []PRComment{}, nil
+	}
+}
+
+// ── commits ──
+
+func (s *Service) githubPRCommits(ctx context.Context, h Host, rem Remote, number int) ([]PRCommit, error) {
+	u := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/commits?per_page=100",
+		githubAPIBase(h.Host), rem.Owner, rem.Repo, number)
+	body, err := s.do(ctx, http.MethodGet, u, "Bearer "+h.Token, "application/vnd.github+json", nil)
+	if err != nil {
+		return nil, err
+	}
+	return decodeGitHubStyleCommits(body)
+}
+
+func (s *Service) giteaPRCommits(ctx context.Context, h Host, rem Remote, number int) ([]PRCommit, error) {
+	u := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/pulls/%d/commits?limit=100",
+		h.Host, rem.Owner, rem.Repo, number)
+	body, err := s.do(ctx, http.MethodGet, u, "token "+h.Token, "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+	return decodeGitHubStyleCommits(body)
+}
+
+func (s *Service) gitlabPRCommits(ctx context.Context, h Host, rem Remote, number int) ([]PRCommit, error) {
+	projectID := url.PathEscape(rem.Owner + "/" + rem.Repo)
+	u := fmt.Sprintf("https://%s/api/v4/projects/%s/merge_requests/%d/commits?per_page=100",
+		h.Host, projectID, number)
+	body, err := s.do(ctx, http.MethodGet, u, "Bearer "+h.Token, "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+	return decodeGitLabCommits(body)
+}
+
+// decodeGitHubStyleCommits handles the GitHub and Gitea commit shapes
+// (identical): {sha, html_url, commit:{message, author:{name,date}},
+// author:{login}}.
+func decodeGitHubStyleCommits(body []byte) ([]PRCommit, error) {
+	var raw []struct {
+		SHA     string `json:"sha"`
+		HTMLURL string `json:"html_url"`
+		Commit  struct {
+			Message string `json:"message"`
+			Author  struct {
+				Name string    `json:"name"`
+				Date time.Time `json:"date"`
+			} `json:"author"`
+		} `json:"commit"`
+		Author struct {
+			Login string `json:"login"`
+		} `json:"author"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("commits decode: %w", err)
+	}
+	out := make([]PRCommit, 0, len(raw))
+	for _, c := range raw {
+		author := c.Author.Login
+		if author == "" {
+			author = c.Commit.Author.Name
+		}
+		out = append(out, PRCommit{
+			SHA:      c.SHA,
+			ShortSHA: shortSHA(c.SHA),
+			Message:  c.Commit.Message,
+			Author:   author,
+			Date:     c.Commit.Author.Date,
+			URL:      c.HTMLURL,
+		})
+	}
+	return out, nil
+}
+
+func decodeGitLabCommits(body []byte) ([]PRCommit, error) {
+	var raw []struct {
+		ID         string    `json:"id"`
+		ShortID    string    `json:"short_id"`
+		Title      string    `json:"title"`
+		Message    string    `json:"message"`
+		AuthorName string    `json:"author_name"`
+		CreatedAt  time.Time `json:"created_at"`
+		WebURL     string    `json:"web_url"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("gitlab commits decode: %w", err)
+	}
+	out := make([]PRCommit, 0, len(raw))
+	for _, c := range raw {
+		msg := c.Message
+		if msg == "" {
+			msg = c.Title
+		}
+		short := c.ShortID
+		if short == "" {
+			short = shortSHA(c.ID)
+		}
+		out = append(out, PRCommit{
+			SHA:      c.ID,
+			ShortSHA: short,
+			Message:  msg,
+			Author:   c.AuthorName,
+			Date:     c.CreatedAt,
+			URL:      c.WebURL,
+		})
+	}
+	return out, nil
+}
+
+// ── files ──
+
+func (s *Service) githubPRFiles(ctx context.Context, h Host, rem Remote, number int) ([]PRFile, error) {
+	u := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/files?per_page=100",
+		githubAPIBase(h.Host), rem.Owner, rem.Repo, number)
+	body, err := s.do(ctx, http.MethodGet, u, "Bearer "+h.Token, "application/vnd.github+json", nil)
+	if err != nil {
+		return nil, err
+	}
+	return decodeGitHubStyleFiles(body)
+}
+
+func (s *Service) giteaPRFiles(ctx context.Context, h Host, rem Remote, number int) ([]PRFile, error) {
+	u := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/pulls/%d/files?limit=100",
+		h.Host, rem.Owner, rem.Repo, number)
+	body, err := s.do(ctx, http.MethodGet, u, "token "+h.Token, "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+	// Gitea's files endpoint returns names + counts but no inline
+	// patch, so Patch stays empty (UI shows the +/- counts only).
+	return decodeGitHubStyleFiles(body)
+}
+
+func (s *Service) gitlabPRFiles(ctx context.Context, h Host, rem Remote, number int) ([]PRFile, error) {
+	projectID := url.PathEscape(rem.Owner + "/" + rem.Repo)
+	u := fmt.Sprintf("https://%s/api/v4/projects/%s/merge_requests/%d/diffs?per_page=100",
+		h.Host, projectID, number)
+	body, err := s.do(ctx, http.MethodGet, u, "Bearer "+h.Token, "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+	return decodeGitLabDiffs(body)
+}
+
+// decodeGitHubStyleFiles handles GitHub and Gitea file shapes. GitHub
+// returns a per-file `patch`; Gitea omits it (Patch ends up empty).
+func decodeGitHubStyleFiles(body []byte) ([]PRFile, error) {
+	var raw []struct {
+		Filename  string `json:"filename"`
+		Status    string `json:"status"`
+		Additions int    `json:"additions"`
+		Deletions int    `json:"deletions"`
+		Patch     string `json:"patch"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("files decode: %w", err)
+	}
+	out := make([]PRFile, 0, len(raw))
+	for _, f := range raw {
+		out = append(out, PRFile{
+			Filename:  f.Filename,
+			Status:    normalizeFileStatus(f.Status),
+			Additions: f.Additions,
+			Deletions: f.Deletions,
+			Patch:     f.Patch,
+		})
+	}
+	return out, nil
+}
+
+func decodeGitLabDiffs(body []byte) ([]PRFile, error) {
+	var raw []struct {
+		OldPath     string `json:"old_path"`
+		NewPath     string `json:"new_path"`
+		Diff        string `json:"diff"`
+		NewFile     bool   `json:"new_file"`
+		RenamedFile bool   `json:"renamed_file"`
+		DeletedFile bool   `json:"deleted_file"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("gitlab diffs decode: %w", err)
+	}
+	out := make([]PRFile, 0, len(raw))
+	for _, d := range raw {
+		name := d.NewPath
+		status := "modified"
+		switch {
+		case d.NewFile:
+			status = "added"
+		case d.DeletedFile:
+			status = "removed"
+			name = d.OldPath
+		case d.RenamedFile:
+			status = "renamed"
+		}
+		add, del := countDiffLines(d.Diff)
+		out = append(out, PRFile{
+			Filename:  name,
+			Status:    status,
+			Additions: add,
+			Deletions: del,
+			Patch:     d.Diff,
+		})
+	}
+	return out, nil
+}
+
+// ── comments / conversation ──
+
+func (s *Service) githubPRComments(ctx context.Context, h Host, rem Remote, number int) ([]PRComment, error) {
+	base := githubAPIBase(h.Host)
+	icURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments?per_page=100",
+		base, rem.Owner, rem.Repo, number)
+	icBody, err := s.do(ctx, http.MethodGet, icURL, "Bearer "+h.Token, "application/vnd.github+json", nil)
+	if err != nil {
+		return nil, err
+	}
+	comments, err := decodeGitHubStyleComments(icBody)
+	if err != nil {
+		return nil, err
+	}
+	// Review summaries are best-effort: a failure here shouldn't drop
+	// the issue comments we already decoded.
+	rvURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews?per_page=100",
+		base, rem.Owner, rem.Repo, number)
+	if rvBody, rerr := s.do(ctx, http.MethodGet, rvURL, "Bearer "+h.Token, "application/vnd.github+json", nil); rerr == nil {
+		if reviews, derr := decodeGitHubStyleReviews(rvBody); derr == nil {
+			comments = append(comments, reviews...)
+		} else {
+			s.log.Warn("github pr reviews decode failed", "err", derr)
+		}
+	} else {
+		s.log.Warn("github pr reviews fetch failed", "err", rerr)
+	}
+	sortPRComments(comments)
+	return comments, nil
+}
+
+func (s *Service) giteaPRComments(ctx context.Context, h Host, rem Remote, number int) ([]PRComment, error) {
+	icURL := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues/%d/comments?limit=100",
+		h.Host, rem.Owner, rem.Repo, number)
+	icBody, err := s.do(ctx, http.MethodGet, icURL, "token "+h.Token, "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+	comments, err := decodeGitHubStyleComments(icBody)
+	if err != nil {
+		return nil, err
+	}
+	rvURL := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/pulls/%d/reviews?limit=100",
+		h.Host, rem.Owner, rem.Repo, number)
+	if rvBody, rerr := s.do(ctx, http.MethodGet, rvURL, "token "+h.Token, "application/json", nil); rerr == nil {
+		if reviews, derr := decodeGitHubStyleReviews(rvBody); derr == nil {
+			comments = append(comments, reviews...)
+		} else {
+			s.log.Warn("gitea pr reviews decode failed", "err", derr)
+		}
+	} else {
+		s.log.Warn("gitea pr reviews fetch failed", "err", rerr)
+	}
+	sortPRComments(comments)
+	return comments, nil
+}
+
+func (s *Service) gitlabPRComments(ctx context.Context, h Host, rem Remote, number int) ([]PRComment, error) {
+	projectID := url.PathEscape(rem.Owner + "/" + rem.Repo)
+	u := fmt.Sprintf("https://%s/api/v4/projects/%s/merge_requests/%d/notes?sort=asc&per_page=100",
+		h.Host, projectID, number)
+	body, err := s.do(ctx, http.MethodGet, u, "Bearer "+h.Token, "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+	comments, err := decodeGitLabNotes(body)
+	if err != nil {
+		return nil, err
+	}
+	sortPRComments(comments)
+	return comments, nil
+}
+
+// decodeGitHubStyleComments handles GitHub and Gitea issue comments:
+// {user:{login}, body, created_at, html_url}.
+func decodeGitHubStyleComments(body []byte) ([]PRComment, error) {
+	var raw []struct {
+		Body      string    `json:"body"`
+		CreatedAt time.Time `json:"created_at"`
+		HTMLURL   string    `json:"html_url"`
+		User      struct {
+			Login string `json:"login"`
+		} `json:"user"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("comments decode: %w", err)
+	}
+	out := make([]PRComment, 0, len(raw))
+	for _, c := range raw {
+		out = append(out, PRComment{
+			Author:    c.User.Login,
+			Body:      c.Body,
+			CreatedAt: c.CreatedAt,
+			URL:       c.HTMLURL,
+		})
+	}
+	return out, nil
+}
+
+// decodeGitHubStyleReviews handles GitHub and Gitea review summaries.
+// Only reviews carrying a body are surfaced in the conversation; a
+// bodyless APPROVED review is conveyed by the checks/merge UI. State is
+// normalised across the two vocabularies.
+func decodeGitHubStyleReviews(body []byte) ([]PRComment, error) {
+	var raw []struct {
+		Body        string    `json:"body"`
+		State       string    `json:"state"`
+		SubmittedAt time.Time `json:"submitted_at"`
+		HTMLURL     string    `json:"html_url"`
+		User        struct {
+			Login string `json:"login"`
+		} `json:"user"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("reviews decode: %w", err)
+	}
+	out := make([]PRComment, 0, len(raw))
+	for _, r := range raw {
+		if strings.TrimSpace(r.Body) == "" {
+			continue
+		}
+		out = append(out, PRComment{
+			Author:    r.User.Login,
+			Body:      r.Body,
+			CreatedAt: r.SubmittedAt,
+			State:     normalizeReviewState(r.State),
+			URL:       r.HTMLURL,
+		})
+	}
+	return out, nil
+}
+
+// decodeGitLabNotes maps MR notes to comments, dropping system notes
+// (label / assignee / milestone churn) so only human comments remain.
+func decodeGitLabNotes(body []byte) ([]PRComment, error) {
+	var raw []struct {
+		Body      string    `json:"body"`
+		CreatedAt time.Time `json:"created_at"`
+		System    bool      `json:"system"`
+		Author    struct {
+			Username string `json:"username"`
+		} `json:"author"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("gitlab notes decode: %w", err)
+	}
+	out := make([]PRComment, 0, len(raw))
+	for _, n := range raw {
+		if n.System {
+			continue
+		}
+		out = append(out, PRComment{
+			Author:    n.Author.Username,
+			Body:      n.Body,
+			CreatedAt: n.CreatedAt,
+		})
+	}
+	return out, nil
+}
+
+// ── small helpers ──
+
+func shortSHA(s string) string {
+	if len(s) <= 7 {
+		return s
+	}
+	return s[:7]
+}
+
+// countDiffLines counts added / removed lines in a unified diff,
+// skipping the +++ / --- file headers and the "\ No newline at end of
+// file" marker — none of which are real content changes. Hunk headers
+// (@@ … @@) start with neither + nor - so they fall through untouched.
+func countDiffLines(patch string) (add, del int) {
+	for _, line := range strings.Split(patch, "\n") {
+		switch {
+		case strings.HasPrefix(line, "+++"),
+			strings.HasPrefix(line, "---"),
+			strings.HasPrefix(line, `\`):
+			continue
+		case strings.HasPrefix(line, "+"):
+			add++
+		case strings.HasPrefix(line, "-"):
+			del++
+		}
+	}
+	return add, del
+}
+
+func normalizeFileStatus(s string) string {
+	switch strings.ToLower(s) {
+	case "added", "new":
+		return "added"
+	case "removed", "deleted":
+		return "removed"
+	case "renamed":
+		return "renamed"
+	case "":
+		return "modified"
+	default:
+		return strings.ToLower(s)
+	}
+}
+
+// normalizeReviewState maps GitHub (CHANGES_REQUESTED) and Gitea
+// (REQUEST_CHANGES) review vocabularies onto one set.
+func normalizeReviewState(s string) string {
+	switch strings.ToUpper(s) {
+	case "APPROVED":
+		return "approved"
+	case "CHANGES_REQUESTED", "REQUEST_CHANGES":
+		return "changes_requested"
+	case "COMMENTED", "COMMENT":
+		return "commented"
+	case "DISMISSED":
+		return "dismissed"
+	default:
+		return strings.ToLower(s)
+	}
+}
+
+func sortPRComments(c []PRComment) {
+	sort.SliceStable(c, func(i, j int) bool {
+		return c[i].CreatedAt.Before(c[j].CreatedAt)
+	})
+}
+
 func (s *Service) fetch(ctx context.Context, u, auth, accept string) ([]byte, error) {
 	return s.do(ctx, http.MethodGet, u, auth, accept, nil)
 }
@@ -1453,6 +1988,9 @@ func (h *Handlers) Mount(r chi.Router) {
 	r.Get("/git/prs/{number}", h.prDetail)
 	r.Post("/git/prs/{number}/merge", h.mergePR)
 	r.Get("/git/prs/{number}/checks", h.prChecks)
+	r.Get("/git/prs/{number}/commits", h.prCommits)
+	r.Get("/git/prs/{number}/files", h.prFiles)
+	r.Get("/git/prs/{number}/comments", h.prComments)
 }
 
 // createPR mounts POST /git/prs. Body matches CreatePRRequest.
@@ -1544,6 +2082,65 @@ func (h *Handlers) prDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, pr)
+}
+
+// prTabParams extracts the shared ?path=<dir> + {number} inputs for the
+// read-only detail-tab handlers, writing a 400 and returning ok=false
+// on bad input.
+func (h *Handlers) prTabParams(w http.ResponseWriter, r *http.Request) (string, int, bool) {
+	dir := strings.TrimSpace(r.URL.Query().Get("path"))
+	if dir == "" {
+		writeError(w, http.StatusBadRequest, errors.New("path required"))
+		return "", 0, false
+	}
+	n, err := strconv.Atoi(chi.URLParam(r, "number"))
+	if err != nil || n <= 0 {
+		writeError(w, http.StatusBadRequest, errors.New("invalid number"))
+		return "", 0, false
+	}
+	return dir, n, true
+}
+
+// prCommits mounts GET /git/prs/{number}/commits?path=<dir>.
+func (h *Handlers) prCommits(w http.ResponseWriter, r *http.Request) {
+	dir, n, ok := h.prTabParams(w, r)
+	if !ok {
+		return
+	}
+	commits, err := h.svc.PRCommits(r.Context(), dir, n)
+	if err != nil {
+		writeError(w, statusFromGitErr(err), err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"commits": commits})
+}
+
+// prFiles mounts GET /git/prs/{number}/files?path=<dir>.
+func (h *Handlers) prFiles(w http.ResponseWriter, r *http.Request) {
+	dir, n, ok := h.prTabParams(w, r)
+	if !ok {
+		return
+	}
+	files, err := h.svc.PRFiles(r.Context(), dir, n)
+	if err != nil {
+		writeError(w, statusFromGitErr(err), err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"files": files})
+}
+
+// prComments mounts GET /git/prs/{number}/comments?path=<dir>.
+func (h *Handlers) prComments(w http.ResponseWriter, r *http.Request) {
+	dir, n, ok := h.prTabParams(w, r)
+	if !ok {
+		return
+	}
+	comments, err := h.svc.PRComments(r.Context(), dir, n)
+	if err != nil {
+		writeError(w, statusFromGitErr(err), err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"comments": comments})
 }
 
 // statusFromGitErr maps the common sentinel errors to HTTP codes so

--- a/internal/githost/pr_helpers_test.go
+++ b/internal/githost/pr_helpers_test.go
@@ -153,3 +153,111 @@ func TestCommitStatusState_MappingMatrix(t *testing.T) {
 		}
 	}
 }
+
+// ── PR body / description capture ──────────────────────────────────
+// The detail surface (web drawer / mobile screen) needs the PR body.
+// Each host adapter must surface it on PullRequest.Body: GitHub and
+// Gitea call it "body"; GitLab calls it "description".
+
+func TestDecodeGiteaPR_Body(t *testing.T) {
+	body := []byte(`{
+		"number": 7,
+		"title": "feat: x",
+		"state": "open",
+		"body": "## Summary\nDoes the thing.",
+		"html_url": "https://git.example.com/o/r/pulls/7",
+		"updated_at": "2026-05-04T10:00:00Z",
+		"user": {"login": "alice"},
+		"head": {"ref": "feat/x"},
+		"base": {"ref": "main"}
+	}`)
+	got, err := decodeGiteaPR(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Body != "## Summary\nDoes the thing." {
+		t.Errorf("gitea body not captured, got %q", got.Body)
+	}
+}
+
+func TestDecodeGitLabMR_DescriptionToBody(t *testing.T) {
+	body := []byte(`{
+		"iid": 9,
+		"title": "feat: y",
+		"state": "opened",
+		"description": "Closes #1. Adds the widget.",
+		"web_url": "https://gitlab.com/g/r/-/merge_requests/9",
+		"updated_at": "2026-05-04T10:00:00Z",
+		"author": {"username": "bob"},
+		"source_branch": "feat/y",
+		"target_branch": "main"
+	}`)
+	got, err := decodeGitLabMR(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Body != "Closes #1. Adds the widget." {
+		t.Errorf("gitlab description should map to body, got %q", got.Body)
+	}
+}
+
+func TestGithubPRResponse_BodyPassthrough(t *testing.T) {
+	body := []byte(`{
+		"number": 11,
+		"title": "fix: z",
+		"state": "open",
+		"body": "Fixes the crash on startup.",
+		"html_url": "https://github.com/o/r/pull/11",
+		"updated_at": "2026-05-04T10:00:00Z",
+		"user": {"login": "carol"},
+		"head": {"ref": "fix/z"},
+		"base": {"ref": "main"}
+	}`)
+	var raw githubPRResponse
+	if err := jsonUnmarshalTestHelper(body, &raw); err != nil {
+		t.Fatal(err)
+	}
+	got := raw.toPullRequest()
+	if got.Body != "Fixes the crash on startup." {
+		t.Errorf("github body should pass through toPullRequest, got %q", got.Body)
+	}
+}
+
+// A description-less PR comes back with "body": null (GitHub) or the
+// field omitted (Gitea / GitLab). All three must decode to an empty
+// Body, never the literal "null".
+func TestDecoders_NullOrMissingBody(t *testing.T) {
+	var gh githubPRResponse
+	if err := jsonUnmarshalTestHelper([]byte(`{
+		"number": 1, "title": "t", "state": "open", "body": null,
+		"user": {"login": "a"}, "head": {"ref": "x"}, "base": {"ref": "main"}
+	}`), &gh); err != nil {
+		t.Fatal(err)
+	}
+	if got := gh.toPullRequest(); got.Body != "" {
+		t.Errorf("github null body should decode to empty, got %q", got.Body)
+	}
+
+	gitea, err := decodeGiteaPR([]byte(`{
+		"number": 1, "title": "t", "state": "open",
+		"user": {"login": "a"}, "head": {"ref": "x"}, "base": {"ref": "main"}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gitea.Body != "" {
+		t.Errorf("gitea missing body should be empty, got %q", gitea.Body)
+	}
+
+	gitlab, err := decodeGitLabMR([]byte(`{
+		"iid": 1, "title": "t", "state": "opened",
+		"author": {"username": "a"},
+		"source_branch": "x", "target_branch": "main"
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gitlab.Body != "" {
+		t.Errorf("gitlab missing description should be empty, got %q", gitlab.Body)
+	}
+}

--- a/internal/githost/pr_helpers_test.go
+++ b/internal/githost/pr_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestGithubAPIBase(t *testing.T) {
@@ -259,5 +260,207 @@ func TestDecoders_NullOrMissingBody(t *testing.T) {
 	}
 	if gitlab.Body != "" {
 		t.Errorf("gitlab missing description should be empty, got %q", gitlab.Body)
+	}
+}
+
+// ── detail tabs: commits / files / comments decoders ───────────────
+
+func TestDecodeGitHubStyleCommits(t *testing.T) {
+	body := []byte(`[
+	  {"sha":"abcdef1234567890","html_url":"https://gh/c/abcdef1",
+	   "commit":{"message":"feat: x\n\nbody","author":{"name":"Alice","date":"2026-05-01T10:00:00Z"}},
+	   "author":{"login":"alice"}},
+	  {"sha":"0123456","html_url":"",
+	   "commit":{"message":"fix","author":{"name":"Bob","date":"2026-05-02T10:00:00Z"}},
+	   "author":{"login":""}}
+	]`)
+	got, err := decodeGitHubStyleCommits(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 commits, got %d", len(got))
+	}
+	if got[0].ShortSHA != "abcdef1" {
+		t.Errorf("short sha = %q, want abcdef1", got[0].ShortSHA)
+	}
+	if got[0].Author != "alice" {
+		t.Errorf("author = %q, want alice", got[0].Author)
+	}
+	if got[1].Author != "Bob" {
+		t.Errorf("missing login should fall back to commit author name, got %q", got[1].Author)
+	}
+	if got[1].ShortSHA != "0123456" {
+		t.Errorf("7-char sha should be returned as-is, got %q", got[1].ShortSHA)
+	}
+}
+
+func TestDecodeGitLabCommits(t *testing.T) {
+	body := []byte(`[{"id":"deadbeefcafe","short_id":"deadbee","title":"t","message":"",
+	   "author_name":"Carol","created_at":"2026-05-01T10:00:00Z","web_url":"https://gl/c"}]`)
+	got, err := decodeGitLabCommits(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].SHA != "deadbeefcafe" || got[0].ShortSHA != "deadbee" {
+		t.Errorf("ids wrong: %+v", got[0])
+	}
+	if got[0].Message != "t" {
+		t.Errorf("empty message should fall back to title, got %q", got[0].Message)
+	}
+	if got[0].Author != "Carol" {
+		t.Errorf("author = %q", got[0].Author)
+	}
+}
+
+func TestDecodeGitHubStyleFiles(t *testing.T) {
+	body := []byte(`[
+	  {"filename":"a.go","status":"modified","additions":3,"deletions":1,"patch":"@@ -1 +1,3 @@"},
+	  {"filename":"b.go","status":"removed","additions":0,"deletions":9}
+	]`)
+	got, err := decodeGitHubStyleFiles(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].Patch == "" {
+		t.Errorf("patch should be captured for github files")
+	}
+	if got[1].Status != "removed" {
+		t.Errorf("status = %q, want removed", got[1].Status)
+	}
+	if got[1].Patch != "" {
+		t.Errorf("absent patch should decode to empty, got %q", got[1].Patch)
+	}
+}
+
+func TestDecodeGitLabDiffs_StatusAndCounts(t *testing.T) {
+	body := []byte(`[
+	  {"old_path":"a.go","new_path":"a.go","new_file":false,"renamed_file":false,"deleted_file":false,
+	   "diff":"@@\n+added one\n+added two\n-removed one\n unchanged\n"},
+	  {"old_path":"gone.go","new_path":"gone.go","deleted_file":true,
+	   "diff":"--- a/gone.go\n+++ /dev/null\n-x\n"}
+	]`)
+	got, err := decodeGitLabDiffs(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].Additions != 2 || got[0].Deletions != 1 {
+		t.Errorf("counts derived from diff wrong: +%d -%d, want +2 -1", got[0].Additions, got[0].Deletions)
+	}
+	if got[1].Status != "removed" || got[1].Filename != "gone.go" {
+		t.Errorf("deleted file: status=%q name=%q", got[1].Status, got[1].Filename)
+	}
+	// The +++ / --- headers in file 2 must not be counted as add/del.
+	if got[1].Additions != 0 || got[1].Deletions != 1 {
+		t.Errorf("diff headers miscounted: +%d -%d, want +0 -1", got[1].Additions, got[1].Deletions)
+	}
+}
+
+func TestDecodeComments_AndReviews(t *testing.T) {
+	comments, err := decodeGitHubStyleComments([]byte(
+		`[{"user":{"login":"alice"},"body":"hi","created_at":"2026-05-01T10:00:00Z","html_url":"u"}]`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comments) != 1 || comments[0].Author != "alice" || comments[0].Body != "hi" {
+		t.Errorf("comment decode: %+v", comments)
+	}
+	reviews, err := decodeGitHubStyleReviews([]byte(`[
+	  {"user":{"login":"bob"},"body":"please fix","state":"CHANGES_REQUESTED","submitted_at":"2026-05-01T11:00:00Z"},
+	  {"user":{"login":"carol"},"body":"","state":"APPROVED","submitted_at":"2026-05-01T12:00:00Z"},
+	  {"user":{"login":"dave"},"body":"changes","state":"REQUEST_CHANGES","submitted_at":"2026-05-01T13:00:00Z"}
+	]`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reviews) != 2 {
+		t.Fatalf("bodyless review should be dropped; want 2 got %d", len(reviews))
+	}
+	if reviews[0].State != "changes_requested" {
+		t.Errorf("github CHANGES_REQUESTED normalize: %q", reviews[0].State)
+	}
+	if reviews[1].State != "changes_requested" {
+		t.Errorf("gitea REQUEST_CHANGES should normalize to changes_requested: %q", reviews[1].State)
+	}
+}
+
+func TestDecodeGitLabNotes_DropSystem(t *testing.T) {
+	got, err := decodeGitLabNotes([]byte(`[
+	  {"author":{"username":"alice"},"body":"real comment","created_at":"2026-05-01T10:00:00Z","system":false},
+	  {"author":{"username":"bot"},"body":"changed the description","created_at":"2026-05-01T10:01:00Z","system":true}
+	]`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Author != "alice" {
+		t.Errorf("system notes must be dropped, got %+v", got)
+	}
+}
+
+func TestSortPRComments(t *testing.T) {
+	mk := func(iso string) PRComment {
+		ts, _ := time.Parse(time.RFC3339, iso)
+		return PRComment{CreatedAt: ts}
+	}
+	c := []PRComment{
+		mk("2026-05-03T00:00:00Z"),
+		mk("2026-05-01T00:00:00Z"),
+		mk("2026-05-02T00:00:00Z"),
+	}
+	sortPRComments(c)
+	if !c[0].CreatedAt.Before(c[1].CreatedAt) || !c[1].CreatedAt.Before(c[2].CreatedAt) {
+		t.Errorf("comments not sorted ascending by time")
+	}
+}
+
+func TestCountDiffLines(t *testing.T) {
+	add, del := countDiffLines("@@ -1,2 +1,3 @@\n context\n+new line\n+another\n-gone\n")
+	if add != 2 || del != 1 {
+		t.Errorf("countDiffLines = +%d -%d, want +2 -1", add, del)
+	}
+}
+
+func TestCountDiffLines_NoNewlineMarker(t *testing.T) {
+	// The "\ No newline at end of file" marker must not be counted.
+	add, del := countDiffLines(
+		"@@ -1 +1 @@\n-old\n\\ No newline at end of file\n+new\n\\ No newline at end of file\n",
+	)
+	if add != 1 || del != 1 {
+		t.Errorf("no-newline marker miscounted: +%d -%d, want +1 -1", add, del)
+	}
+}
+
+func TestNormalizeReviewState(t *testing.T) {
+	cases := map[string]string{
+		"APPROVED":          "approved",
+		"CHANGES_REQUESTED": "changes_requested", // GitHub
+		"REQUEST_CHANGES":   "changes_requested", // Gitea
+		"COMMENTED":         "commented",
+		"COMMENT":           "commented", // Gitea
+		"DISMISSED":         "dismissed",
+		"weird":             "weird", // unknown → lowercased
+	}
+	for in, want := range cases {
+		if got := normalizeReviewState(in); got != want {
+			t.Errorf("normalizeReviewState(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNormalizeFileStatus(t *testing.T) {
+	cases := map[string]string{
+		"added":    "added",
+		"new":      "added",
+		"removed":  "removed",
+		"deleted":  "removed",
+		"renamed":  "renamed",
+		"modified": "modified",
+		"":         "modified",
+		"changed":  "changed", // unknown → passed through lowercased
+	}
+	for in, want := range cases {
+		if got := normalizeFileStatus(in); got != want {
+			t.Errorf("normalizeFileStatus(%q) = %q, want %q", in, got, want)
+		}
 	}
 }


### PR DESCRIPTION
## What & why

The Git tab's PR list showed only number / title / author / branches —
there was no way to read a PR's **description**, see its **status**
clearly, or view **CI checks** for closed/merged PRs (the inline expand
was gated to open PRs only). This adds a dedicated PR **detail** surface
on both clients.

## Scope

- ✅ Description (body), status badge (open / closed / merged / draft),
  CI checks for **all** states (not just open)
- ✅ Dedicated surface: **web** right-side drawer, **mobile** full-screen page
- ⏭️ Deferred (out of scope): commits list, changed files / diff,
  reviews & comments — the layout leaves room for these.

## Changes

**Backend** `internal/githost`
- `PullRequest.Body` (`json:"body,omitempty"`), captured in the
  GitHub / Gitea / GitLab single-PR decoders (GitLab `description` → body).
  List payloads stay lean (body only on the detail fetch).
- `Service.GetPullRequest` + per-host fetchers; new `GET /git/prs/{number}`
  handler mirroring `prChecks` (auth schemes & URL shapes unchanged).
- Decoder tests for body passthrough and null/missing body.

**Shared** `app/shared/src/lib/githost.ts`
- `body?: string` + `getGitPR(path, number)`.

**Web** `PullRequestsSection.tsx`
- Inline expand → `PRDetailDrawer` (portal, `react-markdown` body, CI for
  all states, Merge only when open). Uses `placeholderData` so the body
  loading state is accurate, and holds the selected PR as a snapshot so
  the 60s list refetch can't close the drawer mid-read.

**Mobile** `pr_detail_screen.dart` (new) + `git_pr_section.dart` + `git_api.dart`
- Row navigates to a full-screen detail page (any state); description as
  plain selectable text; open-on-host via `url_launcher`.

## Notes / decisions

- **i18n intentionally not added** — both PR sections are hardcoded
  English by existing convention; the new surfaces match their
  neighbours (no slang regen, no shared-json change).
- **Mobile body is plain text** — no markdown renderer dependency on
  mobile; web uses the existing `react-markdown`.
- **Known follow-up** (surfaced in review, deferred): `statusFromGitErr`
  maps an upstream 404 to HTTP 500 (pre-existing, shared by
  `prChecks` / `mergePR`). The detail happy path taps a listed PR so it
  won't 404; a clean fix is a typed upstream-status sentinel matched via
  `errors.Is`, left out of this focused change.

## Test plan

- [x] `go build ./...`, `go vet ./internal/githost/`
- [x] `go test -race ./internal/githost/` (incl. new body / null-body decoder tests) — green
- [x] web `tsc -b` + `eslint` on the changed component — clean
- [x] `flutter analyze` on the changed mobile files — clean
- [ ] Manual: open a PR in the Git tab on web + mobile; confirm the
  description, status and checks render for open, closed and merged PRs,
  and that Merge still works for open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
