### PR TITLE
fix(web): apply font-scale zoom on #root so Radix popovers position correctly

### DIFF
--- a/app/shared/src/stores/layout.ts
+++ b/app/shared/src/stores/layout.ts
@@ -47,13 +47,23 @@ function clampInspectorWidth(v: number): number {
   )
 }
 
-// Apply on <body> rather than <html>: keeps `100svh`/`100vh` correct
-// (zoom on <html> shifts the viewport math), but still scales every
-// descendant — including hardcoded `text-[12px]`-style px values that
-// won't respond to root font-size changes.
+// Apply the zoom on the app root (#root), NOT <body>/<html>:
+//  - scales every descendant, including hardcoded `text-[12px]`-style px
+//    values that won't respond to a root font-size change;
+//  - keeps `100svh`/`100vh` correct (zoom on <html> shifts viewport math);
+//  - and — critically — leaves Radix portals untouched. Dropdowns / tooltips
+//    / popovers mount at <body>, OUTSIDE #root, so a <body> zoom double-
+//    scaled their floating-ui positions (trigger rect already in zoomed
+//    coords, then the portal got scaled again) and pushed them off-screen at
+//    any scale > 1. With the zoom on #root the portals stay at scale 1, where
+//    floating-ui positions them correctly against the zoom-scaled trigger.
 function applyFontScale(scale: number) {
   if (typeof document === 'undefined') return
-  document.body.style.zoom = String(scale)
+  const target = document.getElementById('root') ?? document.body
+  // Clear any legacy zoom left on <body> by a previous build so the two
+  // don't compound.
+  if (target !== document.body) document.body.style.zoom = ''
+  target.style.zoom = String(scale)
 }
 
 export const useLayout = create<LayoutState>()(


### PR DESCRIPTION
## Problem

With a non-default **Font scale** (Settings → Font, e.g. Comfy/Large), the
account dropdown — and any Radix popover/tooltip/select — rendered **off
the right edge** of the window and looked like it "did nothing". Clearing
site data (which resets fontScale to 1) was the only workaround; hard
refresh / disable-cache did nothing because the bad value lives in
`localStorage`.

## Root cause

`fontScale` was applied as `document.body.style.zoom`. Radix portals mount
at `<body>`, so a `<body>` zoom **double-scaled** floating-ui's position:
the trigger's `getBoundingClientRect` is already in zoomed coords, and the
portal (a child of the zoomed `<body>`) is scaled again → the popper lands
`scale×` too far right. Reproduced with Playwright: at zoom 1.3 the menu
overflowed the right edge by ~411px.

## Fix

Apply the zoom on `#root` instead of `<body>`. The app still scales
(including hardcoded px sizes); `100svh/vh` is unchanged; and the portals
now sit at scale 1 **outside** `#root`, where floating-ui positions them
correctly against the zoom-scaled trigger.

## Verification (Playwright, this gateway)

| fontScale | `<body>` zoom (before) | `#root` zoom (fix) |
|---|---|---|
| 1.0 | in view | in view |
| 1.15 | overflow +200px | in view |
| 1.3 | overflow +411px | in view |

Vertical overflow is identical between body-zoom and #root-zoom (the large
scale makes the app taller than the viewport regardless) — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)