### PR TITLE
docs(readme): seven more README translations — ES, PT-BR, JA, KO, FR, DE, RU

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,382 @@
+<p align="center">
+  <a href="https://opendray.dev"><img src="docs/assets/logo.png" alt="opendray" width="180"></a>
+</p>
+
+<h1 align="center">opendray</h1>
+
+<p align="center">
+  <strong>Self-hosted Gateway für Claude Code · Codex · Gemini · Shell — mit einer gemeinsamen Local-First-Memory-Schicht über alle hinweg.</strong>
+  <br/>
+  <sub>Lass Sessions auf deiner eigenen Infrastruktur laufen. Steuere sie aus dem Web, vom Smartphone oder aus dem Chat. Offene REST- + WebSocket-API für Integrationen.</sub>
+</p>
+
+<p align="center">
+  <strong><a href="https://opendray.dev">🌐 opendray.dev</a></strong>
+</p>
+
+<p align="center">
+  <a href="https://opendray.dev"><img alt="Website" src="https://img.shields.io/badge/website-opendray.dev-F43F5E"></a>
+  <a href="https://github.com/Opendray/opendray/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/Opendray/opendray?label=release&color=4f46e5"></a>
+  <a href="LICENSE"><img alt="License Apache 2.0" src="https://img.shields.io/github/license/Opendray/opendray?color=blue"></a>
+  <a href="https://github.com/Opendray/opendray/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/Opendray/opendray/ci.yml?branch=main&label=CI"></a>
+  <a href="https://github.com/Opendray/opendray/discussions"><img alt="Discussions" src="https://img.shields.io/github/discussions/Opendray/opendray?color=ec4899"></a>
+  <br/>
+  <img alt="Go" src="https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white">
+  <img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black">
+  <img alt="Flutter" src="https://img.shields.io/badge/Flutter-mobile-02569B?logo=flutter&logoColor=white">
+  <img alt="Postgres" src="https://img.shields.io/badge/PostgreSQL-15%2F16%2F17-336791?logo=postgresql&logoColor=white">
+</p>
+
+<p align="center">
+  🌐 <a href="README.md">English</a> · <a href="README.zh.md">简体中文</a> · <a href="README.fa.md">فارسی</a> · <a href="README.es.md">Español</a> · <a href="README.pt-BR.md">Português</a> · <a href="README.ja.md">日本語</a> · <a href="README.ko.md">한국어</a> · <a href="README.fr.md">Français</a> · <strong>Deutsch</strong> · <a href="README.ru.md">Русский</a>
+</p>
+
+---
+
+## Was ist opendray?
+
+**opendray** umschließt die KI-Coding-CLIs, die du eh schon nutzt — Claude Code, Codex, Gemini und jede beliebige Shell — und macht sie zu etwas, das du von überall aus steuern kannst. Lass Sessions auf deinem Heimserver / NAS / VPS laufen, lass dich per Telegram benachrichtigen, wenn eine in den Idle-Zustand geht, und antworte vom Handy aus, um den nächsten Prompt einzufüttern — alles über ein Self-hosted Gateway, das du Ende zu Ende kontrollierst.
+
+- 🛰 **Ein Backend, drei Oberflächen** — ein einziges Go-Binary, das ein React-Webadmin und eine Flutter-Mobile-App ausliefert; jede Aktion ist zusätzlich über eine REST- + WebSocket-API für Drittanbieter-Integrationen verfügbar.
+- 💬 **Sechs bidirektionale Channels, keine Walled Gardens** — Telegram, Slack, Discord, Feishu (飞书), DingTalk (钉钉), WeCom (企业微信), plus ein Bridge-Adapter für alles Eigene. Antworten auf jedem Channel werden zurück in die passende Session geroutet.
+- 🧠 **Local-First Memory** — ONNX- / Ollama- / LM-Studio-Embeddings mit Retrieval in drei Scopes (User · Projekt · Session), smartes Ranking und Konflikterkennung über die Layer hinweg. Keine Vektordaten verlassen dein Netzwerk.
+- 🔌 **API auf Integrations-Niveau** — gescopte API-Keys, Audit-Log pro Call, Reverse-Proxy-Mounts. Nutze opendray als Gateway hinter deinem eigenen Produkt oder einfach als persönliche Kommandozentrale.
+- 🔑 **Flotte mit mehreren Claude-Accounts** — wirf mehrere `claude login`-Accounts ins Gateway; das Panel erkennt sie automatisch über einen Filesystem-Watcher, balanciert neue Sessions über die aktivierten Accounts und lässt dich eine laufende Session zwischen Accounts umschalten, **ohne die Konversation zu verlieren** (das Transcript wird unter der Haube migriert). Jede Account-Zeile zeigt die aktuelle Kapazität (Subscription-Tier, Rate-Limit-Tier, aktive Sessions, zuletzt verwendet, aktuelle Anthropic-E-Mail), sodass du auf einen Blick den richtigen Account auswählen kannst.
+- 🔒 **Self-hosted, klare Lizenz** — Apache 2.0, ein statisches Binary, cosign-signierte Releases mit SPDX-SBOM. Keine Telemetrie, kein Cloud-Account, kein Abo.
+
+## Status
+
+**v2.5.0** (aktuell) — die v2-Generation iteriert weiter. Siehe
+[`VERSIONING.md`](VERSIONING.md) für die Major-als-Generation-Policy
+(Major = Produktgeneration, kein strikter SemVer-"Breaking Change") und
+[`CHANGELOG.md`](CHANGELOG.md) für die vollständige Release-Historie.
+
+Diese Generation liefert:
+
+- **Einzeilige Installer- und Uninstaller-Wizards** (Linux + macOS;
+  Windows läuft über WSL2). Führen den Operator durch Postgres-
+  Bootstrap, AI-CLI-Installation, Admin-Credentials, Listen-Adresse,
+  Binary-Installation, Schema-Migration und Service-Registrierung.
+- **Self-managing Binary** — `opendray update / start / stop /
+  restart / status / providers list / providers update`, damit
+  Operatoren für Routine-Ops nicht an `systemctl` / `launchctl` ran müssen.
+- **Goreleaser-Release-Pipeline** — cross-kompilierte Binaries
+  (linux/darwin × amd64/arm64), keyless cosign-Signing (Sigstore),
+  SPDX-SBOM, atomar verifiziertes Self-Update.
+
+## Installation
+
+### Einzeiliger Installer
+
+**Linux / macOS / WSL2**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh | bash
+```
+
+**Windows** — richtet zuerst WSL2 ein und führt darin dann den Linux-Installer aus. [Details →](scripts/README.md#windows)
+
+```powershell
+irm https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install-windows.ps1 | iex
+```
+
+Führt dich durch Postgres-Setup, AI-CLI-Installation, Admin-Credentials und Service-Registrierung — am Ende läuft ein Gateway in ~5–10 Minuten. Siehe [**`scripts/README.md`**](scripts/README.md) dafür, was der Wizard macht, welches File-Layout er anlegt, welche Optionen es gibt und für Troubleshooting.
+
+> **Lieber den manuellen Walkthrough?** Lies [**docs/getting-started.md**](docs/getting-started.md) — eine 15-minütige End-to-End-Anleitung, die dasselbe wie der Wizard macht, sodass du jeden Schritt selbst nachvollziehen kannst.
+
+### Uninstall (Linux / macOS)
+
+**Standard** — stoppt das Gateway und entfernt das Binary, **behält** aber deine `config.toml`, das Data-Verzeichnis (bcrypt-Keyfile, Sessions, Notes, Vault), die Logs und die PostgreSQL-Datenbank, sodass eine Neuinstallation dort weitermacht, wo du aufgehört hast:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | bash
+```
+
+**Full Purge** — entfernt zusätzlich PG-Datenbank + Role, löscht Config / Data / Logs und entfernt den Service-User. Inklusive Verifikationsschritt nach dem Löschen, der lautstark Alarm schlägt, falls irgendetwas überlebt hat:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
+```
+
+### Day-to-Day-Befehle
+
+Nach der Installation kümmert sich das `opendray`-Binary selbst um seinen Lifecycle — keine `systemctl`- / `launchctl`-Beschwörungsformeln mehr nötig:
+
+```sh
+sudo opendray update --restart   # download latest release, verify SHA, atomic replace + restart
+```
+
+```sh
+sudo opendray providers update   # bump installed AI CLIs (claude / codex / gemini) to npm-latest
+```
+
+```sh
+opendray providers list          # see which AI CLIs are installed + their versions
+```
+
+```sh
+sudo opendray start              # start | stop | restart | status — wraps systemd / launchd
+```
+
+`opendray --help` listet das komplette Subcommand-Set.
+
+### Deploy-Path-Picker
+
+Jeder unterstützte Pfad enthält Session-Spawn, AI-CLI-Zugriff, verschlüsselte Backups und die vollständige Integrations-API. opendray ist ein host-resident Gateway — es spawnt AI-CLIs über PTYs und teilt Prozess-State (`~/.claude`, ssh-agent, Projektdateien) mit ihnen. Dieses Modell ist inkompatibel mit der Container-Isolierung, die ein produktives Docker erzwingen würde — daher ist Docker in v2.x kein unterstützter Deployment-Pfad.
+
+| Pfad | Am besten für | Springe zu |
+|---|---|---|
+| 📦 **Vorgefertigtes Binary** | "Einfach laufen lassen" — Linux / macOS, beliebiger Supervisor | [Releases-Seite](https://github.com/Opendray/opendray/releases) → siehe [Produktions-Deployment](#production-deploy) |
+| 🐧 **systemd-Unit** | Bare-Metal- / VM- / LXC-Linux-Box | [Produktions-Deployment §A](#option-a--systemd-bare-metal--vm--lxc) |
+| 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio als Heimserver | [Produktions-Deployment §C](#option-c--macos-launchd-mac-mini--studio-as-home-server) |
+| 🛠 **Build from Source** | Dev / Contributing / Custom Builds | [Quickstart](#quickstart-5-minute-dev-path) weiter unten |
+
+## Quickstart (5-Minuten-Dev-Path)
+
+Den kompletten Walkthrough mit Voraussetzungen und Troubleshooting findest du in [`docs/quickstart.md`](docs/quickstart.md). Der verdichtete Dev-Path:
+
+```bash
+# 1. Have a Postgres 15+ running on 127.0.0.1:5432 with pgvector enabled
+#    (apt install postgresql-16 postgresql-16-pgvector / brew install postgresql@16 pgvector).
+#    Point [database].url at any other DSN if you'd rather use a remote PG.
+
+# 2. Local config — already gitignored.
+cp config.example.toml config.toml
+$EDITOR config.toml          # set [database].url, [admin].password
+
+# 3. Build the web bundle into the embed tree.
+cd app/web && pnpm install && pnpm build && cd ../..
+
+# 4. Apply schema.
+go run ./cmd/opendray migrate -config config.toml
+
+# 5. Run.
+go run ./cmd/opendray serve -config config.toml
+# → REST + WS:  http://127.0.0.1:8770/api/v1/...
+# → Web admin:  http://127.0.0.1:8770/admin/
+```
+
+Damit läuft OpenDray im Vordergrund — Ctrl-C beendet es. Für einen langlaufenden
+Daemon siehe **Produktions-Deployment** unten.
+
+## Produktions-Deployment
+
+Vier unterstützte Deploy-Pfade, such dir den passenden für deine Umgebung aus.
+Jeder davon liefert dir Auto-Restart bei Crash, persistenten State und
+Trennung von Secrets und Config.
+
+### Option A — systemd (Bare-Metal / VM / LXC)
+
+Der empfohlene Linux-Deploy-Pfad. Liefert eine gehärtete Unit unter
+[`deploy/systemd/opendray.service`](deploy/systemd/opendray.service)
+mit Sandboxing (`ProtectSystem=strict`, `NoNewPrivileges`,
+`MemoryDenyWriteExecute`, Capability-Scrub), `migrate`-dann-`serve`-
+Boot und einem 20-s-Graceful-Stop-Fenster.
+
+**Hol dir zuerst ein Binary.** Schnapp dir entweder ein vorgefertigtes Archiv von der
+[Releases-Seite](https://github.com/Opendray/opendray/releases)
+(`opendray_*_linux_<arch>.tar.gz` — entpackt sich zu einem einzigen `opendray`-
+Binary) oder baue es aus dem Source via [Quickstart](#quickstart-5-minute-dev-path)
+oben (`go build ./cmd/opendray`).
+
+```bash
+# 1. Install the binary you just grabbed (or built).
+sudo install -m 0755 /path/to/opendray /usr/local/bin/opendray
+
+# 2. Create the service user + state dir.
+sudo useradd -r -s /usr/sbin/nologin -d /var/lib/opendray opendray
+sudo install -d -o opendray -g opendray -m 0700 /var/lib/opendray
+
+# 3. Drop config + secrets (root-owned; mode 0640).
+sudo install -D -m 0640 config.example.toml /etc/opendray/config.toml
+sudo $EDITOR /etc/opendray/config.toml             # set [database].url etc.
+sudo install -D -m 0640 -o root -g opendray /dev/null /etc/opendray/env.d/secrets
+sudo $EDITOR /etc/opendray/env.d/secrets           # OPENDRAY_ADMIN_PASSWORD=…
+
+# 4. Install + enable the unit.
+sudo cp deploy/systemd/opendray.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now opendray
+
+# 5. Verify.
+sudo systemctl status opendray
+sudo journalctl -u opendray -f --no-pager
+```
+
+Die Unit führt `opendray migrate` als `ExecStartPre` aus, sodass der erste Boot
+alle Migrations anwendet, bevor `serve` überhaupt startet. Restarts laufen
+`on-failure` mit 5 s Back-off und einem Limit von 5 Bursts pro Minute.
+
+### Option B — Direktes Binary + dein eigener Process-Supervisor
+
+Für LXC ohne systemd, FreeBSD `rc.d`, OpenRC oder sonst irgendwas.
+Einmal bauen, mit dem Supervisor laufen lassen, den du eh schon einsetzt:
+
+```bash
+# Cross-compile a release archive locally:
+goreleaser release --clean --snapshot
+ls dist/                  # opendray_*_linux_amd64.tar.gz etc.
+
+# Or grab a published release artefact:
+# https://github.com/Opendray/opendray/releases
+```
+
+Dann zeigt dein Supervisor (s6, runit, supervisord, runwhen) auf:
+
+```
+/usr/local/bin/opendray serve -config /etc/opendray/config.toml
+```
+
+Pre-Flight: führe `opendray migrate -config /etc/opendray/config.toml`
+einmal vor dem ersten `serve` aus, oder als Pre-Start-Hook im
+Supervisor deiner Wahl.
+
+### Option C — macOS launchd (Mac mini / Studio als Heimserver)
+
+Für Apple-Silicon-Mac-mini / Mac Studio im 24/7-Betrieb. Liefert einen
+LaunchDaemon unter
+[`deploy/launchd/com.opendray.opendray.plist`](deploy/launchd/com.opendray.opendray.plist),
+der vor jedem User-Login beim Boot startet, bei Crashes mit 5-s-Throttle
+neu startet und nach `/usr/local/var/log/opendray/` loggt.
+
+```bash
+# 1. Install the darwin binary + config + state dirs.
+sudo install -m 0755 ./opendray /usr/local/bin/opendray
+sudo install -d -m 0755 \
+  /usr/local/etc/opendray \
+  /usr/local/var/lib/opendray \
+  /usr/local/var/log/opendray
+sudo install -m 0640 config.example.toml /usr/local/etc/opendray/config.toml
+sudo $EDITOR /usr/local/etc/opendray/config.toml    # set [database].url etc.
+
+# 2. Apply migrations once.
+sudo /usr/local/bin/opendray migrate \
+  -config /usr/local/etc/opendray/config.toml
+
+# 3. Install + load the LaunchDaemon.
+sudo cp deploy/launchd/com.opendray.opendray.plist /Library/LaunchDaemons/
+sudo chown root:wheel /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo chmod 0644 /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.opendray.opendray.plist
+
+# 4. Verify.
+sudo launchctl print system/com.opendray.opendray
+tail -f /usr/local/var/log/opendray/opendray.log
+```
+
+Restart mit `sudo launchctl kickstart -k system/com.opendray.opendray`;
+komplett entladen mit `sudo launchctl bootout system/com.opendray.opendray`.
+
+Postgres auf macOS — installiere via Homebrew (`brew install postgresql@17 && brew services start postgresql@17`) und zeige mit `[database].url` auf
+`postgres://$USER@127.0.0.1:5432/opendray`. `pgvector` ergänzt du mit
+`brew install pgvector` und `CREATE EXTENSION vector` innerhalb der
+opendray-Datenbank.
+
+---
+
+Proxmox-spezifische LXC-Notes (PTY in Unprivileged Containers,
+Networking, cgroup-Tweaks) findest du in [`deploy/lxc/proxmox-pty-notes.md`](deploy/lxc/proxmox-pty-notes.md).
+
+Für Reverse-Proxy / TLS-Termination (nginx, Caddy, Traefik, Cloudflare
+Tunnel) siehe [`docs/operator-guide.md`](docs/operator-guide.md) §Topology.
+
+### Optional: verschlüsselte DB-Backups + Daten-Exporte aktivieren
+
+```bash
+# Master passphrase (env-only — never write into config.toml).
+export OPENDRAY_BACKUP_KEY="$(openssl rand -base64 32)"
+export OPENDRAY_BACKUP_ENABLED=1
+
+# pg_dump / pg_restore must match the server's major version. On
+# Apple Silicon dev machines pointing at a PG17 server:
+export OPENDRAY_BACKUP_PG_DUMP_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_dump
+export OPENDRAY_BACKUP_PG_RESTORE_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_restore
+```
+
+Starte opendray neu; in der Sidebar erscheint dann eine Backups-Seite (`/backups`)
+für verschlüsselte PostgreSQL-Dumps + Restore und `/export` für
+Daten-Exporte als Zip-Bundle + Import. Den vollständigen Lifecycle beschreibt [`docs/operator-guide.md`](docs/operator-guide.md) §Backup.
+
+Ein einziges Go-Binary trägt das komplette Web-Bundle in sich — keine Node-Runtime
+zur Laufzeit nötig, kein separater Static-File-Server, kein Caddy/nginx
+erforderlich. Cloudflare Tunnel terminiert TLS vor `:8770`.
+
+## Layout
+
+```
+cmd/opendray/        binary entry point (≤100 LOC per design §14)
+internal/
+├── app/             composition root (wires every subsystem)
+├── audit/           subscribes to bus topics, persists to audit_log
+├── auth/            admin bearer tokens (M2.5)
+├── backup/          encrypted DB dumps + admin export/import├── catalog/         CLI provider manifests + per-id user config (M2)
+├── channel/         channel hub + telegram impl (M4)
+├── config/          TOML loader with OPENDRAY_* env overrides
+├── eventbus/        in-process pub/sub
+├── gateway/         chi HTTP router + middleware + slog
+├── integration/     external-app registry + reverse proxy + events WS (M3)
+├── memory/          cross-CLI persistent memory├── session/         PTY lifecycle + ring buffer + WS stream (M1)
+├── store/           pgx pool + hand-rolled migration runner (M0)
+├── version/         build-time identification
+└── web/             go:embed of the web bundle (W5)
+
+app/web/             React 19 + TypeScript + Vite SPA (Phase 2 W0-W5)
+app/mobile/          Flutter app (iOS + Android), feature parity with web
+docs/
+├── design.md        SSOT north-star
+└── adr/             architecture decisions, dated
+```
+
+## Web-Frontend
+
+`app/web/` baut eine einzelne SPA nach `internal/web/dist/`, die das Go-
+Binary einbettet und unter `/admin/*` ausliefert. Der Vite-Dev-Server auf `:5173`
+proxied `/api` nach `:8770` für HMR-getriebene Entwicklung.
+
+```bash
+# dev (hot reload on the React side, separate Go server for the API)
+cd app/web && pnpm dev               # http://localhost:5173
+go run ./cmd/opendray serve -config ../../config.toml   # other terminal
+
+# prod (one binary delivers everything)
+cd app/web && pnpm build              # writes ../../internal/web/dist
+cd ../..
+go build ./cmd/opendray               # bakes dist into the binary
+./opendray serve -config config.toml
+```
+
+Den Frontend-Stack (React + Vite + Tailwind v4 + shadcn/ui + TanStack
+Router/Query + Zustand + xterm.js) und Notes pro W-Milestone findest du in
+[`app/web/README.md`](app/web/README.md).
+
+## Dokumentation
+
+- [`docs/getting-started.md`](docs/getting-started.md) — **fang hier an**, wenn du neu bist: von null bis zur ersten Session in 15 Minuten, inklusive Installation der gewrappten CLIs und Postgres-Bootstrap
+- [`docs/quickstart.md`](docs/quickstart.md) — 5-Minuten-Dev-Umgebung (setzt voraus, dass du die beweglichen Teile schon kennst)
+- [`docs/operator-guide.md`](docs/operator-guide.md) — Deploy- und Ops-Referenz für produktionsnahe Setups
+- [`docs/integration-guide.md`](docs/integration-guide.md) — wie du eine externe Integration in beliebiger Sprache schreibst
+- [`VERSIONING.md`](VERSIONING.md) — Versioning-Strategie (Major-als-Generation)
+- [`CHANGELOG.md`](CHANGELOG.md) — Release-Historie
+
+## Tests
+
+```bash
+go test -race ./...        # backend
+cd app/web && pnpm build   # web (TS strict + vite production build)
+```
+
+End-to-End-Smoke-Flows werden pro Milestone in den Commit-Messages getrackt.
+Ein Playwright-Harness ist als Follow-up geplant.
+
+## Verhältnis zu v1
+
+v1 (`Opendray/opendray`) ist die Legacy-Codebase, inzwischen archiviert. v2 ist
+die aktuelle und aktive Generation — feature-complete und der einzige
+Branch, der noch Entwicklung sieht. Von den 16 v1-Builtins sind vier ins
+v2-Backend gewandert; der Rest wurde zu Client-seitigen Features, Channel-
+Adaptern oder Konsumenten der Integrations-API.
+
+## Lizenz
+
+Apache 2.0 — siehe [`LICENSE`](LICENSE). (v1 war MIT; v2 wird unabhängig
+davon lizenziert.)

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,381 @@
+<p align="center">
+  <a href="https://opendray.dev"><img src="docs/assets/logo.png" alt="opendray" width="180"></a>
+</p>
+
+<h1 align="center">opendray</h1>
+
+<p align="center">
+  <strong>Gateway autohospedado para Claude Code · Codex · Gemini · shell — con una capa de memoria local-first compartida entre todos ellos.</strong>
+  <br/>
+  <sub>Ejecuta sesiones en tu propia infraestructura. Contrólalo desde la web, el móvil o el chat. API abierta REST + WebSocket para integraciones.</sub>
+</p>
+
+<p align="center">
+  <strong><a href="https://opendray.dev">🌐 opendray.dev</a></strong>
+</p>
+
+<p align="center">
+  <a href="https://opendray.dev"><img alt="Website" src="https://img.shields.io/badge/website-opendray.dev-F43F5E"></a>
+  <a href="https://github.com/Opendray/opendray/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/Opendray/opendray?label=release&color=4f46e5"></a>
+  <a href="LICENSE"><img alt="License Apache 2.0" src="https://img.shields.io/github/license/Opendray/opendray?color=blue"></a>
+  <a href="https://github.com/Opendray/opendray/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/Opendray/opendray/ci.yml?branch=main&label=CI"></a>
+  <a href="https://github.com/Opendray/opendray/discussions"><img alt="Discussions" src="https://img.shields.io/github/discussions/Opendray/opendray?color=ec4899"></a>
+  <br/>
+  <img alt="Go" src="https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white">
+  <img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black">
+  <img alt="Flutter" src="https://img.shields.io/badge/Flutter-mobile-02569B?logo=flutter&logoColor=white">
+  <img alt="Postgres" src="https://img.shields.io/badge/PostgreSQL-15%2F16%2F17-336791?logo=postgresql&logoColor=white">
+</p>
+
+<p align="center">
+  🌐 <a href="README.md">English</a> · <a href="README.zh.md">简体中文</a> · <a href="README.fa.md">فارسی</a> · <strong>Español</strong> · <a href="README.pt-BR.md">Português</a> · <a href="README.ja.md">日本語</a> · <a href="README.ko.md">한국어</a> · <a href="README.fr.md">Français</a> · <a href="README.de.md">Deutsch</a> · <a href="README.ru.md">Русский</a>
+</p>
+
+---
+
+## ¿Qué es opendray?
+
+**opendray** envuelve las CLIs de coding con IA que ya usas — Claude Code, Codex, Gemini y cualquier shell — y las convierte en algo que puedes controlar desde cualquier lugar. Ejecuta sesiones en tu servidor doméstico / NAS / VPS, recibe una notificación en Telegram cuando una queda inactiva y responde desde tu teléfono para alimentar el siguiente prompt — todo a través de un gateway autohospedado que controlas de extremo a extremo.
+
+- 🛰 **Un backend, tres superficies** — un único binario Go que sirve un panel web React y una app móvil Flutter, con cada acción también expuesta sobre una API REST + WebSocket para integraciones de terceros.
+- 💬 **Seis canales bidireccionales, sin jardines amurallados** — Telegram, Slack, Discord, Feishu (飞书), DingTalk (钉钉), WeCom (企业微信), más un adaptador Bridge para cualquier cosa personalizada. Las respuestas en cualquier canal se enrutan de vuelta a la sesión correcta.
+- 🧠 **Memoria local-first** — embeddings con ONNX / Ollama / LM Studio, recuperación en tres ámbitos (usuario · proyecto · sesión), ranking inteligente y detección de conflictos entre capas. Los datos vectoriales no salen de tu red.
+- 🔌 **API de nivel integración** — claves de API con scope, audit log por cada llamada, montajes de reverse-proxy. Trata a opendray como el gateway detrás de tu propio producto, o simplemente como un centro de mando personal.
+- 🔑 **Flota multi-cuenta de Claude** — añade varias cuentas de `claude login` al gateway; el panel las detecta automáticamente con un filesystem watcher, balancea las sesiones nuevas entre cuentas activas, y permite cambiar una sesión en vivo de una cuenta a otra **sin perder la conversación** (la transcripción se migra por debajo). Cada fila de cuenta muestra capacidad en vivo (subscription tier, rate-limit tier, sesiones activas, último uso, email de Anthropic actual) para que elijas la correcta de un vistazo.
+- 🔒 **Autohospedado, licencia clara** — Apache 2.0, un binario estático, releases firmados con cosign más SBOM SPDX. Sin telemetría, sin cuenta en la nube, sin suscripción.
+
+## Estado
+
+**v2.5.0** (última) — la generación v2 continúa iterando. Consulta
+[`VERSIONING.md`](VERSIONING.md) para la política major-como-generación
+(major = generación de producto, no "breaking change" estricto al estilo SemVer) y
+[`CHANGELOG.md`](CHANGELOG.md) para el historial completo de releases.
+
+Esta generación incluye:
+
+- **Asistentes de instalación y desinstalación de una sola línea** (Linux + macOS;
+  Windows se canaliza a través de WSL2). Guían al operador por bootstrap de Postgres,
+  instalación de AI-CLIs, credenciales de admin, dirección de escucha, instalación del
+  binario, migración del esquema y registro del servicio.
+- **Binario autogestionado** — `opendray update / start / stop /
+  restart / status / providers list / providers update`, para que los operadores
+  no toquen `systemctl` / `launchctl` para tareas rutinarias.
+- **Pipeline de release con Goreleaser** — binarios compilados de forma cruzada
+  (linux/darwin × amd64/arm64), firma keyless con cosign (Sigstore),
+  SBOM SPDX, self-update verificado atómicamente.
+
+## Instalación
+
+### Instalador de una sola línea
+
+**Linux / macOS / WSL2**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh | bash
+```
+
+**Windows** — primero configura WSL2 y luego ejecuta el instalador de Linux dentro. [detalles →](scripts/README.md#windows)
+
+```powershell
+irm https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install-windows.ps1 | iex
+```
+
+Recorre la configuración de Postgres, instalación de AI-CLIs, credenciales de admin y registro del servicio — dejando un gateway en marcha en ~5-10 minutos. Consulta [**`scripts/README.md`**](scripts/README.md) para saber qué hace el asistente, qué layout de archivos crea, sus opciones y troubleshooting.
+
+> **¿Prefieres la guía manual?** Lee [**docs/getting-started.md**](docs/getting-started.md) — una guía de 15 minutos de extremo a extremo que replica lo que hace el asistente para que verifiques cada paso tú mismo.
+
+### Desinstalación (Linux / macOS)
+
+**Por defecto** — detiene el gateway y elimina el binario, pero **conserva** tu `config.toml`, el directorio de datos (keyfile bcrypt, sesiones, notas, vault), los logs y la base de datos PostgreSQL para que una reinstalación retome donde lo dejaste:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | bash
+```
+
+**Purga completa** — también elimina la base de datos + el role de PG, borra config / data / logs, y quita el service user. Incluye un paso de verificación post-borrado que falla ruidosamente si algo sobrevive:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
+```
+
+### Comandos del día a día
+
+Tras la instalación, el binario `opendray` gestiona su propio ciclo de vida — no necesitas recordar los rituales de `systemctl` / `launchctl`:
+
+```sh
+sudo opendray update --restart   # download latest release, verify SHA, atomic replace + restart
+```
+
+```sh
+sudo opendray providers update   # bump installed AI CLIs (claude / codex / gemini) to npm-latest
+```
+
+```sh
+opendray providers list          # see which AI CLIs are installed + their versions
+```
+
+```sh
+sudo opendray start              # start | stop | restart | status — wraps systemd / launchd
+```
+
+`opendray --help` muestra el set completo de subcomandos.
+
+### Selector de ruta de despliegue
+
+Cada ruta soportada incluye spawn de sesiones, acceso a AI-CLI, backups cifrados y la API de integración completa. opendray es un gateway host-resident — lanza las AI CLIs vía PTYs y comparte estado de proceso (`~/.claude`, ssh-agent, archivos del proyecto) con ellas. Ese modelo es incompatible con el aislamiento de contenedores que Docker de producción impondría, por lo que Docker no es una ruta de despliegue soportada en v2.x.
+
+| Ruta | Recomendada para | Ir a |
+|---|---|---|
+| 📦 **Binario pre-construido** | "Solo ejecútalo" — Linux / macOS, cualquier supervisor | [Página de releases](https://github.com/Opendray/opendray/releases) → ver [Despliegue de producción](#production-deploy) |
+| 🐧 **Unidad systemd** | Linux bare-metal / VM / LXC | [Despliegue de producción §A](#option-a--systemd-bare-metal--vm--lxc) |
+| 🍎 **LaunchDaemon de macOS** | Mac mini / Mac Studio como servidor doméstico | [Despliegue de producción §C](#option-c--macos-launchd-mac-mini--studio-as-home-server) |
+| 🛠 **Build desde el código fuente** | Desarrollo / contribución / builds personalizados | [Quickstart](#quickstart-5-minute-dev-path) abajo |
+
+## Quickstart (ruta dev de 5 minutos)
+
+Para una guía completa con prerrequisitos y troubleshooting, consulta [`docs/quickstart.md`](docs/quickstart.md). La ruta de desarrollo condensada:
+
+```bash
+# 1. Have a Postgres 15+ running on 127.0.0.1:5432 with pgvector enabled
+#    (apt install postgresql-16 postgresql-16-pgvector / brew install postgresql@16 pgvector).
+#    Point [database].url at any other DSN if you'd rather use a remote PG.
+
+# 2. Local config — already gitignored.
+cp config.example.toml config.toml
+$EDITOR config.toml          # set [database].url, [admin].password
+
+# 3. Build the web bundle into the embed tree.
+cd app/web && pnpm install && pnpm build && cd ../..
+
+# 4. Apply schema.
+go run ./cmd/opendray migrate -config config.toml
+
+# 5. Run.
+go run ./cmd/opendray serve -config config.toml
+# → REST + WS:  http://127.0.0.1:8770/api/v1/...
+# → Web admin:  http://127.0.0.1:8770/admin/
+```
+
+Esto ejecuta OpenDray en primer plano — Ctrl-C lo detiene. Para un demonio de larga duración, consulta **Despliegue de producción** abajo.
+
+## Despliegue de producción
+
+Cuatro rutas de despliegue soportadas; elige la que encaje con tu entorno.
+Cada una te da auto-restart en caso de crash, estado persistente y
+separación de secretos respecto al config.
+
+### Opción A — systemd (bare-metal / VM / LXC)
+
+La ruta de despliegue recomendada en Linux. Incluye una unit endurecida en
+[`deploy/systemd/opendray.service`](deploy/systemd/opendray.service)
+con sandboxing (`ProtectSystem=strict`, `NoNewPrivileges`,
+`MemoryDenyWriteExecute`, capability scrub), arranque `migrate`-luego-`serve`,
+y una ventana de parada elegante de 20 s.
+
+**Consigue primero un binario.** O bien descarga un archivo pre-construido de la
+[página de releases](https://github.com/Opendray/opendray/releases)
+(`opendray_*_linux_<arch>.tar.gz` — se descomprime en un único binario `opendray`),
+o constrúyelo desde el código fuente vía el [Quickstart](#quickstart-5-minute-dev-path)
+de arriba (`go build ./cmd/opendray`).
+
+```bash
+# 1. Install the binary you just grabbed (or built).
+sudo install -m 0755 /path/to/opendray /usr/local/bin/opendray
+
+# 2. Create the service user + state dir.
+sudo useradd -r -s /usr/sbin/nologin -d /var/lib/opendray opendray
+sudo install -d -o opendray -g opendray -m 0700 /var/lib/opendray
+
+# 3. Drop config + secrets (root-owned; mode 0640).
+sudo install -D -m 0640 config.example.toml /etc/opendray/config.toml
+sudo $EDITOR /etc/opendray/config.toml             # set [database].url etc.
+sudo install -D -m 0640 -o root -g opendray /dev/null /etc/opendray/env.d/secrets
+sudo $EDITOR /etc/opendray/env.d/secrets           # OPENDRAY_ADMIN_PASSWORD=…
+
+# 4. Install + enable the unit.
+sudo cp deploy/systemd/opendray.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now opendray
+
+# 5. Verify.
+sudo systemctl status opendray
+sudo journalctl -u opendray -f --no-pager
+```
+
+La unit ejecuta `opendray migrate` como `ExecStartPre`, así que el primer arranque
+aplica todas las migraciones antes de que `serve` comience. Los reinicios son
+`on-failure` con back-off de 5 s y un límite de 5 ráfagas por minuto.
+
+### Opción B — Binario directo + tu propio supervisor de procesos
+
+Para LXC sin systemd, FreeBSD `rc.d`, OpenRC, o cualquier otra cosa.
+Construye una vez, ejecuta con el supervisor que ya uses:
+
+```bash
+# Cross-compile a release archive locally:
+goreleaser release --clean --snapshot
+ls dist/                  # opendray_*_linux_amd64.tar.gz etc.
+
+# Or grab a published release artefact:
+# https://github.com/Opendray/opendray/releases
+```
+
+Luego apunta tu supervisor (s6, runit, supervisord, runwhen) a:
+
+```
+/usr/local/bin/opendray serve -config /etc/opendray/config.toml
+```
+
+Pre-flight: ejecuta `opendray migrate -config /etc/opendray/config.toml`
+una vez antes del primer `serve`, o como hook pre-start en el supervisor
+que prefieras.
+
+### Opción C — launchd de macOS (Mac mini / Studio como servidor doméstico)
+
+Para Mac mini / Mac Studio con Apple Silicon funcionando 24/7. Incluye un
+LaunchDaemon en
+[`deploy/launchd/com.opendray.opendray.plist`](deploy/launchd/com.opendray.opendray.plist)
+que arranca al boot antes de cualquier login de usuario, reinicia ante un crash con
+throttle de 5 s, y loguea a `/usr/local/var/log/opendray/`.
+
+```bash
+# 1. Install the darwin binary + config + state dirs.
+sudo install -m 0755 ./opendray /usr/local/bin/opendray
+sudo install -d -m 0755 \
+  /usr/local/etc/opendray \
+  /usr/local/var/lib/opendray \
+  /usr/local/var/log/opendray
+sudo install -m 0640 config.example.toml /usr/local/etc/opendray/config.toml
+sudo $EDITOR /usr/local/etc/opendray/config.toml    # set [database].url etc.
+
+# 2. Apply migrations once.
+sudo /usr/local/bin/opendray migrate \
+  -config /usr/local/etc/opendray/config.toml
+
+# 3. Install + load the LaunchDaemon.
+sudo cp deploy/launchd/com.opendray.opendray.plist /Library/LaunchDaemons/
+sudo chown root:wheel /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo chmod 0644 /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.opendray.opendray.plist
+
+# 4. Verify.
+sudo launchctl print system/com.opendray.opendray
+tail -f /usr/local/var/log/opendray/opendray.log
+```
+
+Reinicia con `sudo launchctl kickstart -k system/com.opendray.opendray`;
+descarga por completo con `sudo launchctl bootout system/com.opendray.opendray`.
+
+Postgres en macOS — instálalo vía Homebrew (`brew install postgresql@17 && brew services start postgresql@17`) y apunta `[database].url` a
+`postgres://$USER@127.0.0.1:5432/opendray`. Añade `pgvector` con
+`brew install pgvector` y ejecuta `CREATE EXTENSION vector` dentro de la
+base de datos opendray.
+
+---
+
+Para notas específicas de LXC en Proxmox (PTY en contenedores unprivileged,
+networking, ajustes de cgroup), consulta [`deploy/lxc/proxmox-pty-notes.md`](deploy/lxc/proxmox-pty-notes.md).
+
+Para reverse-proxy / terminación TLS (nginx, Caddy, Traefik, Cloudflare
+Tunnel), consulta [`docs/operator-guide.md`](docs/operator-guide.md) §Topology.
+
+### Opcional: habilitar backups cifrados de DB + exportaciones de datos
+
+```bash
+# Master passphrase (env-only — never write into config.toml).
+export OPENDRAY_BACKUP_KEY="$(openssl rand -base64 32)"
+export OPENDRAY_BACKUP_ENABLED=1
+
+# pg_dump / pg_restore must match the server's major version. On
+# Apple Silicon dev machines pointing at a PG17 server:
+export OPENDRAY_BACKUP_PG_DUMP_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_dump
+export OPENDRAY_BACKUP_PG_RESTORE_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_restore
+```
+
+Reinicia opendray; el sidebar muestra una página de Backups (`/backups`)
+para volcados PostgreSQL cifrados + restore, y `/export` para
+exportaciones de datos en bundle zip + import. Consulta [`docs/operator-guide.md`](docs/operator-guide.md) §Backup para el ciclo completo.
+
+Un solo binario Go contiene todo el bundle web — sin runtime de Node en
+runtime, sin servidor de archivos estáticos separado, sin Caddy/nginx
+requeridos. Cloudflare Tunnel termina TLS delante de `:8770`.
+
+## Layout
+
+```
+cmd/opendray/        binary entry point (≤100 LOC per design §14)
+internal/
+├── app/             composition root (wires every subsystem)
+├── audit/           subscribes to bus topics, persists to audit_log
+├── auth/            admin bearer tokens (M2.5)
+├── backup/          encrypted DB dumps + admin export/import├── catalog/         CLI provider manifests + per-id user config (M2)
+├── channel/         channel hub + telegram impl (M4)
+├── config/          TOML loader with OPENDRAY_* env overrides
+├── eventbus/        in-process pub/sub
+├── gateway/         chi HTTP router + middleware + slog
+├── integration/     external-app registry + reverse proxy + events WS (M3)
+├── memory/          cross-CLI persistent memory├── session/         PTY lifecycle + ring buffer + WS stream (M1)
+├── store/           pgx pool + hand-rolled migration runner (M0)
+├── version/         build-time identification
+└── web/             go:embed of the web bundle (W5)
+
+app/web/             React 19 + TypeScript + Vite SPA (Phase 2 W0-W5)
+app/mobile/          Flutter app (iOS + Android), feature parity with web
+docs/
+├── design.md        SSOT north-star
+└── adr/             architecture decisions, dated
+```
+
+## Frontend web
+
+`app/web/` construye una SPA única en `internal/web/dist/`, que el binario Go
+empotra y sirve en `/admin/*`. El dev server de Vite en `:5173` hace proxy de
+`/api` hacia `:8770` para desarrollo con HMR.
+
+```bash
+# dev (hot reload on the React side, separate Go server for the API)
+cd app/web && pnpm dev               # http://localhost:5173
+go run ./cmd/opendray serve -config ../../config.toml   # other terminal
+
+# prod (one binary delivers everything)
+cd app/web && pnpm build              # writes ../../internal/web/dist
+cd ../..
+go build ./cmd/opendray               # bakes dist into the binary
+./opendray serve -config config.toml
+```
+
+Consulta [`app/web/README.md`](app/web/README.md) para el stack de frontend
+(React + Vite + Tailwind v4 + shadcn/ui + TanStack Router/Query +
+Zustand + xterm.js) y notas por milestone W.
+
+## Documentación
+
+- [`docs/getting-started.md`](docs/getting-started.md) — **empieza aquí** si eres nuevo: de cero a tu primera sesión en 15 minutos, incluyendo la instalación de las CLIs envueltas y el bootstrap de Postgres
+- [`docs/quickstart.md`](docs/quickstart.md) — entorno de desarrollo de 5 minutos (asume que ya conoces las piezas en movimiento)
+- [`docs/operator-guide.md`](docs/operator-guide.md) — referencia de despliegue + ops para setups de producción
+- [`docs/integration-guide.md`](docs/integration-guide.md) — cómo escribir una integración externa en cualquier lenguaje
+- [`VERSIONING.md`](VERSIONING.md) — estrategia de versionado (major-as-generation)
+- [`CHANGELOG.md`](CHANGELOG.md) — historial de releases
+
+## Tests
+
+```bash
+go test -race ./...        # backend
+cd app/web && pnpm build   # web (TS strict + vite production build)
+```
+
+Los smoke flows end-to-end se trackean en los commit messages por milestone.
+Un harness Playwright está planificado como follow-up.
+
+## Relación con v1
+
+v1 (`Opendray/opendray`) es el codebase legacy, ahora archivado. v2 es
+la generación actual y activa — feature-complete y la única rama que
+recibe desarrollo. De los 16 builtins de v1, cuatro migraron al backend
+de v2; el resto se convirtió en features del lado del cliente, adaptadores
+de canal, o consumidores de la API de integración.
+
+## Licencia
+
+Apache 2.0 — consulta [`LICENSE`](LICENSE). (v1 era MIT; v2 está
+licenciada de forma independiente.)

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,382 @@
+<p align="center">
+  <a href="https://opendray.dev"><img src="docs/assets/logo.png" alt="opendray" width="180"></a>
+</p>
+
+<h1 align="center">opendray</h1>
+
+<p align="center">
+  <strong>Gateway self-hosted pour Claude Code · Codex · Gemini · shell — avec une couche de mémoire local-first partagée entre tous.</strong>
+  <br/>
+  <sub>Fais tourner tes sessions sur ta propre infra. Pilote depuis le web, le mobile ou le chat. API REST + WebSocket ouverte pour les intégrations.</sub>
+</p>
+
+<p align="center">
+  <strong><a href="https://opendray.dev">🌐 opendray.dev</a></strong>
+</p>
+
+<p align="center">
+  <a href="https://opendray.dev"><img alt="Website" src="https://img.shields.io/badge/website-opendray.dev-F43F5E"></a>
+  <a href="https://github.com/Opendray/opendray/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/Opendray/opendray?label=release&color=4f46e5"></a>
+  <a href="LICENSE"><img alt="License Apache 2.0" src="https://img.shields.io/github/license/Opendray/opendray?color=blue"></a>
+  <a href="https://github.com/Opendray/opendray/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/Opendray/opendray/ci.yml?branch=main&label=CI"></a>
+  <a href="https://github.com/Opendray/opendray/discussions"><img alt="Discussions" src="https://img.shields.io/github/discussions/Opendray/opendray?color=ec4899"></a>
+  <br/>
+  <img alt="Go" src="https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white">
+  <img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black">
+  <img alt="Flutter" src="https://img.shields.io/badge/Flutter-mobile-02569B?logo=flutter&logoColor=white">
+  <img alt="Postgres" src="https://img.shields.io/badge/PostgreSQL-15%2F16%2F17-336791?logo=postgresql&logoColor=white">
+</p>
+
+<p align="center">
+  🌐 <a href="README.md">English</a> · <a href="README.zh.md">简体中文</a> · <a href="README.fa.md">فارسی</a> · <a href="README.es.md">Español</a> · <a href="README.pt-BR.md">Português</a> · <a href="README.ja.md">日本語</a> · <a href="README.ko.md">한국어</a> · <strong>Français</strong> · <a href="README.de.md">Deutsch</a> · <a href="README.ru.md">Русский</a>
+</p>
+
+---
+
+## C'est quoi opendray ?
+
+**opendray** enveloppe les CLI de coding IA que tu utilises déjà — Claude Code, Codex, Gemini, plus n'importe quel shell — et les transforme en quelque chose que tu peux piloter depuis n'importe où. Fais tourner tes sessions sur ton home server / NAS / VPS, reçois une notification Telegram quand l'une d'elles devient inactive, réponds depuis ton téléphone pour relancer le prochain prompt, le tout via un gateway self-hosted que tu contrôles de bout en bout.
+
+- 🛰 **Un backend, trois surfaces** — un seul binaire Go qui sert un admin web React et une app mobile Flutter, avec chaque action également exposée via une API REST + WebSocket pour des intégrations tierces.
+- 💬 **Six canaux bidirectionnels, pas de walled gardens** — Telegram, Slack, Discord, Feishu (飞书), DingTalk (钉钉), WeCom (企业微信), plus un adaptateur Bridge pour tout ce qui est custom. Les réponses sur n'importe quel canal sont routées vers la bonne session.
+- 🧠 **Mémoire local-first** — embeddings ONNX / Ollama / LM Studio avec recherche sur trois scopes (user · projet · session), ranking intelligent et détection des conflits entre couches. Aucune donnée vectorielle ne quitte ton réseau.
+- 🔌 **API de niveau intégration** — clés d'API scopées, audit log par appel, montages reverse-proxy. Traite opendray comme le gateway derrière ton propre produit, ou simplement comme un centre de commande personnel.
+- 🔑 **Flotte multi-comptes Claude** — ajoute plusieurs comptes `claude login` dans le gateway ; le panel les découvre automatiquement via un filesystem watcher, répartit les nouvelles sessions entre les comptes activés, et te permet de basculer une session en vie d'un compte à l'autre **sans perdre la conversation** (le transcript est migré sous le capot). Chaque ligne de compte affiche la capacité en temps réel (subscription tier, rate-limit tier, sessions actives, dernière utilisation, email Anthropic courant) pour que tu choisisses le bon d'un coup d'œil.
+- 🔒 **Self-hosted, licence claire** — Apache 2.0, un binaire statique, releases signées avec cosign + SBOM SPDX. Pas de télémétrie, pas de compte cloud, pas d'abonnement.
+
+## État
+
+**v2.5.0** (dernière) — la génération v2 continue d'itérer. Voir
+[`VERSIONING.md`](VERSIONING.md) pour la politique major-comme-génération
+(major = génération de produit, pas un « breaking change » strict au sens SemVer) et
+[`CHANGELOG.md`](CHANGELOG.md) pour l'historique complet des releases.
+
+Cette génération embarque :
+
+- **Assistants d'installation et de désinstallation en une ligne** (Linux + macOS ;
+  Windows passe par WSL2). Guide l'opérateur à travers le bootstrap de Postgres,
+  l'installation des AI-CLI, les credentials admin, l'adresse d'écoute,
+  l'installation du binaire, la migration du schéma et l'enregistrement du service.
+- **Binaire auto-géré** — `opendray update / start / stop /
+  restart / status / providers list / providers update`, pour que les opérateurs
+  ne touchent plus à `systemctl` / `launchctl` pour les opérations courantes.
+- **Pipeline de release Goreleaser** — binaires cross-compilés
+  (linux/darwin × amd64/arm64), signature keyless cosign (Sigstore),
+  SBOM SPDX, self-update vérifié atomiquement.
+
+## Installation
+
+### Installeur en une ligne
+
+**Linux / macOS / WSL2**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh | bash
+```
+
+**Windows** — met d'abord WSL2 en place, puis lance l'installeur Linux à l'intérieur. [détails →](scripts/README.md#windows)
+
+```powershell
+irm https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install-windows.ps1 | iex
+```
+
+Déroule la mise en place de Postgres, l'installation des AI-CLI, les credentials admin et l'enregistrement du service — pour un gateway en marche en ~5-10 minutes. Voir [**`scripts/README.md`**](scripts/README.md) pour ce que fait l'assistant, le layout de fichiers qu'il crée, les options et le troubleshooting.
+
+> **Tu préfères la procédure manuelle ?** Lis [**docs/getting-started.md**](docs/getting-started.md) — un guide end-to-end de 15 minutes qui reproduit ce que fait l'assistant pour que tu puisses vérifier chaque étape toi-même.
+
+### Désinstallation (Linux / macOS)
+
+**Par défaut** — arrête le gateway et supprime le binaire, mais **conserve** ton `config.toml`, le répertoire de données (keyfile bcrypt, sessions, notes, vault), les logs et la base PostgreSQL pour qu'une réinstallation reprenne là où tu en étais :
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | bash
+```
+
+**Purge complète** — supprime aussi la base PG + le rôle, efface config / data / logs et retire le service user. Inclut une étape de vérification post-suppression qui plante bruyamment si quelque chose a survécu :
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
+```
+
+### Commandes du quotidien
+
+Après l'installation, le binaire `opendray` gère son propre cycle de vie — pas besoin de te souvenir des incantations `systemctl` / `launchctl` :
+
+```sh
+sudo opendray update --restart   # download latest release, verify SHA, atomic replace + restart
+```
+
+```sh
+sudo opendray providers update   # bump installed AI CLIs (claude / codex / gemini) to npm-latest
+```
+
+```sh
+opendray providers list          # see which AI CLIs are installed + their versions
+```
+
+```sh
+sudo opendray start              # start | stop | restart | status — wraps systemd / launchd
+```
+
+`opendray --help` liste l'ensemble des sous-commandes.
+
+### Choisir son chemin de deploy
+
+Chaque chemin supporté inclut le spawn de session, l'accès aux AI-CLI, les backups chiffrés et l'API d'intégration complète. opendray est un gateway host-resident — il spawn les AI CLI via des PTY et partage l'état des process (`~/.claude`, ssh-agent, fichiers projet) avec eux. Ce modèle est incompatible avec l'isolation conteneur qu'imposerait Docker en production, donc Docker n'est pas un chemin de déploiement supporté pour v2.x.
+
+| Chemin | Idéal pour | Aller à |
+|---|---|---|
+| 📦 **Binaire pré-construit** | « Just run it » — Linux / macOS, n'importe quel superviseur | [Page des releases](https://github.com/Opendray/opendray/releases) → voir [Déploiement en production](#production-deploy) |
+| 🐧 **Unit systemd** | Linux bare-metal / VM / LXC | [Déploiement en production §A](#option-a--systemd-bare-metal--vm--lxc) |
+| 🍎 **LaunchDaemon macOS** | Mac mini / Mac Studio en serveur maison | [Déploiement en production §C](#option-c--macos-launchd-mac-mini--studio-as-home-server) |
+| 🛠 **Build depuis les sources** | Dev / contribution / builds custom | [Quickstart](#quickstart-5-minute-dev-path) plus bas |
+
+## Quickstart (chemin dev en 5 minutes)
+
+Pour la procédure complète avec prérequis et troubleshooting, voir [`docs/quickstart.md`](docs/quickstart.md). La version condensée pour les devs :
+
+```bash
+# 1. Have a Postgres 15+ running on 127.0.0.1:5432 with pgvector enabled
+#    (apt install postgresql-16 postgresql-16-pgvector / brew install postgresql@16 pgvector).
+#    Point [database].url at any other DSN if you'd rather use a remote PG.
+
+# 2. Local config — already gitignored.
+cp config.example.toml config.toml
+$EDITOR config.toml          # set [database].url, [admin].password
+
+# 3. Build the web bundle into the embed tree.
+cd app/web && pnpm install && pnpm build && cd ../..
+
+# 4. Apply schema.
+go run ./cmd/opendray migrate -config config.toml
+
+# 5. Run.
+go run ./cmd/opendray serve -config config.toml
+# → REST + WS:  http://127.0.0.1:8770/api/v1/...
+# → Web admin:  http://127.0.0.1:8770/admin/
+```
+
+Ça fait tourner OpenDray en foreground — Ctrl-C l'arrête. Pour un daemon
+long-running, voir **Déploiement en production** plus bas.
+
+## Déploiement en production
+
+Quatre chemins de déploiement supportés, choisis celui qui colle à ton environnement.
+Chacun te donne auto-restart en cas de crash, état persistant et
+séparation des secrets et du config.
+
+### Option A — systemd (bare-metal / VM / LXC)
+
+Le chemin de déploiement recommandé sur Linux. Embarque une unit hardenée dans
+[`deploy/systemd/opendray.service`](deploy/systemd/opendray.service)
+avec sandboxing (`ProtectSystem=strict`, `NoNewPrivileges`,
+`MemoryDenyWriteExecute`, capability scrub), boot `migrate`-puis-`serve`,
+et une fenêtre de graceful stop de 20 s.
+
+**Récupère d'abord un binaire.** Soit attrape une archive pré-construite depuis la
+[page des releases](https://github.com/Opendray/opendray/releases)
+(`opendray_*_linux_<arch>.tar.gz` — décompresse en un seul binaire `opendray`),
+soit build depuis les sources via le [Quickstart](#quickstart-5-minute-dev-path)
+plus haut (`go build ./cmd/opendray`).
+
+```bash
+# 1. Install the binary you just grabbed (or built).
+sudo install -m 0755 /path/to/opendray /usr/local/bin/opendray
+
+# 2. Create the service user + state dir.
+sudo useradd -r -s /usr/sbin/nologin -d /var/lib/opendray opendray
+sudo install -d -o opendray -g opendray -m 0700 /var/lib/opendray
+
+# 3. Drop config + secrets (root-owned; mode 0640).
+sudo install -D -m 0640 config.example.toml /etc/opendray/config.toml
+sudo $EDITOR /etc/opendray/config.toml             # set [database].url etc.
+sudo install -D -m 0640 -o root -g opendray /dev/null /etc/opendray/env.d/secrets
+sudo $EDITOR /etc/opendray/env.d/secrets           # OPENDRAY_ADMIN_PASSWORD=…
+
+# 4. Install + enable the unit.
+sudo cp deploy/systemd/opendray.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now opendray
+
+# 5. Verify.
+sudo systemctl status opendray
+sudo journalctl -u opendray -f --no-pager
+```
+
+L'unit lance `opendray migrate` en `ExecStartPre`, donc le premier boot
+applique toutes les migrations avant que `serve` ne démarre. Les redémarrages sont
+en `on-failure` avec un back-off de 5 s et une limite de 5 rafales par minute.
+
+### Option B — Binaire direct + ton propre superviseur de process
+
+Pour LXC sans systemd, FreeBSD `rc.d`, OpenRC ou autre chose.
+Build une fois, lance avec le superviseur que tu utilises déjà :
+
+```bash
+# Cross-compile a release archive locally:
+goreleaser release --clean --snapshot
+ls dist/                  # opendray_*_linux_amd64.tar.gz etc.
+
+# Or grab a published release artefact:
+# https://github.com/Opendray/opendray/releases
+```
+
+Pointe ensuite ton superviseur (s6, runit, supervisord, runwhen) sur :
+
+```
+/usr/local/bin/opendray serve -config /etc/opendray/config.toml
+```
+
+Pre-flight : lance `opendray migrate -config /etc/opendray/config.toml`
+une fois avant le premier `serve`, ou en hook pre-start dans le superviseur
+de ton choix.
+
+### Option C — launchd macOS (Mac mini / Studio en serveur maison)
+
+Pour les Mac mini / Mac Studio Apple Silicon qui tournent 24/7. Embarque un
+LaunchDaemon dans
+[`deploy/launchd/com.opendray.opendray.plist`](deploy/launchd/com.opendray.opendray.plist)
+qui démarre au boot avant tout login utilisateur, redémarre sur crash avec
+un throttle de 5 s, et log dans `/usr/local/var/log/opendray/`.
+
+```bash
+# 1. Install the darwin binary + config + state dirs.
+sudo install -m 0755 ./opendray /usr/local/bin/opendray
+sudo install -d -m 0755 \
+  /usr/local/etc/opendray \
+  /usr/local/var/lib/opendray \
+  /usr/local/var/log/opendray
+sudo install -m 0640 config.example.toml /usr/local/etc/opendray/config.toml
+sudo $EDITOR /usr/local/etc/opendray/config.toml    # set [database].url etc.
+
+# 2. Apply migrations once.
+sudo /usr/local/bin/opendray migrate \
+  -config /usr/local/etc/opendray/config.toml
+
+# 3. Install + load the LaunchDaemon.
+sudo cp deploy/launchd/com.opendray.opendray.plist /Library/LaunchDaemons/
+sudo chown root:wheel /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo chmod 0644 /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.opendray.opendray.plist
+
+# 4. Verify.
+sudo launchctl print system/com.opendray.opendray
+tail -f /usr/local/var/log/opendray/opendray.log
+```
+
+Redémarre avec `sudo launchctl kickstart -k system/com.opendray.opendray` ;
+unload complètement avec `sudo launchctl bootout system/com.opendray.opendray`.
+
+Postgres sur macOS — installe via Homebrew (`brew install postgresql@17 && brew services start postgresql@17`) et pointe `[database].url` sur
+`postgres://$USER@127.0.0.1:5432/opendray`. Ajoute `pgvector` avec
+`brew install pgvector` puis `CREATE EXTENSION vector` à l'intérieur de la
+base opendray.
+
+---
+
+Pour les notes spécifiques à LXC sur Proxmox (PTY dans des conteneurs unprivileged,
+networking, tweaks cgroup), voir [`deploy/lxc/proxmox-pty-notes.md`](deploy/lxc/proxmox-pty-notes.md).
+
+Pour la terminaison reverse-proxy / TLS (nginx, Caddy, Traefik, Cloudflare
+Tunnel), voir [`docs/operator-guide.md`](docs/operator-guide.md) §Topology.
+
+### Optionnel : activer les backups DB chiffrés + les exports de données
+
+```bash
+# Master passphrase (env-only — never write into config.toml).
+export OPENDRAY_BACKUP_KEY="$(openssl rand -base64 32)"
+export OPENDRAY_BACKUP_ENABLED=1
+
+# pg_dump / pg_restore must match the server's major version. On
+# Apple Silicon dev machines pointing at a PG17 server:
+export OPENDRAY_BACKUP_PG_DUMP_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_dump
+export OPENDRAY_BACKUP_PG_RESTORE_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_restore
+```
+
+Redémarre opendray ; la sidebar fait apparaître une page Backups (`/backups`)
+pour les dumps PostgreSQL chiffrés + restore, et `/export` pour les
+exports de données en bundle zip + import. Voir [`docs/operator-guide.md`](docs/operator-guide.md) §Backup pour le cycle complet.
+
+Un seul binaire Go embarque tout le bundle web — pas de runtime Node
+à l'exécution, pas de serveur de fichiers statiques séparé, pas de Caddy/nginx
+nécessaire. Cloudflare Tunnel termine TLS devant `:8770`.
+
+## Layout
+
+```
+cmd/opendray/        binary entry point (≤100 LOC per design §14)
+internal/
+├── app/             composition root (wires every subsystem)
+├── audit/           subscribes to bus topics, persists to audit_log
+├── auth/            admin bearer tokens (M2.5)
+├── backup/          encrypted DB dumps + admin export/import├── catalog/         CLI provider manifests + per-id user config (M2)
+├── channel/         channel hub + telegram impl (M4)
+├── config/          TOML loader with OPENDRAY_* env overrides
+├── eventbus/        in-process pub/sub
+├── gateway/         chi HTTP router + middleware + slog
+├── integration/     external-app registry + reverse proxy + events WS (M3)
+├── memory/          cross-CLI persistent memory├── session/         PTY lifecycle + ring buffer + WS stream (M1)
+├── store/           pgx pool + hand-rolled migration runner (M0)
+├── version/         build-time identification
+└── web/             go:embed of the web bundle (W5)
+
+app/web/             React 19 + TypeScript + Vite SPA (Phase 2 W0-W5)
+app/mobile/          Flutter app (iOS + Android), feature parity with web
+docs/
+├── design.md        SSOT north-star
+└── adr/             architecture decisions, dated
+```
+
+## Frontend web
+
+`app/web/` construit une SPA unique dans `internal/web/dist/`, que le binaire Go
+embarque et sert sur `/admin/*`. Le dev server Vite sur `:5173` proxy `/api`
+vers `:8770` pour un développement avec HMR.
+
+```bash
+# dev (hot reload on the React side, separate Go server for the API)
+cd app/web && pnpm dev               # http://localhost:5173
+go run ./cmd/opendray serve -config ../../config.toml   # other terminal
+
+# prod (one binary delivers everything)
+cd app/web && pnpm build              # writes ../../internal/web/dist
+cd ../..
+go build ./cmd/opendray               # bakes dist into the binary
+./opendray serve -config config.toml
+```
+
+Voir [`app/web/README.md`](app/web/README.md) pour la stack frontend
+(React + Vite + Tailwind v4 + shadcn/ui + TanStack Router/Query +
+Zustand + xterm.js) et les notes par milestone W.
+
+## Documentation
+
+- [`docs/getting-started.md`](docs/getting-started.md) — **commence ici** si tu débutes : de zéro à ta première session en 15 minutes, installation des CLI wrappées et bootstrap Postgres compris
+- [`docs/quickstart.md`](docs/quickstart.md) — environnement de dev en 5 minutes (suppose que tu connais déjà les morceaux)
+- [`docs/operator-guide.md`](docs/operator-guide.md) — référence deploy + ops pour les setups quasi-production
+- [`docs/integration-guide.md`](docs/integration-guide.md) — comment écrire une intégration externe dans n'importe quel langage
+- [`VERSIONING.md`](VERSIONING.md) — stratégie de versioning (major-as-generation)
+- [`CHANGELOG.md`](CHANGELOG.md) — historique des releases
+
+## Tests
+
+```bash
+go test -race ./...        # backend
+cd app/web && pnpm build   # web (TS strict + vite production build)
+```
+
+Les smoke flows end-to-end sont trackés dans les messages de commit par milestone.
+Un harness Playwright est prévu en follow-up.
+
+## Lien avec la v1
+
+v1 (`Opendray/opendray`) est le codebase legacy, désormais archivé. v2 est
+la génération actuelle et active — feature-complete et la seule branche qui
+reçoit du développement. Sur les 16 builtins de v1, quatre ont migré dans
+le backend v2 ; le reste est devenu des features côté client, des adaptateurs
+de canaux ou des consommateurs de l'API d'intégration.
+
+## Licence
+
+Apache 2.0 — voir [`LICENSE`](LICENSE). (v1 était sous MIT ; v2 est licenciée
+indépendamment.)

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,380 @@
+<p align="center">
+  <a href="https://opendray.dev"><img src="docs/assets/logo.png" alt="opendray" width="180"></a>
+</p>
+
+<h1 align="center">opendray</h1>
+
+<p align="center">
+  <strong>Claude Code・Codex・Gemini・shell のためのセルフホスト型ゲートウェイ — それらすべてにまたがる、ローカルファーストな共通メモリレイヤーを備えています。</strong>
+  <br/>
+  <sub>セッションは自前のインフラ上で動作。web、モバイル、チャットから操作できます。連携用にオープンな REST + WebSocket API を提供。</sub>
+</p>
+
+<p align="center">
+  <strong><a href="https://opendray.dev">🌐 opendray.dev</a></strong>
+</p>
+
+<p align="center">
+  <a href="https://opendray.dev"><img alt="Website" src="https://img.shields.io/badge/website-opendray.dev-F43F5E"></a>
+  <a href="https://github.com/Opendray/opendray/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/Opendray/opendray?label=release&color=4f46e5"></a>
+  <a href="LICENSE"><img alt="License Apache 2.0" src="https://img.shields.io/github/license/Opendray/opendray?color=blue"></a>
+  <a href="https://github.com/Opendray/opendray/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/Opendray/opendray/ci.yml?branch=main&label=CI"></a>
+  <a href="https://github.com/Opendray/opendray/discussions"><img alt="Discussions" src="https://img.shields.io/github/discussions/Opendray/opendray?color=ec4899"></a>
+  <br/>
+  <img alt="Go" src="https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white">
+  <img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black">
+  <img alt="Flutter" src="https://img.shields.io/badge/Flutter-mobile-02569B?logo=flutter&logoColor=white">
+  <img alt="Postgres" src="https://img.shields.io/badge/PostgreSQL-15%2F16%2F17-336791?logo=postgresql&logoColor=white">
+</p>
+
+<p align="center">
+  🌐 <a href="README.md">English</a> · <a href="README.zh.md">简体中文</a> · <a href="README.fa.md">فارسی</a> · <a href="README.es.md">Español</a> · <a href="README.pt-BR.md">Português</a> · <strong>日本語</strong> · <a href="README.ko.md">한국어</a> · <a href="README.fr.md">Français</a> · <a href="README.de.md">Deutsch</a> · <a href="README.ru.md">Русский</a>
+</p>
+
+---
+
+## opendray とは？
+
+**opendray** は、あなたが普段使っている AI コーディング CLI — Claude Code、Codex、Gemini、そして任意の shell — をラップし、どこからでも操作できるものへと変えます。セッションは自宅サーバー / NAS / VPS 上で動作させ、アイドル状態になれば Telegram で通知を受け取り、スマートフォンから返信すれば次のプロンプトとしてそのまま流し込めます。すべては、エンドツーエンドで自分が管理するセルフホスト型ゲートウェイ上で完結します。
+
+- 🛰 **1 つのバックエンド、3 つのサーフェス** — 単一の Go バイナリが React 製の web 管理画面と Flutter 製のモバイルアプリを配信し、すべての操作はサードパーティ連携用に REST + WebSocket API としても公開されます。
+- 💬 **6 つの双方向チャネル、囲い込みなし** — Telegram、Slack、Discord、Feishu（飞书）、DingTalk（钉钉）、WeCom（企业微信）、さらに任意のカスタム連携用の Bridge アダプターを用意。どのチャネルから返信しても、正しいセッションへルーティングされます。
+- 🧠 **ローカルファーストなメモリ** — ONNX / Ollama / LM Studio による埋め込み、3 スコープでの検索（user・project・session）、スマートランキング、レイヤー横断の競合検出。ベクターデータが自分のネットワークの外に出ることはありません。
+- 🔌 **連携向けの API** — スコープ付きの API キー、呼び出しごとの audit log、リバースプロキシマウント。opendray を自社プロダクトの裏側のゲートウェイとして使うことも、単なる個人のコマンドセンターとして使うこともできます。
+- 🔑 **複数 Claude アカウントによるフリート運用** — 複数の `claude login` アカウントをゲートウェイに登録すると、パネルがファイルシステムウォッチャーで自動検出し、新規セッションを有効なアカウント間で負荷分散します。さらに、動作中のセッションを別のアカウントへ **会話を失わずに** 切り替えることも可能です（裏側でトランスクリプトを移行します）。各アカウントの行には、現在のキャパシティ（subscription tier、rate-limit tier、アクティブセッション数、最終使用日時、現在の Anthropic メールアドレス）がライブで表示され、適切なものを一目で選べます。
+- 🔒 **セルフホスト、ライセンスも明快** — Apache 2.0、単一の静的バイナリ、cosign 署名済みリリースと SPDX SBOM 付き。テレメトリ、クラウドアカウント、サブスクリプションは一切ありません。
+
+## ステータス
+
+**v2.5.0**（最新）— v2 世代は引き続き進化を続けています。major-as-generation（major = 製品世代であり、SemVer 厳密な意味での「破壊的変更」ではない）方針については
+[`VERSIONING.md`](VERSIONING.md) を、リリース履歴の全体については
+[`CHANGELOG.md`](CHANGELOG.md) を参照してください。
+
+この世代で提供される主な内容:
+
+- **ワンライナーのインストーラー / アンインストーラーウィザード**（Linux + macOS;
+  Windows は WSL2 経由）。Postgres のブートストラップ、AI-CLI のインストール、
+  管理者認証情報、待ち受けアドレス、バイナリのインストール、スキーママイグレーション、
+  サービス登録まで、オペレーターを順を追って案内します。
+- **自己管理型バイナリ** — `opendray update / start / stop /
+  restart / status / providers list / providers update` により、
+  日常運用で `systemctl` / `launchctl` に直接触れる必要はありません。
+- **Goreleaser によるリリースパイプライン** — クロスコンパイル済みバイナリ
+  （linux/darwin × amd64/arm64）、cosign による keyless 署名（Sigstore）、
+  SPDX SBOM、アトミックに検証されるセルフアップデート。
+
+## インストール
+
+### ワンライナーインストーラー
+
+**Linux / macOS / WSL2**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh | bash
+```
+
+**Windows** — まず WSL2 をセットアップしてから、その中で Linux 用インストーラーを実行します。[詳細 →](scripts/README.md#windows)
+
+```powershell
+irm https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install-windows.ps1 | iex
+```
+
+Postgres のセットアップ、AI-CLI のインストール、管理者認証情報、サービス登録まで案内し、約 5〜10 分で動作するゲートウェイが手に入ります。ウィザードの動作内容、作成されるファイルレイアウト、オプション、トラブルシューティングについては [**`scripts/README.md`**](scripts/README.md) を参照してください。
+
+> **手動の手順を確認したい方へ。** [**docs/getting-started.md**](docs/getting-started.md) をお読みください — ウィザードと同じ手順を 15 分で一通りなぞる、エンドツーエンドのガイドです。各ステップを自分の目で確認できます。
+
+### アンインストール（Linux / macOS）
+
+**デフォルト** — ゲートウェイを停止しバイナリを削除しますが、`config.toml`、データディレクトリ（bcrypt キーファイル、セッション、ノート、vault）、ログ、PostgreSQL データベースは **保持** します。再インストール時には中断したところから再開できます:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | bash
+```
+
+**完全パージ** — さらに PG データベースと role を削除し、config / data / logs を消去、サービスユーザーも削除します。何か残っていれば声高に失敗する、削除後の検証ステップも含まれます:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
+```
+
+### 日常運用コマンド
+
+インストール後、`opendray` バイナリ自身がライフサイクルを管理するため、`systemctl` / `launchctl` の呪文を覚えておく必要はありません:
+
+```sh
+sudo opendray update --restart   # download latest release, verify SHA, atomic replace + restart
+```
+
+```sh
+sudo opendray providers update   # bump installed AI CLIs (claude / codex / gemini) to npm-latest
+```
+
+```sh
+opendray providers list          # see which AI CLIs are installed + their versions
+```
+
+```sh
+sudo opendray start              # start | stop | restart | status — wraps systemd / launchd
+```
+
+サブコマンド一式は `opendray --help` で確認できます。
+
+### デプロイ経路の選び方
+
+サポートされているどの経路でも、セッションの起動、AI-CLI へのアクセス、暗号化バックアップ、連携 API 一式が利用できます。opendray はホスト常駐型のゲートウェイで、AI CLI を PTY 経由で起動し、プロセス状態（`~/.claude`、ssh-agent、プロジェクトファイル）をそれらと共有します。このモデルは本番運用での Docker が課すコンテナ隔離とは相容れないため、v2.x では Docker はサポート対象のデプロイ経路ではありません。
+
+| 経路 | 適した用途 | 詳細 |
+|---|---|---|
+| 📦 **ビルド済みバイナリ** | 「とにかく動かしたい」 — Linux / macOS、任意のスーパーバイザー | [リリースページ](https://github.com/Opendray/opendray/releases) → [本番環境へのデプロイ](#production-deploy) を参照 |
+| 🐧 **systemd ユニット** | ベアメタル / VM / LXC の Linux マシン | [本番環境へのデプロイ §A](#option-a--systemd-bare-metal--vm--lxc) |
+| 🍎 **macOS LaunchDaemon** | 自宅サーバーとして使う Mac mini / Mac Studio | [本番環境へのデプロイ §C](#option-c--macos-launchd-mac-mini--studio-as-home-server) |
+| 🛠 **ソースからビルド** | 開発 / コントリビューション / カスタムビルド | 下記の [Quickstart](#quickstart-5-minute-dev-path) |
+
+## Quickstart（5 分で動かす開発用経路）
+
+前提条件やトラブルシューティングを含む完全な手順は [`docs/quickstart.md`](docs/quickstart.md) を参照してください。凝縮した開発用経路は以下のとおりです:
+
+```bash
+# 1. Have a Postgres 15+ running on 127.0.0.1:5432 with pgvector enabled
+#    (apt install postgresql-16 postgresql-16-pgvector / brew install postgresql@16 pgvector).
+#    Point [database].url at any other DSN if you'd rather use a remote PG.
+
+# 2. Local config — already gitignored.
+cp config.example.toml config.toml
+$EDITOR config.toml          # set [database].url, [admin].password
+
+# 3. Build the web bundle into the embed tree.
+cd app/web && pnpm install && pnpm build && cd ../..
+
+# 4. Apply schema.
+go run ./cmd/opendray migrate -config config.toml
+
+# 5. Run.
+go run ./cmd/opendray serve -config config.toml
+# → REST + WS:  http://127.0.0.1:8770/api/v1/...
+# → Web admin:  http://127.0.0.1:8770/admin/
+```
+
+これは OpenDray をフォアグラウンドで実行します — Ctrl-C で停止します。常駐デーモンとして動かしたい場合は、下記の **本番環境へのデプロイ** を参照してください。
+
+## 本番環境へのデプロイ
+
+サポートされているデプロイ経路は 4 つあります。自分の環境に合うものを選んでください。
+いずれの経路でも、クラッシュ時の自動再起動、永続的な状態管理、
+シークレットと設定の分離が得られます。
+
+### Option A — systemd（ベアメタル / VM / LXC）
+
+Linux で推奨されるデプロイ経路です。
+[`deploy/systemd/opendray.service`](deploy/systemd/opendray.service)
+にハードニング済みのユニットを同梱しており、サンドボックス化（`ProtectSystem=strict`、`NoNewPrivileges`、
+`MemoryDenyWriteExecute`、capability の剥奪）、`migrate` のあとに `serve` を起動する流れ、
+20 秒のグレースフルストップウィンドウを備えています。
+
+**まずはバイナリを入手してください。**
+[リリースページ](https://github.com/Opendray/opendray/releases)
+からビルド済みのアーカイブを取得する
+（`opendray_*_linux_<arch>.tar.gz` — 展開すると単一の `opendray` バイナリになります）か、
+上記の [Quickstart](#quickstart-5-minute-dev-path)
+の手順でソースからビルド（`go build ./cmd/opendray`）します。
+
+```bash
+# 1. Install the binary you just grabbed (or built).
+sudo install -m 0755 /path/to/opendray /usr/local/bin/opendray
+
+# 2. Create the service user + state dir.
+sudo useradd -r -s /usr/sbin/nologin -d /var/lib/opendray opendray
+sudo install -d -o opendray -g opendray -m 0700 /var/lib/opendray
+
+# 3. Drop config + secrets (root-owned; mode 0640).
+sudo install -D -m 0640 config.example.toml /etc/opendray/config.toml
+sudo $EDITOR /etc/opendray/config.toml             # set [database].url etc.
+sudo install -D -m 0640 -o root -g opendray /dev/null /etc/opendray/env.d/secrets
+sudo $EDITOR /etc/opendray/env.d/secrets           # OPENDRAY_ADMIN_PASSWORD=…
+
+# 4. Install + enable the unit.
+sudo cp deploy/systemd/opendray.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now opendray
+
+# 5. Verify.
+sudo systemctl status opendray
+sudo journalctl -u opendray -f --no-pager
+```
+
+ユニットは `ExecStartPre` として `opendray migrate` を実行するため、初回起動時に
+`serve` が始まる前にすべてのマイグレーションが適用されます。再起動ポリシーは
+`on-failure`、5 秒のバックオフ、1 分あたり 5 回までのバースト制限です。
+
+### Option B — 直接バイナリ + 任意のプロセススーパーバイザー
+
+systemd のない LXC、FreeBSD `rc.d`、OpenRC、その他何でも構いません。
+ビルドは一度だけ、起動は普段使いのスーパーバイザーで行えます:
+
+```bash
+# Cross-compile a release archive locally:
+goreleaser release --clean --snapshot
+ls dist/                  # opendray_*_linux_amd64.tar.gz etc.
+
+# Or grab a published release artefact:
+# https://github.com/Opendray/opendray/releases
+```
+
+そして、お好みのスーパーバイザー（s6、runit、supervisord、runwhen）に以下を指し示します:
+
+```
+/usr/local/bin/opendray serve -config /etc/opendray/config.toml
+```
+
+事前準備として、初回の `serve` の前に一度だけ
+`opendray migrate -config /etc/opendray/config.toml` を実行するか、
+お使いのスーパーバイザーの pre-start フックとして組み込んでください。
+
+### Option C — macOS launchd（自宅サーバーとしての Mac mini / Studio）
+
+24 時間 365 日稼働させる Apple Silicon の Mac mini / Mac Studio 向けです。
+[`deploy/launchd/com.opendray.opendray.plist`](deploy/launchd/com.opendray.opendray.plist)
+に LaunchDaemon を同梱しており、ユーザーログインの前のブート時に起動、
+クラッシュ時は 5 秒のスロットルで再起動、ログは `/usr/local/var/log/opendray/` に出力されます。
+
+```bash
+# 1. Install the darwin binary + config + state dirs.
+sudo install -m 0755 ./opendray /usr/local/bin/opendray
+sudo install -d -m 0755 \
+  /usr/local/etc/opendray \
+  /usr/local/var/lib/opendray \
+  /usr/local/var/log/opendray
+sudo install -m 0640 config.example.toml /usr/local/etc/opendray/config.toml
+sudo $EDITOR /usr/local/etc/opendray/config.toml    # set [database].url etc.
+
+# 2. Apply migrations once.
+sudo /usr/local/bin/opendray migrate \
+  -config /usr/local/etc/opendray/config.toml
+
+# 3. Install + load the LaunchDaemon.
+sudo cp deploy/launchd/com.opendray.opendray.plist /Library/LaunchDaemons/
+sudo chown root:wheel /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo chmod 0644 /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.opendray.opendray.plist
+
+# 4. Verify.
+sudo launchctl print system/com.opendray.opendray
+tail -f /usr/local/var/log/opendray/opendray.log
+```
+
+再起動は `sudo launchctl kickstart -k system/com.opendray.opendray`、
+完全にアンロードするには `sudo launchctl bootout system/com.opendray.opendray` を実行します。
+
+macOS での Postgres — Homebrew でインストールし（`brew install postgresql@17 && brew services start postgresql@17`）、`[database].url` を
+`postgres://$USER@127.0.0.1:5432/opendray` に向けます。`pgvector` は
+`brew install pgvector` で導入し、opendray データベース内で
+`CREATE EXTENSION vector` を実行してください。
+
+---
+
+Proxmox 固有の LXC に関するメモ（非特権コンテナでの PTY、ネットワーク、
+cgroup の調整）については、[`deploy/lxc/proxmox-pty-notes.md`](deploy/lxc/proxmox-pty-notes.md) を参照してください。
+
+リバースプロキシ / TLS 終端（nginx、Caddy、Traefik、Cloudflare
+Tunnel）については、[`docs/operator-guide.md`](docs/operator-guide.md) の §Topology を参照してください。
+
+### オプション: 暗号化 DB バックアップとデータエクスポートを有効にする
+
+```bash
+# Master passphrase (env-only — never write into config.toml).
+export OPENDRAY_BACKUP_KEY="$(openssl rand -base64 32)"
+export OPENDRAY_BACKUP_ENABLED=1
+
+# pg_dump / pg_restore must match the server's major version. On
+# Apple Silicon dev machines pointing at a PG17 server:
+export OPENDRAY_BACKUP_PG_DUMP_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_dump
+export OPENDRAY_BACKUP_PG_RESTORE_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_restore
+```
+
+opendray を再起動すると、サイドバーに Backups ページ（`/backups`）が現れ、
+暗号化された PostgreSQL ダンプとリストアを行えます。`/export` では
+zip バンドルでのデータエクスポート / インポートが可能です。ライフサイクル全体については [`docs/operator-guide.md`](docs/operator-guide.md) の §Backup を参照してください。
+
+単一の Go バイナリが web バンドルを丸ごと内包しているため、ランタイムに Node は
+不要で、静的ファイル用の別サーバーも、Caddy / nginx も必要ありません。
+TLS 終端は `:8770` の手前で Cloudflare Tunnel に任せられます。
+
+## レイアウト
+
+```
+cmd/opendray/        binary entry point (≤100 LOC per design §14)
+internal/
+├── app/             composition root (wires every subsystem)
+├── audit/           subscribes to bus topics, persists to audit_log
+├── auth/            admin bearer tokens (M2.5)
+├── backup/          encrypted DB dumps + admin export/import├── catalog/         CLI provider manifests + per-id user config (M2)
+├── channel/         channel hub + telegram impl (M4)
+├── config/          TOML loader with OPENDRAY_* env overrides
+├── eventbus/        in-process pub/sub
+├── gateway/         chi HTTP router + middleware + slog
+├── integration/     external-app registry + reverse proxy + events WS (M3)
+├── memory/          cross-CLI persistent memory├── session/         PTY lifecycle + ring buffer + WS stream (M1)
+├── store/           pgx pool + hand-rolled migration runner (M0)
+├── version/         build-time identification
+└── web/             go:embed of the web bundle (W5)
+
+app/web/             React 19 + TypeScript + Vite SPA (Phase 2 W0-W5)
+app/mobile/          Flutter app (iOS + Android), feature parity with web
+docs/
+├── design.md        SSOT north-star
+└── adr/             architecture decisions, dated
+```
+
+## Web フロントエンド
+
+`app/web/` は単一の SPA を `internal/web/dist/` にビルドし、Go バイナリが
+それを埋め込んで `/admin/*` で配信します。Vite の開発サーバー（`:5173`）は
+`/api` を `:8770` にプロキシし、HMR を効かせた開発が行えます。
+
+```bash
+# dev (hot reload on the React side, separate Go server for the API)
+cd app/web && pnpm dev               # http://localhost:5173
+go run ./cmd/opendray serve -config ../../config.toml   # other terminal
+
+# prod (one binary delivers everything)
+cd app/web && pnpm build              # writes ../../internal/web/dist
+cd ../..
+go build ./cmd/opendray               # bakes dist into the binary
+./opendray serve -config config.toml
+```
+
+フロントエンドのスタック（React + Vite + Tailwind v4 + shadcn/ui + TanStack Router/Query +
+Zustand + xterm.js）や、W マイルストーンごとのノートについては
+[`app/web/README.md`](app/web/README.md) を参照してください。
+
+## ドキュメント
+
+- [`docs/getting-started.md`](docs/getting-started.md) — はじめての方は **まずここから**。ラップ対象の CLI のインストールや Postgres のブートストラップも含めて、ゼロから最初のセッションまでを 15 分で
+- [`docs/quickstart.md`](docs/quickstart.md) — 5 分で動かす開発環境（構成要素は既に把握している前提）
+- [`docs/operator-guide.md`](docs/operator-guide.md) — 本番寄りの構成向けのデプロイ + 運用リファレンス
+- [`docs/integration-guide.md`](docs/integration-guide.md) — 任意の言語で外部連携を書くためのガイド
+- [`VERSIONING.md`](VERSIONING.md) — バージョニング戦略（major-as-generation）
+- [`CHANGELOG.md`](CHANGELOG.md) — リリース履歴
+
+## テスト
+
+```bash
+go test -race ./...        # backend
+cd app/web && pnpm build   # web (TS strict + vite production build)
+```
+
+エンドツーエンドのスモークフローは、マイルストーンごとのコミットメッセージで管理しています。
+Playwright によるハーネスは今後の対応として予定されています。
+
+## v1 との関係
+
+v1（`Opendray/opendray`）は既にアーカイブされたレガシーコードベースです。v2 は
+現行かつアクティブな世代で、feature-complete であり、開発が継続しているのは
+このブランチだけです。v1 の 16 個のビルトインのうち、4 つが v2 のバックエンドへ
+移行し、残りはクライアント側の機能、チャネルアダプター、あるいは連携 API の
+利用側へと姿を変えています。
+
+## ライセンス
+
+Apache 2.0 — 詳細は [`LICENSE`](LICENSE) を参照してください。（v1 は MIT でしたが、
+v2 は独立してライセンスされています。）

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,377 @@
+<p align="center">
+  <a href="https://opendray.dev"><img src="docs/assets/logo.png" alt="opendray" width="180"></a>
+</p>
+
+<h1 align="center">opendray</h1>
+
+<p align="center">
+  <strong>Claude Code · Codex · Gemini · shell을 위한 self-hosted 게이트웨이 — 이 모두를 가로지르는 단일 local-first 메모리 레이어 제공.</strong>
+  <br/>
+  <sub>세션을 본인 인프라에서 실행하고, 웹·모바일·채팅 어디서든 제어하세요. 통합을 위한 개방형 REST + WebSocket API를 제공합니다.</sub>
+</p>
+
+<p align="center">
+  <strong><a href="https://opendray.dev">🌐 opendray.dev</a></strong>
+</p>
+
+<p align="center">
+  <a href="https://opendray.dev"><img alt="Website" src="https://img.shields.io/badge/website-opendray.dev-F43F5E"></a>
+  <a href="https://github.com/Opendray/opendray/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/Opendray/opendray?label=release&color=4f46e5"></a>
+  <a href="LICENSE"><img alt="License Apache 2.0" src="https://img.shields.io/github/license/Opendray/opendray?color=blue"></a>
+  <a href="https://github.com/Opendray/opendray/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/Opendray/opendray/ci.yml?branch=main&label=CI"></a>
+  <a href="https://github.com/Opendray/opendray/discussions"><img alt="Discussions" src="https://img.shields.io/github/discussions/Opendray/opendray?color=ec4899"></a>
+  <br/>
+  <img alt="Go" src="https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white">
+  <img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black">
+  <img alt="Flutter" src="https://img.shields.io/badge/Flutter-mobile-02569B?logo=flutter&logoColor=white">
+  <img alt="Postgres" src="https://img.shields.io/badge/PostgreSQL-15%2F16%2F17-336791?logo=postgresql&logoColor=white">
+</p>
+
+<p align="center">
+  🌐 <a href="README.md">English</a> · <a href="README.zh.md">简体中文</a> · <a href="README.fa.md">فارسی</a> · <a href="README.es.md">Español</a> · <a href="README.pt-BR.md">Português</a> · <a href="README.ja.md">日本語</a> · <strong>한국어</strong> · <a href="README.fr.md">Français</a> · <a href="README.de.md">Deutsch</a> · <a href="README.ru.md">Русский</a>
+</p>
+
+---
+
+## opendray란?
+
+**opendray**는 이미 쓰고 있는 AI 코딩 CLI들 — Claude Code, Codex, Gemini, 그리고 임의의 shell — 을 감싸서, 어디서든 제어 가능한 형태로 바꿔 줍니다. 홈 서버 / NAS / VPS에서 세션을 돌리고, idle 상태가 되면 Telegram으로 알림을 받고, 휴대폰에서 곧바로 다음 prompt를 흘려 넣을 수 있습니다. 모든 흐름이 처음부터 끝까지 본인이 통제하는 self-hosted 게이트웨이를 통해 이뤄집니다.
+
+- 🛰 **하나의 backend, 세 가지 표면** — 단일 Go 바이너리가 React 웹 어드민과 Flutter 모바일 앱을 함께 서빙하며, 모든 동작은 서드파티 통합을 위해 REST + WebSocket API로도 노출됩니다.
+- 💬 **6개의 양방향 채널, 닫힌 정원 없음** — Telegram, Slack, Discord, Feishu (飞书), DingTalk (钉钉), WeCom (企业微信), 그리고 커스텀 용도를 위한 Bridge 어댑터. 어느 채널에서 답장을 보내든 알맞은 세션으로 다시 라우팅됩니다.
+- 🧠 **Local-first 메모리** — ONNX / Ollama / LM Studio 임베딩 기반에 3개 스코프 검색(사용자 · 프로젝트 · 세션), 스마트 랭킹, 레이어 간 충돌 감지까지 갖췄습니다. 벡터 데이터는 네트워크 밖으로 나가지 않습니다.
+- 🔌 **통합 등급 API** — 스코프가 지정된 API 키, 호출 단위 audit log, reverse-proxy 마운트를 지원합니다. opendray를 자체 제품의 뒤를 받치는 게이트웨이로 쓰든, 개인용 command centre로 쓰든 자유입니다.
+- 🔑 **Multi-Claude 계정 플릿** — 여러 `claude login` 계정을 게이트웨이에 넣어두면, 패널이 파일시스템 워처로 자동 감지하고 활성화된 계정들 사이에서 새 세션을 균형 있게 분배합니다. 실행 중인 세션을 **대화 흐름을 잃지 않고** 다른 계정으로 전환할 수도 있습니다(transcript가 내부적으로 마이그레이션됩니다). 각 계정 행에는 현재 capacity(subscription tier, rate-limit tier, 활성 세션 수, 마지막 사용 시각, 현재 Anthropic 이메일)가 실시간으로 표시되어 한눈에 적절한 계정을 고를 수 있습니다.
+- 🔒 **Self-hosted, 명확한 라이선스** — Apache 2.0, 단일 정적 바이너리, cosign 서명된 release와 SPDX SBOM을 제공합니다. 텔레메트리 없음, 클라우드 계정 없음, 구독 없음.
+
+## 현황
+
+**v2.5.0** (최신) — v2 세대는 계속 이터레이션 중입니다.
+[`VERSIONING.md`](VERSIONING.md)에서 major-as-generation 정책
+(major = 제품 세대, 엄격한 SemVer "breaking change"가 아님)을,
+[`CHANGELOG.md`](CHANGELOG.md)에서 전체 release 이력을 확인하세요.
+
+이 세대에서 제공되는 것:
+
+- **원라인 설치 / 제거 마법사** (Linux + macOS;
+  Windows는 WSL2를 거쳐 진행). 운영자에게 Postgres 부트스트랩,
+  AI-CLI 설치, 어드민 자격증명, 리스닝 주소,
+  바이너리 설치, 스키마 마이그레이션, 서비스 등록까지 단계별로 안내합니다.
+- **자기 관리형 바이너리** — `opendray update / start / stop /
+  restart / status / providers list / providers update`를 통해
+  일상 운영 작업에서 `systemctl` / `launchctl`에 손댈 일을 없앴습니다.
+- **Goreleaser release 파이프라인** — 크로스 컴파일된 바이너리
+  (linux/darwin × amd64/arm64), cosign keyless 서명(Sigstore),
+  SPDX SBOM, 원자적으로 검증되는 self-update를 제공합니다.
+
+## 설치
+
+### 원라인 설치 스크립트
+
+**Linux / macOS / WSL2**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh | bash
+```
+
+**Windows** — 먼저 WSL2를 세팅한 다음 그 안에서 Linux용 설치 스크립트를 실행합니다. [상세 →](scripts/README.md#windows)
+
+```powershell
+irm https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install-windows.ps1 | iex
+```
+
+Postgres 설정, AI-CLI 설치, 어드민 자격증명, 서비스 등록까지 차례로 진행하며 — 약 5~10분이면 게이트웨이가 떠 있는 상태가 됩니다. 마법사가 무엇을 하는지, 어떤 파일 레이아웃을 만드는지, 옵션과 트러블슈팅은 [**`scripts/README.md`**](scripts/README.md)를 참고하세요.
+
+> **수동 절차로 진행하고 싶다면?** [**docs/getting-started.md**](docs/getting-started.md)를 읽어보세요 — 마법사가 하는 일을 그대로 풀어 놓은 15분짜리 엔드투엔드 가이드라서 각 단계를 직접 검증할 수 있습니다.
+
+### 제거 (Linux / macOS)
+
+**기본** — 게이트웨이를 중지하고 바이너리를 제거하지만, `config.toml`, 데이터 디렉터리(bcrypt 키파일, 세션, 노트, vault), 로그, PostgreSQL 데이터베이스는 **그대로 유지**합니다. 다시 설치하면 멈췄던 지점에서 이어집니다:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | bash
+```
+
+**완전 삭제** — PG 데이터베이스와 role까지 drop하고, config / data / logs를 지우며, 서비스 사용자도 제거합니다. 삭제 후에 무엇이라도 살아 있으면 시끄럽게 실패하는 검증 단계가 포함되어 있습니다:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
+```
+
+### 일상 운영 명령어
+
+설치 후에는 `opendray` 바이너리가 자기 라이프사이클을 직접 다룹니다 — `systemctl` / `launchctl` 주문을 외울 필요가 없습니다:
+
+```sh
+sudo opendray update --restart   # download latest release, verify SHA, atomic replace + restart
+```
+
+```sh
+sudo opendray providers update   # bump installed AI CLIs (claude / codex / gemini) to npm-latest
+```
+
+```sh
+opendray providers list          # see which AI CLIs are installed + their versions
+```
+
+```sh
+sudo opendray start              # start | stop | restart | status — wraps systemd / launchd
+```
+
+`opendray --help`로 전체 서브커맨드 목록을 볼 수 있습니다.
+
+### Deploy 경로 선택기
+
+지원되는 모든 경로는 세션 spawn, AI-CLI 접근, 암호화 백업, 통합 API 전체를 포함합니다. opendray는 호스트에 상주하는 게이트웨이로 — PTY를 통해 AI CLI를 spawn하고, 그들과 프로세스 상태(`~/.claude`, ssh-agent, 프로젝트 파일)를 공유합니다. 이 모델은 프로덕션 Docker가 강제하는 컨테이너 격리와 맞지 않기 때문에, v2.x에서는 Docker가 지원되는 deploy 경로가 아닙니다.
+
+| 경로 | 추천 대상 | 이동 |
+|---|---|---|
+| 📦 **사전 빌드 바이너리** | "그냥 실행" — Linux / macOS, 임의의 supervisor | [Releases page](https://github.com/Opendray/opendray/releases) → [프로덕션 deploy](#production-deploy) 참고 |
+| 🐧 **systemd 유닛** | 베어메탈 / VM / LXC Linux 박스 | [프로덕션 deploy §A](#option-a--systemd-bare-metal--vm--lxc) |
+| 🍎 **macOS LaunchDaemon** | 홈 서버용 Mac mini / Mac Studio | [프로덕션 deploy §C](#option-c--macos-launchd-mac-mini--studio-as-home-server) |
+| 🛠 **소스에서 빌드** | 개발 / 기여 / 커스텀 빌드 | 아래의 [Quickstart](#quickstart-5-minute-dev-path) |
+
+## Quickstart (5분 개발 경로)
+
+사전 준비물과 트러블슈팅이 포함된 전체 가이드는 [`docs/quickstart.md`](docs/quickstart.md)를 참고하세요. 압축된 개발 경로는 다음과 같습니다:
+
+```bash
+# 1. Have a Postgres 15+ running on 127.0.0.1:5432 with pgvector enabled
+#    (apt install postgresql-16 postgresql-16-pgvector / brew install postgresql@16 pgvector).
+#    Point [database].url at any other DSN if you'd rather use a remote PG.
+
+# 2. Local config — already gitignored.
+cp config.example.toml config.toml
+$EDITOR config.toml          # set [database].url, [admin].password
+
+# 3. Build the web bundle into the embed tree.
+cd app/web && pnpm install && pnpm build && cd ../..
+
+# 4. Apply schema.
+go run ./cmd/opendray migrate -config config.toml
+
+# 5. Run.
+go run ./cmd/opendray serve -config config.toml
+# → REST + WS:  http://127.0.0.1:8770/api/v1/...
+# → Web admin:  http://127.0.0.1:8770/admin/
+```
+
+이 방식은 OpenDray를 포그라운드에서 실행합니다 — Ctrl-C로 종료됩니다. 장기 실행 데몬으로 띄우려면 아래의 **프로덕션 deploy**를 참고하세요.
+
+## 프로덕션 deploy
+
+지원되는 deploy 경로는 네 가지이며, 각자의 환경에 맞는 것을 고르면 됩니다.
+어느 쪽이든 crash 시 auto-restart, 영구 상태 유지, 시크릿과 config의
+분리를 보장합니다.
+
+### Option A — systemd (베어메탈 / VM / LXC)
+
+권장 Linux deploy 경로입니다. [`deploy/systemd/opendray.service`](deploy/systemd/opendray.service)에
+샌드박싱(`ProtectSystem=strict`, `NoNewPrivileges`,
+`MemoryDenyWriteExecute`, capability scrub), `migrate` 이후 `serve`로 이어지는
+부팅 순서, 20초의 graceful-stop 윈도우가 적용된 hardened 유닛이 들어 있습니다.
+
+**먼저 바이너리부터 확보하세요.** [Releases 페이지](https://github.com/Opendray/opendray/releases)에서
+사전 빌드 아카이브(`opendray_*_linux_<arch>.tar.gz` — 압축 해제 시 단일 `opendray`
+바이너리 한 개로 풀립니다)를 받거나, 위의 [Quickstart](#quickstart-5-minute-dev-path)를
+참고해 소스에서 빌드(`go build ./cmd/opendray`)하면 됩니다.
+
+```bash
+# 1. Install the binary you just grabbed (or built).
+sudo install -m 0755 /path/to/opendray /usr/local/bin/opendray
+
+# 2. Create the service user + state dir.
+sudo useradd -r -s /usr/sbin/nologin -d /var/lib/opendray opendray
+sudo install -d -o opendray -g opendray -m 0700 /var/lib/opendray
+
+# 3. Drop config + secrets (root-owned; mode 0640).
+sudo install -D -m 0640 config.example.toml /etc/opendray/config.toml
+sudo $EDITOR /etc/opendray/config.toml             # set [database].url etc.
+sudo install -D -m 0640 -o root -g opendray /dev/null /etc/opendray/env.d/secrets
+sudo $EDITOR /etc/opendray/env.d/secrets           # OPENDRAY_ADMIN_PASSWORD=…
+
+# 4. Install + enable the unit.
+sudo cp deploy/systemd/opendray.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now opendray
+
+# 5. Verify.
+sudo systemctl status opendray
+sudo journalctl -u opendray -f --no-pager
+```
+
+이 유닛은 `opendray migrate`를 `ExecStartPre`로 실행하기 때문에, 최초 부팅에서
+`serve`가 시작되기 전에 모든 마이그레이션이 적용됩니다. 재시작 정책은
+`on-failure`이며 5초 back-off에 분당 5회 burst 제한이 걸려 있습니다.
+
+### Option B — 바이너리 직접 실행 + 자체 프로세스 supervisor
+
+systemd가 없는 LXC, FreeBSD `rc.d`, OpenRC 등 다른 환경을 위한 경로입니다.
+한 번 빌드해두고, 이미 쓰고 있는 supervisor로 띄우면 됩니다:
+
+```bash
+# Cross-compile a release archive locally:
+goreleaser release --clean --snapshot
+ls dist/                  # opendray_*_linux_amd64.tar.gz etc.
+
+# Or grab a published release artefact:
+# https://github.com/Opendray/opendray/releases
+```
+
+그런 다음 supervisor(s6, runit, supervisord, runwhen 등)가 다음을 실행하도록
+설정합니다:
+
+```
+/usr/local/bin/opendray serve -config /etc/opendray/config.toml
+```
+
+Pre-flight: 최초 `serve` 이전에 `opendray migrate -config /etc/opendray/config.toml`을
+한 번 실행하거나, 사용 중인 supervisor의 pre-start 훅으로 걸어두세요.
+
+### Option C — macOS launchd (홈 서버용 Mac mini / Studio)
+
+24/7 가동되는 Apple Silicon Mac mini / Mac Studio를 위한 경로입니다.
+[`deploy/launchd/com.opendray.opendray.plist`](deploy/launchd/com.opendray.opendray.plist)에
+사용자 로그인 이전 부팅 시점에 시작하고, crash 시 5초 throttle로 재시작하며,
+`/usr/local/var/log/opendray/`에 로그를 남기는 LaunchDaemon이 들어 있습니다.
+
+```bash
+# 1. Install the darwin binary + config + state dirs.
+sudo install -m 0755 ./opendray /usr/local/bin/opendray
+sudo install -d -m 0755 \
+  /usr/local/etc/opendray \
+  /usr/local/var/lib/opendray \
+  /usr/local/var/log/opendray
+sudo install -m 0640 config.example.toml /usr/local/etc/opendray/config.toml
+sudo $EDITOR /usr/local/etc/opendray/config.toml    # set [database].url etc.
+
+# 2. Apply migrations once.
+sudo /usr/local/bin/opendray migrate \
+  -config /usr/local/etc/opendray/config.toml
+
+# 3. Install + load the LaunchDaemon.
+sudo cp deploy/launchd/com.opendray.opendray.plist /Library/LaunchDaemons/
+sudo chown root:wheel /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo chmod 0644 /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.opendray.opendray.plist
+
+# 4. Verify.
+sudo launchctl print system/com.opendray.opendray
+tail -f /usr/local/var/log/opendray/opendray.log
+```
+
+재시작은 `sudo launchctl kickstart -k system/com.opendray.opendray`로,
+완전 언로드는 `sudo launchctl bootout system/com.opendray.opendray`로 수행합니다.
+
+macOS의 Postgres — Homebrew로 설치(`brew install postgresql@17 && brew services start postgresql@17`)하고 `[database].url`을
+`postgres://$USER@127.0.0.1:5432/opendray`로 지정하세요. `pgvector`는
+`brew install pgvector`로 추가한 뒤 opendray 데이터베이스 안에서
+`CREATE EXTENSION vector`를 실행하면 됩니다.
+
+---
+
+Proxmox에서의 LXC 관련 노트(unprivileged 컨테이너에서의 PTY,
+네트워킹, cgroup 조정)는 [`deploy/lxc/proxmox-pty-notes.md`](deploy/lxc/proxmox-pty-notes.md)를 참고하세요.
+
+reverse-proxy / TLS 종단(nginx, Caddy, Traefik, Cloudflare
+Tunnel) 관련 내용은 [`docs/operator-guide.md`](docs/operator-guide.md) §Topology에 있습니다.
+
+### 선택: 암호화 DB 백업 + 데이터 export 활성화
+
+```bash
+# Master passphrase (env-only — never write into config.toml).
+export OPENDRAY_BACKUP_KEY="$(openssl rand -base64 32)"
+export OPENDRAY_BACKUP_ENABLED=1
+
+# pg_dump / pg_restore must match the server's major version. On
+# Apple Silicon dev machines pointing at a PG17 server:
+export OPENDRAY_BACKUP_PG_DUMP_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_dump
+export OPENDRAY_BACKUP_PG_RESTORE_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_restore
+```
+
+opendray를 재시작하면 사이드바에 암호화된 PostgreSQL dump + restore를 위한
+Backups 페이지(`/backups`)와, zip 번들 데이터 export + import를 위한
+`/export`가 생깁니다. 전체 라이프사이클은 [`docs/operator-guide.md`](docs/operator-guide.md) §Backup을 참고하세요.
+
+웹 번들 전체를 단일 Go 바이너리가 들고 다닙니다 — 런타임에 Node 런타임이
+필요 없고, 별도의 정적 파일 서버도, Caddy/nginx도 필요 없습니다.
+Cloudflare Tunnel이 `:8770` 앞에서 TLS를 종단합니다.
+
+## 레이아웃
+
+```
+cmd/opendray/        binary entry point (≤100 LOC per design §14)
+internal/
+├── app/             composition root (wires every subsystem)
+├── audit/           subscribes to bus topics, persists to audit_log
+├── auth/            admin bearer tokens (M2.5)
+├── backup/          encrypted DB dumps + admin export/import├── catalog/         CLI provider manifests + per-id user config (M2)
+├── channel/         channel hub + telegram impl (M4)
+├── config/          TOML loader with OPENDRAY_* env overrides
+├── eventbus/        in-process pub/sub
+├── gateway/         chi HTTP router + middleware + slog
+├── integration/     external-app registry + reverse proxy + events WS (M3)
+├── memory/          cross-CLI persistent memory├── session/         PTY lifecycle + ring buffer + WS stream (M1)
+├── store/           pgx pool + hand-rolled migration runner (M0)
+├── version/         build-time identification
+└── web/             go:embed of the web bundle (W5)
+
+app/web/             React 19 + TypeScript + Vite SPA (Phase 2 W0-W5)
+app/mobile/          Flutter app (iOS + Android), feature parity with web
+docs/
+├── design.md        SSOT north-star
+└── adr/             architecture decisions, dated
+```
+
+## 웹 frontend
+
+`app/web/`는 단일 SPA를 `internal/web/dist/`로 빌드하고, Go 바이너리가 이를
+embed해 `/admin/*`에서 서빙합니다. `:5173`의 Vite 개발 서버는 HMR 기반
+개발을 위해 `/api`를 `:8770`으로 프록시합니다.
+
+```bash
+# dev (hot reload on the React side, separate Go server for the API)
+cd app/web && pnpm dev               # http://localhost:5173
+go run ./cmd/opendray serve -config ../../config.toml   # other terminal
+
+# prod (one binary delivers everything)
+cd app/web && pnpm build              # writes ../../internal/web/dist
+cd ../..
+go build ./cmd/opendray               # bakes dist into the binary
+./opendray serve -config config.toml
+```
+
+프론트엔드 스택(React + Vite + Tailwind v4 + shadcn/ui + TanStack Router/Query +
+Zustand + xterm.js) 및 W 마일스톤별 노트는 [`app/web/README.md`](app/web/README.md)에서
+확인할 수 있습니다.
+
+## 문서
+
+- [`docs/getting-started.md`](docs/getting-started.md) — 처음이라면 **여기서 시작**: 감싸는 CLI 설치와 Postgres 부트스트랩을 포함해 15분 만에 첫 세션까지
+- [`docs/quickstart.md`](docs/quickstart.md) — 5분 개발 환경 (구성 요소를 이미 안다고 가정)
+- [`docs/operator-guide.md`](docs/operator-guide.md) — 프로덕션급 셋업을 위한 deploy + 운영 레퍼런스
+- [`docs/integration-guide.md`](docs/integration-guide.md) — 어떤 언어로든 외부 통합을 작성하는 방법
+- [`VERSIONING.md`](VERSIONING.md) — 버저닝 전략 (major-as-generation)
+- [`CHANGELOG.md`](CHANGELOG.md) — release 이력
+
+## 테스트
+
+```bash
+go test -race ./...        # backend
+cd app/web && pnpm build   # web (TS strict + vite production build)
+```
+
+엔드투엔드 smoke flow는 마일스톤별 커밋 메시지에서 추적됩니다.
+Playwright harness는 후속 작업으로 계획되어 있습니다.
+
+## v1과의 관계
+
+v1 (`Opendray/opendray`)은 legacy 코드베이스이며, 현재는 아카이브된 상태입니다.
+v2가 현재이자 활성 세대로 — feature-complete이고 개발이 진행되는 유일한 브랜치입니다.
+v1의 16개 builtin 중 4개가 v2 backend로 이주했으며, 나머지는 클라이언트 측
+기능, 채널 어댑터, 통합 API 소비자로 옮겨갔습니다.
+
+## 라이선스
+
+Apache 2.0 — [`LICENSE`](LICENSE) 참고. (v1은 MIT였으며, v2는 별도로
+라이선스됩니다.)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  🌐 <strong>English</strong> · <a href="README.zh.md">简体中文</a>
+  🌐 <strong>English</strong> · <a href="README.zh.md">简体中文</a> · <a href="README.fa.md">فارسی</a> · <a href="README.es.md">Español</a> · <a href="README.pt-BR.md">Português</a> · <a href="README.ja.md">日本語</a> · <a href="README.ko.md">한국어</a> · <a href="README.fr.md">Français</a> · <a href="README.de.md">Deutsch</a> · <a href="README.ru.md">Русский</a>
 </p>
 
 ---
@@ -128,7 +128,7 @@ Every supported path includes session spawn, AI-CLI access, encrypted backups, a
 |---|---|---|
 | 📦 **Pre-built binary** | "Just run it" — Linux / macOS, any supervisor | [Releases page](https://github.com/Opendray/opendray/releases) → see [Production deploy](#production-deploy) |
 | 🐧 **systemd unit** | Bare-metal / VM / LXC Linux box | [Production deploy §A](#option-a--systemd-bare-metal--vm--lxc) |
-| 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio as home server | [Production deploy §B](#option-b--macos-launchd-mac-mini--studio-as-home-server) |
+| 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio as home server | [Production deploy §C](#option-c--macos-launchd-mac-mini--studio-as-home-server) |
 | 🛠 **Build from source** | Dev / contributing / custom builds | [Quickstart](#quickstart-5-minute-dev-path) below |
 
 ## Quickstart (5-minute dev path)

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,381 @@
+<p align="center">
+  <a href="https://opendray.dev"><img src="docs/assets/logo.png" alt="opendray" width="180"></a>
+</p>
+
+<h1 align="center">opendray</h1>
+
+<p align="center">
+  <strong>Gateway self-hosted para Claude Code · Codex · Gemini · shell — com uma camada de memória local-first compartilhada entre todos eles.</strong>
+  <br/>
+  <sub>Rode sessões na sua própria infra. Controle pelo navegador, celular ou chat. API aberta REST + WebSocket para integrações.</sub>
+</p>
+
+<p align="center">
+  <strong><a href="https://opendray.dev">🌐 opendray.dev</a></strong>
+</p>
+
+<p align="center">
+  <a href="https://opendray.dev"><img alt="Website" src="https://img.shields.io/badge/website-opendray.dev-F43F5E"></a>
+  <a href="https://github.com/Opendray/opendray/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/Opendray/opendray?label=release&color=4f46e5"></a>
+  <a href="LICENSE"><img alt="License Apache 2.0" src="https://img.shields.io/github/license/Opendray/opendray?color=blue"></a>
+  <a href="https://github.com/Opendray/opendray/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/Opendray/opendray/ci.yml?branch=main&label=CI"></a>
+  <a href="https://github.com/Opendray/opendray/discussions"><img alt="Discussions" src="https://img.shields.io/github/discussions/Opendray/opendray?color=ec4899"></a>
+  <br/>
+  <img alt="Go" src="https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white">
+  <img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black">
+  <img alt="Flutter" src="https://img.shields.io/badge/Flutter-mobile-02569B?logo=flutter&logoColor=white">
+  <img alt="Postgres" src="https://img.shields.io/badge/PostgreSQL-15%2F16%2F17-336791?logo=postgresql&logoColor=white">
+</p>
+
+<p align="center">
+  🌐 <a href="README.md">English</a> · <a href="README.zh.md">简体中文</a> · <a href="README.fa.md">فارسی</a> · <a href="README.es.md">Español</a> · <strong>Português</strong> · <a href="README.ja.md">日本語</a> · <a href="README.ko.md">한국어</a> · <a href="README.fr.md">Français</a> · <a href="README.de.md">Deutsch</a> · <a href="README.ru.md">Русский</a>
+</p>
+
+---
+
+## O que é o opendray?
+
+O **opendray** encapsula as CLIs de coding com IA que você já usa — Claude Code, Codex, Gemini, mais qualquer shell — e transforma elas em algo que dá pra controlar de qualquer lugar. Rode sessões no seu servidor de casa / NAS / VPS, receba uma notificação no Telegram quando uma delas ficar ociosa, responda do celular pra mandar o próximo prompt — tudo isso através de um gateway self-hosted que você controla de ponta a ponta.
+
+- 🛰 **Um backend, três superfícies** — um único binário Go que serve um painel web em React e um app mobile em Flutter, com toda ação também exposta numa API REST + WebSocket pra integrações de terceiros.
+- 💬 **Seis canais bidirecionais, sem jardim murado** — Telegram, Slack, Discord, Feishu (飞书), DingTalk (钉钉), WeCom (企业微信), mais um adaptador Bridge pra qualquer coisa custom. Respostas em qualquer canal são roteadas de volta pra sessão certa.
+- 🧠 **Memória local-first** — embeddings via ONNX / Ollama / LM Studio, retrieval em três escopos (usuário · projeto · sessão), ranking inteligente e detecção de conflito entre camadas. Nenhum dado vetorial sai da sua rede.
+- 🔌 **API de nível integração** — API keys com scope, audit log por chamada, mounts de reverse-proxy. Trate o opendray como o gateway por trás do seu próprio produto, ou só como uma central de comando pessoal.
+- 🔑 **Frota multi-conta do Claude** — coloque várias contas de `claude login` no gateway; o painel descobre elas automaticamente via filesystem watcher, balanceia as novas sessões entre as contas habilitadas, e te deixa trocar a conta de uma sessão em execução **sem perder a conversa** (o transcript é migrado por baixo dos panos). Cada linha de conta mostra a capacidade em tempo real (subscription tier, rate-limit tier, sessões ativas, último uso, email do Anthropic atual) pra você escolher a certa de bate-pronto.
+- 🔒 **Self-hosted, licença clara** — Apache 2.0, um único binário estático, releases assinadas com cosign e SBOM SPDX. Sem telemetria, sem conta na nuvem, sem assinatura.
+
+## Status
+
+**v2.5.0** (último) — a geração v2 segue iterando. Veja
+[`VERSIONING.md`](VERSIONING.md) pra política major-como-geração
+(major = geração de produto, não "breaking change" estrito ao estilo SemVer) e
+[`CHANGELOG.md`](CHANGELOG.md) pro histórico completo de releases.
+
+Esta geração entrega:
+
+- **Wizards de instalação e desinstalação em uma linha** (Linux + macOS;
+  Windows passa por WSL2). Guiam o operador pelo bootstrap do Postgres,
+  instalação das AI-CLIs, credenciais de admin, endereço de escuta,
+  instalação do binário, migração do schema e registro do serviço.
+- **Binário autogerenciável** — `opendray update / start / stop /
+  restart / status / providers list / providers update`, pra que os operadores
+  não precisem encostar em `systemctl` / `launchctl` no dia a dia.
+- **Pipeline de release com Goreleaser** — binários cross-compilados
+  (linux/darwin × amd64/arm64), assinatura keyless com cosign (Sigstore),
+  SBOM SPDX, self-update verificado atomicamente.
+
+## Instalação
+
+### Instalador de uma linha
+
+**Linux / macOS / WSL2**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh | bash
+```
+
+**Windows** — configura o WSL2 primeiro e depois roda o instalador do Linux por dentro. [detalhes →](scripts/README.md#windows)
+
+```powershell
+irm https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install-windows.ps1 | iex
+```
+
+Passa pela configuração do Postgres, instalação das AI-CLIs, credenciais de admin e registro do serviço — deixando o gateway rodando em ~5-10 minutos. Veja [**`scripts/README.md`**](scripts/README.md) pra entender o que o wizard faz, o layout de arquivos que ele cria, as opções e troubleshooting.
+
+> **Prefere fazer o passo a passo manual?** Leia [**docs/getting-started.md**](docs/getting-started.md) — um guia de 15 minutos de ponta a ponta que espelha o que o wizard faz, pra você conferir cada etapa por conta própria.
+
+### Desinstalação (Linux / macOS)
+
+**Padrão** — para o gateway e remove o binário, mas **mantém** seu `config.toml`, o diretório de dados (keyfile bcrypt, sessões, notas, vault), os logs e o banco PostgreSQL pra que uma reinstalação retome de onde você parou:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | bash
+```
+
+**Purge completo** — também dropa o banco PG + a role, apaga config / data / logs e remove o service user. Inclui um passo de verificação pós-remoção que falha barulhento se algo sobreviver:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
+```
+
+### Comandos do dia a dia
+
+Depois da instalação, o binário `opendray` cuida do próprio ciclo de vida — sem precisar decorar os encantamentos de `systemctl` / `launchctl`:
+
+```sh
+sudo opendray update --restart   # download latest release, verify SHA, atomic replace + restart
+```
+
+```sh
+sudo opendray providers update   # bump installed AI CLIs (claude / codex / gemini) to npm-latest
+```
+
+```sh
+opendray providers list          # see which AI CLIs are installed + their versions
+```
+
+```sh
+sudo opendray start              # start | stop | restart | status — wraps systemd / launchd
+```
+
+`opendray --help` lista o conjunto completo de subcomandos.
+
+### Escolha do caminho de deploy
+
+Todo caminho suportado inclui spawn de sessões, acesso às AI-CLIs, backups criptografados e a API de integração completa. O opendray é um gateway host-resident — ele spawna as AI CLIs via PTYs e compartilha estado de processo (`~/.claude`, ssh-agent, arquivos do projeto) com elas. Esse modelo é incompatível com o isolamento de container que o Docker de produção imporia, então o Docker não é um caminho de deploy suportado na v2.x.
+
+| Caminho | Recomendado pra | Ir pra |
+|---|---|---|
+| 📦 **Binário pré-buildado** | "Só rodar" — Linux / macOS, qualquer supervisor | [Página de releases](https://github.com/Opendray/opendray/releases) → veja [Deploy de produção](#production-deploy) |
+| 🐧 **Unit systemd** | Linux bare-metal / VM / LXC | [Deploy de produção §A](#option-a--systemd-bare-metal--vm--lxc) |
+| 🍎 **LaunchDaemon do macOS** | Mac mini / Mac Studio como servidor doméstico | [Deploy de produção §C](#option-c--macos-launchd-mac-mini--studio-as-home-server) |
+| 🛠 **Build a partir do código-fonte** | Desenvolvimento / contribuição / builds custom | [Quickstart](#quickstart-5-minute-dev-path) abaixo |
+
+## Quickstart (caminho dev de 5 minutos)
+
+Pra um passo a passo completo com pré-requisitos e troubleshooting, veja [`docs/quickstart.md`](docs/quickstart.md). A versão condensada do caminho de dev:
+
+```bash
+# 1. Have a Postgres 15+ running on 127.0.0.1:5432 with pgvector enabled
+#    (apt install postgresql-16 postgresql-16-pgvector / brew install postgresql@16 pgvector).
+#    Point [database].url at any other DSN if you'd rather use a remote PG.
+
+# 2. Local config — already gitignored.
+cp config.example.toml config.toml
+$EDITOR config.toml          # set [database].url, [admin].password
+
+# 3. Build the web bundle into the embed tree.
+cd app/web && pnpm install && pnpm build && cd ../..
+
+# 4. Apply schema.
+go run ./cmd/opendray migrate -config config.toml
+
+# 5. Run.
+go run ./cmd/opendray serve -config config.toml
+# → REST + WS:  http://127.0.0.1:8770/api/v1/...
+# → Web admin:  http://127.0.0.1:8770/admin/
+```
+
+Isso roda o OpenDray em foreground — Ctrl-C derruba. Pra um daemon de longa duração, veja **Deploy de produção** abaixo.
+
+## Deploy de produção
+
+Quatro caminhos de deploy suportados; escolha o que casar com o seu ambiente.
+Cada um te dá auto-restart em caso de crash, estado persistente e
+separação dos segredos em relação ao config.
+
+### Opção A — systemd (bare-metal / VM / LXC)
+
+O caminho de deploy recomendado no Linux. Vem com uma unit endurecida em
+[`deploy/systemd/opendray.service`](deploy/systemd/opendray.service)
+com sandboxing (`ProtectSystem=strict`, `NoNewPrivileges`,
+`MemoryDenyWriteExecute`, capability scrub), boot no esquema
+`migrate`-depois-`serve`, e uma janela de graceful-stop de 20s.
+
+**Pegue um binário primeiro.** Ou baixe um arquivo pré-buildado da
+[página de releases](https://github.com/Opendray/opendray/releases)
+(`opendray_*_linux_<arch>.tar.gz` — descompacta num único binário `opendray`),
+ou builde do código-fonte pelo [Quickstart](#quickstart-5-minute-dev-path)
+acima (`go build ./cmd/opendray`).
+
+```bash
+# 1. Install the binary you just grabbed (or built).
+sudo install -m 0755 /path/to/opendray /usr/local/bin/opendray
+
+# 2. Create the service user + state dir.
+sudo useradd -r -s /usr/sbin/nologin -d /var/lib/opendray opendray
+sudo install -d -o opendray -g opendray -m 0700 /var/lib/opendray
+
+# 3. Drop config + secrets (root-owned; mode 0640).
+sudo install -D -m 0640 config.example.toml /etc/opendray/config.toml
+sudo $EDITOR /etc/opendray/config.toml             # set [database].url etc.
+sudo install -D -m 0640 -o root -g opendray /dev/null /etc/opendray/env.d/secrets
+sudo $EDITOR /etc/opendray/env.d/secrets           # OPENDRAY_ADMIN_PASSWORD=…
+
+# 4. Install + enable the unit.
+sudo cp deploy/systemd/opendray.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now opendray
+
+# 5. Verify.
+sudo systemctl status opendray
+sudo journalctl -u opendray -f --no-pager
+```
+
+A unit roda `opendray migrate` como `ExecStartPre`, então o primeiro boot
+aplica todas as migrations antes de o `serve` subir. Os restarts são
+`on-failure` com back-off de 5s e limite de 5 rajadas por minuto.
+
+### Opção B — Binário direto + seu próprio supervisor de processos
+
+Pra LXC sem systemd, FreeBSD `rc.d`, OpenRC, ou qualquer outra coisa.
+Builde uma vez, rode com o supervisor que você já usa:
+
+```bash
+# Cross-compile a release archive locally:
+goreleaser release --clean --snapshot
+ls dist/                  # opendray_*_linux_amd64.tar.gz etc.
+
+# Or grab a published release artefact:
+# https://github.com/Opendray/opendray/releases
+```
+
+Depois aponta seu supervisor (s6, runit, supervisord, runwhen) pra:
+
+```
+/usr/local/bin/opendray serve -config /etc/opendray/config.toml
+```
+
+Pré-flight: rode `opendray migrate -config /etc/opendray/config.toml`
+uma vez antes do primeiro `serve`, ou como hook de pre-start no supervisor
+que você preferir.
+
+### Opção C — launchd no macOS (Mac mini / Studio como servidor doméstico)
+
+Pra Mac mini / Mac Studio com Apple Silicon rodando 24/7. Vem com um
+LaunchDaemon em
+[`deploy/launchd/com.opendray.opendray.plist`](deploy/launchd/com.opendray.opendray.plist)
+que sobe no boot antes de qualquer login de usuário, reinicia em caso de crash com
+throttle de 5s, e loga em `/usr/local/var/log/opendray/`.
+
+```bash
+# 1. Install the darwin binary + config + state dirs.
+sudo install -m 0755 ./opendray /usr/local/bin/opendray
+sudo install -d -m 0755 \
+  /usr/local/etc/opendray \
+  /usr/local/var/lib/opendray \
+  /usr/local/var/log/opendray
+sudo install -m 0640 config.example.toml /usr/local/etc/opendray/config.toml
+sudo $EDITOR /usr/local/etc/opendray/config.toml    # set [database].url etc.
+
+# 2. Apply migrations once.
+sudo /usr/local/bin/opendray migrate \
+  -config /usr/local/etc/opendray/config.toml
+
+# 3. Install + load the LaunchDaemon.
+sudo cp deploy/launchd/com.opendray.opendray.plist /Library/LaunchDaemons/
+sudo chown root:wheel /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo chmod 0644 /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.opendray.opendray.plist
+
+# 4. Verify.
+sudo launchctl print system/com.opendray.opendray
+tail -f /usr/local/var/log/opendray/opendray.log
+```
+
+Reinicie com `sudo launchctl kickstart -k system/com.opendray.opendray`;
+desmonte por completo com `sudo launchctl bootout system/com.opendray.opendray`.
+
+Postgres no macOS — instale via Homebrew (`brew install postgresql@17 && brew services start postgresql@17`) e aponte `[database].url` pra
+`postgres://$USER@127.0.0.1:5432/opendray`. Adicione o `pgvector` com
+`brew install pgvector` e rode `CREATE EXTENSION vector` dentro do banco
+do opendray.
+
+---
+
+Pra notas específicas de LXC no Proxmox (PTY em containers unprivileged,
+networking, ajustes de cgroup), veja [`deploy/lxc/proxmox-pty-notes.md`](deploy/lxc/proxmox-pty-notes.md).
+
+Pra reverse-proxy / terminação TLS (nginx, Caddy, Traefik, Cloudflare
+Tunnel), veja [`docs/operator-guide.md`](docs/operator-guide.md) §Topology.
+
+### Opcional: habilitar backups criptografados do DB + exports de dados
+
+```bash
+# Master passphrase (env-only — never write into config.toml).
+export OPENDRAY_BACKUP_KEY="$(openssl rand -base64 32)"
+export OPENDRAY_BACKUP_ENABLED=1
+
+# pg_dump / pg_restore must match the server's major version. On
+# Apple Silicon dev machines pointing at a PG17 server:
+export OPENDRAY_BACKUP_PG_DUMP_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_dump
+export OPENDRAY_BACKUP_PG_RESTORE_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_restore
+```
+
+Reinicie o opendray; o sidebar ganha uma página de Backups (`/backups`)
+pra dumps criptografados do PostgreSQL + restore, e `/export` pra
+exports de dados em bundle zip + import. Veja [`docs/operator-guide.md`](docs/operator-guide.md) §Backup pro ciclo completo.
+
+Um único binário Go carrega o bundle web inteiro — sem runtime de Node em
+runtime, sem servidor de arquivos estáticos separado, sem Caddy/nginx
+necessários. O Cloudflare Tunnel termina TLS na frente do `:8770`.
+
+## Layout
+
+```
+cmd/opendray/        binary entry point (≤100 LOC per design §14)
+internal/
+├── app/             composition root (wires every subsystem)
+├── audit/           subscribes to bus topics, persists to audit_log
+├── auth/            admin bearer tokens (M2.5)
+├── backup/          encrypted DB dumps + admin export/import├── catalog/         CLI provider manifests + per-id user config (M2)
+├── channel/         channel hub + telegram impl (M4)
+├── config/          TOML loader with OPENDRAY_* env overrides
+├── eventbus/        in-process pub/sub
+├── gateway/         chi HTTP router + middleware + slog
+├── integration/     external-app registry + reverse proxy + events WS (M3)
+├── memory/          cross-CLI persistent memory├── session/         PTY lifecycle + ring buffer + WS stream (M1)
+├── store/           pgx pool + hand-rolled migration runner (M0)
+├── version/         build-time identification
+└── web/             go:embed of the web bundle (W5)
+
+app/web/             React 19 + TypeScript + Vite SPA (Phase 2 W0-W5)
+app/mobile/          Flutter app (iOS + Android), feature parity with web
+docs/
+├── design.md        SSOT north-star
+└── adr/             architecture decisions, dated
+```
+
+## Frontend web
+
+O `app/web/` builda uma SPA única em `internal/web/dist/`, que o binário Go
+embeda e serve em `/admin/*`. O dev server do Vite em `:5173` faz proxy de
+`/api` pra `:8770` pra desenvolvimento com HMR.
+
+```bash
+# dev (hot reload on the React side, separate Go server for the API)
+cd app/web && pnpm dev               # http://localhost:5173
+go run ./cmd/opendray serve -config ../../config.toml   # other terminal
+
+# prod (one binary delivers everything)
+cd app/web && pnpm build              # writes ../../internal/web/dist
+cd ../..
+go build ./cmd/opendray               # bakes dist into the binary
+./opendray serve -config config.toml
+```
+
+Veja [`app/web/README.md`](app/web/README.md) pro stack do frontend
+(React + Vite + Tailwind v4 + shadcn/ui + TanStack Router/Query +
+Zustand + xterm.js) e notas por milestone W.
+
+## Documentação
+
+- [`docs/getting-started.md`](docs/getting-started.md) — **comece por aqui** se você é novo: do zero até a primeira sessão em 15 minutos, incluindo a instalação das CLIs encapsuladas e o bootstrap do Postgres
+- [`docs/quickstart.md`](docs/quickstart.md) — ambiente de dev em 5 minutos (assume que você já conhece as peças)
+- [`docs/operator-guide.md`](docs/operator-guide.md) — referência de deploy + ops pra setups mais próximos de produção
+- [`docs/integration-guide.md`](docs/integration-guide.md) — como escrever uma integração externa em qualquer linguagem
+- [`VERSIONING.md`](VERSIONING.md) — estratégia de versionamento (major-as-generation)
+- [`CHANGELOG.md`](CHANGELOG.md) — histórico de releases
+
+## Tests
+
+```bash
+go test -race ./...        # backend
+cd app/web && pnpm build   # web (TS strict + vite production build)
+```
+
+Os smoke flows end-to-end são acompanhados nos commit messages por milestone.
+Um harness Playwright está planejado como follow-up.
+
+## Relação com a v1
+
+A v1 (`Opendray/opendray`) é o codebase legado, agora arquivado. A v2 é
+a geração atual e ativa — feature-complete e o único branch recebendo
+desenvolvimento. Dos 16 builtins da v1, quatro migraram pro backend da
+v2; o resto virou feature client-side, adaptador de canal ou consumidor
+da API de integração.
+
+## Licença
+
+Apache 2.0 — veja [`LICENSE`](LICENSE). (A v1 era MIT; a v2 é licenciada
+de forma independente.)

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,383 @@
+<p align="center">
+  <a href="https://opendray.dev"><img src="docs/assets/logo.png" alt="opendray" width="180"></a>
+</p>
+
+<h1 align="center">opendray</h1>
+
+<p align="center">
+  <strong>Self-hosted шлюз для Claude Code · Codex · Gemini · shell — с единым local-first слоем памяти, общим для всех инструментов.</strong>
+  <br/>
+  <sub>Запускайте сессии на собственной инфраструктуре. Управляйте из веба, с мобильного или из чата. Открытый REST + WebSocket API для интеграций.</sub>
+</p>
+
+<p align="center">
+  <strong><a href="https://opendray.dev">🌐 opendray.dev</a></strong>
+</p>
+
+<p align="center">
+  <a href="https://opendray.dev"><img alt="Website" src="https://img.shields.io/badge/website-opendray.dev-F43F5E"></a>
+  <a href="https://github.com/Opendray/opendray/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/Opendray/opendray?label=release&color=4f46e5"></a>
+  <a href="LICENSE"><img alt="License Apache 2.0" src="https://img.shields.io/github/license/Opendray/opendray?color=blue"></a>
+  <a href="https://github.com/Opendray/opendray/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/Opendray/opendray/ci.yml?branch=main&label=CI"></a>
+  <a href="https://github.com/Opendray/opendray/discussions"><img alt="Discussions" src="https://img.shields.io/github/discussions/Opendray/opendray?color=ec4899"></a>
+  <br/>
+  <img alt="Go" src="https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white">
+  <img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black">
+  <img alt="Flutter" src="https://img.shields.io/badge/Flutter-mobile-02569B?logo=flutter&logoColor=white">
+  <img alt="Postgres" src="https://img.shields.io/badge/PostgreSQL-15%2F16%2F17-336791?logo=postgresql&logoColor=white">
+</p>
+
+<p align="center">
+  🌐 <a href="README.md">English</a> · <a href="README.zh.md">简体中文</a> · <a href="README.fa.md">فارسی</a> · <a href="README.es.md">Español</a> · <a href="README.pt-BR.md">Português</a> · <a href="README.ja.md">日本語</a> · <a href="README.ko.md">한국어</a> · <a href="README.fr.md">Français</a> · <a href="README.de.md">Deutsch</a> · <strong>Русский</strong>
+</p>
+
+---
+
+## Что такое opendray?
+
+**opendray** оборачивает AI-CLI для кодинга, которыми вы уже пользуетесь — Claude Code, Codex, Gemini, плюс любой shell — и превращает их в то, чем можно управлять откуда угодно. Запускайте сессии на домашнем сервере / NAS / VPS, получайте уведомление в Telegram, когда сессия простаивает, отвечайте с телефона, чтобы скормить следующий промпт обратно — всё через self-hosted шлюз, который вы контролируете от и до.
+
+- 🛰 **Один бэкенд, три поверхности** — единый Go-бинарник раздаёт React-админку и Flutter-приложение, а каждое действие также доступно через REST + WebSocket API для сторонних интеграций.
+- 💬 **Шесть двусторонних каналов, без огороженных садов** — Telegram, Slack, Discord, Feishu (飞书), DingTalk (钉钉), WeCom (企业微信), плюс адаптер Bridge для чего угодно кастомного. Ответы в любом канале маршрутизируются обратно в нужную сессию.
+- 🧠 **Local-first память** — эмбеддинги через ONNX / Ollama / LM Studio, поиск в трёх скоупах (пользователь · проект · сессия), умный ranking и детект конфликтов между слоями. Векторные данные не покидают вашу сеть.
+- 🔌 **API уровня интеграции** — scoped API-ключи, аудит-лог по каждому вызову, маунты через reverse-proxy. Используйте opendray как шлюз за вашим собственным продуктом или просто как личный командный центр.
+- 🔑 **Флот из нескольких Claude-аккаунтов** — подкладывайте в шлюз несколько аккаунтов `claude login`; панель автоматически подхватывает их через filesystem watcher, балансирует новые сессии между активными аккаунтами и позволяет переключить живую сессию между аккаунтами **без потери разговора** (транскрипт мигрируется под капотом). В каждой строке аккаунта видна актуальная загрузка (subscription tier, rate-limit tier, активные сессии, время последнего использования, текущий email Anthropic), чтобы выбрать нужный одним взглядом.
+- 🔒 **Self-hosted, лицензия прозрачная** — Apache 2.0, один статический бинарник, релизы подписаны cosign, плюс SPDX SBOM. Без телеметрии, без облачного аккаунта, без подписки.
+
+## Статус
+
+**v2.5.0** (последний) — поколение v2 продолжает итерироваться. См.
+[`VERSIONING.md`](VERSIONING.md) для политики major-как-поколение
+(major = поколение продукта, а не строгий SemVer "breaking change") и
+[`CHANGELOG.md`](CHANGELOG.md) для полной истории релизов.
+
+В это поколение входит:
+
+- **Однострочные мастера установки и удаления** (Linux + macOS;
+  Windows проходит через WSL2). Проводят оператора через bootstrap
+  Postgres, установку AI-CLI, учётные данные админа, адрес прослушивания,
+  установку бинарника, миграцию схемы и регистрацию сервиса.
+- **Самообслуживаемый бинарник** — `opendray update / start / stop /
+  restart / status / providers list / providers update`, чтобы операторы
+  не лезли в `systemctl` / `launchctl` ради рутинных операций.
+- **Релизный пайплайн на Goreleaser** — кросс-компилируемые бинарники
+  (linux/darwin × amd64/arm64), keyless-подпись cosign (Sigstore),
+  SPDX SBOM, атомарно верифицируемый self-update.
+
+## Установка
+
+### Однострочный установщик
+
+**Linux / macOS / WSL2**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh | bash
+```
+
+**Windows** — сначала поднимает WSL2, а затем запускает Linux-инсталлятор внутри него. [подробнее →](scripts/README.md#windows)
+
+```powershell
+irm https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install-windows.ps1 | iex
+```
+
+Проводит через настройку Postgres, установку AI-CLI, учётные данные админа и регистрацию сервиса — поднимает рабочий шлюз примерно за 5–10 минут. См. [**`scripts/README.md`**](scripts/README.md) — что именно делает мастер, какую раскладку файлов он создаёт, доступные опции и troubleshooting.
+
+> **Хотите пройти всё руками?** Прочитайте [**docs/getting-started.md**](docs/getting-started.md) — 15-минутный сквозной гайд, который повторяет действия мастера, чтобы вы могли проверить каждый шаг самостоятельно.
+
+### Удаление (Linux / macOS)
+
+**По умолчанию** — останавливает шлюз и удаляет бинарник, но **сохраняет** ваш `config.toml`, директорию с данными (bcrypt keyfile, сессии, заметки, vault), логи и базу PostgreSQL, чтобы переустановка продолжила с того же места:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | bash
+```
+
+**Полная очистка** — дополнительно сносит базу PG и роль, удаляет config / data / logs, убирает сервисного пользователя. Включает пост-проверку, которая громко падает, если что-то выжило:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
+```
+
+### Повседневные команды
+
+После установки бинарник `opendray` сам управляет своим жизненным циклом — не нужно вспоминать заклинания `systemctl` / `launchctl`:
+
+```sh
+sudo opendray update --restart   # download latest release, verify SHA, atomic replace + restart
+```
+
+```sh
+sudo opendray providers update   # bump installed AI CLIs (claude / codex / gemini) to npm-latest
+```
+
+```sh
+opendray providers list          # see which AI CLIs are installed + their versions
+```
+
+```sh
+sudo opendray start              # start | stop | restart | status — wraps systemd / launchd
+```
+
+`opendray --help` показывает полный набор подкоманд.
+
+### Выбор способа развёртывания
+
+Любой поддерживаемый путь включает спавн сессий, доступ к AI-CLI, шифрованные бэкапы и полный API интеграций. opendray — это host-resident шлюз: он спавнит AI-CLI через PTY и делит состояние процесса (`~/.claude`, ssh-agent, файлы проекта) с ними. Такая модель несовместима с изоляцией контейнеров, которую навязал бы продакшен Docker, поэтому Docker не является поддерживаемым способом развёртывания в v2.x.
+
+| Путь | Подходит для | Перейти к |
+|---|---|---|
+| 📦 **Готовый бинарник** | "Просто запусти" — Linux / macOS, любой супервизор | [Страница релизов](https://github.com/Opendray/opendray/releases) → см. [Развёртывание в продакшене](#production-deploy) |
+| 🐧 **systemd-юнит** | Bare-metal / VM / LXC-машина на Linux | [Развёртывание в продакшене §A](#option-a--systemd-bare-metal--vm--lxc) |
+| 🍎 **LaunchDaemon на macOS** | Mac mini / Mac Studio как домашний сервер | [Развёртывание в продакшене §C](#option-c--macos-launchd-mac-mini--studio-as-home-server) |
+| 🛠 **Сборка из исходников** | Разработка / контрибьют / кастомные сборки | [Quickstart](#quickstart-5-minute-dev-path) ниже |
+
+## Quickstart (dev-путь за 5 минут)
+
+Полный walkthrough с пререквизитами и troubleshooting — в [`docs/quickstart.md`](docs/quickstart.md). Сжатый dev-путь:
+
+```bash
+# 1. Have a Postgres 15+ running on 127.0.0.1:5432 with pgvector enabled
+#    (apt install postgresql-16 postgresql-16-pgvector / brew install postgresql@16 pgvector).
+#    Point [database].url at any other DSN if you'd rather use a remote PG.
+
+# 2. Local config — already gitignored.
+cp config.example.toml config.toml
+$EDITOR config.toml          # set [database].url, [admin].password
+
+# 3. Build the web bundle into the embed tree.
+cd app/web && pnpm install && pnpm build && cd ../..
+
+# 4. Apply schema.
+go run ./cmd/opendray migrate -config config.toml
+
+# 5. Run.
+go run ./cmd/opendray serve -config config.toml
+# → REST + WS:  http://127.0.0.1:8770/api/v1/...
+# → Web admin:  http://127.0.0.1:8770/admin/
+```
+
+Так OpenDray работает на переднем плане — Ctrl-C его убивает. Для долгоживущего демона смотрите **Развёртывание в продакшене** ниже.
+
+## Развёртывание в продакшене
+
+Четыре поддерживаемых способа развёртывания, выбирайте подходящий под ваше окружение.
+Каждый даёт авто-рестарт при крэше, персистентное состояние и
+разделение секретов и конфига.
+
+### Вариант A — systemd (bare-metal / VM / LXC)
+
+Рекомендуемый способ деплоя в Linux. Поставляется захардененный юнит в
+[`deploy/systemd/opendray.service`](deploy/systemd/opendray.service)
+с sandboxing (`ProtectSystem=strict`, `NoNewPrivileges`,
+`MemoryDenyWriteExecute`, очистка capabilities), порядком запуска
+`migrate`-затем-`serve` и окном graceful-stop в 20 секунд.
+
+**Сначала добудьте бинарник.** Либо скачайте готовый архив со
+[страницы релизов](https://github.com/Opendray/opendray/releases)
+(`opendray_*_linux_<arch>.tar.gz` — распаковывается в единственный
+бинарник `opendray`), либо соберите из исходников через [Quickstart](#quickstart-5-minute-dev-path)
+выше (`go build ./cmd/opendray`).
+
+```bash
+# 1. Install the binary you just grabbed (or built).
+sudo install -m 0755 /path/to/opendray /usr/local/bin/opendray
+
+# 2. Create the service user + state dir.
+sudo useradd -r -s /usr/sbin/nologin -d /var/lib/opendray opendray
+sudo install -d -o opendray -g opendray -m 0700 /var/lib/opendray
+
+# 3. Drop config + secrets (root-owned; mode 0640).
+sudo install -D -m 0640 config.example.toml /etc/opendray/config.toml
+sudo $EDITOR /etc/opendray/config.toml             # set [database].url etc.
+sudo install -D -m 0640 -o root -g opendray /dev/null /etc/opendray/env.d/secrets
+sudo $EDITOR /etc/opendray/env.d/secrets           # OPENDRAY_ADMIN_PASSWORD=…
+
+# 4. Install + enable the unit.
+sudo cp deploy/systemd/opendray.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now opendray
+
+# 5. Verify.
+sudo systemctl status opendray
+sudo journalctl -u opendray -f --no-pager
+```
+
+Юнит запускает `opendray migrate` в `ExecStartPre`, так что первый
+старт применит все миграции до того, как `serve` вообще начнёт работать.
+Рестарты — `on-failure` с back-off 5 секунд и лимитом 5 попыток в минуту.
+
+### Вариант B — Прямой бинарник + ваш собственный супервизор процессов
+
+Для LXC без systemd, FreeBSD `rc.d`, OpenRC или чего угодно ещё.
+Собрали один раз — запускайте под тем супервизором, которым уже пользуетесь:
+
+```bash
+# Cross-compile a release archive locally:
+goreleaser release --clean --snapshot
+ls dist/                  # opendray_*_linux_amd64.tar.gz etc.
+
+# Or grab a published release artefact:
+# https://github.com/Opendray/opendray/releases
+```
+
+Затем направьте свой супервизор (s6, runit, supervisord, runwhen) на:
+
+```
+/usr/local/bin/opendray serve -config /etc/opendray/config.toml
+```
+
+Pre-flight: один раз перед первым `serve` запустите
+`opendray migrate -config /etc/opendray/config.toml`, либо повесьте
+это в pre-start хук вашего супервизора.
+
+### Вариант C — macOS launchd (Mac mini / Studio как домашний сервер)
+
+Для Mac mini / Mac Studio на Apple Silicon, работающих 24/7. Поставляется
+LaunchDaemon в
+[`deploy/launchd/com.opendray.opendray.plist`](deploy/launchd/com.opendray.opendray.plist),
+который стартует при загрузке до логина любого пользователя,
+рестартит при крэше с throttle 5 секунд и пишет логи в
+`/usr/local/var/log/opendray/`.
+
+```bash
+# 1. Install the darwin binary + config + state dirs.
+sudo install -m 0755 ./opendray /usr/local/bin/opendray
+sudo install -d -m 0755 \
+  /usr/local/etc/opendray \
+  /usr/local/var/lib/opendray \
+  /usr/local/var/log/opendray
+sudo install -m 0640 config.example.toml /usr/local/etc/opendray/config.toml
+sudo $EDITOR /usr/local/etc/opendray/config.toml    # set [database].url etc.
+
+# 2. Apply migrations once.
+sudo /usr/local/bin/opendray migrate \
+  -config /usr/local/etc/opendray/config.toml
+
+# 3. Install + load the LaunchDaemon.
+sudo cp deploy/launchd/com.opendray.opendray.plist /Library/LaunchDaemons/
+sudo chown root:wheel /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo chmod 0644 /Library/LaunchDaemons/com.opendray.opendray.plist
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.opendray.opendray.plist
+
+# 4. Verify.
+sudo launchctl print system/com.opendray.opendray
+tail -f /usr/local/var/log/opendray/opendray.log
+```
+
+Рестарт — `sudo launchctl kickstart -k system/com.opendray.opendray`;
+полная выгрузка — `sudo launchctl bootout system/com.opendray.opendray`.
+
+Postgres на macOS — ставится через Homebrew (`brew install postgresql@17 && brew services start postgresql@17`), а `[database].url` направляется на
+`postgres://$USER@127.0.0.1:5432/opendray`. Добавьте `pgvector` командой
+`brew install pgvector` и выполните `CREATE EXTENSION vector` внутри
+базы opendray.
+
+---
+
+По специфике LXC в Proxmox (PTY в unprivileged-контейнерах,
+сеть, тюнинг cgroup) — см. [`deploy/lxc/proxmox-pty-notes.md`](deploy/lxc/proxmox-pty-notes.md).
+
+По reverse-proxy / терминации TLS (nginx, Caddy, Traefik, Cloudflare
+Tunnel) — см. [`docs/operator-guide.md`](docs/operator-guide.md) §Topology.
+
+### Опционально: включить шифрованные бэкапы БД + экспорт данных
+
+```bash
+# Master passphrase (env-only — never write into config.toml).
+export OPENDRAY_BACKUP_KEY="$(openssl rand -base64 32)"
+export OPENDRAY_BACKUP_ENABLED=1
+
+# pg_dump / pg_restore must match the server's major version. On
+# Apple Silicon dev machines pointing at a PG17 server:
+export OPENDRAY_BACKUP_PG_DUMP_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_dump
+export OPENDRAY_BACKUP_PG_RESTORE_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_restore
+```
+
+Перезапустите opendray; в сайдбаре появится страница Backups (`/backups`)
+для шифрованных дампов PostgreSQL и restore, а также `/export` для
+экспорта данных в zip-bundle и импорта. Полный жизненный цикл — в
+[`docs/operator-guide.md`](docs/operator-guide.md) §Backup.
+
+Один Go-бинарник несёт весь веб-бандл — никакого Node-рантайма во время
+работы, отдельного сервера статики или Caddy/nginx не требуется.
+Cloudflare Tunnel терминирует TLS перед `:8770`.
+
+## Раскладка
+
+```
+cmd/opendray/        binary entry point (≤100 LOC per design §14)
+internal/
+├── app/             composition root (wires every subsystem)
+├── audit/           subscribes to bus topics, persists to audit_log
+├── auth/            admin bearer tokens (M2.5)
+├── backup/          encrypted DB dumps + admin export/import├── catalog/         CLI provider manifests + per-id user config (M2)
+├── channel/         channel hub + telegram impl (M4)
+├── config/          TOML loader with OPENDRAY_* env overrides
+├── eventbus/        in-process pub/sub
+├── gateway/         chi HTTP router + middleware + slog
+├── integration/     external-app registry + reverse proxy + events WS (M3)
+├── memory/          cross-CLI persistent memory├── session/         PTY lifecycle + ring buffer + WS stream (M1)
+├── store/           pgx pool + hand-rolled migration runner (M0)
+├── version/         build-time identification
+└── web/             go:embed of the web bundle (W5)
+
+app/web/             React 19 + TypeScript + Vite SPA (Phase 2 W0-W5)
+app/mobile/          Flutter app (iOS + Android), feature parity with web
+docs/
+├── design.md        SSOT north-star
+└── adr/             architecture decisions, dated
+```
+
+## Веб-фронтенд
+
+`app/web/` собирается в единую SPA в `internal/web/dist/`, которую Go-бинарник
+встраивает через `go:embed` и раздаёт по `/admin/*`. Dev-сервер Vite на `:5173`
+проксирует `/api` на `:8770` для разработки с HMR.
+
+```bash
+# dev (hot reload on the React side, separate Go server for the API)
+cd app/web && pnpm dev               # http://localhost:5173
+go run ./cmd/opendray serve -config ../../config.toml   # other terminal
+
+# prod (one binary delivers everything)
+cd app/web && pnpm build              # writes ../../internal/web/dist
+cd ../..
+go build ./cmd/opendray               # bakes dist into the binary
+./opendray serve -config config.toml
+```
+
+См. [`app/web/README.md`](app/web/README.md) — там стек фронтенда
+(React + Vite + Tailwind v4 + shadcn/ui + TanStack Router/Query +
+Zustand + xterm.js) и заметки по W-майлстоунам.
+
+## Документация
+
+- [`docs/getting-started.md`](docs/getting-started.md) — **начинайте отсюда**, если вы новичок: от нуля до первой сессии за 15 минут, включая установку оборачиваемых CLI и bootstrap Postgres
+- [`docs/quickstart.md`](docs/quickstart.md) — dev-окружение за 5 минут (предполагается, что вы уже знаете, из чего всё состоит)
+- [`docs/operator-guide.md`](docs/operator-guide.md) — справочник по деплою и эксплуатации для околопродакшен-сетапов
+- [`docs/integration-guide.md`](docs/integration-guide.md) — как написать внешнюю интеграцию на любом языке
+- [`VERSIONING.md`](VERSIONING.md) — стратегия версионирования (major-as-generation)
+- [`CHANGELOG.md`](CHANGELOG.md) — история релизов
+
+## Тесты
+
+```bash
+go test -race ./...        # backend
+cd app/web && pnpm build   # web (TS strict + vite production build)
+```
+
+End-to-end smoke-флоу отслеживаются в commit-сообщениях по майлстоунам.
+Playwright-harness запланирован как follow-up.
+
+## Связь с v1
+
+v1 (`Opendray/opendray`) — это легаси-кодбейс, теперь архивный. v2 —
+текущее и активное поколение, feature-complete и единственная ветка,
+в которой ведётся разработка. Из 16 builtin'ов v1 четыре переехали в
+бэкенд v2; остальные стали клиентскими фичами, channel-адаптерами или
+потребителями API интеграций.
+
+## Лицензия
+
+Apache 2.0 — см. [`LICENSE`](LICENSE). (v1 был под MIT; v2 лицензирован
+независимо.)

--- a/README.zh.md
+++ b/README.zh.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  🌐 <a href="README.md">English</a> · <strong>简体中文</strong>
+  🌐 <a href="README.md">English</a> · <strong>简体中文</strong> · <a href="README.fa.md">فارسی</a> · <a href="README.es.md">Español</a> · <a href="README.pt-BR.md">Português</a> · <a href="README.ja.md">日本語</a> · <a href="README.ko.md">한국어</a> · <a href="README.fr.md">Français</a> · <a href="README.de.md">Deutsch</a> · <a href="README.ru.md">Русский</a>
 </p>
 
 ---
@@ -127,7 +127,7 @@ sudo opendray start              # start | stop | restart | status —— 封装
 |---|---|---|
 | 📦 **预构建二进制** | "拿来就跑" — Linux / macOS,搭配任意进程管理器 | [Releases 页](https://github.com/Opendray/opendray/releases) → 见下方 [生产部署](#生产部署) |
 | 🐧 **systemd unit** | 裸机 / VM / Linux LXC | [生产部署 §A](#方案-a--systemd裸机--vm--lxc) |
-| 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio 当家用 server | [生产部署 §B](#方案-b--macos-launchdmac-mini--studio-当家用-server) |
+| 🍎 **macOS LaunchDaemon** | Mac mini / Mac Studio 当家用 server | [生产部署 §C](#方案-c--macos-launchdmac-mini--studio-当家用-server) |
 | 🛠 **从源码构建** | 开发 / 贡献代码 / 定制构建 | [快速开始](#快速开始5-分钟开发版) |
 
 ## 快速开始(5 分钟开发版)


### PR DESCRIPTION
## Summary

Brings the launch lineup to **10 language READMEs**: English, Simplified Chinese, Persian (via #278), and the seven this PR adds — Spanish, Brazilian Portuguese, Japanese, Korean, French, German, Russian.

Marked **draft** because it stacks on #278 (Persian + the §B→§C anchor fix). Once #278 lands, I'll mark this ready — if main has moved, a clean rebase resolves; this PR's anchor fix and switcher line already mirror what #278 produces so the rebase is mechanical.

## What's in

| File | Lines | Translator note |
| --- | --- | --- |
| `README.es.md` | 381 | Informal "tú", `gateway`/`build`/`release`/`feature-complete` kept in English where Spanish OSS docs do. |
| `README.pt-BR.md` | 381 | Informal "você", same English-borrowing pattern; idiomatic constructions like "por baixo dos panos", "encantamentos de systemctl". |
| `README.ja.md` | 380 | です・ます polite-neutral, katakana for gateway/session/binary, sentences restructured for natural JP flow. |
| `README.ko.md` | 377 | 합니다 register, Hangulized loanwords (게이트웨이, 세션, 바이너리), English kept where K-OSS docs leave it. |
| `README.fr.md` | 382 | Informal "tu" (Vue/Tailwind/Astro convention), French typography (`«»`, non-breaking spaces), `gateway`/`build`/`release` kept English. |
| `README.de.md` | 382 | Informal "Du" (modern DE OSS norm), liberal English borrowings (Gateway, Binary, Build, Release, Self-hosted), compound nouns kept readable. |
| `README.ru.md` | 383 | Lowercase "вы" (Habr-style impersonal), mix of Cyrillicized loanwords (бинарник, шлюз, бэкап) and English kept in Latin where idiomatic. |

Also fixes the **§B → §C macOS LaunchDaemon anchor** in `README.md` and `README.zh.md` — the same fix #278 includes for the EN+ZH files. Keeping it in this PR means the broken link is dead the moment either PR merges. If both PRs touch the same line, the merge resolves cleanly because both produce the same correct anchor.

## Translation rules (applied uniformly)

Every file follows the same conventions:

- **Preserve in English (do not translate)**: file paths, env vars, CLI command names, anchor IDs in URL fragments, code-block contents, package names, library names, the `OPENDRAY_*` env vars, `systemctl`/`launchctl`/`pgvector`/`goreleaser` etc.
- **Translate**: section headings (display text only — anchor stays English), marketing prose, explanatory body text, bullet narratives, image alt text where applicable.
- **English borrowings**: each language uses English for the technical terms that its OSS community actually leaves in English — `gateway`, `binary`, `build`, `release`, `self-hosted`, `feature-complete`, `host-resident` are commonly preserved across all seven; some languages also keep `deploy`, `scope`, `audit log`, etc.
- **Register**: informal where the language's OSS convention is informal (FR `tu`, DE `Du`, PT/ES `você`/`tú`); polite-neutral where convention prefers it (JA `です・ます`, KO `합니다`); lowercase impersonal `вы` for RU per Habr.

## Language switcher

Every README's switcher now lists all ten languages in fixed order:

```
🌐 English · 简体中文 · فارسی · Español · Português · 日本語 · 한국어 · Français · Deutsch · Русский
```

Active language is `<strong>`, others are links. Same pattern #278 established.

## How this was produced

Generated with AI translation under explicit "as native as possible" instructions, with strict preservation rules for technical identifiers. **Native-speaker review PRs are very welcome** — anyone who spots awkward phrasing or a more idiomatic alternative should open a PR. The structure (file naming, switcher, preservation rules) is now in place for either organic contributor improvements or for adding more languages.

## Out of scope (follow-ups)

- Translating `docs/getting-started.md`, `docs/quickstart.md`, `docs/operator-guide.md`, `docs/integration-guide.md` — these are longer-form docs; if README translations get attention from native contributors, the docs are the natural next step.
- Admin UI i18n beyond the existing EN/ZH — the i18next JSON table at `app/i18n/` is 4k strings, which is a separate scope.
- Stale-translation detection (CI hash check that flags translations falling behind English changes) — worth doing if the lineup grows further.
