### PR TITLE
docs(changelog): v2.9.1 — cortex escalate fix + integration guide refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+## [v2.9.1] — 2026-06-19
+
+### Fixed
+
+- **Escalating a Cortex discussion now jumps straight into the spawned
+  session and continues on the same CLI + account.** The escalated session
+  surfaces immediately — web deep-links it via `?open=`, mobile pushes the
+  route — instead of only appearing on the next manual list refresh. It also
+  inherits the conversation's provider / model / Claude-account override
+  rather than always falling back to Claude. (#390)
+
+### Changed
+
+- **Refreshed the third-party integration guide and its searchable
+  `kb_integrations` KB page** to match the shipped v2.9.0 contract:
+  `permission_mode` (`default` | `bypass`) replacing the old
+  `bypass_permissions` boolean, the per-principal `integration:<id>` memory
+  zone, the enforced `providers:write` / `providers:update` scopes, and the
+  reserved `agent_id` field. Removes the stale `FORTHCOMING` framing so any
+  AI or developer reading it gets the current contract. (#391)
+
 ## [v2.9.0] — 2026-06-19
 
 ### Added


### PR DESCRIPTION
## Why

Release gate for **v2.9.1** (a patch release). `release.yml` triggers on tag push and extracts release notes from the matching `CHANGELOG.md` section, so this bump must merge before the tag is pushed.

## Contents (everything on `main` since the v2.9.0 tag)

- **#390** `fix(cortex)` — escalating a Cortex discussion now surfaces the spawned session immediately (web `?open=` deep-link / mobile route push) and continues on the conversation's provider / model / Claude account instead of always falling back to Claude. Web + mobile changed together.
- **#391** `docs(integrations)` — third-party integration guide + `kb_integrations` KB page refreshed to the shipped v2.9.0 contract (`permission_mode`, `integration:<id>` memory zone, `providers:write` / `providers:update` scopes, `agent_id`); stale `FORTHCOMING` framing removed.

## After merge

Tag `v2.9.1` on the merge commit and push → `release.yml` builds the goreleaser archives + signed checksums + SBOM and publishes the GitHub release with these notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)