### PR TITLE
feat(skills): drag-and-drop install of SKILL.md from the Plugins page

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1366,6 +1366,12 @@
         "deleteConfirm": "Delete skill \"{id}\" from your vault? This removes the SKILL.md file.",
         "removedToast": "Skill removed",
         "deleteFailedToast": "Delete failed",
+        "dropHint": "Or drop a SKILL.md here to install it.",
+        "dropToInstall": "Drop SKILL.md to install",
+        "uploading": "Installing skill…",
+        "uploadedToast": "Skill \"{id}\" installed",
+        "uploadFailedToast": "Skill upload failed",
+        "uploadInvalidTypeToast": "Only SKILL.md files can be installed by drop",
         "editor": {
           "createTitle": "New skill",
           "customizeTitle": "Customize built-in: {id}",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -1366,6 +1366,12 @@
         "deleteConfirm": "¿Eliminar la habilidad \"{id}\" de tu vault? Esto elimina el archivo SKILL.md.",
         "removedToast": "Habilidad eliminada",
         "deleteFailedToast": "Error al eliminar",
+        "dropHint": "O suelta un SKILL.md aquí para instalarlo.",
+        "dropToInstall": "Suelta el SKILL.md para instalar",
+        "uploading": "Instalando habilidad…",
+        "uploadedToast": "Habilidad \"{id}\" instalada",
+        "uploadFailedToast": "Error al subir la habilidad",
+        "uploadInvalidTypeToast": "Solo se pueden instalar archivos SKILL.md por arrastre",
         "editor": {
           "createTitle": "Nueva habilidad",
           "customizeTitle": "Personalizar la integrada: {id}",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -1366,6 +1366,12 @@
         "deleteConfirm": "从 vault 删除 skill \"{id}\"? 这会移除该 SKILL.md 文件。",
         "removedToast": "Skill 已移除",
         "deleteFailedToast": "删除失败",
+        "dropHint": "或将 SKILL.md 文件拖放到此处以安装。",
+        "dropToInstall": "拖放 SKILL.md 以安装",
+        "uploading": "正在安装 skill…",
+        "uploadedToast": "Skill \"{id}\" 已安装",
+        "uploadFailedToast": "上传 skill 失败",
+        "uploadInvalidTypeToast": "仅支持拖放 SKILL.md 文件",
         "editor": {
           "createTitle": "新建 skill",
           "customizeTitle": "自定义内置：{id}",

--- a/app/shared/src/lib/skills.ts
+++ b/app/shared/src/lib/skills.ts
@@ -41,3 +41,19 @@ export async function updateSkill(id: string, body: string): Promise<Skill> {
 export async function deleteSkill(id: string): Promise<void> {
   await api(`/api/v1/skills/${id}`, { method: 'DELETE' })
 }
+
+/**
+ * Upload a SKILL.md to install it as a vault skill. The server derives
+ * the id from the frontmatter `name:` field (slugified) — no separate
+ * id prompt. Used by the drag-and-drop affordance on the Plugins page.
+ *
+ * Rejects on:
+ *   - missing/blank `name:` in the frontmatter
+ *   - id collision with an existing vault skill (409 — delete first)
+ *   - empty file or >4 MB body
+ */
+export async function uploadSkill(file: File): Promise<Skill> {
+  const fd = new FormData()
+  fd.append('file', file)
+  return api<Skill>('/api/v1/skills/upload', { method: 'POST', body: fd })
+}

--- a/app/web/src/pages/Plugins.tsx
+++ b/app/web/src/pages/Plugins.tsx
@@ -59,6 +59,7 @@ import {
   createSkill,
   updateSkill,
   deleteSkill,
+  uploadSkill,
 } from '@/lib/skills'
 import {
   listMcps,
@@ -977,6 +978,9 @@ function SkillsSection() {
   })
   const [editingId, setEditingId] = useState<string | null>(null)
   const [creating, setCreating] = useState(false)
+  // Drag-and-drop install: hover state for the overlay + a guard so the
+  // user can't fire two uploads on a double-drop.
+  const [dragActive, setDragActive] = useState(false)
 
   const remove = useMutation({
     mutationFn: deleteSkill,
@@ -989,6 +993,42 @@ function SkillsSection() {
         description: err.message,
       }),
   })
+
+  const upload = useMutation({
+    mutationFn: uploadSkill,
+    onSuccess: (s) => {
+      qc.invalidateQueries({ queryKey: ['skills'] })
+      toast.success(
+        t('web.plugins.skills.uploadedToast', { id: s.id }),
+      )
+    },
+    onError: (err: Error) =>
+      toast.error(t('web.plugins.skills.uploadFailedToast'), {
+        description: err.message,
+      }),
+  })
+
+  // Single entry point for both drop and the hidden file input. .md
+  // gate is best-effort — the server is the authoritative check
+  // (must have a `name:` frontmatter to be a real SKILL).
+  const handleFiles = (files: FileList | File[] | null) => {
+    if (!files) return
+    const arr = Array.from(files)
+    if (arr.length === 0) return
+    for (const f of arr) {
+      const looksLikeMarkdown =
+        f.name.toLowerCase().endsWith('.md') ||
+        f.type === 'text/markdown' ||
+        f.type === ''
+      if (!looksLikeMarkdown) {
+        toast.error(t('web.plugins.skills.uploadInvalidTypeToast'), {
+          description: f.name,
+        })
+        continue
+      }
+      upload.mutate(f)
+    }
+  }
 
   return (
     <CollapsibleSection
@@ -1013,7 +1053,39 @@ function SkillsSection() {
         </Button>
       }
     >
-      <div className="rounded-md border border-border overflow-hidden">
+      <div
+        className={cn(
+          'relative rounded-md border border-border overflow-hidden',
+          dragActive && 'ring-2 ring-accent/70',
+        )}
+        onDragEnter={(e) => {
+          // Only react to file drags — ignore the in-page text drags
+          // (e.g. selection in the SKILL editor) so the overlay stays
+          // out of the way during normal use.
+          if (!Array.from(e.dataTransfer.types).includes('Files')) return
+          e.preventDefault()
+          setDragActive(true)
+        }}
+        onDragOver={(e) => {
+          if (!Array.from(e.dataTransfer.types).includes('Files')) return
+          // preventDefault on dragover is required for the subsequent
+          // drop event to fire.
+          e.preventDefault()
+          e.dataTransfer.dropEffect = 'copy'
+        }}
+        onDragLeave={(e) => {
+          // Fires when crossing into a child element too — only reset
+          // when the cursor actually leaves the container box.
+          if (e.target !== e.currentTarget) return
+          setDragActive(false)
+        }}
+        onDrop={(e) => {
+          if (!Array.from(e.dataTransfer.types).includes('Files')) return
+          e.preventDefault()
+          setDragActive(false)
+          handleFiles(e.dataTransfer.files)
+        }}
+      >
         {isLoading ? (
           <div className="px-4 py-6 flex items-center gap-2 text-[12px] text-muted-foreground">
             <Loader2 className="size-3 animate-spin" />
@@ -1022,6 +1094,9 @@ function SkillsSection() {
         ) : (skills ?? []).length === 0 ? (
           <div className="px-4 py-8 text-center text-[12px] text-muted-foreground">
             {t('web.plugins.skills.empty')}
+            <div className="mt-2 text-[11px] text-muted-foreground/70">
+              {t('web.plugins.skills.dropHint')}
+            </div>
           </div>
         ) : (
           <table className="w-full text-[12px]">
@@ -1142,6 +1217,19 @@ function SkillsSection() {
               ))}
             </tbody>
           </table>
+        )}
+        {dragActive && (
+          <div className="pointer-events-none absolute inset-1 rounded-sm border-2 border-dashed border-accent/70 bg-accent/10 flex items-center justify-center">
+            <div className="text-[12px] font-mono text-accent">
+              {t('web.plugins.skills.dropToInstall')}
+            </div>
+          </div>
+        )}
+        {upload.isPending && (
+          <div className="pointer-events-none absolute inset-1 rounded-sm bg-background/60 flex items-center justify-center text-[12px] text-muted-foreground gap-2">
+            <Loader2 className="size-3.5 animate-spin" />
+            {t('web.plugins.skills.uploading')}
+          </div>
         )}
       </div>
 

--- a/internal/skills/handler.go
+++ b/internal/skills/handler.go
@@ -35,6 +35,11 @@ func (h *Handlers) Mount(r chi.Router) {
 	r.Route("/skills", func(r chi.Router) {
 		r.Get("/", h.list)
 		r.Post("/", h.create)
+		// Multipart upload of a SKILL.md — derives the id from the
+		// frontmatter `name:` field (slugified) rather than asking the
+		// caller for one. Lets the dashboard offer drag-and-drop install
+		// of a skill file without an intermediate "pick an id" step.
+		r.Post("/upload", h.upload)
 		r.Route("/{id}", func(r chi.Router) {
 			r.Get("/", h.get)
 			r.Put("/", h.update)
@@ -233,6 +238,104 @@ func (h *Handlers) delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// upload accepts a multipart-uploaded SKILL.md and installs it in the
+// vault under <vault>/<slug-of-name>/SKILL.md. The id is derived from
+// the frontmatter `name:` field (slugified to validID's alphabet) so
+// the operator doesn't have to pick one — drag the .md, get a working
+// skill. Collides-with-vault is a 409 (delete first); collides-with-
+// builtin is allowed and just becomes an override (matches the
+// existing PUT semantics).
+func (h *Handlers) upload(w http.ResponseWriter, r *http.Request) {
+	if h.loader.VaultRoot() == "" {
+		writeError(w, http.StatusConflict,
+			errors.New("vault root is not configured; cannot upload skills"))
+		return
+	}
+	const maxUploadBytes = 4 << 20 // 4 MB — matches the JSON create cap.
+	r.Body = http.MaxBytesReader(w, r.Body, maxUploadBytes)
+	if err := r.ParseMultipartForm(maxUploadBytes); err != nil {
+		writeError(w, http.StatusBadRequest,
+			fmt.Errorf("read multipart form: %w", err))
+		return
+	}
+	file, _, err := r.FormFile("file")
+	if err != nil {
+		writeError(w, http.StatusBadRequest,
+			errors.New("missing 'file' field in multipart upload"))
+		return
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(io.LimitReader(file, maxUploadBytes))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	body := string(data)
+	if strings.TrimSpace(body) == "" {
+		writeError(w, http.StatusBadRequest, errors.New("uploaded file is empty"))
+		return
+	}
+	name, _ := parseFrontmatter(body)
+	if strings.TrimSpace(name) == "" {
+		writeError(w, http.StatusBadRequest,
+			errors.New("SKILL.md must declare a 'name:' field in its frontmatter"))
+		return
+	}
+	id := slugify(name)
+	if !validID(id) {
+		writeError(w, http.StatusBadRequest,
+			fmt.Errorf("derived id %q is invalid; rename the skill so the frontmatter name slugs to lowercase alphanumeric / dash / underscore", id))
+		return
+	}
+
+	dest := filepath.Join(h.loader.VaultRoot(), id)
+	if _, err := os.Stat(dest); err == nil {
+		writeError(w, http.StatusConflict,
+			fmt.Errorf("skill %s already exists in vault; delete it first or rename the upload", id))
+		return
+	}
+	if err := os.MkdirAll(dest, 0o700); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	if err := os.WriteFile(filepath.Join(dest, "SKILL.md"), []byte(body), 0o600); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	s, err := h.loader.Get(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, skillView{
+		ID: s.ID, Name: s.Name, Description: s.Description,
+		Source: s.Source, Body: s.Body,
+	})
+}
+
+// slugify converts a frontmatter name into an id that validID will
+// accept: lowercase, collapse non-alphanumeric runs into single
+// dashes, trim leading/trailing dashes and underscores. Preserves
+// underscores so authors who want them get them.
+func slugify(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash && b.Len() > 0 {
+			b.WriteRune('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-_")
 }
 
 func validID(id string) bool {


### PR DESCRIPTION
## Summary

The **Plugins → Agent skills** surface already supports CRUD via the modal editor — paste a body, pick an id, save. This adds a faster path for the common case: drag a `SKILL.md` onto the skills table and the daemon slugs the frontmatter `name:` into an id and writes it to the vault.

No new prompt for an id. No editor modal. Drop → installed.

## Backend

- `POST /api/v1/skills/upload` (multipart, admin-only via the same mount as the rest of the skills router).
  - Caps the upload at 4 MB (matching the JSON create cap).
  - Requires a `file` field, requires the body to have `name:` in the YAML frontmatter.
  - Slugifies `name` into an id; rejects with a clear error if the slug ends up empty/invalid (e.g. `name: "!!!"` → empty slug).
  - **Vault collision** → 409 (delete first or rename the upload).
  - **Builtin collision** → allowed; the vault entry becomes an override (same as PUT semantics, surfaces in the UI as the existing `overrides_builtin` badge).
- `slugify` converts `My Cool Helper` → `my-cool-helper` so the id lands inside `validID`'s alphabet without forcing the operator to invent one.

## Frontend

- `uploadSkill(file)` in `app/shared/src/lib/skills.ts`. Same auth shape as the rest of the skills API.
- `SkillsSection` wraps the table region in DnD handlers (Files-type gate so in-page text drags don't trigger), shows a dashed accent overlay while dragging, and a spinner overlay while the upload is in-flight. Empty-state row carries a hint pointing at the dropzone (with no rows there's nothing visual to drop onto).
- `.md` extension/mime check on the client is best-effort — the server's frontmatter parse is the authoritative validator. A SKILL.md without `name:` is rejected with the exact error.

## i18n

`dropHint`, `dropToInstall`, `uploading`, `uploadedToast`, `uploadFailedToast`, `uploadInvalidTypeToast` added to en / es / zh; parity check clean.

## Out of scope

- `.zip` upload for skills with `references/` subdirs — single-file `SKILL.md` covers the common case. Add when someone hits it.
- New CLI command for upload — not needed; the existing `opendray skill` flow already covers the terminal path.

## Test plan

- [ ] Drag a fresh `SKILL.md` with `name: My Helper` onto the table → row appears as `my-helper`, vault badge.
- [ ] Drop a SKILL.md whose name slugs to an existing vault id → 409 toast surfaces the collision.
- [ ] Drop a SKILL.md whose name matches a built-in → row appears with `overrides_builtin` badge, Reset action available.
- [ ] Drop a `.txt` → invalid-type toast, no upload attempt.
- [ ] Drop a `.md` with no `name:` frontmatter → server rejects, toast shows the exact error.
- [ ] In-page text drag (selecting in the SKILL editor) does **not** trigger the dropzone overlay.