### PR TITLE
docs(readme): rewrite README.fa.md in native colloquial Persian voice

### DIFF
--- a/README.fa.md
+++ b/README.fa.md
@@ -1,496 +1,512 @@
-<div dir="rtl" lang="fa">
+# opendray
 
-<p align="center">
-  <a href="https://opendray.dev"><img src="docs/assets/logo.png" alt="opendray" width="180"></a>
-</p>
+یک gateway خودمیزبان برای اجرای Claude Code، Codex، Gemini و shell؛ همراه با یک لایه حافظه مشترک و local-first بین همه آن‌ها.
 
-<h1 align="center">opendray</h1>
+سشن‌های کاری را روی زیرساخت خودتان اجرا کنید، از web، mobile یا chat کنترلشان کنید، و برای integrationهای دیگر هم یک REST + WebSocket API باز داشته باشید.
 
-<p align="center">
-  <strong>درگاه self-hosted برای Claude Code · Codex · Gemini · shell، با یک لایه حافظه مشترک local-first بین همه آن‌ها.</strong>
-  <br/>
-  <sub>سشن‌ها را روی زیرساخت خودتان اجرا کنید. از وب، موبایل یا chat کنترلش کنید. یک API باز REST + WebSocket هم برای integrationها دارید.</sub>
-</p>
+[opendray.dev](https://opendray.dev)
 
-<p align="center">
-  <strong><a href="https://opendray.dev">🌐 opendray.dev</a></strong>
-</p>
-
-<p align="center">
-  <a href="https://opendray.dev"><img alt="Website" src="https://img.shields.io/badge/website-opendray.dev-F43F5E"></a>
-  <a href="https://github.com/Opendray/opendray/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/Opendray/opendray?label=release&color=4f46e5"></a>
-  <a href="LICENSE"><img alt="License Apache 2.0" src="https://img.shields.io/github/license/Opendray/opendray?color=blue"></a>
-  <a href="https://github.com/Opendray/opendray/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/Opendray/opendray/ci.yml?branch=main&label=CI"></a>
-  <a href="https://github.com/Opendray/opendray/discussions"><img alt="Discussions" src="https://img.shields.io/github/discussions/Opendray/opendray?color=ec4899"></a>
-  <br/>
-  <img alt="Go" src="https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white">
-  <img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black">
-  <img alt="Flutter" src="https://img.shields.io/badge/Flutter-mobile-02569B?logo=flutter&logoColor=white">
-  <img alt="Postgres" src="https://img.shields.io/badge/PostgreSQL-15%2F16%2F17-336791?logo=postgresql&logoColor=white">
-</p>
-
-<p align="center">
-  🌐 <a href="README.md">English</a> · <a href="README.zh.md">简体中文</a> · <strong>فارسی</strong> · <a href="README.es.md">Español</a> · <a href="README.pt-BR.md">Português</a> · <a href="README.ja.md">日本語</a> · <a href="README.ko.md">한국어</a> · <a href="README.fr.md">Français</a> · <a href="README.de.md">Deutsch</a> · <a href="README.ru.md">Русский</a>
-</p>
+[English](README.md) · [简体中文](README.zh.md) · فارسی · [Español](README.es.md) · [Português](README.pt-BR.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Русский](README.ru.md)
 
 ---
 
-## چرا opendray وجود دارد
+## چرا opendray وجود دارد؟
 
-سه اصطکاک در کار روزمره با CLIهای کدنویسی هوش مصنوعی که opendray برای حلشان ساخته شده است.
+opendray برای حل چند اصطکاک جدی در کار روزمره با AI coding CLIها ساخته شده است.
 
-**با خوابِ لپ‌تاپ، نشست‌ها هم می‌میرند.** اجرای Claude Code یا Codex روی SSH یعنی همان لحظه‌ای که درِ دستگاهتان را می‌بندید یا Wi-Fi قطع می‌شود، ایجنت هم از بین می‌رود. کانتکست، فراخوانی‌های ابزار در حالِ اجرا، آن diff نیمه‌تمامی که می‌خواستید بازبینی‌اش کنید، همه از دست می‌رود. opendray ایجنت را روی میزبانی اجرا می‌کند که نمی‌خوابد (یک Mac mini زیر میزتان، یک NAS، یک VPS) و به شما اجازه می‌دهد از یک پنل وب، یک اپ موبایل Flutter یا یک پیام چت دوباره به آن متصل شوید. نشست به اجرای خود ادامه می‌دهد، چه کسی متصل باشد چه نباشد.
+### وقتی laptop sleep می‌شود، session نباید از بین برود
 
-**برخورد به محدودیت نرخ نباید کاری را که می‌کردید نابود کند.** اگر چند حساب Anthropic دارید (کاری + شخصی، طرح خانوادگی + Pro)، opendray آن‌ها را به‌مثابهٔ یک استخر در نظر می‌گیرد: تیر، سهمیه و تعداد نشست‌های فعال هر حساب را نشان می‌دهد، نشست‌های جدید را میان آن‌ها متوازن می‌کند، و به شما اجازه می‌دهد یک نشستِ زنده را بدون از دست دادن گفتگو به حسابی دیگر منتقل کنید. ترنسکریپت همراهتان جابه‌جا می‌شود. همین قابلیت برای حساب‌های Codex و Gemini نیز برقرار است.
+اگر Claude Code یا Codex را از طریق SSH روی laptop اجرا کنید، به‌محض این‌که درِ دستگاه را ببندید یا Wi‑Fi قطع شود، agent هم عملاً از بین می‌رود. context، tool callهای در حال اجرا، diff نیمه‌کاره‌ای که قرار بوده review کنید، و هر چیزی که وسط کار بوده ممکن است از دست برود.
 
-**حافظه یک لایهٔ درجه‌یک است، نه یک فکرِ بعدی.** بیشتر CLIهای هوش مصنوعی در هر نشست کانتکستِ پروژه را از صفر ایندکس می‌کنند و توکن‌ها را صرف بازیابی‌های تکراری می‌کنند. opendray یک ذخیره‌سازِ برداریِ local-first عرضه می‌کند (با امبدینگ‌های ONNX / Ollama / LM Studio) همراه با بازیابی در سه دامنه (کاربر، پروژه، نشست) به‌علاوهٔ تشخیصِ drift میان لایه‌ها. هر بایت روی شبکهٔ خودتان باقی می‌ماند.
+opendray agent را روی hostای اجرا می‌کند که قرار نیست sleep شود؛ مثلاً یک Mac mini زیر میز، یک NAS یا یک VPS. بعد شما می‌توانید از web panel، mobile app مبتنی بر Flutter یا حتی از طریق chat دوباره به همان session وصل شوید. session به کارش ادامه می‌دهد، چه شما online باشید چه نباشید.
+
+### rate limit نباید کارتان را خراب کند
+
+اگر چند Anthropic account دارید، مثلاً work account و personal account یا Pro و Family، opendray آن‌ها را مثل یک capacity pool مدیریت می‌کند. status مربوط به quota، tier و تعداد active sessionهای هر account را نشان می‌دهد، sessionهای جدید را بین accountهای فعال balance می‌کند، و حتی اجازه می‌دهد یک live session را بدون از دست دادن conversation به account دیگری منتقل کنید. transcript همراه session جابه‌جا می‌شود. همین مدل برای Codex و Gemini accountها هم در نظر گرفته شده است.
+
+### memory باید جزء اصلی سیستم باشد، نه یک قابلیت اضافه‌شده در آخر
+
+بیشتر AI CLIها در هر session دوباره project context را از صفر index می‌کنند و tokenها را صرف retrievalهای تکراری می‌کنند. opendray یک local-first vector store ارائه می‌دهد که با ONNX، Ollama و LM Studio embeddings کار می‌کند و retrieval را در سه scope انجام می‌دهد: user، project و session. همچنین drift و ناسازگاری بین memory layerها را تشخیص می‌دهد. داده‌ها روی network و infrastructure خودتان باقی می‌مانند.
 
 ---
 
-## ابزار OpenDray چیست؟
+## OpenDray چیست؟
 
-ابزار **OpenDray** ابزارهای AI CLI مورد استفاده شما، از جمله Claude Code، Codex، Gemini و هر Shell دیگری را به یک بستر یکپارچه تبدیل می‌کند که از هر جایی قابل دسترسی است. سشن‌های کاری خود را روی سرور خانگی، NAS یا VPS اجرا کنید، هنگام توقف یا بیکار شدن آن‌ها در تلگرام اعلان دریافت کنید و تنها با پاسخ دادن از طریق گوشی، پرامپت بعدی را برای ادامه کار ارسال کنید. همه این قابلیت‌ها از طریق یک درگاه Self-Hosted تحت کنترل کامل شما ارائه می‌شوند؛ بدون وابستگی به سرویس‌های واسط و با مالکیت کامل بر داده‌ها و ارتباطات.
+**OpenDray** ابزارهای AI CLI شما، مثل Claude Code، Codex، Gemini و هر shell دیگری را به یک platform واحد تبدیل می‌کند؛ platformای که از هرجا قابل دسترسی است و کنترلش دست خودتان می‌ماند.
 
-- 🛰 **یک بک‌اند، سه سطح:** یک باینری Go واحد که یک ادمین وب React و یک اپ موبایل فلاتر را سرویس می‌دهد، و هر عملیات را هم از طریق REST + WebSocket API برای integrationهای third-party در دسترس می‌گذارد.
-- 💬 **شش کانال دوطرفه، بدون قفل‌شدن در اکوسیستم‌های بسته:** تلگرام، اسلک، دیسکورد، Feishu (飞书)، DingTalk (钉钉)، WeCom (企业微信)، به‌علاوه یک Bridge adapter برای هر چیز سفارشی. replyها در هر کانال به سشن درست برمی‌گردند.
-- 🧠 **حافظهٔ محلی‌محور:** استفاده از مدل‌های تعبیه‌سازی ONNX، Ollama و LM Studio با قابلیت بازیابی در سه دامنهٔ کاربر، پروژه و سشن، رتبه‌بندی هوشمند نتایج، و شناسایی تعارض بین لایه‌های مختلف داده. همهٔ داده‌های برداری در شبکهٔ شما باقی می‌مانند و به بیرون از آن ارسال نمی‌شوند.
-- 🔌 **API در سطح integration:** API keyهای scoped، audit log برای هر call، reverse-proxy mountها. opendray را می‌توانید هم به‌عنوان درگاه پشت محصول خودتان ببینید، هم فقط یک مرکز فرمان شخصی.
-- 🔑 **مدیریت چند حساب Claude:** چند حساب `claude login` را داخل gateway بگذارید؛ پنل با filesystem watcher خودش آن‌ها را پیدا می‌کند، سشن‌های جدید را بین حساب‌های فعال balance می‌کند، و اجازه می‌دهد یک سشن زنده را بین حساب‌ها **بدون از دست دادن گفتگو** جابه‌جا کنید (transcript در پشت صحنه منتقل می‌شود). هر ردیف ظرفیت حساب را به صورت زنده نشان می‌دهد (subscription tier، rate-limit tier، active sessions، last-used، current Anthropic email) تا در یک نگاه حساب درست را انتخاب کنید.
-- 🔒 **self-hosted با وضعیت مجوز شفاف:** آپاچی 2.0، یک باینری static، انتشارهای امضاشده با cosign همراه با SPDX SBOM. بدون telemetry، بدون حساب ابری، بدون subscription.
+می‌توانید working sessionها را روی home server، NAS یا VPS اجرا کنید، وقتی idle می‌شوند یا نیاز به input دارند در Telegram notification بگیرید، و فقط با reply کردن از روی گوشی، prompt بعدی را برای ادامه کار ارسال کنید.
 
-## وضعیت
+همه این قابلیت‌ها از طریق یک self-hosted gateway ارائه می‌شود؛ بدون وابستگی به سرویس واسط، بدون lock-in، و با مالکیت کامل روی data و communication.
 
-نسخه ۲٫۶٫۰ (آخرین انتشار): توسعه v2 همچنان ادامه دارد. برای policy مربوط به major-as-generation به [`VERSIONING.md`](VERSIONING.md) مراجعه کنید؛ اینجا ماژور به معنی نسل محصول است، نه لزوماً یک "breaking change" به معنای سخت‌گیرانه SemVer. برای تاریخچه کامل انتشارها هم [`CHANGELOG.md`](CHANGELOG.md) را ببینید.
+- **یک backend، چند interface:** یک Go binary واحد که React web admin و Flutter mobile app را سرویس می‌دهد. تمام operationها از طریق REST و WebSocket API هم برای third-party integrationها قابل استفاده است.
 
-این نسل شامل موارد زیر است:
+- **کانال‌های دوطرفه، بدون lock-in:** Telegram، Slack، Discord، Feishu، DingTalk، WeCom و یک bridge adapter برای اتصال‌های custom. replyهایی که در هر channel می‌فرستید به session درست برمی‌گردند.
 
-- **ویزاردهای نصب و حذف نصب تک‌خطی** (لینوکس + مک؛ ویندوز از طریق WSL2 هدایت می‌شود). این ویزاردها اپراتور را مرحله‌به‌مرحله از راه‌اندازی Postgres، نصب AI-CLI، تنظیم credentialهای ادمین، تعیین listen address، نصب باینری، اجرای schema migration، و ثبت service عبور می‌دهند.
-- **باینری خودمدیریت:** با `opendray update / start / stop / restart / status / providers list / providers update` اپراتورها برای کارهای روزمره دیگر نیازی ندارند مستقیم سراغ `systemctl` / `launchctl` بروند.
-- **پایپ‌لاین انتشار با Goreleaser:** شامل باینری‌های cross-compiled (linux/darwin × amd64/arm64)، امضای keyless با cosign (Sigstore)، SPDX SBOM، و self-update اتمیِ verified است.
+- **local-first memory:** استفاده از ONNX، Ollama و LM Studio embeddings، retrieval در سطح user/project/session، smart ranking برای resultها، و تشخیص conflict بین memory layerها. vector data روی network خودتان می‌ماند و به بیرون ارسال نمی‌شود.
+
+- **API مناسب integration:** scoped API key، audit log برای هر call و reverse-proxy mountها. می‌توانید opendray را به‌عنوان gateway پشت محصول خودتان استفاده کنید یا فقط آن را command centre شخصی خودتان بدانید.
+
+- **multi-account management برای Claude:** چند `claude login` را داخل gateway قرار دهید. panel با filesystem watcher خودش آن‌ها را پیدا می‌کند، sessionهای جدید را بین accountهای فعال balance می‌کند، و اجازه می‌دهد یک live session را **بدون از دست دادن conversation** بین accountها جابه‌جا کنید. transcript در پشت صحنه منتقل می‌شود.
+
+- **ظرفیت accountها در یک نگاه:** هر ردیف، وضعیت account را live نشان می‌دهد؛ از جمله `subscription tier`، `rate-limit tier`، `active sessions`، `last-used` و `current Anthropic email` تا سریع‌تر account درست را انتخاب کنید.
+
+- **self-hosted با license شفاف:** Apache 2.0، یک static binary، releaseهای امضاشده با cosign و SPDX SBOM. بدون telemetry، بدون cloud account و بدون subscription.
+
+---
+
+## وضعیت نسخه
+
+نسخه ۲٫۷٫۱ آخرین release فعلی است و development روی v2 همچنان ادامه دارد.
+
+برای policy مربوط به major-as-generation، فایل [`VERSIONING.md`](VERSIONING.md) را ببینید. در این پروژه، major الزاماً به معنی breaking change به معنای سخت‌گیرانه SemVer نیست؛ بیشتر به نسل محصول اشاره دارد. برای تاریخچه کامل releaseها هم [`CHANGELOG.md`](CHANGELOG.md) را بخوانید.
+
+این generation شامل موارد زیر است:
+
+- **one-line install و uninstall wizard** برای Linux و macOS. مسیر Windows از طریق WSL2 انجام می‌شود. wizard، operator را مرحله‌به‌مرحله از Postgres setup، نصب AI CLIها، تنظیم admin credentialها، تعیین listen address، نصب binary، اجرای schema migration و ثبت service عبور می‌دهد.
+
+- **self-managing binary:** با دستورهای `opendray update / start / stop / restart / status / providers list / providers update` برای کارهای روزمره لازم نیست مستقیم سراغ `systemctl` یا `launchctl` بروید.
+
+- **release pipeline با Goreleaser:** شامل cross-compiled binaryها برای `linux/darwin × amd64/arm64`، keyless signing با cosign و Sigstore، SPDX SBOM و atomic verified self-update.
+
+---
 
 ## نصب
 
-### نصب‌کننده تک‌خطی
+### one-line installer
 
-**لینوکس / مک / WSL2**
-
-<div dir="ltr">
+**Linux / macOS / WSL2**
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install.sh | bash
 ```
 
-</div>
-
-**ویندوز:** ابتدا WSL2 را راه‌اندازی می‌کند، سپس installer لینوکس را داخل آن اجرا می‌کند. [جزئیات →](scripts/README.md#windows)
-
-<div dir="ltr">
+**Windows:** ابتدا WSL2 را راه‌اندازی می‌کند و سپس Linux installer را داخل آن اجرا می‌کند. [جزئیات →](scripts/README.md#windows)
 
 ```powershell
 irm https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install-windows.ps1 | iex
 ```
 
-</div>
+این مسیر Postgres setup، نصب AI CLIها، admin credentialها و service registration را انجام می‌دهد و معمولاً بعد از حدود ۵ تا ۱۰ دقیقه یک gateway آماده تحویل می‌دهد. اگر می‌خواهید دقیقاً بدانید wizard چه کاری انجام می‌دهد، چه layoutای می‌سازد، چه optionهایی دارد و چطور باید debug کنید، به [**`scripts/README.md`**](scripts/README.md) سر بزنید.
 
-این مسیر Postgres setup، نصب AI-CLI، credentialهای ادمین، و service registration را جلو می‌برد و حدود ۵ تا ۱۰ دقیقه بعد یک gateway آماده تحویل می‌دهد. اگر خواستید ببینید ویزارد دقیقاً چه می‌کند، چه چیدمانی می‌سازد، چه optionهایی دارد و چطور باید debug کنید، به [**`scripts/README.md`**](scripts/README.md) سر بزنید.
+> **راهنمای دستی و قدم‌به‌قدم می‌خواهید؟**  
+> [`docs/getting-started.md`](docs/getting-started.md) را بخوانید. این راهنما همان مسیر wizard را در قالب یک walkthrough حدوداً ۱۵ دقیقه‌ای باز می‌کند تا بتوانید هر مرحله را خودتان بررسی کنید.
 
-> **راهنمای گام‌به‌گام دستی می‌خواهید؟** [**docs/getting-started.md**](docs/getting-started.md) را بخوانید: یک راهنمای سرتاسری پانزده‌دقیقه‌ای که همان مسیر ویزارد را قدم‌به‌قدم باز می‌کند تا خودتان هر مرحله را چک کنید.
+---
 
-### npm / npx (Node ≥ 18)
+### npm / npx
 
-نصب global و اضافه کردن `opendray` به `PATH`:
+نیازمند Node نسخه ۱۸ یا بالاتر.
+
+نصب global و اضافه شدن `opendray` به `PATH`:
 
 ```sh
 npm install -g opendray
 ```
 
-یا اجرای on-demand بدون نصب:
+یا اجرای on-demand بدون نصب دائمی:
 
 ```sh
 npx opendray
 ```
 
-این فقط **باینری** را نصب می‌کند — نه wizard، نه service، نه Postgres. پکیج باینری پلتفرم متناظر (`opendray-{linux,darwin}-{x64,arm64}`) را از طریق `optionalDependencies` می‌آورد (همان الگوی esbuild / Biome — بدون `postinstall`، بدون network call هنگام نصب). مناسب برای محیط‌های scripted، runnerهای ephemeral، یا وقتی از قبل Postgres و process supervisor خودتان را دارید.
+این روش فقط **binary** را نصب می‌کند؛ نه wizard، نه service و نه Postgres.
 
-دیتابیس را خودتان می‌آورید و gateway را خودتان راه‌اندازی می‌کنید:
+binary package مناسب platform شما، مثل `opendray-{linux,darwin}-{x64,arm64}` از طریق `optionalDependencies` دریافت می‌شود. این مدل شبیه esbuild و Biome است: بدون `postinstall` و بدون network call هنگام نصب. این روش برای scripted environmentها، ephemeral runnerها یا زمانی مناسب است که Postgres و process supervisor خودتان را از قبل دارید.
 
-<div dir="ltr">
+در این حالت، database و gateway را خودتان آماده و اجرا می‌کنید:
 
 ```sh
-# 1. PostgreSQL 15+ با pgvector — یک DSN به آن اشاره دهید و یک admin password تنظیم کنید.
+# 1. PostgreSQL 15+ with pgvector
+# یک DSN تعریف کنید و برای admin هم password بگذارید.
+
 export OPENDRAY_DATABASE_URL="postgres://opendray:pw@127.0.0.1:5432/opendray?sslmode=disable"
 export OPENDRAY_ADMIN_PASSWORD="$(openssl rand -base64 24)"
-# 2. schema را اعمال کنید، سپس اجرا کنید (foreground).
+
+# 2. schema را اعمال کنید و بعد gateway را در foreground اجرا کنید.
+
 opendray migrate
 opendray serve        # → http://127.0.0.1:8770/admin/
 ```
 
-</div>
+راهنمای کامل راه‌اندازی pgvector، تنظیم `config.toml`، اجرای systemd یا launchd service و update در [`docs/install-binary.fa.md`](docs/install-binary.fa.md) آمده است.
 
-راهنمای کامل — راه‌اندازی pgvector، `config.toml`، اجرا به‌عنوان systemd / launchd service، و به‌روزرسانی — در [**docs/install-binary.fa.md**](docs/install-binary.fa.md).
+---
 
-### حذف نصب (لینوکس / مک)
+## حذف نصب در Linux و macOS
 
-**پیش‌فرض:** درگاه را متوقف می‌کند و باینری را حذف می‌کند، اما `config.toml`، data directory شما (bcrypt keyfile، sessions، notes، vault)، logs، و PostgreSQL دیتابیس را **نگه می‌دارد** تا نصب مجدد از همان‌جایی که رها کرده بودید ادامه پیدا کند:
+### حذف پیش‌فرض
 
-<div dir="ltr">
+gateway را stop می‌کند و binary را حذف می‌کند، اما `config.toml`، مسیر data مثل bcrypt keyfile، sessionها، noteها و vault، logها و PostgreSQL database را نگه می‌دارد تا اگر دوباره نصب کردید، از همان‌جا ادامه دهید.
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | bash
 ```
 
-</div>
+### حذف کامل
 
-**حذف کامل:** همچنین PG دیتابیس + نقش را پاک می‌کند، config / data / logs را می‌زند، و service user را برمی‌دارد. یک مرحله verification بعد از حذف هم دارد که اگر چیزی جا مانده باشد بی‌سر‌وصدا رد نمی‌شود:
-
-<div dir="ltr">
+علاوه بر موارد بالا، PostgreSQL database و role مربوطه، config، data، logها و service user را هم حذف می‌کند. بعد از حذف هم یک verification step اجرا می‌شود تا اگر چیزی باقی مانده بود، بی‌سروصدا نادیده گرفته نشود.
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/Opendray/opendray/main/scripts/uninstall.sh | OPENDRAY_PURGE=1 bash
 ```
 
-</div>
+---
 
-### دستورات روزمره
+## دستورات روزمره
 
-بعد از نصب، باینری `opendray` لایف‌سایکل خودش را مدیریت می‌کند؛ دیگر لازم نیست incantationهای `systemctl` / `launchctl` را حفظ کنید:
-
-<div dir="ltr">
+بعد از نصب، خود binary `opendray` lifecycle سرویس را مدیریت می‌کند. لازم نیست دستورهای طولانی `systemctl` یا `launchctl` را حفظ کنید.
 
 ```sh
 sudo opendray update --restart   # download latest release, verify SHA, atomic replace + restart
 ```
 
-</div>
-
-<div dir="ltr">
-
 ```sh
-sudo opendray providers update   # bump installed AI CLIs (claude / codex / gemini) to npm-latest
+sudo opendray providers update   # bump installed AI CLIs: claude / codex / gemini
 ```
 
-</div>
-
-<div dir="ltr">
-
 ```sh
-opendray providers list          # see which AI CLIs are installed + their versions
+opendray providers list          # see installed AI CLIs and their versions
 ```
 
-</div>
-
-<div dir="ltr">
-
 ```sh
-sudo opendray start              # start | stop | restart | status: wraps systemd / launchd
+sudo opendray start              # start | stop | restart | status via systemd / launchd
 ```
 
-</div>
+برای دیدن همه subcommandها:
 
-`opendray --help` فهرست کامل subcommandها را نشان می‌دهد.
+```sh
+opendray --help
+```
 
-### انتخاب روش راه‌اندازی
+---
 
-هر مسیر پشتیبانی‌شده امکان spawn کردن سشن، دسترسی AI-CLI، backupهای رمزنگاری‌شده، و API کامل integration را دارد. opendray یک gateway host-resident است؛ AI CLIها را از طریق PTY اجرا می‌کند و process state (`~/.claude`، ssh-agent، project files) را با آن‌ها share می‌کند. همین مدل با container isolationای که production Docker تحمیل می‌کند جور درنمی‌آید، بنابراین Docker برای v2.x مسیر پشتیبانی‌شده‌ای نیست.
+## انتخاب روش راه‌اندازی
 
-| مسیر | مناسب برای | برو به |
-|---|---|---|
-| 📦 **نسخهٔ باینری آماده** | کافی است اجرا کنید؛ روی لینوکس و مک با هر ابزار مدیریت فرایند | [صفحه انتشارها](https://github.com/Opendray/opendray/releases) → ببینید [انتشار عملیاتی](#production-deploy) |
-| 🐧 **systemd unit** | bare-metal / VM / LXC Linux box | [انتشار عملیاتی §A](#option-a--systemd-bare-metal--vm--lxc) |
-| 🍎 **مک LaunchDaemon** | مک مینی / مک استودیو به‌عنوان سرور خانگی | [انتشار عملیاتی §C](#option-c--macos-launchd-mac-mini--studio-as-home-server) |
-| 🛠 **ایجاد نسخه از کد منبع** | dev / مشارکت / نسخهٔ سفارشی | [راه‌اندازی سریع](#quickstart-5-minute-dev-path) در ادامه |
+همه مسیرهای پشتیبانی‌شده امکان spawn کردن session، دسترسی به AI CLIها، encrypted backup و integration API کامل را دارند.
 
-## Quickstart (5-minute dev path)
+opendray یک host-resident gateway است. AI CLIها را از طریق PTY اجرا می‌کند و process state مثل `~/.claude`، `ssh-agent` و project fileها را با آن‌ها share می‌کند. این مدل با container isolationای که production Docker تحمیل می‌کند خوب جور درنمی‌آید؛ بنابراین Docker در v2.x مسیر پشتیبانی‌شده محسوب نمی‌شود.
 
-برای یک راهنمای گام به گام کامل همراه با پیش‌نیازها و عیب یابی، به [`docs/quickstart.md`](docs/quickstart.md) نگاه کنید. مسیر فشرده توسعه:
+| مسیر                   | مناسب برای                                                   | ادامه                                                        |
+| ---------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| **ready-made binary**  | وقتی فقط می‌خواهید اجرا کنید؛ روی Linux و macOS با process manager دلخواه | [release page](https://github.com/Opendray/opendray/releases) و سپس [production deploy](#انتشار-عملیاتی) |
+| **systemd unit**       | bare-metal، VM یا Linux LXC                                  | [گزینه ۱: systemd](#گزینه-۱-systemd-برای-bare-metal--vm--lxc) |
+| **macOS LaunchDaemon** | Mac mini یا Mac Studio که نقش home server دارد               | [گزینه ۳: macOS launchd](#گزینه-۳-macos-launchd-برای-mac-mini--mac-studio-به‌عنوان-home-server) |
+| **build from source**  | development، contribution یا custom build                    | [Quickstart](#quickstart-مسیر-۵-دقیقه‌ای-برای-dev)            |
 
-<div dir="ltr">
+---
+
+## Quickstart: مسیر ۵ دقیقه‌ای برای dev
+
+برای راهنمای کامل، همراه با prerequisiteها و troubleshooting، فایل [`docs/quickstart.md`](docs/quickstart.md) را ببینید.
+
+مسیر خلاصه development:
 
 ```bash
-# 1. Have a Postgres 15+ running on 127.0.0.1:5432 with pgvector enabled
-#    (apt install postgresql-16 postgresql-16-pgvector / brew install postgresql@16 pgvector).
-#    Point [database].url at any other DSN if you'd rather use a remote PG.
+# 1. Have a Postgres 15+ running on 127.0.0.1:5432 with pgvector enabled.
+#    Example:
+#    apt install postgresql-16 postgresql-16-pgvector
+#    or:
+#    brew install postgresql@16 pgvector
+#
+#    اگر remote PG را ترجیح می‌دهید،
+#    [database].url را به DSN همان database اشاره دهید.
 
-# 2. Local config: already gitignored.
+# 2. Local config. این فایل از قبل gitignored است.
+
 cp config.example.toml config.toml
 $EDITOR config.toml          # set [database].url, [admin].password
 
 # 3. Build the web bundle into the embed tree.
+
 cd app/web && pnpm install && pnpm build && cd ../..
 
 # 4. Apply schema.
+
 go run ./cmd/opendray migrate -config config.toml
 
 # 5. Run.
+
 go run ./cmd/opendray serve -config config.toml
+
 # → REST + WS:  http://127.0.0.1:8770/api/v1/...
 # → Web admin:  http://127.0.0.1:8770/admin/
 ```
 
-</div>
+این روش opendray را در foreground اجرا می‌کند و با `Ctrl-C` متوقف می‌شود. اگر daemonای می‌خواهید که برای مدت طولانی بالا بماند، بخش **انتشار عملیاتی** را ببینید.
 
-این opendray را در پیش‌زمینه اجرا می‌کند؛ Ctrl-C هم می‌بنددش. برای یک daemon که قرار است مدت زیادی بالا بماند، پایین‌تر به **انتشار عملیاتی** نگاه کنید.
-
-<a id="production-deploy"></a>
+---
 
 ## انتشار عملیاتی
 
-چهار مسیر استقرار پشتیبانی‌شده داریم؛ هرکدام که به محیط شما می‌خورد همان را انتخاب کنید.
-همه‌شان auto-restart هنگام crash، state پایدار، و جدا نگه‌داشتن secrets از config را فراهم می‌کنند.
+چهار مسیر deployment پشتیبانی‌شده داریم؛ هرکدام که به environment شما می‌خورد همان را انتخاب کنید. همه آن‌ها auto-restart هنگام crash، state پایدار، و جداسازی secrets از config را فراهم می‌کنند.
 
-<a id="option-a--systemd-bare-metal--vm--lxc"></a>
+### گزینه ۱: systemd برای bare-metal / VM / LXC
 
-### گزینه ۱: systemd (bare-metal / VM / LXC)
+این مسیر، روش پیشنهادی برای Linux deployment است.
 
-مسیر پیشنهادی استقرار روی لینوکس. یک unit harden‌شده در
-[`deploy/systemd/opendray.service`](deploy/systemd/opendray.service)
-ارائه می‌کند با sandboxing (`ProtectSystem=strict`، `NoNewPrivileges`،
-`MemoryDenyWriteExecute`، capability scrub)، بوت `migrate`-then-`serve`،
-و یک graceful stop window بیست‌ثانیه‌ای.
+یک hardened unit در [`deploy/systemd/opendray.service`](deploy/systemd/opendray.service) ارائه می‌شود که شامل sandboxing مثل `ProtectSystem=strict`، `NoNewPrivileges`، `MemoryDenyWriteExecute` و capability scrub است. boot flow آن `migrate` سپس `serve` است و یک graceful stop window بیست‌ثانیه‌ای دارد.
 
-**اول یک باینری بگیرید.** یا یک آرشیو از پیش ساخته را از
-[صفحه انتشارها](https://github.com/Opendray/opendray/releases)
-بردارید (`opendray_*_linux_<arch>.tar.gz`، که به یک `opendray` single-binary
-unpack می‌شود)، یا از طریق [راه‌اندازی سریع](#quickstart-5-minute-dev-path)
-ایجاد نسخه از کد منبع(`go build ./cmd/opendray`).
-
-<div dir="ltr">
+**اول binary را بگیرید.** یا یک archive آماده را از [release page](https://github.com/Opendray/opendray/releases) بردارید، مثل `opendray_*_linux_.tar.gz` که به یک single `opendray` binary unpack می‌شود، یا از طریق [Quickstart](#quickstart-مسیر-۵-دقیقه‌ای-برای-dev) از source build بگیرید: `go build ./cmd/opendray`.
 
 ```bash
-# 1. Install the binary you just grabbed (or built).
+# 1. Install the binary you just grabbed or built.
+
 sudo install -m 0755 /path/to/opendray /usr/local/bin/opendray
 
-# 2. Create the service user + state dir.
+# 2. Create the service user and state dir.
+
 sudo useradd -r -s /usr/sbin/nologin -d /var/lib/opendray opendray
 sudo install -d -o opendray -g opendray -m 0700 /var/lib/opendray
 
-# 3. Drop config + secrets (root-owned; mode 0640).
-sudo install -D -m 0640 config.example.toml /etc/opendray/config.toml
-sudo $EDITOR /etc/opendray/config.toml             # set [database].url etc.
-sudo install -D -m 0640 -o root -g opendray /dev/null /etc/opendray/env.d/secrets
-sudo $EDITOR /etc/opendray/env.d/secrets           # OPENDRAY_ADMIN_PASSWORD=…
+# 3. Drop config and secrets. root-owned; mode 0640.
 
-# 4. Install + enable the unit.
+sudo install -D -m 0640 config.example.toml /etc/opendray/config.toml
+sudo $EDITOR /etc/opendray/config.toml     # set [database].url etc.
+
+sudo install -D -m 0640 -o root -g opendray /dev/null /etc/opendray/env.d/secrets
+sudo $EDITOR /etc/opendray/env.d/secrets   # OPENDRAY_ADMIN_PASSWORD=...
+
+# 4. Install and enable the unit.
+
 sudo cp deploy/systemd/opendray.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now opendray
 
 # 5. Verify.
+
 sudo systemctl status opendray
 sudo journalctl -u opendray -f --no-pager
 ```
 
-</div>
+این unit، دستور `opendray migrate` را به‌عنوان `ExecStartPre` اجرا می‌کند؛ بنابراین در اولین boot، همه migrationها قبل از شروع `serve` اعمال می‌شوند. restartها هم `on-failure` هستند، با back-off پنج‌ثانیه‌ای و limit پنج‌بار در دقیقه.
 
-این unit `opendray migrate` را به‌عنوان `ExecStartPre` اجرا می‌کند، پس اولین boot همه migrationها را قبل از شروع `serve` اعمال می‌کند. restartها هم `on-failure` هستند با back-off پنج‌ثانیه‌ای و limit پنج‌بار در دقیقه.
+---
 
-### گزینه ۲: باینری مستقیم + ابزار مدیریت فرایند خودتان
+### گزینه ۲: direct binary + process manager دلخواه
 
-برای LXC بدون systemd، FreeBSD `rc.d`، OpenRC، یا هر چیز دیگر.
-یک بار build کنید و با هر ابزار مدیریت فرایندی که از قبل دارید اجرا کنید:
+برای LXC بدون systemd، FreeBSD `rc.d`، OpenRC یا هر process manager دیگری.
 
-<div dir="ltr">
+یک بار build بگیرید و با process managerی که از قبل دارید اجرا کنید:
 
 ```bash
 # Cross-compile a release archive locally:
+
 goreleaser release --clean --snapshot
-ls dist/                  # opendray_*_linux_amd64.tar.gz etc.
+ls dist/        # opendray_*_linux_amd64.tar.gz etc.
 
 # Or grab a published release artefact:
 # https://github.com/Opendray/opendray/releases
 ```
 
-</div>
+بعد process manager خودتان مثل s6، runit، supervisord یا runwhen را به این command اشاره دهید:
 
-بعد ابزار مدیریت فرایند خودتان (s6، runit، supervisord، runwhen) را به این مسیر اشاره دهید:
-
-<div dir="ltr">
-
-```
+```sh
 /usr/local/bin/opendray serve -config /etc/opendray/config.toml
 ```
 
-</div>
+قبل از اولین `serve`، یک بار این command را اجرا کنید:
 
-پیش از اولین `serve` یک بار `opendray migrate -config /etc/opendray/config.toml`
-را اجرا کنید، یا آن را به‌عنوان pre-start hook در ابزار مدیریت فرایند دلخواهتان بگذارید.
+```sh
+opendray migrate -config /etc/opendray/config.toml
+```
 
-<a id="option-c--macos-launchd-mac-mini--studio-as-home-server"></a>
+یا آن را به‌عنوان pre-start hook در process manager دلخواهتان قرار دهید.
 
-### گزینه ۳: مک launchd (مک مینی / مک استودیو به‌عنوان سرور خانگی)
+---
 
-برای اپل سیلیکون مک مینی / مک استودیو که ۲۴/۷ روشن است. یک
-LaunchDaemon در
-[`deploy/launchd/com.opendray.opendray.plist`](deploy/launchd/com.opendray.opendray.plist)
-ارائه می‌کند که در بوت و قبل از هر لاگین کاربر بالا می‌آید، هنگام کرش با
-throttle پنج‌ثانیه‌ای دوباره start می‌شود، و در `/usr/local/var/log/opendray/`
-لاگ می‌نویسد.
+### گزینه ۳: macOS launchd برای Mac mini / Mac Studio به‌عنوان home server
 
-<div dir="ltr">
+برای Apple Silicon Mac mini یا Mac Studio که ۲۴/۷ روشن است.
+
+یک LaunchDaemon در [`deploy/launchd/com.opendray.opendray.plist`](deploy/launchd/com.opendray.opendray.plist) ارائه می‌شود که هنگام boot و قبل از user login بالا می‌آید، در صورت crash با throttle پنج‌ثانیه‌ای دوباره start می‌شود، و در `/usr/local/var/log/opendray/` log می‌نویسد.
 
 ```bash
-# 1. Install the darwin binary + config + state dirs.
+# 1. Install the darwin binary, config and state dirs.
+
 sudo install -m 0755 ./opendray /usr/local/bin/opendray
 sudo install -d -m 0755 \
   /usr/local/etc/opendray \
   /usr/local/var/lib/opendray \
   /usr/local/var/log/opendray
+
 sudo install -m 0640 config.example.toml /usr/local/etc/opendray/config.toml
-sudo $EDITOR /usr/local/etc/opendray/config.toml    # set [database].url etc.
+sudo $EDITOR /usr/local/etc/opendray/config.toml   # set [database].url etc.
 
 # 2. Apply migrations once.
+
 sudo /usr/local/bin/opendray migrate \
   -config /usr/local/etc/opendray/config.toml
 
-# 3. Install + load the LaunchDaemon.
+# 3. Install and load the LaunchDaemon.
+
 sudo cp deploy/launchd/com.opendray.opendray.plist /Library/LaunchDaemons/
 sudo chown root:wheel /Library/LaunchDaemons/com.opendray.opendray.plist
 sudo chmod 0644 /Library/LaunchDaemons/com.opendray.opendray.plist
 sudo launchctl bootstrap system /Library/LaunchDaemons/com.opendray.opendray.plist
 
 # 4. Verify.
+
 sudo launchctl print system/com.opendray.opendray
 tail -f /usr/local/var/log/opendray/opendray.log
 ```
 
-</div>
+برای restart:
 
-با `sudo launchctl kickstart -k system/com.opendray.opendray` دوباره start کنید؛
-با `sudo launchctl bootout system/com.opendray.opendray` هم کامل unload کنید.
+```sh
+sudo launchctl kickstart -k system/com.opendray.opendray
+```
 
-Postgres روی مک: از طریق Homebrew نصبش کنید (`brew install postgresql@17 && brew services start postgresql@17`) و `[database].url` را روی
-`postgres://$USER@127.0.0.1:5432/opendray` بگذارید. `pgvector` را هم با
-`brew install pgvector` اضافه کنید و `CREATE EXTENSION vector` را داخل
-دیتابیس opendray اجرا کنید.
+برای unload کامل:
+
+```sh
+sudo launchctl bootout system/com.opendray.opendray
+```
+
+Postgres روی macOS را می‌توانید با Homebrew نصب کنید:
+
+```sh
+brew install postgresql@17 && brew services start postgresql@17
+```
+
+بعد `[database].url` را روی مقدار زیر بگذارید:
+
+```text
+postgres://$USER@127.0.0.1:5432/opendray
+```
+
+برای pgvector هم:
+
+```sh
+brew install pgvector
+```
+
+و داخل database مربوط به opendray این extension را فعال کنید:
+
+```sql
+CREATE EXTENSION vector;
+```
 
 ---
 
-برای نوت‌های مخصوص Proxmox LXC (PTY در containerهای unprivileged،
-networking، تنظیمات cgroup)، به [`deploy/lxc/proxmox-pty-notes.md`](deploy/lxc/proxmox-pty-notes.md) نگاه کنید.
+برای noteهای مخصوص Proxmox LXC، مثل PTY داخل unprivileged containerها، networking و cgroup settingها، به [`deploy/lxc/proxmox-pty-notes.md`](deploy/lxc/proxmox-pty-notes.md) نگاه کنید.
 
-برای reverse-proxy / TLS termination (nginx، Caddy، Traefik، Cloudflare
-Tunnel)، به [`docs/operator-guide.md`](docs/operator-guide.md) §Topology نگاه کنید.
+برای reverse-proxy و TLS termination، مثل nginx، Caddy، Traefik و Cloudflare Tunnel، بخش Topology در [`docs/operator-guide.md`](docs/operator-guide.md) را ببینید.
 
-### اختیاری: فعال‌سازی backupهای رمزنگاری‌شده DB و data exportها
+---
 
-<div dir="ltr">
+## اختیاری: فعال‌سازی encrypted DB backup و data export
 
 ```bash
-# Master passphrase (env-only: never write into config.toml).
+# Master passphrase. env-only: never write it into config.toml.
+
 export OPENDRAY_BACKUP_KEY="$(openssl rand -base64 32)"
 export OPENDRAY_BACKUP_ENABLED=1
 
-# pg_dump / pg_restore must match the server's major version. On
-# Apple Silicon dev machines pointing at a PG17 server:
+# pg_dump / pg_restore must match the server's major version.
+# Example for Apple Silicon dev machines pointing at a PG17 server:
+
 export OPENDRAY_BACKUP_PG_DUMP_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_dump
 export OPENDRAY_BACKUP_PG_RESTORE_PATH=/opt/homebrew/opt/postgresql@17/bin/pg_restore
 ```
 
-</div>
+opendray را restart کنید. sidebar یک صفحه Backups در مسیر `/backups` برای encrypted PostgreSQL dump و restore اضافه می‌کند. مسیر `/export` هم برای zip-bundle data export و import استفاده می‌شود. برای چرخه کامل، بخش Backup در [`docs/operator-guide.md`](docs/operator-guide.md) را ببینید.
 
-opendray را restart کنید؛ sidebar یک صفحه Backups (`/backups`) برای
-PostgreSQL dumpهای رمزنگاری‌شده + restore و `/export` برای
-zip-bundle data export + import اضافه می‌کند. برای چرخه کامل به
-[`docs/operator-guide.md`](docs/operator-guide.md) §Backup نگاه کنید.
+کل web UI داخل یک Go binary قرار گرفته است؛ بنابراین در runtime نیازی به Node.js، static file server جداگانه یا ابزارهایی مثل Caddy و Nginx ندارید. البته Cloudflare Tunnel همچنان می‌تواند TLS را قبل از رسیدن traffic به پورت `8770` terminate کند.
 
-تمام رابط وب در یک باینری Go قرار گرفته است؛ بنابراین در زمان اجرا نیازی به
-Node.js، سرور جداگانه برای فایل‌های استاتیک یا ابزارهایی مانند Caddy و Nginx
-نخواهید داشت. Cloudflare Tunnel نیز اتصال TLS را پیش از رسیدن ترافیک به پورت `8770` مدیریت می‌کند.
+---
 
-## چیدمان
+## ساختار پروژه
 
-<div dir="ltr">
-
-```
-cmd/opendray/        نقطه ورود اصلی باینری (مطابق design §14 با حداکثر 100 خط کد)
+```text
+cmd/opendray/
+  entrypoint اصلی binary
 
 internal/
-├── app/             راه‌اندازی و اتصال همه بخش‌های برنامه
-├── audit/           دریافت رویدادها از bus و ذخیره آن‌ها در audit_log
-├── auth/            توکن‌های Bearer مدیر (M2.5)
-├── backup/          پشتیبان‌گیری رمزنگاری‌شده از پایگاه داده و درون‌ریزی/برون‌بری داده‌ها
-├── catalog/         مانیفست ارائه‌دهندگان CLI و تنظیمات هر کاربر
-├── channel/         مدیریت کانال‌ها و یکپارچه‌سازی با تلگرام (M4)
-├── config/          بارگذاری فایل‌های TOML و متغیرهای OPENDRAY_*
-├── eventbus/        سیستم Pub/Sub داخلی
-├── gateway/         مسیریابی HTTP با chi، middleware و slog
-├── integration/     ثبت برنامه‌های خارجی، Reverse Proxy و رویدادهای WebSocket (M3)
-├── memory/          حافظه پایدار مشترک بین CLIها
-├── session/         مدیریت نشست‌ها، PTY، بافر حلقوی و جریان WebSocket (M1)
-├── store/           اتصال به PostgreSQL با pgx و اجرای Migrationها (M0)
-├── version/         اطلاعات نسخه و زمان ساخت
-└── web/             جاسازی رابط وب با go:embed (W5)
+├── app/           bootstrap و اتصال componentهای اصلی برنامه
+├── audit/         دریافت eventها از bus و ذخیره در audit_log
+├── auth/          admin Bearer tokenها
+├── backup/        encrypted DB backup و data import/export
+├── catalog/       provider manifestها و per-user config
+├── channel/       channel management و Telegram integration
+├── config/        load کردن TOML config و OPENDRAY_* environment variables
+├── eventbus/      internal Pub/Sub
+├── gateway/       HTTP routing با chi، middleware و slog
+├── integration/   external app registration، Reverse Proxy و WebSocket eventها
+├── memory/        shared persistent memory بین CLIها
+├── session/       session management، PTY، ring buffer و WebSocket stream
+├── store/         PostgreSQL connection با pgx و migrationها
+├── version/       version و build metadata
+└── web/           embedded web UI با go:embed
 
-app/web/             اپلیکیشن تک‌صفحه‌ای (SPA) مبتنی بر React 19، TypeScript و Vite (فاز 2، W0-W5)
+app/web/
+  React 19 + TypeScript + Vite single-page app
 
-app/mobile/          اپلیکیشن Flutter برای اندروید و iOS با قابلیت‌هایی مشابه نسخه وب
+app/mobile/
+  Flutter app برای Android و iOS با featureهای مشابه web version
 
 docs/
-├── design.md        سند اصلی طراحی و مرجع پروژه (SSOT)
-└── adr/             تصمیم‌های معماری ثبت‌شده به همراه تاریخ
+├── design.md      سند اصلی طراحی و مرجع پروژه
+└── adr/           Architecture Decision Recordها
 ```
 
-</div>
+---
 
-## فرانت‌اند وب
+## web frontend
 
-`app/web/` یک SPA واحد را در `internal/web/dist/` build می‌کند، که باینری Go آن را embed می‌کند و در `/admin/*` سرو می‌کند. Vite dev server روی `:5173`
-`/api` را به `:8770` proxy می‌کند تا development با HMR انجام شود.
-
-<div dir="ltr">
+`app/web/` یک SPA واحد را در `internal/web/dist/` build می‌کند. Go binary آن را embed می‌کند و از مسیر `/admin/*` سرو می‌کند. Vite dev server روی `:5173` مسیر `/api` را به `:8770` proxy می‌کند تا development با HMR انجام شود.
 
 ```bash
-# dev (hot reload on the React side, separate Go server for the API)
-cd app/web && pnpm dev               # http://localhost:5173
+# dev: hot reload on React side, separate Go server for API
+
+cd app/web && pnpm dev       # http://localhost:5173
+
 go run ./cmd/opendray serve -config ../../config.toml   # other terminal
 
-# prod (one binary delivers everything)
-cd app/web && pnpm build              # writes ../../internal/web/dist
+# prod: one binary delivers everything
+
+cd app/web && pnpm build     # writes ../../internal/web/dist
 cd ../..
-go build ./cmd/opendray               # bakes dist into the binary
+go build ./cmd/opendray      # bakes dist into the binary
 ./opendray serve -config config.toml
 ```
 
-</div>
+برای frontend stack، یعنی `React` + `Vite` + `Tailwind v4` + `shadcn/ui` + `TanStack Router/Query` + `Zustand` + `xterm.js`، و noteهای مربوط به milestoneهای W، به [`app/web/README.md`](app/web/README.md) نگاه کنید.
 
-برای frontend stack
-(`React` + `Vite` + `Tailwind v4` + `shadcn/ui` + `TanStack Router/Query` +
-`Zustand` + `xterm.js`) و یادداشت‌های milestone هر W به
-[`app/web/README.md`](app/web/README.md) نگاه کنید.
+---
 
 ## مستندات
 
-- [`docs/getting-started.md`](docs/getting-started.md): **اگر تازه‌کارید، از اینجا شروع کنید**؛ از صفر تا اولین سشن در ۱۵ دقیقه، شامل نصب CLIهای دربرگرفته‌شده و bootstrap کردن Postgres
-- [`docs/install-binary.fa.md`](docs/install-binary.fa.md): نصب از پکیج npm یا باینری release (Postgres را خودتان می‌آورید) و اجرا به‌عنوان systemd / launchd service
-- [`docs/quickstart.md`](docs/quickstart.md): محیط dev پنج‌دقیقه‌ای (فرض می‌کند از قبل moving parts را می‌شناسید)
-- [`docs/operator-guide.md`](docs/operator-guide.md): مرجع deploy + ops برای setupهای production-ish
-- [`docs/integration-guide.md`](docs/integration-guide.md): چطور یک integration خارجی را در هر زبانی بنویسید
-- [`VERSIONING.md`](VERSIONING.md): استراتژی versioning (major-as-generation)
-- [`CHANGELOG.md`](CHANGELOG.md): تاریخچه releaseها
+- [`docs/getting-started.md`](docs/getting-started.md): اگر تازه شروع کرده‌اید، از اینجا شروع کنید؛ از صفر تا اولین session در حدود ۱۵ دقیقه، شامل نصب CLIهای موردنیاز و bootstrap کردن Postgres.
+- [`docs/install-binary.fa.md`](docs/install-binary.fa.md): نصب از npm package یا release binary، با فرض این‌که Postgres را خودتان آماده می‌کنید، و اجرا به‌عنوان systemd یا launchd service.
+- [`docs/quickstart.md`](docs/quickstart.md): مسیر پنج‌دقیقه‌ای برای dev environment؛ مناسب وقتی که moving partها را از قبل می‌شناسید.
+- [`docs/operator-guide.md`](docs/operator-guide.md): مرجع deploy و ops برای production-like setupها.
+- [`docs/integration-guide.md`](docs/integration-guide.md): راهنمای نوشتن external integration با هر زبان برنامه‌نویسی.
+- [`VERSIONING.md`](VERSIONING.md): استراتژی versioning مبتنی بر major-as-generation.
+- [`CHANGELOG.md`](CHANGELOG.md): تاریخچه releaseها.
+
+---
 
 ## تست‌ها
 
-<div dir="ltr">
-
 ```bash
-go test -race ./...        # backend
-cd app/web && pnpm build   # web (TS strict + vite production build)
+go test -race ./...          # backend
+cd app/web && pnpm build     # web: TS strict + Vite production build
 ```
 
-</div>
+smoke flowهای end-to-end را بر اساس هر milestone در commit messageها track می‌کنیم. یک Playwright harness هم به‌عنوان follow-up برنامه‌ریزی شده است.
 
-smoke flowهای سرتاسری را در commit messageها بر اساس هر milestone track می‌کنیم.
-یک Playwright harness هم به‌عنوان follow-up برنامه‌ریزی شده است.
+---
 
 ## نسبت به v1
 
-v1 (`Opendray/opendray`) codebase قدیمی است که حالا archived شده. v2 نسل
-فعلی و active است؛ feature-complete و تنها branchی که development می‌گیرد.
-از 16 builtin در v1، چهار مورد به بک‌اند v2 منتقل شدند؛ بقیه رفتند سمت
-featureهای client-side، channel adapterها، یا integration-API consumerها.
+v1 یعنی `Opendray/opendray` codebase قدیمی پروژه است که حالا archived شده. v2 نسل فعلی و active پروژه است؛ feature-complete است و تنها branchای است که development می‌گیرد.
 
-## مجوز
+از ۱۶ builtin موجود در v1، چهار مورد به backend در v2 منتقل شده‌اند. بقیه به سمت client-side featureها، channel adapterها یا integration API consumerها منتقل شده‌اند.
 
-آپاچی ۲.۰: به [`لایسنس`](LICENSE) نگاه کنید. (v1 تحت مجوز MIT بود؛ v2 مجوز جداگانهٔ خودش را دارد.)
+---
 
-</div>
+## License
+
+Apache 2.0. فایل [`LICENSE`](LICENSE) را ببینید.
+
+v1 تحت MIT license بود؛ v2 license جداگانه خودش را دارد.


### PR DESCRIPTION
Full rewrite of `README.fa.md` to match how Iranian developers actually read and write OSS docs ("Finglish": heavy Latin-script English for technical terms with Persian connective tissue) instead of the literal-translation register the previous version used.

## Why

Hand-reviewed against typical Persian-language dev community writing (Telegram channels, Iranian YouTube tutorials, X/Twitter dev threads). The previous translation Persianized too many OSS terms (`نشست` for session, `ایجنت` for agent, `بازیابی` for retrieval, `استخر` for pool, `لایه` for layer, etc) which reads as translated rather than native. Real-world Persian dev prose keeps `session`, `agent`, `retrieval`, `pool`, `layer` in Latin script and uses Persian only for the connective tissue.

## Substitution pattern

| Previous (literal) | New (native Finglish) |
|---|---|
| نشست‌ها | sessionها |
| ایجنت | agent |
| میزبان | host |
| بازیابی | retrieval |
| استخر | pool / capacity pool |
| لایه | layer |
| ذخیره‌سازِ برداریِ local-first | local-first vector store |
| توکن | token |
| کانتکست | context |
| تشخیصِ drift | drift و ناسازگاری |

## Other corrections

- **Version reference** bumped from `۲٫۶٫۰` to `۲٫۷٫۱` to match the actual latest release.
- **Language switcher link fixed**: `README.zh-CN.md` → `README.zh.md` (the actual filename on `main`). The previous link would 404.
- **All em-dashes (`—`) removed**, including three sites outside the Why-exists section that #307 didn't reach (in the installation and docs sections). The whole file is now em-dash-free, per the project-wide style rule.

## Structural changes

- **No `<div dir="rtl" lang="fa">` wrapper.** GitHub handles bidi correctly for Persian + Latin mixed text without it; the wrapper was making line spacing slightly off in the GitHub rendered view.
- **No badges/shields header.** The previous translation had the canonical centered hero with logo + 9 shields. The new version drops to a simple `# opendray` heading + tagline + `opendray.dev` link + switcher. Matches the more direct style Persian readers expect.
- **No per-codeblock `<div dir="ltr">` wrappers.** Markdown code fences render LTR by default; the explicit wrappers were redundant.
- **"Why opendray exists" restructured.** Previous version had three bolded sentence leads inside one paragraph block (matching the other 9 READMEs). New version splits into three `###` sub-headings (`وقتی laptop sleep می‌شود...` / `rate limit نباید کارتان را خراب کند` / `memory باید جزء اصلی سیستم باشد...`) which scans better for Persian readers.

## Translation matrix consistency

This intentionally **diverges** from the other 9 READMEs (which all share the same `<div>` + shields + bold-lead structure). The reasoning is that the Persian-language audience reads differently — a simpler, more direct structure works better than mirroring the centered-hero Western OSS convention. The other 9 translations stay as-is.

If we want to bring the others into line later, that's a separate discussion. This PR is specifically a quality-of-translation upgrade for `README.fa.md`.

## Test plan

- [x] All referenced files verified to exist on main (`README.zh.md`, `docs/install-binary.fa.md`, `docs/getting-started.md`, `docs/quickstart.md`, `docs/operator-guide.md`, `docs/integration-guide.md`, `VERSIONING.md`, `CHANGELOG.md`, `LICENSE`)
- [x] Zero em-dashes / en-dashes used as prose punctuation
- [x] Markdown links, anchors, and code blocks render cleanly
- [x] CI green expected (docs-only)
