### PR TITLE
feat(integrations): default-agent config UI (web + mobile + i18n)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1345,6 +1345,18 @@
         "deleteConfirm": "Delete integration {name}?",
         "removedToast": "Integration removed"
       },
+      "defaultAgent": {
+        "title": "Default agent",
+        "description": "Applied to sessions this integration creates when its request omits the field. The request always wins — these are defaults, not enforcement.",
+        "providerLabel": "Default provider",
+        "providerNone": "No default",
+        "modelLabel": "Default model",
+        "modelPlaceholder": "Provider default (e.g. opus)",
+        "accountLabel": "Default Claude account",
+        "accountNone": "No default",
+        "accountTokenMissing": "(token missing)",
+        "accountHint": "Only applies when the default provider is Claude."
+      },
       "register_dialog": {
         "title": "Register integration",
         "description": "Issues a one-time API key. Copy it before closing — opendray never displays the plaintext again.",
@@ -3624,6 +3636,18 @@
       "apiKeyWarn": "You won't see this key again.",
       "copyCopied": "Copied",
       "copyCopy": "Copy"
+    },
+    "defaultAgent": {
+      "title": "Default agent",
+      "description": "Applied to sessions this integration creates when its request omits the field. The request always wins.",
+      "providerLabel": "Default provider",
+      "providerNone": "No default",
+      "modelLabel": "Default model",
+      "modelHint": "Provider default (e.g. opus)",
+      "accountLabel": "Default Claude account",
+      "accountNone": "No default",
+      "accountTokenMissing": "(token missing)",
+      "accountHint": "Only applies when the default provider is Claude."
     },
     "emptyState": "Register from the web admin: Integrations → New.",
     "sectionRegistered": "Registered",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -1345,6 +1345,18 @@
         "deleteConfirm": "¿Eliminar la integración {name}?",
         "removedToast": "Integración eliminada"
       },
+      "defaultAgent": {
+        "title": "Agente predeterminado",
+        "description": "Se aplica a las sesiones que crea esta integración cuando la petición omite el campo. La petición siempre prevalece: son valores predeterminados, no obligatorios.",
+        "providerLabel": "Proveedor predeterminado",
+        "providerNone": "Sin predeterminado",
+        "modelLabel": "Modelo predeterminado",
+        "modelPlaceholder": "Predeterminado del proveedor (p. ej. opus)",
+        "accountLabel": "Cuenta de Claude predeterminada",
+        "accountNone": "Sin predeterminado",
+        "accountTokenMissing": "(falta el token)",
+        "accountHint": "Solo se aplica cuando el proveedor predeterminado es Claude."
+      },
       "register_dialog": {
         "title": "Registrar integración",
         "description": "Emite una API key de un solo uso. Cópiala antes de cerrar: opendray nunca vuelve a mostrar el texto en claro.",
@@ -3624,6 +3636,18 @@
       "apiKeyWarn": "No volverás a ver esta key.",
       "copyCopied": "Copiado",
       "copyCopy": "Copiar"
+    },
+    "defaultAgent": {
+      "title": "Agente predeterminado",
+      "description": "Se aplica a las sesiones que crea esta integración cuando la petición omite el campo. La petición siempre prevalece.",
+      "providerLabel": "Proveedor predeterminado",
+      "providerNone": "Sin predeterminado",
+      "modelLabel": "Modelo predeterminado",
+      "modelHint": "Predeterminado del proveedor (p. ej. opus)",
+      "accountLabel": "Cuenta de Claude predeterminada",
+      "accountNone": "Sin predeterminado",
+      "accountTokenMissing": "(falta el token)",
+      "accountHint": "Solo se aplica cuando el proveedor predeterminado es Claude."
     },
     "emptyState": "Regístrala desde el admin web: Integraciones → Nueva.",
     "sectionRegistered": "Registradas",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -1345,6 +1345,18 @@
         "deleteConfirm": "删除集成 {name}?",
         "removedToast": "集成已移除"
       },
+      "defaultAgent": {
+        "title": "默认 agent",
+        "description": "当该集成创建会话且请求未指定相应字段时套用。请求值始终优先 — 这是默认值,而非强制。",
+        "providerLabel": "默认 provider",
+        "providerNone": "无默认",
+        "modelLabel": "默认模型",
+        "modelPlaceholder": "provider 默认(如 opus)",
+        "accountLabel": "默认 Claude 账号",
+        "accountNone": "无默认",
+        "accountTokenMissing": "(缺少 token)",
+        "accountHint": "仅当默认 provider 为 Claude 时生效。"
+      },
       "register_dialog": {
         "title": "注册集成",
         "description": "签发一次性 API key。关闭前请复制它 — opendray 不会再显示明文。",
@@ -3624,6 +3636,18 @@
       "apiKeyWarn": "此 key 只显示这一次。",
       "copyCopied": "已复制",
       "copyCopy": "复制"
+    },
+    "defaultAgent": {
+      "title": "默认 agent",
+      "description": "当该集成创建会话且请求未指定相应字段时套用。请求值始终优先。",
+      "providerLabel": "默认 provider",
+      "providerNone": "无默认",
+      "modelLabel": "默认模型",
+      "modelHint": "provider 默认(如 opus)",
+      "accountLabel": "默认 Claude 账号",
+      "accountNone": "无默认",
+      "accountTokenMissing": "(缺少 token)",
+      "accountHint": "仅当默认 provider 为 Claude 时生效。"
     },
     "emptyState": "在 Web 管理端注册：集成 → 新建。",
     "sectionRegistered": "已注册",

--- a/app/mobile/lib/core/api/integrations_api.dart
+++ b/app/mobile/lib/core/api/integrations_api.dart
@@ -21,6 +21,9 @@ class Integration {
     this.version,
     this.healthLastSeen,
     this.rotatedAt,
+    this.defaultProviderId = '',
+    this.defaultModel = '',
+    this.defaultClaudeAccountId = '',
   });
 
   factory Integration.fromJson(Map<String, dynamic> json) {
@@ -45,6 +48,10 @@ class Integration {
       rotatedAt:
           DateTime.tryParse(json['rotated_at'] as String? ?? '')?.toUtc(),
       isSystem: json['is_system'] as bool? ?? false,
+      defaultProviderId: json['default_provider_id'] as String? ?? '',
+      defaultModel: json['default_model'] as String? ?? '',
+      defaultClaudeAccountId:
+          json['default_claude_account_id'] as String? ?? '',
     );
   }
 
@@ -63,6 +70,11 @@ class Integration {
   // System rows are managed by opendray itself (e.g. opendray-memory MCP)
   // — not operator-mutable.
   final bool isSystem;
+  // Spawn defaults applied to sessions this integration creates when the
+  // request omits the field (the request always wins). Empty = no default.
+  final String defaultProviderId;
+  final String defaultModel;
+  final String defaultClaudeAccountId;
 }
 
 class CallEntry {
@@ -222,6 +234,9 @@ class IntegrationsApi {
     required String routePrefix,
     List<String>? scopes,
     String? version,
+    String? defaultProviderId,
+    String? defaultModel,
+    String? defaultClaudeAccountId,
   }) async {
     try {
       final res = await _dio.post<Map<String, dynamic>>(
@@ -232,6 +247,13 @@ class IntegrationsApi {
           'route_prefix': routePrefix,
           if (scopes != null && scopes.isNotEmpty) 'scopes': scopes,
           if (version != null && version.isNotEmpty) 'version': version,
+          if (defaultProviderId != null && defaultProviderId.isNotEmpty)
+            'default_provider_id': defaultProviderId,
+          if (defaultModel != null && defaultModel.isNotEmpty)
+            'default_model': defaultModel,
+          if (defaultClaudeAccountId != null &&
+              defaultClaudeAccountId.isNotEmpty)
+            'default_claude_account_id': defaultClaudeAccountId,
         },
       );
       return RegisterResult.fromJson(res.data ?? {});
@@ -248,6 +270,9 @@ class IntegrationsApi {
     List<String>? scopes,
     String? version,
     bool? enabled,
+    String? defaultProviderId,
+    String? defaultModel,
+    String? defaultClaudeAccountId,
   }) async {
     try {
       final res = await _dio.patch<Map<String, dynamic>>(
@@ -257,6 +282,12 @@ class IntegrationsApi {
           if (scopes != null) 'scopes': scopes,
           if (version != null) 'version': version,
           if (enabled != null) 'enabled': enabled,
+          // Non-null means "set" — empty string clears the default.
+          if (defaultProviderId != null)
+            'default_provider_id': defaultProviderId,
+          if (defaultModel != null) 'default_model': defaultModel,
+          if (defaultClaudeAccountId != null)
+            'default_claude_account_id': defaultClaudeAccountId,
         },
       );
       return Integration.fromJson(res.data ?? {});

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 11571 (3857 per locale)
+/// Strings: 11631 (3877 per locale)
 ///
-/// Built on 2026-06-16 at 14:32 UTC
+/// Built on 2026-06-17 at 08:37 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -735,6 +735,7 @@ class TranslationsIntegrationsEn {
 	String get directionOutbound => 'Outbound';
 
 	late final TranslationsIntegrationsFormEn form = TranslationsIntegrationsFormEn.internal(_root);
+	late final TranslationsIntegrationsDefaultAgentEn defaultAgent = TranslationsIntegrationsDefaultAgentEn.internal(_root);
 
 	/// en: 'Register from the web admin: Integrations → New.'
 	String get emptyState => 'Register from the web admin: Integrations → New.';
@@ -2979,6 +2980,7 @@ class TranslationsWebIntegrationsEn {
 	String get groupOperator => 'Operator-registered';
 
 	late final TranslationsWebIntegrationsCardEn card = TranslationsWebIntegrationsCardEn.internal(_root);
+	late final TranslationsWebIntegrationsDefaultAgentEn defaultAgent = TranslationsWebIntegrationsDefaultAgentEn.internal(_root);
 	late final TranslationsWebIntegrationsRegisterDialogEn register_dialog = TranslationsWebIntegrationsRegisterDialogEn.internal(_root);
 	late final TranslationsWebIntegrationsRevealEn reveal = TranslationsWebIntegrationsRevealEn.internal(_root);
 	late final TranslationsWebIntegrationsEditDialogEn edit_dialog = TranslationsWebIntegrationsEditDialogEn.internal(_root);
@@ -4215,6 +4217,45 @@ class TranslationsIntegrationsFormEn {
 
 	/// en: 'Copy'
 	String get copyCopy => 'Copy';
+}
+
+// Path: integrations.defaultAgent
+class TranslationsIntegrationsDefaultAgentEn {
+	TranslationsIntegrationsDefaultAgentEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Default agent'
+	String get title => 'Default agent';
+
+	/// en: 'Applied to sessions this integration creates when its request omits the field. The request always wins.'
+	String get description => 'Applied to sessions this integration creates when its request omits the field. The request always wins.';
+
+	/// en: 'Default provider'
+	String get providerLabel => 'Default provider';
+
+	/// en: 'No default'
+	String get providerNone => 'No default';
+
+	/// en: 'Default model'
+	String get modelLabel => 'Default model';
+
+	/// en: 'Provider default (e.g. opus)'
+	String get modelHint => 'Provider default (e.g. opus)';
+
+	/// en: 'Default Claude account'
+	String get accountLabel => 'Default Claude account';
+
+	/// en: 'No default'
+	String get accountNone => 'No default';
+
+	/// en: '(token missing)'
+	String get accountTokenMissing => '(token missing)';
+
+	/// en: 'Only applies when the default provider is Claude.'
+	String get accountHint => 'Only applies when the default provider is Claude.';
 }
 
 // Path: memoryWorkers.tasks
@@ -8566,6 +8607,45 @@ class TranslationsWebIntegrationsCardEn {
 
 	/// en: 'Integration removed'
 	String get removedToast => 'Integration removed';
+}
+
+// Path: web.integrations.defaultAgent
+class TranslationsWebIntegrationsDefaultAgentEn {
+	TranslationsWebIntegrationsDefaultAgentEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Default agent'
+	String get title => 'Default agent';
+
+	/// en: 'Applied to sessions this integration creates when its request omits the field. The request always wins — these are defaults, not enforcement.'
+	String get description => 'Applied to sessions this integration creates when its request omits the field. The request always wins — these are defaults, not enforcement.';
+
+	/// en: 'Default provider'
+	String get providerLabel => 'Default provider';
+
+	/// en: 'No default'
+	String get providerNone => 'No default';
+
+	/// en: 'Default model'
+	String get modelLabel => 'Default model';
+
+	/// en: 'Provider default (e.g. opus)'
+	String get modelPlaceholder => 'Provider default (e.g. opus)';
+
+	/// en: 'Default Claude account'
+	String get accountLabel => 'Default Claude account';
+
+	/// en: 'No default'
+	String get accountNone => 'No default';
+
+	/// en: '(token missing)'
+	String get accountTokenMissing => '(token missing)';
+
+	/// en: 'Only applies when the default provider is Claude.'
+	String get accountHint => 'Only applies when the default provider is Claude.';
 }
 
 // Path: web.integrations.register_dialog
@@ -17856,6 +17936,16 @@ extension on Translations {
 			'web.integrations.card.rotateConfirm' => ({required Object name}) => 'Rotate the API key for "${name}"? The current key will stop working immediately.',
 			'web.integrations.card.deleteConfirm' => ({required Object name}) => 'Delete integration ${name}?',
 			'web.integrations.card.removedToast' => 'Integration removed',
+			'web.integrations.defaultAgent.title' => 'Default agent',
+			'web.integrations.defaultAgent.description' => 'Applied to sessions this integration creates when its request omits the field. The request always wins — these are defaults, not enforcement.',
+			'web.integrations.defaultAgent.providerLabel' => 'Default provider',
+			'web.integrations.defaultAgent.providerNone' => 'No default',
+			'web.integrations.defaultAgent.modelLabel' => 'Default model',
+			'web.integrations.defaultAgent.modelPlaceholder' => 'Provider default (e.g. opus)',
+			'web.integrations.defaultAgent.accountLabel' => 'Default Claude account',
+			'web.integrations.defaultAgent.accountNone' => 'No default',
+			'web.integrations.defaultAgent.accountTokenMissing' => '(token missing)',
+			'web.integrations.defaultAgent.accountHint' => 'Only applies when the default provider is Claude.',
 			'web.integrations.register_dialog.title' => 'Register integration',
 			'web.integrations.register_dialog.description' => 'Issues a one-time API key. Copy it before closing — opendray never displays the plaintext again.',
 			'web.integrations.register_dialog.nameLabel' => 'Name',
@@ -18296,6 +18386,8 @@ extension on Translations {
 			'web.backups.targetEditor.enableImmediately' => 'Enable immediately (otherwise saved as disabled — useful for "configure now, turn on later")',
 			'web.backups.targetEditor.local.rootLabel' => 'Root directory',
 			'web.backups.targetEditor.local.rootHint' => 'Empty = cfg.backup.local_dir (~/.opendray/backups)',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.targetEditor.local.rootPlaceholder' => '~/backups/opendray  or  /mnt/external-hdd/opendray',
 			'web.backups.targetEditor.smb.hostLabel' => 'Host',
 			'web.backups.targetEditor.smb.hostPlaceholder' => '192.168.1.20',
@@ -18306,8 +18398,6 @@ extension on Translations {
 			'web.backups.targetEditor.smb.userLabel' => 'User',
 			'web.backups.targetEditor.smb.passwordLabel' => 'Password',
 			'web.backups.targetEditor.smb.pathPrefixLabel' => 'Path prefix',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.targetEditor.smb.pathPrefixHint' => 'Sub-folder under the share root (optional)',
 			'web.backups.targetEditor.smb.pathPrefixPlaceholder' => 'opendray/backups',
 			'web.backups.targetEditor.s3.endpointLabel' => 'Endpoint',
@@ -18810,6 +18900,8 @@ extension on Translations {
 			'web.export.backToBackups' => '← Backups',
 			'web.export.sections.export' => 'Export',
 			'web.export.sections.import' => 'Import',
+			_ => null,
+		} ?? switch (path) {
 			'web.export.form.scope' => 'Scope',
 			'web.export.form.memories' => 'Memories',
 			'web.export.form.memoriesHint' => 'Cross-CLI persistent memory rows (text + scope + metadata). Embedding vectors are omitted; importer re-embeds.',
@@ -18820,8 +18912,6 @@ extension on Translations {
 			'web.export.form.integrationOptions.noneHint' => 'Skip the integrations table entirely.',
 			'web.export.form.integrationOptions.metadata' => 'Metadata only (recommended)',
 			'web.export.form.integrationOptions.metadataHint' => 'ID, name, route prefix, scopes — no API key material.',
-			_ => null,
-		} ?? switch (path) {
 			'web.export.form.integrationOptions.plaintext' => 'Include plaintext API keys',
 			'web.export.form.integrationOptions.plaintextHint' => 'v1 bcrypt-only: no recoverable plaintext exists. Manifest documents this; nothing leaks.',
 			'web.export.form.confirmWarning' => 'Type <1>I understand</1> to confirm. opendray currently stores only bcrypt hashes — selecting plaintext does NOT export any plaintext (the feature is reserved for a future release that keeps plaintext caches).',
@@ -19324,6 +19414,8 @@ extension on Translations {
 			'sessions.inspector.git.tabLog' => 'Log',
 			'sessions.inspector.tasks.runCommand' => 'Run command',
 			'sessions.inspector.tasks.runCommandSubtitle' => 'Runs in a new shell session and switches to it',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.tasks.filterHint' => 'Filter tasks…',
 			'sessions.inspector.tasks.noMatch' => ({required Object query}) => 'No tasks match "${query}"',
 			'sessions.inspector.tasks.emptyTitle' => 'No tasks in this folder',
@@ -19334,8 +19426,6 @@ extension on Translations {
 			'sessions.inspector.notes.insertAtRefTooltip' => 'Insert as @reference',
 			'sessions.inspector.notes.insertAtRefShort' => 'Insert @reference',
 			'sessions.inspector.notes.draftHint' => ({required Object project}) => '# ${project}\n\nThoughts, todos, context for the agent…',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.createFailed' => ({required Object error}) => 'Create failed: ${error}',
 			'sessions.inspector.notes.saveFailed' => ({required Object error}) => 'Save failed: ${error}',
 			'sessions.inspector.notes.changeLocationTooltip' => 'Change project docs location',
@@ -19605,6 +19695,16 @@ extension on Translations {
 			'integrations.form.apiKeyWarn' => 'You won\'t see this key again.',
 			'integrations.form.copyCopied' => 'Copied',
 			'integrations.form.copyCopy' => 'Copy',
+			'integrations.defaultAgent.title' => 'Default agent',
+			'integrations.defaultAgent.description' => 'Applied to sessions this integration creates when its request omits the field. The request always wins.',
+			'integrations.defaultAgent.providerLabel' => 'Default provider',
+			'integrations.defaultAgent.providerNone' => 'No default',
+			'integrations.defaultAgent.modelLabel' => 'Default model',
+			'integrations.defaultAgent.modelHint' => 'Provider default (e.g. opus)',
+			'integrations.defaultAgent.accountLabel' => 'Default Claude account',
+			'integrations.defaultAgent.accountNone' => 'No default',
+			'integrations.defaultAgent.accountTokenMissing' => '(token missing)',
+			'integrations.defaultAgent.accountHint' => 'Only applies when the default provider is Claude.',
 			'integrations.emptyState' => 'Register from the web admin: Integrations → New.',
 			'integrations.sectionRegistered' => 'Registered',
 			'integrations.sectionSystem' => 'System',
@@ -19828,6 +19928,8 @@ extension on Translations {
 			'backups.overviewTargets' => 'Targets',
 			'backups.overviewSchedules' => 'Schedules',
 			'backups.overviewBackups' => 'Backups',
+			_ => null,
+		} ?? switch (path) {
 			'backups.health.headlineHealthy' => 'Backups healthy',
 			'backups.health.headlineAttention' => 'Needs attention',
 			'backups.health.headlineNever' => 'No backups yet',
@@ -19848,8 +19950,6 @@ extension on Translations {
 			'backups.encryption.passphraseLabel' => 'Your passphrase',
 			'backups.encryption.passphraseHint' => 'At least 20 characters',
 			'backups.encryption.passphraseCopied' => 'Passphrase copied to clipboard',
-			_ => null,
-		} ?? switch (path) {
 			'backups.restoreFromFile' => 'Restore from file',
 			'backups.restore.title' => 'Restore from bundle',
 			'backups.restore.subtitle' => 'Replay an encrypted .tar.gz.enc bundle into a Postgres database. The bundle is uploaded from this phone — pick a file produced by a prior backup.',
@@ -20342,6 +20442,8 @@ extension on Translations {
 			'dataExport.imports.columns.source' => 'Source',
 			'dataExport.imports.columns.counts' => 'Counts',
 			'dataExport.imports.columns.when' => 'When',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.relative.inSeconds' => ({required Object n}) => 'in ${n}s',
 			'dataExport.relative.inMinutes' => ({required Object n}) => 'in ${n}m',
 			'dataExport.relative.inHours' => ({required Object n}) => 'in ${n}h',
@@ -20362,8 +20464,6 @@ extension on Translations {
 			'memory.status.floorNoModel' => 'Keyword (BM25) retrieval only — no embedding model configured. Configure a dense endpoint in Settings to enable semantic memory.',
 			'memory.status.denseConfiguredPendingRestart' => ({required Object model}) => 'Configured ${model} (dense) — restart the gateway to activate semantic memory and re-embed existing memories.',
 			'memory.status.denseUnreachableFloor' => ({required Object model}) => 'Configured ${model} (dense) but the endpoint is unreachable — using the keyword floor until it responds (auto-upgrades on restart).',
-			_ => null,
-		} ?? switch (path) {
 			'memory.status.denseDegraded' => 'Dense embedder active but its endpoint is unreachable right now — existing vectors are preserved; new writes and similarity search pause until it responds.',
 			'memory.title' => 'Memory',
 			'memory.more' => 'More',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -388,6 +388,7 @@ class _TranslationsIntegrationsEs extends TranslationsIntegrationsEn {
 	@override String get directionInbound => 'Entrantes';
 	@override String get directionOutbound => 'Salientes';
 	@override late final _TranslationsIntegrationsFormEs form = _TranslationsIntegrationsFormEs._(_root);
+	@override late final _TranslationsIntegrationsDefaultAgentEs defaultAgent = _TranslationsIntegrationsDefaultAgentEs._(_root);
 	@override String get emptyState => 'Regístrala desde el admin web: Integraciones → Nueva.';
 	@override String get sectionRegistered => 'Registradas';
 	@override String get sectionSystem => 'Sistema';
@@ -1424,6 +1425,7 @@ class _TranslationsWebIntegrationsEs extends TranslationsWebIntegrationsEn {
 	@override String get groupSystem => 'Sistema (gestionado por opendray)';
 	@override String get groupOperator => 'Registradas por el operador';
 	@override late final _TranslationsWebIntegrationsCardEs card = _TranslationsWebIntegrationsCardEs._(_root);
+	@override late final _TranslationsWebIntegrationsDefaultAgentEs defaultAgent = _TranslationsWebIntegrationsDefaultAgentEs._(_root);
 	@override late final _TranslationsWebIntegrationsRegisterDialogEs register_dialog = _TranslationsWebIntegrationsRegisterDialogEs._(_root);
 	@override late final _TranslationsWebIntegrationsRevealEs reveal = _TranslationsWebIntegrationsRevealEs._(_root);
 	@override late final _TranslationsWebIntegrationsEditDialogEs edit_dialog = _TranslationsWebIntegrationsEditDialogEs._(_root);
@@ -2115,6 +2117,25 @@ class _TranslationsIntegrationsFormEs extends TranslationsIntegrationsFormEn {
 	@override String get apiKeyWarn => 'No volverás a ver esta key.';
 	@override String get copyCopied => 'Copiado';
 	@override String get copyCopy => 'Copiar';
+}
+
+// Path: integrations.defaultAgent
+class _TranslationsIntegrationsDefaultAgentEs extends TranslationsIntegrationsDefaultAgentEn {
+	_TranslationsIntegrationsDefaultAgentEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Agente predeterminado';
+	@override String get description => 'Se aplica a las sesiones que crea esta integración cuando la petición omite el campo. La petición siempre prevalece.';
+	@override String get providerLabel => 'Proveedor predeterminado';
+	@override String get providerNone => 'Sin predeterminado';
+	@override String get modelLabel => 'Modelo predeterminado';
+	@override String get modelHint => 'Predeterminado del proveedor (p. ej. opus)';
+	@override String get accountLabel => 'Cuenta de Claude predeterminada';
+	@override String get accountNone => 'Sin predeterminado';
+	@override String get accountTokenMissing => '(falta el token)';
+	@override String get accountHint => 'Solo se aplica cuando el proveedor predeterminado es Claude.';
 }
 
 // Path: memoryWorkers.tasks
@@ -4355,6 +4376,25 @@ class _TranslationsWebIntegrationsCardEs extends TranslationsWebIntegrationsCard
 	@override String rotateConfirm({required Object name}) => '¿Rotar la API key de "${name}"? La key actual dejará de funcionar de inmediato.';
 	@override String deleteConfirm({required Object name}) => '¿Eliminar la integración ${name}?';
 	@override String get removedToast => 'Integración eliminada';
+}
+
+// Path: web.integrations.defaultAgent
+class _TranslationsWebIntegrationsDefaultAgentEs extends TranslationsWebIntegrationsDefaultAgentEn {
+	_TranslationsWebIntegrationsDefaultAgentEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Agente predeterminado';
+	@override String get description => 'Se aplica a las sesiones que crea esta integración cuando la petición omite el campo. La petición siempre prevalece: son valores predeterminados, no obligatorios.';
+	@override String get providerLabel => 'Proveedor predeterminado';
+	@override String get providerNone => 'Sin predeterminado';
+	@override String get modelLabel => 'Modelo predeterminado';
+	@override String get modelPlaceholder => 'Predeterminado del proveedor (p. ej. opus)';
+	@override String get accountLabel => 'Cuenta de Claude predeterminada';
+	@override String get accountNone => 'Sin predeterminado';
+	@override String get accountTokenMissing => '(falta el token)';
+	@override String get accountHint => 'Solo se aplica cuando el proveedor predeterminado es Claude.';
 }
 
 // Path: web.integrations.register_dialog
@@ -10026,6 +10066,16 @@ extension on TranslationsEs {
 			'web.integrations.card.rotateConfirm' => ({required Object name}) => '¿Rotar la API key de "${name}"? La key actual dejará de funcionar de inmediato.',
 			'web.integrations.card.deleteConfirm' => ({required Object name}) => '¿Eliminar la integración ${name}?',
 			'web.integrations.card.removedToast' => 'Integración eliminada',
+			'web.integrations.defaultAgent.title' => 'Agente predeterminado',
+			'web.integrations.defaultAgent.description' => 'Se aplica a las sesiones que crea esta integración cuando la petición omite el campo. La petición siempre prevalece: son valores predeterminados, no obligatorios.',
+			'web.integrations.defaultAgent.providerLabel' => 'Proveedor predeterminado',
+			'web.integrations.defaultAgent.providerNone' => 'Sin predeterminado',
+			'web.integrations.defaultAgent.modelLabel' => 'Modelo predeterminado',
+			'web.integrations.defaultAgent.modelPlaceholder' => 'Predeterminado del proveedor (p. ej. opus)',
+			'web.integrations.defaultAgent.accountLabel' => 'Cuenta de Claude predeterminada',
+			'web.integrations.defaultAgent.accountNone' => 'Sin predeterminado',
+			'web.integrations.defaultAgent.accountTokenMissing' => '(falta el token)',
+			'web.integrations.defaultAgent.accountHint' => 'Solo se aplica cuando el proveedor predeterminado es Claude.',
 			'web.integrations.register_dialog.title' => 'Registrar integración',
 			'web.integrations.register_dialog.description' => 'Emite una API key de un solo uso. Cópiala antes de cerrar: opendray nunca vuelve a mostrar el texto en claro.',
 			'web.integrations.register_dialog.nameLabel' => 'Nombre',
@@ -10466,6 +10516,8 @@ extension on TranslationsEs {
 			'web.backups.targetEditor.enableImmediately' => 'Habilitar inmediatamente (de lo contrario se guarda como deshabilitado, útil para "configurar ahora, activar más tarde")',
 			'web.backups.targetEditor.local.rootLabel' => 'Directorio raíz',
 			'web.backups.targetEditor.local.rootHint' => 'Vacío = cfg.backup.local_dir (~/.opendray/backups)',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.targetEditor.local.rootPlaceholder' => '~/backups/opendray  o  /mnt/external-hdd/opendray',
 			'web.backups.targetEditor.smb.hostLabel' => 'Host',
 			'web.backups.targetEditor.smb.hostPlaceholder' => '192.168.1.20',
@@ -10476,8 +10528,6 @@ extension on TranslationsEs {
 			'web.backups.targetEditor.smb.userLabel' => 'Usuario',
 			'web.backups.targetEditor.smb.passwordLabel' => 'Contraseña',
 			'web.backups.targetEditor.smb.pathPrefixLabel' => 'Prefijo de ruta',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.targetEditor.smb.pathPrefixHint' => 'Subcarpeta bajo la raíz del recurso compartido (opcional)',
 			'web.backups.targetEditor.smb.pathPrefixPlaceholder' => 'opendray/backups',
 			'web.backups.targetEditor.s3.endpointLabel' => 'Endpoint',
@@ -10980,6 +11030,8 @@ extension on TranslationsEs {
 			'web.export.backToBackups' => '← Backups',
 			'web.export.sections.export' => 'Exportar',
 			'web.export.sections.import' => 'Importar',
+			_ => null,
+		} ?? switch (path) {
 			'web.export.form.scope' => 'Alcance',
 			'web.export.form.memories' => 'Memorias',
 			'web.export.form.memoriesHint' => 'Filas de memoria persistente entre CLI (texto + alcance + metadatos). Los vectores de embedding se omiten; el importador vuelve a generarlos.',
@@ -10990,8 +11042,6 @@ extension on TranslationsEs {
 			'web.export.form.integrationOptions.noneHint' => 'Omitir por completo la tabla de integraciones.',
 			'web.export.form.integrationOptions.metadata' => 'Solo metadatos (recomendado)',
 			'web.export.form.integrationOptions.metadataHint' => 'ID, nombre, prefijo de ruta, alcances. Sin material de API key.',
-			_ => null,
-		} ?? switch (path) {
 			'web.export.form.integrationOptions.plaintext' => 'Incluir las API keys en texto plano',
 			'web.export.form.integrationOptions.plaintextHint' => 'v1 solo con bcrypt: no existe texto plano recuperable. El manifiesto lo documenta; no se filtra nada.',
 			'web.export.form.confirmWarning' => 'Escribe <1>Lo entiendo</1> para confirmar. opendray actualmente almacena solo hashes bcrypt, así que seleccionar texto plano NO exporta ningún texto plano (la función está reservada para una versión futura que mantenga cachés de texto plano).',
@@ -11494,6 +11544,8 @@ extension on TranslationsEs {
 			'sessions.inspector.git.tabLog' => 'Log',
 			'sessions.inspector.tasks.runCommand' => 'Ejecutar comando',
 			'sessions.inspector.tasks.runCommandSubtitle' => 'Se ejecuta en una nueva session de shell y cambia a ella',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.tasks.filterHint' => 'Filtrar tareas…',
 			'sessions.inspector.tasks.noMatch' => ({required Object query}) => 'Ninguna tarea coincide con "${query}"',
 			'sessions.inspector.tasks.emptyTitle' => 'No hay tareas en esta carpeta',
@@ -11504,8 +11556,6 @@ extension on TranslationsEs {
 			'sessions.inspector.notes.insertAtRefTooltip' => 'Insertar como @referencia',
 			'sessions.inspector.notes.insertAtRefShort' => 'Insertar @referencia',
 			'sessions.inspector.notes.draftHint' => ({required Object project}) => '# ${project}\n\nIdeas, tareas pendientes, contexto para el agente…',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.createFailed' => ({required Object error}) => 'Falló al crear: ${error}',
 			'sessions.inspector.notes.saveFailed' => ({required Object error}) => 'Falló al guardar: ${error}',
 			'sessions.inspector.notes.changeLocationTooltip' => 'Cambiar la ubicación de los documentos del proyecto',
@@ -11775,6 +11825,16 @@ extension on TranslationsEs {
 			'integrations.form.apiKeyWarn' => 'No volverás a ver esta key.',
 			'integrations.form.copyCopied' => 'Copiado',
 			'integrations.form.copyCopy' => 'Copiar',
+			'integrations.defaultAgent.title' => 'Agente predeterminado',
+			'integrations.defaultAgent.description' => 'Se aplica a las sesiones que crea esta integración cuando la petición omite el campo. La petición siempre prevalece.',
+			'integrations.defaultAgent.providerLabel' => 'Proveedor predeterminado',
+			'integrations.defaultAgent.providerNone' => 'Sin predeterminado',
+			'integrations.defaultAgent.modelLabel' => 'Modelo predeterminado',
+			'integrations.defaultAgent.modelHint' => 'Predeterminado del proveedor (p. ej. opus)',
+			'integrations.defaultAgent.accountLabel' => 'Cuenta de Claude predeterminada',
+			'integrations.defaultAgent.accountNone' => 'Sin predeterminado',
+			'integrations.defaultAgent.accountTokenMissing' => '(falta el token)',
+			'integrations.defaultAgent.accountHint' => 'Solo se aplica cuando el proveedor predeterminado es Claude.',
 			'integrations.emptyState' => 'Regístrala desde el admin web: Integraciones → Nueva.',
 			'integrations.sectionRegistered' => 'Registradas',
 			'integrations.sectionSystem' => 'Sistema',
@@ -11998,6 +12058,8 @@ extension on TranslationsEs {
 			'backups.overviewTargets' => 'Destinos',
 			'backups.overviewSchedules' => 'Programaciones',
 			'backups.overviewBackups' => 'Copias de seguridad',
+			_ => null,
+		} ?? switch (path) {
 			'backups.health.headlineHealthy' => 'Copias correctas',
 			'backups.health.headlineAttention' => 'Requiere atención',
 			'backups.health.headlineNever' => 'Aún sin copias',
@@ -12018,8 +12080,6 @@ extension on TranslationsEs {
 			'backups.encryption.passphraseLabel' => 'Tu passphrase',
 			'backups.encryption.passphraseHint' => 'Al menos 20 caracteres',
 			'backups.encryption.passphraseCopied' => 'Passphrase copiada al portapapeles',
-			_ => null,
-		} ?? switch (path) {
 			'backups.restoreFromFile' => 'Restaurar desde archivo',
 			'backups.restore.title' => 'Restaurar desde paquete',
 			'backups.restore.subtitle' => 'Reproduce un paquete cifrado .tar.gz.enc en una base de datos Postgres. El paquete se sube desde este teléfono: elige un archivo generado por una copia de seguridad anterior.',
@@ -12512,6 +12572,8 @@ extension on TranslationsEs {
 			'dataExport.imports.columns.source' => 'Origen',
 			'dataExport.imports.columns.counts' => 'Recuentos',
 			'dataExport.imports.columns.when' => 'Cuándo',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.relative.inSeconds' => ({required Object n}) => 'en ${n}s',
 			'dataExport.relative.inMinutes' => ({required Object n}) => 'en ${n}m',
 			'dataExport.relative.inHours' => ({required Object n}) => 'en ${n}h',
@@ -12532,8 +12594,6 @@ extension on TranslationsEs {
 			'memory.status.floorNoModel' => 'Solo recuperación por palabras clave (BM25) — no hay modelo de embedding configurado. Configura un endpoint denso en Settings para habilitar la memoria semántica.',
 			'memory.status.denseConfiguredPendingRestart' => ({required Object model}) => 'Configurado ${model} (denso) — reinicia el gateway para activar la memoria semántica y re-embeber las memorias existentes.',
 			'memory.status.denseUnreachableFloor' => ({required Object model}) => 'Configurado ${model} (denso) pero el endpoint está inalcanzable — se usa el piso de palabras clave hasta que responda (se actualiza al reiniciar).',
-			_ => null,
-		} ?? switch (path) {
 			'memory.status.denseDegraded' => 'Embedder denso activo pero su endpoint está inalcanzable ahora — los vectores existentes se conservan; las nuevas escrituras y la búsqueda por similitud se pausan hasta que responda.',
 			'memory.title' => 'Memoria',
 			'memory.more' => 'Más',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -388,6 +388,7 @@ class _TranslationsIntegrationsZh extends TranslationsIntegrationsEn {
 	@override String get directionInbound => '入站';
 	@override String get directionOutbound => '出站';
 	@override late final _TranslationsIntegrationsFormZh form = _TranslationsIntegrationsFormZh._(_root);
+	@override late final _TranslationsIntegrationsDefaultAgentZh defaultAgent = _TranslationsIntegrationsDefaultAgentZh._(_root);
 	@override String get emptyState => '在 Web 管理端注册：集成 → 新建。';
 	@override String get sectionRegistered => '已注册';
 	@override String get sectionSystem => '系统';
@@ -1424,6 +1425,7 @@ class _TranslationsWebIntegrationsZh extends TranslationsWebIntegrationsEn {
 	@override String get groupSystem => '系统（由 opendray 管理）';
 	@override String get groupOperator => '用户注册';
 	@override late final _TranslationsWebIntegrationsCardZh card = _TranslationsWebIntegrationsCardZh._(_root);
+	@override late final _TranslationsWebIntegrationsDefaultAgentZh defaultAgent = _TranslationsWebIntegrationsDefaultAgentZh._(_root);
 	@override late final _TranslationsWebIntegrationsRegisterDialogZh register_dialog = _TranslationsWebIntegrationsRegisterDialogZh._(_root);
 	@override late final _TranslationsWebIntegrationsRevealZh reveal = _TranslationsWebIntegrationsRevealZh._(_root);
 	@override late final _TranslationsWebIntegrationsEditDialogZh edit_dialog = _TranslationsWebIntegrationsEditDialogZh._(_root);
@@ -2115,6 +2117,25 @@ class _TranslationsIntegrationsFormZh extends TranslationsIntegrationsFormEn {
 	@override String get apiKeyWarn => '此 key 只显示这一次。';
 	@override String get copyCopied => '已复制';
 	@override String get copyCopy => '复制';
+}
+
+// Path: integrations.defaultAgent
+class _TranslationsIntegrationsDefaultAgentZh extends TranslationsIntegrationsDefaultAgentEn {
+	_TranslationsIntegrationsDefaultAgentZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '默认 agent';
+	@override String get description => '当该集成创建会话且请求未指定相应字段时套用。请求值始终优先。';
+	@override String get providerLabel => '默认 provider';
+	@override String get providerNone => '无默认';
+	@override String get modelLabel => '默认模型';
+	@override String get modelHint => 'provider 默认(如 opus)';
+	@override String get accountLabel => '默认 Claude 账号';
+	@override String get accountNone => '无默认';
+	@override String get accountTokenMissing => '(缺少 token)';
+	@override String get accountHint => '仅当默认 provider 为 Claude 时生效。';
 }
 
 // Path: memoryWorkers.tasks
@@ -4355,6 +4376,25 @@ class _TranslationsWebIntegrationsCardZh extends TranslationsWebIntegrationsCard
 	@override String rotateConfirm({required Object name}) => '轮换 "${name}" 的 API key? 当前 key 将立即失效。';
 	@override String deleteConfirm({required Object name}) => '删除集成 ${name}?';
 	@override String get removedToast => '集成已移除';
+}
+
+// Path: web.integrations.defaultAgent
+class _TranslationsWebIntegrationsDefaultAgentZh extends TranslationsWebIntegrationsDefaultAgentEn {
+	_TranslationsWebIntegrationsDefaultAgentZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '默认 agent';
+	@override String get description => '当该集成创建会话且请求未指定相应字段时套用。请求值始终优先 — 这是默认值,而非强制。';
+	@override String get providerLabel => '默认 provider';
+	@override String get providerNone => '无默认';
+	@override String get modelLabel => '默认模型';
+	@override String get modelPlaceholder => 'provider 默认(如 opus)';
+	@override String get accountLabel => '默认 Claude 账号';
+	@override String get accountNone => '无默认';
+	@override String get accountTokenMissing => '(缺少 token)';
+	@override String get accountHint => '仅当默认 provider 为 Claude 时生效。';
 }
 
 // Path: web.integrations.register_dialog
@@ -10026,6 +10066,16 @@ extension on TranslationsZh {
 			'web.integrations.card.rotateConfirm' => ({required Object name}) => '轮换 "${name}" 的 API key? 当前 key 将立即失效。',
 			'web.integrations.card.deleteConfirm' => ({required Object name}) => '删除集成 ${name}?',
 			'web.integrations.card.removedToast' => '集成已移除',
+			'web.integrations.defaultAgent.title' => '默认 agent',
+			'web.integrations.defaultAgent.description' => '当该集成创建会话且请求未指定相应字段时套用。请求值始终优先 — 这是默认值,而非强制。',
+			'web.integrations.defaultAgent.providerLabel' => '默认 provider',
+			'web.integrations.defaultAgent.providerNone' => '无默认',
+			'web.integrations.defaultAgent.modelLabel' => '默认模型',
+			'web.integrations.defaultAgent.modelPlaceholder' => 'provider 默认(如 opus)',
+			'web.integrations.defaultAgent.accountLabel' => '默认 Claude 账号',
+			'web.integrations.defaultAgent.accountNone' => '无默认',
+			'web.integrations.defaultAgent.accountTokenMissing' => '(缺少 token)',
+			'web.integrations.defaultAgent.accountHint' => '仅当默认 provider 为 Claude 时生效。',
 			'web.integrations.register_dialog.title' => '注册集成',
 			'web.integrations.register_dialog.description' => '签发一次性 API key。关闭前请复制它 — opendray 不会再显示明文。',
 			'web.integrations.register_dialog.nameLabel' => '名称',
@@ -10466,6 +10516,8 @@ extension on TranslationsZh {
 			'web.backups.targetEditor.enableImmediately' => '立即启用（否则保存为禁用 — 适合 "先配置好，稍后开启"）',
 			'web.backups.targetEditor.local.rootLabel' => '根目录',
 			'web.backups.targetEditor.local.rootHint' => '留空 = cfg.backup.local_dir (~/.opendray/backups)',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.targetEditor.local.rootPlaceholder' => '~/backups/opendray  或  /mnt/external-hdd/opendray',
 			'web.backups.targetEditor.smb.hostLabel' => '主机',
 			'web.backups.targetEditor.smb.hostPlaceholder' => '192.168.1.20',
@@ -10476,8 +10528,6 @@ extension on TranslationsZh {
 			'web.backups.targetEditor.smb.userLabel' => '用户',
 			'web.backups.targetEditor.smb.passwordLabel' => '密码',
 			'web.backups.targetEditor.smb.pathPrefixLabel' => '路径前缀',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.targetEditor.smb.pathPrefixHint' => '共享根下的子文件夹（可选）',
 			'web.backups.targetEditor.smb.pathPrefixPlaceholder' => 'opendray/backups',
 			'web.backups.targetEditor.s3.endpointLabel' => 'Endpoint',
@@ -10980,6 +11030,8 @@ extension on TranslationsZh {
 			'web.export.backToBackups' => '← 备份',
 			'web.export.sections.export' => '导出',
 			'web.export.sections.import' => '导入',
+			_ => null,
+		} ?? switch (path) {
 			'web.export.form.scope' => '范围',
 			'web.export.form.memories' => '记忆',
 			'web.export.form.memoriesHint' => '跨 CLI 持久化的记忆行（text + scope + metadata）。向量被省略；导入端重嵌入。',
@@ -10990,8 +11042,6 @@ extension on TranslationsZh {
 			'web.export.form.integrationOptions.noneHint' => '完全跳过 integrations 表。',
 			'web.export.form.integrationOptions.metadata' => '仅元数据（推荐）',
 			'web.export.form.integrationOptions.metadataHint' => 'ID、name、route prefix、scopes — 不包含任何 API key 凭证。',
-			_ => null,
-		} ?? switch (path) {
 			'web.export.form.integrationOptions.plaintext' => '包含明文 API key',
 			'web.export.form.integrationOptions.plaintextHint' => 'v1 仅 bcrypt：不存在可恢复的明文。Manifest 会记录此事实；不会泄露任何内容。',
 			'web.export.form.confirmWarning' => '输入 <1>I understand</1> 以确认。opendray 当前只存 bcrypt 哈希 — 选择明文也不会导出任何明文（该选项为将来保留明文缓存的版本而预留）。',
@@ -11494,6 +11544,8 @@ extension on TranslationsZh {
 			'sessions.inspector.git.tabLog' => '日志',
 			'sessions.inspector.tasks.runCommand' => '运行命令',
 			'sessions.inspector.tasks.runCommandSubtitle' => '在新的 shell 会话中运行并切换过去',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.tasks.filterHint' => '筛选任务…',
 			'sessions.inspector.tasks.noMatch' => ({required Object query}) => '没有匹配“${query}”的任务',
 			'sessions.inspector.tasks.emptyTitle' => '此目录没有任务',
@@ -11504,8 +11556,6 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.insertAtRefTooltip' => '作为 @引用 插入',
 			'sessions.inspector.notes.insertAtRefShort' => '插入 @引用',
 			'sessions.inspector.notes.draftHint' => ({required Object project}) => '# ${project}\n\n想法、待办、为 agent 提供的上下文…',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.createFailed' => ({required Object error}) => '创建失败：${error}',
 			'sessions.inspector.notes.saveFailed' => ({required Object error}) => '保存失败：${error}',
 			'sessions.inspector.notes.changeLocationTooltip' => '更改项目文档位置',
@@ -11775,6 +11825,16 @@ extension on TranslationsZh {
 			'integrations.form.apiKeyWarn' => '此 key 只显示这一次。',
 			'integrations.form.copyCopied' => '已复制',
 			'integrations.form.copyCopy' => '复制',
+			'integrations.defaultAgent.title' => '默认 agent',
+			'integrations.defaultAgent.description' => '当该集成创建会话且请求未指定相应字段时套用。请求值始终优先。',
+			'integrations.defaultAgent.providerLabel' => '默认 provider',
+			'integrations.defaultAgent.providerNone' => '无默认',
+			'integrations.defaultAgent.modelLabel' => '默认模型',
+			'integrations.defaultAgent.modelHint' => 'provider 默认(如 opus)',
+			'integrations.defaultAgent.accountLabel' => '默认 Claude 账号',
+			'integrations.defaultAgent.accountNone' => '无默认',
+			'integrations.defaultAgent.accountTokenMissing' => '(缺少 token)',
+			'integrations.defaultAgent.accountHint' => '仅当默认 provider 为 Claude 时生效。',
 			'integrations.emptyState' => '在 Web 管理端注册：集成 → 新建。',
 			'integrations.sectionRegistered' => '已注册',
 			'integrations.sectionSystem' => '系统',
@@ -11998,6 +12058,8 @@ extension on TranslationsZh {
 			'backups.overviewTargets' => '目标',
 			'backups.overviewSchedules' => '计划',
 			'backups.overviewBackups' => '备份',
+			_ => null,
+		} ?? switch (path) {
 			'backups.health.headlineHealthy' => '备份正常',
 			'backups.health.headlineAttention' => '需要关注',
 			'backups.health.headlineNever' => '尚无备份',
@@ -12018,8 +12080,6 @@ extension on TranslationsZh {
 			'backups.encryption.passphraseLabel' => '你的密语',
 			'backups.encryption.passphraseHint' => '至少 20 个字符',
 			'backups.encryption.passphraseCopied' => '密语已复制到剪贴板',
-			_ => null,
-		} ?? switch (path) {
 			'backups.restoreFromFile' => '从文件恢复',
 			'backups.restore.title' => '从备份包恢复',
 			'backups.restore.subtitle' => '将加密的 .tar.gz.enc 备份包重放到 Postgres 数据库。备份包将从本机上传 — 请选择此前生成的文件。',
@@ -12512,6 +12572,8 @@ extension on TranslationsZh {
 			'dataExport.imports.columns.source' => '来源',
 			'dataExport.imports.columns.counts' => '计数',
 			'dataExport.imports.columns.when' => '时间',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.relative.inSeconds' => ({required Object n}) => '${n} 秒后',
 			'dataExport.relative.inMinutes' => ({required Object n}) => '${n} 分钟后',
 			'dataExport.relative.inHours' => ({required Object n}) => '${n} 小时后',
@@ -12532,8 +12594,6 @@ extension on TranslationsZh {
 			'memory.status.floorNoModel' => '仅关键词（BM25）检索 — 未配置 embedding 模型。在 Settings 配置 dense 端点即可启用语义记忆。',
 			'memory.status.denseConfiguredPendingRestart' => ({required Object model}) => '已配置 ${model}（dense）— 重启网关即启用语义记忆并自动重嵌历史记忆。',
 			'memory.status.denseUnreachableFloor' => ({required Object model}) => '已配置 ${model}（dense）但端点当前不可达 — 暂用关键词 floor，端点恢复后重启会自动升级。',
-			_ => null,
-		} ?? switch (path) {
 			'memory.status.denseDegraded' => 'dense embedder 已激活，但其端点当前不可达 — 现有向量已保留；新写入与相似度检索暂停，直到端点恢复。',
 			'memory.title' => '记忆',
 			'memory.more' => '更多',

--- a/app/mobile/lib/features/integrations/default_agent_fields.dart
+++ b/app/mobile/lib/features/integrations/default_agent_fields.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/api/claude_accounts_api.dart';
+import 'package:opendray/core/api/providers_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+
+// DefaultAgentFields renders the provider / model / claude-account
+// selectors for an integration's spawn defaults, shared by the register
+// and edit forms. Provider + account are dropdowns; model is a free-text
+// field (its controller is owned by the parent form, matching the
+// existing form pattern). Empty = no default.
+//
+// The account selector applies only when the default provider is
+// "claude"; it stays visible but disabled otherwise, with a hint.
+class DefaultAgentFields extends ConsumerWidget {
+  const DefaultAgentFields({
+    required this.providerId,
+    required this.claudeAccountId,
+    required this.modelController,
+    required this.onProviderChanged,
+    required this.onAccountChanged,
+    super.key,
+  });
+
+  // Sentinel for "no default" — a DropdownMenuItem can't use a bare
+  // empty string as a distinct value cleanly, so we map '' ⇄ _none.
+  static const String _none = '__none__';
+
+  final String providerId;
+  final String claudeAccountId;
+  final TextEditingController modelController;
+  final ValueChanged<String> onProviderChanged;
+  final ValueChanged<String> onAccountChanged;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final providers = ref.watch(providersListProvider);
+    final accounts = ref.watch(claudeAccountsListProvider);
+    final isClaude = providerId == 'claude';
+    final theme = Theme.of(context);
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        border: Border.all(color: theme.dividerColor.withValues(alpha: 0.4)),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            t.integrations.defaultAgent.title,
+            style: theme.textTheme.titleSmall,
+          ),
+          const SizedBox(height: 2),
+          Text(
+            t.integrations.defaultAgent.description,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 12),
+
+          // Provider dropdown.
+          DropdownButtonFormField<String>(
+            initialValue: providerId.isEmpty ? _none : providerId,
+            isExpanded: true,
+            decoration: InputDecoration(
+              labelText: t.integrations.defaultAgent.providerLabel,
+              border: const OutlineInputBorder(),
+            ),
+            items: [
+              DropdownMenuItem(
+                value: _none,
+                child: Text(t.integrations.defaultAgent.providerNone),
+              ),
+              ...providers.maybeWhen(
+                data: (list) => list.map(
+                  (p) => DropdownMenuItem(
+                    value: p.id,
+                    child: Text('${p.name} (${p.id})'),
+                  ),
+                ),
+                orElse: () => const <DropdownMenuItem<String>>[],
+              ),
+            ],
+            onChanged: (v) => onProviderChanged(v == _none ? '' : (v ?? '')),
+          ),
+          const SizedBox(height: 12),
+
+          // Model free-text field (controller owned by parent).
+          TextField(
+            controller: modelController,
+            autocorrect: false,
+            decoration: InputDecoration(
+              labelText: t.integrations.defaultAgent.modelLabel,
+              hintText: t.integrations.defaultAgent.modelHint,
+              border: const OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 12),
+
+          // Claude account dropdown — only meaningful for the claude provider.
+          DropdownButtonFormField<String>(
+            initialValue: claudeAccountId.isEmpty ? _none : claudeAccountId,
+            isExpanded: true,
+            decoration: InputDecoration(
+              labelText: t.integrations.defaultAgent.accountLabel,
+              helperText: t.integrations.defaultAgent.accountHint,
+              helperMaxLines: 2,
+              border: const OutlineInputBorder(),
+            ),
+            items: [
+              DropdownMenuItem(
+                value: _none,
+                child: Text(t.integrations.defaultAgent.accountNone),
+              ),
+              ...accounts.maybeWhen(
+                data: (list) => list.map(
+                  (a) => DropdownMenuItem(
+                    value: a.id,
+                    child: Text(
+                      a.tokenFilled
+                          ? a.displayName
+                          : '${a.displayName} '
+                              '${t.integrations.defaultAgent.accountTokenMissing}',
+                    ),
+                  ),
+                ),
+                orElse: () => const <DropdownMenuItem<String>>[],
+              ),
+            ],
+            onChanged: isClaude
+                ? (v) => onAccountChanged(v == _none ? '' : (v ?? ''))
+                : null,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/mobile/lib/features/integrations/integration_detail_screen.dart
+++ b/app/mobile/lib/features/integrations/integration_detail_screen.dart
@@ -150,6 +150,9 @@ class _IntegrationDetailScreenState
             scopes: patch.scopes,
             version: patch.version,
             enabled: patch.enabled,
+            defaultProviderId: patch.defaultProviderId,
+            defaultModel: patch.defaultModel,
+            defaultClaudeAccountId: patch.defaultClaudeAccountId,
           );
       if (!mounted) return;
       messenger.showSnackBar(

--- a/app/mobile/lib/features/integrations/integration_forms.dart
+++ b/app/mobile/lib/features/integrations/integration_forms.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 
 import 'package:opendray/core/api/integrations_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/integrations/default_agent_fields.dart';
 
 // Form pages and small read-only dialogs shared by the Integrations
 // screens. Multi-field forms (register / edit) are full-screen pages
@@ -38,6 +39,9 @@ class _RegisterIntegrationScreenState
   final _prefix = TextEditingController();
   final _scopes = TextEditingController();
   final _version = TextEditingController();
+  final _defaultModel = TextEditingController();
+  String _defaultProviderId = '';
+  String _defaultClaudeAccountId = '';
   String? _error;
 
   @override
@@ -47,6 +51,7 @@ class _RegisterIntegrationScreenState
     _prefix.dispose();
     _scopes.dispose();
     _version.dispose();
+    _defaultModel.dispose();
     super.dispose();
   }
 
@@ -72,6 +77,9 @@ class _RegisterIntegrationScreenState
         routePrefix: prefix.replaceAll(RegExp(r'^/+|/+$'), ''),
         scopes: scopes,
         version: _version.text.trim(),
+        defaultProviderId: _defaultProviderId,
+        defaultModel: _defaultModel.text.trim(),
+        defaultClaudeAccountId: _defaultClaudeAccountId,
       ),
     );
   }
@@ -120,6 +128,18 @@ class _RegisterIntegrationScreenState
             label: t.integrations.form.fieldVersion,
             hint: '1.0.0',
           ),
+          DefaultAgentFields(
+            providerId: _defaultProviderId,
+            claudeAccountId: _defaultClaudeAccountId,
+            modelController: _defaultModel,
+            onProviderChanged: (v) => setState(() {
+              _defaultProviderId = v;
+              // The account default is only meaningful for claude.
+              if (v != 'claude') _defaultClaudeAccountId = '';
+            }),
+            onAccountChanged: (v) =>
+                setState(() => _defaultClaudeAccountId = v),
+          ),
           if (_error != null) ...[
             const SizedBox(height: 8),
             Text(
@@ -143,12 +163,18 @@ class RegisterIntegrationFormResult {
     required this.routePrefix,
     required this.scopes,
     required this.version,
+    this.defaultProviderId = '',
+    this.defaultModel = '',
+    this.defaultClaudeAccountId = '',
   });
   final String name;
   final String baseUrl;
   final String routePrefix;
   final List<String> scopes;
   final String version;
+  final String defaultProviderId;
+  final String defaultModel;
+  final String defaultClaudeAccountId;
 }
 
 // EditIntegrationScreen patches base_url / scopes / version / enabled.
@@ -178,7 +204,10 @@ class _EditIntegrationScreenState extends State<EditIntegrationScreen> {
   late final TextEditingController _baseUrl;
   late final TextEditingController _scopes;
   late final TextEditingController _version;
+  late final TextEditingController _defaultModel;
   late bool _enabled;
+  late String _defaultProviderId;
+  late String _defaultClaudeAccountId;
   String? _error;
 
   @override
@@ -187,7 +216,11 @@ class _EditIntegrationScreenState extends State<EditIntegrationScreen> {
     _baseUrl = TextEditingController(text: widget.current.baseUrl);
     _scopes = TextEditingController(text: widget.current.scopes.join(', '));
     _version = TextEditingController(text: widget.current.version ?? '');
+    _defaultModel =
+        TextEditingController(text: widget.current.defaultModel);
     _enabled = widget.current.enabled;
+    _defaultProviderId = widget.current.defaultProviderId;
+    _defaultClaudeAccountId = widget.current.defaultClaudeAccountId;
   }
 
   @override
@@ -195,6 +228,7 @@ class _EditIntegrationScreenState extends State<EditIntegrationScreen> {
     _baseUrl.dispose();
     _scopes.dispose();
     _version.dispose();
+    _defaultModel.dispose();
     super.dispose();
   }
 
@@ -213,12 +247,23 @@ class _EditIntegrationScreenState extends State<EditIntegrationScreen> {
     final initialScopes = widget.current.scopes;
     final scopesChanged = scopes.length != initialScopes.length ||
         !scopes.asMap().entries.every((e) => e.value == initialScopes[e.key]);
+    final model = _defaultModel.text.trim();
     Navigator.of(context).pop(
       EditIntegrationFormResult(
         baseUrl: baseUrl != widget.current.baseUrl ? baseUrl : null,
         scopes: scopesChanged ? scopes : null,
         version: version != (widget.current.version ?? '') ? version : null,
         enabled: _enabled != widget.current.enabled ? _enabled : null,
+        defaultProviderId:
+            _defaultProviderId != widget.current.defaultProviderId
+                ? _defaultProviderId
+                : null,
+        defaultModel:
+            model != widget.current.defaultModel ? model : null,
+        defaultClaudeAccountId:
+            _defaultClaudeAccountId != widget.current.defaultClaudeAccountId
+                ? _defaultClaudeAccountId
+                : null,
       ),
     );
   }
@@ -253,6 +298,17 @@ class _EditIntegrationScreenState extends State<EditIntegrationScreen> {
             label: t.integrations.form.editFieldVersion,
           ),
           const SizedBox(height: 8),
+          DefaultAgentFields(
+            providerId: _defaultProviderId,
+            claudeAccountId: _defaultClaudeAccountId,
+            modelController: _defaultModel,
+            onProviderChanged: (v) => setState(() {
+              _defaultProviderId = v;
+              if (v != 'claude') _defaultClaudeAccountId = '';
+            }),
+            onAccountChanged: (v) =>
+                setState(() => _defaultClaudeAccountId = v),
+          ),
           SwitchListTile(
             contentPadding: EdgeInsets.zero,
             title: Text(t.integrations.enabledLabel),
@@ -279,14 +335,26 @@ class EditIntegrationFormResult {
     this.scopes,
     this.version,
     this.enabled,
+    this.defaultProviderId,
+    this.defaultModel,
+    this.defaultClaudeAccountId,
   });
   final String? baseUrl;
   final List<String>? scopes;
   final String? version;
   final bool? enabled;
+  final String? defaultProviderId;
+  final String? defaultModel;
+  final String? defaultClaudeAccountId;
 
   bool get isEmpty =>
-      baseUrl == null && scopes == null && version == null && enabled == null;
+      baseUrl == null &&
+      scopes == null &&
+      version == null &&
+      enabled == null &&
+      defaultProviderId == null &&
+      defaultModel == null &&
+      defaultClaudeAccountId == null;
 }
 
 // RevealApiKeyDialog displays a freshly-minted API key once. The

--- a/app/mobile/lib/features/integrations/integrations_screen.dart
+++ b/app/mobile/lib/features/integrations/integrations_screen.dart
@@ -69,6 +69,9 @@ class _IntegrationsScreenState extends ConsumerState<IntegrationsScreen> {
             routePrefix: form.routePrefix,
             scopes: form.scopes,
             version: form.version,
+            defaultProviderId: form.defaultProviderId,
+            defaultModel: form.defaultModel,
+            defaultClaudeAccountId: form.defaultClaudeAccountId,
           );
       if (!mounted) return;
       await RevealApiKeyDialog.show(

--- a/app/shared/src/lib/integrations.ts
+++ b/app/shared/src/lib/integrations.ts
@@ -39,6 +39,9 @@ export async function updateIntegration(
     scopes?: string[]
     version?: string
     enabled?: boolean
+    default_provider_id?: string
+    default_model?: string
+    default_claude_account_id?: string
   },
 ): Promise<Integration> {
   return api<Integration>(`/api/v1/integrations/${id}`, {

--- a/app/shared/src/lib/types.ts
+++ b/app/shared/src/lib/types.ts
@@ -208,6 +208,12 @@ export interface Integration {
   /** True for rows opendray manages itself (e.g. opendray-memory).
       Operators can't delete or rotate these from the UI. */
   is_system: boolean
+  /** Spawn defaults applied to sessions this integration creates when
+      the request omits the field (the request always wins). Empty =
+      no default. */
+  default_provider_id?: string
+  default_model?: string
+  default_claude_account_id?: string
 }
 
 export interface RegisterIntegrationRequest {
@@ -216,6 +222,9 @@ export interface RegisterIntegrationRequest {
   route_prefix: string
   scopes?: string[]
   version?: string
+  default_provider_id?: string
+  default_model?: string
+  default_claude_account_id?: string
 }
 
 export interface RegisterIntegrationResult {

--- a/app/web/src/components/integrations/DefaultAgentFields.tsx
+++ b/app/web/src/components/integrations/DefaultAgentFields.tsx
@@ -1,0 +1,166 @@
+import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { listProviders } from '@/lib/catalog'
+import { listClaudeAccounts } from '@/lib/claudeAccounts'
+
+// NONE is the sentinel for "no default" — Radix Select can't hold an
+// empty-string value, so the caller maps it to '' on change.
+const NONE = '__none__'
+
+export interface DefaultAgentValue {
+  providerId: string
+  model: string
+  claudeAccountId: string
+}
+
+interface DefaultAgentFieldsProps {
+  value: DefaultAgentValue
+  onChange: (next: DefaultAgentValue) => void
+}
+
+// DefaultAgentFields renders the provider / model / claude-account
+// selectors for an integration's spawn defaults. Used by both the
+// register and edit dialogs. Fully controlled and immutable: every
+// change emits a fresh value object, never mutating the prop.
+//
+// The model field is a free-text input with a datalist of the selected
+// provider's known models — defaults shouldn't be locked to a curated
+// list (knownModels is only a suggestion source). The claude-account
+// selector applies only when the default provider is "claude"; it stays
+// visible (as an advisory) but the hint makes the scope clear.
+export function DefaultAgentFields({ value, onChange }: DefaultAgentFieldsProps) {
+  const { t } = useTranslation()
+  const providers = useQuery({ queryKey: ['providers'], queryFn: listProviders })
+  const accounts = useQuery({
+    queryKey: ['claude-accounts'],
+    queryFn: listClaudeAccounts,
+  })
+
+  const selectedProvider = providers.data?.find(
+    (p) => p.manifest.id === value.providerId,
+  )
+  const knownModels = selectedProvider?.manifest.knownModels ?? []
+  const modelListId = 'default-agent-models'
+  const isClaude = value.providerId === 'claude'
+
+  return (
+    <div className="space-y-4 rounded-md border border-border/60 bg-muted/10 p-3">
+      <div className="space-y-1">
+        <p className="text-[12px] font-medium">
+          {t('web.integrations.defaultAgent.title')}
+        </p>
+        <p className="text-[10.5px] text-muted-foreground/70 leading-snug">
+          {t('web.integrations.defaultAgent.description')}
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="text-[11px] text-muted-foreground/80">
+          {t('web.integrations.defaultAgent.providerLabel')}
+        </Label>
+        <Select
+          value={value.providerId || NONE}
+          onValueChange={(v) =>
+            onChange({
+              ...value,
+              providerId: v === NONE ? '' : v,
+              // Dropping the provider clears the claude-account default,
+              // which is only meaningful for the claude provider.
+              claudeAccountId:
+                v === 'claude' ? value.claudeAccountId : '',
+            })
+          }
+        >
+          <SelectTrigger className="h-9 text-[12px]">
+            <SelectValue
+              placeholder={t('web.integrations.defaultAgent.providerNone')}
+            />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={NONE}>
+              {t('web.integrations.defaultAgent.providerNone')}
+            </SelectItem>
+            {(providers.data ?? []).map((p) => (
+              <SelectItem key={p.manifest.id} value={p.manifest.id}>
+                {p.manifest.displayName}{' '}
+                <span className="text-muted-foreground/60 font-mono">
+                  {p.manifest.id}
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label
+          htmlFor="default_model"
+          className="text-[11px] text-muted-foreground/80"
+        >
+          {t('web.integrations.defaultAgent.modelLabel')}
+        </Label>
+        <Input
+          id="default_model"
+          value={value.model}
+          onChange={(e) => onChange({ ...value, model: e.target.value })}
+          placeholder={t('web.integrations.defaultAgent.modelPlaceholder')}
+          className="font-mono"
+          list={modelListId}
+        />
+        <datalist id={modelListId}>
+          {knownModels.map((m) => (
+            <option key={m} value={m} />
+          ))}
+        </datalist>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="text-[11px] text-muted-foreground/80">
+          {t('web.integrations.defaultAgent.accountLabel')}
+        </Label>
+        <Select
+          value={value.claudeAccountId || NONE}
+          onValueChange={(v) =>
+            onChange({ ...value, claudeAccountId: v === NONE ? '' : v })
+          }
+          disabled={!isClaude}
+        >
+          <SelectTrigger className="h-9 text-[12px]">
+            <SelectValue
+              placeholder={t('web.integrations.defaultAgent.accountNone')}
+            />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={NONE}>
+              {t('web.integrations.defaultAgent.accountNone')}
+            </SelectItem>
+            {(accounts.data ?? []).map((a) => (
+              <SelectItem key={a.id} value={a.id}>
+                {a.display_name || a.name}
+                {!a.token_filled && (
+                  <span className="text-muted-foreground/60">
+                    {' '}
+                    {t('web.integrations.defaultAgent.accountTokenMissing')}
+                  </span>
+                )}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-[10.5px] text-muted-foreground/60">
+          {t('web.integrations.defaultAgent.accountHint')}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/web/src/components/integrations/EditIntegrationDialog.tsx
+++ b/app/web/src/components/integrations/EditIntegrationDialog.tsx
@@ -19,6 +19,7 @@ import { updateIntegration } from '@/lib/integrations'
 import type { Integration } from '@/lib/types'
 
 import { ScopePicker } from './ScopePicker'
+import { DefaultAgentFields, type DefaultAgentValue } from './DefaultAgentFields'
 
 interface EditIntegrationDialogProps {
   open: boolean
@@ -41,6 +42,11 @@ export function EditIntegrationDialog({
   const [baseURL, setBaseURL] = useState('')
   const [version, setVersion] = useState('')
   const [scopes, setScopes] = useState<string[]>([])
+  const [defaults, setDefaults] = useState<DefaultAgentValue>({
+    providerId: '',
+    model: '',
+    claudeAccountId: '',
+  })
   const [error, setError] = useState<string | null>(null)
 
   // Reset form when the integration prop changes (different row
@@ -50,6 +56,11 @@ export function EditIntegrationDialog({
     setBaseURL(integration.base_url ?? '')
     setVersion(integration.version ?? '')
     setScopes(integration.scopes ?? [])
+    setDefaults({
+      providerId: integration.default_provider_id ?? '',
+      model: integration.default_model ?? '',
+      claudeAccountId: integration.default_claude_account_id ?? '',
+    })
     setError(null)
   }, [integration, open])
 
@@ -94,6 +105,17 @@ export function EditIntegrationDialog({
       JSON.stringify(scopes) !== JSON.stringify(integration.scopes ?? [])
     ) {
       patch.scopes = scopes
+    }
+    if (defaults.providerId !== (integration.default_provider_id ?? '')) {
+      patch.default_provider_id = defaults.providerId
+    }
+    if (defaults.model.trim() !== (integration.default_model ?? '')) {
+      patch.default_model = defaults.model.trim()
+    }
+    if (
+      defaults.claudeAccountId !== (integration.default_claude_account_id ?? '')
+    ) {
+      patch.default_claude_account_id = defaults.claudeAccountId
     }
     if (Object.keys(patch).length === 0) {
       onOpenChange(false)
@@ -192,6 +214,8 @@ export function EditIntegrationDialog({
               intro={t('web.integrations.edit_dialog.scopesIntro')}
             />
           </div>
+
+          <DefaultAgentFields value={defaults} onChange={setDefaults} />
 
           {error && (
             <div className="text-[12px] text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">

--- a/app/web/src/pages/Integrations.tsx
+++ b/app/web/src/pages/Integrations.tsx
@@ -35,6 +35,10 @@ import { EditIntegrationDialog } from '@/components/integrations/EditIntegration
 import { ProxyConsole } from '@/components/integrations/ProxyConsole'
 import { ScopePicker } from '@/components/integrations/ScopePicker'
 import {
+  DefaultAgentFields,
+  type DefaultAgentValue,
+} from '@/components/integrations/DefaultAgentFields'
+import {
   listIntegrations,
   registerIntegration,
   rotateIntegrationKey,
@@ -411,6 +415,11 @@ function RegisterDialog({
     'session:read',
     'event:subscribe:session.*',
   ])
+  const [defaults, setDefaults] = useState<DefaultAgentValue>({
+    providerId: '',
+    model: '',
+    claudeAccountId: '',
+  })
   const [error, setError] = useState<string | null>(null)
 
   const reset = () => {
@@ -419,6 +428,7 @@ function RegisterDialog({
     setRoutePrefix('')
     setVersion('')
     setScopes(['session:read', 'event:subscribe:session.*'])
+    setDefaults({ providerId: '', model: '', claudeAccountId: '' })
     setError(null)
   }
 
@@ -452,6 +462,9 @@ function RegisterDialog({
       route_prefix: prefix,
       scopes,
       version: version.trim() || undefined,
+      default_provider_id: defaults.providerId || undefined,
+      default_model: defaults.model.trim() || undefined,
+      default_claude_account_id: defaults.claudeAccountId || undefined,
     })
   }
 
@@ -463,7 +476,7 @@ function RegisterDialog({
         onOpenChange(v)
       }}
     >
-      <DialogContent className="max-w-[520px]">
+      <DialogContent className="max-w-[520px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{t('web.integrations.register_dialog.title')}</DialogTitle>
           <DialogDescription>
@@ -551,6 +564,8 @@ function RegisterDialog({
               intro={t('web.integrations.register_dialog.scopesIntro')}
             />
           </div>
+
+          <DefaultAgentFields value={defaults} onChange={setDefaults} />
 
           {error && (
             <div className="text-[12px] text-destructive bg-destructive/10 border border-destructive/30 rounded-md px-3 py-2">


### PR DESCRIPTION
## Summary

**PR-3b** of the integration default-agent feature — the UI for the spawn defaults landed in **#378 (PR-3a)**. Lets an operator pick an integration's default **provider + model + Claude account** from both the web admin and the mobile app. UI-only; no behavior change beyond editing the fields.

> Stacked on #378 (`feat/integration-default-agent`), which is stacked on #376. Merge order: #376 → #378 → this. Base retargets to `main` as the stack lands. Diff here is UI-only.

## Web

- New reusable `DefaultAgentFields` (`app/web/src/components/integrations/DefaultAgentFields.tsx`):
  - provider `Select` (with a "No default" sentinel),
  - model free-text `Input` with a `<datalist>` of the selected provider's `knownModels` (suggestions, not a hard list — defaults shouldn't be locked to the curated set),
  - Claude-account `Select`, disabled unless the default provider is `claude`.
- Used in both the **register** and **edit** dialogs. Edit only patches changed fields; register sends non-empty defaults.
- Shared `Integration` type + register request + update patch carry `default_provider_id` / `default_model` / `default_claude_account_id`.

## Mobile (Flutter)

- Mirror `DefaultAgentFields` widget (`DropdownButtonFormField` for provider/account, `TextField` for model) wired into the register + edit forms.
- `Integration` model + `IntegrationsApi.register/update` carry the three fields.

## i18n

- `en` / `es` / `zh` for both the web (`web.integrations.defaultAgent`) and mobile (`integrations.defaultAgent`) namespaces. Slang regenerated for mobile. Single-brace interpolation preserved.

## Test plan

- `pnpm exec tsc -b --noEmit` (web) ✅
- `pnpm build` (web) ✅
- `dart run slang` regenerated cleanly ✅
- `flutter analyze lib` → No issues found ✅
- Manual: register/edit an integration → set provider=claude, model=opus, account=X → reopen edit and confirm the values round-trip; switching provider away from claude clears the account selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)