### PR TITLE
chore(release): publish-npm skips cleanly when NPM_TOKEN is unset

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,6 +68,35 @@ Recovery if you tagged first: PATCH the release body via the GitHub
 API with the changelog section after the fact. Annoying, single-use
 mistake — better to do it in the right order.
 
+## Repository secrets (one-time setup)
+
+The release pipeline reads two repository secrets. `GITHUB_TOKEN` is
+provided automatically by Actions — you don't manage it. The other:
+
+- **`NPM_TOKEN`** — npm Automation token with publish permission for
+  `opendray`, `opendray-{linux,darwin}-{x64,arm64}`, and
+  `@opendray/sdk`. Used by the `Publish to npm` job in `release.yml`.
+
+  Generate at https://www.npmjs.com/settings/~/tokens → "Generate New
+  Token" → Classic → **Automation** (not Read-only, not Publish).
+  Automation tokens bypass 2FA challenges in CI.
+
+  Add at
+  https://github.com/Opendray/opendray/settings/secrets/actions/new
+  with the name `NPM_TOKEN`.
+
+  If the secret is missing, `scripts/publish-npm.mjs` skips cleanly
+  with a clear log message — the GitHub release tarballs still ship,
+  just without the npm channel. To recover after adding the secret:
+  re-run the failed `Publish to npm` job on the existing workflow
+  run, or trigger `workflow_dispatch` on `release.yml` with the
+  existing tag.
+
+  Operational note: never paste an npm token into a chat transcript,
+  PR comment, issue, or any persisted log. If you do, treat it as
+  compromised — revoke immediately at the npm tokens page above and
+  rotate the secret value.
+
 ## Picking the version number
 
 The rules from [`VERSIONING.md`](VERSIONING.md):
@@ -275,6 +304,10 @@ After publishing:
 - [ ] `https://opendray.dev/changelog/` shows the new entry within
       ~2 minutes
 - [ ] `opendray update --check` on a host reports the new version
+- [ ] `npm view opendray version` returns the new version (and the
+      four `opendray-{linux,darwin}-{x64,arm64}` packages match —
+      one-liner:
+      `for p in opendray opendray-linux-x64 opendray-linux-arm64 opendray-darwin-x64 opendray-darwin-arm64 @opendray/sdk; do npm view "$p" version; done`)
 
 ## Skipped today, on the roadmap
 

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -160,7 +160,26 @@ function prepareSdk(version) {
 async function main() {
   const { tag, version } = parseArgs();
   const ghToken = process.env.GITHUB_TOKEN || "";
-  if (!process.env.NODE_AUTH_TOKEN) die("NODE_AUTH_TOKEN not set");
+
+  if (!process.env.NODE_AUTH_TOKEN) {
+    console.log("publish-npm: SKIPPED — NODE_AUTH_TOKEN is empty.");
+    console.log("");
+    console.log("The NPM_TOKEN repository secret is not configured, so the");
+    console.log("npm distribution channel is skipped for this release. The");
+    console.log("GitHub release tarballs are unaffected.");
+    console.log("");
+    console.log("To enable npm publishing:");
+    console.log("  1. Generate an npm Automation token at");
+    console.log("     https://www.npmjs.com/settings/~/tokens");
+    console.log("  2. Add it as the NPM_TOKEN repository secret at");
+    console.log("     https://github.com/Opendray/opendray/settings/secrets/actions/new");
+    console.log("  3. Re-run this workflow (workflow_dispatch against the");
+    console.log(`     existing tag ${tag}) — npm publish will pick up the secret`);
+    console.log("     on the next attempt.");
+    console.log("");
+    console.log("See RELEASING.md for details.");
+    process.exit(0);
+  }
 
   console.log(`Publishing opendray @ ${version} (tag ${tag})`);
 


### PR DESCRIPTION
## Summary

Surfaced by the v2.6.0 release: when the `NPM_TOKEN` repo secret is missing, `scripts/publish-npm.mjs` failed hard with `NODE_AUTH_TOKEN not set` and exited 1 — even though Goreleaser had already produced the GitHub release tarballs. Distribution channels shouldn't fail each other.

### What changes

- `scripts/publish-npm.mjs` — detect empty `NODE_AUTH_TOKEN`, log a multi-line message (links to the npm token settings page and the GitHub Actions secrets page, plus the recovery path), exit `0`.
- `RELEASING.md`:
  - New "Repository secrets (one-time setup)" section covering `NPM_TOKEN`: which token type to generate (Automation), where to add it, what happens if it's missing (graceful skip + clear log), how to recover.
  - Operational note: never paste npm tokens into chat transcripts / PR comments / issues — treat as compromised, revoke + rotate.
  - Post-publish checklist gains an `npm view <pkg> version` row covering all six published packages.

### What doesn't change

- The npm publish step still uses `--provenance` (OIDC-signed attestation) and only runs in CI.
- `workflow_dispatch` on `release.yml` with a `tag` input already supports re-running against an existing tag — no new workflow needed.
- Re-running just the `Publish to npm` job via GitHub's "Re-run failed jobs" picks up the updated secret. That's the documented recovery path.

## Test plan

- [x] `node scripts/publish-npm.mjs --tag v2.6.0` with `NODE_AUTH_TOKEN=""` prints the skip message and exits 0 locally
- [x] `node scripts/publish-npm.mjs --tag v2.6.0` with no `--tag` still dies with usage (unchanged)
- [ ] CI green (Backend Go, Frontend web, Lint Go)
- [ ] After merge: next release-without-token-rotation publishes cleanly OR skips cleanly depending on whether `NPM_TOKEN` is set
