### PR TITLE
feat(sessions): isolate integration-origin sessions

### DIFF
--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -345,7 +345,15 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 	// Auto-attach opendray's memory MCP server when enabled at app
 	// startup. This is what makes "the agent remembers things across
 	// sessions" actually work without per-CLI manual setup.
-	if sp.memory.Enabled && p.Manifest.Capabilities.SupportsMcp {
+	//
+	// Exception: third-party integration sessions are isolated. They are
+	// self-managed — they bring their own tools and own their data — so
+	// we never auto-attach the cross-project memory MCP, which would let
+	// the agent read other projects' facts/journal/docs. Operator and CLI
+	// sessions are unaffected (project data is already cwd-scoped; the
+	// shared global/KB layer stays available to them).
+	isIntegration := session.OriginFromContext(ctx) == session.OriginIntegration
+	if sp.memory.Enabled && p.Manifest.Capabilities.SupportsMcp && !isIntegration {
 		servers = append(servers, MCPServer{
 			Name:    "opendray-memory",
 			Command: sp.memory.BinaryPath,

--- a/internal/channel/hub.go
+++ b/internal/channel/hub.go
@@ -918,6 +918,20 @@ func sessionIDFromEvent(ev eventbus.Event) string {
 	return ""
 }
 
+// originFromEvent pulls the session origin out of an event's data
+// payload (best effort). Empty when the topic doesn't carry one
+// (e.g. backup.*), which callers treat as "not an integration".
+func originFromEvent(ev eventbus.Event) string {
+	data, _ := ev.Data.(map[string]any)
+	if data == nil {
+		return ""
+	}
+	if s, ok := data["origin"].(string); ok {
+		return s
+	}
+	return ""
+}
+
 func (h *Hub) runOutbound(ctx context.Context) {
 	defer close(h.outDone)
 	chIdle, unsubI := h.bus.Subscribe("session.idle", 64)
@@ -1019,6 +1033,16 @@ func (h *Hub) dispatch(ctx context.Context, ev eventbus.Event) {
 		chs = append(chs, c)
 	}
 	h.mu.RUnlock()
+
+	// Third-party integration sessions are self-managed: the integration
+	// owns its own delivery (e.g. its own Telegram bot), so opendray never
+	// mirrors their idle/ended notification cards to operator channels.
+	// Non-session events (backup.* etc.) carry no origin and fall through.
+	// Literal "integration" mirrors session.OriginIntegration; kept inline
+	// to avoid a channel→session import just for one constant.
+	if originFromEvent(ev) == "integration" {
+		return
+	}
 
 	sessionID := sessionIDFromEvent(ev)
 

--- a/internal/channel/hub_integration_isolation_test.go
+++ b/internal/channel/hub_integration_isolation_test.go
@@ -1,0 +1,54 @@
+package channel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/opendray/opendray-v2/internal/eventbus"
+)
+
+// Third-party integration sessions are self-managed: opendray must never
+// mirror their idle/ended notification cards to operator channels (the
+// integration owns its own delivery, e.g. its own Telegram bot). The skip
+// happens in dispatch before any store access, so a nil-pool test hub is
+// sufficient.
+
+func TestDispatch_SkipsIntegrationSessions(t *testing.T) {
+	h := newTestHub(t)
+	fc := &fakeChannel{id: "ch_test", kind: "telegram"}
+	h.channels[fc.id] = fc
+
+	h.dispatch(context.Background(), eventbus.Event{
+		Topic: "session.idle",
+		Data: map[string]any{
+			"session_id":    "ses_x",
+			"origin":        "integration",
+			"recent_output": "an agent reply meant for the integration's own bot",
+		},
+	})
+
+	if got := len(fc.sentTexts()); got != 0 {
+		t.Fatalf("integration session must not be mirrored to channels, got %d sends", got)
+	}
+}
+
+func TestOriginFromEvent(t *testing.T) {
+	cases := []struct {
+		name string
+		data any
+		want string
+	}{
+		{"integration", map[string]any{"origin": "integration"}, "integration"},
+		{"operator", map[string]any{"origin": "operator"}, "operator"},
+		{"missing origin", map[string]any{"session_id": "x"}, ""},
+		{"non-map data", "not-a-map", ""},
+		{"nil data", nil, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := originFromEvent(eventbus.Event{Data: tc.data}); got != tc.want {
+				t.Fatalf("originFromEvent = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -630,7 +630,7 @@ func (m *Manager) spawn(ctx context.Context, sess Session, reactivate bool) (*ru
 		return nil, fmt.Errorf("cwd is not a directory: %s", sess.Cwd)
 	}
 
-	resolveCtx := WithAccountID(ctx, sess.ClaudeAccountID)
+	resolveCtx := WithOrigin(WithAccountID(ctx, sess.ClaudeAccountID), sess.Origin)
 	p, err := m.providers.Resolve(resolveCtx, sess.ProviderID)
 	if err != nil {
 		return nil, err

--- a/internal/session/origin_ctx_test.go
+++ b/internal/session/origin_ctx_test.go
@@ -1,0 +1,39 @@
+package session
+
+import (
+	"context"
+	"testing"
+)
+
+// WithOrigin/OriginFromContext thread the session provenance to the
+// catalog adapter so integration sessions can be denied the auto-attached
+// cross-project memory MCP. See provider.go and adapter.go.
+
+func TestWithOrigin_RoundTrip(t *testing.T) {
+	ctx := WithOrigin(context.Background(), OriginIntegration)
+	if got := OriginFromContext(ctx); got != OriginIntegration {
+		t.Fatalf("OriginFromContext = %q, want %q", got, OriginIntegration)
+	}
+}
+
+func TestWithOrigin_EmptyIsNoOp(t *testing.T) {
+	ctx := WithOrigin(context.Background(), "")
+	if got := OriginFromContext(ctx); got != "" {
+		t.Fatalf("empty origin must be a no-op, got %q", got)
+	}
+}
+
+func TestOriginFromContext_DefaultEmpty(t *testing.T) {
+	if got := OriginFromContext(context.Background()); got != "" {
+		t.Fatalf("unset origin must return empty, got %q", got)
+	}
+}
+
+func TestWithOrigin_OperatorAndCLI(t *testing.T) {
+	for _, o := range []Origin{OriginOperator, OriginCLI} {
+		ctx := WithOrigin(context.Background(), o)
+		if got := OriginFromContext(ctx); got != o {
+			t.Fatalf("OriginFromContext = %q, want %q", got, o)
+		}
+	}
+}

--- a/internal/session/provider.go
+++ b/internal/session/provider.go
@@ -111,6 +111,34 @@ func Cwd(ctx context.Context) string {
 	return ""
 }
 
+// ── Origin propagation ─────────────────────────────────────────────
+//
+// Prepare-time isolation decisions need the session's provenance: a
+// third-party integration session is self-managed — it drives its own
+// delivery and brings its own tools — so opendray must NOT auto-attach
+// the cross-project memory MCP to it (see adapter Resolve). Like cwd,
+// origin lives on the Session struct but isn't a Resolve() parameter,
+// so we thread it through context.
+
+type originCtxKey struct{}
+
+// WithOrigin attaches the session's origin to ctx for resolve-time use.
+// Empty origin is a no-op.
+func WithOrigin(ctx context.Context, o Origin) context.Context {
+	if o == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, originCtxKey{}, o)
+}
+
+// OriginFromContext retrieves the value set by WithOrigin, or "" if none.
+func OriginFromContext(ctx context.Context) Origin {
+	if v, ok := ctx.Value(originCtxKey{}).(Origin); ok {
+		return v
+	}
+	return ""
+}
+
 // sessionIDCtxKey + WithSessionID + SessionIDFromContext mirror the
 // cwd plumbing for the session.id, used by ambient-memory rendering
 // at spawn time. Defined here (alongside WithCwd) so callers don't

--- a/internal/session/pump.go
+++ b/internal/session/pump.go
@@ -99,6 +99,10 @@ func (m *Manager) idleWatcher(rs *runningSession) {
 			data := map[string]any{
 				"session_id":  rs.sess.ID,
 				"idle_for_ms": m.idleThreshold.Milliseconds(),
+				// origin lets the channel hub skip integration-driven
+				// sessions: third-party apps own their own delivery, so
+				// opendray must not mirror them to operator channels.
+				"origin": string(rs.sess.Origin),
 			}
 			if snippet := m.recentResponseSnippet(rs); snippet != "" {
 				data["recent_output"] = snippet
@@ -263,6 +267,9 @@ func (m *Manager) waitExit(rs *runningSession) {
 				"exit_code":  exitCode,
 				"ended_at":   now,
 				"state":      string(state),
+				// origin lets the channel hub skip integration-driven
+				// sessions (self-managed delivery — never mirrored).
+				"origin": string(rs.sess.Origin),
 			},
 		})
 	})


### PR DESCRIPTION
## Summary

Third-party **integration** sessions (created via a scoped API key, e.g. the PDAweb invoicing secretary) are self-managed tenants: the integration owns its own delivery (its own Telegram bot) and brings its own tools/data. opendray was treating them like any monitored session, which leaked them two ways:

1. **Channel mirroring** — the channel hub broadcast every session's `session.idle`/`session.ended` notification card to all enabled operator channels, so an integration's agent reply surfaced on opendray's *own* Telegram bot instead of staying inside the integration.
2. **Cross-project memory** — the catalog adapter auto-attached the cross-project `opendray-memory` MCP to every claude session, letting an integration agent read other projects' facts/journal/docs.

This PR isolates integration-origin sessions on both axes. The gate is strictly `Origin == integration`; **operator and CLI sessions are unchanged**, and the shared global/KB memory layer stays available to them.

## Changes

- `internal/session/provider.go` — add `WithOrigin`/`OriginFromContext` context plumbing (mirrors the existing `WithCwd`/`WithAccountID` pattern).
- `internal/session/manager.go` — `spawn` threads `sess.Origin` into the resolve context.
- `internal/catalog/adapter.go` — skip the `opendray-memory` MCP auto-attach for integration-origin sessions.
- `internal/session/pump.go` — stamp `origin` onto `session.idle`/`session.ended` event payloads.
- `internal/channel/hub.go` — `dispatch()` skips events whose origin is `integration` (non-session events carry no origin and fall through).

## Test plan

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race ./internal/session/ ./internal/channel/ ./internal/catalog/` — green
- New tests:
  - `internal/session/origin_ctx_test.go` — `WithOrigin`/`OriginFromContext` round-trip, empty no-op, operator/CLI.
  - `internal/channel/hub_integration_isolation_test.go` — `dispatch()` skips integration sessions; `originFromEvent` extraction table.
- Manual: an integration-driven claude session no longer mirrors its reply to the operator's Telegram channel, and its agent has no `opendray-memory` tools.

## Notes

- No DB migration; no web/mobile/i18n surface touched.
- Follow-ups (separate PRs): hide integration sessions from the operator session list; per-integration default provider/model; integration `memory_policy=none` for full capture isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)