### PR TITLE
ci(i18n): translation parity guard + backfill missing zh key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,20 @@ jobs:
           # Pin to a specific version. Bumps go through a PR so a
           # surprise lint regression can be reviewed, not absorbed.
           version: v2.12.1
+
+  i18n:
+    name: i18n parity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # Zero-dependency Node script, so no pnpm install needed. Compares
+      # every app/i18n/<locale>.json against the canonical en.json. Fails
+      # only on token mismatch / invalid JSON; missing keys are advisory
+      # (they fall back to English at runtime). See the script header.
+      - name: Translation parity check
+        run: node scripts/check-i18n-parity.mjs

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -1003,6 +1003,7 @@
         "addingTitle": "添加新账号。",
         "addingBodyPrefix": "在网关主机执行：",
         "addingBodySuffix": "opendray 的文件系统监听会自动注册新目录，或点击 <1>导入本地</1> 立即扫描。",
+        "architectureLink": "架构与完整指南 →",
         "loading": "加载中…",
         "empty": "暂无 Claude 账号。最简单的方式:打开会话页,spawn 一个 Claude 会话,在终端里运行 <1>claude login</1> —— 完成 OAuth 后,凭据会落到网关的 <3>~/.claude</3>,自动出现在这里。需要管理多账号身份时,可改用上方的 shell 工作流。",
         "noTokenYet": "尚无 token",

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 9467 (3155 per locale)
+/// Strings: 9468 (3156 per locale)
 ///
-/// Built on 2026-06-03 at 05:21 UTC
+/// Built on 2026-06-03 at 05:48 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -3616,6 +3616,7 @@ class _TranslationsWebProvidersClaudeAccountsZh extends TranslationsWebProviders
 	@override String get addingTitle => '添加新账号。';
 	@override String get addingBodyPrefix => '在网关主机执行：';
 	@override String get addingBodySuffix => 'opendray 的文件系统监听会自动注册新目录，或点击 <1>导入本地</1> 立即扫描。';
+	@override String get architectureLink => '架构与完整指南 →';
 	@override String get loading => '加载中…';
 	@override String get empty => '暂无 Claude 账号。最简单的方式:打开会话页,spawn 一个 Claude 会话,在终端里运行 <1>claude login</1> —— 完成 OAuth 后,凭据会落到网关的 <3>~/.claude</3>,自动出现在这里。需要管理多账号身份时,可改用上方的 shell 工作流。';
 	@override String get noTokenYet => '尚无 token';
@@ -8179,6 +8180,7 @@ extension on TranslationsZh {
 			'web.providers.claudeAccounts.addingTitle' => '添加新账号。',
 			'web.providers.claudeAccounts.addingBodyPrefix' => '在网关主机执行：',
 			'web.providers.claudeAccounts.addingBodySuffix' => 'opendray 的文件系统监听会自动注册新目录，或点击 <1>导入本地</1> 立即扫描。',
+			'web.providers.claudeAccounts.architectureLink' => '架构与完整指南 →',
 			'web.providers.claudeAccounts.loading' => '加载中…',
 			'web.providers.claudeAccounts.empty' => '暂无 Claude 账号。最简单的方式:打开会话页,spawn 一个 Claude 会话,在终端里运行 <1>claude login</1> —— 完成 OAuth 后,凭据会落到网关的 <3>~/.claude</3>,自动出现在这里。需要管理多账号身份时,可改用上方的 shell 工作流。',
 			'web.providers.claudeAccounts.noTokenYet' => '尚无 token',
@@ -8399,9 +8401,9 @@ extension on TranslationsZh {
 			'web.integrations.proxy.send' => '发送',
 			'web.integrations.proxy.sending' => '发送中…',
 			'web.integrations.proxy.extraHeadersLabel' => '额外 header（每行一条，Name: Value）',
-			'web.integrations.proxy.bodyLabel' => 'Body',
 			_ => null,
 		} ?? switch (path) {
+			'web.integrations.proxy.bodyLabel' => 'Body',
 			'web.integrations.proxy.headers' => 'Headers',
 			'web.integrations.proxy.body' => 'Body',
 			'web.integrations.proxy.emptyBody' => '(空)',
@@ -8913,9 +8915,9 @@ extension on TranslationsZh {
 			'web.serverSettings.fields.backupLocalDir.label' => '本地备份目录',
 			'web.serverSettings.fields.backupLocalDir.hint' => '自动创建的 `local` 目标的默认根目录。留空 = ~/.opendray/backups。需要重启。',
 			'web.serverSettings.fields.backupExportDir.label' => '导出目录',
-			'web.serverSettings.fields.backupExportDir.hint' => '一次性导出 zip 在磁盘上的暂存位置。留空 = ~/.opendray/exports。包将在 24 小时后自动过期。需要重启。',
 			_ => null,
 		} ?? switch (path) {
+			'web.serverSettings.fields.backupExportDir.hint' => '一次性导出 zip 在磁盘上的暂存位置。留空 = ~/.opendray/exports。包将在 24 小时后自动过期。需要重启。',
 			'web.serverSettings.fields.backupPgDumpPath.label' => 'pg_dump 路径',
 			'web.serverSettings.fields.backupPgDumpPath.hint' => 'pg_dump 的绝对路径。主版本号必须 ≥ 服务器的。留空 = PATH 上的第一个 pg_dump。',
 			'web.serverSettings.fields.backupPgRestorePath.label' => 'pg_restore 路径',
@@ -9427,9 +9429,9 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.emptyProjectDocs' => '暂无项目文档。点击 + 创建一个，或让 AI agent 根据提示生成。',
 			'sessions.inspector.notes.emptyFilterMatch' => ({required Object query}) => '未找到匹配「${query}」的内容。',
 			'sessions.inspector.notes.locationDialogHelp' => '将此会话的 cwd 固定到笔记库下的某个文件夹。留空 = 重置。',
-			'sessions.inspector.notes.sessionCwd' => '会话 cwd',
 			_ => null,
 		} ?? switch (path) {
+			'sessions.inspector.notes.sessionCwd' => '会话 cwd',
 			'sessions.inspector.notes.projectDocsPath' => '相对笔记库的项目文档路径',
 			'sessions.inspector.notes.locationStoredHint' => '存储于 <vault>/.opendray-projects.json — 与笔记库其余部分一起 git 同步。',
 			'sessions.inspector.notes.pinnedHint' => ({required Object path, required Object defaultPath}) => '已固定到 ${path}/（覆盖 ${defaultPath}）。AI agent 也会在此撰写文档。',
@@ -9941,9 +9943,9 @@ extension on TranslationsZh {
 			'backupTargetEditor.kinds.sftp.description' => '任何可 SSH 访问的服务器',
 			'backupTargetEditor.kinds.s3.label' => 'S3 / 兼容',
 			'backupTargetEditor.kinds.s3.description' => 'Amazon S3 + S3 兼容存储桶（MinIO、R2、B2）',
-			'backupTargetEditor.kinds.rclone.label' => 'rclone（任意）',
 			_ => null,
 		} ?? switch (path) {
+			'backupTargetEditor.kinds.rclone.label' => 'rclone（任意）',
 			'backupTargetEditor.kinds.rclone.description' => '通过 rclone CLI 访问 OneDrive、Google Drive、Dropbox',
 			'backupTargetEditor.formTitleEdit' => '编辑目标',
 			'backupTargetEditor.formTitleNew' => '新建备份目标',
@@ -10455,9 +10457,9 @@ extension on TranslationsZh {
 			'settings.serverSettings.loadedFrom' => ({required Object path}) => '加载自：${path}',
 			'settings.serverSettings.restartHint' => '大部分配置需要重启网关后生效。重启按钮在 AppBar 中。',
 			'settings.serverSettings.savedNeedsRestart' => '已保存。重启网关以生效。',
-			'settings.serverSettings.savedSimple' => '已保存。',
 			_ => null,
 		} ?? switch (path) {
+			'settings.serverSettings.savedSimple' => '已保存。',
 			'settings.serverSettings.changesNeedRestart' => '此配置的修改需重启网关。',
 			'settings.serverSettings.loadFailed' => '加载服务器设置失败',
 			'settings.serverSettings.sections.general' => '通用',

--- a/scripts/check-i18n-parity.mjs
+++ b/scripts/check-i18n-parity.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// i18n parity guard.
+//
+// Compares every app/i18n/<locale>.json against the canonical en.json and
+// reports drift, so it surfaces in PR review instead of silently degrading
+// to English at runtime. The web (i18next fallbackLng: 'en') and mobile
+// (slang fallback_strategy: base_locale) both fall back to English for a
+// missing key, which means drift is otherwise INVISIBLE: a translated UI
+// just shows an English string in one spot and nobody notices.
+//
+// Severity:
+//   FAIL  (blocking, exit 1) - invalid JSON, or an interpolation-token
+//          mismatch on a shared key. A dropped or renamed {placeholder} or
+//          <1> Trans tag breaks interpolation at runtime; the fallback does
+//          NOT save you from that, so it is a real bug.
+//   WARN  (advisory, exit 0) - a key in en is missing here (renders English
+//          via fallback) or an extra key not in en (stale or a typo).
+//
+// Plural-aware: i18next CLDR plural suffixes (_zero/_one/_two/_few/_many/
+// _other) are grouped by base key for the missing/extra comparison, so a
+// language with different plural rules than English (Russian, Arabic, ...)
+// is not falsely flagged.
+//
+// Zero dependencies. Runs in CI (`node scripts/check-i18n-parity.mjs`) and
+// locally. Exits non-zero only on blocking issues.
+
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const I18N_DIR = resolve(import.meta.dirname, '../app/i18n')
+const CANONICAL = 'en'
+const inCI = !!process.env.GITHUB_ACTIONS
+
+// {name} single-brace vars (i18next/slang) + <1>/</1> numbered Trans tags.
+// Both MUST be preserved (order may change) across a translation.
+const TOKEN = /\{[^{}]*\}|<\/?\d+>/g
+const PLURAL = /_(zero|one|two|few|many|other)$/
+
+const base = (k) => k.replace(PLURAL, '')
+const tokens = (s) => (s.match(TOKEN) ?? []).sort()
+
+function flatten(node, prefix, out) {
+  if (typeof node === 'string') out.set(prefix, node)
+  else if (Array.isArray(node)) node.forEach((v, i) => flatten(v, `${prefix}[${i}]`, out))
+  else if (node && typeof node === 'object')
+    for (const [k, v] of Object.entries(node)) flatten(v, prefix ? `${prefix}.${k}` : k, out)
+  return out
+}
+
+const readFlat = (file) => flatten(JSON.parse(readFileSync(resolve(I18N_DIR, file), 'utf8')), '', new Map())
+
+let enFlat
+try {
+  enFlat = readFlat(`${CANONICAL}.json`)
+} catch (e) {
+  console.error(`FATAL: cannot parse canonical ${CANONICAL}.json: ${e.message}`)
+  process.exit(2)
+}
+
+// en groups (plural bases / plain keys) + a representative token set per group
+// (prefer the _other form) for checking locale-only plural forms.
+const enGroups = new Set()
+const enGroupTokens = new Map()
+for (const [k, v] of enFlat) {
+  const g = base(k)
+  enGroups.add(g)
+  if (!enGroupTokens.has(g) || k.endsWith('_other')) enGroupTokens.set(g, tokens(v).join('|'))
+}
+
+const locales = readdirSync(I18N_DIR)
+  .filter((f) => f.endsWith('.json') && f !== `${CANONICAL}.json`)
+  .map((f) => f.replace(/\.json$/, ''))
+  .sort()
+
+let blocking = 0
+const summary = []
+
+const annotate = (level, file, msg) => {
+  if (inCI) console.log(`::${level} file=${file}::${msg}`)
+}
+
+for (const loc of locales) {
+  const file = `app/i18n/${loc}.json`
+  let locFlat
+  try {
+    locFlat = readFlat(`${loc}.json`)
+  } catch (e) {
+    blocking++
+    console.error(`\n[${loc}] FAIL invalid JSON: ${e.message}`)
+    annotate('error', file, `invalid JSON: ${e.message}`)
+    summary.push(`| \`${loc}\` | invalid JSON | - | - |`)
+    continue
+  }
+
+  const locGroups = new Set([...locFlat.keys()].map(base))
+  const missing = [...enGroups].filter((g) => !locGroups.has(g)).sort()
+  const extra = [...locGroups].filter((g) => !enGroups.has(g)).sort()
+
+  // Token check: every shared exact key, plus locale-only plural forms whose
+  // base exists in en (compared against en's representative form).
+  const mismatch = []
+  for (const [k, v] of locFlat) {
+    const exact = enFlat.has(k)
+    const g = base(k)
+    if (!exact && !enGroups.has(g)) continue // truly extra; reported above
+    const want = exact ? tokens(enFlat.get(k)).join('|') : enGroupTokens.get(g)
+    const got = tokens(v).join('|')
+    if (want !== got) mismatch.push({ k, en: want, loc: got })
+  }
+
+  if (missing.length) blocking += 0 // advisory
+  if (mismatch.length) blocking += mismatch.length
+
+  const pct = Math.round(((enGroups.size - missing.length) / enGroups.size) * 100)
+  console.log(
+    `\n[${loc}] ${pct}% complete  (missing:${missing.length} extra:${extra.length} token-mismatch:${mismatch.length})`,
+  )
+  for (const g of missing) {
+    console.log(`  WARN missing (renders English via fallback): ${g}`)
+    annotate('warning', file, `missing key, renders English via fallback: ${g}`)
+  }
+  for (const g of extra) {
+    console.log(`  WARN extra, not in en (stale or typo): ${g}`)
+    annotate('warning', file, `extra key not in en (stale or typo): ${g}`)
+  }
+  for (const m of mismatch) {
+    console.error(`  FAIL token mismatch ${m.k}: en=[${m.en}] ${loc}=[${m.loc}]`)
+    annotate('error', file, `interpolation token mismatch at ${m.k}: en=[${m.en}] vs ${loc}=[${m.loc}]`)
+  }
+
+  const miss = missing.length ? `${missing.length} missing` : 'complete'
+  summary.push(`| \`${loc}\` | ${miss} | ${extra.length} | ${mismatch.length} |`)
+}
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  const md = [
+    '### i18n parity vs `en.json`',
+    '',
+    '| locale | missing keys | extra keys | token mismatches |',
+    '| --- | --- | --- | --- |',
+    ...summary,
+    '',
+    blocking
+      ? `**${blocking} blocking issue(s)** (token mismatch or invalid JSON).`
+      : 'No blocking issues.',
+    '',
+    'Missing keys are advisory (they render English via the i18next / slang fallback). Token mismatches and invalid JSON are blocking, because a dropped or renamed `{placeholder}` / `<1>` tag breaks interpolation at runtime.',
+    '',
+  ]
+  writeFileSync(process.env.GITHUB_STEP_SUMMARY, md.join('\n') + '\n', { flag: 'a' })
+}
+
+console.log(`\n${blocking ? `FAILED: ${blocking} blocking issue(s).` : 'OK: no blocking issues.'}`)
+process.exit(blocking ? 1 : 0)


### PR DESCRIPTION
## What

Adds a CI **translation parity guard** so i18n drift is caught in PR review, and backfills the one key `zh.json` was already missing.

## Why

The web (i18next `fallbackLng: 'en'`) and mobile (slang `fallback_strategy: base_locale`) both fall back to English for a missing key. That's good for resilience but means **drift is invisible**: a translated UI just shows an English string in one spot, no crash, no log, nobody reports it. We already had a live example: `zh.json` was silently missing `web.providers.claudeAccounts.architectureLink`. As we scale toward ~10 languages, hand-tracking this is impossible.

## The guard — `scripts/check-i18n-parity.mjs`

Zero-dependency Node script; compares every `app/i18n/<locale>.json` against canonical `en.json`.

| Issue | Severity | Rationale |
| --- | --- | --- |
| Key in en missing from locale | **WARN** (advisory) | Renders English via fallback. Don't block shipping a feature before it's translated. |
| Extra key not in en | **WARN** | Stale key or a typo. |
| Interpolation-token mismatch (`{x}` / `<1>`) | **FAIL** | A dropped/renamed placeholder or Trans tag breaks interpolation at runtime; the fallback does NOT catch this. A real bug. |
| Invalid JSON | **FAIL** | Breaks the web import / slang codegen. |

- **Plural-aware**: i18next CLDR plural suffixes (`_one`/`_other`/`_few`/...) are grouped by base key, so a future language with different plural rules (Russian, Arabic, ...) isn't falsely flagged.
- Emits GitHub `::warning::` / `::error::` annotations + a markdown job summary in CI; prints a readable report locally (`node scripts/check-i18n-parity.mjs`).

`.github/workflows/ci.yml` gets a new **i18n parity** job (runs on push / PR, no `pnpm install` needed).

> Related to #319 (stale-translation guard for the 10 README files) but distinct: this checks the *app* i18n JSON at the key + placeholder level, not the README markdown files.

## Also in this PR

- Backfilled `web.providers.claudeAccounts.architectureLink` in `zh.json` ("架构与完整指南 →") and regenerated `strings_zh.g.dart` via `dart run slang`. `es` and `zh` now both have full parity with `en`.

## Test plan

- [x] `node scripts/check-i18n-parity.mjs` → clean (es + zh 100%, 0 blocking), exit 0.
- [x] Negative test: temporarily introduced a missing key, an extra key, and a renamed placeholder in `zh.json` → guard reported 1 WARN missing, 1 WARN extra, 1 **FAIL** token mismatch, exit 1. Restored after.
- [x] `ci.yml` is valid (job mirrors the existing `lint` job structure); new job name: **i18n parity**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
