### PR TITLE
docs(readme): backfill 10-way language switcher in README.fa.md

### DIFF
--- a/README.fa.md
+++ b/README.fa.md
@@ -30,7 +30,7 @@
 </p>
 
 <p align="center">
-  🌐 <strong>فارسی</strong> · <a href="README.zh.md">简体中文</a> · <a href="README.md">English</a>
+  🌐 <a href="README.md">English</a> · <a href="README.zh.md">简体中文</a> · <strong>فارسی</strong> · <a href="README.es.md">Español</a> · <a href="README.pt-BR.md">Português</a> · <a href="README.ja.md">日本語</a> · <a href="README.ko.md">한국어</a> · <a href="README.fr.md">Français</a> · <a href="README.de.md">Deutsch</a> · <a href="README.ru.md">Русский</a>
 </p>
 
 ---


### PR DESCRIPTION
## What

One-line docs change: brings `README.fa.md`'s language switcher up to parity with the other nine READMEs.

## Why

`README.fa.md` landed via #278 with a 3-way switcher (English · 简体中文 · فارسی). #282 introduced the canonical 10-way switcher order and updated EN/ZH and the seven new translations, but did not touch the Farsi file (it was outside #282's diff scope). Result: readers on `README.fa.md` couldn't navigate to ES/PT-BR/JA/KO/FR/DE/RU.

## Diff

```diff
-  🌐 <strong>فارسی</strong> · <a href="README.zh.md">简体中文</a> · <a href="README.md">English</a>
+  🌐 <a href="README.md">English</a> · <a href="README.zh.md">简体中文</a> · <strong>فارسی</strong> · <a href="README.es.md">Español</a> · <a href="README.pt-BR.md">Português</a> · <a href="README.ja.md">日本語</a> · <a href="README.ko.md">한국어</a> · <a href="README.fr.md">Français</a> · <a href="README.de.md">Deutsch</a> · <a href="README.ru.md">Русский</a>
```

Same fixed order #282 used across the other nine READMEs (active language as `<strong>`, others as links).

## Test plan

- [x] `git diff --check` clean
- [x] Single-line diff; nothing else touched
- [x] No code paths affected — pure docs change, no CI risk to the gateway
- [x] Each new link target file (`README.es.md`, `README.pt-BR.md`, …) already exists on `main` from #282
