### PR TITLE
docs(integrations): refresh integration guide + re-seed kb_integrations for v2.9.0

### DIFF
--- a/internal/store/migrations/0068_kb_integrations_refresh.sql
+++ b/internal/store/migrations/0068_kb_integrations_refresh.sql
@@ -1,3 +1,30 @@
+-- 0068 — kb_integrations refresh: re-seed the Third-Party Integration
+-- Guide after the v2.9.0 integrations-hardening arc landed several
+-- contract changes the original 0066 seed predates:
+--   * permission_mode (default|bypass) replaced the bypass_permissions boolean
+--     (#381) — the boolean is no longer accepted on the wire.
+--   * the per-principal integration:<id> memory capture zone shipped (#380),
+--     so isolation no longer depends on per-integration cwd collisions.
+--   * provider mutation routes now enforce providers:write / providers:update.
+--   * agent_id reserved forward-compat slot added to the spawn profile.
+--
+-- Why a new migration instead of editing 0066: the runner records applied
+-- versions by filename and never re-applies one, and 0066's project_docs
+-- insert used ON CONFLICT (cwd, kind) DO NOTHING — so the live KB page is
+-- frozen at the original (now stale) text on every DB that already ran 0066.
+-- This migration force-updates the page content (DO UPDATE), keeping
+-- updated_by='operator' so the AI KB drafter still treats it as human-locked
+-- and never overwrites it. The operator can still edit it live afterwards.
+--
+-- Source of truth for the prose: docs/integrations/INTEGRATION_GUIDE.md.
+-- Keep them in sync (see the guide's "Versioning" section).
+
+INSERT INTO project_docs (id, cwd, kind, content, updated_by, updated_at)
+VALUES (
+    'doc_global_kb_integrations',
+    '__global__',
+    'kb_integrations',
+    $ODGUIDE$
 # opendray Third-Party Integration Guide
 
 This is the canonical, forward-looking contract that **every** third-party app or website MUST follow to integrate with opendray. opendray is a self-hosted gateway that drives AI coding CLIs (Claude Code, Codex, Gemini, OpenCode, antigravity) over a PTY behind a unified REST + WebSocket API. A third-party app integrates by being **registered by an operator** (admin-only), receiving a **one-time scoped API key**, and then spawning and driving agent sessions over REST while optionally proxying its own UI and subscribing to a live event stream. This document states the rules as explicit **MUST / SHOULD / NEVER**, documents the current reality honestly (including what is *not* enforced yet), and gives you a runnable end-to-end path.
@@ -836,3 +863,11 @@ This guide describes the opendray `/api/v1` integration contract as of **opendra
 - **Roadmap:** per-route scope enforcement for the still-unenforced `session:*` / `channel:*` / `provider:read`. Design your client now to handle `403` on any endpoint without breaking.
 
 When the code changes (new enforced scopes, spawn-profile fields, memory-zone semantics, or any endpoint addition), this guide MUST be updated in lockstep and re-seeded into the `kb_integrations` knowledge page (add a new `project_docs` upsert migration — the original seed migration is immutable once applied).
+$ODGUIDE$,
+    'operator',
+    NOW()
+)
+ON CONFLICT (cwd, kind) DO UPDATE
+    SET content    = EXCLUDED.content,
+        updated_by = EXCLUDED.updated_by,
+        updated_at = EXCLUDED.updated_at;


### PR DESCRIPTION
## Why

The third-party integration guide (`docs/integrations/INTEGRATION_GUIDE.md`) and the `kb_integrations` Cortex KB page it seeds (migration `0066`) were authored against the early "M3 / feat/integration-spawn-profile" state. The integrations-hardening arc that shipped in **v2.9.0** turned several behaviors the guide still labeled **FORTHCOMING** into the live contract. An AI or developer following the stale text would send fields that are now silently dropped and reason about isolation guarantees that have since changed.

This PR reconciles the guide with the current code in `internal/integration`, `internal/catalog`, and `internal/memory`.

## What changed in the contract (verified against code)

| Stale doc claim | Current reality (v2.9.0) |
|---|---|
| `permission_mode` is FORTHCOMING; use the `bypass_permissions` boolean | `permission_mode` (`default`\|`bypass`) is the live field; `bypass_permissions` is **no longer accepted on the wire** (#381) — empty normalizes to `default` |
| `integration:<id>` memory zone is FORTHCOMING (#380); isolation is cwd-based | Shipped: `quarantine`/`full` capture routes to `scope_key="integration:<id>"`; isolation is per-principal, not cwd-collision-dependent |
| Only `event:*` + `memory:*` scopes enforced | Provider mutation routes also enforce `providers:write` / `providers:update` |
| (undocumented) | `agent_id` reserved forward-compat field documented |

Plus: re-versioned the guide to v2.9.0 and removed the `FORTHCOMING` / `M3` framing throughout (§1/§3/§5/§6/§8/§11/§12/§13/§16/§17/§18/§20/§21).

## The migration

`0066` already ran on live DBs with `ON CONFLICT (cwd, kind) DO NOTHING`, and the migration runner never re-applies a recorded version — so the live KB page is frozen at the stale text. **`0068`** force-updates the page via `DO UPDATE`, keeping `updated_by='operator'` so the KB drafter still treats it as human-locked and never overwrites it.

The guide remains the source of truth; `0068` embeds the same prose.

## Test plan

- [x] Applied the full migration chain `0001..0068` on an **ephemeral pg17** cluster (`LC_ALL=C`). Simulates the live-DB upgrade path: `0066` inserts the stale page, then `0068 DO UPDATE` replaces it.
- [x] Post-migration page asserts: `updated_by='operator'`, bypass-boolean text retired, integration-zone described as current, provider scopes present, `agent_id` documented, **zero `FORTHCOMING` markers remaining**.
- [x] `go build ./internal/store/...` (embedded migrations compile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)