### PR TITLE
feat: scrollable session conversation + relocate theme/language to Settings

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -2603,7 +2603,8 @@
           "git": "Git",
           "tasks": "Tasks",
           "history": "History",
-          "notes": "Notes"
+          "notes": "Notes",
+          "conversation": "Conversation"
         }
       },
       "shared": {
@@ -2688,6 +2689,13 @@
         "noProjectMapping2": "(no project mapping)",
         "clearOverride": "Clear override",
         "save": "Save"
+      },
+      "conversation": {
+        "empty": "No conversation yet.",
+        "loadFailed": "Couldn’t load the conversation.",
+        "copyAll": "Copy all",
+        "copied": "Conversation copied",
+        "count": "{count} turns"
       }
     },
     "spawnSheet": {

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -48,16 +48,6 @@
       "collapseSidebar": "Collapse sidebar",
       "search": "Search",
       "openPalette": "Open command palette",
-      "theme": "Theme",
-      "themeLabel": "Theme: {mode}",
-      "appearance": "Appearance",
-      "themeLight": "Light",
-      "themeDark": "Dark",
-      "themeSystem": "System",
-      "language": "Language",
-      "languageEnglish": "English",
-      "languageChinese": "中文",
-      "languageSpanish": "Español",
       "signedInAs": "Signed in as",
       "tokenExpires": "Token expires",
       "signOut": "Sign out"
@@ -2161,6 +2151,15 @@
         "checkUpdates": "Check for updates",
         "checking": "Checking…",
         "reinstall": "Re-install"
+      },
+      "language": {
+        "title": "Language",
+        "description": "Choose the interface language.",
+        "options": {
+          "en": "English",
+          "zh": "中文",
+          "es": "Español"
+        }
       }
     },
     "logViewer": {

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -210,7 +210,15 @@
           "tasks": "Tasks",
           "history": "History",
           "notes": "Notes",
-          "memory": "Memory"
+          "memory": "Memory",
+          "conversation": "Conversation"
+        },
+        "transcript": {
+          "empty": "No conversation yet.",
+          "loadFailed": "Couldn't load the conversation.",
+          "copyAll": "Copy all",
+          "copied": "Conversation copied",
+          "count": "{count} turns"
         }
       },
       "ended": {

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -48,16 +48,6 @@
       "collapseSidebar": "Contraer barra lateral",
       "search": "Buscar",
       "openPalette": "Abrir paleta de comandos",
-      "theme": "Tema",
-      "themeLabel": "Tema: {mode}",
-      "appearance": "Apariencia",
-      "themeLight": "Claro",
-      "themeDark": "Oscuro",
-      "themeSystem": "Sistema",
-      "language": "Idioma",
-      "languageEnglish": "English",
-      "languageChinese": "中文",
-      "languageSpanish": "Español",
       "signedInAs": "Sesión iniciada como",
       "tokenExpires": "El token caduca",
       "signOut": "Cerrar sesión"
@@ -2161,6 +2151,15 @@
         "checkUpdates": "Comprobar actualizaciones",
         "checking": "Comprobando…",
         "reinstall": "Reinstalar"
+      },
+      "language": {
+        "title": "Idioma",
+        "description": "Elige el idioma de la interfaz.",
+        "options": {
+          "en": "English",
+          "zh": "中文",
+          "es": "Español"
+        }
       }
     },
     "logViewer": {

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -2603,7 +2603,8 @@
           "git": "Git",
           "tasks": "Tareas",
           "history": "Historial",
-          "notes": "Notas"
+          "notes": "Notas",
+          "conversation": "Conversación"
         }
       },
       "shared": {
@@ -2688,6 +2689,13 @@
         "noProjectMapping2": "(sin asignación de proyecto)",
         "clearOverride": "Borrar anulación",
         "save": "Guardar"
+      },
+      "conversation": {
+        "empty": "Aún no hay conversación.",
+        "loadFailed": "No se pudo cargar la conversación.",
+        "copyAll": "Copiar todo",
+        "copied": "Conversación copiada",
+        "count": "{count} turnos"
       }
     },
     "spawnSheet": {

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -210,7 +210,15 @@
           "tasks": "Tareas",
           "history": "Historial",
           "notes": "Notas",
-          "memory": "Memoria"
+          "memory": "Memoria",
+          "conversation": "Conversación"
+        },
+        "transcript": {
+          "empty": "Aún no hay conversación.",
+          "loadFailed": "No se pudo cargar la conversación.",
+          "copyAll": "Copiar todo",
+          "copied": "Conversación copiada",
+          "count": "{count} turnos"
         }
       },
       "ended": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -2603,7 +2603,8 @@
           "git": "Git",
           "tasks": "任务",
           "history": "历史",
-          "notes": "笔记"
+          "notes": "笔记",
+          "conversation": "对话"
         }
       },
       "shared": {
@@ -2688,6 +2689,13 @@
         "noProjectMapping2": "（无项目映射）",
         "clearOverride": "清除覆盖",
         "save": "保存"
+      },
+      "conversation": {
+        "empty": "暂无对话。",
+        "loadFailed": "无法加载对话。",
+        "copyAll": "复制全部",
+        "copied": "已复制对话",
+        "count": "{count} 轮"
       }
     },
     "spawnSheet": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -210,7 +210,15 @@
           "tasks": "任务",
           "history": "历史",
           "notes": "笔记",
-          "memory": "记忆"
+          "memory": "记忆",
+          "conversation": "对话"
+        },
+        "transcript": {
+          "empty": "暂无对话。",
+          "loadFailed": "无法加载对话。",
+          "copyAll": "复制全部",
+          "copied": "已复制对话",
+          "count": "{count} 轮"
         }
       },
       "ended": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -48,16 +48,6 @@
       "collapseSidebar": "收起侧边栏",
       "search": "搜索",
       "openPalette": "打开命令面板",
-      "theme": "主题",
-      "themeLabel": "主题：{mode}",
-      "appearance": "外观",
-      "themeLight": "浅色",
-      "themeDark": "深色",
-      "themeSystem": "跟随系统",
-      "language": "语言",
-      "languageEnglish": "English",
-      "languageChinese": "中文",
-      "languageSpanish": "Español",
       "signedInAs": "登录账号",
       "tokenExpires": "令牌到期",
       "signOut": "退出登录"
@@ -2161,6 +2151,15 @@
         "checkUpdates": "检查更新",
         "checking": "检查中…",
         "reinstall": "重新安装"
+      },
+      "language": {
+        "title": "语言",
+        "description": "选择界面语言。",
+        "options": {
+          "en": "English",
+          "zh": "中文",
+          "es": "Español"
+        }
       }
     },
     "logViewer": {

--- a/app/mobile/lib/core/api/models.dart
+++ b/app/mobile/lib/core/api/models.dart
@@ -408,6 +408,46 @@ class HistoryResponse {
   final bool unsupportedProvider;
 }
 
+// One turn of a session's reconstructed conversation — a user prompt
+// or a chunk of assistant prose parsed from the CLI's JSONL. This is
+// the scrollback the live alternate-screen TUI terminal can't provide.
+class TranscriptTurn {
+  TranscriptTurn({
+    required this.role,
+    required this.text,
+    this.timestamp,
+  });
+
+  factory TranscriptTurn.fromJson(Map<String, dynamic> json) => TranscriptTurn(
+        role: json['role'] as String? ?? '',
+        text: json['text'] as String? ?? '',
+        timestamp: DateTime.tryParse(json['ts'] as String? ?? '')?.toUtc(),
+      );
+
+  // "user" | "assistant".
+  final String role;
+  final String text;
+  // When the turn was emitted (UTC), when the source records it.
+  final DateTime? timestamp;
+}
+
+class TranscriptResponse {
+  TranscriptResponse({required this.turns});
+
+  factory TranscriptResponse.fromJson(Map<String, dynamic> json) {
+    final raw = json['turns'];
+    final turns = raw is List
+        ? raw
+            .whereType<Map<String, dynamic>>()
+            .map(TranscriptTurn.fromJson)
+            .toList()
+        : <TranscriptTurn>[];
+    return TranscriptResponse(turns: turns);
+  }
+
+  final List<TranscriptTurn> turns;
+}
+
 // Multi-account picker option for the Claude provider. Mirrors the
 // fields the spawn-session form actually renders; the full
 // account record lives in /api/v1/claude-accounts.

--- a/app/mobile/lib/core/api/sessions_api.dart
+++ b/app/mobile/lib/core/api/sessions_api.dart
@@ -90,6 +90,21 @@ class SessionsApi {
     }
   }
 
+  // GET /api/v1/sessions/:id/transcript?max_bytes=N — the session's
+  // reconstructed conversation (user prompts + assistant prose) from
+  // the CLI's JSONL. The scrollback the live alt-screen TUI lacks.
+  Future<TranscriptResponse> transcript(String id, {int maxBytes = 1 << 20}) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/sessions/$id/transcript',
+        queryParameters: {'max_bytes': maxBytes},
+      );
+      return TranscriptResponse.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
   // POST /api/v1/sessions/:id/input — sends raw bytes to the PTY
   // stdin. Used by the inspector "push to terminal" actions to
   // inject things like `@/path/to/file` or a recalled prompt

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 9540 (3180 per locale)
+/// Strings: 9558 (3186 per locale)
 ///
-/// Built on 2026-06-03 at 15:23 UTC
+/// Built on 2026-06-06 at 04:33 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 9543 (3181 per locale)
+/// Strings: 9561 (3187 per locale)
 ///
-/// Built on 2026-06-06 at 04:38 UTC
+/// Built on 2026-06-06 at 04:40 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 9558 (3186 per locale)
+/// Strings: 9543 (3181 per locale)
 ///
-/// Built on 2026-06-06 at 04:33 UTC
+/// Built on 2026-06-06 at 04:38 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -1847,36 +1847,6 @@ class TranslationsWebTopbarEn {
 	/// en: 'Open command palette'
 	String get openPalette => 'Open command palette';
 
-	/// en: 'Theme'
-	String get theme => 'Theme';
-
-	/// en: 'Theme: {mode}'
-	String themeLabel({required Object mode}) => 'Theme: ${mode}';
-
-	/// en: 'Appearance'
-	String get appearance => 'Appearance';
-
-	/// en: 'Light'
-	String get themeLight => 'Light';
-
-	/// en: 'Dark'
-	String get themeDark => 'Dark';
-
-	/// en: 'System'
-	String get themeSystem => 'System';
-
-	/// en: 'Language'
-	String get language => 'Language';
-
-	/// en: 'English'
-	String get languageEnglish => 'English';
-
-	/// en: '中文'
-	String get languageChinese => '中文';
-
-	/// en: 'Español'
-	String get languageSpanish => 'Español';
-
 	/// en: 'Signed in as'
 	String get signedInAs => 'Signed in as';
 
@@ -2658,6 +2628,7 @@ class TranslationsWebSettingsEn {
 	late final TranslationsWebSettingsChangeCredentialsEn changeCredentials = TranslationsWebSettingsChangeCredentialsEn.internal(_root);
 	late final TranslationsWebSettingsSystemEn system = TranslationsWebSettingsSystemEn.internal(_root);
 	late final TranslationsWebSettingsAboutEn about = TranslationsWebSettingsAboutEn.internal(_root);
+	late final TranslationsWebSettingsLanguageEn language = TranslationsWebSettingsLanguageEn.internal(_root);
 }
 
 // Path: web.logViewer
@@ -9193,6 +9164,23 @@ class TranslationsWebSettingsAboutEn {
 	String get reinstall => 'Re-install';
 }
 
+// Path: web.settings.language
+class TranslationsWebSettingsLanguageEn {
+	TranslationsWebSettingsLanguageEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Language'
+	String get title => 'Language';
+
+	/// en: 'Choose the interface language.'
+	String get description => 'Choose the interface language.';
+
+	late final TranslationsWebSettingsLanguageOptionsEn options = TranslationsWebSettingsLanguageOptionsEn.internal(_root);
+}
+
 // Path: web.memoryAmbient.header
 class TranslationsWebMemoryAmbientHeaderEn {
 	TranslationsWebMemoryAmbientHeaderEn.internal(this._root);
@@ -13451,6 +13439,24 @@ class TranslationsWebSettingsFontOptionsEn {
 	String get large => 'Large';
 }
 
+// Path: web.settings.language.options
+class TranslationsWebSettingsLanguageOptionsEn {
+	TranslationsWebSettingsLanguageOptionsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'English'
+	String get en => 'English';
+
+	/// en: '中文'
+	String get zh => '中文';
+
+	/// en: 'Español'
+	String get es => 'Español';
+}
+
 // Path: web.memoryAmbient.providers.row
 class TranslationsWebMemoryAmbientProvidersRowEn {
 	TranslationsWebMemoryAmbientProvidersRowEn.internal(this._root);
@@ -13946,16 +13952,6 @@ extension on Translations {
 			'web.topbar.collapseSidebar' => 'Collapse sidebar',
 			'web.topbar.search' => 'Search',
 			'web.topbar.openPalette' => 'Open command palette',
-			'web.topbar.theme' => 'Theme',
-			'web.topbar.themeLabel' => ({required Object mode}) => 'Theme: ${mode}',
-			'web.topbar.appearance' => 'Appearance',
-			'web.topbar.themeLight' => 'Light',
-			'web.topbar.themeDark' => 'Dark',
-			'web.topbar.themeSystem' => 'System',
-			'web.topbar.language' => 'Language',
-			'web.topbar.languageEnglish' => 'English',
-			'web.topbar.languageChinese' => '中文',
-			'web.topbar.languageSpanish' => 'Español',
 			'web.topbar.signedInAs' => 'Signed in as',
 			'web.topbar.tokenExpires' => 'Token expires',
 			'web.topbar.signOut' => 'Sign out',
@@ -14417,8 +14413,6 @@ extension on Translations {
 			'web.memoryInspector.row.editTooltip' => 'Edit this memory',
 			'web.memoryInspector.row.deleteTooltip' => 'Delete this memory',
 			'web.memoryInspector.row.emptyError' => 'Memory text cannot be empty',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryInspector.row.deleteConfirm' => ({required Object id}) => 'Delete memory ${id}? This is permanent.',
 			'web.memoryInspector.toasts.deleted' => 'Memory deleted',
 			'web.memoryInspector.toasts.deleteFailed' => 'Delete failed',
@@ -14429,6 +14423,8 @@ extension on Translations {
 			'web.memoryInspector.toasts.createFailed' => 'Create failed',
 			'web.memoryInspector.toasts.updated' => 'Memory updated',
 			'web.memoryInspector.toasts.updateFailed' => 'Update failed',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryInspector.toasts.migrated' => ({required Object reembed, required Object examined, required Object to}) => 'Migrated ${reembed}/${examined} memories to ${to}',
 			'web.memoryInspector.toasts.migrationFailed' => 'Migration failed',
 			'web.memoryInspector.toasts.syncIngested_one' => ({required Object count}) => 'Ingested ${count} new memory file',
@@ -14931,8 +14927,6 @@ extension on Translations {
 			'web.integrations.proxy.emptyDescription' => ({required Object prefix}) => 'Register an integration first; the console proxies through /api/v1/proxy/${prefix}/* using the admin token.',
 			'web.integrations.proxy.targetLabel' => 'Target',
 			'web.integrations.proxy.selectPlaceholder' => 'Select integration…',
-			_ => null,
-		} ?? switch (path) {
 			'web.integrations.proxy.baseLabel' => 'base:',
 			'web.integrations.proxy.history' => 'History',
 			'web.integrations.proxy.historyEmpty' => 'no past requests for this integration',
@@ -14943,6 +14937,8 @@ extension on Translations {
 			'web.integrations.proxy.headers' => 'Headers',
 			'web.integrations.proxy.body' => 'Body',
 			'web.integrations.proxy.emptyBody' => '(empty)',
+			_ => null,
+		} ?? switch (path) {
 			'web.integrations.proxy.requestFailed' => 'request failed',
 			'web.integrations.proxy.stubText' => 'Send a request to see the upstream response.',
 			'web.integrations.proxy.stubInjects' => 'opendray injects <1>X-Integration-ID</1> and strips your <3>Authorization</3> header.',
@@ -15445,8 +15441,6 @@ extension on Translations {
 			'web.serverSettings.fields.codexSessionsRoot.label' => 'Sessions root',
 			'web.serverSettings.fields.codexSessionsRoot.hint' => 'Directory walked for Codex rollout JSONL files. Default ~/.codex/sessions.',
 			'web.serverSettings.fields.geminiTmpRoot.label' => 'Tmp directory',
-			_ => null,
-		} ?? switch (path) {
 			'web.serverSettings.fields.geminiTmpRoot.hint' => 'Root holding Gemini per-project tmp folders. Default ~/.gemini/tmp.',
 			'web.serverSettings.fields.geminiProjectsFile.label' => 'projects.json',
 			'web.serverSettings.fields.geminiProjectsFile.hint' => 'Path to Gemini\'s cwd→short-name mapping file. Default ~/.gemini/projects.json.',
@@ -15457,6 +15451,8 @@ extension on Translations {
 			'web.serverSettings.fields.backupPgDumpPath.label' => 'pg_dump path',
 			'web.serverSettings.fields.backupPgDumpPath.hint' => 'Absolute path to pg_dump. Major version must be ≥ the server\'s. Empty = first pg_dump on PATH.',
 			'web.serverSettings.fields.backupPgRestorePath.label' => 'pg_restore path',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.fields.backupPgRestorePath.hint' => 'Absolute path to pg_restore for the /backups/restore flow. Same major-version rule.',
 			'web.serverSettings.liveTail.heading' => 'Live tail',
 			'web.serverSettings.liveTail.description' => 'In-memory ring buffer (last ~2,000 records). Resets on restart.',
@@ -15598,6 +15594,11 @@ extension on Translations {
 			'web.settings.about.checkUpdates' => 'Check for updates',
 			'web.settings.about.checking' => 'Checking…',
 			'web.settings.about.reinstall' => 'Re-install',
+			'web.settings.language.title' => 'Language',
+			'web.settings.language.description' => 'Choose the interface language.',
+			'web.settings.language.options.en' => 'English',
+			'web.settings.language.options.zh' => '中文',
+			'web.settings.language.options.es' => 'Español',
 			'web.logViewer.filterPlaceholder' => 'Filter…',
 			'web.logViewer.debugTooltip' => 'Debug count',
 			'web.logViewer.infoTooltip' => 'Info count',
@@ -15959,13 +15960,13 @@ extension on Translations {
 			'sessions.inspector.notes.changeLocationTooltip' => 'Change project docs location',
 			'sessions.inspector.notes.filenameHint' => 'filename (e.g. spec or design.md)',
 			'sessions.inspector.notes.create' => 'Create',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.filterHint' => 'Filter…',
 			'sessions.inspector.notes.locationDialogTitle' => 'Project docs location',
 			'sessions.inspector.notes.loadFailedApi' => ({required Object error}) => 'Load failed: ${error}',
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => 'Load failed: ${error}',
 			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => 'Save failed: ${error}',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.notes.saveFailedGeneric' => ({required Object error}) => 'Save failed: ${error}',
 			'sessions.inspector.notes.insertFailedApi' => ({required Object error}) => 'Insert failed: ${error}',
 			'sessions.inspector.notes.insertFailedGeneric' => ({required Object error}) => 'Insert failed: ${error}',
@@ -16473,13 +16474,13 @@ extension on Translations {
 			'backupSchedules.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}: ${error}',
 			'backupSchedules.noTargets' => 'No backup targets configured. Add one from the web admin or the Targets screen.',
 			'backupSchedules.okMsgCreate' => 'Schedule created.',
-			_ => null,
-		} ?? switch (path) {
 			'backupSchedules.okMsgUpdate' => 'Schedule updated.',
 			'backupSchedules.okMsgDelete' => 'Schedule deleted.',
 			'backupSchedules.errorPrefixCreate' => 'Create failed',
 			'backupSchedules.errorPrefixUpdate' => 'Update failed',
 			'backupSchedules.errorPrefixDelete' => 'Delete failed',
+			_ => null,
+		} ?? switch (path) {
 			'backupSchedules.deleteBody' => ({required Object targetId}) => 'Removes the recurring spec for target ${targetId}. Existing backup blobs are not touched.',
 			'backupSchedules.emptyList' => 'No schedules yet.\nTap "New" to create one.',
 			'backupSchedules.validatePickTarget' => 'Pick a target.',
@@ -16987,13 +16988,13 @@ extension on Translations {
 			'settings.changeCredentials.newPassword' => 'New password',
 			'settings.changeCredentials.confirmPassword' => 'Confirm new password',
 			'settings.changeCredentials.validatorRequired' => 'Required',
-			_ => null,
-		} ?? switch (path) {
 			'settings.changeCredentials.passwordHelper' => 'At least 8 characters',
 			'settings.changeCredentials.passwordTooShort' => 'Must be at least 8 characters',
 			'settings.changeCredentials.passwordMismatch' => 'Doesn\'t match the new password',
 			'settings.changeCredentials.updatedSnack' => 'Credentials updated.',
 			'settings.changeCredentials.wrongCurrent' => 'Current password is wrong.',
+			_ => null,
+		} ?? switch (path) {
 			'settings.changeCredentials.saving' => 'Saving…',
 			'settings.changeCredentials.update' => 'Update',
 			'settings.logViewer.title' => 'Live logs',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -3048,6 +3048,7 @@ class TranslationsSessionsInspectorEn {
 	late final TranslationsSessionsInspectorGitEn git = TranslationsSessionsInspectorGitEn.internal(_root);
 	late final TranslationsSessionsInspectorTasksEn tasks = TranslationsSessionsInspectorTasksEn.internal(_root);
 	late final TranslationsSessionsInspectorNotesEn notes = TranslationsSessionsInspectorNotesEn.internal(_root);
+	late final TranslationsSessionsInspectorConversationEn conversation = TranslationsSessionsInspectorConversationEn.internal(_root);
 }
 
 // Path: sessions.spawnSheet
@@ -10159,6 +10160,30 @@ class TranslationsSessionsInspectorNotesEn {
 	String get save => 'Save';
 }
 
+// Path: sessions.inspector.conversation
+class TranslationsSessionsInspectorConversationEn {
+	TranslationsSessionsInspectorConversationEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'No conversation yet.'
+	String get empty => 'No conversation yet.';
+
+	/// en: 'Couldn’t load the conversation.'
+	String get loadFailed => 'Couldn’t load the conversation.';
+
+	/// en: 'Copy all'
+	String get copyAll => 'Copy all';
+
+	/// en: 'Conversation copied'
+	String get copied => 'Conversation copied';
+
+	/// en: '{count} turns'
+	String count({required Object count}) => '${count} turns';
+}
+
 // Path: sessions.spawnSheet.bypass
 class TranslationsSessionsSpawnSheetBypassEn {
 	TranslationsSessionsSpawnSheetBypassEn.internal(this._root);
@@ -13859,6 +13884,9 @@ class TranslationsSessionsInspectorShellTabsEn {
 
 	/// en: 'Notes'
 	String get notes => 'Notes';
+
+	/// en: 'Conversation'
+	String get conversation => 'Conversation';
 }
 
 // Path: web.notes.vaultSync.conflict.kinds
@@ -15916,6 +15944,7 @@ extension on Translations {
 			'sessions.inspector.shell.tabs.tasks' => 'Tasks',
 			'sessions.inspector.shell.tabs.history' => 'History',
 			'sessions.inspector.shell.tabs.notes' => 'Notes',
+			'sessions.inspector.shell.tabs.conversation' => 'Conversation',
 			'sessions.inspector.shared.refresh' => 'Refresh',
 			'sessions.inspector.shared.inserted' => ({required Object text}) => 'Inserted: ${text}',
 			'sessions.inspector.shared.insertFailedApi' => ({required Object status, required Object message}) => 'Insert failed (${status}): ${message}',
@@ -15964,9 +15993,9 @@ extension on Translations {
 			'sessions.inspector.notes.locationDialogTitle' => 'Project docs location',
 			'sessions.inspector.notes.loadFailedApi' => ({required Object error}) => 'Load failed: ${error}',
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => 'Load failed: ${error}',
-			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => 'Save failed: ${error}',
 			_ => null,
 		} ?? switch (path) {
+			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => 'Save failed: ${error}',
 			'sessions.inspector.notes.saveFailedGeneric' => ({required Object error}) => 'Save failed: ${error}',
 			'sessions.inspector.notes.insertFailedApi' => ({required Object error}) => 'Insert failed: ${error}',
 			'sessions.inspector.notes.insertFailedGeneric' => ({required Object error}) => 'Insert failed: ${error}',
@@ -15989,6 +16018,11 @@ extension on Translations {
 			'sessions.inspector.notes.noProjectMapping2' => '(no project mapping)',
 			'sessions.inspector.notes.clearOverride' => 'Clear override',
 			'sessions.inspector.notes.save' => 'Save',
+			'sessions.inspector.conversation.empty' => 'No conversation yet.',
+			'sessions.inspector.conversation.loadFailed' => 'Couldn’t load the conversation.',
+			'sessions.inspector.conversation.copyAll' => 'Copy all',
+			'sessions.inspector.conversation.copied' => 'Conversation copied',
+			'sessions.inspector.conversation.count' => ({required Object count}) => '${count} turns',
 			'sessions.spawnSheet.title' => 'New session',
 			'sessions.spawnSheet.errorRequired' => 'Provider and working directory are required',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => 'Failed to spawn session: ${error}',
@@ -16473,14 +16507,14 @@ extension on Translations {
 			'backupSchedules.retentionLabel' => 'Retention (keep N most recent)',
 			'backupSchedules.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}: ${error}',
 			'backupSchedules.noTargets' => 'No backup targets configured. Add one from the web admin or the Targets screen.',
+			_ => null,
+		} ?? switch (path) {
 			'backupSchedules.okMsgCreate' => 'Schedule created.',
 			'backupSchedules.okMsgUpdate' => 'Schedule updated.',
 			'backupSchedules.okMsgDelete' => 'Schedule deleted.',
 			'backupSchedules.errorPrefixCreate' => 'Create failed',
 			'backupSchedules.errorPrefixUpdate' => 'Update failed',
 			'backupSchedules.errorPrefixDelete' => 'Delete failed',
-			_ => null,
-		} ?? switch (path) {
 			'backupSchedules.deleteBody' => ({required Object targetId}) => 'Removes the recurring spec for target ${targetId}. Existing backup blobs are not touched.',
 			'backupSchedules.emptyList' => 'No schedules yet.\nTap "New" to create one.',
 			'backupSchedules.validatePickTarget' => 'Pick a target.',
@@ -16987,14 +17021,14 @@ extension on Translations {
 			'settings.changeCredentials.newUsername' => 'New username',
 			'settings.changeCredentials.newPassword' => 'New password',
 			'settings.changeCredentials.confirmPassword' => 'Confirm new password',
+			_ => null,
+		} ?? switch (path) {
 			'settings.changeCredentials.validatorRequired' => 'Required',
 			'settings.changeCredentials.passwordHelper' => 'At least 8 characters',
 			'settings.changeCredentials.passwordTooShort' => 'Must be at least 8 characters',
 			'settings.changeCredentials.passwordMismatch' => 'Doesn\'t match the new password',
 			'settings.changeCredentials.updatedSnack' => 'Credentials updated.',
 			'settings.changeCredentials.wrongCurrent' => 'Current password is wrong.',
-			_ => null,
-		} ?? switch (path) {
 			'settings.changeCredentials.saving' => 'Saving…',
 			'settings.changeCredentials.update' => 'Update',
 			'settings.logViewer.title' => 'Live logs',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -5457,6 +5457,7 @@ class TranslationsWebSessionsInspectorEn {
 
 	// Translations
 	late final TranslationsWebSessionsInspectorTabsEn tabs = TranslationsWebSessionsInspectorTabsEn.internal(_root);
+	late final TranslationsWebSessionsInspectorTranscriptEn transcript = TranslationsWebSessionsInspectorTranscriptEn.internal(_root);
 }
 
 // Path: web.sessions.ended
@@ -11206,6 +11207,33 @@ class TranslationsWebSessionsInspectorTabsEn {
 
 	/// en: 'Memory'
 	String get memory => 'Memory';
+
+	/// en: 'Conversation'
+	String get conversation => 'Conversation';
+}
+
+// Path: web.sessions.inspector.transcript
+class TranslationsWebSessionsInspectorTranscriptEn {
+	TranslationsWebSessionsInspectorTranscriptEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'No conversation yet.'
+	String get empty => 'No conversation yet.';
+
+	/// en: 'Couldn't load the conversation.'
+	String get loadFailed => 'Couldn\'t load the conversation.';
+
+	/// en: 'Copy all'
+	String get copyAll => 'Copy all';
+
+	/// en: 'Conversation copied'
+	String get copied => 'Conversation copied';
+
+	/// en: '{count} turns'
+	String count({required Object count}) => '${count} turns';
 }
 
 // Path: web.memoryWorkers.tasks.gatekeeper
@@ -14057,6 +14085,12 @@ extension on Translations {
 			'web.sessions.inspector.tabs.history' => 'History',
 			'web.sessions.inspector.tabs.notes' => 'Notes',
 			'web.sessions.inspector.tabs.memory' => 'Memory',
+			'web.sessions.inspector.tabs.conversation' => 'Conversation',
+			'web.sessions.inspector.transcript.empty' => 'No conversation yet.',
+			'web.sessions.inspector.transcript.loadFailed' => 'Couldn\'t load the conversation.',
+			'web.sessions.inspector.transcript.copyAll' => 'Copy all',
+			'web.sessions.inspector.transcript.copied' => 'Conversation copied',
+			'web.sessions.inspector.transcript.count' => ({required Object count}) => '${count} turns',
 			'web.sessions.ended.bufferUnavailable' => '[buffer unavailable]',
 			'web.sessions.ended.readOnlyBanner' => '[session ended — read-only buffer]',
 			'web.sessions.fileBrowser.title' => 'Choose working directory',
@@ -14383,14 +14417,14 @@ extension on Translations {
 			'web.memoryInspector.row.editTooltip' => 'Edit this memory',
 			'web.memoryInspector.row.deleteTooltip' => 'Delete this memory',
 			'web.memoryInspector.row.emptyError' => 'Memory text cannot be empty',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryInspector.row.deleteConfirm' => ({required Object id}) => 'Delete memory ${id}? This is permanent.',
 			'web.memoryInspector.toasts.deleted' => 'Memory deleted',
 			'web.memoryInspector.toasts.deleteFailed' => 'Delete failed',
 			'web.memoryInspector.toasts.bulkDeleted_one' => ({required Object count}) => 'Deleted ${count} memory from this scope',
 			'web.memoryInspector.toasts.bulkDeleted_other' => ({required Object count}) => 'Deleted ${count} memories from this scope',
 			'web.memoryInspector.toasts.bulkDeleteFailed' => 'Bulk delete failed',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryInspector.toasts.created' => 'Memory created',
 			'web.memoryInspector.toasts.createFailed' => 'Create failed',
 			'web.memoryInspector.toasts.updated' => 'Memory updated',
@@ -14897,14 +14931,14 @@ extension on Translations {
 			'web.integrations.proxy.emptyDescription' => ({required Object prefix}) => 'Register an integration first; the console proxies through /api/v1/proxy/${prefix}/* using the admin token.',
 			'web.integrations.proxy.targetLabel' => 'Target',
 			'web.integrations.proxy.selectPlaceholder' => 'Select integration…',
+			_ => null,
+		} ?? switch (path) {
 			'web.integrations.proxy.baseLabel' => 'base:',
 			'web.integrations.proxy.history' => 'History',
 			'web.integrations.proxy.historyEmpty' => 'no past requests for this integration',
 			'web.integrations.proxy.send' => 'Send',
 			'web.integrations.proxy.sending' => 'Sending…',
 			'web.integrations.proxy.extraHeadersLabel' => 'Extra headers (one per line, Name: Value)',
-			_ => null,
-		} ?? switch (path) {
 			'web.integrations.proxy.bodyLabel' => 'Body',
 			'web.integrations.proxy.headers' => 'Headers',
 			'web.integrations.proxy.body' => 'Body',
@@ -15411,14 +15445,14 @@ extension on Translations {
 			'web.serverSettings.fields.codexSessionsRoot.label' => 'Sessions root',
 			'web.serverSettings.fields.codexSessionsRoot.hint' => 'Directory walked for Codex rollout JSONL files. Default ~/.codex/sessions.',
 			'web.serverSettings.fields.geminiTmpRoot.label' => 'Tmp directory',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.fields.geminiTmpRoot.hint' => 'Root holding Gemini per-project tmp folders. Default ~/.gemini/tmp.',
 			'web.serverSettings.fields.geminiProjectsFile.label' => 'projects.json',
 			'web.serverSettings.fields.geminiProjectsFile.hint' => 'Path to Gemini\'s cwd→short-name mapping file. Default ~/.gemini/projects.json.',
 			'web.serverSettings.fields.backupLocalDir.label' => 'Local backup directory',
 			'web.serverSettings.fields.backupLocalDir.hint' => 'Default root for the auto-created `local` target. Empty = ~/.opendray/backups. Restart required.',
 			'web.serverSettings.fields.backupExportDir.label' => 'Export directory',
-			_ => null,
-		} ?? switch (path) {
 			'web.serverSettings.fields.backupExportDir.hint' => 'Where one-shot export zips are staged on disk. Empty = ~/.opendray/exports. Bundles auto-expire after 24h. Restart required.',
 			'web.serverSettings.fields.backupPgDumpPath.label' => 'pg_dump path',
 			'web.serverSettings.fields.backupPgDumpPath.hint' => 'Absolute path to pg_dump. Major version must be ≥ the server\'s. Empty = first pg_dump on PATH.',
@@ -15925,14 +15959,14 @@ extension on Translations {
 			'sessions.inspector.notes.changeLocationTooltip' => 'Change project docs location',
 			'sessions.inspector.notes.filenameHint' => 'filename (e.g. spec or design.md)',
 			'sessions.inspector.notes.create' => 'Create',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.notes.filterHint' => 'Filter…',
 			'sessions.inspector.notes.locationDialogTitle' => 'Project docs location',
 			'sessions.inspector.notes.loadFailedApi' => ({required Object error}) => 'Load failed: ${error}',
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => 'Load failed: ${error}',
 			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => 'Save failed: ${error}',
 			'sessions.inspector.notes.saveFailedGeneric' => ({required Object error}) => 'Save failed: ${error}',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.insertFailedApi' => ({required Object error}) => 'Insert failed: ${error}',
 			'sessions.inspector.notes.insertFailedGeneric' => ({required Object error}) => 'Insert failed: ${error}',
 			'sessions.inspector.notes.createFailedApi' => ({required Object error}) => 'Create failed: ${error}',
@@ -16439,14 +16473,14 @@ extension on Translations {
 			'backupSchedules.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}: ${error}',
 			'backupSchedules.noTargets' => 'No backup targets configured. Add one from the web admin or the Targets screen.',
 			'backupSchedules.okMsgCreate' => 'Schedule created.',
+			_ => null,
+		} ?? switch (path) {
 			'backupSchedules.okMsgUpdate' => 'Schedule updated.',
 			'backupSchedules.okMsgDelete' => 'Schedule deleted.',
 			'backupSchedules.errorPrefixCreate' => 'Create failed',
 			'backupSchedules.errorPrefixUpdate' => 'Update failed',
 			'backupSchedules.errorPrefixDelete' => 'Delete failed',
 			'backupSchedules.deleteBody' => ({required Object targetId}) => 'Removes the recurring spec for target ${targetId}. Existing backup blobs are not touched.',
-			_ => null,
-		} ?? switch (path) {
 			'backupSchedules.emptyList' => 'No schedules yet.\nTap "New" to create one.',
 			'backupSchedules.validatePickTarget' => 'Pick a target.',
 			'backupSchedules.validateInterval' => 'Interval must be > 0.',
@@ -16953,14 +16987,14 @@ extension on Translations {
 			'settings.changeCredentials.newPassword' => 'New password',
 			'settings.changeCredentials.confirmPassword' => 'Confirm new password',
 			'settings.changeCredentials.validatorRequired' => 'Required',
+			_ => null,
+		} ?? switch (path) {
 			'settings.changeCredentials.passwordHelper' => 'At least 8 characters',
 			'settings.changeCredentials.passwordTooShort' => 'Must be at least 8 characters',
 			'settings.changeCredentials.passwordMismatch' => 'Doesn\'t match the new password',
 			'settings.changeCredentials.updatedSnack' => 'Credentials updated.',
 			'settings.changeCredentials.wrongCurrent' => 'Current password is wrong.',
 			'settings.changeCredentials.saving' => 'Saving…',
-			_ => null,
-		} ?? switch (path) {
 			'settings.changeCredentials.update' => 'Update',
 			'settings.logViewer.title' => 'Live logs',
 			'settings.logViewer.reconnect' => 'Reconnect',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -873,16 +873,6 @@ class _TranslationsWebTopbarEs extends TranslationsWebTopbarEn {
 	@override String get collapseSidebar => 'Contraer barra lateral';
 	@override String get search => 'Buscar';
 	@override String get openPalette => 'Abrir paleta de comandos';
-	@override String get theme => 'Tema';
-	@override String themeLabel({required Object mode}) => 'Tema: ${mode}';
-	@override String get appearance => 'Apariencia';
-	@override String get themeLight => 'Claro';
-	@override String get themeDark => 'Oscuro';
-	@override String get themeSystem => 'Sistema';
-	@override String get language => 'Idioma';
-	@override String get languageEnglish => 'English';
-	@override String get languageChinese => '中文';
-	@override String get languageSpanish => 'Español';
 	@override String get signedInAs => 'Sesión iniciada como';
 	@override String get tokenExpires => 'El token caduca';
 	@override String get signOut => 'Cerrar sesión';
@@ -1327,6 +1317,7 @@ class _TranslationsWebSettingsEs extends TranslationsWebSettingsEn {
 	@override late final _TranslationsWebSettingsChangeCredentialsEs changeCredentials = _TranslationsWebSettingsChangeCredentialsEs._(_root);
 	@override late final _TranslationsWebSettingsSystemEs system = _TranslationsWebSettingsSystemEs._(_root);
 	@override late final _TranslationsWebSettingsAboutEs about = _TranslationsWebSettingsAboutEs._(_root);
+	@override late final _TranslationsWebSettingsLanguageEs language = _TranslationsWebSettingsLanguageEs._(_root);
 }
 
 // Path: web.logViewer
@@ -4725,6 +4716,18 @@ class _TranslationsWebSettingsAboutEs extends TranslationsWebSettingsAboutEn {
 	@override String get reinstall => 'Reinstalar';
 }
 
+// Path: web.settings.language
+class _TranslationsWebSettingsLanguageEs extends TranslationsWebSettingsLanguageEn {
+	_TranslationsWebSettingsLanguageEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Idioma';
+	@override String get description => 'Elige el idioma de la interfaz.';
+	@override late final _TranslationsWebSettingsLanguageOptionsEs options = _TranslationsWebSettingsLanguageOptionsEs._(_root);
+}
+
 // Path: web.memoryAmbient.header
 class _TranslationsWebMemoryAmbientHeaderEs extends TranslationsWebMemoryAmbientHeaderEn {
 	_TranslationsWebMemoryAmbientHeaderEs._(TranslationsEs root) : this._root = root, super.internal(root);
@@ -7194,6 +7197,18 @@ class _TranslationsWebSettingsFontOptionsEs extends TranslationsWebSettingsFontO
 	@override String get large => 'Grande';
 }
 
+// Path: web.settings.language.options
+class _TranslationsWebSettingsLanguageOptionsEs extends TranslationsWebSettingsLanguageOptionsEn {
+	_TranslationsWebSettingsLanguageOptionsEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get en => 'English';
+	@override String get zh => '中文';
+	@override String get es => 'Español';
+}
+
 // Path: web.memoryAmbient.providers.row
 class _TranslationsWebMemoryAmbientProvidersRowEs extends TranslationsWebMemoryAmbientProvidersRowEn {
 	_TranslationsWebMemoryAmbientProvidersRowEs._(TranslationsEs root) : this._root = root, super.internal(root);
@@ -7476,16 +7491,6 @@ extension on TranslationsEs {
 			'web.topbar.collapseSidebar' => 'Contraer barra lateral',
 			'web.topbar.search' => 'Buscar',
 			'web.topbar.openPalette' => 'Abrir paleta de comandos',
-			'web.topbar.theme' => 'Tema',
-			'web.topbar.themeLabel' => ({required Object mode}) => 'Tema: ${mode}',
-			'web.topbar.appearance' => 'Apariencia',
-			'web.topbar.themeLight' => 'Claro',
-			'web.topbar.themeDark' => 'Oscuro',
-			'web.topbar.themeSystem' => 'Sistema',
-			'web.topbar.language' => 'Idioma',
-			'web.topbar.languageEnglish' => 'English',
-			'web.topbar.languageChinese' => '中文',
-			'web.topbar.languageSpanish' => 'Español',
 			'web.topbar.signedInAs' => 'Sesión iniciada como',
 			'web.topbar.tokenExpires' => 'El token caduca',
 			'web.topbar.signOut' => 'Cerrar sesión',
@@ -7947,8 +7952,6 @@ extension on TranslationsEs {
 			'web.memoryInspector.row.editTooltip' => 'Editar esta memoria',
 			'web.memoryInspector.row.deleteTooltip' => 'Eliminar esta memoria',
 			'web.memoryInspector.row.emptyError' => 'El texto de la memoria no puede estar vacío',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryInspector.row.deleteConfirm' => ({required Object id}) => '¿Eliminar la memoria ${id}? Esto es permanente.',
 			'web.memoryInspector.toasts.deleted' => 'Memoria eliminada',
 			'web.memoryInspector.toasts.deleteFailed' => 'La eliminación falló',
@@ -7959,6 +7962,8 @@ extension on TranslationsEs {
 			'web.memoryInspector.toasts.createFailed' => 'La creación falló',
 			'web.memoryInspector.toasts.updated' => 'Memoria actualizada',
 			'web.memoryInspector.toasts.updateFailed' => 'La actualización falló',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryInspector.toasts.migrated' => ({required Object reembed, required Object examined, required Object to}) => 'Se migraron ${reembed}/${examined} memorias a ${to}',
 			'web.memoryInspector.toasts.migrationFailed' => 'La migración falló',
 			'web.memoryInspector.toasts.syncIngested_one' => ({required Object count}) => 'Se importó ${count} nuevo archivo de memoria',
@@ -8461,8 +8466,6 @@ extension on TranslationsEs {
 			'web.integrations.proxy.emptyDescription' => ({required Object prefix}) => 'Registra primero una integración; la consola hace de proxy a través de /api/v1/proxy/${prefix}/* usando el token de administrador.',
 			'web.integrations.proxy.targetLabel' => 'Destino',
 			'web.integrations.proxy.selectPlaceholder' => 'Selecciona una integración…',
-			_ => null,
-		} ?? switch (path) {
 			'web.integrations.proxy.baseLabel' => 'base:',
 			'web.integrations.proxy.history' => 'Historial',
 			'web.integrations.proxy.historyEmpty' => 'no hay peticiones anteriores para esta integración',
@@ -8473,6 +8476,8 @@ extension on TranslationsEs {
 			'web.integrations.proxy.headers' => 'Headers',
 			'web.integrations.proxy.body' => 'Body',
 			'web.integrations.proxy.emptyBody' => '(vacío)',
+			_ => null,
+		} ?? switch (path) {
 			'web.integrations.proxy.requestFailed' => 'la petición falló',
 			'web.integrations.proxy.stubText' => 'Envía una petición para ver la respuesta del upstream.',
 			'web.integrations.proxy.stubInjects' => 'opendray inyecta <1>X-Integration-ID</1> y elimina tu header <3>Authorization</3>.',
@@ -8975,8 +8980,6 @@ extension on TranslationsEs {
 			'web.serverSettings.fields.codexSessionsRoot.label' => 'Raíz de sesiones',
 			'web.serverSettings.fields.codexSessionsRoot.hint' => 'Directorio que se recorre en busca de los archivos JSONL de rollout de Codex. Por defecto ~/.codex/sessions.',
 			'web.serverSettings.fields.geminiTmpRoot.label' => 'Directorio tmp',
-			_ => null,
-		} ?? switch (path) {
 			'web.serverSettings.fields.geminiTmpRoot.hint' => 'Raíz que contiene las carpetas tmp por proyecto de Gemini. Por defecto ~/.gemini/tmp.',
 			'web.serverSettings.fields.geminiProjectsFile.label' => 'projects.json',
 			'web.serverSettings.fields.geminiProjectsFile.hint' => 'Ruta al archivo de mapeo cwd→nombre-corto de Gemini. Por defecto ~/.gemini/projects.json.',
@@ -8987,6 +8990,8 @@ extension on TranslationsEs {
 			'web.serverSettings.fields.backupPgDumpPath.label' => 'Ruta de pg_dump',
 			'web.serverSettings.fields.backupPgDumpPath.hint' => 'Ruta absoluta a pg_dump. La versión mayor debe ser ≥ la del servidor. Vacío = el primer pg_dump en el PATH.',
 			'web.serverSettings.fields.backupPgRestorePath.label' => 'Ruta de pg_restore',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.fields.backupPgRestorePath.hint' => 'Ruta absoluta a pg_restore para el flujo /backups/restore. Misma regla de versión mayor.',
 			'web.serverSettings.liveTail.heading' => 'Seguimiento en vivo',
 			'web.serverSettings.liveTail.description' => 'Búfer circular en memoria (los últimos ~2.000 registros). Se reinicia al reiniciar.',
@@ -9128,6 +9133,11 @@ extension on TranslationsEs {
 			'web.settings.about.checkUpdates' => 'Comprobar actualizaciones',
 			'web.settings.about.checking' => 'Comprobando…',
 			'web.settings.about.reinstall' => 'Reinstalar',
+			'web.settings.language.title' => 'Idioma',
+			'web.settings.language.description' => 'Elige el idioma de la interfaz.',
+			'web.settings.language.options.en' => 'English',
+			'web.settings.language.options.zh' => '中文',
+			'web.settings.language.options.es' => 'Español',
 			'web.logViewer.filterPlaceholder' => 'Filtrar…',
 			'web.logViewer.debugTooltip' => 'Recuento de debug',
 			'web.logViewer.infoTooltip' => 'Recuento de info',
@@ -9489,13 +9499,13 @@ extension on TranslationsEs {
 			'sessions.inspector.notes.changeLocationTooltip' => 'Cambiar la ubicación de los documentos del proyecto',
 			'sessions.inspector.notes.filenameHint' => 'nombre de archivo (p. ej. spec o design.md)',
 			'sessions.inspector.notes.create' => 'Crear',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.filterHint' => 'Filtrar…',
 			'sessions.inspector.notes.locationDialogTitle' => 'Ubicación de los documentos del proyecto',
 			'sessions.inspector.notes.loadFailedApi' => ({required Object error}) => 'Falló la carga: ${error}',
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => 'Falló la carga: ${error}',
 			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => 'Falló al guardar: ${error}',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.notes.saveFailedGeneric' => ({required Object error}) => 'Falló al guardar: ${error}',
 			'sessions.inspector.notes.insertFailedApi' => ({required Object error}) => 'Falló la inserción: ${error}',
 			'sessions.inspector.notes.insertFailedGeneric' => ({required Object error}) => 'Falló la inserción: ${error}',
@@ -10003,13 +10013,13 @@ extension on TranslationsEs {
 			'backupSchedules.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}: ${error}',
 			'backupSchedules.noTargets' => 'No hay destinos de copia de seguridad configurados. Añade uno desde el panel de administración web o la pantalla de Destinos.',
 			'backupSchedules.okMsgCreate' => 'Programación creada.',
-			_ => null,
-		} ?? switch (path) {
 			'backupSchedules.okMsgUpdate' => 'Programación actualizada.',
 			'backupSchedules.okMsgDelete' => 'Programación eliminada.',
 			'backupSchedules.errorPrefixCreate' => 'Error al crear',
 			'backupSchedules.errorPrefixUpdate' => 'Error al actualizar',
 			'backupSchedules.errorPrefixDelete' => 'Error al eliminar',
+			_ => null,
+		} ?? switch (path) {
 			'backupSchedules.deleteBody' => ({required Object targetId}) => 'Elimina la especificación recurrente para el destino ${targetId}. Los blobs de copia de seguridad existentes no se modifican.',
 			'backupSchedules.emptyList' => 'Aún no hay programaciones.\nToca "Nueva" para crear una.',
 			'backupSchedules.validatePickTarget' => 'Elige un destino.',
@@ -10517,13 +10527,13 @@ extension on TranslationsEs {
 			'settings.changeCredentials.newPassword' => 'Nueva contraseña',
 			'settings.changeCredentials.confirmPassword' => 'Confirma la nueva contraseña',
 			'settings.changeCredentials.validatorRequired' => 'Obligatorio',
-			_ => null,
-		} ?? switch (path) {
 			'settings.changeCredentials.passwordHelper' => 'Al menos 8 caracteres',
 			'settings.changeCredentials.passwordTooShort' => 'Debe tener al menos 8 caracteres',
 			'settings.changeCredentials.passwordMismatch' => 'No coincide con la nueva contraseña',
 			'settings.changeCredentials.updatedSnack' => 'Credenciales actualizadas.',
 			'settings.changeCredentials.wrongCurrent' => 'La contraseña actual es incorrecta.',
+			_ => null,
+		} ?? switch (path) {
 			'settings.changeCredentials.saving' => 'Guardando…',
 			'settings.changeCredentials.update' => 'Actualizar',
 			'settings.logViewer.title' => 'Logs en vivo',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -2802,6 +2802,7 @@ class _TranslationsWebSessionsInspectorEs extends TranslationsWebSessionsInspect
 
 	// Translations
 	@override late final _TranslationsWebSessionsInspectorTabsEs tabs = _TranslationsWebSessionsInspectorTabsEs._(_root);
+	@override late final _TranslationsWebSessionsInspectorTranscriptEs transcript = _TranslationsWebSessionsInspectorTranscriptEs._(_root);
 }
 
 // Path: web.sessions.ended
@@ -5849,6 +5850,21 @@ class _TranslationsWebSessionsInspectorTabsEs extends TranslationsWebSessionsIns
 	@override String get history => 'Historial';
 	@override String get notes => 'Notas';
 	@override String get memory => 'Memoria';
+	@override String get conversation => 'Conversación';
+}
+
+// Path: web.sessions.inspector.transcript
+class _TranslationsWebSessionsInspectorTranscriptEs extends TranslationsWebSessionsInspectorTranscriptEn {
+	_TranslationsWebSessionsInspectorTranscriptEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get empty => 'Aún no hay conversación.';
+	@override String get loadFailed => 'No se pudo cargar la conversación.';
+	@override String get copyAll => 'Copiar todo';
+	@override String get copied => 'Conversación copiada';
+	@override String count({required Object count}) => '${count} turnos';
 }
 
 // Path: web.memoryWorkers.tasks.gatekeeper
@@ -7599,6 +7615,12 @@ extension on TranslationsEs {
 			'web.sessions.inspector.tabs.history' => 'Historial',
 			'web.sessions.inspector.tabs.notes' => 'Notas',
 			'web.sessions.inspector.tabs.memory' => 'Memoria',
+			'web.sessions.inspector.tabs.conversation' => 'Conversación',
+			'web.sessions.inspector.transcript.empty' => 'Aún no hay conversación.',
+			'web.sessions.inspector.transcript.loadFailed' => 'No se pudo cargar la conversación.',
+			'web.sessions.inspector.transcript.copyAll' => 'Copiar todo',
+			'web.sessions.inspector.transcript.copied' => 'Conversación copiada',
+			'web.sessions.inspector.transcript.count' => ({required Object count}) => '${count} turnos',
 			'web.sessions.ended.bufferUnavailable' => '[búfer no disponible]',
 			'web.sessions.ended.readOnlyBanner' => '[session finalizada. búfer de solo lectura]',
 			'web.sessions.fileBrowser.title' => 'Elige el directorio de trabajo',
@@ -7925,14 +7947,14 @@ extension on TranslationsEs {
 			'web.memoryInspector.row.editTooltip' => 'Editar esta memoria',
 			'web.memoryInspector.row.deleteTooltip' => 'Eliminar esta memoria',
 			'web.memoryInspector.row.emptyError' => 'El texto de la memoria no puede estar vacío',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryInspector.row.deleteConfirm' => ({required Object id}) => '¿Eliminar la memoria ${id}? Esto es permanente.',
 			'web.memoryInspector.toasts.deleted' => 'Memoria eliminada',
 			'web.memoryInspector.toasts.deleteFailed' => 'La eliminación falló',
 			'web.memoryInspector.toasts.bulkDeleted_one' => ({required Object count}) => 'Se eliminó ${count} memoria de este scope',
 			'web.memoryInspector.toasts.bulkDeleted_other' => ({required Object count}) => 'Se eliminaron ${count} memorias de este scope',
 			'web.memoryInspector.toasts.bulkDeleteFailed' => 'La eliminación masiva falló',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryInspector.toasts.created' => 'Memoria creada',
 			'web.memoryInspector.toasts.createFailed' => 'La creación falló',
 			'web.memoryInspector.toasts.updated' => 'Memoria actualizada',
@@ -8439,14 +8461,14 @@ extension on TranslationsEs {
 			'web.integrations.proxy.emptyDescription' => ({required Object prefix}) => 'Registra primero una integración; la consola hace de proxy a través de /api/v1/proxy/${prefix}/* usando el token de administrador.',
 			'web.integrations.proxy.targetLabel' => 'Destino',
 			'web.integrations.proxy.selectPlaceholder' => 'Selecciona una integración…',
+			_ => null,
+		} ?? switch (path) {
 			'web.integrations.proxy.baseLabel' => 'base:',
 			'web.integrations.proxy.history' => 'Historial',
 			'web.integrations.proxy.historyEmpty' => 'no hay peticiones anteriores para esta integración',
 			'web.integrations.proxy.send' => 'Enviar',
 			'web.integrations.proxy.sending' => 'Enviando…',
 			'web.integrations.proxy.extraHeadersLabel' => 'Headers adicionales (uno por línea, Nombre: Valor)',
-			_ => null,
-		} ?? switch (path) {
 			'web.integrations.proxy.bodyLabel' => 'Body',
 			'web.integrations.proxy.headers' => 'Headers',
 			'web.integrations.proxy.body' => 'Body',
@@ -8953,14 +8975,14 @@ extension on TranslationsEs {
 			'web.serverSettings.fields.codexSessionsRoot.label' => 'Raíz de sesiones',
 			'web.serverSettings.fields.codexSessionsRoot.hint' => 'Directorio que se recorre en busca de los archivos JSONL de rollout de Codex. Por defecto ~/.codex/sessions.',
 			'web.serverSettings.fields.geminiTmpRoot.label' => 'Directorio tmp',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.fields.geminiTmpRoot.hint' => 'Raíz que contiene las carpetas tmp por proyecto de Gemini. Por defecto ~/.gemini/tmp.',
 			'web.serverSettings.fields.geminiProjectsFile.label' => 'projects.json',
 			'web.serverSettings.fields.geminiProjectsFile.hint' => 'Ruta al archivo de mapeo cwd→nombre-corto de Gemini. Por defecto ~/.gemini/projects.json.',
 			'web.serverSettings.fields.backupLocalDir.label' => 'Directorio local de copias de seguridad',
 			'web.serverSettings.fields.backupLocalDir.hint' => 'Raíz por defecto para el destino `local` creado automáticamente. Vacío = ~/.opendray/backups. Requiere reinicio.',
 			'web.serverSettings.fields.backupExportDir.label' => 'Directorio de exportación',
-			_ => null,
-		} ?? switch (path) {
 			'web.serverSettings.fields.backupExportDir.hint' => 'Dónde se preparan en disco los zips de exportación puntual. Vacío = ~/.opendray/exports. Los paquetes expiran automáticamente tras 24h. Requiere reinicio.',
 			'web.serverSettings.fields.backupPgDumpPath.label' => 'Ruta de pg_dump',
 			'web.serverSettings.fields.backupPgDumpPath.hint' => 'Ruta absoluta a pg_dump. La versión mayor debe ser ≥ la del servidor. Vacío = el primer pg_dump en el PATH.',
@@ -9467,14 +9489,14 @@ extension on TranslationsEs {
 			'sessions.inspector.notes.changeLocationTooltip' => 'Cambiar la ubicación de los documentos del proyecto',
 			'sessions.inspector.notes.filenameHint' => 'nombre de archivo (p. ej. spec o design.md)',
 			'sessions.inspector.notes.create' => 'Crear',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.notes.filterHint' => 'Filtrar…',
 			'sessions.inspector.notes.locationDialogTitle' => 'Ubicación de los documentos del proyecto',
 			'sessions.inspector.notes.loadFailedApi' => ({required Object error}) => 'Falló la carga: ${error}',
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => 'Falló la carga: ${error}',
 			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => 'Falló al guardar: ${error}',
 			'sessions.inspector.notes.saveFailedGeneric' => ({required Object error}) => 'Falló al guardar: ${error}',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.insertFailedApi' => ({required Object error}) => 'Falló la inserción: ${error}',
 			'sessions.inspector.notes.insertFailedGeneric' => ({required Object error}) => 'Falló la inserción: ${error}',
 			'sessions.inspector.notes.createFailedApi' => ({required Object error}) => 'Falló al crear: ${error}',
@@ -9981,14 +10003,14 @@ extension on TranslationsEs {
 			'backupSchedules.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}: ${error}',
 			'backupSchedules.noTargets' => 'No hay destinos de copia de seguridad configurados. Añade uno desde el panel de administración web o la pantalla de Destinos.',
 			'backupSchedules.okMsgCreate' => 'Programación creada.',
+			_ => null,
+		} ?? switch (path) {
 			'backupSchedules.okMsgUpdate' => 'Programación actualizada.',
 			'backupSchedules.okMsgDelete' => 'Programación eliminada.',
 			'backupSchedules.errorPrefixCreate' => 'Error al crear',
 			'backupSchedules.errorPrefixUpdate' => 'Error al actualizar',
 			'backupSchedules.errorPrefixDelete' => 'Error al eliminar',
 			'backupSchedules.deleteBody' => ({required Object targetId}) => 'Elimina la especificación recurrente para el destino ${targetId}. Los blobs de copia de seguridad existentes no se modifican.',
-			_ => null,
-		} ?? switch (path) {
 			'backupSchedules.emptyList' => 'Aún no hay programaciones.\nToca "Nueva" para crear una.',
 			'backupSchedules.validatePickTarget' => 'Elige un destino.',
 			'backupSchedules.validateInterval' => 'El intervalo debe ser > 0.',
@@ -10495,14 +10517,14 @@ extension on TranslationsEs {
 			'settings.changeCredentials.newPassword' => 'Nueva contraseña',
 			'settings.changeCredentials.confirmPassword' => 'Confirma la nueva contraseña',
 			'settings.changeCredentials.validatorRequired' => 'Obligatorio',
+			_ => null,
+		} ?? switch (path) {
 			'settings.changeCredentials.passwordHelper' => 'Al menos 8 caracteres',
 			'settings.changeCredentials.passwordTooShort' => 'Debe tener al menos 8 caracteres',
 			'settings.changeCredentials.passwordMismatch' => 'No coincide con la nueva contraseña',
 			'settings.changeCredentials.updatedSnack' => 'Credenciales actualizadas.',
 			'settings.changeCredentials.wrongCurrent' => 'La contraseña actual es incorrecta.',
 			'settings.changeCredentials.saving' => 'Guardando…',
-			_ => null,
-		} ?? switch (path) {
 			'settings.changeCredentials.update' => 'Actualizar',
 			'settings.logViewer.title' => 'Logs en vivo',
 			'settings.logViewer.reconnect' => 'Reconectar',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -1583,6 +1583,7 @@ class _TranslationsSessionsInspectorEs extends TranslationsSessionsInspectorEn {
 	@override late final _TranslationsSessionsInspectorGitEs git = _TranslationsSessionsInspectorGitEs._(_root);
 	@override late final _TranslationsSessionsInspectorTasksEs tasks = _TranslationsSessionsInspectorTasksEs._(_root);
 	@override late final _TranslationsSessionsInspectorNotesEs notes = _TranslationsSessionsInspectorNotesEs._(_root);
+	@override late final _TranslationsSessionsInspectorConversationEs conversation = _TranslationsSessionsInspectorConversationEs._(_root);
 }
 
 // Path: sessions.spawnSheet
@@ -5287,6 +5288,20 @@ class _TranslationsSessionsInspectorNotesEs extends TranslationsSessionsInspecto
 	@override String get save => 'Guardar';
 }
 
+// Path: sessions.inspector.conversation
+class _TranslationsSessionsInspectorConversationEs extends TranslationsSessionsInspectorConversationEn {
+	_TranslationsSessionsInspectorConversationEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get empty => 'Aún no hay conversación.';
+	@override String get loadFailed => 'No se pudo cargar la conversación.';
+	@override String get copyAll => 'Copiar todo';
+	@override String get copied => 'Conversación copiada';
+	@override String count({required Object count}) => '${count} turnos';
+}
+
 // Path: sessions.spawnSheet.bypass
 class _TranslationsSessionsSpawnSheetBypassEs extends TranslationsSessionsSpawnSheetBypassEn {
 	_TranslationsSessionsSpawnSheetBypassEs._(TranslationsEs root) : this._root = root, super.internal(root);
@@ -7414,6 +7429,7 @@ class _TranslationsSessionsInspectorShellTabsEs extends TranslationsSessionsInsp
 	@override String get tasks => 'Tareas';
 	@override String get history => 'Historial';
 	@override String get notes => 'Notas';
+	@override String get conversation => 'Conversación';
 }
 
 // Path: web.notes.vaultSync.conflict.kinds
@@ -9455,6 +9471,7 @@ extension on TranslationsEs {
 			'sessions.inspector.shell.tabs.tasks' => 'Tareas',
 			'sessions.inspector.shell.tabs.history' => 'Historial',
 			'sessions.inspector.shell.tabs.notes' => 'Notas',
+			'sessions.inspector.shell.tabs.conversation' => 'Conversación',
 			'sessions.inspector.shared.refresh' => 'Actualizar',
 			'sessions.inspector.shared.inserted' => ({required Object text}) => 'Insertado: ${text}',
 			'sessions.inspector.shared.insertFailedApi' => ({required Object status, required Object message}) => 'Falló la inserción (${status}): ${message}',
@@ -9503,9 +9520,9 @@ extension on TranslationsEs {
 			'sessions.inspector.notes.locationDialogTitle' => 'Ubicación de los documentos del proyecto',
 			'sessions.inspector.notes.loadFailedApi' => ({required Object error}) => 'Falló la carga: ${error}',
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => 'Falló la carga: ${error}',
-			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => 'Falló al guardar: ${error}',
 			_ => null,
 		} ?? switch (path) {
+			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => 'Falló al guardar: ${error}',
 			'sessions.inspector.notes.saveFailedGeneric' => ({required Object error}) => 'Falló al guardar: ${error}',
 			'sessions.inspector.notes.insertFailedApi' => ({required Object error}) => 'Falló la inserción: ${error}',
 			'sessions.inspector.notes.insertFailedGeneric' => ({required Object error}) => 'Falló la inserción: ${error}',
@@ -9528,6 +9545,11 @@ extension on TranslationsEs {
 			'sessions.inspector.notes.noProjectMapping2' => '(sin asignación de proyecto)',
 			'sessions.inspector.notes.clearOverride' => 'Borrar anulación',
 			'sessions.inspector.notes.save' => 'Guardar',
+			'sessions.inspector.conversation.empty' => 'Aún no hay conversación.',
+			'sessions.inspector.conversation.loadFailed' => 'No se pudo cargar la conversación.',
+			'sessions.inspector.conversation.copyAll' => 'Copiar todo',
+			'sessions.inspector.conversation.copied' => 'Conversación copiada',
+			'sessions.inspector.conversation.count' => ({required Object count}) => '${count} turnos',
 			'sessions.spawnSheet.title' => 'Nueva session',
 			'sessions.spawnSheet.errorRequired' => 'El proveedor y el directorio de trabajo son obligatorios',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => 'No se pudo crear la session: ${error}',
@@ -10012,14 +10034,14 @@ extension on TranslationsEs {
 			'backupSchedules.retentionLabel' => 'Retención (conservar las N más recientes)',
 			'backupSchedules.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}: ${error}',
 			'backupSchedules.noTargets' => 'No hay destinos de copia de seguridad configurados. Añade uno desde el panel de administración web o la pantalla de Destinos.',
+			_ => null,
+		} ?? switch (path) {
 			'backupSchedules.okMsgCreate' => 'Programación creada.',
 			'backupSchedules.okMsgUpdate' => 'Programación actualizada.',
 			'backupSchedules.okMsgDelete' => 'Programación eliminada.',
 			'backupSchedules.errorPrefixCreate' => 'Error al crear',
 			'backupSchedules.errorPrefixUpdate' => 'Error al actualizar',
 			'backupSchedules.errorPrefixDelete' => 'Error al eliminar',
-			_ => null,
-		} ?? switch (path) {
 			'backupSchedules.deleteBody' => ({required Object targetId}) => 'Elimina la especificación recurrente para el destino ${targetId}. Los blobs de copia de seguridad existentes no se modifican.',
 			'backupSchedules.emptyList' => 'Aún no hay programaciones.\nToca "Nueva" para crear una.',
 			'backupSchedules.validatePickTarget' => 'Elige un destino.',
@@ -10526,14 +10548,14 @@ extension on TranslationsEs {
 			'settings.changeCredentials.newUsername' => 'Nuevo usuario',
 			'settings.changeCredentials.newPassword' => 'Nueva contraseña',
 			'settings.changeCredentials.confirmPassword' => 'Confirma la nueva contraseña',
+			_ => null,
+		} ?? switch (path) {
 			'settings.changeCredentials.validatorRequired' => 'Obligatorio',
 			'settings.changeCredentials.passwordHelper' => 'Al menos 8 caracteres',
 			'settings.changeCredentials.passwordTooShort' => 'Debe tener al menos 8 caracteres',
 			'settings.changeCredentials.passwordMismatch' => 'No coincide con la nueva contraseña',
 			'settings.changeCredentials.updatedSnack' => 'Credenciales actualizadas.',
 			'settings.changeCredentials.wrongCurrent' => 'La contraseña actual es incorrecta.',
-			_ => null,
-		} ?? switch (path) {
 			'settings.changeCredentials.saving' => 'Guardando…',
 			'settings.changeCredentials.update' => 'Actualizar',
 			'settings.logViewer.title' => 'Logs en vivo',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -2802,6 +2802,7 @@ class _TranslationsWebSessionsInspectorZh extends TranslationsWebSessionsInspect
 
 	// Translations
 	@override late final _TranslationsWebSessionsInspectorTabsZh tabs = _TranslationsWebSessionsInspectorTabsZh._(_root);
+	@override late final _TranslationsWebSessionsInspectorTranscriptZh transcript = _TranslationsWebSessionsInspectorTranscriptZh._(_root);
 }
 
 // Path: web.sessions.ended
@@ -5849,6 +5850,21 @@ class _TranslationsWebSessionsInspectorTabsZh extends TranslationsWebSessionsIns
 	@override String get history => '历史';
 	@override String get notes => '笔记';
 	@override String get memory => '记忆';
+	@override String get conversation => '对话';
+}
+
+// Path: web.sessions.inspector.transcript
+class _TranslationsWebSessionsInspectorTranscriptZh extends TranslationsWebSessionsInspectorTranscriptEn {
+	_TranslationsWebSessionsInspectorTranscriptZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get empty => '暂无对话。';
+	@override String get loadFailed => '无法加载对话。';
+	@override String get copyAll => '复制全部';
+	@override String get copied => '已复制对话';
+	@override String count({required Object count}) => '${count} 轮';
 }
 
 // Path: web.memoryWorkers.tasks.gatekeeper
@@ -7599,6 +7615,12 @@ extension on TranslationsZh {
 			'web.sessions.inspector.tabs.history' => '历史',
 			'web.sessions.inspector.tabs.notes' => '笔记',
 			'web.sessions.inspector.tabs.memory' => '记忆',
+			'web.sessions.inspector.tabs.conversation' => '对话',
+			'web.sessions.inspector.transcript.empty' => '暂无对话。',
+			'web.sessions.inspector.transcript.loadFailed' => '无法加载对话。',
+			'web.sessions.inspector.transcript.copyAll' => '复制全部',
+			'web.sessions.inspector.transcript.copied' => '已复制对话',
+			'web.sessions.inspector.transcript.count' => ({required Object count}) => '${count} 轮',
 			'web.sessions.ended.bufferUnavailable' => '[缓冲区不可用]',
 			'web.sessions.ended.readOnlyBanner' => '[会话已结束 — 只读缓冲区]',
 			'web.sessions.fileBrowser.title' => '选择工作目录',
@@ -7925,14 +7947,14 @@ extension on TranslationsZh {
 			'web.memoryInspector.row.editTooltip' => '编辑该记忆',
 			'web.memoryInspector.row.deleteTooltip' => '删除该记忆',
 			'web.memoryInspector.row.emptyError' => '记忆文本不能为空',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryInspector.row.deleteConfirm' => ({required Object id}) => '删除记忆 ${id}? 不可恢复。',
 			'web.memoryInspector.toasts.deleted' => '记忆已删除',
 			'web.memoryInspector.toasts.deleteFailed' => '删除失败',
 			'web.memoryInspector.toasts.bulkDeleted_one' => ({required Object count}) => '已从此 scope 删除 ${count} 条记忆',
 			'web.memoryInspector.toasts.bulkDeleted_other' => ({required Object count}) => '已从此 scope 删除 ${count} 条记忆',
 			'web.memoryInspector.toasts.bulkDeleteFailed' => '批量删除失败',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryInspector.toasts.created' => '记忆已创建',
 			'web.memoryInspector.toasts.createFailed' => '创建失败',
 			'web.memoryInspector.toasts.updated' => '记忆已更新',
@@ -8439,14 +8461,14 @@ extension on TranslationsZh {
 			'web.integrations.proxy.emptyDescription' => ({required Object prefix}) => '请先注册一个集成；控制台通过 /api/v1/proxy/${prefix}/* 以 admin token 代理请求。',
 			'web.integrations.proxy.targetLabel' => '目标',
 			'web.integrations.proxy.selectPlaceholder' => '选择集成…',
+			_ => null,
+		} ?? switch (path) {
 			'web.integrations.proxy.baseLabel' => 'base:',
 			'web.integrations.proxy.history' => '历史',
 			'web.integrations.proxy.historyEmpty' => '此集成尚无历史请求',
 			'web.integrations.proxy.send' => '发送',
 			'web.integrations.proxy.sending' => '发送中…',
 			'web.integrations.proxy.extraHeadersLabel' => '额外 header（每行一条，Name: Value）',
-			_ => null,
-		} ?? switch (path) {
 			'web.integrations.proxy.bodyLabel' => 'Body',
 			'web.integrations.proxy.headers' => 'Headers',
 			'web.integrations.proxy.body' => 'Body',
@@ -8953,14 +8975,14 @@ extension on TranslationsZh {
 			'web.serverSettings.fields.codexSessionsRoot.label' => '会话根目录',
 			'web.serverSettings.fields.codexSessionsRoot.hint' => '遍历 Codex rollout JSONL 文件的目录。默认 ~/.codex/sessions。',
 			'web.serverSettings.fields.geminiTmpRoot.label' => 'tmp 目录',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.fields.geminiTmpRoot.hint' => '存放 Gemini 每项目 tmp 文件夹的根目录。默认 ~/.gemini/tmp。',
 			'web.serverSettings.fields.geminiProjectsFile.label' => 'projects.json',
 			'web.serverSettings.fields.geminiProjectsFile.hint' => 'Gemini cwd→短名映射文件的路径。默认 ~/.gemini/projects.json。',
 			'web.serverSettings.fields.backupLocalDir.label' => '本地备份目录',
 			'web.serverSettings.fields.backupLocalDir.hint' => '自动创建的 `local` 目标的默认根目录。留空 = ~/.opendray/backups。需要重启。',
 			'web.serverSettings.fields.backupExportDir.label' => '导出目录',
-			_ => null,
-		} ?? switch (path) {
 			'web.serverSettings.fields.backupExportDir.hint' => '一次性导出 zip 在磁盘上的暂存位置。留空 = ~/.opendray/exports。包将在 24 小时后自动过期。需要重启。',
 			'web.serverSettings.fields.backupPgDumpPath.label' => 'pg_dump 路径',
 			'web.serverSettings.fields.backupPgDumpPath.hint' => 'pg_dump 的绝对路径。主版本号必须 ≥ 服务器的。留空 = PATH 上的第一个 pg_dump。',
@@ -9467,14 +9489,14 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.changeLocationTooltip' => '更改项目文档位置',
 			'sessions.inspector.notes.filenameHint' => '文件名（例如：spec 或 design.md）',
 			'sessions.inspector.notes.create' => '创建',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.notes.filterHint' => '筛选…',
 			'sessions.inspector.notes.locationDialogTitle' => '项目文档位置',
 			'sessions.inspector.notes.loadFailedApi' => ({required Object error}) => '加载失败：${error}',
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => '加载失败：${error}',
 			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => '保存失败：${error}',
 			'sessions.inspector.notes.saveFailedGeneric' => ({required Object error}) => '保存失败：${error}',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.insertFailedApi' => ({required Object error}) => '插入失败：${error}',
 			'sessions.inspector.notes.insertFailedGeneric' => ({required Object error}) => '插入失败：${error}',
 			'sessions.inspector.notes.createFailedApi' => ({required Object error}) => '创建失败：${error}',
@@ -9981,14 +10003,14 @@ extension on TranslationsZh {
 			'backupSchedules.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}：${error}',
 			'backupSchedules.noTargets' => '未配置任何备份目标。请从 Web 管理端或「目标」屏添加。',
 			'backupSchedules.okMsgCreate' => '计划已创建。',
+			_ => null,
+		} ?? switch (path) {
 			'backupSchedules.okMsgUpdate' => '计划已更新。',
 			'backupSchedules.okMsgDelete' => '计划已删除。',
 			'backupSchedules.errorPrefixCreate' => '创建失败',
 			'backupSchedules.errorPrefixUpdate' => '更新失败',
 			'backupSchedules.errorPrefixDelete' => '删除失败',
 			'backupSchedules.deleteBody' => ({required Object targetId}) => '移除目标 ${targetId} 的定期规格。已存在的备份不受影响。',
-			_ => null,
-		} ?? switch (path) {
 			'backupSchedules.emptyList' => '暂无计划。\n点击「新建」创建一个。',
 			'backupSchedules.validatePickTarget' => '请选择一个目标。',
 			'backupSchedules.validateInterval' => '间隔必须大于 0。',
@@ -10495,14 +10517,14 @@ extension on TranslationsZh {
 			'settings.changeCredentials.newPassword' => '新密码',
 			'settings.changeCredentials.confirmPassword' => '确认新密码',
 			'settings.changeCredentials.validatorRequired' => '必填',
+			_ => null,
+		} ?? switch (path) {
 			'settings.changeCredentials.passwordHelper' => '至少 8 个字符',
 			'settings.changeCredentials.passwordTooShort' => '至少需要 8 个字符',
 			'settings.changeCredentials.passwordMismatch' => '与新密码不一致',
 			'settings.changeCredentials.updatedSnack' => '凭据已更新。',
 			'settings.changeCredentials.wrongCurrent' => '当前密码不正确。',
 			'settings.changeCredentials.saving' => '保存中…',
-			_ => null,
-		} ?? switch (path) {
 			'settings.changeCredentials.update' => '更新',
 			'settings.logViewer.title' => '实时日志',
 			'settings.logViewer.reconnect' => '重新连接',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -873,16 +873,6 @@ class _TranslationsWebTopbarZh extends TranslationsWebTopbarEn {
 	@override String get collapseSidebar => '收起侧边栏';
 	@override String get search => '搜索';
 	@override String get openPalette => '打开命令面板';
-	@override String get theme => '主题';
-	@override String themeLabel({required Object mode}) => '主题：${mode}';
-	@override String get appearance => '外观';
-	@override String get themeLight => '浅色';
-	@override String get themeDark => '深色';
-	@override String get themeSystem => '跟随系统';
-	@override String get language => '语言';
-	@override String get languageEnglish => 'English';
-	@override String get languageChinese => '中文';
-	@override String get languageSpanish => 'Español';
 	@override String get signedInAs => '登录账号';
 	@override String get tokenExpires => '令牌到期';
 	@override String get signOut => '退出登录';
@@ -1327,6 +1317,7 @@ class _TranslationsWebSettingsZh extends TranslationsWebSettingsEn {
 	@override late final _TranslationsWebSettingsChangeCredentialsZh changeCredentials = _TranslationsWebSettingsChangeCredentialsZh._(_root);
 	@override late final _TranslationsWebSettingsSystemZh system = _TranslationsWebSettingsSystemZh._(_root);
 	@override late final _TranslationsWebSettingsAboutZh about = _TranslationsWebSettingsAboutZh._(_root);
+	@override late final _TranslationsWebSettingsLanguageZh language = _TranslationsWebSettingsLanguageZh._(_root);
 }
 
 // Path: web.logViewer
@@ -4725,6 +4716,18 @@ class _TranslationsWebSettingsAboutZh extends TranslationsWebSettingsAboutEn {
 	@override String get reinstall => '重新安装';
 }
 
+// Path: web.settings.language
+class _TranslationsWebSettingsLanguageZh extends TranslationsWebSettingsLanguageEn {
+	_TranslationsWebSettingsLanguageZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '语言';
+	@override String get description => '选择界面语言。';
+	@override late final _TranslationsWebSettingsLanguageOptionsZh options = _TranslationsWebSettingsLanguageOptionsZh._(_root);
+}
+
 // Path: web.memoryAmbient.header
 class _TranslationsWebMemoryAmbientHeaderZh extends TranslationsWebMemoryAmbientHeaderEn {
 	_TranslationsWebMemoryAmbientHeaderZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -7194,6 +7197,18 @@ class _TranslationsWebSettingsFontOptionsZh extends TranslationsWebSettingsFontO
 	@override String get large => '大';
 }
 
+// Path: web.settings.language.options
+class _TranslationsWebSettingsLanguageOptionsZh extends TranslationsWebSettingsLanguageOptionsEn {
+	_TranslationsWebSettingsLanguageOptionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get en => 'English';
+	@override String get zh => '中文';
+	@override String get es => 'Español';
+}
+
 // Path: web.memoryAmbient.providers.row
 class _TranslationsWebMemoryAmbientProvidersRowZh extends TranslationsWebMemoryAmbientProvidersRowEn {
 	_TranslationsWebMemoryAmbientProvidersRowZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -7476,16 +7491,6 @@ extension on TranslationsZh {
 			'web.topbar.collapseSidebar' => '收起侧边栏',
 			'web.topbar.search' => '搜索',
 			'web.topbar.openPalette' => '打开命令面板',
-			'web.topbar.theme' => '主题',
-			'web.topbar.themeLabel' => ({required Object mode}) => '主题：${mode}',
-			'web.topbar.appearance' => '外观',
-			'web.topbar.themeLight' => '浅色',
-			'web.topbar.themeDark' => '深色',
-			'web.topbar.themeSystem' => '跟随系统',
-			'web.topbar.language' => '语言',
-			'web.topbar.languageEnglish' => 'English',
-			'web.topbar.languageChinese' => '中文',
-			'web.topbar.languageSpanish' => 'Español',
 			'web.topbar.signedInAs' => '登录账号',
 			'web.topbar.tokenExpires' => '令牌到期',
 			'web.topbar.signOut' => '退出登录',
@@ -7947,8 +7952,6 @@ extension on TranslationsZh {
 			'web.memoryInspector.row.editTooltip' => '编辑该记忆',
 			'web.memoryInspector.row.deleteTooltip' => '删除该记忆',
 			'web.memoryInspector.row.emptyError' => '记忆文本不能为空',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryInspector.row.deleteConfirm' => ({required Object id}) => '删除记忆 ${id}? 不可恢复。',
 			'web.memoryInspector.toasts.deleted' => '记忆已删除',
 			'web.memoryInspector.toasts.deleteFailed' => '删除失败',
@@ -7959,6 +7962,8 @@ extension on TranslationsZh {
 			'web.memoryInspector.toasts.createFailed' => '创建失败',
 			'web.memoryInspector.toasts.updated' => '记忆已更新',
 			'web.memoryInspector.toasts.updateFailed' => '更新失败',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryInspector.toasts.migrated' => ({required Object reembed, required Object examined, required Object to}) => '已迁移 ${reembed}/${examined} 条记忆到 ${to}',
 			'web.memoryInspector.toasts.migrationFailed' => '迁移失败',
 			'web.memoryInspector.toasts.syncIngested_one' => ({required Object count}) => '已摄取 ${count} 个新记忆文件',
@@ -8461,8 +8466,6 @@ extension on TranslationsZh {
 			'web.integrations.proxy.emptyDescription' => ({required Object prefix}) => '请先注册一个集成；控制台通过 /api/v1/proxy/${prefix}/* 以 admin token 代理请求。',
 			'web.integrations.proxy.targetLabel' => '目标',
 			'web.integrations.proxy.selectPlaceholder' => '选择集成…',
-			_ => null,
-		} ?? switch (path) {
 			'web.integrations.proxy.baseLabel' => 'base:',
 			'web.integrations.proxy.history' => '历史',
 			'web.integrations.proxy.historyEmpty' => '此集成尚无历史请求',
@@ -8473,6 +8476,8 @@ extension on TranslationsZh {
 			'web.integrations.proxy.headers' => 'Headers',
 			'web.integrations.proxy.body' => 'Body',
 			'web.integrations.proxy.emptyBody' => '(空)',
+			_ => null,
+		} ?? switch (path) {
 			'web.integrations.proxy.requestFailed' => '请求失败',
 			'web.integrations.proxy.stubText' => '发送一个请求即可查看上游响应。',
 			'web.integrations.proxy.stubInjects' => 'opendray 会注入 <1>X-Integration-ID</1>，并剥离你的 <3>Authorization</3> header。',
@@ -8975,8 +8980,6 @@ extension on TranslationsZh {
 			'web.serverSettings.fields.codexSessionsRoot.label' => '会话根目录',
 			'web.serverSettings.fields.codexSessionsRoot.hint' => '遍历 Codex rollout JSONL 文件的目录。默认 ~/.codex/sessions。',
 			'web.serverSettings.fields.geminiTmpRoot.label' => 'tmp 目录',
-			_ => null,
-		} ?? switch (path) {
 			'web.serverSettings.fields.geminiTmpRoot.hint' => '存放 Gemini 每项目 tmp 文件夹的根目录。默认 ~/.gemini/tmp。',
 			'web.serverSettings.fields.geminiProjectsFile.label' => 'projects.json',
 			'web.serverSettings.fields.geminiProjectsFile.hint' => 'Gemini cwd→短名映射文件的路径。默认 ~/.gemini/projects.json。',
@@ -8987,6 +8990,8 @@ extension on TranslationsZh {
 			'web.serverSettings.fields.backupPgDumpPath.label' => 'pg_dump 路径',
 			'web.serverSettings.fields.backupPgDumpPath.hint' => 'pg_dump 的绝对路径。主版本号必须 ≥ 服务器的。留空 = PATH 上的第一个 pg_dump。',
 			'web.serverSettings.fields.backupPgRestorePath.label' => 'pg_restore 路径',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.fields.backupPgRestorePath.hint' => '/backups/restore 流程使用的 pg_restore 绝对路径。同样的主版本号规则。',
 			'web.serverSettings.liveTail.heading' => '实时日志',
 			'web.serverSettings.liveTail.description' => '内存中的环形缓冲区（最近约 2,000 条）。重启后清空。',
@@ -9128,6 +9133,11 @@ extension on TranslationsZh {
 			'web.settings.about.checkUpdates' => '检查更新',
 			'web.settings.about.checking' => '检查中…',
 			'web.settings.about.reinstall' => '重新安装',
+			'web.settings.language.title' => '语言',
+			'web.settings.language.description' => '选择界面语言。',
+			'web.settings.language.options.en' => 'English',
+			'web.settings.language.options.zh' => '中文',
+			'web.settings.language.options.es' => 'Español',
 			'web.logViewer.filterPlaceholder' => '过滤…',
 			'web.logViewer.debugTooltip' => 'Debug 计数',
 			'web.logViewer.infoTooltip' => 'Info 计数',
@@ -9489,13 +9499,13 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.changeLocationTooltip' => '更改项目文档位置',
 			'sessions.inspector.notes.filenameHint' => '文件名（例如：spec 或 design.md）',
 			'sessions.inspector.notes.create' => '创建',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.filterHint' => '筛选…',
 			'sessions.inspector.notes.locationDialogTitle' => '项目文档位置',
 			'sessions.inspector.notes.loadFailedApi' => ({required Object error}) => '加载失败：${error}',
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => '加载失败：${error}',
 			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => '保存失败：${error}',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.notes.saveFailedGeneric' => ({required Object error}) => '保存失败：${error}',
 			'sessions.inspector.notes.insertFailedApi' => ({required Object error}) => '插入失败：${error}',
 			'sessions.inspector.notes.insertFailedGeneric' => ({required Object error}) => '插入失败：${error}',
@@ -10003,13 +10013,13 @@ extension on TranslationsZh {
 			'backupSchedules.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}：${error}',
 			'backupSchedules.noTargets' => '未配置任何备份目标。请从 Web 管理端或「目标」屏添加。',
 			'backupSchedules.okMsgCreate' => '计划已创建。',
-			_ => null,
-		} ?? switch (path) {
 			'backupSchedules.okMsgUpdate' => '计划已更新。',
 			'backupSchedules.okMsgDelete' => '计划已删除。',
 			'backupSchedules.errorPrefixCreate' => '创建失败',
 			'backupSchedules.errorPrefixUpdate' => '更新失败',
 			'backupSchedules.errorPrefixDelete' => '删除失败',
+			_ => null,
+		} ?? switch (path) {
 			'backupSchedules.deleteBody' => ({required Object targetId}) => '移除目标 ${targetId} 的定期规格。已存在的备份不受影响。',
 			'backupSchedules.emptyList' => '暂无计划。\n点击「新建」创建一个。',
 			'backupSchedules.validatePickTarget' => '请选择一个目标。',
@@ -10517,13 +10527,13 @@ extension on TranslationsZh {
 			'settings.changeCredentials.newPassword' => '新密码',
 			'settings.changeCredentials.confirmPassword' => '确认新密码',
 			'settings.changeCredentials.validatorRequired' => '必填',
-			_ => null,
-		} ?? switch (path) {
 			'settings.changeCredentials.passwordHelper' => '至少 8 个字符',
 			'settings.changeCredentials.passwordTooShort' => '至少需要 8 个字符',
 			'settings.changeCredentials.passwordMismatch' => '与新密码不一致',
 			'settings.changeCredentials.updatedSnack' => '凭据已更新。',
 			'settings.changeCredentials.wrongCurrent' => '当前密码不正确。',
+			_ => null,
+		} ?? switch (path) {
 			'settings.changeCredentials.saving' => '保存中…',
 			'settings.changeCredentials.update' => '更新',
 			'settings.logViewer.title' => '实时日志',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -1583,6 +1583,7 @@ class _TranslationsSessionsInspectorZh extends TranslationsSessionsInspectorEn {
 	@override late final _TranslationsSessionsInspectorGitZh git = _TranslationsSessionsInspectorGitZh._(_root);
 	@override late final _TranslationsSessionsInspectorTasksZh tasks = _TranslationsSessionsInspectorTasksZh._(_root);
 	@override late final _TranslationsSessionsInspectorNotesZh notes = _TranslationsSessionsInspectorNotesZh._(_root);
+	@override late final _TranslationsSessionsInspectorConversationZh conversation = _TranslationsSessionsInspectorConversationZh._(_root);
 }
 
 // Path: sessions.spawnSheet
@@ -5287,6 +5288,20 @@ class _TranslationsSessionsInspectorNotesZh extends TranslationsSessionsInspecto
 	@override String get save => '保存';
 }
 
+// Path: sessions.inspector.conversation
+class _TranslationsSessionsInspectorConversationZh extends TranslationsSessionsInspectorConversationEn {
+	_TranslationsSessionsInspectorConversationZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get empty => '暂无对话。';
+	@override String get loadFailed => '无法加载对话。';
+	@override String get copyAll => '复制全部';
+	@override String get copied => '已复制对话';
+	@override String count({required Object count}) => '${count} 轮';
+}
+
 // Path: sessions.spawnSheet.bypass
 class _TranslationsSessionsSpawnSheetBypassZh extends TranslationsSessionsSpawnSheetBypassEn {
 	_TranslationsSessionsSpawnSheetBypassZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -7414,6 +7429,7 @@ class _TranslationsSessionsInspectorShellTabsZh extends TranslationsSessionsInsp
 	@override String get tasks => '任务';
 	@override String get history => '历史';
 	@override String get notes => '笔记';
+	@override String get conversation => '对话';
 }
 
 // Path: web.notes.vaultSync.conflict.kinds
@@ -9455,6 +9471,7 @@ extension on TranslationsZh {
 			'sessions.inspector.shell.tabs.tasks' => '任务',
 			'sessions.inspector.shell.tabs.history' => '历史',
 			'sessions.inspector.shell.tabs.notes' => '笔记',
+			'sessions.inspector.shell.tabs.conversation' => '对话',
 			'sessions.inspector.shared.refresh' => '刷新',
 			'sessions.inspector.shared.inserted' => ({required Object text}) => '已插入：${text}',
 			'sessions.inspector.shared.insertFailedApi' => ({required Object status, required Object message}) => '插入失败（${status}）：${message}',
@@ -9503,9 +9520,9 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.locationDialogTitle' => '项目文档位置',
 			'sessions.inspector.notes.loadFailedApi' => ({required Object error}) => '加载失败：${error}',
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => '加载失败：${error}',
-			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => '保存失败：${error}',
 			_ => null,
 		} ?? switch (path) {
+			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => '保存失败：${error}',
 			'sessions.inspector.notes.saveFailedGeneric' => ({required Object error}) => '保存失败：${error}',
 			'sessions.inspector.notes.insertFailedApi' => ({required Object error}) => '插入失败：${error}',
 			'sessions.inspector.notes.insertFailedGeneric' => ({required Object error}) => '插入失败：${error}',
@@ -9528,6 +9545,11 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.noProjectMapping2' => '（无项目映射）',
 			'sessions.inspector.notes.clearOverride' => '清除覆盖',
 			'sessions.inspector.notes.save' => '保存',
+			'sessions.inspector.conversation.empty' => '暂无对话。',
+			'sessions.inspector.conversation.loadFailed' => '无法加载对话。',
+			'sessions.inspector.conversation.copyAll' => '复制全部',
+			'sessions.inspector.conversation.copied' => '已复制对话',
+			'sessions.inspector.conversation.count' => ({required Object count}) => '${count} 轮',
 			'sessions.spawnSheet.title' => '新建会话',
 			'sessions.spawnSheet.errorRequired' => '需要指定提供商和工作目录',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => '创建会话失败：${error}',
@@ -10012,14 +10034,14 @@ extension on TranslationsZh {
 			'backupSchedules.retentionLabel' => '保留（最近 N 个）',
 			'backupSchedules.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}：${error}',
 			'backupSchedules.noTargets' => '未配置任何备份目标。请从 Web 管理端或「目标」屏添加。',
+			_ => null,
+		} ?? switch (path) {
 			'backupSchedules.okMsgCreate' => '计划已创建。',
 			'backupSchedules.okMsgUpdate' => '计划已更新。',
 			'backupSchedules.okMsgDelete' => '计划已删除。',
 			'backupSchedules.errorPrefixCreate' => '创建失败',
 			'backupSchedules.errorPrefixUpdate' => '更新失败',
 			'backupSchedules.errorPrefixDelete' => '删除失败',
-			_ => null,
-		} ?? switch (path) {
 			'backupSchedules.deleteBody' => ({required Object targetId}) => '移除目标 ${targetId} 的定期规格。已存在的备份不受影响。',
 			'backupSchedules.emptyList' => '暂无计划。\n点击「新建」创建一个。',
 			'backupSchedules.validatePickTarget' => '请选择一个目标。',
@@ -10526,14 +10548,14 @@ extension on TranslationsZh {
 			'settings.changeCredentials.newUsername' => '新用户名',
 			'settings.changeCredentials.newPassword' => '新密码',
 			'settings.changeCredentials.confirmPassword' => '确认新密码',
+			_ => null,
+		} ?? switch (path) {
 			'settings.changeCredentials.validatorRequired' => '必填',
 			'settings.changeCredentials.passwordHelper' => '至少 8 个字符',
 			'settings.changeCredentials.passwordTooShort' => '至少需要 8 个字符',
 			'settings.changeCredentials.passwordMismatch' => '与新密码不一致',
 			'settings.changeCredentials.updatedSnack' => '凭据已更新。',
 			'settings.changeCredentials.wrongCurrent' => '当前密码不正确。',
-			_ => null,
-		} ?? switch (path) {
 			'settings.changeCredentials.saving' => '保存中…',
 			'settings.changeCredentials.update' => '更新',
 			'settings.logViewer.title' => '实时日志',

--- a/app/mobile/lib/features/sessions/inspector/session_inspector_screen.dart
+++ b/app/mobile/lib/features/sessions/inspector/session_inspector_screen.dart
@@ -8,6 +8,7 @@ import 'package:opendray/features/sessions/inspector/git_tab.dart';
 import 'package:opendray/features/sessions/inspector/history_tab.dart';
 import 'package:opendray/features/sessions/inspector/notes_tab.dart';
 import 'package:opendray/features/sessions/inspector/tasks_tab.dart';
+import 'package:opendray/features/sessions/inspector/transcript_tab.dart';
 import 'package:path/path.dart' as p;
 
 // Per-session inspector screen. Mirrors the cwd-scoped panels the
@@ -40,7 +41,7 @@ class _Body extends StatelessWidget {
   Widget build(BuildContext context) {
     final lastSegment = p.basename(session.cwd);
     return DefaultTabController(
-      length: 5,
+      length: 6,
       child: Scaffold(
         appBar: AppBar(
           title: Column(
@@ -79,6 +80,10 @@ class _Body extends StatelessWidget {
                 text: t.sessions.inspector.shell.tabs.history,
               ),
               Tab(
+                icon: const Icon(Icons.forum_outlined),
+                text: t.sessions.inspector.shell.tabs.conversation,
+              ),
+              Tab(
                 icon: const Icon(Icons.description_outlined),
                 text: t.sessions.inspector.shell.tabs.notes,
               ),
@@ -91,6 +96,7 @@ class _Body extends StatelessWidget {
             GitTab(sessionId: session.id, cwd: session.cwd),
             TasksTab(sessionId: session.id, cwd: session.cwd),
             HistoryTab(sessionId: session.id),
+            TranscriptTab(sessionId: session.id),
             NotesTab(sessionId: session.id, cwd: session.cwd),
           ],
         ),

--- a/app/mobile/lib/features/sessions/inspector/transcript_tab.dart
+++ b/app/mobile/lib/features/sessions/inspector/transcript_tab.dart
@@ -1,0 +1,248 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/api/api_exception.dart';
+import 'package:opendray/core/api/models.dart';
+import 'package:opendray/core/api/sessions_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+
+// Conversation surface inside the session inspector. Renders the
+// session's reconstructed conversation (user prompts + assistant
+// prose) parsed from the CLI's JSONL as a scrollable list. This is
+// the scrollback the live terminal can't give: the agent CLIs run a
+// full-screen alternate-screen TUI, which has no scrollback.
+class TranscriptTab extends ConsumerStatefulWidget {
+  const TranscriptTab({required this.sessionId, super.key});
+
+  final String sessionId;
+
+  @override
+  ConsumerState<TranscriptTab> createState() => _TranscriptTabState();
+}
+
+class _TranscriptTabState extends ConsumerState<TranscriptTab>
+    with AutomaticKeepAliveClientMixin {
+  AsyncValue<TranscriptResponse> _state = const AsyncValue.loading();
+
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _state = const AsyncValue.loading());
+    try {
+      final res =
+          await ref.read(sessionsApiProvider).transcript(widget.sessionId);
+      if (!mounted) return;
+      setState(() => _state = AsyncValue.data(res));
+    } on ApiException catch (e) {
+      if (mounted) {
+        setState(() => _state = AsyncValue.error(e, StackTrace.current));
+      }
+    } on Object catch (e, st) {
+      if (mounted) setState(() => _state = AsyncValue.error(e, st));
+    }
+  }
+
+  Future<void> _copyAll(List<TranscriptTurn> turns) async {
+    final text = turns
+        .map((tn) => '${tn.role.toUpperCase()}: ${tn.text}')
+        .join('\n\n');
+    await Clipboard.setData(ClipboardData(text: text));
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(t.sessions.inspector.conversation.copied),
+        duration: const Duration(seconds: 2),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return _state.when(
+      data: (res) {
+        if (res.turns.isEmpty) {
+          return _EmptyView(onRefresh: _load);
+        }
+        return Column(
+          children: [
+            _Toolbar(
+              count: res.turns.length,
+              onCopyAll: () => _copyAll(res.turns),
+              onRefresh: _load,
+            ),
+            const Divider(height: 1),
+            Expanded(
+              child: RefreshIndicator(
+                onRefresh: _load,
+                child: ListView.separated(
+                  padding: const EdgeInsets.all(12),
+                  itemCount: res.turns.length,
+                  separatorBuilder: (_, __) => const SizedBox(height: 8),
+                  itemBuilder: (_, i) => _TurnCard(turn: res.turns[i]),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => _ErrorView(error: e, onRetry: _load),
+    );
+  }
+}
+
+class _Toolbar extends StatelessWidget {
+  const _Toolbar({
+    required this.count,
+    required this.onCopyAll,
+    required this.onRefresh,
+  });
+
+  final int count;
+  final VoidCallback onCopyAll;
+  final VoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 4, 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              t.sessions.inspector.conversation.count(count: count.toString()),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+          TextButton.icon(
+            icon: const Icon(Icons.copy_all_outlined, size: 18),
+            label: Text(t.sessions.inspector.conversation.copyAll),
+            onPressed: onCopyAll,
+          ),
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: t.sessions.inspector.shared.refresh,
+            onPressed: onRefresh,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TurnCard extends StatelessWidget {
+  const _TurnCard({required this.turn});
+
+  final TranscriptTurn turn;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isUser = turn.role == 'user';
+    final roleColor =
+        isUser ? theme.colorScheme.primary : theme.colorScheme.secondary;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: theme.dividerColor),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            turn.role.toUpperCase(),
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: roleColor,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0.5,
+            ),
+          ),
+          const SizedBox(height: 4),
+          SelectableText(
+            turn.text,
+            style: theme.textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyView extends StatelessWidget {
+  const _EmptyView({required this.onRefresh});
+  final Future<void> Function() onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    return RefreshIndicator(
+      onRefresh: onRefresh,
+      child: ListView(
+        children: [
+          const SizedBox(height: 96),
+          Icon(
+            Icons.forum_outlined,
+            size: 48,
+            color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.4),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            t.sessions.inspector.conversation.empty,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.error, required this.onRetry});
+  final Object error;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: 48,
+              color: Theme.of(context).colorScheme.error,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              t.sessions.inspector.conversation.loadFailed,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              error.toString(),
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 16),
+            FilledButton(onPressed: onRetry, child: Text(t.common.retry)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/shared/src/lib/sessions.ts
+++ b/app/shared/src/lib/sessions.ts
@@ -80,6 +80,26 @@ export async function fetchSessionHistory(
   )
 }
 
+export interface TranscriptTurn {
+  ts: string
+  role: string // "user" | "assistant"
+  text: string
+}
+
+export interface TranscriptResponse {
+  turns: TranscriptTurn[]
+}
+
+// fetchSessionTranscript returns the session's conversation (user prompts
+// + assistant prose) reconstructed from the CLI's JSONL — the scrollable
+// history the live alternate-screen terminal can't offer. Claude / Codex /
+// Gemini are supported; other providers return an empty list.
+export async function fetchSessionTranscript(
+  id: string,
+): Promise<TranscriptResponse> {
+  return api<TranscriptResponse>(`/api/v1/sessions/${id}/transcript`)
+}
+
 // resendInput re-submits a prompt to the live session. Claude runs
 // the PTY in raw mode where Enter is `\r`, not `\n` — using `\n`
 // produces a literal newline in the prompt instead of submitting.

--- a/app/web/src/components/Topbar.tsx
+++ b/app/web/src/components/Topbar.tsx
@@ -1,15 +1,10 @@
 import { useNavigate } from '@tanstack/react-router'
 import {
-  Sun,
-  Moon,
-  Monitor,
   Terminal as TerminalIcon,
   LogOut,
   Search,
-  Check,
   PanelLeftClose,
   PanelLeftOpen,
-  Languages,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -24,42 +19,21 @@ import {
   DropdownMenuShortcut,
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { useTheme, type ThemeMode } from '@/stores/theme'
 import { useAuth } from '@/stores/auth'
 import { useLayout } from '@/stores/layout'
-import { useLocale, type Locale } from '@/stores/locale'
 
 interface TopbarProps {
   onOpenPalette?: () => void
 }
 
-const themeOptions: { mode: ThemeMode; labelKey: string; icon: typeof Sun }[] = [
-  { mode: 'light', labelKey: 'web.topbar.themeLight', icon: Sun },
-  { mode: 'dark', labelKey: 'web.topbar.themeDark', icon: Moon },
-  { mode: 'system', labelKey: 'web.topbar.themeSystem', icon: Monitor },
-]
-
-const localeOptions: { locale: Locale; labelKey: string }[] = [
-  { locale: 'en', labelKey: 'web.topbar.languageEnglish' },
-  { locale: 'zh', labelKey: 'web.topbar.languageChinese' },
-  { locale: 'es', labelKey: 'web.topbar.languageSpanish' },
-]
-
 export function Topbar({ onOpenPalette }: TopbarProps) {
   const { t } = useTranslation()
-  const mode = useTheme((s) => s.mode)
-  const setMode = useTheme((s) => s.setMode)
-  const locale = useLocale((s) => s.locale)
-  const setLocale = useLocale((s) => s.setLocale)
   const username = useAuth((s) => s.username)
   const expiresAt = useAuth((s) => s.expiresAt)
   const clear = useAuth((s) => s.clear)
   const navigate = useNavigate()
   const sidebarCollapsed = useLayout((s) => s.sidebarCollapsed)
   const toggleSidebar = useLayout((s) => s.toggleSidebar)
-
-  const ThemeIcon =
-    mode === 'dark' ? Moon : mode === 'light' ? Sun : Monitor
 
   const sidebarToggleLabel = sidebarCollapsed
     ? t('web.topbar.expandSidebar')
@@ -113,59 +87,6 @@ export function Topbar({ onOpenPalette }: TopbarProps) {
           <TooltipContent>{t('web.topbar.openPalette')}</TooltipContent>
         </Tooltip>
       )}
-
-      <DropdownMenu>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                aria-label={t('web.topbar.language')}
-              >
-                <Languages className="size-3.5" />
-              </Button>
-            </DropdownMenuTrigger>
-          </TooltipTrigger>
-          <TooltipContent>{t('web.topbar.language')}</TooltipContent>
-        </Tooltip>
-        <DropdownMenuContent align="end">
-          <DropdownMenuLabel>{t('web.topbar.language')}</DropdownMenuLabel>
-          {localeOptions.map(({ locale: l, labelKey }) => (
-            <DropdownMenuItem key={l} onSelect={() => setLocale(l)}>
-              <span>{t(labelKey)}</span>
-              {locale === l && <Check className="ml-auto size-3" />}
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      <DropdownMenu>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                aria-label={t('web.topbar.themeLabel', { mode })}
-              >
-                <ThemeIcon className="size-3.5" />
-              </Button>
-            </DropdownMenuTrigger>
-          </TooltipTrigger>
-          <TooltipContent>{t('web.topbar.theme')}</TooltipContent>
-        </Tooltip>
-        <DropdownMenuContent align="end">
-          <DropdownMenuLabel>{t('web.topbar.appearance')}</DropdownMenuLabel>
-          {themeOptions.map(({ mode: m, labelKey, icon: Icon }) => (
-            <DropdownMenuItem key={m} onSelect={() => setMode(m)}>
-              <Icon />
-              <span>{t(labelKey)}</span>
-              {mode === m && <Check className="ml-auto size-3" />}
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
 
       {username && (
         <DropdownMenu>

--- a/app/web/src/components/sessions/InspectorPanel.tsx
+++ b/app/web/src/components/sessions/InspectorPanel.tsx
@@ -7,6 +7,7 @@ import {
   Play,
   NotebookPen,
   History as HistoryIcon,
+  MessageSquare,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -23,6 +24,7 @@ import type { Session } from '@/lib/types'
 import { FilesPanel } from './inspector/FilesPanel'
 import { GitPanel } from './inspector/GitPanel'
 import { HistoryPanel } from './inspector/HistoryPanel'
+import { TranscriptPanel } from './inspector/TranscriptPanel'
 import { MemoryPanel } from './inspector/MemoryPanel'
 import { NotesPanel } from './inspector/NotesPanel'
 import { SearchPanel } from './inspector/SearchPanel'
@@ -145,6 +147,13 @@ export function InspectorPanel({ session }: InspectorPanelProps) {
               {t('web.sessions.inspector.tabs.history')}
             </TabsTrigger>
             <TabsTrigger
+              value="conversation"
+              className="flex items-center justify-center gap-1.5 col-span-2 data-[state=active]:bg-card"
+            >
+              <MessageSquare className="size-3" />
+              {t('web.sessions.inspector.tabs.conversation')}
+            </TabsTrigger>
+            <TabsTrigger
               value="notes"
               className="flex items-center justify-center gap-1.5 col-span-2 data-[state=active]:bg-card"
             >
@@ -153,7 +162,7 @@ export function InspectorPanel({ session }: InspectorPanelProps) {
             </TabsTrigger>
             <TabsTrigger
               value="memory"
-              className="flex items-center justify-center gap-1.5 col-span-4 data-[state=active]:bg-card"
+              className="flex items-center justify-center gap-1.5 col-span-2 data-[state=active]:bg-card"
             >
               <Brain className="size-3" />
               {t('web.sessions.inspector.tabs.memory')}
@@ -176,6 +185,9 @@ export function InspectorPanel({ session }: InspectorPanelProps) {
           </TabsContent>
           <TabsContent value="history" className="m-0 p-3">
             <HistoryPanel session={session} />
+          </TabsContent>
+          <TabsContent value="conversation" className="m-0 p-3">
+            <TranscriptPanel session={session} />
           </TabsContent>
           <TabsContent value="notes" className="m-0 p-3">
             <NotesPanel cwd={session.cwd} />

--- a/app/web/src/components/sessions/inspector/TranscriptPanel.tsx
+++ b/app/web/src/components/sessions/inspector/TranscriptPanel.tsx
@@ -1,0 +1,94 @@
+import { useQuery } from '@tanstack/react-query'
+import { Copy, MessageSquare, Loader2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import { fetchSessionTranscript } from '@/lib/sessions'
+import type { Session } from '@/lib/types'
+import { copyText } from '@/lib/clipboard'
+
+// TranscriptPanel — Inspector "Conversation" tab. Renders the session's
+// reconstructed conversation (user prompts + assistant prose) from the
+// CLI's JSONL as a scrollable list. This is the scrollback the live
+// terminal can't give: the agent CLIs run a full-screen alternate-screen
+// TUI, which has no scrollback. The parent Inspector wraps this in a
+// ScrollArea, so the list itself just flows.
+export function TranscriptPanel({ session }: { session: Session }) {
+  const { t } = useTranslation()
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['session-transcript', session.id],
+    queryFn: () => fetchSessionTranscript(session.id),
+    refetchInterval: 10_000,
+  })
+
+  const turns = data?.turns ?? []
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12 text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" />
+      </div>
+    )
+  }
+  if (isError) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 py-12 text-center text-xs text-muted-foreground">
+        <MessageSquare className="size-6 opacity-40" />
+        {t('web.sessions.inspector.transcript.loadFailed')}
+      </div>
+    )
+  }
+  if (turns.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 py-12 text-center text-xs text-muted-foreground">
+        <MessageSquare className="size-6 opacity-40" />
+        {t('web.sessions.inspector.transcript.empty')}
+      </div>
+    )
+  }
+
+  const copyAll = async () => {
+    const text = turns
+      .map((tn) => `${tn.role.toUpperCase()}: ${tn.text}`)
+      .join('\n\n')
+    await copyText(text)
+    toast.success(t('web.sessions.inspector.transcript.copied'))
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] text-muted-foreground">
+          {t('web.sessions.inspector.transcript.count', { count: turns.length })}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-6 gap-1 text-[11px]"
+          onClick={copyAll}
+        >
+          <Copy className="size-3" />
+          {t('web.sessions.inspector.transcript.copyAll')}
+        </Button>
+      </div>
+      {turns.map((turn, i) => (
+        <div key={i} className="rounded-md border border-border bg-card/30 p-2">
+          <span
+            className={
+              turn.role === 'user'
+                ? 'text-[10px] font-semibold uppercase tracking-wider text-accent'
+                : 'text-[10px] font-semibold uppercase tracking-wider text-muted-foreground'
+            }
+          >
+            {turn.role}
+          </span>
+          <div className="mt-1 whitespace-pre-wrap break-words text-[12px] leading-relaxed">
+            {turn.text}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/app/web/src/pages/Settings.tsx
+++ b/app/web/src/pages/Settings.tsx
@@ -8,6 +8,7 @@ import {
   Monitor,
   Check,
   Type,
+  Languages,
   User as UserIcon,
   Server,
   Settings2,
@@ -22,6 +23,7 @@ import { toast } from 'sonner'
 import { api } from '@/lib/api'
 import { getVersionInfo, requestSelfUpdate, type VersionInfo } from '@/lib/version'
 import { useTheme, type ThemeMode } from '@/stores/theme'
+import { useLocale, SUPPORTED_LOCALES, type Locale } from '@/stores/locale'
 import { useAuth } from '@/stores/auth'
 import { useLayout } from '@/stores/layout'
 import { cn } from '@/lib/utils'
@@ -267,7 +269,12 @@ function ContentRouter({
 
   switch (active) {
     case 'appearance':
-      return <AppearanceSection mode={mode} setMode={setMode} />
+      return (
+        <div className="space-y-8">
+          <AppearanceSection mode={mode} setMode={setMode} />
+          <LanguageSection />
+        </div>
+      )
     case 'font':
       return (
         <FontSection fontScale={fontScale} setFontScale={setFontScale} />
@@ -404,6 +411,49 @@ function AppearanceSection({
                   {t(descKey)}
                 </span>
               </div>
+              {active && (
+                <Check className="absolute right-2 top-2 size-3 text-accent" />
+              )}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function LanguageSection() {
+  const { t } = useTranslation()
+  const locale = useLocale((s) => s.locale)
+  const setLocale = useLocale((s) => s.setLocale)
+  const labels: Record<Locale, string> = {
+    en: t('web.settings.language.options.en'),
+    zh: t('web.settings.language.options.zh'),
+    es: t('web.settings.language.options.es'),
+  }
+  return (
+    <div>
+      <SectionHeader
+        title={t('web.settings.language.title')}
+        description={t('web.settings.language.description')}
+      />
+      <div className="grid grid-cols-3 gap-2">
+        {SUPPORTED_LOCALES.map((l) => {
+          const active = locale === l
+          return (
+            <button
+              key={l}
+              type="button"
+              onClick={() => setLocale(l)}
+              className={cn(
+                'relative flex flex-col gap-2 items-start text-left p-3 rounded-md border transition-colors',
+                active
+                  ? 'border-foreground/30 bg-card'
+                  : 'border-border hover:bg-card hover:border-foreground/20',
+              )}
+            >
+              <Languages className="size-4 text-muted-foreground" />
+              <span className="text-[13px] font-medium">{labels[l]}</span>
               {active && (
                 <Check className="absolute right-2 top-2 size-3 text-accent" />
               )}

--- a/internal/session/handler.go
+++ b/internal/session/handler.go
@@ -38,6 +38,7 @@ type Service interface {
 	Buffer(ctx context.Context, id string, since int64) (Replay, error)
 	SwitchClaudeAccount(ctx context.Context, id, accountID string) (Session, error)
 	History(ctx context.Context, id string, limit int) (HistoryResponse, error)
+	Transcript(ctx context.Context, sessionID string, maxBytes int) ([]Turn, error)
 }
 
 // ClaudeAccountChecker is the minimal cliacct surface the session
@@ -128,6 +129,7 @@ func (h *Handlers) Mount(r chi.Router) {
 			r.Get("/buffer", h.buffer)
 			r.Get("/stream", h.stream)
 			r.Get("/history", h.history)
+			r.Get("/transcript", h.transcript)
 			r.Patch("/claude-account", h.switchClaudeAccount)
 			r.Post("/uploads", h.upload)
 		})
@@ -486,6 +488,36 @@ func (h *Handlers) history(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, res)
+}
+
+// transcript handles GET /sessions/{id}/transcript. Returns the session's
+// conversation reconstructed from the CLI's JSONL as ordered turns (user
+// prompts + assistant prose) — the scrollable history the live
+// alternate-screen TUI terminal cannot offer. Claude / Codex / Gemini are
+// supported; other providers return {turns: []}.
+func (h *Handlers) transcript(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	maxBytes := 1 << 20 // 1 MiB of conversation text — plenty for scrollback
+	if v := r.URL.Query().Get("max_bytes"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			writeError(w, http.StatusBadRequest, errors.New("invalid max_bytes: must be non-negative integer"))
+			return
+		}
+		if n > 4<<20 {
+			n = 4 << 20
+		}
+		maxBytes = n
+	}
+	turns, err := h.svc.Transcript(r.Context(), id, maxBytes)
+	if err != nil {
+		h.respondError(w, err)
+		return
+	}
+	if turns == nil {
+		turns = []Turn{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"turns": turns})
 }
 
 // switchClaudeAccount handles PATCH /sessions/{id}/claude-account.

--- a/internal/session/handler_test.go
+++ b/internal/session/handler_test.go
@@ -154,6 +154,13 @@ func (f *fakeSvc) History(_ context.Context, id string, _ int) (HistoryResponse,
 	return HistoryResponse{Entries: []ProjectInput{}}, nil
 }
 
+func (f *fakeSvc) Transcript(_ context.Context, id string, _ int) ([]Turn, error) {
+	if _, ok := f.sessions[id]; !ok {
+		return nil, ErrNotFound
+	}
+	return []Turn{}, nil
+}
+
 func newRouter(svc Service) http.Handler {
 	r := chi.NewRouter()
 	NewHandlers(svc, nil).Mount(r)

--- a/internal/session/transcript.go
+++ b/internal/session/transcript.go
@@ -16,9 +16,9 @@ import (
 // — no tool-use JSON blobs, no system messages, no thinking. This
 // is what the M18 journaler feeds to an LLM summariser.
 type Turn struct {
-	Role string    // "user" | "assistant"
-	Text string    // already trimmed
-	Ts   time.Time // when this turn was emitted, when available
+	Role string    `json:"role"` // "user" | "assistant"
+	Text string    `json:"text"` // already trimmed
+	Ts   time.Time `json:"ts"`   // when this turn was emitted, when available
 }
 
 // Transcript returns the latest CLI conversation as ordered turns.


### PR DESCRIPTION
## Why

Two header/terminal UX issues, fixed together because they touch the same surfaces (session inspector + web chrome) and the same i18n files.

**1. You can't scroll back through a session's conversation.** The agent CLIs (Claude Code / Codex / Gemini) run a full-screen **alternate-screen TUI**, which has no scrollback by design — once output scrolls off, it's gone from the live terminal on both web and mobile. (Shell sessions scroll; agent sessions don't. This is `isatty`-driven alt-screen, not a regression in our code — verified against pristine `main`.)

**2. Theme and language buttons cluttered the top bar.** Theme already had a full picker in Settings → Appearance; language had no settings home at all.

## What

**Conversation history (the real scrollback):**
- **backend** — `GET /api/v1/sessions/:id/transcript` exposes the existing M18 journaler reader (`Manager.Transcript`), which parses Claude/Codex/Gemini JSONL into ordered turns with the M22 isolation guards. `max_bytes` query (default 1 MiB, cap 4 MiB).
- **web** — a "Conversation" tab in the session inspector renders the reconstructed transcript as a scrollable list (copy-all, 10s refresh).
- **mobile** — parity: a sixth inspector tab with the same list (selectable text, copy-all, pull-to-refresh).

**Theme/language relocation:**
- Drop the theme + language dropdowns from the web top bar.
- Settings → Appearance gains a **Language** section (English / 中文 / Español) beside the existing theme picker.

**i18n** — en/zh/es updated for both surfaces; orphaned `web.topbar` theme/language keys removed; slang regenerated.

## Test plan

- `go build ./...` ✓ · `go test ./internal/session/` ✓
- `pnpm --filter web build` ✓ (tsc + vite)
- `cd app/mobile && dart analyze lib` ✓ (no issues)
- `node scripts/check-i18n-parity.mjs` ✓ (en/zh/es 100%)
- Manual: open a long-running session → inspector → Conversation tab scrolls the full transcript on web and mobile; theme/language switch from Settings → Appearance.

## Notes

- Separate from the memory-unification PR (#341); branches off `main`.
- Draft: opened for local testing first per the usual flow — mark ready when verified on the local build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)