### PR TITLE
docs(changelog): credit Majid Allahverdi for Farsi translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+### Credits
+
+- Farsi (Persian) README translation by [Majid Allahverdi](https://github.com/devwithmj) — originally contributed in #278, brought to `main` via #283 after a rebase-conflict workaround.
+
 ## [v2.5.0] — 2026-05-31
 
 Phase 2 Tier A of the multi-Claude-account work: rate-limit-aware


### PR DESCRIPTION
Small follow-up to PR #283. The squash-merge of that PR attributed the commit to navidrast because GitHub's squash-merge endpoint doesnt accept an author override. This PR adds a Credits entry in CHANGELOG.md and uses a Co-Authored-By trailer so the squashed commit on main displays Majid Allahverdi (@devwithmj) as co-author.

This is the closest the GitHub model lets us get to restoring proper attribution after a cross-fork rebase that had to land via cherry-pick.