### PR TITLE
docs(mobile): surface the app in READMEs + add per-doc language switcher

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -446,6 +446,12 @@ Den Frontend-Stack (React + Vite + Tailwind v4 + shadcn/ui + TanStack
 Router/Query + Zustand + xterm.js) und Notes pro W-Milestone findest du in
 [`app/web/README.md`](app/web/README.md).
 
+## Mobile-App
+
+`app/mobile/` ist eine Flutter-App für **iOS und Android** mit Feature-Parität zum Web-Admin. Sie klinkt sich über HTTPS in ein laufendes Gateway ein — gib beim ersten Start die **Gateway URL** + die Admin-Anmeldedaten ein, und du bekommst dieselben Sessions- / Channels- / Integrations- / Memory- / Git-Oberflächen. Einen App-Store- / Play-Store-Build gibt es bewusst nicht (Self-hosted, Single-Tenant): Du baust sie selbst und signierst sie mit deiner eigenen Identität.
+
+**[→ Bau- & Installationsanleitung](docs/mobile-app.de.md)** — mach das Gateway vom Smartphone aus erreichbar, dann ein Android-APK sideloaden oder per Xcode aufs iPhone installieren.
+
 ## Dokumentation
 
 - [`docs/getting-started.md`](docs/getting-started.md): **fang hier an**, wenn du neu bist. Von null bis zur ersten Session in 15 Minuten, inklusive Installation der gewrappten CLIs und Postgres-Bootstrap

--- a/README.es.md
+++ b/README.es.md
@@ -447,6 +447,19 @@ Consulta [`app/web/README.md`](app/web/README.md) para el stack de frontend
 (React + Vite + Tailwind v4 + shadcn/ui + TanStack Router/Query +
 Zustand + xterm.js) y notas por milestone W.
 
+## App móvil
+
+`app/mobile/` es una app Flutter para **iOS y Android** con paridad de funciones
+con el panel de administración web. Se conecta a un gateway en marcha sobre HTTPS:
+introduce la **Gateway URL** + el login de admin en el primer arranque y obtienes
+las mismas superficies de Sesiones / Canales / Integraciones / Memoria / Git. No hay
+build para App Store / Play Store por diseño (autohospedado, single-tenant): la
+compilas tú mismo y la firmas con tu propia identidad.
+
+**[→ Guía de compilación e instalación](docs/mobile-app.es.md)** — haz que el gateway
+sea alcanzable desde el teléfono, y luego sideloadea un APK de Android o instálala en
+el iPhone vía Xcode.
+
 ## Documentación
 
 - [`docs/getting-started.md`](docs/getting-started.md): **empieza aquí** si eres nuevo. De cero a tu primera sesión en 15 minutos, incluyendo la instalación de las CLIs envueltas y el bootstrap de Postgres

--- a/README.fa.md
+++ b/README.fa.md
@@ -600,6 +600,18 @@ go build ./cmd/opendray      # bakes dist into the binary
 
 ---
 
+<h2 dir="rtl" align="right">اپ موبایل</h2>
+
+<p dir="rtl" align="right">
+<code>app/mobile/</code> یک Flutter app برای iOS و Android است که از نظر featureها با web admin برابری دارد. از طریق HTTPS به یک gateway فعال وصل می‌شود — در اولین اجرا <code>Gateway URL</code> و اطلاعات ورود admin را وارد می‌کنید و همان surfaceهای Sessions / Channels / Integrations / Memory / Git را در اختیار می‌گیرید. به‌صورت عمدی هیچ build مربوط به App Store / Play Store وجود ندارد (self-hosted و single-tenant): خودتان آن را build می‌کنید و با هویت خودتان امضایش می‌کنید.
+</p>
+
+<p dir="rtl" align="right">
+<strong>← <a href="docs/mobile-app.fa.md">راهنمای build و نصب</a></strong> — کاری کنید gateway از گوشی در دسترس باشد، بعد یک Android APK را sideload کنید یا با Xcode روی iPhone نصبش کنید.
+</p>
+
+---
+
 <h2 dir="rtl" align="right">مستندات</h2>
 
 <ul dir="rtl" align="right">

--- a/README.fr.md
+++ b/README.fr.md
@@ -446,6 +446,12 @@ Voir [`app/web/README.md`](app/web/README.md) pour la stack frontend
 (React + Vite + Tailwind v4 + shadcn/ui + TanStack Router/Query +
 Zustand + xterm.js) et les notes par milestone W.
 
+## Application mobile
+
+`app/mobile/` est une app Flutter pour **iOS et Android**, à parité de fonctionnalités avec l'admin web. Elle se rattache à un gateway en marche via HTTPS — saisis l'**URL du gateway** (`Gateway URL`) + le login admin au premier lancement et tu retrouves les mêmes surfaces Sessions / Channels / Integrations / Memory / Git. Il n'y a pas de build App Store / Play Store, et c'est voulu (self-hosted, single-tenant) : tu la compiles toi-même et la signes avec ta propre identité.
+
+**[→ Guide de build & installation](docs/mobile-app.fr.md)** — rends le gateway accessible depuis le téléphone, puis sideload un APK Android ou installe sur iPhone via Xcode.
+
 ## Documentation
 
 - [`docs/getting-started.md`](docs/getting-started.md) : **commence ici** si tu débutes, de zéro à ta première session en 15 minutes, installation des CLI wrappées et bootstrap Postgres compris

--- a/README.ja.md
+++ b/README.ja.md
@@ -446,6 +446,12 @@ go build ./cmd/opendray               # bakes dist into the binary
 Zustand + xterm.js）や、W マイルストーンごとのノートについては
 [`app/web/README.md`](app/web/README.md) を参照してください。
 
+## モバイルアプリ
+
+`app/mobile/` は **iOS と Android** 向けの Flutter アプリで、web 管理画面と同等の機能を備えています。HTTPS 経由で稼働中のゲートウェイに接続し、初回起動時に **Gateway URL** と管理者ログインを入力すると、同じ Sessions / Channels / Integrations / Memory / Git のサーフェスがそのまま使えます。App Store / Play Store 向けのビルドは設計上あえて用意していません（セルフホスト、シングルテナント）。自分でビルドし、自分の identity で署名してください。
+
+**[→ ビルドとインストールのガイド](docs/mobile-app.ja.md)** — まずゲートウェイをスマートフォンから到達可能にし、そのうえで Android APK をサイドロードするか、Xcode で iPhone にインストールします。
+
 ## ドキュメント
 
 - [`docs/getting-started.md`](docs/getting-started.md): はじめての方は **まずここから**。ラップ対象の CLI のインストールや Postgres のブートストラップも含めて、ゼロから最初のセッションまでを 15 分で

--- a/README.ko.md
+++ b/README.ko.md
@@ -444,6 +444,12 @@ go build ./cmd/opendray               # bakes dist into the binary
 Zustand + xterm.js) 및 W 마일스톤별 노트는 [`app/web/README.md`](app/web/README.md)에서
 확인할 수 있습니다.
 
+## 모바일 앱
+
+`app/mobile/`은 **iOS와 Android**를 위한 Flutter 앱으로, 웹 어드민과 동일한 기능을 제공합니다. 실행 중인 게이트웨이에 HTTPS로 접속합니다 — 최초 실행 시 **Gateway URL** + 어드민 로그인을 입력하면, 동일한 Sessions / Channels / Integrations / Memory / Git 표면을 그대로 사용할 수 있습니다. 설계상 App Store / Play Store 빌드는 제공하지 않습니다(self-hosted, single-tenant). 직접 빌드하고 본인의 인증서로 서명합니다.
+
+**[→ 빌드 및 설치 가이드](docs/mobile-app.ko.md)** — 휴대폰에서 게이트웨이에 접근할 수 있게 한 뒤, Android APK를 사이드로드하거나 Xcode로 iPhone에 설치하세요.
+
 ## 문서
 
 - [`docs/getting-started.md`](docs/getting-started.md): 처음이라면 **여기서 시작**. 감싸는 CLI 설치와 Postgres 부트스트랩을 포함해 15분 만에 첫 세션까지

--- a/README.md
+++ b/README.md
@@ -440,6 +440,20 @@ See [`app/web/README.md`](app/web/README.md) for the frontend stack
 (React + Vite + Tailwind v4 + shadcn/ui + TanStack Router/Query +
 Zustand + xterm.js) and per-W milestone notes.
 
+## Mobile app
+
+`app/mobile/` is a Flutter app for **iOS and Android** with feature
+parity with the web admin. It attaches to a running gateway over HTTPS —
+enter the **Gateway URL** + admin login on first launch and you get the
+same Sessions / Channels / Integrations / Memory / Git surfaces. There's
+no App Store / Play Store build by design (self-hosted, single-tenant):
+you build it yourself and sign it with your own identity.
+
+**[→ Build & install guide](docs/mobile-app.md)** — make the gateway
+reachable from the phone, then sideload an Android APK or install on
+iPhone via Xcode. ([all 10 languages](docs/mobile-app.md) — switch at the
+top of the guide.)
+
 ## Documentation
 
 - [`docs/getting-started.md`](docs/getting-started.md): **start here** if you're new. Zero to first session in 15 minutes, including installing the wrapped CLIs and bootstrapping Postgres.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -447,6 +447,20 @@ Veja [`app/web/README.md`](app/web/README.md) pro stack do frontend
 (React + Vite + Tailwind v4 + shadcn/ui + TanStack Router/Query +
 Zustand + xterm.js) e notas por milestone W.
 
+## App mobile
+
+O `app/mobile/` é um app em Flutter para **iOS e Android** com paridade de
+funcionalidades em relação ao admin web. Ele se conecta a um gateway em
+execução via HTTPS — informe a **Gateway URL** + o login de admin no primeiro
+lançamento e você ganha as mesmas superfícies de Sessões / Canais / Integrações
+/ Memória / Git. Não existe build na App Store / Play Store por design
+(self-hosted, single-tenant): você mesmo compila e assina com a sua própria
+identidade.
+
+**[→ Guia de build e instalação](docs/mobile-app.pt-BR.md)** — torne o gateway
+acessível a partir do celular, depois faça sideload de um APK Android ou instale
+no iPhone via Xcode.
+
 ## Documentação
 
 - [`docs/getting-started.md`](docs/getting-started.md): **comece por aqui** se você é novo. Do zero até a primeira sessão em 15 minutos, incluindo a instalação das CLIs encapsuladas e o bootstrap do Postgres

--- a/README.ru.md
+++ b/README.ru.md
@@ -449,6 +449,19 @@ go build ./cmd/opendray               # bakes dist into the binary
 (React + Vite + Tailwind v4 + shadcn/ui + TanStack Router/Query +
 Zustand + xterm.js) и заметки по W-майлстоунам.
 
+## Мобильное приложение
+
+`app/mobile/` — это Flutter-приложение для **iOS и Android** с полным паритетом
+функций с веб-админкой. Оно подключается к работающему шлюзу по HTTPS — укажите
+**Gateway URL** и логин администратора при первом запуске, и вы получаете те же
+поверхности Sessions / Channels / Integrations / Memory / Git. Сборки в App Store /
+Play Store нет by design (self-hosted, single-tenant): вы собираете приложение сами
+и подписываете его собственной идентичностью.
+
+**[→ Гайд по сборке и установке](docs/mobile-app.ru.md)** — сделайте шлюз доступным
+с телефона, затем установите Android-APK через sideload или поставьте на iPhone
+через Xcode.
+
 ## Документация
 
 - [`docs/getting-started.md`](docs/getting-started.md): **начинайте отсюда**, если вы новичок: от нуля до первой сессии за 15 минут, включая установку оборачиваемых CLI и bootstrap Postgres

--- a/README.zh.md
+++ b/README.zh.md
@@ -436,6 +436,12 @@ go build ./cmd/opendray               # 把 dist 打进二进制
 Router/Query + Zustand + xterm.js)和每个 W 里程碑笔记见
 [`app/web/README.md`](app/web/README.md)。
 
+## 移动 App
+
+`app/mobile/` 是一个面向 **iOS 和 Android** 的 Flutter app，功能与网页后台完全对齐。它通过 HTTPS 连接到运行中的网关 —— 首次启动时填入 **Gateway URL** + admin 登录信息，即可获得同样的会话 / Channel / Integration / Memory / Git 各个 surface。按设计没有 App Store / Play Store 构建（自托管、单租户）：由你自己构建，并用你自己的身份签名。
+
+**[→ 构建与安装指南](docs/mobile-app.zh.md)** —— 让手机能访问到网关，然后旁加载 Android APK，或通过 Xcode 装到 iPhone 上。
+
 ## 文档
 
 - [`docs/getting-started.zh.md`](docs/getting-started.zh.md)：**新手从这开始**,零到首次会话 15 分钟,含装 wrap 的 CLI + bootstrap Postgres + 收第一条 Telegram 通知

--- a/app/mobile/README.md
+++ b/app/mobile/README.md
@@ -10,8 +10,11 @@ itself.
 Full walkthrough — Android APK sideload and iOS install via Xcode,
 plus making the gateway reachable from the phone:
 
-- [`docs/mobile-app.md`](../../docs/mobile-app.md) (English)
-- [`docs/mobile-app.zh.md`](../../docs/mobile-app.zh.md) (简体中文)
+**[→ `docs/mobile-app.md`](../../docs/mobile-app.md)**
+
+Available in 10 languages (English, 简体中文, فارسی, Español, Português,
+日本語, 한국어, Français, Deutsch, Русский) — use the language switcher at
+the top of the guide.
 
 ## Quick reference
 

--- a/docs/mobile-app.de.md
+++ b/docs/mobile-app.de.md
@@ -1,5 +1,7 @@
 # Mobile App — bauen & installieren
 
+🌐 [English](mobile-app.md) · [简体中文](mobile-app.zh.md) · [فارسی](mobile-app.fa.md) · [Español](mobile-app.es.md) · [Português](mobile-app.pt-BR.md) · [日本語](mobile-app.ja.md) · [한국어](mobile-app.ko.md) · [Français](mobile-app.fr.md) · **Deutsch** · [Русский](mobile-app.ru.md)
+
 Die opendray-Mobile-App (`app/mobile/`) ist ein **Control-Client**, kein
 zweites Gateway. Sie erledigt dieselbe Aufgabe wie das Web-Admin unter
 `/admin/`: Sessions starten und steuern, Channels und Integrationen

--- a/docs/mobile-app.es.md
+++ b/docs/mobile-app.es.md
@@ -1,5 +1,7 @@
 # App móvil — compilar e instalar
 
+🌐 [English](mobile-app.md) · [简体中文](mobile-app.zh.md) · [فارسی](mobile-app.fa.md) · **Español** · [Português](mobile-app.pt-BR.md) · [日本語](mobile-app.ja.md) · [한국어](mobile-app.ko.md) · [Français](mobile-app.fr.md) · [Deutsch](mobile-app.de.md) · [Русский](mobile-app.ru.md)
+
 La app móvil de opendray (`app/mobile/`) es un **cliente de control**, no un
 segundo gateway. Hace el mismo trabajo que el panel de administración web en `/admin/`:
 lanzar y dirigir sesiones, gestionar canales e integraciones, explorar

--- a/docs/mobile-app.fa.md
+++ b/docs/mobile-app.fa.md
@@ -2,6 +2,10 @@
 
 # اپ موبایل — build و نصب
 
+<p dir="ltr" align="center">
+🌐 <a href="mobile-app.md">English</a> · <a href="mobile-app.zh.md">简体中文</a> · <strong>فارسی</strong> · <a href="mobile-app.es.md">Español</a> · <a href="mobile-app.pt-BR.md">Português</a> · <a href="mobile-app.ja.md">日本語</a> · <a href="mobile-app.ko.md">한국어</a> · <a href="mobile-app.fr.md">Français</a> · <a href="mobile-app.de.md">Deutsch</a> · <a href="mobile-app.ru.md">Русский</a>
+</p>
+
 اپ موبایل opendray (`app/mobile/`) یک **کلاینت کنترل** است، نه یک gateway دوم. همان کاری را می‌کند که web admin روی `/admin/` انجام می‌دهد: ساختن و راندن سشن‌ها، مدیریت channelها و integrationها، مرور حافظه، خواندن git hostها. خودِ agentها همچنان روی gateway host شما در حال اجرا می‌مانند — گوشی فقط به آن‌ها وصل می‌شود.
 
 به همین خاطر، اپ به‌تنهایی به‌دردنخور است: از طریق HTTPS به یک **gateway فعالِ opendray** وصل می‌شود. اول gateway را بالا بیاورید ([getting-started](getting-started.md))، بعد اپ را build کنید و آن را به URL gateway خودتان نشانه بگیرید.

--- a/docs/mobile-app.fr.md
+++ b/docs/mobile-app.fr.md
@@ -1,5 +1,7 @@
 # Application mobile — build & installation
 
+🌐 [English](mobile-app.md) · [简体中文](mobile-app.zh.md) · [فارسی](mobile-app.fa.md) · [Español](mobile-app.es.md) · [Português](mobile-app.pt-BR.md) · [日本語](mobile-app.ja.md) · [한국어](mobile-app.ko.md) · **Français** · [Deutsch](mobile-app.de.md) · [Русский](mobile-app.ru.md)
+
 L'application mobile opendray (`app/mobile/`) est un **client de contrôle**, pas
 un second gateway. Elle fait le même travail que l'admin web à `/admin/` :
 lancer et piloter des sessions, gérer les channels et les intégrations, parcourir

--- a/docs/mobile-app.ja.md
+++ b/docs/mobile-app.ja.md
@@ -1,5 +1,7 @@
 # モバイルアプリ — ビルドとインストール
 
+🌐 [English](mobile-app.md) · [简体中文](mobile-app.zh.md) · [فارسی](mobile-app.fa.md) · [Español](mobile-app.es.md) · [Português](mobile-app.pt-BR.md) · **日本語** · [한국어](mobile-app.ko.md) · [Français](mobile-app.fr.md) · [Deutsch](mobile-app.de.md) · [Русский](mobile-app.ru.md)
+
 opendray モバイルアプリ（`app/mobile/`）は **コントロールクライアント** であり、
 2 台目のゲートウェイではありません。`/admin/` の web 管理画面と同じ仕事をします:
 セッションの起動と操作、チャンネルと連携の管理、メモリの閲覧、

--- a/docs/mobile-app.ko.md
+++ b/docs/mobile-app.ko.md
@@ -1,5 +1,7 @@
 # 모바일 앱 — 빌드 및 설치
 
+🌐 [English](mobile-app.md) · [简体中文](mobile-app.zh.md) · [فارسی](mobile-app.fa.md) · [Español](mobile-app.es.md) · [Português](mobile-app.pt-BR.md) · [日本語](mobile-app.ja.md) · **한국어** · [Français](mobile-app.fr.md) · [Deutsch](mobile-app.de.md) · [Русский](mobile-app.ru.md)
+
 opendray 모바일 앱(`app/mobile/`)은 **컨트롤 클라이언트**이며,
 두 번째 게이트웨이가 아닙니다. `/admin/`의 웹 어드민과 동일한 일을 합니다:
 세션을 spawn하고 조작하며, 채널과 통합을 관리하고, 메모리를 탐색하고,

--- a/docs/mobile-app.md
+++ b/docs/mobile-app.md
@@ -1,5 +1,7 @@
 # Mobile app — build & install
 
+🌐 **English** · [简体中文](mobile-app.zh.md) · [فارسی](mobile-app.fa.md) · [Español](mobile-app.es.md) · [Português](mobile-app.pt-BR.md) · [日本語](mobile-app.ja.md) · [한국어](mobile-app.ko.md) · [Français](mobile-app.fr.md) · [Deutsch](mobile-app.de.md) · [Русский](mobile-app.ru.md)
+
 The opendray mobile app (`app/mobile/`) is a **control client**, not a
 second gateway. It does the same job as the web admin at `/admin/`:
 spawn and drive sessions, manage channels and integrations, browse

--- a/docs/mobile-app.pt-BR.md
+++ b/docs/mobile-app.pt-BR.md
@@ -1,5 +1,7 @@
 # App mobile — build e instalação
 
+🌐 [English](mobile-app.md) · [简体中文](mobile-app.zh.md) · [فارسی](mobile-app.fa.md) · [Español](mobile-app.es.md) · **Português** · [日本語](mobile-app.ja.md) · [한국어](mobile-app.ko.md) · [Français](mobile-app.fr.md) · [Deutsch](mobile-app.de.md) · [Русский](mobile-app.ru.md)
+
 O app mobile do opendray (`app/mobile/`) é um **cliente de controle**, não um
 segundo gateway. Ele faz o mesmo trabalho do admin web em `/admin/`: cria e
 conduz sessões, gerencia canais e integrações, navega pela memória, lê hosts

--- a/docs/mobile-app.ru.md
+++ b/docs/mobile-app.ru.md
@@ -1,5 +1,7 @@
 # Мобильное приложение — сборка и установка
 
+🌐 [English](mobile-app.md) · [简体中文](mobile-app.zh.md) · [فارسی](mobile-app.fa.md) · [Español](mobile-app.es.md) · [Português](mobile-app.pt-BR.md) · [日本語](mobile-app.ja.md) · [한국어](mobile-app.ko.md) · [Français](mobile-app.fr.md) · [Deutsch](mobile-app.de.md) · **Русский**
+
 Мобильное приложение opendray (`app/mobile/`) — это **клиент управления**, а
 не второй шлюз. Оно выполняет ту же работу, что и веб-админка по адресу
 `/admin/`: запускает и ведёт сессии, управляет каналами и интеграциями,

--- a/docs/mobile-app.zh.md
+++ b/docs/mobile-app.zh.md
@@ -1,5 +1,7 @@
 # 移动 App —— 构建与安装
 
+🌐 [English](mobile-app.md) · **简体中文** · [فارسی](mobile-app.fa.md) · [Español](mobile-app.es.md) · [Português](mobile-app.pt-BR.md) · [日本語](mobile-app.ja.md) · [한국어](mobile-app.ko.md) · [Français](mobile-app.fr.md) · [Deutsch](mobile-app.de.md) · [Русский](mobile-app.ru.md)
+
 opendray 移动 App（`app/mobile/`）是一个**控制端客户端**，并不是第二个网关。
 它和网页后台 `/admin/` 做的是同一件事：创建并驱动会话、管理 channel 与
 integration、浏览 memory、查看 git host。Agent 本身始终运行在你的网关主机上 ——


### PR DESCRIPTION
## Why

Follow-up to #314. Two discoverability gaps remained:

1. **The mobile app was buried.** It only appeared as one line in the bottom Documentation list of each README — nothing on the landing area, despite there being a dedicated `## Web frontend` section. You had to scroll deep to learn the app exists or how to get it.
2. **No way to switch languages inside the guide.** Each `docs/mobile-app.<lang>.md` had no language switcher, so a reader who opened (say) the French variant couldn't jump to another language — unlike the README family, which has a switcher row at the top.
3. **`app/mobile/README.md` linked only English + Chinese**, hiding the other 8 localized guides.

## What

- **Dedicated `## Mobile app` section in every README** (all 10 locales), placed right after `## Web frontend` and parallel to it: a short description (control client, attaches to a gateway via Gateway URL + admin login, no store build by design) plus a prominent link to the localized build & install guide.
- **Language-switcher row at the top of all 10 `docs/mobile-app.*` files**, mirroring the README switcher (current language bolded, others linked). The `fa` variant wraps the row in `<p dir="ltr" align="center">` so the links render left-to-right inside the RTL document.
- **`app/mobile/README.md`** now links the guide directly and notes the in-doc switcher covers all 10 languages, instead of listing only EN + ZH.

## Test plan

- [x] All 10 mobile-app docs carry a switcher row (🌐 + 9 sibling-language links each).
- [x] All 10 READMEs link their localized guide from the new section (verified per-locale).
- [x] `fa` switcher + README section use LTR/RTL HTML wrappers consistent with the existing `*.fa.md` markup.
- [ ] Reviewer: render-check the new README section + the `fa` switcher on GitHub.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)