### PR TITLE
fix(backup): auto-discover newest pg_dump to root-cure the pre-migrate restart loop

### DIFF
--- a/internal/backup/pgdump.go
+++ b/internal/backup/pgdump.go
@@ -5,9 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // PgDump wraps the pg_dump CLI. We don't link libpq because every
@@ -22,23 +26,122 @@ type PgDump struct {
 	binPath string
 }
 
-// NewPgDump resolves the pg_dump binary. Empty binPath falls back
-// to PATH lookup. Returns ErrPgDumpUnavailable when nothing usable
-// is found, so callers can errors.Is and surface a 503 instead of
-// a generic exec error.
+// pgDumpSearchGlobs lists locations probed (in addition to PATH) to find
+// the newest installed pg_dump when no explicit path is configured.
+// pg_dump is forward-compatible — a newer binary dumps same-or-older
+// servers fine, but an OLDER binary refuses a newer server ("server
+// version mismatch") — so "newest installed wins" is the safe default.
+// This is what stops a stale PATH default (e.g. an old Homebrew pg_dump
+// 14 ahead of an installed 17) from version-mismatching the server and
+// failing the FAIL-CLOSED pre-migrate snapshot into a launchd restart
+// loop. A package var so tests can neutralize filesystem discovery.
+var pgDumpSearchGlobs = []string{
+	"/opt/homebrew/opt/postgresql@*/bin/pg_dump", // macOS Homebrew (Apple silicon)
+	"/opt/homebrew/bin/pg_dump",
+	"/usr/local/opt/postgresql@*/bin/pg_dump", // macOS Homebrew (Intel)
+	"/usr/local/bin/pg_dump",
+	"/usr/lib/postgresql/*/bin/pg_dump", // Debian/Ubuntu
+	"/usr/pgsql-*/bin/pg_dump",          // RHEL/PGDG
+	"/usr/bin/pg_dump",
+}
+
+// NewPgDump resolves the pg_dump binary.
+//   - A non-empty binPath is an explicit operator override (cfg.backup.
+//     pg_dump_path); it is used as-is so operators stay in control.
+//   - An empty binPath triggers AUTO-DISCOVERY: PATH plus the well-known
+//     install locations are probed and the NEWEST major.minor wins, so a
+//     fresh install prefers e.g. postgresql@17 over a PATH default of 14
+//     with zero config. Falls back to a plain PATH lookup when discovery
+//     turns up nothing usable.
+//
+// Returns ErrPgDumpUnavailable when nothing usable is found, so callers
+// can errors.Is and surface a 503 instead of a generic exec error.
 func NewPgDump(binPath string) (*PgDump, error) {
-	if binPath == "" {
-		resolved, err := exec.LookPath("pg_dump")
-		if err != nil {
+	if binPath != "" {
+		if _, err := exec.LookPath(binPath); err != nil {
 			return nil, fmt.Errorf("%w: %v", ErrPgDumpUnavailable, err)
 		}
-		binPath = resolved
 		return &PgDump{binPath: binPath}, nil
 	}
-	if _, err := exec.LookPath(binPath); err != nil {
+	if best := pickNewestPgDump(discoverPgDumpCandidates()); best != "" {
+		return &PgDump{binPath: best}, nil
+	}
+	// Fallback: a plain PATH lookup (also covers odd environments where
+	// `--version` probing failed for every discovered candidate).
+	resolved, err := exec.LookPath("pg_dump")
+	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrPgDumpUnavailable, err)
 	}
-	return &PgDump{binPath: binPath}, nil
+	return &PgDump{binPath: resolved}, nil
+}
+
+// pgDumpCandidate is a discovered pg_dump binary and its parsed version.
+type pgDumpCandidate struct {
+	path  string
+	major int
+	minor int
+}
+
+// discoverPgDumpCandidates probes PATH and pgDumpSearchGlobs for usable
+// pg_dump binaries, de-duplicated by absolute path, each annotated with
+// its `--version`. Binaries whose version can't be probed/parsed are
+// skipped.
+func discoverPgDumpCandidates() []pgDumpCandidate {
+	seen := map[string]bool{}
+	var out []pgDumpCandidate
+	consider := func(path string) {
+		if path == "" {
+			return
+		}
+		if abs, err := filepath.Abs(path); err == nil {
+			path = abs
+		}
+		if seen[path] {
+			return
+		}
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+			return
+		}
+		seen[path] = true
+		if maj, min, ok := pgDumpVersionOf(path); ok {
+			out = append(out, pgDumpCandidate{path: path, major: maj, minor: min})
+		}
+	}
+	if p, err := exec.LookPath("pg_dump"); err == nil {
+		consider(p)
+	}
+	for _, g := range pgDumpSearchGlobs {
+		matches, _ := filepath.Glob(g)
+		for _, m := range matches {
+			consider(m)
+		}
+	}
+	return out
+}
+
+// pgDumpVersionOf runs `<path> --version` and parses its major.minor.
+func pgDumpVersionOf(path string) (int, int, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, path, "--version").Output()
+	if err != nil {
+		return 0, 0, false
+	}
+	return parsePGMajorMinorInts(strings.TrimSpace(string(out)))
+}
+
+// pickNewestPgDump returns the path of the candidate with the highest
+// (major, minor), or "" when the list is empty. Pure — unit-tested.
+func pickNewestPgDump(cands []pgDumpCandidate) string {
+	best := ""
+	bestMaj, bestMin := -1, -1
+	for _, c := range cands {
+		if c.major > bestMaj || (c.major == bestMaj && c.minor > bestMin) {
+			best, bestMaj, bestMin = c.path, c.major, c.minor
+		}
+	}
+	return best
 }
 
 // BinPath returns the absolute path to the resolved pg_dump binary.
@@ -134,6 +237,21 @@ func ParsePGMajorMinor(versionLine string) string {
 		return ""
 	}
 	return m[1] + "." + m[2]
+}
+
+// parsePGMajorMinorInts is ParsePGMajorMinor as integers, for version
+// comparison. Returns ok=false when no version pattern is present.
+func parsePGMajorMinorInts(versionLine string) (int, int, bool) {
+	m := versionMajorMinorRe.FindStringSubmatch(versionLine)
+	if len(m) < 3 {
+		return 0, 0, false
+	}
+	maj, err1 := strconv.Atoi(m[1])
+	min, err2 := strconv.Atoi(m[2])
+	if err1 != nil || err2 != nil {
+		return 0, 0, false
+	}
+	return maj, min, true
 }
 
 var versionMajorMinorRe = regexp.MustCompile(`(\d+)\.(\d+)`)

--- a/internal/backup/pgdump_test.go
+++ b/internal/backup/pgdump_test.go
@@ -29,11 +29,80 @@ func TestNewPgDump_MissingBinary(t *testing.T) {
 }
 
 func TestNewPgDump_PATHFallback_Missing(t *testing.T) {
-	// Force PATH to empty so PATH lookup fails.
+	// Force PATH to empty AND neutralize filesystem discovery so neither
+	// PATH nor the well-known install locations can resolve a binary.
 	t.Setenv("PATH", "")
+	defer withSearchGlobs(nil)()
 	_, err := NewPgDump("")
 	if !errors.Is(err, ErrPgDumpUnavailable) {
 		t.Fatalf("got %v, want ErrPgDumpUnavailable", err)
+	}
+}
+
+// withSearchGlobs temporarily swaps pgDumpSearchGlobs; the returned func
+// restores the original.
+func withSearchGlobs(g []string) func() {
+	prev := pgDumpSearchGlobs
+	pgDumpSearchGlobs = g
+	return func() { pgDumpSearchGlobs = prev }
+}
+
+func TestParsePGMajorMinorInts(t *testing.T) {
+	tests := []struct {
+		line     string
+		maj, min int
+		ok       bool
+	}{
+		{"pg_dump (PostgreSQL) 17.9 (Homebrew)", 17, 9, true},
+		{"pg_dump (PostgreSQL) 14.19 (Homebrew)", 14, 19, true},
+		{"pg_dump (PostgreSQL) 17.6 (Debian 17.6-1.pgdg13+1)", 17, 6, true},
+		{"no version here", 0, 0, false},
+		{"", 0, 0, false},
+	}
+	for _, tt := range tests {
+		maj, min, ok := parsePGMajorMinorInts(tt.line)
+		if ok != tt.ok || maj != tt.maj || min != tt.min {
+			t.Errorf("parsePGMajorMinorInts(%q) = (%d,%d,%v), want (%d,%d,%v)",
+				tt.line, maj, min, ok, tt.maj, tt.min, tt.ok)
+		}
+	}
+}
+
+func TestPickNewestPgDump(t *testing.T) {
+	tests := []struct {
+		name  string
+		cands []pgDumpCandidate
+		want  string
+	}{
+		{"empty", nil, ""},
+		{
+			"prefers higher major (the crash-loop fix)",
+			[]pgDumpCandidate{
+				{path: "/opt/homebrew/bin/pg_dump", major: 14, minor: 19},
+				{path: "/opt/homebrew/opt/postgresql@17/bin/pg_dump", major: 17, minor: 9},
+			},
+			"/opt/homebrew/opt/postgresql@17/bin/pg_dump",
+		},
+		{
+			"same major prefers higher minor",
+			[]pgDumpCandidate{
+				{path: "/a/pg_dump", major: 17, minor: 2},
+				{path: "/b/pg_dump", major: 17, minor: 9},
+			},
+			"/b/pg_dump",
+		},
+		{
+			"single candidate wins",
+			[]pgDumpCandidate{{path: "/only/pg_dump", major: 14, minor: 1}},
+			"/only/pg_dump",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pickNewestPgDump(tt.cands); got != tt.want {
+				t.Errorf("pickNewestPgDump() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem (root cause of the pre-migrate restart loop)

The pre-migrate snapshot is **fail-closed**: if it can't `pg_dump` the DB, it aborts before applying migrations. Under launchd `KeepAlive`, that abort becomes an **infinite restart loop that takes the whole gateway (frontend included) down**.

The trigger: `NewPgDump("")` resolved `pg_dump` from **PATH**, where Homebrew's default is an older major (e.g. `pg_dump` 14) sitting ahead of the actually-installed 17. An older `pg_dump` **refuses** a newer server (`server version mismatch`). The only guard was a hand-pinned `backup.pg_dump_path` in local `config.toml` — easy to forget, not in git, and **absent on a fresh install**. (This bit us on 2026-06-15.)

## Fix

`NewPgDump("")` now **auto-discovers** pg_dump: it probes PATH **plus** the well-known install locations (Homebrew `postgresql@*`, Debian `/usr/lib/postgresql/*`, RHEL `/usr/pgsql-*`) and picks the **newest `major.minor`**. pg_dump is forward-compatible — a newer binary dumps same-or-older servers fine — so *"newest installed wins"* is always safe and makes opendray prefer 17 over a PATH 14 **with zero config**.

- An explicit `backup.pg_dump_path` still **wins** (operator override, unchanged).
- A plain PATH lookup remains the **final fallback** (and the `ErrPgDumpUnavailable` contract is preserved).
- Applies at the single resolution point, so **both** the pre-migrate snapshot and the backup feature benefit.

## Test plan

- `go build ./...`, `go vet`, `gofmt` — clean
- `go test -race ./internal/backup/...` — green
- New table-driven tests: `pickNewestPgDump` (prefers higher major — the exact crash-loop fix — and higher minor; empty; single) and `parsePGMajorMinorInts` (Homebrew/Debian formats, garbage). The PATH-empty "unavailable" test now also neutralizes filesystem discovery (search roots are a package var).

## Notes

- Pure code change, **no migration** — deploying it is restart-safe (it does not itself trigger a pre-migrate snapshot).
- The existing local `config.toml` pin (`backup.pg_dump_path = …postgresql@17…`) already protects the running instance; this fix removes the **reliance** on that manual pin going forward (fresh installs, lost config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)