### PR TITLE
fix(worker,cortex): correct per-CLI headless invocation for AI discussion (gemini/codex/antigravity)

### DIFF
--- a/internal/cortex/conversation.go
+++ b/internal/cortex/conversation.go
@@ -58,9 +58,14 @@ type Conversation struct {
 // validConvProvider reports whether p is an allowed cloud-agent override
 // provider (empty = no cloud-agent override). Mirrors the agent worker's
 // supported provider set.
+// validConvProvider lists the cloud-agent providers the Cortex
+// conversation worker can actually drive headlessly. Must stay in sync
+// with the worker fabric's AgentWorker.buildCommand switch (claude /
+// gemini / codex / antigravity). opencode has no headless worker path
+// yet, so it is intentionally NOT accepted here.
 func validConvProvider(p string) bool {
 	switch p {
-	case "", "claude", "gemini", "codex":
+	case "", "claude", "gemini", "codex", "antigravity":
 		return true
 	}
 	return false
@@ -81,7 +86,7 @@ func normalizeConvOverride(providerID, model, summarizerID string) (p, m, s stri
 		return "", model, summarizerID, nil
 	}
 	if !validConvProvider(providerID) {
-		return "", "", "", fmt.Errorf("cortex: bad provider_id %q (want claude|gemini|codex)", providerID)
+		return "", "", "", fmt.Errorf("cortex: provider_id %q is not supported for AI discussion (want claude|gemini|codex|antigravity)", providerID)
 	}
 	if providerID == "" {
 		model = "" // a model with no provider is meaningless

--- a/internal/memory/worker/agent.go
+++ b/internal/memory/worker/agent.go
@@ -133,6 +133,11 @@ func (w *AgentWorker) Run(ctx context.Context, req Request) (Response, error) {
 	// JSON-schema instruction) is folded into stdin ahead of the
 	// user input.
 	input := req.UserInput
+	// Gemini receives the prompt via the --prompt arg (see buildCommand),
+	// not stdin, so leave its stdin empty to avoid duplicating the prompt.
+	if w.cfg.ProviderID == "gemini" {
+		input = ""
+	}
 	// codex and antigravity (agy) have no system-prompt CLI flag, so the
 	// system block (+ JSON-schema instruction) is folded into stdin ahead
 	// of the user input.
@@ -162,7 +167,7 @@ func (w *AgentWorker) Run(ctx context.Context, req Request) (Response, error) {
 			return Response{}, fmt.Errorf("agent worker: timeout after %s (stdout: %s, stderr: %s)",
 				timeout, stdoutTrunc, stderrTrunc)
 		}
-		return Response{}, fmt.Errorf("agent worker: %s --print: %w (stdout: %s, stderr: %s)",
+		return Response{}, fmt.Errorf("agent worker: %s headless run: %w (stdout: %s, stderr: %s)",
 			w.cfg.ProviderID, err, stdoutTrunc, stderrTrunc)
 	}
 	dur := time.Since(t0).Milliseconds()
@@ -254,8 +259,13 @@ func (w *AgentWorker) buildCommand(req Request, sessionID, scratch string) ([]st
 		args = append(args, "-")
 		return args, nil, nil
 	case "gemini":
+		// Gemini's headless flag is -p/--prompt (NOT --print, which is
+		// Claude-only — gemini errors "Unknown argument: print"). The
+		// prompt is passed as the flag value; the system block is read
+		// from GEMINI.md via --include-directories below. Run does not
+		// also pipe the prompt to stdin for gemini (it is here in args).
 		args := []string{
-			"--print",
+			"--prompt", req.UserInput,
 			"--session-id", sessionID,
 		}
 		if w.cfg.Model != "" {

--- a/internal/memory/worker/agent_buildcommand_test.go
+++ b/internal/memory/worker/agent_buildcommand_test.go
@@ -1,0 +1,63 @@
+package worker
+
+import (
+	"testing"
+)
+
+func argsContain(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBuildCommand_GeminiUsesPromptNotPrint(t *testing.T) {
+	w := &AgentWorker{cfg: Config{ProviderID: "gemini"}}
+	args, _, err := w.buildCommand(Request{UserInput: "hello world"}, "sid-1", t.TempDir())
+	if err != nil {
+		t.Fatalf("buildCommand: %v", err)
+	}
+	if argsContain(args, "--print") {
+		t.Errorf("gemini must NOT use --print (Claude-only flag); got %v", args)
+	}
+	if !argsContain(args, "--prompt") {
+		t.Errorf("gemini must use --prompt for headless mode; got %v", args)
+	}
+	if !argsContain(args, "hello world") {
+		t.Errorf("gemini --prompt must carry the user input; got %v", args)
+	}
+}
+
+func TestBuildCommand_ClaudeUsesPrint(t *testing.T) {
+	w := &AgentWorker{cfg: Config{ProviderID: "claude"}}
+	args, _, err := w.buildCommand(Request{UserInput: "x"}, "sid", t.TempDir())
+	if err != nil {
+		t.Fatalf("buildCommand: %v", err)
+	}
+	if !argsContain(args, "--print") {
+		t.Errorf("claude uses --print; got %v", args)
+	}
+}
+
+func TestBuildCommand_CodexUsesExecNotPrint(t *testing.T) {
+	w := &AgentWorker{cfg: Config{ProviderID: "codex"}}
+	args, _, err := w.buildCommand(Request{UserInput: "x"}, "sid", t.TempDir())
+	if err != nil {
+		t.Fatalf("buildCommand: %v", err)
+	}
+	if len(args) == 0 || args[0] != "exec" {
+		t.Errorf("codex must use the `exec` subcommand; got %v", args)
+	}
+	if argsContain(args, "--print") {
+		t.Errorf("codex must NOT use --print; got %v", args)
+	}
+}
+
+func TestBuildCommand_OpencodeUnsupported(t *testing.T) {
+	w := &AgentWorker{cfg: Config{ProviderID: "opencode"}}
+	if _, _, err := w.buildCommand(Request{UserInput: "x"}, "sid", t.TempDir()); err == nil {
+		t.Error("opencode has no headless worker path; buildCommand must return ErrAgentUnsupported")
+	}
+}

--- a/internal/memory/worker/worker.go
+++ b/internal/memory/worker/worker.go
@@ -149,10 +149,10 @@ var (
 	ErrNoWorkerConfigured = errors.New("memory worker: no worker configured for task")
 
 	// ErrAgentUnsupported is returned when an operator picked an
-	// agent provider that doesn't support --print mode (today:
-	// codex). The UI should validate before saving but we
-	// double-check defensively.
-	ErrAgentUnsupported = errors.New("memory worker: agent provider unsupported in --print mode")
+	// agent provider with no headless worker path (today: opencode).
+	// The UI should validate before saving but we double-check
+	// defensively.
+	ErrAgentUnsupported = errors.New("memory worker: agent provider unsupported in headless mode")
 )
 
 // Worker is the single-method interface every implementation


### PR DESCRIPTION
## Problem (from the operator's screenshots)

The Cortex **"AI discussion"** feature only worked with **claude**:

1. `agent worker: gemini --print: exit status 1 … Unknown argument: print` — the worker invoked gemini with **`--print`**, a **Claude-only** flag. Gemini wants **`-p`/`--prompt`** for headless mode.
2. `cortex: bad provider_id "antigravity" (want claude|gemini|codex)` — cortex rejected **antigravity** even though the worker fabric **supports** it (`agy`).
3. The failure string hard-coded **`--print`**, so a codex failure read as `codex --print` even though codex actually runs `codex exec` — misleading.

This is why "only claude worked" (claude is the one CLI whose headless flag really is `--print`).

## Fix (backend — worker + cortex)

- **gemini** → `--prompt <user input>` (not `--print`); system block still via `GEMINI.md` (`--include-directories`). `Run` leaves gemini's stdin empty so the prompt isn't doubled.
- **error message** → `"<provider> headless run"` instead of a hard-coded `--print`.
- **cortex `validConvProvider`** → `claude|gemini|codex|antigravity` (matches the worker's real support set), clearer rejection message; **opencode** stays rejected (no headless worker path).
- `ErrAgentUnsupported` text de-references `--print`.

## Out of scope (noted, not fixed here)

- **codex's own exit-1** in the report is an **environment** issue, not an invocation bug: the banner shows `codex exec` started fine (model `gpt-5.4`, provider openai, approval never) — the failure is **auth/model** (ChatGPT login or the configured model), so codex's args are left unchanged.
- **Claude account selector in the AI-discussion UI** — the worker already honors `AccountID`, but the cortex conversation has no way to pick one, so a multi-account claude falls back to the default config dir and can hit a login prompt. Deferred to a focused follow-up (UI + cortex conversation `account_id`), per scope.

## Test plan

- `go build ./...`, `go vet`, `gofmt` — clean
- `go test -race ./internal/memory/worker/ ./internal/cortex/` — green
- New `buildCommand` tests: gemini → `--prompt` (and **not** `--print`, carries the input), claude → `--print`, codex → `exec` (not `--print`), opencode → `ErrAgentUnsupported`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)