### PR TITLE
chore(ghcr): note container package removal in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+### Removed
+
+- **`ghcr.io/Opendray/opendray` container image (all 370 versions / 84
+  tags).** The image was orphaned — the most recent tag was `v2.1.0`
+  (five releases behind), no workflow in `.github/` was building it
+  any more, no docs / installer scripts / discussions referenced it.
+  More importantly, a pullable container contradicted the host-
+  resident-only deploy policy (Discussion #300, README "Choose how
+  to run it" table): opendray runs AI CLIs through PTYs and shares
+  filesystem state (`~/.claude`, ssh-agent, project files) with
+  them, which container isolation breaks. Operators who landed on
+  the GHCR page following stale links from external blog posts
+  would have pulled v2.1.0 and hit exactly that failure mode.
+  Supported install paths remain the
+  [one-line installer](https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh),
+  the [from-source quickstart](docs/quickstart.md), and
+  `npm install -g opendray`.
+
 ## [v2.7.1] — 2026-06-01
 
 Security + bug-fix rollup on top of v2.7.0. No API, config, or schema


### PR DESCRIPTION
Paper trail for an out-of-band action: the `ghcr.io/Opendray/opendray` container package was deleted from GitHub Container Registry today (370 versions, 84 tags removed). This PR adds an entry under `[Unreleased]` so the next release groups the change into a public changelog.

## Why the image was deleted

- **Orphaned.** Most recent tag was `v2.1.0` — five releases behind `v2.7.1`. No workflow in `.github/` was building containers anymore (verified: zero matches for container build steps in CI / release workflows; no `Dockerfile` in the repo).
- **Zero downstream references.** Single mention of `ghcr.io/opendray` across the entire repo, and that was a historical line in `CHANGELOG.md`. No installer script, no docs page, no discussion, no PR pointed at it.
- **Contradicted policy.** Discussion #300 explicitly lists *"Production Docker / Compose path"* under things we don't plan to add — opendray runs AI CLIs through PTYs and shares filesystem state (`~/.claude`, ssh-agent, project files) that container isolation breaks. A pullable image at a known location undermined that stance every time someone landed on the package page from a stale external blog post.

## What this PR is

- 18-line `CHANGELOG.md` addition under `[Unreleased]` → `### Removed`.
- Links the three remaining supported install paths so anyone discovering the removal can find the alternative.

## What this PR is NOT

- Not a policy change. If a defined containerized use case ever emerges (e.g. a headless REST/WS-only deploy with no PTY agents), the path is to re-add a `Dockerfile`, wire up a build workflow, document the use case, and republish — not to undo this CHANGELOG entry.
- Not a backwards-compat shim. No fallback redirect, no "this image is deprecated" placeholder; the package is gone and the GitHub package page now 404s.

## Test plan

- [x] CHANGELOG-only diff, no code touched
- [x] Removal verified: `https://github.com/Opendray/opendray/pkgs/container/opendray` → 404, registry `latest` manifest → 403
- [x] Vault token has been rotated to the short-lifetime variant required by the org's PAT policy