### PR TITLE
fix(web/topbar): pin the account menu to the top-right corner

### DIFF
--- a/app/web/src/components/Topbar.tsx
+++ b/app/web/src/components/Topbar.tsx
@@ -100,7 +100,17 @@ export function Topbar({ onOpenPalette }: TopbarProps) {
               {username}
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="min-w-[220px]">
+          <DropdownMenuContent
+            align="end"
+            side="bottom"
+            sideOffset={6}
+            // The trigger sits in the top-right corner. Opening down-and-left
+            // from the right edge is always on-screen, so pin it: collision
+            // avoidance was mis-flipping this menu to open rightward, pushing
+            // it off the right edge of the window.
+            avoidCollisions={false}
+            className="min-w-[220px]"
+          >
             <DropdownMenuLabel>{t('web.topbar.signedInAs')}</DropdownMenuLabel>
             <div className="px-2 pb-1.5 text-[12px]">{username}</div>
             {expiresAt && (


### PR DESCRIPTION
## Problem

Clicking the 🟢 username in the header appeared to do nothing on desktop:
the account dropdown opened but rendered off the **right edge** of the
window (clipped / off-screen). Radix collision-avoidance was mis-flipping
this top-right menu to open rightward.

## Fix

`Topbar.tsx` — pin the account `DropdownMenuContent`: `align="end"` +
`side="bottom"` + `avoidCollisions={false}`. A menu anchored at the
top-right opening down-and-left from the right edge is always within the
viewport, so disabling the flip is safe and deterministic.

## Verification

Headless-browser automation (Playwright) against the running gateway,
logged in, opened the account menu, measured its rect:

| viewport | menu right edge | result |
|---|---|---|
| 1920 | 1908 | in view ✓ |
| 1440 | 1428 | in view ✓ |
| 1280 | 1268 | in view ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)