### PR TITLE
feat(telegram): transcribe inbound voice notes via Deepgram

### DIFF
--- a/app/shared/src/lib/channelKinds.ts
+++ b/app/shared/src/lib/channelKinds.ts
@@ -121,6 +121,21 @@ export const KIND_DEFS: KindDef[] = [
         placeholder: '3500 (blank = 3500, 0 = unlimited)',
         hint: 'Caps how much of the agent’s reply is sent before it’s trimmed with a “…(truncated)” note. Blank uses the 3500 default (~one message); set 0 to send the whole reply, split across multiple messages.',
       },
+      {
+        name: 'voice_transcription_enabled',
+        label: 'Voice notes → text (Deepgram)',
+        type: 'boolean',
+        default: false,
+        hint: 'When on, voice messages sent to the bot are transcribed with Deepgram and forwarded to the session as text. Requires an API key below.',
+      },
+      {
+        name: 'voice_transcription_api_key',
+        label: 'Deepgram API key',
+        type: 'password',
+        optional: true,
+        placeholder: 'Token from console.deepgram.com',
+        hint: 'Only used when voice transcription is on. Stored alongside the bot token.',
+      },
     ],
   },
   {

--- a/internal/channel/telegram/telegram.go
+++ b/internal/channel/telegram/telegram.go
@@ -56,6 +56,16 @@ type config struct {
 	BotToken string   `json:"bot_token"`
 	ChatID   int64    `json:"chat_id"`
 	NotifyOn []string `json:"notify_on,omitempty"`
+
+	// VoiceTranscriptionEnabled opts the channel in to converting
+	// inbound voice notes into text via Deepgram before the message
+	// reaches the session. Default off — the operator must paste an
+	// API key for it to actually run.
+	VoiceTranscriptionEnabled bool `json:"voice_transcription_enabled,omitempty"`
+	// VoiceTranscriptionAPIKey is the Deepgram API key used for STT.
+	// Stored alongside the bot token in the channel config blob —
+	// same trust boundary, same admin-only API surface.
+	VoiceTranscriptionAPIKey string `json:"voice_transcription_api_key,omitempty"`
 }
 
 // Telegram implements channel.Channel + several capability interfaces.
@@ -498,18 +508,58 @@ func (t *Telegram) deliverMessage(ctx context.Context, inbound channel.InboundFu
 	if m.ReplyToMessage != nil && m.ReplyToMessage.MessageID != 0 {
 		meta["reply_to_outbound_msg_id"] = strconv.Itoa(m.ReplyToMessage.MessageID)
 	}
+
+	text := m.Text
+
+	// Voice notes: when transcription is enabled, replace empty Text
+	// with the Deepgram transcript before handing off to the Hub.
+	// Failure modes are surfaced to the user as a short reply so a
+	// silent drop never leaves them wondering whether the bot got it.
+	if m.Voice != nil && text == "" {
+		if !t.cfg.VoiceTranscriptionEnabled {
+			t.replyVoiceError(ctx, rc, "Voice messages aren't enabled for this bot. Send text instead.")
+			return
+		}
+		transcript, err := t.transcribeVoice(ctx, m.Voice)
+		if err != nil {
+			t.log.Warn("voice transcription failed", "err", err, "duration_s", m.Voice.Duration)
+			t.replyVoiceError(ctx, rc, "Couldn't transcribe that voice note — try again or send text.")
+			return
+		}
+		text = transcript
+		meta["transcribed_by"] = "deepgram"
+		meta["voice_duration_s"] = m.Voice.Duration
+	}
+
 	msg := channel.ChannelMessage{
 		ChannelID:      t.id,
 		Direction:      channel.DirectionInbound,
 		ConversationID: strconv.FormatInt(m.Chat.ID, 10),
 		Author:         m.From.username(),
-		Text:           m.Text,
+		Text:           text,
 		Timestamp:      time.Unix(m.Date, 0).UTC(),
 		ReplyCtx:       rc,
 		Metadata:       meta,
 	}
 	if err := inbound(ctx, msg); err != nil {
 		t.log.Error("inbound handler failed", "err", err)
+	}
+}
+
+// replyVoiceError sends a one-shot apology back to the chat when the
+// transcription path can't deliver — disabled, network error, empty
+// transcript, etc. Best-effort: a send failure here is logged but
+// doesn't escalate, since we're already on an error branch.
+func (t *Telegram) replyVoiceError(ctx context.Context, rc ReplyCtx, text string) {
+	body := map[string]any{
+		"chat_id": rc.ChatID,
+		"text":    text,
+	}
+	if rc.MessageID != 0 {
+		body["reply_parameters"] = map[string]any{"message_id": rc.MessageID}
+	}
+	if err := t.callAPI(ctx, "sendMessage", body, nil); err != nil {
+		t.log.Warn("voice error reply failed", "err", err)
 	}
 }
 
@@ -677,6 +727,17 @@ type tgMessage struct {
 	Date           int64      `json:"date"`
 	Text           string     `json:"text"`
 	ReplyToMessage *tgMessage `json:"reply_to_message,omitempty"`
+	Voice          *tgVoice   `json:"voice,omitempty"`
+}
+
+// tgVoice is Telegram's voice-note payload — OGG/Opus by default.
+// FileID is the opaque handle the getFile API resolves to a download
+// path; Duration is whole seconds; MimeType is normally "audio/ogg".
+type tgVoice struct {
+	FileID   string `json:"file_id"`
+	Duration int    `json:"duration"`
+	MimeType string `json:"mime_type,omitempty"`
+	FileSize int64  `json:"file_size,omitempty"`
 }
 
 type tgCallbackQuery struct {

--- a/internal/channel/telegram/voice.go
+++ b/internal/channel/telegram/voice.go
@@ -1,0 +1,185 @@
+package telegram
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Voice-note transcription. Telegram → Deepgram → text.
+//
+// Inbound flow (deliverMessage):
+//  1. tgMessage.Voice arrives with an opaque FileID.
+//  2. getFile (Telegram Bot API) resolves FileID → file_path.
+//  3. Download the OGG/Opus blob from the file CDN.
+//  4. POST it to Deepgram /v1/listen.
+//  5. The transcript becomes msg.Text; everything downstream of
+//     deliverMessage stays unchanged.
+//
+// Telegram caps voice notes at 1MB on the receive side (~5 min at the
+// usual 24 kbps), so we don't stream — one bounded read fits.
+
+const (
+	deepgramListenURL    = "https://api.deepgram.com/v1/listen"
+	deepgramTimeout      = 30 * time.Second
+	maxVoiceDownloadSize = 5 * 1024 * 1024 // 5MB hard ceiling on the OGG payload
+)
+
+// errVoiceTranscriptionDisabled is returned when a voice message
+// arrives but the channel doesn't have transcription enabled. Caller
+// surfaces a friendly reply instead of silently dropping.
+var errVoiceTranscriptionDisabled = errors.New("voice transcription not enabled for this channel")
+
+// transcribeVoice pulls the voice payload from Telegram, hands it to
+// Deepgram, and returns the transcript text.
+//
+// The caller is responsible for checking VoiceTranscriptionEnabled
+// before invoking — this function will error out if the API key is
+// missing.
+func (t *Telegram) transcribeVoice(ctx context.Context, v *tgVoice) (string, error) {
+	if v == nil || v.FileID == "" {
+		return "", errors.New("voice: empty file_id")
+	}
+	if t.cfg.VoiceTranscriptionAPIKey == "" {
+		return "", errors.New("voice: deepgram api key not configured")
+	}
+
+	body, mime, err := t.downloadVoiceFile(ctx, v.FileID)
+	if err != nil {
+		return "", fmt.Errorf("voice: download: %w", err)
+	}
+
+	if mime == "" {
+		mime = v.MimeType
+	}
+	if mime == "" {
+		mime = "audio/ogg"
+	}
+
+	return t.deepgramTranscribe(ctx, body, mime)
+}
+
+// downloadVoiceFile fetches the OGG blob behind a Telegram file_id.
+// Returns the raw bytes + the platform-reported content-type.
+func (t *Telegram) downloadVoiceFile(ctx context.Context, fileID string) ([]byte, string, error) {
+	var resp struct {
+		Ok     bool `json:"ok"`
+		Result struct {
+			FilePath string `json:"file_path"`
+			FileSize int64  `json:"file_size"`
+		} `json:"result"`
+	}
+	if err := t.callAPI(ctx, "getFile", map[string]any{"file_id": fileID}, &resp); err != nil {
+		return nil, "", fmt.Errorf("getFile: %w", err)
+	}
+	if !resp.Ok || resp.Result.FilePath == "" {
+		return nil, "", errors.New("getFile: empty file_path")
+	}
+
+	// Telegram file CDN URLs are bot-scoped and contain the token.
+	// Build manually (apiBase strips "bot" off so callAPI can't be reused).
+	dlURL := strings.TrimSuffix(apiBase(), "bot") + "file/bot" +
+		url.PathEscape(t.cfg.BotToken) + "/" + resp.Result.FilePath
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dlURL, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	httpResp, err := t.client.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer httpResp.Body.Close()
+	if httpResp.StatusCode/100 != 2 {
+		return nil, "", fmt.Errorf("download: HTTP %d", httpResp.StatusCode)
+	}
+
+	// Bounded read — Telegram caps voice notes well below this, the
+	// limit is just a runaway guard.
+	data, err := io.ReadAll(io.LimitReader(httpResp.Body, maxVoiceDownloadSize+1))
+	if err != nil {
+		return nil, "", err
+	}
+	if int64(len(data)) > maxVoiceDownloadSize {
+		return nil, "", fmt.Errorf("download: payload exceeds %d bytes", maxVoiceDownloadSize)
+	}
+	return data, httpResp.Header.Get("Content-Type"), nil
+}
+
+// deepgramTranscribe sends the audio bytes to Deepgram and returns the
+// first alternative transcript across all channels.
+//
+// We use nova-3 multilingual with smart_format on by default —
+// punctuation + capitalisation make the transcript usable as session
+// stdin without further cleanup.
+func (t *Telegram) deepgramTranscribe(ctx context.Context, audio []byte, mime string) (string, error) {
+	q := url.Values{}
+	q.Set("model", "nova-3")
+	q.Set("language", "multi")
+	q.Set("smart_format", "true")
+	q.Set("punctuate", "true")
+
+	reqURL := deepgramListenURL + "?" + q.Encode()
+	ctx, cancel := context.WithTimeout(ctx, deepgramTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(audio))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Token "+t.cfg.VoiceTranscriptionAPIKey)
+	req.Header.Set("Content-Type", mime)
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("deepgram request: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("deepgram read: %w", err)
+	}
+	if resp.StatusCode/100 != 2 {
+		// Deepgram returns JSON errors but a non-2xx with a short body
+		// is enough for the operator to diagnose (bad key, quota, etc.).
+		return "", fmt.Errorf("deepgram HTTP %d: %s", resp.StatusCode, truncForLog(body))
+	}
+
+	var dg struct {
+		Results struct {
+			Channels []struct {
+				Alternatives []struct {
+					Transcript string  `json:"transcript"`
+					Confidence float64 `json:"confidence"`
+				} `json:"alternatives"`
+			} `json:"channels"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(body, &dg); err != nil {
+		return "", fmt.Errorf("deepgram decode: %w", err)
+	}
+	if len(dg.Results.Channels) == 0 || len(dg.Results.Channels[0].Alternatives) == 0 {
+		return "", errors.New("deepgram: no transcript returned")
+	}
+	text := strings.TrimSpace(dg.Results.Channels[0].Alternatives[0].Transcript)
+	if text == "" {
+		return "", errors.New("deepgram: empty transcript")
+	}
+	return text, nil
+}
+
+func truncForLog(b []byte) string {
+	const max = 200
+	s := string(bytes.TrimSpace(b))
+	if len(s) > max {
+		return s[:max] + "…"
+	}
+	return s
+}


### PR DESCRIPTION
## Closed in favor of a cleaner architecture (PR #333)

This PR baked Deepgram credentials and code path into the Telegram channel — workable but wrong shape per linivek's review:

> *"the third party cannot be used for a long time, and it should not be hardcoded into the system"*

Opendray already has the install/delete plugin pattern — MCP servers (`internal/mcp/mcp.go`: *"No built-ins are embedded in the binary. Users add servers via the Plugins page."*). The voice integration belongs there, not on the channel.

**Successor PR #333** redoes this as:

- Two MCP tool contracts: `voice/transcribe` + `voice/synthesize`
- Generic MCP voice client in Opendray (~100 lines, no Deepgram code)
- Deepgram becomes an external npm package (`@opendray/voice-deepgram`) — install/delete, no binary release coupling
- Channels reference an installed MCP server by name; toggles enable/disable per-channel

Closing this branch unmerged; the work continues in `feat/voice-mcp-plugin` → PR #333.

What was validated here that carries over to #333:
- ✅ Deepgram REST `/v1/listen` produces clean transcripts (Nova-3, multilingual, smart_format)
- ✅ Telegram `getFile` + OGG/Opus download path
- ✅ Failure-mode UX: friendly chat replies when disabled or transcription fails
- ✅ Web form field-binding works end-to-end (with one toggle-state bug to fix in #333)