### PR TITLE
feat(web/nav): badge the Settings icon when an update is available

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -38,7 +38,8 @@
     "plugins": "Plugins",
     "backups": "Backups",
     "settings": "Settings",
-    "workspace": "Workspace"
+    "workspace": "Workspace",
+    "updateAvailable": "Update available"
   },
   "web": {
     "brand": "opendray",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -38,7 +38,8 @@
     "plugins": "Plugins",
     "backups": "Copias de seguridad",
     "settings": "Ajustes",
-    "workspace": "Espacio de trabajo"
+    "workspace": "Espacio de trabajo",
+    "updateAvailable": "Actualización disponible"
   },
   "web": {
     "brand": "opendray",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -38,7 +38,8 @@
     "plugins": "插件",
     "backups": "备份",
     "settings": "设置",
-    "workspace": "工作区"
+    "workspace": "工作区",
+    "updateAvailable": "有可用更新"
   },
   "web": {
     "brand": "opendray",

--- a/app/web/src/components/SidebarNav.tsx
+++ b/app/web/src/components/SidebarNav.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
 import {
   Layers,
   Cpu,
@@ -19,6 +20,14 @@ import { cn } from '@/lib/utils'
 import { useLayout } from '@/stores/layout'
 import { useIsMobile } from '../lib/useIsMobile'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { getVersionInfo, type VersionInfo } from '@/lib/version'
+
+// 6 hours between background version checks — releases are weekly at
+// most, so anything more frequent burns server cycles for a state
+// that rarely changes. The badge also picks up any refetch the
+// Settings/About panel triggers, since both observers share the
+// `['version']` query cache.
+const UPDATE_POLL_INTERVAL_MS = 6 * 60 * 60 * 1000
 
 interface NavItem {
   to: string
@@ -58,6 +67,19 @@ export function SidebarNav() {
   // On mobile the nav is a full-width slide-over (positioned by AppShell),
   // so never collapse it to the icon rail there.
   const collapsed = collapsedState && !isMobile
+  // Background poll for available updates so the gear icon can carry
+  // a "new version waiting" dot without the operator having to open
+  // the About panel. Shares the `['version']` cache with AboutSection.
+  const { data: version } = useQuery<VersionInfo>({
+    queryKey: ['version'],
+    queryFn: getVersionInfo,
+    refetchInterval: UPDATE_POLL_INTERVAL_MS,
+    staleTime: UPDATE_POLL_INTERVAL_MS,
+  })
+  // Don't badge while an upgrade is already queued — the operator
+  // has already acted, the dot would just be noise until the daemon
+  // restarts and the version check resolves clean.
+  const updateAvailable = !!version?.updateAvailable && !version?.pending
   return (
     <nav
       className={cn(
@@ -88,11 +110,15 @@ export function SidebarNav() {
                 ? location.pathname.startsWith('/sessions') ||
                   location.pathname === '/'
                 : location.pathname.startsWith(to)
+            const showUpdateDot = to === '/settings' && updateAvailable
+            const updateLabel = t('nav.updateAvailable')
             const link = (
               <Link
                 key={to}
                 to={to}
-                aria-label={label}
+                aria-label={
+                  showUpdateDot ? `${label} — ${updateLabel}` : label
+                }
                 className={cn(
                   'flex items-center h-7 rounded-md text-[13px] transition-all duration-100',
                   'text-muted-foreground hover:text-foreground hover:bg-card',
@@ -100,7 +126,19 @@ export function SidebarNav() {
                   collapsed ? 'justify-center px-0' : 'gap-2.5 px-2.5',
                 )}
               >
-                <Icon className="size-3.5 shrink-0" />
+                <span className="relative shrink-0">
+                  <Icon className="size-3.5 shrink-0" />
+                  {showUpdateDot && (
+                    // Small accent dot anchored to the icon so it
+                    // reads as a badge on the gear, not a separate
+                    // chip — visible in both collapsed and expanded
+                    // sidebar without changing the row height.
+                    <span
+                      className="absolute -right-0.5 -top-0.5 size-1.5 rounded-full bg-accent ring-2 ring-card"
+                      aria-hidden
+                    />
+                  )}
+                </span>
                 {!collapsed && (
                   <>
                     <span className="flex-1">{label}</span>
@@ -118,6 +156,9 @@ export function SidebarNav() {
                 <TooltipContent side="right">
                   {label}
                   <span className="ml-2 text-muted-foreground">{shortcut}</span>
+                  {showUpdateDot && (
+                    <span className="ml-2 text-accent">{updateLabel}</span>
+                  )}
                 </TooltipContent>
               </Tooltip>
             )


### PR DESCRIPTION
## Summary

The in-place upgrade flow already lives in **Settings → About** (check-now → confirm → background self-update → poll-until-restart). But operators only learn about a new release if they happen to open that panel.

This adds a small accent dot on the gear icon in the sidebar so the prompt finds them — not a loud top banner, just a passive nudge that's visible in both expanded and icon-rail modes.

## Behaviour

- **Background poll.** `SidebarNav` opens a `useQuery(['version'])` with a 6-hour `refetchInterval`. Releases ship at most weekly, so anything more frequent burns server cycles for a state that rarely flips.
- **Shared cache.** Same query key as the About panel — a manual "Check now" there updates the badge immediately, no extra round-trip.
- **Suppressed during upgrade.** When `pending=true` (an upgrade is already queued) the dot hides — the operator has already acted; further nagging would only add noise until the daemon restarts and the version resolves clean.
- **Accessible.** `aria-label` and the collapsed-rail tooltip get a "— Update available" suffix so keyboard and screen-reader users get the same signal as sighted ones.
- **i18n parity.** `nav.updateAvailable` added to en/es/zh.

## Out of scope

Visual upgrade panel — already shipped in `AboutSection`. This PR only adds the discovery surface.

## Files

- `app/web/src/components/SidebarNav.tsx` — version query + badge overlay
- `app/i18n/{en,es,zh}.json` — `nav.updateAvailable` string

Web only. No server change.

## Test plan

- [ ] On a host with an available update: dot shows on the gear (expanded sidebar, collapsed icon rail, mobile slide-over)
- [ ] Click gear → land in Settings → About → "Update available" shown there too (existing behaviour)
- [ ] Confirm + start upgrade → dot disappears while `pending` (badge gated by `!pending`)
- [ ] After daemon restarts and the version matches latest → dot stays away
- [ ] In a stuck/offline state (`checkError` set): no dot, no spam
- [ ] Hover the gear in collapsed mode → tooltip reads "Settings g , Update available"