### PR TITLE
feat(integrations): hide integration sessions from operator + default to no-capture

### DIFF
--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -33,16 +33,18 @@ const (
 )
 
 // MemoryPolicy declares what the memory capture pipeline does with
-// sessions an integration creates (Cortex Phase 2 — quarantine by
-// default so third-party temp sessions can't pollute durable memory).
+// sessions an integration creates (Cortex Phase 2 — "none" by default
+// so a third-party consumer's sessions are fully isolated: their content
+// is never captured into the shared memory store).
 type MemoryPolicy string
 
 const (
-	// MemoryPolicyNone — sessions never produce memory.
+	// MemoryPolicyNone — sessions never produce memory. The default for
+	// integrations: privacy-safe isolation for third-party consumers.
 	MemoryPolicyNone MemoryPolicy = "none"
 	// MemoryPolicyQuarantine — facts land in the quarantine tier:
 	// excluded from consolidation + spawn injection, reviewable and
-	// promotable, auto-expired after a TTL. The default.
+	// promotable, auto-expired after a TTL. Opt-in for trusted integrations.
 	MemoryPolicyQuarantine MemoryPolicy = "quarantine"
 	// MemoryPolicyFull — trusted: facts are durable, same as operator
 	// sessions.
@@ -76,7 +78,7 @@ type Integration struct {
 	RotatedAt      *time.Time     `json:"rotated_at,omitempty"`
 
 	// MemoryPolicy routes memory capture for sessions this integration
-	// creates: none | quarantine (default) | full.
+	// creates: none (default) | quarantine | full.
 	MemoryPolicy MemoryPolicy `json:"memory_policy"`
 
 	// IsSystem flags rows opendray manages itself (e.g. the

--- a/internal/integration/service.go
+++ b/internal/integration/service.go
@@ -108,7 +108,12 @@ func (s *Service) Register(ctx context.Context, req RegisterRequest) (RegisterRe
 	}
 	policy := req.MemoryPolicy
 	if policy == "" {
-		policy = MemoryPolicyQuarantine
+		// Integration-created sessions are isolated by default: their
+		// transcripts are never captured into the memory store. Third-party
+		// consumers may serve many end users, so their session content is
+		// private by default. An operator can opt a trusted integration into
+		// quarantine/full explicitly.
+		policy = MemoryPolicyNone
 	}
 	i := Integration{
 		ID:           id,

--- a/internal/session/handler.go
+++ b/internal/session/handler.go
@@ -189,10 +189,36 @@ func (h *Handlers) list(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
+	p, ok := integration.CurrentPrincipal(r.Context())
+	list = visibleSessions(p, ok, list)
 	if list == nil {
 		list = []Session{}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"sessions": list})
+}
+
+// visibleSessions filters the session list for the calling principal.
+// An integration token sees only its own integration's sessions; the
+// operator console (admin token, or no integration principal) never sees
+// integration-origin sessions at all. Third-party consumer sessions are
+// private — they may serve many end users — so they must not surface in
+// the operator's session list. Returns a fresh slice (never mutates).
+func visibleSessions(p integration.Principal, ok bool, list []Session) []Session {
+	asIntegration := ok && p.Kind == integration.KindIntegration
+	out := make([]Session, 0, len(list))
+	for _, s := range list {
+		if asIntegration {
+			if s.IntegrationID == p.ID {
+				out = append(out, s)
+			}
+			continue
+		}
+		if s.Origin == OriginIntegration {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
 }
 
 func (h *Handlers) get(w http.ResponseWriter, r *http.Request) {

--- a/internal/session/visible_sessions_test.go
+++ b/internal/session/visible_sessions_test.go
@@ -1,0 +1,66 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/opendray/opendray-v2/internal/integration"
+)
+
+// visibleSessions hides third-party integration sessions from the operator
+// console and scopes an integration token to its own sessions.
+
+func sample() []Session {
+	return []Session{
+		{ID: "op1", Origin: OriginOperator},
+		{ID: "cli1", Origin: OriginCLI},
+		{ID: "intA", Origin: OriginIntegration, IntegrationID: "int_A"},
+		{ID: "intB", Origin: OriginIntegration, IntegrationID: "int_B"},
+	}
+}
+
+func ids(list []Session) []string {
+	out := make([]string, len(list))
+	for i, s := range list {
+		out[i] = s.ID
+	}
+	return out
+}
+
+func TestVisibleSessions_OperatorHidesIntegration(t *testing.T) {
+	got := ids(visibleSessions(integration.Principal{Kind: integration.KindAdmin, ID: "admin"}, true, sample()))
+	want := []string{"op1", "cli1"}
+	if len(got) != len(want) {
+		t.Fatalf("operator visible = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("operator visible = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestVisibleSessions_NoPrincipalTreatedAsOperator(t *testing.T) {
+	got := ids(visibleSessions(integration.Principal{}, false, sample()))
+	for _, id := range got {
+		if id == "intA" || id == "intB" {
+			t.Fatalf("no-principal must not expose integration sessions, got %v", got)
+		}
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected only operator/cli sessions, got %v", got)
+	}
+}
+
+func TestVisibleSessions_IntegrationSeesOnlyOwn(t *testing.T) {
+	got := ids(visibleSessions(integration.Principal{Kind: integration.KindIntegration, ID: "int_A"}, true, sample()))
+	if len(got) != 1 || got[0] != "intA" {
+		t.Fatalf("integration int_A visible = %v, want [intA]", got)
+	}
+}
+
+func TestVisibleSessions_IntegrationWithNoOwnSessions(t *testing.T) {
+	got := visibleSessions(integration.Principal{Kind: integration.KindIntegration, ID: "int_Z"}, true, sample())
+	if len(got) != 0 {
+		t.Fatalf("integration with no own sessions must see none, got %v", ids(got))
+	}
+}


### PR DESCRIPTION
## Summary

Two privacy/isolation refinements for third-party **integration** sessions, building on #375 (integration-origin isolation):

1. **Hidden sessions** — `GET /sessions` now filters by the calling principal:
   - an **integration token** sees only its *own* integration's sessions;
   - the **operator console** (admin token, or no integration principal) never sees integration-origin sessions at all.

   Third-party consumers may serve many end users, so their sessions must not surface in the operator's session list (privacy). Audit stays available via `/integrations/_calls`.

2. **No-capture by default** — new integrations default to `memory_policy=none` (was `quarantine`), so a third-party consumer's session content is never captured into the shared memory store unless an operator explicitly opts the integration into `quarantine`/`full`.

## Changes

- `internal/session/handler.go` — `list` filters via new `visibleSessions(principal, ok, list)` helper (returns a fresh slice; never mutates).
- `internal/integration/service.go` — registration default `memory_policy` → `none`.
- `internal/integration/integration.go` — doc comments updated (none is the default).

## Test plan

- `go build ./...` / `go vet ./...` — clean
- `go test -race ./internal/session/ ./internal/integration/` — green
- New tests (`internal/session/visible_sessions_test.go`): operator hides integration sessions; no-principal treated as operator; integration sees only its own; integration with no own sessions sees none.
- Manual: operator web/mobile session list no longer shows the PDAweb secretary sessions; the PDAweb integration was set to `memory_policy=none` at runtime.

## Notes

- No DB migration; no UI code change (web/mobile session lists reflect the filtered API automatically).
- Direct by-id access (`GET/DELETE /sessions/{id}`) is unchanged — out of scope here; the operator console only reaches sessions via the (now-filtered) list.
- Follow-up (separate PR): per-integration default provider/model (#3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)