### PR TITLE
fix(web/terminal): stop xterm jitter by isolating the pane from <main>'s scrollbar

### DIFF
--- a/app/web/src/components/sessions/EndedSessionView.tsx
+++ b/app/web/src/components/sessions/EndedSessionView.tsx
@@ -100,17 +100,29 @@ export function EndedSessionView({ sessionId }: EndedSessionViewProps) {
         }
       })
 
-    const ro = new ResizeObserver(() => {
-      try {
-        fit.fit()
-      } catch {
-        /* not measured yet */
-      }
-    })
+    // rAF-coalesced fit — see Terminal.tsx for the full rationale
+    // (mid-notification DOM mutation + scrollbar-toggle oscillation).
+    let fitRaf = 0
+    const scheduleFit = () => {
+      if (cancelled || fitRaf) return
+      fitRaf = requestAnimationFrame(() => {
+        fitRaf = 0
+        if (cancelled) return
+        try {
+          fit.fit()
+        } catch {
+          /* not measured yet */
+        }
+      })
+    }
+    const ro = new ResizeObserver(scheduleFit)
     ro.observe(containerRef.current)
+    scheduleFit()
+    void document.fonts?.ready?.then(scheduleFit)
 
     return () => {
       cancelled = true
+      if (fitRaf) cancelAnimationFrame(fitRaf)
       ro.disconnect()
       term.dispose()
       xtermRef.current = null
@@ -119,8 +131,11 @@ export function EndedSessionView({ sessionId }: EndedSessionViewProps) {
   }, [sessionId, themeApplied, t])
 
   return (
-    <div className="h-full w-full bg-background">
-      <div ref={containerRef} className="h-full w-full p-2" />
+    <div className="h-full w-full bg-background relative overflow-hidden">
+      {/* Clipped + absolutely sized so replay content can't escape to
+          the scrollable <main> and start a fit()/scrollbar feedback
+          loop — same isolation as the live Terminal. */}
+      <div ref={containerRef} className="absolute inset-0 p-2 overflow-hidden" />
     </div>
   )
 }

--- a/app/web/src/components/sessions/Terminal.tsx
+++ b/app/web/src/components/sessions/Terminal.tsx
@@ -324,18 +324,40 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       resizeSession(sessionId, cols, rows).catch(() => {})
     })
 
-    const ro = new ResizeObserver(() => {
-      if (!alive) return
-      try {
-        fit.fit()
-      } catch {
-        /* element not measured yet */
-      }
-    })
+    // Coalesce resize bursts into one fit per animation frame. Calling
+    // fit() synchronously inside the ResizeObserver callback mutates
+    // the DOM mid-notification ("ResizeObserver loop completed with
+    // undelivered notifications") and, at some widths, oscillates;
+    // deferring to rAF lets the frame's layout settle first and folds
+    // a window-drag storm of notifications into a single fit.
+    let fitRaf = 0
+    const scheduleFit = () => {
+      if (!alive || fitRaf) return
+      fitRaf = requestAnimationFrame(() => {
+        fitRaf = 0
+        if (!alive) return
+        try {
+          fit.fit()
+        } catch {
+          /* element not measured yet */
+        }
+      })
+    }
+    const ro = new ResizeObserver(scheduleFit)
     ro.observe(containerRef.current)
+
+    // The synchronous fit() at open ran before the first post-mount
+    // layout had settled (and before a webfont monospace face, on
+    // deployments that ship one, has loaded) — both shift the measured
+    // cell width, so re-fit once each has settled. A PTY left a few
+    // columns too wide is exactly what reads as "long input doesn't
+    // wrap, it runs off the right edge until I resize the window."
+    scheduleFit()
+    void document.fonts?.ready?.then(scheduleFit)
 
     return () => {
       alive = false
+      if (fitRaf) cancelAnimationFrame(fitRaf)
       ro.disconnect()
       ws.close()
       term.dispose()
@@ -465,8 +487,16 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
   }, [])
 
   return (
-    <div ref={rootRef} className="h-full w-full bg-background relative">
-      <div ref={containerRef} className="h-full w-full p-3" />
+    <div ref={rootRef} className="h-full w-full bg-background relative overflow-hidden">
+      {/* The xterm host is absolutely positioned + clipped so its size
+          is driven SOLELY by this (flex/viewport-sized) pane and never
+          by its own rendered content. Without the clip, a line wider
+          than the pane escapes up to the scrollable <main>, toggling
+          its scrollbar, which re-measures the pane and re-runs fit() —
+          a feedback loop that reads as the terminal "jittering" as you
+          type a long line. Clipping breaks the loop at the source and
+          forces xterm to wrap at the real visible width. */}
+      <div ref={containerRef} className="absolute inset-0 p-3 overflow-hidden" />
       <DetectedURLs urls={detectedURLs} />
       {pill && (
         <Button


### PR DESCRIPTION
## Problem

Typing in a web session made the terminal **jitter** — worse the longer the input, dependent on browser width, and recoverable only by manually resizing the window. Long lines also appeared not to wrap (they ran off the right edge).

## Root cause

A `ResizeObserver` / scrollbar **feedback loop**, not input handling.

Nothing in the flex chain from the xterm host up to `AppShell`'s scrollable `<main className="flex-1 overflow-auto min-w-0">` set `overflow-hidden`. So when xterm rendered a row wider than the pane (a long CLI input line at the current PTY `cols`), the overflow bubbled up through `overflow: visible` ancestors to `<main>` and **toggled its scrollbar**. The toggle changed the pane's measured size → `ResizeObserver` fired → `fit()` recomputed `cols/rows` → content width changed → scrollbar toggled back → loop.

This matches every symptom:
- **width-dependent** — only oscillates at widths sitting on the scrollbar threshold;
- **worse with longer input** — longer lines push further past the threshold;
- **"no wrap / must resize"** — `fit()` never converged to the right `cols`; a manual resize moves off the threshold and forces a clean fit.

(Ruled out font-load timing: the web app ships no webfont, so the monospace face resolves to a local / `ui-monospace` fallback synchronously.)

## Fix (web-only)

No server or mobile change. Fully consistent with the post-#153 "original dynamic-resize behaviour" — **no** fixed canvas, client gating, font auto-scale, `?client=` param, or `pty_size` frame.

- **Isolate the xterm host**: mount it `absolute inset-0 overflow-hidden` inside a `relative overflow-hidden` pane, so its size is driven solely by the viewport-sized flex pane and never by its own content. Overflow is clipped at the pane boundary and can't reach `<main>` → loop broken at the source; long lines wrap at the real visible width.
- **rAF-coalesce the `ResizeObserver` `fit()`** → kills the "ResizeObserver loop completed with undelivered notifications" path and folds a window-drag storm into one fit per frame.
- **Re-fit on next frame + `document.fonts.ready`** → initial PTY `cols` match the settled layout / final cell metrics.
- Same isolation applied to `EndedSessionView`'s read-only replay terminal.

### Cross-client note

This actually **reduces** web/mobile interference: the pre-fix jitter was the web spamming `/resize` with oscillating dimensions; it now converges and goes quiet. The shared-PTY last-writer-wins fight when web + mobile attach the same session simultaneously is **unchanged** (a separate, deliberately-accepted known issue from #153).

## Test plan

- [x] `tsc -b` — clean
- [x] `vite build` — clean (2.36s)
- [x] `eslint` on changed files — clean (only a pre-existing, intentional `themeApplied` dep warning)
- [ ] Manual: open a live session, type a long line — terminal stays still and wraps at the visible width (previously jittered / overflowed).
- [ ] Manual: drag the browser width across the previously-jittery threshold — terminal follows smoothly, no flicker.
- [ ] Manual: toggle the session list / inspector panels — terminal re-fits cleanly.
- [ ] Manual: open an ended session — replay terminal renders without jitter on resize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
