### PR TITLE
fix(web/sessions): reclaim vertical space + breathing room around the chat pane

### DIFF
--- a/app/web/src/components/sessions/SessionTabs.tsx
+++ b/app/web/src/components/sessions/SessionTabs.tsx
@@ -20,7 +20,7 @@ export function SessionTabs({ onCloseTab }: SessionTabsProps) {
   if (tabs.length === 0) return null
 
   return (
-    <div className="h-9 flex items-center border-b border-border bg-background overflow-x-auto">
+    <div className="h-7 flex items-center border-b border-border bg-background overflow-x-auto">
       {tabs.map((tab, i) => {
         const active = tab.id === currentId
         return (
@@ -34,7 +34,7 @@ export function SessionTabs({ onCloseTab }: SessionTabsProps) {
               if (e.key === 'Enter') setCurrent(tab.id)
             }}
             className={cn(
-              'group h-9 px-3 flex items-center gap-2 border-r border-border cursor-pointer min-w-[140px] max-w-[220px] shrink-0 transition-colors',
+              'group h-7 px-3 flex items-center gap-2 border-r border-border cursor-pointer min-w-[140px] max-w-[220px] shrink-0 transition-colors',
               active
                 ? 'bg-card text-foreground'
                 : 'text-muted-foreground hover:text-foreground hover:bg-card/60',

--- a/app/web/src/pages/Sessions.tsx
+++ b/app/web/src/pages/Sessions.tsx
@@ -264,7 +264,15 @@ export function SessionsPage() {
               inspectorOpen={inspectorOpen}
               onToggleInspector={toggleInspector}
             />
-            <div className="flex-1 min-h-0">
+            {/* pb-3 reserves a small breathing strip so Claude's
+                prompt+footer never sit flush against the browser bottom
+                edge — the input is the most-interacted-with row in the
+                whole UI, and an extra ~12px of breathing room makes
+                typing on a tall desktop window feel noticeably less
+                cramped. The Terminal's FitAddon picks up the smaller
+                available height on the next ResizeObserver tick, so the
+                PTY stays in sync. */}
+            <div className="flex-1 min-h-0 pb-3">
               {currentSession &&
               isTerminalSessionState(currentSession.state) ? (
                 <EndedSessionView key={currentId} sessionId={currentId} />
@@ -400,7 +408,7 @@ function WorkbenchHeader({
   const { t } = useTranslation()
   if (!session) {
     return (
-      <div className="h-14 border-b border-border flex items-center px-3 text-[12px] text-muted-foreground">
+      <div className="h-11 border-b border-border flex items-center px-3 text-[12px] text-muted-foreground">
         <Loader2 className="size-3 animate-spin" />
         <span className="ml-2">{t('web.sessions.header.loadingSession')}</span>
       </div>
@@ -418,7 +426,7 @@ function WorkbenchHeader({
   const copyLabel = t('web.sessions.header.copyOutput')
   const copyTooltip = t('web.sessions.header.copyOutputTooltip')
   return (
-    <div className="h-14 border-b border-border flex items-center px-3 gap-3">
+    <div className="h-11 border-b border-border flex items-center px-3 gap-3">
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
@@ -440,7 +448,7 @@ function WorkbenchHeader({
       <BrandAvatar
         iconKey={providerIconKey(session.provider_id)}
         fallbackLetter={visual.letter}
-        size={36}
+        size={28}
         title={visual.name}
       />
       <div className="flex-1 min-w-0 flex flex-col gap-0.5">


### PR DESCRIPTION
## Summary

After the v2.7.3 Safari fix (#353) landed correctly the chat pane fits the viewport, but operator feedback was that the active input row sits flush against the browser bottom and ~140px of chrome (Topbar + SessionTabs + WorkbenchHeader) pushes the chat-top deep into the page. On a tall window this reads as **"the chat is too low and hard to work with"** even though no content is actually clipped.

This is a small ergonomic tightening — not a bug fix.

## Changes

| Element | Before | After | Delta |
|---|---|---|---|
| `SessionTabs` row | `h-9` (36px) | `h-7` (28px) | +8px |
| `WorkbenchHeader` row | `h-14` (56px) | `h-11` (44px) | +12px |
| `BrandAvatar` in header | `size={36}` | `size={28}` | fits slimmer row |
| Terminal wrapper | `flex-1 min-h-0` | `flex-1 min-h-0 pb-3` | -12px |

**Net:** chat-top moves up ~20px and the input is no longer flush with the browser bottom edge. FitAddon picks up the new available height on the next ResizeObserver tick, so the PTY stays in sync; no Terminal logic changed.

## Test plan

- [ ] Mac Safari, live session: chat-top sits closer to the WorkbenchHeader; Claude's `>` prompt no longer hugs the browser bottom edge
- [ ] Mac Safari, resize window narrower then taller: PTY reflows correctly, no clipped status row
- [ ] Mac Chrome: same — sanity check the original #323 jitter fix still holds
- [ ] iOS web: smaller chrome is easier on a narrow viewport, no regression in scrollback
- [ ] EndedSessionView (open an ended session): replay row stays vertically centered, no overlap with the slimmer header

Web only. No server or PTY change.