### PR TITLE
feat(integrations): per-integration default agent + first-class session model

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -474,6 +474,12 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	if err := sessionMgr.ReconcileStartup(ctx); err != nil {
 		log.Warn("session reconcile on startup failed", "err", err)
 	}
+	// Built before the session handlers so POST /sessions can inherit an
+	// integration's configured spawn defaults (provider / model / claude
+	// account). The handlers (proxy, events, health) that consume it are
+	// constructed further below where the rest of the integration surface
+	// is assembled.
+	intgrSvc := integration.NewService(st.Pool(), bus, log)
 	sessionHandlers := session.NewHandlers(sessionMgr, log,
 		// Inject the cliacct validator so POST /sessions and
 		// PATCH /sessions/{id}/claude-account fail fast with 400
@@ -481,6 +487,10 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		// letting the row be persisted/mutated and then erroring
 		// at spawn time with 500.
 		session.WithClaudeAccountChecker(cliacctSvc),
+		// Fill provider/model/claude-account from the integration's
+		// configured defaults for sessions an integration creates and
+		// the request leaves those fields empty (request still wins).
+		session.WithIntegrationDefaults(&integrationDefaultsLookup{svc: intgrSvc}),
 	)
 	// Now that the session manager exists, let the catalog handler
 	// populate RuntimeInfo.ActiveSessions on update-check responses so
@@ -509,7 +519,6 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	channelHandlers := channel.NewHandlers(channelHub, log)
 	bridgeHandlers := bridge.NewHandlers(bridge.DefaultBroker(), log)
 
-	intgrSvc := integration.NewService(st.Pool(), bus, log)
 	intgrHandlers := integration.NewHandlers(intgrSvc, log)
 	intgrCallLogger := integration.NewCallLogger(st.Pool(), log)
 	intgrCallLogHandlers := integration.NewCallLogHandlers(intgrCallLogger, log)
@@ -2103,6 +2112,22 @@ func resolveAntigravityHistoryConfig(c config.AntigravityProviderConfig) session
 		out.ConversationsRoot = expandPath(c.ConversationsRoot)
 	}
 	return out
+}
+
+// integrationDefaultsLookup adapts integration.Service to the session
+// package's IntegrationDefaults interface, so a session an integration
+// creates inherits that integration's configured provider / model /
+// claude account when the POST /sessions request omits them.
+type integrationDefaultsLookup struct {
+	svc *integration.Service
+}
+
+func (l *integrationDefaultsLookup) DefaultsFor(ctx context.Context, integrationID string) (provider, model, claudeAccount string, err error) {
+	i, err := l.svc.Get(ctx, integrationID)
+	if err != nil {
+		return "", "", "", err
+	}
+	return i.DefaultProviderID, i.DefaultModel, i.DefaultClaudeAccountID, nil
 }
 
 // summarizerIntegrationLookup adapts integration.Service to the

--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -313,8 +313,9 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 	// manifest, which keeps spawn args reproducible across restarts.
 	configArgs, configEnv := applyConfigSchema(p.Manifest.ConfigSchema, p.Config)
 	args = append(args, configArgs...)
-	// Per-provider default model (operator-managed) → e.g. `--model X`.
-	args = append(args, modelArgs(p.Manifest, p.Config)...)
+	// Model → e.g. `--model X`. A per-session pin (Session.Model, threaded
+	// via context) wins over the per-provider operator default.
+	args = append(args, modelArgs(p.Manifest, p.Config, session.ModelFromContext(ctx))...)
 	if p.Manifest.ID == "codex" {
 		if approval, ok := p.Config["approval"].(string); ok && approval != "" {
 			args = append(args, "-c", "approval_policy="+tomlString(approval))

--- a/internal/catalog/configargs.go
+++ b/internal/catalog/configargs.go
@@ -27,15 +27,20 @@ import (
 // missing or unequal to dependsVal — lets fields like apiKey only apply
 // when authType=="custom".
 //
-// modelArgs renders the per-provider default model into CLI args when
-// the operator has set one (config["model"]) and the manifest declares a
-// model flag. A per-session --model in the spawn args still wins — the
-// session manager drops provider-derived flags the user re-specifies.
-func modelArgs(m Manifest, cfg map[string]any) []string {
+// modelArgs renders a model selection into CLI args when the manifest
+// declares a model flag. The per-session `override` (Session.Model) wins
+// over the per-provider default (config["model"]); empty override falls
+// back to the configured default. A per-session --model in the spawn
+// args still wins over both — the session manager drops provider-derived
+// flags the user re-specifies.
+func modelArgs(m Manifest, cfg map[string]any, override string) []string {
 	if m.ModelFlag == "" {
 		return nil
 	}
-	model, _ := cfg["model"].(string)
+	model := override
+	if model == "" {
+		model, _ = cfg["model"].(string)
+	}
 	if model == "" {
 		return nil
 	}

--- a/internal/catalog/configargs_test.go
+++ b/internal/catalog/configargs_test.go
@@ -291,20 +291,24 @@ func TestApplyConfigSchema_RealManifests(t *testing.T) {
 func TestModelArgs(t *testing.T) {
 	cli := Manifest{ModelFlag: "--model"}
 	cases := []struct {
-		name string
-		m    Manifest
-		cfg  map[string]any
-		want []string
+		name     string
+		m        Manifest
+		cfg      map[string]any
+		override string
+		want     []string
 	}{
-		{"default set", cli, map[string]any{"model": "opus"}, []string{"--model", "opus"}},
-		{"no default", cli, map[string]any{}, nil},
-		{"empty default", cli, map[string]any{"model": ""}, nil},
-		{"non-string default", cli, map[string]any{"model": 3}, nil},
-		{"no model flag", Manifest{}, map[string]any{"model": "opus"}, nil},
+		{"default set", cli, map[string]any{"model": "opus"}, "", []string{"--model", "opus"}},
+		{"no default", cli, map[string]any{}, "", nil},
+		{"empty default", cli, map[string]any{"model": ""}, "", nil},
+		{"non-string default", cli, map[string]any{"model": 3}, "", nil},
+		{"no model flag", Manifest{}, map[string]any{"model": "opus"}, "", nil},
+		{"override wins over default", cli, map[string]any{"model": "opus"}, "sonnet", []string{"--model", "sonnet"}},
+		{"override with no default", cli, map[string]any{}, "haiku", []string{"--model", "haiku"}},
+		{"override ignored without flag", Manifest{}, map[string]any{}, "haiku", nil},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := modelArgs(c.m, c.cfg)
+			got := modelArgs(c.m, c.cfg, c.override)
 			if len(got) != len(c.want) {
 				t.Fatalf("modelArgs=%v want %v", got, c.want)
 			}

--- a/internal/integration/handler.go
+++ b/internal/integration/handler.go
@@ -92,11 +92,14 @@ func (h *Handlers) get(w http.ResponseWriter, r *http.Request) {
 func (h *Handlers) update(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	var req struct {
-		BaseURL      *string       `json:"base_url,omitempty"`
-		Scopes       *[]string     `json:"scopes,omitempty"`
-		Version      *string       `json:"version,omitempty"`
-		Enabled      *bool         `json:"enabled,omitempty"`
-		MemoryPolicy *MemoryPolicy `json:"memory_policy,omitempty"`
+		BaseURL                *string       `json:"base_url,omitempty"`
+		Scopes                 *[]string     `json:"scopes,omitempty"`
+		Version                *string       `json:"version,omitempty"`
+		Enabled                *bool         `json:"enabled,omitempty"`
+		MemoryPolicy           *MemoryPolicy `json:"memory_policy,omitempty"`
+		DefaultProviderID      *string       `json:"default_provider_id,omitempty"`
+		DefaultModel           *string       `json:"default_model,omitempty"`
+		DefaultClaudeAccountID *string       `json:"default_claude_account_id,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, err)
@@ -108,11 +111,14 @@ func (h *Handlers) update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	patch := UpdatePatch{
-		BaseURL:      req.BaseURL,
-		Scopes:       req.Scopes,
-		Version:      req.Version,
-		Enabled:      req.Enabled,
-		MemoryPolicy: req.MemoryPolicy,
+		BaseURL:                req.BaseURL,
+		Scopes:                 req.Scopes,
+		Version:                req.Version,
+		Enabled:                req.Enabled,
+		MemoryPolicy:           req.MemoryPolicy,
+		DefaultProviderID:      req.DefaultProviderID,
+		DefaultModel:           req.DefaultModel,
+		DefaultClaudeAccountID: req.DefaultClaudeAccountID,
 	}
 	i, err := h.svc.Update(r.Context(), id, patch)
 	if errors.Is(err, ErrNotFound) {

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -81,6 +81,17 @@ type Integration struct {
 	// creates: none (default) | quarantine | full.
 	MemoryPolicy MemoryPolicy `json:"memory_policy"`
 
+	// DefaultProviderID / DefaultModel / DefaultClaudeAccountID are the
+	// spawn defaults applied to sessions this integration creates when
+	// the POST /sessions request omits the corresponding field. They are
+	// DEFAULTS, not enforcement: a request that supplies its own
+	// provider_id / model / claude_account_id always wins. Empty means
+	// "no default" — the session falls back to the request value (or the
+	// provider/CLI default when the request is also empty).
+	DefaultProviderID      string `json:"default_provider_id,omitempty"`
+	DefaultModel           string `json:"default_model,omitempty"`
+	DefaultClaudeAccountID string `json:"default_claude_account_id,omitempty"`
+
 	// IsSystem flags rows opendray manages itself (e.g. the
 	// auto-registered opendray-memory MCP integration). The UI
 	// renders system rows in a separate group and disables

--- a/internal/integration/service.go
+++ b/internal/integration/service.go
@@ -57,6 +57,13 @@ type RegisterRequest struct {
 	// this integration creates (none|quarantine|full). Empty defaults
 	// to quarantine — safe by default.
 	MemoryPolicy MemoryPolicy `json:"memory_policy,omitempty"`
+
+	// DefaultProviderID / DefaultModel / DefaultClaudeAccountID seed the
+	// spawn defaults for sessions this integration creates. All optional;
+	// empty means "no default". See Integration for semantics.
+	DefaultProviderID      string `json:"default_provider_id,omitempty"`
+	DefaultModel           string `json:"default_model,omitempty"`
+	DefaultClaudeAccountID string `json:"default_claude_account_id,omitempty"`
 }
 
 // RegisterResult bundles the persisted integration with the one-time
@@ -127,7 +134,12 @@ func (s *Service) Register(ctx context.Context, req RegisterRequest) (RegisterRe
 		CreatedAt:    time.Now().UTC(),
 		IsSystem:     req.IsSystem,
 		MemoryPolicy: policy,
-		apiKeyHash:   hash,
+
+		DefaultProviderID:      req.DefaultProviderID,
+		DefaultModel:           req.DefaultModel,
+		DefaultClaudeAccountID: req.DefaultClaudeAccountID,
+
+		apiKeyHash: hash,
 	}
 	if len(i.Scopes) == 0 {
 		i.Scopes = append([]string{}, defaultScopes...)

--- a/internal/integration/store.go
+++ b/internal/integration/store.go
@@ -32,11 +32,14 @@ func (s *store) Insert(ctx context.Context, i Integration) error {
 	_, err = s.pool.Exec(ctx, `
         INSERT INTO integrations
             (id, name, base_url, route_prefix, api_key_hash, scopes, version,
-             enabled, health_status, created_at, is_system, memory_policy)
-        VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9, $10, $11, $12)`,
+             enabled, health_status, created_at, is_system, memory_policy,
+             default_provider_id, default_model, default_claude_account_id)
+        VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9, $10, $11, $12,
+                $13, $14, $15)`,
 		i.ID, i.Name, i.BaseURL, i.RoutePrefix, i.apiKeyHash, scopesJSON,
 		nullIfEmpty(i.Version), i.Enabled, string(i.HealthStatus), i.CreatedAt,
-		i.IsSystem, string(policy))
+		i.IsSystem, string(policy),
+		i.DefaultProviderID, i.DefaultModel, i.DefaultClaudeAccountID)
 	if err != nil {
 		return fmt.Errorf("insert integration: %w", err)
 	}
@@ -125,6 +128,27 @@ func (s *store) Update(ctx context.Context, id string, patch UpdatePatch) error 
 			return fmt.Errorf("update memory_policy: %w", err)
 		}
 	}
+	if patch.DefaultProviderID != nil {
+		if _, err := s.pool.Exec(ctx,
+			`UPDATE integrations SET default_provider_id=$1 WHERE id=$2`,
+			*patch.DefaultProviderID, id); err != nil {
+			return fmt.Errorf("update default_provider_id: %w", err)
+		}
+	}
+	if patch.DefaultModel != nil {
+		if _, err := s.pool.Exec(ctx,
+			`UPDATE integrations SET default_model=$1 WHERE id=$2`,
+			*patch.DefaultModel, id); err != nil {
+			return fmt.Errorf("update default_model: %w", err)
+		}
+	}
+	if patch.DefaultClaudeAccountID != nil {
+		if _, err := s.pool.Exec(ctx,
+			`UPDATE integrations SET default_claude_account_id=$1 WHERE id=$2`,
+			*patch.DefaultClaudeAccountID, id); err != nil {
+			return fmt.Errorf("update default_claude_account_id: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -181,7 +205,10 @@ const selectStmt = `
            enabled, health_status, health_payload,
            health_last_seen, created_at, rotated_at,
            COALESCE(is_system, FALSE),
-           COALESCE(memory_policy, 'quarantine')
+           COALESCE(memory_policy, 'quarantine'),
+           COALESCE(default_provider_id, ''),
+           COALESCE(default_model, ''),
+           COALESCE(default_claude_account_id, '')
     FROM integrations`
 
 type rowScanner interface {
@@ -211,6 +238,7 @@ func (s *store) scanRow(row rowScanner) (Integration, error) {
 		&scopesRaw, &i.Version, &i.Enabled, &healthStatus, &healthRaw,
 		&healthLastSeen, &i.CreatedAt, &rotatedAt, &i.IsSystem,
 		&memoryPolicy,
+		&i.DefaultProviderID, &i.DefaultModel, &i.DefaultClaudeAccountID,
 	)
 	if err != nil {
 		return Integration{}, err
@@ -256,4 +284,10 @@ type UpdatePatch struct {
 	Version      *string
 	Enabled      *bool
 	MemoryPolicy *MemoryPolicy
+
+	// Spawn defaults for sessions this integration creates. A non-nil
+	// pointer sets the column (empty string clears the default).
+	DefaultProviderID      *string
+	DefaultModel           *string
+	DefaultClaudeAccountID *string
 }

--- a/internal/session/handler.go
+++ b/internal/session/handler.go
@@ -68,9 +68,23 @@ type ClaudeAccountChecker interface {
 	PickAutoAssignClaudeAccount(ctx context.Context) (string, error)
 }
 
+// IntegrationDefaults resolves the spawn defaults an integration has
+// configured (provider / model / claude account). create() applies them
+// to integration-origin sessions for any field the request omits. Kept
+// as a small interface so the session package needn't import the
+// integration registry directly. Optional; a nil resolver disables
+// default application.
+type IntegrationDefaults interface {
+	// DefaultsFor returns the configured spawn defaults for the
+	// integration with the given id. Any field may be empty ("no
+	// default"). The caller treats a non-nil error as "no defaults".
+	DefaultsFor(ctx context.Context, integrationID string) (provider, model, claudeAccount string, err error)
+}
+
 type Handlers struct {
 	svc      Service
 	acct     ClaudeAccountChecker // optional; nil disables early validation
+	defaults IntegrationDefaults  // optional; nil disables integration spawn defaults
 	log      *slog.Logger
 	upgrader websocket.Upgrader
 }
@@ -85,6 +99,14 @@ type HandlerOption func(*Handlers)
 // is equivalent to omitting the option (validation is skipped).
 func WithClaudeAccountChecker(c ClaudeAccountChecker) HandlerOption {
 	return func(h *Handlers) { h.acct = c }
+}
+
+// WithIntegrationDefaults wires the resolver used to fill provider /
+// model / claude account from an integration's configured spawn
+// defaults in create(). Passing nil is equivalent to omitting it
+// (defaults are not applied).
+func WithIntegrationDefaults(d IntegrationDefaults) HandlerOption {
+	return func(h *Handlers) { h.defaults = d }
 }
 
 func NewHandlers(svc Service, log *slog.Logger, opts ...HandlerOption) *Handlers {
@@ -141,6 +163,22 @@ func (h *Handlers) create(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
+	// Provenance — derived from the authenticated principal, never the
+	// JSON body (Cortex Phase 2). Integration-created sessions are
+	// tagged so the memory capture pipeline can route their facts by
+	// the integration's memory_policy instead of polluting durable
+	// memory. No principal (route not behind auth middleware, e.g. in
+	// tests) falls through to the operator default.
+	//
+	// Stamped first so integration defaults below see the resolved
+	// origin, and so the default-filled provider/account flow through
+	// the same validation + auto-assign as a client-supplied request.
+	if p, ok := integration.CurrentPrincipal(r.Context()); ok && p.Kind == integration.KindIntegration {
+		req.SetOrigin(OriginIntegration, p.ID)
+		h.applyIntegrationDefaults(r.Context(), p.ID, &req)
+	} else if ok {
+		req.SetOrigin(OriginOperator, "")
+	}
 	// Validate claude_account_id up front so the operator gets a clean
 	// 400 instead of a 500 on the deferred spawn-time error. We only
 	// check when an id was actually supplied; empty means "use the
@@ -164,23 +202,38 @@ func (h *Handlers) create(w http.ResponseWriter, r *http.Request) {
 		// Auto-assign errors are non-fatal: we still try to spawn
 		// with the CLI default rather than failing the create call.
 	}
-	// Provenance — derived from the authenticated principal, never the
-	// JSON body (Cortex Phase 2). Integration-created sessions are
-	// tagged so the memory capture pipeline can route their facts by
-	// the integration's memory_policy instead of polluting durable
-	// memory. No principal (route not behind auth middleware, e.g. in
-	// tests) falls through to the operator default.
-	if p, ok := integration.CurrentPrincipal(r.Context()); ok && p.Kind == integration.KindIntegration {
-		req.SetOrigin(OriginIntegration, p.ID)
-	} else if ok {
-		req.SetOrigin(OriginOperator, "")
-	}
 	sess, err := h.svc.Create(r.Context(), req)
 	if err != nil {
 		h.respondError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, sess)
+}
+
+// applyIntegrationDefaults fills provider / model / claude account from
+// the integration's configured spawn defaults, but only for fields the
+// request left empty — a client-supplied value always wins. A nil
+// resolver (option not wired) or any lookup error is a silent no-op:
+// defaults are a convenience, never a hard requirement for spawning.
+func (h *Handlers) applyIntegrationDefaults(ctx context.Context, integrationID string, req *CreateRequest) {
+	if h.defaults == nil {
+		return
+	}
+	provider, model, account, err := h.defaults.DefaultsFor(ctx, integrationID)
+	if err != nil {
+		h.log.Warn("integration defaults lookup failed",
+			"integration", integrationID, "err", err)
+		return
+	}
+	if req.ProviderID == "" {
+		req.ProviderID = provider
+	}
+	if req.Model == "" {
+		req.Model = model
+	}
+	if req.ClaudeAccountID == "" {
+		req.ClaudeAccountID = account
+	}
 }
 
 func (h *Handlers) list(w http.ResponseWriter, r *http.Request) {

--- a/internal/session/handler_test.go
+++ b/internal/session/handler_test.go
@@ -32,6 +32,7 @@ func (f *fakeSvc) Create(_ context.Context, req CreateRequest) (Session, error) 
 	}
 	s := Session{
 		ID: "ses_test", ProviderID: req.ProviderID, Cwd: req.Cwd,
+		Model:           req.Model, // surface so integration-default tests can assert it
 		Args:            req.Args,
 		State:           StateRunning,
 		ClaudeAccountID: req.ClaudeAccountID, // surface the field so auto-assign tests can assert it

--- a/internal/session/integration_defaults_test.go
+++ b/internal/session/integration_defaults_test.go
@@ -1,0 +1,169 @@
+package session
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/opendray/opendray-v2/internal/integration"
+)
+
+// fakeDefaults is a stand-in for the IntegrationDefaults resolver. It
+// returns the configured spawn defaults for a single integration id; any
+// other id yields err so the handler's "no defaults on error" path is
+// exercised too.
+type fakeDefaults struct {
+	id       string
+	provider string
+	model    string
+	account  string
+	err      error
+}
+
+func (f *fakeDefaults) DefaultsFor(_ context.Context, id string) (string, string, string, error) {
+	if f.err != nil {
+		return "", "", "", f.err
+	}
+	if id != f.id {
+		return "", "", "", errors.New("not found")
+	}
+	return f.provider, f.model, f.account, nil
+}
+
+// newRouterWithDefaults mounts the session handlers with both the
+// account checker (so a default account passes validation) and the
+// integration-defaults resolver.
+func newRouterWithDefaults(svc Service, c ClaudeAccountChecker, d IntegrationDefaults) http.Handler {
+	r := chi.NewRouter()
+	NewHandlers(svc, nil,
+		WithClaudeAccountChecker(c),
+		WithIntegrationDefaults(d),
+	).Mount(r)
+	return r
+}
+
+// asIntegration wraps a request's context with an integration principal,
+// mirroring what the auth middleware does in production.
+func asIntegration(req *http.Request, id string) *http.Request {
+	ctx := integration.WithPrincipal(req.Context(),
+		integration.Principal{Kind: integration.KindIntegration, ID: id})
+	return req.WithContext(ctx)
+}
+
+func TestCreate_IntegrationDefaultsFillEmptyFields(t *testing.T) {
+	svc := newFakeSvc()
+	checker := &fakeAcctChecker{known: map[string]bool{"cla_def": true}}
+	defs := &fakeDefaults{
+		id: "int_A", provider: "claude", model: "opus", account: "cla_def",
+	}
+	// Body omits provider/model/account entirely — only cwd is supplied.
+	req := httptest.NewRequest(http.MethodPost, "/sessions",
+		bytes.NewBufferString(`{"cwd":"/tmp"}`))
+	req = asIntegration(req, "int_A")
+	rr := httptest.NewRecorder()
+	newRouterWithDefaults(svc, checker, defs).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s; want 201", rr.Code, rr.Body)
+	}
+	var s Session
+	if err := json.Unmarshal(rr.Body.Bytes(), &s); err != nil {
+		t.Fatal(err)
+	}
+	if s.ProviderID != "claude" {
+		t.Errorf("provider: got %q, want defaulted 'claude'", s.ProviderID)
+	}
+	if s.Model != "opus" {
+		t.Errorf("model: got %q, want defaulted 'opus'", s.Model)
+	}
+	if s.ClaudeAccountID != "cla_def" {
+		t.Errorf("account: got %q, want defaulted 'cla_def'", s.ClaudeAccountID)
+	}
+}
+
+func TestCreate_RequestOverridesIntegrationDefaults(t *testing.T) {
+	svc := newFakeSvc()
+	checker := &fakeAcctChecker{known: map[string]bool{"cla_req": true, "cla_def": true}}
+	defs := &fakeDefaults{
+		id: "int_A", provider: "claude", model: "opus", account: "cla_def",
+	}
+	// Request supplies every field; defaults must NOT clobber them.
+	body := `{"provider_id":"codex","model":"sonnet","claude_account_id":"cla_req","cwd":"/tmp"}`
+	req := httptest.NewRequest(http.MethodPost, "/sessions", bytes.NewBufferString(body))
+	req = asIntegration(req, "int_A")
+	rr := httptest.NewRecorder()
+	newRouterWithDefaults(svc, checker, defs).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s; want 201", rr.Code, rr.Body)
+	}
+	var s Session
+	if err := json.Unmarshal(rr.Body.Bytes(), &s); err != nil {
+		t.Fatal(err)
+	}
+	if s.ProviderID != "codex" {
+		t.Errorf("provider: got %q, want request value 'codex'", s.ProviderID)
+	}
+	if s.Model != "sonnet" {
+		t.Errorf("model: got %q, want request value 'sonnet'", s.Model)
+	}
+	if s.ClaudeAccountID != "cla_req" {
+		t.Errorf("account: got %q, want request value 'cla_req'", s.ClaudeAccountID)
+	}
+}
+
+func TestCreate_OperatorOriginIgnoresIntegrationDefaults(t *testing.T) {
+	// An admin/operator principal (or no integration principal) must not
+	// pick up any integration's defaults.
+	svc := newFakeSvc()
+	defs := &fakeDefaults{id: "int_A", provider: "claude", model: "opus"}
+	req := httptest.NewRequest(http.MethodPost, "/sessions",
+		bytes.NewBufferString(`{"provider_id":"shell","cwd":"/tmp"}`))
+	req = req.WithContext(integration.WithPrincipal(req.Context(),
+		integration.Principal{Kind: integration.KindAdmin, ID: "admin"}))
+	rr := httptest.NewRecorder()
+	newRouterWithDefaults(svc, &fakeAcctChecker{}, defs).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s; want 201", rr.Code, rr.Body)
+	}
+	var s Session
+	if err := json.Unmarshal(rr.Body.Bytes(), &s); err != nil {
+		t.Fatal(err)
+	}
+	if s.ProviderID != "shell" {
+		t.Errorf("provider: got %q, want request value 'shell'", s.ProviderID)
+	}
+	if s.Model != "" {
+		t.Errorf("model: got %q, want empty (no integration default applied)", s.Model)
+	}
+}
+
+func TestCreate_IntegrationDefaultsLookupErrorIsNonFatal(t *testing.T) {
+	// A resolver error must not fail the spawn — the session is created
+	// with whatever the request carried.
+	svc := newFakeSvc()
+	defs := &fakeDefaults{err: errors.New("db down")}
+	req := httptest.NewRequest(http.MethodPost, "/sessions",
+		bytes.NewBufferString(`{"provider_id":"shell","cwd":"/tmp"}`))
+	req = asIntegration(req, "int_A")
+	rr := httptest.NewRecorder()
+	newRouterWithDefaults(svc, &fakeAcctChecker{}, defs).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s; want 201", rr.Code, rr.Body)
+	}
+	var s Session
+	if err := json.Unmarshal(rr.Body.Bytes(), &s); err != nil {
+		t.Fatal(err)
+	}
+	if s.ProviderID != "shell" {
+		t.Errorf("provider: got %q, want request value 'shell'", s.ProviderID)
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -540,6 +540,7 @@ func (m *Manager) Create(ctx context.Context, req CreateRequest) (Session, error
 		ID:              sessID,
 		Name:            name,
 		ProviderID:      req.ProviderID,
+		Model:           req.Model,
 		Cwd:             req.Cwd,
 		Args:            req.Args,
 		State:           StateRunning,
@@ -630,7 +631,7 @@ func (m *Manager) spawn(ctx context.Context, sess Session, reactivate bool) (*ru
 		return nil, fmt.Errorf("cwd is not a directory: %s", sess.Cwd)
 	}
 
-	resolveCtx := WithOrigin(WithAccountID(ctx, sess.ClaudeAccountID), sess.Origin)
+	resolveCtx := WithModel(WithOrigin(WithAccountID(ctx, sess.ClaudeAccountID), sess.Origin), sess.Model)
 	p, err := m.providers.Resolve(resolveCtx, sess.ProviderID)
 	if err != nil {
 		return nil, err

--- a/internal/session/model_ctx_test.go
+++ b/internal/session/model_ctx_test.go
@@ -1,0 +1,30 @@
+package session
+
+import (
+	"context"
+	"testing"
+)
+
+// WithModel/ModelFromContext thread a session's pinned model to the
+// catalog adapter so it renders the provider's model flag. See
+// provider.go and adapter.go.
+
+func TestWithModel_RoundTrip(t *testing.T) {
+	ctx := WithModel(context.Background(), "opus")
+	if got := ModelFromContext(ctx); got != "opus" {
+		t.Fatalf("ModelFromContext = %q, want %q", got, "opus")
+	}
+}
+
+func TestWithModel_EmptyIsNoOp(t *testing.T) {
+	ctx := WithModel(context.Background(), "")
+	if got := ModelFromContext(ctx); got != "" {
+		t.Fatalf("empty model must be a no-op, got %q", got)
+	}
+}
+
+func TestModelFromContext_DefaultEmpty(t *testing.T) {
+	if got := ModelFromContext(context.Background()); got != "" {
+		t.Fatalf("unset model must return empty, got %q", got)
+	}
+}

--- a/internal/session/provider.go
+++ b/internal/session/provider.go
@@ -84,6 +84,33 @@ func AccountID(ctx context.Context) string {
 	return ""
 }
 
+// ── Model selection ────────────────────────────────────────────────
+//
+// A session can pin its own model (Session.Model). Like the account
+// selection it isn't a Resolve() parameter, so we thread it through
+// context; the ProviderResolver renders it via the manifest's model
+// flag, taking precedence over the provider config default. Empty is a
+// no-op so the resolver falls back to the configured default.
+
+type modelCtxKey struct{}
+
+// WithModel attaches the session's pinned model to ctx for resolve-time
+// use. Empty model is a no-op.
+func WithModel(ctx context.Context, model string) context.Context {
+	if model == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, modelCtxKey{}, model)
+}
+
+// ModelFromContext retrieves the value set by WithModel, or "" if none.
+func ModelFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(modelCtxKey{}).(string); ok {
+		return v
+	}
+	return ""
+}
+
 // ── Cwd propagation ────────────────────────────────────────────────
 //
 // Some prepare-time decisions (notably the memory MCP auto-attach)

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -56,9 +56,13 @@ func classifyExitState(stopRequested, closing bool) State {
 // resources (PTY fd, ring buffer, subscribers) live on the Manager's
 // internal struct, not here.
 type Session struct {
-	ID              string   `json:"id"`
-	Name            string   `json:"name,omitempty"`
-	ProviderID      string   `json:"provider_id"`
+	ID         string `json:"id"`
+	Name       string `json:"name,omitempty"`
+	ProviderID string `json:"provider_id"`
+	// Model pins the model this session spawns against, applied at
+	// spawn via the provider's model flag. Empty falls back to the
+	// provider config default. See CreateRequest.Model.
+	Model           string   `json:"model,omitempty"`
 	Cwd             string   `json:"cwd"`
 	Args            []string `json:"args"`
 	State           State    `json:"state"`
@@ -97,8 +101,13 @@ const (
 
 // CreateRequest is the JSON body for POST /api/v1/sessions.
 type CreateRequest struct {
-	Name            string   `json:"name"`
-	ProviderID      string   `json:"provider_id"`
+	Name       string `json:"name"`
+	ProviderID string `json:"provider_id"`
+	// Model optionally pins the model for this session (e.g. an "opus"
+	// id for the claude provider). Empty means "use the provider config
+	// default". Applied at spawn via the provider's model flag, so a
+	// `--model` in Args still wins (the manager dedups overridden flags).
+	Model           string   `json:"model,omitempty"`
 	ClaudeAccountID string   `json:"claude_account_id,omitempty"`
 	ParentSessionID string   `json:"parent_session_id,omitempty"`
 	Cwd             string   `json:"cwd"`

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -18,8 +18,8 @@ type sessionStore struct{ pool *pgxpool.Pool }
 func newStore(pool *pgxpool.Pool) *sessionStore { return &sessionStore{pool: pool} }
 
 const sessionSelect = `
-    SELECT id, COALESCE(name, ''), provider_id, cwd, args, state,
-           COALESCE(pid, 0),
+    SELECT id, COALESCE(name, ''), provider_id, COALESCE(model, ''), cwd,
+           args, state, COALESCE(pid, 0),
            COALESCE(claude_account_id, ''), COALESCE(claude_session_id, ''),
            COALESCE(parent_session_id, ''),
            COALESCE(origin, 'operator'), COALESCE(integration_id, ''),
@@ -40,12 +40,12 @@ func (s *sessionStore) Insert(ctx context.Context, sess Session) error {
 	}
 	_, err = s.pool.Exec(ctx, `
         INSERT INTO sessions
-            (id, name, provider_id, cwd, args, state, pid,
+            (id, name, provider_id, model, cwd, args, state, pid,
              claude_account_id, claude_session_id, parent_session_id,
              origin, integration_id, started_at)
-        VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13)`,
-		sess.ID, nullableString(sess.Name), sess.ProviderID, sess.Cwd,
-		argsJSON, string(sess.State), nullableInt(sess.PID),
+        VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9, $10, $11, $12, $13, $14)`,
+		sess.ID, nullableString(sess.Name), sess.ProviderID, sess.Model,
+		sess.Cwd, argsJSON, string(sess.State), nullableInt(sess.PID),
 		nullableString(sess.ClaudeAccountID), nullableString(sess.ClaudeSessionID),
 		nullableString(sess.ParentSessionID),
 		string(origin), nullableString(sess.IntegrationID),
@@ -237,7 +237,7 @@ func scanSession(row rowScanner) (Session, error) {
 		stateStr  string
 		originStr string
 	)
-	err := row.Scan(&s.ID, &s.Name, &s.ProviderID, &s.Cwd, &argsJSON,
+	err := row.Scan(&s.ID, &s.Name, &s.ProviderID, &s.Model, &s.Cwd, &argsJSON,
 		&stateStr, &s.PID, &s.ClaudeAccountID, &s.ClaudeSessionID,
 		&s.ParentSessionID, &originStr, &s.IntegrationID,
 		&s.StartedAt, &endedAt, &exitCode)

--- a/internal/store/migrations/0064_integration_default_agent.sql
+++ b/internal/store/migrations/0064_integration_default_agent.sql
@@ -1,0 +1,29 @@
+-- 0064 — per-integration default agent (provider + model + claude account)
+-- and a first-class per-session model.
+--
+-- Third-party integrations (Cortex Phase 2 / #3) often spawn every
+-- session against the same provider, model, and Claude account. Rather
+-- than make the consumer repeat that on each POST /sessions, an operator
+-- configures the integration's defaults once; session create fills any
+-- field the request omits (the request still wins when it supplies one —
+-- these are DEFAULTS, not enforcement).
+--
+--   default_provider_id:       '' (none) | 'claude' | 'codex' | 'gemini' | …
+--   default_model:             '' (CLI/provider default) | a model id
+--   default_claude_account_id: '' (none) | a cliacct id
+--
+-- `sessions.model` promotes model selection to a first-class request
+-- field. Until now a model could only be pinned per-provider (provider
+-- config `model`) or hand-typed into the spawn args (`--model X`). The
+-- column lets a single session carry its own model — applied at spawn
+-- time via the provider's model flag — so integration defaults (and a
+-- future per-session model picker) have a clean home. Empty means
+-- "fall back to the provider config default", preserving prior behavior.
+
+ALTER TABLE integrations
+    ADD COLUMN default_provider_id       TEXT NOT NULL DEFAULT '',
+    ADD COLUMN default_model             TEXT NOT NULL DEFAULT '',
+    ADD COLUMN default_claude_account_id TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE sessions
+    ADD COLUMN model TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
## Summary

Backend for **#3 of the integration-isolation arc** (stacked on #376). Lets an operator configure an integration's default **provider + model + Claude account** once; sessions that integration creates inherit them when the `POST /sessions` request omits the field. Defaults are a *convenience, not enforcement* — a request value always wins.

> Stacked on #376 (`feat/hide-integration-sessions`). Review/merge that first; this PR's base will retarget to `main` once #376 lands. The diff here is #3-only.

## What changed

- **migration 0064** — `integrations.default_provider_id` / `default_model` / `default_claude_account_id`, and a first-class `sessions.model` column (all `TEXT NOT NULL DEFAULT ''`).
- **integration registry** — the three `default_*` fields flow through `Integration`, the store (insert/select/scan), `RegisterRequest`, and `UpdatePatch`.
- **session create** — for an integration-origin request, empty `provider_id` / `model` / `claude_account_id` are filled from the integration's defaults via a small `IntegrationDefaults` resolver (wired in `app` from `integration.Service`). Provenance is now stamped *before* validation, so a default-filled account flows through the same checker + auto-assign as a client-supplied one. A resolver error is a non-fatal no-op.
- **first-class model** — `CreateRequest.Model` / `Session.Model`, threaded to the catalog adapter via `WithModel` / `ModelFromContext` and rendered through the manifest's model flag. Precedence: spawn-args `--model` > per-session model > provider config default. Persisted, so it survives restart / gateway-resume.

UI (web + mobile + i18n) follows in **PR-3b**.

## Design notes

- `model` had no first-class request field before — it could only be pinned per-provider (provider config) or hand-typed into spawn args. Promoting it to a column/field is the clean home for the integration default and also unblocks a future per-session model picker on web (current parity gap).
- The resolver is an interface so the `session` package stays decoupled from the integration registry, mirroring the existing `ClaudeAccountChecker` optional-dependency pattern.

## Test plan

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test -race ./internal/session/... ./internal/catalog/... ./internal/integration/... ./internal/app/...` ✅
- New tests:
  - integration defaults: fill-empty-fields, request-overrides, operator-origin-ignores, lookup-error-non-fatal
  - `WithModel` / `ModelFromContext` round-trip
  - `modelArgs` override precedence (override wins over config default, ignored without a model flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)