### PR TITLE
fix(terminal): swipe-to-scroll the live session on touch devices

### DIFF
--- a/app/mobile/lib/features/sessions/session_terminal_view.dart
+++ b/app/mobile/lib/features/sessions/session_terminal_view.dart
@@ -637,6 +637,11 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
                   controller: _controller,
                   autofocus: true,
                   backgroundOpacity: 1,
+                  // A swipe in the alternate buffer is forwarded to the app
+                  // as mouse-wheel input (see TerminalScrollGestureHandler);
+                  // never fall back to arrow keys, which a phone TUI reads
+                  // as cursor moves, not scrolling.
+                  simulateScroll: false,
                   theme: const TerminalTheme(
                     cursor: Color(0xFFE6AE57),
                     selection: Color(0x66E6AE57),

--- a/app/web/src/components/sessions/Terminal.tsx
+++ b/app/web/src/components/sessions/Terminal.tsx
@@ -324,6 +324,66 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       resizeSession(sessionId, cols, rows).catch(() => {})
     })
 
+    // Touch-scroll forwarding. A phone has no mouse wheel, and a
+    // full-screen TUI that has grabbed the mouse (Claude Code / Codex /
+    // Gemini all enable mouse tracking, so modes.mouseTrackingMode is
+    // not 'none') runs in the alternate screen — which has no xterm
+    // scrollback to scroll, AND xterm doesn't translate a finger swipe
+    // into the wheel events the app is waiting for. The conversation is
+    // scrolled by the APP itself in response to wheel input, exactly
+    // like a desktop mouse wheel. So translate a one-finger vertical
+    // swipe into SGR (1006) wheel events sent straight to the PTY. For
+    // a plain shell (mouseTrackingMode 'none') we leave the event alone
+    // so xterm's own viewport scroll / native behaviour still works.
+    const SWIPE_STEP = 18 // px of finger travel per wheel tick
+    const touchHost = containerRef.current
+    let touchActive = false
+    let lastTouchY = 0
+    let touchAccum = 0
+    const sendWheel = (up: boolean) => {
+      // SGR mouse: button 64 = wheel up, 65 = wheel down; press ('M').
+      // Report the pointer at screen centre so the app treats it as a
+      // scroll over its content region.
+      const col = Math.max(1, Math.floor(term.cols / 2))
+      const row = Math.max(1, Math.floor(term.rows / 2))
+      const seq = `\x1b[<${up ? 64 : 65};${col};${row}M`
+      const enc = new TextEncoder().encode(seq)
+      ws.send(
+        enc.buffer.slice(enc.byteOffset, enc.byteOffset + enc.byteLength) as ArrayBuffer,
+      )
+    }
+    const onTouchStart = (e: TouchEvent) => {
+      if (e.touches.length !== 1 || term.modes.mouseTrackingMode === 'none') {
+        touchActive = false
+        return
+      }
+      touchActive = true
+      lastTouchY = e.touches[0].clientY
+      touchAccum = 0
+    }
+    const onTouchMove = (e: TouchEvent) => {
+      if (!touchActive || e.touches.length !== 1) return
+      if (term.modes.mouseTrackingMode === 'none') return
+      e.preventDefault() // stop the page/pane from scrolling instead
+      const y = e.touches[0].clientY
+      touchAccum += y - lastTouchY
+      lastTouchY = y
+      // Finger moving DOWN (positive delta) reveals earlier content →
+      // wheel up; finger up → wheel down.
+      while (Math.abs(touchAccum) >= SWIPE_STEP) {
+        const up = touchAccum > 0
+        sendWheel(up)
+        touchAccum += up ? -SWIPE_STEP : SWIPE_STEP
+      }
+    }
+    const onTouchEnd = () => {
+      touchActive = false
+    }
+    touchHost?.addEventListener('touchstart', onTouchStart, { passive: true })
+    touchHost?.addEventListener('touchmove', onTouchMove, { passive: false })
+    touchHost?.addEventListener('touchend', onTouchEnd, { passive: true })
+    touchHost?.addEventListener('touchcancel', onTouchEnd, { passive: true })
+
     // Coalesce resize bursts into one fit per animation frame. Calling
     // fit() synchronously inside the ResizeObserver callback mutates
     // the DOM mid-notification ("ResizeObserver loop completed with
@@ -358,6 +418,10 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     return () => {
       alive = false
       if (fitRaf) cancelAnimationFrame(fitRaf)
+      touchHost?.removeEventListener('touchstart', onTouchStart)
+      touchHost?.removeEventListener('touchmove', onTouchMove)
+      touchHost?.removeEventListener('touchend', onTouchEnd)
+      touchHost?.removeEventListener('touchcancel', onTouchEnd)
       ro.disconnect()
       ws.close()
       term.dispose()

--- a/third_party/xterm/lib/src/ui/scroll_handler.dart
+++ b/third_party/xterm/lib/src/ui/scroll_handler.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:xterm/core.dart';
 import 'package:xterm/src/ui/infinite_scroll_view.dart';
@@ -49,6 +50,10 @@ class _TerminalScrollGestureHandlerState
   /// This variable tracks the last offset where the scroll gesture started.
   /// Used to calculate the cell offset of the terminal mouse event.
   var lastPointerPosition = Offset.zero;
+
+  /// Accumulated vertical travel (px) of an in-progress touch drag, used to
+  /// emit one scroll event per line of finger movement. See [_onPointerMove].
+  var _touchScrollAccum = 0.0;
 
   @override
   void initState() {
@@ -111,6 +116,29 @@ class _TerminalScrollGestureHandlerState
     lastLineOffset = currentLineOffset;
   }
 
+  /// Translate a one-finger touch drag into scroll events. The
+  /// [InfiniteScrollView] below already turns a mouse wheel
+  /// ([PointerScrollEvent]) into [_onScroll], but a *touch* drag in the
+  /// alternate buffer is swallowed by the inner viewport [Scrollable]
+  /// (which has nothing to scroll there), so on a phone the gesture never
+  /// reaches [_onScroll] and the application never receives wheel input.
+  /// A [Listener] observes the raw pointer stream regardless of the gesture
+  /// arena, so we emit one scroll event per line of finger travel here.
+  /// Mouse drags are left alone (they drive text selection).
+  void _onPointerMove(PointerMoveEvent event) {
+    if (event.kind != PointerDeviceKind.touch) return;
+    final lineHeight = widget.getLineHeight();
+    if (lineHeight <= 0) return;
+    lastPointerPosition = event.position;
+    _touchScrollAccum += event.delta.dy;
+    while (_touchScrollAccum.abs() >= lineHeight) {
+      // Finger moving down (positive dy) reveals earlier content → scroll up.
+      final up = _touchScrollAccum > 0;
+      _sendScrollEvent(up);
+      _touchScrollAccum += up ? -lineHeight : lineHeight;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     if (!isAltBuffer) {
@@ -123,7 +151,9 @@ class _TerminalScrollGestureHandlerState
       },
       onPointerDown: (event) {
         lastPointerPosition = event.position;
+        _touchScrollAccum = 0;
       },
+      onPointerMove: _onPointerMove,
       child: InfiniteScrollView(
         onScroll: _onScroll,
         child: widget.child,


### PR DESCRIPTION
## Problem

You can't scroll the live session's on-screen conversation by touch.

A full-screen agent TUI (Claude Code / Codex / Gemini) enables mouse
tracking and runs in the **alternate screen buffer**, so it scrolls its
**own** conversation in response to wheel input. On desktop the mouse
wheel is forwarded and scrolling works; on a phone there is no wheel and
the terminals don't translate a finger swipe into the wheel events the
app is waiting for — so the live session can't be scrolled at all.

## Fix (web + mobile)

**Web** — `app/web/src/components/sessions/Terminal.tsx`: translate a
one-finger vertical swipe into SGR (1006) mouse-wheel events sent to the
PTY, only when `modes.mouseTrackingMode !== 'none'`.

**Mobile** — in the alternate buffer the vendored Flutter xterm wraps an
`InfiniteScrollView` (outer Scrollable) around the main viewport
Scrollable (inner); a touch drag is won by the inner Scrollable, which
has nothing to scroll there, so the outer view's `onScroll` never fires.
- `third_party/xterm/.../scroll_handler.dart`: add `Listener.onPointerMove`
  that, for touch pointers, drives the existing `_sendScrollEvent`
  directly (one event per line of finger travel). A `Listener` sees the
  raw pointer stream regardless of the gesture arena, so the swallowing
  inner Scrollable no longer matters. Mouse wheel still flows through the
  `InfiniteScrollView`.
- `app/mobile/.../session_terminal_view.dart`: `TerminalView(simulateScroll:
  false)` — never fall back to arrow keys for scrolling (a phone TUI reads
  those as cursor moves, not scrollback).

Plain shells (no mouse tracking, normal buffer) keep native viewport
scroll; desktop mouse wheel is unchanged. Branched clean off `main`.

## Test plan

- `pnpm --filter web build` ✓ ; `go build ./...` ✓ ; `dart analyze` ✓
- Manual web (phone): swipe in a running Claude session → conversation
  scrolls (down = earlier, up = latest). **Confirmed.**
- Manual mobile app (release APK 2.3.3+14): same swipe-to-scroll.
  **Confirmed on device.**
- Desktop wheel + shell native scroll unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)