### PR TITLE
Revert: restore theme + language toggles in the header

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -48,6 +48,16 @@
       "collapseSidebar": "Collapse sidebar",
       "search": "Search",
       "openPalette": "Open command palette",
+      "theme": "Theme",
+      "themeLabel": "Theme: {mode}",
+      "appearance": "Appearance",
+      "themeLight": "Light",
+      "themeDark": "Dark",
+      "themeSystem": "System",
+      "language": "Language",
+      "languageEnglish": "English",
+      "languageChinese": "中文",
+      "languageSpanish": "Español",
       "signedInAs": "Signed in as",
       "tokenExpires": "Token expires",
       "signOut": "Sign out"
@@ -2118,15 +2128,6 @@
         "checkUpdates": "Check for updates",
         "checking": "Checking…",
         "reinstall": "Re-install"
-      },
-      "language": {
-        "title": "Language",
-        "description": "Choose the interface language.",
-        "options": {
-          "en": "English",
-          "zh": "中文",
-          "es": "Español"
-        }
       }
     },
     "logViewer": {

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -48,6 +48,16 @@
       "collapseSidebar": "Contraer barra lateral",
       "search": "Buscar",
       "openPalette": "Abrir paleta de comandos",
+      "theme": "Tema",
+      "themeLabel": "Tema: {mode}",
+      "appearance": "Apariencia",
+      "themeLight": "Claro",
+      "themeDark": "Oscuro",
+      "themeSystem": "Sistema",
+      "language": "Idioma",
+      "languageEnglish": "English",
+      "languageChinese": "中文",
+      "languageSpanish": "Español",
       "signedInAs": "Sesión iniciada como",
       "tokenExpires": "El token caduca",
       "signOut": "Cerrar sesión"
@@ -2118,15 +2128,6 @@
         "checkUpdates": "Comprobar actualizaciones",
         "checking": "Comprobando…",
         "reinstall": "Reinstalar"
-      },
-      "language": {
-        "title": "Idioma",
-        "description": "Elige el idioma de la interfaz.",
-        "options": {
-          "en": "English",
-          "zh": "中文",
-          "es": "Español"
-        }
       }
     },
     "logViewer": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -48,6 +48,16 @@
       "collapseSidebar": "收起侧边栏",
       "search": "搜索",
       "openPalette": "打开命令面板",
+      "theme": "主题",
+      "themeLabel": "主题：{mode}",
+      "appearance": "外观",
+      "themeLight": "浅色",
+      "themeDark": "深色",
+      "themeSystem": "跟随系统",
+      "language": "语言",
+      "languageEnglish": "English",
+      "languageChinese": "中文",
+      "languageSpanish": "Español",
       "signedInAs": "登录账号",
       "tokenExpires": "令牌到期",
       "signOut": "退出登录"
@@ -2118,15 +2128,6 @@
         "checkUpdates": "检查更新",
         "checking": "检查中…",
         "reinstall": "重新安装"
-      },
-      "language": {
-        "title": "语言",
-        "description": "选择界面语言。",
-        "options": {
-          "en": "English",
-          "zh": "中文",
-          "es": "Español"
-        }
       }
     },
     "logViewer": {

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 9486 (3162 per locale)
+/// Strings: 9501 (3167 per locale)
 ///
-/// Built on 2026-06-06 at 10:05 UTC
+/// Built on 2026-06-06 at 12:00 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -1853,6 +1853,36 @@ class TranslationsWebTopbarEn {
 	/// en: 'Open command palette'
 	String get openPalette => 'Open command palette';
 
+	/// en: 'Theme'
+	String get theme => 'Theme';
+
+	/// en: 'Theme: {mode}'
+	String themeLabel({required Object mode}) => 'Theme: ${mode}';
+
+	/// en: 'Appearance'
+	String get appearance => 'Appearance';
+
+	/// en: 'Light'
+	String get themeLight => 'Light';
+
+	/// en: 'Dark'
+	String get themeDark => 'Dark';
+
+	/// en: 'System'
+	String get themeSystem => 'System';
+
+	/// en: 'Language'
+	String get language => 'Language';
+
+	/// en: 'English'
+	String get languageEnglish => 'English';
+
+	/// en: '中文'
+	String get languageChinese => '中文';
+
+	/// en: 'Español'
+	String get languageSpanish => 'Español';
+
 	/// en: 'Signed in as'
 	String get signedInAs => 'Signed in as';
 
@@ -2605,7 +2635,6 @@ class TranslationsWebSettingsEn {
 	late final TranslationsWebSettingsChangeCredentialsEn changeCredentials = TranslationsWebSettingsChangeCredentialsEn.internal(_root);
 	late final TranslationsWebSettingsSystemEn system = TranslationsWebSettingsSystemEn.internal(_root);
 	late final TranslationsWebSettingsAboutEn about = TranslationsWebSettingsAboutEn.internal(_root);
-	late final TranslationsWebSettingsLanguageEn language = TranslationsWebSettingsLanguageEn.internal(_root);
 }
 
 // Path: web.logViewer
@@ -9146,23 +9175,6 @@ class TranslationsWebSettingsAboutEn {
 	String get reinstall => 'Re-install';
 }
 
-// Path: web.settings.language
-class TranslationsWebSettingsLanguageEn {
-	TranslationsWebSettingsLanguageEn.internal(this._root);
-
-	final Translations _root; // ignore: unused_field
-
-	// Translations
-
-	/// en: 'Language'
-	String get title => 'Language';
-
-	/// en: 'Choose the interface language.'
-	String get description => 'Choose the interface language.';
-
-	late final TranslationsWebSettingsLanguageOptionsEn options = TranslationsWebSettingsLanguageOptionsEn.internal(_root);
-}
-
 // Path: web.memoryAmbient.header
 class TranslationsWebMemoryAmbientHeaderEn {
 	TranslationsWebMemoryAmbientHeaderEn.internal(this._root);
@@ -13385,24 +13397,6 @@ class TranslationsWebSettingsFontOptionsEn {
 	String get large => 'Large';
 }
 
-// Path: web.settings.language.options
-class TranslationsWebSettingsLanguageOptionsEn {
-	TranslationsWebSettingsLanguageOptionsEn.internal(this._root);
-
-	final Translations _root; // ignore: unused_field
-
-	// Translations
-
-	/// en: 'English'
-	String get en => 'English';
-
-	/// en: '中文'
-	String get zh => '中文';
-
-	/// en: 'Español'
-	String get es => 'Español';
-}
-
 // Path: web.memoryAmbient.providers.row
 class TranslationsWebMemoryAmbientProvidersRowEn {
 	TranslationsWebMemoryAmbientProvidersRowEn.internal(this._root);
@@ -13895,6 +13889,16 @@ extension on Translations {
 			'web.topbar.collapseSidebar' => 'Collapse sidebar',
 			'web.topbar.search' => 'Search',
 			'web.topbar.openPalette' => 'Open command palette',
+			'web.topbar.theme' => 'Theme',
+			'web.topbar.themeLabel' => ({required Object mode}) => 'Theme: ${mode}',
+			'web.topbar.appearance' => 'Appearance',
+			'web.topbar.themeLight' => 'Light',
+			'web.topbar.themeDark' => 'Dark',
+			'web.topbar.themeSystem' => 'System',
+			'web.topbar.language' => 'Language',
+			'web.topbar.languageEnglish' => 'English',
+			'web.topbar.languageChinese' => '中文',
+			'web.topbar.languageSpanish' => 'Español',
 			'web.topbar.signedInAs' => 'Signed in as',
 			'web.topbar.tokenExpires' => 'Token expires',
 			'web.topbar.signOut' => 'Sign out',
@@ -14356,6 +14360,8 @@ extension on Translations {
 			'web.memoryInspector.bulkDelete.items_other' => ({required Object count}) => '${count} memory items',
 			'web.memoryInspector.bulkDelete.cancel' => 'Cancel',
 			'web.memoryInspector.bulkDelete.deleteAll' => 'Delete all',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryInspector.addMem.title' => 'Add memory',
 			'web.memoryInspector.addMem.description' => 'Manually create a memory. Agents create these automatically via the <1>memory_store</1> MCP tool — this form is for cases where the operator wants to seed a fact without going through an agent.',
 			'web.memoryInspector.addMem.textLabel' => 'Text',
@@ -14366,8 +14372,6 @@ extension on Translations {
 			'web.memoryInspector.picker.buttonTooltip' => 'Pick from saved scope keys or active sessions',
 			'web.memoryInspector.picker.loading' => 'Loading…',
 			'web.memoryInspector.picker.empty' => ({required Object scope}) => 'No saved keys or active sessions for ${scope}.',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryInspector.picker.savedHeader' => 'Saved memories',
 			'web.memoryInspector.picker.activeHeader' => 'Active sessions',
 			'web.memoryInspector.migrationBanner.headline_one' => ({required Object count}) => '${count} memory won\'t appear in searches',
@@ -14870,6 +14874,8 @@ extension on Translations {
 			'web.plugins.mcp.columns.name' => 'Name',
 			'web.plugins.mcp.columns.transport' => 'Transport',
 			'web.plugins.mcp.columns.spec' => 'Spec',
+			_ => null,
+		} ?? switch (path) {
 			'web.plugins.mcp.columns.enabled' => 'Enabled',
 			'web.plugins.mcp.noUrl' => 'no url',
 			'web.plugins.mcp.noCommand' => 'no command',
@@ -14880,8 +14886,6 @@ extension on Translations {
 			'web.plugins.mcp.codexUnsupportedBadge' => 'Codex: unsupported',
 			'web.plugins.mcp.codexUnsupportedTooltip' => 'The codex CLI supports stdio transport only. This server will be skipped for codex sessions; claude and gemini will still use it.',
 			'web.plugins.mcp.editor.createTitle' => 'New MCP server',
-			_ => null,
-		} ?? switch (path) {
 			'web.plugins.mcp.editor.editTitle' => ({required Object id}) => 'Edit MCP: ${id}',
 			'web.plugins.mcp.editor.description' => ({required Object API_KEY}) => 'JSON shape: <1>command</1>+<3>args</3>+<5>env</5> for stdio (default), or <7>transport</7> +<9> url</9>+<11>headers</11> for sse / http. Reference secrets as <13>\$${API_KEY}</13> — they get substituted at spawn time from the secrets file.',
 			'web.plugins.mcp.editor.idLabel' => 'ID',
@@ -15384,6 +15388,8 @@ extension on Translations {
 			'web.serverSettings.httpHelpers.presetTip.openai' => 'OpenAI cloud (needs API key)',
 			'web.serverSettings.probe.unreachable' => ({required Object error}) => '✗ unreachable: ${error}',
 			'web.serverSettings.probe.connectionFailed' => 'connection failed',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.probe.reachable' => ({required Object detected, required Object total, required Object embedding}) => '✓ reachable ${detected}· ${total} model(s) total · ${embedding} embedding',
 			'web.serverSettings.probe.modelMissing' => ({required Object model}) => '⚠ Configured model ${model} isn\'t in the list. Pick one of the embedding models below or fix the name.',
 			'web.serverSettings.probe.embeddingModelsLabel' => 'embedding models:',
@@ -15394,8 +15400,6 @@ extension on Translations {
 			'web.serverSettings.backup.featureDisabledTitle' => 'Feature disabled',
 			'web.serverSettings.backup.featureDisabledHint' => 'Set <1>OPENDRAY_BACKUP_ENABLED=1</1> + <3>OPENDRAY_BACKUP_KEY=&lt;passphrase&gt;</3> in opendray\'s environment, then restart. The master passphrase is env-only — it never touches config.toml.',
 			'web.serverSettings.backup.statusRowLabel' => 'Status',
-			_ => null,
-		} ?? switch (path) {
 			'web.serverSettings.backup.enabledHealthy' => 'enabled · healthy',
 			'web.serverSettings.backup.enabledDegraded' => 'enabled · degraded',
 			'web.serverSettings.backup.keyFingerprintLabel' => 'Key fingerprint',
@@ -15508,11 +15512,6 @@ extension on Translations {
 			'web.settings.about.checkUpdates' => 'Check for updates',
 			'web.settings.about.checking' => 'Checking…',
 			'web.settings.about.reinstall' => 'Re-install',
-			'web.settings.language.title' => 'Language',
-			'web.settings.language.description' => 'Choose the interface language.',
-			'web.settings.language.options.en' => 'English',
-			'web.settings.language.options.zh' => '中文',
-			'web.settings.language.options.es' => 'Español',
 			'web.logViewer.filterPlaceholder' => 'Filter…',
 			'web.logViewer.debugTooltip' => 'Debug count',
 			'web.logViewer.infoTooltip' => 'Info count',
@@ -15903,13 +15902,13 @@ extension on Translations {
 			'sessions.spawnSheet.title' => 'New session',
 			'sessions.spawnSheet.errorRequired' => 'Provider and working directory are required',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => 'Failed to spawn session: ${error}',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.spawnSheet.cancel' => 'Cancel',
 			'sessions.spawnSheet.spawn' => 'Spawn',
 			'sessions.spawnSheet.providerLabel' => 'Provider',
 			'sessions.spawnSheet.disabledSuffix' => ' (disabled)',
 			'sessions.spawnSheet.cwdLabel' => 'Working directory',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.spawnSheet.cwdHint' => '/Users/you/projects/foo',
 			'sessions.spawnSheet.cwdHelper' => 'Absolute path on the gateway host.',
 			'sessions.spawnSheet.browse' => 'Browse',
@@ -16417,13 +16416,13 @@ extension on Translations {
 			'backupTargetEditor.useHttps' => 'Use HTTPS',
 			'backupTargetEditor.pathStyle' => 'Path-style addressing',
 			'backupTargetEditor.pathStyleSubtitle' => 'Legacy / MinIO',
+			_ => null,
+		} ?? switch (path) {
 			'backupTargetEditor.kinds.local.label' => 'Local disk',
 			'backupTargetEditor.kinds.local.description' => 'Folder on the machine running opendray',
 			'backupTargetEditor.kinds.smb.label' => 'SMB share',
 			'backupTargetEditor.kinds.smb.description' => 'Windows shares + most home NAS appliances',
 			'backupTargetEditor.kinds.webdav.label' => 'WebDAV',
-			_ => null,
-		} ?? switch (path) {
 			'backupTargetEditor.kinds.webdav.description' => 'Self-hosted clouds + file-sharing services',
 			'backupTargetEditor.kinds.sftp.label' => 'SFTP',
 			'backupTargetEditor.kinds.sftp.description' => 'Any SSH-accessible server',
@@ -16931,13 +16930,13 @@ extension on Translations {
 			'settings.logViewer.levels.debug' => 'Debug',
 			'settings.logViewer.levels.info' => 'Info',
 			'settings.logViewer.levels.warn' => 'Warn',
+			_ => null,
+		} ?? switch (path) {
 			'settings.logViewer.levels.error' => 'Error',
 			'settings.serverSettings.title' => 'Server settings',
 			'settings.serverSettings.reloadTooltip' => 'Reload from server',
 			'settings.serverSettings.restartTooltip' => 'Restart gateway',
 			'settings.serverSettings.restartConfirmTitle' => 'Restart opendray?',
-			_ => null,
-		} ?? switch (path) {
 			'settings.serverSettings.restartConfirmBody' => 'The gateway will exec itself. The mobile app may briefly lose connection.',
 			'settings.serverSettings.restart' => 'Restart',
 			'settings.serverSettings.restartQueuedSnack' => 'Restart requested. Pull-to-refresh in a moment.',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -876,6 +876,16 @@ class _TranslationsWebTopbarEs extends TranslationsWebTopbarEn {
 	@override String get collapseSidebar => 'Contraer barra lateral';
 	@override String get search => 'Buscar';
 	@override String get openPalette => 'Abrir paleta de comandos';
+	@override String get theme => 'Tema';
+	@override String themeLabel({required Object mode}) => 'Tema: ${mode}';
+	@override String get appearance => 'Apariencia';
+	@override String get themeLight => 'Claro';
+	@override String get themeDark => 'Oscuro';
+	@override String get themeSystem => 'Sistema';
+	@override String get language => 'Idioma';
+	@override String get languageEnglish => 'English';
+	@override String get languageChinese => '中文';
+	@override String get languageSpanish => 'Español';
 	@override String get signedInAs => 'Sesión iniciada como';
 	@override String get tokenExpires => 'El token caduca';
 	@override String get signOut => 'Cerrar sesión';
@@ -1310,7 +1320,6 @@ class _TranslationsWebSettingsEs extends TranslationsWebSettingsEn {
 	@override late final _TranslationsWebSettingsChangeCredentialsEs changeCredentials = _TranslationsWebSettingsChangeCredentialsEs._(_root);
 	@override late final _TranslationsWebSettingsSystemEs system = _TranslationsWebSettingsSystemEs._(_root);
 	@override late final _TranslationsWebSettingsAboutEs about = _TranslationsWebSettingsAboutEs._(_root);
-	@override late final _TranslationsWebSettingsLanguageEs language = _TranslationsWebSettingsLanguageEs._(_root);
 }
 
 // Path: web.logViewer
@@ -4716,18 +4725,6 @@ class _TranslationsWebSettingsAboutEs extends TranslationsWebSettingsAboutEn {
 	@override String get reinstall => 'Reinstalar';
 }
 
-// Path: web.settings.language
-class _TranslationsWebSettingsLanguageEs extends TranslationsWebSettingsLanguageEn {
-	_TranslationsWebSettingsLanguageEs._(TranslationsEs root) : this._root = root, super.internal(root);
-
-	final TranslationsEs _root; // ignore: unused_field
-
-	// Translations
-	@override String get title => 'Idioma';
-	@override String get description => 'Elige el idioma de la interfaz.';
-	@override late final _TranslationsWebSettingsLanguageOptionsEs options = _TranslationsWebSettingsLanguageOptionsEs._(_root);
-}
-
 // Path: web.memoryAmbient.header
 class _TranslationsWebMemoryAmbientHeaderEs extends TranslationsWebMemoryAmbientHeaderEn {
 	_TranslationsWebMemoryAmbientHeaderEs._(TranslationsEs root) : this._root = root, super.internal(root);
@@ -7179,18 +7176,6 @@ class _TranslationsWebSettingsFontOptionsEs extends TranslationsWebSettingsFontO
 	@override String get large => 'Grande';
 }
 
-// Path: web.settings.language.options
-class _TranslationsWebSettingsLanguageOptionsEs extends TranslationsWebSettingsLanguageOptionsEn {
-	_TranslationsWebSettingsLanguageOptionsEs._(TranslationsEs root) : this._root = root, super.internal(root);
-
-	final TranslationsEs _root; // ignore: unused_field
-
-	// Translations
-	@override String get en => 'English';
-	@override String get zh => '中文';
-	@override String get es => 'Español';
-}
-
 // Path: web.memoryAmbient.providers.row
 class _TranslationsWebMemoryAmbientProvidersRowEs extends TranslationsWebMemoryAmbientProvidersRowEn {
 	_TranslationsWebMemoryAmbientProvidersRowEs._(TranslationsEs root) : this._root = root, super.internal(root);
@@ -7472,6 +7457,16 @@ extension on TranslationsEs {
 			'web.topbar.collapseSidebar' => 'Contraer barra lateral',
 			'web.topbar.search' => 'Buscar',
 			'web.topbar.openPalette' => 'Abrir paleta de comandos',
+			'web.topbar.theme' => 'Tema',
+			'web.topbar.themeLabel' => ({required Object mode}) => 'Tema: ${mode}',
+			'web.topbar.appearance' => 'Apariencia',
+			'web.topbar.themeLight' => 'Claro',
+			'web.topbar.themeDark' => 'Oscuro',
+			'web.topbar.themeSystem' => 'Sistema',
+			'web.topbar.language' => 'Idioma',
+			'web.topbar.languageEnglish' => 'English',
+			'web.topbar.languageChinese' => '中文',
+			'web.topbar.languageSpanish' => 'Español',
 			'web.topbar.signedInAs' => 'Sesión iniciada como',
 			'web.topbar.tokenExpires' => 'El token caduca',
 			'web.topbar.signOut' => 'Cerrar sesión',
@@ -7933,6 +7928,8 @@ extension on TranslationsEs {
 			'web.memoryInspector.bulkDelete.items_other' => ({required Object count}) => '${count} elementos de memoria',
 			'web.memoryInspector.bulkDelete.cancel' => 'Cancelar',
 			'web.memoryInspector.bulkDelete.deleteAll' => 'Eliminar todo',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryInspector.addMem.title' => 'Añadir memoria',
 			'web.memoryInspector.addMem.description' => 'Crea manualmente una memoria. Los agentes las crean automáticamente mediante la herramienta MCP <1>memory_store</1>. Este formulario es para los casos en que el operador quiere insertar un hecho sin pasar por un agente.',
 			'web.memoryInspector.addMem.textLabel' => 'Texto',
@@ -7943,8 +7940,6 @@ extension on TranslationsEs {
 			'web.memoryInspector.picker.buttonTooltip' => 'Elige entre las claves de scope guardadas o las sessions activas',
 			'web.memoryInspector.picker.loading' => 'Cargando…',
 			'web.memoryInspector.picker.empty' => ({required Object scope}) => 'No hay claves guardadas ni sessions activas para ${scope}.',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryInspector.picker.savedHeader' => 'Memorias guardadas',
 			'web.memoryInspector.picker.activeHeader' => 'Sessions activas',
 			'web.memoryInspector.migrationBanner.headline_one' => ({required Object count}) => '${count} memoria no aparecerá en las búsquedas',
@@ -8447,6 +8442,8 @@ extension on TranslationsEs {
 			'web.plugins.mcp.columns.name' => 'Nombre',
 			'web.plugins.mcp.columns.transport' => 'Transport',
 			'web.plugins.mcp.columns.spec' => 'Spec',
+			_ => null,
+		} ?? switch (path) {
 			'web.plugins.mcp.columns.enabled' => 'Habilitado',
 			'web.plugins.mcp.noUrl' => 'sin url',
 			'web.plugins.mcp.noCommand' => 'sin comando',
@@ -8457,8 +8454,6 @@ extension on TranslationsEs {
 			'web.plugins.mcp.codexUnsupportedBadge' => 'Codex: no compatible',
 			'web.plugins.mcp.codexUnsupportedTooltip' => 'El CLI de codex solo admite el transport stdio. Este servidor se omitirá en las sessions de codex; claude y gemini lo seguirán usando.',
 			'web.plugins.mcp.editor.createTitle' => 'Nuevo servidor MCP',
-			_ => null,
-		} ?? switch (path) {
 			'web.plugins.mcp.editor.editTitle' => ({required Object id}) => 'Editar MCP: ${id}',
 			'web.plugins.mcp.editor.description' => ({required Object API_KEY}) => 'Forma del JSON: <1>command</1>+<3>args</3>+<5>env</5> para stdio (predeterminado), o <7>transport</7> +<9> url</9>+<11>headers</11> para sse / http. Referencia los secretos como <13>\$${API_KEY}</13>, se sustituyen en el momento del spawn desde el archivo de secretos.',
 			'web.plugins.mcp.editor.idLabel' => 'ID',
@@ -8961,6 +8956,8 @@ extension on TranslationsEs {
 			'web.serverSettings.httpHelpers.presetTip.openai' => 'Nube de OpenAI (necesita API key)',
 			'web.serverSettings.probe.unreachable' => ({required Object error}) => '✗ inaccesible: ${error}',
 			'web.serverSettings.probe.connectionFailed' => 'conexión fallida',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.probe.reachable' => ({required Object detected, required Object total, required Object embedding}) => '✓ accesible ${detected}· ${total} modelo(s) en total · ${embedding} embedding',
 			'web.serverSettings.probe.modelMissing' => ({required Object model}) => '⚠ El modelo configurado ${model} no está en la lista. Elige uno de los modelos de embedding de abajo o corrige el nombre.',
 			'web.serverSettings.probe.embeddingModelsLabel' => 'modelos de embedding:',
@@ -8971,8 +8968,6 @@ extension on TranslationsEs {
 			'web.serverSettings.backup.featureDisabledTitle' => 'Función deshabilitada',
 			'web.serverSettings.backup.featureDisabledHint' => 'Define <1>OPENDRAY_BACKUP_ENABLED=1</1> + <3>OPENDRAY_BACKUP_KEY=&lt;passphrase&gt;</3> en el entorno de opendray y luego reinicia. La passphrase maestra es solo de entorno, nunca toca config.toml.',
 			'web.serverSettings.backup.statusRowLabel' => 'Estado',
-			_ => null,
-		} ?? switch (path) {
 			'web.serverSettings.backup.enabledHealthy' => 'habilitado · correcto',
 			'web.serverSettings.backup.enabledDegraded' => 'habilitado · degradado',
 			'web.serverSettings.backup.keyFingerprintLabel' => 'Huella de la clave',
@@ -9085,11 +9080,6 @@ extension on TranslationsEs {
 			'web.settings.about.checkUpdates' => 'Comprobar actualizaciones',
 			'web.settings.about.checking' => 'Comprobando…',
 			'web.settings.about.reinstall' => 'Reinstalar',
-			'web.settings.language.title' => 'Idioma',
-			'web.settings.language.description' => 'Elige el idioma de la interfaz.',
-			'web.settings.language.options.en' => 'English',
-			'web.settings.language.options.zh' => '中文',
-			'web.settings.language.options.es' => 'Español',
 			'web.logViewer.filterPlaceholder' => 'Filtrar…',
 			'web.logViewer.debugTooltip' => 'Recuento de debug',
 			'web.logViewer.infoTooltip' => 'Recuento de info',
@@ -9480,13 +9470,13 @@ extension on TranslationsEs {
 			'sessions.spawnSheet.title' => 'Nueva session',
 			'sessions.spawnSheet.errorRequired' => 'El proveedor y el directorio de trabajo son obligatorios',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => 'No se pudo crear la session: ${error}',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.spawnSheet.cancel' => 'Cancelar',
 			'sessions.spawnSheet.spawn' => 'Crear',
 			'sessions.spawnSheet.providerLabel' => 'Proveedor',
 			'sessions.spawnSheet.disabledSuffix' => ' (desactivado)',
 			'sessions.spawnSheet.cwdLabel' => 'Directorio de trabajo',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.spawnSheet.cwdHint' => '/Users/you/projects/foo',
 			'sessions.spawnSheet.cwdHelper' => 'Ruta absoluta en el host del gateway.',
 			'sessions.spawnSheet.browse' => 'Examinar',
@@ -9994,13 +9984,13 @@ extension on TranslationsEs {
 			'backupTargetEditor.useHttps' => 'Usar HTTPS',
 			'backupTargetEditor.pathStyle' => 'Direccionamiento por ruta (path-style)',
 			'backupTargetEditor.pathStyleSubtitle' => 'Heredado / MinIO',
+			_ => null,
+		} ?? switch (path) {
 			'backupTargetEditor.kinds.local.label' => 'Disco local',
 			'backupTargetEditor.kinds.local.description' => 'Carpeta en la máquina que ejecuta opendray',
 			'backupTargetEditor.kinds.smb.label' => 'Recurso compartido SMB',
 			'backupTargetEditor.kinds.smb.description' => 'Recursos compartidos de Windows y la mayoría de los NAS domésticos',
 			'backupTargetEditor.kinds.webdav.label' => 'WebDAV',
-			_ => null,
-		} ?? switch (path) {
 			'backupTargetEditor.kinds.webdav.description' => 'Nubes autoalojadas y servicios para compartir archivos',
 			'backupTargetEditor.kinds.sftp.label' => 'SFTP',
 			'backupTargetEditor.kinds.sftp.description' => 'Cualquier servidor accesible por SSH',
@@ -10508,13 +10498,13 @@ extension on TranslationsEs {
 			'settings.logViewer.levels.debug' => 'Debug',
 			'settings.logViewer.levels.info' => 'Info',
 			'settings.logViewer.levels.warn' => 'Warn',
+			_ => null,
+		} ?? switch (path) {
 			'settings.logViewer.levels.error' => 'Error',
 			'settings.serverSettings.title' => 'Ajustes del servidor',
 			'settings.serverSettings.reloadTooltip' => 'Recargar desde el servidor',
 			'settings.serverSettings.restartTooltip' => 'Reiniciar gateway',
 			'settings.serverSettings.restartConfirmTitle' => '¿Reiniciar opendray?',
-			_ => null,
-		} ?? switch (path) {
 			'settings.serverSettings.restartConfirmBody' => 'El gateway se ejecutará de nuevo a sí mismo. La app móvil puede perder la conexión brevemente.',
 			'settings.serverSettings.restart' => 'Reiniciar',
 			'settings.serverSettings.restartQueuedSnack' => 'Reinicio solicitado. Desliza para actualizar en un momento.',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -876,6 +876,16 @@ class _TranslationsWebTopbarZh extends TranslationsWebTopbarEn {
 	@override String get collapseSidebar => '收起侧边栏';
 	@override String get search => '搜索';
 	@override String get openPalette => '打开命令面板';
+	@override String get theme => '主题';
+	@override String themeLabel({required Object mode}) => '主题：${mode}';
+	@override String get appearance => '外观';
+	@override String get themeLight => '浅色';
+	@override String get themeDark => '深色';
+	@override String get themeSystem => '跟随系统';
+	@override String get language => '语言';
+	@override String get languageEnglish => 'English';
+	@override String get languageChinese => '中文';
+	@override String get languageSpanish => 'Español';
 	@override String get signedInAs => '登录账号';
 	@override String get tokenExpires => '令牌到期';
 	@override String get signOut => '退出登录';
@@ -1310,7 +1320,6 @@ class _TranslationsWebSettingsZh extends TranslationsWebSettingsEn {
 	@override late final _TranslationsWebSettingsChangeCredentialsZh changeCredentials = _TranslationsWebSettingsChangeCredentialsZh._(_root);
 	@override late final _TranslationsWebSettingsSystemZh system = _TranslationsWebSettingsSystemZh._(_root);
 	@override late final _TranslationsWebSettingsAboutZh about = _TranslationsWebSettingsAboutZh._(_root);
-	@override late final _TranslationsWebSettingsLanguageZh language = _TranslationsWebSettingsLanguageZh._(_root);
 }
 
 // Path: web.logViewer
@@ -4716,18 +4725,6 @@ class _TranslationsWebSettingsAboutZh extends TranslationsWebSettingsAboutEn {
 	@override String get reinstall => '重新安装';
 }
 
-// Path: web.settings.language
-class _TranslationsWebSettingsLanguageZh extends TranslationsWebSettingsLanguageEn {
-	_TranslationsWebSettingsLanguageZh._(TranslationsZh root) : this._root = root, super.internal(root);
-
-	final TranslationsZh _root; // ignore: unused_field
-
-	// Translations
-	@override String get title => '语言';
-	@override String get description => '选择界面语言。';
-	@override late final _TranslationsWebSettingsLanguageOptionsZh options = _TranslationsWebSettingsLanguageOptionsZh._(_root);
-}
-
 // Path: web.memoryAmbient.header
 class _TranslationsWebMemoryAmbientHeaderZh extends TranslationsWebMemoryAmbientHeaderEn {
 	_TranslationsWebMemoryAmbientHeaderZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -7179,18 +7176,6 @@ class _TranslationsWebSettingsFontOptionsZh extends TranslationsWebSettingsFontO
 	@override String get large => '大';
 }
 
-// Path: web.settings.language.options
-class _TranslationsWebSettingsLanguageOptionsZh extends TranslationsWebSettingsLanguageOptionsEn {
-	_TranslationsWebSettingsLanguageOptionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
-
-	final TranslationsZh _root; // ignore: unused_field
-
-	// Translations
-	@override String get en => 'English';
-	@override String get zh => '中文';
-	@override String get es => 'Español';
-}
-
 // Path: web.memoryAmbient.providers.row
 class _TranslationsWebMemoryAmbientProvidersRowZh extends TranslationsWebMemoryAmbientProvidersRowEn {
 	_TranslationsWebMemoryAmbientProvidersRowZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -7472,6 +7457,16 @@ extension on TranslationsZh {
 			'web.topbar.collapseSidebar' => '收起侧边栏',
 			'web.topbar.search' => '搜索',
 			'web.topbar.openPalette' => '打开命令面板',
+			'web.topbar.theme' => '主题',
+			'web.topbar.themeLabel' => ({required Object mode}) => '主题：${mode}',
+			'web.topbar.appearance' => '外观',
+			'web.topbar.themeLight' => '浅色',
+			'web.topbar.themeDark' => '深色',
+			'web.topbar.themeSystem' => '跟随系统',
+			'web.topbar.language' => '语言',
+			'web.topbar.languageEnglish' => 'English',
+			'web.topbar.languageChinese' => '中文',
+			'web.topbar.languageSpanish' => 'Español',
 			'web.topbar.signedInAs' => '登录账号',
 			'web.topbar.tokenExpires' => '令牌到期',
 			'web.topbar.signOut' => '退出登录',
@@ -7933,6 +7928,8 @@ extension on TranslationsZh {
 			'web.memoryInspector.bulkDelete.items_other' => ({required Object count}) => '${count} 条记忆',
 			'web.memoryInspector.bulkDelete.cancel' => '取消',
 			'web.memoryInspector.bulkDelete.deleteAll' => '全部删除',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryInspector.addMem.title' => '添加记忆',
 			'web.memoryInspector.addMem.description' => '手动创建一条记忆。Agent 会通过 <1>memory_store</1> MCP 工具自动创建；此表单用于运维想跳过 agent 直接录入事实的场景。',
 			'web.memoryInspector.addMem.textLabel' => '文本',
@@ -7943,8 +7940,6 @@ extension on TranslationsZh {
 			'web.memoryInspector.picker.buttonTooltip' => '从已保存的 scope key 或活跃会话中选择',
 			'web.memoryInspector.picker.loading' => '加载中…',
 			'web.memoryInspector.picker.empty' => ({required Object scope}) => '${scope} 暂无已保存的 key 或活跃会话。',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryInspector.picker.savedHeader' => '已保存的记忆',
 			'web.memoryInspector.picker.activeHeader' => '活跃会话',
 			'web.memoryInspector.migrationBanner.headline_one' => ({required Object count}) => '${count} 条记忆不会出现在搜索结果中',
@@ -8447,6 +8442,8 @@ extension on TranslationsZh {
 			'web.plugins.mcp.columns.name' => '名称',
 			'web.plugins.mcp.columns.transport' => 'Transport',
 			'web.plugins.mcp.columns.spec' => '规范',
+			_ => null,
+		} ?? switch (path) {
 			'web.plugins.mcp.columns.enabled' => '启用',
 			'web.plugins.mcp.noUrl' => '无 URL',
 			'web.plugins.mcp.noCommand' => '无 command',
@@ -8457,8 +8454,6 @@ extension on TranslationsZh {
 			'web.plugins.mcp.codexUnsupportedBadge' => 'Codex: 不支持',
 			'web.plugins.mcp.codexUnsupportedTooltip' => 'Codex CLI 仅支持 stdio 传输方式。Codex 会话将跳过此服务器；claude 和 gemini 仍会使用。',
 			'web.plugins.mcp.editor.createTitle' => '新建 MCP 服务器',
-			_ => null,
-		} ?? switch (path) {
 			'web.plugins.mcp.editor.editTitle' => ({required Object id}) => '编辑 MCP: ${id}',
 			'web.plugins.mcp.editor.description' => ({required Object API_KEY}) => 'JSON 结构：stdio（默认）使用 <1>command</1>+<3>args</3>+<5>env</5>；sse / http 使用 <7>transport</7> +<9> url</9>+<11>headers</11>。以 <13>\$${API_KEY}</13> 引用密钥 — spawn 时会从密钥文件替换。',
 			'web.plugins.mcp.editor.idLabel' => 'ID',
@@ -8961,6 +8956,8 @@ extension on TranslationsZh {
 			'web.serverSettings.httpHelpers.presetTip.openai' => 'OpenAI 云端（需要 API key）',
 			'web.serverSettings.probe.unreachable' => ({required Object error}) => '✗ 不可达：${error}',
 			'web.serverSettings.probe.connectionFailed' => '连接失败',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.probe.reachable' => ({required Object detected, required Object total, required Object embedding}) => '✓ 可达 ${detected}· 共 ${total} 个模型 · ${embedding} 个嵌入',
 			'web.serverSettings.probe.modelMissing' => ({required Object model}) => '⚠ 配置的模型 ${model} 不在列表中。从下方嵌入模型中选一个，或修正名称。',
 			'web.serverSettings.probe.embeddingModelsLabel' => '嵌入模型：',
@@ -8971,8 +8968,6 @@ extension on TranslationsZh {
 			'web.serverSettings.backup.featureDisabledTitle' => '功能已禁用',
 			'web.serverSettings.backup.featureDisabledHint' => '在 opendray 的环境变量中设置 <1>OPENDRAY_BACKUP_ENABLED=1</1> + <3>OPENDRAY_BACKUP_KEY=&lt;passphrase&gt;</3>，然后重启。主密码仅来自环境变量 — 永不写入 config.toml。',
 			'web.serverSettings.backup.statusRowLabel' => '状态',
-			_ => null,
-		} ?? switch (path) {
 			'web.serverSettings.backup.enabledHealthy' => '已启用 · 健康',
 			'web.serverSettings.backup.enabledDegraded' => '已启用 · 异常',
 			'web.serverSettings.backup.keyFingerprintLabel' => '密钥指纹',
@@ -9085,11 +9080,6 @@ extension on TranslationsZh {
 			'web.settings.about.checkUpdates' => '检查更新',
 			'web.settings.about.checking' => '检查中…',
 			'web.settings.about.reinstall' => '重新安装',
-			'web.settings.language.title' => '语言',
-			'web.settings.language.description' => '选择界面语言。',
-			'web.settings.language.options.en' => 'English',
-			'web.settings.language.options.zh' => '中文',
-			'web.settings.language.options.es' => 'Español',
 			'web.logViewer.filterPlaceholder' => '过滤…',
 			'web.logViewer.debugTooltip' => 'Debug 计数',
 			'web.logViewer.infoTooltip' => 'Info 计数',
@@ -9480,13 +9470,13 @@ extension on TranslationsZh {
 			'sessions.spawnSheet.title' => '新建会话',
 			'sessions.spawnSheet.errorRequired' => '需要指定提供商和工作目录',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => '创建会话失败：${error}',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.spawnSheet.cancel' => '取消',
 			'sessions.spawnSheet.spawn' => '创建',
 			'sessions.spawnSheet.providerLabel' => '提供商',
 			'sessions.spawnSheet.disabledSuffix' => '（已停用）',
 			'sessions.spawnSheet.cwdLabel' => '工作目录',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.spawnSheet.cwdHint' => '/Users/you/projects/foo',
 			'sessions.spawnSheet.cwdHelper' => '网关主机上的绝对路径。',
 			'sessions.spawnSheet.browse' => '浏览',
@@ -9994,13 +9984,13 @@ extension on TranslationsZh {
 			'backupTargetEditor.useHttps' => '使用 HTTPS',
 			'backupTargetEditor.pathStyle' => '路径风格寻址',
 			'backupTargetEditor.pathStyleSubtitle' => '旧版 / MinIO',
+			_ => null,
+		} ?? switch (path) {
 			'backupTargetEditor.kinds.local.label' => '本地磁盘',
 			'backupTargetEditor.kinds.local.description' => '运行 opendray 的机器上的文件夹',
 			'backupTargetEditor.kinds.smb.label' => 'SMB 共享',
 			'backupTargetEditor.kinds.smb.description' => 'Windows 共享 + 多数家用 NAS 设备',
 			'backupTargetEditor.kinds.webdav.label' => 'WebDAV',
-			_ => null,
-		} ?? switch (path) {
 			'backupTargetEditor.kinds.webdav.description' => '自托管云盘 + 文件共享服务',
 			'backupTargetEditor.kinds.sftp.label' => 'SFTP',
 			'backupTargetEditor.kinds.sftp.description' => '任何可 SSH 访问的服务器',
@@ -10508,13 +10498,13 @@ extension on TranslationsZh {
 			'settings.logViewer.levels.debug' => '调试',
 			'settings.logViewer.levels.info' => '信息',
 			'settings.logViewer.levels.warn' => '警告',
+			_ => null,
+		} ?? switch (path) {
 			'settings.logViewer.levels.error' => '错误',
 			'settings.serverSettings.title' => '服务器设置',
 			'settings.serverSettings.reloadTooltip' => '从服务器重新加载',
 			'settings.serverSettings.restartTooltip' => '重启网关',
 			'settings.serverSettings.restartConfirmTitle' => '重启 opendray？',
-			_ => null,
-		} ?? switch (path) {
 			'settings.serverSettings.restartConfirmBody' => '网关将自我 exec。手机应用可能短暂断开连接。',
 			'settings.serverSettings.restart' => '重启',
 			'settings.serverSettings.restartQueuedSnack' => '已请求重启。稍后下拉刷新。',

--- a/app/web/src/components/Topbar.tsx
+++ b/app/web/src/components/Topbar.tsx
@@ -1,10 +1,15 @@
 import { useNavigate } from '@tanstack/react-router'
 import {
+  Sun,
+  Moon,
+  Monitor,
   Terminal as TerminalIcon,
   LogOut,
   Search,
+  Check,
   PanelLeftClose,
   PanelLeftOpen,
+  Languages,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -19,21 +24,42 @@ import {
   DropdownMenuShortcut,
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useTheme, type ThemeMode } from '@/stores/theme'
 import { useAuth } from '@/stores/auth'
 import { useLayout } from '@/stores/layout'
+import { useLocale, type Locale } from '@/stores/locale'
 
 interface TopbarProps {
   onOpenPalette?: () => void
 }
 
+const themeOptions: { mode: ThemeMode; labelKey: string; icon: typeof Sun }[] = [
+  { mode: 'light', labelKey: 'web.topbar.themeLight', icon: Sun },
+  { mode: 'dark', labelKey: 'web.topbar.themeDark', icon: Moon },
+  { mode: 'system', labelKey: 'web.topbar.themeSystem', icon: Monitor },
+]
+
+const localeOptions: { locale: Locale; labelKey: string }[] = [
+  { locale: 'en', labelKey: 'web.topbar.languageEnglish' },
+  { locale: 'zh', labelKey: 'web.topbar.languageChinese' },
+  { locale: 'es', labelKey: 'web.topbar.languageSpanish' },
+]
+
 export function Topbar({ onOpenPalette }: TopbarProps) {
   const { t } = useTranslation()
+  const mode = useTheme((s) => s.mode)
+  const setMode = useTheme((s) => s.setMode)
+  const locale = useLocale((s) => s.locale)
+  const setLocale = useLocale((s) => s.setLocale)
   const username = useAuth((s) => s.username)
   const expiresAt = useAuth((s) => s.expiresAt)
   const clear = useAuth((s) => s.clear)
   const navigate = useNavigate()
   const sidebarCollapsed = useLayout((s) => s.sidebarCollapsed)
   const toggleSidebar = useLayout((s) => s.toggleSidebar)
+
+  const ThemeIcon =
+    mode === 'dark' ? Moon : mode === 'light' ? Sun : Monitor
 
   const sidebarToggleLabel = sidebarCollapsed
     ? t('web.topbar.expandSidebar')
@@ -87,6 +113,59 @@ export function Topbar({ onOpenPalette }: TopbarProps) {
           <TooltipContent>{t('web.topbar.openPalette')}</TooltipContent>
         </Tooltip>
       )}
+
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label={t('web.topbar.language')}
+              >
+                <Languages className="size-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>{t('web.topbar.language')}</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="end">
+          <DropdownMenuLabel>{t('web.topbar.language')}</DropdownMenuLabel>
+          {localeOptions.map(({ locale: l, labelKey }) => (
+            <DropdownMenuItem key={l} onSelect={() => setLocale(l)}>
+              <span>{t(labelKey)}</span>
+              {locale === l && <Check className="ml-auto size-3" />}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label={t('web.topbar.themeLabel', { mode })}
+              >
+                <ThemeIcon className="size-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>{t('web.topbar.theme')}</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="end">
+          <DropdownMenuLabel>{t('web.topbar.appearance')}</DropdownMenuLabel>
+          {themeOptions.map(({ mode: m, labelKey, icon: Icon }) => (
+            <DropdownMenuItem key={m} onSelect={() => setMode(m)}>
+              <Icon />
+              <span>{t(labelKey)}</span>
+              {mode === m && <Check className="ml-auto size-3" />}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
 
       {username && (
         <DropdownMenu>

--- a/app/web/src/pages/Settings.tsx
+++ b/app/web/src/pages/Settings.tsx
@@ -8,7 +8,6 @@ import {
   Monitor,
   Check,
   Type,
-  Languages,
   User as UserIcon,
   Server,
   Settings2,
@@ -23,7 +22,6 @@ import { toast } from 'sonner'
 import { api } from '@/lib/api'
 import { getVersionInfo, requestSelfUpdate, type VersionInfo } from '@/lib/version'
 import { useTheme, type ThemeMode } from '@/stores/theme'
-import { useLocale, SUPPORTED_LOCALES, type Locale } from '@/stores/locale'
 import { useAuth } from '@/stores/auth'
 import { useLayout } from '@/stores/layout'
 import { cn } from '@/lib/utils'
@@ -269,12 +267,7 @@ function ContentRouter({
 
   switch (active) {
     case 'appearance':
-      return (
-        <div className="space-y-8">
-          <AppearanceSection mode={mode} setMode={setMode} />
-          <LanguageSection />
-        </div>
-      )
+      return <AppearanceSection mode={mode} setMode={setMode} />
     case 'font':
       return (
         <FontSection fontScale={fontScale} setFontScale={setFontScale} />
@@ -411,49 +404,6 @@ function AppearanceSection({
                   {t(descKey)}
                 </span>
               </div>
-              {active && (
-                <Check className="absolute right-2 top-2 size-3 text-accent" />
-              )}
-            </button>
-          )
-        })}
-      </div>
-    </div>
-  )
-}
-
-function LanguageSection() {
-  const { t } = useTranslation()
-  const locale = useLocale((s) => s.locale)
-  const setLocale = useLocale((s) => s.setLocale)
-  const labels: Record<Locale, string> = {
-    en: t('web.settings.language.options.en'),
-    zh: t('web.settings.language.options.zh'),
-    es: t('web.settings.language.options.es'),
-  }
-  return (
-    <div>
-      <SectionHeader
-        title={t('web.settings.language.title')}
-        description={t('web.settings.language.description')}
-      />
-      <div className="grid grid-cols-3 gap-2">
-        {SUPPORTED_LOCALES.map((l) => {
-          const active = locale === l
-          return (
-            <button
-              key={l}
-              type="button"
-              onClick={() => setLocale(l)}
-              className={cn(
-                'relative flex flex-col gap-2 items-start text-left p-3 rounded-md border transition-colors',
-                active
-                  ? 'border-foreground/30 bg-card'
-                  : 'border-border hover:bg-card hover:border-foreground/20',
-              )}
-            >
-              <Languages className="size-4 text-muted-foreground" />
-              <span className="text-[13px] font-medium">{labels[l]}</span>
               {active && (
                 <Check className="absolute right-2 top-2 size-3 text-accent" />
               )}


### PR DESCRIPTION
Reverts the #347 relocation. Theme + language were moved out of the header
only because their dropdowns appeared off-screen — but the real cause was
the font-scale `<body>` zoom double-scaling Radix popovers (fixed in #349
by zooming `#root`). With that fixed, the header toggles position
correctly, so bring them back.

- Topbar: theme + language dropdowns restored (account menu keeps the #348
  avoidCollisions pin).
- Settings → Appearance: Language section removed; `web.settings.language.*`
  keys removed; `web.topbar` theme/language keys restored; slang regenerated.

Verified: `pnpm --filter web build` ✓, `dart analyze` ✓, i18n parity ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)