### PR TITLE
feat(mobile): bring mobile to parity with recent web fixes

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -3444,7 +3444,19 @@
         "botTokenLabel": "Bot token",
         "botTokenHint": "From @BotFather. Stored in channel config; admin-only API.",
         "chatIdLabel": "Default chat ID",
-        "chatIdPlaceholder": "42 (optional — used when no ReplyCtx)"
+        "chatIdPlaceholder": "42 (optional — used when no ReplyCtx)",
+        "ownerUserIdsLabel": "Owner Telegram user ID(s)",
+        "ownerUserIdsPlaceholder": "123456789 (comma-separated for more than one)",
+        "ownerUserIdsHint": "Only these numeric Telegram user IDs may drive sessions, run commands, or tap buttons; everyone else is ignored. Leave blank to allow anyone (not recommended for two-way chat). Get yours by DMing @userinfobot.",
+        "chatEnabledLabel": "Two-way chat (route messages into the session)",
+        "chatEnabledHint": "When on, your messages are typed into the selected session and the agent replies here. Turn off for notifications only.",
+        "chatTypingLabel": "Show “typing…” while the agent works",
+        "chatTypingHint": "Displays a typing indicator until the agent’s reply settles.",
+        "notifyEnabledLabel": "Activity notifications (idle / finished cards)",
+        "notifyEnabledHint": "Off keeps the chat clean — you still get replies to your messages. Turn on to also get a card when a session goes idle or finishes.",
+        "replyMaxCharsLabel": "Max reply length (characters)",
+        "replyMaxCharsPlaceholder": "3500 (blank = 3500, 0 = unlimited)",
+        "replyMaxCharsHint": "Caps how much of the agent’s reply is sent before it’s trimmed with a “…(truncated)” note. Blank uses the 3500 default (~one message); set 0 to send the whole reply, split across multiple messages."
       },
       "slack": {
         "description": "Socket Mode — no public webhook needed. Requires a bot OAuth token (xoxb-) and an app-level token (xapp-) with connections:write.",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -2827,7 +2827,14 @@
       "intro": "Sessions spawned with the Claude provider pick from these accounts (or fall back to env).",
       "enabledSnack": "{name} enabled.",
       "disabledSnack": "{name} disabled.",
-      "renamedSnack": "Renamed to {name}."
+      "renamedSnack": "Renamed to {name}.",
+      "activeSessions": "{count} active",
+      "usedAgo": "used {when}",
+      "identityChanged": "Identity changed",
+      "identityWas": "was {email}",
+      "acceptIdentity": "Accept",
+      "identityAcceptedSnack": "Identity change accepted",
+      "identityAcceptFailed": "Accept failed"
     },
     "configFallbackTitle": "Provider config",
     "saving": "Saving…",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -3788,7 +3788,8 @@
     "loading": "Loading…",
     "sections": {
       "app": "App",
-      "server": "Server"
+      "server": "Server",
+      "gateway": "Gateway"
     },
     "fields": {
       "app": "App",
@@ -3805,7 +3806,16 @@
       "version": "version",
       "serverUrl": "server URL"
     },
-    "tagline": "opendray mobile — multi-CLI gateway control.\nSource: github.com/Opendray/opendray"
+    "tagline": "opendray mobile — multi-CLI gateway control.\nSource: github.com/Opendray/opendray",
+    "gateway": {
+      "version": "Version",
+      "commit": "Commit",
+      "checking": "Checking for updates…",
+      "upToDate": "Up to date",
+      "updateAvailable": "Update available: {version}",
+      "releaseNotes": "Release notes",
+      "checkFailed": "Update check unavailable"
+    }
   },
   "settings": {
     "title": "Settings",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -3787,7 +3787,8 @@
     "loading": "加载中…",
     "sections": {
       "app": "应用",
-      "server": "服务器"
+      "server": "服务器",
+      "gateway": "网关"
     },
     "fields": {
       "app": "应用",
@@ -3804,7 +3805,16 @@
       "version": "版本",
       "serverUrl": "服务器 URL"
     },
-    "tagline": "opendray mobile — 多 CLI 网关控制。\n源码：github.com/Opendray/opendray"
+    "tagline": "opendray mobile — 多 CLI 网关控制。\n源码：github.com/Opendray/opendray",
+    "gateway": {
+      "version": "版本",
+      "commit": "提交",
+      "checking": "正在检查更新…",
+      "upToDate": "已是最新",
+      "updateAvailable": "有可用更新：{version}",
+      "releaseNotes": "更新说明",
+      "checkFailed": "无法检查更新"
+    }
   },
   "settings": {
     "title": "设置",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -3443,7 +3443,19 @@
         "botTokenLabel": "机器人 Token",
         "botTokenHint": "从 @BotFather 获取。存储于通道配置；仅管理员 API 可见。",
         "chatIdLabel": "默认 chat ID",
-        "chatIdPlaceholder": "42（可选 — 没有 ReplyCtx 时使用）"
+        "chatIdPlaceholder": "42（可选 — 没有 ReplyCtx 时使用）",
+        "ownerUserIdsLabel": "Telegram 拥有者用户 ID",
+        "ownerUserIdsPlaceholder": "123456789（多个用逗号分隔）",
+        "ownerUserIdsHint": "只有这些数字 Telegram 用户 ID 才能驱动会话、运行命令或点击按钮；其他人一律忽略。留空则允许任何人（双向聊天不推荐）。私聊 @userinfobot 获取你的 ID。",
+        "chatEnabledLabel": "双向聊天（将消息路由进会话）",
+        "chatEnabledHint": "开启后，你的消息会被输入选定会话，agent 在此回复。仅需通知时关闭。",
+        "chatTypingLabel": "agent 工作时显示“正在输入…”",
+        "chatTypingHint": "在 agent 回复稳定前显示正在输入指示。",
+        "notifyEnabledLabel": "活动通知（空闲 / 完成卡片）",
+        "notifyEnabledHint": "关闭可保持聊天整洁 — 你仍会收到对消息的回复。开启后会话空闲或完成时也会收到卡片。",
+        "replyMaxCharsLabel": "回复最大长度（字符）",
+        "replyMaxCharsPlaceholder": "3500（留空 = 3500，0 = 不限）",
+        "replyMaxCharsHint": "限制 agent 回复发送多少字符后被截断并附“…(已截断)”。留空使用 3500 默认（约一条消息）；设为 0 则发送完整回复，跨多条消息拆分。"
       },
       "slack": {
         "description": "Socket Mode — 无需公网 webhook。需要 bot OAuth token（xoxb-）和带 connections:write 的 app-level token（xapp-）。",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -2826,7 +2826,14 @@
       "intro": "以 Claude 提供商启动的会话会从这些账号中选择（或回退到环境变量）。",
       "enabledSnack": "{name} 已启用。",
       "disabledSnack": "{name} 已停用。",
-      "renamedSnack": "已重命名为 {name}。"
+      "renamedSnack": "已重命名为 {name}。",
+      "activeSessions": "{count} 个活跃",
+      "usedAgo": "{when}使用",
+      "identityChanged": "身份已变更",
+      "identityWas": "原为 {email}",
+      "acceptIdentity": "接受",
+      "identityAcceptedSnack": "已接受身份变更",
+      "identityAcceptFailed": "接受失败"
     },
     "configFallbackTitle": "提供商配置",
     "saving": "保存中…",

--- a/app/mobile/lib/core/api/claude_accounts_api.dart
+++ b/app/mobile/lib/core/api/claude_accounts_api.dart
@@ -113,6 +113,18 @@ class ClaudeAccountsApi {
     }
   }
 
+  // POST /claude-accounts/{id}/accept-identity — acknowledges that the
+  // on-disk OAuth identity legitimately changed (clears identity_drift).
+  Future<void> acceptIdentity(String id) async {
+    try {
+      await _dio.post<Map<String, dynamic>>(
+        '/api/v1/claude-accounts/$id/accept-identity',
+      );
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
   // POST /claude-accounts/import-local — gateway scans
   // ~/.claude-accounts/ on its own host filesystem and registers any
   // directory it finds that doesn't already have a matching DB row.

--- a/app/mobile/lib/core/api/models.dart
+++ b/app/mobile/lib/core/api/models.dart
@@ -409,12 +409,24 @@ class ClaudeAccountSummary {
     required this.displayName,
     required this.enabled,
     required this.tokenFilled,
+    this.subscriptionType,
+    this.rateLimitTier,
+    this.lastUsedAt,
+    this.activeSessions,
+    this.oauthEmail,
+    this.previousEmail,
+    this.identityDrift = false,
   });
 
   factory ClaudeAccountSummary.fromJson(Map<String, dynamic> json) {
     final id = json['id'] as String? ?? '';
     final name = json['name'] as String? ?? '';
     final display = json['display_name'] as String? ?? '';
+    String? str(String key) {
+      final v = json[key];
+      return v is String && v.isNotEmpty ? v : null;
+    }
+
     return ClaudeAccountSummary(
       id: id,
       name: name,
@@ -424,6 +436,14 @@ class ClaudeAccountSummary {
           display.isNotEmpty ? display : (name.isNotEmpty ? name : id),
       enabled: json['enabled'] as bool? ?? false,
       tokenFilled: json['token_filled'] as bool? ?? false,
+      // Decorated metadata — optional; older gateways omit these.
+      subscriptionType: str('subscription_type'),
+      rateLimitTier: str('rate_limit_tier'),
+      lastUsedAt: str('last_used_at'),
+      activeSessions: (json['active_sessions'] as num?)?.toInt(),
+      oauthEmail: str('oauth_email'),
+      previousEmail: str('previous_email'),
+      identityDrift: json['identity_drift'] as bool? ?? false,
     );
   }
 
@@ -432,6 +452,15 @@ class ClaudeAccountSummary {
   final String displayName;
   final bool enabled;
   final bool tokenFilled;
+  // Decorated fields from the gateway's account JSON (see web
+  // app/shared/src/lib/types.ts ClaudeAccount). All optional.
+  final String? subscriptionType;
+  final String? rateLimitTier;
+  final String? lastUsedAt; // ISO timestamp
+  final int? activeSessions;
+  final String? oauthEmail; // current Anthropic account email
+  final String? previousEmail; // prior email when drift detected
+  final bool identityDrift; // oauth_email differs from baseline
 
   bool get isUsable => enabled && tokenFilled;
 }

--- a/app/mobile/lib/core/api/sessions_api.dart
+++ b/app/mobile/lib/core/api/sessions_api.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:opendray/core/api/dio_provider.dart';
 import 'package:opendray/core/api/models.dart';
+import 'package:opendray/core/session_recents/recents_controller.dart';
 
 // Sessions endpoint surface. F2 covers full CRUD: list, fetch one,
 // create, stop, start (re-spawn), delete.
@@ -159,4 +160,26 @@ final sessionsListProvider =
 final sessionByIdProvider =
     FutureProvider.autoDispose.family<SessionSummary, String>((ref, id) {
   return ref.watch(sessionsApiProvider).getById(id);
+});
+
+// Sessions ordered most-recently-used first, then live before ended.
+// Mirrors web SessionList.orderBy: recency (per-device, recorded on
+// open) wins; sessions this device never opened fall back to
+// started_at. Live/ended grouping is applied after the recency sort.
+final sortedSessionsListProvider =
+    FutureProvider.autoDispose<List<SessionSummary>>((ref) async {
+  final sessions = await ref.watch(sessionsListProvider.future);
+  final recents = ref.watch(recentsProvider);
+
+  int byRecency(SessionSummary a, SessionSummary b) {
+    final ra = recents[a.id] ?? 0;
+    final rb = recents[b.id] ?? 0;
+    if (ra != rb) return rb.compareTo(ra);
+    return b.startedAt.compareTo(a.startedAt);
+  }
+
+  final sorted = [...sessions]..sort(byRecency);
+  final live = sorted.where((s) => !s.isFinished).toList();
+  final ended = sorted.where((s) => s.isFinished).toList();
+  return [...live, ...ended];
 });

--- a/app/mobile/lib/core/api/version_api.dart
+++ b/app/mobile/lib/core/api/version_api.dart
@@ -1,0 +1,76 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/api/dio_provider.dart';
+
+// /api/v1/version — gateway version + update-availability, mobile mirror
+// of app/shared/src/lib/version.ts. Read-only here: the mobile About
+// screen displays the running gateway version and whether an upgrade is
+// available, but does NOT trigger the in-app self-update (that restarts
+// the gateway binary and is left to the web dashboard / host shell).
+//
+// The endpoint soft-fails: when the upstream release check is
+// unreachable it still returns current/commit + capability flags and
+// sets checkError, so the call always resolves with useful data.
+
+class VersionInfo {
+  VersionInfo({
+    required this.current,
+    required this.updateAvailable,
+    required this.selfUpdate,
+    required this.pending,
+    this.commit,
+    this.latest,
+    this.notesUrl,
+    this.checkError,
+  });
+
+  factory VersionInfo.fromJson(Map<String, dynamic> j) {
+    String? str(String key) {
+      final v = j[key];
+      return v is String && v.isNotEmpty ? v : null;
+    }
+
+    return VersionInfo(
+      current: (j['current'] as String?) ?? '',
+      updateAvailable: j['updateAvailable'] as bool? ?? false,
+      selfUpdate: j['selfUpdate'] as bool? ?? false,
+      pending: j['pending'] as bool? ?? false,
+      commit: str('commit'),
+      latest: str('latest'),
+      notesUrl: str('notesUrl'),
+      checkError: str('checkError'),
+    );
+  }
+
+  final String current;
+  final bool updateAvailable;
+  final bool selfUpdate; // gateway is capable of in-app self-update
+  final bool pending; // an upgrade is already in progress
+  final String? commit;
+  final String? latest;
+  final String? notesUrl;
+  final String? checkError; // set when the release check couldn't run
+}
+
+class VersionApi {
+  VersionApi(this._dio);
+  final Dio _dio;
+
+  Future<VersionInfo> getVersionInfo() async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>('/api/v1/version');
+      return VersionInfo.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+}
+
+final versionApiProvider = Provider<VersionApi>((ref) {
+  return VersionApi(ref.watch(dioProvider));
+});
+
+final versionInfoProvider = FutureProvider.autoDispose<VersionInfo>((ref) {
+  return ref.watch(versionApiProvider).getVersionInfo();
+});

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 6223 (3111 per locale)
+/// Strings: 6269 (3134 per locale)
 ///
-/// Built on 2026-05-28 at 15:49 UTC
+/// Built on 2026-06-01 at 11:23 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 6269 (3134 per locale)
+/// Strings: 6283 (3141 per locale)
 ///
-/// Built on 2026-06-01 at 11:23 UTC
+/// Built on 2026-06-01 at 11:26 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 6283 (3141 per locale)
+/// Strings: 6299 (3149 per locale)
 ///
-/// Built on 2026-06-01 at 11:26 UTC
+/// Built on 2026-06-01 at 12:51 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -5120,6 +5120,12 @@ class TranslationsWebSessionsHeaderEn {
 	/// en: 'Attach image (or paste / drop into terminal)'
 	String get attachImageTooltip => 'Attach image (or paste / drop into terminal)';
 
+	/// en: 'Copy output'
+	String get copyOutput => 'Copy output';
+
+	/// en: 'Copy the terminal output (selection if any, otherwise everything)'
+	String get copyOutputTooltip => 'Copy the terminal output (selection if any, otherwise everything)';
+
 	/// en: 'Restart'
 	String get restart => 'Restart';
 
@@ -5164,6 +5170,27 @@ class TranslationsWebSessionsTerminalEn {
 
 	/// en: 'Drop image to attach'
 	String get dropToAttach => 'Drop image to attach';
+
+	/// en: 'Copy'
+	String get copyButton => 'Copy';
+
+	/// en: 'Copy terminal output to clipboard (selection if any, otherwise everything)'
+	String get copyAllTooltip => 'Copy terminal output to clipboard (selection if any, otherwise everything)';
+
+	/// en: 'Copy'
+	String get copySelection => 'Copy';
+
+	/// en: 'Copy selected text'
+	String get copySelectionTooltip => 'Copy selected text';
+
+	/// en: 'Copied to clipboard'
+	String get copiedToast => 'Copied to clipboard';
+
+	/// en: 'Nothing to copy yet'
+	String get copyEmptyToast => 'Nothing to copy yet';
+
+	/// en: 'Couldn't copy to clipboard'
+	String get copyFailedToast => 'Couldn\'t copy to clipboard';
 
 	late final TranslationsWebSessionsTerminalUrlsEn urls = TranslationsWebSessionsTerminalUrlsEn.internal(_root);
 }
@@ -5293,8 +5320,8 @@ class TranslationsWebSessionsAccountSwitcherEn {
 	/// en: '·empty'
 	String get tokenEmpty => '·empty';
 
-	/// en: 'Switching account will restart the Claude CLI process. In-progress conversation state inside the CLI will be lost. Continue?'
-	String get confirmSwitch => 'Switching account will restart the Claude CLI process. In-progress conversation state inside the CLI will be lost. Continue?';
+	/// en: 'Switching account will restart the Claude CLI. The conversation history is preserved (transcript is migrated and --resume replays it under the new account), but any in-flight tool execution or unsent input will be lost. Continue?'
+	String get confirmSwitch => 'Switching account will restart the Claude CLI. The conversation history is preserved (transcript is migrated and --resume replays it under the new account), but any in-flight tool execution or unsent input will be lost. Continue?';
 
 	/// en: 'Account switched'
 	String get switchedToast => 'Account switched';
@@ -6942,6 +6969,12 @@ class TranslationsWebProvidersClaudeAccountsEn {
 
 	/// en: 'Remove {name}'
 	String removeAria({required Object name}) => 'Remove ${name}';
+
+	/// en: 'New identity recorded'
+	String get identityAcceptedToast => 'New identity recorded';
+
+	/// en: 'Could not accept identity'
+	String get identityAcceptFailedToast => 'Could not accept identity';
 }
 
 // Path: web.providers.models
@@ -10346,6 +10379,42 @@ class TranslationsChannelsKindsTelegramEn {
 
 	/// en: '42 (optional — used when no ReplyCtx)'
 	String get chatIdPlaceholder => '42 (optional — used when no ReplyCtx)';
+
+	/// en: 'Owner Telegram user ID(s)'
+	String get ownerUserIdsLabel => 'Owner Telegram user ID(s)';
+
+	/// en: '123456789 (comma-separated for more than one)'
+	String get ownerUserIdsPlaceholder => '123456789 (comma-separated for more than one)';
+
+	/// en: 'Only these numeric Telegram user IDs may drive sessions, run commands, or tap buttons; everyone else is ignored. Leave blank to allow anyone (not recommended for two-way chat). Get yours by DMing @userinfobot.'
+	String get ownerUserIdsHint => 'Only these numeric Telegram user IDs may drive sessions, run commands, or tap buttons; everyone else is ignored. Leave blank to allow anyone (not recommended for two-way chat). Get yours by DMing @userinfobot.';
+
+	/// en: 'Two-way chat (route messages into the session)'
+	String get chatEnabledLabel => 'Two-way chat (route messages into the session)';
+
+	/// en: 'When on, your messages are typed into the selected session and the agent replies here. Turn off for notifications only.'
+	String get chatEnabledHint => 'When on, your messages are typed into the selected session and the agent replies here. Turn off for notifications only.';
+
+	/// en: 'Show “typing…” while the agent works'
+	String get chatTypingLabel => 'Show “typing…” while the agent works';
+
+	/// en: 'Displays a typing indicator until the agent’s reply settles.'
+	String get chatTypingHint => 'Displays a typing indicator until the agent’s reply settles.';
+
+	/// en: 'Activity notifications (idle / finished cards)'
+	String get notifyEnabledLabel => 'Activity notifications (idle / finished cards)';
+
+	/// en: 'Off keeps the chat clean — you still get replies to your messages. Turn on to also get a card when a session goes idle or finishes.'
+	String get notifyEnabledHint => 'Off keeps the chat clean — you still get replies to your messages. Turn on to also get a card when a session goes idle or finishes.';
+
+	/// en: 'Max reply length (characters)'
+	String get replyMaxCharsLabel => 'Max reply length (characters)';
+
+	/// en: '3500 (blank = 3500, 0 = unlimited)'
+	String get replyMaxCharsPlaceholder => '3500 (blank = 3500, 0 = unlimited)';
+
+	/// en: 'Caps how much of the agent’s reply is sent before it’s trimmed with a “…(truncated)” note. Blank uses the 3500 default (~one message); set 0 to send the whole reply, split across multiple messages.'
+	String get replyMaxCharsHint => 'Caps how much of the agent’s reply is sent before it’s trimmed with a “…(truncated)” note. Blank uses the 3500 default (~one message); set 0 to send the whole reply, split across multiple messages.';
 }
 
 // Path: channels.kinds.slack
@@ -13738,6 +13807,8 @@ extension on Translations {
 			'web.sessions.header.hideInspector' => 'Hide inspector',
 			'web.sessions.header.attachImage' => 'Attach image',
 			'web.sessions.header.attachImageTooltip' => 'Attach image (or paste / drop into terminal)',
+			'web.sessions.header.copyOutput' => 'Copy output',
+			'web.sessions.header.copyOutputTooltip' => 'Copy the terminal output (selection if any, otherwise everything)',
 			'web.sessions.header.restart' => 'Restart',
 			'web.sessions.header.restarting' => 'Restarting…',
 			'web.sessions.header.remove' => 'Remove',
@@ -13750,6 +13821,13 @@ extension on Translations {
 			'web.sessions.terminal.uploadFailedToast' => 'Upload failed',
 			'web.sessions.terminal.uploadInvalidTypeToast' => 'Only image files can be attached',
 			'web.sessions.terminal.dropToAttach' => 'Drop image to attach',
+			'web.sessions.terminal.copyButton' => 'Copy',
+			'web.sessions.terminal.copyAllTooltip' => 'Copy terminal output to clipboard (selection if any, otherwise everything)',
+			'web.sessions.terminal.copySelection' => 'Copy',
+			'web.sessions.terminal.copySelectionTooltip' => 'Copy selected text',
+			'web.sessions.terminal.copiedToast' => 'Copied to clipboard',
+			'web.sessions.terminal.copyEmptyToast' => 'Nothing to copy yet',
+			'web.sessions.terminal.copyFailedToast' => 'Couldn\'t copy to clipboard',
 			'web.sessions.terminal.urls.tooltip' => 'Open the latest link detected in this session',
 			'web.sessions.terminal.urls.tapToOpenLatest' => 'Tap to open the latest link (most recent OAuth URL)',
 			'web.sessions.terminal.urls.openListTooltip' => 'Show all links',
@@ -13798,7 +13876,7 @@ extension on Translations {
 			'web.sessions.accountSwitcher.defaultName' => 'Default',
 			'web.sessions.accountSwitcher.defaultSubtitle' => 'CLI\'s system keychain / env',
 			'web.sessions.accountSwitcher.tokenEmpty' => '·empty',
-			'web.sessions.accountSwitcher.confirmSwitch' => 'Switching account will restart the Claude CLI process. In-progress conversation state inside the CLI will be lost. Continue?',
+			'web.sessions.accountSwitcher.confirmSwitch' => 'Switching account will restart the Claude CLI. The conversation history is preserved (transcript is migrated and --resume replays it under the new account), but any in-flight tool execution or unsent input will be lost. Continue?',
 			'web.sessions.accountSwitcher.switchedToast' => 'Account switched',
 			'web.sessions.accountSwitcher.switchedDescription' => ({required Object account, required Object pid}) => 'Now using @${account} · pid ${pid}',
 			'web.sessions.accountSwitcher.switchedDefault' => 'default',
@@ -14144,6 +14222,8 @@ extension on Translations {
 			'web.memoryInspector.toasts.bulkDeleteFailed' => 'Bulk delete failed',
 			'web.memoryInspector.toasts.created' => 'Memory created',
 			'web.memoryInspector.toasts.createFailed' => 'Create failed',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryInspector.toasts.updated' => 'Memory updated',
 			'web.memoryInspector.toasts.updateFailed' => 'Update failed',
 			'web.memoryInspector.toasts.migrated' => ({required Object reembed, required Object examined, required Object to}) => 'Migrated ${reembed}/${examined} memories to ${to}',
@@ -14153,8 +14233,6 @@ extension on Translations {
 			'web.memoryInspector.toasts.syncEmpty' => 'No new .md files to sync',
 			'web.memoryInspector.toasts.syncEmptyDescription' => 'Already in sync, or no Claude memory dir for this cwd.',
 			'web.memoryInspector.toasts.syncFailed' => 'Sync failed',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryInspector.toasts.testOk' => ({required Object embedder, required Object dim}) => 'Embedder OK: ${embedder} · ${dim} dimensions',
 			'web.memoryInspector.toasts.testOkDescription' => ({required Object preview}) => 'vector_preview = [${preview}…]',
 			'web.memoryInspector.toasts.testFailed' => 'Embedder probe failed',
@@ -14447,6 +14525,8 @@ extension on Translations {
 			'web.providers.claudeAccounts.removeFailedToast' => 'Remove failed',
 			'web.providers.claudeAccounts.toggleAria' => ({required Object name}) => 'Toggle ${name}',
 			'web.providers.claudeAccounts.removeAria' => ({required Object name}) => 'Remove ${name}',
+			'web.providers.claudeAccounts.identityAcceptedToast' => 'New identity recorded',
+			'web.providers.claudeAccounts.identityAcceptFailedToast' => 'Could not accept identity',
 			'web.providers.models.title' => 'Models',
 			'web.providers.models.help' => 'Models offered for this provider. The default is passed to every session via the model flag; sessions can still override it.',
 			'web.providers.models.empty' => 'No models configured yet.',
@@ -14656,6 +14736,8 @@ extension on Translations {
 			'web.integrations.proxy.extraHeadersLabel' => 'Extra headers (one per line, Name: Value)',
 			'web.integrations.proxy.bodyLabel' => 'Body',
 			'web.integrations.proxy.headers' => 'Headers',
+			_ => null,
+		} ?? switch (path) {
 			'web.integrations.proxy.body' => 'Body',
 			'web.integrations.proxy.emptyBody' => '(empty)',
 			'web.integrations.proxy.requestFailed' => 'request failed',
@@ -14667,8 +14749,6 @@ extension on Translations {
 			'web.plugins.common.loading' => 'Loading…',
 			'web.plugins.common.cancel' => 'Cancel',
 			'web.plugins.common.edit' => 'Edit',
-			_ => null,
-		} ?? switch (path) {
 			'web.plugins.common.add' => 'Add',
 			'web.plugins.common.save' => 'Save',
 			'web.plugins.common.create' => 'Create',
@@ -15170,6 +15250,8 @@ extension on Translations {
 			'web.serverSettings.fields.backupExportDir.label' => 'Export directory',
 			'web.serverSettings.fields.backupExportDir.hint' => 'Where one-shot export zips are staged on disk. Empty = ~/.opendray/exports. Bundles auto-expire after 24h. Restart required.',
 			'web.serverSettings.fields.backupPgDumpPath.label' => 'pg_dump path',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.fields.backupPgDumpPath.hint' => 'Absolute path to pg_dump. Major version must be ≥ the server\'s. Empty = first pg_dump on PATH.',
 			'web.serverSettings.fields.backupPgRestorePath.label' => 'pg_restore path',
 			'web.serverSettings.fields.backupPgRestorePath.hint' => 'Absolute path to pg_restore for the /backups/restore flow. Same major-version rule.',
@@ -15181,8 +15263,6 @@ extension on Translations {
 			'web.serverSettings.localOnnxBanner' => 'Requires the binary to be compiled with <1>-tags local_onnx</1>. The standard build returns a clear stub error when this backend is selected. See <3>Memory → Local ONNX</3> tutorial for setup steps.',
 			'web.serverSettings.stringList.noneDefault' => '(none — using built-in defaults)',
 			'web.serverSettings.stringList.addPath' => 'Add path',
-			_ => null,
-		} ?? switch (path) {
 			'web.serverSettings.stringList.removeTitle' => 'Remove',
 			'web.serverSettings.httpHelpers.autoDetected' => 'Auto-detected at startup',
 			'web.serverSettings.httpHelpers.modelCount' => ({required Object count}) => '${count} model(s) — click to use',
@@ -15684,6 +15764,8 @@ extension on Translations {
 			'sessions.inspector.notes.locationStoredHint' => 'Stored in <vault>/.opendray-projects.json — git-syncs with the rest of the vault.',
 			'sessions.inspector.notes.pinnedHint' => ({required Object path, required Object defaultPath}) => 'Pinned to ${path}/ (overrides ${defaultPath}). AI agents author docs here too.',
 			'sessions.inspector.notes.noProjectMapping2' => '(no project mapping)',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.notes.clearOverride' => 'Clear override',
 			'sessions.inspector.notes.save' => 'Save',
 			'sessions.spawnSheet.title' => 'New session',
@@ -15695,8 +15777,6 @@ extension on Translations {
 			'sessions.spawnSheet.disabledSuffix' => ' (disabled)',
 			'sessions.spawnSheet.cwdLabel' => 'Working directory',
 			'sessions.spawnSheet.cwdHint' => '/Users/you/projects/foo',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.spawnSheet.cwdHelper' => 'Absolute path on the gateway host.',
 			'sessions.spawnSheet.browse' => 'Browse',
 			'sessions.spawnSheet.nameLabel' => 'Name (optional)',
@@ -16198,6 +16278,8 @@ extension on Translations {
 			'backupTargetEditor.create' => 'Create',
 			'backupTargetEditor.rootDirLabel' => 'Root directory',
 			'backupTargetEditor.rootDirHint' => 'Empty = cfg.backup.local_dir (~/.opendray/backups)',
+			_ => null,
+		} ?? switch (path) {
 			'backupTargetEditor.hostLabel' => 'Host',
 			'backupTargetEditor.portLabel' => 'Port',
 			'backupTargetEditor.shareLabel' => 'Share',
@@ -16209,8 +16291,6 @@ extension on Translations {
 			'backupTargetEditor.passwordHintKeep' => 'Leave blank to keep',
 			'backupTargetEditor.pathPrefixLabel' => 'Path prefix',
 			'backupTargetEditor.pathPrefixHintShareRoot' => 'Sub-folder under the share root (optional)',
-			_ => null,
-		} ?? switch (path) {
 			'backupTargetEditor.pathPrefixHintBaseUrl' => 'Sub-folder under the base URL (optional)',
 			'backupTargetEditor.pathPrefixHintObjectKey' => 'Object-key prefix (optional)',
 			'backupTargetEditor.pathPrefixHintSshFolder' => 'Absolute or relative to user home (optional)',
@@ -16345,6 +16425,18 @@ extension on Translations {
 			'channels.kinds.telegram.botTokenHint' => 'From @BotFather. Stored in channel config; admin-only API.',
 			'channels.kinds.telegram.chatIdLabel' => 'Default chat ID',
 			'channels.kinds.telegram.chatIdPlaceholder' => '42 (optional — used when no ReplyCtx)',
+			'channels.kinds.telegram.ownerUserIdsLabel' => 'Owner Telegram user ID(s)',
+			'channels.kinds.telegram.ownerUserIdsPlaceholder' => '123456789 (comma-separated for more than one)',
+			'channels.kinds.telegram.ownerUserIdsHint' => 'Only these numeric Telegram user IDs may drive sessions, run commands, or tap buttons; everyone else is ignored. Leave blank to allow anyone (not recommended for two-way chat). Get yours by DMing @userinfobot.',
+			'channels.kinds.telegram.chatEnabledLabel' => 'Two-way chat (route messages into the session)',
+			'channels.kinds.telegram.chatEnabledHint' => 'When on, your messages are typed into the selected session and the agent replies here. Turn off for notifications only.',
+			'channels.kinds.telegram.chatTypingLabel' => 'Show “typing…” while the agent works',
+			'channels.kinds.telegram.chatTypingHint' => 'Displays a typing indicator until the agent’s reply settles.',
+			'channels.kinds.telegram.notifyEnabledLabel' => 'Activity notifications (idle / finished cards)',
+			'channels.kinds.telegram.notifyEnabledHint' => 'Off keeps the chat clean — you still get replies to your messages. Turn on to also get a card when a session goes idle or finishes.',
+			'channels.kinds.telegram.replyMaxCharsLabel' => 'Max reply length (characters)',
+			'channels.kinds.telegram.replyMaxCharsPlaceholder' => '3500 (blank = 3500, 0 = unlimited)',
+			'channels.kinds.telegram.replyMaxCharsHint' => 'Caps how much of the agent’s reply is sent before it’s trimmed with a “…(truncated)” note. Blank uses the 3500 default (~one message); set 0 to send the whole reply, split across multiple messages.',
 			'channels.kinds.slack.description' => 'Socket Mode — no public webhook needed. Requires a bot OAuth token (xoxb-) and an app-level token (xapp-) with connections:write.',
 			'channels.kinds.slack.botTokenLabel' => 'Bot token (xoxb-…)',
 			'channels.kinds.slack.botTokenHint' => 'OAuth & Permissions → Bot User OAuth Token. Needs chat:write.',
@@ -16700,6 +16792,8 @@ extension on Translations {
 			'settings.serverSettings.sectionDescriptions.memory' => 'Cross-CLI persistent memory subsystem.',
 			'settings.serverSettings.sectionDescriptions.backup' => 'Encrypted DB backups + admin data exports. Passphrase lives in the keyfile (Settings → Backups).',
 			'settings.serverSettings.sectionDescriptions.storageClaude' => 'Where Claude transcripts live on disk.',
+			_ => null,
+		} ?? switch (path) {
 			'settings.serverSettings.sectionDescriptions.storageCodex' => 'Codex sessions root.',
 			'settings.serverSettings.sectionDescriptions.storageGemini' => 'Per-project tmp + projects.json paths.',
 			'settings.serverSettings.fields.listenAddress' => 'Listen address',
@@ -16723,8 +16817,6 @@ extension on Translations {
 			'settings.serverSettings.fields.skillsPath' => 'Skills path',
 			'settings.serverSettings.fields.gitRoot' => 'Git root',
 			'settings.serverSettings.fields.personalPrefix' => 'Personal prefix',
-			_ => null,
-		} ?? switch (path) {
 			'settings.serverSettings.fields.projectsPrefix' => 'Projects prefix',
 			'settings.serverSettings.fields.registryRoot' => 'Registry root',
 			'settings.serverSettings.fields.secretsFile' => 'Secrets file',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -1799,6 +1799,8 @@ class TranslationsAboutEn {
 
 	/// en: 'opendray mobile — multi-CLI gateway control. Source: github.com/Opendray/opendray'
 	String get tagline => 'opendray mobile — multi-CLI gateway control.\nSource: github.com/Opendray/opendray';
+
+	late final TranslationsAboutGatewayEn gateway = TranslationsAboutGatewayEn.internal(_root);
 }
 
 // Path: settings
@@ -4688,6 +4690,9 @@ class TranslationsAboutSectionsEn {
 
 	/// en: 'Server'
 	String get server => 'Server';
+
+	/// en: 'Gateway'
+	String get gateway => 'Gateway';
 }
 
 // Path: about.fields
@@ -4733,6 +4738,36 @@ class TranslationsAboutCopyLabelsEn {
 
 	/// en: 'server URL'
 	String get serverUrl => 'server URL';
+}
+
+// Path: about.gateway
+class TranslationsAboutGatewayEn {
+	TranslationsAboutGatewayEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Version'
+	String get version => 'Version';
+
+	/// en: 'Commit'
+	String get commit => 'Commit';
+
+	/// en: 'Checking for updates…'
+	String get checking => 'Checking for updates…';
+
+	/// en: 'Up to date'
+	String get upToDate => 'Up to date';
+
+	/// en: 'Update available: {version}'
+	String updateAvailable({required Object version}) => 'Update available: ${version}';
+
+	/// en: 'Release notes'
+	String get releaseNotes => 'Release notes';
+
+	/// en: 'Update check unavailable'
+	String get checkFailed => 'Update check unavailable';
 }
 
 // Path: settings.language
@@ -16729,6 +16764,7 @@ extension on Translations {
 			'about.loading' => 'Loading…',
 			'about.sections.app' => 'App',
 			'about.sections.server' => 'Server',
+			'about.sections.gateway' => 'Gateway',
 			'about.fields.app' => 'App',
 			'about.fields.version' => 'Version',
 			'about.fields.versionFormat' => ({required Object version, required Object build}) => '${version} (build ${build})',
@@ -16741,6 +16777,13 @@ extension on Translations {
 			'about.copyLabels.version' => 'version',
 			'about.copyLabels.serverUrl' => 'server URL',
 			'about.tagline' => 'opendray mobile — multi-CLI gateway control.\nSource: github.com/Opendray/opendray',
+			'about.gateway.version' => 'Version',
+			'about.gateway.commit' => 'Commit',
+			'about.gateway.checking' => 'Checking for updates…',
+			'about.gateway.upToDate' => 'Up to date',
+			'about.gateway.updateAvailable' => ({required Object version}) => 'Update available: ${version}',
+			'about.gateway.releaseNotes' => 'Release notes',
+			'about.gateway.checkFailed' => 'Update check unavailable',
 			'settings.title' => 'Settings',
 			'settings.language.section' => 'Language',
 			'settings.language.system' => 'System',
@@ -16805,6 +16848,8 @@ extension on Translations {
 			'settings.serverSettings.sections.general' => 'General',
 			'settings.serverSettings.sections.logging' => 'Logging',
 			'settings.serverSettings.sections.sessions' => 'Sessions',
+			_ => null,
+		} ?? switch (path) {
 			'settings.serverSettings.sections.vault' => 'Vault',
 			'settings.serverSettings.sections.mcpRegistry' => 'MCP registry',
 			'settings.serverSettings.sections.memory' => 'Memory',
@@ -16813,8 +16858,6 @@ extension on Translations {
 			'settings.serverSettings.sections.storageCodex' => 'Storage · Codex',
 			'settings.serverSettings.sections.storageGemini' => 'Storage · Gemini',
 			'settings.serverSettings.sectionDescriptions.general' => 'Listen address, operator account, token TTL.',
-			_ => null,
-		} ?? switch (path) {
 			'settings.serverSettings.sectionDescriptions.logging' => 'Verbosity, format, and on-disk log path.',
 			'settings.serverSettings.sectionDescriptions.sessions' => 'Idle detection thresholds.',
 			'settings.serverSettings.sectionDescriptions.vault' => 'Notes, skills, and git-versioned root.',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -3404,6 +3404,27 @@ class TranslationsProvidersAccountsEn {
 
 	/// en: 'Renamed to {name}.'
 	String renamedSnack({required Object name}) => 'Renamed to ${name}.';
+
+	/// en: '{count} active'
+	String activeSessions({required Object count}) => '${count} active';
+
+	/// en: 'used {when}'
+	String usedAgo({required Object when}) => 'used ${when}';
+
+	/// en: 'Identity changed'
+	String get identityChanged => 'Identity changed';
+
+	/// en: 'was {email}'
+	String identityWas({required Object email}) => 'was ${email}';
+
+	/// en: 'Accept'
+	String get acceptIdentity => 'Accept';
+
+	/// en: 'Identity change accepted'
+	String get identityAcceptedSnack => 'Identity change accepted';
+
+	/// en: 'Accept failed'
+	String get identityAcceptFailed => 'Accept failed';
 }
 
 // Path: integrations.form
@@ -15907,6 +15928,13 @@ extension on Translations {
 			'providers.accounts.enabledSnack' => ({required Object name}) => '${name} enabled.',
 			'providers.accounts.disabledSnack' => ({required Object name}) => '${name} disabled.',
 			'providers.accounts.renamedSnack' => ({required Object name}) => 'Renamed to ${name}.',
+			'providers.accounts.activeSessions' => ({required Object count}) => '${count} active',
+			'providers.accounts.usedAgo' => ({required Object when}) => 'used ${when}',
+			'providers.accounts.identityChanged' => 'Identity changed',
+			'providers.accounts.identityWas' => ({required Object email}) => 'was ${email}',
+			'providers.accounts.acceptIdentity' => 'Accept',
+			'providers.accounts.identityAcceptedSnack' => 'Identity change accepted',
+			'providers.accounts.identityAcceptFailed' => 'Accept failed',
 			'providers.configFallbackTitle' => 'Provider config',
 			'providers.saving' => 'Saving…',
 			'providers.save' => 'Save',
@@ -16271,6 +16299,8 @@ extension on Translations {
 			'backupTargetEditor.formTitleEdit' => 'Edit target',
 			'backupTargetEditor.formTitleNew' => 'New backup target',
 			'backupTargetEditor.idHintAuto' => ({required Object prefix}) => 'Auto: ${prefix}-1',
+			_ => null,
+		} ?? switch (path) {
 			'backupTargetEditor.idHelper' => 'Lower-case letters, digits, dashes. Defaults to the next available slot.',
 			'backupTargetEditor.enabledOn' => 'Scheduled and ad-hoc backups can target this.',
 			'backupTargetEditor.enabledOff' => 'Server will refuse to write backups here.',
@@ -16278,8 +16308,6 @@ extension on Translations {
 			'backupTargetEditor.create' => 'Create',
 			'backupTargetEditor.rootDirLabel' => 'Root directory',
 			'backupTargetEditor.rootDirHint' => 'Empty = cfg.backup.local_dir (~/.opendray/backups)',
-			_ => null,
-		} ?? switch (path) {
 			'backupTargetEditor.hostLabel' => 'Host',
 			'backupTargetEditor.portLabel' => 'Port',
 			'backupTargetEditor.shareLabel' => 'Share',
@@ -16785,6 +16813,8 @@ extension on Translations {
 			'settings.serverSettings.sections.storageCodex' => 'Storage · Codex',
 			'settings.serverSettings.sections.storageGemini' => 'Storage · Gemini',
 			'settings.serverSettings.sectionDescriptions.general' => 'Listen address, operator account, token TTL.',
+			_ => null,
+		} ?? switch (path) {
 			'settings.serverSettings.sectionDescriptions.logging' => 'Verbosity, format, and on-disk log path.',
 			'settings.serverSettings.sectionDescriptions.sessions' => 'Idle detection thresholds.',
 			'settings.serverSettings.sectionDescriptions.vault' => 'Notes, skills, and git-versioned root.',
@@ -16792,8 +16822,6 @@ extension on Translations {
 			'settings.serverSettings.sectionDescriptions.memory' => 'Cross-CLI persistent memory subsystem.',
 			'settings.serverSettings.sectionDescriptions.backup' => 'Encrypted DB backups + admin data exports. Passphrase lives in the keyfile (Settings → Backups).',
 			'settings.serverSettings.sectionDescriptions.storageClaude' => 'Where Claude transcripts live on disk.',
-			_ => null,
-		} ?? switch (path) {
 			'settings.serverSettings.sectionDescriptions.storageCodex' => 'Codex sessions root.',
 			'settings.serverSettings.sectionDescriptions.storageGemini' => 'Per-project tmp + projects.json paths.',
 			'settings.serverSettings.fields.listenAddress' => 'Listen address',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -2651,6 +2651,8 @@ class _TranslationsWebSessionsHeaderZh extends TranslationsWebSessionsHeaderEn {
 	@override String get hideInspector => '隐藏检查器';
 	@override String get attachImage => '附加图片';
 	@override String get attachImageTooltip => '附加图片（或直接粘贴 / 拖入终端）';
+	@override String get copyOutput => '复制输出';
+	@override String get copyOutputTooltip => '复制终端输出（若有选区则复制选区，否则复制全部）';
 	@override String get restart => '重启';
 	@override String get restarting => '重启中…';
 	@override String get remove => '移除';
@@ -2672,6 +2674,13 @@ class _TranslationsWebSessionsTerminalZh extends TranslationsWebSessionsTerminal
 	@override String get uploadFailedToast => '上传失败';
 	@override String get uploadInvalidTypeToast => '仅支持图片文件';
 	@override String get dropToAttach => '释放以附加图片';
+	@override String get copyButton => '复制';
+	@override String get copyAllTooltip => '复制终端输出到剪贴板(若有选区则复制选区,否则复制全部)';
+	@override String get copySelection => '复制';
+	@override String get copySelectionTooltip => '复制选中的文本';
+	@override String get copiedToast => '已复制到剪贴板';
+	@override String get copyEmptyToast => '暂无可复制内容';
+	@override String get copyFailedToast => '无法复制到剪贴板';
 	@override late final _TranslationsWebSessionsTerminalUrlsZh urls = _TranslationsWebSessionsTerminalUrlsZh._(_root);
 }
 
@@ -2727,7 +2736,7 @@ class _TranslationsWebSessionsAccountSwitcherZh extends TranslationsWebSessionsA
 	@override String get defaultName => '默认';
 	@override String get defaultSubtitle => 'CLI 的系统 keychain / 环境变量';
 	@override String get tokenEmpty => '·未填';
-	@override String get confirmSwitch => '切换账号将重启 Claude CLI 进程。CLI 内部进行中的对话状态将丢失。继续？';
+	@override String get confirmSwitch => '切换账户将重启 Claude CLI。对话历史会被保留（脚本会迁移并通过 --resume 恢复），但正在进行的工具调用或未发送的输入会丢失。是否继续？';
 	@override String get switchedToast => '账号已切换';
 	@override String switchedDescription({required Object account, required Object pid}) => '当前使用 @${account} · pid ${pid}';
 	@override String get switchedDefault => '默认';
@@ -3590,6 +3599,8 @@ class _TranslationsWebProvidersClaudeAccountsZh extends TranslationsWebProviders
 	@override String get removeFailedToast => '移除失败';
 	@override String toggleAria({required Object name}) => '切换 ${name}';
 	@override String removeAria({required Object name}) => '移除 ${name}';
+	@override String get identityAcceptedToast => '已接受新身份';
+	@override String get identityAcceptFailedToast => '无法接受新身份';
 }
 
 // Path: web.providers.models
@@ -5446,6 +5457,18 @@ class _TranslationsChannelsKindsTelegramZh extends TranslationsChannelsKindsTele
 	@override String get botTokenHint => '从 @BotFather 获取。存储于通道配置；仅管理员 API 可见。';
 	@override String get chatIdLabel => '默认 chat ID';
 	@override String get chatIdPlaceholder => '42（可选 — 没有 ReplyCtx 时使用）';
+	@override String get ownerUserIdsLabel => 'Telegram 拥有者用户 ID';
+	@override String get ownerUserIdsPlaceholder => '123456789（多个用逗号分隔）';
+	@override String get ownerUserIdsHint => '只有这些数字 Telegram 用户 ID 才能驱动会话、运行命令或点击按钮；其他人一律忽略。留空则允许任何人（双向聊天不推荐）。私聊 @userinfobot 获取你的 ID。';
+	@override String get chatEnabledLabel => '双向聊天（将消息路由进会话）';
+	@override String get chatEnabledHint => '开启后，你的消息会被输入选定会话，agent 在此回复。仅需通知时关闭。';
+	@override String get chatTypingLabel => 'agent 工作时显示“正在输入…”';
+	@override String get chatTypingHint => '在 agent 回复稳定前显示正在输入指示。';
+	@override String get notifyEnabledLabel => '活动通知（空闲 / 完成卡片）';
+	@override String get notifyEnabledHint => '关闭可保持聊天整洁 — 你仍会收到对消息的回复。开启后会话空闲或完成时也会收到卡片。';
+	@override String get replyMaxCharsLabel => '回复最大长度（字符）';
+	@override String get replyMaxCharsPlaceholder => '3500（留空 = 3500，0 = 不限）';
+	@override String get replyMaxCharsHint => '限制 agent 回复发送多少字符后被截断并附“…(已截断)”。留空使用 3500 默认（约一条消息）；设为 0 则发送完整回复，跨多条消息拆分。';
 }
 
 // Path: channels.kinds.slack
@@ -7417,6 +7440,8 @@ extension on TranslationsZh {
 			'web.sessions.header.hideInspector' => '隐藏检查器',
 			'web.sessions.header.attachImage' => '附加图片',
 			'web.sessions.header.attachImageTooltip' => '附加图片（或直接粘贴 / 拖入终端）',
+			'web.sessions.header.copyOutput' => '复制输出',
+			'web.sessions.header.copyOutputTooltip' => '复制终端输出（若有选区则复制选区，否则复制全部）',
 			'web.sessions.header.restart' => '重启',
 			'web.sessions.header.restarting' => '重启中…',
 			'web.sessions.header.remove' => '移除',
@@ -7429,6 +7454,13 @@ extension on TranslationsZh {
 			'web.sessions.terminal.uploadFailedToast' => '上传失败',
 			'web.sessions.terminal.uploadInvalidTypeToast' => '仅支持图片文件',
 			'web.sessions.terminal.dropToAttach' => '释放以附加图片',
+			'web.sessions.terminal.copyButton' => '复制',
+			'web.sessions.terminal.copyAllTooltip' => '复制终端输出到剪贴板(若有选区则复制选区,否则复制全部)',
+			'web.sessions.terminal.copySelection' => '复制',
+			'web.sessions.terminal.copySelectionTooltip' => '复制选中的文本',
+			'web.sessions.terminal.copiedToast' => '已复制到剪贴板',
+			'web.sessions.terminal.copyEmptyToast' => '暂无可复制内容',
+			'web.sessions.terminal.copyFailedToast' => '无法复制到剪贴板',
 			'web.sessions.terminal.urls.tooltip' => '打开本会话最新检测到的链接',
 			'web.sessions.terminal.urls.tapToOpenLatest' => '点击打开最新链接(通常是 OAuth URL)',
 			'web.sessions.terminal.urls.openListTooltip' => '显示所有链接',
@@ -7477,7 +7509,7 @@ extension on TranslationsZh {
 			'web.sessions.accountSwitcher.defaultName' => '默认',
 			'web.sessions.accountSwitcher.defaultSubtitle' => 'CLI 的系统 keychain / 环境变量',
 			'web.sessions.accountSwitcher.tokenEmpty' => '·未填',
-			'web.sessions.accountSwitcher.confirmSwitch' => '切换账号将重启 Claude CLI 进程。CLI 内部进行中的对话状态将丢失。继续？',
+			'web.sessions.accountSwitcher.confirmSwitch' => '切换账户将重启 Claude CLI。对话历史会被保留（脚本会迁移并通过 --resume 恢复），但正在进行的工具调用或未发送的输入会丢失。是否继续？',
 			'web.sessions.accountSwitcher.switchedToast' => '账号已切换',
 			'web.sessions.accountSwitcher.switchedDescription' => ({required Object account, required Object pid}) => '当前使用 @${account} · pid ${pid}',
 			'web.sessions.accountSwitcher.switchedDefault' => '默认',
@@ -7823,6 +7855,8 @@ extension on TranslationsZh {
 			'web.memoryInspector.toasts.bulkDeleteFailed' => '批量删除失败',
 			'web.memoryInspector.toasts.created' => '记忆已创建',
 			'web.memoryInspector.toasts.createFailed' => '创建失败',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryInspector.toasts.updated' => '记忆已更新',
 			'web.memoryInspector.toasts.updateFailed' => '更新失败',
 			'web.memoryInspector.toasts.migrated' => ({required Object reembed, required Object examined, required Object to}) => '已迁移 ${reembed}/${examined} 条记忆到 ${to}',
@@ -7832,8 +7866,6 @@ extension on TranslationsZh {
 			'web.memoryInspector.toasts.syncEmpty' => '没有需要同步的新 .md 文件',
 			'web.memoryInspector.toasts.syncEmptyDescription' => '已是最新，或该 cwd 没有 Claude memory 目录。',
 			'web.memoryInspector.toasts.syncFailed' => '同步失败',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryInspector.toasts.testOk' => ({required Object embedder, required Object dim}) => 'Embedder OK：${embedder} · ${dim} 维',
 			'web.memoryInspector.toasts.testOkDescription' => ({required Object preview}) => 'vector_preview = [${preview}…]',
 			'web.memoryInspector.toasts.testFailed' => 'Embedder 探测失败',
@@ -8125,6 +8157,8 @@ extension on TranslationsZh {
 			'web.providers.claudeAccounts.removeFailedToast' => '移除失败',
 			'web.providers.claudeAccounts.toggleAria' => ({required Object name}) => '切换 ${name}',
 			'web.providers.claudeAccounts.removeAria' => ({required Object name}) => '移除 ${name}',
+			'web.providers.claudeAccounts.identityAcceptedToast' => '已接受新身份',
+			'web.providers.claudeAccounts.identityAcceptFailedToast' => '无法接受新身份',
 			'web.providers.models.title' => '模型',
 			'web.providers.models.help' => '该提供方可用的模型。默认模型会通过 model 参数传给每个会话；会话仍可覆盖。',
 			'web.providers.models.empty' => '尚未配置任何模型。',
@@ -8335,6 +8369,8 @@ extension on TranslationsZh {
 			'web.integrations.proxy.bodyLabel' => 'Body',
 			'web.integrations.proxy.headers' => 'Headers',
 			'web.integrations.proxy.body' => 'Body',
+			_ => null,
+		} ?? switch (path) {
 			'web.integrations.proxy.emptyBody' => '(空)',
 			'web.integrations.proxy.requestFailed' => '请求失败',
 			'web.integrations.proxy.stubText' => '发送一个请求即可查看上游响应。',
@@ -8346,8 +8382,6 @@ extension on TranslationsZh {
 			'web.plugins.common.cancel' => '取消',
 			'web.plugins.common.edit' => '编辑',
 			'web.plugins.common.add' => '添加',
-			_ => null,
-		} ?? switch (path) {
 			'web.plugins.common.save' => '保存',
 			'web.plugins.common.create' => '创建',
 			'web.plugins.mcp.title' => 'MCP 服务器',
@@ -8849,6 +8883,8 @@ extension on TranslationsZh {
 			'web.serverSettings.fields.backupExportDir.hint' => '一次性导出 zip 在磁盘上的暂存位置。留空 = ~/.opendray/exports。包将在 24 小时后自动过期。需要重启。',
 			'web.serverSettings.fields.backupPgDumpPath.label' => 'pg_dump 路径',
 			'web.serverSettings.fields.backupPgDumpPath.hint' => 'pg_dump 的绝对路径。主版本号必须 ≥ 服务器的。留空 = PATH 上的第一个 pg_dump。',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.fields.backupPgRestorePath.label' => 'pg_restore 路径',
 			'web.serverSettings.fields.backupPgRestorePath.hint' => '/backups/restore 流程使用的 pg_restore 绝对路径。同样的主版本号规则。',
 			'web.serverSettings.liveTail.heading' => '实时日志',
@@ -8860,8 +8896,6 @@ extension on TranslationsZh {
 			'web.serverSettings.stringList.noneDefault' => '（无 — 使用内置默认值）',
 			'web.serverSettings.stringList.addPath' => '添加路径',
 			'web.serverSettings.stringList.removeTitle' => '移除',
-			_ => null,
-		} ?? switch (path) {
 			'web.serverSettings.httpHelpers.autoDetected' => '启动时自动检测到',
 			'web.serverSettings.httpHelpers.modelCount' => ({required Object count}) => '${count} 个模型 — 点击使用',
 			'web.serverSettings.httpHelpers.presets' => '预设：',
@@ -9363,6 +9397,8 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.pinnedHint' => ({required Object path, required Object defaultPath}) => '已固定到 ${path}/（覆盖 ${defaultPath}）。AI agent 也会在此撰写文档。',
 			'sessions.inspector.notes.noProjectMapping2' => '（无项目映射）',
 			'sessions.inspector.notes.clearOverride' => '清除覆盖',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.notes.save' => '保存',
 			'sessions.spawnSheet.title' => '新建会话',
 			'sessions.spawnSheet.errorRequired' => '需要指定提供商和工作目录',
@@ -9374,8 +9410,6 @@ extension on TranslationsZh {
 			'sessions.spawnSheet.cwdLabel' => '工作目录',
 			'sessions.spawnSheet.cwdHint' => '/Users/you/projects/foo',
 			'sessions.spawnSheet.cwdHelper' => '网关主机上的绝对路径。',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.spawnSheet.browse' => '浏览',
 			'sessions.spawnSheet.nameLabel' => '名称（可选）',
 			'sessions.spawnSheet.nameHint' => '例如：backend-refactor',
@@ -9877,6 +9911,8 @@ extension on TranslationsZh {
 			'backupTargetEditor.rootDirLabel' => '根目录',
 			'backupTargetEditor.rootDirHint' => '留空 = cfg.backup.local_dir (~/.opendray/backups)',
 			'backupTargetEditor.hostLabel' => '主机',
+			_ => null,
+		} ?? switch (path) {
 			'backupTargetEditor.portLabel' => '端口',
 			'backupTargetEditor.shareLabel' => '共享',
 			'backupTargetEditor.shareHint' => '顶层共享名',
@@ -9888,8 +9924,6 @@ extension on TranslationsZh {
 			'backupTargetEditor.pathPrefixLabel' => '路径前缀',
 			'backupTargetEditor.pathPrefixHintShareRoot' => '共享根下的子文件夹（可选）',
 			'backupTargetEditor.pathPrefixHintBaseUrl' => 'Base URL 下的子文件夹（可选）',
-			_ => null,
-		} ?? switch (path) {
 			'backupTargetEditor.pathPrefixHintObjectKey' => '对象键前缀（可选）',
 			'backupTargetEditor.pathPrefixHintSshFolder' => '绝对路径或相对用户主目录（可选）',
 			'backupTargetEditor.pathPrefixHintRemoteRoot' => '远端根下的子文件夹（可选）',
@@ -10023,6 +10057,18 @@ extension on TranslationsZh {
 			'channels.kinds.telegram.botTokenHint' => '从 @BotFather 获取。存储于通道配置；仅管理员 API 可见。',
 			'channels.kinds.telegram.chatIdLabel' => '默认 chat ID',
 			'channels.kinds.telegram.chatIdPlaceholder' => '42（可选 — 没有 ReplyCtx 时使用）',
+			'channels.kinds.telegram.ownerUserIdsLabel' => 'Telegram 拥有者用户 ID',
+			'channels.kinds.telegram.ownerUserIdsPlaceholder' => '123456789（多个用逗号分隔）',
+			'channels.kinds.telegram.ownerUserIdsHint' => '只有这些数字 Telegram 用户 ID 才能驱动会话、运行命令或点击按钮；其他人一律忽略。留空则允许任何人（双向聊天不推荐）。私聊 @userinfobot 获取你的 ID。',
+			'channels.kinds.telegram.chatEnabledLabel' => '双向聊天（将消息路由进会话）',
+			'channels.kinds.telegram.chatEnabledHint' => '开启后，你的消息会被输入选定会话，agent 在此回复。仅需通知时关闭。',
+			'channels.kinds.telegram.chatTypingLabel' => 'agent 工作时显示“正在输入…”',
+			'channels.kinds.telegram.chatTypingHint' => '在 agent 回复稳定前显示正在输入指示。',
+			'channels.kinds.telegram.notifyEnabledLabel' => '活动通知（空闲 / 完成卡片）',
+			'channels.kinds.telegram.notifyEnabledHint' => '关闭可保持聊天整洁 — 你仍会收到对消息的回复。开启后会话空闲或完成时也会收到卡片。',
+			'channels.kinds.telegram.replyMaxCharsLabel' => '回复最大长度（字符）',
+			'channels.kinds.telegram.replyMaxCharsPlaceholder' => '3500（留空 = 3500，0 = 不限）',
+			'channels.kinds.telegram.replyMaxCharsHint' => '限制 agent 回复发送多少字符后被截断并附“…(已截断)”。留空使用 3500 默认（约一条消息）；设为 0 则发送完整回复，跨多条消息拆分。',
 			'channels.kinds.slack.description' => 'Socket Mode — 无需公网 webhook。需要 bot OAuth token（xoxb-）和带 connections:write 的 app-level token（xapp-）。',
 			'channels.kinds.slack.botTokenLabel' => 'Bot token（xoxb-…）',
 			'channels.kinds.slack.botTokenHint' => 'OAuth & Permissions → Bot User OAuth Token。需要 chat:write。',
@@ -10379,6 +10425,8 @@ extension on TranslationsZh {
 			'settings.serverSettings.sectionDescriptions.backup' => '加密的数据库备份 + 管理数据导出。密语保存在密钥文件（设置 → 备份）。',
 			'settings.serverSettings.sectionDescriptions.storageClaude' => 'Claude 会话记录在磁盘的存放位置。',
 			'settings.serverSettings.sectionDescriptions.storageCodex' => 'Codex 会话根目录。',
+			_ => null,
+		} ?? switch (path) {
 			'settings.serverSettings.sectionDescriptions.storageGemini' => '按项目的临时目录 + projects.json 路径。',
 			'settings.serverSettings.fields.listenAddress' => '监听地址',
 			'settings.serverSettings.fields.adminUser' => '管理员用户',
@@ -10402,8 +10450,6 @@ extension on TranslationsZh {
 			'settings.serverSettings.fields.gitRoot' => 'Git 根',
 			'settings.serverSettings.fields.personalPrefix' => '个人前缀',
 			'settings.serverSettings.fields.projectsPrefix' => '项目前缀',
-			_ => null,
-		} ?? switch (path) {
 			'settings.serverSettings.fields.registryRoot' => '注册表根',
 			'settings.serverSettings.fields.secretsFile' => '密钥文件',
 			'settings.serverSettings.fields.backend' => '后端',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -840,6 +840,7 @@ class _TranslationsAboutZh extends TranslationsAboutEn {
 	@override String get copyTooltip => '复制';
 	@override late final _TranslationsAboutCopyLabelsZh copyLabels = _TranslationsAboutCopyLabelsZh._(_root);
 	@override String get tagline => 'opendray mobile — 多 CLI 网关控制。\n源码：github.com/Opendray/opendray';
+	@override late final _TranslationsAboutGatewayZh gateway = _TranslationsAboutGatewayZh._(_root);
 }
 
 // Path: settings
@@ -2421,6 +2422,7 @@ class _TranslationsAboutSectionsZh extends TranslationsAboutSectionsEn {
 	// Translations
 	@override String get app => '应用';
 	@override String get server => '服务器';
+	@override String get gateway => '网关';
 }
 
 // Path: about.fields
@@ -2448,6 +2450,22 @@ class _TranslationsAboutCopyLabelsZh extends TranslationsAboutCopyLabelsEn {
 	// Translations
 	@override String get version => '版本';
 	@override String get serverUrl => '服务器 URL';
+}
+
+// Path: about.gateway
+class _TranslationsAboutGatewayZh extends TranslationsAboutGatewayEn {
+	_TranslationsAboutGatewayZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get version => '版本';
+	@override String get commit => '提交';
+	@override String get checking => '正在检查更新…';
+	@override String get upToDate => '已是最新';
+	@override String updateAvailable({required Object version}) => '有可用更新：${version}';
+	@override String get releaseNotes => '更新说明';
+	@override String get checkFailed => '无法检查更新';
 }
 
 // Path: settings.language
@@ -10347,6 +10365,7 @@ extension on TranslationsZh {
 			'about.loading' => '加载中…',
 			'about.sections.app' => '应用',
 			'about.sections.server' => '服务器',
+			'about.sections.gateway' => '网关',
 			'about.fields.app' => '应用',
 			'about.fields.version' => '版本',
 			'about.fields.versionFormat' => ({required Object version, required Object build}) => '${version}（build ${build}）',
@@ -10359,6 +10378,13 @@ extension on TranslationsZh {
 			'about.copyLabels.version' => '版本',
 			'about.copyLabels.serverUrl' => '服务器 URL',
 			'about.tagline' => 'opendray mobile — 多 CLI 网关控制。\n源码：github.com/Opendray/opendray',
+			'about.gateway.version' => '版本',
+			'about.gateway.commit' => '提交',
+			'about.gateway.checking' => '正在检查更新…',
+			'about.gateway.upToDate' => '已是最新',
+			'about.gateway.updateAvailable' => ({required Object version}) => '有可用更新：${version}',
+			'about.gateway.releaseNotes' => '更新说明',
+			'about.gateway.checkFailed' => '无法检查更新',
 			'settings.title' => '设置',
 			'settings.language.section' => '语言',
 			'settings.language.system' => '跟随系统',
@@ -10424,6 +10450,8 @@ extension on TranslationsZh {
 			'settings.serverSettings.sections.logging' => '日志',
 			'settings.serverSettings.sections.sessions' => '会话',
 			'settings.serverSettings.sections.vault' => '凭据库',
+			_ => null,
+		} ?? switch (path) {
 			'settings.serverSettings.sections.mcpRegistry' => 'MCP 注册表',
 			'settings.serverSettings.sections.memory' => '记忆',
 			'settings.serverSettings.sections.backup' => '备份',
@@ -10432,8 +10460,6 @@ extension on TranslationsZh {
 			'settings.serverSettings.sections.storageGemini' => '存储 · Gemini',
 			'settings.serverSettings.sectionDescriptions.general' => '监听地址、管理员账号、令牌 TTL。',
 			'settings.serverSettings.sectionDescriptions.logging' => '详细程度、格式、磁盘日志路径。',
-			_ => null,
-		} ?? switch (path) {
 			'settings.serverSettings.sectionDescriptions.sessions' => '空闲检测阈值。',
 			'settings.serverSettings.sectionDescriptions.vault' => '笔记、技能、git 版本化的根目录。',
 			'settings.serverSettings.sectionDescriptions.mcpRegistry' => 'MCP 服务器 + 密钥文件的凭据库路径。',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -1750,6 +1750,13 @@ class _TranslationsProvidersAccountsZh extends TranslationsProvidersAccountsEn {
 	@override String enabledSnack({required Object name}) => '${name} 已启用。';
 	@override String disabledSnack({required Object name}) => '${name} 已停用。';
 	@override String renamedSnack({required Object name}) => '已重命名为 ${name}。';
+	@override String activeSessions({required Object count}) => '${count} 个活跃';
+	@override String usedAgo({required Object when}) => '${when}使用';
+	@override String get identityChanged => '身份已变更';
+	@override String identityWas({required Object email}) => '原为 ${email}';
+	@override String get acceptIdentity => '接受';
+	@override String get identityAcceptedSnack => '已接受身份变更';
+	@override String get identityAcceptFailed => '接受失败';
 }
 
 // Path: integrations.form
@@ -9539,6 +9546,13 @@ extension on TranslationsZh {
 			'providers.accounts.enabledSnack' => ({required Object name}) => '${name} 已启用。',
 			'providers.accounts.disabledSnack' => ({required Object name}) => '${name} 已停用。',
 			'providers.accounts.renamedSnack' => ({required Object name}) => '已重命名为 ${name}。',
+			'providers.accounts.activeSessions' => ({required Object count}) => '${count} 个活跃',
+			'providers.accounts.usedAgo' => ({required Object when}) => '${when}使用',
+			'providers.accounts.identityChanged' => '身份已变更',
+			'providers.accounts.identityWas' => ({required Object email}) => '原为 ${email}',
+			'providers.accounts.acceptIdentity' => '接受',
+			'providers.accounts.identityAcceptedSnack' => '已接受身份变更',
+			'providers.accounts.identityAcceptFailed' => '接受失败',
 			'providers.configFallbackTitle' => '提供商配置',
 			'providers.saving' => '保存中…',
 			'providers.save' => '保存',
@@ -9904,6 +9918,8 @@ extension on TranslationsZh {
 			'backupTargetEditor.formTitleNew' => '新建备份目标',
 			'backupTargetEditor.idHintAuto' => ({required Object prefix}) => '自动：${prefix}-1',
 			'backupTargetEditor.idHelper' => '小写字母、数字、连字符。默认为下一个可用槽。',
+			_ => null,
+		} ?? switch (path) {
 			'backupTargetEditor.enabledOn' => '定期和临时备份可使用此目标。',
 			'backupTargetEditor.enabledOff' => '服务器将拒绝向此处写入备份。',
 			'backupTargetEditor.saving' => '保存中…',
@@ -9911,8 +9927,6 @@ extension on TranslationsZh {
 			'backupTargetEditor.rootDirLabel' => '根目录',
 			'backupTargetEditor.rootDirHint' => '留空 = cfg.backup.local_dir (~/.opendray/backups)',
 			'backupTargetEditor.hostLabel' => '主机',
-			_ => null,
-		} ?? switch (path) {
 			'backupTargetEditor.portLabel' => '端口',
 			'backupTargetEditor.shareLabel' => '共享',
 			'backupTargetEditor.shareHint' => '顶层共享名',
@@ -10418,6 +10432,8 @@ extension on TranslationsZh {
 			'settings.serverSettings.sections.storageGemini' => '存储 · Gemini',
 			'settings.serverSettings.sectionDescriptions.general' => '监听地址、管理员账号、令牌 TTL。',
 			'settings.serverSettings.sectionDescriptions.logging' => '详细程度、格式、磁盘日志路径。',
+			_ => null,
+		} ?? switch (path) {
 			'settings.serverSettings.sectionDescriptions.sessions' => '空闲检测阈值。',
 			'settings.serverSettings.sectionDescriptions.vault' => '笔记、技能、git 版本化的根目录。',
 			'settings.serverSettings.sectionDescriptions.mcpRegistry' => 'MCP 服务器 + 密钥文件的凭据库路径。',
@@ -10425,8 +10441,6 @@ extension on TranslationsZh {
 			'settings.serverSettings.sectionDescriptions.backup' => '加密的数据库备份 + 管理数据导出。密语保存在密钥文件（设置 → 备份）。',
 			'settings.serverSettings.sectionDescriptions.storageClaude' => 'Claude 会话记录在磁盘的存放位置。',
 			'settings.serverSettings.sectionDescriptions.storageCodex' => 'Codex 会话根目录。',
-			_ => null,
-		} ?? switch (path) {
 			'settings.serverSettings.sectionDescriptions.storageGemini' => '按项目的临时目录 + projects.json 路径。',
 			'settings.serverSettings.fields.listenAddress' => '监听地址',
 			'settings.serverSettings.fields.adminUser' => '管理员用户',

--- a/app/mobile/lib/core/session_recents/recents_controller.dart
+++ b/app/mobile/lib/core/session_recents/recents_controller.dart
@@ -1,0 +1,55 @@
+// RecentsController — per-device "most recently opened" timestamps for
+// sessions, so the sessions list can surface what you actually use on
+// top. Mirrors the web zustand sessionTabs.recents map (opendray.
+// sessionTabs in localStorage). Persists to shared_preferences like
+// LocaleController / ThemeController so the order survives restarts.
+
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _prefsKey = 'opendray.sessions.recents.v1';
+
+class RecentsController extends StateNotifier<Map<String, int>> {
+  RecentsController() : super(const {}) {
+    _restore();
+  }
+
+  Future<void> _restore() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(_prefsKey);
+      if (raw == null || raw.isEmpty) return;
+      final decoded = jsonDecode(raw);
+      if (decoded is Map) {
+        state = decoded.map(
+          (k, v) => MapEntry(k as String, (v as num).toInt()),
+        );
+      }
+    } on Object {
+      // Best-effort; empty map fallback keeps the list working.
+    }
+  }
+
+  // Record that session [id] was opened now (epoch millis). The web
+  // store stamps on both open and tab-activate; mobile has one path
+  // (tap → push), so a single mark is enough.
+  Future<void> markOpened(String id) async {
+    if (id.isEmpty) return;
+    final next = Map<String, int>.from(state)
+      ..[id] = DateTime.now().millisecondsSinceEpoch;
+    state = next;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_prefsKey, jsonEncode(next));
+    } on Object {
+      // Best-effort persistence; in-memory order still works this run.
+    }
+  }
+}
+
+final recentsProvider =
+    StateNotifierProvider<RecentsController, Map<String, int>>(
+  (ref) => RecentsController(),
+);

--- a/app/mobile/lib/features/channels/channel_form_dialog.dart
+++ b/app/mobile/lib/features/channels/channel_form_dialog.dart
@@ -48,6 +48,9 @@ class ChannelFormScreen extends StatefulWidget {
 
 class _ChannelFormScreenState extends State<ChannelFormScreen> {
   final _ctrls = <String, TextEditingController>{};
+  // Boolean fields render as a Switch rather than a text input; their
+  // state lives here so _submit can serialise a real bool into config.
+  final _bools = <String, bool>{};
   String? _error;
 
   @override
@@ -55,8 +58,16 @@ class _ChannelFormScreenState extends State<ChannelFormScreen> {
     super.initState();
     final init = widget.initial ?? const {};
     for (final f in widget.kind.fields) {
-      final v = init[f.name];
-      _ctrls[f.name] = TextEditingController(text: v is String ? v : '');
+      if (f.type == ChannelFieldType.boolean) {
+        // Seed from the stored config; fall back to the field default so
+        // a new channel (or an old one missing this field) toggles into
+        // its intended state. Mirrors the web default-seeding.
+        final v = init[f.name];
+        _bools[f.name] = v is bool ? v : (f.defaultValue ?? false);
+      } else {
+        final v = init[f.name];
+        _ctrls[f.name] = TextEditingController(text: v is String ? v : '');
+      }
     }
   }
 
@@ -71,6 +82,10 @@ class _ChannelFormScreenState extends State<ChannelFormScreen> {
   void _submit() {
     final cfg = <String, dynamic>{};
     for (final f in widget.kind.fields) {
+      if (f.type == ChannelFieldType.boolean) {
+        cfg[f.name] = _bools[f.name] ?? f.defaultValue ?? false;
+        continue;
+      }
       final raw = _ctrls[f.name]?.text.trim() ?? '';
       if (raw.isEmpty) {
         if (f.required) {
@@ -110,10 +125,17 @@ class _ChannelFormScreenState extends State<ChannelFormScreen> {
             ),
           ),
           for (final f in widget.kind.fields)
-            _ChannelFieldEditor(
-              field: f,
-              controller: _ctrls[f.name]!,
-            ),
+            if (f.type == ChannelFieldType.boolean)
+              _ChannelBoolField(
+                field: f,
+                value: _bools[f.name] ?? f.defaultValue ?? false,
+                onChanged: (v) => setState(() => _bools[f.name] = v),
+              )
+            else
+              _ChannelFieldEditor(
+                field: f,
+                controller: _ctrls[f.name]!,
+              ),
           if (_error != null) ...[
             const SizedBox(height: 8),
             Text(
@@ -208,6 +230,46 @@ class _ChannelFieldEditorState extends State<_ChannelFieldEditor> {
                 )
               : null,
         ),
+      ),
+    );
+  }
+}
+
+// _ChannelBoolField renders a boolean channel field as a labelled Switch
+// with the field's hint underneath. Mirrors the web Switch row.
+class _ChannelBoolField extends StatelessWidget {
+  const _ChannelBoolField({
+    required this.field,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final ChannelField field;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            title: Text(field.label, style: theme.textTheme.bodyMedium),
+            value: value,
+            onChanged: onChanged,
+          ),
+          if (field.hint != null)
+            Text(
+              field.hint!,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.outline,
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/app/mobile/lib/features/channels/channel_kinds.dart
+++ b/app/mobile/lib/features/channels/channel_kinds.dart
@@ -7,7 +7,7 @@
 
 import 'package:opendray/core/i18n/strings.g.dart';
 
-enum ChannelFieldType { text, password, textarea }
+enum ChannelFieldType { text, password, textarea, boolean }
 
 class ChannelField {
   const ChannelField({
@@ -18,6 +18,7 @@ class ChannelField {
     this.placeholder,
     this.hint,
     this.optional = false,
+    this.defaultValue,
   });
 
   final String name;
@@ -30,6 +31,9 @@ class ChannelField {
   // omit it from the submitted config so server defaults apply
   // (rather than persisting an empty string).
   final bool optional;
+  // Initial value for `boolean` fields when the channel config has no
+  // stored value. (`default` is a Dart reserved word, hence the name.)
+  final bool? defaultValue;
 }
 
 class ChannelKind {
@@ -83,6 +87,43 @@ List<ChannelKind> channelKindsList() => [
             type: ChannelFieldType.text,
             placeholder: t.channels.kinds.telegram.chatIdPlaceholder,
             optional: true,
+          ),
+          ChannelField(
+            name: 'owner_user_ids',
+            label: t.channels.kinds.telegram.ownerUserIdsLabel,
+            type: ChannelFieldType.text,
+            optional: true,
+            placeholder: t.channels.kinds.telegram.ownerUserIdsPlaceholder,
+            hint: t.channels.kinds.telegram.ownerUserIdsHint,
+          ),
+          ChannelField(
+            name: 'chat_enabled',
+            label: t.channels.kinds.telegram.chatEnabledLabel,
+            type: ChannelFieldType.boolean,
+            defaultValue: true,
+            hint: t.channels.kinds.telegram.chatEnabledHint,
+          ),
+          ChannelField(
+            name: 'chat_typing',
+            label: t.channels.kinds.telegram.chatTypingLabel,
+            type: ChannelFieldType.boolean,
+            defaultValue: true,
+            hint: t.channels.kinds.telegram.chatTypingHint,
+          ),
+          ChannelField(
+            name: 'notify_enabled',
+            label: t.channels.kinds.telegram.notifyEnabledLabel,
+            type: ChannelFieldType.boolean,
+            defaultValue: false,
+            hint: t.channels.kinds.telegram.notifyEnabledHint,
+          ),
+          ChannelField(
+            name: 'reply_max_chars',
+            label: t.channels.kinds.telegram.replyMaxCharsLabel,
+            type: ChannelFieldType.text,
+            optional: true,
+            placeholder: t.channels.kinds.telegram.replyMaxCharsPlaceholder,
+            hint: t.channels.kinds.telegram.replyMaxCharsHint,
           ),
         ],
       ),

--- a/app/mobile/lib/features/more/about_screen.dart
+++ b/app/mobile/lib/features/more/about_screen.dart
@@ -2,9 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:opendray/core/api/version_api.dart';
 import 'package:opendray/core/auth/auth_state.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 // Diagnostics screen for "what version is this and which server am
 // I pointed at" — exactly the information that gets lost when bug
@@ -113,6 +115,9 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
                   .add_Hms()
                   .format(loggedIn.expiresAt.toLocal()),
             ),
+            const SizedBox(height: 8),
+            _SectionHeader(label: t.about.sections.gateway),
+            const _GatewayVersion(),
           ],
           const SizedBox(height: 24),
           Center(
@@ -159,6 +164,95 @@ class _AboutScreenState extends ConsumerState<AboutScreen> {
             ),
       dense: true,
     );
+  }
+}
+
+// _GatewayVersion shows the running gateway's version + update status,
+// read-only (no self-update trigger — see version_api.dart). The
+// /version endpoint soft-fails, so an unreachable release check renders
+// as "update check unavailable" rather than an error.
+class _GatewayVersion extends ConsumerWidget {
+  const _GatewayVersion();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final async = ref.watch(versionInfoProvider);
+    return async.when(
+      loading: () => ListTile(
+        dense: true,
+        leading: const SizedBox(
+          width: 18,
+          height: 18,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+        title: Text(t.about.gateway.checking,
+            style: theme.textTheme.bodySmall),
+      ),
+      error: (e, _) => ListTile(
+        dense: true,
+        title: Text(t.about.gateway.checkFailed,
+            style: theme.textTheme.bodySmall
+                ?.copyWith(color: theme.colorScheme.outline)),
+      ),
+      data: (v) {
+        final muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+        final hasUpdate = v.checkError == null && v.updateAvailable;
+        final statusText = v.checkError != null
+            ? t.about.gateway.checkFailed
+            : v.updateAvailable
+                ? t.about.gateway.updateAvailable(version: v.latest ?? '')
+                : t.about.gateway.upToDate;
+        final statusColor = hasUpdate ? theme.colorScheme.primary : muted;
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ListTile(
+              dense: true,
+              title: Text(t.about.gateway.version,
+                  style: theme.textTheme.bodySmall),
+              subtitle: Padding(
+                padding: const EdgeInsets.only(top: 2),
+                child: Text(
+                  v.commit != null && v.commit!.isNotEmpty
+                      ? '${v.current} (${_shortSha(v.commit!)})'
+                      : v.current,
+                  style: const TextStyle(fontSize: 14, fontFamily: 'monospace'),
+                ),
+              ),
+              trailing: Text(statusText,
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: statusColor)),
+            ),
+            if (v.updateAvailable && v.notesUrl != null)
+              Padding(
+                padding: const EdgeInsets.only(left: 16, bottom: 4),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton.icon(
+                    icon: const Icon(Icons.open_in_new, size: 16),
+                    label: Text(t.about.gateway.releaseNotes),
+                    onPressed: () => _openNotes(v.notesUrl!),
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+
+  static String _shortSha(String sha) =>
+      sha.length > 7 ? sha.substring(0, 7) : sha;
+
+  Future<void> _openNotes(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    try {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } on Object {
+      // Best-effort convenience link.
+    }
   }
 }
 

--- a/app/mobile/lib/features/providers/claude_accounts_section.dart
+++ b/app/mobile/lib/features/providers/claude_accounts_section.dart
@@ -392,6 +392,15 @@ class _ClaudeAccountsSectionState
     );
   }
 
+  Future<void> _acceptIdentity(ClaudeAccountSummary a) async {
+    await _runOp(
+      key: 'a:${a.id}',
+      okMsg: t.providers.accounts.identityAcceptedSnack,
+      failPrefix: t.providers.accounts.identityAcceptFailed,
+      op: () => ref.read(claudeAccountsApiProvider).acceptIdentity(a.id),
+    );
+  }
+
   Widget _buildList(List<ClaudeAccountSummary> list) {
     if (list.isEmpty) {
       return Padding(
@@ -410,6 +419,7 @@ class _ClaudeAccountsSectionState
             account: a,
             busy: _busy.contains('a:${a.id}'),
             onTap: () => _openActions(a),
+            onAcceptIdentity: () => _acceptIdentity(a),
           ),
       ],
     );
@@ -423,70 +433,184 @@ class _AccountTile extends StatelessWidget {
     required this.account,
     required this.busy,
     required this.onTap,
+    required this.onAcceptIdentity,
   });
 
   final ClaudeAccountSummary account;
   final bool busy;
   final VoidCallback onTap;
+  final VoidCallback onAcceptIdentity;
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final usable = account.isUsable;
-    return ListTile(
-      onTap: busy ? null : onTap,
-      contentPadding: EdgeInsets.zero,
-      leading: Icon(
-        usable ? Icons.account_circle : Icons.account_circle_outlined,
-        color: usable
-            ? Theme.of(context).colorScheme.primary
-            : Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.4),
-      ),
-      title: Row(
-        children: [
-          Flexible(
-            child: Text(
-              account.displayName,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                color: account.enabled
-                    ? null
-                    : Theme.of(context)
-                        .colorScheme
-                        .onSurface
-                        .withValues(alpha: 0.55),
+    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        ListTile(
+          onTap: busy ? null : onTap,
+          contentPadding: EdgeInsets.zero,
+          leading: Icon(
+            usable ? Icons.account_circle : Icons.account_circle_outlined,
+            color: usable
+                ? theme.colorScheme.primary
+                : theme.colorScheme.onSurface.withValues(alpha: 0.4),
+          ),
+          title: Row(
+            children: [
+              Flexible(
+                child: Text(
+                  account.displayName,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: account.enabled
+                        ? null
+                        : theme.colorScheme.onSurface.withValues(alpha: 0.55),
+                  ),
+                ),
               ),
+              const SizedBox(width: 6),
+              if (!account.enabled)
+                _MiniBadge(label: 'disabled', color: theme.colorScheme.error),
+              if (!account.tokenFilled) ...[
+                const SizedBox(width: 4),
+                _MiniBadge(label: 'no token', color: theme.colorScheme.error),
+              ],
+            ],
+          ),
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                account.id,
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(fontFamily: 'monospace'),
+              ),
+              if (_hasMeta) ...[
+                const SizedBox(height: 4),
+                _metaChips(context, muted),
+              ],
+            ],
+          ),
+          isThreeLine: _hasMeta,
+          trailing: busy
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.more_vert),
+        ),
+        if (account.identityDrift) _identityBanner(context),
+      ],
+    );
+  }
+
+  bool get _hasMeta =>
+      account.subscriptionType != null ||
+      account.rateLimitTier != null ||
+      account.activeSessions != null ||
+      account.lastUsedAt != null ||
+      account.oauthEmail != null;
+
+  // Capacity-at-a-glance metadata, wrapped so it never overflows a phone
+  // row. Mirrors the inline chips in web's ClaudeAccountsPanel.
+  Widget _metaChips(BuildContext context, Color muted) {
+    final theme = Theme.of(context);
+    final used = _relTime(account.lastUsedAt);
+    return Wrap(
+      spacing: 6,
+      runSpacing: 4,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        if (account.subscriptionType != null)
+          _MiniBadge(
+            label: account.subscriptionType!.toUpperCase(),
+            color: theme.colorScheme.tertiary,
+          ),
+        if (account.rateLimitTier != null)
+          _MiniBadge(label: account.rateLimitTier!, color: muted),
+        if (account.activeSessions != null)
+          _MiniBadge(
+            label: t.providers.accounts
+                .activeSessions(count: account.activeSessions!.toString()),
+            color: muted,
+          ),
+        if (used != null)
+          Text(
+            t.providers.accounts.usedAgo(when: used),
+            style: theme.textTheme.bodySmall?.copyWith(color: muted),
+          ),
+        if (account.oauthEmail != null)
+          Text(
+            account.oauthEmail!,
+            style: theme.textTheme.bodySmall?.copyWith(color: muted),
+          ),
+      ],
+    );
+  }
+
+  // Identity-drift banner: the on-disk OAuth identity no longer matches
+  // the first-seen baseline. The Accept button acknowledges the swap.
+  Widget _identityBanner(BuildContext context) {
+    final theme = Theme.of(context);
+    final err = theme.colorScheme.error;
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: err.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: err.withValues(alpha: 0.4)),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.warning_amber_rounded, size: 16, color: err),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  t.providers.accounts.identityChanged,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: err,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                if (account.previousEmail != null)
+                  Text(
+                    t.providers.accounts
+                        .identityWas(email: account.previousEmail!),
+                    style: theme.textTheme.bodySmall?.copyWith(color: err),
+                  ),
+              ],
             ),
           ),
-          const SizedBox(width: 6),
-          if (!account.enabled)
-            _MiniBadge(
-              label: 'disabled',
-              color: Theme.of(context).colorScheme.error,
-            ),
-          if (!account.tokenFilled) ...[
-            const SizedBox(width: 4),
-            _MiniBadge(
-              label: 'no token',
-              color: Theme.of(context).colorScheme.error,
-            ),
-          ],
+          TextButton(
+            onPressed: busy ? null : onAcceptIdentity,
+            style: TextButton.styleFrom(foregroundColor: err),
+            child: Text(t.providers.accounts.acceptIdentity),
+          ),
         ],
       ),
-      subtitle: Text(
-        account.id,
-        style: Theme.of(context)
-            .textTheme
-            .bodySmall
-            ?.copyWith(fontFamily: 'monospace'),
-      ),
-      trailing: busy
-          ? const SizedBox(
-              width: 18,
-              height: 18,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            )
-          : const Icon(Icons.more_vert),
     );
+  }
+
+  // Coarse relative time for last_used_at; null when absent/unparseable.
+  static String? _relTime(String? iso) {
+    if (iso == null) return null;
+    final t = DateTime.tryParse(iso);
+    if (t == null) return null;
+    final d = DateTime.now().difference(t);
+    if (d.inDays > 365) return '${(d.inDays / 365).floor()}y ago';
+    if (d.inDays > 30) return '${(d.inDays / 30).floor()}mo ago';
+    if (d.inDays > 0) return '${d.inDays}d ago';
+    if (d.inHours > 0) return '${d.inHours}h ago';
+    if (d.inMinutes > 0) return '${d.inMinutes}m ago';
+    return 'just now';
   }
 }
 

--- a/app/mobile/lib/features/providers/claude_accounts_section.dart
+++ b/app/mobile/lib/features/providers/claude_accounts_section.dart
@@ -480,21 +480,11 @@ class _AccountTile extends StatelessWidget {
               ],
             ],
           ),
-          subtitle: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                account.id,
-                style: theme.textTheme.bodySmall
-                    ?.copyWith(fontFamily: 'monospace'),
-              ),
-              if (_hasMeta) ...[
-                const SizedBox(height: 4),
-                _metaChips(context, muted),
-              ],
-            ],
+          subtitle: Text(
+            account.id,
+            style:
+                theme.textTheme.bodySmall?.copyWith(fontFamily: 'monospace'),
           ),
-          isThreeLine: _hasMeta,
           trailing: busy
               ? const SizedBox(
                   width: 18,
@@ -503,6 +493,14 @@ class _AccountTile extends StatelessWidget {
                 )
               : const Icon(Icons.more_vert),
         ),
+        // Metadata chips live below the ListTile (not in its subtitle
+        // slot, which clips to a fixed height) so a fully-populated
+        // account with all chips + a long OAuth email never gets cut off.
+        if (_hasMeta)
+          Padding(
+            padding: const EdgeInsets.only(left: 40, bottom: 8),
+            child: _metaChips(context, muted),
+          ),
         if (account.identityDrift) _identityBanner(context),
       ],
     );

--- a/app/mobile/lib/features/sessions/sessions_screen.dart
+++ b/app/mobile/lib/features/sessions/sessions_screen.dart
@@ -73,7 +73,7 @@ class _SessionsScreenState extends ConsumerState<SessionsScreen> {
         ),
       ),
       body: RefreshIndicator(
-        onRefresh: () async => ref.refresh(sessionsListProvider.future),
+        onRefresh: () async => ref.refresh(sortedSessionsListProvider.future),
         child: async.when(
           data: (sessions) {
             final visible =

--- a/app/mobile/lib/features/sessions/sessions_screen.dart
+++ b/app/mobile/lib/features/sessions/sessions_screen.dart
@@ -8,6 +8,7 @@ import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/sessions_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/core/providers/provider_visual.dart';
+import 'package:opendray/core/session_recents/recents_controller.dart';
 import 'package:opendray/core/widgets/brand_avatar.dart';
 import 'package:opendray/features/sessions/session_action_sheet.dart';
 import 'package:opendray/features/sessions/spawn_session_sheet.dart';
@@ -49,7 +50,7 @@ class _SessionsScreenState extends ConsumerState<SessionsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final async = ref.watch(sessionsListProvider);
+    final async = ref.watch(sortedSessionsListProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -91,7 +92,10 @@ class _SessionsScreenState extends ConsumerState<SessionsScreen> {
                 final s = visible[i];
                 return _SessionCard(
                   session: s,
-                  onTap: () => context.push('/session/${s.id}'),
+                  onTap: () {
+                    ref.read(recentsProvider.notifier).markOpened(s.id);
+                    context.push('/session/${s.id}');
+                  },
                   onLongPress: () => _onAction(s),
                   onMore: () => _onAction(s),
                 );


### PR DESCRIPTION
## Summary

Recent web work (notably #270) landed several features and fixes on the React admin that never made it to the Flutter mobile app. This brings mobile up to parity across 4 areas. After surveying every recent web-touching change, these were the genuine shared-behavior gaps — the rest were already present on mobile, desktop-only (Cmd+K), or server-side/platform N/A.

## What's included (one commit each)

1. **Telegram two-way channel config** — the web channel form gained 5 Telegram fields in #270; the Flutter form only had `bot_token` + `chat_id`. Add a `boolean` field type (rendered as a `SwitchListTile`) + the 5 fields (`owner_user_ids`, `chat_enabled`, `chat_typing`, `notify_enabled`, `reply_max_chars`), seeded/serialized to match web exactly.
2. **Claude account metadata** — surface the gateway-decorated fields (subscription tier, rate-limit tier, active sessions, last used, OAuth email) as chips under each account, plus an identity-drift banner with an **Accept** button (`POST .../accept-identity`).
3. **Gateway version check** (read-only) — new `version_api.dart` + a Gateway section in the About screen showing the running gateway version, commit, and update-available status with a release-notes link. No in-app self-update button (that restarts the gateway binary; left to web / host shell).
4. **Session MRU ordering** — sessions now sort most-recently-used first (per-device recents map persisted to `shared_preferences`), mirroring web's `SessionList.orderBy`; live-before-ended grouping preserved.

UI strings go through slang i18n (en + zh), consistent with the rest of the mobile app.

## Test plan

- `cd app/mobile && flutter analyze` — clean (0 issues).
- `dart run slang` — generated strings in sync.
- A code review pass flagged two real issues, both fixed in the final commit: account metadata chips moved out of the `ListTile` subtitle (avoids clipping on phones with many chips); pull-to-refresh now awaits the sorted provider.
- Manual (gateway with a configured token): Telegram channel create/edit shows the 5 new fields with Switches and persists real bools; provider page shows account metadata chips + drift banner/accept; About shows the Gateway version section; sessions reorder by recent use and the order survives an app restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)