### PR TITLE
feat(git): read-only Issues surface on web + mobile

### DIFF
--- a/app/mobile/lib/core/api/git_api.dart
+++ b/app/mobile/lib/core/api/git_api.dart
@@ -364,6 +364,100 @@ class GitPRComment {
   final String url;
 }
 
+// One issue label. color is a hex string without the leading '#'; it
+// may be empty (GitLab issue payloads carry only the label name).
+class GitLabel {
+  GitLabel({required this.name, required this.color});
+
+  factory GitLabel.fromJson(Map<String, dynamic> json) => GitLabel(
+    name: json['name'] as String? ?? '',
+    color: json['color'] as String? ?? '',
+  );
+
+  final String name;
+  final String color;
+}
+
+// An issue (read-only). Mirrors GitPullRequest minus the PR-only
+// fields; adds labels. body is empty on list responses — only the
+// single-issue detail fetch (getIssue) populates it.
+class GitIssue {
+  GitIssue({
+    required this.number,
+    required this.title,
+    required this.state,
+    required this.author,
+    required this.url,
+    required this.updatedAt,
+    required this.labels,
+    this.body = '',
+  });
+
+  factory GitIssue.fromJson(Map<String, dynamic> json) {
+    final rawLabels = json['labels'];
+    final labels = rawLabels is List
+        ? rawLabels
+              .whereType<Map<String, dynamic>>()
+              .map(GitLabel.fromJson)
+              .toList()
+        : <GitLabel>[];
+    return GitIssue(
+      number: (json['number'] as num?)?.toInt() ?? 0,
+      title: json['title'] as String? ?? '',
+      state: json['state'] as String? ?? '',
+      author: json['author'] as String? ?? '',
+      url: json['url'] as String? ?? '',
+      updatedAt: json['updated_at'] as String? ?? '',
+      labels: labels,
+      body: json['body'] as String? ?? '',
+    );
+  }
+
+  final int number;
+  // open | closed
+  final String state;
+  final String title;
+  final String author;
+  final String url;
+  final String updatedAt;
+  final List<GitLabel> labels;
+  final String body;
+}
+
+// Container for the /git/issues response: issues plus repo metadata so
+// callers can render a "configure your token" hint. Mirrors
+// GitPullRequestList.
+class GitIssueList {
+  GitIssueList({
+    required this.issues,
+    required this.needsToken,
+    required this.host,
+    required this.errorMessage,
+  });
+
+  factory GitIssueList.fromJson(Map<String, dynamic> json) {
+    final raw = json['issues'];
+    final issues = raw is List
+        ? raw.whereType<Map<String, dynamic>>().map(GitIssue.fromJson).toList()
+        : <GitIssue>[];
+    final remote = json['remote'];
+    final host = remote is Map<String, dynamic>
+        ? (remote['host'] as String? ?? '')
+        : '';
+    return GitIssueList(
+      issues: issues,
+      needsToken: json['need_token'] as bool? ?? false,
+      host: host,
+      errorMessage: json['error'] as String? ?? '',
+    );
+  }
+
+  final List<GitIssue> issues;
+  final bool needsToken;
+  final String host;
+  final String errorMessage;
+}
+
 class GitApi {
   GitApi(this._dio);
   final Dio _dio;
@@ -614,6 +708,62 @@ class GitApi {
         queryParameters: {'path': dir},
       );
       return GitPullRequest.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // ── Issues (read-only) ───────────────────────────────────────
+
+  // GET /git/issues?path=<dir>&state=<open|closed|all>. Mirrors
+  // listPullRequests; the server returns metadata (remote + need_token)
+  // alongside the issue array. PRs are filtered out server-side.
+  Future<GitIssueList> listIssues({
+    required String dir,
+    String state = 'open',
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/git/issues',
+        queryParameters: {'path': dir, 'state': state},
+      );
+      return GitIssueList.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // GET /git/issues/{n}?path=<dir> — a single issue including its body.
+  // The list endpoint omits body to stay lean.
+  Future<GitIssue> getIssue({required String dir, required int number}) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/git/issues/$number',
+        queryParameters: {'path': dir},
+      );
+      return GitIssue.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // GET /git/issues/{n}/comments — conversation. Reuses GitPRComment
+  // (issues never carry a review state, so it stays empty).
+  Future<List<GitPRComment>> issueComments({
+    required String dir,
+    required int number,
+  }) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/git/issues/$number/comments',
+        queryParameters: {'path': dir},
+      );
+      final raw = res.data?['comments'];
+      if (raw is! List) return const [];
+      return raw
+          .whereType<Map<String, dynamic>>()
+          .map(GitPRComment.fromJson)
+          .toList();
     } on Object catch (e) {
       throw toApiException(e);
     }

--- a/app/mobile/lib/features/sessions/inspector/git_issue_section.dart
+++ b/app/mobile/lib/features/sessions/inspector/git_issue_section.dart
@@ -1,0 +1,277 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/api/api_exception.dart';
+import 'package:opendray/core/api/git_api.dart';
+import 'package:opendray/features/sessions/inspector/issue_detail_screen.dart';
+
+// GitIssueSection sits directly below GitPRSection in the Git tab. It
+// mirrors the PR surface but read-only: list issues for the repo, tap a
+// row to open the detail screen (description + labels + comments). There
+// is no create / close action — issues are view-only here.
+//
+// Polls /git/issues every 60s while mounted. GitHub/Gitea expose issues
+// and PRs through one endpoint; the backend filters PRs out, so this
+// list is issues only.
+class GitIssueSection extends ConsumerStatefulWidget {
+  const GitIssueSection({required this.cwd, super.key});
+  final String cwd;
+
+  @override
+  ConsumerState<GitIssueSection> createState() => _GitIssueSectionState();
+}
+
+class _GitIssueSectionState extends ConsumerState<GitIssueSection> {
+  GitIssueList? _list;
+  bool _loading = true;
+  Object? _error;
+  Timer? _refreshTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
+    _refreshTimer = Timer.periodic(
+      const Duration(seconds: 60),
+      (_) => unawaited(_load()),
+    );
+  }
+
+  @override
+  void dispose() {
+    _refreshTimer?.cancel();
+    super.dispose();
+  }
+
+  String _errorMessage() {
+    final e = _error;
+    if (e is ApiException) return e.message;
+    return '$e';
+  }
+
+  Future<void> _load() async {
+    try {
+      final list = await ref.read(gitApiProvider).listIssues(dir: widget.cwd);
+      if (!mounted) return;
+      setState(() {
+        _list = list;
+        _loading = false;
+        _error = null;
+      });
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e;
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              Icon(
+                Icons.adjust_outlined,
+                size: 16,
+                color: theme.colorScheme.outline,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                'Issues',
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: theme.colorScheme.outline,
+                ),
+              ),
+            ],
+          ),
+          if (_loading)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 6),
+              child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+            )
+          else if (_error != null)
+            Text(
+              'Error: ${_errorMessage()}',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.error,
+              ),
+            )
+          else if (_list?.needsToken ?? false)
+            _NeedTokenHint(host: _list!.host)
+          else if ((_list?.errorMessage ?? '').isNotEmpty)
+            Text(
+              _list!.errorMessage,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.error,
+              ),
+            )
+          else if ((_list?.issues ?? []).isEmpty)
+            Text(
+              'No open issues.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.outline,
+              ),
+            )
+          else
+            for (final issue in _list!.issues)
+              _IssueRow(issue: issue, onTap: () => unawaited(_openDetail(issue))),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _openDetail(GitIssue issue) async {
+    await Navigator.of(context).push<void>(
+      MaterialPageRoute(
+        builder: (_) => IssueDetailScreen(cwd: widget.cwd, issue: issue),
+      ),
+    );
+  }
+}
+
+class _IssueRow extends StatelessWidget {
+  const _IssueRow({required this.issue, required this.onTap});
+
+  final GitIssue issue;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final closed = issue.state == 'closed';
+    final stateColor = closed ? Colors.purple : Colors.green;
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+        child: Row(
+          children: [
+            Icon(
+              closed ? Icons.check_circle_outline : Icons.error_outline,
+              size: 14,
+              color: stateColor,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    issue.title,
+                    style: theme.textTheme.bodyMedium,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text(
+                    '#${issue.number} · ${issue.author}',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.outline,
+                      fontFamily: 'monospace',
+                      fontSize: 10,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (issue.labels.isNotEmpty) ...[
+                    const SizedBox(height: 4),
+                    IssueLabelChips(labels: issue.labels),
+                  ],
+                ],
+              ),
+            ),
+            Icon(
+              Icons.chevron_right,
+              size: 16,
+              color: theme.colorScheme.outline,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// IssueLabelChips renders an issue's labels as small pills. GitHub/Gitea
+// supply a hex colour (no leading '#'); GitLab leaves it empty, in which
+// case the chip falls back to the theme outline. Shared between the row
+// and the detail header.
+class IssueLabelChips extends StatelessWidget {
+  const IssueLabelChips({required this.labels, super.key});
+  final List<GitLabel> labels;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Wrap(
+      spacing: 4,
+      runSpacing: 4,
+      children: [
+        for (final l in labels)
+          () {
+            final color = _parseHex(l.color) ?? theme.colorScheme.outline;
+            return Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+              decoration: BoxDecoration(
+                border: Border.all(color: color),
+                borderRadius: BorderRadius.circular(8),
+                color: color.withValues(alpha: 0.1),
+              ),
+              child: Text(
+                l.name,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: color,
+                  fontSize: 9,
+                ),
+              ),
+            );
+          }(),
+      ],
+    );
+  }
+
+  // _parseHex turns a 6-digit hex string (no leading '#') into a Color.
+  // Returns null for empty / malformed input so the caller falls back.
+  static Color? _parseHex(String hex) {
+    if (hex.length != 6) return null;
+    final v = int.tryParse(hex, radix: 16);
+    if (v == null) return null;
+    return Color(0xFF000000 | v);
+  }
+}
+
+class _NeedTokenHint extends StatelessWidget {
+  const _NeedTokenHint({required this.host});
+  final String host;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        border: Border.all(color: theme.dividerColor, style: BorderStyle.solid),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.key_outlined, size: 16, color: theme.colorScheme.outline),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              'No token configured for $host. Add one in Plugins → Git hosts.',
+              style: theme.textTheme.bodySmall,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/mobile/lib/features/sessions/inspector/git_tab.dart
+++ b/app/mobile/lib/features/sessions/inspector/git_tab.dart
@@ -7,6 +7,7 @@ import 'package:opendray/core/api/sessions_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/sessions/inspector/git_branch_controls.dart';
 import 'package:opendray/features/sessions/inspector/git_commit_form.dart';
+import 'package:opendray/features/sessions/inspector/git_issue_section.dart';
 import 'package:opendray/features/sessions/inspector/git_pr_section.dart';
 
 // Git surface inside the session inspector. Two views toggle via a
@@ -446,6 +447,8 @@ class _GitTabState extends ConsumerState<GitTab>
               // Phase 1+2: PR command-center. Always renders so
               // operators can create a PR even on a clean tree.
               GitPRSection(cwd: widget.cwd),
+              // Issues — read-only sibling of the PR section.
+              GitIssueSection(cwd: widget.cwd),
             ],
           ),
         );

--- a/app/mobile/lib/features/sessions/inspector/issue_detail_screen.dart
+++ b/app/mobile/lib/features/sessions/inspector/issue_detail_screen.dart
@@ -1,0 +1,307 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/api/api_exception.dart';
+import 'package:opendray/core/api/git_api.dart';
+import 'package:opendray/features/sessions/inspector/git_issue_section.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+// IssueDetailScreen is the full-screen issue view opened when a row is
+// tapped. Read-only: a single scrolling pane with the description
+// followed by the comment thread. Mirrors PRDetailScreen minus the
+// tabs and merge footer (issues have no commits / checks / files /
+// merge).
+class IssueDetailScreen extends ConsumerStatefulWidget {
+  const IssueDetailScreen({required this.cwd, required this.issue, super.key});
+
+  final String cwd;
+  final GitIssue issue;
+
+  @override
+  ConsumerState<IssueDetailScreen> createState() => _IssueDetailScreenState();
+}
+
+class _IssueDetailScreenState extends ConsumerState<IssueDetailScreen> {
+  // Seeded from the list row so the header paints instantly; replaced by
+  // the detail fetch (which carries the body) once it resolves.
+  late GitIssue _issue;
+  bool _detailLoading = true;
+  Object? _detailError;
+
+  List<GitPRComment>? _comments;
+  Object? _commentsError;
+
+  @override
+  void initState() {
+    super.initState();
+    _issue = widget.issue;
+    unawaited(_loadDetail());
+    unawaited(_loadComments());
+  }
+
+  Future<void> _loadDetail() async {
+    try {
+      final full = await ref
+          .read(gitApiProvider)
+          .getIssue(dir: widget.cwd, number: widget.issue.number);
+      if (!mounted) return;
+      setState(() {
+        _issue = full;
+        _detailLoading = false;
+        _detailError = null;
+      });
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _detailError = e;
+        _detailLoading = false;
+      });
+    }
+  }
+
+  Future<void> _loadComments() async {
+    try {
+      final c = await ref
+          .read(gitApiProvider)
+          .issueComments(dir: widget.cwd, number: widget.issue.number);
+      if (!mounted) return;
+      setState(() {
+        _comments = c;
+        _commentsError = null;
+      });
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() => _commentsError = e);
+    }
+  }
+
+  Future<void> _openInBrowser() async {
+    final uri = Uri.tryParse(_issue.url);
+    if (uri == null) return;
+    try {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } on Object {
+      // Best-effort convenience link; never crash the screen.
+    }
+  }
+
+  String _errMsg(Object? e) {
+    if (e is ApiException) return e.message;
+    return '$e';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final comments = _comments ?? const <GitPRComment>[];
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Issue #${_issue.number}'),
+        actions: [
+          if (_issue.url.isNotEmpty)
+            IconButton(
+              tooltip: 'Open on host',
+              icon: const Icon(Icons.open_in_new),
+              onPressed: _openInBrowser,
+            ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          // Header: title + state + labels
+          Text(_issue.title, style: theme.textTheme.titleMedium),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 4,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              _StateBadge(state: _issue.state),
+              Text(
+                '#${_issue.number} · ${_issue.author}',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.outline,
+                ),
+              ),
+            ],
+          ),
+          if (_issue.labels.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            IssueLabelChips(labels: _issue.labels),
+          ],
+          const SizedBox(height: 16),
+          // Description
+          _CommentCard(
+            author: _issue.author,
+            when: '',
+            child: _descriptionBody(theme),
+          ),
+          const SizedBox(height: 8),
+          // Comments
+          if (_commentsError != null)
+            Text(
+              'Comments unavailable: ${_errMsg(_commentsError)}',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.outline,
+              ),
+            )
+          else if (_comments == null)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 8),
+              child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+            )
+          else if (comments.isEmpty)
+            Text(
+              'No comments yet.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.outline,
+              ),
+            )
+          else
+            for (final c in comments) ...[
+              _CommentCard(
+                author: c.author,
+                when: _relTime(c.createdAt),
+                child: SelectableText(c.body, style: theme.textTheme.bodyMedium),
+              ),
+              const SizedBox(height: 8),
+            ],
+        ],
+      ),
+    );
+  }
+
+  Widget _descriptionBody(ThemeData theme) {
+    if (_detailLoading && _issue.body.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 4),
+        child: SizedBox(
+          height: 16,
+          child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+        ),
+      );
+    }
+    if (_detailError != null && _issue.body.isEmpty) {
+      return Text(
+        "Couldn't load details: ${_errMsg(_detailError)}",
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.error,
+        ),
+      );
+    }
+    if (_issue.body.trim().isEmpty) {
+      return Text(
+        'No description provided.',
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.outline,
+          fontStyle: FontStyle.italic,
+        ),
+      );
+    }
+    return SelectableText(_issue.body.trim(), style: theme.textTheme.bodyMedium);
+  }
+}
+
+// _CommentCard is the bordered card used for both the description and
+// each comment. Mirrors the PR detail screen's card.
+class _CommentCard extends StatelessWidget {
+  const _CommentCard({
+    required this.author,
+    required this.when,
+    required this.child,
+  });
+
+  final String author;
+  final String when;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: theme.dividerColor),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            decoration: BoxDecoration(
+              color: theme.colorScheme.surfaceContainerHighest,
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
+            ),
+            child: Row(
+              children: [
+                Text(
+                  author,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    fontFamily: 'monospace',
+                  ),
+                ),
+                const Spacer(),
+                if (when.isNotEmpty)
+                  Text(
+                    when,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.outline,
+                      fontSize: 10,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(10),
+            child: SizedBox(width: double.infinity, child: child),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// _StateBadge is the textual status pill in the detail header.
+class _StateBadge extends StatelessWidget {
+  const _StateBadge({required this.state});
+
+  final String state;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (String label, Color color) = state == 'closed'
+        ? ('CLOSED', Colors.purple)
+        : ('OPEN', Colors.green);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        border: Border.all(color: color),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: color,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+String _relTime(String iso) {
+  final t = DateTime.tryParse(iso);
+  if (t == null) return iso;
+  final d = DateTime.now().difference(t);
+  if (d.inDays > 365) return '${(d.inDays / 365).floor()}y ago';
+  if (d.inDays > 30) return '${(d.inDays / 30).floor()}mo ago';
+  if (d.inDays > 0) return '${d.inDays}d ago';
+  if (d.inHours > 0) return '${d.inHours}h ago';
+  if (d.inMinutes > 0) return '${d.inMinutes}m ago';
+  return 'just now';
+}

--- a/app/shared/src/lib/githost.ts
+++ b/app/shared/src/lib/githost.ts
@@ -234,3 +234,63 @@ export async function getPRComments(
   )
   return res.comments ?? []
 }
+
+// ── Issues (read-only) ─────────────────────────────────────────
+
+export interface GitLabel {
+  name: string
+  // Hex colour without the leading '#'. May be empty (GitLab issue
+  // payloads carry only the label name).
+  color: string
+}
+
+export interface GitIssue {
+  number: number
+  title: string
+  state: 'open' | 'closed'
+  author: string
+  url: string
+  // Description (markdown). Only populated by getGitIssue (the single-
+  // issue detail fetch); the list endpoint omits it to stay lean.
+  body?: string
+  labels: GitLabel[]
+  updated_at: string
+}
+
+export interface GitIssuesResponse {
+  remote: GitRemote
+  issues: GitIssue[]
+  need_token?: boolean
+  error?: string
+}
+
+export async function listGitIssues(
+  path: string,
+  state: 'open' | 'closed' | 'all' = 'open',
+): Promise<GitIssuesResponse> {
+  const params = new URLSearchParams({ path, state })
+  return api<GitIssuesResponse>(`/api/v1/git/issues?${params.toString()}`)
+}
+
+// getGitIssue fetches a single issue including its body/description. Use
+// this for the detail surface; listGitIssues leaves body empty.
+export async function getGitIssue(
+  path: string,
+  number: number,
+): Promise<GitIssue> {
+  const params = new URLSearchParams({ path })
+  return api<GitIssue>(`/api/v1/git/issues/${number}?${params.toString()}`)
+}
+
+// Issue comments reuse PRComment — the conversation shape is identical
+// (issues never carry a review state, so it stays empty).
+export async function getIssueComments(
+  path: string,
+  number: number,
+): Promise<PRComment[]> {
+  const params = new URLSearchParams({ path })
+  const res = await api<{ comments: PRComment[] }>(
+    `/api/v1/git/issues/${number}/comments?${params.toString()}`,
+  )
+  return res.comments ?? []
+}

--- a/app/web/src/components/sessions/inspector/GitPanel.tsx
+++ b/app/web/src/components/sessions/inspector/GitPanel.tsx
@@ -15,6 +15,7 @@ import { cn } from '@/lib/utils'
 import { BranchControls } from './BranchControls'
 import { CommitForm } from './CommitForm'
 import { DiffViewer } from './DiffViewer'
+import { IssuesSection } from './IssuesSection'
 import { PullRequestsSection } from './PullRequestsSection'
 
 interface GitPanelProps {
@@ -128,6 +129,8 @@ export function GitPanel({ cwd }: GitPanelProps) {
       )}
 
       <PullRequestsSection cwd={cwd} />
+
+      <IssuesSection cwd={cwd} />
 
       <section className="flex flex-col gap-1">
         <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70 font-medium px-1">

--- a/app/web/src/components/sessions/inspector/IssuesSection.tsx
+++ b/app/web/src/components/sessions/inspector/IssuesSection.tsx
@@ -1,0 +1,461 @@
+import { type ComponentPropsWithoutRef, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { Link } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import {
+  CircleDot,
+  CheckCircle2,
+  Loader2,
+  ExternalLink,
+  KeyRound,
+  X,
+} from 'lucide-react'
+import { formatDistanceToNow } from 'date-fns'
+import ReactMarkdown, { type Components } from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+import {
+  type GitIssue as Issue,
+  type GitLabel,
+  type PRComment,
+  getGitIssue,
+  getIssueComments,
+  listGitIssues,
+} from '@/lib/githost'
+import { cn } from '@/lib/utils'
+
+interface IssuesSectionProps {
+  cwd: string
+}
+
+// IssuesSection sits in GitPanel directly below PullRequestsSection. It
+// mirrors the PR surface but read-only: `GET /git/issues?path=<cwd>`
+// returns issues from the matching git_hosts row or `need_token: true`,
+// rendered as a deep link to /plugins. GitHub/Gitea expose issues and
+// PRs through one endpoint; the backend filters PRs out, so this list is
+// issues only.
+//
+// Each row opens a right-side detail drawer (description + labels +
+// comment thread). There is no create / close / comment action — issues
+// are view-only here.
+export function IssuesSection({ cwd }: IssuesSectionProps) {
+  const [state, setState] = useState<'open' | 'closed' | 'all'>('open')
+  // Hold the row object (not just the number) so the drawer survives the
+  // 60s list refetch — see PullRequestsSection for the rationale.
+  const [detailIssue, setDetailIssue] = useState<Issue | null>(null)
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['git-issues', cwd, state],
+    queryFn: () => listGitIssues(cwd, state),
+    refetchInterval: 60_000,
+  })
+
+  return (
+    <section className="flex flex-col gap-1">
+      <div className="flex items-center justify-between px-1">
+        <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70 font-medium flex items-center gap-1.5">
+          <CircleDot className="size-3" />
+          Issues
+        </div>
+        <div className="flex items-center gap-0.5 text-[10px]">
+          {(['open', 'closed', 'all'] as const).map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => setState(s)}
+              className={cn(
+                'px-1.5 py-0.5 rounded-sm transition-colors',
+                state === s
+                  ? 'text-foreground bg-card'
+                  : 'text-muted-foreground/60 hover:text-foreground',
+              )}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center gap-2 text-[11px] text-muted-foreground px-1 py-1">
+          <Loader2 className="size-3 animate-spin" />
+          Fetching…
+        </div>
+      )}
+      {error && (
+        <div className="text-[11px] text-state-failed px-1 py-1">
+          {(error as Error).message}
+        </div>
+      )}
+      {data && data.error && !data.need_token && (
+        <div className="text-[11px] text-state-failed px-1 py-1 break-words">
+          {data.error}
+        </div>
+      )}
+      {data && data.need_token && <NeedTokenHint host={data.remote.host} />}
+      {data && !data.error && !data.need_token && data.issues.length === 0 && (
+        <div className="text-[11px] text-muted-foreground/60 px-1 py-1">
+          No {state === 'all' ? '' : `${state} `}issues.
+        </div>
+      )}
+      {data && !data.need_token && (
+        <div className="flex flex-col">
+          {data.issues.map((it) => (
+            <IssueRow
+              key={it.number}
+              issue={it}
+              onOpen={() => setDetailIssue(it)}
+            />
+          ))}
+        </div>
+      )}
+
+      {detailIssue && (
+        <IssueDetailDrawer
+          cwd={cwd}
+          issue={detailIssue}
+          onClose={() => setDetailIssue(null)}
+        />
+      )}
+    </section>
+  )
+}
+
+// IssueRow is the per-issue card. Click opens the detail drawer; the
+// external-link icon jumps to the host's web view.
+function IssueRow({ issue, onOpen }: { issue: Issue; onOpen: () => void }) {
+  return (
+    <div className="border-b border-border/30 last:border-b-0">
+      <button
+        type="button"
+        onClick={onOpen}
+        className="w-full px-1 py-1.5 flex items-start gap-2 hover:bg-card rounded-sm group text-left"
+        title={`#${issue.number} · ${issue.author}`}
+      >
+        <IssueStateIcon issue={issue} className="mt-0.5" />
+        <div className="flex flex-col min-w-0 flex-1 gap-0.5">
+          <span className="text-[12px] truncate group-hover:text-foreground">
+            {issue.title}
+          </span>
+          <span className="text-[10px] text-muted-foreground/70 font-mono truncate">
+            #{issue.number} · {issue.author} · {relTime(issue.updated_at)}
+          </span>
+          {issue.labels.length > 0 && <LabelChips labels={issue.labels} />}
+        </div>
+        <a
+          href={issue.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className="text-muted-foreground/50 hover:text-foreground"
+          title="Open on host"
+        >
+          <ExternalLink className="size-3 mt-0.5" />
+        </a>
+      </button>
+    </div>
+  )
+}
+
+// IssueStateIcon renders the issue glyph coloured by state. Open issues
+// use the green open-circle; closed issues use a purple check (matching
+// the host convention of "closed = resolved").
+function IssueStateIcon({
+  issue,
+  className,
+}: {
+  issue: Issue
+  className?: string
+}) {
+  if (issue.state === 'closed') {
+    return (
+      <CheckCircle2 className={cn('size-3 text-purple-400 shrink-0', className)} />
+    )
+  }
+  return (
+    <CircleDot className={cn('size-3 text-state-running shrink-0', className)} />
+  )
+}
+
+// StateBadge is the textual status pill in the drawer header.
+function StateBadge({ issue }: { issue: Issue }) {
+  const { label, cls } =
+    issue.state === 'closed'
+      ? { label: 'Closed', cls: 'text-purple-400 border-purple-400/40' }
+      : { label: 'Open', cls: 'text-state-running border-state-running/40' }
+  return (
+    <span
+      className={cn(
+        'text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded border shrink-0',
+        cls,
+      )}
+    >
+      {label}
+    </span>
+  )
+}
+
+// LabelChips renders the issue's labels as small pills. GitHub/Gitea
+// supply a hex colour (no leading '#'); GitLab leaves it empty, in which
+// case we fall back to a muted border-only chip.
+function LabelChips({ labels }: { labels: GitLabel[] }) {
+  return (
+    <div className="flex flex-wrap gap-1">
+      {labels.map((l) => {
+        const color = l.color ? `#${l.color}` : undefined
+        return (
+          <span
+            key={l.name}
+            className={cn(
+              'text-[9px] px-1.5 py-px rounded-full border leading-tight',
+              !color && 'border-border text-muted-foreground/80',
+            )}
+            style={
+              color
+                ? {
+                    borderColor: color,
+                    color,
+                    backgroundColor: `${color}1a`, // ~10% alpha
+                  }
+                : undefined
+            }
+          >
+            {l.name}
+          </span>
+        )
+      })}
+    </div>
+  )
+}
+
+// mdComponents keeps rendered markdown inside the panel: links open in a
+// new tab, code blocks scroll, images are width-constrained. Mirrors the
+// PR drawer's overrides.
+const mdComponents: Components = {
+  a: (props: ComponentPropsWithoutRef<'a'>) => (
+    <a
+      {...props}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-state-running hover:underline break-words"
+    />
+  ),
+  pre: (props: ComponentPropsWithoutRef<'pre'>) => (
+    <pre
+      {...props}
+      className="overflow-x-auto rounded bg-card/60 p-2 text-[11px]"
+    />
+  ),
+  img: (props: ComponentPropsWithoutRef<'img'>) => (
+    <img {...props} alt={props.alt ?? ''} className="max-w-full rounded" />
+  ),
+}
+
+// IssueDetailDrawer is the right-side panel shown when an issue row is
+// clicked. Read-only: a single scrolling pane with the description
+// (markdown) followed by the comment thread. No tabs, no footer action.
+//
+// Mounted into a portal on document.body so it overlays the whole
+// viewport rather than being clipped by the inspector sidebar.
+function IssueDetailDrawer({
+  cwd,
+  issue,
+  onClose,
+}: {
+  cwd: string
+  issue: Issue
+  onClose: () => void
+}) {
+  // Close on Escape.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  // Full issue incl. body. Seeded from the list row so the header paints
+  // instantly; the body fills in when the single-issue fetch resolves
+  // (the list endpoint omits body to stay lean). See PR drawer for why
+  // placeholderData (not initialData) is used.
+  const detail = useQuery({
+    queryKey: ['git-issue', cwd, issue.number],
+    queryFn: () => getGitIssue(cwd, issue.number),
+    placeholderData: issue,
+  })
+  const full = detail.data ?? issue
+
+  const comments = useQuery({
+    queryKey: ['git-issue-comments', cwd, issue.number],
+    queryFn: () => getIssueComments(cwd, issue.number),
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const body = full.body?.trim() ?? ''
+  const bodyPending = detail.isPlaceholderData
+  const detailError = detail.isError ? (detail.error as Error).message : null
+  const list = comments.data ?? []
+
+  return createPortal(
+    <div className="fixed inset-0 z-[60] flex justify-end">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-black/40 backdrop-blur-[1px]"
+        onClick={onClose}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="relative h-full w-full max-w-2xl bg-background border-l border-border shadow-2xl flex flex-col"
+      >
+        {/* Header */}
+        <div className="flex items-start gap-2 px-3 py-2.5 border-b border-border">
+          <IssueStateIcon issue={full} className="mt-1" />
+          <div className="min-w-0 flex-1">
+            <div className="text-[13px] font-medium leading-snug break-words">
+              {full.title}
+            </div>
+            <div className="text-[10px] text-muted-foreground/70 font-mono mt-0.5">
+              #{full.number} · {full.author}
+            </div>
+          </div>
+          <a
+            href={full.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground/50 hover:text-foreground p-0.5"
+            title="Open on host"
+          >
+            <ExternalLink className="size-3.5" />
+          </a>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="text-muted-foreground/50 hover:text-foreground p-0.5"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        {/* Meta row */}
+        <div className="px-3 py-2 border-b border-border/50 flex items-center gap-2 flex-wrap text-[11px]">
+          <StateBadge issue={full} />
+          {full.labels.length > 0 && <LabelChips labels={full.labels} />}
+          <span className="text-muted-foreground/50">
+            · {relTime(full.updated_at)}
+          </span>
+        </div>
+
+        {/* Body: description + comment thread */}
+        <div className="flex-1 overflow-y-auto px-3 py-3">
+          <div className="flex flex-col gap-3">
+            <div className="rounded border border-border/50 bg-card/30">
+              <div className="px-2.5 py-1.5 border-b border-border/40 text-[10px] text-muted-foreground/80">
+                <span className="font-mono text-foreground/90">
+                  {full.author}
+                </span>{' '}
+                opened this issue
+              </div>
+              <div className="px-2.5 py-2">
+                {detailError ? (
+                  <div className="text-[11px] text-state-failed">
+                    Couldn't load details: {detailError}
+                  </div>
+                ) : bodyPending ? (
+                  <TabLoading />
+                ) : body ? (
+                  <div className="prose-md text-[12px] leading-relaxed break-words">
+                    <ReactMarkdown
+                      remarkPlugins={[remarkGfm]}
+                      components={mdComponents}
+                    >
+                      {body}
+                    </ReactMarkdown>
+                  </div>
+                ) : (
+                  <div className="text-[11px] text-muted-foreground/60 italic">
+                    No description provided.
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {comments.isLoading && <TabLoading text="Loading comments…" />}
+            {comments.error && (
+              <div className="text-[11px] text-state-failed py-2 break-words">
+                comments unavailable: {(comments.error as Error).message}
+              </div>
+            )}
+            {!comments.isLoading && !comments.error && list.length === 0 && (
+              <div className="text-[11px] text-muted-foreground/60 py-2">
+                No comments yet.
+              </div>
+            )}
+            {list.map((c, i) => (
+              <CommentItem
+                key={c.url ?? `${c.author}-${c.created_at}-${i}`}
+                c={c}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+function TabLoading({ text = 'Loading…' }: { text?: string }) {
+  return (
+    <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground py-2">
+      <Loader2 className="size-3 animate-spin" />
+      {text}
+    </div>
+  )
+}
+
+function CommentItem({ c }: { c: PRComment }) {
+  return (
+    <div className="rounded border border-border/50 bg-card/30">
+      <div className="flex items-center gap-2 px-2.5 py-1.5 border-b border-border/40 text-[10px] text-muted-foreground/80">
+        <span className="font-mono text-foreground/90">{c.author}</span>
+        <span className="ml-auto">{relTime(c.created_at)}</span>
+      </div>
+      <div className="prose-md text-[12px] leading-relaxed break-words px-2.5 py-2">
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
+          {c.body}
+        </ReactMarkdown>
+      </div>
+    </div>
+  )
+}
+
+function NeedTokenHint({ host }: { host: string }) {
+  return (
+    <div className="rounded-md border border-dashed border-border bg-card/40 p-2.5 flex flex-col gap-2">
+      <div className="flex items-start gap-2 text-[11px] text-muted-foreground">
+        <KeyRound className="size-3.5 mt-0.5 text-muted-foreground/60 shrink-0" />
+        <span>
+          No token configured for <span className="font-mono">{host}</span>. Add
+          one to fetch issues.
+        </span>
+      </div>
+      <Link
+        to="/plugins"
+        className="text-[11px] text-state-running hover:underline self-start"
+      >
+        Configure git host →
+      </Link>
+    </div>
+  )
+}
+
+function relTime(iso: string): string {
+  try {
+    return formatDistanceToNow(new Date(iso), { addSuffix: true })
+  } catch {
+    return iso
+  }
+}

--- a/internal/githost/githost.go
+++ b/internal/githost/githost.go
@@ -1991,6 +1991,10 @@ func (h *Handlers) Mount(r chi.Router) {
 	r.Get("/git/prs/{number}/commits", h.prCommits)
 	r.Get("/git/prs/{number}/files", h.prFiles)
 	r.Get("/git/prs/{number}/comments", h.prComments)
+	// Issues — read-only sibling of the PR surface (see issues.go).
+	r.Get("/git/issues", h.issues)
+	r.Get("/git/issues/{number}", h.issueDetail)
+	r.Get("/git/issues/{number}/comments", h.issueComments)
 }
 
 // createPR mounts POST /git/prs. Body matches CreatePRRequest.

--- a/internal/githost/issues.go
+++ b/internal/githost/issues.go
@@ -1,0 +1,447 @@
+package githost
+
+// Issue viewing — a read-only sibling of the pull-request surface in
+// githost.go. Issues mirror PRs (list + detail + comments across
+// GitHub / Gitea / GitLab) but drop the PR-only concepts: no commits,
+// checks, files, or merge. The conversation reuses PRComment.
+//
+// Two cross-provider quirks shape this file:
+//
+//  1. GitHub and Gitea expose issues and PRs through the SAME /issues
+//     endpoint; PR items carry a `pull_request` field. We skip those so
+//     a repo's PRs don't double-show as issues. GitLab keeps issues on a
+//     separate endpoint, so no filtering there.
+//  2. Labels differ: GitHub/Gitea return [{name,color}] objects; GitLab
+//     returns a flat []string. Both normalise to []Label (GitLab colour
+//     is left empty).
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Label is one issue label. Color is a hex string without the leading
+// '#'; it may be empty (GitLab labels carry only a name in the issue
+// payload).
+type Label struct {
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+// Issue is the trimmed-down view surfaced in the panel. Body is the
+// description (markdown); like PullRequest.Body it is only populated by
+// the single-issue detail fetch (GetIssue), so the list endpoint keeps
+// its payload lean. Labels has no omitempty so the JSON always carries
+// an array rather than null.
+type Issue struct {
+	Number    int       `json:"number"`
+	Title     string    `json:"title"`
+	State     string    `json:"state"` // open | closed
+	Author    string    `json:"author"`
+	URL       string    `json:"url"`
+	Body      string    `json:"body,omitempty"`
+	Labels    []Label   `json:"labels"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// ── label normalisation ───────────────────────────────────────────
+
+// githubStyleLabels maps GitHub/Gitea {name,color} label objects to
+// []Label. Returns a non-nil empty slice so JSON emits [].
+func githubStyleLabels(raw []struct {
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}) []Label {
+	out := make([]Label, 0, len(raw))
+	for _, l := range raw {
+		out = append(out, Label{Name: l.Name, Color: l.Color})
+	}
+	return out
+}
+
+// gitlabStringLabels maps GitLab's flat []string labels to []Label with
+// empty Color. Returns a non-nil empty slice so JSON emits [].
+func gitlabStringLabels(raw []string) []Label {
+	out := make([]Label, 0, len(raw))
+	for _, name := range raw {
+		out = append(out, Label{Name: name})
+	}
+	return out
+}
+
+// ── service dispatch ───────────────────────────────────────────────
+
+// ListIssues lists issues for dir's remote in the given state
+// (open|closed|all, default open). PRs are filtered out for GitHub /
+// Gitea; see the per-provider adapters.
+func (s *Service) ListIssues(ctx context.Context, dir, state string) (Remote, []Issue, error) {
+	rem, err := s.DetectRemote(ctx, dir)
+	if err != nil {
+		return Remote{}, nil, err
+	}
+	if !rem.HasToken {
+		return rem, nil, ErrNoTokenForHost
+	}
+	hostRow, err := s.GetByHost(ctx, rem.Host)
+	if err != nil {
+		return rem, nil, err
+	}
+	if state == "" {
+		state = "open"
+	}
+	switch hostRow.Kind {
+	case KindGitHub:
+		body, ferr := s.fetch(ctx, fmt.Sprintf("%s/repos/%s/%s/issues?state=%s&per_page=20",
+			githubAPIBase(hostRow.Host), rem.Owner, rem.Repo, url.QueryEscape(state)),
+			"Bearer "+hostRow.Token, "application/vnd.github+json")
+		if ferr != nil {
+			return rem, nil, ferr
+		}
+		issues, derr := decodeGitHubIssues(body)
+		return rem, issues, derr
+	case KindGitea:
+		body, ferr := s.fetch(ctx, fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues?state=%s&type=issues&limit=20",
+			hostRow.Host, rem.Owner, rem.Repo, url.QueryEscape(state)),
+			"token "+hostRow.Token, "application/json")
+		if ferr != nil {
+			return rem, nil, ferr
+		}
+		issues, derr := decodeGitHubIssues(body)
+		return rem, issues, derr
+	case KindGitLab:
+		// GitLab's issues API accepts only opened|closed for the state
+		// param; "all" is expressed by omitting it entirely.
+		projectID := url.PathEscape(rem.Owner + "/" + rem.Repo)
+		u := fmt.Sprintf("https://%s/api/v4/projects/%s/issues?per_page=20",
+			hostRow.Host, projectID)
+		switch state {
+		case "open":
+			u += "&state=opened"
+		case "closed":
+			u += "&state=closed"
+		}
+		body, ferr := s.fetch(ctx, u, "Bearer "+hostRow.Token, "application/json")
+		if ferr != nil {
+			return rem, nil, ferr
+		}
+		issues, derr := decodeGitLabIssues(body)
+		return rem, issues, derr
+	default:
+		return rem, nil, fmt.Errorf("unsupported host kind: %s", hostRow.Kind)
+	}
+}
+
+// GetIssue fetches a single issue — including its body — for the detail
+// surface. Mirrors GetPullRequest.
+func (s *Service) GetIssue(ctx context.Context, dir string, number int) (Issue, error) {
+	rem, hostRow, err := s.resolveHost(ctx, dir)
+	if err != nil {
+		return Issue{}, err
+	}
+	if number <= 0 {
+		return Issue{}, errors.New("number required")
+	}
+	switch hostRow.Kind {
+	case KindGitHub:
+		body, ferr := s.do(ctx, http.MethodGet, fmt.Sprintf("%s/repos/%s/%s/issues/%d",
+			githubAPIBase(hostRow.Host), rem.Owner, rem.Repo, number),
+			"Bearer "+hostRow.Token, "application/vnd.github+json", nil)
+		if ferr != nil {
+			return Issue{}, ferr
+		}
+		return decodeGitHubIssue(body)
+	case KindGitea:
+		body, ferr := s.do(ctx, http.MethodGet, fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues/%d",
+			hostRow.Host, rem.Owner, rem.Repo, number),
+			"token "+hostRow.Token, "application/json", nil)
+		if ferr != nil {
+			return Issue{}, ferr
+		}
+		return decodeGitHubIssue(body)
+	case KindGitLab:
+		projectID := url.PathEscape(rem.Owner + "/" + rem.Repo)
+		body, ferr := s.do(ctx, http.MethodGet, fmt.Sprintf("https://%s/api/v4/projects/%s/issues/%d",
+			hostRow.Host, projectID, number),
+			"Bearer "+hostRow.Token, "application/json", nil)
+		if ferr != nil {
+			return Issue{}, ferr
+		}
+		return decodeGitLabIssue(body)
+	default:
+		return Issue{}, fmt.Errorf("unsupported host kind: %s", hostRow.Kind)
+	}
+}
+
+// IssueComments returns an issue's conversation oldest-first. Reuses the
+// PRComment type and the shared comment decoders. Unlike PRComments it
+// never fetches reviews — issues have none, and the /pulls/{n}/reviews
+// path would error for a non-PR number.
+func (s *Service) IssueComments(ctx context.Context, dir string, number int) ([]PRComment, error) {
+	rem, hostRow, err := s.resolveHost(ctx, dir)
+	if err != nil {
+		return nil, err
+	}
+	if number <= 0 {
+		return nil, errors.New("number required")
+	}
+	switch hostRow.Kind {
+	case KindGitHub:
+		return s.githubIssueComments(ctx, hostRow, rem, number)
+	case KindGitea:
+		return s.giteaIssueComments(ctx, hostRow, rem, number)
+	case KindGitLab:
+		return s.gitlabIssueComments(ctx, hostRow, rem, number)
+	default:
+		return []PRComment{}, nil
+	}
+}
+
+// ── decode: list ───────────────────────────────────────────────────
+
+// githubIssueItem is one entry from GitHub/Gitea's /issues list. The
+// PullRequest field is the discriminator: when present the item is a PR,
+// not an issue, and must be skipped.
+type githubIssueItem struct {
+	Number      int             `json:"number"`
+	Title       string          `json:"title"`
+	State       string          `json:"state"`
+	HTMLURL     string          `json:"html_url"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+	PullRequest json.RawMessage `json:"pull_request"`
+	User        struct {
+		Login string `json:"login"`
+	} `json:"user"`
+	Labels []struct {
+		Name  string `json:"name"`
+		Color string `json:"color"`
+	} `json:"labels"`
+}
+
+// isPullRequestItem reports whether a GitHub/Gitea /issues entry is
+// actually a pull request. The discriminator is a non-empty,
+// non-null pull_request field; a missing field decodes to a zero-length
+// RawMessage, and a literal `null` (some hosts) must also be treated as
+// "not a PR".
+func isPullRequestItem(pr json.RawMessage) bool {
+	return len(pr) > 0 && string(pr) != "null"
+}
+
+// decodeGitHubIssues decodes a GitHub/Gitea /issues list, dropping any
+// item that is actually a pull request (carries a pull_request field).
+func decodeGitHubIssues(body []byte) ([]Issue, error) {
+	var raw []githubIssueItem
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("github issues decode: %w", err)
+	}
+	out := make([]Issue, 0, len(raw))
+	for _, it := range raw {
+		if isPullRequestItem(it.PullRequest) {
+			continue // a PR masquerading as an issue — skip it
+		}
+		out = append(out, Issue{
+			Number:    it.Number,
+			Title:     it.Title,
+			State:     it.State,
+			Author:    it.User.Login,
+			URL:       it.HTMLURL,
+			Labels:    githubStyleLabels(it.Labels),
+			UpdatedAt: it.UpdatedAt,
+		})
+	}
+	return out, nil
+}
+
+// gitlabIssueItem is one entry from GitLab's /issues list/detail. Labels
+// are a flat []string and the identifier is the project-scoped iid.
+type gitlabIssueItem struct {
+	IID         int       `json:"iid"`
+	Title       string    `json:"title"`
+	State       string    `json:"state"`
+	WebURL      string    `json:"web_url"`
+	Description string    `json:"description"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	Labels      []string  `json:"labels"`
+	Author      struct {
+		Username string `json:"username"`
+	} `json:"author"`
+}
+
+func (it gitlabIssueItem) toIssue() Issue {
+	return Issue{
+		Number:    it.IID,
+		Title:     it.Title,
+		State:     normaliseGitlabState(it.State),
+		Author:    it.Author.Username,
+		URL:       it.WebURL,
+		Body:      it.Description,
+		Labels:    gitlabStringLabels(it.Labels),
+		UpdatedAt: it.UpdatedAt,
+	}
+}
+
+func decodeGitLabIssues(body []byte) ([]Issue, error) {
+	var raw []gitlabIssueItem
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("gitlab issues decode: %w", err)
+	}
+	out := make([]Issue, 0, len(raw))
+	for _, it := range raw {
+		iss := it.toIssue()
+		iss.Body = "" // list payloads stay lean; detail fetch fills Body
+		out = append(out, iss)
+	}
+	return out, nil
+}
+
+// ── decode: detail ─────────────────────────────────────────────────
+
+// decodeGitHubIssue decodes a single GitHub/Gitea issue, including the
+// body. Shares the githubIssueItem shape plus a body field.
+func decodeGitHubIssue(body []byte) (Issue, error) {
+	var raw struct {
+		githubIssueItem
+		Body string `json:"body"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return Issue{}, fmt.Errorf("github issue decode: %w", err)
+	}
+	if isPullRequestItem(raw.PullRequest) {
+		return Issue{}, errors.New("requested number is a pull request, not an issue")
+	}
+	return Issue{
+		Number:    raw.Number,
+		Title:     raw.Title,
+		State:     raw.State,
+		Author:    raw.User.Login,
+		URL:       raw.HTMLURL,
+		Body:      raw.Body,
+		Labels:    githubStyleLabels(raw.Labels),
+		UpdatedAt: raw.UpdatedAt,
+	}, nil
+}
+
+func decodeGitLabIssue(body []byte) (Issue, error) {
+	var raw gitlabIssueItem
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return Issue{}, fmt.Errorf("gitlab issue decode: %w", err)
+	}
+	return raw.toIssue(), nil
+}
+
+// ── comments (issue-only, no reviews) ──────────────────────────────
+
+func (s *Service) githubIssueComments(ctx context.Context, h Host, rem Remote, number int) ([]PRComment, error) {
+	u := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments?per_page=100",
+		githubAPIBase(h.Host), rem.Owner, rem.Repo, number)
+	body, err := s.do(ctx, http.MethodGet, u, "Bearer "+h.Token, "application/vnd.github+json", nil)
+	if err != nil {
+		return nil, err
+	}
+	comments, err := decodeGitHubStyleComments(body)
+	if err != nil {
+		return nil, err
+	}
+	sortPRComments(comments)
+	return comments, nil
+}
+
+func (s *Service) giteaIssueComments(ctx context.Context, h Host, rem Remote, number int) ([]PRComment, error) {
+	u := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues/%d/comments?limit=100",
+		h.Host, rem.Owner, rem.Repo, number)
+	body, err := s.do(ctx, http.MethodGet, u, "token "+h.Token, "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+	comments, err := decodeGitHubStyleComments(body)
+	if err != nil {
+		return nil, err
+	}
+	sortPRComments(comments)
+	return comments, nil
+}
+
+func (s *Service) gitlabIssueComments(ctx context.Context, h Host, rem Remote, number int) ([]PRComment, error) {
+	projectID := url.PathEscape(rem.Owner + "/" + rem.Repo)
+	u := fmt.Sprintf("https://%s/api/v4/projects/%s/issues/%d/notes?sort=asc&per_page=100",
+		h.Host, projectID, number)
+	body, err := s.do(ctx, http.MethodGet, u, "Bearer "+h.Token, "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+	comments, err := decodeGitLabNotes(body)
+	if err != nil {
+		return nil, err
+	}
+	sortPRComments(comments)
+	return comments, nil
+}
+
+// ── HTTP handlers ──────────────────────────────────────────────────
+
+// issues mounts GET /git/issues?path=<dir>&state=<open|closed|all>.
+// Mirrors prs; the no-token / error envelopes match so the client can
+// reuse its handling. The list key is "issues".
+func (h *Handlers) issues(w http.ResponseWriter, r *http.Request) {
+	dir := strings.TrimSpace(r.URL.Query().Get("path"))
+	if dir == "" {
+		writeError(w, http.StatusBadRequest, errors.New("path is required"))
+		return
+	}
+	state := r.URL.Query().Get("state")
+	rem, issues, err := h.svc.ListIssues(r.Context(), dir, state)
+	if errors.Is(err, ErrNoTokenForHost) {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"remote":     rem,
+			"issues":     []Issue{},
+			"need_token": true,
+		})
+		return
+	}
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"remote": rem,
+			"issues": []Issue{},
+			"error":  err.Error(),
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"remote": rem,
+		"issues": issues,
+	})
+}
+
+// issueDetail mounts GET /git/issues/{number}?path=<dir>. Returns the
+// full Issue envelope — including body — for the detail surface.
+func (h *Handlers) issueDetail(w http.ResponseWriter, r *http.Request) {
+	dir, n, ok := h.prTabParams(w, r)
+	if !ok {
+		return
+	}
+	iss, err := h.svc.GetIssue(r.Context(), dir, n)
+	if err != nil {
+		writeError(w, statusFromGitErr(err), err)
+		return
+	}
+	writeJSON(w, http.StatusOK, iss)
+}
+
+// issueComments mounts GET /git/issues/{number}/comments?path=<dir>.
+func (h *Handlers) issueComments(w http.ResponseWriter, r *http.Request) {
+	dir, n, ok := h.prTabParams(w, r)
+	if !ok {
+		return
+	}
+	comments, err := h.svc.IssueComments(r.Context(), dir, n)
+	if err != nil {
+		writeError(w, statusFromGitErr(err), err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"comments": comments})
+}

--- a/internal/githost/issues_test.go
+++ b/internal/githost/issues_test.go
@@ -1,0 +1,207 @@
+package githost
+
+import (
+	"testing"
+)
+
+// TestDecodeGitHubIssues_FiltersPRs is the highest-value test: GitHub's
+// /issues endpoint returns pull requests too (each carrying a
+// pull_request field). The list adapter must drop them so PRs don't
+// double-show as issues.
+func TestDecodeGitHubIssues_FiltersPRs(t *testing.T) {
+	body := []byte(`[
+		{"number": 7, "title": "real issue", "state": "open",
+		 "html_url": "https://github.com/o/r/issues/7",
+		 "updated_at": "2026-05-04T10:00:00Z", "user": {"login": "alice"},
+		 "labels": [{"name": "bug", "color": "d73a4a"}]},
+		{"number": 8, "title": "a PR", "state": "open",
+		 "html_url": "https://github.com/o/r/pull/8",
+		 "updated_at": "2026-05-04T11:00:00Z", "user": {"login": "bob"},
+		 "pull_request": {"url": "https://api.github.com/repos/o/r/pulls/8"}},
+		{"number": 9, "title": "another issue", "state": "closed",
+		 "html_url": "https://github.com/o/r/issues/9",
+		 "updated_at": "2026-05-04T12:00:00Z", "user": {"login": "carol"},
+		 "labels": []}
+	]`)
+	got, err := decodeGitHubIssues(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 issues (PR #8 filtered), got %d: %+v", len(got), got)
+	}
+	if got[0].Number != 7 || got[1].Number != 9 {
+		t.Errorf("wrong issues survived: %+v", got)
+	}
+	if got[0].Author != "alice" || got[0].State != "open" {
+		t.Errorf("issue #7 meta wrong: %+v", got[0])
+	}
+}
+
+func TestDecodeGitHubIssues_Labels(t *testing.T) {
+	body := []byte(`[
+		{"number": 1, "title": "t", "state": "open", "html_url": "u",
+		 "updated_at": "2026-05-04T10:00:00Z", "user": {"login": "a"},
+		 "labels": [{"name": "bug", "color": "d73a4a"}, {"name": "p1", "color": "ff0000"}]}
+	]`)
+	got, err := decodeGitHubIssues(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || len(got[0].Labels) != 2 {
+		t.Fatalf("want 1 issue with 2 labels, got %+v", got)
+	}
+	if got[0].Labels[0].Name != "bug" || got[0].Labels[0].Color != "d73a4a" {
+		t.Errorf("label[0] wrong: %+v", got[0].Labels[0])
+	}
+	if got[0].Labels[1].Name != "p1" || got[0].Labels[1].Color != "ff0000" {
+		t.Errorf("label[1] wrong: %+v", got[0].Labels[1])
+	}
+}
+
+// TestDecodeGitHubIssues_EmptyLabelsNonNil guards the JSON contract: the
+// Labels field has no omitempty, so it must serialise as [] not null.
+func TestDecodeGitHubIssues_EmptyLabelsNonNil(t *testing.T) {
+	body := []byte(`[
+		{"number": 1, "title": "t", "state": "open", "html_url": "u",
+		 "updated_at": "2026-05-04T10:00:00Z", "user": {"login": "a"}}
+	]`)
+	got, err := decodeGitHubIssues(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].Labels == nil {
+		t.Error("Labels should be non-nil empty slice, got nil")
+	}
+}
+
+func TestDecodeGitHubIssue_Detail(t *testing.T) {
+	body := []byte(`{
+		"number": 12, "title": "detail issue", "state": "open",
+		"html_url": "https://github.com/o/r/issues/12",
+		"updated_at": "2026-05-04T10:00:00Z", "user": {"login": "dora"},
+		"body": "the description",
+		"labels": [{"name": "enhancement", "color": "a2eeef"}]
+	}`)
+	got, err := decodeGitHubIssue(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Number != 12 || got.Body != "the description" {
+		t.Errorf("detail meta/body wrong: %+v", got)
+	}
+	if len(got.Labels) != 1 || got.Labels[0].Name != "enhancement" {
+		t.Errorf("detail labels wrong: %+v", got.Labels)
+	}
+}
+
+func TestDecodeGitLabIssues_StringLabelsAndState(t *testing.T) {
+	body := []byte(`[
+		{"iid": 3, "title": "gl issue", "state": "opened",
+		 "web_url": "https://gitlab.com/o/r/-/issues/3",
+		 "updated_at": "2026-05-04T10:00:00Z", "author": {"username": "eve"},
+		 "labels": ["bug", "p1"]}
+	]`)
+	got, err := decodeGitLabIssues(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 issue, got %d", len(got))
+	}
+	is := got[0]
+	if is.Number != 3 || is.Author != "eve" {
+		t.Errorf("gitlab meta wrong (iid→number, author): %+v", is)
+	}
+	if is.State != "open" {
+		t.Errorf("gitlab state should normalise opened→open, got %q", is.State)
+	}
+	if len(is.Labels) != 2 || is.Labels[0].Name != "bug" || is.Labels[0].Color != "" {
+		t.Errorf("gitlab string labels should map to {name, empty color}: %+v", is.Labels)
+	}
+	// list payloads must stay lean — Body is detail-only.
+	if is.Body != "" {
+		t.Errorf("list issue should not carry body, got %q", is.Body)
+	}
+}
+
+func TestDecodeGitLabIssue_Detail(t *testing.T) {
+	body := []byte(`{
+		"iid": 5, "title": "gl detail", "state": "closed",
+		"web_url": "https://gitlab.com/o/r/-/issues/5",
+		"description": "gl body text",
+		"updated_at": "2026-05-04T10:00:00Z", "author": {"username": "frank"},
+		"labels": ["wontfix"]
+	}`)
+	got, err := decodeGitLabIssue(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Number != 5 || got.State != "closed" || got.Body != "gl body text" {
+		t.Errorf("gitlab detail wrong: %+v", got)
+	}
+	if len(got.Labels) != 1 || got.Labels[0].Name != "wontfix" {
+		t.Errorf("gitlab detail labels wrong: %+v", got.Labels)
+	}
+}
+
+func TestGitlabStringLabels_EmptyNonNil(t *testing.T) {
+	if got := gitlabStringLabels(nil); got == nil {
+		t.Error("gitlabStringLabels(nil) should return non-nil empty slice")
+	}
+}
+
+// TestIsPullRequestItem covers the discriminator's three input shapes:
+// missing (zero-length), literal null, and a real object.
+func TestIsPullRequestItem(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string // raw bytes; "" means a missing field (zero-length)
+		want bool
+	}{
+		{"missing", "", false},
+		{"null", "null", false},
+		{"object", `{"url":"https://api.github.com/repos/o/r/pulls/8"}`, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var raw []byte
+			if c.in != "" {
+				raw = []byte(c.in)
+			}
+			if got := isPullRequestItem(raw); got != c.want {
+				t.Errorf("isPullRequestItem(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestDecodeGitHubIssues_NullPullRequestKept guards the robustness fix:
+// a real issue carrying "pull_request": null must NOT be filtered out.
+func TestDecodeGitHubIssues_NullPullRequestKept(t *testing.T) {
+	body := []byte(`[
+		{"number": 7, "title": "real issue", "state": "open", "html_url": "u",
+		 "updated_at": "2026-05-04T10:00:00Z", "user": {"login": "alice"},
+		 "pull_request": null}
+	]`)
+	got, err := decodeGitHubIssues(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Number != 7 {
+		t.Errorf("issue with null pull_request should be kept, got %+v", got)
+	}
+}
+
+// TestDecodeGitHubIssue_RejectsPR guards the detail-fetch guard: asking
+// for a number that resolves to a PR returns an error, not a fake issue.
+func TestDecodeGitHubIssue_RejectsPR(t *testing.T) {
+	body := []byte(`{
+		"number": 8, "title": "a PR", "state": "open", "html_url": "u",
+		"updated_at": "2026-05-04T10:00:00Z", "user": {"login": "bob"},
+		"pull_request": {"url": "https://api.github.com/repos/o/r/pulls/8"}
+	}`)
+	if _, err := decodeGitHubIssue(body); err == nil {
+		t.Error("decodeGitHubIssue should reject a pull request, got nil error")
+	}
+}


### PR DESCRIPTION
## Summary

Adds an **Issues** viewing feature to the session inspector's Git tab, mirroring the pull-request surface from #279 across all three layers. The Git tab could view PRs but not issues; this closes that gap.

**Scope:** read-only — list (open/closed/all filter) + detail (description, state, labels, comment thread). No create / comment / close actions.

## What's included

**Backend** (`internal/githost/issues.go`, new):
- `Issue` + `Label` types; `ListIssues` / `GetIssue` / `IssueComments` dispatching over GitHub / Gitea / GitLab, mirroring the PR pattern.
- **PR filtering:** GitHub & Gitea return PRs through the same `/issues` endpoint (PR items carry a `pull_request` field). Those are skipped — handling missing, `null`, and object forms — so PRs don't double-show as issues. GitLab's `/issues` is separate.
- **Label normalisation:** GitHub/Gitea `[{name,color}]` vs GitLab `[]string` → unified `[]Label` (GitLab colour left empty).
- **GitLab state:** `opened`↔`open`; `all` omits the param (the API rejects it).
- Comments reuse the existing `decodeGitHubStyleComments` / `decodeGitLabNotes` decoders without the PR-reviews call (which errors on non-PR numbers).
- Routes `/git/issues`, `/git/issues/{n}`, `/git/issues/{n}/comments`; handlers reuse `prTabParams` and the PR no-token/error envelope.

**Shared TS / Web / Mobile:** mirror the PR client + components — `GitIssue`/`GitLabel` types + `listGitIssues`/`getGitIssue`/`getIssueComments`; `IssuesSection.tsx` and `git_issue_section.dart` + `issue_detail_screen.dart`, mounted directly below the PR section. Comments reuse `PRComment` / `GitPRComment`.

## Test plan

- `go build ./...`, `go test -race ./internal/githost/...`, `go vet`, `golangci-lint run` — all green. New tests cover the PR-filter (incl. null), label normalisation, GitLab state/iid mapping, and the detail-fetch PR guard.
- `pnpm --filter web build` (tsc + vite) — clean.
- `flutter analyze` (mobile) — no issues.

## Notes

UI text is hardcoded English, consistent with the existing PR components (no i18n JSON changes). A pre-merge review flagged the GitLab `all`-state mapping and `pull_request: null` robustness; both are fixed and covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)