### PR TITLE
fix(windows): resolve build and test failures on Windows

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -90,11 +92,16 @@ func TestNewLogger_JSONFormat(t *testing.T) {
 }
 
 func TestNewLogger_BadFilePath(t *testing.T) {
-	// A file path under a missing directory should surface a real
-	// error instead of silently returning a no-op writer.
+	// Use an existing regular file as the supposed parent directory.
+	// os.MkdirAll will fail on all platforms (including Windows) when
+	// a path component already exists as a file instead of a directory.
+	blocker := filepath.Join(t.TempDir(), "notadir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	_, _, err := newLogger(config.LogConfig{
 		Level: "info",
-		File:  "/nonexistent-dir-" + t.Name() + "/opendray.log",
+		File:  filepath.Join(blocker, "opendray.log"),
 	})
 	if err == nil {
 		t.Error("expected error for unwritable log path, got nil")

--- a/internal/applog/handler.go
+++ b/internal/applog/handler.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -163,13 +164,13 @@ func NewFileWriter(opt FileWriterOption) (io.Writer, error) {
 	}, nil
 }
 
-// filepathDir is filepath.Dir but tolerates the empty / current-dir
-// case so callers don't need to handle os.MkdirAll("./", ...).
+// filepathDir returns the parent directory of p, using filepath.Dir
+// so it handles both Unix (/) and Windows (\) path separators.
+// Returns "" when there is no meaningful parent (equivalent to ".").
 func filepathDir(p string) string {
-	for i := len(p) - 1; i >= 0; i-- {
-		if p[i] == '/' {
-			return p[:i]
-		}
+	dir := filepath.Dir(p)
+	if dir == "." {
+		return ""
 	}
-	return ""
+	return dir
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -23,6 +23,7 @@ func TestMain(m *testing.M) {
 	}
 	defer func() { _ = os.RemoveAll(tmp) }()
 	_ = os.Setenv("HOME", tmp)
+	_ = os.Setenv("USERPROFILE", tmp) // Windows: os.UserHomeDir reads USERPROFILE
 	_ = os.Unsetenv(envOverride)
 	os.Exit(m.Run())
 }

--- a/internal/auth/keyfile_test.go
+++ b/internal/auth/keyfile_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -16,6 +17,7 @@ func setTempHome(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir) // Windows: os.UserHomeDir reads USERPROFILE
 	t.Setenv(envOverride, "")
 	return dir
 }
@@ -105,14 +107,18 @@ func TestWriteKeyFile_PermsAndAtomicity(t *testing.T) {
 		t.Fatal(err)
 	}
 	if mode := info.Mode().Perm(); mode != 0o600 {
-		t.Errorf("file perms: got %#o want 0600", mode)
+		if runtime.GOOS != "windows" {
+			t.Errorf("file perms: got %#o want 0600", mode)
+		}
 	}
 	dirInfo, err := os.Stat(filepath.Dir(path))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if mode := dirInfo.Mode().Perm(); mode != 0o700 {
-		t.Errorf("dir perms: got %#o want 0700", mode)
+		if runtime.GOOS != "windows" {
+			t.Errorf("dir perms: got %#o want 0700", mode)
+		}
 	}
 	// No stray tempfile after a successful write.
 	entries, _ := os.ReadDir(filepath.Dir(path))

--- a/internal/backup/keyfile_test.go
+++ b/internal/backup/keyfile_test.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -15,6 +16,7 @@ func setTempHome(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir) // Windows: os.UserHomeDir reads USERPROFILE
 	// Clear the two env-var inputs so individual tests can opt
 	// them back in deterministically.
 	t.Setenv(envKey, "")
@@ -35,7 +37,7 @@ func TestLoadPassphrase_None(t *testing.T) {
 	if got.Source != KeySourceNone {
 		t.Fatalf("expected KeySourceNone, got %q", got.Source)
 	}
-	if !strings.HasSuffix(got.Path, "/.opendray/secrets/backup.key") {
+	if !strings.HasSuffix(filepath.ToSlash(got.Path), "/.opendray/secrets/backup.key") {
 		t.Fatalf("expected default path under fake home, got %q", got.Path)
 	}
 }
@@ -133,7 +135,9 @@ func TestWriteKeyFile_PermsAndAtomicity(t *testing.T) {
 		t.Fatal(err)
 	}
 	if mode := info.Mode().Perm(); mode != 0o600 {
-		t.Errorf("file perms: got %#o want 0600", mode)
+		if runtime.GOOS != "windows" {
+			t.Errorf("file perms: got %#o want 0600", mode)
+		}
 	}
 	// Parent dir 0700 for the same reason — a 0755 dir
 	// containing a 0600 file is fine in theory but tightening
@@ -143,7 +147,9 @@ func TestWriteKeyFile_PermsAndAtomicity(t *testing.T) {
 		t.Fatal(err)
 	}
 	if mode := dirInfo.Mode().Perm(); mode != 0o700 {
-		t.Errorf("dir perms: got %#o want 0700", mode)
+		if runtime.GOOS != "windows" {
+			t.Errorf("dir perms: got %#o want 0700", mode)
+		}
 	}
 
 	// No stray tempfile from the atomic write — defer-cleanup

--- a/internal/backup/keyfile_test.go
+++ b/internal/backup/keyfile_test.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -15,6 +16,7 @@ func setTempHome(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir) // Windows: os.UserHomeDir reads USERPROFILE
 	// Clear the two env-var inputs so individual tests can opt
 	// them back in deterministically.
 	t.Setenv(envKey, "")
@@ -35,7 +37,7 @@ func TestLoadPassphrase_None(t *testing.T) {
 	if got.Source != KeySourceNone {
 		t.Fatalf("expected KeySourceNone, got %q", got.Source)
 	}
-	if !strings.HasSuffix(got.Path, "/.opendray/secrets/backup.key") {
+	if !strings.HasSuffix(filepath.ToSlash(got.Path), "/.opendray/secrets/backup.key") {
 		t.Fatalf("expected default path under fake home, got %q", got.Path)
 	}
 }
@@ -133,7 +135,9 @@ func TestWriteKeyFile_PermsAndAtomicity(t *testing.T) {
 		t.Fatal(err)
 	}
 	if mode := info.Mode().Perm(); mode != 0o600 {
-		t.Errorf("file perms: got %#o want 0600", mode)
+		if runtime.GOOS != "windows" {
+			t.Errorf("file perms: got %#o want 0600", mode)
+		}
 	}
 	// Parent dir 0700 for the same reason — a 0755 dir
 	// containing a 0600 file is fine in theory but tightening
@@ -143,7 +147,9 @@ func TestWriteKeyFile_PermsAndAtomicity(t *testing.T) {
 		t.Fatal(err)
 	}
 	if mode := dirInfo.Mode().Perm(); mode != 0o700 {
-		t.Errorf("dir perms: got %#o want 0700", mode)
+		if runtime.GOOS != "windows" {
+			t.Errorf("dir perms: got %#o want 0700", mode)
+		}
 	}
 
 	// No stray tempfile from the atomic write — defer-cleanup
@@ -241,3 +247,4 @@ func TestReadKeyFile_TrimsAndRejectsEmpty(t *testing.T) {
 		t.Fatal("expected whitespace-only file to error")
 	}
 }
+

--- a/internal/backup/target_local.go
+++ b/internal/backup/target_local.go
@@ -61,7 +61,7 @@ func (t *LocalTarget) resolve(p string) (string, error) {
 	if strings.ContainsRune(p, 0) {
 		return "", fmt.Errorf("%w: null byte", ErrTargetRejectedPath)
 	}
-	if filepath.IsAbs(p) {
+	if filepath.IsAbs(p) || strings.HasPrefix(p, "/") || strings.HasPrefix(p, `\`) {
 		return "", fmt.Errorf("%w: absolute path %q", ErrTargetRejectedPath, p)
 	}
 	cleaned := filepath.Clean(p)

--- a/internal/backup/target_local.go
+++ b/internal/backup/target_local.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -63,6 +64,14 @@ func (t *LocalTarget) resolve(p string) (string, error) {
 	}
 	if filepath.IsAbs(p) || strings.HasPrefix(p, "/") || strings.HasPrefix(p, `\`) {
 		return "", fmt.Errorf("%w: absolute path %q", ErrTargetRejectedPath, p)
+	}
+	// Windows drive-relative paths (`C:foo`, `C:..\evil`) are NOT
+	// caught by filepath.IsAbs but resolve against the current
+	// directory of that drive, so they can escape `root`. Reject
+	// any colon on Windows — colons are never valid in cleaned
+	// relative paths on that platform.
+	if runtime.GOOS == "windows" && strings.ContainsRune(p, ':') {
+		return "", fmt.Errorf("%w: drive-relative path %q", ErrTargetRejectedPath, p)
 	}
 	cleaned := filepath.Clean(p)
 	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {

--- a/internal/backup/target_local_test.go
+++ b/internal/backup/target_local_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -142,6 +143,9 @@ func TestLocalTarget_HealthCheck_OK(t *testing.T) {
 }
 
 func TestLocalTarget_HealthCheck_ReadOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not restrict writes on Windows")
+	}
 	dir := t.TempDir()
 	if err := os.Chmod(dir, 0o500); err != nil {
 		t.Fatalf("chmod: %v", err)

--- a/internal/catalog/inject_test.go
+++ b/internal/catalog/inject_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -294,6 +295,9 @@ func TestMirrorCodexHome_SkipsDanglingSymlinks(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.Symlink(filepath.Join(src, "nonexistent-target"), filepath.Join(skillsDir, "broken")); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink creation requires elevated privileges on Windows: " + err.Error())
+		}
 		t.Fatal(err)
 	}
 

--- a/internal/cliacct/identity_test.go
+++ b/internal/cliacct/identity_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -61,7 +62,7 @@ func TestIdentityStore_PersistsToDisk(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if fi != 0o600 {
+	if fi != 0o600 && runtime.GOOS != "windows" {
 		t.Errorf("perm = %o, want 0600", fi)
 	}
 }

--- a/internal/cliacct/service_local_test.go
+++ b/internal/cliacct/service_local_test.go
@@ -33,7 +33,9 @@ func TestDiscoverLocalAccounts(t *testing.T) {
 	// Isolate HOME so the test never sees the host's real ~/.claude
 	// (which would change the result based on which machine you run
 	// the suite on).
-	t.Setenv("HOME", t.TempDir())
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome) // Windows: os.UserHomeDir reads USERPROFILE
 
 	dir := t.TempDir()
 
@@ -83,7 +85,9 @@ func TestDiscoverLocalAccounts(t *testing.T) {
 func TestDiscoverLocalAccounts_MissingDirIsNotError(t *testing.T) {
 	// Nonexistent accounts dir → empty result, no error (this is the bug
 	// that produced "run `claude-acc init`").
-	t.Setenv("HOME", t.TempDir())
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome) // Windows: os.UserHomeDir reads USERPROFILE
 	got, err := discoverLocalAccounts(filepath.Join(t.TempDir(), "does-not-exist"))
 	if err != nil {
 		t.Fatalf("missing dir should not error: %v", err)
@@ -98,6 +102,7 @@ func TestDiscoverLocalAccounts_EmitsDefaultWhenClaudeHomeHasCreds(t *testing.T) 
 	// The synthetic "default" entry should surface, pointing at HOME/.claude.
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows: os.UserHomeDir reads USERPROFILE
 	writeFile(t, filepath.Join(home, ".claude", ".credentials.json"), `{"claudeAiOauth":{}}`)
 
 	// Empty accountsDir (no named accounts) → only 'default' should appear.
@@ -128,6 +133,7 @@ func TestDiscoverLocalAccounts_DefaultEmittedAlongsideNamedAccounts(t *testing.T
 	// should both surface, default first.
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows: os.UserHomeDir reads USERPROFILE
 	writeFile(t, filepath.Join(home, ".claude", ".credentials.json"), `{"claudeAiOauth":{}}`)
 	accountsDir := filepath.Join(t.TempDir(), "accounts")
 	writeFile(t, filepath.Join(accountsDir, "kevin", ".credentials.json"), `{"claudeAiOauth":{}}`)
@@ -245,6 +251,7 @@ func TestResolveClaudeConfigDir_EmptyIDReturnsHomeClaude(t *testing.T) {
 	// switching from "no pin" to a named account.
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows: os.UserHomeDir reads USERPROFILE
 	svc := &Service{} // store not needed for empty-id path
 	got, err := svc.ResolveClaudeConfigDir(context.Background(), "")
 	if err != nil {

--- a/internal/cliacct/service_local_test.go
+++ b/internal/cliacct/service_local_test.go
@@ -33,7 +33,9 @@ func TestDiscoverLocalAccounts(t *testing.T) {
 	// Isolate HOME so the test never sees the host's real ~/.claude
 	// (which would change the result based on which machine you run
 	// the suite on).
-	t.Setenv("HOME", t.TempDir())
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome) // Windows: os.UserHomeDir reads USERPROFILE
 
 	dir := t.TempDir()
 
@@ -83,7 +85,9 @@ func TestDiscoverLocalAccounts(t *testing.T) {
 func TestDiscoverLocalAccounts_MissingDirIsNotError(t *testing.T) {
 	// Nonexistent accounts dir → empty result, no error (this is the bug
 	// that produced "run `claude-acc init`").
-	t.Setenv("HOME", t.TempDir())
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome) // Windows: os.UserHomeDir reads USERPROFILE
 	got, err := discoverLocalAccounts(filepath.Join(t.TempDir(), "does-not-exist"))
 	if err != nil {
 		t.Fatalf("missing dir should not error: %v", err)
@@ -98,6 +102,7 @@ func TestDiscoverLocalAccounts_EmitsDefaultWhenClaudeHomeHasCreds(t *testing.T) 
 	// The synthetic "default" entry should surface, pointing at HOME/.claude.
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows: os.UserHomeDir reads USERPROFILE
 	writeFile(t, filepath.Join(home, ".claude", ".credentials.json"), `{"claudeAiOauth":{}}`)
 
 	// Empty accountsDir (no named accounts) → only 'default' should appear.
@@ -128,6 +133,7 @@ func TestDiscoverLocalAccounts_DefaultEmittedAlongsideNamedAccounts(t *testing.T
 	// should both surface, default first.
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows: os.UserHomeDir reads USERPROFILE
 	writeFile(t, filepath.Join(home, ".claude", ".credentials.json"), `{"claudeAiOauth":{}}`)
 	accountsDir := filepath.Join(t.TempDir(), "accounts")
 	writeFile(t, filepath.Join(accountsDir, "kevin", ".credentials.json"), `{"claudeAiOauth":{}}`)
@@ -245,7 +251,8 @@ func TestResolveClaudeConfigDir_EmptyIDReturnsHomeClaude(t *testing.T) {
 	// switching from "no pin" to a named account.
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	svc := &Service{} // store not needed for empty-id path
+	t.Setenv("USERPROFILE", home) // Windows: os.UserHomeDir reads USERPROFILE
+	svc := &Service{}             // store not needed for empty-id path
 	got, err := svc.ResolveClaudeConfigDir(context.Background(), "")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cliacct/watcher_test.go
+++ b/internal/cliacct/watcher_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -174,6 +175,9 @@ func TestWatcher_RefusesSymlinkedRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.Symlink(real, link); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink creation requires elevated privileges on Windows: " + err.Error())
+		}
 		t.Fatal(err)
 	}
 

--- a/internal/mcp/validate_test.go
+++ b/internal/mcp/validate_test.go
@@ -1,12 +1,32 @@
 package mcp
 
 import (
+	"bufio"
 	"context"
+	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// TestMain intercepts the test binary when used as a fake MCP server.
+// When OPENDRAY_TEST_FAKE_MCP=1, the process acts as a minimal stdio
+// MCP server and exits instead of running tests.
+func TestMain(m *testing.M) {
+	if os.Getenv("OPENDRAY_TEST_FAKE_MCP") == "1" {
+		scanner := bufio.NewScanner(os.Stdin)
+		// initialize request
+		scanner.Scan()
+		fmt.Fprintln(os.Stdout, `{"jsonrpc":"2.0","id":1,"result":{"serverInfo":{"name":"fake-vault","version":"9.9"},"capabilities":{}}}`)
+		// initialized notification
+		scanner.Scan()
+		// tools/list request
+		scanner.Scan()
+		fmt.Fprintln(os.Stdout, `{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"read_secret"},{"name":"list_mounts"}]}}`)
+		return
+	}
+	os.Exit(m.Run())
+}
 
 func checkByName(res ValidationResult, name string) (Check, bool) {
 	for _, c := range res.Checks {
@@ -51,23 +71,19 @@ func TestValidate_SSEReachability_Unreachable(t *testing.T) {
 }
 
 func TestValidate_StdioHandshake(t *testing.T) {
-	dir := t.TempDir()
-	script := filepath.Join(dir, "fakemcp.sh")
-	// Minimal MCP server: the validator writes initialize, then the
-	// initialized notification, then tools/list — in that order. Reply
-	// to the two requests with canned JSON-RPC results.
-	body := `#!/bin/sh
-read _init
-printf '{"jsonrpc":"2.0","id":1,"result":{"serverInfo":{"name":"fake-vault","version":"9.9"},"capabilities":{}}}\n'
-read _initialized
-read _toolslist
-printf '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"read_secret"},{"name":"list_mounts"}]}}\n'
-`
-	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+	// Use the test binary itself as the fake MCP server (cross-platform).
+	// When invoked with OPENDRAY_TEST_FAKE_MCP=1, TestMain handles the
+	// MCP handshake and exits before running any tests.
+	exe, err := os.Executable()
+	if err != nil {
 		t.Fatal(err)
 	}
 
-	res := Validate(context.Background(), Server{Transport: "stdio", Command: script}, nil)
+	res := Validate(context.Background(), Server{
+		Transport: "stdio",
+		Command:   exe,
+		Env:       map[string]string{"OPENDRAY_TEST_FAKE_MCP": "1"},
+	}, nil)
 	if !res.OK {
 		t.Fatalf("handshake should succeed: %+v", res.Checks)
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/creack/pty"
@@ -906,7 +905,7 @@ func (m *Manager) Stop(ctx context.Context, id string) error {
 	}
 
 	m.markStopRequested(id)
-	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
+	if err := termProcess(pid); err != nil {
 		return fmt.Errorf("sigterm: %w", err)
 	}
 
@@ -914,7 +913,7 @@ func (m *Manager) Stop(ctx context.Context, id string) error {
 	case <-rs.endedCh:
 		return nil
 	case <-time.After(terminateGrace):
-		_ = syscall.Kill(pid, syscall.SIGKILL)
+		killProcess(pid)
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -1213,7 +1212,7 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 		terminal := rs.sess.State.IsTerminal()
 		rs.sessMu.RUnlock()
 		if !terminal {
-			_ = syscall.Kill(pid, syscall.SIGTERM)
+			_ = termProcess(pid)
 		}
 	}
 
@@ -1234,7 +1233,7 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 			ended := rs.sess.State == StateEnded
 			rs.sessMu.RUnlock()
 			if !ended {
-				_ = syscall.Kill(pid, syscall.SIGKILL)
+				killProcess(pid)
 			}
 		}
 		select {

--- a/internal/session/signals_unix.go
+++ b/internal/session/signals_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package session
+
+import (
+	"errors"
+	"syscall"
+)
+
+// termProcess sends SIGTERM to the process with the given PID.
+// Returns nil if the process no longer exists.
+func termProcess(pid int) error {
+	err := syscall.Kill(pid, syscall.SIGTERM)
+	if errors.Is(err, syscall.ESRCH) {
+		return nil
+	}
+	return err
+}
+
+// killProcess sends SIGKILL to the process with the given PID.
+func killProcess(pid int) {
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+}

--- a/internal/session/signals_windows.go
+++ b/internal/session/signals_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package session
+
+import "os"
+
+// termProcess sends a termination signal to the process with the given PID.
+// On Windows there is no SIGTERM; we call Kill as the best available equivalent.
+// Returns nil if the process no longer exists.
+func termProcess(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return nil // process not found
+	}
+	if err := proc.Kill(); err != nil {
+		return nil // already exited
+	}
+	return nil
+}
+
+// killProcess forcibly terminates the process with the given PID.
+func killProcess(pid int) {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return
+	}
+	_ = proc.Kill()
+}

--- a/internal/session/transcript_migrate_test.go
+++ b/internal/session/transcript_migrate_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -153,6 +154,9 @@ func TestMigrateClaudeTranscript_RejectsSymlinkedSource(t *testing.T) {
 	}
 	src := filepath.Join(dir, id+".jsonl")
 	if err := os.Symlink(victim, src); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink creation requires elevated privileges on Windows: " + err.Error())
+		}
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION

## Summary

`go test -race ./...` failed to build and run on Windows across 7 packages due to OS-specific behaviour the test suite did not account for. This PR fixes the build failure in `internal/session` (undefined `syscall.SIGTERM`/`SIGKILL`), closes a path-traversal gap in `internal/backup/target_local` (`filepath.IsAbs` returns `false` for `/abs/path` on Windows), and corrects home-directory isolation, permission assertions, symlink handling, and cross-platform path separators across the remaining affected packages.

## Related issue

Closes #295

## Type of change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)

## Surface(s) touched

- [x] Backend (Go) — `internal/*`, `cmd/*`

## Test plan

- [x] `go test -race ./...` passes locally (or DB-skipped tests skip cleanly)
- [x] `cd app/web && pnpm build` (TS strict + Vite prod) succeeds
- [x] Manual smoke: full `go test -race ./...` run on Windows — all 44 packages pass, 0 failures

## DB / config / operator impact

- [x] No DB migration
- [x] None of the above

## Anything else?

### Production changes (non-test)

| File | Change |
|---|---|
| `internal/session/signals_unix.go` *(new)* | Build-tagged (`!windows`) helper wrapping `syscall.SIGTERM` / `syscall.SIGKILL` |
| `internal/session/signals_windows.go` *(new)* | Build-tagged (`windows`) equivalent using `os.FindProcess` + `proc.Kill()` |
| `internal/session/manager.go` | Replace four inline `syscall.Kill` calls with the new helpers |
| `internal/applog/handler.go` | Replace manual `/`-scan in `filepathDir` with `filepath.Dir` — Windows uses `\` |
| `internal/backup/target_local.go` | `resolve()` now also rejects paths prefixed with `/` or `\` — `filepath.IsAbs("/abs/path")` returns `false` on Windows, leaving a path-traversal gap |

### Test-only changes

| Root cause | Affected packages | Fix |
|---|---|---|
| `os.UserHomeDir()` reads `USERPROFILE` on Windows, not `HOME` | `auth`, `backup`, `cliacct` | Add `t.Setenv("USERPROFILE", dir)` alongside `HOME` in all home-isolation helpers and `TestMain` |
| `os.Chmod` does not enforce Unix permission bits on Windows | `auth`, `backup`, `cliacct` | Skip `0600`/`0700` assertions on `runtime.GOOS == "windows"` |
| `os.Symlink` requires elevated privileges on Windows by default | `catalog`, `cliacct`, `session` | Skip symlink tests when `os.Symlink` returns an error on Windows |
| `.sh` helper script not executable on Windows | `mcp` | Rewrite `validate_test.go` using the `TestMain`-as-fake-server pattern — test binary re-executes itself via `OPENDRAY_TEST_FAKE_MCP=1` |
| Unix-rooted path `/nonexistent-dir/…` is not unwritable on Windows | `app` | `TestNewLogger_BadFilePath` now uses an existing regular file as the supposed parent directory — `os.MkdirAll` fails on all platforms when a path component is already a file |
| Path suffix check used `/` but Windows paths use `\` | `backup` | Normalise with `filepath.ToSlash` before `strings.HasSuffix` |
| `os.Chmod(dir, 0o500)` does not prevent writes on Windows | `backup` | Skip `TestLocalTarget_HealthCheck_ReadOnly` on Windows |


