### PR TITLE
fix(cortex): surface escalated session + carry provider/account

### DIFF
--- a/app/mobile/lib/features/cortex/curation_chat_screen.dart
+++ b/app/mobile/lib/features/cortex/curation_chat_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:opendray/core/api/claude_accounts_api.dart';
 import 'package:opendray/core/api/cortex_api.dart';
@@ -9,6 +10,7 @@ import 'package:opendray/core/api/memory_api.dart';
 import 'package:opendray/core/api/memory_summarizers_api.dart';
 import 'package:opendray/core/api/memory_workers_api.dart';
 import 'package:opendray/core/api/models.dart';
+import 'package:opendray/core/api/sessions_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 
 // CurationChat — the conversational maintenance channel (Cortex Phase 4),
@@ -326,6 +328,14 @@ class _CurationChatScreenState extends ConsumerState<CurationChatScreen> {
         _escalating = false;
       });
       _snack(t.web.cortex.chat.escalatedToast);
+      // Refresh the session list and jump straight into the freshly
+      // spawned session — mirrors web's ?open= deep-link. Without this
+      // the new session only surfaces on the next manual list refresh.
+      ref.invalidate(sessionsListProvider);
+      final sid = updated.escalatedSessionId;
+      if (sid.isNotEmpty) {
+        unawaited(context.push('/session/$sid'));
+      }
     } on Object catch (e) {
       if (!mounted) return;
       setState(() => _escalating = false);

--- a/app/web/src/components/cortex/CurationChat.tsx
+++ b/app/web/src/components/cortex/CurationChat.tsx
@@ -256,8 +256,12 @@ export function CurationChat({
     onSuccess: (conv) => {
       toast.success(t('web.cortex.chat.escalatedToast'))
       qc.invalidateQueries({ queryKey: ['cortex-conversation', conv.id] })
+      // Force the session list to refetch so the freshly-spawned session
+      // is present by the time /sessions reads it (its ?open= deep-link
+      // waits for the row before auto-selecting).
+      qc.invalidateQueries({ queryKey: ['sessions'] })
       if (conv.escalated_session_id) {
-        navigate({ to: '/sessions', search: { open: conv.escalated_session_id } as any })
+        navigate({ to: '/sessions', search: { open: conv.escalated_session_id } })
       }
     },
     onError: (e: Error) =>

--- a/app/web/src/pages/Sessions.tsx
+++ b/app/web/src/pages/Sessions.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useNavigate, useSearch } from '@tanstack/react-router'
 import {
   ImagePlus,
   Layers,
@@ -68,6 +69,25 @@ export function SessionsPage() {
   })
 
   const currentSession = sessions?.find((s) => s.id === currentId)
+
+  // Deep-link: /sessions?open=<id> auto-selects a session on arrival —
+  // used when a Cortex discussion is escalated into a session. We wait
+  // for the list to actually contain the row (the escalate flow
+  // invalidates ['sessions'], so it lands within one refetch), open it,
+  // then strip the param so a manual tab switch isn't yanked back.
+  const search = useSearch({ strict: false }) as { open?: string }
+  const navigate = useNavigate()
+  const openedParamRef = useRef<string | null>(null)
+  useEffect(() => {
+    const id = search.open
+    if (!id || !sessions) return
+    if (openedParamRef.current === id) return
+    const target = sessions.find((s) => s.id === id)
+    if (!target) return
+    openedParamRef.current = id
+    open({ id: target.id, name: target.name || target.provider_id })
+    navigate({ to: '/sessions', search: {}, replace: true })
+  }, [search.open, sessions, open, navigate])
 
   const remove = useMutation({
     mutationFn: removeSession,

--- a/app/web/src/router.tsx
+++ b/app/web/src/router.tsx
@@ -58,6 +58,11 @@ const sessionsRoute = createRoute({
   getParentRoute: () => protectedRoute,
   path: '/sessions',
   component: SessionsPage,
+  // `open` deep-links a session to auto-select on arrival — used when
+  // escalating a Cortex discussion into a session. Without this the
+  // param is stripped and the new session never gets focused.
+  validateSearch: (search): { open?: string } =>
+    typeof search.open === 'string' ? { open: search.open } : {},
 })
 
 const providersRoute = createRoute({

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2234,11 +2234,20 @@ type curationSessionLauncher struct {
 	mgr *session.Manager
 }
 
-func (l *curationSessionLauncher) Launch(ctx context.Context, cwd, name, seedPrompt string) (string, error) {
+func (l *curationSessionLauncher) Launch(ctx context.Context, spec cortex.LaunchSpec) (string, error) {
+	// Continue the escalated session on the same CLI + account the
+	// discussion ran on. A conversation with no cloud-agent override (or
+	// a local-summarizer override, which has no CLI) falls back to claude.
+	providerID := spec.ProviderID
+	if providerID == "" {
+		providerID = "claude"
+	}
 	sess, err := l.mgr.Create(ctx, session.CreateRequest{
-		Name:       name,
-		ProviderID: "claude",
-		Cwd:        cwd,
+		Name:            spec.Name,
+		ProviderID:      providerID,
+		Model:           spec.Model,
+		ClaudeAccountID: spec.ClaudeAccountID,
+		Cwd:             spec.Cwd,
 	})
 	if err != nil {
 		return "", err
@@ -2255,7 +2264,7 @@ func (l *curationSessionLauncher) Launch(ctx context.Context, cwd, name, seedPro
 		}
 		time.Sleep(500 * time.Millisecond)
 		_ = l.mgr.Input(bg, sid, []byte{'\r'})
-	}(sess.ID, seedPrompt)
+	}(sess.ID, spec.SeedPrompt)
 	return sess.ID, nil
 }
 

--- a/internal/cortex/conversation_worker.go
+++ b/internal/cortex/conversation_worker.go
@@ -21,11 +21,26 @@ type ContextSource interface {
 	RelevantContext(ctx context.Context, cwd, query string, topK int) (string, error)
 }
 
+// LaunchSpec describes the session to spawn when escalating a
+// conversation. ProviderID/Model/ClaudeAccountID carry the
+// conversation's cloud-agent override so the escalated session continues
+// on the SAME CLI + account the discussion ran on. An empty ProviderID
+// (no override, or a local-summarizer override that has no CLI to
+// continue on) lets the launcher pick its default.
+type LaunchSpec struct {
+	Cwd             string
+	Name            string
+	SeedPrompt      string
+	ProviderID      string
+	Model           string
+	ClaudeAccountID string
+}
+
 // SessionLauncher escalates a conversation into a full agent session.
 // Implemented in the app over session.Manager — cortex never imports
 // internal/session.
 type SessionLauncher interface {
-	Launch(ctx context.Context, cwd, name, seedPrompt string) (sessionID string, err error)
+	Launch(ctx context.Context, spec LaunchSpec) (sessionID string, err error)
 }
 
 // CurationService runs the conversational maintenance channel.
@@ -427,7 +442,14 @@ func (s *CurationService) Escalate(ctx context.Context, conversationID string) (
 	seed.WriteString("Use the project_goal_set / project_plan_set MCP tools (or the project-docs HTTP API) so changes flow through the standard proposal/approval path — do not edit doc mirrors on disk.\n")
 
 	name := "curation: " + conv.TargetSlug
-	sessionID, err := s.sessions.Launch(ctx, cwd, name, seed.String())
+	sessionID, err := s.sessions.Launch(ctx, LaunchSpec{
+		Cwd:             cwd,
+		Name:            name,
+		SeedPrompt:      seed.String(),
+		ProviderID:      conv.ProviderID,
+		Model:           conv.Model,
+		ClaudeAccountID: conv.ClaudeAccountID,
+	})
 	if err != nil {
 		return Conversation{}, fmt.Errorf("cortex: launch session: %w", err)
 	}


### PR DESCRIPTION
## Problem

Escalating a Cortex AI discussion into a session **created the session correctly** — verified live: the row spawns with `origin=operator` and is returned by `/api/v1/sessions` — but it never **surfaced** in the UI, so it looked like nothing was created.

Two root causes, both post-escalate wiring:

1. **Dead deep-link + stale list (web).** The escalate flow navigated to `/sessions?open=<id>`, but the sessions route had no `validateSearch` (so TanStack Router stripped `open`) and `SessionsPage` never read it — the new session was never auto-selected. The escalate mutation also didn't invalidate `['sessions']`, so the left list lagged by up to one 4s poll. By contrast, the normal `SpawnDialog` works because it invalidates `['sessions']` **and** calls `open({id})`.
2. **No navigation (mobile).** `_escalate()` only showed a toast — no navigation into the session, no list refresh.

Separately, the launcher hardcoded `ProviderID="claude"` with no account (`app.go`), ignoring the conversation's own cloud-agent override. A discussion held on a specific CLI/account escalated onto the wrong one, and multi-account claude could hit the login screen.

## Fix

**Web**
- Add `validateSearch(open?)` to the sessions route; consume it in `SessionsPage` — wait for the row to appear in the list, auto-select it, then strip the param (so a manual tab switch isn't yanked back).
- Invalidate `['sessions']` on escalate success so the row lands within one refetch; drop the now-unneeded `as any`.

**Mobile**
- After escalate, `ref.invalidate(sessionsListProvider)` + `context.push('/session/<id>')`, mirroring web's deep-link.

**Backend**
- Replace `SessionLauncher.Launch(cwd, name, seed)` with a `LaunchSpec` carrying `ProviderID/Model/ClaudeAccountID` from the conversation. Empty provider (no override, or a local-summarizer override with no CLI) falls back to `claude`.

## Test plan
- `go build ./...`, `go vet ./internal/cortex/... ./internal/app/...`, `go test ./internal/cortex/...` — all green.
- Web `tsc --noEmit` — clean.
- Mobile `flutter analyze` on the changed file — no issues.
- Manual: escalate a discussion on web → lands in the new session, row visible in the list. Escalate a claude discussion pinned to a non-default account → session spawns on that account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)