### PR TITLE
release(notes): inject CHANGELOG section into release body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,9 @@
 name: Release
 
-# Triggered automatically on tag push (v*) — produces a draft GitHub
-# release with goreleaser archives, cosign-signed checksums, and an
-# anchore-generated SBOM. The release lands as DRAFT (per
-# .goreleaser.yml release.draft: true) so a human reviews notes before
-# flipping it to public.
+# Triggered automatically on tag push (v*) — produces a published GitHub
+# release with goreleaser archives, cosign-signed checksums, an anchore-
+# generated SBOM, and release notes extracted from the matching section
+# of CHANGELOG.md. The CHANGELOG bump PR is the review gate.
 #
 # workflow_dispatch is wired for two scenarios:
 #   * Re-running the pipeline against an existing tag (e.g. v1.0.0,
@@ -80,15 +79,39 @@ jobs:
         with:
           go-version: "1.25"
 
-      # ── Goreleaser: archives + checksums in ./dist, draft release on GH.
-      #    SHA-pinned for supply-chain integrity. Intentionally pinned
-      #    on v6 (not v7) to avoid the v7 ESM/Node 24 breaking change
-      #    until we explicitly validate it.
+      # ── Extract the matching CHANGELOG section into release-notes.md
+      #    so goreleaser uses it as the release body instead of the
+      #    static "See CHANGELOG.md" placeholder. Falls back to that
+      #    placeholder if the tag has no section yet (re-running an
+      #    old tag via workflow_dispatch).
+      - name: Extract release notes from CHANGELOG.md
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          ver="${TAG#v}"
+          awk -v ver="$ver" '
+            $0 ~ "^## \\[v" ver "\\]" { capture = 1; next }
+            capture && /^## \[/ { exit }
+            capture { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "(no CHANGELOG section found for $TAG — using fallback notes)"
+            echo "See [CHANGELOG.md](https://github.com/Opendray/opendray/blob/main/CHANGELOG.md) for the full release notes." > release-notes.md
+          fi
+          echo "--- release-notes.md ($(wc -l < release-notes.md) lines) ---"
+          head -30 release-notes.md
+
+      # ── Goreleaser: archives + checksums in ./dist, published release on GH.
+      #    --release-notes overrides the static header in .goreleaser.yml
+      #    with the extracted CHANGELOG section. SHA-pinned for supply-
+      #    chain integrity. Intentionally pinned on v6 (not v7) to
+      #    avoid the v7 ESM/Node 24 breaking change until we explicitly
+      #    validate it.
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a  # v6
         with:
           version: latest
-          args: release --clean
+          args: release --clean --release-notes=release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Makes GitHub releases (and consequently `opendray.dev/changelog`) render the actual change list inline instead of the static "See CHANGELOG.md for the full release notes" placeholder.

## What

New step in `release.yml` extracts the matching CHANGELOG section into `release-notes.md` and passes it to GoReleaser via `--release-notes=release-notes.md`, which overrides the static `header:` from `.goreleaser.yml`.

```yaml
- name: Extract release notes from CHANGELOG.md
  env:
    TAG: ${{ github.event.inputs.tag || github.ref_name }}
  run: |
    ver="${TAG#v}"
    awk -v ver="$ver" '
      $0 ~ "^## \\[v" ver "\\]" { capture = 1; next }
      capture && /^## \[/ { exit }
      capture { print }
    ' CHANGELOG.md > release-notes.md
    if [ ! -s release-notes.md ]; then
      echo "See [CHANGELOG.md](https://github.com/Opendray/opendray/blob/main/CHANGELOG.md) for the full release notes." > release-notes.md
    fi
```

Smoke-tested locally on `CHANGELOG.md`: extracted 55 lines from the `## [v2.7.1] —` section, stopped cleanly at the next `## [v2.7.0] —` header.

## Why

Caught while reviewing the live site after the v2.7.1 ship:

- `https://opendray.dev/changelog` rendered v2.7.1 with only "See CHANGELOG.md for the full release notes" as its body.
- Same on the GitHub release page itself.

GoReleaser doesn't auto-pull the version-matching section from `CHANGELOG.md`; the `release.header:` in `.goreleaser.yml` is a *static* template that gets applied to every release. Either we duplicate every changelog entry into both `CHANGELOG.md` and `.goreleaser.yml` per release, or we extract on the fly. This PR does the latter.

## Fallback

If the workflow runs against a tag with no matching `CHANGELOG.md` section (e.g. re-running v1.0.0 via `workflow_dispatch`), the extract step writes the original placeholder so GoReleaser still gets a non-empty file.

## Drive-by

The workflow's top-of-file comment still described releases as draft. Updated alongside (the actual behaviour changed in #303).

## Test plan

- [x] Smoke-tested the awk extractor on the current CHANGELOG.md against `v2.7.1` — produced expected output.
- [x] `release-notes.md` always non-empty (fallback path).
- [x] Next tagged release verifies the full pipeline end-to-end on a real CI run.
