### PR TITLE
feat(cortex): Claude account selector for AI discussion (web + mobile + i18n)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -2938,6 +2938,8 @@
         "modelChangeFailed": "Couldn't change the discussion model",
         "modelGroupCloud": "Cloud agents",
         "modelGroupLocal": "Local models",
+        "accountDefault": "Default account",
+        "accountHint": "Which Claude account this discussion runs against (Claude is multi-account).",
         "modelProviderDefault": "Provider default",
         "modelProbeFailed": "Couldn't reach the endpoint to list models — pick the provider default or configure it in Memory settings."
       },

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -2938,6 +2938,8 @@
         "modelChangeFailed": "No se pudo cambiar el modelo de la conversación",
         "modelGroupCloud": "Agentes en la nube",
         "modelGroupLocal": "Modelos locales",
+        "accountDefault": "Cuenta predeterminada",
+        "accountHint": "Con qué cuenta de Claude se ejecuta esta discusión (Claude es multicuenta).",
         "modelProviderDefault": "Predeterminado del proveedor",
         "modelProbeFailed": "No se pudo contactar el endpoint para listar modelos: usa el predeterminado del proveedor o configúralo en Ajustes de memoria."
       },

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -2938,6 +2938,8 @@
         "modelChangeFailed": "切换讨论模型失败",
         "modelGroupCloud": "云端 agent",
         "modelGroupLocal": "本地模型",
+        "accountDefault": "默认账号",
+        "accountHint": "本次讨论使用哪个 Claude 账号(Claude 是多账号)。",
         "modelProviderDefault": "供应商默认",
         "modelProbeFailed": "无法连接端点列出模型——用供应商默认，或在 Memory 设置里配置。"
       },

--- a/app/mobile/lib/core/api/cortex_api.dart
+++ b/app/mobile/lib/core/api/cortex_api.dart
@@ -142,6 +142,7 @@ class CortexApi {
     // providerId+model, OR a local summarizerId).
     String providerId = '',
     String model = '',
+    String claudeAccountId = '',
     String summarizerId = '',
   }) async {
     try {
@@ -153,6 +154,7 @@ class CortexApi {
           'target_slug': targetSlug,
           if (providerId.isNotEmpty) 'provider_id': providerId,
           if (model.isNotEmpty) 'model': model,
+          if (claudeAccountId.isNotEmpty) 'claude_account_id': claudeAccountId,
           if (summarizerId.isNotEmpty) 'summarizer_id': summarizerId,
         },
       );
@@ -169,6 +171,7 @@ class CortexApi {
     String id, {
     String providerId = '',
     String model = '',
+    String claudeAccountId = '',
     String summarizerId = '',
   }) async {
     try {
@@ -177,6 +180,7 @@ class CortexApi {
         data: {
           'provider_id': providerId,
           'model': model,
+          'claude_account_id': claudeAccountId,
           'summarizer_id': summarizerId,
         },
       );
@@ -427,6 +431,7 @@ class CortexConversation {
     required this.escalatedSessionId,
     required this.providerId,
     required this.model,
+    required this.claudeAccountId,
     required this.summarizerId,
   });
 
@@ -440,6 +445,7 @@ class CortexConversation {
         escalatedSessionId: j['escalated_session_id']?.toString() ?? '',
         providerId: j['provider_id']?.toString() ?? '',
         model: j['model']?.toString() ?? '',
+        claudeAccountId: j['claude_account_id']?.toString() ?? '',
         summarizerId: j['summarizer_id']?.toString() ?? '',
       );
 
@@ -454,6 +460,9 @@ class CortexConversation {
   // model pin a cloud-agent CLI.
   final String providerId;
   final String model;
+  // Which Claude (cliacct) account a claude turn runs against — Claude is
+  // multi-account. Only meaningful when providerId == 'claude'.
+  final String claudeAccountId;
   final String summarizerId;
 }
 

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 11673 (3891 per locale)
+/// Strings: 11679 (3893 per locale)
 ///
-/// Built on 2026-06-17 at 10:48 UTC
+/// Built on 2026-06-18 at 04:16 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -11336,6 +11336,12 @@ class TranslationsWebCortexChatEn {
 	/// en: 'Local models'
 	String get modelGroupLocal => 'Local models';
 
+	/// en: 'Default account'
+	String get accountDefault => 'Default account';
+
+	/// en: 'Which Claude account this discussion runs against (Claude is multi-account).'
+	String get accountHint => 'Which Claude account this discussion runs against (Claude is multi-account).';
+
 	/// en: 'Provider default'
 	String get modelProviderDefault => 'Provider default';
 
@@ -19196,6 +19202,8 @@ extension on Translations {
 			'web.cortex.chat.modelChangeFailed' => 'Couldn\'t change the discussion model',
 			'web.cortex.chat.modelGroupCloud' => 'Cloud agents',
 			'web.cortex.chat.modelGroupLocal' => 'Local models',
+			'web.cortex.chat.accountDefault' => 'Default account',
+			'web.cortex.chat.accountHint' => 'Which Claude account this discussion runs against (Claude is multi-account).',
 			'web.cortex.chat.modelProviderDefault' => 'Provider default',
 			'web.cortex.chat.modelProbeFailed' => 'Couldn\'t reach the endpoint to list models — pick the provider default or configure it in Memory settings.',
 			'web.cortex.blueprint.open' => 'Blueprint',
@@ -19454,10 +19462,10 @@ extension on Translations {
 			'sessions.inspector.git.insertPath' => 'Insert path',
 			'sessions.inspector.git.showDiff' => 'Show diff',
 			'sessions.inspector.git.diffFailedApi' => ({required Object status, required Object message}) => 'Diff failed (${status}): ${message}',
-			'sessions.inspector.git.diffFailedGeneric' => ({required Object error}) => 'Diff failed: ${error}',
-			'sessions.inspector.git.insertHash' => 'Insert hash',
 			_ => null,
 		} ?? switch (path) {
+			'sessions.inspector.git.diffFailedGeneric' => ({required Object error}) => 'Diff failed: ${error}',
+			'sessions.inspector.git.insertHash' => 'Insert hash',
 			'sessions.inspector.git.showFullPatch' => 'Show full patch',
 			'sessions.inspector.git.showFailedApi' => ({required Object status, required Object message}) => 'Show failed (${status}): ${message}',
 			'sessions.inspector.git.showFailedGeneric' => ({required Object error}) => 'Show failed: ${error}',
@@ -19968,10 +19976,10 @@ extension on Translations {
 			'backups.emptyNoTargets.body' => 'Open the More menu → Targets to add a destination (local / S3 / SMB / SFTP / WebDAV / rclone). Then come back and tap "Run now".',
 			'backups.emptyNoBackups.headline' => 'No backups yet',
 			'backups.emptyNoBackups.body' => 'Tap "Run now" to take a fresh snapshot, or open Schedules to set up recurring runs.',
-			'backups.restartToActivate' => 'Restart opendray to activate backups',
-			'backups.passphraseSaved' => 'Your passphrase is saved. The gateway only loads it at startup, so changes only take effect after a restart.',
 			_ => null,
 		} ?? switch (path) {
+			'backups.restartToActivate' => 'Restart opendray to activate backups',
+			'backups.passphraseSaved' => 'Your passphrase is saved. The gateway only loads it at startup, so changes only take effect after a restart.',
 			'backups.keyFileLabel' => 'Key file',
 			'backups.configuredViaLabel' => 'Configured via',
 			'backups.wizard.title' => 'Set up backups',
@@ -20482,10 +20490,10 @@ extension on Translations {
 			'dataExport.import.finishedWithErrors' => 'Import finished with errors',
 			'dataExport.import.failedToast' => ({required Object error}) => 'Import failed: ${error}',
 			'dataExport.import.summaryCard.memories' => 'Memories',
-			'dataExport.import.summaryCard.integrations' => 'Integrations',
-			'dataExport.import.summaryCard.customTasks' => 'Custom tasks',
 			_ => null,
 		} ?? switch (path) {
+			'dataExport.import.summaryCard.integrations' => 'Integrations',
+			'dataExport.import.summaryCard.customTasks' => 'Custom tasks',
 			'dataExport.import.summaryCard.created' => 'created',
 			'dataExport.import.summaryCard.skipped' => 'skipped',
 			'dataExport.import.summaryCard.failed' => 'failed',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -5766,6 +5766,8 @@ class _TranslationsWebCortexChatEs extends TranslationsWebCortexChatEn {
 	@override String get modelChangeFailed => 'No se pudo cambiar el modelo de la conversación';
 	@override String get modelGroupCloud => 'Agentes en la nube';
 	@override String get modelGroupLocal => 'Modelos locales';
+	@override String get accountDefault => 'Cuenta predeterminada';
+	@override String get accountHint => 'Con qué cuenta de Claude se ejecuta esta discusión (Claude es multicuenta).';
 	@override String get modelProviderDefault => 'Predeterminado del proveedor';
 	@override String get modelProbeFailed => 'No se pudo contactar el endpoint para listar modelos: usa el predeterminado del proveedor o configúralo en Ajustes de memoria.';
 }
@@ -11298,6 +11300,8 @@ extension on TranslationsEs {
 			'web.cortex.chat.modelChangeFailed' => 'No se pudo cambiar el modelo de la conversación',
 			'web.cortex.chat.modelGroupCloud' => 'Agentes en la nube',
 			'web.cortex.chat.modelGroupLocal' => 'Modelos locales',
+			'web.cortex.chat.accountDefault' => 'Cuenta predeterminada',
+			'web.cortex.chat.accountHint' => 'Con qué cuenta de Claude se ejecuta esta discusión (Claude es multicuenta).',
 			'web.cortex.chat.modelProviderDefault' => 'Predeterminado del proveedor',
 			'web.cortex.chat.modelProbeFailed' => 'No se pudo contactar el endpoint para listar modelos: usa el predeterminado del proveedor o configúralo en Ajustes de memoria.',
 			'web.cortex.blueprint.open' => 'Plano',
@@ -11556,10 +11560,10 @@ extension on TranslationsEs {
 			'sessions.inspector.git.insertPath' => 'Insertar ruta',
 			'sessions.inspector.git.showDiff' => 'Mostrar diff',
 			'sessions.inspector.git.diffFailedApi' => ({required Object status, required Object message}) => 'Falló el diff (${status}): ${message}',
-			'sessions.inspector.git.diffFailedGeneric' => ({required Object error}) => 'Falló el diff: ${error}',
-			'sessions.inspector.git.insertHash' => 'Insertar hash',
 			_ => null,
 		} ?? switch (path) {
+			'sessions.inspector.git.diffFailedGeneric' => ({required Object error}) => 'Falló el diff: ${error}',
+			'sessions.inspector.git.insertHash' => 'Insertar hash',
 			'sessions.inspector.git.showFullPatch' => 'Mostrar el parche completo',
 			'sessions.inspector.git.showFailedApi' => ({required Object status, required Object message}) => 'Falló al mostrar (${status}): ${message}',
 			'sessions.inspector.git.showFailedGeneric' => ({required Object error}) => 'Falló al mostrar: ${error}',
@@ -12070,10 +12074,10 @@ extension on TranslationsEs {
 			'backups.emptyNoTargets.body' => 'Abre el menú Más → Destinos para añadir un destino (local / S3 / SMB / SFTP / WebDAV / rclone). Luego vuelve y toca "Ejecutar ahora".',
 			'backups.emptyNoBackups.headline' => 'Aún no hay copias de seguridad',
 			'backups.emptyNoBackups.body' => 'Toca "Ejecutar ahora" para tomar una nueva instantánea, o abre Programaciones para configurar ejecuciones periódicas.',
-			'backups.restartToActivate' => 'Reinicia opendray para activar las copias de seguridad',
-			'backups.passphraseSaved' => 'Tu passphrase está guardada. El gateway solo la carga al iniciarse, así que los cambios solo surten efecto tras un reinicio.',
 			_ => null,
 		} ?? switch (path) {
+			'backups.restartToActivate' => 'Reinicia opendray para activar las copias de seguridad',
+			'backups.passphraseSaved' => 'Tu passphrase está guardada. El gateway solo la carga al iniciarse, así que los cambios solo surten efecto tras un reinicio.',
 			'backups.keyFileLabel' => 'Archivo de clave',
 			'backups.configuredViaLabel' => 'Configurado mediante',
 			'backups.wizard.title' => 'Configurar copias de seguridad',
@@ -12584,10 +12588,10 @@ extension on TranslationsEs {
 			'dataExport.import.finishedWithErrors' => 'Importación finalizada con errores',
 			'dataExport.import.failedToast' => ({required Object error}) => 'Error en la importación: ${error}',
 			'dataExport.import.summaryCard.memories' => 'Memorias',
-			'dataExport.import.summaryCard.integrations' => 'Integraciones',
-			'dataExport.import.summaryCard.customTasks' => 'Tareas personalizadas',
 			_ => null,
 		} ?? switch (path) {
+			'dataExport.import.summaryCard.integrations' => 'Integraciones',
+			'dataExport.import.summaryCard.customTasks' => 'Tareas personalizadas',
 			'dataExport.import.summaryCard.created' => 'creadas',
 			'dataExport.import.summaryCard.skipped' => 'omitidas',
 			'dataExport.import.summaryCard.failed' => 'fallidas',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -5766,6 +5766,8 @@ class _TranslationsWebCortexChatZh extends TranslationsWebCortexChatEn {
 	@override String get modelChangeFailed => '切换讨论模型失败';
 	@override String get modelGroupCloud => '云端 agent';
 	@override String get modelGroupLocal => '本地模型';
+	@override String get accountDefault => '默认账号';
+	@override String get accountHint => '本次讨论使用哪个 Claude 账号(Claude 是多账号)。';
 	@override String get modelProviderDefault => '供应商默认';
 	@override String get modelProbeFailed => '无法连接端点列出模型——用供应商默认，或在 Memory 设置里配置。';
 }
@@ -11298,6 +11300,8 @@ extension on TranslationsZh {
 			'web.cortex.chat.modelChangeFailed' => '切换讨论模型失败',
 			'web.cortex.chat.modelGroupCloud' => '云端 agent',
 			'web.cortex.chat.modelGroupLocal' => '本地模型',
+			'web.cortex.chat.accountDefault' => '默认账号',
+			'web.cortex.chat.accountHint' => '本次讨论使用哪个 Claude 账号(Claude 是多账号)。',
 			'web.cortex.chat.modelProviderDefault' => '供应商默认',
 			'web.cortex.chat.modelProbeFailed' => '无法连接端点列出模型——用供应商默认，或在 Memory 设置里配置。',
 			'web.cortex.blueprint.open' => '蓝图',
@@ -11556,10 +11560,10 @@ extension on TranslationsZh {
 			'sessions.inspector.git.insertPath' => '插入路径',
 			'sessions.inspector.git.showDiff' => '查看 diff',
 			'sessions.inspector.git.diffFailedApi' => ({required Object status, required Object message}) => 'Diff 失败（${status}）：${message}',
-			'sessions.inspector.git.diffFailedGeneric' => ({required Object error}) => 'Diff 失败：${error}',
-			'sessions.inspector.git.insertHash' => '插入哈希',
 			_ => null,
 		} ?? switch (path) {
+			'sessions.inspector.git.diffFailedGeneric' => ({required Object error}) => 'Diff 失败：${error}',
+			'sessions.inspector.git.insertHash' => '插入哈希',
 			'sessions.inspector.git.showFullPatch' => '查看完整 patch',
 			'sessions.inspector.git.showFailedApi' => ({required Object status, required Object message}) => '查看失败（${status}）：${message}',
 			'sessions.inspector.git.showFailedGeneric' => ({required Object error}) => '查看失败：${error}',
@@ -12070,10 +12074,10 @@ extension on TranslationsZh {
 			'backups.emptyNoTargets.body' => '打开「更多」菜单 → 目标，添加一个目的地（本地 / S3 / SMB / SFTP / WebDAV / rclone）。然后返回并点击「立即运行」。',
 			'backups.emptyNoBackups.headline' => '暂无备份',
 			'backups.emptyNoBackups.body' => '点击「立即运行」生成一次新快照，或打开「计划」设置定期运行。',
-			'backups.restartToActivate' => '重启 opendray 以激活备份',
-			'backups.passphraseSaved' => '你的密语已保存。网关仅在启动时加载，因此更改需重启后才生效。',
 			_ => null,
 		} ?? switch (path) {
+			'backups.restartToActivate' => '重启 opendray 以激活备份',
+			'backups.passphraseSaved' => '你的密语已保存。网关仅在启动时加载，因此更改需重启后才生效。',
 			'backups.keyFileLabel' => '密钥文件',
 			'backups.configuredViaLabel' => '配置方式',
 			'backups.wizard.title' => '设置备份',
@@ -12584,10 +12588,10 @@ extension on TranslationsZh {
 			'dataExport.import.finishedWithErrors' => '导入完成但有错误',
 			'dataExport.import.failedToast' => ({required Object error}) => '导入失败：${error}',
 			'dataExport.import.summaryCard.memories' => '记忆',
-			'dataExport.import.summaryCard.integrations' => '集成',
-			'dataExport.import.summaryCard.customTasks' => '自定义任务',
 			_ => null,
 		} ?? switch (path) {
+			'dataExport.import.summaryCard.integrations' => '集成',
+			'dataExport.import.summaryCard.customTasks' => '自定义任务',
 			'dataExport.import.summaryCard.created' => '创建',
 			'dataExport.import.summaryCard.skipped' => '跳过',
 			'dataExport.import.summaryCard.failed' => '失败',

--- a/app/mobile/lib/features/cortex/curation_chat_screen.dart
+++ b/app/mobile/lib/features/cortex/curation_chat_screen.dart
@@ -3,10 +3,12 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:opendray/core/api/claude_accounts_api.dart';
 import 'package:opendray/core/api/cortex_api.dart';
 import 'package:opendray/core/api/memory_api.dart';
 import 'package:opendray/core/api/memory_summarizers_api.dart';
 import 'package:opendray/core/api/memory_workers_api.dart';
+import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 
 // CurationChat — the conversational maintenance channel (Cortex Phase 4),
@@ -60,6 +62,10 @@ class _CurationChatScreenState extends ConsumerState<CurationChatScreen> {
   // Picker: '' | 'agent:<id>' | 'local:<id>', plus the chosen model.
   String _selection = '';
   String _model = '';
+  // Claude is multi-account — which account a claude turn runs against
+  // ('' = default). Only used when the agent is claude.
+  String _claudeAccountId = '';
+  List<ClaudeAccountSummary> _claudeAccounts = const [];
   List<SummarizerProvider> _localProviders = const [];
   List<ModelOption> _agentModels = const [];
   List<String> _localModels = const [];
@@ -85,6 +91,7 @@ class _CurationChatScreenState extends ConsumerState<CurationChatScreen> {
     try {
       final cortex = ref.read(cortexApiProvider);
       final summarizers = await ref.read(memorySummarizersApiProvider).list();
+      final accounts = await ref.read(claudeAccountsApiProvider).list();
       final convs = await cortex.listConversations(
         cwd: widget.targetCwd,
         slug: widget.targetSlug,
@@ -100,6 +107,7 @@ class _CurationChatScreenState extends ConsumerState<CurationChatScreen> {
       if (!mounted) return;
       setState(() {
         _localProviders = summarizers.where((p) => p.enabled).toList();
+        _claudeAccounts = accounts.where((a) => a.enabled).toList();
         _conv = conv;
         _messages = msgs;
         _loading = false;
@@ -112,6 +120,7 @@ class _CurationChatScreenState extends ConsumerState<CurationChatScreen> {
             _selection = '';
           }
           _model = conv.model;
+          _claudeAccountId = conv.claudeAccountId;
         }
       });
       await _refreshModelCatalog();
@@ -163,19 +172,29 @@ class _CurationChatScreenState extends ConsumerState<CurationChatScreen> {
     }
   }
 
-  // Maps the picker state to the backend override shape.
-  ({String providerId, String model, String summarizerId}) _override() {
+  // Maps the picker state to the backend override shape. The claude
+  // account is only carried for the claude agent (backend clears it
+  // otherwise).
+  ({String providerId, String model, String claudeAccountId, String summarizerId})
+      _override() {
     if (_selection.startsWith('agent:')) {
+      final providerId = _selection.substring(6);
       return (
-        providerId: _selection.substring(6),
+        providerId: providerId,
         model: _model,
+        claudeAccountId: providerId == 'claude' ? _claudeAccountId : '',
         summarizerId: '',
       );
     }
     if (_selection.startsWith('local:')) {
-      return (providerId: '', model: '', summarizerId: _selection.substring(6));
+      return (
+        providerId: '',
+        model: '',
+        claudeAccountId: '',
+        summarizerId: _selection.substring(6),
+      );
     }
-    return (providerId: '', model: '', summarizerId: '');
+    return (providerId: '', model: '', claudeAccountId: '', summarizerId: '');
   }
 
   Future<void> _persistOverride() async {
@@ -189,6 +208,7 @@ class _CurationChatScreenState extends ConsumerState<CurationChatScreen> {
             conv.id,
             providerId: o.providerId,
             model: o.model,
+            claudeAccountId: o.claudeAccountId,
             summarizerId: o.summarizerId,
           );
       if (mounted) setState(() => _conv = updated);
@@ -211,6 +231,11 @@ class _CurationChatScreenState extends ConsumerState<CurationChatScreen> {
     await _persistOverride();
   }
 
+  Future<void> _onAccountChanged(String acct) async {
+    setState(() => _claudeAccountId = acct);
+    await _persistOverride();
+  }
+
   Future<void> _send() async {
     final text = _draftCtrl.text.trim();
     if (text.isEmpty || _sending || _awaitingReply) return;
@@ -226,6 +251,7 @@ class _CurationChatScreenState extends ConsumerState<CurationChatScreen> {
           targetSlug: widget.targetSlug,
           providerId: o.providerId,
           model: o.model,
+          claudeAccountId: o.claudeAccountId,
           summarizerId: o.summarizerId,
         );
       }
@@ -421,8 +447,43 @@ class _CurationChatScreenState extends ConsumerState<CurationChatScreen> {
             const SizedBox(width: 8),
             Expanded(child: _modelDropdown(context)),
           ],
+          if (_agentProvider == 'claude') ...[
+            const SizedBox(width: 8),
+            Expanded(child: _accountDropdown(context)),
+          ],
         ],
       ),
+    );
+  }
+
+  // Claude account picker — Claude is multi-account; pin which account
+  // this discussion's claude turns run against ('' = default).
+  Widget _accountDropdown(BuildContext context) {
+    final items = <DropdownMenuItem<String>>[
+      DropdownMenuItem(
+        value: '',
+        child: Text(t.web.cortex.chat.accountDefault),
+      ),
+      for (final a in _claudeAccounts)
+        DropdownMenuItem(
+          value: a.id,
+          child: Text(
+            a.displayName.isNotEmpty
+                ? a.displayName
+                : (a.name.isNotEmpty ? a.name : a.id),
+          ),
+        ),
+    ];
+    final value = items.any((it) => it.value == _claudeAccountId)
+        ? _claudeAccountId
+        : '';
+    return DropdownButton<String>(
+      value: value,
+      isExpanded: true,
+      isDense: true,
+      underline: const SizedBox.shrink(),
+      items: items,
+      onChanged: (v) => _onAccountChanged(v ?? ''),
     );
   }
 

--- a/app/shared/src/lib/cortex.ts
+++ b/app/shared/src/lib/cortex.ts
@@ -128,6 +128,9 @@ export interface CortexConversation {
    * provider_id+model pins a cloud-agent CLI. */
   provider_id?: string
   model?: string
+  /** Which Claude (cliacct) account a claude turn runs against — Claude
+   * is multi-account. Only meaningful when provider_id === 'claude'. */
+  claude_account_id?: string
   summarizer_id?: string
   created_at: string
   updated_at: string
@@ -152,6 +155,7 @@ export async function createConversation(input: {
    * summarizer_id) for the new conversation. */
   provider_id?: string
   model?: string
+  claude_account_id?: string
   summarizer_id?: string
 }): Promise<CortexConversation> {
   return api<CortexConversation>('/api/v1/cortex/conversations', {
@@ -165,7 +169,12 @@ export async function createConversation(input: {
  * exclusive). Returns the updated conversation. */
 export async function setConversationProvider(
   id: string,
-  override: { provider_id?: string; model?: string; summarizer_id?: string },
+  override: {
+    provider_id?: string
+    model?: string
+    claude_account_id?: string
+    summarizer_id?: string
+  },
 ): Promise<CortexConversation> {
   return api<CortexConversation>(
     `/api/v1/cortex/conversations/${id}/provider`,
@@ -174,6 +183,7 @@ export async function setConversationProvider(
       body: {
         provider_id: override.provider_id ?? '',
         model: override.model ?? '',
+        claude_account_id: override.claude_account_id ?? '',
         summarizer_id: override.summarizer_id ?? '',
       },
     },

--- a/app/web/src/components/cortex/CurationChat.tsx
+++ b/app/web/src/components/cortex/CurationChat.tsx
@@ -37,6 +37,7 @@ import {
   setConversationProvider,
 } from '@/lib/cortex'
 import { type AgentProviderID, listAgentModels } from '@/lib/memoryWorkers'
+import { listClaudeAccounts } from '@/lib/claudeAccounts'
 import { listProviders } from '@/lib/memoryAmbient'
 import { probeEmbeddingEndpoint } from '@/lib/memory'
 
@@ -76,6 +77,9 @@ export function CurationChat({
   // Seeded from the active conversation once it loads (sync effect below).
   const [selection, setSelection] = useState('')
   const [model, setModel] = useState('')
+  // Claude is multi-account — pin which account a claude turn runs against
+  // ('' = the default account/config). Only used when the agent is claude.
+  const [claudeAccountId, setClaudeAccountId] = useState('')
   const agentProvider: AgentProviderID | '' = selection.startsWith('agent:')
     ? (selection.slice('agent:'.length) as AgentProviderID)
     : ''
@@ -147,6 +151,7 @@ export function CurationChat({
       else if (active.provider_id) setSelection(`agent:${active.provider_id}`)
       else setSelection('')
       setModel(active.model ?? '')
+      setClaudeAccountId(active.claude_account_id ?? '')
     }
   }, [active])
 
@@ -173,10 +178,24 @@ export function CurationChat({
     ? (localModelsQuery.data.models ?? [])
     : []
 
-  // Map a selection + agent model to the backend override shape.
-  const overrideFor = (sel: string, m: string) => {
-    if (sel.startsWith('agent:'))
-      return { provider_id: sel.slice('agent:'.length), model: m }
+  // Configured Claude accounts (multi-account auth). Only needed when the
+  // discussion runs on the claude agent.
+  const claudeAccountsQuery = useQuery({
+    queryKey: ['claude-accounts'],
+    queryFn: listClaudeAccounts,
+    enabled: agentProvider === 'claude',
+  })
+
+  // Map a selection + agent model (+ claude account) to the backend
+  // override shape. The account is only carried for the claude agent; the
+  // backend clears it for any other provider.
+  const overrideFor = (sel: string, m: string, acct: string) => {
+    if (sel.startsWith('agent:')) {
+      const provider_id = sel.slice('agent:'.length)
+      return provider_id === 'claude'
+        ? { provider_id, model: m, claude_account_id: acct }
+        : { provider_id, model: m }
+    }
     if (sel.startsWith('local:'))
       return { summarizer_id: sel.slice('local:'.length) }
     return {}
@@ -185,8 +204,8 @@ export function CurationChat({
   // Persist an override change. When no conversation exists yet the
   // selection is held locally and applied at creation time (see send).
   const persistOverride = useMutation({
-    mutationFn: (next: { sel: string; model: string }) =>
-      setConversationProvider(active!.id, overrideFor(next.sel, next.model)),
+    mutationFn: (next: { sel: string; model: string; acct: string }) =>
+      setConversationProvider(active!.id, overrideFor(next.sel, next.model, next.acct)),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['cortex-conversations', targetCwd, targetSlug] })
       if (active) qc.invalidateQueries({ queryKey: ['cortex-conversation', active.id] })
@@ -198,11 +217,15 @@ export function CurationChat({
   const changeSelection = (sel: string) => {
     setSelection(sel)
     setModel('')
-    if (active) persistOverride.mutate({ sel, model: '' })
+    if (active) persistOverride.mutate({ sel, model: '', acct: claudeAccountId })
   }
   const changeModel = (m: string) => {
     setModel(m)
-    if (active) persistOverride.mutate({ sel: selection, model: m })
+    if (active) persistOverride.mutate({ sel: selection, model: m, acct: claudeAccountId })
+  }
+  const changeAccount = (acct: string) => {
+    setClaudeAccountId(acct)
+    if (active) persistOverride.mutate({ sel: selection, model, acct })
   }
 
   const send = useMutation({
@@ -213,7 +236,7 @@ export function CurationChat({
           target_kind: targetKind,
           target_cwd: targetCwd,
           target_slug: targetSlug,
-          ...overrideFor(selection, model),
+          ...overrideFor(selection, model, claudeAccountId),
         })
       }
       await sendConversationMessage(conv.id, text)
@@ -328,6 +351,23 @@ export function CurationChat({
                 {m.label}
               </option>
             ))}
+          </select>
+        )}
+        {agentProvider === 'claude' && (
+          <select
+            value={claudeAccountId}
+            onChange={(e) => changeAccount(e.target.value)}
+            className="bg-background min-w-0 flex-1 rounded border px-1.5 py-0.5 text-[11px]"
+            title={t('web.cortex.chat.accountHint')}
+          >
+            <option value="">{t('web.cortex.chat.accountDefault')}</option>
+            {(claudeAccountsQuery.data ?? [])
+              .filter((a) => a.enabled)
+              .map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.display_name || a.name || a.id}
+                </option>
+              ))}
           </select>
         )}
         {selection.startsWith('local:') && (

--- a/internal/cortex/conversation.go
+++ b/internal/cortex/conversation.go
@@ -48,11 +48,15 @@ type Conversation struct {
 	// worker config). Mutually exclusive: SummarizerID pins a local/HTTP
 	// model (a summarizer_providers row); ProviderID+Model pins a
 	// cloud-agent CLI. See SetProvider.
-	ProviderID   string    `json:"provider_id,omitempty"`
-	Model        string    `json:"model,omitempty"`
-	SummarizerID string    `json:"summarizer_id,omitempty"`
-	CreatedAt    time.Time `json:"created_at"`
-	UpdatedAt    time.Time `json:"updated_at"`
+	ProviderID string `json:"provider_id,omitempty"`
+	Model      string `json:"model,omitempty"`
+	// ClaudeAccountID pins which Claude (cliacct) account a claude turn
+	// runs against — Claude is multi-account. Only meaningful when
+	// ProviderID == "claude"; threaded into the worker as Config.AccountID.
+	ClaudeAccountID string    `json:"claude_account_id,omitempty"`
+	SummarizerID    string    `json:"summarizer_id,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
 }
 
 // validConvProvider reports whether p is an allowed cloud-agent override
@@ -73,25 +77,32 @@ func validConvProvider(p string) bool {
 
 // normalizeConvOverride validates + canonicalises a conversation override.
 // Local model (summarizerID) and cloud-agent (providerID) are mutually
-// exclusive; all empty means "use the global curation worker".
-func normalizeConvOverride(providerID, model, summarizerID string) (p, m, s string, err error) {
+// exclusive; all empty means "use the global curation worker". A Claude
+// account override is only meaningful for provider=claude and is cleared
+// otherwise.
+func normalizeConvOverride(providerID, model, summarizerID, claudeAccountID string) (p, m, s, acct string, err error) {
 	providerID = strings.TrimSpace(providerID)
 	summarizerID = strings.TrimSpace(summarizerID)
+	claudeAccountID = strings.TrimSpace(claudeAccountID)
 	if summarizerID != "" {
 		if providerID != "" {
-			return "", "", "", errors.New("cortex: set either a cloud-agent provider or a local model, not both")
+			return "", "", "", "", errors.New("cortex: set either a cloud-agent provider or a local model, not both")
 		}
 		// model is an OPTIONAL per-call override of the model the local
 		// endpoint serves (empty → the provider row's configured model).
-		return "", model, summarizerID, nil
+		// A local model has no Claude account.
+		return "", model, summarizerID, "", nil
 	}
 	if !validConvProvider(providerID) {
-		return "", "", "", fmt.Errorf("cortex: provider_id %q is not supported for AI discussion (want claude|gemini|codex|antigravity)", providerID)
+		return "", "", "", "", fmt.Errorf("cortex: provider_id %q is not supported for AI discussion (want claude|gemini|codex|antigravity)", providerID)
 	}
 	if providerID == "" {
 		model = "" // a model with no provider is meaningless
 	}
-	return providerID, model, "", nil
+	if providerID != "claude" {
+		claudeAccountID = "" // account selection only applies to claude
+	}
+	return providerID, model, "", claudeAccountID, nil
 }
 
 // Message is one turn in a conversation. RevisionAction records what
@@ -132,23 +143,23 @@ func validTargetKind(k string) bool {
 // Create opens a conversation bound to a target. The override (providerID/
 // model for a cloud agent, OR summarizerID for a local model) is optional;
 // all empty = use the global curation worker.
-func (s *ConversationStore) Create(ctx context.Context, targetKind, targetCwd, targetSlug, providerID, model, summarizerID string) (Conversation, error) {
+func (s *ConversationStore) Create(ctx context.Context, targetKind, targetCwd, targetSlug, providerID, model, summarizerID, claudeAccountID string) (Conversation, error) {
 	if !validTargetKind(targetKind) {
 		return Conversation{}, fmt.Errorf("cortex: bad target_kind %q", targetKind)
 	}
 	if strings.TrimSpace(targetCwd) == "" || strings.TrimSpace(targetSlug) == "" {
 		return Conversation{}, errors.New("cortex: target_cwd and target_slug are required")
 	}
-	providerID, model, summarizerID, err := normalizeConvOverride(providerID, model, summarizerID)
+	providerID, model, summarizerID, claudeAccountID, err := normalizeConvOverride(providerID, model, summarizerID, claudeAccountID)
 	if err != nil {
 		return Conversation{}, err
 	}
 	row := s.pool.QueryRow(ctx, `
-		INSERT INTO cortex_conversations (id, target_kind, target_cwd, target_slug, provider_id, model, summarizer_id)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		INSERT INTO cortex_conversations (id, target_kind, target_cwd, target_slug, provider_id, model, claude_account_id, summarizer_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		RETURNING id, target_kind, target_cwd, target_slug, status,
-		          COALESCE(escalated_session_id, ''), provider_id, model, summarizer_id, created_at, updated_at`,
-		newConvID("cc_"), targetKind, targetCwd, targetSlug, providerID, model, summarizerID)
+		          COALESCE(escalated_session_id, ''), provider_id, model, claude_account_id, summarizer_id, created_at, updated_at`,
+		newConvID("cc_"), targetKind, targetCwd, targetSlug, providerID, model, claudeAccountID, summarizerID)
 	return scanConversation(row)
 }
 
@@ -156,7 +167,7 @@ func (s *ConversationStore) Create(ctx context.Context, targetKind, targetCwd, t
 func (s *ConversationStore) Get(ctx context.Context, id string) (Conversation, error) {
 	row := s.pool.QueryRow(ctx, `
 		SELECT id, target_kind, target_cwd, target_slug, status,
-		       COALESCE(escalated_session_id, ''), provider_id, model, summarizer_id, created_at, updated_at
+		       COALESCE(escalated_session_id, ''), provider_id, model, claude_account_id, summarizer_id, created_at, updated_at
 		  FROM cortex_conversations WHERE id = $1`, id)
 	c, err := scanConversation(row)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -168,15 +179,15 @@ func (s *ConversationStore) Get(ctx context.Context, id string) (Conversation, e
 // SetProvider pins (or clears) the conversation's model override. All empty
 // resets it to the global curation worker config; otherwise either a
 // cloud-agent provider (+model) OR a local summarizer provider.
-func (s *ConversationStore) SetProvider(ctx context.Context, id, providerID, model, summarizerID string) error {
-	providerID, model, summarizerID, err := normalizeConvOverride(providerID, model, summarizerID)
+func (s *ConversationStore) SetProvider(ctx context.Context, id, providerID, model, summarizerID, claudeAccountID string) error {
+	providerID, model, summarizerID, claudeAccountID, err := normalizeConvOverride(providerID, model, summarizerID, claudeAccountID)
 	if err != nil {
 		return err
 	}
 	tag, err := s.pool.Exec(ctx, `
 		UPDATE cortex_conversations
-		   SET provider_id = $1, model = $2, summarizer_id = $3, updated_at = NOW()
-		 WHERE id = $4`, providerID, model, summarizerID, id)
+		   SET provider_id = $1, model = $2, summarizer_id = $3, claude_account_id = $4, updated_at = NOW()
+		 WHERE id = $5`, providerID, model, summarizerID, claudeAccountID, id)
 	if err != nil {
 		return fmt.Errorf("cortex: set conversation provider: %w", err)
 	}
@@ -197,13 +208,13 @@ func (s *ConversationStore) ListByTarget(ctx context.Context, targetCwd, targetS
 	if targetCwd == "" && targetSlug == "" {
 		rows, err = s.pool.Query(ctx, `
 			SELECT id, target_kind, target_cwd, target_slug, status,
-			       COALESCE(escalated_session_id, ''), provider_id, model, summarizer_id, created_at, updated_at
+			       COALESCE(escalated_session_id, ''), provider_id, model, claude_account_id, summarizer_id, created_at, updated_at
 			  FROM cortex_conversations
 			 ORDER BY updated_at DESC LIMIT $1`, limit)
 	} else {
 		rows, err = s.pool.Query(ctx, `
 			SELECT id, target_kind, target_cwd, target_slug, status,
-			       COALESCE(escalated_session_id, ''), provider_id, model, summarizer_id, created_at, updated_at
+			       COALESCE(escalated_session_id, ''), provider_id, model, claude_account_id, summarizer_id, created_at, updated_at
 			  FROM cortex_conversations
 			 WHERE target_cwd = $1 AND target_slug = $2
 			 ORDER BY updated_at DESC LIMIT $3`, targetCwd, targetSlug, limit)
@@ -296,7 +307,7 @@ type convRowScanner interface{ Scan(dest ...any) error }
 func scanConversation(row convRowScanner) (Conversation, error) {
 	var c Conversation
 	err := row.Scan(&c.ID, &c.TargetKind, &c.TargetCwd, &c.TargetSlug,
-		&c.Status, &c.EscalatedSessionID, &c.ProviderID, &c.Model, &c.SummarizerID,
+		&c.Status, &c.EscalatedSessionID, &c.ProviderID, &c.Model, &c.ClaudeAccountID, &c.SummarizerID,
 		&c.CreatedAt, &c.UpdatedAt)
 	if err != nil {
 		return Conversation{}, err

--- a/internal/cortex/conversation_account_test.go
+++ b/internal/cortex/conversation_account_test.go
@@ -1,0 +1,34 @@
+package cortex
+
+import "testing"
+
+func TestNormalizeConvOverride_ClaudeAccount(t *testing.T) {
+	tests := []struct {
+		name                                 string
+		provider, model, summarizer, account string
+		wantProvider, wantAccount            string
+		wantErr                              bool
+	}{
+		{"claude keeps account", "claude", "opus", "", "acc-1", "claude", "acc-1", false},
+		{"non-claude clears account", "gemini", "", "", "acc-1", "gemini", "", false},
+		{"codex clears account", "codex", "", "", "acc-1", "codex", "", false},
+		{"summarizer clears account+provider", "", "", "sum-1", "acc-1", "", "", false},
+		{"empty provider clears account", "", "", "", "acc-1", "", "", false},
+		{"account trimmed", "claude", "", "", "  acc-2  ", "claude", "acc-2", false},
+		{"both provider and summarizer is error", "claude", "", "sum-1", "acc-1", "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, _, _, a, err := normalizeConvOverride(tt.provider, tt.model, tt.summarizer, tt.account)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err=%v, wantErr=%v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if p != tt.wantProvider || a != tt.wantAccount {
+				t.Errorf("got provider=%q account=%q, want provider=%q account=%q", p, a, tt.wantProvider, tt.wantAccount)
+			}
+		})
+	}
+}

--- a/internal/cortex/conversation_handler.go
+++ b/internal/cortex/conversation_handler.go
@@ -44,18 +44,19 @@ func (h *Handlers) createConversation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var body struct {
-		TargetKind   string `json:"target_kind"`
-		TargetCwd    string `json:"target_cwd"`
-		TargetSlug   string `json:"target_slug"`
-		ProviderID   string `json:"provider_id"`
-		Model        string `json:"model"`
-		SummarizerID string `json:"summarizer_id"`
+		TargetKind      string `json:"target_kind"`
+		TargetCwd       string `json:"target_cwd"`
+		TargetSlug      string `json:"target_slug"`
+		ProviderID      string `json:"provider_id"`
+		Model           string `json:"model"`
+		ClaudeAccountID string `json:"claude_account_id"`
+		SummarizerID    string `json:"summarizer_id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
-	conv, err := h.convStore.Create(r.Context(), body.TargetKind, body.TargetCwd, body.TargetSlug, body.ProviderID, body.Model, body.SummarizerID)
+	conv, err := h.convStore.Create(r.Context(), body.TargetKind, body.TargetCwd, body.TargetSlug, body.ProviderID, body.Model, body.SummarizerID, body.ClaudeAccountID)
 	if err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
@@ -71,15 +72,16 @@ func (h *Handlers) setConversationProvider(w http.ResponseWriter, r *http.Reques
 	}
 	id := chi.URLParam(r, "id")
 	var body struct {
-		ProviderID   string `json:"provider_id"`
-		Model        string `json:"model"`
-		SummarizerID string `json:"summarizer_id"`
+		ProviderID      string `json:"provider_id"`
+		Model           string `json:"model"`
+		ClaudeAccountID string `json:"claude_account_id"`
+		SummarizerID    string `json:"summarizer_id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
-	if err := h.convStore.SetProvider(r.Context(), id, body.ProviderID, body.Model, body.SummarizerID); err != nil {
+	if err := h.convStore.SetProvider(r.Context(), id, body.ProviderID, body.Model, body.SummarizerID, body.ClaudeAccountID); err != nil {
 		if errors.Is(err, ErrConversationNotFound) {
 			writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
 			return

--- a/internal/cortex/conversation_worker.go
+++ b/internal/cortex/conversation_worker.go
@@ -193,6 +193,7 @@ func (s *CurationService) runAITurn(conversationID string) {
 			Kind:       worker.WorkerAgent,
 			ProviderID: conv.ProviderID,
 			Model:      conv.Model,
+			AccountID:  conv.ClaudeAccountID, // multi-account claude: pin the chosen account
 			Enabled:    true,
 		}, req)
 	default:

--- a/internal/store/migrations/0067_conversation_claude_account.sql
+++ b/internal/store/migrations/0067_conversation_claude_account.sql
@@ -1,0 +1,19 @@
+-- 0067 — per-conversation Claude account override for the Cortex "AI
+-- discussion" channel.
+--
+-- 0062 let a conversation pin its cloud-agent provider + model; 0063 added
+-- the local-model summarizer override. But Claude is a MULTI-ACCOUNT setup
+-- (cliacct rows, each its own OAuth token + config dir), and the AI
+-- discussion had no way to choose WHICH account a claude turn runs against
+-- — so it fell back to the default config dir and could hit a "Not logged
+-- in" prompt. This column lets the chat UI pin the account, threaded into
+-- the worker as Config.AccountID (resolved to CLAUDE_CODE_OAUTH_TOKEN +
+-- CLAUDE_CONFIG_DIR, the same plumbing sessions use).
+--
+--   claude_account_id: '' (use the default account/config) | a cliacct id
+--
+-- Only meaningful when provider_id = 'claude'; cleared for other providers
+-- and for the local-model (summarizer) override.
+
+ALTER TABLE cortex_conversations
+    ADD COLUMN IF NOT EXISTS claude_account_id TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
## Problem

Claude is **multi-account**, but the Cortex **"AI discussion"** had no way to choose **which** account a claude turn runs against — so it fell back to the default config dir and could hit a **"Not logged in"** prompt (the operator's reported pain point). The worker fabric already honors `Config.AccountID`; this wires it end to end.

## Backend

- **0067 migration**: `cortex_conversations.claude_account_id` (additive, `IF NOT EXISTS`).
- `Conversation` carries `ClaudeAccountID`; `normalizeConvOverride` keeps it **only** for `provider=claude` and clears it for other providers / local models. Threaded through `Create` / `Get` / `SetProvider` / `ListByTarget` / scan and the create + set-provider handlers.
- `conversation_worker` passes `conv.ClaudeAccountID` as `worker.Config.AccountID` for the claude agent → `ResolveSpawnCreds` (`CLAUDE_CODE_OAUTH_TOKEN` + `CLAUDE_CONFIG_DIR`), the same plumbing sessions use.

## UI (web + mobile + i18n)

- **web** `CurationChat.tsx` and **mobile** `curation_chat_screen.dart`: a Claude account dropdown appears next to the model picker **only when the agent is claude**; `''` = default account. Persists on change and is applied at conversation-create time.
- i18n keys `accountDefault` / `accountHint` added to `en/es/zh` (+ slang regen for mobile).

## Test plan

- `go build ./...`, `go vet`, `gofmt` — clean
- `go test -race ./internal/cortex/` — green; new `normalizeConvOverride` test: claude keeps the account; gemini/codex/summarizer/empty clear it; trimming
- web `tsc --noEmit` — clean
- mobile `flutter analyze` — no issues (slang regenerated)
- i18n parity preserved (keys in all three locales)

This completes the follow-up flagged in #384 (the AI-discussion account selector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)