### PR TITLE
fix(web/terminal): restore iOS copy pill on text selection

### DIFF
--- a/app/web/src/components/sessions/Terminal.tsx
+++ b/app/web/src/components/sessions/Terminal.tsx
@@ -551,13 +551,19 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
   }, [themeApplied])
 
   // Anchor the copy pill where the selection ended. pointerup covers
-  // both mouse-drag and touch; we defer one frame so xterm finalizes
+  // mouse and most touch cases; we defer one frame so xterm finalizes
   // the selection first, then place the pill at the pointer (clamped
   // inside the box, flipped below the point near the top edge).
+  //
+  // touchend is a belt-and-suspenders fallback for iOS Safari: with
+  // touch events directly on a <canvas> inside an overflow-hidden
+  // container, the synthesised pointerup occasionally doesn't fire
+  // (or fires with stale coordinates), leaving a finished selection
+  // with no pill anchored to it.
   useEffect(() => {
     const root = rootRef.current
     if (!root) return
-    const onPointerUp = (e: PointerEvent) => {
+    const anchorAt = (x: number, y: number) => {
       requestAnimationFrame(() => {
         const term = xtermRef.current
         if (!term || !term.hasSelection()) {
@@ -565,16 +571,26 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
           return
         }
         const rect = root.getBoundingClientRect()
-        const rawY = e.clientY - rect.top
+        const rawY = y - rect.top
         setPill({
-          x: Math.min(Math.max(e.clientX - rect.left, 48), rect.width - 48),
+          x: Math.min(Math.max(x - rect.left, 48), rect.width - 48),
           y: rawY,
           below: rawY < 44,
         })
       })
     }
+    const onPointerUp = (e: PointerEvent) => anchorAt(e.clientX, e.clientY)
+    const onTouchEnd = (e: TouchEvent) => {
+      const t = e.changedTouches[0]
+      if (!t) return
+      anchorAt(t.clientX, t.clientY)
+    }
     root.addEventListener('pointerup', onPointerUp)
-    return () => root.removeEventListener('pointerup', onPointerUp)
+    root.addEventListener('touchend', onTouchEnd, { passive: true })
+    return () => {
+      root.removeEventListener('pointerup', onPointerUp)
+      root.removeEventListener('touchend', onTouchEnd)
+    }
   }, [])
 
   return (

--- a/app/web/src/index.css
+++ b/app/web/src/index.css
@@ -153,11 +153,14 @@
    the canvas doesn't scroll xterm's scrollback at all, which reads
    as "I can't scroll up to see previous output on iOS." The
    `overscroll-behavior: contain` prevents the gesture from leaking
-   to the page (which used to scroll the whole AppShell instead). */
+   to the page (which used to scroll the whole AppShell instead).
+   `touch-action` is deliberately left at the default `auto` (not
+   `pan-y`) — claiming pan-y for the browser broke xterm's
+   selection-drag on iOS (the contextual copy pill never anchored
+   because pointerup arrived without a finished selection). */
 .xterm-viewport {
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
-  touch-action: pan-y;
 }
 
 /* highlight.js theme — a compact mapping that uses palette-friendly


### PR DESCRIPTION
## Summary

User-reported regression after #353 / v2.7.3 on iPad + iPhone Safari: selecting text in the terminal no longer surfaces the contextual copy pill that anchored next to the selection.

## Root cause

#353 added `touch-action: pan-y` to `.xterm-viewport` so iOS scrollback worked with the new clipped pane. The side effect was claiming horizontal / diagonal gestures for the browser, which broke xterm's selection-drag on iOS — the pill (anchored at `pointerup` once a selection finishes) never appeared because `pointerup` arrived with no finished selection to anchor to.

## Fix

- **Drop `touch-action: pan-y`** from `.xterm-viewport`. `-webkit-overflow-scrolling: touch` plus the default `touch-action: auto` is sufficient for iOS scrollback and leaves the selection gesture intact.
- **Add a `touchend` fallback** to the pill anchor effect. With touch events on a `<canvas>` inside an `overflow-hidden` container, the synthesised `pointerup` occasionally doesn't fire (or fires with stale coordinates) on iOS Safari. `touchend` uses the same `anchorAt(x, y)` helper as pointerup so behavior is identical on both paths.

## Test plan

- [ ] iPad Safari, live session: long-press to select a line, drag to extend, release → copy pill anchors next to the selection; tap → text copied
- [ ] iPad Safari: two-finger drag on the terminal still scrolls scrollback (the #353 iOS scrollback fix is preserved)
- [ ] Mac Safari + Mac Chrome: existing pointer-based selection still anchors the pill correctly (no regression)
- [ ] iPhone Safari: same as iPad — selection + copy pill works

Web only. No PTY, server, or mobile change.