### PR TITLE
feat(sessions): native Select & Copy for terminal, drop whole-buffer copy

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -123,15 +123,15 @@
         "hideInspector": "Hide inspector",
         "attachImage": "Attach image",
         "attachImageTooltip": "Attach image (or paste / drop into terminal)",
-        "copyOutput": "Copy output",
-        "copyOutputTooltip": "Copy the terminal output (selection if any, otherwise everything)",
         "restart": "Restart",
         "restarting": "Restarting…",
         "remove": "Remove",
         "removing": "Removing…",
         "stop": "Stop",
         "stopping": "Stopping…",
-        "pid": "pid {pid}"
+        "pid": "pid {pid}",
+        "selectText": "Select & copy",
+        "selectTextTooltip": "Open a selectable text view to copy any part of the output"
       },
       "terminal": {
         "uploadingToast": "Uploading image…",
@@ -139,12 +139,7 @@
         "uploadFailedToast": "Upload failed",
         "uploadInvalidTypeToast": "Only image files can be attached",
         "dropToAttach": "Drop image to attach",
-        "copyButton": "Copy",
-        "copyAllTooltip": "Copy terminal output to clipboard (selection if any, otherwise everything)",
-        "copySelection": "Copy",
-        "copySelectionTooltip": "Copy selected text",
         "copiedToast": "Copied to clipboard",
-        "copyEmptyToast": "Nothing to copy yet",
         "copyFailedToast": "Couldn't copy to clipboard",
         "urls": {
           "tooltip": "Open the latest link detected in this session",
@@ -159,7 +154,13 @@
           "copiedToast": "URL copied",
           "copyFailedToast": "Couldn't copy — long-press the URL and copy manually",
           "noneHint": "No links detected yet."
-        }
+        },
+        "selectCopyTitle": "Select & copy",
+        "selectCopyDesc": "Drag (or long-press on touch) to select any part of the output, then copy it.",
+        "selectCopyCopySelection": "Copy selection",
+        "selectCopyCopyAll": "Copy all",
+        "selectCopyNoSelection": "Select some text first",
+        "selectCopyEmpty": "No output to copy yet"
       },
       "spawn": {
         "title": "Spawn session",
@@ -3199,10 +3200,10 @@
         "takePhoto": "Take a photo"
       },
       "keyboard": {
-        "copyBuffer": "Copy buffer",
         "paste": "Paste",
         "attachImage": "Attach image",
-        "enter": "Enter"
+        "enter": "Enter",
+        "selectText": "Select text"
       },
       "connection": {
         "connecting": "Connecting…",
@@ -3212,6 +3213,13 @@
         "disconnected": "Disconnected",
         "disconnectedWithError": "Disconnected ({error})",
         "ended": "Session ended"
+      },
+      "selectCopy": {
+        "title": "Select & copy",
+        "hint": "Long-press to select any part of the output, then copy it.",
+        "copyAll": "Copy all",
+        "copiedAll": "Copied all output ({count} chars)",
+        "empty": "No output to copy yet"
       }
     },
     "action": {

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -123,15 +123,15 @@
         "hideInspector": "Ocultar inspector",
         "attachImage": "Adjuntar imagen",
         "attachImageTooltip": "Adjuntar imagen (o pega / suelta en el terminal)",
-        "copyOutput": "Copiar salida",
-        "copyOutputTooltip": "Copia la salida del terminal (la selección si hay alguna, si no, todo)",
         "restart": "Reiniciar",
         "restarting": "Reiniciando…",
         "remove": "Eliminar",
         "removing": "Eliminando…",
         "stop": "Detener",
         "stopping": "Deteniendo…",
-        "pid": "pid {pid}"
+        "pid": "pid {pid}",
+        "selectText": "Seleccionar y copiar",
+        "selectTextTooltip": "Abre una vista de texto seleccionable para copiar cualquier parte de la salida"
       },
       "terminal": {
         "uploadingToast": "Subiendo imagen…",
@@ -139,12 +139,7 @@
         "uploadFailedToast": "Error al subir",
         "uploadInvalidTypeToast": "Solo se pueden adjuntar archivos de imagen",
         "dropToAttach": "Suelta la imagen para adjuntarla",
-        "copyButton": "Copiar",
-        "copyAllTooltip": "Copia la salida del terminal al portapapeles (la selección si hay alguna, si no, todo)",
-        "copySelection": "Copiar",
-        "copySelectionTooltip": "Copiar el texto seleccionado",
         "copiedToast": "Copiado al portapapeles",
-        "copyEmptyToast": "Aún no hay nada que copiar",
         "copyFailedToast": "No se pudo copiar al portapapeles",
         "urls": {
           "tooltip": "Abre el último enlace detectado en esta session",
@@ -159,7 +154,13 @@
           "copiedToast": "URL copiada",
           "copyFailedToast": "No se pudo copiar. Mantén pulsada la URL y cópiala manualmente",
           "noneHint": "Aún no se han detectado enlaces."
-        }
+        },
+        "selectCopyTitle": "Seleccionar y copiar",
+        "selectCopyDesc": "Arrastra (o mantén pulsado en pantalla táctil) para seleccionar cualquier parte de la salida y cópiala.",
+        "selectCopyCopySelection": "Copiar selección",
+        "selectCopyCopyAll": "Copiar todo",
+        "selectCopyNoSelection": "Selecciona primero algún texto",
+        "selectCopyEmpty": "Aún no hay salida que copiar"
       },
       "spawn": {
         "title": "Crear session",
@@ -3199,10 +3200,10 @@
         "takePhoto": "Tomar una foto"
       },
       "keyboard": {
-        "copyBuffer": "Copiar búfer",
         "paste": "Pegar",
         "attachImage": "Adjuntar imagen",
-        "enter": "Intro"
+        "enter": "Intro",
+        "selectText": "Seleccionar texto"
       },
       "connection": {
         "connecting": "Conectando…",
@@ -3212,6 +3213,13 @@
         "disconnected": "Desconectado",
         "disconnectedWithError": "Desconectado ({error})",
         "ended": "Sesión finalizada"
+      },
+      "selectCopy": {
+        "title": "Seleccionar y copiar",
+        "hint": "Mantén pulsado para seleccionar cualquier parte de la salida y cópiala.",
+        "copyAll": "Copiar todo",
+        "copiedAll": "Salida copiada ({count} caracteres)",
+        "empty": "Aún no hay salida que copiar"
       }
     },
     "action": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -123,15 +123,15 @@
         "hideInspector": "隐藏检查器",
         "attachImage": "附加图片",
         "attachImageTooltip": "附加图片（或直接粘贴 / 拖入终端）",
-        "copyOutput": "复制输出",
-        "copyOutputTooltip": "复制终端输出（若有选区则复制选区，否则复制全部）",
         "restart": "重启",
         "restarting": "重启中…",
         "remove": "移除",
         "removing": "移除中…",
         "stop": "停止",
         "stopping": "停止中…",
-        "pid": "pid {pid}"
+        "pid": "pid {pid}",
+        "selectText": "选择并复制",
+        "selectTextTooltip": "打开可选择文本视图,复制输出中的任意部分"
       },
       "terminal": {
         "uploadingToast": "正在上传图片…",
@@ -139,12 +139,7 @@
         "uploadFailedToast": "上传失败",
         "uploadInvalidTypeToast": "仅支持图片文件",
         "dropToAttach": "释放以附加图片",
-        "copyButton": "复制",
-        "copyAllTooltip": "复制终端输出到剪贴板(若有选区则复制选区,否则复制全部)",
-        "copySelection": "复制",
-        "copySelectionTooltip": "复制选中的文本",
         "copiedToast": "已复制到剪贴板",
-        "copyEmptyToast": "暂无可复制内容",
         "copyFailedToast": "无法复制到剪贴板",
         "urls": {
           "tooltip": "打开本会话最新检测到的链接",
@@ -159,7 +154,13 @@
           "copiedToast": "链接已复制",
           "copyFailedToast": "复制失败 —— 请长按链接手动复制",
           "noneHint": "暂未检测到链接。"
-        }
+        },
+        "selectCopyTitle": "选择并复制",
+        "selectCopyDesc": "拖动(触屏长按)选择输出中的任意部分,然后复制。",
+        "selectCopyCopySelection": "复制选中",
+        "selectCopyCopyAll": "全部复制",
+        "selectCopyNoSelection": "请先选择文本",
+        "selectCopyEmpty": "暂无可复制的输出"
       },
       "spawn": {
         "title": "创建会话",
@@ -3199,10 +3200,10 @@
         "takePhoto": "拍照"
       },
       "keyboard": {
-        "copyBuffer": "复制缓冲",
         "paste": "粘贴",
         "attachImage": "附加图片",
-        "enter": "回车"
+        "enter": "回车",
+        "selectText": "选择文本"
       },
       "connection": {
         "connecting": "连接中…",
@@ -3212,6 +3213,13 @@
         "disconnected": "已断开",
         "disconnectedWithError": "已断开（{error}）",
         "ended": "会话已结束"
+      },
+      "selectCopy": {
+        "title": "选择并复制",
+        "hint": "长按选择输出中的任意部分,然后复制。",
+        "copyAll": "全部复制",
+        "copiedAll": "已复制全部输出({count} 个字符)",
+        "empty": "暂无可复制的输出"
       }
     },
     "action": {

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 11553 (3851 per locale)
+/// Strings: 11571 (3857 per locale)
 ///
-/// Built on 2026-06-16 at 11:31 UTC
+/// Built on 2026-06-16 at 14:32 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -3657,6 +3657,7 @@ class TranslationsSessionsTerminalEn {
 	late final TranslationsSessionsTerminalImageSourceEn imageSource = TranslationsSessionsTerminalImageSourceEn.internal(_root);
 	late final TranslationsSessionsTerminalKeyboardEn keyboard = TranslationsSessionsTerminalKeyboardEn.internal(_root);
 	late final TranslationsSessionsTerminalConnectionEn connection = TranslationsSessionsTerminalConnectionEn.internal(_root);
+	late final TranslationsSessionsTerminalSelectCopyEn selectCopy = TranslationsSessionsTerminalSelectCopyEn.internal(_root);
 }
 
 // Path: sessions.action
@@ -6090,12 +6091,6 @@ class TranslationsWebSessionsHeaderEn {
 	/// en: 'Attach image (or paste / drop into terminal)'
 	String get attachImageTooltip => 'Attach image (or paste / drop into terminal)';
 
-	/// en: 'Copy output'
-	String get copyOutput => 'Copy output';
-
-	/// en: 'Copy the terminal output (selection if any, otherwise everything)'
-	String get copyOutputTooltip => 'Copy the terminal output (selection if any, otherwise everything)';
-
 	/// en: 'Restart'
 	String get restart => 'Restart';
 
@@ -6116,6 +6111,12 @@ class TranslationsWebSessionsHeaderEn {
 
 	/// en: 'pid {pid}'
 	String pid({required Object pid}) => 'pid ${pid}';
+
+	/// en: 'Select & copy'
+	String get selectText => 'Select & copy';
+
+	/// en: 'Open a selectable text view to copy any part of the output'
+	String get selectTextTooltip => 'Open a selectable text view to copy any part of the output';
 }
 
 // Path: web.sessions.terminal
@@ -6141,28 +6142,31 @@ class TranslationsWebSessionsTerminalEn {
 	/// en: 'Drop image to attach'
 	String get dropToAttach => 'Drop image to attach';
 
-	/// en: 'Copy'
-	String get copyButton => 'Copy';
-
-	/// en: 'Copy terminal output to clipboard (selection if any, otherwise everything)'
-	String get copyAllTooltip => 'Copy terminal output to clipboard (selection if any, otherwise everything)';
-
-	/// en: 'Copy'
-	String get copySelection => 'Copy';
-
-	/// en: 'Copy selected text'
-	String get copySelectionTooltip => 'Copy selected text';
-
 	/// en: 'Copied to clipboard'
 	String get copiedToast => 'Copied to clipboard';
-
-	/// en: 'Nothing to copy yet'
-	String get copyEmptyToast => 'Nothing to copy yet';
 
 	/// en: 'Couldn't copy to clipboard'
 	String get copyFailedToast => 'Couldn\'t copy to clipboard';
 
 	late final TranslationsWebSessionsTerminalUrlsEn urls = TranslationsWebSessionsTerminalUrlsEn.internal(_root);
+
+	/// en: 'Select & copy'
+	String get selectCopyTitle => 'Select & copy';
+
+	/// en: 'Drag (or long-press on touch) to select any part of the output, then copy it.'
+	String get selectCopyDesc => 'Drag (or long-press on touch) to select any part of the output, then copy it.';
+
+	/// en: 'Copy selection'
+	String get selectCopyCopySelection => 'Copy selection';
+
+	/// en: 'Copy all'
+	String get selectCopyCopyAll => 'Copy all';
+
+	/// en: 'Select some text first'
+	String get selectCopyNoSelection => 'Select some text first';
+
+	/// en: 'No output to copy yet'
+	String get selectCopyEmpty => 'No output to copy yet';
 }
 
 // Path: web.sessions.spawn
@@ -11704,9 +11708,6 @@ class TranslationsSessionsTerminalKeyboardEn {
 
 	// Translations
 
-	/// en: 'Copy buffer'
-	String get copyBuffer => 'Copy buffer';
-
 	/// en: 'Paste'
 	String get paste => 'Paste';
 
@@ -11715,6 +11716,9 @@ class TranslationsSessionsTerminalKeyboardEn {
 
 	/// en: 'Enter'
 	String get enter => 'Enter';
+
+	/// en: 'Select text'
+	String get selectText => 'Select text';
 }
 
 // Path: sessions.terminal.connection
@@ -11745,6 +11749,30 @@ class TranslationsSessionsTerminalConnectionEn {
 
 	/// en: 'Session ended'
 	String get ended => 'Session ended';
+}
+
+// Path: sessions.terminal.selectCopy
+class TranslationsSessionsTerminalSelectCopyEn {
+	TranslationsSessionsTerminalSelectCopyEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Select & copy'
+	String get title => 'Select & copy';
+
+	/// en: 'Long-press to select any part of the output, then copy it.'
+	String get hint => 'Long-press to select any part of the output, then copy it.';
+
+	/// en: 'Copy all'
+	String get copyAll => 'Copy all';
+
+	/// en: 'Copied all output ({count} chars)'
+	String copiedAll({required Object count}) => 'Copied all output (${count} chars)';
+
+	/// en: 'No output to copy yet'
+	String get empty => 'No output to copy yet';
 }
 
 // Path: sessions.action.errors
@@ -16841,8 +16869,6 @@ extension on Translations {
 			'web.sessions.header.hideInspector' => 'Hide inspector',
 			'web.sessions.header.attachImage' => 'Attach image',
 			'web.sessions.header.attachImageTooltip' => 'Attach image (or paste / drop into terminal)',
-			'web.sessions.header.copyOutput' => 'Copy output',
-			'web.sessions.header.copyOutputTooltip' => 'Copy the terminal output (selection if any, otherwise everything)',
 			'web.sessions.header.restart' => 'Restart',
 			'web.sessions.header.restarting' => 'Restarting…',
 			'web.sessions.header.remove' => 'Remove',
@@ -16850,17 +16876,14 @@ extension on Translations {
 			'web.sessions.header.stop' => 'Stop',
 			'web.sessions.header.stopping' => 'Stopping…',
 			'web.sessions.header.pid' => ({required Object pid}) => 'pid ${pid}',
+			'web.sessions.header.selectText' => 'Select & copy',
+			'web.sessions.header.selectTextTooltip' => 'Open a selectable text view to copy any part of the output',
 			'web.sessions.terminal.uploadingToast' => 'Uploading image…',
 			'web.sessions.terminal.uploadedToast' => 'Image attached',
 			'web.sessions.terminal.uploadFailedToast' => 'Upload failed',
 			'web.sessions.terminal.uploadInvalidTypeToast' => 'Only image files can be attached',
 			'web.sessions.terminal.dropToAttach' => 'Drop image to attach',
-			'web.sessions.terminal.copyButton' => 'Copy',
-			'web.sessions.terminal.copyAllTooltip' => 'Copy terminal output to clipboard (selection if any, otherwise everything)',
-			'web.sessions.terminal.copySelection' => 'Copy',
-			'web.sessions.terminal.copySelectionTooltip' => 'Copy selected text',
 			'web.sessions.terminal.copiedToast' => 'Copied to clipboard',
-			'web.sessions.terminal.copyEmptyToast' => 'Nothing to copy yet',
 			'web.sessions.terminal.copyFailedToast' => 'Couldn\'t copy to clipboard',
 			'web.sessions.terminal.urls.tooltip' => 'Open the latest link detected in this session',
 			'web.sessions.terminal.urls.tapToOpenLatest' => 'Tap to open the latest link (most recent OAuth URL)',
@@ -16874,6 +16897,12 @@ extension on Translations {
 			'web.sessions.terminal.urls.copiedToast' => 'URL copied',
 			'web.sessions.terminal.urls.copyFailedToast' => 'Couldn\'t copy — long-press the URL and copy manually',
 			'web.sessions.terminal.urls.noneHint' => 'No links detected yet.',
+			'web.sessions.terminal.selectCopyTitle' => 'Select & copy',
+			'web.sessions.terminal.selectCopyDesc' => 'Drag (or long-press on touch) to select any part of the output, then copy it.',
+			'web.sessions.terminal.selectCopyCopySelection' => 'Copy selection',
+			'web.sessions.terminal.selectCopyCopyAll' => 'Copy all',
+			'web.sessions.terminal.selectCopyNoSelection' => 'Select some text first',
+			'web.sessions.terminal.selectCopyEmpty' => 'No output to copy yet',
 			'web.sessions.spawn.title' => 'Spawn session',
 			'web.sessions.spawn.description' => 'Start a CLI session under a registered provider.',
 			'web.sessions.spawn.provider' => 'Provider',
@@ -17249,9 +17278,9 @@ extension on Translations {
 			'web.project.archived.archivedAtPrefix' => 'Archived',
 			'web.project.archived.restoreButton' => 'Restore',
 			'web.project.archived.restoredToast' => 'Restored',
-			'web.project.archived.restoreFailedToast' => 'Restore failed',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.archived.restoreFailedToast' => 'Restore failed',
 			'web.project.reset.button' => 'Reset',
 			'web.project.reset.dialogTitle' => 'Reset project memory?',
 			'web.project.reset.dialogDescription' => 'Deletes all stored project context for this cwd. This cannot be undone.',
@@ -17763,9 +17792,9 @@ extension on Translations {
 			'web.channels.notifications.modes.everyHint' => 'No suppression. Use only for low-frequency channels.',
 			'web.channels.notifications.cooldowns.k60' => '1 minute',
 			'web.channels.notifications.cooldowns.k300' => '5 minutes',
-			'web.channels.notifications.cooldowns.k900' => '15 minutes',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.notifications.cooldowns.k900' => '15 minutes',
 			'web.channels.notifications.cooldowns.k1800' => '30 minutes',
 			'web.channels.notifications.cooldowns.k3600' => '1 hour',
 			'web.channels.notifications.snippetCaps.k0' => 'No cap — chunk into multiple messages (default)',
@@ -18277,9 +18306,9 @@ extension on Translations {
 			'web.backups.targetEditor.smb.userLabel' => 'User',
 			'web.backups.targetEditor.smb.passwordLabel' => 'Password',
 			'web.backups.targetEditor.smb.pathPrefixLabel' => 'Path prefix',
-			'web.backups.targetEditor.smb.pathPrefixHint' => 'Sub-folder under the share root (optional)',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.targetEditor.smb.pathPrefixHint' => 'Sub-folder under the share root (optional)',
 			'web.backups.targetEditor.smb.pathPrefixPlaceholder' => 'opendray/backups',
 			'web.backups.targetEditor.s3.endpointLabel' => 'Endpoint',
 			'web.backups.targetEditor.s3.endpointHint' => 'Host (no protocol). AWS: s3.amazonaws.com · R2: <accountid>.r2.cloudflarestorage.com · MinIO: minio.local:9000',
@@ -18791,9 +18820,9 @@ extension on Translations {
 			'web.export.form.integrationOptions.noneHint' => 'Skip the integrations table entirely.',
 			'web.export.form.integrationOptions.metadata' => 'Metadata only (recommended)',
 			'web.export.form.integrationOptions.metadataHint' => 'ID, name, route prefix, scopes — no API key material.',
-			'web.export.form.integrationOptions.plaintext' => 'Include plaintext API keys',
 			_ => null,
 		} ?? switch (path) {
+			'web.export.form.integrationOptions.plaintext' => 'Include plaintext API keys',
 			'web.export.form.integrationOptions.plaintextHint' => 'v1 bcrypt-only: no recoverable plaintext exists. Manifest documents this; nothing leaks.',
 			'web.export.form.confirmWarning' => 'Type <1>I understand</1> to confirm. opendray currently stores only bcrypt hashes — selecting plaintext does NOT export any plaintext (the feature is reserved for a future release that keeps plaintext caches).',
 			'web.export.form.confirmPlaceholder' => 'I understand',
@@ -19217,10 +19246,10 @@ extension on Translations {
 			'sessions.terminal.snackbar.uploadFailedGeneric' => ({required Object error}) => 'Upload failed: ${error}',
 			'sessions.terminal.imageSource.photoLibrary' => 'Photo library',
 			'sessions.terminal.imageSource.takePhoto' => 'Take a photo',
-			'sessions.terminal.keyboard.copyBuffer' => 'Copy buffer',
 			'sessions.terminal.keyboard.paste' => 'Paste',
 			'sessions.terminal.keyboard.attachImage' => 'Attach image',
 			'sessions.terminal.keyboard.enter' => 'Enter',
+			'sessions.terminal.keyboard.selectText' => 'Select text',
 			'sessions.terminal.connection.connecting' => 'Connecting…',
 			'sessions.terminal.connection.connected' => 'Connected',
 			'sessions.terminal.connection.reconnecting' => 'Reconnecting…',
@@ -19228,6 +19257,11 @@ extension on Translations {
 			'sessions.terminal.connection.disconnected' => 'Disconnected',
 			'sessions.terminal.connection.disconnectedWithError' => ({required Object error}) => 'Disconnected (${error})',
 			'sessions.terminal.connection.ended' => 'Session ended',
+			'sessions.terminal.selectCopy.title' => 'Select & copy',
+			'sessions.terminal.selectCopy.hint' => 'Long-press to select any part of the output, then copy it.',
+			'sessions.terminal.selectCopy.copyAll' => 'Copy all',
+			'sessions.terminal.selectCopy.copiedAll' => ({required Object count}) => 'Copied all output (${count} chars)',
+			'sessions.terminal.selectCopy.empty' => 'No output to copy yet',
 			'sessions.action.stop' => 'Stop',
 			'sessions.action.stopping' => 'Stopping…',
 			'sessions.action.stopDescription' => 'Send SIGTERM, retain history',
@@ -19300,14 +19334,14 @@ extension on Translations {
 			'sessions.inspector.notes.insertAtRefTooltip' => 'Insert as @reference',
 			'sessions.inspector.notes.insertAtRefShort' => 'Insert @reference',
 			'sessions.inspector.notes.draftHint' => ({required Object project}) => '# ${project}\n\nThoughts, todos, context for the agent…',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.notes.createFailed' => ({required Object error}) => 'Create failed: ${error}',
 			'sessions.inspector.notes.saveFailed' => ({required Object error}) => 'Save failed: ${error}',
 			'sessions.inspector.notes.changeLocationTooltip' => 'Change project docs location',
 			'sessions.inspector.notes.filenameHint' => 'filename (e.g. spec or design.md)',
 			'sessions.inspector.notes.create' => 'Create',
 			'sessions.inspector.notes.filterHint' => 'Filter…',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.locationDialogTitle' => 'Project docs location',
 			'sessions.inspector.notes.loadFailedApi' => ({required Object error}) => 'Load failed: ${error}',
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => 'Load failed: ${error}',
@@ -19814,14 +19848,14 @@ extension on Translations {
 			'backups.encryption.passphraseLabel' => 'Your passphrase',
 			'backups.encryption.passphraseHint' => 'At least 20 characters',
 			'backups.encryption.passphraseCopied' => 'Passphrase copied to clipboard',
+			_ => null,
+		} ?? switch (path) {
 			'backups.restoreFromFile' => 'Restore from file',
 			'backups.restore.title' => 'Restore from bundle',
 			'backups.restore.subtitle' => 'Replay an encrypted .tar.gz.enc bundle into a Postgres database. The bundle is uploaded from this phone — pick a file produced by a prior backup.',
 			'backups.restore.bundleLabel' => 'Bundle file (.tar.gz.enc)',
 			'backups.restore.pickFile' => 'Pick file',
 			'backups.restore.fileSelected' => ({required Object name, required Object size}) => '${name} · ${size}',
-			_ => null,
-		} ?? switch (path) {
 			'backups.restore.noFile' => 'No file selected',
 			'backups.restore.targetDsnLabel' => 'Target Postgres DSN',
 			'backups.restore.targetDsnHint' => 'Leave empty to restore into opendray\'s own DB.',
@@ -20328,14 +20362,14 @@ extension on Translations {
 			'memory.status.floorNoModel' => 'Keyword (BM25) retrieval only — no embedding model configured. Configure a dense endpoint in Settings to enable semantic memory.',
 			'memory.status.denseConfiguredPendingRestart' => ({required Object model}) => 'Configured ${model} (dense) — restart the gateway to activate semantic memory and re-embed existing memories.',
 			'memory.status.denseUnreachableFloor' => ({required Object model}) => 'Configured ${model} (dense) but the endpoint is unreachable — using the keyword floor until it responds (auto-upgrades on restart).',
+			_ => null,
+		} ?? switch (path) {
 			'memory.status.denseDegraded' => 'Dense embedder active but its endpoint is unreachable right now — existing vectors are preserved; new writes and similarity search pause until it responds.',
 			'memory.title' => 'Memory',
 			'memory.more' => 'More',
 			'memory.workers' => 'Memory workers',
 			'memory.rank.title' => 'Rank breakdown',
 			'memory.rank.effective' => ({required Object value}) => 'Effective score: ${value}',
-			_ => null,
-		} ?? switch (path) {
 			'memory.rank.similarity' => 'Cosine similarity',
 			'memory.rank.ageMultiplier' => ({required Object days}) => 'Age multiplier (${days}d old)',
 			'memory.rank.hitMultiplier' => ({required Object hits}) => 'Hit-count multiplier (${hits} hits)',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -1842,6 +1842,7 @@ class _TranslationsSessionsTerminalEs extends TranslationsSessionsTerminalEn {
 	@override late final _TranslationsSessionsTerminalImageSourceEs imageSource = _TranslationsSessionsTerminalImageSourceEs._(_root);
 	@override late final _TranslationsSessionsTerminalKeyboardEs keyboard = _TranslationsSessionsTerminalKeyboardEs._(_root);
 	@override late final _TranslationsSessionsTerminalConnectionEs connection = _TranslationsSessionsTerminalConnectionEs._(_root);
+	@override late final _TranslationsSessionsTerminalSelectCopyEs selectCopy = _TranslationsSessionsTerminalSelectCopyEs._(_root);
 }
 
 // Path: sessions.action
@@ -3099,8 +3100,6 @@ class _TranslationsWebSessionsHeaderEs extends TranslationsWebSessionsHeaderEn {
 	@override String get hideInspector => 'Ocultar inspector';
 	@override String get attachImage => 'Adjuntar imagen';
 	@override String get attachImageTooltip => 'Adjuntar imagen (o pega / suelta en el terminal)';
-	@override String get copyOutput => 'Copiar salida';
-	@override String get copyOutputTooltip => 'Copia la salida del terminal (la selección si hay alguna, si no, todo)';
 	@override String get restart => 'Reiniciar';
 	@override String get restarting => 'Reiniciando…';
 	@override String get remove => 'Eliminar';
@@ -3108,6 +3107,8 @@ class _TranslationsWebSessionsHeaderEs extends TranslationsWebSessionsHeaderEn {
 	@override String get stop => 'Detener';
 	@override String get stopping => 'Deteniendo…';
 	@override String pid({required Object pid}) => 'pid ${pid}';
+	@override String get selectText => 'Seleccionar y copiar';
+	@override String get selectTextTooltip => 'Abre una vista de texto seleccionable para copiar cualquier parte de la salida';
 }
 
 // Path: web.sessions.terminal
@@ -3122,14 +3123,15 @@ class _TranslationsWebSessionsTerminalEs extends TranslationsWebSessionsTerminal
 	@override String get uploadFailedToast => 'Error al subir';
 	@override String get uploadInvalidTypeToast => 'Solo se pueden adjuntar archivos de imagen';
 	@override String get dropToAttach => 'Suelta la imagen para adjuntarla';
-	@override String get copyButton => 'Copiar';
-	@override String get copyAllTooltip => 'Copia la salida del terminal al portapapeles (la selección si hay alguna, si no, todo)';
-	@override String get copySelection => 'Copiar';
-	@override String get copySelectionTooltip => 'Copiar el texto seleccionado';
 	@override String get copiedToast => 'Copiado al portapapeles';
-	@override String get copyEmptyToast => 'Aún no hay nada que copiar';
 	@override String get copyFailedToast => 'No se pudo copiar al portapapeles';
 	@override late final _TranslationsWebSessionsTerminalUrlsEs urls = _TranslationsWebSessionsTerminalUrlsEs._(_root);
+	@override String get selectCopyTitle => 'Seleccionar y copiar';
+	@override String get selectCopyDesc => 'Arrastra (o mantén pulsado en pantalla táctil) para seleccionar cualquier parte de la salida y cópiala.';
+	@override String get selectCopyCopySelection => 'Copiar selección';
+	@override String get selectCopyCopyAll => 'Copiar todo';
+	@override String get selectCopyNoSelection => 'Selecciona primero algún texto';
+	@override String get selectCopyEmpty => 'Aún no hay salida que copiar';
 }
 
 // Path: web.sessions.spawn
@@ -6026,10 +6028,10 @@ class _TranslationsSessionsTerminalKeyboardEs extends TranslationsSessionsTermin
 	final TranslationsEs _root; // ignore: unused_field
 
 	// Translations
-	@override String get copyBuffer => 'Copiar búfer';
 	@override String get paste => 'Pegar';
 	@override String get attachImage => 'Adjuntar imagen';
 	@override String get enter => 'Intro';
+	@override String get selectText => 'Seleccionar texto';
 }
 
 // Path: sessions.terminal.connection
@@ -6046,6 +6048,20 @@ class _TranslationsSessionsTerminalConnectionEs extends TranslationsSessionsTerm
 	@override String get disconnected => 'Desconectado';
 	@override String disconnectedWithError({required Object error}) => 'Desconectado (${error})';
 	@override String get ended => 'Sesión finalizada';
+}
+
+// Path: sessions.terminal.selectCopy
+class _TranslationsSessionsTerminalSelectCopyEs extends TranslationsSessionsTerminalSelectCopyEn {
+	_TranslationsSessionsTerminalSelectCopyEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Seleccionar y copiar';
+	@override String get hint => 'Mantén pulsado para seleccionar cualquier parte de la salida y cópiala.';
+	@override String get copyAll => 'Copiar todo';
+	@override String copiedAll({required Object count}) => 'Salida copiada (${count} caracteres)';
+	@override String get empty => 'Aún no hay salida que copiar';
 }
 
 // Path: sessions.action.errors
@@ -9023,8 +9039,6 @@ extension on TranslationsEs {
 			'web.sessions.header.hideInspector' => 'Ocultar inspector',
 			'web.sessions.header.attachImage' => 'Adjuntar imagen',
 			'web.sessions.header.attachImageTooltip' => 'Adjuntar imagen (o pega / suelta en el terminal)',
-			'web.sessions.header.copyOutput' => 'Copiar salida',
-			'web.sessions.header.copyOutputTooltip' => 'Copia la salida del terminal (la selección si hay alguna, si no, todo)',
 			'web.sessions.header.restart' => 'Reiniciar',
 			'web.sessions.header.restarting' => 'Reiniciando…',
 			'web.sessions.header.remove' => 'Eliminar',
@@ -9032,17 +9046,14 @@ extension on TranslationsEs {
 			'web.sessions.header.stop' => 'Detener',
 			'web.sessions.header.stopping' => 'Deteniendo…',
 			'web.sessions.header.pid' => ({required Object pid}) => 'pid ${pid}',
+			'web.sessions.header.selectText' => 'Seleccionar y copiar',
+			'web.sessions.header.selectTextTooltip' => 'Abre una vista de texto seleccionable para copiar cualquier parte de la salida',
 			'web.sessions.terminal.uploadingToast' => 'Subiendo imagen…',
 			'web.sessions.terminal.uploadedToast' => 'Imagen adjuntada',
 			'web.sessions.terminal.uploadFailedToast' => 'Error al subir',
 			'web.sessions.terminal.uploadInvalidTypeToast' => 'Solo se pueden adjuntar archivos de imagen',
 			'web.sessions.terminal.dropToAttach' => 'Suelta la imagen para adjuntarla',
-			'web.sessions.terminal.copyButton' => 'Copiar',
-			'web.sessions.terminal.copyAllTooltip' => 'Copia la salida del terminal al portapapeles (la selección si hay alguna, si no, todo)',
-			'web.sessions.terminal.copySelection' => 'Copiar',
-			'web.sessions.terminal.copySelectionTooltip' => 'Copiar el texto seleccionado',
 			'web.sessions.terminal.copiedToast' => 'Copiado al portapapeles',
-			'web.sessions.terminal.copyEmptyToast' => 'Aún no hay nada que copiar',
 			'web.sessions.terminal.copyFailedToast' => 'No se pudo copiar al portapapeles',
 			'web.sessions.terminal.urls.tooltip' => 'Abre el último enlace detectado en esta session',
 			'web.sessions.terminal.urls.tapToOpenLatest' => 'Toca para abrir el último enlace (la URL de OAuth más reciente)',
@@ -9056,6 +9067,12 @@ extension on TranslationsEs {
 			'web.sessions.terminal.urls.copiedToast' => 'URL copiada',
 			'web.sessions.terminal.urls.copyFailedToast' => 'No se pudo copiar. Mantén pulsada la URL y cópiala manualmente',
 			'web.sessions.terminal.urls.noneHint' => 'Aún no se han detectado enlaces.',
+			'web.sessions.terminal.selectCopyTitle' => 'Seleccionar y copiar',
+			'web.sessions.terminal.selectCopyDesc' => 'Arrastra (o mantén pulsado en pantalla táctil) para seleccionar cualquier parte de la salida y cópiala.',
+			'web.sessions.terminal.selectCopyCopySelection' => 'Copiar selección',
+			'web.sessions.terminal.selectCopyCopyAll' => 'Copiar todo',
+			'web.sessions.terminal.selectCopyNoSelection' => 'Selecciona primero algún texto',
+			'web.sessions.terminal.selectCopyEmpty' => 'Aún no hay salida que copiar',
 			'web.sessions.spawn.title' => 'Crear session',
 			'web.sessions.spawn.description' => 'Inicia una session de la CLI con un proveedor registrado.',
 			'web.sessions.spawn.provider' => 'Proveedor',
@@ -9431,9 +9448,9 @@ extension on TranslationsEs {
 			'web.project.archived.archivedAtPrefix' => 'Archivado',
 			'web.project.archived.restoreButton' => 'Restaurar',
 			'web.project.archived.restoredToast' => 'Restaurado',
-			'web.project.archived.restoreFailedToast' => 'Error al restaurar',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.archived.restoreFailedToast' => 'Error al restaurar',
 			'web.project.reset.button' => 'Restablecer',
 			'web.project.reset.dialogTitle' => '¿Restablecer la memoria del proyecto?',
 			'web.project.reset.dialogDescription' => 'Elimina todo el contexto de proyecto almacenado para este cwd. Esto no se puede deshacer.',
@@ -9945,9 +9962,9 @@ extension on TranslationsEs {
 			'web.channels.notifications.modes.everyHint' => 'Sin supresión. Úsalo solo para canales de baja frecuencia.',
 			'web.channels.notifications.cooldowns.k60' => '1 minuto',
 			'web.channels.notifications.cooldowns.k300' => '5 minutos',
-			'web.channels.notifications.cooldowns.k900' => '15 minutos',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.notifications.cooldowns.k900' => '15 minutos',
 			'web.channels.notifications.cooldowns.k1800' => '30 minutos',
 			'web.channels.notifications.cooldowns.k3600' => '1 hora',
 			'web.channels.notifications.snippetCaps.k0' => 'Sin límite, dividir en varios mensajes (predeterminado)',
@@ -10459,9 +10476,9 @@ extension on TranslationsEs {
 			'web.backups.targetEditor.smb.userLabel' => 'Usuario',
 			'web.backups.targetEditor.smb.passwordLabel' => 'Contraseña',
 			'web.backups.targetEditor.smb.pathPrefixLabel' => 'Prefijo de ruta',
-			'web.backups.targetEditor.smb.pathPrefixHint' => 'Subcarpeta bajo la raíz del recurso compartido (opcional)',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.targetEditor.smb.pathPrefixHint' => 'Subcarpeta bajo la raíz del recurso compartido (opcional)',
 			'web.backups.targetEditor.smb.pathPrefixPlaceholder' => 'opendray/backups',
 			'web.backups.targetEditor.s3.endpointLabel' => 'Endpoint',
 			'web.backups.targetEditor.s3.endpointHint' => 'Host (sin protocolo). AWS: s3.amazonaws.com · R2: <accountid>.r2.cloudflarestorage.com · MinIO: minio.local:9000',
@@ -10973,9 +10990,9 @@ extension on TranslationsEs {
 			'web.export.form.integrationOptions.noneHint' => 'Omitir por completo la tabla de integraciones.',
 			'web.export.form.integrationOptions.metadata' => 'Solo metadatos (recomendado)',
 			'web.export.form.integrationOptions.metadataHint' => 'ID, nombre, prefijo de ruta, alcances. Sin material de API key.',
-			'web.export.form.integrationOptions.plaintext' => 'Incluir las API keys en texto plano',
 			_ => null,
 		} ?? switch (path) {
+			'web.export.form.integrationOptions.plaintext' => 'Incluir las API keys en texto plano',
 			'web.export.form.integrationOptions.plaintextHint' => 'v1 solo con bcrypt: no existe texto plano recuperable. El manifiesto lo documenta; no se filtra nada.',
 			'web.export.form.confirmWarning' => 'Escribe <1>Lo entiendo</1> para confirmar. opendray actualmente almacena solo hashes bcrypt, así que seleccionar texto plano NO exporta ningún texto plano (la función está reservada para una versión futura que mantenga cachés de texto plano).',
 			'web.export.form.confirmPlaceholder' => 'Lo entiendo',
@@ -11399,10 +11416,10 @@ extension on TranslationsEs {
 			'sessions.terminal.snackbar.uploadFailedGeneric' => ({required Object error}) => 'Falló la subida: ${error}',
 			'sessions.terminal.imageSource.photoLibrary' => 'Biblioteca de fotos',
 			'sessions.terminal.imageSource.takePhoto' => 'Tomar una foto',
-			'sessions.terminal.keyboard.copyBuffer' => 'Copiar búfer',
 			'sessions.terminal.keyboard.paste' => 'Pegar',
 			'sessions.terminal.keyboard.attachImage' => 'Adjuntar imagen',
 			'sessions.terminal.keyboard.enter' => 'Intro',
+			'sessions.terminal.keyboard.selectText' => 'Seleccionar texto',
 			'sessions.terminal.connection.connecting' => 'Conectando…',
 			'sessions.terminal.connection.connected' => 'Conectado',
 			'sessions.terminal.connection.reconnecting' => 'Reconectando…',
@@ -11410,6 +11427,11 @@ extension on TranslationsEs {
 			'sessions.terminal.connection.disconnected' => 'Desconectado',
 			'sessions.terminal.connection.disconnectedWithError' => ({required Object error}) => 'Desconectado (${error})',
 			'sessions.terminal.connection.ended' => 'Sesión finalizada',
+			'sessions.terminal.selectCopy.title' => 'Seleccionar y copiar',
+			'sessions.terminal.selectCopy.hint' => 'Mantén pulsado para seleccionar cualquier parte de la salida y cópiala.',
+			'sessions.terminal.selectCopy.copyAll' => 'Copiar todo',
+			'sessions.terminal.selectCopy.copiedAll' => ({required Object count}) => 'Salida copiada (${count} caracteres)',
+			'sessions.terminal.selectCopy.empty' => 'Aún no hay salida que copiar',
 			'sessions.action.stop' => 'Detener',
 			'sessions.action.stopping' => 'Deteniendo…',
 			'sessions.action.stopDescription' => 'Envía SIGTERM, conserva el historial',
@@ -11482,14 +11504,14 @@ extension on TranslationsEs {
 			'sessions.inspector.notes.insertAtRefTooltip' => 'Insertar como @referencia',
 			'sessions.inspector.notes.insertAtRefShort' => 'Insertar @referencia',
 			'sessions.inspector.notes.draftHint' => ({required Object project}) => '# ${project}\n\nIdeas, tareas pendientes, contexto para el agente…',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.notes.createFailed' => ({required Object error}) => 'Falló al crear: ${error}',
 			'sessions.inspector.notes.saveFailed' => ({required Object error}) => 'Falló al guardar: ${error}',
 			'sessions.inspector.notes.changeLocationTooltip' => 'Cambiar la ubicación de los documentos del proyecto',
 			'sessions.inspector.notes.filenameHint' => 'nombre de archivo (p. ej. spec o design.md)',
 			'sessions.inspector.notes.create' => 'Crear',
 			'sessions.inspector.notes.filterHint' => 'Filtrar…',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.locationDialogTitle' => 'Ubicación de los documentos del proyecto',
 			'sessions.inspector.notes.loadFailedApi' => ({required Object error}) => 'Falló la carga: ${error}',
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => 'Falló la carga: ${error}',
@@ -11996,14 +12018,14 @@ extension on TranslationsEs {
 			'backups.encryption.passphraseLabel' => 'Tu passphrase',
 			'backups.encryption.passphraseHint' => 'Al menos 20 caracteres',
 			'backups.encryption.passphraseCopied' => 'Passphrase copiada al portapapeles',
+			_ => null,
+		} ?? switch (path) {
 			'backups.restoreFromFile' => 'Restaurar desde archivo',
 			'backups.restore.title' => 'Restaurar desde paquete',
 			'backups.restore.subtitle' => 'Reproduce un paquete cifrado .tar.gz.enc en una base de datos Postgres. El paquete se sube desde este teléfono: elige un archivo generado por una copia de seguridad anterior.',
 			'backups.restore.bundleLabel' => 'Archivo de paquete (.tar.gz.enc)',
 			'backups.restore.pickFile' => 'Elegir archivo',
 			'backups.restore.fileSelected' => ({required Object name, required Object size}) => '${name} · ${size}',
-			_ => null,
-		} ?? switch (path) {
 			'backups.restore.noFile' => 'Ningún archivo seleccionado',
 			'backups.restore.targetDsnLabel' => 'DSN de Postgres de destino',
 			'backups.restore.targetDsnHint' => 'Déjalo vacío para restaurar en la propia base de datos de opendray.',
@@ -12510,14 +12532,14 @@ extension on TranslationsEs {
 			'memory.status.floorNoModel' => 'Solo recuperación por palabras clave (BM25) — no hay modelo de embedding configurado. Configura un endpoint denso en Settings para habilitar la memoria semántica.',
 			'memory.status.denseConfiguredPendingRestart' => ({required Object model}) => 'Configurado ${model} (denso) — reinicia el gateway para activar la memoria semántica y re-embeber las memorias existentes.',
 			'memory.status.denseUnreachableFloor' => ({required Object model}) => 'Configurado ${model} (denso) pero el endpoint está inalcanzable — se usa el piso de palabras clave hasta que responda (se actualiza al reiniciar).',
+			_ => null,
+		} ?? switch (path) {
 			'memory.status.denseDegraded' => 'Embedder denso activo pero su endpoint está inalcanzable ahora — los vectores existentes se conservan; las nuevas escrituras y la búsqueda por similitud se pausan hasta que responda.',
 			'memory.title' => 'Memoria',
 			'memory.more' => 'Más',
 			'memory.workers' => 'Workers de memoria',
 			'memory.rank.title' => 'Desglose del ranking',
 			'memory.rank.effective' => ({required Object value}) => 'Puntuación efectiva: ${value}',
-			_ => null,
-		} ?? switch (path) {
 			'memory.rank.similarity' => 'Similitud del coseno',
 			'memory.rank.ageMultiplier' => ({required Object days}) => 'Multiplicador por antigüedad (${days}d de antigüedad)',
 			'memory.rank.hitMultiplier' => ({required Object hits}) => 'Multiplicador por número de hits (${hits} hits)',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -1842,6 +1842,7 @@ class _TranslationsSessionsTerminalZh extends TranslationsSessionsTerminalEn {
 	@override late final _TranslationsSessionsTerminalImageSourceZh imageSource = _TranslationsSessionsTerminalImageSourceZh._(_root);
 	@override late final _TranslationsSessionsTerminalKeyboardZh keyboard = _TranslationsSessionsTerminalKeyboardZh._(_root);
 	@override late final _TranslationsSessionsTerminalConnectionZh connection = _TranslationsSessionsTerminalConnectionZh._(_root);
+	@override late final _TranslationsSessionsTerminalSelectCopyZh selectCopy = _TranslationsSessionsTerminalSelectCopyZh._(_root);
 }
 
 // Path: sessions.action
@@ -3099,8 +3100,6 @@ class _TranslationsWebSessionsHeaderZh extends TranslationsWebSessionsHeaderEn {
 	@override String get hideInspector => '隐藏检查器';
 	@override String get attachImage => '附加图片';
 	@override String get attachImageTooltip => '附加图片（或直接粘贴 / 拖入终端）';
-	@override String get copyOutput => '复制输出';
-	@override String get copyOutputTooltip => '复制终端输出（若有选区则复制选区，否则复制全部）';
 	@override String get restart => '重启';
 	@override String get restarting => '重启中…';
 	@override String get remove => '移除';
@@ -3108,6 +3107,8 @@ class _TranslationsWebSessionsHeaderZh extends TranslationsWebSessionsHeaderEn {
 	@override String get stop => '停止';
 	@override String get stopping => '停止中…';
 	@override String pid({required Object pid}) => 'pid ${pid}';
+	@override String get selectText => '选择并复制';
+	@override String get selectTextTooltip => '打开可选择文本视图,复制输出中的任意部分';
 }
 
 // Path: web.sessions.terminal
@@ -3122,14 +3123,15 @@ class _TranslationsWebSessionsTerminalZh extends TranslationsWebSessionsTerminal
 	@override String get uploadFailedToast => '上传失败';
 	@override String get uploadInvalidTypeToast => '仅支持图片文件';
 	@override String get dropToAttach => '释放以附加图片';
-	@override String get copyButton => '复制';
-	@override String get copyAllTooltip => '复制终端输出到剪贴板(若有选区则复制选区,否则复制全部)';
-	@override String get copySelection => '复制';
-	@override String get copySelectionTooltip => '复制选中的文本';
 	@override String get copiedToast => '已复制到剪贴板';
-	@override String get copyEmptyToast => '暂无可复制内容';
 	@override String get copyFailedToast => '无法复制到剪贴板';
 	@override late final _TranslationsWebSessionsTerminalUrlsZh urls = _TranslationsWebSessionsTerminalUrlsZh._(_root);
+	@override String get selectCopyTitle => '选择并复制';
+	@override String get selectCopyDesc => '拖动(触屏长按)选择输出中的任意部分,然后复制。';
+	@override String get selectCopyCopySelection => '复制选中';
+	@override String get selectCopyCopyAll => '全部复制';
+	@override String get selectCopyNoSelection => '请先选择文本';
+	@override String get selectCopyEmpty => '暂无可复制的输出';
 }
 
 // Path: web.sessions.spawn
@@ -6026,10 +6028,10 @@ class _TranslationsSessionsTerminalKeyboardZh extends TranslationsSessionsTermin
 	final TranslationsZh _root; // ignore: unused_field
 
 	// Translations
-	@override String get copyBuffer => '复制缓冲';
 	@override String get paste => '粘贴';
 	@override String get attachImage => '附加图片';
 	@override String get enter => '回车';
+	@override String get selectText => '选择文本';
 }
 
 // Path: sessions.terminal.connection
@@ -6046,6 +6048,20 @@ class _TranslationsSessionsTerminalConnectionZh extends TranslationsSessionsTerm
 	@override String get disconnected => '已断开';
 	@override String disconnectedWithError({required Object error}) => '已断开（${error}）';
 	@override String get ended => '会话已结束';
+}
+
+// Path: sessions.terminal.selectCopy
+class _TranslationsSessionsTerminalSelectCopyZh extends TranslationsSessionsTerminalSelectCopyEn {
+	_TranslationsSessionsTerminalSelectCopyZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '选择并复制';
+	@override String get hint => '长按选择输出中的任意部分,然后复制。';
+	@override String get copyAll => '全部复制';
+	@override String copiedAll({required Object count}) => '已复制全部输出(${count} 个字符)';
+	@override String get empty => '暂无可复制的输出';
 }
 
 // Path: sessions.action.errors
@@ -9023,8 +9039,6 @@ extension on TranslationsZh {
 			'web.sessions.header.hideInspector' => '隐藏检查器',
 			'web.sessions.header.attachImage' => '附加图片',
 			'web.sessions.header.attachImageTooltip' => '附加图片（或直接粘贴 / 拖入终端）',
-			'web.sessions.header.copyOutput' => '复制输出',
-			'web.sessions.header.copyOutputTooltip' => '复制终端输出（若有选区则复制选区，否则复制全部）',
 			'web.sessions.header.restart' => '重启',
 			'web.sessions.header.restarting' => '重启中…',
 			'web.sessions.header.remove' => '移除',
@@ -9032,17 +9046,14 @@ extension on TranslationsZh {
 			'web.sessions.header.stop' => '停止',
 			'web.sessions.header.stopping' => '停止中…',
 			'web.sessions.header.pid' => ({required Object pid}) => 'pid ${pid}',
+			'web.sessions.header.selectText' => '选择并复制',
+			'web.sessions.header.selectTextTooltip' => '打开可选择文本视图,复制输出中的任意部分',
 			'web.sessions.terminal.uploadingToast' => '正在上传图片…',
 			'web.sessions.terminal.uploadedToast' => '图片已附加',
 			'web.sessions.terminal.uploadFailedToast' => '上传失败',
 			'web.sessions.terminal.uploadInvalidTypeToast' => '仅支持图片文件',
 			'web.sessions.terminal.dropToAttach' => '释放以附加图片',
-			'web.sessions.terminal.copyButton' => '复制',
-			'web.sessions.terminal.copyAllTooltip' => '复制终端输出到剪贴板(若有选区则复制选区,否则复制全部)',
-			'web.sessions.terminal.copySelection' => '复制',
-			'web.sessions.terminal.copySelectionTooltip' => '复制选中的文本',
 			'web.sessions.terminal.copiedToast' => '已复制到剪贴板',
-			'web.sessions.terminal.copyEmptyToast' => '暂无可复制内容',
 			'web.sessions.terminal.copyFailedToast' => '无法复制到剪贴板',
 			'web.sessions.terminal.urls.tooltip' => '打开本会话最新检测到的链接',
 			'web.sessions.terminal.urls.tapToOpenLatest' => '点击打开最新链接(通常是 OAuth URL)',
@@ -9056,6 +9067,12 @@ extension on TranslationsZh {
 			'web.sessions.terminal.urls.copiedToast' => '链接已复制',
 			'web.sessions.terminal.urls.copyFailedToast' => '复制失败 —— 请长按链接手动复制',
 			'web.sessions.terminal.urls.noneHint' => '暂未检测到链接。',
+			'web.sessions.terminal.selectCopyTitle' => '选择并复制',
+			'web.sessions.terminal.selectCopyDesc' => '拖动(触屏长按)选择输出中的任意部分,然后复制。',
+			'web.sessions.terminal.selectCopyCopySelection' => '复制选中',
+			'web.sessions.terminal.selectCopyCopyAll' => '全部复制',
+			'web.sessions.terminal.selectCopyNoSelection' => '请先选择文本',
+			'web.sessions.terminal.selectCopyEmpty' => '暂无可复制的输出',
 			'web.sessions.spawn.title' => '创建会话',
 			'web.sessions.spawn.description' => '在已注册的 Provider 下启动一个 CLI 会话。',
 			'web.sessions.spawn.provider' => 'Provider',
@@ -9431,9 +9448,9 @@ extension on TranslationsZh {
 			'web.project.archived.archivedAtPrefix' => '归档于',
 			'web.project.archived.restoreButton' => '恢复',
 			'web.project.archived.restoredToast' => '已恢复',
-			'web.project.archived.restoreFailedToast' => '恢复失败',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.archived.restoreFailedToast' => '恢复失败',
 			'web.project.reset.button' => '重置',
 			'web.project.reset.dialogTitle' => '重置项目记忆?',
 			'web.project.reset.dialogDescription' => '删除该 cwd 下存储的所有项目上下文。不可撤销。',
@@ -9945,9 +9962,9 @@ extension on TranslationsZh {
 			'web.channels.notifications.modes.everyHint' => '不做抑制。仅用于低频频道。',
 			'web.channels.notifications.cooldowns.k60' => '1 分钟',
 			'web.channels.notifications.cooldowns.k300' => '5 分钟',
-			'web.channels.notifications.cooldowns.k900' => '15 分钟',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.notifications.cooldowns.k900' => '15 分钟',
 			'web.channels.notifications.cooldowns.k1800' => '30 分钟',
 			'web.channels.notifications.cooldowns.k3600' => '1 小时',
 			'web.channels.notifications.snippetCaps.k0' => '不限制 — 拆分到多条消息（默认）',
@@ -10459,9 +10476,9 @@ extension on TranslationsZh {
 			'web.backups.targetEditor.smb.userLabel' => '用户',
 			'web.backups.targetEditor.smb.passwordLabel' => '密码',
 			'web.backups.targetEditor.smb.pathPrefixLabel' => '路径前缀',
-			'web.backups.targetEditor.smb.pathPrefixHint' => '共享根下的子文件夹（可选）',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.targetEditor.smb.pathPrefixHint' => '共享根下的子文件夹（可选）',
 			'web.backups.targetEditor.smb.pathPrefixPlaceholder' => 'opendray/backups',
 			'web.backups.targetEditor.s3.endpointLabel' => 'Endpoint',
 			'web.backups.targetEditor.s3.endpointHint' => '主机（不要带协议）。AWS: s3.amazonaws.com · R2: <accountid>.r2.cloudflarestorage.com · MinIO: minio.local:9000',
@@ -10973,9 +10990,9 @@ extension on TranslationsZh {
 			'web.export.form.integrationOptions.noneHint' => '完全跳过 integrations 表。',
 			'web.export.form.integrationOptions.metadata' => '仅元数据（推荐）',
 			'web.export.form.integrationOptions.metadataHint' => 'ID、name、route prefix、scopes — 不包含任何 API key 凭证。',
-			'web.export.form.integrationOptions.plaintext' => '包含明文 API key',
 			_ => null,
 		} ?? switch (path) {
+			'web.export.form.integrationOptions.plaintext' => '包含明文 API key',
 			'web.export.form.integrationOptions.plaintextHint' => 'v1 仅 bcrypt：不存在可恢复的明文。Manifest 会记录此事实；不会泄露任何内容。',
 			'web.export.form.confirmWarning' => '输入 <1>I understand</1> 以确认。opendray 当前只存 bcrypt 哈希 — 选择明文也不会导出任何明文（该选项为将来保留明文缓存的版本而预留）。',
 			'web.export.form.confirmPlaceholder' => 'I understand',
@@ -11399,10 +11416,10 @@ extension on TranslationsZh {
 			'sessions.terminal.snackbar.uploadFailedGeneric' => ({required Object error}) => '上传失败：${error}',
 			'sessions.terminal.imageSource.photoLibrary' => '相册',
 			'sessions.terminal.imageSource.takePhoto' => '拍照',
-			'sessions.terminal.keyboard.copyBuffer' => '复制缓冲',
 			'sessions.terminal.keyboard.paste' => '粘贴',
 			'sessions.terminal.keyboard.attachImage' => '附加图片',
 			'sessions.terminal.keyboard.enter' => '回车',
+			'sessions.terminal.keyboard.selectText' => '选择文本',
 			'sessions.terminal.connection.connecting' => '连接中…',
 			'sessions.terminal.connection.connected' => '已连接',
 			'sessions.terminal.connection.reconnecting' => '重连中…',
@@ -11410,6 +11427,11 @@ extension on TranslationsZh {
 			'sessions.terminal.connection.disconnected' => '已断开',
 			'sessions.terminal.connection.disconnectedWithError' => ({required Object error}) => '已断开（${error}）',
 			'sessions.terminal.connection.ended' => '会话已结束',
+			'sessions.terminal.selectCopy.title' => '选择并复制',
+			'sessions.terminal.selectCopy.hint' => '长按选择输出中的任意部分,然后复制。',
+			'sessions.terminal.selectCopy.copyAll' => '全部复制',
+			'sessions.terminal.selectCopy.copiedAll' => ({required Object count}) => '已复制全部输出(${count} 个字符)',
+			'sessions.terminal.selectCopy.empty' => '暂无可复制的输出',
 			'sessions.action.stop' => '停止',
 			'sessions.action.stopping' => '停止中…',
 			'sessions.action.stopDescription' => '发送 SIGTERM，保留历史',
@@ -11482,14 +11504,14 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.insertAtRefTooltip' => '作为 @引用 插入',
 			'sessions.inspector.notes.insertAtRefShort' => '插入 @引用',
 			'sessions.inspector.notes.draftHint' => ({required Object project}) => '# ${project}\n\n想法、待办、为 agent 提供的上下文…',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.notes.createFailed' => ({required Object error}) => '创建失败：${error}',
 			'sessions.inspector.notes.saveFailed' => ({required Object error}) => '保存失败：${error}',
 			'sessions.inspector.notes.changeLocationTooltip' => '更改项目文档位置',
 			'sessions.inspector.notes.filenameHint' => '文件名（例如：spec 或 design.md）',
 			'sessions.inspector.notes.create' => '创建',
 			'sessions.inspector.notes.filterHint' => '筛选…',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.locationDialogTitle' => '项目文档位置',
 			'sessions.inspector.notes.loadFailedApi' => ({required Object error}) => '加载失败：${error}',
 			'sessions.inspector.notes.loadFailedGeneric' => ({required Object error}) => '加载失败：${error}',
@@ -11996,14 +12018,14 @@ extension on TranslationsZh {
 			'backups.encryption.passphraseLabel' => '你的密语',
 			'backups.encryption.passphraseHint' => '至少 20 个字符',
 			'backups.encryption.passphraseCopied' => '密语已复制到剪贴板',
+			_ => null,
+		} ?? switch (path) {
 			'backups.restoreFromFile' => '从文件恢复',
 			'backups.restore.title' => '从备份包恢复',
 			'backups.restore.subtitle' => '将加密的 .tar.gz.enc 备份包重放到 Postgres 数据库。备份包将从本机上传 — 请选择此前生成的文件。',
 			'backups.restore.bundleLabel' => '备份文件（.tar.gz.enc）',
 			'backups.restore.pickFile' => '选择文件',
 			'backups.restore.fileSelected' => ({required Object name, required Object size}) => '${name} · ${size}',
-			_ => null,
-		} ?? switch (path) {
 			'backups.restore.noFile' => '未选择文件',
 			'backups.restore.targetDsnLabel' => '目标 Postgres DSN',
 			'backups.restore.targetDsnHint' => '留空表示恢复到 opendray 自身的数据库。',
@@ -12510,14 +12532,14 @@ extension on TranslationsZh {
 			'memory.status.floorNoModel' => '仅关键词（BM25）检索 — 未配置 embedding 模型。在 Settings 配置 dense 端点即可启用语义记忆。',
 			'memory.status.denseConfiguredPendingRestart' => ({required Object model}) => '已配置 ${model}（dense）— 重启网关即启用语义记忆并自动重嵌历史记忆。',
 			'memory.status.denseUnreachableFloor' => ({required Object model}) => '已配置 ${model}（dense）但端点当前不可达 — 暂用关键词 floor，端点恢复后重启会自动升级。',
+			_ => null,
+		} ?? switch (path) {
 			'memory.status.denseDegraded' => 'dense embedder 已激活，但其端点当前不可达 — 现有向量已保留；新写入与相似度检索暂停，直到端点恢复。',
 			'memory.title' => '记忆',
 			'memory.more' => '更多',
 			'memory.workers' => '记忆工作器',
 			'memory.rank.title' => '排名分解',
 			'memory.rank.effective' => ({required Object value}) => '有效分：${value}',
-			_ => null,
-		} ?? switch (path) {
 			'memory.rank.similarity' => '余弦相似度',
 			'memory.rank.ageMultiplier' => ({required Object days}) => '时效系数（${days} 天前）',
 			'memory.rank.hitMultiplier' => ({required Object hits}) => '命中系数（${hits} 次命中）',

--- a/app/mobile/lib/features/sessions/session_terminal_view.dart
+++ b/app/mobile/lib/features/sessions/session_terminal_view.dart
@@ -11,6 +11,7 @@ import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/sessions_api.dart';
 import 'package:opendray/core/auth/auth_state.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/sessions/terminal_select_sheet.dart';
 import 'package:opendray/features/sessions/url_extractor.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -463,27 +464,25 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
 
   void _sendKey(String text) => _onTerminalOutput(text);
 
-  // Copy the entire xterm buffer (scrollback + visible) to the
-  // system clipboard. Triggered from the keyboard helper bar.
-  Future<void> _copyBuffer() async {
-    final selection = _controller.selection;
-    final text = selection != null
-        ? _terminal.buffer.getText(selection)
-        : _terminal.buffer.getText();
-    if (text.isEmpty) return;
-    await Clipboard.setData(ClipboardData(text: text));
-    if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          selection != null
-              ? 'Selection copied (${text.length} chars)'
-              : 'Buffer copied (${text.length} chars)',
-        ),
-        duration: const Duration(seconds: 2),
-        behavior: SnackBarBehavior.floating,
-      ),
-    );
+  // Reconstruct the buffer as clean text: drop each line's trailing
+  // padding and the run of blank lines past the last printed row, so a
+  // freshly-started session doesn't copy a wall of empty rows. Shared
+  // by the keyboard-bar Copy and the "Select & copy" sheet.
+  String _cleanBufferText() {
+    final raw = _terminal.buffer.getText();
+    final lines = raw.split('\n').map((l) => l.trimRight()).toList();
+    var end = lines.length;
+    while (end > 0 && lines[end - 1].isEmpty) {
+      end--;
+    }
+    return lines.sublist(0, end).join('\n');
+  }
+
+  // Open the "Select & copy" sheet with the cleaned buffer rendered as
+  // SelectableText, so the operator can select any portion (a command,
+  // a URL) — the canvas terminal won't allow a partial selection.
+  Future<void> _openSelectSheet() async {
+    await showTerminalSelectSheet(context, _cleanBufferText());
   }
 
   // Read the system clipboard and feed the text into the terminal
@@ -685,7 +684,7 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
         ),
         _MobileKeyboardBar(
           onKey: _sendKey,
-          onCopy: _copyBuffer,
+          onSelectText: _openSelectSheet,
           onPaste: _pasteFromClipboard,
           onAttachImage: _attachImage,
         ),
@@ -796,13 +795,13 @@ class _StatusStrip extends StatelessWidget {
 class _MobileKeyboardBar extends StatefulWidget {
   const _MobileKeyboardBar({
     required this.onKey,
-    required this.onCopy,
+    required this.onSelectText,
     required this.onPaste,
     required this.onAttachImage,
   });
 
   final void Function(String) onKey;
-  final Future<void> Function() onCopy;
+  final Future<void> Function() onSelectText;
   final Future<void> Function() onPaste;
   final Future<void> Function() onAttachImage;
 
@@ -905,11 +904,11 @@ class _MobileKeyboardBarState extends State<_MobileKeyboardBar> {
               },
             ),
             _Key(
-              icon: Icons.content_copy,
-              tooltip: t.sessions.terminal.keyboard.copyBuffer,
+              icon: Icons.text_fields,
+              tooltip: t.sessions.terminal.keyboard.selectText,
               onTap: () {
                 _haptic();
-                unawaited(widget.onCopy());
+                unawaited(widget.onSelectText());
               },
             ),
             _Key(

--- a/app/mobile/lib/features/sessions/terminal_select_sheet.dart
+++ b/app/mobile/lib/features/sessions/terminal_select_sheet.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+
+// showTerminalSelectSheet presents the terminal output as native,
+// selectable text in a tall bottom sheet.
+//
+// The live terminal is a custom-painted xterm canvas: the OS selection
+// handles don't reliably appear over it, and while a TUI has mouse
+// tracking on (Claude Code / Codex / Gemini all do) a long-press is
+// forwarded to the program as a mouse event instead of starting a
+// selection. Rendering the buffer into a SelectableText sidesteps both
+// — long-press brings up the system selection handles, so the operator
+// can grab just a command or a URL and copy it, mirroring the web
+// "Select & copy" dialog.
+Future<void> showTerminalSelectSheet(
+  BuildContext context,
+  String text,
+) {
+  return showModalBottomSheet<void>(
+    context: context,
+    backgroundColor: const Color(0xFF1A1A1F),
+    isScrollControlled: true,
+    builder: (sheetCtx) {
+      final empty = text.trim().isEmpty;
+      return SafeArea(
+        child: FractionallySizedBox(
+          heightFactor: 0.85,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  t.sessions.terminal.selectCopy.title,
+                  style: const TextStyle(
+                    color: Color(0xFFE7E7EA),
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  t.sessions.terminal.selectCopy.hint,
+                  style: const TextStyle(
+                    color: Color(0xFF9999A0),
+                    fontSize: 12,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Expanded(
+                  child: Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(10),
+                    decoration: BoxDecoration(
+                      color: const Color(0xFF101012),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: empty
+                        ? Center(
+                            child: Text(
+                              t.sessions.terminal.selectCopy.empty,
+                              style: const TextStyle(
+                                color: Color(0xFF9999A0),
+                                fontSize: 12,
+                              ),
+                            ),
+                          )
+                        : SingleChildScrollView(
+                            child: SelectableText(
+                              text,
+                              style: const TextStyle(
+                                color: Color(0xFFE7E7EA),
+                                fontSize: 12,
+                                fontFamily: 'monospace',
+                                height: 1.35,
+                              ),
+                            ),
+                          ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(
+                      child: FilledButton.icon(
+                        icon: const Icon(Icons.copy_all, size: 16),
+                        label: Text(t.sessions.terminal.selectCopy.copyAll),
+                        onPressed: empty
+                            ? null
+                            : () async {
+                                await Clipboard.setData(
+                                  ClipboardData(text: text),
+                                );
+                                if (!sheetCtx.mounted) return;
+                                ScaffoldMessenger.of(sheetCtx).showSnackBar(
+                                  SnackBar(
+                                    content: Text(
+                                      t.sessions.terminal.selectCopy
+                                          .copiedAll(count: text.length),
+                                    ),
+                                    behavior: SnackBarBehavior.floating,
+                                    duration: const Duration(seconds: 2),
+                                  ),
+                                );
+                                Navigator.of(sheetCtx).pop();
+                              },
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed: () => Navigator.of(sheetCtx).pop(),
+                        child: Text(t.common.close),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    },
+  );
+}

--- a/app/mobile/pubspec.yaml
+++ b/app/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: opendray
 description: opendray mobile — multi-CLI gateway control
 publish_to: none
-version: 2.3.3+41
+version: 2.3.3+43
 
 environment:
   sdk: ^3.11.0

--- a/app/web/src/components/sessions/EndedSessionView.tsx
+++ b/app/web/src/components/sessions/EndedSessionView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
 import { Terminal as XTerm } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
@@ -6,9 +6,15 @@ import { useTranslation } from 'react-i18next'
 
 import { api } from '@/lib/api'
 import { useTheme } from '@/stores/theme'
+import { terminalBufferText } from './terminal-text'
 
 interface EndedSessionViewProps {
   sessionId: string
+}
+
+export interface EndedSessionHandle {
+  /** Full replayed buffer as clean plain text — feeds "Select & copy". */
+  getBufferText: () => string
 }
 
 function readVar(name: string): string {
@@ -49,13 +55,22 @@ function buildTheme(applied: 'light' | 'dark') {
  * session. No WebSocket — fixes the reconnect loop that happens when
  * the workbench tries to stream a process that has already exited.
  */
-export function EndedSessionView({ sessionId }: EndedSessionViewProps) {
+export const EndedSessionView = forwardRef<
+  EndedSessionHandle,
+  EndedSessionViewProps
+>(function EndedSessionView({ sessionId }, ref) {
   const { t } = useTranslation()
   const rootRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const xtermRef = useRef<XTerm | null>(null)
   const fitRef = useRef<FitAddon | null>(null)
   const themeApplied = useTheme((s) => s.applied())
+
+  useImperativeHandle(
+    ref,
+    () => ({ getBufferText: () => terminalBufferText(xtermRef.current) }),
+    [],
+  )
 
   useEffect(() => {
     if (!containerRef.current) return
@@ -147,4 +162,4 @@ export function EndedSessionView({ sessionId }: EndedSessionViewProps) {
       />
     </div>
   )
-}
+})

--- a/app/web/src/components/sessions/SelectCopyDialog.tsx
+++ b/app/web/src/components/sessions/SelectCopyDialog.tsx
@@ -1,0 +1,131 @@
+import { useRef } from 'react'
+import { Copy, CopyCheck, TextCursorInput } from 'lucide-react'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { copyText } from '@/lib/clipboard'
+
+interface SelectCopyDialogProps {
+  text: string
+  open: boolean
+  onOpenChange: (v: boolean) => void
+}
+
+// SelectCopyDialog renders the terminal output as native, selectable
+// DOM text. The live terminal is an xterm <canvas>: on touch devices a
+// finger drag can't select canvas text, and while a TUI has mouse
+// tracking on (Claude Code / Codex / Gemini all do), pointer gestures
+// are forwarded to the program as mouse events instead of forming a
+// selection. Reconstructing the buffer into a <pre> with user-select
+// sidesteps both — the OS's own selection (drag on desktop, long-press
+// handles on touch) works, so the operator can grab any portion (a
+// command, a URL) and copy just that, identically on web and mobile.
+export function SelectCopyDialog({
+  text,
+  open,
+  onOpenChange,
+}: SelectCopyDialogProps) {
+  const { t } = useTranslation()
+  const preRef = useRef<HTMLPreElement>(null)
+
+  const copySelection = async () => {
+    // Whatever the user highlighted inside the dialog. The <pre> is the
+    // only selectable text on screen while the modal is up, so reading
+    // the document selection is enough — no need to range-check it
+    // against the node.
+    const sel = window.getSelection()?.toString() ?? ''
+    if (!sel.trim()) {
+      toast(t('web.sessions.terminal.selectCopyNoSelection'))
+      return
+    }
+    if (await copyText(sel)) {
+      toast.success(t('web.sessions.terminal.copiedToast'))
+    } else {
+      toast.error(t('web.sessions.terminal.copyFailedToast'))
+    }
+  }
+
+  const copyAll = async () => {
+    if (!text.trim()) {
+      toast(t('web.sessions.terminal.selectCopyEmpty'))
+      return
+    }
+    if (await copyText(text)) {
+      toast.success(t('web.sessions.terminal.copiedToast'))
+    } else {
+      toast.error(t('web.sessions.terminal.copyFailedToast'))
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[min(92vw,1100px)] w-[min(92vw,1100px)] h-[min(85vh,800px)] gap-2 flex flex-col">
+        <DialogHeader className="shrink-0">
+          <div className="flex items-start gap-2 min-w-0">
+            <TextCursorInput className="size-4 mt-0.5 text-muted-foreground shrink-0" />
+            <div className="flex flex-col min-w-0 flex-1">
+              <DialogTitle>{t('web.sessions.terminal.selectCopyTitle')}</DialogTitle>
+              <span className="text-[11px] text-muted-foreground/70">
+                {t('web.sessions.terminal.selectCopyDesc')}
+              </span>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="rounded-md border border-border bg-card/30 overflow-hidden flex-1 min-h-0 flex">
+          <ScrollArea className="flex-1">
+            <pre
+              ref={preRef}
+              // select-text re-enables selection (xterm's wrapper sets
+              // user-select:none in places); whitespace-pre-wrap keeps
+              // long lines readable without a horizontal scrollbar.
+              className="select-text whitespace-pre-wrap break-words font-mono text-[12px] leading-[1.55] p-3 text-foreground/90"
+            >
+              {text || ' '}
+            </pre>
+          </ScrollArea>
+        </div>
+
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={copySelection}
+            className="text-[11px] gap-1.5"
+          >
+            <Copy className="size-3" />
+            {t('web.sessions.terminal.selectCopyCopySelection')}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={copyAll}
+            className="text-[11px] gap-1.5"
+          >
+            <CopyCheck className="size-3" />
+            {t('web.sessions.terminal.selectCopyCopyAll')}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+            className="text-[11px]"
+          >
+            {t('common.close')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/web/src/components/sessions/Terminal.tsx
+++ b/app/web/src/components/sessions/Terminal.tsx
@@ -12,16 +12,14 @@ import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
-import { Copy } from 'lucide-react'
 
-import { Button } from 'shared-ui/primitives/button'
 import { useAuth } from '@/stores/auth'
 import { useTheme } from '@/stores/theme'
 import { BinaryWS, wsURL } from '@/lib/ws'
 import { resizeSession, uploadSessionFile } from '@/lib/sessions'
-import { copyText } from '@/lib/clipboard'
 import { DetectedURLs } from './DetectedURLs'
 import { extractURLs, stripANSI } from './url-extractor'
+import { terminalBufferText } from './terminal-text'
 
 // Keep the last N URLs we've seen in this session. 50 is enough for
 // any realistic OAuth-heavy session (each CLI prints 1-2 auth URLs),
@@ -55,12 +53,12 @@ export interface TerminalHandle {
    */
   uploadFile: (file: File) => Promise<void>
   /**
-   * Copy the current selection, or the whole buffer when nothing is
-   * selected, to the clipboard. Used by the header "Copy output"
-   * button — the always-available path for touch devices that can't
-   * tap-select the canvas.
+   * Return the full buffer (scrollback + viewport) as clean plain text,
+   * trailing per-line padding and blank rows stripped. Feeds the
+   * "Select & copy" dialog, which renders it as natively-selectable DOM
+   * text so touch users can select a portion the canvas won't let them.
    */
-  copyAll: () => void
+  getBufferText: () => string
 }
 
 function readVar(name: string): string {
@@ -118,13 +116,6 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
   // the terminal — particularly useful for OAuth flows on mobile.
   const [detectedURLs, setDetectedURLs] = useState<string[]>([])
   const rootRef = useRef<HTMLDivElement>(null)
-  // Position (root-relative px) of the contextual copy pill, anchored
-  // at where the selection ended. null = no selection, pill hidden.
-  // `below` flips the pill under the point when selecting near the top
-  // edge so it never clips off-screen.
-  const [pill, setPill] = useState<{ x: number; y: number; below: boolean } | null>(
-    null,
-  )
 
   const sendInput = useCallback((data: string) => {
     const ws = wsRef.current
@@ -169,50 +160,13 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     [sessionId, sendInput, t],
   )
 
-  const writeClip = useCallback(
-    async (text: string) => {
-      if (await copyText(text)) {
-        toast.success(t('web.sessions.terminal.copiedToast'))
-      } else {
-        toast.error(t('web.sessions.terminal.copyFailedToast'))
-      }
-    },
-    [t],
+  const getBufferText = useCallback(() => terminalBufferText(xtermRef.current), [])
+
+  useImperativeHandle(
+    ref,
+    () => ({ sendInput, uploadFile, getBufferText }),
+    [sendInput, uploadFile, getBufferText],
   )
-
-  // Copy the current selection — triggered by the contextual pill that
-  // only appears while text is selected.
-  const copySelection = useCallback(() => {
-    const text = xtermRef.current?.getSelection() ?? ''
-    if (text.trim()) void writeClip(text)
-  }, [writeClip])
-
-  // Copy the selection if present, otherwise the whole buffer. Exposed
-  // on the handle for the session header's "Copy output" button — the
-  // reliable path on iOS, where tap-selecting xterm's canvas doesn't
-  // work and the async Clipboard API is unavailable over plain-http LAN
-  // (copyText falls back to execCommand).
-  const copyAll = useCallback(() => {
-    const term = xtermRef.current
-    if (!term) return
-    let text = term.getSelection()
-    if (!text) {
-      term.selectAll()
-      text = term.getSelection()
-      term.clearSelection()
-    }
-    if (!text.trim()) {
-      toast(t('web.sessions.terminal.copyEmptyToast'))
-      return
-    }
-    void writeClip(text)
-  }, [writeClip, t])
-
-  useImperativeHandle(ref, () => ({ sendInput, uploadFile, copyAll }), [
-    sendInput,
-    uploadFile,
-    copyAll,
-  ])
 
   // Mount xterm + WS once per session id.
   useEffect(() => {
@@ -245,14 +199,6 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     fit.fit()
     xtermRef.current = term
     fitRef.current = fit
-
-    // Hide the copy pill the moment a selection is cleared (click
-    // elsewhere, typing, scroll-reset). Showing/positioning it happens
-    // on pointerup — see the pill-anchor effect. term.dispose() (cleanup
-    // below) tears this listener down with it.
-    term.onSelectionChange(() => {
-      if (!term.hasSelection()) setPill(null)
-    })
 
     // alive flips false on cleanup so any straggler resize/onOpen
     // callbacks scheduled before unmount don't fire `/resize` against
@@ -550,49 +496,6 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     fitRef.current?.fit()
   }, [themeApplied])
 
-  // Anchor the copy pill where the selection ended. pointerup covers
-  // mouse and most touch cases; we defer one frame so xterm finalizes
-  // the selection first, then place the pill at the pointer (clamped
-  // inside the box, flipped below the point near the top edge).
-  //
-  // touchend is a belt-and-suspenders fallback for iOS Safari: with
-  // touch events directly on a <canvas> inside an overflow-hidden
-  // container, the synthesised pointerup occasionally doesn't fire
-  // (or fires with stale coordinates), leaving a finished selection
-  // with no pill anchored to it.
-  useEffect(() => {
-    const root = rootRef.current
-    if (!root) return
-    const anchorAt = (x: number, y: number) => {
-      requestAnimationFrame(() => {
-        const term = xtermRef.current
-        if (!term || !term.hasSelection()) {
-          setPill(null)
-          return
-        }
-        const rect = root.getBoundingClientRect()
-        const rawY = y - rect.top
-        setPill({
-          x: Math.min(Math.max(x - rect.left, 48), rect.width - 48),
-          y: rawY,
-          below: rawY < 44,
-        })
-      })
-    }
-    const onPointerUp = (e: PointerEvent) => anchorAt(e.clientX, e.clientY)
-    const onTouchEnd = (e: TouchEvent) => {
-      const t = e.changedTouches[0]
-      if (!t) return
-      anchorAt(t.clientX, t.clientY)
-    }
-    root.addEventListener('pointerup', onPointerUp)
-    root.addEventListener('touchend', onTouchEnd, { passive: true })
-    return () => {
-      root.removeEventListener('pointerup', onPointerUp)
-      root.removeEventListener('touchend', onTouchEnd)
-    }
-  }, [])
-
   return (
     <div ref={rootRef} className="h-full w-full bg-background relative overflow-hidden">
       {/* `contain: layout` + `overflow-hidden` isolate xterm's inner
@@ -611,27 +514,6 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         style={{ contain: 'layout paint' }}
       />
       <DetectedURLs urls={detectedURLs} />
-      {pill && (
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          // preventDefault on mousedown so clicking the pill doesn't
-          // blur/clear the xterm selection before copySelection reads it.
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={copySelection}
-          title={t('web.sessions.terminal.copySelectionTooltip')}
-          style={{
-            left: pill.x,
-            top: pill.y,
-            transform: `translate(-50%, ${pill.below ? '8px' : 'calc(-100% - 8px)'})`,
-          }}
-          className="absolute z-20 h-7 gap-1.5 px-2.5 text-[11px] border border-border shadow-md"
-        >
-          <Copy className="size-3.5" />
-          {t('web.sessions.terminal.copySelection')}
-        </Button>
-      )}
       {dragActive && (
         <div className="pointer-events-none absolute inset-2 rounded-md border-2 border-dashed border-accent/70 bg-accent/10 flex items-center justify-center">
           <div className="text-[12px] font-mono text-accent">

--- a/app/web/src/components/sessions/terminal-text.ts
+++ b/app/web/src/components/sessions/terminal-text.ts
@@ -1,0 +1,27 @@
+import type { Terminal as XTerm } from '@xterm/xterm'
+
+// terminalBufferText reconstructs the terminal's full buffer (scrollback
+// + viewport) as clean plain text.
+//
+// We deliberately do NOT use term.selectAll()+getSelection(): that path
+// keeps every cell's trailing padding, so each line comes back padded to
+// the terminal width with spaces, and a session that only printed a few
+// lines copies as a wall of blank rows. Instead we walk the buffer and
+// translateToString(true) each line — `true` trims trailing whitespace —
+// then drop the trailing run of empty lines so a freshly-started session
+// doesn't copy thousands of blanks below its output.
+export function terminalBufferText(term: XTerm | null | undefined): string {
+  if (!term) return ''
+  const buf = term.buffer.active
+  const lines: string[] = []
+  for (let i = 0; i < buf.length; i++) {
+    // trimRight (the translateToString arg) strips the per-cell padding
+    // xterm keeps to the right of the last printed glyph on each row.
+    lines.push(buf.getLine(i)?.translateToString(true) ?? '')
+  }
+  // Drop trailing blank lines — the scrollback past the last printed row
+  // is just empty cells we don't want in the clipboard.
+  let end = lines.length
+  while (end > 0 && lines[end - 1].trim() === '') end--
+  return lines.slice(0, end).join('\n')
+}

--- a/app/web/src/pages/Sessions.tsx
+++ b/app/web/src/pages/Sessions.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
-  ClipboardCopy,
   ImagePlus,
   Layers,
   Plus,
@@ -14,6 +13,7 @@ import {
   PanelRightClose,
   PanelRightOpen,
   ChevronLeft,
+  TextCursorInput,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Trans, useTranslation } from 'react-i18next'
@@ -27,7 +27,11 @@ import {
   Terminal,
   type TerminalHandle,
 } from '@/components/sessions/Terminal'
-import { EndedSessionView } from '@/components/sessions/EndedSessionView'
+import {
+  EndedSessionView,
+  type EndedSessionHandle,
+} from '@/components/sessions/EndedSessionView'
+import { SelectCopyDialog } from '@/components/sessions/SelectCopyDialog'
 import { SpawnDialog } from '@/components/sessions/SpawnDialog'
 import { StatePill } from '@/components/sessions/StatePill'
 import { AccountSwitcher } from '@/components/sessions/AccountSwitcher'
@@ -190,7 +194,20 @@ export function SessionsPage() {
   }, [isMobile, setListCollapsed, setInspectorOpen])
 
   const termRef = useRef<TerminalHandle>(null)
+  const endedRef = useRef<EndedSessionHandle>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // "Select & copy" dialog: holds the reconstructed buffer text so the
+  // operator can natively select any portion (works on touch, unlike
+  // the xterm canvas). Sourced from whichever view is mounted — the
+  // live Terminal or the read-only EndedSessionView.
+  const [selectText, setSelectText] = useState<string | null>(null)
+  const openSelectCopy = () => {
+    const text = currentSession && isTerminalSessionState(currentSession.state)
+      ? endedRef.current?.getBufferText()
+      : termRef.current?.getBufferText()
+    setSelectText(text ?? '')
+  }
 
   const handlePickImage = () => fileInputRef.current?.click()
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -256,11 +273,7 @@ export function SessionsPage() {
                 !isTerminalSessionState(currentSession.state)
               }
               onAttachImage={handlePickImage}
-              copyEnabled={
-                !!currentSession &&
-                !isTerminalSessionState(currentSession.state)
-              }
-              onCopyOutput={() => termRef.current?.copyAll()}
+              onSelectText={openSelectCopy}
               inspectorOpen={inspectorOpen}
               onToggleInspector={toggleInspector}
             />
@@ -275,7 +288,11 @@ export function SessionsPage() {
             <div className="flex-1 min-h-0 pb-3">
               {currentSession &&
               isTerminalSessionState(currentSession.state) ? (
-                <EndedSessionView key={currentId} sessionId={currentId} />
+                <EndedSessionView
+                  key={currentId}
+                  ref={endedRef}
+                  sessionId={currentId}
+                />
               ) : (
                 <Terminal
                   ref={termRef}
@@ -339,6 +356,11 @@ export function SessionsPage() {
         onOpenChange={setSpawnOpen}
         onSpawned={(s) => open({ id: s.id, name: s.name || s.provider_id })}
       />
+      <SelectCopyDialog
+        text={selectText ?? ''}
+        open={selectText !== null}
+        onOpenChange={(v) => !v && setSelectText(null)}
+      />
       {confirmDialogEl}
     </div>
   )
@@ -384,8 +406,7 @@ function WorkbenchHeader({
   onToggleList,
   attachImageEnabled,
   onAttachImage,
-  copyEnabled,
-  onCopyOutput,
+  onSelectText,
   inspectorOpen,
   onToggleInspector,
 }: {
@@ -400,8 +421,7 @@ function WorkbenchHeader({
   onToggleList: () => void
   attachImageEnabled: boolean
   onAttachImage: () => void
-  copyEnabled: boolean
-  onCopyOutput: () => void
+  onSelectText: () => void
   inspectorOpen: boolean
   onToggleInspector: () => void
 }) {
@@ -423,8 +443,8 @@ function WorkbenchHeader({
     : t('web.sessions.header.showInspector')
   const attachLabel = t('web.sessions.header.attachImage')
   const attachTooltip = t('web.sessions.header.attachImageTooltip')
-  const copyLabel = t('web.sessions.header.copyOutput')
-  const copyTooltip = t('web.sessions.header.copyOutputTooltip')
+  const selectLabel = t('web.sessions.header.selectText')
+  const selectTooltip = t('web.sessions.header.selectTextTooltip')
   return (
     <div className="h-11 border-b border-border flex items-center px-3 gap-3">
       <Tooltip>
@@ -489,15 +509,14 @@ function WorkbenchHeader({
           <Button
             variant="ghost"
             size="icon"
-            onClick={onCopyOutput}
-            disabled={!copyEnabled}
-            aria-label={copyLabel}
+            onClick={onSelectText}
+            aria-label={selectLabel}
             className="size-7 shrink-0"
           >
-            <ClipboardCopy className="size-3.5" />
+            <TextCursorInput className="size-3.5" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent>{copyTooltip}</TooltipContent>
+        <TooltipContent>{selectTooltip}</TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>


### PR DESCRIPTION
## Why

The live terminal is an xterm canvas, and the running TUIs (Claude Code / Codex / Gemini) all enable mouse tracking. On touch, a finger drag can't select canvas text, and pointer gestures are forwarded to the program as mouse events instead of forming a selection — so users could **not select a portion** (a command, a URL) to copy, on either web or mobile. The only copy paths were whole-buffer buttons that dumped the entire terminal (space-padded, with blank scrollback) when nothing was selected.

## What

Add a **"Select & copy"** view that reconstructs the buffer as native, selectable text, so the OS selection works on touch and desktop alike and any portion can be copied.

- **web**: new `terminal-text.ts` (`terminalBufferText`) + `SelectCopyDialog.tsx` (`<pre user-select:text>`). `Terminal` exposes `getBufferText()`; `EndedSessionView` forwards it too so ended sessions are selectable; header gains a Select & copy button.
- **mobile**: new `terminal_select_sheet.dart` (a `SelectableText` sheet); keyboard bar gains a Select text button.
- Buffer text is rebuilt line-by-line with trailing padding and blank scrollback stripped → fixes the messy, space-padded copy output.

### Removed (the old whole-buffer copy)

Per request, the old paths that copied everything when nothing was selected are gone — only the new Select & copy entry point remains:

- web header **"Copy output"** button
- desktop **floating copy pill**
- mobile keyboard-bar **"Copy buffer"** button

### i18n

Added `selectCopy` / `selectText` keys (en/es/zh), removed now-dead copy keys, regenerated slang.

## Test plan

- [x] `pnpm --filter web build` (tsc + vite) — green
- [x] `flutter analyze` — No issues found
- [x] web lint on changed files — no new issues (only pre-existing `handleCloseTab` hoisting / `themeApplied` dep warning)
- [ ] Manual: web over LAN http (non-secure context, iPad) — open a Claude Code session → Select & copy → drag/long-press to select a URL → copy → paste elsewhere, output is clean
- [ ] Manual: mobile (Pixel 10 Pro XL) → keyboard bar Select text → long-press selection handles → copy a portion

🤖 Generated with [Claude Code](https://claude.com/claude-code)