### PR TITLE
feat(mobile): AI discussion (Cortex curation chat) with web-matching model picker

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -480,7 +480,7 @@
         },
         "curation": {
           "modelAdvice": "Your conversational doc/policy editor — strong model recommended (sonnet/opus); it rewrites documents you rely on.",
-          "label": "Curation chat",
+          "label": "AI discussion",
           "description": "Drives the talk-to-AI channel that updates doc sections and re-drafts knowledge pages; revisions respect lock state."
         }
       },
@@ -2895,7 +2895,7 @@
         }
       },
       "chat": {
-        "title": "Curation chat",
+        "title": "AI discussion",
         "show": "Discuss with AI",
         "hide": "Hide chat",
         "emptyHint": "Ask the AI to update, restructure, or re-draft this document. Changes apply directly when AI-maintained, or land in the Inbox when you've locked it.",
@@ -2911,7 +2911,7 @@
         "revisionApplied": "Document updated",
         "revisionProposed": "Proposal filed — review in Inbox",
         "modelLabel": "Model:",
-        "modelHint": "Pick a cloud-agent provider + model for THIS discussion. Default uses the global curation worker.",
+        "modelHint": "Pick a cloud-agent provider + model for THIS discussion. Default uses the global discussion model.",
         "modelGlobalDefault": "Default (global)",
         "modelCliDefault": "CLI default",
         "modelChangeFailed": "Couldn't change the discussion model",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -480,7 +480,7 @@
         },
         "curation": {
           "modelAdvice": "Tu editor conversacional de docs/políticas — modelo fuerte recomendado (sonnet/opus).",
-          "label": "Chat de curación",
+          "label": "Discusión con IA",
           "description": "Impulsa el canal conversacional que actualiza secciones y re-redacta páginas de conocimiento."
         }
       },
@@ -2895,7 +2895,7 @@
         }
       },
       "chat": {
-        "title": "Chat de curación",
+        "title": "Discusión con IA",
         "show": "Hablar con la IA",
         "hide": "Ocultar chat",
         "emptyHint": "Pide a la IA actualizar, reestructurar o reescribir este documento. Los cambios se aplican directamente si lo mantiene la IA, o llegan a la bandeja si lo bloqueaste.",
@@ -2911,7 +2911,7 @@
         "revisionApplied": "Documento actualizado",
         "revisionProposed": "Propuesta creada — revísala en la bandeja",
         "modelLabel": "Modelo:",
-        "modelHint": "Elige un proveedor de cloud-agent + modelo para ESTA conversación. Por defecto usa el worker de curación global.",
+        "modelHint": "Elige un proveedor de cloud-agent + modelo para ESTA conversación. Por defecto usa el modelo de discusión global.",
         "modelGlobalDefault": "Predeterminado (global)",
         "modelCliDefault": "Predeterminado del CLI",
         "modelChangeFailed": "No se pudo cambiar el modelo de la conversación",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -480,7 +480,7 @@
         },
         "curation": {
           "modelAdvice": "你的对话式文档/方针编辑器——推荐强模型（sonnet/opus）；它改写的是你依赖的文档。",
-          "label": "管护对话",
+          "label": "AI 讨论",
           "description": "驱动「与 AI 讨论」通道：更新文档章节、重订知识页；修订遵循锁定状态。"
         }
       },
@@ -2895,7 +2895,7 @@
         }
       },
       "chat": {
-        "title": "管护对话",
+        "title": "AI 讨论",
         "show": "与 AI 讨论",
         "hide": "收起对话",
         "emptyHint": "让 AI 更新、重组或重写这份文档。AI 维护且未锁定时直接生效；你锁定过的文档会以提案进入收件箱。",
@@ -2911,7 +2911,7 @@
         "revisionApplied": "文档已更新",
         "revisionProposed": "已生成提案——请到收件箱审阅",
         "modelLabel": "模型：",
-        "modelHint": "为本次讨论选择 cloud-agent 供应商 + 模型。默认沿用全局 curation worker。",
+        "modelHint": "为本次讨论选择 cloud-agent 供应商 + 模型。默认沿用全局讨论模型配置。",
         "modelGlobalDefault": "默认（全局）",
         "modelCliDefault": "CLI 默认",
         "modelChangeFailed": "切换讨论模型失败",

--- a/app/mobile/lib/core/api/cortex_api.dart
+++ b/app/mobile/lib/core/api/cortex_api.dart
@@ -138,6 +138,11 @@ class CortexApi {
     required String targetKind,
     required String targetCwd,
     required String targetSlug,
+    // Optional model override for the new conversation (cloud-agent
+    // providerId+model, OR a local summarizerId).
+    String providerId = '',
+    String model = '',
+    String summarizerId = '',
   }) async {
     try {
       final res = await _dio.post<Map<String, dynamic>>(
@@ -146,6 +151,33 @@ class CortexApi {
           'target_kind': targetKind,
           'target_cwd': targetCwd,
           'target_slug': targetSlug,
+          if (providerId.isNotEmpty) 'provider_id': providerId,
+          if (model.isNotEmpty) 'model': model,
+          if (summarizerId.isNotEmpty) 'summarizer_id': summarizerId,
+        },
+      );
+      return CortexConversation.fromJson(res.data ?? const {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  /// Pins (or clears, with all empty) a conversation's model override:
+  /// a cloud-agent providerId+model OR a local summarizerId (mutually
+  /// exclusive). Returns the updated conversation.
+  Future<CortexConversation> setConversationProvider(
+    String id, {
+    String providerId = '',
+    String model = '',
+    String summarizerId = '',
+  }) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/cortex/conversations/$id/provider',
+        data: {
+          'provider_id': providerId,
+          'model': model,
+          'summarizer_id': summarizerId,
         },
       );
       return CortexConversation.fromJson(res.data ?? const {});
@@ -393,6 +425,9 @@ class CortexConversation {
     required this.targetSlug,
     required this.status,
     required this.escalatedSessionId,
+    required this.providerId,
+    required this.model,
+    required this.summarizerId,
   });
 
   factory CortexConversation.fromJson(Map<String, dynamic> j) =>
@@ -403,6 +438,9 @@ class CortexConversation {
         targetSlug: j['target_slug']?.toString() ?? '',
         status: j['status']?.toString() ?? 'open',
         escalatedSessionId: j['escalated_session_id']?.toString() ?? '',
+        providerId: j['provider_id']?.toString() ?? '',
+        model: j['model']?.toString() ?? '',
+        summarizerId: j['summarizer_id']?.toString() ?? '',
       );
 
   final String id;
@@ -411,6 +449,12 @@ class CortexConversation {
   final String targetSlug;
   final String status; // open | closed | escalated
   final String escalatedSessionId;
+  // Per-conversation model override (all empty = global curation worker).
+  // Mutually exclusive: summarizerId pins a local/HTTP model; providerId+
+  // model pin a cloud-agent CLI.
+  final String providerId;
+  final String model;
+  final String summarizerId;
 }
 
 class ConversationMessage {

--- a/app/mobile/lib/core/api/memory_summarizers_api.dart
+++ b/app/mobile/lib/core/api/memory_summarizers_api.dart
@@ -16,6 +16,8 @@ class SummarizerProvider {
     required this.kind,
     required this.model,
     required this.isDefault,
+    required this.enabled,
+    required this.baseUrl,
   });
 
   factory SummarizerProvider.fromJson(Map<String, dynamic> json) =>
@@ -25,6 +27,8 @@ class SummarizerProvider {
         kind: json['kind'] as String? ?? '',
         model: json['model'] as String? ?? '',
         isDefault: json['is_default'] as bool? ?? false,
+        enabled: json['enabled'] as bool? ?? false,
+        baseUrl: json['base_url'] as String? ?? '',
       );
 
   final String id;
@@ -32,6 +36,9 @@ class SummarizerProvider {
   final String kind;
   final String model;
   final bool isDefault;
+  final bool enabled;
+  // OpenAI-compatible endpoint; used to live-probe the models it serves.
+  final String baseUrl;
 
   /// "name · model" for the dropdown label.
   String get label => model.isEmpty ? name : '$name · $model';

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 11532 (3844 per locale)
+/// Strings: 11547 (3849 per locale)
 ///
-/// Built on 2026-06-15 at 14:28 UTC
+/// Built on 2026-06-15 at 16:09 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -6293,8 +6293,17 @@ class TranslationsWebSessionsAccountSwitcherEn {
 	/// en: '·empty'
 	String get tokenEmpty => '·empty';
 
-	/// en: 'Switching account will restart the Claude CLI. The conversation history is preserved (transcript is migrated and --resume replays it under the new account), but any in-flight tool execution or unsent input will be lost. Continue?'
-	String get confirmSwitch => 'Switching account will restart the Claude CLI. The conversation history is preserved (transcript is migrated and --resume replays it under the new account), but any in-flight tool execution or unsent input will be lost. Continue?';
+	/// en: 'Switching account restarts the Claude CLI under a fresh conversation — the in-CLI history doesn't carry across accounts. Any in-flight tool execution or unsent input is lost. Continue?'
+	String get confirmSwitch => 'Switching account restarts the Claude CLI under a fresh conversation — the in-CLI history doesn\'t carry across accounts. Any in-flight tool execution or unsent input is lost. Continue?';
+
+	/// en: 'Switching account restarts the Claude CLI. A recap of your recent conversation will be carried over and sent to the provider under the NEW account. Any in-flight tool execution or unsent input is lost. Continue?'
+	String get confirmSwitchCarry => 'Switching account restarts the Claude CLI. A recap of your recent conversation will be carried over and sent to the provider under the NEW account. Any in-flight tool execution or unsent input is lost. Continue?';
+
+	/// en: 'Carry over conversation context'
+	String get carryContext => 'Carry over conversation context';
+
+	/// en: 'Seeds the new account with a recap of your recent conversation. Prior content is sent to the provider under the new account.'
+	String get carryContextHelp => 'Seeds the new account with a recap of your recent conversation. Prior content is sent to the provider under the new account.';
 
 	/// en: 'Account switched'
 	String get switchedToast => 'Account switched';
@@ -10462,6 +10471,12 @@ class TranslationsWebSettingsAboutEn {
 
 	/// en: 'Re-install'
 	String get reinstall => 'Re-install';
+
+	/// en: '{count} live session(s) will be interrupted by the restart (they auto-resume afterward).'
+	String forcePrompt({required Object count}) => '${count} live session(s) will be interrupted by the restart (they auto-resume afterward).';
+
+	/// en: 'Upgrade anyway'
+	String get upgradeAnyway => 'Upgrade anyway';
 }
 
 // Path: web.memoryAmbient.header
@@ -11126,8 +11141,8 @@ class TranslationsWebCortexChatEn {
 
 	// Translations
 
-	/// en: 'Curation chat'
-	String get title => 'Curation chat';
+	/// en: 'AI discussion'
+	String get title => 'AI discussion';
 
 	/// en: 'Discuss with AI'
 	String get show => 'Discuss with AI';
@@ -11174,8 +11189,8 @@ class TranslationsWebCortexChatEn {
 	/// en: 'Model:'
 	String get modelLabel => 'Model:';
 
-	/// en: 'Pick a cloud-agent provider + model for THIS discussion. Default uses the global curation worker.'
-	String get modelHint => 'Pick a cloud-agent provider + model for THIS discussion. Default uses the global curation worker.';
+	/// en: 'Pick a cloud-agent provider + model for THIS discussion. Default uses the global discussion model.'
+	String get modelHint => 'Pick a cloud-agent provider + model for THIS discussion. Default uses the global discussion model.';
 
 	/// en: 'Default (global)'
 	String get modelGlobalDefault => 'Default (global)';
@@ -13452,8 +13467,8 @@ class TranslationsWebMemoryWorkersTasksCurationEn {
 	/// en: 'Your conversational doc/policy editor — strong model recommended (sonnet/opus); it rewrites documents you rely on.'
 	String get modelAdvice => 'Your conversational doc/policy editor — strong model recommended (sonnet/opus); it rewrites documents you rely on.';
 
-	/// en: 'Curation chat'
-	String get label => 'Curation chat';
+	/// en: 'AI discussion'
+	String get label => 'AI discussion';
 
 	/// en: 'Drives the talk-to-AI channel that updates doc sections and re-drafts knowledge pages; revisions respect lock state.'
 	String get description => 'Drives the talk-to-AI channel that updates doc sections and re-drafts knowledge pages; revisions respect lock state.';
@@ -16890,7 +16905,10 @@ extension on Translations {
 			'web.sessions.accountSwitcher.defaultName' => 'Default',
 			'web.sessions.accountSwitcher.defaultSubtitle' => 'CLI\'s system keychain / env',
 			'web.sessions.accountSwitcher.tokenEmpty' => '·empty',
-			'web.sessions.accountSwitcher.confirmSwitch' => 'Switching account will restart the Claude CLI. The conversation history is preserved (transcript is migrated and --resume replays it under the new account), but any in-flight tool execution or unsent input will be lost. Continue?',
+			'web.sessions.accountSwitcher.confirmSwitch' => 'Switching account restarts the Claude CLI under a fresh conversation — the in-CLI history doesn\'t carry across accounts. Any in-flight tool execution or unsent input is lost. Continue?',
+			'web.sessions.accountSwitcher.confirmSwitchCarry' => 'Switching account restarts the Claude CLI. A recap of your recent conversation will be carried over and sent to the provider under the NEW account. Any in-flight tool execution or unsent input is lost. Continue?',
+			'web.sessions.accountSwitcher.carryContext' => 'Carry over conversation context',
+			'web.sessions.accountSwitcher.carryContextHelp' => 'Seeds the new account with a recap of your recent conversation. Prior content is sent to the provider under the new account.',
 			'web.sessions.accountSwitcher.switchedToast' => 'Account switched',
 			'web.sessions.accountSwitcher.switchedDescription' => ({required Object account, required Object pid}) => 'Now using @${account} · pid ${pid}',
 			'web.sessions.accountSwitcher.switchedDefault' => 'default',
@@ -17109,7 +17127,7 @@ extension on Translations {
 			'web.memoryWorkers.tasks.blueprint.label' => 'Blueprint proposer',
 			'web.memoryWorkers.tasks.blueprint.description' => 'Classifies a project from repo signals and proposes its doc section set. Operator-triggered from the blueprint editor.',
 			'web.memoryWorkers.tasks.curation.modelAdvice' => 'Your conversational doc/policy editor — strong model recommended (sonnet/opus); it rewrites documents you rely on.',
-			'web.memoryWorkers.tasks.curation.label' => 'Curation chat',
+			'web.memoryWorkers.tasks.curation.label' => 'AI discussion',
 			'web.memoryWorkers.tasks.curation.description' => 'Drives the talk-to-AI channel that updates doc sections and re-drafts knowledge pages; revisions respect lock state.',
 			'web.memoryWorkers.modelLabel' => 'Model',
 			'web.memoryWorkers.modelHint' => 'Pin the CLI model for this task (e.g. haiku for cheap chores). Empty = CLI default.',
@@ -17226,11 +17244,11 @@ extension on Translations {
 			'web.project.archived.restoredToast' => 'Restored',
 			'web.project.archived.restoreFailedToast' => 'Restore failed',
 			'web.project.reset.button' => 'Reset',
+			_ => null,
+		} ?? switch (path) {
 			'web.project.reset.dialogTitle' => 'Reset project memory?',
 			'web.project.reset.dialogDescription' => 'Deletes all stored project context for this cwd. This cannot be undone.',
 			'web.project.reset.alwaysDeleted' => 'Always deleted: goal, plan, proposals, journal, cleanup decisions.',
-			_ => null,
-		} ?? switch (path) {
 			'web.project.reset.alsoDeleteScannerLabel' => 'Also delete scanner docs',
 			'web.project.reset.alsoDeleteScannerSuffix' => '(tech_stack + recent_activity).',
 			'web.project.reset.alsoDeleteScannerHint' => 'Auto-rebuild on next spawn anyway — leaving unchecked is usually fine.',
@@ -17740,11 +17758,11 @@ extension on Translations {
 			'web.channels.notifications.cooldowns.k300' => '5 minutes',
 			'web.channels.notifications.cooldowns.k900' => '15 minutes',
 			'web.channels.notifications.cooldowns.k1800' => '30 minutes',
+			_ => null,
+		} ?? switch (path) {
 			'web.channels.notifications.cooldowns.k3600' => '1 hour',
 			'web.channels.notifications.snippetCaps.k0' => 'No cap — chunk into multiple messages (default)',
 			'web.channels.notifications.snippetCaps.k1000' => '1000 chars (terse)',
-			_ => null,
-		} ?? switch (path) {
 			'web.channels.notifications.snippetCaps.k3000' => '3000 chars',
 			'web.channels.notifications.snippetCaps.k6000' => '6000 chars',
 			'web.channels.notifications.snippetCaps.k12000' => '12000 chars',
@@ -18254,11 +18272,11 @@ extension on Translations {
 			'web.backups.targetEditor.smb.pathPrefixLabel' => 'Path prefix',
 			'web.backups.targetEditor.smb.pathPrefixHint' => 'Sub-folder under the share root (optional)',
 			'web.backups.targetEditor.smb.pathPrefixPlaceholder' => 'opendray/backups',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.targetEditor.s3.endpointLabel' => 'Endpoint',
 			'web.backups.targetEditor.s3.endpointHint' => 'Host (no protocol). AWS: s3.amazonaws.com · R2: <accountid>.r2.cloudflarestorage.com · MinIO: minio.local:9000',
 			'web.backups.targetEditor.s3.endpointPlaceholder' => 's3.amazonaws.com',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.targetEditor.s3.regionLabel' => 'Region',
 			'web.backups.targetEditor.s3.regionHint' => 'AWS only; R2 use \'auto\'',
 			'web.backups.targetEditor.s3.regionPlaceholder' => 'us-east-1 / auto',
@@ -18617,6 +18635,8 @@ extension on Translations {
 			'web.settings.about.checkUpdates' => 'Check for updates',
 			'web.settings.about.checking' => 'Checking…',
 			'web.settings.about.reinstall' => 'Re-install',
+			'web.settings.about.forcePrompt' => ({required Object count}) => '${count} live session(s) will be interrupted by the restart (they auto-resume afterward).',
+			'web.settings.about.upgradeAnyway' => 'Upgrade anyway',
 			'web.logViewer.filterPlaceholder' => 'Filter…',
 			'web.logViewer.debugTooltip' => 'Debug count',
 			'web.logViewer.infoTooltip' => 'Info count',
@@ -18766,13 +18786,13 @@ extension on Translations {
 			'web.export.form.integrationOptions.metadataHint' => 'ID, name, route prefix, scopes — no API key material.',
 			'web.export.form.integrationOptions.plaintext' => 'Include plaintext API keys',
 			'web.export.form.integrationOptions.plaintextHint' => 'v1 bcrypt-only: no recoverable plaintext exists. Manifest documents this; nothing leaks.',
+			_ => null,
+		} ?? switch (path) {
 			'web.export.form.confirmWarning' => 'Type <1>I understand</1> to confirm. opendray currently stores only bcrypt hashes — selecting plaintext does NOT export any plaintext (the feature is reserved for a future release that keeps plaintext caches).',
 			'web.export.form.confirmPlaceholder' => 'I understand',
 			'web.export.form.confirmSentinel' => 'i understand',
 			'web.export.form.footnote' => 'Audit logs and session transcripts are out of scope — covered by /backups (operator dump) instead.',
 			'web.export.form.building' => 'Building…',
-			_ => null,
-		} ?? switch (path) {
 			'web.export.form.create' => 'Create export',
 			'web.export.form.readyToast' => 'Export ready',
 			'web.export.form.readyDescription' => ({required Object bytes}) => '${bytes} bytes',
@@ -18979,7 +18999,7 @@ extension on Translations {
 			'web.cortex.home.proposals.approvedToast' => 'Proposal approved — document updated',
 			'web.cortex.home.proposals.rejectedToast' => 'Proposal rejected',
 			'web.cortex.home.proposals.failedToast' => 'Action failed',
-			'web.cortex.chat.title' => 'Curation chat',
+			'web.cortex.chat.title' => 'AI discussion',
 			'web.cortex.chat.show' => 'Discuss with AI',
 			'web.cortex.chat.hide' => 'Hide chat',
 			'web.cortex.chat.emptyHint' => 'Ask the AI to update, restructure, or re-draft this document. Changes apply directly when AI-maintained, or land in the Inbox when you\'ve locked it.',
@@ -18995,7 +19015,7 @@ extension on Translations {
 			'web.cortex.chat.revisionApplied' => 'Document updated',
 			'web.cortex.chat.revisionProposed' => 'Proposal filed — review in Inbox',
 			'web.cortex.chat.modelLabel' => 'Model:',
-			'web.cortex.chat.modelHint' => 'Pick a cloud-agent provider + model for THIS discussion. Default uses the global curation worker.',
+			'web.cortex.chat.modelHint' => 'Pick a cloud-agent provider + model for THIS discussion. Default uses the global discussion model.',
 			'web.cortex.chat.modelGlobalDefault' => 'Default (global)',
 			'web.cortex.chat.modelCliDefault' => 'CLI default',
 			'web.cortex.chat.modelChangeFailed' => 'Couldn\'t change the discussion model',
@@ -19280,13 +19300,13 @@ extension on Translations {
 			'sessions.inspector.notes.create' => 'Create',
 			'sessions.inspector.notes.filterHint' => 'Filter…',
 			'sessions.inspector.notes.locationDialogTitle' => 'Project docs location',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.notes.loadFailedApi' => ({required Object error}) => 'Load failed: ${error}',
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => 'Load failed: ${error}',
 			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => 'Save failed: ${error}',
 			'sessions.inspector.notes.saveFailedGeneric' => ({required Object error}) => 'Save failed: ${error}',
 			'sessions.inspector.notes.insertFailedApi' => ({required Object error}) => 'Insert failed: ${error}',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.insertFailedGeneric' => ({required Object error}) => 'Insert failed: ${error}',
 			'sessions.inspector.notes.createFailedApi' => ({required Object error}) => 'Create failed: ${error}',
 			'sessions.inspector.notes.createFailedGeneric' => ({required Object error}) => 'Create failed: ${error}',
@@ -19794,13 +19814,13 @@ extension on Translations {
 			'backups.restore.fileSelected' => ({required Object name, required Object size}) => '${name} · ${size}',
 			'backups.restore.noFile' => 'No file selected',
 			'backups.restore.targetDsnLabel' => 'Target Postgres DSN',
+			_ => null,
+		} ?? switch (path) {
 			'backups.restore.targetDsnHint' => 'Leave empty to restore into opendray\'s own DB.',
 			'backups.restore.targetDsnPlaceholder' => 'postgres://user:pass@host:5432/dbname',
 			'backups.restore.cleanLabel' => 'pg_restore --clean --if-exists',
 			'backups.restore.cleanHint' => 'Drops existing objects before recreating them.',
 			'backups.restore.auditNoteLabel' => 'Audit note (optional)',
-			_ => null,
-		} ?? switch (path) {
 			'backups.restore.auditNotePlaceholder' => 'e.g. recovering from #INC-481',
 			'backups.restore.ownDbWarning' => 'Restoring into opendray\'s OWN database will rewrite the rows this gateway is currently serving. Type "I understand" to confirm.',
 			'backups.restore.confirmPlaceholder' => 'Type "I understand"',
@@ -20308,13 +20328,13 @@ extension on Translations {
 			'memory.rank.effective' => ({required Object value}) => 'Effective score: ${value}',
 			'memory.rank.similarity' => 'Cosine similarity',
 			'memory.rank.ageMultiplier' => ({required Object days}) => 'Age multiplier (${days}d old)',
+			_ => null,
+		} ?? switch (path) {
 			'memory.rank.hitMultiplier' => ({required Object hits}) => 'Hit-count multiplier (${hits} hits)',
 			'memory.rank.confidenceMultiplier' => 'Confidence multiplier',
 			'memory.rank.formula' => 'effective = similarity × age × hits × confidence',
 			'memory.rank.close' => 'Close',
 			'memory.kNew' => 'New',
-			_ => null,
-		} ?? switch (path) {
 			'memory.searchHint' => 'Search…',
 			'memory.projectLabel' => 'Project',
 			'memory.filterHint' => 'Filter by name or path…',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -3185,7 +3185,10 @@ class _TranslationsWebSessionsAccountSwitcherEs extends TranslationsWebSessionsA
 	@override String get defaultName => 'Predeterminada';
 	@override String get defaultSubtitle => 'keychain del sistema / env de la CLI';
 	@override String get tokenEmpty => '·vacío';
-	@override String get confirmSwitch => 'Cambiar de cuenta reiniciará la CLI de Claude. El historial de la conversación se conserva (el transcript se migra y --resume lo reproduce con la nueva cuenta), pero se perderá cualquier ejecución de herramienta en curso o entrada sin enviar. ¿Continuar?';
+	@override String get confirmSwitch => 'Cambiar de cuenta reinicia la CLI de Claude con una conversación nueva: el historial dentro de la CLI no se transfiere entre cuentas. Se perderá cualquier ejecución de herramienta en curso o entrada sin enviar. ¿Continuar?';
+	@override String get confirmSwitchCarry => 'Cambiar de cuenta reinicia la CLI de Claude. Se transferirá un resumen de tu conversación reciente y se enviará al proveedor con la NUEVA cuenta. Se perderá cualquier ejecución de herramienta en curso o entrada sin enviar. ¿Continuar?';
+	@override String get carryContext => 'Transferir el contexto de la conversación';
+	@override String get carryContextHelp => 'Inicializa la nueva cuenta con un resumen de tu conversación reciente. El contenido previo se envía al proveedor con la nueva cuenta.';
 	@override String get switchedToast => 'Cuenta cambiada';
 	@override String switchedDescription({required Object account, required Object pid}) => 'Ahora usando @${account} · pid ${pid}';
 	@override String get switchedDefault => 'predeterminada';
@@ -5344,6 +5347,8 @@ class _TranslationsWebSettingsAboutEs extends TranslationsWebSettingsAboutEn {
 	@override String get checkUpdates => 'Comprobar actualizaciones';
 	@override String get checking => 'Comprobando…';
 	@override String get reinstall => 'Reinstalar';
+	@override String forcePrompt({required Object count}) => 'El reinicio interrumpirá ${count} sesión(es) activa(s) (se reanudan automáticamente después).';
+	@override String get upgradeAnyway => 'Actualizar de todos modos';
 }
 
 // Path: web.memoryAmbient.header
@@ -5682,7 +5687,7 @@ class _TranslationsWebCortexChatEs extends TranslationsWebCortexChatEn {
 	final TranslationsEs _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Chat de curación';
+	@override String get title => 'Discusión con IA';
 	@override String get show => 'Hablar con la IA';
 	@override String get hide => 'Ocultar chat';
 	@override String get emptyHint => 'Pide a la IA actualizar, reestructurar o reescribir este documento. Los cambios se aplican directamente si lo mantiene la IA, o llegan a la bandeja si lo bloqueaste.';
@@ -5698,7 +5703,7 @@ class _TranslationsWebCortexChatEs extends TranslationsWebCortexChatEn {
 	@override String get revisionApplied => 'Documento actualizado';
 	@override String get revisionProposed => 'Propuesta creada — revísala en la bandeja';
 	@override String get modelLabel => 'Modelo:';
-	@override String get modelHint => 'Elige un proveedor de cloud-agent + modelo para ESTA conversación. Por defecto usa el worker de curación global.';
+	@override String get modelHint => 'Elige un proveedor de cloud-agent + modelo para ESTA conversación. Por defecto usa el modelo de discusión global.';
 	@override String get modelGlobalDefault => 'Predeterminado (global)';
 	@override String get modelCliDefault => 'Predeterminado del CLI';
 	@override String get modelChangeFailed => 'No se pudo cambiar el modelo de la conversación';
@@ -6975,7 +6980,7 @@ class _TranslationsWebMemoryWorkersTasksCurationEs extends TranslationsWebMemory
 
 	// Translations
 	@override String get modelAdvice => 'Tu editor conversacional de docs/políticas — modelo fuerte recomendado (sonnet/opus).';
-	@override String get label => 'Chat de curación';
+	@override String get label => 'Discusión con IA';
 	@override String get description => 'Impulsa el canal conversacional que actualiza secciones y re-redacta páginas de conocimiento.';
 }
 
@@ -9086,7 +9091,10 @@ extension on TranslationsEs {
 			'web.sessions.accountSwitcher.defaultName' => 'Predeterminada',
 			'web.sessions.accountSwitcher.defaultSubtitle' => 'keychain del sistema / env de la CLI',
 			'web.sessions.accountSwitcher.tokenEmpty' => '·vacío',
-			'web.sessions.accountSwitcher.confirmSwitch' => 'Cambiar de cuenta reiniciará la CLI de Claude. El historial de la conversación se conserva (el transcript se migra y --resume lo reproduce con la nueva cuenta), pero se perderá cualquier ejecución de herramienta en curso o entrada sin enviar. ¿Continuar?',
+			'web.sessions.accountSwitcher.confirmSwitch' => 'Cambiar de cuenta reinicia la CLI de Claude con una conversación nueva: el historial dentro de la CLI no se transfiere entre cuentas. Se perderá cualquier ejecución de herramienta en curso o entrada sin enviar. ¿Continuar?',
+			'web.sessions.accountSwitcher.confirmSwitchCarry' => 'Cambiar de cuenta reinicia la CLI de Claude. Se transferirá un resumen de tu conversación reciente y se enviará al proveedor con la NUEVA cuenta. Se perderá cualquier ejecución de herramienta en curso o entrada sin enviar. ¿Continuar?',
+			'web.sessions.accountSwitcher.carryContext' => 'Transferir el contexto de la conversación',
+			'web.sessions.accountSwitcher.carryContextHelp' => 'Inicializa la nueva cuenta con un resumen de tu conversación reciente. El contenido previo se envía al proveedor con la nueva cuenta.',
 			'web.sessions.accountSwitcher.switchedToast' => 'Cuenta cambiada',
 			'web.sessions.accountSwitcher.switchedDescription' => ({required Object account, required Object pid}) => 'Ahora usando @${account} · pid ${pid}',
 			'web.sessions.accountSwitcher.switchedDefault' => 'predeterminada',
@@ -9305,7 +9313,7 @@ extension on TranslationsEs {
 			'web.memoryWorkers.tasks.blueprint.label' => 'Proponedor de planos',
 			'web.memoryWorkers.tasks.blueprint.description' => 'Clasifica un proyecto y propone su conjunto de secciones. Disparado por el operador.',
 			'web.memoryWorkers.tasks.curation.modelAdvice' => 'Tu editor conversacional de docs/políticas — modelo fuerte recomendado (sonnet/opus).',
-			'web.memoryWorkers.tasks.curation.label' => 'Chat de curación',
+			'web.memoryWorkers.tasks.curation.label' => 'Discusión con IA',
 			'web.memoryWorkers.tasks.curation.description' => 'Impulsa el canal conversacional que actualiza secciones y re-redacta páginas de conocimiento.',
 			'web.memoryWorkers.modelLabel' => 'Modelo',
 			'web.memoryWorkers.modelHint' => 'Fija el modelo del CLI para esta tarea (p. ej. haiku para tareas básicas). Vacío = predeterminado del CLI.',
@@ -9422,11 +9430,11 @@ extension on TranslationsEs {
 			'web.project.archived.restoredToast' => 'Restaurado',
 			'web.project.archived.restoreFailedToast' => 'Error al restaurar',
 			'web.project.reset.button' => 'Restablecer',
+			_ => null,
+		} ?? switch (path) {
 			'web.project.reset.dialogTitle' => '¿Restablecer la memoria del proyecto?',
 			'web.project.reset.dialogDescription' => 'Elimina todo el contexto de proyecto almacenado para este cwd. Esto no se puede deshacer.',
 			'web.project.reset.alwaysDeleted' => 'Siempre se elimina: objetivo, plan, propuestas, diario, decisiones de limpieza.',
-			_ => null,
-		} ?? switch (path) {
 			'web.project.reset.alsoDeleteScannerLabel' => 'Eliminar también los documentos del escáner',
 			'web.project.reset.alsoDeleteScannerSuffix' => '(tech_stack + recent_activity).',
 			'web.project.reset.alsoDeleteScannerHint' => 'De todos modos se reconstruyen automáticamente en el siguiente inicio; dejarlo sin marcar suele estar bien.',
@@ -9936,11 +9944,11 @@ extension on TranslationsEs {
 			'web.channels.notifications.cooldowns.k300' => '5 minutos',
 			'web.channels.notifications.cooldowns.k900' => '15 minutos',
 			'web.channels.notifications.cooldowns.k1800' => '30 minutos',
+			_ => null,
+		} ?? switch (path) {
 			'web.channels.notifications.cooldowns.k3600' => '1 hora',
 			'web.channels.notifications.snippetCaps.k0' => 'Sin límite, dividir en varios mensajes (predeterminado)',
 			'web.channels.notifications.snippetCaps.k1000' => '1000 caracteres (conciso)',
-			_ => null,
-		} ?? switch (path) {
 			'web.channels.notifications.snippetCaps.k3000' => '3000 caracteres',
 			'web.channels.notifications.snippetCaps.k6000' => '6000 caracteres',
 			'web.channels.notifications.snippetCaps.k12000' => '12000 caracteres',
@@ -10450,11 +10458,11 @@ extension on TranslationsEs {
 			'web.backups.targetEditor.smb.pathPrefixLabel' => 'Prefijo de ruta',
 			'web.backups.targetEditor.smb.pathPrefixHint' => 'Subcarpeta bajo la raíz del recurso compartido (opcional)',
 			'web.backups.targetEditor.smb.pathPrefixPlaceholder' => 'opendray/backups',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.targetEditor.s3.endpointLabel' => 'Endpoint',
 			'web.backups.targetEditor.s3.endpointHint' => 'Host (sin protocolo). AWS: s3.amazonaws.com · R2: <accountid>.r2.cloudflarestorage.com · MinIO: minio.local:9000',
 			'web.backups.targetEditor.s3.endpointPlaceholder' => 's3.amazonaws.com',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.targetEditor.s3.regionLabel' => 'Región',
 			'web.backups.targetEditor.s3.regionHint' => 'Solo AWS; en R2 usa \'auto\'',
 			'web.backups.targetEditor.s3.regionPlaceholder' => 'us-east-1 / auto',
@@ -10813,6 +10821,8 @@ extension on TranslationsEs {
 			'web.settings.about.checkUpdates' => 'Comprobar actualizaciones',
 			'web.settings.about.checking' => 'Comprobando…',
 			'web.settings.about.reinstall' => 'Reinstalar',
+			'web.settings.about.forcePrompt' => ({required Object count}) => 'El reinicio interrumpirá ${count} sesión(es) activa(s) (se reanudan automáticamente después).',
+			'web.settings.about.upgradeAnyway' => 'Actualizar de todos modos',
 			'web.logViewer.filterPlaceholder' => 'Filtrar…',
 			'web.logViewer.debugTooltip' => 'Recuento de debug',
 			'web.logViewer.infoTooltip' => 'Recuento de info',
@@ -10962,13 +10972,13 @@ extension on TranslationsEs {
 			'web.export.form.integrationOptions.metadataHint' => 'ID, nombre, prefijo de ruta, alcances. Sin material de API key.',
 			'web.export.form.integrationOptions.plaintext' => 'Incluir las API keys en texto plano',
 			'web.export.form.integrationOptions.plaintextHint' => 'v1 solo con bcrypt: no existe texto plano recuperable. El manifiesto lo documenta; no se filtra nada.',
+			_ => null,
+		} ?? switch (path) {
 			'web.export.form.confirmWarning' => 'Escribe <1>Lo entiendo</1> para confirmar. opendray actualmente almacena solo hashes bcrypt, así que seleccionar texto plano NO exporta ningún texto plano (la función está reservada para una versión futura que mantenga cachés de texto plano).',
 			'web.export.form.confirmPlaceholder' => 'Lo entiendo',
 			'web.export.form.confirmSentinel' => 'lo entiendo',
 			'web.export.form.footnote' => 'Los logs de auditoría y los transcripts de session quedan fuera del alcance; en su lugar los cubre /backups (volcado del operador).',
 			'web.export.form.building' => 'Generando…',
-			_ => null,
-		} ?? switch (path) {
 			'web.export.form.create' => 'Crear exportación',
 			'web.export.form.readyToast' => 'Exportación lista',
 			'web.export.form.readyDescription' => ({required Object bytes}) => '${bytes} bytes',
@@ -11175,7 +11185,7 @@ extension on TranslationsEs {
 			'web.cortex.home.proposals.approvedToast' => 'Propuesta aprobada — documento actualizado',
 			'web.cortex.home.proposals.rejectedToast' => 'Propuesta rechazada',
 			'web.cortex.home.proposals.failedToast' => 'La acción falló',
-			'web.cortex.chat.title' => 'Chat de curación',
+			'web.cortex.chat.title' => 'Discusión con IA',
 			'web.cortex.chat.show' => 'Hablar con la IA',
 			'web.cortex.chat.hide' => 'Ocultar chat',
 			'web.cortex.chat.emptyHint' => 'Pide a la IA actualizar, reestructurar o reescribir este documento. Los cambios se aplican directamente si lo mantiene la IA, o llegan a la bandeja si lo bloqueaste.',
@@ -11191,7 +11201,7 @@ extension on TranslationsEs {
 			'web.cortex.chat.revisionApplied' => 'Documento actualizado',
 			'web.cortex.chat.revisionProposed' => 'Propuesta creada — revísala en la bandeja',
 			'web.cortex.chat.modelLabel' => 'Modelo:',
-			'web.cortex.chat.modelHint' => 'Elige un proveedor de cloud-agent + modelo para ESTA conversación. Por defecto usa el worker de curación global.',
+			'web.cortex.chat.modelHint' => 'Elige un proveedor de cloud-agent + modelo para ESTA conversación. Por defecto usa el modelo de discusión global.',
 			'web.cortex.chat.modelGlobalDefault' => 'Predeterminado (global)',
 			'web.cortex.chat.modelCliDefault' => 'Predeterminado del CLI',
 			'web.cortex.chat.modelChangeFailed' => 'No se pudo cambiar el modelo de la conversación',
@@ -11476,13 +11486,13 @@ extension on TranslationsEs {
 			'sessions.inspector.notes.create' => 'Crear',
 			'sessions.inspector.notes.filterHint' => 'Filtrar…',
 			'sessions.inspector.notes.locationDialogTitle' => 'Ubicación de los documentos del proyecto',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.notes.loadFailedApi' => ({required Object error}) => 'Falló la carga: ${error}',
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => 'Falló la carga: ${error}',
 			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => 'Falló al guardar: ${error}',
 			'sessions.inspector.notes.saveFailedGeneric' => ({required Object error}) => 'Falló al guardar: ${error}',
 			'sessions.inspector.notes.insertFailedApi' => ({required Object error}) => 'Falló la inserción: ${error}',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.insertFailedGeneric' => ({required Object error}) => 'Falló la inserción: ${error}',
 			'sessions.inspector.notes.createFailedApi' => ({required Object error}) => 'Falló al crear: ${error}',
 			'sessions.inspector.notes.createFailedGeneric' => ({required Object error}) => 'Falló al crear: ${error}',
@@ -11990,13 +12000,13 @@ extension on TranslationsEs {
 			'backups.restore.fileSelected' => ({required Object name, required Object size}) => '${name} · ${size}',
 			'backups.restore.noFile' => 'Ningún archivo seleccionado',
 			'backups.restore.targetDsnLabel' => 'DSN de Postgres de destino',
+			_ => null,
+		} ?? switch (path) {
 			'backups.restore.targetDsnHint' => 'Déjalo vacío para restaurar en la propia base de datos de opendray.',
 			'backups.restore.targetDsnPlaceholder' => 'postgres://user:pass@host:5432/dbname',
 			'backups.restore.cleanLabel' => 'pg_restore --clean --if-exists',
 			'backups.restore.cleanHint' => 'Elimina los objetos existentes antes de volver a crearlos.',
 			'backups.restore.auditNoteLabel' => 'Nota de auditoría (opcional)',
-			_ => null,
-		} ?? switch (path) {
 			'backups.restore.auditNotePlaceholder' => 'p. ej. recuperando de #INC-481',
 			'backups.restore.ownDbWarning' => 'Restaurar en la PROPIA base de datos de opendray reescribirá las filas que este gateway está sirviendo actualmente. Escribe "I understand" para confirmar.',
 			'backups.restore.confirmPlaceholder' => 'Escribe "I understand"',
@@ -12504,13 +12514,13 @@ extension on TranslationsEs {
 			'memory.rank.effective' => ({required Object value}) => 'Puntuación efectiva: ${value}',
 			'memory.rank.similarity' => 'Similitud del coseno',
 			'memory.rank.ageMultiplier' => ({required Object days}) => 'Multiplicador por antigüedad (${days}d de antigüedad)',
+			_ => null,
+		} ?? switch (path) {
 			'memory.rank.hitMultiplier' => ({required Object hits}) => 'Multiplicador por número de hits (${hits} hits)',
 			'memory.rank.confidenceMultiplier' => 'Multiplicador por confianza',
 			'memory.rank.formula' => 'effective = similarity × age × hits × confidence',
 			'memory.rank.close' => 'Cerrar',
 			'memory.kNew' => 'Nuevo',
-			_ => null,
-		} ?? switch (path) {
 			'memory.searchHint' => 'Buscar…',
 			'memory.projectLabel' => 'Proyecto',
 			'memory.filterHint' => 'Filtrar por nombre o ruta…',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -3185,7 +3185,10 @@ class _TranslationsWebSessionsAccountSwitcherZh extends TranslationsWebSessionsA
 	@override String get defaultName => '默认';
 	@override String get defaultSubtitle => 'CLI 的系统 keychain / 环境变量';
 	@override String get tokenEmpty => '·未填';
-	@override String get confirmSwitch => '切换账户将重启 Claude CLI。对话历史会被保留（脚本会迁移并通过 --resume 恢复），但正在进行的工具调用或未发送的输入会丢失。是否继续？';
+	@override String get confirmSwitch => '切换账户会以全新对话重启 Claude CLI —— CLI 内的历史不会跨账户保留。正在进行的工具调用或未发送的输入会丢失。是否继续？';
+	@override String get confirmSwitchCarry => '切换账户将重启 Claude CLI。你最近对话的摘要会被带入，并以新账户发送给服务商。正在进行的工具调用或未发送的输入会丢失。是否继续？';
+	@override String get carryContext => '带入对话上下文';
+	@override String get carryContextHelp => '用你最近对话的摘要初始化新账户。先前内容会以新账户发送给服务商。';
 	@override String get switchedToast => '账号已切换';
 	@override String switchedDescription({required Object account, required Object pid}) => '当前使用 @${account} · pid ${pid}';
 	@override String get switchedDefault => '默认';
@@ -5344,6 +5347,8 @@ class _TranslationsWebSettingsAboutZh extends TranslationsWebSettingsAboutEn {
 	@override String get checkUpdates => '检查更新';
 	@override String get checking => '检查中…';
 	@override String get reinstall => '重新安装';
+	@override String forcePrompt({required Object count}) => '重启将中断 ${count} 个进行中的会话（之后会自动恢复）。';
+	@override String get upgradeAnyway => '仍然升级';
 }
 
 // Path: web.memoryAmbient.header
@@ -5682,7 +5687,7 @@ class _TranslationsWebCortexChatZh extends TranslationsWebCortexChatEn {
 	final TranslationsZh _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => '管护对话';
+	@override String get title => 'AI 讨论';
 	@override String get show => '与 AI 讨论';
 	@override String get hide => '收起对话';
 	@override String get emptyHint => '让 AI 更新、重组或重写这份文档。AI 维护且未锁定时直接生效；你锁定过的文档会以提案进入收件箱。';
@@ -5698,7 +5703,7 @@ class _TranslationsWebCortexChatZh extends TranslationsWebCortexChatEn {
 	@override String get revisionApplied => '文档已更新';
 	@override String get revisionProposed => '已生成提案——请到收件箱审阅';
 	@override String get modelLabel => '模型：';
-	@override String get modelHint => '为本次讨论选择 cloud-agent 供应商 + 模型。默认沿用全局 curation worker。';
+	@override String get modelHint => '为本次讨论选择 cloud-agent 供应商 + 模型。默认沿用全局讨论模型配置。';
 	@override String get modelGlobalDefault => '默认（全局）';
 	@override String get modelCliDefault => 'CLI 默认';
 	@override String get modelChangeFailed => '切换讨论模型失败';
@@ -6975,7 +6980,7 @@ class _TranslationsWebMemoryWorkersTasksCurationZh extends TranslationsWebMemory
 
 	// Translations
 	@override String get modelAdvice => '你的对话式文档/方针编辑器——推荐强模型（sonnet/opus）；它改写的是你依赖的文档。';
-	@override String get label => '管护对话';
+	@override String get label => 'AI 讨论';
 	@override String get description => '驱动「与 AI 讨论」通道：更新文档章节、重订知识页；修订遵循锁定状态。';
 }
 
@@ -9086,7 +9091,10 @@ extension on TranslationsZh {
 			'web.sessions.accountSwitcher.defaultName' => '默认',
 			'web.sessions.accountSwitcher.defaultSubtitle' => 'CLI 的系统 keychain / 环境变量',
 			'web.sessions.accountSwitcher.tokenEmpty' => '·未填',
-			'web.sessions.accountSwitcher.confirmSwitch' => '切换账户将重启 Claude CLI。对话历史会被保留（脚本会迁移并通过 --resume 恢复），但正在进行的工具调用或未发送的输入会丢失。是否继续？',
+			'web.sessions.accountSwitcher.confirmSwitch' => '切换账户会以全新对话重启 Claude CLI —— CLI 内的历史不会跨账户保留。正在进行的工具调用或未发送的输入会丢失。是否继续？',
+			'web.sessions.accountSwitcher.confirmSwitchCarry' => '切换账户将重启 Claude CLI。你最近对话的摘要会被带入，并以新账户发送给服务商。正在进行的工具调用或未发送的输入会丢失。是否继续？',
+			'web.sessions.accountSwitcher.carryContext' => '带入对话上下文',
+			'web.sessions.accountSwitcher.carryContextHelp' => '用你最近对话的摘要初始化新账户。先前内容会以新账户发送给服务商。',
 			'web.sessions.accountSwitcher.switchedToast' => '账号已切换',
 			'web.sessions.accountSwitcher.switchedDescription' => ({required Object account, required Object pid}) => '当前使用 @${account} · pid ${pid}',
 			'web.sessions.accountSwitcher.switchedDefault' => '默认',
@@ -9305,7 +9313,7 @@ extension on TranslationsZh {
 			'web.memoryWorkers.tasks.blueprint.label' => '蓝图提议器',
 			'web.memoryWorkers.tasks.blueprint.description' => '根据仓库信号识别项目类型并提议文档章节结构。由蓝图编辑器手动触发。',
 			'web.memoryWorkers.tasks.curation.modelAdvice' => '你的对话式文档/方针编辑器——推荐强模型（sonnet/opus）；它改写的是你依赖的文档。',
-			'web.memoryWorkers.tasks.curation.label' => '管护对话',
+			'web.memoryWorkers.tasks.curation.label' => 'AI 讨论',
 			'web.memoryWorkers.tasks.curation.description' => '驱动「与 AI 讨论」通道：更新文档章节、重订知识页；修订遵循锁定状态。',
 			'web.memoryWorkers.modelLabel' => '模型',
 			'web.memoryWorkers.modelHint' => '为该任务固定 CLI 模型（如基础杂活用 haiku）。留空 = CLI 默认。',
@@ -9422,11 +9430,11 @@ extension on TranslationsZh {
 			'web.project.archived.restoredToast' => '已恢复',
 			'web.project.archived.restoreFailedToast' => '恢复失败',
 			'web.project.reset.button' => '重置',
+			_ => null,
+		} ?? switch (path) {
 			'web.project.reset.dialogTitle' => '重置项目记忆?',
 			'web.project.reset.dialogDescription' => '删除该 cwd 下存储的所有项目上下文。不可撤销。',
 			'web.project.reset.alwaysDeleted' => '始终删除：目标、计划、提案、日志、清理决策。',
-			_ => null,
-		} ?? switch (path) {
 			'web.project.reset.alsoDeleteScannerLabel' => '同时删除 scanner 文档',
 			'web.project.reset.alsoDeleteScannerSuffix' => '(tech_stack + recent_activity)。',
 			'web.project.reset.alsoDeleteScannerHint' => '下次 spawn 会自动重建 — 通常不勾选即可。',
@@ -9936,11 +9944,11 @@ extension on TranslationsZh {
 			'web.channels.notifications.cooldowns.k300' => '5 分钟',
 			'web.channels.notifications.cooldowns.k900' => '15 分钟',
 			'web.channels.notifications.cooldowns.k1800' => '30 分钟',
+			_ => null,
+		} ?? switch (path) {
 			'web.channels.notifications.cooldowns.k3600' => '1 小时',
 			'web.channels.notifications.snippetCaps.k0' => '不限制 — 拆分到多条消息（默认）',
 			'web.channels.notifications.snippetCaps.k1000' => '1000 字符（精简）',
-			_ => null,
-		} ?? switch (path) {
 			'web.channels.notifications.snippetCaps.k3000' => '3000 字符',
 			'web.channels.notifications.snippetCaps.k6000' => '6000 字符',
 			'web.channels.notifications.snippetCaps.k12000' => '12000 字符',
@@ -10450,11 +10458,11 @@ extension on TranslationsZh {
 			'web.backups.targetEditor.smb.pathPrefixLabel' => '路径前缀',
 			'web.backups.targetEditor.smb.pathPrefixHint' => '共享根下的子文件夹（可选）',
 			'web.backups.targetEditor.smb.pathPrefixPlaceholder' => 'opendray/backups',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.targetEditor.s3.endpointLabel' => 'Endpoint',
 			'web.backups.targetEditor.s3.endpointHint' => '主机（不要带协议）。AWS: s3.amazonaws.com · R2: <accountid>.r2.cloudflarestorage.com · MinIO: minio.local:9000',
 			'web.backups.targetEditor.s3.endpointPlaceholder' => 's3.amazonaws.com',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.targetEditor.s3.regionLabel' => 'Region',
 			'web.backups.targetEditor.s3.regionHint' => '仅 AWS；R2 用 \'auto\'',
 			'web.backups.targetEditor.s3.regionPlaceholder' => 'us-east-1 / auto',
@@ -10813,6 +10821,8 @@ extension on TranslationsZh {
 			'web.settings.about.checkUpdates' => '检查更新',
 			'web.settings.about.checking' => '检查中…',
 			'web.settings.about.reinstall' => '重新安装',
+			'web.settings.about.forcePrompt' => ({required Object count}) => '重启将中断 ${count} 个进行中的会话（之后会自动恢复）。',
+			'web.settings.about.upgradeAnyway' => '仍然升级',
 			'web.logViewer.filterPlaceholder' => '过滤…',
 			'web.logViewer.debugTooltip' => 'Debug 计数',
 			'web.logViewer.infoTooltip' => 'Info 计数',
@@ -10962,13 +10972,13 @@ extension on TranslationsZh {
 			'web.export.form.integrationOptions.metadataHint' => 'ID、name、route prefix、scopes — 不包含任何 API key 凭证。',
 			'web.export.form.integrationOptions.plaintext' => '包含明文 API key',
 			'web.export.form.integrationOptions.plaintextHint' => 'v1 仅 bcrypt：不存在可恢复的明文。Manifest 会记录此事实；不会泄露任何内容。',
+			_ => null,
+		} ?? switch (path) {
 			'web.export.form.confirmWarning' => '输入 <1>I understand</1> 以确认。opendray 当前只存 bcrypt 哈希 — 选择明文也不会导出任何明文（该选项为将来保留明文缓存的版本而预留）。',
 			'web.export.form.confirmPlaceholder' => 'I understand',
 			'web.export.form.confirmSentinel' => 'i understand',
 			'web.export.form.footnote' => '审计日志与会话记录不在范围内 — 由 /backups（运维 dump）覆盖。',
 			'web.export.form.building' => '构建中…',
-			_ => null,
-		} ?? switch (path) {
 			'web.export.form.create' => '创建导出',
 			'web.export.form.readyToast' => '导出就绪',
 			'web.export.form.readyDescription' => ({required Object bytes}) => '${bytes} 字节',
@@ -11175,7 +11185,7 @@ extension on TranslationsZh {
 			'web.cortex.home.proposals.approvedToast' => '提案已批准——文档已更新',
 			'web.cortex.home.proposals.rejectedToast' => '提案已拒绝',
 			'web.cortex.home.proposals.failedToast' => '操作失败',
-			'web.cortex.chat.title' => '管护对话',
+			'web.cortex.chat.title' => 'AI 讨论',
 			'web.cortex.chat.show' => '与 AI 讨论',
 			'web.cortex.chat.hide' => '收起对话',
 			'web.cortex.chat.emptyHint' => '让 AI 更新、重组或重写这份文档。AI 维护且未锁定时直接生效；你锁定过的文档会以提案进入收件箱。',
@@ -11191,7 +11201,7 @@ extension on TranslationsZh {
 			'web.cortex.chat.revisionApplied' => '文档已更新',
 			'web.cortex.chat.revisionProposed' => '已生成提案——请到收件箱审阅',
 			'web.cortex.chat.modelLabel' => '模型：',
-			'web.cortex.chat.modelHint' => '为本次讨论选择 cloud-agent 供应商 + 模型。默认沿用全局 curation worker。',
+			'web.cortex.chat.modelHint' => '为本次讨论选择 cloud-agent 供应商 + 模型。默认沿用全局讨论模型配置。',
 			'web.cortex.chat.modelGlobalDefault' => '默认（全局）',
 			'web.cortex.chat.modelCliDefault' => 'CLI 默认',
 			'web.cortex.chat.modelChangeFailed' => '切换讨论模型失败',
@@ -11476,13 +11486,13 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.create' => '创建',
 			'sessions.inspector.notes.filterHint' => '筛选…',
 			'sessions.inspector.notes.locationDialogTitle' => '项目文档位置',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.notes.loadFailedApi' => ({required Object error}) => '加载失败：${error}',
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => '加载失败：${error}',
 			'sessions.inspector.notes.saveFailedApi' => ({required Object error}) => '保存失败：${error}',
 			'sessions.inspector.notes.saveFailedGeneric' => ({required Object error}) => '保存失败：${error}',
 			'sessions.inspector.notes.insertFailedApi' => ({required Object error}) => '插入失败：${error}',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.insertFailedGeneric' => ({required Object error}) => '插入失败：${error}',
 			'sessions.inspector.notes.createFailedApi' => ({required Object error}) => '创建失败：${error}',
 			'sessions.inspector.notes.createFailedGeneric' => ({required Object error}) => '创建失败：${error}',
@@ -11990,13 +12000,13 @@ extension on TranslationsZh {
 			'backups.restore.fileSelected' => ({required Object name, required Object size}) => '${name} · ${size}',
 			'backups.restore.noFile' => '未选择文件',
 			'backups.restore.targetDsnLabel' => '目标 Postgres DSN',
+			_ => null,
+		} ?? switch (path) {
 			'backups.restore.targetDsnHint' => '留空表示恢复到 opendray 自身的数据库。',
 			'backups.restore.targetDsnPlaceholder' => 'postgres://user:pass@host:5432/dbname',
 			'backups.restore.cleanLabel' => 'pg_restore --clean --if-exists',
 			'backups.restore.cleanHint' => '重新创建之前先删除已存在的对象。',
 			'backups.restore.auditNoteLabel' => '审计备注（可选）',
-			_ => null,
-		} ?? switch (path) {
 			'backups.restore.auditNotePlaceholder' => '例如：恢复 #INC-481',
 			'backups.restore.ownDbWarning' => '恢复到 opendray 自身的数据库将覆写本网关当前提供服务的数据。请输入 "I understand" 以确认。',
 			'backups.restore.confirmPlaceholder' => '输入 "I understand"',
@@ -12504,13 +12514,13 @@ extension on TranslationsZh {
 			'memory.rank.effective' => ({required Object value}) => '有效分：${value}',
 			'memory.rank.similarity' => '余弦相似度',
 			'memory.rank.ageMultiplier' => ({required Object days}) => '时效系数（${days} 天前）',
+			_ => null,
+		} ?? switch (path) {
 			'memory.rank.hitMultiplier' => ({required Object hits}) => '命中系数（${hits} 次命中）',
 			'memory.rank.confidenceMultiplier' => '置信度系数',
 			'memory.rank.formula' => '有效分 = 相似度 × 时效 × 命中 × 置信度',
 			'memory.rank.close' => '关闭',
 			'memory.kNew' => '新建',
-			_ => null,
-		} ?? switch (path) {
 			'memory.searchHint' => '搜索…',
 			'memory.projectLabel' => '项目',
 			'memory.filterHint' => '按名称或路径筛选…',

--- a/app/mobile/lib/features/cortex/curation_chat_screen.dart
+++ b/app/mobile/lib/features/cortex/curation_chat_screen.dart
@@ -1,0 +1,632 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/api/cortex_api.dart';
+import 'package:opendray/core/api/memory_api.dart';
+import 'package:opendray/core/api/memory_summarizers_api.dart';
+import 'package:opendray/core/api/memory_workers_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+
+// CurationChat — the conversational maintenance channel (Cortex Phase 4),
+// mobile parity with app/web/src/components/cortex/CurationChat.tsx. Bound
+// to a doc section or knowledge page; the operator asks the AI to update /
+// re-draft it. The model/provider picker mirrors web: global curation
+// worker, a cloud-agent CLI (claude/gemini/codex) + model, or a local
+// summarizer/HTTP provider + a probed model.
+
+// Cloud-agent providers selectable for a discussion (mirrors the backend's
+// curation override set). '' = the global curation worker.
+const _curationProviders = <({String id, String label})>[
+  (id: 'claude', label: 'Claude'),
+  (id: 'gemini', label: 'Gemini'),
+  (id: 'codex', label: 'Codex'),
+];
+
+class CurationChatScreen extends ConsumerStatefulWidget {
+  const CurationChatScreen({
+    required this.targetKind, // doc_section | kb_page | blueprint
+    required this.targetCwd,
+    required this.targetSlug,
+    this.onRevision,
+    super.key,
+  });
+
+  final String targetKind;
+  final String targetCwd;
+  final String targetSlug;
+  // Called after the AI applied/proposed a revision, so the host can
+  // refetch the underlying doc.
+  final VoidCallback? onRevision;
+
+  @override
+  ConsumerState<CurationChatScreen> createState() => _CurationChatScreenState();
+}
+
+class _CurationChatScreenState extends ConsumerState<CurationChatScreen> {
+  CortexConversation? _conv;
+  List<ConversationMessage> _messages = const [];
+  final _draftCtrl = TextEditingController();
+  final _scrollCtrl = ScrollController();
+
+  bool _loading = true;
+  bool _sending = false;
+  bool _escalating = false;
+  Timer? _poll;
+  String _seenRevisionId = '';
+
+  // Picker: '' | 'agent:<id>' | 'local:<id>', plus the chosen model.
+  String _selection = '';
+  String _model = '';
+  List<SummarizerProvider> _localProviders = const [];
+  List<ModelOption> _agentModels = const [];
+  List<String> _localModels = const [];
+
+  bool get _awaitingReply =>
+      _messages.isNotEmpty && _messages.last.role == 'operator';
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _poll?.cancel();
+    _draftCtrl.dispose();
+    _scrollCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    try {
+      final cortex = ref.read(cortexApiProvider);
+      final summarizers = await ref.read(memorySummarizersApiProvider).list();
+      final convs = await cortex.listConversations(
+        cwd: widget.targetCwd,
+        slug: widget.targetSlug,
+      );
+      final active = convs.where((c) => c.status != 'closed').toList();
+      CortexConversation? conv;
+      var msgs = const <ConversationMessage>[];
+      if (active.isNotEmpty) {
+        final (c, m) = await cortex.getConversation(active.first.id);
+        conv = c;
+        msgs = m;
+      }
+      if (!mounted) return;
+      setState(() {
+        _localProviders = summarizers.where((p) => p.enabled).toList();
+        _conv = conv;
+        _messages = msgs;
+        _loading = false;
+        if (conv != null) {
+          if (conv.summarizerId.isNotEmpty) {
+            _selection = 'local:${conv.summarizerId}';
+          } else if (conv.providerId.isNotEmpty) {
+            _selection = 'agent:${conv.providerId}';
+          } else {
+            _selection = '';
+          }
+          _model = conv.model;
+        }
+      });
+      await _refreshModelCatalog();
+      _maybePoll();
+      _scrollToBottom();
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() => _loading = false);
+      _snack('${t.web.cortex.chat.sendFailed}: $e');
+    }
+  }
+
+  String get _agentProvider =>
+      _selection.startsWith('agent:') ? _selection.substring(6) : '';
+
+  SummarizerProvider? get _localSelected => _selection.startsWith('local:')
+      ? _localProviders
+            .where((p) => p.id == _selection.substring(6))
+            .cast<SummarizerProvider?>()
+            .firstWhere((p) => true, orElse: () => null)
+      : null;
+
+  // Loads the second-dropdown model catalog for the current selection.
+  Future<void> _refreshModelCatalog() async {
+    if (_agentProvider.isNotEmpty) {
+      try {
+        final models = await ref
+            .read(memoryWorkersApiProvider)
+            .listAgentModels(_agentProvider);
+        if (mounted) setState(() => _agentModels = models);
+      } on Object {
+        if (mounted) setState(() => _agentModels = const []);
+      }
+    } else {
+      setState(() => _agentModels = const []);
+    }
+    final local = _localSelected;
+    if (local != null && local.baseUrl.isNotEmpty) {
+      try {
+        final probe = await ref
+            .read(memoryApiProvider)
+            .probe(baseUrl: local.baseUrl);
+        if (mounted) setState(() => _localModels = probe.models);
+      } on Object {
+        if (mounted) setState(() => _localModels = const []);
+      }
+    } else {
+      setState(() => _localModels = const []);
+    }
+  }
+
+  // Maps the picker state to the backend override shape.
+  ({String providerId, String model, String summarizerId}) _override() {
+    if (_selection.startsWith('agent:')) {
+      return (
+        providerId: _selection.substring(6),
+        model: _model,
+        summarizerId: '',
+      );
+    }
+    if (_selection.startsWith('local:')) {
+      return (providerId: '', model: '', summarizerId: _selection.substring(6));
+    }
+    return (providerId: '', model: '', summarizerId: '');
+  }
+
+  Future<void> _persistOverride() async {
+    final conv = _conv;
+    if (conv == null) return; // applied at create time otherwise
+    final o = _override();
+    try {
+      final updated = await ref
+          .read(cortexApiProvider)
+          .setConversationProvider(
+            conv.id,
+            providerId: o.providerId,
+            model: o.model,
+            summarizerId: o.summarizerId,
+          );
+      if (mounted) setState(() => _conv = updated);
+    } on Object catch (e) {
+      _snack('${t.web.cortex.chat.modelChangeFailed}: $e');
+    }
+  }
+
+  Future<void> _onSelectionChanged(String sel) async {
+    setState(() {
+      _selection = sel;
+      _model = '';
+    });
+    await _refreshModelCatalog();
+    await _persistOverride();
+  }
+
+  Future<void> _onModelChanged(String m) async {
+    setState(() => _model = m);
+    await _persistOverride();
+  }
+
+  Future<void> _send() async {
+    final text = _draftCtrl.text.trim();
+    if (text.isEmpty || _sending || _awaitingReply) return;
+    setState(() => _sending = true);
+    try {
+      final cortex = ref.read(cortexApiProvider);
+      var conv = _conv;
+      if (conv == null) {
+        final o = _override();
+        conv = await cortex.createConversation(
+          targetKind: widget.targetKind,
+          targetCwd: widget.targetCwd,
+          targetSlug: widget.targetSlug,
+          providerId: o.providerId,
+          model: o.model,
+          summarizerId: o.summarizerId,
+        );
+      }
+      await cortex.sendMessage(conv.id, text);
+      _draftCtrl.clear();
+      // Reload detail so the operator message shows immediately, then poll.
+      final (c, m) = await cortex.getConversation(conv.id);
+      if (!mounted) return;
+      setState(() {
+        _conv = c;
+        _messages = m;
+        _sending = false;
+      });
+      _maybePoll();
+      _scrollToBottom();
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() => _sending = false);
+      _snack('${t.web.cortex.chat.sendFailed}: $e');
+    }
+  }
+
+  // Polls for the AI reply while the last message is still the operator's.
+  void _maybePoll() {
+    _poll?.cancel();
+    if (!_awaitingReply || _conv == null) return;
+    _poll = Timer.periodic(const Duration(milliseconds: 2500), (_) async {
+      final conv = _conv;
+      if (conv == null) return;
+      try {
+        final (c, m) = await ref.read(cortexApiProvider).getConversation(
+          conv.id,
+        );
+        if (!mounted) return;
+        setState(() {
+          _conv = c;
+          _messages = m;
+        });
+        _notifyRevision();
+        if (!_awaitingReply) {
+          _poll?.cancel();
+          _scrollToBottom();
+        }
+      } on Object {
+        // transient; keep polling
+      }
+    });
+  }
+
+  void _notifyRevision() {
+    for (var i = _messages.length - 1; i >= 0; i--) {
+      final m = _messages[i];
+      if (m.revisionAction.isNotEmpty) {
+        if (m.id != _seenRevisionId) {
+          _seenRevisionId = m.id;
+          widget.onRevision?.call();
+        }
+        return;
+      }
+    }
+  }
+
+  Future<void> _escalate() async {
+    final conv = _conv;
+    if (conv == null || _escalating || conv.status == 'escalated') return;
+    setState(() => _escalating = true);
+    try {
+      final updated = await ref.read(cortexApiProvider).escalate(conv.id);
+      if (!mounted) return;
+      setState(() {
+        _conv = updated;
+        _escalating = false;
+      });
+      _snack(t.web.cortex.chat.escalatedToast);
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() => _escalating = false);
+      _snack('${t.web.cortex.chat.escalateFailed}: $e');
+    }
+  }
+
+  Future<void> _close() async {
+    final conv = _conv;
+    if (conv != null) {
+      try {
+        await ref.read(cortexApiProvider).closeConversation(conv.id);
+      } on Object {
+        // best-effort
+      }
+    }
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  void _snack(String msg) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollCtrl.hasClients) {
+        _scrollCtrl.animateTo(
+          _scrollCtrl.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final conv = _conv;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(t.web.cortex.chat.title),
+        actions: [
+          if (conv != null)
+            TextButton.icon(
+              onPressed: conv.status == 'escalated' || _escalating
+                  ? null
+                  : _escalate,
+              icon: _escalating
+                  ? const SizedBox(
+                      width: 14,
+                      height: 14,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.north_east, size: 16),
+              label: Text(
+                conv.status == 'escalated'
+                    ? t.web.cortex.chat.escalated
+                    : t.web.cortex.chat.escalate,
+              ),
+            ),
+          IconButton(
+            tooltip: t.web.cortex.chat.closeHint,
+            icon: const Icon(Icons.close),
+            onPressed: _close,
+          ),
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : Column(
+              children: [
+                _modelPicker(context),
+                Expanded(child: _messageList(context)),
+                _inputBar(context),
+              ],
+            ),
+    );
+  }
+
+  Widget _modelPicker(BuildContext context) {
+    final theme = Theme.of(context);
+    final items = <DropdownMenuItem<String>>[
+      DropdownMenuItem(value: '', child: Text(t.web.cortex.chat.modelGlobalDefault)),
+      for (final p in _curationProviders)
+        DropdownMenuItem(
+          value: 'agent:${p.id}',
+          child: Text('${t.web.cortex.chat.modelGroupCloud} · ${p.label}'),
+        ),
+      for (final p in _localProviders)
+        DropdownMenuItem(
+          value: 'local:${p.id}',
+          child: Text('${t.web.cortex.chat.modelGroupLocal} · ${p.label}'),
+        ),
+    ];
+    return Container(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: theme.dividerColor)),
+      ),
+      child: Row(
+        children: [
+          Text(
+            t.web.cortex.chat.modelLabel,
+            style: theme.textTheme.bodySmall,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: DropdownButton<String>(
+              value: _selection,
+              isExpanded: true,
+              isDense: true,
+              underline: const SizedBox.shrink(),
+              items: items,
+              onChanged: (v) => _onSelectionChanged(v ?? ''),
+            ),
+          ),
+          if (_agentProvider.isNotEmpty || _selection.startsWith('local:')) ...[
+            const SizedBox(width: 8),
+            Expanded(child: _modelDropdown(context)),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _modelDropdown(BuildContext context) {
+    final isAgent = _agentProvider.isNotEmpty;
+    final local = _localSelected;
+    final defaultLabel = isAgent
+        ? t.web.cortex.chat.modelCliDefault
+        : (local != null && local.model.isNotEmpty)
+        ? '${t.web.cortex.chat.modelProviderDefault} · ${local.model}'
+        : t.web.cortex.chat.modelCliDefault;
+    final items = <DropdownMenuItem<String>>[
+      DropdownMenuItem(value: '', child: Text(defaultLabel)),
+      if (isAgent)
+        for (final m in _agentModels)
+          DropdownMenuItem(value: m.id, child: Text(m.label))
+      else
+        for (final m in _localModels)
+          DropdownMenuItem(value: m, child: Text(m)),
+    ];
+    // Guard: if the pinned model isn't in the catalog, fall back to default.
+    final value = items.any((it) => it.value == _model) ? _model : '';
+    return DropdownButton<String>(
+      value: value,
+      isExpanded: true,
+      isDense: true,
+      underline: const SizedBox.shrink(),
+      items: items,
+      onChanged: (v) => _onModelChanged(v ?? ''),
+    );
+  }
+
+  Widget _messageList(BuildContext context) {
+    if (_messages.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.forum_outlined,
+                size: 28,
+                color: Theme.of(context).colorScheme.outline,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                t.web.cortex.chat.emptyHint,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+    return ListView.builder(
+      controller: _scrollCtrl,
+      padding: const EdgeInsets.all(12),
+      itemCount: _messages.length + (_awaitingReply ? 1 : 0),
+      itemBuilder: (context, i) {
+        if (i >= _messages.length) return _thinkingBubble(context);
+        return _bubble(context, _messages[i]);
+      },
+    );
+  }
+
+  Widget _bubble(BuildContext context, ConversationMessage m) {
+    final theme = Theme.of(context);
+    final isOperator = m.role == 'operator';
+    final isSystem = m.role == 'system';
+    final align = isOperator ? Alignment.centerRight : Alignment.centerLeft;
+    final color = isOperator
+        ? theme.colorScheme.primary.withValues(alpha: 0.12)
+        : isSystem
+        ? theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.4)
+        : theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.7);
+    return Align(
+      alignment: align,
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width * 0.85,
+        ),
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(8),
+          border: isSystem
+              ? Border.all(
+                  color: theme.dividerColor,
+                  style: BorderStyle.solid,
+                )
+              : null,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SelectableText(
+              m.content,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: isSystem ? theme.colorScheme.outline : null,
+              ),
+            ),
+            if (m.revisionAction == 'applied') _revisionBadge(context, true),
+            if (m.revisionAction == 'proposed') _revisionBadge(context, false),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _revisionBadge(BuildContext context, bool applied) {
+    final theme = Theme.of(context);
+    final c = applied ? Colors.green : theme.colorScheme.tertiary;
+    return Padding(
+      padding: const EdgeInsets.only(top: 6),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(applied ? Icons.check_circle : Icons.inbox, size: 13, color: c),
+          const SizedBox(width: 4),
+          Text(
+            applied
+                ? t.web.cortex.chat.revisionApplied
+                : t.web.cortex.chat.revisionProposed,
+            style: theme.textTheme.labelSmall?.copyWith(color: c),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _thinkingBubble(BuildContext context) {
+    final theme = Theme.of(context);
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceContainerHighest.withValues(
+            alpha: 0.7,
+          ),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(
+              width: 14,
+              height: 14,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+            const SizedBox(width: 8),
+            Text(t.web.cortex.chat.thinking, style: theme.textTheme.bodySmall),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _inputBar(BuildContext context) {
+    final theme = Theme.of(context);
+    return SafeArea(
+      top: false,
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+        decoration: BoxDecoration(
+          border: Border(top: BorderSide(color: theme.dividerColor)),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _draftCtrl,
+                minLines: 1,
+                maxLines: 4,
+                textInputAction: TextInputAction.newline,
+                decoration: InputDecoration(
+                  isDense: true,
+                  border: const OutlineInputBorder(),
+                  hintText: t.web.cortex.chat.placeholder,
+                ),
+                onChanged: (_) => setState(() {}),
+              ),
+            ),
+            const SizedBox(width: 8),
+            FilledButton(
+              onPressed:
+                  _draftCtrl.text.trim().isEmpty || _sending || _awaitingReply
+                  ? null
+                  : _send,
+              child: _sending
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.send, size: 18),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/mobile/lib/features/knowledge/knowledge_screen.dart
+++ b/app/mobile/lib/features/knowledge/knowledge_screen.dart
@@ -6,6 +6,7 @@ import 'package:opendray/core/api/cortex_api.dart';
 import 'package:opendray/core/api/knowledge_api.dart';
 import 'package:opendray/core/api/project_docs_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/cortex/curation_chat_screen.dart';
 import 'package:opendray/features/knowledge/force_graph.dart';
 
 // Knowledge tab — read-mostly browser over the M-KG knowledge graph.
@@ -551,6 +552,20 @@ class _KbViewState extends ConsumerState<_KbView> {
                                 MaterialTapTargetSize.shrinkWrap,
                           ),
                         if (!_editing) ...[
+                          TextButton(
+                            onPressed: () =>
+                                Navigator.of(context).push(
+                                  MaterialPageRoute<void>(
+                                    builder: (_) => CurationChatScreen(
+                                      targetKind: 'kb_page',
+                                      targetCwd: _global,
+                                      targetSlug: _kind,
+                                      onRevision: _load,
+                                    ),
+                                  ),
+                                ),
+                            child: Text(t.web.cortex.chat.title),
+                          ),
                           TextButton(
                             onPressed: () {
                               _editCtrl.text = content;

--- a/app/mobile/lib/features/knowledge/knowledge_screen.dart
+++ b/app/mobile/lib/features/knowledge/knowledge_screen.dart
@@ -564,7 +564,7 @@ class _KbViewState extends ConsumerState<_KbView> {
                                     ),
                                   ),
                                 ),
-                            child: Text(t.web.cortex.chat.title),
+                            child: Text(t.web.cortex.chat.show),
                           ),
                           TextButton(
                             onPressed: () {

--- a/app/mobile/lib/features/project/project_screen.dart
+++ b/app/mobile/lib/features/project/project_screen.dart
@@ -691,7 +691,7 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
                     child: OutlinedButton.icon(
                       onPressed: () => _openDiscussion('doc_section', kind),
                       icon: const Icon(Icons.forum_outlined, size: 16),
-                      label: Text(t.web.cortex.chat.title),
+                      label: Text(t.web.cortex.chat.show),
                     ),
                   ),
                 ],

--- a/app/mobile/lib/features/project/project_screen.dart
+++ b/app/mobile/lib/features/project/project_screen.dart
@@ -11,6 +11,7 @@ import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/project_docs_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/cortex/blueprint_editor_screen.dart';
+import 'package:opendray/features/cortex/curation_chat_screen.dart';
 import 'package:opendray/features/sessions/directory_picker_sheet.dart';
 import 'package:path/path.dart' as p;
 
@@ -633,6 +634,23 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
 
   // ── Goal / Plan editor ─────────────────────────────────────────
 
+  // Opens the AI discussion (CurationChat) for a doc section — web parity
+  // with the per-section "discuss / re-draft with AI" panel.
+  void _openDiscussion(String targetKind, String slug) {
+    final cwd = _selectedKey;
+    if (cwd == null || cwd.isEmpty) return;
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => CurationChatScreen(
+          targetKind: targetKind,
+          targetCwd: cwd,
+          targetSlug: slug,
+          onRevision: () => _loadAll(cwd),
+        ),
+      ),
+    );
+  }
+
   Widget _docTab(String kind) {
     if (_selectedKey == null) {
       return Center(child: Text(t.project.pickFirst));
@@ -668,6 +686,14 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
                 children: [
                   _docMetaStrip(kind, current.isPersisted ? current : null),
                   if (hasPending) _proposalBanner(),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: OutlinedButton.icon(
+                      onPressed: () => _openDiscussion('doc_section', kind),
+                      icon: const Icon(Icons.forum_outlined, size: 16),
+                      label: Text(t.web.cortex.chat.title),
+                    ),
+                  ),
                 ],
               ),
             ),

--- a/app/mobile/pubspec.yaml
+++ b/app/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: opendray
 description: opendray mobile — multi-CLI gateway control
 publish_to: none
-version: 2.3.3+40
+version: 2.3.3+41
 
 environment:
   sdk: ^3.11.0

--- a/app/mobile/pubspec.yaml
+++ b/app/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: opendray
 description: opendray mobile — multi-CLI gateway control
 publish_to: none
-version: 2.3.3+39
+version: 2.3.3+40
 
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
## Summary

Brings the Cortex **AI discussion** (formerly "curation chat") to the mobile app at full parity with web, and clarifies its confusing naming everywhere.

The web had the discussion panel per doc-section (Project workspace) and per KB page (Knowledge) with a model/provider picker; mobile only had an unused API stub. Now mobile has the full feature.

## Changes

**Mobile AI-discussion feature** (`a5c6261`)
- `cortex_api`: `CortexConversation` gains `provider_id`/`model`/`summarizer_id`; `createConversation` accepts the override; new `setConversationProvider`.
- `memory_summarizers_api`: `SummarizerProvider` gains `enabled` + `base_url` (filter enabled providers, live-probe their served models).
- New `CurationChatScreen`: the same model picker as web — global discussion model, a cloud-agent CLI (claude/gemini/codex) + its model catalog, or a configured local summarizer provider + its probed models; persisted via `setConversationProvider`. Message bubbles (operator/ai/system) with applied/proposed revision badges, poll-on-await-reply, escalate + close.
- Wired into both entry points: a "Discuss with AI" button per editable doc section (`project_screen`) and per KB page (`knowledge_screen`), each refetching its doc on a revision.

**Naming clarity** (`3493195`)
- Renamed the opaque "Curation chat" / 管护对话 / Chat de curación → **AI discussion / AI 讨论 / Discusión con IA** (panel title + memory-worker task label) across en/zh/es; dropped "global curation worker" jargon from the model hint. (The entry button already said "Discuss with AI" and the zh description already referenced 与 AI 讨论 — the title was internally inconsistent.)

Mobile-only + i18n; no backend or web behaviour change. Reuses existing `web.cortex.chat.*` keys (no key additions).

## Test plan
- `flutter analyze lib` — clean (whole mobile lib).
- `cd app/web && pnpm exec tsc -b` — clean (i18n value changes only).
- `dart run slang` — regenerates cleanly.
- JSON validity for en/zh/es confirmed.
- Manual: open a project doc section / KB page on mobile → "Discuss with AI" → switch model (global / cloud agent + model / local provider + model) → send → AI reply + revision badge; escalate + close.

Note: mobile has no markdown package, so AI replies render as plain selectable text (web uses ReactMarkdown) — a minor parity gap, flagged for future polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)