### PR TITLE
docs(integrations): visayabai bridge guide + runnable Telegram adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ tmp/
 # code; it's a maintainer-machine helper, not a shipped script. Keep it under
 # ~/.opendray/scripts/ on the dev box.
 scripts/update-local.sh
+docs/integrations/__pycache__/

--- a/docs/integrations/connecting-visayabai-bot.md
+++ b/docs/integrations/connecting-visayabai-bot.md
@@ -1,0 +1,265 @@
+# Connecting the visayabai bot to opendray
+
+Goal: let the **visayabai bot** drive opendray-managed Claude Code (or
+Codex / Gemini / shell) sessions — send a user's message in, stream the
+agent's reply back out — using opendray's **Integrations** system.
+
+> Scope note: this is the *legitimate* integration path — your own bot
+> orchestrating your own interactive sessions through opendray's API.
+> It is NOT a way to resell Claude-subscription inference to third
+> parties (that violates Anthropic's terms). Keep visayabai as a
+> front-end you control.
+
+---
+
+## ✅ DECISION (2026-06-17): Bridge channel (Pattern B)
+
+Operator chose the **bridge channel** path. It's the best outcome for a
+chat bot: opendray handles session routing, reply detection
+(`session.turn_completed`), notification policy, `/new` provider
+selection, account switching, and the voice MCP — visayabai just relays
+messages in/out. Runnable reference adapter:
+**`docs/integrations/visayabai_bridge_adapter.py`**.
+
+### Bridge wire protocol (verified against `internal/channel/bridge`)
+
+- **Connect:** WebSocket to
+  `wss://<host>/api/v1/channels/bridge/ws?token=<BRIDGE_TOKEN>`
+  (token also accepted via `X-Bridge-Token` / `Authorization: Bearer`
+  / or inside the register frame).
+- **First frame (adapter → opendray):**
+  ```json
+  {"type":"register","platform":"visayabai",
+   "capabilities":["text","typing"],"metadata":{}}
+  ```
+  opendray replies `{"type":"register_ack","ok":true}` (or
+  `ok:false`+`error`). Capabilities (exact strings): `text`, `card`,
+  `buttons`, `image`, `file`, `typing`, `update_message`,
+  `reply_to_message`. Declare only what visayabai can render — opendray
+  only sends frames for declared caps; everything degrades to `text`.
+- **Inbound (adapter → opendray):** a user message →
+  ```json
+  {"type":"message","conversation_id":"<stable per-user/chat id>",
+   "user_id":"...","user_name":"...","text":"hello"}
+  ```
+  Button taps → `{"type":"card_action","action":"<id>","conversation_id":...}`.
+  Adapter ping → `{"type":"ping"}` (opendray replies `{"type":"pong"}`).
+- **Outbound (opendray → adapter):** render to the user —
+  `{"type":"send",...,"text"}`, `{"type":"start_typing"/"stop_typing"}`,
+  `{"type":"send_card",...,"card"}`, `{"type":"send_buttons",...,"buttons":[[…]]}`,
+  `{"type":"send_image"/"send_file",...}`, `{"type":"update_message",...}`.
+- **`conversation_id` is the routing key** — use a stable id per
+  visayabai user/chat. opendray binds each `conversation_id` to its own
+  session, so N users → N independent Claude sessions automatically.
+
+### Operator setup (one-time)
+
+1. opendray → **Channels** → add a channel of kind **bridge**: set a
+   `name` (`visayabai`) and a shared `token`. Bind it to a session (or
+   let `/new` create one).
+2. Put that token in visayabai's env as `BRIDGE_TOKEN`, point the
+   adapter at the gateway host, run `visayabai_bridge_adapter.py`.
+3. Optional: add `buttons`/`card` to the adapter's capabilities later to
+   get the rich control keyboard + provider picker instead of text
+   fallback.
+
+---
+
+## Reference: the two ways to connect (B chosen above)
+
+| | **A. Consumer integration** (recommended for a custom app) | **B. Bridge channel** (recommended if visayabai is "just another chat surface") |
+|---|---|---|
+| What it is | The bot holds an opendray API key and calls the REST/WS API directly to create + drive sessions. | The bot registers as a `kind=bridge` channel; opendray's channel machinery handles session binding, notifications, and replies (same as Telegram/Slack). |
+| Bot owns | Session lifecycle + routing (full control). | Just message relay in/out. |
+| Effort | More code, more control. | Less code, reuses reply/notify logic. |
+| Mount | `/api/v1/sessions/*` + `/api/v1/integrations/_events` | Public webhook `/api/v1/channels/<id>/inbound` + `channel:send` |
+
+The rest of this doc walks **Pattern A** in full (matches the
+Integrations UI in the screenshots), then summarizes **Pattern B**.
+
+---
+
+## Pattern A — Consumer integration
+
+### A1. Register the integration (operator, one-time, in the web UI)
+
+opendray → **Integrations** → **Register**. A *consumer* integration
+has **no Base URL** and **no route prefix** (those are only for the
+reverse-proxy direction). Give it:
+
+- **Name:** `visayabai`
+- **Base URL:** *(leave blank — consumer, not reverse-proxied)*
+- **Scopes** (minimum to drive a chat→Claude→chat loop):
+  - `session:read` — list/get sessions, read buffer, fetch history
+  - `session:create` — spawn / restart / delete sessions
+  - `session:input` — **required** to forward messages into the PTY
+  - `event:subscribe:session.*` — live-tail `session.idle` /
+    `session.turn_completed` / `session.ended` so the bot knows when a
+    reply has settled
+  - `provider:read` *(optional)* — list providers (claude/codex/…)
+
+On save, opendray shows the **API key once** — format
+`odk_live_<...>`. Copy it into visayabai's secret store (env var, not
+source). It's bcrypt-hashed server-side and never shown again; use
+**Rotate key** to issue a new one.
+
+> Registration itself is admin-only (`POST /api/v1/integrations` needs
+> the admin token), so the operator does this in the UI and hands the
+> key to the bot. The bot never self-registers.
+
+### A2. Authenticate every request
+
+Send the key as a Bearer token (or `?token=` for WebSocket URLs, since
+browsers/WS can't set headers):
+
+```
+Authorization: Bearer odk_live_xxxxxxxx
+```
+
+Base path for everything below: `https://<opendray-host>/api/v1`.
+
+### A3. The drive loop (REST + WS)
+
+**1. Create a session** (one per conversation, or reuse one):
+
+```bash
+curl -sX POST https://HOST/api/v1/sessions \
+  -H "Authorization: Bearer $OPENDRAY_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "name": "visayabai · user-123",
+        "provider_id": "claude",
+        "cwd": "/var/lib/opendray/projects/visayabai",
+        "args": []
+      }'
+# → 201 { "id": "ses_...", "state": "running", "pid": ..., ... }
+```
+
+Optional: pin a specific Claude account with
+`"claude_account_id": "cla_..."`.
+
+**2. Send the user's message into the PTY:**
+
+```bash
+curl -sX POST https://HOST/api/v1/sessions/$SES/input \
+  -H "Authorization: Bearer $OPENDRAY_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"data": "summarize the latest sales report\n"}'
+# → 204 No Content
+```
+
+`data` is raw bytes written to stdin. Include the trailing `\n` to
+"press enter". You can send control bytes too (e.g. `` = Ctrl-C).
+
+**3. Read the reply.** Two options:
+
+- **WebSocket stream (live PTY bytes):**
+  `wss://HOST/api/v1/sessions/$SES/stream?token=$OPENDRAY_KEY`
+  On connect it replays the recent buffer, then streams live output as
+  binary frames. Send binary frames back to write to stdin (alternative
+  to the `/input` POST). This is the raw terminal stream (ANSI included)
+  — strip ANSI for a chat surface.
+
+- **Event bus (know when the turn is done):**
+  `wss://HOST/api/v1/integrations/_events?topics=session.*&token=$OPENDRAY_KEY`
+  JSON frames like:
+  ```json
+  { "topic": "session.turn_completed",
+    "ts": "2026-06-17T...Z",
+    "data": { "session_id": "ses_...", "recent_output": "..." } }
+  ```
+  `session.turn_completed` fires a few seconds after the agent stops
+  emitting — the right signal to grab `recent_output` and post it back
+  to the visayabai user, and to stop any "typing…" indicator.
+
+**Recommended bot pattern:** open the `_events` WS once (not per
+session), filter by `session_id`. On a user message → `POST /input`.
+On `session.turn_completed` for that session → read `recent_output`
+(or `GET /sessions/{id}/buffer`), strip ANSI, send to the user. Use
+`session.idle` as a "still thinking / nudge" cue and `session.ended`
+to recreate a session if the CLI exited.
+
+### A4. Useful extras
+
+- `GET /api/v1/sessions` — list (filter to visayabai's own by name).
+- `GET /api/v1/sessions/{id}/buffer?since=<cursor>` — pull output
+  since a byte cursor (headers `X-OpenDray-Buffer-Cursor`) instead of
+  the WS, if the bot prefers polling.
+- `GET /api/v1/sessions/{id}/history?limit=N` — past user prompts.
+- `POST /api/v1/sessions/{id}/stop` / `POST /.../start` /
+  `DELETE /.../{id}` — lifecycle.
+- `POST /api/v1/sessions/{id}/uploads` — attach a file (multipart);
+  returns a server path to reference in a prompt.
+
+---
+
+## Pattern B — Bridge channel (alternative)
+
+If visayabai is fundamentally a chat surface (user texts, Claude
+replies) and you'd rather not write the session-routing yourself, model
+it on the built-in channels (Telegram/Slack/Discord) via the **bridge
+adapter** (`kind=bridge`, registered in opendray's channel system).
+
+- Inbound: visayabai forwards user messages to opendray's public
+  webhook `POST /api/v1/channels/<id>/inbound` (needs `channel:receive`
+  to verify traffic). opendray binds the message to the channel's
+  active session and writes it to the PTY.
+- Outbound: opendray pushes replies/notifications back out through the
+  registered channel; the bot relays them to the user (needs
+  `channel:send`).
+
+This reuses opendray's reply detection, notification policy, and
+`/new`-style session management for free — at the cost of less
+low-level control than Pattern A. The bridge adapter WS endpoint is
+mounted publicly (`bridgeHandlers.Mount`, see `internal/channel/bridge`).
+
+---
+
+## Reverse-proxy direction (for completeness — NOT this use case)
+
+The "Base URL + route prefix" fields you saw on the PDAweb integration
+are the *other* direction: opendray reverse-proxies
+`/api/v1/proxy/<prefix>/*` **to** the integration's Base URL (opendray
+→ your app). Use that when you want opendray to be the authenticated
+front door to a service. visayabai driving sessions does **not** need
+it — leave Base URL blank.
+
+---
+
+## Quick reference
+
+| Thing | Value |
+|---|---|
+| Base path | `https://<host>/api/v1` |
+| Auth | `Authorization: Bearer odk_live_...` (or `?token=` on WS) |
+| Register (admin/UI) | `POST /integrations` → returns key once |
+| Create session | `POST /sessions` `{provider_id, cwd, name, args}` |
+| Send input | `POST /sessions/{id}/input` `{"data":"...\n"}` → 204 |
+| Live output WS | `wss://…/sessions/{id}/stream?token=…` (binary) |
+| Events WS | `wss://…/integrations/_events?topics=session.*&token=…` |
+| Turn-done signal | event topic `session.turn_completed` → `data.recent_output` |
+| Min scopes | `session:read`, `session:create`, `session:input`, `event:subscribe:session.*` |
+
+## Open questions to resolve next session
+
+- Is visayabai a chat relay (→ lean Pattern B / bridge channel) or a
+  full app needing programmatic control (→ Pattern A / consumer)?
+- One long-lived session per user, or ephemeral per-conversation?
+- Where should session `cwd` point for visayabai's work?
+- Does it need `channel:send`/`channel:receive` (only if Pattern B)?
+
+## Source references (verified in repo)
+
+- Integration model + register: `internal/integration/integration.go`,
+  `internal/integration/service.go`, `internal/integration/handler.go`
+- Auth + scope enforcement: `internal/integration/middleware.go`
+  (`CombinedMiddleware`, `bearerFromRequest`), `service.go` (`HasScope`)
+- Session routes: `internal/session/handler.go` (`Handlers.Mount`)
+- Events WS: `internal/integration/events.go`,
+  `internal/app/app.go:759` (`/integrations/_events`)
+- Reverse proxy: `internal/integration/proxy.go`
+  (`/proxy/{prefix}/*`)
+- Scope catalog (UI strings): web bundle `QO{...}` —
+  session:read/create/input, channel:send/receive,
+  event:subscribe:{session,channel,integration}.*, provider:read,
+  memory:read/write

--- a/docs/integrations/visayabai_bridge_adapter.py
+++ b/docs/integrations/visayabai_bridge_adapter.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""
+visayabai ↔ opendray bridge adapter (reference implementation).
+
+This is the thin relay that connects the visayabai bot to opendray as a
+`kind=bridge` channel. opendray does all the session routing, reply
+detection, and notification policy; this adapter only:
+
+  1. opens a WebSocket to /api/v1/channels/bridge/ws and registers,
+  2. forwards each visayabai user message to opendray as a `message` frame,
+  3. renders opendray's outbound frames (send / typing / card / buttons)
+     back to the visayabai user.
+
+Wire protocol (verified against internal/channel/bridge):
+  - connect:  wss://HOST/api/v1/channels/bridge/ws?token=<BRIDGE_TOKEN>
+  - 1st frame (adapter→opendray):
+        {"type":"register","platform":"visayabai",
+         "capabilities":["text","typing"], "metadata":{}}
+    opendray replies {"type":"register_ack","ok":true}
+  - inbound (adapter→opendray), a user said something:
+        {"type":"message","conversation_id":"<stable per-user/chat id>",
+         "user_id":"...","user_name":"...","text":"hello"}
+    button taps: {"type":"card_action","action":"<id>","conversation_id":...}
+  - outbound (opendray→adapter), render to the user — only the frame
+    types matching capabilities you declared arrive:
+        {"type":"send","conversation_id":...,"text":...}
+        {"type":"start_typing",...} / {"type":"stop_typing",...}
+        {"type":"send_card",...,"card":{...}}        (declare "card")
+        {"type":"send_buttons",...,"text":...,"buttons":[[...]]} ("buttons")
+        {"type":"send_image"/"send_file",...}        ("image"/"file")
+  - heartbeats: opendray sends WS ping frames; the `websockets` lib
+    auto-pongs. Adapter-level {"type":"ping"} → {"type":"pong"} also ok.
+
+`conversation_id` is THE key idea: use a stable id per visayabai user
+(or per chat). opendray binds each conversation_id to its own session,
+so N users get N independent Claude sessions automatically.
+
+Run:
+  pip install websockets
+  OPENDRAY_HOST=opendray.example.com:8770 \
+  BRIDGE_TOKEN=... \
+  python visayabai_bridge_adapter.py
+"""
+
+import asyncio
+import json
+import os
+import signal
+from typing import Any
+
+import websockets  # pip install websockets
+
+OPENDRAY_HOST = os.environ["OPENDRAY_HOST"]          # host:port, no scheme
+BRIDGE_TOKEN = os.environ["BRIDGE_TOKEN"]            # from the bridge channel config
+USE_TLS = os.environ.get("OPENDRAY_TLS", "1") != "0"  # wss by default
+
+# Capabilities this adapter can actually render. Start minimal; add
+# "card"/"buttons"/"image"/"file" once visayabai can display them — then
+# opendray's control keyboard + provider picker render as rich UI instead
+# of falling back to plain text.
+CAPABILITIES = ["text", "typing"]
+
+_scheme = "wss" if USE_TLS else "ws"
+WS_URL = f"{_scheme}://{OPENDRAY_HOST}/api/v1/channels/bridge/ws?token={BRIDGE_TOKEN}"
+
+
+# ── visayabai side (STUBS — wire these to your real bot) ──────────────
+async def send_to_visayabai_user(conversation_id: str, text: str) -> None:
+    """Render an opendray reply to the visayabai user identified by
+    conversation_id. Replace with your bot's real send call."""
+    print(f"[→ visayabai:{conversation_id}] {text}")
+
+
+async def set_typing(conversation_id: str, on: bool) -> None:
+    """Show/hide a typing indicator, if visayabai supports one."""
+    print(f"[→ visayabai:{conversation_id}] typing={on}")
+
+
+# ── opendray side ────────────────────────────────────────────────────
+class BridgeAdapter:
+    def __init__(self) -> None:
+        self._conn: websockets.WebSocketClientProtocol | None = None
+
+    async def run_forever(self) -> None:
+        """Connect with exponential backoff; reconnect on drop."""
+        backoff = 1
+        while True:
+            try:
+                async with websockets.connect(
+                    WS_URL, max_size=256 * 1024, ping_interval=None
+                ) as conn:
+                    self._conn = conn
+                    await self._register(conn)
+                    backoff = 1  # reset after a clean register
+                    await self._read_loop(conn)
+            except Exception as e:  # noqa: BLE001 — reconnect on anything
+                print(f"[bridge] connection error: {e!r}")
+            finally:
+                self._conn = None
+            print(f"[bridge] reconnecting in {backoff}s")
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 30)
+
+    async def _register(self, conn) -> None:
+        await conn.send(
+            json.dumps(
+                {
+                    "type": "register",
+                    "platform": "visayabai",
+                    "capabilities": CAPABILITIES,
+                    "metadata": {"adapter": "visayabai-bridge", "version": "0.1.0"},
+                }
+            )
+        )
+        ack = json.loads(await conn.recv())
+        if ack.get("type") != "register_ack" or not ack.get("ok"):
+            raise RuntimeError(f"register rejected: {ack!r}")
+        print("[bridge] registered with opendray")
+
+    async def _read_loop(self, conn) -> None:
+        async for raw in conn:
+            try:
+                frame = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            await self._handle_outbound(frame)
+
+    async def _handle_outbound(self, frame: dict[str, Any]) -> None:
+        """opendray → visayabai. One handler per outbound frame type."""
+        t = frame.get("type")
+        conv = frame.get("conversation_id") or ""
+        if t == "send":
+            await send_to_visayabai_user(conv, frame.get("text", ""))
+        elif t == "send_buttons":
+            # Render text; flatten button labels as a fallback if visayabai
+            # can't show inline keyboards yet.
+            text = frame.get("text", "")
+            labels = [
+                b.get("label", "")
+                for row in frame.get("buttons", [])
+                for b in row
+            ]
+            if labels:
+                text += "\n\n[" + " | ".join(labels) + "]"
+            await send_to_visayabai_user(conv, text)
+        elif t == "send_card":
+            card = frame.get("card") or {}
+            await send_to_visayabai_user(
+                conv, card.get("text") or card.get("title") or json.dumps(card)
+            )
+        elif t == "start_typing":
+            await set_typing(conv, True)
+        elif t == "stop_typing":
+            await set_typing(conv, False)
+        elif t == "pong":
+            pass
+        else:
+            print(f"[bridge] unhandled outbound frame: {t}")
+
+    # ── call this from your visayabai message handler ────────────────
+    async def forward_user_message(
+        self, conversation_id: str, text: str, user_id: str = "", user_name: str = ""
+    ) -> None:
+        """visayabai → opendray. Call when a user sends a message."""
+        if self._conn is None:
+            print("[bridge] not connected; dropping message")
+            return
+        await self._conn.send(
+            json.dumps(
+                {
+                    "type": "message",
+                    "conversation_id": conversation_id,  # stable per user/chat
+                    "user_id": user_id,
+                    "user_name": user_name,
+                    "text": text,
+                }
+            )
+        )
+
+    async def forward_button_press(self, conversation_id: str, action: str) -> None:
+        """visayabai → opendray. Call when a user taps an inline button."""
+        if self._conn is None:
+            return
+        await self._conn.send(
+            json.dumps(
+                {
+                    "type": "card_action",
+                    "conversation_id": conversation_id,
+                    "action": action,
+                }
+            )
+        )
+
+
+async def main() -> None:
+    adapter = BridgeAdapter()
+
+    # DEMO: feed one fake user message 3s after connect so you can see the
+    # round-trip. Delete this and call adapter.forward_user_message(...)
+    # from your real visayabai handler instead.
+    async def _demo() -> None:
+        await asyncio.sleep(3)
+        await adapter.forward_user_message(
+            conversation_id="visayabai-user-123",
+            text="hello from visayabai — what can you do?",
+            user_name="Navid",
+        )
+
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, stop.set)
+
+    runner = asyncio.create_task(adapter.run_forever())
+    demo = asyncio.create_task(_demo())
+    await stop.wait()
+    runner.cancel()
+    demo.cancel()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/integrations/visayabai_telegram_bridge.py
+++ b/docs/integrations/visayabai_telegram_bridge.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+visayabai Telegram ↔ opendray bridge — complete, runnable.
+
+Runs a Telegram bot and relays it to opendray as a `kind=bridge`
+channel. opendray owns session routing, reply detection, the control
+keyboard, /new provider selection, account switching, and voice;
+this process is the thin relay between Telegram and opendray.
+
+Two concurrent loops:
+  • bridge loop  — WS to /api/v1/channels/bridge/ws, register, then
+                   render opendray's outbound frames into Telegram.
+  • telegram loop — long-poll getUpdates; forward user messages and
+                    inline-button taps into opendray.
+
+Routing: conversation_id = Telegram chat id (stable per chat), so each
+chat gets its own opendray session automatically.
+
+Setup:
+  pip install aiohttp websockets
+  export TELEGRAM_BOT_TOKEN=123456:ABC...        # @BotFather token
+  export OPENDRAY_HOST=opendray.example.com:8770  # host:port, no scheme
+  export BRIDGE_TOKEN=...                          # bridge channel token
+  export OPENDRAY_TLS=1                            # 0 for ws:// (LAN/dev)
+  python visayabai_telegram_bridge.py
+
+opendray side (one-time): Channels → add kind=bridge, set name
+"visayabai" + the same BRIDGE_TOKEN, bind/allow a session.
+"""
+
+import asyncio
+import json
+import os
+import signal
+from typing import Any
+
+import aiohttp           # pip install aiohttp
+import websockets        # pip install websockets
+
+TELEGRAM_BOT_TOKEN = os.environ["TELEGRAM_BOT_TOKEN"]
+OPENDRAY_HOST = os.environ["OPENDRAY_HOST"]          # host:port, no scheme
+BRIDGE_TOKEN = os.environ["BRIDGE_TOKEN"]
+USE_TLS = os.environ.get("OPENDRAY_TLS", "1") != "0"
+
+# Declare what we can render. buttons → opendray sends the control
+# keyboard (Stop/Restart/Switch) and the /new provider picker as real
+# inline keyboards instead of plain text.
+CAPABILITIES = ["text", "typing", "buttons"]
+
+_scheme = "wss" if USE_TLS else "ws"
+WS_URL = f"{_scheme}://{OPENDRAY_HOST}/api/v1/channels/bridge/ws?token={BRIDGE_TOKEN}"
+TG_API = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}"
+
+# Telegram callback_data is capped at 64 bytes. opendray button values
+# (e.g. "nav:/sessions/<id>", control actions) normally fit; we guard
+# anyway and keep a map from a short id back to the full value when a
+# value is too long.
+_cb_overflow: dict[str, str] = {}
+_cb_seq = 0
+
+
+class Telegram:
+    """Thin Telegram Bot API client (long-poll + sends)."""
+
+    def __init__(self, session: aiohttp.ClientSession) -> None:
+        self._s = session
+        self._offset = 0
+
+    async def _call(self, method: str, **params: Any) -> dict[str, Any]:
+        async with self._s.post(f"{TG_API}/{method}", json=params) as r:
+            return await r.json()
+
+    async def send_text(
+        self, chat_id: str, text: str, buttons: list[list[dict]] | None = None
+    ) -> None:
+        if not text.strip() and not buttons:
+            return
+        params: dict[str, Any] = {"chat_id": chat_id, "text": text or "…"}
+        if buttons:
+            params["reply_markup"] = {"inline_keyboard": buttons}
+        await self._call("sendMessage", **params)
+
+    async def typing(self, chat_id: str) -> None:
+        # Telegram typing auto-expires after ~5s; opendray sends a fresh
+        # start_typing before each reply, so we just re-assert it.
+        await self._call("sendChatAction", chat_id=chat_id, action="typing")
+
+    async def answer_callback(self, callback_id: str) -> None:
+        await self._call("answerCallbackQuery", callback_query_id=callback_id)
+
+    async def poll_forever(self, on_message, on_callback) -> None:
+        # allowed_updates keeps the stream to what we handle.
+        while True:
+            try:
+                resp = await self._call(
+                    "getUpdates",
+                    offset=self._offset,
+                    timeout=30,
+                    allowed_updates=["message", "callback_query"],
+                )
+            except Exception as e:  # noqa: BLE001
+                print(f"[tg] getUpdates error: {e!r}")
+                await asyncio.sleep(3)
+                continue
+            for upd in resp.get("result", []):
+                self._offset = upd["update_id"] + 1
+                if "message" in upd and "text" in upd["message"]:
+                    m = upd["message"]
+                    await on_message(
+                        chat_id=str(m["chat"]["id"]),
+                        text=m["text"],
+                        user_id=str(m["from"].get("id", "")),
+                        user_name=m["from"].get("first_name", "")
+                        or m["from"].get("username", ""),
+                    )
+                elif "callback_query" in upd:
+                    cq = upd["callback_query"]
+                    data = cq.get("data", "")
+                    action = _cb_overflow.get(data, data)
+                    await on_callback(
+                        chat_id=str(cq["message"]["chat"]["id"]),
+                        action=action,
+                    )
+                    await self.answer_callback(cq["id"])
+
+
+class Bridge:
+    """opendray bridge-channel WS client."""
+
+    def __init__(self, telegram: Telegram) -> None:
+        self._tg = telegram
+        self._conn: websockets.WebSocketClientProtocol | None = None
+
+    # ── opendray → Telegram ──────────────────────────────────────────
+    async def _handle_outbound(self, frame: dict[str, Any]) -> None:
+        t = frame.get("type")
+        chat_id = frame.get("conversation_id") or ""
+        if not chat_id:
+            return
+        if t == "send":
+            await self._tg.send_text(chat_id, frame.get("text", ""))
+        elif t == "send_buttons":
+            await self._tg.send_text(
+                chat_id,
+                frame.get("text", ""),
+                _to_inline_keyboard(frame.get("buttons", [])),
+            )
+        elif t == "start_typing":
+            await self._tg.typing(chat_id)
+        elif t in ("stop_typing", "pong"):
+            pass  # Telegram typing self-expires; nothing to do
+        else:
+            print(f"[bridge] unhandled outbound: {t}")
+
+    # ── Telegram → opendray ──────────────────────────────────────────
+    async def forward_message(
+        self, chat_id: str, text: str, user_id: str = "", user_name: str = ""
+    ) -> None:
+        await self._send(
+            {
+                "type": "message",
+                "conversation_id": chat_id,
+                "user_id": user_id,
+                "user_name": user_name,
+                "text": text,
+            }
+        )
+
+    async def forward_callback(self, chat_id: str, action: str) -> None:
+        await self._send(
+            {"type": "card_action", "conversation_id": chat_id, "action": action}
+        )
+
+    async def _send(self, frame: dict[str, Any]) -> None:
+        if self._conn is None:
+            print("[bridge] not connected; dropping", frame.get("type"))
+            return
+        await self._conn.send(json.dumps(frame))
+
+    async def run_forever(self) -> None:
+        backoff = 1
+        while True:
+            try:
+                async with websockets.connect(
+                    WS_URL, max_size=256 * 1024, ping_interval=None
+                ) as conn:
+                    self._conn = conn
+                    await conn.send(
+                        json.dumps(
+                            {
+                                "type": "register",
+                                "platform": "visayabai",
+                                "capabilities": CAPABILITIES,
+                                "metadata": {"adapter": "visayabai-telegram", "version": "0.1.0"},
+                            }
+                        )
+                    )
+                    ack = json.loads(await conn.recv())
+                    if ack.get("type") != "register_ack" or not ack.get("ok"):
+                        raise RuntimeError(f"register rejected: {ack!r}")
+                    print("[bridge] registered with opendray")
+                    backoff = 1
+                    async for raw in conn:
+                        try:
+                            await self._handle_outbound(json.loads(raw))
+                        except json.JSONDecodeError:
+                            continue
+            except Exception as e:  # noqa: BLE001
+                print(f"[bridge] error: {e!r}")
+            finally:
+                self._conn = None
+            print(f"[bridge] reconnecting in {backoff}s")
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 30)
+
+
+def _to_inline_keyboard(rows: list[list[dict]]) -> list[list[dict]]:
+    """Map opendray button rows ([[{text,value,style}]]) to Telegram
+    inline_keyboard. callback_data is the button value, with a 64-byte
+    overflow fallback."""
+    global _cb_seq
+    out: list[list[dict]] = []
+    for row in rows:
+        tg_row: list[dict] = []
+        for b in row:
+            value = str(b.get("value", ""))
+            if len(value.encode()) > 64:
+                _cb_seq += 1
+                key = f"#{_cb_seq}"
+                _cb_overflow[key] = value
+                value = key
+            tg_row.append({"text": b.get("text", "·"), "callback_data": value})
+        if tg_row:
+            out.append(tg_row)
+    return out
+
+
+async def main() -> None:
+    async with aiohttp.ClientSession() as session:
+        tg = Telegram(session)
+        bridge = Bridge(tg)
+
+        stop = asyncio.Event()
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(sig, stop.set)
+
+        tasks = [
+            asyncio.create_task(bridge.run_forever()),
+            asyncio.create_task(
+                tg.poll_forever(
+                    on_message=bridge.forward_message,
+                    on_callback=bridge.forward_callback,
+                )
+            ),
+        ]
+        await stop.wait()
+        for t in tasks:
+            t.cancel()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Documents and scaffolds connecting an external chat bot (**visayabai**) to opendray as a `kind=bridge` channel, with a complete runnable **Telegram** relay.

The bridge path was chosen over the consumer-integration path because visayabai is a chat surface: opendray then owns session routing, reply detection (`session.turn_completed`), notification policy, `/new` provider selection, account switching, and the voice MCP — the bot is a thin relay.

## Files (docs + reference scripts only — no product code)

- **`docs/integrations/connecting-visayabai-bot.md`** — the decision, the bridge wire protocol (verified against `internal/channel/bridge`), operator setup, and the consumer / reverse-proxy alternatives for reference.
- **`docs/integrations/visayabai_bridge_adapter.py`** — minimal, platform-agnostic reference adapter (register → forward messages → render outbound frames). Two stubs to wire to any bot.
- **`docs/integrations/visayabai_telegram_bridge.py`** — complete Telegram bot:
  - long-poll `getUpdates` → bridge `message` frames
  - opendray outbound → `sendMessage` / `sendChatAction`
  - declares `text` + `typing` + `buttons`, so the control keyboard and `/new` provider picker render as **real Telegram inline keyboards**; button taps → `card_action`
  - `conversation_id = Telegram chat id` → each chat maps to its own opendray session automatically
  - tokens via env (`TELEGRAM_BOT_TOKEN`, `OPENDRAY_HOST`, `BRIDGE_TOKEN`), never hardcoded

Both scripts pass `python -m py_compile`.

## Operator setup (in the guide)

1. opendray → Channels → add kind **bridge**, name `visayabai` + a shared token; bind/allow a session.
2. `pip install aiohttp websockets`, set the three env vars, run `visayabai_telegram_bridge.py`.
3. Message the Telegram bot → it round-trips through opendray.

## Test plan

- [ ] Register a bridge channel; run the Telegram adapter; confirm `register_ack ok=true` in logs.
- [ ] DM the bot → reply comes back from the bound Claude session.
- [ ] Two different chats → two independent sessions (distinct `conversation_id`).
- [ ] Control keyboard / `/new` render as inline buttons; a tap drives the session (`card_action`).
- [ ] Kill + restart opendray → adapter reconnects with backoff, keeps working.