### PR TITLE
feat(mobile): in-session account switch + agent CLI update awareness (web parity)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -2511,7 +2511,23 @@
       "started": "started {when}",
       "startedEnded": "started {started}  ·  ended {ended}",
       "idPrefix": "id: {id}",
-      "errorTitle": "Failed to load session"
+      "errorTitle": "Failed to load session",
+      "accountSwitcher": {
+        "tooltip": "Switch Claude account",
+        "sheetTitle": "Switch Claude account",
+        "current": "Currently: {account}",
+        "defaultName": "Default (system credential)",
+        "defaultSubtitle": "Use the CLI's own login, no specific account",
+        "defaultShort": "default",
+        "tokenEmpty": "no token",
+        "confirmTitle": "Switch account?",
+        "confirmBody": "This restarts the CLI under the new account — the current in-CLI conversation context is lost (the session tab is kept).",
+        "confirmAction": "Switch",
+        "cancel": "Cancel",
+        "switchedSnack": "Switched to {account}",
+        "switchFailed": "Switch failed: {error}",
+        "noneHint": "No Claude accounts configured. Add them in More → Providers → Claude."
+      }
     },
     "terminal": {
       "snackbar": {
@@ -2808,6 +2824,23 @@
       "delete": "Delete failed"
     },
     "errorWithMessage": "{prefix}: {error}",
+    "updateCheck": {
+      "sectionTitle": "CLI version",
+      "checking": "Checking for updates…",
+      "checkFailed": "Couldn't check for updates",
+      "notInstalled": "Not installed on the gateway host",
+      "installed": "Installed: {version}",
+      "upToDate": "Up to date",
+      "updateAvailable": "Update available: {version}",
+      "latest": "latest {version}",
+      "updateButton": "Update CLI",
+      "updating": "Updating…",
+      "updatedSnack": "Updated to {version}.",
+      "noChangeSnack": "Already on the latest version.",
+      "updateFailed": "Update failed: {error}",
+      "notAvailableHere": "In-app update isn't available on this host: {reason}",
+      "activeSessionsWarning": "{n} active session(s) are using this CLI — updating won't interrupt them, but they keep the old version until restarted."
+    },
     "accounts": {
       "rename": "Rename",
       "renameTitle": "Rename {name}",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -2511,7 +2511,23 @@
       "started": "iniciada {when}",
       "startedEnded": "iniciada {started}  ·  finalizada {ended}",
       "idPrefix": "id: {id}",
-      "errorTitle": "No se pudo cargar la sesión"
+      "errorTitle": "No se pudo cargar la sesión",
+      "accountSwitcher": {
+        "tooltip": "Cambiar de cuenta de Claude",
+        "sheetTitle": "Cambiar de cuenta de Claude",
+        "current": "Actual: {account}",
+        "defaultName": "Predeterminada (credencial del sistema)",
+        "defaultSubtitle": "Usa el propio inicio de sesión del CLI, sin cuenta específica",
+        "defaultShort": "predeterminada",
+        "tokenEmpty": "sin token",
+        "confirmTitle": "¿Cambiar de cuenta?",
+        "confirmBody": "Esto reinicia el CLI con la nueva cuenta — se pierde el contexto de conversación actual dentro del CLI (la pestaña de la sesión se conserva).",
+        "confirmAction": "Cambiar",
+        "cancel": "Cancelar",
+        "switchedSnack": "Cambiado a {account}",
+        "switchFailed": "Cambio fallido: {error}",
+        "noneHint": "No hay cuentas de Claude configuradas. Agrégalas en Más → Providers → Claude."
+      }
     },
     "terminal": {
       "snackbar": {
@@ -2808,6 +2824,23 @@
       "delete": "Error al eliminar"
     },
     "errorWithMessage": "{prefix}: {error}",
+    "updateCheck": {
+      "sectionTitle": "Versión del CLI",
+      "checking": "Buscando actualizaciones…",
+      "checkFailed": "No se pudo buscar actualizaciones",
+      "notInstalled": "No instalado en el host del gateway",
+      "installed": "Instalado: {version}",
+      "upToDate": "Actualizado",
+      "updateAvailable": "Actualización disponible: {version}",
+      "latest": "última {version}",
+      "updateButton": "Actualizar CLI",
+      "updating": "Actualizando…",
+      "updatedSnack": "Actualizado a {version}.",
+      "noChangeSnack": "Ya está en la última versión.",
+      "updateFailed": "Actualización fallida: {error}",
+      "notAvailableHere": "La actualización en la app no está disponible en este host: {reason}",
+      "activeSessionsWarning": "{n} sesión(es) activa(s) usan este CLI — actualizar no las interrumpe, pero mantienen la versión anterior hasta reiniciarse."
+    },
     "accounts": {
       "rename": "Renombrar",
       "renameTitle": "Renombrar {name}",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -2511,7 +2511,23 @@
       "started": "{when} 启动",
       "startedEnded": "{started} 启动  ·  {ended} 结束",
       "idPrefix": "id: {id}",
-      "errorTitle": "加载会话失败"
+      "errorTitle": "加载会话失败",
+      "accountSwitcher": {
+        "tooltip": "切换 Claude 账号",
+        "sheetTitle": "切换 Claude 账号",
+        "current": "当前：{account}",
+        "defaultName": "默认（系统凭据）",
+        "defaultSubtitle": "使用 CLI 自身的登录，不指定具体账号",
+        "defaultShort": "默认",
+        "tokenEmpty": "无 token",
+        "confirmTitle": "切换账号？",
+        "confirmBody": "这会用新账号重启 CLI——当前 CLI 内的对话上下文会丢失（会话标签保留）。",
+        "confirmAction": "切换",
+        "cancel": "取消",
+        "switchedSnack": "已切换到 {account}",
+        "switchFailed": "切换失败：{error}",
+        "noneHint": "未配置 Claude 账号。请在 更多 → Providers → Claude 中添加。"
+      }
     },
     "terminal": {
       "snackbar": {
@@ -2808,6 +2824,23 @@
       "delete": "删除失败"
     },
     "errorWithMessage": "{prefix}：{error}",
+    "updateCheck": {
+      "sectionTitle": "CLI 版本",
+      "checking": "正在检查更新…",
+      "checkFailed": "无法检查更新",
+      "notInstalled": "网关主机上未安装",
+      "installed": "已安装：{version}",
+      "upToDate": "已是最新",
+      "updateAvailable": "有可用更新：{version}",
+      "latest": "最新 {version}",
+      "updateButton": "更新 CLI",
+      "updating": "正在更新…",
+      "updatedSnack": "已更新到 {version}。",
+      "noChangeSnack": "已是最新版本。",
+      "updateFailed": "更新失败：{error}",
+      "notAvailableHere": "此主机不支持应用内更新：{reason}",
+      "activeSessionsWarning": "有 {n} 个活跃会话正在使用此 CLI——更新不会中断它们，但它们在重启前仍使用旧版本。"
+    },
     "accounts": {
       "rename": "重命名",
       "renameTitle": "重命名 {name}",

--- a/app/mobile/lib/core/api/models.dart
+++ b/app/mobile/lib/core/api/models.dart
@@ -89,6 +89,7 @@ class SessionSummary {
     required this.startedAt,
     this.name,
     this.endedAt,
+    this.claudeAccountId,
   });
 
   factory SessionSummary.fromJson(Map<String, dynamic> json) => SessionSummary(
@@ -102,6 +103,10 @@ class SessionSummary {
         endedAt: (json['ended_at'] is String)
             ? DateTime.tryParse(json['ended_at'] as String)
             : null,
+        claudeAccountId:
+            (json['claude_account_id'] as String?)?.isNotEmpty ?? false
+                ? json['claude_account_id'] as String
+                : null,
       );
 
   final String id;
@@ -111,6 +116,10 @@ class SessionSummary {
   final SessionState state;
   final DateTime startedAt;
   final DateTime? endedAt;
+  // Which Claude OAuth account this session is bound to (null = the
+  // CLI's system-default credential). Only meaningful for Claude
+  // sessions; drives the in-session account switcher.
+  final String? claudeAccountId;
 
   String get displayName => name?.isNotEmpty ?? false ? name! : id;
 

--- a/app/mobile/lib/core/api/providers_api.dart
+++ b/app/mobile/lib/core/api/providers_api.dart
@@ -112,6 +112,83 @@ class ProviderDetail {
   final bool enabled;
 }
 
+// ProviderRuntime is the live, probed CLI state (not from the manifest):
+// whether the binary is installed and its real `--version`, plus the
+// latest npm version once an update-check has run. Mirrors web
+// ProviderRuntime (app/shared/src/lib/types.ts).
+class ProviderRuntime {
+  ProviderRuntime({
+    required this.installed,
+    required this.updateAvailable,
+    this.installedVersion,
+    this.latestVersion,
+    this.checkedAt,
+    this.activeSessions = 0,
+  });
+
+  factory ProviderRuntime.fromJson(Map<String, dynamic> json) {
+    String? str(String key) {
+      final v = json[key];
+      return v is String && v.isNotEmpty ? v : null;
+    }
+
+    return ProviderRuntime(
+      installed: json['installed'] as bool? ?? false,
+      updateAvailable: json['updateAvailable'] as bool? ?? false,
+      installedVersion: str('installedVersion'),
+      latestVersion: str('latestVersion'),
+      checkedAt: str('checkedAt'),
+      activeSessions: (json['activeSessions'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  final bool installed;
+  final bool updateAvailable;
+  final String? installedVersion;
+  final String? latestVersion;
+  final String? checkedAt; // RFC3339, when latestVersion was fetched
+  // Non-terminal sessions currently on this CLI — the UI warns before
+  // upgrading a CLI that running sessions depend on.
+  final int activeSessions;
+}
+
+// ProviderUpdateResult is the outcome of a CLI npm update. `available`
+// is false when an in-app update can't run on this host (e.g. the npm
+// prefix isn't writable); `reason` explains why.
+class ProviderUpdateResult {
+  ProviderUpdateResult({
+    required this.changed,
+    required this.available,
+    this.beforeVersion,
+    this.afterVersion,
+    this.output,
+    this.reason,
+  });
+
+  factory ProviderUpdateResult.fromJson(Map<String, dynamic> json) {
+    String? str(String key) {
+      final v = json[key];
+      return v is String && v.isNotEmpty ? v : null;
+    }
+
+    return ProviderUpdateResult(
+      changed: json['changed'] as bool? ?? false,
+      available: json['available'] as bool? ?? false,
+      beforeVersion: str('beforeVersion'),
+      afterVersion: str('afterVersion'),
+      output: str('output'),
+      reason: str('reason'),
+    );
+  }
+
+  final bool changed;
+  final bool available;
+  final String? beforeVersion;
+  final String? afterVersion;
+  final String? output;
+  final String? reason;
+}
+
 class ProvidersApi {
   ProvidersApi(this._dio);
   final Dio _dio;
@@ -169,6 +246,33 @@ class ProvidersApi {
       throw toApiException(e);
     }
   }
+
+  // GET /providers/{id}/update-check — probes the installed CLI version
+  // AND the latest npm version, reporting whether an update is available.
+  // Makes a network call (server caches it ~1h), so it's separate from
+  // get(). Mirrors web checkProviderUpdate (app/shared/src/lib/catalog.ts).
+  Future<ProviderRuntime> checkUpdate(String id) async {
+    try {
+      final res = await _dio
+          .get<Map<String, dynamic>>('/api/v1/providers/$id/update-check');
+      return ProviderRuntime.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // POST /providers/{id}/update — patch the provider's CLI to the latest
+  // npm version (privileged; the npm package comes from the trusted
+  // manifest, not the request). Returns the before/after versions.
+  Future<ProviderUpdateResult> update(String id) async {
+    try {
+      final res =
+          await _dio.post<Map<String, dynamic>>('/api/v1/providers/$id/update');
+      return ProviderUpdateResult.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
 }
 
 final providersApiProvider = Provider<ProvidersApi>((ref) {
@@ -178,4 +282,12 @@ final providersApiProvider = Provider<ProvidersApi>((ref) {
 final providersListProvider =
     FutureProvider.autoDispose<List<ProviderSummary>>((ref) {
   return ref.watch(providersApiProvider).list();
+});
+
+// Per-provider CLI update-check. autoDispose.family so each provider's
+// config page fetches (and caches for its lifetime) its own probe;
+// makes a network call, so it's not part of the cheap providers list.
+final providerUpdateCheckProvider =
+    FutureProvider.autoDispose.family<ProviderRuntime, String>((ref, id) {
+  return ref.watch(providersApiProvider).checkUpdate(id);
 });

--- a/app/mobile/lib/core/api/sessions_api.dart
+++ b/app/mobile/lib/core/api/sessions_api.dart
@@ -117,6 +117,27 @@ class SessionsApi {
     }
   }
 
+  // PATCH /api/v1/sessions/:id/claude-account — rebind a running Claude
+  // session to a different OAuth account. The gateway terminates the
+  // current child process and respawns it under the new credential, so
+  // the in-CLI conversation context is lost (the session id / tab is
+  // preserved). `accountId == ''` clears the binding (system default).
+  // Mirrors web switchClaudeAccount (app/shared/src/lib/sessions.ts).
+  Future<SessionSummary> switchClaudeAccount(
+    String id,
+    String accountId,
+  ) async {
+    try {
+      final res = await _dio.patch<Map<String, dynamic>>(
+        '/api/v1/sessions/$id/claude-account',
+        data: {'account_id': accountId},
+      );
+      return SessionSummary.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
   // Upload a file (typically an image) and let the gateway hand
   // back the absolute path it landed at on the server's tempdir.
   // The caller pastes that path into the live PTY so the running

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 9453 (3151 per locale)
+/// Strings: 9540 (3180 per locale)
 ///
-/// Built on 2026-06-03 at 12:27 UTC
+/// Built on 2026-06-03 at 15:23 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -418,6 +418,7 @@ class TranslationsProvidersEn {
 	/// en: '{prefix}: {error}'
 	String errorWithMessage({required Object prefix, required Object error}) => '${prefix}: ${error}';
 
+	late final TranslationsProvidersUpdateCheckEn updateCheck = TranslationsProvidersUpdateCheckEn.internal(_root);
 	late final TranslationsProvidersAccountsEn accounts = TranslationsProvidersAccountsEn.internal(_root);
 
 	/// en: 'Provider config'
@@ -2975,6 +2976,8 @@ class TranslationsSessionsDetailEn {
 
 	/// en: 'Failed to load session'
 	String get errorTitle => 'Failed to load session';
+
+	late final TranslationsSessionsDetailAccountSwitcherEn accountSwitcher = TranslationsSessionsDetailAccountSwitcherEn.internal(_root);
 }
 
 // Path: sessions.terminal
@@ -3331,6 +3334,60 @@ class TranslationsProvidersErrorPrefixEn {
 
 	/// en: 'Delete failed'
 	String get delete => 'Delete failed';
+}
+
+// Path: providers.updateCheck
+class TranslationsProvidersUpdateCheckEn {
+	TranslationsProvidersUpdateCheckEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'CLI version'
+	String get sectionTitle => 'CLI version';
+
+	/// en: 'Checking for updates…'
+	String get checking => 'Checking for updates…';
+
+	/// en: 'Couldn't check for updates'
+	String get checkFailed => 'Couldn\'t check for updates';
+
+	/// en: 'Not installed on the gateway host'
+	String get notInstalled => 'Not installed on the gateway host';
+
+	/// en: 'Installed: {version}'
+	String installed({required Object version}) => 'Installed: ${version}';
+
+	/// en: 'Up to date'
+	String get upToDate => 'Up to date';
+
+	/// en: 'Update available: {version}'
+	String updateAvailable({required Object version}) => 'Update available: ${version}';
+
+	/// en: 'latest {version}'
+	String latest({required Object version}) => 'latest ${version}';
+
+	/// en: 'Update CLI'
+	String get updateButton => 'Update CLI';
+
+	/// en: 'Updating…'
+	String get updating => 'Updating…';
+
+	/// en: 'Updated to {version}.'
+	String updatedSnack({required Object version}) => 'Updated to ${version}.';
+
+	/// en: 'Already on the latest version.'
+	String get noChangeSnack => 'Already on the latest version.';
+
+	/// en: 'Update failed: {error}'
+	String updateFailed({required Object error}) => 'Update failed: ${error}';
+
+	/// en: 'In-app update isn't available on this host: {reason}'
+	String notAvailableHere({required Object reason}) => 'In-app update isn\'t available on this host: ${reason}';
+
+	/// en: '{n} active session(s) are using this CLI — updating won't interrupt them, but they keep the old version until restarted.'
+	String activeSessionsWarning({required Object n}) => '${n} active session(s) are using this CLI — updating won\'t interrupt them, but they keep the old version until restarted.';
 }
 
 // Path: providers.accounts
@@ -9652,6 +9709,57 @@ class TranslationsMoreItemsAboutEn {
 	String get subtitle => 'Build version & server info';
 }
 
+// Path: sessions.detail.accountSwitcher
+class TranslationsSessionsDetailAccountSwitcherEn {
+	TranslationsSessionsDetailAccountSwitcherEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Switch Claude account'
+	String get tooltip => 'Switch Claude account';
+
+	/// en: 'Switch Claude account'
+	String get sheetTitle => 'Switch Claude account';
+
+	/// en: 'Currently: {account}'
+	String current({required Object account}) => 'Currently: ${account}';
+
+	/// en: 'Default (system credential)'
+	String get defaultName => 'Default (system credential)';
+
+	/// en: 'Use the CLI's own login, no specific account'
+	String get defaultSubtitle => 'Use the CLI\'s own login, no specific account';
+
+	/// en: 'default'
+	String get defaultShort => 'default';
+
+	/// en: 'no token'
+	String get tokenEmpty => 'no token';
+
+	/// en: 'Switch account?'
+	String get confirmTitle => 'Switch account?';
+
+	/// en: 'This restarts the CLI under the new account — the current in-CLI conversation context is lost (the session tab is kept).'
+	String get confirmBody => 'This restarts the CLI under the new account — the current in-CLI conversation context is lost (the session tab is kept).';
+
+	/// en: 'Switch'
+	String get confirmAction => 'Switch';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Switched to {account}'
+	String switchedSnack({required Object account}) => 'Switched to ${account}';
+
+	/// en: 'Switch failed: {error}'
+	String switchFailed({required Object error}) => 'Switch failed: ${error}';
+
+	/// en: 'No Claude accounts configured. Add them in More → Providers → Claude.'
+	String get noneHint => 'No Claude accounts configured. Add them in More → Providers → Claude.';
+}
+
 // Path: sessions.terminal.snackbar
 class TranslationsSessionsTerminalSnackbarEn {
 	TranslationsSessionsTerminalSnackbarEn.internal(this._root);
@@ -15712,6 +15820,20 @@ extension on Translations {
 			'sessions.detail.startedEnded' => ({required Object started, required Object ended}) => 'started ${started}  ·  ended ${ended}',
 			'sessions.detail.idPrefix' => ({required Object id}) => 'id: ${id}',
 			'sessions.detail.errorTitle' => 'Failed to load session',
+			'sessions.detail.accountSwitcher.tooltip' => 'Switch Claude account',
+			'sessions.detail.accountSwitcher.sheetTitle' => 'Switch Claude account',
+			'sessions.detail.accountSwitcher.current' => ({required Object account}) => 'Currently: ${account}',
+			'sessions.detail.accountSwitcher.defaultName' => 'Default (system credential)',
+			'sessions.detail.accountSwitcher.defaultSubtitle' => 'Use the CLI\'s own login, no specific account',
+			'sessions.detail.accountSwitcher.defaultShort' => 'default',
+			'sessions.detail.accountSwitcher.tokenEmpty' => 'no token',
+			'sessions.detail.accountSwitcher.confirmTitle' => 'Switch account?',
+			'sessions.detail.accountSwitcher.confirmBody' => 'This restarts the CLI under the new account — the current in-CLI conversation context is lost (the session tab is kept).',
+			'sessions.detail.accountSwitcher.confirmAction' => 'Switch',
+			'sessions.detail.accountSwitcher.cancel' => 'Cancel',
+			'sessions.detail.accountSwitcher.switchedSnack' => ({required Object account}) => 'Switched to ${account}',
+			'sessions.detail.accountSwitcher.switchFailed' => ({required Object error}) => 'Switch failed: ${error}',
+			'sessions.detail.accountSwitcher.noneHint' => 'No Claude accounts configured. Add them in More → Providers → Claude.',
 			'sessions.terminal.snackbar.imagePickerFailed' => ({required Object error}) => 'Image picker failed: ${error}',
 			'sessions.terminal.snackbar.uploadingImage' => 'Uploading image…',
 			'sessions.terminal.snackbar.imageAttached' => ({required Object path}) => 'Image attached: ${path}',
@@ -15809,6 +15931,8 @@ extension on Translations {
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => 'Load failed: ${error}',
 			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => 'Save failed: ${error}',
 			'sessions.inspector.notes.saveFailedGeneric' => ({required Object error}) => 'Save failed: ${error}',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.notes.insertFailedApi' => ({required Object error}) => 'Insert failed: ${error}',
 			'sessions.inspector.notes.insertFailedGeneric' => ({required Object error}) => 'Insert failed: ${error}',
 			'sessions.inspector.notes.createFailedApi' => ({required Object error}) => 'Create failed: ${error}',
@@ -15823,8 +15947,6 @@ extension on Translations {
 			'sessions.inspector.notes.emptyProjectDocs' => 'No project docs yet. Tap + to create one, or let an AI agent generate from a prompt.',
 			'sessions.inspector.notes.emptyFilterMatch' => ({required Object query}) => 'No matches for "${query}".',
 			'sessions.inspector.notes.locationDialogHelp' => 'Pin this session\'s cwd to a specific folder under your notes vault. Leave blank to reset.',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.sessionCwd' => 'Session cwd',
 			'sessions.inspector.notes.projectDocsPath' => 'Vault-relative project docs path',
 			'sessions.inspector.notes.locationStoredHint' => 'Stored in <vault>/.opendray-projects.json — git-syncs with the rest of the vault.',
@@ -15947,6 +16069,21 @@ extension on Translations {
 			'providers.errorPrefix.rename' => 'Rename failed',
 			'providers.errorPrefix.delete' => 'Delete failed',
 			'providers.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}: ${error}',
+			'providers.updateCheck.sectionTitle' => 'CLI version',
+			'providers.updateCheck.checking' => 'Checking for updates…',
+			'providers.updateCheck.checkFailed' => 'Couldn\'t check for updates',
+			'providers.updateCheck.notInstalled' => 'Not installed on the gateway host',
+			'providers.updateCheck.installed' => ({required Object version}) => 'Installed: ${version}',
+			'providers.updateCheck.upToDate' => 'Up to date',
+			'providers.updateCheck.updateAvailable' => ({required Object version}) => 'Update available: ${version}',
+			'providers.updateCheck.latest' => ({required Object version}) => 'latest ${version}',
+			'providers.updateCheck.updateButton' => 'Update CLI',
+			'providers.updateCheck.updating' => 'Updating…',
+			'providers.updateCheck.updatedSnack' => ({required Object version}) => 'Updated to ${version}.',
+			'providers.updateCheck.noChangeSnack' => 'Already on the latest version.',
+			'providers.updateCheck.updateFailed' => ({required Object error}) => 'Update failed: ${error}',
+			'providers.updateCheck.notAvailableHere' => ({required Object reason}) => 'In-app update isn\'t available on this host: ${reason}',
+			'providers.updateCheck.activeSessionsWarning' => ({required Object n}) => '${n} active session(s) are using this CLI — updating won\'t interrupt them, but they keep the old version until restarted.',
 			'providers.accounts.rename' => 'Rename',
 			'providers.accounts.renameTitle' => ({required Object name}) => 'Rename ${name}',
 			'providers.accounts.displayNameLabel' => 'Display name',
@@ -16308,6 +16445,8 @@ extension on Translations {
 			'backupSchedules.errorPrefixUpdate' => 'Update failed',
 			'backupSchedules.errorPrefixDelete' => 'Delete failed',
 			'backupSchedules.deleteBody' => ({required Object targetId}) => 'Removes the recurring spec for target ${targetId}. Existing backup blobs are not touched.',
+			_ => null,
+		} ?? switch (path) {
 			'backupSchedules.emptyList' => 'No schedules yet.\nTap "New" to create one.',
 			'backupSchedules.validatePickTarget' => 'Pick a target.',
 			'backupSchedules.validateInterval' => 'Interval must be > 0.',
@@ -16337,8 +16476,6 @@ extension on Translations {
 			'backupTargetEditor.kinds.sftp.description' => 'Any SSH-accessible server',
 			'backupTargetEditor.kinds.s3.label' => 'S3 / compatible',
 			'backupTargetEditor.kinds.s3.description' => 'Amazon S3 + S3-compatible buckets (MinIO, R2, B2)',
-			_ => null,
-		} ?? switch (path) {
 			'backupTargetEditor.kinds.rclone.label' => 'rclone (any)',
 			'backupTargetEditor.kinds.rclone.description' => 'OneDrive, Google Drive, Dropbox via the rclone CLI',
 			'backupTargetEditor.formTitleEdit' => 'Edit target',
@@ -16822,6 +16959,8 @@ extension on Translations {
 			'settings.changeCredentials.updatedSnack' => 'Credentials updated.',
 			'settings.changeCredentials.wrongCurrent' => 'Current password is wrong.',
 			'settings.changeCredentials.saving' => 'Saving…',
+			_ => null,
+		} ?? switch (path) {
 			'settings.changeCredentials.update' => 'Update',
 			'settings.logViewer.title' => 'Live logs',
 			'settings.logViewer.reconnect' => 'Reconnect',
@@ -16851,8 +16990,6 @@ extension on Translations {
 			'settings.serverSettings.loadFailed' => 'Failed to load server settings',
 			'settings.serverSettings.sections.general' => 'General',
 			'settings.serverSettings.sections.logging' => 'Logging',
-			_ => null,
-		} ?? switch (path) {
 			'settings.serverSettings.sections.sessions' => 'Sessions',
 			'settings.serverSettings.sections.vault' => 'Vault',
 			'settings.serverSettings.sections.mcpRegistry' => 'MCP registry',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -257,6 +257,7 @@ class _TranslationsProvidersEs extends TranslationsProvidersEn {
 	@override String get reload => 'Recargar';
 	@override late final _TranslationsProvidersErrorPrefixEs errorPrefix = _TranslationsProvidersErrorPrefixEs._(_root);
 	@override String errorWithMessage({required Object prefix, required Object error}) => '${prefix}: ${error}';
+	@override late final _TranslationsProvidersUpdateCheckEs updateCheck = _TranslationsProvidersUpdateCheckEs._(_root);
 	@override late final _TranslationsProvidersAccountsEs accounts = _TranslationsProvidersAccountsEs._(_root);
 	@override String get configFallbackTitle => 'Configuración del proveedor';
 	@override String get saving => 'Guardando…';
@@ -1525,6 +1526,7 @@ class _TranslationsSessionsDetailEs extends TranslationsSessionsDetailEn {
 	@override String startedEnded({required Object started, required Object ended}) => 'iniciada ${started}  ·  finalizada ${ended}';
 	@override String idPrefix({required Object id}) => 'id: ${id}';
 	@override String get errorTitle => 'No se pudo cargar la sesión';
+	@override late final _TranslationsSessionsDetailAccountSwitcherEs accountSwitcher = _TranslationsSessionsDetailAccountSwitcherEs._(_root);
 }
 
 // Path: sessions.terminal
@@ -1720,6 +1722,30 @@ class _TranslationsProvidersErrorPrefixEs extends TranslationsProvidersErrorPref
 	@override String get toggle => 'Error al alternar';
 	@override String get rename => 'Error al renombrar';
 	@override String get delete => 'Error al eliminar';
+}
+
+// Path: providers.updateCheck
+class _TranslationsProvidersUpdateCheckEs extends TranslationsProvidersUpdateCheckEn {
+	_TranslationsProvidersUpdateCheckEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get sectionTitle => 'Versión del CLI';
+	@override String get checking => 'Buscando actualizaciones…';
+	@override String get checkFailed => 'No se pudo buscar actualizaciones';
+	@override String get notInstalled => 'No instalado en el host del gateway';
+	@override String installed({required Object version}) => 'Instalado: ${version}';
+	@override String get upToDate => 'Actualizado';
+	@override String updateAvailable({required Object version}) => 'Actualización disponible: ${version}';
+	@override String latest({required Object version}) => 'última ${version}';
+	@override String get updateButton => 'Actualizar CLI';
+	@override String get updating => 'Actualizando…';
+	@override String updatedSnack({required Object version}) => 'Actualizado a ${version}.';
+	@override String get noChangeSnack => 'Ya está en la última versión.';
+	@override String updateFailed({required Object error}) => 'Actualización fallida: ${error}';
+	@override String notAvailableHere({required Object reason}) => 'La actualización en la app no está disponible en este host: ${reason}';
+	@override String activeSessionsWarning({required Object n}) => '${n} sesión(es) activa(s) usan este CLI — actualizar no las interrumpe, pero mantienen la versión anterior hasta reiniciarse.';
 }
 
 // Path: providers.accounts
@@ -5017,6 +5043,29 @@ class _TranslationsMoreItemsAboutEs extends TranslationsMoreItemsAboutEn {
 	// Translations
 	@override String get title => 'Acerca de';
 	@override String get subtitle => 'Versión de compilación e información del servidor';
+}
+
+// Path: sessions.detail.accountSwitcher
+class _TranslationsSessionsDetailAccountSwitcherEs extends TranslationsSessionsDetailAccountSwitcherEn {
+	_TranslationsSessionsDetailAccountSwitcherEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get tooltip => 'Cambiar de cuenta de Claude';
+	@override String get sheetTitle => 'Cambiar de cuenta de Claude';
+	@override String current({required Object account}) => 'Actual: ${account}';
+	@override String get defaultName => 'Predeterminada (credencial del sistema)';
+	@override String get defaultSubtitle => 'Usa el propio inicio de sesión del CLI, sin cuenta específica';
+	@override String get defaultShort => 'predeterminada';
+	@override String get tokenEmpty => 'sin token';
+	@override String get confirmTitle => '¿Cambiar de cuenta?';
+	@override String get confirmBody => 'Esto reinicia el CLI con la nueva cuenta — se pierde el contexto de conversación actual dentro del CLI (la pestaña de la sesión se conserva).';
+	@override String get confirmAction => 'Cambiar';
+	@override String get cancel => 'Cancelar';
+	@override String switchedSnack({required Object account}) => 'Cambiado a ${account}';
+	@override String switchFailed({required Object error}) => 'Cambio fallido: ${error}';
+	@override String get noneHint => 'No hay cuentas de Claude configuradas. Agrégalas en Más → Providers → Claude.';
 }
 
 // Path: sessions.terminal.snackbar
@@ -9313,6 +9362,20 @@ extension on TranslationsEs {
 			'sessions.detail.startedEnded' => ({required Object started, required Object ended}) => 'iniciada ${started}  ·  finalizada ${ended}',
 			'sessions.detail.idPrefix' => ({required Object id}) => 'id: ${id}',
 			'sessions.detail.errorTitle' => 'No se pudo cargar la sesión',
+			'sessions.detail.accountSwitcher.tooltip' => 'Cambiar de cuenta de Claude',
+			'sessions.detail.accountSwitcher.sheetTitle' => 'Cambiar de cuenta de Claude',
+			'sessions.detail.accountSwitcher.current' => ({required Object account}) => 'Actual: ${account}',
+			'sessions.detail.accountSwitcher.defaultName' => 'Predeterminada (credencial del sistema)',
+			'sessions.detail.accountSwitcher.defaultSubtitle' => 'Usa el propio inicio de sesión del CLI, sin cuenta específica',
+			'sessions.detail.accountSwitcher.defaultShort' => 'predeterminada',
+			'sessions.detail.accountSwitcher.tokenEmpty' => 'sin token',
+			'sessions.detail.accountSwitcher.confirmTitle' => '¿Cambiar de cuenta?',
+			'sessions.detail.accountSwitcher.confirmBody' => 'Esto reinicia el CLI con la nueva cuenta — se pierde el contexto de conversación actual dentro del CLI (la pestaña de la sesión se conserva).',
+			'sessions.detail.accountSwitcher.confirmAction' => 'Cambiar',
+			'sessions.detail.accountSwitcher.cancel' => 'Cancelar',
+			'sessions.detail.accountSwitcher.switchedSnack' => ({required Object account}) => 'Cambiado a ${account}',
+			'sessions.detail.accountSwitcher.switchFailed' => ({required Object error}) => 'Cambio fallido: ${error}',
+			'sessions.detail.accountSwitcher.noneHint' => 'No hay cuentas de Claude configuradas. Agrégalas en Más → Providers → Claude.',
 			'sessions.terminal.snackbar.imagePickerFailed' => ({required Object error}) => 'Falló el selector de imágenes: ${error}',
 			'sessions.terminal.snackbar.uploadingImage' => 'Subiendo imagen…',
 			'sessions.terminal.snackbar.imageAttached' => ({required Object path}) => 'Imagen adjuntada: ${path}',
@@ -9410,6 +9473,8 @@ extension on TranslationsEs {
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => 'Falló la carga: ${error}',
 			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => 'Falló al guardar: ${error}',
 			'sessions.inspector.notes.saveFailedGeneric' => ({required Object error}) => 'Falló al guardar: ${error}',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.notes.insertFailedApi' => ({required Object error}) => 'Falló la inserción: ${error}',
 			'sessions.inspector.notes.insertFailedGeneric' => ({required Object error}) => 'Falló la inserción: ${error}',
 			'sessions.inspector.notes.createFailedApi' => ({required Object error}) => 'Falló al crear: ${error}',
@@ -9424,8 +9489,6 @@ extension on TranslationsEs {
 			'sessions.inspector.notes.emptyProjectDocs' => 'Aún no hay documentos del proyecto. Toca + para crear uno o deja que un agente de IA lo genere a partir de un prompt.',
 			'sessions.inspector.notes.emptyFilterMatch' => ({required Object query}) => 'No hay coincidencias para "${query}".',
 			'sessions.inspector.notes.locationDialogHelp' => 'Fija el cwd de esta session a una carpeta específica dentro de tu almacén de notas. Déjalo en blanco para restablecer.',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.sessionCwd' => 'cwd de la session',
 			'sessions.inspector.notes.projectDocsPath' => 'Ruta de los documentos del proyecto relativa al almacén',
 			'sessions.inspector.notes.locationStoredHint' => 'Almacenado en <vault>/.opendray-projects.json. Se sincroniza con git junto con el resto del almacén.',
@@ -9548,6 +9611,21 @@ extension on TranslationsEs {
 			'providers.errorPrefix.rename' => 'Error al renombrar',
 			'providers.errorPrefix.delete' => 'Error al eliminar',
 			'providers.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}: ${error}',
+			'providers.updateCheck.sectionTitle' => 'Versión del CLI',
+			'providers.updateCheck.checking' => 'Buscando actualizaciones…',
+			'providers.updateCheck.checkFailed' => 'No se pudo buscar actualizaciones',
+			'providers.updateCheck.notInstalled' => 'No instalado en el host del gateway',
+			'providers.updateCheck.installed' => ({required Object version}) => 'Instalado: ${version}',
+			'providers.updateCheck.upToDate' => 'Actualizado',
+			'providers.updateCheck.updateAvailable' => ({required Object version}) => 'Actualización disponible: ${version}',
+			'providers.updateCheck.latest' => ({required Object version}) => 'última ${version}',
+			'providers.updateCheck.updateButton' => 'Actualizar CLI',
+			'providers.updateCheck.updating' => 'Actualizando…',
+			'providers.updateCheck.updatedSnack' => ({required Object version}) => 'Actualizado a ${version}.',
+			'providers.updateCheck.noChangeSnack' => 'Ya está en la última versión.',
+			'providers.updateCheck.updateFailed' => ({required Object error}) => 'Actualización fallida: ${error}',
+			'providers.updateCheck.notAvailableHere' => ({required Object reason}) => 'La actualización en la app no está disponible en este host: ${reason}',
+			'providers.updateCheck.activeSessionsWarning' => ({required Object n}) => '${n} sesión(es) activa(s) usan este CLI — actualizar no las interrumpe, pero mantienen la versión anterior hasta reiniciarse.',
 			'providers.accounts.rename' => 'Renombrar',
 			'providers.accounts.renameTitle' => ({required Object name}) => 'Renombrar ${name}',
 			'providers.accounts.displayNameLabel' => 'Nombre visible',
@@ -9909,6 +9987,8 @@ extension on TranslationsEs {
 			'backupSchedules.errorPrefixUpdate' => 'Error al actualizar',
 			'backupSchedules.errorPrefixDelete' => 'Error al eliminar',
 			'backupSchedules.deleteBody' => ({required Object targetId}) => 'Elimina la especificación recurrente para el destino ${targetId}. Los blobs de copia de seguridad existentes no se modifican.',
+			_ => null,
+		} ?? switch (path) {
 			'backupSchedules.emptyList' => 'Aún no hay programaciones.\nToca "Nueva" para crear una.',
 			'backupSchedules.validatePickTarget' => 'Elige un destino.',
 			'backupSchedules.validateInterval' => 'El intervalo debe ser > 0.',
@@ -9938,8 +10018,6 @@ extension on TranslationsEs {
 			'backupTargetEditor.kinds.sftp.description' => 'Cualquier servidor accesible por SSH',
 			'backupTargetEditor.kinds.s3.label' => 'S3 / compatible',
 			'backupTargetEditor.kinds.s3.description' => 'Amazon S3 y buckets compatibles con S3 (MinIO, R2, B2)',
-			_ => null,
-		} ?? switch (path) {
 			'backupTargetEditor.kinds.rclone.label' => 'rclone (cualquiera)',
 			'backupTargetEditor.kinds.rclone.description' => 'OneDrive, Google Drive, Dropbox a través de la CLI de rclone',
 			'backupTargetEditor.formTitleEdit' => 'Editar destino',
@@ -10423,6 +10501,8 @@ extension on TranslationsEs {
 			'settings.changeCredentials.updatedSnack' => 'Credenciales actualizadas.',
 			'settings.changeCredentials.wrongCurrent' => 'La contraseña actual es incorrecta.',
 			'settings.changeCredentials.saving' => 'Guardando…',
+			_ => null,
+		} ?? switch (path) {
 			'settings.changeCredentials.update' => 'Actualizar',
 			'settings.logViewer.title' => 'Logs en vivo',
 			'settings.logViewer.reconnect' => 'Reconectar',
@@ -10452,8 +10532,6 @@ extension on TranslationsEs {
 			'settings.serverSettings.loadFailed' => 'No se pudieron cargar los ajustes del servidor',
 			'settings.serverSettings.sections.general' => 'General',
 			'settings.serverSettings.sections.logging' => 'Registro',
-			_ => null,
-		} ?? switch (path) {
 			'settings.serverSettings.sections.sessions' => 'Sessions',
 			'settings.serverSettings.sections.vault' => 'Vault',
 			'settings.serverSettings.sections.mcpRegistry' => 'Registro de MCP',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -257,6 +257,7 @@ class _TranslationsProvidersZh extends TranslationsProvidersEn {
 	@override String get reload => '重新加载';
 	@override late final _TranslationsProvidersErrorPrefixZh errorPrefix = _TranslationsProvidersErrorPrefixZh._(_root);
 	@override String errorWithMessage({required Object prefix, required Object error}) => '${prefix}：${error}';
+	@override late final _TranslationsProvidersUpdateCheckZh updateCheck = _TranslationsProvidersUpdateCheckZh._(_root);
 	@override late final _TranslationsProvidersAccountsZh accounts = _TranslationsProvidersAccountsZh._(_root);
 	@override String get configFallbackTitle => '提供商配置';
 	@override String get saving => '保存中…';
@@ -1525,6 +1526,7 @@ class _TranslationsSessionsDetailZh extends TranslationsSessionsDetailEn {
 	@override String startedEnded({required Object started, required Object ended}) => '${started} 启动  ·  ${ended} 结束';
 	@override String idPrefix({required Object id}) => 'id: ${id}';
 	@override String get errorTitle => '加载会话失败';
+	@override late final _TranslationsSessionsDetailAccountSwitcherZh accountSwitcher = _TranslationsSessionsDetailAccountSwitcherZh._(_root);
 }
 
 // Path: sessions.terminal
@@ -1720,6 +1722,30 @@ class _TranslationsProvidersErrorPrefixZh extends TranslationsProvidersErrorPref
 	@override String get toggle => '切换失败';
 	@override String get rename => '重命名失败';
 	@override String get delete => '删除失败';
+}
+
+// Path: providers.updateCheck
+class _TranslationsProvidersUpdateCheckZh extends TranslationsProvidersUpdateCheckEn {
+	_TranslationsProvidersUpdateCheckZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get sectionTitle => 'CLI 版本';
+	@override String get checking => '正在检查更新…';
+	@override String get checkFailed => '无法检查更新';
+	@override String get notInstalled => '网关主机上未安装';
+	@override String installed({required Object version}) => '已安装：${version}';
+	@override String get upToDate => '已是最新';
+	@override String updateAvailable({required Object version}) => '有可用更新：${version}';
+	@override String latest({required Object version}) => '最新 ${version}';
+	@override String get updateButton => '更新 CLI';
+	@override String get updating => '正在更新…';
+	@override String updatedSnack({required Object version}) => '已更新到 ${version}。';
+	@override String get noChangeSnack => '已是最新版本。';
+	@override String updateFailed({required Object error}) => '更新失败：${error}';
+	@override String notAvailableHere({required Object reason}) => '此主机不支持应用内更新：${reason}';
+	@override String activeSessionsWarning({required Object n}) => '有 ${n} 个活跃会话正在使用此 CLI——更新不会中断它们，但它们在重启前仍使用旧版本。';
 }
 
 // Path: providers.accounts
@@ -5017,6 +5043,29 @@ class _TranslationsMoreItemsAboutZh extends TranslationsMoreItemsAboutEn {
 	// Translations
 	@override String get title => '关于';
 	@override String get subtitle => '构建版本与服务器信息';
+}
+
+// Path: sessions.detail.accountSwitcher
+class _TranslationsSessionsDetailAccountSwitcherZh extends TranslationsSessionsDetailAccountSwitcherEn {
+	_TranslationsSessionsDetailAccountSwitcherZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get tooltip => '切换 Claude 账号';
+	@override String get sheetTitle => '切换 Claude 账号';
+	@override String current({required Object account}) => '当前：${account}';
+	@override String get defaultName => '默认（系统凭据）';
+	@override String get defaultSubtitle => '使用 CLI 自身的登录，不指定具体账号';
+	@override String get defaultShort => '默认';
+	@override String get tokenEmpty => '无 token';
+	@override String get confirmTitle => '切换账号？';
+	@override String get confirmBody => '这会用新账号重启 CLI——当前 CLI 内的对话上下文会丢失（会话标签保留）。';
+	@override String get confirmAction => '切换';
+	@override String get cancel => '取消';
+	@override String switchedSnack({required Object account}) => '已切换到 ${account}';
+	@override String switchFailed({required Object error}) => '切换失败：${error}';
+	@override String get noneHint => '未配置 Claude 账号。请在 更多 → Providers → Claude 中添加。';
 }
 
 // Path: sessions.terminal.snackbar
@@ -9313,6 +9362,20 @@ extension on TranslationsZh {
 			'sessions.detail.startedEnded' => ({required Object started, required Object ended}) => '${started} 启动  ·  ${ended} 结束',
 			'sessions.detail.idPrefix' => ({required Object id}) => 'id: ${id}',
 			'sessions.detail.errorTitle' => '加载会话失败',
+			'sessions.detail.accountSwitcher.tooltip' => '切换 Claude 账号',
+			'sessions.detail.accountSwitcher.sheetTitle' => '切换 Claude 账号',
+			'sessions.detail.accountSwitcher.current' => ({required Object account}) => '当前：${account}',
+			'sessions.detail.accountSwitcher.defaultName' => '默认（系统凭据）',
+			'sessions.detail.accountSwitcher.defaultSubtitle' => '使用 CLI 自身的登录，不指定具体账号',
+			'sessions.detail.accountSwitcher.defaultShort' => '默认',
+			'sessions.detail.accountSwitcher.tokenEmpty' => '无 token',
+			'sessions.detail.accountSwitcher.confirmTitle' => '切换账号？',
+			'sessions.detail.accountSwitcher.confirmBody' => '这会用新账号重启 CLI——当前 CLI 内的对话上下文会丢失（会话标签保留）。',
+			'sessions.detail.accountSwitcher.confirmAction' => '切换',
+			'sessions.detail.accountSwitcher.cancel' => '取消',
+			'sessions.detail.accountSwitcher.switchedSnack' => ({required Object account}) => '已切换到 ${account}',
+			'sessions.detail.accountSwitcher.switchFailed' => ({required Object error}) => '切换失败：${error}',
+			'sessions.detail.accountSwitcher.noneHint' => '未配置 Claude 账号。请在 更多 → Providers → Claude 中添加。',
 			'sessions.terminal.snackbar.imagePickerFailed' => ({required Object error}) => '图片选择失败：${error}',
 			'sessions.terminal.snackbar.uploadingImage' => '正在上传图片…',
 			'sessions.terminal.snackbar.imageAttached' => ({required Object path}) => '已附加图片：${path}',
@@ -9410,6 +9473,8 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => '加载失败：${error}',
 			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => '保存失败：${error}',
 			'sessions.inspector.notes.saveFailedGeneric' => ({required Object error}) => '保存失败：${error}',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.notes.insertFailedApi' => ({required Object error}) => '插入失败：${error}',
 			'sessions.inspector.notes.insertFailedGeneric' => ({required Object error}) => '插入失败：${error}',
 			'sessions.inspector.notes.createFailedApi' => ({required Object error}) => '创建失败：${error}',
@@ -9424,8 +9489,6 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.emptyProjectDocs' => '暂无项目文档。点击 + 创建一个，或让 AI agent 根据提示生成。',
 			'sessions.inspector.notes.emptyFilterMatch' => ({required Object query}) => '未找到匹配「${query}」的内容。',
 			'sessions.inspector.notes.locationDialogHelp' => '将此会话的 cwd 固定到笔记库下的某个文件夹。留空 = 重置。',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.sessionCwd' => '会话 cwd',
 			'sessions.inspector.notes.projectDocsPath' => '相对笔记库的项目文档路径',
 			'sessions.inspector.notes.locationStoredHint' => '存储于 <vault>/.opendray-projects.json — 与笔记库其余部分一起 git 同步。',
@@ -9548,6 +9611,21 @@ extension on TranslationsZh {
 			'providers.errorPrefix.rename' => '重命名失败',
 			'providers.errorPrefix.delete' => '删除失败',
 			'providers.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}：${error}',
+			'providers.updateCheck.sectionTitle' => 'CLI 版本',
+			'providers.updateCheck.checking' => '正在检查更新…',
+			'providers.updateCheck.checkFailed' => '无法检查更新',
+			'providers.updateCheck.notInstalled' => '网关主机上未安装',
+			'providers.updateCheck.installed' => ({required Object version}) => '已安装：${version}',
+			'providers.updateCheck.upToDate' => '已是最新',
+			'providers.updateCheck.updateAvailable' => ({required Object version}) => '有可用更新：${version}',
+			'providers.updateCheck.latest' => ({required Object version}) => '最新 ${version}',
+			'providers.updateCheck.updateButton' => '更新 CLI',
+			'providers.updateCheck.updating' => '正在更新…',
+			'providers.updateCheck.updatedSnack' => ({required Object version}) => '已更新到 ${version}。',
+			'providers.updateCheck.noChangeSnack' => '已是最新版本。',
+			'providers.updateCheck.updateFailed' => ({required Object error}) => '更新失败：${error}',
+			'providers.updateCheck.notAvailableHere' => ({required Object reason}) => '此主机不支持应用内更新：${reason}',
+			'providers.updateCheck.activeSessionsWarning' => ({required Object n}) => '有 ${n} 个活跃会话正在使用此 CLI——更新不会中断它们，但它们在重启前仍使用旧版本。',
 			'providers.accounts.rename' => '重命名',
 			'providers.accounts.renameTitle' => ({required Object name}) => '重命名 ${name}',
 			'providers.accounts.displayNameLabel' => '显示名',
@@ -9909,6 +9987,8 @@ extension on TranslationsZh {
 			'backupSchedules.errorPrefixUpdate' => '更新失败',
 			'backupSchedules.errorPrefixDelete' => '删除失败',
 			'backupSchedules.deleteBody' => ({required Object targetId}) => '移除目标 ${targetId} 的定期规格。已存在的备份不受影响。',
+			_ => null,
+		} ?? switch (path) {
 			'backupSchedules.emptyList' => '暂无计划。\n点击「新建」创建一个。',
 			'backupSchedules.validatePickTarget' => '请选择一个目标。',
 			'backupSchedules.validateInterval' => '间隔必须大于 0。',
@@ -9938,8 +10018,6 @@ extension on TranslationsZh {
 			'backupTargetEditor.kinds.sftp.description' => '任何可 SSH 访问的服务器',
 			'backupTargetEditor.kinds.s3.label' => 'S3 / 兼容',
 			'backupTargetEditor.kinds.s3.description' => 'Amazon S3 + S3 兼容存储桶（MinIO、R2、B2）',
-			_ => null,
-		} ?? switch (path) {
 			'backupTargetEditor.kinds.rclone.label' => 'rclone（任意）',
 			'backupTargetEditor.kinds.rclone.description' => '通过 rclone CLI 访问 OneDrive、Google Drive、Dropbox',
 			'backupTargetEditor.formTitleEdit' => '编辑目标',
@@ -10423,6 +10501,8 @@ extension on TranslationsZh {
 			'settings.changeCredentials.updatedSnack' => '凭据已更新。',
 			'settings.changeCredentials.wrongCurrent' => '当前密码不正确。',
 			'settings.changeCredentials.saving' => '保存中…',
+			_ => null,
+		} ?? switch (path) {
 			'settings.changeCredentials.update' => '更新',
 			'settings.logViewer.title' => '实时日志',
 			'settings.logViewer.reconnect' => '重新连接',
@@ -10452,8 +10532,6 @@ extension on TranslationsZh {
 			'settings.serverSettings.loadFailed' => '加载服务器设置失败',
 			'settings.serverSettings.sections.general' => '通用',
 			'settings.serverSettings.sections.logging' => '日志',
-			_ => null,
-		} ?? switch (path) {
 			'settings.serverSettings.sections.sessions' => '会话',
 			'settings.serverSettings.sections.vault' => '凭据库',
 			'settings.serverSettings.sections.mcpRegistry' => 'MCP 注册表',

--- a/app/mobile/lib/features/providers/provider_config_screen.dart
+++ b/app/mobile/lib/features/providers/provider_config_screen.dart
@@ -200,6 +200,10 @@ class _ProviderConfigScreenState
               style: Theme.of(context).textTheme.bodySmall,
             ),
           ),
+        // CLI version + update awareness (installed vs latest npm),
+        // mirroring the web Providers page. Shell has no npm package, so
+        // the card only renders for CLIs the gateway can probe.
+        _UpdateCheckCard(providerId: p.id),
         if (hasFields) ...[
           for (final entry in groups.entries) ...[
             if (entry.key.isNotEmpty) _SectionHeader(label: entry.key),
@@ -469,6 +473,183 @@ class _TextFieldState extends State<_TextField> {
               ),
       ),
       onChanged: _onChanged,
+    );
+  }
+}
+
+// _UpdateCheckCard surfaces the CLI's installed version, whether an
+// update is available (probed vs latest npm), and an in-app Update
+// action — the mobile mirror of the web Providers update-check. It
+// collapses to nothing for non-versioned providers (e.g. Shell), so the
+// editor stays calm for CLIs there's nothing to check.
+class _UpdateCheckCard extends ConsumerStatefulWidget {
+  const _UpdateCheckCard({required this.providerId});
+
+  final String providerId;
+
+  @override
+  ConsumerState<_UpdateCheckCard> createState() => _UpdateCheckCardState();
+}
+
+class _UpdateCheckCardState extends ConsumerState<_UpdateCheckCard> {
+  bool _updating = false;
+
+  Future<void> _runUpdate() async {
+    final tr = t.providers.updateCheck;
+    setState(() => _updating = true);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final res =
+          await ref.read(providersApiProvider).update(widget.providerId);
+      if (!mounted) return;
+      if (!res.available) {
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text(tr.notAvailableHere(reason: res.reason ?? '')),
+          ),
+        );
+      } else {
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text(
+              res.changed
+                  ? tr.updatedSnack(version: res.afterVersion ?? '')
+                  : tr.noChangeSnack,
+            ),
+            behavior: SnackBarBehavior.floating,
+            duration: const Duration(seconds: 2),
+          ),
+        );
+      }
+      ref.invalidate(providerUpdateCheckProvider(widget.providerId));
+    } on Object catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            tr.updateFailed(
+              error: e is ApiException ? e.message : e.toString(),
+            ),
+          ),
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _updating = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tr = t.providers.updateCheck;
+    final theme = Theme.of(context);
+    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    final async = ref.watch(providerUpdateCheckProvider(widget.providerId));
+
+    return async.when(
+      loading: () => _wrap(
+        theme,
+        Row(
+          children: [
+            const SizedBox(
+              width: 14,
+              height: 14,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+            const SizedBox(width: 10),
+            Text(tr.checking, style: theme.textTheme.bodySmall),
+          ],
+        ),
+      ),
+      error: (_, __) => _wrap(
+        theme,
+        Text(
+          tr.checkFailed,
+          style: theme.textTheme.bodySmall?.copyWith(color: muted),
+        ),
+      ),
+      data: (rt) {
+        // Non-versioned provider (e.g. Shell — no npm package): nothing
+        // useful to show, so collapse the card entirely.
+        if (!rt.installed && rt.latestVersion == null) {
+          return const SizedBox.shrink();
+        }
+        final hasUpdate = rt.updateAvailable && rt.latestVersion != null;
+        final statusText = hasUpdate
+            ? tr.updateAvailable(version: rt.latestVersion!)
+            : tr.upToDate;
+        final statusColor = hasUpdate ? theme.colorScheme.primary : muted;
+        return _wrap(
+          theme,
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      rt.installed
+                          ? tr.installed(version: rt.installedVersion ?? '?')
+                          : tr.notInstalled,
+                      style: const TextStyle(
+                        fontSize: 13,
+                        fontFamily: 'monospace',
+                      ),
+                    ),
+                  ),
+                  Text(
+                    statusText,
+                    style: theme.textTheme.bodySmall
+                        ?.copyWith(color: statusColor),
+                  ),
+                ],
+              ),
+              if (hasUpdate && rt.activeSessions > 0)
+                Padding(
+                  padding: const EdgeInsets.only(top: 6),
+                  child: Text(
+                    tr.activeSessionsWarning(n: rt.activeSessions),
+                    style: theme.textTheme.bodySmall?.copyWith(color: muted),
+                  ),
+                ),
+              if (hasUpdate)
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: FilledButton.tonalIcon(
+                      onPressed: _updating ? null : _runUpdate,
+                      icon: _updating
+                          ? const SizedBox(
+                              width: 14,
+                              height: 14,
+                              child:
+                                  CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.download, size: 16),
+                      label:
+                          Text(_updating ? tr.updating : tr.updateButton),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _wrap(ThemeData theme, Widget child) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          border: Border.all(color: theme.colorScheme.outlineVariant),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: child,
+      ),
     );
   }
 }

--- a/app/mobile/lib/features/sessions/account_switch_sheet.dart
+++ b/app/mobile/lib/features/sessions/account_switch_sheet.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/api/api_exception.dart';
+import 'package:opendray/core/api/claude_accounts_api.dart';
+import 'package:opendray/core/api/models.dart';
+import 'package:opendray/core/api/sessions_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+
+// AccountSwitchSheet rebinds a *running* Claude session to a different
+// OAuth account — the mobile mirror of the web header AccountSwitcher
+// (app/web/src/components/sessions/AccountSwitcher.tsx). The gateway
+// terminates the current child process and respawns it under the new
+// credential, so the in-CLI conversation context is lost (the session
+// id / tab is preserved). A confirm dialog gates the switch.
+//
+// Returns true via the modal result when a switch succeeded, so the
+// caller can refresh the session + accounts views.
+class AccountSwitchSheet extends ConsumerStatefulWidget {
+  const AccountSwitchSheet({required this.session, super.key});
+
+  final SessionSummary session;
+
+  static Future<bool> show(
+    BuildContext context, {
+    required SessionSummary session,
+  }) async {
+    final res = await showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (_) => AccountSwitchSheet(session: session),
+    );
+    return res ?? false;
+  }
+
+  @override
+  ConsumerState<AccountSwitchSheet> createState() => _AccountSwitchSheetState();
+}
+
+class _AccountSwitchSheetState extends ConsumerState<AccountSwitchSheet> {
+  bool _busy = false;
+
+  Translations get _t => Translations.of(context);
+
+  Future<void> _pick(String accountId, String label) async {
+    final tr = _t.sessions.detail.accountSwitcher;
+    // No-op when picking the already-bound account.
+    if (accountId == (widget.session.claudeAccountId ?? '')) {
+      Navigator.of(context).pop(false);
+      return;
+    }
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(tr.confirmTitle),
+        content: Text(tr.confirmBody),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(tr.cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(tr.confirmAction),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    setState(() => _busy = true);
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+    try {
+      await ref
+          .read(sessionsApiProvider)
+          .switchClaudeAccount(widget.session.id, accountId);
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(tr.switchedSnack(account: label)),
+          behavior: SnackBarBehavior.floating,
+          duration: const Duration(seconds: 2),
+        ),
+      );
+      navigator.pop(true);
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() => _busy = false);
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            tr.switchFailed(
+              error: e is ApiException ? e.message : e.toString(),
+            ),
+          ),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tr = _t.sessions.detail.accountSwitcher;
+    final accountsAsync = ref.watch(claudeAccountsListProvider);
+    final theme = Theme.of(context);
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 12),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
+              child: Text(tr.sheetTitle, style: theme.textTheme.titleMedium),
+            ),
+            if (_busy) const LinearProgressIndicator(minHeight: 2),
+            accountsAsync.when(
+              data: (accounts) {
+                final enabled = accounts.where((a) => a.enabled).toList();
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _AccountRow(
+                      selected: widget.session.claudeAccountId == null,
+                      title: tr.defaultName,
+                      subtitle: tr.defaultSubtitle,
+                      enabled: !_busy,
+                      onTap: () => _pick('', tr.defaultShort),
+                    ),
+                    if (enabled.isNotEmpty) const Divider(height: 1),
+                    for (final a in enabled)
+                      _AccountRow(
+                        selected: widget.session.claudeAccountId == a.id,
+                        title: a.displayName,
+                        subtitle: a.tokenFilled
+                            ? (a.oauthEmail ?? a.name)
+                            : tr.tokenEmpty,
+                        enabled: !_busy && a.tokenFilled,
+                        onTap: () => _pick(a.id, a.displayName),
+                      ),
+                    if (accounts.isEmpty)
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(20, 12, 20, 4),
+                        child: Text(
+                          tr.noneHint,
+                          style: theme.textTheme.bodySmall,
+                        ),
+                      ),
+                  ],
+                );
+              },
+              loading: () => const Padding(
+                padding: EdgeInsets.all(24),
+                child: Center(child: CircularProgressIndicator()),
+              ),
+              error: (e, _) => Padding(
+                padding: const EdgeInsets.fromLTRB(20, 12, 20, 4),
+                child: Text(
+                  tr.switchFailed(
+                    error: e is ApiException ? e.message : e.toString(),
+                  ),
+                  style: theme.textTheme.bodySmall,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AccountRow extends StatelessWidget {
+  const _AccountRow({
+    required this.selected,
+    required this.title,
+    required this.subtitle,
+    required this.enabled,
+    required this.onTap,
+  });
+
+  final bool selected;
+  final String title;
+  final String subtitle;
+  final bool enabled;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return ListTile(
+      enabled: enabled,
+      leading: Icon(
+        selected ? Icons.check_circle : Icons.circle_outlined,
+        color: selected ? scheme.primary : scheme.outline,
+      ),
+      title: Text(title),
+      subtitle: Text(subtitle, maxLines: 1, overflow: TextOverflow.ellipsis),
+      onTap: enabled ? onTap : null,
+    );
+  }
+}

--- a/app/mobile/lib/features/sessions/session_detail_screen.dart
+++ b/app/mobile/lib/features/sessions/session_detail_screen.dart
@@ -3,12 +3,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 
+import 'package:opendray/core/api/claude_accounts_api.dart';
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/sessions_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/core/providers/provider_visual.dart';
 import 'package:opendray/core/widgets/brand_avatar.dart';
 import 'package:opendray/features/project/project_screen.dart';
+import 'package:opendray/features/sessions/account_switch_sheet.dart';
 import 'package:opendray/features/sessions/session_action_sheet.dart';
 import 'package:opendray/features/sessions/session_terminal_view.dart';
 
@@ -89,6 +91,31 @@ class _SessionDetailScreenState extends ConsumerState<SessionDetailScreen> {
                 );
               },
             ),
+            orElse: SizedBox.shrink,
+          ),
+          // Account switcher — Claude live sessions only. Rebinds the
+          // running session to a different OAuth account (mirrors the
+          // web header AccountSwitcher). Hidden for non-Claude providers
+          // (no account concept) and terminated sessions (nothing to
+          // rebind — /resume first).
+          async.maybeWhen(
+            data: (s) => (s.providerId == 'claude' && s.isLive)
+                ? IconButton(
+                    icon: const Icon(Icons.manage_accounts_outlined),
+                    tooltip: t.sessions.detail.accountSwitcher.tooltip,
+                    onPressed: () async {
+                      final switched = await AccountSwitchSheet.show(
+                        context,
+                        session: s,
+                      );
+                      if (!switched || !context.mounted) return;
+                      ref
+                        ..invalidate(sessionByIdProvider(widget.sessionId))
+                        ..invalidate(sessionsListProvider)
+                        ..invalidate(claudeAccountsListProvider);
+                    },
+                  )
+                : const SizedBox.shrink(),
             orElse: SizedBox.shrink,
           ),
           async.maybeWhen(

--- a/app/mobile/test/core/api/models_parse_test.dart
+++ b/app/mobile/test/core/api/models_parse_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opendray/core/api/models.dart';
+import 'package:opendray/core/api/providers_api.dart';
+
+// Guards the JSON parsing for the account-switch + CLI-update-check
+// surfaces (PR: mobile account switch + provider update awareness).
+void main() {
+  group('SessionSummary.claudeAccountId', () {
+    test('reads a non-empty claude_account_id', () {
+      final s = SessionSummary.fromJson({
+        'id': 'ses_1',
+        'provider_id': 'claude',
+        'state': 'running',
+        'started_at': '2026-01-01T00:00:00Z',
+        'claude_account_id': 'acc_work',
+      });
+      expect(s.claudeAccountId, 'acc_work');
+    });
+
+    test('treats absent / empty as null (system default binding)', () {
+      final absent = SessionSummary.fromJson({
+        'id': 'ses_2',
+        'provider_id': 'claude',
+        'state': 'running',
+        'started_at': '2026-01-01T00:00:00Z',
+      });
+      final empty = SessionSummary.fromJson({
+        'id': 'ses_3',
+        'provider_id': 'claude',
+        'state': 'running',
+        'started_at': '2026-01-01T00:00:00Z',
+        'claude_account_id': '',
+      });
+      expect(absent.claudeAccountId, isNull);
+      expect(empty.claudeAccountId, isNull);
+    });
+  });
+
+  group('ProviderRuntime.fromJson', () {
+    test('parses a probed update-available state', () {
+      final rt = ProviderRuntime.fromJson({
+        'installed': true,
+        'installedVersion': '1.2.0',
+        'latestVersion': '1.3.0',
+        'updateAvailable': true,
+        'activeSessions': 2,
+      });
+      expect(rt.installed, isTrue);
+      expect(rt.installedVersion, '1.2.0');
+      expect(rt.latestVersion, '1.3.0');
+      expect(rt.updateAvailable, isTrue);
+      expect(rt.activeSessions, 2);
+    });
+
+    test('defaults are safe when fields are missing', () {
+      final rt = ProviderRuntime.fromJson({});
+      expect(rt.installed, isFalse);
+      expect(rt.updateAvailable, isFalse);
+      expect(rt.installedVersion, isNull);
+      expect(rt.latestVersion, isNull);
+      expect(rt.activeSessions, 0);
+    });
+  });
+
+  group('ProviderUpdateResult.fromJson', () {
+    test('parses a successful change', () {
+      final r = ProviderUpdateResult.fromJson({
+        'changed': true,
+        'available': true,
+        'beforeVersion': '1.2.0',
+        'afterVersion': '1.3.0',
+        'output': 'updated 1 package',
+      });
+      expect(r.changed, isTrue);
+      expect(r.available, isTrue);
+      expect(r.afterVersion, '1.3.0');
+    });
+
+    test('parses an unavailable result with a reason', () {
+      final r = ProviderUpdateResult.fromJson({
+        'changed': false,
+        'available': false,
+        'reason': 'npm prefix not writable',
+      });
+      expect(r.available, isFalse);
+      expect(r.reason, 'npm prefix not writable');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Brings two web-only capabilities to the Flutter mobile app, closing parity gaps. Both consume **existing** gateway endpoints — no backend changes.

### 1. Per-session Claude account switch (mirrors web `AccountSwitcher`)

Mobile could only pick a Claude account at **spawn** time; the web app can rebind a **running** session to a different account from the session header. Now mobile can too:

- `SessionSummary` gains `claude_account_id` (the running session's bound account; `null` = system default).
- `SessionsApi.switchClaudeAccount` → `PATCH /sessions/{id}/claude-account`.
- A "manage accounts" app-bar action on the session detail screen (Claude **live** sessions only) opens `AccountSwitchSheet`: Default + enabled accounts, current marked, a confirm dialog (the switch restarts the CLI and drops in-CLI context — the session tab is kept), then rebinds and refreshes the session + accounts views.

### 2. Agent CLI update awareness (mirrors web Providers update-check)

The user asked whether mobile can perceive version updates like web does. **opendray's own** version/update awareness already existed on the mobile About screen. The gap was **agent CLI** (Claude/Codex/Gemini) update awareness:

- `ProviderRuntime` + `ProviderUpdateResult` models; `ProvidersApi.checkUpdate` → `GET /providers/{id}/update-check` and `update` → `POST /providers/{id}/update`.
- `provider_config_screen` shows a CLI-version card: installed vs latest npm, an up-to-date / update-available status, an active-sessions note, and an in-app Update action. Collapses for non-versioned providers (e.g. Shell).

## Changes

- `core/api/models.dart`, `core/api/sessions_api.dart`, `core/api/providers_api.dart` — models + API methods + a `providerUpdateCheckProvider` family.
- `features/sessions/account_switch_sheet.dart` (new) + `session_detail_screen.dart` app-bar action.
- `features/providers/provider_config_screen.dart` — update-check card.
- `app/i18n/{en,zh,es}.json` — `sessions.detail.accountSwitcher.*` + `providers.updateCheck.*` (+ regenerated slang).

## Test plan

- [x] `flutter analyze` clean (whole app)
- [x] `flutter test` green (existing suite + new `models_parse_test.dart` covering the new JSON shapes)
- [x] i18n parity guard 100% (en/zh/es)
- [x] Confirmed against live backend routes: `PATCH /sessions/{id}/claude-account`, `GET /providers/{id}/update-check`, `POST /providers/{id}/update`

## Note

Mobile-only + i18n; no Go changes. Needs a mobile release build to reach devices (not included here).
