### PR TITLE
fix(mobile/channels): submit numeric chat_id as a number, not a string

### DIFF
--- a/app/mobile/lib/features/channels/channel_form_dialog.dart
+++ b/app/mobile/lib/features/channels/channel_form_dialog.dart
@@ -65,8 +65,11 @@ class _ChannelFormScreenState extends State<ChannelFormScreen> {
         final v = init[f.name];
         _bools[f.name] = v is bool ? v : (f.defaultValue ?? false);
       } else {
-        final v = init[f.name];
-        _ctrls[f.name] = TextEditingController(text: v is String ? v : '');
+        // Seed the text field from the stored config, rendering a numeric
+        // value (e.g. an int64 chat_id) back to its digits so editing
+        // never blanks — and then drops — it. Mirrors _submit's coercion.
+        _ctrls[f.name] =
+            TextEditingController(text: channelConfigFieldText(init[f.name]));
       }
     }
   }
@@ -94,7 +97,9 @@ class _ChannelFormScreenState extends State<ChannelFormScreen> {
         }
         if (f.optional) continue; // server default
       }
-      cfg[f.name] = raw;
+      // Serialize to the JSON type the gateway expects (e.g. Telegram
+      // chat_id must be an int64, not a string) — matches the web form.
+      cfg[f.name] = coerceChannelConfigValue(f.name, raw);
     }
     Navigator.of(context).pop(cfg);
   }

--- a/app/mobile/lib/features/channels/channel_kinds.dart
+++ b/app/mobile/lib/features/channels/channel_kinds.dart
@@ -291,3 +291,48 @@ String maskToken(String raw) {
   if (raw.length <= 10) return '••••';
   return '${raw.substring(0, 6)}…${raw.substring(raw.length - 4)}';
 }
+
+/// Serialize a channel-config field's (already-trimmed) text value to the
+/// JSON type the gateway expects, mirroring the web form
+/// (app/web/src/pages/Channels.tsx → buildConfigFromValues).
+///
+/// Only `chat_id` needs coercion among the kinds the mobile form
+/// supports: Telegram persists it as an `int64`, so submitting it as a
+/// string makes the server reject the whole config —
+/// "json: cannot unmarshal string into Go struct field config.chat_id
+/// of type int64" — which is why a Telegram channel configured from the
+/// phone failed to start. The numeric guard leaves every other value a
+/// string, exactly as the web form submits it:
+///   - Feishu's `oc_…` chat_id (non-numeric, stays a string),
+///   - Slack/Discord `channel_id` snowflakes (18-digit IDs that must NOT
+///     be narrowed to a number — precision loss; note this is a
+///     different field name, so it is never matched here anyway),
+///   - `owner_user_ids` / `reply_max_chars` / tokens (the server reads
+///     reply_max_chars from a number or a numeric string, so a string is
+///     fine).
+///
+/// The mobile form exposes no `topic_ids` / `uids` fields, so — unlike
+/// the web builder — those need no handling here.
+Object coerceChannelConfigValue(String name, String raw) {
+  if (name == 'chat_id' && _bareIntPattern.hasMatch(raw)) {
+    return int.tryParse(raw) ?? raw;
+  }
+  return raw;
+}
+
+// A bare integer with an optional leading '-' (Telegram group /
+// supergroup ids look like -1001234567890). Mirrors the web guard
+// /^-?\d+$/ so numeric-looking-but-not-numeric values stay strings.
+final RegExp _bareIntPattern = RegExp(r'^-?\d+$');
+
+/// Render a stored config value as the text its TextField should show
+/// when editing — the inverse of [coerceChannelConfigValue]. A numeric
+/// chat_id (persisted as a JSON number) must round-trip back to its
+/// digits; without this the edit form seeds the field empty and the next
+/// save silently drops the chat_id (losing outbound notifications).
+/// Absent / non-scalar values seed empty.
+String channelConfigFieldText(Object? value) {
+  if (value is String) return value;
+  if (value is num) return value.toString();
+  return '';
+}

--- a/app/mobile/test/features/channels/channel_config_test.dart
+++ b/app/mobile/test/features/channels/channel_config_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opendray/features/channels/channel_kinds.dart';
+
+// Regression guard for the mobile Telegram channel that failed to start
+// with: "factory: telegram: parse config: json: cannot unmarshal string
+// into Go struct field config.chat_id of type int64".
+//
+// The mobile form previously submitted every non-boolean field as a raw
+// string, but the gateway stores Telegram's chat_id as an int64. These
+// tests pin the serialization rule (mirrors the web form's
+// buildConfigFromValues in app/web/src/pages/Channels.tsx).
+void main() {
+  group('coerceChannelConfigValue', () {
+    test('numeric Telegram chat_id becomes an int', () {
+      final v = coerceChannelConfigValue('chat_id', '123456789');
+      expect(v, isA<int>());
+      expect(v, 123456789);
+    });
+
+    test('negative group/supergroup chat_id becomes an int', () {
+      final v = coerceChannelConfigValue('chat_id', '-1001234567890');
+      expect(v, isA<int>());
+      expect(v, -1001234567890);
+    });
+
+    test('Feishu oc_ chat_id stays a string', () {
+      final v = coerceChannelConfigValue('chat_id', 'oc_abc123');
+      expect(v, isA<String>());
+      expect(v, 'oc_abc123');
+    });
+
+    test('Slack/Discord channel_id snowflake is never narrowed', () {
+      // 18-digit ID: coercing to a number would lose precision, and the
+      // gateway wants channel_id as a string anyway.
+      const snowflake = '123456789012345678';
+      final v = coerceChannelConfigValue('channel_id', snowflake);
+      expect(v, isA<String>());
+      expect(v, snowflake);
+    });
+
+    test('owner_user_ids stays a string (comma-separated allowlist)', () {
+      final v = coerceChannelConfigValue('owner_user_ids', '123,456');
+      expect(v, isA<String>());
+      expect(v, '123,456');
+    });
+
+    test('reply_max_chars stays a string (server parses either form)', () {
+      final v = coerceChannelConfigValue('reply_max_chars', '3500');
+      expect(v, isA<String>());
+      expect(v, '3500');
+    });
+
+    test('non-numeric chat_id is left untouched (no false coercion)', () {
+      expect(coerceChannelConfigValue('chat_id', '@mychannel'), '@mychannel');
+      expect(coerceChannelConfigValue('chat_id', '4 2'), '4 2');
+      expect(coerceChannelConfigValue('chat_id', ''), '');
+    });
+  });
+
+  // The edit form seeds TextFields from the stored config. A numeric
+  // chat_id must render back to its digits, else editing blanks it and
+  // the next save drops it (losing outbound notifications).
+  group('channelConfigFieldText', () {
+    test('numeric chat_id round-trips to its digits', () {
+      expect(channelConfigFieldText(123456789), '123456789');
+    });
+
+    test('negative numeric chat_id round-trips', () {
+      expect(channelConfigFieldText(-1001234567890), '-1001234567890');
+    });
+
+    test('string value passes through unchanged', () {
+      expect(channelConfigFieldText('oc_abc123'), 'oc_abc123');
+    });
+
+    test('absent / non-scalar value seeds empty', () {
+      expect(channelConfigFieldText(null), '');
+      expect(channelConfigFieldText(<String>['a', 'b']), '');
+    });
+
+    test('serialize -> seed round-trip is stable for a numeric chat_id', () {
+      final stored = coerceChannelConfigValue('chat_id', '123456789');
+      expect(stored, isA<int>());
+      expect(channelConfigFieldText(stored), '123456789');
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Creating/editing a **Telegram** channel from the **mobile app** failed to save, and the channel got stuck "starting":

```
更新失败：factory: telegram: parse config: json: cannot unmarshal
string into Go struct field config.chat_id of type int64
```

The mobile channel form (`_submit`) serialized every non-boolean field as a **raw string**, but the gateway persists Telegram's `chat_id` as an **`int64`**. So a perfectly valid numeric chat ID was submitted as `"123456789"` (string) and the server rejected the whole config — no send, no receive.

The **web** form has handled this all along (`Channels.tsx` → `buildConfigFromValues` coerces a numeric `chat_id` to a JSON number); mobile simply never got the same treatment.

## Fix (mobile-only, no functionality removed)

- **`coerceChannelConfigValue(name, raw)`** — submit a numeric `chat_id` (optional leading `-` for group/supergroup IDs like `-1001234567890`) as an `int`; leave everything else a string. The `^-?\d+$` guard is deliberate so it keeps:
  - Feishu's `oc_…` `chat_id` a string,
  - Slack/Discord `channel_id` 18-digit snowflakes strings (narrowing them to a number would lose precision),
  - `owner_user_ids` / `reply_max_chars` / tokens strings (the server reads `reply_max_chars` from either form).

  This matches the web form exactly.
- **Edit-form seeding fix** — `channelConfigFieldText()` renders a stored numeric value back to its digits when pre-filling the edit form. Without it, editing a channel whose `chat_id` is a number (created from web, or after this fix) would seed the field **empty** and the next save would silently **drop** `chat_id`, losing outbound notifications. Serialize ↔ seed now round-trips.
- **Unit tests** for both directions (numeric/negative/`oc_`/snowflake/round-trip).

No server or web change. Outbound notifications (need `chat_id`) **and** two-way chat both work from the phone now — nothing sacrificed.

## Test plan

- [x] `dart analyze` (changed files) — clean
- [x] `flutter test` — 13/13 pass (6 serialize + 5 seed + the existing widget smoke test)
- [ ] On device: add a Telegram channel from the phone with a numeric chat ID → saves, channel reaches "running", bot sends + receives
- [ ] On device: edit that channel → `chat_id` field is pre-filled (not blank); save keeps it

> Note: CI does not build/test the Flutter app yet (`ci.yml`: "soon … mobile"), so the checks above were run locally. This needs a new **mobile app build** to reach a phone; the gateway binary is unchanged. Until then, configuring the channel from the **web dashboard** is the working path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
