### PR TITLE
ci(release): optional Developer ID signing + notarization for macOS binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TAG: ${{ github.event.inputs.tag || github.ref_name }}
+      # Developer ID signing is opt-in: it activates only once the
+      # MACOS_CERT_P12_BASE64 secret is configured. Until then every step
+      # below that depends on it is skipped and the release is byte-for-byte
+      # what it is today (ad-hoc macOS binaries).
+      HAS_MACOS_SIGNING: ${{ secrets.MACOS_CERT_P12_BASE64 != '' }}
     steps:
       # ── Validate the tag input on manual dispatch BEFORE doing any
       #    heavy work (checkout, setup-go, goreleaser). A typo like
@@ -79,6 +84,16 @@ jobs:
         with:
           go-version: "1.25"
 
+      # ── quill: signs + notarizes Mach-O binaries with a Developer ID
+      #    from a Linux runner (no macOS runner / Xcode). Installed only
+      #    when signing is configured; goreleaser's per-build post hook
+      #    (scripts/macos-sign.sh) calls it for the darwin artifacts.
+      - name: Install quill (macOS Developer ID signing)
+        if: env.HAS_MACOS_SIGNING == 'true'
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/quill/main/install.sh | sh -s -- -b /usr/local/bin
+          quill version
+
       # ── Extract the matching CHANGELOG section into release-notes.md
       #    so goreleaser uses it as the release body instead of the
       #    static "See CHANGELOG.md" placeholder. Falls back to that
@@ -114,6 +129,16 @@ jobs:
           args: release --clean --release-notes=release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # macOS Developer ID signing + notarization (consumed by the
+          # build's post hook → scripts/macos-sign.sh → quill). All empty
+          # until the secrets are set, in which case the hook is a no-op.
+          # The .p12 / .p8 are secrets; the ASC key id + issuer are plain
+          # identifiers (also embedded in the signed binary).
+          QUILL_SIGN_P12: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          QUILL_SIGN_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          MACOS_NOTARY_KEY_P8: ${{ secrets.MACOS_NOTARY_KEY_P8 }}
+          QUILL_NOTARY_KEY_ID: BPL8QFJ8M2
+          QUILL_NOTARY_ISSUER: d2ec008d-9e90-49a5-82f5-d5dfbdeff726
 
       # ── Cosign keyless: sign the SHA256SUMS produced by goreleaser.
       #    No long-lived signing key — Sigstore Fulcio mints a short-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,6 +37,16 @@ builds:
       - -X github.com/opendray/opendray-v2/internal/version.Version={{.Version}}
       - -X github.com/opendray/opendray-v2/internal/version.Commit={{.ShortCommit}}
       - -X github.com/opendray/opendray-v2/internal/version.Date={{.Date}}
+    hooks:
+      # Per-binary post hook: Developer ID sign + notarize the macOS
+      # artifacts via quill (runs on the Linux runner). The script is a
+      # no-op for non-darwin targets and when no signing creds are
+      # configured (QUILL_SIGN_P12 empty) — so Linux/Windows builds and
+      # unsigned snapshot/PR builds are unaffected. Reads QUILL_* /
+      # MACOS_NOTARY_KEY_P8 from the inherited (workflow) environment.
+      post:
+        - cmd: ./scripts/macos-sign.sh "{{ .Path }}" "{{ .Os }}"
+          output: true
 
 archives:
   - id: default

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -97,6 +97,58 @@ provided automatically by Actions — you don't manage it. The other:
   compromised — revoke immediately at the npm tokens page above and
   rotate the secret value.
 
+### macOS Developer ID signing + notarization (optional)
+
+When configured, the Release workflow Developer ID-signs and notarizes
+the macOS binaries via [quill](https://github.com/anchore/quill) on the
+Linux runner (no macOS runner needed). The payoff: a signed release keeps
+a **stable code-signing identity across versions**, so a user's macOS
+Full Disk Access grant survives `opendray update`, and notarization
+clears Gatekeeper for browser-downloaded assets.
+
+This is **opt-in and gated**: with no cert secret set, the signing step is
+skipped and the release is exactly what it is today (ad-hoc macOS
+binaries). Nothing breaks for contributors or non-macOS users, and the
+signing job only runs on tag/dispatch in this repo — never on fork PRs, so
+the cert can't leak.
+
+One-time setup (maintainer with an Apple Developer account):
+
+1. **Create a _Developer ID Application_ certificate** (distinct from the
+   "Apple Development" cert). Easiest path: Xcode → Settings → Accounts →
+   select your team → Manage Certificates → ➕ → *Developer ID
+   Application*. Then in Keychain Access, right-click that certificate →
+   **Export** as a `.p12` (this bundles the private key); set an export
+   password.
+
+2. **Add the secrets** (run in your own terminal — the private keys never
+   touch the repo, a PR, or a chat; `gh secret set` reads from a file/stdin
+   without echoing):
+
+   ```sh
+   # Developer ID Application cert (private key) + its export password
+   base64 -i DeveloperID.p12 | gh secret set MACOS_CERT_P12_BASE64 -R Opendray/opendray
+   printf '%s' '<p12-export-password>' | gh secret set MACOS_CERT_PASSWORD -R Opendray/opendray
+
+   # App Store Connect API key (.p8) for notarization — reuse the existing
+   # TestFlight key. Optional: omit to sign without notarizing.
+   gh secret set MACOS_NOTARY_KEY_P8 -R Opendray/opendray < AuthKey_BPL8QFJ8M2.p8
+   ```
+
+   The ASC **key id** (`BPL8QFJ8M2`) and **issuer id** are non-secret
+   identifiers and are set directly in `release.yml` (`QUILL_NOTARY_KEY_ID`
+   / `QUILL_NOTARY_ISSUER`) — edit them there if you rotate keys.
+
+3. **Cut a release** as usual. The `Install quill` step and the build's
+   sign hook (`scripts/macos-sign.sh`) activate automatically once
+   `MACOS_CERT_P12_BASE64` exists. Verify on a Mac with
+   `codesign -dvvv $(which opendray)` (should show `Authority=Developer ID
+   Application: …`, not `adhoc`) and `spctl -a -vv` / `stapler validate`.
+
+   Same operational rule as the npm token: never paste the `.p12` / `.p8`
+   contents anywhere persisted. If leaked, revoke the cert/key in the Apple
+   Developer portal and rotate the secrets.
+
 ## Picking the version number
 
 The rules from [`VERSIONING.md`](VERSIONING.md):

--- a/scripts/macos-sign.sh
+++ b/scripts/macos-sign.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Sign + notarize a macOS binary with an Apple Developer ID, using quill
+# (github.com/anchore/quill) so it runs on the Linux release runner — no
+# macOS runner or Xcode needed. Invoked by goreleaser as a per-build post
+# hook (see .goreleaser.yml).
+#
+# Safe no-op in three cases, so source builds, Linux/Windows artifacts, and
+# unsigned snapshot/PR builds keep working unchanged:
+#   - the built target isn't darwin;
+#   - no Developer ID cert is configured (QUILL_SIGN_P12 empty);
+#   - no notary key is configured → sign only (skip notarization).
+#
+# Why this matters: a Developer ID-signed release binary keeps a STABLE TCC
+# identity across versions, so a user's Full Disk Access grant survives
+# `opendray update`; notarization additionally clears Gatekeeper for
+# browser-downloaded release assets.
+#
+# Expected environment (set by the Release workflow from repo secrets):
+#   QUILL_SIGN_P12        base64 of the Developer ID Application .p12 (or a path)
+#   QUILL_SIGN_PASSWORD   the .p12 export password
+#   MACOS_NOTARY_KEY_P8   App Store Connect API key (.p8) CONTENTS (optional)
+#   QUILL_NOTARY_KEY_ID   ASC key id        (default below)
+#   QUILL_NOTARY_ISSUER   ASC issuer id     (default below)
+set -euo pipefail
+
+BIN="${1:?usage: macos-sign.sh <binary-path> <goos>}"
+OS="${2:-}"
+
+if [ "$OS" != "darwin" ]; then
+  exit 0
+fi
+if [ -z "${QUILL_SIGN_P12:-}" ]; then
+  echo "macos-sign: no Developer ID cert (QUILL_SIGN_P12 unset) — leaving '$BIN' ad-hoc signed."
+  exit 0
+fi
+
+if ! command -v quill >/dev/null 2>&1; then
+  echo "macos-sign: signing requested but 'quill' is not installed — aborting." >&2
+  exit 1
+fi
+
+# App Store Connect .p8 arrives as content; quill wants a file path.
+if [ -n "${MACOS_NOTARY_KEY_P8:-}" ]; then
+  keyfile="$(mktemp)"
+  trap 'rm -f "$keyfile"' EXIT
+  printf '%s' "$MACOS_NOTARY_KEY_P8" > "$keyfile"
+  export QUILL_NOTARY_KEY="$keyfile"
+fi
+# Identifiers the maintainer supplied (not secrets — also embedded in the
+# signed/notarized binary). Overridable via the environment.
+: "${QUILL_NOTARY_KEY_ID:=BPL8QFJ8M2}"
+: "${QUILL_NOTARY_ISSUER:=d2ec008d-9e90-49a5-82f5-d5dfbdeff726}"
+export QUILL_NOTARY_KEY_ID QUILL_NOTARY_ISSUER
+
+if [ -n "${QUILL_NOTARY_KEY:-}" ]; then
+  echo "macos-sign: signing + notarizing '$BIN' with Developer ID via quill…"
+  quill sign-and-notarize "$BIN"
+else
+  echo "macos-sign: signing '$BIN' with Developer ID via quill (no notary key → skipping notarization)…"
+  quill sign "$BIN"
+fi
+echo "macos-sign: done — $BIN"


### PR DESCRIPTION
## Summary

Wires **optional** Apple Developer ID signing + notarization of the macOS release binaries into the release pipeline, using [quill](https://github.com/anchore/quill) so it runs on the existing Linux runner (no macOS runner / Xcode).

This is the **permanent** half of the macOS TCC fix: a Developer ID-signed release keeps a **stable code-signing identity across versions**, so a user's Full Disk Access grant survives `opendray update`, and notarization clears Gatekeeper for browser-downloaded assets. (The local `opendray setup-macos` self-sign from #333 covers source/dev builds.)

## Opt-in & gated — nothing changes until secrets are set

- The whole path is gated on `HAS_MACOS_SIGNING` (= the `MACOS_CERT_P12_BASE64` secret exists). With **no secret set, the release is byte-for-byte what it is today** (ad-hoc macOS binaries). Contributors and non-macOS users are unaffected.
- `scripts/macos-sign.sh` is a no-op for non-darwin targets, when no cert is configured, and (notarization only) when no ASC key is set.
- Signing runs only on tag push / `workflow_dispatch` in this repo — **never on fork PRs**, so the cert can't leak.

## What's wired

- **`scripts/macos-sign.sh`** — signs + notarizes a Mach-O via quill; called as a goreleaser per-build post hook (darwin-only effect).
- **`.goreleaser.yml`** — adds the post hook to the `opendray` build.
- **`.github/workflows/release.yml`** — `HAS_MACOS_SIGNING` gate; conditional `Install quill` step; passes `QUILL_SIGN_P12` / `QUILL_SIGN_PASSWORD` / `MACOS_NOTARY_KEY_P8` (secrets) + `QUILL_NOTARY_KEY_ID` / `QUILL_NOTARY_ISSUER` (non-secret identifiers, inline) to goreleaser.
- **`RELEASING.md`** — one-time maintainer setup: create a *Developer ID Application* cert, set the secrets via `gh secret set` without leaking the keys.

## Secrets to configure (maintainer, when ready)

| Secret | What |
|---|---|
| `MACOS_CERT_P12_BASE64` | base64 of the Developer ID Application `.p12` (cert + key) |
| `MACOS_CERT_PASSWORD` | the `.p12` export password |
| `MACOS_NOTARY_KEY_P8` | App Store Connect API `.p8` contents (reuse the TestFlight key); optional → sign-only |

Identifiers `QUILL_NOTARY_KEY_ID=BPL8QFJ8M2` and `QUILL_NOTARY_ISSUER=d2ec008d-…` are set inline in `release.yml`.

## Test plan

- [x] `goreleaser check` passes
- [x] `release.yml` + `.goreleaser.yml` parse as valid YAML
- [x] `scripts/macos-sign.sh` passes `bash -n`; tracked mode `100755`
- [ ] First signed release after secrets are configured: `codesign -dvvv $(which opendray)` shows `Authority=Developer ID Application: …` (not adhoc); `spctl`/`stapler validate` pass (verified by maintainer)

## Note

No code or non-macOS behavior changes. Developer ID enrollment is individual (the maintainer's name appears in signed binaries, per their choice).
