### PR TITLE
docs(changelog): v2.8.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+## [v2.8.0] — 2026-06-16
+
+### Added
+
+- **OpenCode CLI provider.** Drive OpenCode — the open-source,
+  provider-agnostic agentic coding CLI — through the same PTY gateway as
+  Claude Code / Codex / Gemini. Point it at a local OpenAI-compatible
+  endpoint (Ollama / LM Studio / vLLM) with just a base URL: opendray
+  generates a per-session config, auto-discovers the endpoint's models so
+  they all appear in OpenCode's `/model` picker, and wires the shared
+  `opendray-memory` MCP, skills, and a spawn-dialog bypass toggle. (#369)
+- **AI discussion model picker on mobile**, matching the web admin's
+  cloud-agent + local-model selection in Cortex's Discuss With AI. (#368)
+- **Antigravity** is now selectable as a cloud agent in Cortex's Discuss
+  With AI. (#370)
+- **Backup-hardening arc + Cortex memory/notes UX** integrated from beta:
+  scheduled/fan-out backups across pluggable targets, pre-migration
+  snapshots, and the conversational notes/knowledge maintenance surface. (#367)
+
+### Changed
+
+- **Recovery Kit clarity.** The dialog now states what the kit is for
+  (disaster-recovery insurance, rarely needed), that each generation is an
+  independent file sealed with its own password (nothing is stored — there
+  is no master password), and that the password protects the file, not the
+  gateway. Downloaded kits are named by key fingerprint + date so
+  regenerating no longer silently overwrites a prior kit. (#371)
+
+### Fixed
+
+- Release announcements trigger via `workflow_run` instead of the release
+  event. (#366)
+
 ## [v2.7.6] — 2026-06-14
 
 ### Added


### PR DESCRIPTION
## Summary

CHANGELOG bump for **v2.8.0** — this is the review gate before tagging. The release workflow extracts the `## [v2.8.0]` section as the GitHub release notes on `v2.8.0` tag push.

### v2.8.0 highlights (since v2.7.6)
- **OpenCode CLI provider** with local-model auto-discovery, shared memory MCP, skills, and a bypass toggle (#369)
- Mobile AI-discussion model picker (#368)
- Antigravity in Cortex Discuss-With-AI (#370)
- Backup-hardening arc + Cortex memory/notes UX from beta (#367)
- Recovery Kit UX clarity + no-overwrite filenames (#371)
- CI: release announce via `workflow_run` (#366)

Minor bump (feature iteration) per VERSIONING.md — OpenCode provider is the headline feature, not a new product generation.

## Pre-release checks (local, on main)
- [x] `go mod verify` — all modules verified
- [x] `go build ./...` / `go vet ./...` clean
- [x] web `tsc -b` passes

## After merge
Tag `v2.8.0` on main → release workflow builds multi-platform archives + cosign checksums + SBOM and publishes the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)