### PR TITLE
release(goreleaser): publish releases directly (not as draft)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,7 +63,11 @@ changelog:
   disable: true
 
 release:
-  draft: true
+  # Publish directly (not as draft). The publish-npm job in
+  # release.yml fetches SHA256SUMS via the public release
+  # download URL — that path only exists once the release is
+  # published, so a draft release breaks the npm publish chain.
+  draft: false
   prerelease: auto
   name_template: "v{{ .Version }}"
   header: |


### PR DESCRIPTION
One-line config change so future tagged releases auto-publish without a manual un-draft step.

## What

```diff
 release:
-  draft: true
+  draft: false
   prerelease: auto
```

Plus a 4-line comment explaining why (the WHY isn't obvious — see below).

## Why

The release workflow chains two jobs:

1. **GoReleaser** builds tarballs, signs with cosign, attaches SBOM, creates the GitHub release.
2. **publish-npm** fetches `https://github.com/Opendray/opendray/releases/download/v{version}/SHA256SUMS` to verify the binaries before pushing to npm.

With `draft: true`, step 1 leaves the release in draft state. The `releases/download/...` public path only resolves once the release is published. So step 2 404s every patch release, fails the job, and the maintainer has to manually un-draft + re-run the npm job.

Hit this on the v2.7.1 ship today: the `Publish to npm` job failed with `fetch https://github.com/Opendray/opendray/releases/download/v2.7.1/SHA256SUMS -> 404 Not Found`. Manual fix was `PATCH /releases/{id} { draft: false }` followed by `POST /actions/runs/{run_id}/rerun-failed-jobs`. Five-minute detour each release.

## What changes operationally

- Tagged release → release is **immediately public** instead of sitting as a draft for review.
- The CHANGELOG entry + tag annotation are the review surface now (both live before the tag push).
- `prerelease: auto` still routes `v*-rc.*` tags into the prerelease bucket so they don't flip the "Latest release" badge.

If you want a review gate for the release content, the right place is the **CHANGELOG bump PR** (this is how v2.7.1 worked) — not a post-build draft state that breaks the npm pipeline.

## Test plan

- [x] Single-file config change, no code behaviour change
- [x] Next tagged release (whenever v2.7.2 / v2.8 lands) will verify the full pipeline
- [x] `prerelease: auto` semantics preserved
