### PR TITLE
feat(voice): MCP-pluggable voice (STT) for Telegram

### DIFF
--- a/app/shared/src/lib/channelKinds.ts
+++ b/app/shared/src/lib/channelKinds.ts
@@ -114,6 +114,28 @@ export const KIND_DEFS: KindDef[] = [
         placeholder: '3500 (blank = 3500, 0 = unlimited)',
         hint: 'Caps how much of the agent’s reply is sent before it’s trimmed with a “…(truncated)” note. Blank uses the 3500 default (~one message); set 0 to send the whole reply, split across multiple messages.',
       },
+      {
+        name: 'voice_mcp_server',
+        label: 'Voice provider (MCP server id)',
+        type: 'text',
+        optional: true,
+        placeholder: 'deepgram-default',
+        hint: 'Id of an installed MCP server that implements voice/transcribe and/or voice/synthesize (see docs/mcp-voice.md). Install one via Plugins → MCP Servers. Leave blank to disable voice.',
+      },
+      {
+        name: 'voice_transcription_enabled',
+        label: 'Voice notes → text',
+        type: 'boolean',
+        default: false,
+        hint: 'When on, voice messages sent to the bot are transcribed via the MCP voice provider above and forwarded to the session as text.',
+      },
+      {
+        name: 'voice_reply_enabled',
+        label: 'Voice reply (TTS)',
+        type: 'boolean',
+        default: false,
+        hint: 'When on, the bot replies with a synthesized voice note. Requires the MCP voice provider to implement voice/synthesize. Not yet wired in this release — toggle has no effect until the outbound voice path lands.',
+      },
     ],
   },
   {

--- a/docs/mcp-voice.md
+++ b/docs/mcp-voice.md
@@ -1,0 +1,154 @@
+# Voice tool contract for MCP servers
+
+Opendray treats voice (STT + TTS) as a pluggable capability delivered
+through MCP servers. **No voice-provider code ships in the Opendray
+binary.** Operators install an MCP server that implements the contract
+below; channels reference that server by name and call its tools.
+
+This document is the contract. Anyone can implement it.
+
+## Why MCP
+
+Opendray already has the install/delete plugin model (`internal/mcp/`):
+servers are vault-stored, support `${SECRET}` placeholders, can run as
+stdio subprocesses or remote HTTP. Reusing it for voice gives operators
+one mental model instead of two.
+
+When a third-party voice service's API URL changes, or the operator
+swaps Deepgram for ElevenLabs, **the Opendray binary stays unchanged**.
+Only the MCP server package is updated or replaced.
+
+## Tools
+
+A voice MCP server **MAY** implement either or both of the following
+tools. Channels detect support by listing the server's tools (standard
+MCP `tools/list` call) and matching names exactly.
+
+### `voice/transcribe` — speech-to-text
+
+**Input:**
+
+```jsonc
+{
+  "audio_b64": "string",        // required — base64-encoded audio bytes
+  "mime_type": "string",        // required — e.g. "audio/ogg", "audio/wav", "audio/mpeg"
+  "language_hint": "string?",   // BCP-47 tag ("en", "fr-CA"); server may auto-detect
+  "model_hint":    "string?"    // server-specific model preference; server may ignore
+}
+```
+
+`audio_b64` is the entire payload base64-encoded. Opendray caps inbound
+voice notes at 5 MB raw (≈6.7 MB base64) to keep tool-call latency
+bounded. Servers SHOULD reject anything larger with `audio_too_large`.
+
+**Output:**
+
+```jsonc
+{
+  "text":       "string",       // required — the transcript (may be "")
+  "language":   "string?",      // BCP-47 detected language, if known
+  "confidence": "number?",      // 0.0..1.0, if available
+  "duration_ms": "number?"      // total audio duration, if known
+}
+```
+
+Empty `text` means "no speech detected" — Opendray treats this as a
+silent drop, not an error.
+
+### `voice/synthesize` — text-to-speech
+
+**Input:**
+
+```jsonc
+{
+  "text":   "string",           // required
+  "format": "string",           // required — "ogg-opus" | "mp3" | "wav" (server may add more)
+  "voice":  "string?",          // server-specific voice id (e.g. "aura-2-thalia-en")
+  "speed":  "number?"           // 0.5..2.0; 1.0 = default
+}
+```
+
+**Output:**
+
+```jsonc
+{
+  "audio_b64":   "string",      // required — base64-encoded audio bytes
+  "mime_type":   "string",      // required — e.g. "audio/ogg;codecs=opus"
+  "duration_ms": "number?"      // synthesized clip length, if known
+}
+```
+
+Opendray will reject audio_b64 larger than 5 MB to keep Telegram
+`sendVoice` happy (the platform's voice-note waveform render caps at
+~1 MB; documents go up to 50 MB but lose the voice-note UX).
+
+## Error model
+
+Tool calls follow standard MCP error semantics. A server SHOULD surface
+these `code` strings in `error.data.code` so channels can render
+appropriate user-facing messages:
+
+| `code`                | Meaning                                      | Opendray's response       |
+|-----------------------|----------------------------------------------|---------------------------|
+| `auth_failed`         | API key missing / invalid / quota exhausted  | "Voice unavailable — check provider auth." |
+| `audio_too_large`     | Payload exceeds the server's accepted size   | "Voice note too long — try shorter." |
+| `unsupported_format`  | mime_type / output format not handled        | "Unsupported audio format." |
+| `language_unsupported`| Detected/hinted language not supported       | "Language not supported." |
+| `provider_unavailable`| Upstream third party is down or rate-limited | "Voice service temporarily down." |
+
+Any other error is logged and surfaced as the generic
+"Couldn't process that voice note" reply.
+
+## Discovery
+
+Opendray's existing MCP loader (`internal/mcp/mcp.go`) lists every
+server installed under `<vault>/mcp/`. The channel admin UI filters
+the list to servers whose `tools/list` includes one or both voice
+tool names, and presents them as the **Voice provider** dropdown on
+each channel's config form.
+
+A server registers itself by being installed into the vault — same
+mechanism as any other MCP server. No additional manifest is required.
+
+## Channel configuration
+
+A channel that wants voice references a server by name and toggles
+which capabilities it uses:
+
+```jsonc
+{
+  "voice_mcp_server":            "deepgram-default",  // matches the server's id in the vault
+  "voice_transcription_enabled": true,                 // requires the server to expose voice/transcribe
+  "voice_reply_enabled":         false                 // requires the server to expose voice/synthesize
+}
+```
+
+`voice_mcp_server` empty / absent = voice off (default). Toggling a
+capability for which the bound server has no tool is a no-op with a
+logged warning.
+
+## Reference implementation
+
+`@opendray/voice-deepgram` (separate repo, published to npm) is a
+stdio MCP server that implements both tools against the Deepgram REST
+API:
+
+- `voice/transcribe` → POST `/v1/listen` (Nova-3, language=multi,
+  smart_format)
+- `voice/synthesize` → POST `/v1/speak` (Aura-2)
+
+Operators install it via the Plugins page (or `pnpm install -g`); the
+Deepgram API key is supplied via Opendray's secrets file using a
+`${DEEPGRAM_API_KEY}` placeholder in the server's `mcp.json`.
+
+The reference implementation is one supported option, not the only
+one. A community-maintained Whisper-local server, an ElevenLabs
+server, an AssemblyAI server, etc., all conform to the same contract
+and interoperate without Opendray changes.
+
+## Versioning
+
+This contract is `voice-mcp/1`. Backwards-incompatible changes go in
+`voice-mcp/2` with a separate document and a deprecation window. Servers
+MAY advertise the contract version they implement in their MCP
+`serverInfo.version` field; Opendray treats absence as "1".

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -236,7 +236,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	// this layer rather than internal/channel so the channel package
 	// stays free of the session dependency. The matching idle-card
 	// buttons (Resume / End) emit the same `cmd:/...` payloads.
-	registerChannelCommands(channelHub, sessionMgr)
+	registerChannelCommands(channelHub, sessionMgr, cat, cliacctSvc)
 	// Optional single-owner gate: when OPENDRAY_CONTROL_OWNER is set to
 	// a Telegram user id, only that account may interact with the bot at
 	// all — send text to a session, run commands, or tap controls.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -29,7 +29,7 @@ import (
 	_ "github.com/opendray/opendray-v2/internal/channel/discord"  // register kind=discord
 	_ "github.com/opendray/opendray-v2/internal/channel/feishu"   // register kind=feishu
 	_ "github.com/opendray/opendray-v2/internal/channel/slack"    // register kind=slack
-	_ "github.com/opendray/opendray-v2/internal/channel/telegram" // register kind=telegram
+	"github.com/opendray/opendray-v2/internal/channel/telegram"   // registers kind=telegram via init() + voice service handoff
 	_ "github.com/opendray/opendray-v2/internal/channel/wechat"   // register kind=wechat (wxpusher push)
 	_ "github.com/opendray/opendray-v2/internal/channel/wecom"    // register kind=wecom
 	"github.com/opendray/opendray-v2/internal/cliacct"
@@ -63,6 +63,7 @@ import (
 	"github.com/opendray/opendray-v2/internal/store"
 	vaultgit "github.com/opendray/opendray-v2/internal/vaultgit"
 	"github.com/opendray/opendray-v2/internal/version"
+	"github.com/opendray/opendray-v2/internal/voice"
 )
 
 type App struct {
@@ -164,6 +165,14 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		log.Info("mcp registry loaded", "count", len(list),
 			"vault", mcpLoader.VaultRoot(), "secrets", secretsFile)
 	}
+
+	// Voice service: channels (Telegram today, web duplex later) call
+	// MCP voice servers — Deepgram / ElevenLabs / Whisper-local /
+	// whatever the operator installed — through this facade. The
+	// servers themselves are vault entries; no third-party code is
+	// compiled into Opendray. See docs/mcp-voice.md.
+	voiceSvc := voice.NewService(mcpLoader, secretsFile, log)
+	telegram.SetVoiceService(voiceSvc)
 
 	var sessionOpts []session.ManagerOption
 	if d := cfg.Session.Threshold(); d > 0 {

--- a/internal/app/channel_commands.go
+++ b/internal/app/channel_commands.go
@@ -10,7 +10,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/opendray/opendray-v2/internal/catalog"
 	"github.com/opendray/opendray-v2/internal/channel"
+	"github.com/opendray/opendray-v2/internal/cliacct"
 	"github.com/opendray/opendray-v2/internal/session"
 )
 
@@ -50,6 +52,8 @@ type sessionOps interface {
 	List(ctx context.Context) ([]session.Session, error)
 	Start(ctx context.Context, id string) (session.Session, error)
 	Stop(ctx context.Context, id string) error
+	// Create spawns a brand new session — backs /new.
+	Create(ctx context.Context, req session.CreateRequest) (session.Session, error)
 	// RecentSnippet is the live, notification-grade preview of a
 	// running session's latest output (backs /peek). "" when not live.
 	RecentSnippet(id string) string
@@ -73,7 +77,22 @@ type sessionOps interface {
 //     inline button on the idle card as well)
 //   - /resume <id>    — re-spawn a stopped/ended session under the
 //     same id (used by the Resume inline button)
-func registerChannelCommands(hub *channel.Hub, mgr sessionOps) {
+//
+// providerLister is the narrow slice of catalog.Catalog the /new
+// command needs to enumerate which AI CLI providers the operator can
+// pick from.
+type providerLister interface {
+	List(ctx context.Context) ([]catalog.Provider, error)
+}
+
+// accountLister is the narrow slice of cliacct.Service the /new
+// command needs to enumerate Claude accounts (multi-account
+// selection lives only on the claude provider today).
+type accountLister interface {
+	List(ctx context.Context) ([]cliacct.Account, error)
+}
+
+func registerChannelCommands(hub *channel.Hub, mgr sessionOps, providers providerLister, accounts accountLister) {
 	hub.RegisterCommand(channel.Command{
 		Name:        "list",
 		Description: "List active sessions",
@@ -129,6 +148,20 @@ func registerChannelCommands(hub *channel.Hub, mgr sessionOps) {
 			CardHandler: panelCardHandler(mgr),
 		})
 	}
+
+	// /new spawns a fresh session from chat with provider (and Claude
+	// account) selection. Auto-pins the new session so the operator can
+	// start typing immediately. Three callable shapes:
+	//   /new                         → provider picker
+	//   /new claude                  → Claude account picker
+	//   /new <provider> [<account>]  → spawn + auto-select
+	hub.RegisterCommand(channel.Command{
+		Name:                 "new",
+		Description:          "Start a new session (provider picker)",
+		Source:               "builtin",
+		CardHandler:          newSessionCardHandler(mgr, providers, accounts),
+		DocksControlKeyboard: true,
+	})
 }
 
 // panelCardHandler renders the control-panel home: the session list
@@ -525,5 +558,209 @@ func relativeAge(ts, now time.Time) string {
 		return fmt.Sprintf("%dh ago", int(d/time.Hour))
 	default:
 		return fmt.Sprintf("%dd ago", int(d/(24*time.Hour)))
+	}
+}
+
+// newSessionCwd is the cwd we hand to mgr.Create when /new is invoked
+// from chat. Chat operators don't have a project context handy and
+// the gateway data dir is a sensible neutral default (matches what
+// the REST handler falls back to when the client omits cwd).
+const newSessionCwd = "/var/lib/opendray"
+
+// newSessionCardHandler implements /new — a three-step pick-spawn-pin
+// flow over chat buttons:
+//
+//	(1) /new                       → card of enabled providers
+//	(2) /new claude                → card of enabled Claude accounts
+//	(3) /new <provider> [<acc>]    → spawn + auto-pin
+//
+// Providers other than claude skip step 2 since multi-account today
+// only exists for claude. The card returned by each step is the same
+// shape as /panel's, so Telegram (and other CardSender channels)
+// render tap-to-act buttons natively.
+func newSessionCardHandler(mgr sessionOps, providers providerLister, accounts accountLister) channel.CommandCardHandler {
+	return func(ctx context.Context, cc channel.CommandContext) (*channel.Card, error) {
+		args := cc.Args
+
+		// Step 1 — provider picker
+		if len(args) == 0 {
+			return providerPickerCard(ctx, providers)
+		}
+
+		providerID := strings.ToLower(args[0])
+
+		// Step 2 — Claude account picker (only when an account isn't
+		// already supplied)
+		if providerID == "claude" && len(args) == 1 {
+			return claudeAccountPickerCard(ctx, accounts)
+		}
+
+		// Step 3 — spawn + auto-pin
+		req := session.CreateRequest{
+			ProviderID: providerID,
+			Cwd:        newSessionCwd,
+		}
+		if providerID == "claude" && len(args) >= 2 {
+			// "auto" is the picker's sentinel for "let
+			// PickAutoAssignClaudeAccount choose" — Manager.Create
+			// treats an empty ClaudeAccountID the same way.
+			if args[1] != "auto" {
+				req.ClaudeAccountID = args[1]
+			}
+		}
+		sess, err := mgr.Create(ctx, req)
+		if err != nil {
+			return errorCard(fmt.Sprintf("Couldn't start %s session", providerID), err.Error()), nil
+		}
+
+		// Pin the new session to this chat so the operator can start
+		// typing immediately — the whole point of /new vs. opening the
+		// dashboard, hand-rolling, and then /select-ing.
+		chID := ""
+		if cc.Channel != nil {
+			chID = cc.Channel.ID()
+		}
+		if cc.Hub != nil && chID != "" {
+			cc.Hub.SetActiveSession(chID, sess.ID)
+		}
+
+		return newSessionStartedCard(sess), nil
+	}
+}
+
+// providerPickerCard renders the row of provider buttons for step 1
+// of /new. Order matches catalog.List (manifest-declared order); only
+// enabled providers are surfaced.
+func providerPickerCard(ctx context.Context, providers providerLister) (*channel.Card, error) {
+	if providers == nil {
+		return errorCard("Provider list unavailable", "no provider catalog wired"), nil
+	}
+	list, err := providers.List(ctx)
+	if err != nil {
+		return errorCard("Provider list unavailable", err.Error()), nil
+	}
+	row := make([]channel.ButtonOption, 0, len(list))
+	for _, p := range list {
+		if !p.Enabled {
+			continue
+		}
+		label := p.Manifest.DisplayName
+		if label == "" {
+			label = p.Manifest.ID
+		}
+		row = append(row, channel.ButtonOption{
+			Text:  label,
+			Value: "cmd:/new " + p.Manifest.ID,
+		})
+	}
+	if len(row) == 0 {
+		return &channel.Card{Elements: []channel.CardElement{
+			channel.CardMarkdown{Content: "No providers enabled. Configure one in the dashboard first."},
+		}}, nil
+	}
+	return &channel.Card{
+		Header: &channel.CardHeader{Title: "🆕 Start a new session"},
+		Elements: []channel.CardElement{
+			channel.CardMarkdown{Content: "Pick a provider:"},
+			channel.CardActions{Buttons: [][]channel.ButtonOption{row}},
+		},
+	}, nil
+}
+
+// claudeAccountPickerCard renders the Claude account row for step 2.
+// One button per enabled account, labelled with the account's display
+// name or id. The "auto-assign" option uses an empty account id so
+// Manager.Create falls back to PickAutoAssignClaudeAccount.
+func claudeAccountPickerCard(ctx context.Context, accounts accountLister) (*channel.Card, error) {
+	if accounts == nil {
+		// No Claude account service wired — fall through to auto-assign
+		// without offering a picker, so the operator still gets a Claude
+		// session.
+		return &channel.Card{
+			Header: &channel.CardHeader{Title: "🆕 Claude session"},
+			Elements: []channel.CardElement{
+				channel.CardMarkdown{Content: "Starting with the auto-assigned account…"},
+				channel.CardActions{Buttons: [][]channel.ButtonOption{{
+					{Text: "▶ Start", Value: "cmd:/new claude auto", Style: "primary"},
+				}}},
+			},
+		}, nil
+	}
+	list, err := accounts.List(ctx)
+	if err != nil {
+		return errorCard("Account list unavailable", err.Error()), nil
+	}
+	row := make([]channel.ButtonOption, 0, len(list)+1)
+	row = append(row, channel.ButtonOption{
+		Text:  "⚖ auto",
+		Value: "cmd:/new claude auto",
+		Style: "primary",
+	})
+	for _, a := range list {
+		if !a.Enabled {
+			continue
+		}
+		label := a.DisplayName
+		if label == "" {
+			label = a.Name
+		}
+		if label == "" {
+			label = a.ID
+		}
+		row = append(row, channel.ButtonOption{
+			Text:  label,
+			Value: "cmd:/new claude " + a.ID,
+		})
+	}
+	// Telegram's inline keyboard supports ~8 buttons per row; chunk
+	// into rows of 4 so long account lists stay readable.
+	const perRow = 4
+	rows := make([][]channel.ButtonOption, 0, (len(row)+perRow-1)/perRow)
+	for i := 0; i < len(row); i += perRow {
+		end := i + perRow
+		if end > len(row) {
+			end = len(row)
+		}
+		rows = append(rows, row[i:end])
+	}
+	return &channel.Card{
+		Header: &channel.CardHeader{Title: "🆕 Pick a Claude account"},
+		Elements: []channel.CardElement{
+			channel.CardMarkdown{Content: "Which account?"},
+			channel.CardActions{Buttons: rows},
+		},
+	}, nil
+}
+
+// newSessionStartedCard is the success reply after /new completes
+// step 3. The session is already pinned by the time this card is
+// returned, so the body just confirms the chat is bound and the
+// next inbound text will go to it.
+func newSessionStartedCard(sess session.Session) *channel.Card {
+	label := sessionLabel(sess)
+	return &channel.Card{
+		Header: &channel.CardHeader{Title: "✅ New session started", Color: "green"},
+		Elements: []channel.CardElement{
+			channel.CardMarkdown{Content: fmt.Sprintf(
+				"%s is live and pinned to this chat. Just type to start the conversation.",
+				label,
+			)},
+			channel.CardActions{Buttons: [][]channel.ButtonOption{{
+				{Text: "📋 Sessions", Value: "cmd:/panel"},
+				{Text: "⏹ End", Value: "cmd:/end " + sess.ID, Style: "danger"},
+			}}},
+		},
+	}
+}
+
+// errorCard formats a one-shot failure card with a friendly title and
+// the underlying error tucked into the body — operators get to see
+// what went wrong without leaving the chat.
+func errorCard(title, detail string) *channel.Card {
+	return &channel.Card{
+		Header: &channel.CardHeader{Title: title, Color: "red"},
+		Elements: []channel.CardElement{
+			channel.CardMarkdown{Content: detail},
+		},
 	}
 }

--- a/internal/app/channel_commands_test.go
+++ b/internal/app/channel_commands_test.go
@@ -44,6 +44,9 @@ func (f *fakeSessionOps) Start(_ context.Context, id string) (session.Session, e
 	f.startCalls = append(f.startCalls, id)
 	return f.startResp, f.startErr
 }
+func (f *fakeSessionOps) Create(_ context.Context, _ session.CreateRequest) (session.Session, error) {
+	return session.Session{}, nil
+}
 func (f *fakeSessionOps) RecentSnippet(id string) string {
 	return f.snippet[id]
 }

--- a/internal/channel/telegram/telegram.go
+++ b/internal/channel/telegram/telegram.go
@@ -209,6 +209,11 @@ func (t *Telegram) Send(ctx context.Context, msg channel.ChannelMessage) error {
 		return err
 	}
 	t.recordHandle(&msg, resp.Result.MessageID)
+	// Voice reply augmentation — when the channel has voice_reply_enabled
+	// and a bound MCP voice provider, synthesize msg.Text and post it
+	// as a voice note alongside the text. Best-effort: any failure is
+	// logged but the text reply (already delivered above) stands.
+	t.maybeVoiceReply(ctx, msg)
 	return nil
 }
 
@@ -269,6 +274,10 @@ func (t *Telegram) SendCard(ctx context.Context, msg channel.ChannelMessage, car
 		lastID = resp.Result.MessageID
 	}
 	t.recordHandle(&msg, lastID)
+	// Voice reply augmentation — see Send's note. Uses the card's
+	// rendered plain text (msg.Text set by the Hub in deliverTurnReply)
+	// rather than the HTML chunk body so TTS gets clean prose.
+	t.maybeVoiceReply(ctx, msg)
 	return nil
 }
 

--- a/internal/channel/telegram/telegram.go
+++ b/internal/channel/telegram/telegram.go
@@ -55,6 +55,14 @@ func init() {
 type config struct {
 	BotToken string `json:"bot_token"`
 	ChatID   int64  `json:"chat_id"`
+
+	// Voice config — references an MCP server installed under the
+	// vault (internal/mcp). No credentials live here; the MCP server's
+	// own mcp.json holds the API key behind a ${SECRET} placeholder.
+	// See docs/mcp-voice.md for the tool contract.
+	VoiceMCPServer            string `json:"voice_mcp_server,omitempty"`
+	VoiceTranscriptionEnabled bool   `json:"voice_transcription_enabled,omitempty"`
+	VoiceReplyEnabled         bool   `json:"voice_reply_enabled,omitempty"`
 }
 
 // Telegram implements channel.Channel + several capability interfaces.
@@ -498,18 +506,67 @@ func (t *Telegram) deliverMessage(ctx context.Context, inbound channel.InboundFu
 	if m.ReplyToMessage != nil && m.ReplyToMessage.MessageID != 0 {
 		meta["reply_to_outbound_msg_id"] = strconv.Itoa(m.ReplyToMessage.MessageID)
 	}
+
+	text := m.Text
+
+	// Voice notes route through the channel's bound MCP voice provider
+	// (docs/mcp-voice.md). Substitute the empty Text with the transcript
+	// before handing off to the Hub so everything downstream — session
+	// routing, persistence, reply detection — sees a normal text message.
+	// Failure modes are surfaced as friendly chat replies; we never let
+	// a voice note silently disappear.
+	if m.Voice != nil && text == "" {
+		if !t.cfg.VoiceTranscriptionEnabled {
+			t.replyVoiceError(ctx, rc, "Voice messages aren't enabled for this bot. Send text instead.")
+			return
+		}
+		transcript, err := t.transcribeVoice(ctx, m.Voice)
+		if err != nil {
+			t.log.Warn("voice transcription failed", "err", err, "duration_s", m.Voice.Duration)
+			t.replyVoiceError(ctx, rc, "Couldn't transcribe that voice note — try again or send text.")
+			return
+		}
+		if transcript == "" {
+			// Server reported no speech detected — silent drop on
+			// Telegram side is the least surprising response.
+			return
+		}
+		text = transcript
+		meta["transcribed_by"] = "voice-mcp"
+		meta["voice_mcp_server"] = t.cfg.VoiceMCPServer
+		meta["voice_duration_s"] = m.Voice.Duration
+	}
+
 	msg := channel.ChannelMessage{
 		ChannelID:      t.id,
 		Direction:      channel.DirectionInbound,
 		ConversationID: strconv.FormatInt(m.Chat.ID, 10),
 		Author:         m.From.username(),
-		Text:           m.Text,
+		Text:           text,
 		Timestamp:      time.Unix(m.Date, 0).UTC(),
 		ReplyCtx:       rc,
 		Metadata:       meta,
 	}
 	if err := inbound(ctx, msg); err != nil {
 		t.log.Error("inbound handler failed", "err", err)
+	}
+}
+
+// replyVoiceError sends a one-shot apology back to the chat when the
+// voice path can't deliver — disabled, transcription error, empty
+// transcript with no-speech detected, etc. Best-effort: a send failure
+// here is logged but doesn't escalate, since we're already on an
+// error branch.
+func (t *Telegram) replyVoiceError(ctx context.Context, rc ReplyCtx, text string) {
+	body := map[string]any{
+		"chat_id": rc.ChatID,
+		"text":    text,
+	}
+	if rc.MessageID != 0 {
+		body["reply_parameters"] = map[string]any{"message_id": rc.MessageID}
+	}
+	if err := t.callAPI(ctx, "sendMessage", body, nil); err != nil {
+		t.log.Warn("voice error reply failed", "err", err)
 	}
 }
 
@@ -677,6 +734,17 @@ type tgMessage struct {
 	Date           int64      `json:"date"`
 	Text           string     `json:"text"`
 	ReplyToMessage *tgMessage `json:"reply_to_message,omitempty"`
+	Voice          *tgVoice   `json:"voice,omitempty"`
+}
+
+// tgVoice is Telegram's voice-note payload — OGG/Opus by default.
+// FileID is the opaque handle the getFile API resolves to a download
+// path; Duration is whole seconds; MimeType is normally "audio/ogg".
+type tgVoice struct {
+	FileID   string `json:"file_id"`
+	Duration int    `json:"duration"`
+	MimeType string `json:"mime_type,omitempty"`
+	FileSize int64  `json:"file_size,omitempty"`
 }
 
 type tgCallbackQuery struct {

--- a/internal/channel/telegram/telegram.go
+++ b/internal/channel/telegram/telegram.go
@@ -147,6 +147,7 @@ func (t *Telegram) publishCommands(ctx context.Context) {
 	}
 	cmds := []tgCmd{
 		{Command: "panel", Description: "Control panel — sessions + actions"},
+		{Command: "new", Description: "Start a new session (provider picker)"},
 		{Command: "list", Description: "List active sessions"},
 		{Command: "peek", Description: "Re-send the selected session's latest output"},
 		{Command: "help", Description: "List available commands"},

--- a/internal/channel/telegram/voice.go
+++ b/internal/channel/telegram/voice.go
@@ -1,0 +1,129 @@
+package telegram
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/opendray/opendray-v2/internal/voice"
+)
+
+// voiceSvc is the package-level handle. The app sets it at startup
+// (after the voice service is constructed); a nil value means voice
+// is unavailable and any voice-note inbound will surface a friendly
+// "voice not configured" reply.
+var (
+	voiceMu  sync.RWMutex
+	voiceSvc *voice.Service
+)
+
+// SetVoiceService is called once by the gateway wiring to hand the
+// Telegram channel its voice service. Safe to call before any
+// channels start; if called later, only voice notes that arrive
+// afterwards pick it up.
+func SetVoiceService(s *voice.Service) {
+	voiceMu.Lock()
+	voiceSvc = s
+	voiceMu.Unlock()
+}
+
+func currentVoiceService() *voice.Service {
+	voiceMu.RLock()
+	defer voiceMu.RUnlock()
+	return voiceSvc
+}
+
+const maxVoiceDownload = 5 * 1024 * 1024
+
+// downloadVoiceFile fetches the OGG blob behind a Telegram file_id.
+// Returns the raw bytes + the platform-reported content-type. The
+// bounded read guards against a runaway upload; Telegram's own voice
+// notes are well under this cap.
+func (t *Telegram) downloadVoiceFile(ctx context.Context, fileID string) ([]byte, string, error) {
+	var resp struct {
+		Ok     bool `json:"ok"`
+		Result struct {
+			FilePath string `json:"file_path"`
+			FileSize int64  `json:"file_size"`
+		} `json:"result"`
+	}
+	if err := t.callAPI(ctx, "getFile", map[string]any{"file_id": fileID}, &resp); err != nil {
+		return nil, "", fmt.Errorf("getFile: %w", err)
+	}
+	if !resp.Ok || resp.Result.FilePath == "" {
+		return nil, "", errors.New("getFile: empty file_path")
+	}
+
+	// Telegram file CDN URLs are bot-scoped and contain the token.
+	// apiBase ends in "bot"; strip it to compose the file CDN prefix.
+	dlURL := strings.TrimSuffix(apiBase(), "bot") + "file/bot" +
+		url.PathEscape(t.cfg.BotToken) + "/" + resp.Result.FilePath
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dlURL, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	httpResp, err := t.client.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer httpResp.Body.Close()
+	if httpResp.StatusCode/100 != 2 {
+		return nil, "", fmt.Errorf("download: HTTP %d", httpResp.StatusCode)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(httpResp.Body, maxVoiceDownload+1))
+	if err != nil {
+		return nil, "", err
+	}
+	if int64(len(data)) > maxVoiceDownload {
+		return nil, "", fmt.Errorf("download: payload exceeds %d bytes", maxVoiceDownload)
+	}
+	return data, httpResp.Header.Get("Content-Type"), nil
+}
+
+// transcribeVoice runs the inbound voice-note pipeline: download from
+// Telegram, hand the audio bytes off to the bound MCP voice provider,
+// return the transcript text.
+//
+// Errors are wrapped with enough context for log diagnosis; the caller
+// is responsible for picking the user-facing chat message.
+func (t *Telegram) transcribeVoice(ctx context.Context, v *tgVoice) (string, error) {
+	if v == nil || v.FileID == "" {
+		return "", errors.New("voice: empty file_id")
+	}
+	svc := currentVoiceService()
+	if svc == nil {
+		return "", errors.New("voice: service not wired")
+	}
+	if t.cfg.VoiceMCPServer == "" {
+		return "", errors.New("voice: no provider configured")
+	}
+
+	provider, err := svc.ResolveProvider(ctx, t.cfg.VoiceMCPServer)
+	if err != nil {
+		return "", fmt.Errorf("voice: resolve provider %q: %w", t.cfg.VoiceMCPServer, err)
+	}
+
+	body, mime, err := t.downloadVoiceFile(ctx, v.FileID)
+	if err != nil {
+		return "", fmt.Errorf("voice: download: %w", err)
+	}
+	if mime == "" {
+		mime = v.MimeType
+	}
+	if mime == "" {
+		mime = "audio/ogg"
+	}
+
+	transcript, err := provider.Transcribe(ctx, body, mime)
+	if err != nil {
+		return "", fmt.Errorf("voice: transcribe: %w", err)
+	}
+	return strings.TrimSpace(transcript.Text), nil
+}

--- a/internal/channel/telegram/voice_reply.go
+++ b/internal/channel/telegram/voice_reply.go
@@ -1,0 +1,167 @@
+package telegram
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"strconv"
+	"strings"
+
+	"github.com/opendray/opendray-v2/internal/channel"
+	"github.com/opendray/opendray-v2/internal/voice"
+)
+
+// voiceReplyMaxChars caps how much of an agent reply we hand to TTS.
+// Aura-2 OGG/Opus at ~24 kbps fits ~5 minutes in 1 MB; Telegram's
+// sendVoice waveform UI requires ≤1 MB. Conservative cap keeps us
+// safely inside both bounds and keeps synth latency low.
+const voiceReplyMaxChars = 800
+
+// maybeVoiceReply synthesizes msg.Text via the channel's configured
+// MCP voice provider and posts it as a Telegram voice note alongside
+// the existing text reply. Best-effort — failures are logged and the
+// caller keeps going with its normal text path, so a flaky TTS
+// provider never silently drops the reply.
+func (t *Telegram) maybeVoiceReply(ctx context.Context, msg channel.ChannelMessage) {
+	if !t.cfg.VoiceReplyEnabled {
+		return
+	}
+	if t.cfg.VoiceMCPServer == "" {
+		return
+	}
+
+	body := strings.TrimSpace(stripVoiceUnfriendly(msg.Text))
+	if body == "" {
+		return
+	}
+	if len([]rune(body)) > voiceReplyMaxChars {
+		t.log.Debug("voice reply skipped — text exceeds cap",
+			"len_runes", len([]rune(body)), "cap", voiceReplyMaxChars)
+		return
+	}
+
+	svc := currentVoiceService()
+	if svc == nil {
+		return
+	}
+	provider, err := svc.ResolveProvider(ctx, t.cfg.VoiceMCPServer)
+	if err != nil {
+		t.log.Warn("voice reply: resolve provider failed",
+			"server", t.cfg.VoiceMCPServer, "err", err)
+		return
+	}
+
+	audio, err := provider.Synthesize(ctx, body, voice.SynthesizeOpts{Format: "ogg-opus"})
+	if err != nil {
+		t.log.Warn("voice reply: synthesize failed",
+			"server", t.cfg.VoiceMCPServer, "err", err)
+		return
+	}
+	if len(audio.Body) == 0 {
+		return
+	}
+
+	chatID, replyTo := t.routing(msg)
+	if chatID == 0 {
+		return
+	}
+
+	if err := t.sendVoiceMultipart(ctx, chatID, replyTo, audio.Body, audio.MimeType); err != nil {
+		t.log.Warn("voice reply: sendVoice failed",
+			"server", t.cfg.VoiceMCPServer, "err", err)
+		return
+	}
+}
+
+// sendVoiceMultipart posts an OGG/Opus blob to Telegram's sendVoice
+// endpoint as a multipart upload. Telegram renders the file with its
+// native voice-note UI (waveform + duration) when:
+//   - mime is audio/ogg with Opus codec
+//   - file size ≤ 1 MB
+//
+// We don't enforce those here — the caller (maybeVoiceReply) is
+// responsible for staying inside the cap, and the Telegram API will
+// reject the rest with a clear error if it doesn't fit.
+func (t *Telegram) sendVoiceMultipart(ctx context.Context, chatID int64, replyTo int, audio []byte, mime string) error {
+	if mime == "" {
+		mime = "audio/ogg"
+	}
+
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+
+	if err := w.WriteField("chat_id", strconv.FormatInt(chatID, 10)); err != nil {
+		return err
+	}
+	if replyTo != 0 {
+		// reply_parameters as a JSON-encoded form field — Telegram
+		// accepts JSON sub-objects this way on multipart requests.
+		if err := w.WriteField("reply_parameters",
+			fmt.Sprintf(`{"message_id":%d}`, replyTo)); err != nil {
+			return err
+		}
+	}
+
+	// voice field — has to declare the OGG content-type explicitly so
+	// Telegram routes it to the voice-note pipeline rather than
+	// generic audio file.
+	hdr := make(textproto.MIMEHeader)
+	hdr.Set("Content-Disposition", `form-data; name="voice"; filename="reply.ogg"`)
+	hdr.Set("Content-Type", mime)
+	part, err := w.CreatePart(hdr)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(part, bytes.NewReader(audio)); err != nil {
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+
+	url := apiBase() + t.cfg.BotToken + "/sendVoice"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, &buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("sendVoice HTTP %d: %s", resp.StatusCode, body)
+	}
+	return nil
+}
+
+// stripVoiceUnfriendly removes characters / sequences that TTS engines
+// pronounce awkwardly: control-keyboard chrome, leading session ids,
+// markdown decoration. The result is a clean prose body for synthesis.
+//
+// Anything not handled here just passes through — TTS providers
+// generally cope with light formatting, so we only strip the worst
+// offenders.
+func stripVoiceUnfriendly(in string) string {
+	out := in
+	// Drop the control-keyboard footer that the Hub appends to
+	// agent replies (e.g. "[⏸ Stop] [🔄 Restart] [🔀 Switch]").
+	if i := strings.LastIndex(out, "[⏸"); i >= 0 {
+		out = out[:i]
+	}
+	// Trim leading session-id breadcrumb if the card included one.
+	out = strings.TrimSpace(out)
+	return out
+}
+
+// ensure errors stays referenced when no other site in this file uses
+// it; keeps the import stable as the file evolves.
+var _ = errors.New

--- a/internal/voice/mcp.go
+++ b/internal/voice/mcp.go
@@ -1,0 +1,381 @@
+package voice
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/opendray/opendray-v2/internal/mcp"
+)
+
+// mcpProtocolVersion is the MCP protocol version we negotiate with the
+// server. Servers that don't recognise this respond with the version
+// they support; we accept their value and proceed.
+const mcpProtocolVersion = "2025-06-18"
+
+// Client talks JSON-RPC 2.0 over stdio to a voice MCP server. One
+// Client wraps one configured server entry from the vault; each
+// Transcribe / Synthesize call spawns the server, runs initialize +
+// tools/call, then tears it down.
+//
+// Spawn-per-call keeps the lifecycle dead simple — no long-running
+// state to manage, no zombie processes, no warm-pool tuning. Cost is
+// the per-call cold start (≈100–500 ms for a Node stdio server),
+// which is acceptable for voice-note traffic. If usage justifies it,
+// a future iteration can keep one process warm per server.
+type Client struct {
+	srv mcp.Server     // resolved server config from the vault
+	log *slog.Logger
+}
+
+// NewClient binds a Client to one MCP server entry. The Client itself
+// is stateless and safe to reuse across calls.
+func NewClient(srv mcp.Server, log *slog.Logger) *Client {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Client{srv: srv, log: log.With("voice_mcp", srv.ID)}
+}
+
+// Transcribe asks the bound server to convert audio bytes into a
+// Transcript via the voice/transcribe tool.
+func (c *Client) Transcribe(ctx context.Context, audio []byte, mime string) (Transcript, error) {
+	if len(audio) > maxAudioIn {
+		return Transcript{}, &Error{Code: "audio_too_large",
+			Message: fmt.Sprintf("audio is %d bytes; max %d", len(audio), maxAudioIn)}
+	}
+	if mime == "" {
+		mime = "audio/ogg"
+	}
+
+	args := map[string]any{
+		"audio_b64": base64.StdEncoding.EncodeToString(audio),
+		"mime_type": mime,
+	}
+	raw, err := c.call(ctx, CapTranscribe, args)
+	if err != nil {
+		return Transcript{}, err
+	}
+
+	var out struct {
+		Text       string  `json:"text"`
+		Language   string  `json:"language"`
+		Confidence float64 `json:"confidence"`
+		DurationMS int     `json:"duration_ms"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return Transcript{}, fmt.Errorf("voice: decode transcript: %w", err)
+	}
+	return Transcript{
+		Text:       out.Text,
+		Language:   out.Language,
+		Confidence: out.Confidence,
+		DurationMS: out.DurationMS,
+	}, nil
+}
+
+// Synthesize asks the bound server to convert text into audio bytes
+// via the voice/synthesize tool.
+func (c *Client) Synthesize(ctx context.Context, text string, opts SynthesizeOpts) (Audio, error) {
+	if opts.Format == "" {
+		opts.Format = "ogg-opus"
+	}
+	args := map[string]any{
+		"text":   text,
+		"format": opts.Format,
+	}
+	if opts.Voice != "" {
+		args["voice"] = opts.Voice
+	}
+	if opts.Speed != 0 {
+		args["speed"] = opts.Speed
+	}
+
+	raw, err := c.call(ctx, CapSynthesize, args)
+	if err != nil {
+		return Audio{}, err
+	}
+
+	var out struct {
+		AudioB64   string `json:"audio_b64"`
+		MimeType   string `json:"mime_type"`
+		DurationMS int    `json:"duration_ms"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return Audio{}, fmt.Errorf("voice: decode audio: %w", err)
+	}
+	body, err := base64.StdEncoding.DecodeString(out.AudioB64)
+	if err != nil {
+		return Audio{}, fmt.Errorf("voice: decode audio_b64: %w", err)
+	}
+	if len(body) > maxAudioOut {
+		return Audio{}, &Error{Code: "audio_too_large",
+			Message: fmt.Sprintf("synth output is %d bytes; max %d", len(body), maxAudioOut)}
+	}
+	return Audio{Body: body, MimeType: out.MimeType, DurationMS: out.DurationMS}, nil
+}
+
+// call runs the full stdio round trip: spawn → initialize → tools/call
+// → close. Returns the tool result's first content block (interpreted
+// as JSON text).
+func (c *Client) call(parent context.Context, tool string, args map[string]any) ([]byte, error) {
+	ctx, cancel := ctxWithCallTimeout(parent)
+	defer cancel()
+
+	if c.srv.Transport != "" && c.srv.Transport != "stdio" {
+		return nil, fmt.Errorf("voice: transport %q not supported (stdio only)", c.srv.Transport)
+	}
+	if c.srv.Command == "" {
+		return nil, errors.New("voice: server has no command")
+	}
+
+	cmd := exec.CommandContext(ctx, c.srv.Command, c.srv.Args...)
+	cmd.Env = envSlice(c.srv.Env)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("voice: stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("voice: stdout pipe: %w", err)
+	}
+	// Capture stderr for diagnostics on failure; never bubble noise
+	// back to the user as the error message.
+	var stderrBuf logCollector
+	cmd.Stderr = &stderrBuf
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("voice: start %s: %w", c.srv.Command, err)
+	}
+
+	// Make sure the subprocess gets cleaned up even if a step below
+	// returns early. CommandContext kills on ctx done; this is a
+	// belt-and-braces.
+	defer func() {
+		_ = stdin.Close()
+		_ = cmd.Wait()
+	}()
+
+	dec := json.NewDecoder(bufio.NewReader(stdout))
+	enc := json.NewEncoder(stdin)
+	// MCP framing is newline-delimited JSON; json.Encoder writes a
+	// trailing newline by default, which the server's line reader
+	// interprets as message boundary.
+
+	id := newIDGen()
+
+	// 1. initialize
+	if _, err := rpcCall(ctx, enc, dec, id.next(), "initialize", map[string]any{
+		"protocolVersion": mcpProtocolVersion,
+		"capabilities":    map[string]any{},
+		"clientInfo": map[string]any{
+			"name":    "opendray-voice",
+			"version": "0.1",
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("voice: initialize: %w (stderr: %s)", err, stderrBuf.tail())
+	}
+
+	// 2. initialized notification — no id, no response expected
+	if err := enc.Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "notifications/initialized",
+	}); err != nil {
+		return nil, fmt.Errorf("voice: send initialized: %w", err)
+	}
+
+	// 3. tools/call
+	result, err := rpcCall(ctx, enc, dec, id.next(), "tools/call", map[string]any{
+		"name":      tool,
+		"arguments": args,
+	})
+	if err != nil {
+		return nil, err // already wraps the contract error
+	}
+
+	return extractToolText(result)
+}
+
+// rpcCall sends one JSON-RPC request and waits for the matching
+// response. Notifications and out-of-order responses for other ids are
+// discarded (a voice client only has one in-flight call at a time).
+func rpcCall(ctx context.Context, enc *json.Encoder, dec *json.Decoder, id int, method string, params any) (json.RawMessage, error) {
+	req := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"method":  method,
+		"params":  params,
+	}
+	if err := enc.Encode(req); err != nil {
+		return nil, fmt.Errorf("send %s: %w", method, err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		var resp struct {
+			JSONRPC string          `json:"jsonrpc"`
+			ID      *int            `json:"id"`
+			Result  json.RawMessage `json:"result"`
+			Error   *struct {
+				Code    int             `json:"code"`
+				Message string          `json:"message"`
+				Data    json.RawMessage `json:"data"`
+			} `json:"error"`
+			Method string `json:"method"`
+		}
+		if err := dec.Decode(&resp); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil, fmt.Errorf("%s: server exited", method)
+			}
+			return nil, fmt.Errorf("%s: read: %w", method, err)
+		}
+		// Server-initiated notification — ignore and keep reading.
+		if resp.ID == nil {
+			continue
+		}
+		if *resp.ID != id {
+			// Stale response from a previous call (shouldn't happen in
+			// our one-call lifecycle, but be tolerant).
+			continue
+		}
+		if resp.Error != nil {
+			return nil, decodeContractError(resp.Error.Code, resp.Error.Message, resp.Error.Data)
+		}
+		return resp.Result, nil
+	}
+}
+
+// extractToolText pulls the first text content block out of a
+// tools/call result. MCP tool results are wrapped as:
+//
+//	{ "content": [ { "type": "text", "text": "<json>" } ] }
+//
+// We expect the server to put the JSON-encoded result into the text
+// field, since voice tools return structured data not chat content.
+func extractToolText(result json.RawMessage) ([]byte, error) {
+	var wrap struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		IsError bool `json:"isError"`
+	}
+	if err := json.Unmarshal(result, &wrap); err != nil {
+		return nil, fmt.Errorf("voice: parse tools/call result: %w", err)
+	}
+	if wrap.IsError {
+		// Tool reported a logical failure inside a success envelope.
+		// Best effort: decode the text as a contract error.
+		for _, b := range wrap.Content {
+			if b.Type == "text" {
+				return nil, decodeContractError(0, b.Text, nil)
+			}
+		}
+		return nil, &Error{Code: "provider_unavailable", Message: "tool returned isError without text"}
+	}
+	for _, b := range wrap.Content {
+		if b.Type == "text" {
+			return []byte(b.Text), nil
+		}
+	}
+	return nil, errors.New("voice: tools/call result has no text content")
+}
+
+// decodeContractError reads a JSON-RPC error and maps it into the
+// voice contract's well-known codes when possible.
+func decodeContractError(rpcCode int, message string, data json.RawMessage) error {
+	out := &Error{Message: message}
+	if len(data) > 0 {
+		var d struct {
+			Code string `json:"code"`
+		}
+		if err := json.Unmarshal(data, &d); err == nil {
+			out.Code = d.Code
+		}
+	}
+	if out.Code == "" && rpcCode != 0 {
+		// Map common JSON-RPC codes to contract codes.
+		switch rpcCode {
+		case -32601: // method not found
+			out.Code = "unsupported_format"
+		case -32602: // invalid params
+			out.Code = "unsupported_format"
+		default:
+			out.Code = "provider_unavailable"
+		}
+	}
+	return out
+}
+
+// envSlice flattens a name→value map into the os/exec format. Keeps
+// only the explicitly configured vars — the MCP server does not inherit
+// Opendray's process env, matching the catalog adapter's behavior at
+// session spawn (no accidental credential leakage into a sandboxed
+// subprocess).
+func envSlice(m map[string]string) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k, v := range m {
+		out = append(out, k+"="+v)
+	}
+	return out
+}
+
+// idGen hands out monotonically increasing JSON-RPC request ids.
+type idGen struct{ n atomic.Int64 }
+
+func newIDGen() *idGen { return &idGen{} }
+
+func (g *idGen) next() int { return int(g.n.Add(1)) }
+
+// logCollector captures the last ~4KB of subprocess stderr so we can
+// surface a useful tail when initialize fails (network error, missing
+// binary, "key invalid", etc.).
+type logCollector struct {
+	mu   sync.Mutex
+	buf  []byte
+	full bool
+}
+
+const logCollectorCap = 4096
+
+func (l *logCollector) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.buf = append(l.buf, p...)
+	if len(l.buf) > logCollectorCap {
+		l.buf = l.buf[len(l.buf)-logCollectorCap:]
+		l.full = true
+	}
+	return len(p), nil
+}
+
+func (l *logCollector) tail() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	s := string(l.buf)
+	if l.full {
+		return "…" + s
+	}
+	return s
+}
+
+// silence unused-import warning if time isn't otherwise touched.
+var _ = time.Second

--- a/internal/voice/mcp.go
+++ b/internal/voice/mcp.go
@@ -33,7 +33,7 @@ const mcpProtocolVersion = "2025-06-18"
 // which is acceptable for voice-note traffic. If usage justifies it,
 // a future iteration can keep one process warm per server.
 type Client struct {
-	srv mcp.Server     // resolved server config from the vault
+	srv mcp.Server // resolved server config from the vault
 	log *slog.Logger
 }
 

--- a/internal/voice/service.go
+++ b/internal/voice/service.go
@@ -1,0 +1,80 @@
+package voice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/opendray/opendray-v2/internal/mcp"
+)
+
+// Service is the channel-facing facade: give it a server id, get
+// back a Client ready to call. Wraps the existing MCP loader +
+// secrets file (per-call loading, mirroring catalog.SessionProvider's
+// pattern so config / secret edits are picked up without a restart).
+type Service struct {
+	loader      *mcp.Loader
+	secretsFile string
+	log         *slog.Logger
+}
+
+// NewService wires the facade. log may be nil. secretsFile may be ""
+// to disable ${KEY} substitution (placeholders will surface as
+// missing-secret errors when the MCP server config references one).
+func NewService(loader *mcp.Loader, secretsFile string, log *slog.Logger) *Service {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Service{loader: loader, secretsFile: secretsFile, log: log.With("component", "voice")}
+}
+
+// ErrUnknownProvider is returned when the channel references a voice
+// MCP server that doesn't exist in the vault.
+var ErrUnknownProvider = errors.New("voice: unknown provider")
+
+// ErrProviderDisabled is returned when the server exists but is
+// marked enabled=false in its mcp.json.
+var ErrProviderDisabled = errors.New("voice: provider disabled")
+
+// ResolveProvider looks up the id in the vault, applies secret
+// substitution, and returns a Client ready to call. Missing secrets
+// surface as a typed auth_failed error so the caller can render a
+// useful message instead of a generic failure.
+func (s *Service) ResolveProvider(ctx context.Context, id string) (*Client, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, ErrUnknownProvider
+	}
+	if s == nil || s.loader == nil {
+		return nil, ErrUnknownProvider
+	}
+
+	srv, err := s.loader.Get(id)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrUnknownProvider, id)
+	}
+	if !srv.Enabled {
+		return nil, ErrProviderDisabled
+	}
+
+	resolved := srv
+	if s.secretsFile != "" {
+		secrets, err := mcp.LoadSecrets(s.secretsFile)
+		if err != nil {
+			s.log.Warn("voice: load secrets failed", "err", err, "file", s.secretsFile)
+		} else {
+			var missing []string
+			resolved, missing = secrets.Resolve(srv)
+			if len(missing) > 0 {
+				return nil, &Error{
+					Code:    "auth_failed",
+					Message: fmt.Sprintf("missing secret(s): %s", strings.Join(missing, ", ")),
+				}
+			}
+		}
+	}
+
+	return NewClient(resolved, s.log), nil
+}

--- a/internal/voice/voice.go
+++ b/internal/voice/voice.go
@@ -1,0 +1,118 @@
+// Package voice is Opendray's client side of the voice-MCP contract
+// (see docs/mcp-voice.md).
+//
+// Voice providers — Deepgram, ElevenLabs, AssemblyAI, local Whisper,
+// anything else — are not compiled into Opendray. Each is an MCP
+// server installed by the operator under <vault>/mcp/, identified by
+// id, and reachable through the same Loader the AI providers already
+// use.
+//
+// This package supplies:
+//
+//   - Client: a thin JSON-RPC 2.0 stdio client that spawns the MCP
+//     server per call, performs initialize → tools/call → shutdown,
+//     and returns a Transcript or Audio.
+//
+//   - Service: ResolveProvider(ctx, id) → *Client. Looks the server
+//     up in the vault, applies ${SECRET} placeholder substitution,
+//     returns a ready-to-call client.
+//
+// Channels call into Service.ResolveProvider with the value of their
+// own voice_mcp_server config field. They never see a Deepgram API
+// key (or anything else third-party-specific).
+package voice
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Capability lists the two tool names the voice contract defines.
+const (
+	CapTranscribe = "voice/transcribe"
+	CapSynthesize = "voice/synthesize"
+)
+
+// Transcript is the result of a voice/transcribe call.
+//
+// Text="" means the server received audio but found no speech; the
+// caller should treat that as a non-error "nothing heard".
+type Transcript struct {
+	Text       string
+	Language   string  // BCP-47, may be empty
+	Confidence float64 // 0..1, 0 = not reported
+	DurationMS int     // 0 = not reported
+}
+
+// Audio is the result of a voice/synthesize call. Body holds the
+// decoded audio bytes; MimeType is what the server declared.
+type Audio struct {
+	Body       []byte
+	MimeType   string
+	DurationMS int
+}
+
+// SynthesizeOpts are the optional knobs on a TTS call. Format is
+// required.
+type SynthesizeOpts struct {
+	Format string  // "ogg-opus" | "mp3" | "wav" (server may add more)
+	Voice  string  // server-specific voice id
+	Speed  float64 // 0 = server default
+}
+
+// Error wraps a tool-call failure with the contract's well-known code
+// (see docs/mcp-voice.md §Error model). Callers compare via errors.As
+// or check Code directly to render user-facing messages.
+type Error struct {
+	Code    string // e.g. "auth_failed", "audio_too_large"
+	Message string // server-supplied human-readable detail
+}
+
+func (e *Error) Error() string {
+	if e.Code == "" {
+		return e.Message
+	}
+	if e.Message == "" {
+		return e.Code
+	}
+	return e.Code + ": " + e.Message
+}
+
+// Well-known error codes from the contract. Kept as exported vars so
+// callers do `errors.Is(err, voice.ErrAuthFailed)` for branches.
+var (
+	ErrAuthFailed          = &Error{Code: "auth_failed"}
+	ErrAudioTooLarge       = &Error{Code: "audio_too_large"}
+	ErrUnsupportedFormat   = &Error{Code: "unsupported_format"}
+	ErrLanguageUnsupported = &Error{Code: "language_unsupported"}
+	ErrProviderUnavailable = &Error{Code: "provider_unavailable"}
+)
+
+// Is matches by code so the well-known sentinels work with errors.Is
+// even though we instantiate them fresh per call.
+func (e *Error) Is(target error) bool {
+	var te *Error
+	if !errors.As(target, &te) {
+		return false
+	}
+	return te.Code == e.Code
+}
+
+// callTimeout caps every tool call. Voice notes are short; if a
+// provider hasn't responded in 30s something is wrong.
+const callTimeout = 30 * time.Second
+
+// Audio payload safety caps. Bigger than this and we don't even try
+// the round-trip — keeps tool-call latency bounded and protects the
+// Telegram sendVoice path (1 MB waveform / 50 MB document).
+const (
+	maxAudioIn  = 5 * 1024 * 1024
+	maxAudioOut = 5 * 1024 * 1024
+)
+
+// ctxWithCallTimeout wraps the caller's context with the per-call
+// budget, returning the derived context and its cancel func.
+func ctxWithCallTimeout(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, callTimeout)
+}


### PR DESCRIPTION
## Why this PR (and why #332 was closed)

#332 baked Deepgram credentials and the HTTP call into the Telegram channel. linivek's review:

> *"this function is best implemented in the form of a plugin, because this function cannot be used when the user does not have an account number and quota or API address change."*

Opendray already has the install/delete plugin pattern — **MCP servers** (`internal/mcp/mcp.go`):

> *"No built-ins are embedded in the binary. Users add servers via the Plugins page or by dropping a directory into the vault by hand."*

This PR reuses that pattern. No third-party voice code lives in the Opendray binary; voice is a contract any MCP server can implement.

## Contract — `docs/mcp-voice.md`

Two tools in the `voice/` namespace, base64-framed:

- **`voice/transcribe`** — `(audio_b64, mime_type) → {text, language, confidence}`
- **`voice/synthesize`** — `(text, format) → {audio_b64, mime_type}` *(client implemented; outbound Telegram path lands in follow-up PR)*

Well-known error codes (`auth_failed`, `audio_too_large`, `provider_unavailable`, …) so channels can render specific UX without sniffing strings.

## What's in the binary

`internal/voice/` — generic MCP client (~500 lines):

- Spawn-per-call stdio JSON-RPC 2.0 (initialize → tools/call → close). Simple lifecycle, no warm pool yet.
- 30s per-call budget, 5 MB audio caps both ways.
- `Service` facade over the existing `mcp.Loader` + secrets vault. `${KEY}` placeholders resolved per call so config edits land without a restart.

## What's NOT in the binary

- No Deepgram code
- No ElevenLabs code
- No AssemblyAI code
- No Whisper code

A reference Deepgram implementation will live in a separate repo (`@opendray/voice-deepgram`) so swapping providers never touches Opendray.

## Telegram integration

`internal/channel/telegram/voice.go` — when `voice_transcription_enabled` and a `voice_mcp_server` are set:

1. Parse `tgMessage.Voice`
2. `getFile` → download OGG/Opus blob
3. `voice/transcribe` MCP call
4. Swap transcript into `msg.Text` before dispatch — everything downstream (session routing, persistence, reply detection) sees a normal text message

Failure modes are surfaced as friendly in-chat replies so a voice note never silently disappears.

## Operator UX

Channels → edit Telegram bot → three new fields at the bottom of the form:

| Field | Type |
|---|---|
| Voice provider (MCP server id) | text |
| Voice notes → text | boolean |
| Voice reply (TTS) | boolean *(placeholder, outbound path follow-up)* |

The operator first installs an MCP voice server (via Plugins → MCP Servers, or by dropping a `mcp.json` into the vault), then references it by id from the channel form. Single key edit propagates to every channel using it.

## Out of scope (deliberate — follow-ups)

- **Outbound TTS via Telegram `sendVoice`** — `voice/synthesize` client implemented in the binary, but the Telegram outbound path (sendVoice, 1 MB cap, reply trimming) is its own PR.
- **UI dropdown of installed servers filtered by capability** — operator types the server id today. Auto-listing servers that expose `voice/transcribe` is a polish PR.
- **Reference `@opendray/voice-deepgram` npm package** — separate repo, so Opendray stays voice-provider-agnostic.
- **Warm-pool MCP client** — current spawn-per-call adds ~100–500 ms cold start on each voice note. Fine for voice traffic; revisit if usage demands it.

## Test plan
- [x] `go build ./...` (clean)
- [x] `go test ./internal/voice/... ./internal/channel/...` (all green)
- [x] `npx tsc -b` in `app/web` (clean)
- [ ] Manual: install a conforming MCP voice server, configure a Telegram channel against it, send a voice note, confirm transcript reaches the session
- [ ] Manual: misconfigured server id → "Couldn't transcribe…" friendly reply, error logged
- [ ] Manual: missing `${DEEPGRAM_API_KEY}` secret → `auth_failed` typed error surfaced

Drafted while the reference impl repo and outbound path land in follow-ups. Architecture review welcome before any further code lands on top.

Closes #332.