### PR TITLE
docs(contributing): add finding-work, translating, and Q&A sections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,16 @@ Thanks for your interest. v2 is in `v1.0-rc`; the cutover from
 [Opendray/opendray](https://github.com/Opendray/opendray) (v1) happens after
 this release ships.
 
+## Finding something to work on
+
+If you're looking for an easy way in:
+
+- **Good first issues:** [github.com/Opendray/opendray/labels/good first issue](https://github.com/Opendray/opendray/labels/good%20first%20issue). Each one has a clear acceptance criteria and a pointer to where to start.
+- **Help wanted:** [github.com/Opendray/opendray/labels/help wanted](https://github.com/Opendray/opendray/labels/help%20wanted). Larger pieces of work where outside contribution is especially welcome.
+- **Discussion #300 (v2.8 roadmap):** [the "What should we ship in v2.8?" thread](https://github.com/Opendray/opendray/discussions/300) lists the ideas currently on the radar. Comment there before starting work on anything bigger than a contained fix, so we can align on scope.
+
+If you'd rather just open a PR for something not in the issue tracker (a small fix, a typo, a missing log line), go ahead. For anything that crosses subsystem boundaries or introduces a new external dependency, please open an issue or discussion first.
+
 ## Prerequisites
 
 | Tool | Version | Purpose |
@@ -106,6 +116,32 @@ relevant operator / integration guide updates from the same PR.
   mutate in place.
 - **TypeScript:** TS strict mode + the rules already enforced by the Vite +
   ESLint setup in `app/web/`.
+
+## Translating opendray
+
+Translation contributions land in two places.
+
+**README translations.** Ten languages live alongside `README.md` at the repo root (`README.zh.md`, `README.fa.md`, `README.es.md`, `README.pt-BR.md`, `README.ja.md`, `README.ko.md`, `README.fr.md`, `README.de.md`, `README.ru.md`). The convention is "Finglish" style: technical product names and OSS terms stay in Latin script (Claude Code, Codex, gateway, session, host, transcript, embedding) while the connective tissue is native. Each language uses its own register:
+
+- ES, PT-BR, FR: informal (tú / você / tu).
+- DE: informal "Du".
+- JA: です・ます polite-neutral.
+- KO: 합니다 register.
+- RU: lowercase impersonal "вы" (Habr-style), with the project-wide override of no em-dash тире.
+- FA: heavy Latin-English borrowing, RTL-wrapped body.
+
+**Style rule that applies to every language:** no em-dashes (`—`) or prose en-dashes (`–`) anywhere in user-facing text. Use periods, commas, parentheses, or colons instead. Compound-noun hyphens in code identifiers (`local-first`, `--from-source`, `AI-Coding-CLIs`) are fine.
+
+**Admin UI translations.** The Flutter / React app reads from `app/i18n/<lang>.json`. Currently shipped: `en.json` (canonical, ~4 k keys) and `zh.json`. Adding a new language means copying `en.json` to `<lang>.json`, translating the values, and wiring it into the i18next config. See the open good-first-issue for the canonical walkthrough.
+
+**Stale translation policy.** If your PR changes English-language docs or strings, ideally update the other-language equivalents in the same PR. If that's too much work, flag the affected translations as stale in the PR description and someone will pick them up.
+
+## Asking questions
+
+- **General questions, build logs, philosophy:** [Discussions → General](https://github.com/Opendray/opendray/discussions/categories/general).
+- **Ideas for new features:** [Discussions → Ideas](https://github.com/Opendray/opendray/discussions/categories/ideas).
+- **Stuck on setup / config / a specific error:** [Discussions → Q&A](https://github.com/Opendray/opendray/discussions/categories/q-a).
+- **Bug reports:** [Issues → New issue](https://github.com/Opendray/opendray/issues/new/choose).
 
 ## Reporting a security vulnerability
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ If you'd rather just open a PR for something not in the issue tracker (a small f
 |---|---|---|
 | Go | 1.25+ | Backend + embedded web bundle |
 | pnpm | 10+ | Web SPA build (`app/web/`) |
-| Node.js | 22+ | pnpm runtime (build only — not needed at deploy) |
+| Node.js | 22+ | pnpm runtime (build only, not needed at deploy) |
 | PostgreSQL | 15+ | Required at runtime; v2 has no bundled mode |
 
 ## Development Setup
@@ -81,12 +81,12 @@ export OPENDRAY_DEV_DB_URL='postgres://opendray:opendray@127.0.0.1:5432/opendray
 go test -race ./internal/memory/summarizer/...
 ```
 
-Never hard-code DSNs in source — they will leak via git history.
+Never hard-code DSNs in source. They will leak via git history.
 
 ## Pull Request Process
 
 1. Fork or branch from `main`.
-2. Make focused changes — one PR, one concern.
+2. Make focused changes. One PR, one concern.
 3. Run checks locally:
    ```bash
    go vet ./...
@@ -130,7 +130,7 @@ Translation contributions land in two places.
 - RU: lowercase impersonal "вы" (Habr-style), with the project-wide override of no em-dash тире.
 - FA: heavy Latin-English borrowing, RTL-wrapped body.
 
-**Style rule that applies to every language:** no em-dashes (`—`) or prose en-dashes (`–`) anywhere in user-facing text. Use periods, commas, parentheses, or colons instead. Compound-noun hyphens in code identifiers (`local-first`, `--from-source`, `AI-Coding-CLIs`) are fine.
+**Style rule that applies to every language:** no em-dashes or prose en-dashes anywhere in user-facing text (the `U+2014` and `U+2013` Unicode characters used as prose punctuation). Use periods, commas, parentheses, or colons instead. Compound-noun hyphens in code identifiers (`local-first`, `--from-source`, `AI-Coding-CLIs`) are the regular hyphen-minus `U+002D` and stay.
 
 **Admin UI translations.** The Flutter / React app reads from `app/i18n/<lang>.json`. Currently shipped: `en.json` (canonical, ~4 k keys) and `zh.json`. Adding a new language means copying `en.json` to `<lang>.json`, translating the values, and wiring it into the i18next config. See the open good-first-issue for the canonical walkthrough.
 


### PR DESCRIPTION
Extends `CONTRIBUTING.md` with three sections that help new contributors land. Existing prereqs / dev setup / tests / PR process content preserved verbatim.

## What's new

1. **"Finding something to work on"** (near the top): pointers to the `good first issue` / `help wanted` labels and Discussion #300 as the v2.8 roadmap home. Sets the expectation that bigger work needs an issue or discussion first.

2. **"Translating opendray"** (mid-file): explains the README + admin-UI translation tracks, per-language register (informal "tú/você/tu/Du", JA です・ます, KO 합니다, RU lowercase impersonal "вы", FA Finglish style), the project-wide no-em-dash style rule, and the stale-translation policy.

3. **"Asking questions"** (before security): routes general questions, ideas, "stuck on X", and bug reports to the right surface (Discussions categories vs Issues).

## Drive-by

Removed 4 em-dashes from the file: 3 from pre-existing prose (table cell, security warning, PR-process bullet) and 1 from the new rule-explanation sentence that referenced the character literally. The rule callout now uses Unicode codepoint references (`U+2014`, `U+2013`, `U+002D`) so we can describe the rule without violating it.

## Test plan

- [x] Both em-dashes and en-dashes verified at 0 occurrences via grep
- [x] All existing sections (prereqs, dev setup, project structure, tests, PR process, commit messages, architecture changes, code style, security, license) preserved unchanged
- [x] All links resolve (Discussion #300, label URLs, doc paths)
