### PR TITLE
docs(fa): fix Persian doc links + RTL polish (follow-up to #324)

### DIFF
--- a/README.fa.md
+++ b/README.fa.md
@@ -175,7 +175,7 @@ irm https://raw.githubusercontent.com/Opendray/opendray/main/scripts/install-win
 <blockquote dir="rtl">
 <p align="right">
 <strong>راهنمای دستی و قدم‌به‌قدم می‌خواهید؟</strong><br>
-<a href="docs/getting-started.md"><code>docs/getting-started.md</code></a> را بخوانید. این راهنما همان مسیر wizard را در قالب یک walkthrough حدوداً ۱۵ دقیقه‌ای باز می‌کند تا بتوانید هر مرحله را خودتان بررسی کنید.
+<a href="docs/getting-started.fa.md"><code>docs/getting-started.fa.md</code></a> را بخوانید. این راهنما همان مسیر wizard را در قالب یک walkthrough حدوداً ۱۵ دقیقه‌ای باز می‌کند تا بتوانید هر مرحله را خودتان بررسی کنید.
 </p>
 </blockquote>
 
@@ -296,7 +296,7 @@ opendray یک host-resident gateway است. AI CLIها را از طریق PTY ا
 <h2 dir="rtl" align="right">Quickstart: مسیر ۵ دقیقه‌ای برای dev</h2>
 
 <p dir="rtl" align="right">
-برای راهنمای کامل، همراه با prerequisiteها و troubleshooting، فایل <a href="docs/quickstart.fa.md"><code>docs/quickstart.fa.md</code></a> را ببینید.
+برای راهنمای کامل، همراه با prerequisiteها و troubleshooting، فایل <a href="docs/quickstart.md"><code>docs/quickstart.md</code></a> را ببینید.
 </p>
 
 <p dir="rtl" align="right">
@@ -593,9 +593,9 @@ go build ./cmd/opendray      # bakes dist into the binary
 <h2 dir="rtl" align="right">مستندات</h2>
 
 <ul dir="rtl" align="right">
-<li><a href="docs/getting-started.md"><code>docs/getting-started.md</code></a>: اگر تازه شروع کرده‌اید، از اینجا شروع کنید؛ از صفر تا اولین session در حدود ۱۵ دقیقه، شامل نصب CLIهای موردنیاز و bootstrap کردن Postgres.</li>
+<li><a href="docs/getting-started.fa.md"><code>docs/getting-started.fa.md</code></a>: اگر تازه شروع کرده‌اید، از اینجا شروع کنید؛ از صفر تا اولین session در حدود ۱۵ دقیقه، شامل نصب CLIهای موردنیاز و bootstrap کردن Postgres.</li>
 <li><a href="docs/install-binary.fa.md"><code>docs/install-binary.fa.md</code></a>: نصب از npm package یا release binary، با فرض این‌که Postgres را خودتان آماده می‌کنید، و اجرا به‌عنوان systemd یا launchd service.</li>
-<li><a href="docs/quickstart.fa.md"><code>docs/quickstart.fa.md</code></a>: مسیر پنج‌دقیقه‌ای برای dev environment؛ مناسب وقتی که moving partها را از قبل می‌شناسید.</li>
+<li><a href="docs/quickstart.md"><code>docs/quickstart.md</code></a>: مسیر پنج‌دقیقه‌ای برای dev environment؛ مناسب وقتی که moving partها را از قبل می‌شناسید.</li>
 <li><a href="docs/mobile-app.fa.md"><code>docs/mobile-app.fa.md</code></a>: ساخت و نصب اپ موبایل Flutter — یک Android APK را sideload کنید یا با Xcode روی iPhone نصب کنید، و بعد آن را به gateway خودتان وصل کنید.</li>
 <li><a href="docs/operator-guide.md"><code>docs/operator-guide.md</code></a>: مرجع deploy و ops برای production-like setupها.</li>
 <li><a href="docs/integration-guide.md"><code>docs/integration-guide.md</code></a>: راهنمای نوشتن external integration با هر زبان برنامه‌نویسی.</li>

--- a/docs/getting-started.fa.md
+++ b/docs/getting-started.fa.md
@@ -1,4 +1,4 @@
-<div dir="rtl">
+<div dir="rtl" lang="fa">
 
 # شروع کار
 

--- a/docs/install-binary.fa.md
+++ b/docs/install-binary.fa.md
@@ -4,13 +4,13 @@
 
 برای وقتی که فقط باینری `opendray` را می‌خواهید — بدون wizard نصب‌کننده که دست به تنظیمات ماشین شما بزند. این مسیر مناسب است برای:
 
-- **`npm install -g opendray` / `npx opendray`** — پکیج npm باینری رسمی Go release را شامل می‌شود (ببینید [README → npm / npx](../README.fa.md#نصب)).
+- **`npm install -g opendray` / `npx opendray`** — پکیج npm باینری رسمی Go release را شامل می‌شود (ببینید [README → npm / npx](../README.fa.md)).
 - **دانلود Release** — فایل `opendray_*_<os>_<arch>.tar.gz` را از [صفحه Releases](https://github.com/Opendray/opendray/releases) بردارید.
 - **محیط‌های scripted / ephemeral** — CI runnerها، golden imageها، config management (Ansible، Nix، Docker)، یا هر hostی که Postgres و process supervisor خودتان را دارید.
 
 باینری همان *کل* gateway است — web admin SPA داخلش embed شده، پس نه Node runtime لازم است، نه static server جداگانه، و نه چیزی برای build کردن. آنچه **نمی‌کند** این است که چیزی را برای شما setup نکند. این همان معامله است: شما یک دیتابیس PostgreSQL و روشی برای نگه‌داشتن فرایند می‌آورید، و در عوض هیچ‌چیزی بدون اطلاع شما نصب، تنظیم، یا ثبت نمی‌شود.
 
-**می‌خواهید همه‌چیز برایتان انجام شود؟** روی یک Linux / macOS تازه، installer تک‌خطی Postgres را provision می‌کند، AI CLIها را نصب می‌کند، config را می‌نویسد، و یک service را در ۵ تا ۱۰ دقیقه ثبت می‌کند. ببینید [README → نصب‌کننده تک‌خطی](../README.fa.md#نصب) یا راهنمای دستی [getting-started.fa.md](getting-started.fa.md).
+> **می‌خواهید همه‌چیز برایتان انجام شود؟** روی یک Linux / macOS تازه، installer تک‌خطی Postgres را provision می‌کند، AI CLIها را نصب می‌کند، config را می‌نویسد، و یک service را در ۵ تا ۱۰ دقیقه ثبت می‌کند. ببینید [README → نصب‌کننده تک‌خطی](../README.fa.md) یا راهنمای دستی [getting-started.fa.md](getting-started.fa.md).
 
 این راهنما شما را از «باینری روی PATH» به «gateway در حال اجرا» در پنج گام می‌رساند، سپس نشان می‌دهد چطور آن را به‌صورت یک service اجرا کنید.
 


### PR DESCRIPTION
Follow-up to the merged Persian docs PR #324, addressing the review-thread points:

- **README.fa.md**: fix broken links to `docs/quickstart.fa.md` (no Persian quickstart exists) → `docs/quickstart.md`; point the two `docs/getting-started.md` references at the new `docs/getting-started.fa.md`.
- **docs/getting-started.fa.md**: add `lang="fa"` to the RTL wrapper `<div>`, matching the other Persian docs.
- **docs/install-binary.fa.md**: drop the non-resolving `../README.fa.md#نصب` anchor (README.fa.md uses raw HTML headings, which GitHub doesn't auto-anchor) → link to the page; restore the blockquote callout that lost its `>`.

Audited all relative links in the fa docs — **no broken targets remain**. The getting-started.fa.md links into the English README keep their working markdown anchors (the fa README's HTML headings can't provide resolving anchors).