### PR TITLE
feat(channel): Telegram /peek command + control-keyboard button & refresh

### DIFF
--- a/internal/app/channel_commands.go
+++ b/internal/app/channel_commands.go
@@ -50,6 +50,12 @@ type sessionOps interface {
 	List(ctx context.Context) ([]session.Session, error)
 	Start(ctx context.Context, id string) (session.Session, error)
 	Stop(ctx context.Context, id string) error
+	// RecentSnippet is the live, notification-grade preview of a
+	// running session's latest output (backs /peek). "" when not live.
+	RecentSnippet(id string) string
+	// TranscriptText is the /peek fallback for a session that isn't
+	// running anymore — the recorded conversation tail.
+	TranscriptText(ctx context.Context, id string, maxBytes int) (string, error)
 }
 
 // registerChannelCommands wires the session-aware slash commands
@@ -96,6 +102,16 @@ func registerChannelCommands(hub *channel.Hub, mgr sessionOps) {
 			"(pin where your messages go; /select off to clear)",
 		Source:  "builtin",
 		Handler: selectSessionHandler(mgr),
+	})
+	// /peek re-pushes the current (selected) session's latest output on
+	// demand — for when the notification scrolled away or arrived while
+	// the operator was elsewhere. Reads the same content a notification
+	// would carry; takes no argument (operates on the chat's /select pin).
+	hub.RegisterCommand(channel.Command{
+		Name:        "peek",
+		Description: "Re-send the selected session's latest output",
+		Source:      "builtin",
+		Handler:     peekSessionHandler(mgr),
 	})
 	// /panel (alias /menu) is the friendly home: the session list with
 	// tap-to-act buttons plus a one-line how-to. It's what we point new
@@ -359,6 +375,52 @@ func selectSessionHandler(mgr sessionOps) channel.CommandHandler {
 		cc.Hub.SetActiveSession(chID, sess.ID)
 		return fmt.Sprintf("✅ Now talking to %s. Your messages go here until you /select another (or /select off).",
 			sessionLabel(sess)), nil
+	}
+}
+
+// peekTranscriptMaxBytes caps the transcript fallback so an ended
+// session's whole conversation can't flood the chat. The channel
+// layer still splits anything past the platform's per-message limit.
+const peekTranscriptMaxBytes = 4000
+
+// peekSessionHandler re-sends the current (selected) session's latest
+// output on demand. It resolves the chat's /select pin, pulls the live
+// notification-grade snippet (the same content a notification carries),
+// and falls back to the recorded transcript tail when the session is no
+// longer running. Takes no argument — it operates on the active pin so
+// it pairs naturally with the /list → "💬 Talk to" flow.
+func peekSessionHandler(mgr sessionOps) channel.CommandHandler {
+	return func(ctx context.Context, cc channel.CommandContext) (string, error) {
+		chID := ""
+		if cc.Channel != nil {
+			chID = cc.Channel.ID()
+		}
+		if cc.Hub == nil || chID == "" {
+			return "Peek isn't available on this channel.", nil
+		}
+		sid := cc.Hub.ActiveSession(chID)
+		if sid == "" {
+			return "No session selected. Use /list and tap “💬 Talk to”, or /select <session_id>, then /peek.", nil
+		}
+		sess, found, err := findSession(ctx, mgr, sid)
+		if err != nil {
+			return "", fmt.Errorf("peek %s: %w", sid, err)
+		}
+		if !found {
+			return "Session " + sid + " not found — /list shows current sessions.", nil
+		}
+		content := strings.TrimSpace(mgr.RecentSnippet(sid))
+		if content == "" {
+			// Not running (or no live screen) — fall back to the recorded
+			// conversation tail so an ended session can still be peeked.
+			if txt, terr := mgr.TranscriptText(ctx, sid, peekTranscriptMaxBytes); terr == nil {
+				content = strings.TrimSpace(txt)
+			}
+		}
+		if content == "" {
+			return fmt.Sprintf("No recent output for %s.", sessionLabel(sess)), nil
+		}
+		return fmt.Sprintf("📄 %s — latest output:\n\n%s", sessionLabel(sess), content), nil
 	}
 }
 

--- a/internal/app/channel_commands.go
+++ b/internal/app/channel_commands.go
@@ -102,6 +102,11 @@ func registerChannelCommands(hub *channel.Hub, mgr sessionOps) {
 			"(pin where your messages go; /select off to clear)",
 		Source:  "builtin",
 		Handler: selectSessionHandler(mgr),
+		// "💬 Talk to" on /list resolves to /select, so docking the
+		// keyboard here refreshes it on the most common tap in the flow —
+		// the operator picks a session and immediately has the current
+		// control layout.
+		DocksControlKeyboard: true,
 	})
 	// /peek re-pushes the current (selected) session's latest output on
 	// demand — for when the notification scrolled away or arrived while

--- a/internal/app/channel_commands_test.go
+++ b/internal/app/channel_commands_test.go
@@ -26,6 +26,11 @@ type fakeSessionOps struct {
 	startCalls []string
 	startResp  session.Session
 	startErr   error
+
+	// snippet keyed by session id (live notification-grade preview);
+	// transcript keyed by session id (the ended-session fallback).
+	snippet    map[string]string
+	transcript map[string]string
 }
 
 func (f *fakeSessionOps) List(_ context.Context) ([]session.Session, error) {
@@ -38,6 +43,12 @@ func (f *fakeSessionOps) Stop(_ context.Context, id string) error {
 func (f *fakeSessionOps) Start(_ context.Context, id string) (session.Session, error) {
 	f.startCalls = append(f.startCalls, id)
 	return f.startResp, f.startErr
+}
+func (f *fakeSessionOps) RecentSnippet(id string) string {
+	return f.snippet[id]
+}
+func (f *fakeSessionOps) TranscriptText(_ context.Context, id string, _ int) (string, error) {
+	return f.transcript[id], nil
 }
 
 // cardText extracts the markdown body from a /list card so the
@@ -440,5 +451,57 @@ func TestSelectSessionHandler(t *testing.T) {
 	// A terminated session is rejected with a resume hint.
 	if resp, _ = h(context.Background(), mk("ses_dead1")); !strings.Contains(resp, "resume") {
 		t.Errorf("terminated session should suggest /resume, got %q", resp)
+	}
+}
+
+func TestPeekSessionHandler(t *testing.T) {
+	hub := channel.NewHub(nil, nil, nil)
+	ch := &fakeChannel{id: "ch_test"}
+	mgr := &fakeSessionOps{
+		sessions: []session.Session{
+			{ID: "ses_live1", Name: "deploy", ProviderID: "claude", State: session.StateRunning},
+			{ID: "ses_dead1", ProviderID: "gemini", State: session.StateEnded},
+		},
+		snippet:    map[string]string{"ses_live1": "Build passed ✓"},
+		transcript: map[string]string{"ses_dead1": "USER: ship it\nASSISTANT: shipped"},
+	}
+	h := peekSessionHandler(mgr)
+	ctx := context.Background()
+	mk := func() channel.CommandContext {
+		return channel.CommandContext{Channel: ch, Hub: hub}
+	}
+
+	// No pin → guidance pointing at /list + /select.
+	if resp, _ := h(ctx, mk()); !strings.Contains(resp, "No session selected") {
+		t.Errorf("expected no-pin guidance, got %q", resp)
+	}
+
+	// Live session → the notification-grade snippet, labelled.
+	hub.SetActiveSession("ch_test", "ses_live1")
+	resp, err := h(ctx, mk())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(resp, "Build passed ✓") || !strings.Contains(resp, "deploy (ses_live1)") {
+		t.Errorf("expected live snippet for the labelled session, got %q", resp)
+	}
+
+	// Ended session with no live snippet → transcript fallback.
+	hub.SetActiveSession("ch_test", "ses_dead1")
+	if resp, _ = h(ctx, mk()); !strings.Contains(resp, "ASSISTANT: shipped") {
+		t.Errorf("expected transcript fallback for ended session, got %q", resp)
+	}
+
+	// Pinned id no longer in the live set → not-found, no panic.
+	hub.SetActiveSession("ch_test", "ses_ghost")
+	if resp, _ = h(ctx, mk()); !strings.Contains(resp, "not found") {
+		t.Errorf("stale pin should report not found, got %q", resp)
+	}
+
+	// Live session present but no output anywhere → friendly empty note.
+	mgr.snippet["ses_live1"] = ""
+	hub.SetActiveSession("ch_test", "ses_live1")
+	if resp, _ = h(ctx, mk()); !strings.Contains(resp, "No recent output") {
+		t.Errorf("empty output should report a friendly note, got %q", resp)
 	}
 }

--- a/internal/channel/command.go
+++ b/internal/channel/command.go
@@ -45,6 +45,14 @@ type Command struct {
 	Handler     CommandHandler     // plain-text reply
 	CardHandler CommandCardHandler // structured reply (cards + buttons)
 	Source      string             // "builtin" | "session" | "custom"
+	// DocksControlKeyboard, when set on a plain-text (Handler) command,
+	// makes its reply also (re)dock the persistent control keyboard on
+	// transports that support one. Use it for text-only commands at a
+	// natural refresh point (e.g. /select, /start) so the docked keyboard
+	// picks up layout changes without waiting for the next agent reply.
+	// Ignored for CardHandler commands — their inline buttons and the
+	// docked keyboard are mutually exclusive per message on Telegram.
+	DocksControlKeyboard bool
 }
 
 // CommandRegistry holds the set of available slash commands.
@@ -75,6 +83,10 @@ func NewCommandRegistry() *CommandRegistry {
 		Description: "Welcome message + command list",
 		Source:      "builtin",
 		Handler:     startHandler(r),
+		// /start is the natural "(re)initialise my bot UI" command, so
+		// dock the control keyboard here — a one-command way to refresh it
+		// (e.g. after a layout change) without waiting for an agent reply.
+		DocksControlKeyboard: true,
 	})
 	return r
 }

--- a/internal/channel/controls.go
+++ b/internal/channel/controls.go
@@ -44,7 +44,10 @@ func (b ControlButton) Resolve(sid string) string {
 //
 // Stop/Restart route through /confirm (a fat-fingered tap must never
 // interrupt a live session); Switch opens /list to retarget which
-// session the chat talks to; Panel opens the /panel home.
+// session the chat talks to; Peek re-sends the current session's latest
+// output; Panel opens the /panel home. Peek carries no "%s" so it isn't
+// session-templated — the /peek handler resolves the chat's active pin
+// itself and reports cleanly when none is selected.
 func ControlKeyboardLayout() [][]ControlButton {
 	return [][]ControlButton{
 		{
@@ -53,6 +56,7 @@ func ControlKeyboardLayout() [][]ControlButton {
 		},
 		{
 			{Label: "🔀 Switch", Command: "/list"},
+			{Label: "👀 Peek", Command: "/peek"},
 			{Label: "🎛 Panel", Command: "/panel"},
 		},
 	}

--- a/internal/channel/controls_test.go
+++ b/internal/channel/controls_test.go
@@ -88,6 +88,14 @@ func TestControlButtonAction(t *testing.T) {
 	if !isBtn || hint != "" || name != "list" {
 		t.Errorf("Switch → isBtn=%v hint=%q name=%q, want list", isBtn, hint, name)
 	}
+
+	// Peek is session-agnostic too: it carries no "%s", so it dispatches
+	// even with no active session (the /peek handler reports the no-pin
+	// case itself rather than being gated here like Stop).
+	name, _, hint, isBtn = h.controlButtonAction(ChannelMessage{ChannelID: "ch_empty", Text: "👀 Peek"})
+	if !isBtn || hint != "" || name != "peek" {
+		t.Errorf("Peek → isBtn=%v hint=%q name=%q, want peek", isBtn, hint, name)
+	}
 }
 
 func TestControlCommandsAreParseable(t *testing.T) {

--- a/internal/channel/hub.go
+++ b/internal/channel/hub.go
@@ -600,7 +600,16 @@ func (h *Hub) handleCommand(ctx context.Context, msg ChannelMessage, mid int64, 
 		return
 	}
 	if reply != "" {
-		h.replyText(ctx, ch, msg, reply)
+		// Commands flagged DocksControlKeyboard refresh the persistent
+		// keyboard alongside their text reply (e.g. /select, /start), so a
+		// layout change shows up at a natural tap point rather than only on
+		// the next agent reply. replyControlText falls back to plain text
+		// on transports without a docked keyboard.
+		if cmd.DocksControlKeyboard {
+			h.replyControlText(ctx, ch, msg, reply)
+		} else {
+			h.replyText(ctx, ch, msg, reply)
+		}
 	}
 }
 

--- a/internal/channel/hub_command_test.go
+++ b/internal/channel/hub_command_test.go
@@ -97,6 +97,33 @@ func TestHub_HandleCommand_UnknownReplies(t *testing.T) {
 	}
 }
 
+func TestHub_HandleCommand_DocksControlKeyboard(t *testing.T) {
+	h := newTestHub(t)
+	fc := &fakeChannel{id: "ch_test", kind: "stub"}
+	h.mu.Lock()
+	h.channels[fc.id] = fc
+	h.mu.Unlock()
+
+	reply := func(_ context.Context, _ CommandContext) (string, error) { return "ok", nil }
+	h.RegisterCommand(Command{Name: "dock", Handler: reply, DocksControlKeyboard: true})
+	h.RegisterCommand(Command{Name: "plain", Handler: reply})
+
+	h.dispatchCommandForTest(t, ChannelMessage{ChannelID: "ch_test", Text: "/dock"}, "dock", nil)
+	h.dispatchCommandForTest(t, ChannelMessage{ChannelID: "ch_test", Text: "/plain"}, "plain", nil)
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	if len(fc.sent) != 2 {
+		t.Fatalf("want 2 sends, got %d", len(fc.sent))
+	}
+	if v, _ := fc.sent[0].Metadata[MetaControlKeyboard].(bool); !v {
+		t.Error("DocksControlKeyboard command reply should carry MetaControlKeyboard")
+	}
+	if _, has := fc.sent[1].Metadata[MetaControlKeyboard]; has {
+		t.Error("plain command reply must not carry MetaControlKeyboard")
+	}
+}
+
 // dispatchCommandForTest runs handleCommand without touching the DB.
 // Tests insert channels directly into Hub.channels via the lock above
 // and then exercise the lookup → handler → reply path.
@@ -120,7 +147,12 @@ func (h *Hub) dispatchCommandForTest(t *testing.T, msg ChannelMessage, name stri
 		t.Fatalf("handler err: %v", err)
 	}
 	if reply != "" {
-		h.replyText(context.Background(), ch, msg, reply)
+		// Mirror handleCommand's DocksControlKeyboard branch.
+		if cmd.DocksControlKeyboard {
+			h.replyControlText(context.Background(), ch, msg, reply)
+		} else {
+			h.replyText(context.Background(), ch, msg, reply)
+		}
 	}
 }
 

--- a/internal/channel/telegram/telegram.go
+++ b/internal/channel/telegram/telegram.go
@@ -140,6 +140,7 @@ func (t *Telegram) publishCommands(ctx context.Context) {
 	cmds := []tgCmd{
 		{Command: "panel", Description: "Control panel — sessions + actions"},
 		{Command: "list", Description: "List active sessions"},
+		{Command: "peek", Description: "Re-send the selected session's latest output"},
 		{Command: "help", Description: "List available commands"},
 		{Command: "end", Description: "End a session: /end <session_id>"},
 		{Command: "resume", Description: "Resume a stopped session: /resume <session_id>"},

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -765,6 +765,24 @@ func (m *Manager) RecentScreen(id string) string {
 	return ScreenSnapshot(rs.vt)
 }
 
+// RecentSnippet returns the notification-grade preview of a running
+// session's latest output — the same content the idle / turn cards
+// carry. Unlike RecentScreen it is provider-aware: claude / gemini
+// prefer their JSONL recent-response (clean assistant text), and
+// anything else falls back to the chrome-stripped visible screen.
+// This is what an on-demand "show me the current output" affordance
+// (e.g. the Telegram /peek command) should surface so it matches what
+// a notification would have pushed.
+//
+// Returns "" when the session is not currently running.
+func (m *Manager) RecentSnippet(id string) string {
+	rs := m.lookup(id)
+	if rs == nil {
+		return ""
+	}
+	return m.recentResponseSnippet(rs)
+}
+
 // mergeEnv overlays `overrides` onto a base "K=V" slice. Keys present
 // in both win for `overrides`. Used so PrepareFunc can inject env vars
 // like CODEX_HOME without losing the inherited environment.


### PR DESCRIPTION
## Summary

Adds a Telegram `/peek` command and surfaces it on the docked control keyboard, so an operator can re-pull a session's latest output on demand — without opening the web dashboard.

After `/list` → "💬 Talk to" (or `/select <id>`) pins a session, the only way to see its current output was to wait for the next notification or open the dashboard. `/peek` re-sends the selected session's latest output into the chat, reading the same notification-grade content a card would carry.

## Changes

**`/peek` command (`internal/app`, `internal/session`)**
- New `Manager.RecentSnippet(id)` wraps the existing `recentResponseSnippet` (claude/gemini JSONL recent response, else chrome-stripped visible screen) for on-demand use by id.
- `peekSessionHandler` resolves the chat's `/select` pin via `Hub.ActiveSession`, pulls `RecentSnippet`, and falls back to the recorded transcript tail (capped) when the session is no longer running.
- Registered as a builtin (shows in `/help`) and added to the Telegram native `/` autocomplete menu. Extends the `sessionOps` interface with `RecentSnippet` + `TranscriptText`.

**Peek on the docked control keyboard (`internal/channel`)**
- Add "👀 Peek" to `ControlKeyboardLayout` (row 2 is now Switch / Peek / Panel). It carries no `%s`, so `controlButtonAction` dispatches it session-agnostically — the handler reports the no-selection case itself.

**Docked-keyboard refresh (`internal/channel`)**
- Telegram's reply keyboard is sticky: it only changes when a message carries a new `ReplyKeyboardMarkup`, which previously happened only on an agent turn reply. So a layout change (like adding Peek) didn't show until the user next chatted, and tapping the existing buttons (card replies) never re-docked it.
- New opt-in `Command.DocksControlKeyboard`: a text (Handler) command's reply routes through `replyControlText`, re-docking the keyboard. Enabled on `/select` and `/start` — both text-only (no inline buttons to lose) and natural refresh points (the "💬 Talk to" button resolves to `/select`). CardHandler commands are unaffected (inline buttons and the docked keyboard are mutually exclusive per Telegram message).

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race ./internal/channel/... ./internal/app/... ./internal/session/...` green
- [x] New tests: `TestPeekSessionHandler` (live / ended / stale-pin / empty), `TestControlButtonAction` Peek case, `TestHub_HandleCommand_DocksControlKeyboard`
- [x] Local gateway: `/peek` re-sends the selected session's latest output; tapping 👀 Peek works; `/start` (or tapping "💬 Talk to") re-docks the keyboard with the new layout; `getMyCommands` lists `/peek`

## Note for reviewers

Touches the channel component (commands + control keyboard). Flagging for @navidrast.
