### PR TITLE
fix(web/terminal): repair Safari regressions from #323 + iOS scrollback

### DIFF
--- a/app/shared/src/lib/ws.ts
+++ b/app/shared/src/lib/ws.ts
@@ -13,7 +13,24 @@ export function wsURL(path: string, token: string): string {
 export interface BinaryWSCallbacks {
   onMessage?: (data: Uint8Array) => void
   onOpen?: () => void
+  /**
+   * Fires once per disconnect *cycle* — the first time the connection
+   * drops, and not again until a successful reconnect resets the state.
+   * Lets callers surface a "reconnecting" line without stacking it on
+   * every bounce when an idle proxy drops the socket every few seconds.
+   */
   onClose?: () => void
+  /**
+   * Fires once when the socket comes back up after a prior onClose.
+   * Lets callers clear/replace the "reconnecting" line they wrote.
+   */
+  onReconnect?: () => void
+  /**
+   * Fires when reconnect attempts have been exhausted and the socket
+   * is permanently dead. Callers should surface a CTA (refresh / reopen)
+   * rather than the still-trying "reconnecting" line.
+   */
+  onGiveUp?: () => void
   onError?: (err: Event) => void
 }
 
@@ -31,10 +48,18 @@ export class BinaryWS {
   private ws: WebSocket | null = null
   private closed = false
   private backoff = 500
-  private readonly maxBackoff = 8_000
-  private readonly maxRetries = 6
+  private readonly maxBackoff = 15_000
+  // High enough that an idle-proxy bouncing the socket every few
+  // seconds doesn't hit the permanent-give-up path during normal
+  // use; capped so a server that's gone for good still eventually
+  // surfaces the give-up state instead of polling forever.
+  private readonly maxRetries = 30
   private retries = 0
   private timer: ReturnType<typeof setTimeout> | null = null
+  // True between the first onClose of a disconnect cycle and the
+  // next successful onopen. Prevents stacking "[disconnected]" lines
+  // when the proxy closes the socket every backoff window.
+  private disconnectAnnounced = false
 
   constructor(url: string, cb: BinaryWSCallbacks = {}) {
     this.url = url
@@ -76,7 +101,10 @@ export class BinaryWS {
     ws.onopen = () => {
       this.backoff = 500
       this.retries = 0
+      const wasDisconnected = this.disconnectAnnounced
+      this.disconnectAnnounced = false
       this.cb.onOpen?.()
+      if (wasDisconnected) this.cb.onReconnect?.()
     }
     ws.onmessage = (ev) => {
       if (ev.data instanceof ArrayBuffer) {
@@ -89,7 +117,14 @@ export class BinaryWS {
       this.cb.onError?.(ev)
     }
     ws.onclose = (ev) => {
-      this.cb.onClose?.()
+      // Announce the disconnect ONCE per cycle — not on every retry.
+      // A flaky proxy that drops the socket every backoff window used
+      // to write a fresh "[disconnected]" line each bounce, which
+      // stacked on screen and obscured what Claude was actually saying.
+      if (!this.closed && !this.disconnectAnnounced) {
+        this.disconnectAnnounced = true
+        this.cb.onClose?.()
+      }
       if (this.closed) return
       // Stop retrying for normal / explicit server-side close. The
       // server uses 1000 (normal) or 1001 (going away); also halt
@@ -102,6 +137,7 @@ export class BinaryWS {
       this.retries++
       if (this.retries >= this.maxRetries) {
         this.closed = true
+        this.cb.onGiveUp?.()
         return
       }
       const wait = this.backoff

--- a/app/web/src/components/AppShell.tsx
+++ b/app/web/src/components/AppShell.tsx
@@ -30,7 +30,13 @@ export function AppShell() {
 
   return (
     <TooltipProvider delayDuration={200}>
-      <div className="h-svh flex flex-col bg-background text-foreground">
+      {/* h-dvh (not h-svh): on iOS the visual viewport shrinks when the
+          soft keyboard opens or grows when the address bar collapses.
+          h-svh locks the shell to the address-bar-visible height, which
+          leaves the bottom of the chat clipped past the visible viewport
+          when the keyboard is up. h-dvh tracks the live viewport so the
+          shell always fits exactly what the user can see. */}
+      <div className="h-dvh flex flex-col bg-background text-foreground">
         <Topbar onOpenPalette={() => setPaletteOpen(true)} />
         <HealthBanner />
         <div className="flex-1 flex overflow-hidden min-h-0 relative">

--- a/app/web/src/components/sessions/EndedSessionView.tsx
+++ b/app/web/src/components/sessions/EndedSessionView.tsx
@@ -51,6 +51,7 @@ function buildTheme(applied: 'light' | 'dark') {
  */
 export function EndedSessionView({ sessionId }: EndedSessionViewProps) {
   const { t } = useTranslation()
+  const rootRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const xtermRef = useRef<XTerm | null>(null)
   const fitRef = useRef<FitAddon | null>(null)
@@ -115,8 +116,11 @@ export function EndedSessionView({ sessionId }: EndedSessionViewProps) {
         }
       })
     }
+    // Observe the in-flow root (not the host) — WebKit's RO fires late
+    // on absolute-positioned elements inside flex-1 min-h-0; see
+    // Terminal.tsx for the full rationale.
     const ro = new ResizeObserver(scheduleFit)
-    ro.observe(containerRef.current)
+    if (rootRef.current) ro.observe(rootRef.current)
     scheduleFit()
     void document.fonts?.ready?.then(scheduleFit)
 
@@ -131,11 +135,16 @@ export function EndedSessionView({ sessionId }: EndedSessionViewProps) {
   }, [sessionId, themeApplied, t])
 
   return (
-    <div className="h-full w-full bg-background relative overflow-hidden">
-      {/* Clipped + absolutely sized so replay content can't escape to
-          the scrollable <main> and start a fit()/scrollbar feedback
-          loop — same isolation as the live Terminal. */}
-      <div ref={containerRef} className="absolute inset-0 p-2 overflow-hidden" />
+    <div ref={rootRef} className="h-full w-full bg-background relative overflow-hidden">
+      {/* `contain: layout` + `overflow-hidden` isolates the replay
+          terminal from <main>'s scrollbar without the WebKit-late RO
+          quirk that `absolute inset-0` has inside flex-1 min-h-0 —
+          see Terminal.tsx for the full rationale. */}
+      <div
+        ref={containerRef}
+        className="h-full w-full p-2 overflow-hidden"
+        style={{ contain: 'layout paint' }}
+      />
     </div>
   )
 }

--- a/app/web/src/components/sessions/Terminal.tsx
+++ b/app/web/src/components/sessions/Terminal.tsx
@@ -303,6 +303,16 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         term.writeln('')
         term.writeln('\x1b[33m[disconnected — reconnecting…]\x1b[0m')
       },
+      onReconnect: () => {
+        if (!alive) return
+        term.writeln('\x1b[32m[reconnected]\x1b[0m')
+      },
+      onGiveUp: () => {
+        if (!alive) return
+        term.writeln(
+          '\x1b[31m[connection lost — refresh the page to reconnect]\x1b[0m',
+        )
+      },
       onOpen: () => {
         // After (re)connect, push current dimensions so server sizes the PTY.
         if (!alive) return
@@ -403,8 +413,23 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         }
       })
     }
+    // Observe the in-flow root (not the absolute-positioned host).
+    // WebKit's ResizeObserver fires late on absolute elements nested
+    // inside `flex-1 min-h-0`, leaving the PTY a few cols too wide
+    // after a sidebar/banner-driven layout shift — the user sees
+    // input wrap past the visible right edge after 3-4 lines.
     const ro = new ResizeObserver(scheduleFit)
-    ro.observe(containerRef.current)
+    if (rootRef.current) ro.observe(rootRef.current)
+
+    // Safari/iOS don't surface keyboard show/hide or address-bar
+    // collapse through window resize alone — the visualViewport API
+    // is the only event that reliably fires. Without this, opening
+    // the soft keyboard would clip xterm's bottom rows without ever
+    // refitting, which reads as "chat goes below the browser window."
+    const vv =
+      typeof window !== 'undefined' ? window.visualViewport : null
+    vv?.addEventListener('resize', scheduleFit)
+    vv?.addEventListener('scroll', scheduleFit)
 
     // The synchronous fit() at open ran before the first post-mount
     // layout had settled (and before a webfont monospace face, on
@@ -423,6 +448,8 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       touchHost?.removeEventListener('touchend', onTouchEnd)
       touchHost?.removeEventListener('touchcancel', onTouchEnd)
       ro.disconnect()
+      vv?.removeEventListener('resize', scheduleFit)
+      vv?.removeEventListener('scroll', scheduleFit)
       ws.close()
       term.dispose()
       xtermRef.current = null
@@ -552,15 +579,21 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
 
   return (
     <div ref={rootRef} className="h-full w-full bg-background relative overflow-hidden">
-      {/* The xterm host is absolutely positioned + clipped so its size
-          is driven SOLELY by this (flex/viewport-sized) pane and never
-          by its own rendered content. Without the clip, a line wider
-          than the pane escapes up to the scrollable <main>, toggling
-          its scrollbar, which re-measures the pane and re-runs fit() —
-          a feedback loop that reads as the terminal "jittering" as you
-          type a long line. Clipping breaks the loop at the source and
-          forces xterm to wrap at the real visible width. */}
-      <div ref={containerRef} className="absolute inset-0 p-3 overflow-hidden" />
+      {/* `contain: layout` + `overflow-hidden` isolate xterm's inner
+          viewport from the surrounding flex/scroll layout: a line
+          wider than the pane can't escape up to <main>'s scrollbar
+          (which would re-measure the pane and re-run fit() — the
+          jitter feedback loop). We previously used `absolute inset-0`
+          for the same goal, but on WebKit ResizeObserver fires late
+          on absolute-positioned elements inside `flex-1 min-h-0`,
+          leaving fit() reading a stale size after layout shifts.
+          Staying in-flow with containment gives us the same isolation
+          and reliable RO timing across Safari/Chrome. */}
+      <div
+        ref={containerRef}
+        className="h-full w-full p-3 overflow-hidden"
+        style={{ contain: 'layout paint' }}
+      />
       <DetectedURLs urls={detectedURLs} />
       {pill && (
         <Button

--- a/app/web/src/index.css
+++ b/app/web/src/index.css
@@ -148,6 +148,18 @@
   }
 }
 
+/* xterm scrollback on iOS Safari needs explicit momentum-touch
+   scrolling on the viewport div — without it, two-finger drag on
+   the canvas doesn't scroll xterm's scrollback at all, which reads
+   as "I can't scroll up to see previous output on iOS." The
+   `overscroll-behavior: contain` prevents the gesture from leaking
+   to the page (which used to scroll the whole AppShell instead). */
+.xterm-viewport {
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  touch-action: pan-y;
+}
+
 /* highlight.js theme — a compact mapping that uses palette-friendly
    colors for both light and dark modes. The Inspector's file viewer
    wraps lines into our own gutter, so only inline class colors are


### PR DESCRIPTION
## Summary

Fixes four user-reported regressions after upgrading to the post-v2.7.1 build that includes #323:

1. **Chat extends past the browser bottom** on Mac Safari
2. **`[disconnected — reconnecting…]` stacks repeatedly** and never clears on reconnect
3. **Claude's TUI input stops wrapping after 3-4 lines**, with the cursor running off the right edge until the window is resized
4. **iOS web can't scroll the terminal up** to review earlier output

## Root cause

PR #323 isolated the xterm pane with `absolute inset-0 + overflow-hidden` to break a scrollbar-feedback loop on Chrome. On WebKit the same layout leaves `fit()` reading a stale size after sidebar/banner-driven layout shifts — `ResizeObserver` fires late on absolute-positioned elements nested inside `flex-1 min-h-0`, so the PTY ends up a few cols too wide and a few rows too tall. The new clipped pane also blocked the page-level fallback scroll that used to (accidentally) let iOS users review scrollback.

Independently, `BinaryWS` wrote a fresh `[disconnected]` line on every retry and gave up after only 6 attempts, which made an idle-proxy bounce read as "broken forever."

## Changes

- **`Terminal.tsx` / `EndedSessionView.tsx`** — keep #323's jitter isolation by replacing `absolute inset-0` with in-flow `h-full w-full` plus `contain: layout paint`. Same outer-layout opacity, but WebKit's RO timing is reliable on in-flow elements. The `ResizeObserver` is repointed at the in-flow `rootRef` as well.
- **`Terminal.tsx`** — subscribe to `visualViewport.resize`/`scroll` so iOS keyboard and address-bar transitions trigger a refit. `window` resize alone misses those on Safari.
- **`AppShell.tsx`** — `h-svh` → `h-dvh` so the shell tracks the live visual viewport instead of locking to the address-bar-visible height.
- **`index.css`** — `.xterm-viewport` gets `-webkit-overflow-scrolling: touch`, `overscroll-behavior: contain`, and `touch-action: pan-y` so two-finger drag on the canvas scrolls xterm's scrollback without leaking to the page.
- **`ws.ts` (BinaryWS)** — announce a disconnect only once per cycle (no more stacking); add `onReconnect`/`onGiveUp` so the Terminal can replace the warning line with `[reconnected]` on success or a refresh-to-recover CTA after retries are exhausted. Bumped `maxRetries` 6 → 30 and `maxBackoff` 8s → 15s.

Web only. No server, mobile, or PTY behaviour change. Does not re-introduce the #149/#151/#152 resize-gating machinery that #153 reverted.

## Test plan

- [ ] Mac Safari, live session: chat fits inside the viewport; resizing the window/sidebar doesn't leave Claude's bottom status rows clipped
- [ ] Mac Safari, live session: type a long Claude prompt past 4 wraps — input wraps inside the visible column, cursor never runs off the right edge
- [ ] Mac Safari, induce a WS bounce (e.g. restart opendray) — exactly one `[disconnected — reconnecting…]` line, then `[reconnected]` on recovery
- [ ] Mac Safari, leave the page idle longer than the WS retry cap — surfaces `[connection lost — refresh the page to reconnect]`
- [ ] Mac Chrome: original jitter fix from #323 still holds (no oscillation while typing long lines)
- [ ] iOS Safari (PWA + web): two-finger drag on the terminal scrolls xterm scrollback; shell stays inside the visible viewport when the keyboard is open
- [ ] EndedSessionView (open an ended session): replay terminal lays out correctly without jitter