### PR TITLE
fix(memory): isolate third-party integration capture into per-integration zones

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -107,7 +107,28 @@ type App struct {
 type knowledgeMemorySource struct{ mem *memory.Service }
 
 func (a knowledgeMemorySource) ListProjectKeys(ctx context.Context) ([]string, error) {
-	return a.mem.ListScopeKeys(ctx, memory.ScopeProject)
+	keys, err := a.mem.ListScopeKeys(ctx, memory.ScopeProject)
+	if err != nil {
+		return nil, err
+	}
+	// Third-party integration zones are isolated: their captured facts
+	// must never feed the operator-facing knowledge base.
+	return filterOutIntegrationZones(keys), nil
+}
+
+// filterOutIntegrationZones drops per-integration memory zones from a
+// list of project scope_keys, returning a new slice (the inputs are
+// never mutated). Used wherever project memory is treated as operator
+// knowledge or as a real cwd.
+func filterOutIntegrationZones(keys []string) []string {
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if memory.IsIntegrationScopeKey(k) {
+			continue
+		}
+		out = append(out, k)
+	}
+	return out
 }
 
 func (a knowledgeMemorySource) ListProjectMemories(ctx context.Context, scopeKey string, limit int) ([]knowledge.MemoryRow, error) {
@@ -130,6 +151,8 @@ func (a knowledgeMemorySource) ListAllMemories(ctx context.Context, limit int) (
 	if err != nil {
 		return nil, err
 	}
+	// Integration zones are isolated from the cross-project KB.
+	keys = filterOutIntegrationZones(keys)
 	if limit <= 0 {
 		limit = 400
 	}

--- a/internal/gitactivity/scheduler.go
+++ b/internal/gitactivity/scheduler.go
@@ -128,6 +128,11 @@ func (s *Scheduler) tick(ctx context.Context) {
 		if k == "" {
 			continue
 		}
+		// Integration memory zones aren't real working dirs; skip them
+		// so the git scanner never runs against a non-path scope_key.
+		if memory.IsIntegrationScopeKey(k) {
+			continue
+		}
 		if !s.svc.IsStale(ctx, k, s.cfg.MaxAge) {
 			s.log.Debug("scheduler.skip_fresh", "scope_key", k)
 			continue

--- a/internal/memory/capture/routing_test.go
+++ b/internal/memory/capture/routing_test.go
@@ -114,6 +114,65 @@ func TestRouteForSession(t *testing.T) {
 	}
 }
 
+// TestScopeKeyForRule pins the memory-partition key per session origin.
+// Integration-origin sessions MUST land in their own per-integration
+// zone ("integration:<id>") regardless of target scope, so their facts
+// never share the operator's cwd-scoped project partition or the shared
+// "operator" global partition. Without this the isolation zone is a
+// no-op: every integration sharing a cwd reads/writes the same memory.
+func TestScopeKeyForRule(t *testing.T) {
+	tests := []struct {
+		name string
+		rule Rule
+		sess SessionInfo
+		want string
+	}{
+		{
+			name: "operator project scope keys on cwd",
+			rule: Rule{TargetScope: "project"},
+			sess: SessionInfo{Origin: "operator", Cwd: "/home/dev/proj"},
+			want: "/home/dev/proj",
+		},
+		{
+			name: "operator global scope keys on operator",
+			rule: Rule{TargetScope: "global"},
+			sess: SessionInfo{Origin: "operator", Cwd: "/home/dev/proj"},
+			want: "operator",
+		},
+		{
+			name: "cli session behaves like operator",
+			rule: Rule{TargetScope: "project"},
+			sess: SessionInfo{Origin: "cli", Cwd: "/home/dev/proj"},
+			want: "/home/dev/proj",
+		},
+		{
+			name: "integration project scope is isolated to its own zone",
+			rule: Rule{TargetScope: "project"},
+			sess: SessionInfo{Origin: "integration", IntegrationID: "intg-42", Cwd: "/home/dev/proj"},
+			want: "integration:intg-42",
+		},
+		{
+			name: "integration global scope is ALSO isolated (no operator pollution)",
+			rule: Rule{TargetScope: "global"},
+			sess: SessionInfo{Origin: "integration", IntegrationID: "intg-42", Cwd: "/home/dev/proj"},
+			want: "integration:intg-42",
+		},
+		{
+			name: "integration origin without id falls back to cwd (defensive)",
+			rule: Rule{TargetScope: "project"},
+			sess: SessionInfo{Origin: "integration", Cwd: "/home/dev/proj"},
+			want: "/home/dev/proj",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := scopeKeyForRule(tt.rule, tt.sess); got != tt.want {
+				t.Errorf("scopeKeyForRule() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestIntegrationSessionQuarantinesFacts drives the FULL capture path
 // (trigger → summarize → store) via runForceForSession with the
 // worker-provider default, proving captured facts land in quarantine
@@ -159,6 +218,9 @@ func TestIntegrationSessionQuarantinesFacts(t *testing.T) {
 	}
 	if got.Metadata["integration_id"] != "intg-42" {
 		t.Errorf("metadata integration_id = %v, want intg-42", got.Metadata["integration_id"])
+	}
+	if got.ScopeKey != "integration:intg-42" {
+		t.Errorf("scope_key = %q, want integration:intg-42 (isolated zone, not cwd %q)", got.ScopeKey, sess.Cwd)
 	}
 }
 
@@ -235,6 +297,9 @@ func TestOperatorSessionStaysDurable(t *testing.T) {
 	}
 	if mem.storeCalls[0].QuarantineExpiresAt != nil {
 		t.Errorf("operator fact must not carry a quarantine expiry")
+	}
+	if got := mem.storeCalls[0].ScopeKey; got != "/x" {
+		t.Errorf("operator scope_key = %q, want cwd /x (no regression)", got)
 	}
 	if fp := r.policy.(*fakePolicy); fp.calls != 0 {
 		t.Errorf("policy resolver consulted %d times for an operator session, want 0", fp.calls)

--- a/internal/memory/capture/service.go
+++ b/internal/memory/capture/service.go
@@ -392,6 +392,19 @@ func (r *runner) isDuplicate(ctx context.Context, fact summarizer.Fact, rule Rul
 // project) use the session's cwd; 'global' uses an operator-style
 // placeholder.
 func scopeKeyForRule(rule Rule, sess SessionInfo) string {
+	// Third-party integration sessions get their own per-integration
+	// memory zone, independent of the rule's target scope. Otherwise a
+	// captured fact lands under the operator's shared partition — the
+	// cwd for project scope, "operator" for global scope — i.e. every
+	// integration sharing a cwd reads/writes the same memory and the
+	// data is unattributable. The "integration:" prefix can't collide
+	// with a real absolute-path cwd or the "operator" global key, so
+	// the zone is both isolated and identifiable (e.g. via
+	// ListScopeKeys). Origin/IntegrationID are populated at capture
+	// time from the authenticated principal (migration 0044).
+	if sess.Origin == "integration" && sess.IntegrationID != "" {
+		return memory.IntegrationScopeKey(sess.IntegrationID)
+	}
 	switch rule.TargetScope {
 	case "global":
 		return "operator"

--- a/internal/memory/mirror.go
+++ b/internal/memory/mirror.go
@@ -176,6 +176,11 @@ func (m *Mirror) BackfillAll(ctx context.Context) (projects, ingested int, err e
 		if strings.TrimSpace(cwd) == "" {
 			continue
 		}
+		// Integration zones are isolated partitions, not real working
+		// dirs — there is no .claude/projects tree to mirror for them.
+		if IsIntegrationScopeKey(cwd) {
+			continue
+		}
 		n, serr := m.SyncCwd(ctx, cwd)
 		if serr != nil {
 			m.log.Debug("backfill sync", "cwd", cwd, "err", serr)

--- a/internal/memory/scopekey.go
+++ b/internal/memory/scopekey.go
@@ -1,0 +1,35 @@
+package memory
+
+import "strings"
+
+// IntegrationScopeKeyPrefix marks a project-scope memory partition that
+// belongs to a single third-party integration instead of a real working
+// directory. Captured facts from integration-origin sessions are routed
+// here (see capture.scopeKeyForRule) so they never share the operator's
+// cwd-scoped project partition — this is the third-party memory
+// isolation zone. The "integration:" prefix can't collide with an
+// absolute-path cwd or the "operator" global key, so the zone is both
+// isolated and identifiable (e.g. via ListScopeKeys / the admin memory
+// list).
+const IntegrationScopeKeyPrefix = "integration:"
+
+// IntegrationScopeKey returns the project-scope scope_key for an
+// integration's isolated memory zone. Single source of truth for the
+// on-disk key format.
+func IntegrationScopeKey(integrationID string) string {
+	return IntegrationScopeKeyPrefix + integrationID
+}
+
+// IsIntegrationScopeKey reports whether a project-scope scope_key names a
+// third-party integration's isolated zone rather than a real cwd.
+//
+// Callers that interpret a project scope_key as a filesystem path (the
+// git-activity scanner, the .claude/projects file mirror) or that distil
+// operator-facing knowledge from project memory MUST skip these keys, so
+// the zone stays isolated from the operator and path-assuming work never
+// runs against a non-path key. Lifecycle passes that operate purely on
+// memory rows (the cleaner) and surfaces meant to expose the zone (the
+// admin memory list) should NOT skip them.
+func IsIntegrationScopeKey(scopeKey string) bool {
+	return strings.HasPrefix(scopeKey, IntegrationScopeKeyPrefix)
+}

--- a/internal/memory/scopekey_test.go
+++ b/internal/memory/scopekey_test.go
@@ -1,0 +1,28 @@
+package memory
+
+import "testing"
+
+func TestIntegrationScopeKey(t *testing.T) {
+	if got := IntegrationScopeKey("intg-42"); got != "integration:intg-42" {
+		t.Errorf("IntegrationScopeKey = %q, want integration:intg-42", got)
+	}
+}
+
+func TestIsIntegrationScopeKey(t *testing.T) {
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		{"integration:intg-42", true},
+		{"integration:", true},
+		{"/home/dev/proj", false},
+		{"operator", false},
+		{"", false},
+		{"/srv/integration-stuff", false}, // substring, not prefix
+	}
+	for _, tt := range tests {
+		if got := IsIntegrationScopeKey(tt.key); got != tt.want {
+			t.Errorf("IsIntegrationScopeKey(%q) = %v, want %v", tt.key, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The operator suspected the per-integration **memory isolation zone** does nothing — and at the storage layer, it didn't.

Captured memory from integration-origin sessions shared the operator's project partition:

- `scopeKeyForRule` returned the session **cwd** for project scope (and `"operator"` for global) regardless of origin (`internal/memory/capture/service.go`).
- So every integration capturing from the same cwd landed in the **same `(scope, scope_key)` partition** as the operator and each other.
- `integration_id` was written **only into the `metadata` JSONB** and **never referenced in any `WHERE` clause** — the `memories` table has no `integration_id` column (only the `sessions` table does, migration 0044). The zone could neither **separate** nor **identify** a third-party integration.

The read side was already guarded — integration sessions don't get the `opendray-memory` MCP attached (`internal/catalog/adapter.go`) — so this was a **write-side** leak: integration facts accumulated in the operator's partition (quarantine tier) and, worse, were distilled into the operator-facing **knowledge base**.

## Fix

Route integration-origin captures to a dedicated, identifiable **`integration:<id>`** project scope_key, regardless of target scope, so an integration's facts never mix with the operator's project or global memory. The `integration:` prefix can't collide with an absolute-path cwd or the `operator` global key, so the zone is both isolated and identifiable (e.g. via `ListScopeKeys` / the admin memory list).

Single source of truth for the key format: `memory.IntegrationScopeKey` / `memory.IsIntegrationScopeKey` (new `internal/memory/scopekey.go`).

Guard the enumerators that treat a project scope_key as a real cwd or as operator knowledge, so isolation actually holds:

| Caller | Action | Why |
|--------|--------|-----|
| knowledge KB (`ListProjectKeys` / `ListAllMemories`) | **skip** zones | else integration facts feed operator-facing KB pages |
| git-activity scanner / `.claude/projects` mirror | **skip** zones | else shell `git` / walk FS against a non-path key |
| cleaner (lifecycle by timestamp) | **keep** | operates on memory rows, not paths — zones get aged out correctly |
| admin memory list | **keep** | surfacing the zone aids identifiability |

## Scope

Backend-only. No UI strings changed — the admin memory list automatically surfaces `integration:<id>` zones, so no web/mobile/i18n changes are needed.

## Test plan

- `go build ./...`, `go vet ./...` — clean
- `go test -race ./internal/memory/... ./internal/gitactivity/... ./internal/app/...` — green
- New/updated tests:
  - `scopekey_test.go` — `IntegrationScopeKey` / `IsIntegrationScopeKey` (incl. substring-not-prefix)
  - `routing_test.go` — `scopeKeyForRule` across origin × target-scope; isolation assertion on the full capture path; operator no-regression assertion (`scope_key == cwd`)

## Note / possible follow-up

`integration:<id>` is shown raw in the admin memory list. A small follow-up could resolve it to the integration's display name. Left out to keep this change minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)