### PR TITLE
fix(web): keep dropdown menus inside the viewport

### DIFF
--- a/app/shared-ui/src/primitives/dropdown-menu.tsx
+++ b/app/shared-ui/src/primitives/dropdown-menu.tsx
@@ -12,13 +12,22 @@ const DropdownMenuPortal = DropdownMenuPrimitive.Portal
 const DropdownMenuContent = React.forwardRef<
   React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 6, ...props }, ref) => (
+>(({ className, sideOffset = 6, collisionPadding = 8, ...props }, ref) => (
   <DropdownMenuPrimitive.Portal>
     <DropdownMenuPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
+      // Keep the menu inside the viewport. align="end" triggers in the
+      // top-right corner (e.g. the Topbar language / theme toggles) could
+      // otherwise render off-screen at narrow widths — the menu opened
+      // but its items were clipped beyond the right edge. collisionPadding
+      // guarantees a margin so Radix shifts the menu fully into view.
+      collisionPadding={collisionPadding}
       className={cn(
         'z-50 min-w-[180px] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground',
+        // Never exceed the space Radix measured to the viewport edge, so
+        // the menu stays fully visible even on very narrow screens.
+        'max-w-[var(--radix-dropdown-menu-content-available-width)]',
         'shadow-[0_4px_16px_rgba(0,0,0,0.2)]',
         'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
         'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',


### PR DESCRIPTION
## Summary

The header language / theme toggles use `align=\"end\"` and trigger in the top-right corner. At narrow window widths the dropdown opened but rendered **off-screen past the right edge** — its items were clipped and couldn't be selected. This made the language switch appear to "do nothing": the menu was simply not visible (only at certain resolutions did it land back in view).

Not an i18n regression — the store→i18next bridge from #267 is intact. The root cause is purely dropdown positioning.

## Fix

One change to the shared `DropdownMenuContent` primitive (`app/shared-ui/src/primitives/dropdown-menu.tsx`), so it fixes **every dropdown app-wide**:

- `collisionPadding={8}` (default, opt-out via prop) — Radix shifts the menu fully into view with an 8px margin instead of letting it overflow.
- `max-w-[var(--radix-dropdown-menu-content-available-width)]` — caps the menu width to the space measured to the viewport edge, so it never overflows horizontally on very narrow screens.

## Test plan

- `pnpm --filter web build` (tsc + vite) — clean.
- Manual: shrink the window to a width where the language menu previously rendered off-screen; the menu now stays fully inside the viewport and en/zh are selectable, switching UI strings. Verified by reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)