### PR TITLE
docs(catalog): link enable-cli-updates.sh helper from guidance + README

### DIFF
--- a/internal/catalog/handler.go
+++ b/internal/catalog/handler.go
@@ -165,7 +165,7 @@ func (h *Handlers) update(w http.ResponseWriter, r *http.Request) {
 		// Report "unavailable" so the UI shows guidance, not a failure.
 		res.Available = false
 		res.Reason = "In-app updates aren't available here — the npm global prefix isn't writable by the opendray service. " +
-			"Install the CLI into an opendray-owned npm prefix (on the service PATH) to enable one-tap updates."
+			"Run `sudo bash scripts/enable-cli-updates.sh` on the host to set up an opendray-owned prefix and enable one-tap updates."
 		h.log.Info("provider update unavailable (read-only prefix)", "provider", id)
 		h.publishUpdate(id, res, false, "prefix-readonly")
 		writeJSON(w, http.StatusOK, res)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -314,3 +314,32 @@ psql "<your DSN>" -tAc \
 If all three pass, the wizard did its job. Open the admin UI and
 proceed with [docs/getting-started.md § Step 4 — first login](
 ../docs/getting-started.md#step-4--first-login--change-admin-password).
+
+
+## `enable-cli-updates.sh` — one-shot helper to enable in-app CLI updates
+
+On a non-root install the opendray service user can't write to the global
+npm prefix (`/usr/lib/node_modules` or similar), so the per-provider
+**Update** button on the Providers page returns *"In-app updates aren't
+available here — npm global prefix isn't writable."*
+
+`scripts/enable-cli-updates.sh` flips that by creating an opendray-owned
+npm prefix at `$OPENDRAY_DATA_DIR/.npm-global`, dropping a systemd unit
+fragment that pins `NPM_CONFIG_PREFIX` + prepends the prefix's `bin` onto
+`PATH`, reinstalling `@anthropic-ai/claude-code` / `@google/gemini-cli` /
+`@openai/codex` into it as the service user, and restarting the daemon.
+
+```sh
+sudo bash scripts/enable-cli-updates.sh
+```
+
+Idempotent — re-running just refreshes the CLIs in the prefix.
+
+**Skip individual providers** with env vars:
+
+```sh
+sudo SKIP_GEMINI=1 SKIP_CODEX=1 bash scripts/enable-cli-updates.sh
+```
+
+After it finishes, **Providers → Update** on each CLI writes into the
+new prefix and one-tap upgrades work as designed.


### PR DESCRIPTION
Closes #262.

## What

The helper script that resolves the read-only-prefix path already exists on main — `scripts/enable-cli-updates.sh` (landed via #270). But it's invisible to users who hit the failure:

1. The in-app guidance toast says *"Install the CLI into an opendray-owned npm prefix (on the service PATH)"* — accurate, but doesn't tell the operator how. There's no command they can copy.
2. `scripts/README.md` doesn't mention the helper at all.

So a user hitting the "unavailable" path on Providers → Update has no signal that a one-shot fix exists.

## Diff

**`internal/catalog/handler.go`** — guidance message now includes the literal command:

```diff
-"Install the CLI into an opendray-owned npm prefix (on the service PATH) to enable one-tap updates."
+"Run `sudo bash scripts/enable-cli-updates.sh` on the host to set up an opendray-owned prefix and enable one-tap updates."
```

**`scripts/README.md`** — new section documenting the helper alongside install/uninstall, including the `SKIP_*` skip-individually env vars.

## Why this shape

#262 listed three options (standalone helper, fold-into-install-linux.sh, just docs). #270 already shipped Option 1's script during the multi-account work — this PR is the missing glue (the *discoverability* piece that the original issue body didn't separately call out) so operators who hit the failure path actually find the fix.

## Test plan

- [x] Docs-only + one string change
- [x] No code-path behavior change beyond the toast text
- [x] `go vet ./...` happy with the string-literal swap (tests don't pin the text)
