### PR TITLE
feat: Loop Engine (autoloop) — gateway-level autonomous agent loops

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -42,7 +42,8 @@
     "knowledge": "Knowledge",
     "vault": "Vault",
     "cortex": "Cortex",
-    "updateAvailable": "Update available"
+    "updateAvailable": "Update available",
+    "loops": "Loops"
   },
   "web": {
     "brand": "opendray",
@@ -2992,6 +2993,62 @@
           "note": "Per-section and per-page inject flags (blueprint editor / knowledge pages) still apply in full mode; in lean mode foundational rules always inject and everything else is indexed."
         }
       }
+    },
+    "loops": {
+      "title": "Loops",
+      "subtitle": "Autonomous agent loops — run a session on an interval, or until a goal is met.",
+      "create": "Create loop",
+      "createHint": "The loop drives an existing session. A deadline is required.",
+      "empty": "No loops yet. Create one to drive a session autonomously.",
+      "createdToast": "Loop created",
+      "kind": {
+        "goal": "Goal",
+        "interval": "Interval"
+      },
+      "kindHint": {
+        "goal": "run until a judge says the goal is met",
+        "interval": "re-send the prompt every N seconds"
+      },
+      "status": {
+        "pending": "Pending",
+        "running": "Running",
+        "paused": "Paused",
+        "done": "Done",
+        "stopped": "Stopped",
+        "failed": "Failed",
+        "escalated": "Escalated"
+      },
+      "origin": {
+        "integration": "Integration"
+      },
+      "iterationOf": "{n} / {max}",
+      "action": {
+        "pause": "Pause",
+        "resume": "Resume",
+        "stop": "Stop",
+        "details": "Details",
+        "cancel": "Cancel",
+        "create": "Create"
+      },
+      "field": {
+        "session": "Session ID",
+        "sessionPlaceholder": "the session this loop drives",
+        "kind": "Kind",
+        "goal": "Goal",
+        "goalPlaceholder": "what the loop should accomplish",
+        "seedPrompt": "Seed prompt",
+        "prompt": "Prompt",
+        "promptPlaceholder": "the instruction sent to the agent",
+        "intervalSeconds": "Interval (seconds)",
+        "maxIterations": "Max iterations",
+        "durationMinutes": "Deadline (minutes)",
+        "failureCap": "Failure cap"
+      },
+      "runs": {
+        "title": "Iterations",
+        "empty": "No iterations yet.",
+        "iteration": "Iteration {n}"
+      }
     }
   },
   "more": {
@@ -3079,6 +3136,10 @@
       "vault": {
         "title": "Vault",
         "subtitle": "Freeform markdown notes (Obsidian-sync)"
+      },
+      "loops": {
+        "title": "Loops",
+        "subtitle": "Autonomous agent loops"
       }
     },
     "signOut": "Sign out"
@@ -4876,5 +4937,61 @@
     "providersManageOnWeb": "Add or edit providers on the web admin.",
     "providersLoadFailed": "Failed to load providers",
     "defaultBadge": "default"
+  },
+  "loops": {
+    "title": "Loops",
+    "subtitle": "Autonomous agent loops — run a session on an interval, or until a goal is met.",
+    "create": "Create loop",
+    "createHint": "The loop drives an existing session. A deadline is required.",
+    "empty": "No loops yet. Create one to drive a session autonomously.",
+    "createdToast": "Loop created",
+    "kind": {
+      "goal": "Goal",
+      "interval": "Interval"
+    },
+    "kindHint": {
+      "goal": "run until a judge says the goal is met",
+      "interval": "re-send the prompt every N seconds"
+    },
+    "status": {
+      "pending": "Pending",
+      "running": "Running",
+      "paused": "Paused",
+      "done": "Done",
+      "stopped": "Stopped",
+      "failed": "Failed",
+      "escalated": "Escalated"
+    },
+    "origin": {
+      "integration": "Integration"
+    },
+    "iterationOf": "{n} / {max}",
+    "action": {
+      "pause": "Pause",
+      "resume": "Resume",
+      "stop": "Stop",
+      "details": "Details",
+      "cancel": "Cancel",
+      "create": "Create"
+    },
+    "field": {
+      "session": "Session ID",
+      "sessionPlaceholder": "the session this loop drives",
+      "kind": "Kind",
+      "goal": "Goal",
+      "goalPlaceholder": "what the loop should accomplish",
+      "seedPrompt": "Seed prompt",
+      "prompt": "Prompt",
+      "promptPlaceholder": "the instruction sent to the agent",
+      "intervalSeconds": "Interval (seconds)",
+      "maxIterations": "Max iterations",
+      "durationMinutes": "Deadline (minutes)",
+      "failureCap": "Failure cap"
+    },
+    "runs": {
+      "title": "Iterations",
+      "empty": "No iterations yet.",
+      "iteration": "Iteration {n}"
+    }
   }
 }

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -42,7 +42,8 @@
     "knowledge": "Conocimiento",
     "vault": "Bóveda",
     "cortex": "Cortex",
-    "updateAvailable": "Actualización disponible"
+    "updateAvailable": "Actualización disponible",
+    "loops": "Bucles"
   },
   "web": {
     "brand": "opendray",
@@ -2992,6 +2993,62 @@
           "note": "En modo completo siguen aplicando los flags de inyección por sección/página; en modo ligero las reglas fundacionales siempre se inyectan y el resto va al índice."
         }
       }
+    },
+    "loops": {
+      "title": "Bucles",
+      "subtitle": "Bucles de agente autónomos: ejecuta una sesión por intervalo o hasta cumplir un objetivo.",
+      "create": "Crear bucle",
+      "createHint": "El bucle controla una sesión existente. Se requiere una fecha límite.",
+      "empty": "Aún no hay bucles. Crea uno para controlar una sesión de forma autónoma.",
+      "createdToast": "Bucle creado",
+      "kind": {
+        "goal": "Objetivo",
+        "interval": "Intervalo"
+      },
+      "kindHint": {
+        "goal": "ejecutar hasta que un evaluador confirme el objetivo",
+        "interval": "reenviar el prompt cada N segundos"
+      },
+      "status": {
+        "pending": "Pendiente",
+        "running": "En ejecución",
+        "paused": "Pausado",
+        "done": "Completado",
+        "stopped": "Detenido",
+        "failed": "Fallido",
+        "escalated": "Escalado"
+      },
+      "origin": {
+        "integration": "Integración"
+      },
+      "iterationOf": "{n} / {max}",
+      "action": {
+        "pause": "Pausar",
+        "resume": "Reanudar",
+        "stop": "Detener",
+        "details": "Detalles",
+        "cancel": "Cancelar",
+        "create": "Crear"
+      },
+      "field": {
+        "session": "ID de sesión",
+        "sessionPlaceholder": "la sesión que controla este bucle",
+        "kind": "Tipo",
+        "goal": "Objetivo",
+        "goalPlaceholder": "qué debe lograr el bucle",
+        "seedPrompt": "Prompt inicial",
+        "prompt": "Prompt",
+        "promptPlaceholder": "la instrucción enviada al agente",
+        "intervalSeconds": "Intervalo (segundos)",
+        "maxIterations": "Iteraciones máximas",
+        "durationMinutes": "Fecha límite (minutos)",
+        "failureCap": "Límite de fallos"
+      },
+      "runs": {
+        "title": "Iteraciones",
+        "empty": "Aún no hay iteraciones.",
+        "iteration": "Iteración {n}"
+      }
     }
   },
   "more": {
@@ -3079,6 +3136,10 @@
       "vault": {
         "title": "Bóveda",
         "subtitle": "Notas markdown libres (sincronización Obsidian)"
+      },
+      "loops": {
+        "title": "Bucles",
+        "subtitle": "Bucles de agente autónomos"
       }
     },
     "signOut": "Cerrar sesión"
@@ -4876,5 +4937,61 @@
     "providersManageOnWeb": "Añade o edita proveedores en el panel web.",
     "providersLoadFailed": "Error al cargar proveedores",
     "defaultBadge": "predeterminado"
+  },
+  "loops": {
+    "title": "Bucles",
+    "subtitle": "Bucles de agente autónomos: ejecuta una sesión por intervalo o hasta cumplir un objetivo.",
+    "create": "Crear bucle",
+    "createHint": "El bucle controla una sesión existente. Se requiere una fecha límite.",
+    "empty": "Aún no hay bucles. Crea uno para controlar una sesión de forma autónoma.",
+    "createdToast": "Bucle creado",
+    "kind": {
+      "goal": "Objetivo",
+      "interval": "Intervalo"
+    },
+    "kindHint": {
+      "goal": "ejecutar hasta que un evaluador confirme el objetivo",
+      "interval": "reenviar el prompt cada N segundos"
+    },
+    "status": {
+      "pending": "Pendiente",
+      "running": "En ejecución",
+      "paused": "Pausado",
+      "done": "Completado",
+      "stopped": "Detenido",
+      "failed": "Fallido",
+      "escalated": "Escalado"
+    },
+    "origin": {
+      "integration": "Integración"
+    },
+    "iterationOf": "{n} / {max}",
+    "action": {
+      "pause": "Pausar",
+      "resume": "Reanudar",
+      "stop": "Detener",
+      "details": "Detalles",
+      "cancel": "Cancelar",
+      "create": "Crear"
+    },
+    "field": {
+      "session": "ID de sesión",
+      "sessionPlaceholder": "la sesión que controla este bucle",
+      "kind": "Tipo",
+      "goal": "Objetivo",
+      "goalPlaceholder": "qué debe lograr el bucle",
+      "seedPrompt": "Prompt inicial",
+      "prompt": "Prompt",
+      "promptPlaceholder": "la instrucción enviada al agente",
+      "intervalSeconds": "Intervalo (segundos)",
+      "maxIterations": "Iteraciones máximas",
+      "durationMinutes": "Fecha límite (minutos)",
+      "failureCap": "Límite de fallos"
+    },
+    "runs": {
+      "title": "Iteraciones",
+      "empty": "Aún no hay iteraciones.",
+      "iteration": "Iteración {n}"
+    }
   }
 }

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -42,7 +42,8 @@
     "knowledge": "知识",
     "vault": "文档库",
     "cortex": "心智中枢",
-    "updateAvailable": "有可用更新"
+    "updateAvailable": "有可用更新",
+    "loops": "循环"
   },
   "web": {
     "brand": "opendray",
@@ -2992,6 +2993,62 @@
           "note": "完整模式下章节/知识页各自的注入开关（蓝图编辑器 / 知识页）仍然生效；精简模式下基础方针始终注入，其余一律走索引。"
         }
       }
+    },
+    "loops": {
+      "title": "循环",
+      "subtitle": "自主 agent 循环 —— 按间隔运行 session,或跑到目标达成。",
+      "create": "创建循环",
+      "createHint": "循环驱动一个已有 session,必须设置截止时间。",
+      "empty": "还没有循环。创建一个来自主驱动 session。",
+      "createdToast": "已创建循环",
+      "kind": {
+        "goal": "目标",
+        "interval": "定时"
+      },
+      "kindHint": {
+        "goal": "跑到评审判定目标达成",
+        "interval": "每隔 N 秒重发 prompt"
+      },
+      "status": {
+        "pending": "待启动",
+        "running": "运行中",
+        "paused": "已暂停",
+        "done": "已完成",
+        "stopped": "已停止",
+        "failed": "失败",
+        "escalated": "已升级"
+      },
+      "origin": {
+        "integration": "集成"
+      },
+      "iterationOf": "{n} / {max}",
+      "action": {
+        "pause": "暂停",
+        "resume": "恢复",
+        "stop": "停止",
+        "details": "详情",
+        "cancel": "取消",
+        "create": "创建"
+      },
+      "field": {
+        "session": "Session ID",
+        "sessionPlaceholder": "该循环驱动的 session",
+        "kind": "类型",
+        "goal": "目标",
+        "goalPlaceholder": "循环要达成什么",
+        "seedPrompt": "初始 prompt",
+        "prompt": "Prompt",
+        "promptPlaceholder": "发送给 agent 的指令",
+        "intervalSeconds": "间隔(秒)",
+        "maxIterations": "最大迭代数",
+        "durationMinutes": "截止(分钟)",
+        "failureCap": "失败上限"
+      },
+      "runs": {
+        "title": "迭代记录",
+        "empty": "还没有迭代。",
+        "iteration": "第 {n} 轮"
+      }
     }
   },
   "more": {
@@ -3079,6 +3136,10 @@
       "vault": {
         "title": "文档库",
         "subtitle": "自由 markdown 笔记(Obsidian 同步)"
+      },
+      "loops": {
+        "title": "循环",
+        "subtitle": "自主 agent 循环"
       }
     },
     "signOut": "退出登录"
@@ -4876,5 +4937,61 @@
     "providersManageOnWeb": "在 web 管理端添加或编辑 provider。",
     "providersLoadFailed": "加载 provider 失败",
     "defaultBadge": "默认"
+  },
+  "loops": {
+    "title": "循环",
+    "subtitle": "自主 agent 循环 —— 按间隔运行 session,或跑到目标达成。",
+    "create": "创建循环",
+    "createHint": "循环驱动一个已有 session,必须设置截止时间。",
+    "empty": "还没有循环。创建一个来自主驱动 session。",
+    "createdToast": "已创建循环",
+    "kind": {
+      "goal": "目标",
+      "interval": "定时"
+    },
+    "kindHint": {
+      "goal": "跑到评审判定目标达成",
+      "interval": "每隔 N 秒重发 prompt"
+    },
+    "status": {
+      "pending": "待启动",
+      "running": "运行中",
+      "paused": "已暂停",
+      "done": "已完成",
+      "stopped": "已停止",
+      "failed": "失败",
+      "escalated": "已升级"
+    },
+    "origin": {
+      "integration": "集成"
+    },
+    "iterationOf": "{n} / {max}",
+    "action": {
+      "pause": "暂停",
+      "resume": "恢复",
+      "stop": "停止",
+      "details": "详情",
+      "cancel": "取消",
+      "create": "创建"
+    },
+    "field": {
+      "session": "Session ID",
+      "sessionPlaceholder": "该循环驱动的 session",
+      "kind": "类型",
+      "goal": "目标",
+      "goalPlaceholder": "循环要达成什么",
+      "seedPrompt": "初始 prompt",
+      "prompt": "Prompt",
+      "promptPlaceholder": "发送给 agent 的指令",
+      "intervalSeconds": "间隔(秒)",
+      "maxIterations": "最大迭代数",
+      "durationMinutes": "截止(分钟)",
+      "failureCap": "失败上限"
+    },
+    "runs": {
+      "title": "迭代记录",
+      "empty": "还没有迭代。",
+      "iteration": "第 {n} 轮"
+    }
   }
 }

--- a/app/mobile/lib/core/api/loops_api.dart
+++ b/app/mobile/lib/core/api/loops_api.dart
@@ -1,0 +1,238 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/api/dio_provider.dart';
+
+// Loop Engine (autoloop) endpoint surface. The gateway returns a bare JSON
+// array for list/runs and a bare object for a single loop (see
+// internal/autoloop/handler.go) — no wrapper envelope.
+
+enum LoopKind {
+  interval,
+  goal,
+  unknown;
+
+  static LoopKind parse(String? raw) => switch (raw) {
+        'interval' => LoopKind.interval,
+        'goal' => LoopKind.goal,
+        _ => LoopKind.unknown,
+      };
+
+  String get wire => switch (this) {
+        LoopKind.interval => 'interval',
+        LoopKind.goal => 'goal',
+        LoopKind.unknown => 'goal',
+      };
+}
+
+enum LoopStatus {
+  pending,
+  running,
+  paused,
+  done,
+  stopped,
+  failed,
+  escalated,
+  unknown;
+
+  static LoopStatus parse(String? raw) => switch (raw) {
+        'pending' => LoopStatus.pending,
+        'running' => LoopStatus.running,
+        'paused' => LoopStatus.paused,
+        'done' => LoopStatus.done,
+        'stopped' => LoopStatus.stopped,
+        'failed' => LoopStatus.failed,
+        'escalated' => LoopStatus.escalated,
+        _ => LoopStatus.unknown,
+      };
+
+  bool get isTerminal =>
+      this == LoopStatus.done ||
+      this == LoopStatus.stopped ||
+      this == LoopStatus.failed ||
+      this == LoopStatus.escalated;
+}
+
+class LoopSummary {
+  LoopSummary({
+    required this.id,
+    required this.sessionId,
+    required this.origin,
+    required this.kind,
+    required this.status,
+    required this.prompt,
+    required this.maxIterations,
+    required this.failureCap,
+    required this.iteration,
+    this.goal,
+    this.intervalSeconds,
+    this.lastVerdict,
+    this.lastReason,
+    this.deadlineAt,
+  });
+
+  factory LoopSummary.fromJson(Map<String, dynamic> json) => LoopSummary(
+        id: json['id'] as String? ?? '',
+        sessionId: json['session_id'] as String? ?? '',
+        origin: json['origin'] as String? ?? 'operator',
+        kind: LoopKind.parse(json['kind'] as String?),
+        status: LoopStatus.parse(json['status'] as String?),
+        prompt: json['prompt'] as String? ?? '',
+        maxIterations: (json['max_iterations'] as num?)?.toInt() ?? 0,
+        failureCap: (json['failure_cap'] as num?)?.toInt() ?? 0,
+        iteration: (json['iteration'] as num?)?.toInt() ?? 0,
+        goal: json['goal'] as String?,
+        intervalSeconds: (json['interval_seconds'] as num?)?.toInt(),
+        lastVerdict: json['last_verdict'] as String?,
+        lastReason: json['last_reason'] as String?,
+        deadlineAt: DateTime.tryParse(json['deadline_at'] as String? ?? ''),
+      );
+
+  final String id;
+  final String sessionId;
+  final String origin;
+  final LoopKind kind;
+  final LoopStatus status;
+  final String prompt;
+  final int maxIterations;
+  final int failureCap;
+  final int iteration;
+  final String? goal;
+  final int? intervalSeconds;
+  final String? lastVerdict;
+  final String? lastReason;
+  final DateTime? deadlineAt;
+
+  bool get isIntegration => origin == 'integration';
+}
+
+class LoopRun {
+  LoopRun({
+    required this.id,
+    required this.iteration,
+    required this.prompt,
+    this.verdict,
+    this.reason,
+  });
+
+  factory LoopRun.fromJson(Map<String, dynamic> json) => LoopRun(
+        id: (json['id'] as num?)?.toInt() ?? 0,
+        iteration: (json['iteration'] as num?)?.toInt() ?? 0,
+        prompt: json['prompt'] as String? ?? '',
+        verdict: json['verdict'] as String?,
+        reason: json['reason'] as String?,
+      );
+
+  final int id;
+  final int iteration;
+  final String prompt;
+  final String? verdict;
+  final String? reason;
+}
+
+class CreateLoopRequest {
+  CreateLoopRequest({
+    required this.sessionId,
+    required this.kind,
+    required this.prompt,
+    required this.maxIterations,
+    required this.deadlineAt,
+    required this.failureCap,
+    this.goal,
+    this.intervalSeconds,
+  });
+
+  final String sessionId;
+  final LoopKind kind;
+  final String prompt;
+  final int maxIterations;
+  final DateTime deadlineAt;
+  final int failureCap;
+  final String? goal;
+  final int? intervalSeconds;
+
+  Map<String, dynamic> toJson() => {
+        'session_id': sessionId,
+        'kind': kind.wire,
+        'prompt': prompt,
+        'max_iterations': maxIterations,
+        'deadline_at': deadlineAt.toUtc().toIso8601String(),
+        'failure_cap': failureCap,
+        if (kind == LoopKind.goal && goal != null) 'goal': goal,
+        if (kind == LoopKind.interval && intervalSeconds != null)
+          'interval_seconds': intervalSeconds,
+      };
+}
+
+class LoopsApi {
+  LoopsApi(this._dio);
+  final Dio _dio;
+
+  Future<List<LoopSummary>> list() async {
+    try {
+      final res = await _dio.get<List<dynamic>>('/api/v1/loops');
+      final raw = res.data;
+      if (raw == null) return [];
+      return raw
+          .whereType<Map<String, dynamic>>()
+          .map(LoopSummary.fromJson)
+          .toList();
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  Future<List<LoopRun>> runs(String id) async {
+    try {
+      final res = await _dio.get<List<dynamic>>('/api/v1/loops/$id/runs');
+      final raw = res.data;
+      if (raw == null) return [];
+      return raw
+          .whereType<Map<String, dynamic>>()
+          .map(LoopRun.fromJson)
+          .toList();
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  Future<LoopSummary> create(CreateLoopRequest req) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/loops',
+        data: req.toJson(),
+      );
+      return LoopSummary.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  Future<LoopSummary> _transition(String id, String action) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/loops/$id/$action',
+      );
+      return LoopSummary.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  Future<LoopSummary> pause(String id) => _transition(id, 'pause');
+  Future<LoopSummary> resume(String id) => _transition(id, 'resume');
+  Future<LoopSummary> stop(String id) => _transition(id, 'stop');
+}
+
+final loopsApiProvider = Provider<LoopsApi>((ref) {
+  return LoopsApi(ref.watch(dioProvider));
+});
+
+final loopsListProvider = FutureProvider.autoDispose<List<LoopSummary>>((ref) {
+  return ref.watch(loopsApiProvider).list();
+});
+
+final loopRunsProvider =
+    FutureProvider.autoDispose.family<List<LoopRun>, String>((ref, id) {
+  return ref.watch(loopsApiProvider).runs(id);
+});

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 11610 (3870 per locale)
+/// Strings: 11859 (3953 per locale)
 ///
-/// Built on 2026-06-18 at 15:03 UTC
+/// Built on 2026-06-19 at 09:45 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -71,6 +71,7 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	late final TranslationsMemoryQuarantineEn memoryQuarantine = TranslationsMemoryQuarantineEn.internal(_root);
 	late final TranslationsCortexHubEn cortexHub = TranslationsCortexHubEn.internal(_root);
 	late final TranslationsCortexSettingsEn cortexSettings = TranslationsCortexSettingsEn.internal(_root);
+	late final TranslationsLoopsEn loops = TranslationsLoopsEn.internal(_root);
 }
 
 // Path: common
@@ -215,6 +216,9 @@ class TranslationsNavEn {
 
 	/// en: 'Update available'
 	String get updateAvailable => 'Update available';
+
+	/// en: 'Loops'
+	String get loops => 'Loops';
 }
 
 // Path: web
@@ -258,6 +262,7 @@ class TranslationsWebEn {
 	late final TranslationsWebExportEn export = TranslationsWebExportEn.internal(_root);
 	late final TranslationsWebKnowledgeEn knowledge = TranslationsWebKnowledgeEn.internal(_root);
 	late final TranslationsWebCortexEn cortex = TranslationsWebCortexEn.internal(_root);
+	late final TranslationsWebLoopsEn loops = TranslationsWebLoopsEn.internal(_root);
 }
 
 // Path: more
@@ -2254,6 +2259,45 @@ class TranslationsCortexSettingsEn {
 	String get defaultBadge => 'default';
 }
 
+// Path: loops
+class TranslationsLoopsEn {
+	TranslationsLoopsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Loops'
+	String get title => 'Loops';
+
+	/// en: 'Autonomous agent loops — run a session on an interval, or until a goal is met.'
+	String get subtitle => 'Autonomous agent loops — run a session on an interval, or until a goal is met.';
+
+	/// en: 'Create loop'
+	String get create => 'Create loop';
+
+	/// en: 'The loop drives an existing session. A deadline is required.'
+	String get createHint => 'The loop drives an existing session. A deadline is required.';
+
+	/// en: 'No loops yet. Create one to drive a session autonomously.'
+	String get empty => 'No loops yet. Create one to drive a session autonomously.';
+
+	/// en: 'Loop created'
+	String get createdToast => 'Loop created';
+
+	late final TranslationsLoopsKindEn kind = TranslationsLoopsKindEn.internal(_root);
+	late final TranslationsLoopsKindHintEn kindHint = TranslationsLoopsKindHintEn.internal(_root);
+	late final TranslationsLoopsStatusEn status = TranslationsLoopsStatusEn.internal(_root);
+	late final TranslationsLoopsOriginEn origin = TranslationsLoopsOriginEn.internal(_root);
+
+	/// en: '{n} / {max}'
+	String iterationOf({required Object n, required Object max}) => '${n} / ${max}';
+
+	late final TranslationsLoopsActionEn action = TranslationsLoopsActionEn.internal(_root);
+	late final TranslationsLoopsFieldEn field = TranslationsLoopsFieldEn.internal(_root);
+	late final TranslationsLoopsRunsEn runs = TranslationsLoopsRunsEn.internal(_root);
+}
+
 // Path: web.topbar
 class TranslationsWebTopbarEn {
 	TranslationsWebTopbarEn.internal(this._root);
@@ -3394,6 +3438,45 @@ class TranslationsWebCortexEn {
 	late final TranslationsWebCortexSettingsEn settings = TranslationsWebCortexSettingsEn.internal(_root);
 }
 
+// Path: web.loops
+class TranslationsWebLoopsEn {
+	TranslationsWebLoopsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Loops'
+	String get title => 'Loops';
+
+	/// en: 'Autonomous agent loops — run a session on an interval, or until a goal is met.'
+	String get subtitle => 'Autonomous agent loops — run a session on an interval, or until a goal is met.';
+
+	/// en: 'Create loop'
+	String get create => 'Create loop';
+
+	/// en: 'The loop drives an existing session. A deadline is required.'
+	String get createHint => 'The loop drives an existing session. A deadline is required.';
+
+	/// en: 'No loops yet. Create one to drive a session autonomously.'
+	String get empty => 'No loops yet. Create one to drive a session autonomously.';
+
+	/// en: 'Loop created'
+	String get createdToast => 'Loop created';
+
+	late final TranslationsWebLoopsKindEn kind = TranslationsWebLoopsKindEn.internal(_root);
+	late final TranslationsWebLoopsKindHintEn kindHint = TranslationsWebLoopsKindHintEn.internal(_root);
+	late final TranslationsWebLoopsStatusEn status = TranslationsWebLoopsStatusEn.internal(_root);
+	late final TranslationsWebLoopsOriginEn origin = TranslationsWebLoopsOriginEn.internal(_root);
+
+	/// en: '{n} / {max}'
+	String iterationOf({required Object n, required Object max}) => '${n} / ${max}';
+
+	late final TranslationsWebLoopsActionEn action = TranslationsWebLoopsActionEn.internal(_root);
+	late final TranslationsWebLoopsFieldEn field = TranslationsWebLoopsFieldEn.internal(_root);
+	late final TranslationsWebLoopsRunsEn runs = TranslationsWebLoopsRunsEn.internal(_root);
+}
+
 // Path: more.identity
 class TranslationsMoreIdentityEn {
 	TranslationsMoreIdentityEn.internal(this._root);
@@ -3458,6 +3541,7 @@ class TranslationsMoreItemsEn {
 	late final TranslationsMoreItemsSettingsEn settings = TranslationsMoreItemsSettingsEn.internal(_root);
 	late final TranslationsMoreItemsAboutEn about = TranslationsMoreItemsAboutEn.internal(_root);
 	late final TranslationsMoreItemsVaultEn vault = TranslationsMoreItemsVaultEn.internal(_root);
+	late final TranslationsMoreItemsLoopsEn loops = TranslationsMoreItemsLoopsEn.internal(_root);
 }
 
 // Path: activity.filter
@@ -5952,6 +6036,168 @@ class TranslationsSettingsServerSettingsEn {
 	String validateNumber({required Object field}) => '"${field}" must be a number';
 
 	late final TranslationsSettingsServerSettingsEmbedderModelEn embedderModel = TranslationsSettingsServerSettingsEmbedderModelEn.internal(_root);
+}
+
+// Path: loops.kind
+class TranslationsLoopsKindEn {
+	TranslationsLoopsKindEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Goal'
+	String get goal => 'Goal';
+
+	/// en: 'Interval'
+	String get interval => 'Interval';
+}
+
+// Path: loops.kindHint
+class TranslationsLoopsKindHintEn {
+	TranslationsLoopsKindHintEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'run until a judge says the goal is met'
+	String get goal => 'run until a judge says the goal is met';
+
+	/// en: 're-send the prompt every N seconds'
+	String get interval => 're-send the prompt every N seconds';
+}
+
+// Path: loops.status
+class TranslationsLoopsStatusEn {
+	TranslationsLoopsStatusEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Pending'
+	String get pending => 'Pending';
+
+	/// en: 'Running'
+	String get running => 'Running';
+
+	/// en: 'Paused'
+	String get paused => 'Paused';
+
+	/// en: 'Done'
+	String get done => 'Done';
+
+	/// en: 'Stopped'
+	String get stopped => 'Stopped';
+
+	/// en: 'Failed'
+	String get failed => 'Failed';
+
+	/// en: 'Escalated'
+	String get escalated => 'Escalated';
+}
+
+// Path: loops.origin
+class TranslationsLoopsOriginEn {
+	TranslationsLoopsOriginEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Integration'
+	String get integration => 'Integration';
+}
+
+// Path: loops.action
+class TranslationsLoopsActionEn {
+	TranslationsLoopsActionEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Pause'
+	String get pause => 'Pause';
+
+	/// en: 'Resume'
+	String get resume => 'Resume';
+
+	/// en: 'Stop'
+	String get stop => 'Stop';
+
+	/// en: 'Details'
+	String get details => 'Details';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Create'
+	String get create => 'Create';
+}
+
+// Path: loops.field
+class TranslationsLoopsFieldEn {
+	TranslationsLoopsFieldEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Session ID'
+	String get session => 'Session ID';
+
+	/// en: 'the session this loop drives'
+	String get sessionPlaceholder => 'the session this loop drives';
+
+	/// en: 'Kind'
+	String get kind => 'Kind';
+
+	/// en: 'Goal'
+	String get goal => 'Goal';
+
+	/// en: 'what the loop should accomplish'
+	String get goalPlaceholder => 'what the loop should accomplish';
+
+	/// en: 'Seed prompt'
+	String get seedPrompt => 'Seed prompt';
+
+	/// en: 'Prompt'
+	String get prompt => 'Prompt';
+
+	/// en: 'the instruction sent to the agent'
+	String get promptPlaceholder => 'the instruction sent to the agent';
+
+	/// en: 'Interval (seconds)'
+	String get intervalSeconds => 'Interval (seconds)';
+
+	/// en: 'Max iterations'
+	String get maxIterations => 'Max iterations';
+
+	/// en: 'Deadline (minutes)'
+	String get durationMinutes => 'Deadline (minutes)';
+
+	/// en: 'Failure cap'
+	String get failureCap => 'Failure cap';
+}
+
+// Path: loops.runs
+class TranslationsLoopsRunsEn {
+	TranslationsLoopsRunsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Iterations'
+	String get title => 'Iterations';
+
+	/// en: 'No iterations yet.'
+	String get empty => 'No iterations yet.';
+
+	/// en: 'Iteration {n}'
+	String iteration({required Object n}) => 'Iteration ${n}';
 }
 
 // Path: web.sessions.list
@@ -11433,6 +11679,168 @@ class TranslationsWebCortexSettingsEn {
 	late final TranslationsWebCortexSettingsInjectionEn injection = TranslationsWebCortexSettingsInjectionEn.internal(_root);
 }
 
+// Path: web.loops.kind
+class TranslationsWebLoopsKindEn {
+	TranslationsWebLoopsKindEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Goal'
+	String get goal => 'Goal';
+
+	/// en: 'Interval'
+	String get interval => 'Interval';
+}
+
+// Path: web.loops.kindHint
+class TranslationsWebLoopsKindHintEn {
+	TranslationsWebLoopsKindHintEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'run until a judge says the goal is met'
+	String get goal => 'run until a judge says the goal is met';
+
+	/// en: 're-send the prompt every N seconds'
+	String get interval => 're-send the prompt every N seconds';
+}
+
+// Path: web.loops.status
+class TranslationsWebLoopsStatusEn {
+	TranslationsWebLoopsStatusEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Pending'
+	String get pending => 'Pending';
+
+	/// en: 'Running'
+	String get running => 'Running';
+
+	/// en: 'Paused'
+	String get paused => 'Paused';
+
+	/// en: 'Done'
+	String get done => 'Done';
+
+	/// en: 'Stopped'
+	String get stopped => 'Stopped';
+
+	/// en: 'Failed'
+	String get failed => 'Failed';
+
+	/// en: 'Escalated'
+	String get escalated => 'Escalated';
+}
+
+// Path: web.loops.origin
+class TranslationsWebLoopsOriginEn {
+	TranslationsWebLoopsOriginEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Integration'
+	String get integration => 'Integration';
+}
+
+// Path: web.loops.action
+class TranslationsWebLoopsActionEn {
+	TranslationsWebLoopsActionEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Pause'
+	String get pause => 'Pause';
+
+	/// en: 'Resume'
+	String get resume => 'Resume';
+
+	/// en: 'Stop'
+	String get stop => 'Stop';
+
+	/// en: 'Details'
+	String get details => 'Details';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Create'
+	String get create => 'Create';
+}
+
+// Path: web.loops.field
+class TranslationsWebLoopsFieldEn {
+	TranslationsWebLoopsFieldEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Session ID'
+	String get session => 'Session ID';
+
+	/// en: 'the session this loop drives'
+	String get sessionPlaceholder => 'the session this loop drives';
+
+	/// en: 'Kind'
+	String get kind => 'Kind';
+
+	/// en: 'Goal'
+	String get goal => 'Goal';
+
+	/// en: 'what the loop should accomplish'
+	String get goalPlaceholder => 'what the loop should accomplish';
+
+	/// en: 'Seed prompt'
+	String get seedPrompt => 'Seed prompt';
+
+	/// en: 'Prompt'
+	String get prompt => 'Prompt';
+
+	/// en: 'the instruction sent to the agent'
+	String get promptPlaceholder => 'the instruction sent to the agent';
+
+	/// en: 'Interval (seconds)'
+	String get intervalSeconds => 'Interval (seconds)';
+
+	/// en: 'Max iterations'
+	String get maxIterations => 'Max iterations';
+
+	/// en: 'Deadline (minutes)'
+	String get durationMinutes => 'Deadline (minutes)';
+
+	/// en: 'Failure cap'
+	String get failureCap => 'Failure cap';
+}
+
+// Path: web.loops.runs
+class TranslationsWebLoopsRunsEn {
+	TranslationsWebLoopsRunsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Iterations'
+	String get title => 'Iterations';
+
+	/// en: 'No iterations yet.'
+	String get empty => 'No iterations yet.';
+
+	/// en: 'Iteration {n}'
+	String iteration({required Object n}) => 'Iteration ${n}';
+}
+
 // Path: more.items.integrations
 class TranslationsMoreItemsIntegrationsEn {
 	TranslationsMoreItemsIntegrationsEn.internal(this._root);
@@ -11701,6 +12109,21 @@ class TranslationsMoreItemsVaultEn {
 
 	/// en: 'Freeform markdown notes (Obsidian-sync)'
 	String get subtitle => 'Freeform markdown notes (Obsidian-sync)';
+}
+
+// Path: more.items.loops
+class TranslationsMoreItemsLoopsEn {
+	TranslationsMoreItemsLoopsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Loops'
+	String get title => 'Loops';
+
+	/// en: 'Autonomous agent loops'
+	String get subtitle => 'Autonomous agent loops';
 }
 
 // Path: sessions.detail.accountSwitcher
@@ -16853,6 +17276,7 @@ extension on Translations {
 			'nav.vault' => 'Vault',
 			'nav.cortex' => 'Cortex',
 			'nav.updateAvailable' => 'Update available',
+			'nav.loops' => 'Loops',
 			'web.brand' => 'opendray',
 			'web.loading' => 'Loading…',
 			'web.topbar.expandSidebar' => 'Expand sidebar',
@@ -17325,9 +17749,9 @@ extension on Translations {
 			'web.project.reset.alsoDeleteMemoriesLabel' => 'Also delete pgvector memories',
 			'web.project.reset.alsoDeleteMemoriesSuffix' => 'for this scope_key.',
 			'web.project.reset.alsoDeleteMemoriesHint' => 'Long-term facts the agent stored (user preferences, project facts). Cannot be recovered.',
-			'web.project.reset.cancel' => 'Cancel',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.reset.cancel' => 'Cancel',
 			'web.project.reset.deleteForever' => 'Delete forever',
 			'web.project.reset.successToast' => ({required Object summary}) => 'Reset: deleted ${summary}',
 			'web.project.reset.summary.docs_one' => ({required Object count}) => '${count} doc',
@@ -17839,9 +18263,9 @@ extension on Translations {
 			'web.channels.bridge.nameLabel' => 'Bridge name',
 			'web.channels.bridge.namePlaceholder' => 'wechat / discord-custom / whatsapp...',
 			'web.channels.bridge.nameHint' => 'Human label for the adapter. Shown in the channels list.',
-			'web.channels.bridge.tokenLabel' => 'Adapter token',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.bridge.tokenLabel' => 'Adapter token',
 			'web.channels.bridge.regenerateTooltip' => 'Regenerate',
 			'web.channels.bridge.copyTooltip' => 'Copy',
 			'web.channels.bridge.tokenCopiedToast' => 'Token copied',
@@ -18353,9 +18777,9 @@ extension on Translations {
 			'web.backups.targetEditor.smb.hostLabel' => 'Host',
 			'web.backups.targetEditor.smb.hostPlaceholder' => '192.168.1.20',
 			'web.backups.targetEditor.smb.portLabel' => 'Port',
-			'web.backups.targetEditor.smb.shareLabel' => 'Share',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.targetEditor.smb.shareLabel' => 'Share',
 			'web.backups.targetEditor.smb.shareHint' => 'Top-level share name on the SMB server',
 			'web.backups.targetEditor.smb.sharePlaceholder' => 'Claude_Workspace',
 			'web.backups.targetEditor.smb.userLabel' => 'User',
@@ -18867,9 +19291,9 @@ extension on Translations {
 			'web.export.form.memories' => 'Memories',
 			'web.export.form.memoriesHint' => 'Cross-CLI persistent memory rows (text + scope + metadata). Embedding vectors are omitted; importer re-embeds.',
 			'web.export.form.integrations' => 'Integrations',
-			'web.export.form.customTasks' => 'Custom tasks',
 			_ => null,
 		} ?? switch (path) {
+			'web.export.form.customTasks' => 'Custom tasks',
 			'web.export.form.customTasksHint' => 'Operator-defined tasks shown in the Inspector\'s Tasks tab.',
 			'web.export.form.integrationOptions.none' => 'None',
 			'web.export.form.integrationOptions.noneHint' => 'Skip the integrations table entirely.',
@@ -19159,6 +19583,46 @@ extension on Translations {
 			'web.cortex.settings.injection.savedToast' => 'Injection mode saved — new sessions use it immediately (no backend restart)',
 			'web.cortex.settings.injection.saveFailed' => 'Save failed',
 			'web.cortex.settings.injection.note' => 'Per-section and per-page inject flags (blueprint editor / knowledge pages) still apply in full mode; in lean mode foundational rules always inject and everything else is indexed.',
+			'web.loops.title' => 'Loops',
+			'web.loops.subtitle' => 'Autonomous agent loops — run a session on an interval, or until a goal is met.',
+			'web.loops.create' => 'Create loop',
+			'web.loops.createHint' => 'The loop drives an existing session. A deadline is required.',
+			'web.loops.empty' => 'No loops yet. Create one to drive a session autonomously.',
+			'web.loops.createdToast' => 'Loop created',
+			'web.loops.kind.goal' => 'Goal',
+			'web.loops.kind.interval' => 'Interval',
+			'web.loops.kindHint.goal' => 'run until a judge says the goal is met',
+			'web.loops.kindHint.interval' => 're-send the prompt every N seconds',
+			'web.loops.status.pending' => 'Pending',
+			'web.loops.status.running' => 'Running',
+			'web.loops.status.paused' => 'Paused',
+			'web.loops.status.done' => 'Done',
+			'web.loops.status.stopped' => 'Stopped',
+			'web.loops.status.failed' => 'Failed',
+			'web.loops.status.escalated' => 'Escalated',
+			'web.loops.origin.integration' => 'Integration',
+			'web.loops.iterationOf' => ({required Object n, required Object max}) => '${n} / ${max}',
+			'web.loops.action.pause' => 'Pause',
+			'web.loops.action.resume' => 'Resume',
+			'web.loops.action.stop' => 'Stop',
+			'web.loops.action.details' => 'Details',
+			'web.loops.action.cancel' => 'Cancel',
+			'web.loops.action.create' => 'Create',
+			'web.loops.field.session' => 'Session ID',
+			'web.loops.field.sessionPlaceholder' => 'the session this loop drives',
+			'web.loops.field.kind' => 'Kind',
+			'web.loops.field.goal' => 'Goal',
+			'web.loops.field.goalPlaceholder' => 'what the loop should accomplish',
+			'web.loops.field.seedPrompt' => 'Seed prompt',
+			'web.loops.field.prompt' => 'Prompt',
+			'web.loops.field.promptPlaceholder' => 'the instruction sent to the agent',
+			'web.loops.field.intervalSeconds' => 'Interval (seconds)',
+			'web.loops.field.maxIterations' => 'Max iterations',
+			'web.loops.field.durationMinutes' => 'Deadline (minutes)',
+			'web.loops.field.failureCap' => 'Failure cap',
+			'web.loops.runs.title' => 'Iterations',
+			'web.loops.runs.empty' => 'No iterations yet.',
+			'web.loops.runs.iteration' => ({required Object n}) => 'Iteration ${n}',
 			'more.title' => 'More',
 			'more.identity.signedInAs' => 'Signed in as',
 			'more.identity.server' => 'Server',
@@ -19203,6 +19667,8 @@ extension on Translations {
 			'more.items.about.subtitle' => 'Build version & server info',
 			'more.items.vault.title' => 'Vault',
 			'more.items.vault.subtitle' => 'Freeform markdown notes (Obsidian-sync)',
+			'more.items.loops.title' => 'Loops',
+			'more.items.loops.subtitle' => 'Autonomous agent loops',
 			'more.signOut' => 'Sign out',
 			'activity.title' => 'Activity',
 			'activity.empty' => 'No integration calls recorded yet.',
@@ -19339,6 +19805,8 @@ extension on Translations {
 			'sessions.dirPicker.dialog.title' => 'New folder',
 			'sessions.dirPicker.dialog.hint' => 'Folder name',
 			'sessions.dirPicker.dialog.create' => 'Create',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.shell.title' => 'Inspector',
 			'sessions.inspector.shell.loadError' => ({required Object error}) => 'Failed to load session: ${error}',
 			'sessions.inspector.shell.tabs.files' => 'Files',
@@ -19382,8 +19850,6 @@ extension on Translations {
 			'sessions.inspector.tasks.filterHint' => 'Filter tasks…',
 			'sessions.inspector.tasks.noMatch' => ({required Object query}) => 'No tasks match "${query}"',
 			'sessions.inspector.tasks.emptyTitle' => 'No tasks in this folder',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.tasks.emptyHint' => 'Looking for package.json, Makefile, Taskfile, justfile, Cargo.toml, go.mod, pyproject.toml, or shell scripts',
 			'sessions.inspector.notes.insertedAt' => ({required Object path}) => 'Inserted: @${path}',
 			'sessions.inspector.notes.myNotes' => 'My notes',
@@ -19853,6 +20319,8 @@ extension on Translations {
 			'backups.kv.started' => 'Started',
 			'backups.kv.finished' => 'Finished',
 			'backups.kv.size' => 'Size',
+			_ => null,
+		} ?? switch (path) {
 			'backups.kv.encrypted' => 'Encrypted',
 			'backups.kv.targetPath' => 'Target path',
 			'backups.kv.error' => 'Error',
@@ -19896,8 +20364,6 @@ extension on Translations {
 			'backups.health.never' => 'never',
 			'backups.health.tiles.recentFailures' => 'Recent failures',
 			'backups.health.tiles.verifyFailures' => 'Verify failures',
-			_ => null,
-		} ?? switch (path) {
 			'backups.health.tiles.overdue' => 'Overdue',
 			'backups.health.tiles.schedules' => 'Schedules',
 			'backups.failedToLoad' => 'Failed to load backups',
@@ -20367,6 +20833,8 @@ extension on Translations {
 			'dataExport.history.columns.scope' => 'Scope',
 			'dataExport.history.columns.size' => 'Size',
 			'dataExport.history.columns.expires' => 'Expires',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.history.columns.actions' => 'Actions',
 			'dataExport.history.scopeEmpty' => '(empty)',
 			'dataExport.history.scopeMemories' => 'memories',
@@ -20410,8 +20878,6 @@ extension on Translations {
 			'dataExport.relative.secondsAgo' => ({required Object n}) => '${n}s ago',
 			'dataExport.relative.minutesAgo' => ({required Object n}) => '${n}m ago',
 			'dataExport.relative.hoursAgo' => ({required Object n}) => '${n}h ago',
-			_ => null,
-		} ?? switch (path) {
 			'dataExport.status.pending' => 'pending',
 			'dataExport.status.running' => 'running',
 			'dataExport.status.ready' => 'ready',
@@ -20698,6 +21164,46 @@ extension on Translations {
 			'cortexSettings.providersManageOnWeb' => 'Add or edit providers on the web admin.',
 			'cortexSettings.providersLoadFailed' => 'Failed to load providers',
 			'cortexSettings.defaultBadge' => 'default',
+			'loops.title' => 'Loops',
+			'loops.subtitle' => 'Autonomous agent loops — run a session on an interval, or until a goal is met.',
+			'loops.create' => 'Create loop',
+			'loops.createHint' => 'The loop drives an existing session. A deadline is required.',
+			'loops.empty' => 'No loops yet. Create one to drive a session autonomously.',
+			'loops.createdToast' => 'Loop created',
+			'loops.kind.goal' => 'Goal',
+			'loops.kind.interval' => 'Interval',
+			'loops.kindHint.goal' => 'run until a judge says the goal is met',
+			'loops.kindHint.interval' => 're-send the prompt every N seconds',
+			'loops.status.pending' => 'Pending',
+			'loops.status.running' => 'Running',
+			'loops.status.paused' => 'Paused',
+			'loops.status.done' => 'Done',
+			'loops.status.stopped' => 'Stopped',
+			'loops.status.failed' => 'Failed',
+			'loops.status.escalated' => 'Escalated',
+			'loops.origin.integration' => 'Integration',
+			'loops.iterationOf' => ({required Object n, required Object max}) => '${n} / ${max}',
+			'loops.action.pause' => 'Pause',
+			'loops.action.resume' => 'Resume',
+			'loops.action.stop' => 'Stop',
+			'loops.action.details' => 'Details',
+			'loops.action.cancel' => 'Cancel',
+			'loops.action.create' => 'Create',
+			'loops.field.session' => 'Session ID',
+			'loops.field.sessionPlaceholder' => 'the session this loop drives',
+			'loops.field.kind' => 'Kind',
+			'loops.field.goal' => 'Goal',
+			'loops.field.goalPlaceholder' => 'what the loop should accomplish',
+			'loops.field.seedPrompt' => 'Seed prompt',
+			'loops.field.prompt' => 'Prompt',
+			'loops.field.promptPlaceholder' => 'the instruction sent to the agent',
+			'loops.field.intervalSeconds' => 'Interval (seconds)',
+			'loops.field.maxIterations' => 'Max iterations',
+			'loops.field.durationMinutes' => 'Deadline (minutes)',
+			'loops.field.failureCap' => 'Failure cap',
+			'loops.runs.title' => 'Iterations',
+			'loops.runs.empty' => 'No iterations yet.',
+			'loops.runs.iteration' => ({required Object n}) => 'Iteration ${n}',
 			_ => null,
 		};
 	}

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -70,6 +70,7 @@ class TranslationsEs extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsMemoryQuarantineEs memoryQuarantine = _TranslationsMemoryQuarantineEs._(_root);
 	@override late final _TranslationsCortexHubEs cortexHub = _TranslationsCortexHubEs._(_root);
 	@override late final _TranslationsCortexSettingsEs cortexSettings = _TranslationsCortexSettingsEs._(_root);
+	@override late final _TranslationsLoopsEs loops = _TranslationsLoopsEs._(_root);
 }
 
 // Path: common
@@ -136,6 +137,7 @@ class _TranslationsNavEs extends TranslationsNavEn {
 	@override String get vault => 'Bóveda';
 	@override String get cortex => 'Cortex';
 	@override String get updateAvailable => 'Actualización disponible';
+	@override String get loops => 'Bucles';
 }
 
 // Path: web
@@ -174,6 +176,7 @@ class _TranslationsWebEs extends TranslationsWebEn {
 	@override late final _TranslationsWebExportEs export = _TranslationsWebExportEs._(_root);
 	@override late final _TranslationsWebKnowledgeEs knowledge = _TranslationsWebKnowledgeEs._(_root);
 	@override late final _TranslationsWebCortexEs cortex = _TranslationsWebCortexEs._(_root);
+	@override late final _TranslationsWebLoopsEs loops = _TranslationsWebLoopsEs._(_root);
 }
 
 // Path: more
@@ -1043,6 +1046,29 @@ class _TranslationsCortexSettingsEs extends TranslationsCortexSettingsEn {
 	@override String get defaultBadge => 'predeterminado';
 }
 
+// Path: loops
+class _TranslationsLoopsEs extends TranslationsLoopsEn {
+	_TranslationsLoopsEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Bucles';
+	@override String get subtitle => 'Bucles de agente autónomos: ejecuta una sesión por intervalo o hasta cumplir un objetivo.';
+	@override String get create => 'Crear bucle';
+	@override String get createHint => 'El bucle controla una sesión existente. Se requiere una fecha límite.';
+	@override String get empty => 'Aún no hay bucles. Crea uno para controlar una sesión de forma autónoma.';
+	@override String get createdToast => 'Bucle creado';
+	@override late final _TranslationsLoopsKindEs kind = _TranslationsLoopsKindEs._(_root);
+	@override late final _TranslationsLoopsKindHintEs kindHint = _TranslationsLoopsKindHintEs._(_root);
+	@override late final _TranslationsLoopsStatusEs status = _TranslationsLoopsStatusEs._(_root);
+	@override late final _TranslationsLoopsOriginEs origin = _TranslationsLoopsOriginEs._(_root);
+	@override String iterationOf({required Object n, required Object max}) => '${n} / ${max}';
+	@override late final _TranslationsLoopsActionEs action = _TranslationsLoopsActionEs._(_root);
+	@override late final _TranslationsLoopsFieldEs field = _TranslationsLoopsFieldEs._(_root);
+	@override late final _TranslationsLoopsRunsEs runs = _TranslationsLoopsRunsEs._(_root);
+}
+
 // Path: web.topbar
 class _TranslationsWebTopbarEs extends TranslationsWebTopbarEn {
 	_TranslationsWebTopbarEs._(TranslationsEs root) : this._root = root, super.internal(root);
@@ -1676,6 +1702,29 @@ class _TranslationsWebCortexEs extends TranslationsWebCortexEn {
 	@override late final _TranslationsWebCortexSettingsEs settings = _TranslationsWebCortexSettingsEs._(_root);
 }
 
+// Path: web.loops
+class _TranslationsWebLoopsEs extends TranslationsWebLoopsEn {
+	_TranslationsWebLoopsEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Bucles';
+	@override String get subtitle => 'Bucles de agente autónomos: ejecuta una sesión por intervalo o hasta cumplir un objetivo.';
+	@override String get create => 'Crear bucle';
+	@override String get createHint => 'El bucle controla una sesión existente. Se requiere una fecha límite.';
+	@override String get empty => 'Aún no hay bucles. Crea uno para controlar una sesión de forma autónoma.';
+	@override String get createdToast => 'Bucle creado';
+	@override late final _TranslationsWebLoopsKindEs kind = _TranslationsWebLoopsKindEs._(_root);
+	@override late final _TranslationsWebLoopsKindHintEs kindHint = _TranslationsWebLoopsKindHintEs._(_root);
+	@override late final _TranslationsWebLoopsStatusEs status = _TranslationsWebLoopsStatusEs._(_root);
+	@override late final _TranslationsWebLoopsOriginEs origin = _TranslationsWebLoopsOriginEs._(_root);
+	@override String iterationOf({required Object n, required Object max}) => '${n} / ${max}';
+	@override late final _TranslationsWebLoopsActionEs action = _TranslationsWebLoopsActionEs._(_root);
+	@override late final _TranslationsWebLoopsFieldEs field = _TranslationsWebLoopsFieldEs._(_root);
+	@override late final _TranslationsWebLoopsRunsEs runs = _TranslationsWebLoopsRunsEs._(_root);
+}
+
 // Path: more.identity
 class _TranslationsMoreIdentityEs extends TranslationsMoreIdentityEn {
 	_TranslationsMoreIdentityEs._(TranslationsEs root) : this._root = root, super.internal(root);
@@ -1726,6 +1775,7 @@ class _TranslationsMoreItemsEs extends TranslationsMoreItemsEn {
 	@override late final _TranslationsMoreItemsSettingsEs settings = _TranslationsMoreItemsSettingsEs._(_root);
 	@override late final _TranslationsMoreItemsAboutEs about = _TranslationsMoreItemsAboutEs._(_root);
 	@override late final _TranslationsMoreItemsVaultEs vault = _TranslationsMoreItemsVaultEs._(_root);
+	@override late final _TranslationsMoreItemsLoopsEs loops = _TranslationsMoreItemsLoopsEs._(_root);
 }
 
 // Path: activity.filter
@@ -3031,6 +3081,102 @@ class _TranslationsSettingsServerSettingsEs extends TranslationsSettingsServerSe
 	@override String validateInteger({required Object field}) => '"${field}" debe ser un entero';
 	@override String validateNumber({required Object field}) => '"${field}" debe ser un número';
 	@override late final _TranslationsSettingsServerSettingsEmbedderModelEs embedderModel = _TranslationsSettingsServerSettingsEmbedderModelEs._(_root);
+}
+
+// Path: loops.kind
+class _TranslationsLoopsKindEs extends TranslationsLoopsKindEn {
+	_TranslationsLoopsKindEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get goal => 'Objetivo';
+	@override String get interval => 'Intervalo';
+}
+
+// Path: loops.kindHint
+class _TranslationsLoopsKindHintEs extends TranslationsLoopsKindHintEn {
+	_TranslationsLoopsKindHintEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get goal => 'ejecutar hasta que un evaluador confirme el objetivo';
+	@override String get interval => 'reenviar el prompt cada N segundos';
+}
+
+// Path: loops.status
+class _TranslationsLoopsStatusEs extends TranslationsLoopsStatusEn {
+	_TranslationsLoopsStatusEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get pending => 'Pendiente';
+	@override String get running => 'En ejecución';
+	@override String get paused => 'Pausado';
+	@override String get done => 'Completado';
+	@override String get stopped => 'Detenido';
+	@override String get failed => 'Fallido';
+	@override String get escalated => 'Escalado';
+}
+
+// Path: loops.origin
+class _TranslationsLoopsOriginEs extends TranslationsLoopsOriginEn {
+	_TranslationsLoopsOriginEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get integration => 'Integración';
+}
+
+// Path: loops.action
+class _TranslationsLoopsActionEs extends TranslationsLoopsActionEn {
+	_TranslationsLoopsActionEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get pause => 'Pausar';
+	@override String get resume => 'Reanudar';
+	@override String get stop => 'Detener';
+	@override String get details => 'Detalles';
+	@override String get cancel => 'Cancelar';
+	@override String get create => 'Crear';
+}
+
+// Path: loops.field
+class _TranslationsLoopsFieldEs extends TranslationsLoopsFieldEn {
+	_TranslationsLoopsFieldEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get session => 'ID de sesión';
+	@override String get sessionPlaceholder => 'la sesión que controla este bucle';
+	@override String get kind => 'Tipo';
+	@override String get goal => 'Objetivo';
+	@override String get goalPlaceholder => 'qué debe lograr el bucle';
+	@override String get seedPrompt => 'Prompt inicial';
+	@override String get prompt => 'Prompt';
+	@override String get promptPlaceholder => 'la instrucción enviada al agente';
+	@override String get intervalSeconds => 'Intervalo (segundos)';
+	@override String get maxIterations => 'Iteraciones máximas';
+	@override String get durationMinutes => 'Fecha límite (minutos)';
+	@override String get failureCap => 'Límite de fallos';
+}
+
+// Path: loops.runs
+class _TranslationsLoopsRunsEs extends TranslationsLoopsRunsEn {
+	_TranslationsLoopsRunsEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Iteraciones';
+	@override String get empty => 'Aún no hay iteraciones.';
+	@override String iteration({required Object n}) => 'Iteración ${n}';
 }
 
 // Path: web.sessions.list
@@ -5819,6 +5965,102 @@ class _TranslationsWebCortexSettingsEs extends TranslationsWebCortexSettingsEn {
 	@override late final _TranslationsWebCortexSettingsInjectionEs injection = _TranslationsWebCortexSettingsInjectionEs._(_root);
 }
 
+// Path: web.loops.kind
+class _TranslationsWebLoopsKindEs extends TranslationsWebLoopsKindEn {
+	_TranslationsWebLoopsKindEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get goal => 'Objetivo';
+	@override String get interval => 'Intervalo';
+}
+
+// Path: web.loops.kindHint
+class _TranslationsWebLoopsKindHintEs extends TranslationsWebLoopsKindHintEn {
+	_TranslationsWebLoopsKindHintEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get goal => 'ejecutar hasta que un evaluador confirme el objetivo';
+	@override String get interval => 'reenviar el prompt cada N segundos';
+}
+
+// Path: web.loops.status
+class _TranslationsWebLoopsStatusEs extends TranslationsWebLoopsStatusEn {
+	_TranslationsWebLoopsStatusEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get pending => 'Pendiente';
+	@override String get running => 'En ejecución';
+	@override String get paused => 'Pausado';
+	@override String get done => 'Completado';
+	@override String get stopped => 'Detenido';
+	@override String get failed => 'Fallido';
+	@override String get escalated => 'Escalado';
+}
+
+// Path: web.loops.origin
+class _TranslationsWebLoopsOriginEs extends TranslationsWebLoopsOriginEn {
+	_TranslationsWebLoopsOriginEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get integration => 'Integración';
+}
+
+// Path: web.loops.action
+class _TranslationsWebLoopsActionEs extends TranslationsWebLoopsActionEn {
+	_TranslationsWebLoopsActionEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get pause => 'Pausar';
+	@override String get resume => 'Reanudar';
+	@override String get stop => 'Detener';
+	@override String get details => 'Detalles';
+	@override String get cancel => 'Cancelar';
+	@override String get create => 'Crear';
+}
+
+// Path: web.loops.field
+class _TranslationsWebLoopsFieldEs extends TranslationsWebLoopsFieldEn {
+	_TranslationsWebLoopsFieldEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get session => 'ID de sesión';
+	@override String get sessionPlaceholder => 'la sesión que controla este bucle';
+	@override String get kind => 'Tipo';
+	@override String get goal => 'Objetivo';
+	@override String get goalPlaceholder => 'qué debe lograr el bucle';
+	@override String get seedPrompt => 'Prompt inicial';
+	@override String get prompt => 'Prompt';
+	@override String get promptPlaceholder => 'la instrucción enviada al agente';
+	@override String get intervalSeconds => 'Intervalo (segundos)';
+	@override String get maxIterations => 'Iteraciones máximas';
+	@override String get durationMinutes => 'Fecha límite (minutos)';
+	@override String get failureCap => 'Límite de fallos';
+}
+
+// Path: web.loops.runs
+class _TranslationsWebLoopsRunsEs extends TranslationsWebLoopsRunsEn {
+	_TranslationsWebLoopsRunsEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Iteraciones';
+	@override String get empty => 'Aún no hay iteraciones.';
+	@override String iteration({required Object n}) => 'Iteración ${n}';
+}
+
 // Path: more.items.integrations
 class _TranslationsMoreItemsIntegrationsEs extends TranslationsMoreItemsIntegrationsEn {
 	_TranslationsMoreItemsIntegrationsEs._(TranslationsEs root) : this._root = root, super.internal(root);
@@ -6015,6 +6257,17 @@ class _TranslationsMoreItemsVaultEs extends TranslationsMoreItemsVaultEn {
 	// Translations
 	@override String get title => 'Bóveda';
 	@override String get subtitle => 'Notas markdown libres (sincronización Obsidian)';
+}
+
+// Path: more.items.loops
+class _TranslationsMoreItemsLoopsEs extends TranslationsMoreItemsLoopsEn {
+	_TranslationsMoreItemsLoopsEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Bucles';
+	@override String get subtitle => 'Bucles de agente autónomos';
 }
 
 // Path: sessions.detail.accountSwitcher
@@ -8998,6 +9251,7 @@ extension on TranslationsEs {
 			'nav.vault' => 'Bóveda',
 			'nav.cortex' => 'Cortex',
 			'nav.updateAvailable' => 'Actualización disponible',
+			'nav.loops' => 'Bucles',
 			'web.brand' => 'opendray',
 			'web.loading' => 'Cargando…',
 			'web.topbar.expandSidebar' => 'Expandir barra lateral',
@@ -9470,9 +9724,9 @@ extension on TranslationsEs {
 			'web.project.reset.alsoDeleteMemoriesLabel' => 'Eliminar también las memorias de pgvector',
 			'web.project.reset.alsoDeleteMemoriesSuffix' => 'para este scope_key.',
 			'web.project.reset.alsoDeleteMemoriesHint' => 'Hechos a largo plazo que el agente almacenó (preferencias del usuario, datos del proyecto). No se pueden recuperar.',
-			'web.project.reset.cancel' => 'Cancelar',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.reset.cancel' => 'Cancelar',
 			'web.project.reset.deleteForever' => 'Eliminar para siempre',
 			'web.project.reset.successToast' => ({required Object summary}) => 'Restablecido: se eliminó ${summary}',
 			'web.project.reset.summary.docs_one' => ({required Object count}) => '${count} documento',
@@ -9984,9 +10238,9 @@ extension on TranslationsEs {
 			'web.channels.bridge.nameLabel' => 'Nombre del bridge',
 			'web.channels.bridge.namePlaceholder' => 'wechat / discord-custom / whatsapp...',
 			'web.channels.bridge.nameHint' => 'Etiqueta legible para el adaptador. Se muestra en la lista de canales.',
-			'web.channels.bridge.tokenLabel' => 'Token del adaptador',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.bridge.tokenLabel' => 'Token del adaptador',
 			'web.channels.bridge.regenerateTooltip' => 'Regenerar',
 			'web.channels.bridge.copyTooltip' => 'Copiar',
 			'web.channels.bridge.tokenCopiedToast' => 'Token copiado',
@@ -10498,9 +10752,9 @@ extension on TranslationsEs {
 			'web.backups.targetEditor.smb.hostLabel' => 'Host',
 			'web.backups.targetEditor.smb.hostPlaceholder' => '192.168.1.20',
 			'web.backups.targetEditor.smb.portLabel' => 'Puerto',
-			'web.backups.targetEditor.smb.shareLabel' => 'Recurso compartido',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.targetEditor.smb.shareLabel' => 'Recurso compartido',
 			'web.backups.targetEditor.smb.shareHint' => 'Nombre del recurso compartido de nivel superior en el servidor SMB',
 			'web.backups.targetEditor.smb.sharePlaceholder' => 'Claude_Workspace',
 			'web.backups.targetEditor.smb.userLabel' => 'Usuario',
@@ -11012,9 +11266,9 @@ extension on TranslationsEs {
 			'web.export.form.memories' => 'Memorias',
 			'web.export.form.memoriesHint' => 'Filas de memoria persistente entre CLI (texto + alcance + metadatos). Los vectores de embedding se omiten; el importador vuelve a generarlos.',
 			'web.export.form.integrations' => 'Integraciones',
-			'web.export.form.customTasks' => 'Tareas personalizadas',
 			_ => null,
 		} ?? switch (path) {
+			'web.export.form.customTasks' => 'Tareas personalizadas',
 			'web.export.form.customTasksHint' => 'Tareas definidas por el operador que se muestran en la pestaña Tareas del Inspector.',
 			'web.export.form.integrationOptions.none' => 'Ninguna',
 			'web.export.form.integrationOptions.noneHint' => 'Omitir por completo la tabla de integraciones.',
@@ -11304,6 +11558,46 @@ extension on TranslationsEs {
 			'web.cortex.settings.injection.savedToast' => 'Modo guardado — las sesiones nuevas lo usan de inmediato (sin reiniciar el backend)',
 			'web.cortex.settings.injection.saveFailed' => 'Error al guardar',
 			'web.cortex.settings.injection.note' => 'En modo completo siguen aplicando los flags de inyección por sección/página; en modo ligero las reglas fundacionales siempre se inyectan y el resto va al índice.',
+			'web.loops.title' => 'Bucles',
+			'web.loops.subtitle' => 'Bucles de agente autónomos: ejecuta una sesión por intervalo o hasta cumplir un objetivo.',
+			'web.loops.create' => 'Crear bucle',
+			'web.loops.createHint' => 'El bucle controla una sesión existente. Se requiere una fecha límite.',
+			'web.loops.empty' => 'Aún no hay bucles. Crea uno para controlar una sesión de forma autónoma.',
+			'web.loops.createdToast' => 'Bucle creado',
+			'web.loops.kind.goal' => 'Objetivo',
+			'web.loops.kind.interval' => 'Intervalo',
+			'web.loops.kindHint.goal' => 'ejecutar hasta que un evaluador confirme el objetivo',
+			'web.loops.kindHint.interval' => 'reenviar el prompt cada N segundos',
+			'web.loops.status.pending' => 'Pendiente',
+			'web.loops.status.running' => 'En ejecución',
+			'web.loops.status.paused' => 'Pausado',
+			'web.loops.status.done' => 'Completado',
+			'web.loops.status.stopped' => 'Detenido',
+			'web.loops.status.failed' => 'Fallido',
+			'web.loops.status.escalated' => 'Escalado',
+			'web.loops.origin.integration' => 'Integración',
+			'web.loops.iterationOf' => ({required Object n, required Object max}) => '${n} / ${max}',
+			'web.loops.action.pause' => 'Pausar',
+			'web.loops.action.resume' => 'Reanudar',
+			'web.loops.action.stop' => 'Detener',
+			'web.loops.action.details' => 'Detalles',
+			'web.loops.action.cancel' => 'Cancelar',
+			'web.loops.action.create' => 'Crear',
+			'web.loops.field.session' => 'ID de sesión',
+			'web.loops.field.sessionPlaceholder' => 'la sesión que controla este bucle',
+			'web.loops.field.kind' => 'Tipo',
+			'web.loops.field.goal' => 'Objetivo',
+			'web.loops.field.goalPlaceholder' => 'qué debe lograr el bucle',
+			'web.loops.field.seedPrompt' => 'Prompt inicial',
+			'web.loops.field.prompt' => 'Prompt',
+			'web.loops.field.promptPlaceholder' => 'la instrucción enviada al agente',
+			'web.loops.field.intervalSeconds' => 'Intervalo (segundos)',
+			'web.loops.field.maxIterations' => 'Iteraciones máximas',
+			'web.loops.field.durationMinutes' => 'Fecha límite (minutos)',
+			'web.loops.field.failureCap' => 'Límite de fallos',
+			'web.loops.runs.title' => 'Iteraciones',
+			'web.loops.runs.empty' => 'Aún no hay iteraciones.',
+			'web.loops.runs.iteration' => ({required Object n}) => 'Iteración ${n}',
 			'more.title' => 'Más',
 			'more.identity.signedInAs' => 'Sesión iniciada como',
 			'more.identity.server' => 'Servidor',
@@ -11348,6 +11642,8 @@ extension on TranslationsEs {
 			'more.items.about.subtitle' => 'Versión de compilación e información del servidor',
 			'more.items.vault.title' => 'Bóveda',
 			'more.items.vault.subtitle' => 'Notas markdown libres (sincronización Obsidian)',
+			'more.items.loops.title' => 'Bucles',
+			'more.items.loops.subtitle' => 'Bucles de agente autónomos',
 			'more.signOut' => 'Cerrar sesión',
 			'activity.title' => 'Actividad',
 			'activity.empty' => 'Aún no hay llamadas de integración registradas.',
@@ -11484,6 +11780,8 @@ extension on TranslationsEs {
 			'sessions.dirPicker.dialog.title' => 'Nueva carpeta',
 			'sessions.dirPicker.dialog.hint' => 'Nombre de la carpeta',
 			'sessions.dirPicker.dialog.create' => 'Crear',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.shell.title' => 'Inspector',
 			'sessions.inspector.shell.loadError' => ({required Object error}) => 'No se pudo cargar la sesión: ${error}',
 			'sessions.inspector.shell.tabs.files' => 'Archivos',
@@ -11527,8 +11825,6 @@ extension on TranslationsEs {
 			'sessions.inspector.tasks.filterHint' => 'Filtrar tareas…',
 			'sessions.inspector.tasks.noMatch' => ({required Object query}) => 'Ninguna tarea coincide con "${query}"',
 			'sessions.inspector.tasks.emptyTitle' => 'No hay tareas en esta carpeta',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.tasks.emptyHint' => 'Buscando package.json, Makefile, Taskfile, justfile, Cargo.toml, go.mod, pyproject.toml o scripts de shell',
 			'sessions.inspector.notes.insertedAt' => ({required Object path}) => 'Insertado: @${path}',
 			'sessions.inspector.notes.myNotes' => 'Mis notas',
@@ -11998,6 +12294,8 @@ extension on TranslationsEs {
 			'backups.kv.started' => 'Iniciado',
 			'backups.kv.finished' => 'Finalizado',
 			'backups.kv.size' => 'Tamaño',
+			_ => null,
+		} ?? switch (path) {
 			'backups.kv.encrypted' => 'Cifrado',
 			'backups.kv.targetPath' => 'Ruta de destino',
 			'backups.kv.error' => 'Error',
@@ -12041,8 +12339,6 @@ extension on TranslationsEs {
 			'backups.health.never' => 'nunca',
 			'backups.health.tiles.recentFailures' => 'Fallos recientes',
 			'backups.health.tiles.verifyFailures' => 'Verificación fallida',
-			_ => null,
-		} ?? switch (path) {
 			'backups.health.tiles.overdue' => 'Atrasadas',
 			'backups.health.tiles.schedules' => 'Programaciones',
 			'backups.failedToLoad' => 'Error al cargar las copias de seguridad',
@@ -12512,6 +12808,8 @@ extension on TranslationsEs {
 			'dataExport.history.columns.scope' => 'Alcance',
 			'dataExport.history.columns.size' => 'Tamaño',
 			'dataExport.history.columns.expires' => 'Caduca',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.history.columns.actions' => 'Acciones',
 			'dataExport.history.scopeEmpty' => '(vacío)',
 			'dataExport.history.scopeMemories' => 'memorias',
@@ -12555,8 +12853,6 @@ extension on TranslationsEs {
 			'dataExport.relative.secondsAgo' => ({required Object n}) => 'hace ${n}s',
 			'dataExport.relative.minutesAgo' => ({required Object n}) => 'hace ${n}m',
 			'dataExport.relative.hoursAgo' => ({required Object n}) => 'hace ${n}h',
-			_ => null,
-		} ?? switch (path) {
 			'dataExport.status.pending' => 'pendiente',
 			'dataExport.status.running' => 'en ejecución',
 			'dataExport.status.ready' => 'listo',
@@ -12843,6 +13139,46 @@ extension on TranslationsEs {
 			'cortexSettings.providersManageOnWeb' => 'Añade o edita proveedores en el panel web.',
 			'cortexSettings.providersLoadFailed' => 'Error al cargar proveedores',
 			'cortexSettings.defaultBadge' => 'predeterminado',
+			'loops.title' => 'Bucles',
+			'loops.subtitle' => 'Bucles de agente autónomos: ejecuta una sesión por intervalo o hasta cumplir un objetivo.',
+			'loops.create' => 'Crear bucle',
+			'loops.createHint' => 'El bucle controla una sesión existente. Se requiere una fecha límite.',
+			'loops.empty' => 'Aún no hay bucles. Crea uno para controlar una sesión de forma autónoma.',
+			'loops.createdToast' => 'Bucle creado',
+			'loops.kind.goal' => 'Objetivo',
+			'loops.kind.interval' => 'Intervalo',
+			'loops.kindHint.goal' => 'ejecutar hasta que un evaluador confirme el objetivo',
+			'loops.kindHint.interval' => 'reenviar el prompt cada N segundos',
+			'loops.status.pending' => 'Pendiente',
+			'loops.status.running' => 'En ejecución',
+			'loops.status.paused' => 'Pausado',
+			'loops.status.done' => 'Completado',
+			'loops.status.stopped' => 'Detenido',
+			'loops.status.failed' => 'Fallido',
+			'loops.status.escalated' => 'Escalado',
+			'loops.origin.integration' => 'Integración',
+			'loops.iterationOf' => ({required Object n, required Object max}) => '${n} / ${max}',
+			'loops.action.pause' => 'Pausar',
+			'loops.action.resume' => 'Reanudar',
+			'loops.action.stop' => 'Detener',
+			'loops.action.details' => 'Detalles',
+			'loops.action.cancel' => 'Cancelar',
+			'loops.action.create' => 'Crear',
+			'loops.field.session' => 'ID de sesión',
+			'loops.field.sessionPlaceholder' => 'la sesión que controla este bucle',
+			'loops.field.kind' => 'Tipo',
+			'loops.field.goal' => 'Objetivo',
+			'loops.field.goalPlaceholder' => 'qué debe lograr el bucle',
+			'loops.field.seedPrompt' => 'Prompt inicial',
+			'loops.field.prompt' => 'Prompt',
+			'loops.field.promptPlaceholder' => 'la instrucción enviada al agente',
+			'loops.field.intervalSeconds' => 'Intervalo (segundos)',
+			'loops.field.maxIterations' => 'Iteraciones máximas',
+			'loops.field.durationMinutes' => 'Fecha límite (minutos)',
+			'loops.field.failureCap' => 'Límite de fallos',
+			'loops.runs.title' => 'Iteraciones',
+			'loops.runs.empty' => 'Aún no hay iteraciones.',
+			'loops.runs.iteration' => ({required Object n}) => 'Iteración ${n}',
 			_ => null,
 		};
 	}

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -70,6 +70,7 @@ class TranslationsZh extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsMemoryQuarantineZh memoryQuarantine = _TranslationsMemoryQuarantineZh._(_root);
 	@override late final _TranslationsCortexHubZh cortexHub = _TranslationsCortexHubZh._(_root);
 	@override late final _TranslationsCortexSettingsZh cortexSettings = _TranslationsCortexSettingsZh._(_root);
+	@override late final _TranslationsLoopsZh loops = _TranslationsLoopsZh._(_root);
 }
 
 // Path: common
@@ -136,6 +137,7 @@ class _TranslationsNavZh extends TranslationsNavEn {
 	@override String get vault => '文档库';
 	@override String get cortex => '心智中枢';
 	@override String get updateAvailable => '有可用更新';
+	@override String get loops => '循环';
 }
 
 // Path: web
@@ -174,6 +176,7 @@ class _TranslationsWebZh extends TranslationsWebEn {
 	@override late final _TranslationsWebExportZh export = _TranslationsWebExportZh._(_root);
 	@override late final _TranslationsWebKnowledgeZh knowledge = _TranslationsWebKnowledgeZh._(_root);
 	@override late final _TranslationsWebCortexZh cortex = _TranslationsWebCortexZh._(_root);
+	@override late final _TranslationsWebLoopsZh loops = _TranslationsWebLoopsZh._(_root);
 }
 
 // Path: more
@@ -1043,6 +1046,29 @@ class _TranslationsCortexSettingsZh extends TranslationsCortexSettingsEn {
 	@override String get defaultBadge => '默认';
 }
 
+// Path: loops
+class _TranslationsLoopsZh extends TranslationsLoopsEn {
+	_TranslationsLoopsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '循环';
+	@override String get subtitle => '自主 agent 循环 —— 按间隔运行 session,或跑到目标达成。';
+	@override String get create => '创建循环';
+	@override String get createHint => '循环驱动一个已有 session,必须设置截止时间。';
+	@override String get empty => '还没有循环。创建一个来自主驱动 session。';
+	@override String get createdToast => '已创建循环';
+	@override late final _TranslationsLoopsKindZh kind = _TranslationsLoopsKindZh._(_root);
+	@override late final _TranslationsLoopsKindHintZh kindHint = _TranslationsLoopsKindHintZh._(_root);
+	@override late final _TranslationsLoopsStatusZh status = _TranslationsLoopsStatusZh._(_root);
+	@override late final _TranslationsLoopsOriginZh origin = _TranslationsLoopsOriginZh._(_root);
+	@override String iterationOf({required Object n, required Object max}) => '${n} / ${max}';
+	@override late final _TranslationsLoopsActionZh action = _TranslationsLoopsActionZh._(_root);
+	@override late final _TranslationsLoopsFieldZh field = _TranslationsLoopsFieldZh._(_root);
+	@override late final _TranslationsLoopsRunsZh runs = _TranslationsLoopsRunsZh._(_root);
+}
+
 // Path: web.topbar
 class _TranslationsWebTopbarZh extends TranslationsWebTopbarEn {
 	_TranslationsWebTopbarZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -1676,6 +1702,29 @@ class _TranslationsWebCortexZh extends TranslationsWebCortexEn {
 	@override late final _TranslationsWebCortexSettingsZh settings = _TranslationsWebCortexSettingsZh._(_root);
 }
 
+// Path: web.loops
+class _TranslationsWebLoopsZh extends TranslationsWebLoopsEn {
+	_TranslationsWebLoopsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '循环';
+	@override String get subtitle => '自主 agent 循环 —— 按间隔运行 session,或跑到目标达成。';
+	@override String get create => '创建循环';
+	@override String get createHint => '循环驱动一个已有 session,必须设置截止时间。';
+	@override String get empty => '还没有循环。创建一个来自主驱动 session。';
+	@override String get createdToast => '已创建循环';
+	@override late final _TranslationsWebLoopsKindZh kind = _TranslationsWebLoopsKindZh._(_root);
+	@override late final _TranslationsWebLoopsKindHintZh kindHint = _TranslationsWebLoopsKindHintZh._(_root);
+	@override late final _TranslationsWebLoopsStatusZh status = _TranslationsWebLoopsStatusZh._(_root);
+	@override late final _TranslationsWebLoopsOriginZh origin = _TranslationsWebLoopsOriginZh._(_root);
+	@override String iterationOf({required Object n, required Object max}) => '${n} / ${max}';
+	@override late final _TranslationsWebLoopsActionZh action = _TranslationsWebLoopsActionZh._(_root);
+	@override late final _TranslationsWebLoopsFieldZh field = _TranslationsWebLoopsFieldZh._(_root);
+	@override late final _TranslationsWebLoopsRunsZh runs = _TranslationsWebLoopsRunsZh._(_root);
+}
+
 // Path: more.identity
 class _TranslationsMoreIdentityZh extends TranslationsMoreIdentityEn {
 	_TranslationsMoreIdentityZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -1726,6 +1775,7 @@ class _TranslationsMoreItemsZh extends TranslationsMoreItemsEn {
 	@override late final _TranslationsMoreItemsSettingsZh settings = _TranslationsMoreItemsSettingsZh._(_root);
 	@override late final _TranslationsMoreItemsAboutZh about = _TranslationsMoreItemsAboutZh._(_root);
 	@override late final _TranslationsMoreItemsVaultZh vault = _TranslationsMoreItemsVaultZh._(_root);
+	@override late final _TranslationsMoreItemsLoopsZh loops = _TranslationsMoreItemsLoopsZh._(_root);
 }
 
 // Path: activity.filter
@@ -3031,6 +3081,102 @@ class _TranslationsSettingsServerSettingsZh extends TranslationsSettingsServerSe
 	@override String validateInteger({required Object field}) => '「${field}」必须是整数';
 	@override String validateNumber({required Object field}) => '「${field}」必须是数字';
 	@override late final _TranslationsSettingsServerSettingsEmbedderModelZh embedderModel = _TranslationsSettingsServerSettingsEmbedderModelZh._(_root);
+}
+
+// Path: loops.kind
+class _TranslationsLoopsKindZh extends TranslationsLoopsKindEn {
+	_TranslationsLoopsKindZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get goal => '目标';
+	@override String get interval => '定时';
+}
+
+// Path: loops.kindHint
+class _TranslationsLoopsKindHintZh extends TranslationsLoopsKindHintEn {
+	_TranslationsLoopsKindHintZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get goal => '跑到评审判定目标达成';
+	@override String get interval => '每隔 N 秒重发 prompt';
+}
+
+// Path: loops.status
+class _TranslationsLoopsStatusZh extends TranslationsLoopsStatusEn {
+	_TranslationsLoopsStatusZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get pending => '待启动';
+	@override String get running => '运行中';
+	@override String get paused => '已暂停';
+	@override String get done => '已完成';
+	@override String get stopped => '已停止';
+	@override String get failed => '失败';
+	@override String get escalated => '已升级';
+}
+
+// Path: loops.origin
+class _TranslationsLoopsOriginZh extends TranslationsLoopsOriginEn {
+	_TranslationsLoopsOriginZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get integration => '集成';
+}
+
+// Path: loops.action
+class _TranslationsLoopsActionZh extends TranslationsLoopsActionEn {
+	_TranslationsLoopsActionZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get pause => '暂停';
+	@override String get resume => '恢复';
+	@override String get stop => '停止';
+	@override String get details => '详情';
+	@override String get cancel => '取消';
+	@override String get create => '创建';
+}
+
+// Path: loops.field
+class _TranslationsLoopsFieldZh extends TranslationsLoopsFieldEn {
+	_TranslationsLoopsFieldZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get session => 'Session ID';
+	@override String get sessionPlaceholder => '该循环驱动的 session';
+	@override String get kind => '类型';
+	@override String get goal => '目标';
+	@override String get goalPlaceholder => '循环要达成什么';
+	@override String get seedPrompt => '初始 prompt';
+	@override String get prompt => 'Prompt';
+	@override String get promptPlaceholder => '发送给 agent 的指令';
+	@override String get intervalSeconds => '间隔(秒)';
+	@override String get maxIterations => '最大迭代数';
+	@override String get durationMinutes => '截止(分钟)';
+	@override String get failureCap => '失败上限';
+}
+
+// Path: loops.runs
+class _TranslationsLoopsRunsZh extends TranslationsLoopsRunsEn {
+	_TranslationsLoopsRunsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '迭代记录';
+	@override String get empty => '还没有迭代。';
+	@override String iteration({required Object n}) => '第 ${n} 轮';
 }
 
 // Path: web.sessions.list
@@ -5819,6 +5965,102 @@ class _TranslationsWebCortexSettingsZh extends TranslationsWebCortexSettingsEn {
 	@override late final _TranslationsWebCortexSettingsInjectionZh injection = _TranslationsWebCortexSettingsInjectionZh._(_root);
 }
 
+// Path: web.loops.kind
+class _TranslationsWebLoopsKindZh extends TranslationsWebLoopsKindEn {
+	_TranslationsWebLoopsKindZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get goal => '目标';
+	@override String get interval => '定时';
+}
+
+// Path: web.loops.kindHint
+class _TranslationsWebLoopsKindHintZh extends TranslationsWebLoopsKindHintEn {
+	_TranslationsWebLoopsKindHintZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get goal => '跑到评审判定目标达成';
+	@override String get interval => '每隔 N 秒重发 prompt';
+}
+
+// Path: web.loops.status
+class _TranslationsWebLoopsStatusZh extends TranslationsWebLoopsStatusEn {
+	_TranslationsWebLoopsStatusZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get pending => '待启动';
+	@override String get running => '运行中';
+	@override String get paused => '已暂停';
+	@override String get done => '已完成';
+	@override String get stopped => '已停止';
+	@override String get failed => '失败';
+	@override String get escalated => '已升级';
+}
+
+// Path: web.loops.origin
+class _TranslationsWebLoopsOriginZh extends TranslationsWebLoopsOriginEn {
+	_TranslationsWebLoopsOriginZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get integration => '集成';
+}
+
+// Path: web.loops.action
+class _TranslationsWebLoopsActionZh extends TranslationsWebLoopsActionEn {
+	_TranslationsWebLoopsActionZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get pause => '暂停';
+	@override String get resume => '恢复';
+	@override String get stop => '停止';
+	@override String get details => '详情';
+	@override String get cancel => '取消';
+	@override String get create => '创建';
+}
+
+// Path: web.loops.field
+class _TranslationsWebLoopsFieldZh extends TranslationsWebLoopsFieldEn {
+	_TranslationsWebLoopsFieldZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get session => 'Session ID';
+	@override String get sessionPlaceholder => '该循环驱动的 session';
+	@override String get kind => '类型';
+	@override String get goal => '目标';
+	@override String get goalPlaceholder => '循环要达成什么';
+	@override String get seedPrompt => '初始 prompt';
+	@override String get prompt => 'Prompt';
+	@override String get promptPlaceholder => '发送给 agent 的指令';
+	@override String get intervalSeconds => '间隔(秒)';
+	@override String get maxIterations => '最大迭代数';
+	@override String get durationMinutes => '截止(分钟)';
+	@override String get failureCap => '失败上限';
+}
+
+// Path: web.loops.runs
+class _TranslationsWebLoopsRunsZh extends TranslationsWebLoopsRunsEn {
+	_TranslationsWebLoopsRunsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '迭代记录';
+	@override String get empty => '还没有迭代。';
+	@override String iteration({required Object n}) => '第 ${n} 轮';
+}
+
 // Path: more.items.integrations
 class _TranslationsMoreItemsIntegrationsZh extends TranslationsMoreItemsIntegrationsEn {
 	_TranslationsMoreItemsIntegrationsZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -6015,6 +6257,17 @@ class _TranslationsMoreItemsVaultZh extends TranslationsMoreItemsVaultEn {
 	// Translations
 	@override String get title => '文档库';
 	@override String get subtitle => '自由 markdown 笔记(Obsidian 同步)';
+}
+
+// Path: more.items.loops
+class _TranslationsMoreItemsLoopsZh extends TranslationsMoreItemsLoopsEn {
+	_TranslationsMoreItemsLoopsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '循环';
+	@override String get subtitle => '自主 agent 循环';
 }
 
 // Path: sessions.detail.accountSwitcher
@@ -8998,6 +9251,7 @@ extension on TranslationsZh {
 			'nav.vault' => '文档库',
 			'nav.cortex' => '心智中枢',
 			'nav.updateAvailable' => '有可用更新',
+			'nav.loops' => '循环',
 			'web.brand' => 'opendray',
 			'web.loading' => '加载中…',
 			'web.topbar.expandSidebar' => '展开侧边栏',
@@ -9470,9 +9724,9 @@ extension on TranslationsZh {
 			'web.project.reset.alsoDeleteMemoriesLabel' => '同时删除 pgvector 记忆',
 			'web.project.reset.alsoDeleteMemoriesSuffix' => '（该 scope_key 下的）。',
 			'web.project.reset.alsoDeleteMemoriesHint' => 'Agent 存储的长期事实（用户偏好、项目事实）。无法恢复。',
-			'web.project.reset.cancel' => '取消',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.reset.cancel' => '取消',
 			'web.project.reset.deleteForever' => '永久删除',
 			'web.project.reset.successToast' => ({required Object summary}) => '重置：已删除 ${summary}',
 			'web.project.reset.summary.docs_one' => ({required Object count}) => '${count} 份文档',
@@ -9984,9 +10238,9 @@ extension on TranslationsZh {
 			'web.channels.bridge.nameLabel' => 'Bridge 名称',
 			'web.channels.bridge.namePlaceholder' => 'wechat / discord-custom / whatsapp...',
 			'web.channels.bridge.nameHint' => '适配器的人类可读标签。会显示在频道列表中。',
-			'web.channels.bridge.tokenLabel' => '适配器 token',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.bridge.tokenLabel' => '适配器 token',
 			'web.channels.bridge.regenerateTooltip' => '重新生成',
 			'web.channels.bridge.copyTooltip' => '复制',
 			'web.channels.bridge.tokenCopiedToast' => '已复制 token',
@@ -10498,9 +10752,9 @@ extension on TranslationsZh {
 			'web.backups.targetEditor.smb.hostLabel' => '主机',
 			'web.backups.targetEditor.smb.hostPlaceholder' => '192.168.1.20',
 			'web.backups.targetEditor.smb.portLabel' => '端口',
-			'web.backups.targetEditor.smb.shareLabel' => 'Share',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.targetEditor.smb.shareLabel' => 'Share',
 			'web.backups.targetEditor.smb.shareHint' => 'SMB 服务器上的顶层共享名',
 			'web.backups.targetEditor.smb.sharePlaceholder' => 'Claude_Workspace',
 			'web.backups.targetEditor.smb.userLabel' => '用户',
@@ -11012,9 +11266,9 @@ extension on TranslationsZh {
 			'web.export.form.memories' => '记忆',
 			'web.export.form.memoriesHint' => '跨 CLI 持久化的记忆行（text + scope + metadata）。向量被省略；导入端重嵌入。',
 			'web.export.form.integrations' => '集成',
-			'web.export.form.customTasks' => '自定义任务',
 			_ => null,
 		} ?? switch (path) {
+			'web.export.form.customTasks' => '自定义任务',
 			'web.export.form.customTasksHint' => '在 Inspector 的 Tasks 标签里展示的运维自定义任务。',
 			'web.export.form.integrationOptions.none' => '无',
 			'web.export.form.integrationOptions.noneHint' => '完全跳过 integrations 表。',
@@ -11304,6 +11558,46 @@ extension on TranslationsZh {
 			'web.cortex.settings.injection.savedToast' => '注入模式已保存——新建会话立即采用，后端无需重启',
 			'web.cortex.settings.injection.saveFailed' => '保存失败',
 			'web.cortex.settings.injection.note' => '完整模式下章节/知识页各自的注入开关（蓝图编辑器 / 知识页）仍然生效；精简模式下基础方针始终注入，其余一律走索引。',
+			'web.loops.title' => '循环',
+			'web.loops.subtitle' => '自主 agent 循环 —— 按间隔运行 session,或跑到目标达成。',
+			'web.loops.create' => '创建循环',
+			'web.loops.createHint' => '循环驱动一个已有 session,必须设置截止时间。',
+			'web.loops.empty' => '还没有循环。创建一个来自主驱动 session。',
+			'web.loops.createdToast' => '已创建循环',
+			'web.loops.kind.goal' => '目标',
+			'web.loops.kind.interval' => '定时',
+			'web.loops.kindHint.goal' => '跑到评审判定目标达成',
+			'web.loops.kindHint.interval' => '每隔 N 秒重发 prompt',
+			'web.loops.status.pending' => '待启动',
+			'web.loops.status.running' => '运行中',
+			'web.loops.status.paused' => '已暂停',
+			'web.loops.status.done' => '已完成',
+			'web.loops.status.stopped' => '已停止',
+			'web.loops.status.failed' => '失败',
+			'web.loops.status.escalated' => '已升级',
+			'web.loops.origin.integration' => '集成',
+			'web.loops.iterationOf' => ({required Object n, required Object max}) => '${n} / ${max}',
+			'web.loops.action.pause' => '暂停',
+			'web.loops.action.resume' => '恢复',
+			'web.loops.action.stop' => '停止',
+			'web.loops.action.details' => '详情',
+			'web.loops.action.cancel' => '取消',
+			'web.loops.action.create' => '创建',
+			'web.loops.field.session' => 'Session ID',
+			'web.loops.field.sessionPlaceholder' => '该循环驱动的 session',
+			'web.loops.field.kind' => '类型',
+			'web.loops.field.goal' => '目标',
+			'web.loops.field.goalPlaceholder' => '循环要达成什么',
+			'web.loops.field.seedPrompt' => '初始 prompt',
+			'web.loops.field.prompt' => 'Prompt',
+			'web.loops.field.promptPlaceholder' => '发送给 agent 的指令',
+			'web.loops.field.intervalSeconds' => '间隔(秒)',
+			'web.loops.field.maxIterations' => '最大迭代数',
+			'web.loops.field.durationMinutes' => '截止(分钟)',
+			'web.loops.field.failureCap' => '失败上限',
+			'web.loops.runs.title' => '迭代记录',
+			'web.loops.runs.empty' => '还没有迭代。',
+			'web.loops.runs.iteration' => ({required Object n}) => '第 ${n} 轮',
 			'more.title' => '更多',
 			'more.identity.signedInAs' => '登录账号',
 			'more.identity.server' => '服务器',
@@ -11348,6 +11642,8 @@ extension on TranslationsZh {
 			'more.items.about.subtitle' => '构建版本与服务器信息',
 			'more.items.vault.title' => '文档库',
 			'more.items.vault.subtitle' => '自由 markdown 笔记(Obsidian 同步)',
+			'more.items.loops.title' => '循环',
+			'more.items.loops.subtitle' => '自主 agent 循环',
 			'more.signOut' => '退出登录',
 			'activity.title' => '活动',
 			'activity.empty' => '暂无集成调用记录。',
@@ -11484,6 +11780,8 @@ extension on TranslationsZh {
 			'sessions.dirPicker.dialog.title' => '新建文件夹',
 			'sessions.dirPicker.dialog.hint' => '文件夹名',
 			'sessions.dirPicker.dialog.create' => '创建',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.shell.title' => '检查器',
 			'sessions.inspector.shell.loadError' => ({required Object error}) => '加载会话失败：${error}',
 			'sessions.inspector.shell.tabs.files' => '文件',
@@ -11527,8 +11825,6 @@ extension on TranslationsZh {
 			'sessions.inspector.tasks.filterHint' => '筛选任务…',
 			'sessions.inspector.tasks.noMatch' => ({required Object query}) => '没有匹配“${query}”的任务',
 			'sessions.inspector.tasks.emptyTitle' => '此目录没有任务',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.tasks.emptyHint' => '正在查找 package.json、Makefile、Taskfile、justfile、Cargo.toml、go.mod、pyproject.toml 或 shell 脚本',
 			'sessions.inspector.notes.insertedAt' => ({required Object path}) => '已插入：@${path}',
 			'sessions.inspector.notes.myNotes' => '我的笔记',
@@ -11998,6 +12294,8 @@ extension on TranslationsZh {
 			'backups.kv.started' => '开始',
 			'backups.kv.finished' => '完成',
 			'backups.kv.size' => '大小',
+			_ => null,
+		} ?? switch (path) {
 			'backups.kv.encrypted' => '已加密',
 			'backups.kv.targetPath' => '目标路径',
 			'backups.kv.error' => '错误',
@@ -12041,8 +12339,6 @@ extension on TranslationsZh {
 			'backups.health.never' => '从未',
 			'backups.health.tiles.recentFailures' => '近期失败',
 			'backups.health.tiles.verifyFailures' => '校验失败',
-			_ => null,
-		} ?? switch (path) {
 			'backups.health.tiles.overdue' => '逾期',
 			'backups.health.tiles.schedules' => '计划',
 			'backups.failedToLoad' => '加载备份失败',
@@ -12512,6 +12808,8 @@ extension on TranslationsZh {
 			'dataExport.history.columns.scope' => '范围',
 			'dataExport.history.columns.size' => '大小',
 			'dataExport.history.columns.expires' => '过期',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.history.columns.actions' => '操作',
 			'dataExport.history.scopeEmpty' => '（空）',
 			'dataExport.history.scopeMemories' => '记忆',
@@ -12555,8 +12853,6 @@ extension on TranslationsZh {
 			'dataExport.relative.secondsAgo' => ({required Object n}) => '${n} 秒前',
 			'dataExport.relative.minutesAgo' => ({required Object n}) => '${n} 分钟前',
 			'dataExport.relative.hoursAgo' => ({required Object n}) => '${n} 小时前',
-			_ => null,
-		} ?? switch (path) {
 			'dataExport.status.pending' => '等待',
 			'dataExport.status.running' => '运行中',
 			'dataExport.status.ready' => '就绪',
@@ -12843,6 +13139,46 @@ extension on TranslationsZh {
 			'cortexSettings.providersManageOnWeb' => '在 web 管理端添加或编辑 provider。',
 			'cortexSettings.providersLoadFailed' => '加载 provider 失败',
 			'cortexSettings.defaultBadge' => '默认',
+			'loops.title' => '循环',
+			'loops.subtitle' => '自主 agent 循环 —— 按间隔运行 session,或跑到目标达成。',
+			'loops.create' => '创建循环',
+			'loops.createHint' => '循环驱动一个已有 session,必须设置截止时间。',
+			'loops.empty' => '还没有循环。创建一个来自主驱动 session。',
+			'loops.createdToast' => '已创建循环',
+			'loops.kind.goal' => '目标',
+			'loops.kind.interval' => '定时',
+			'loops.kindHint.goal' => '跑到评审判定目标达成',
+			'loops.kindHint.interval' => '每隔 N 秒重发 prompt',
+			'loops.status.pending' => '待启动',
+			'loops.status.running' => '运行中',
+			'loops.status.paused' => '已暂停',
+			'loops.status.done' => '已完成',
+			'loops.status.stopped' => '已停止',
+			'loops.status.failed' => '失败',
+			'loops.status.escalated' => '已升级',
+			'loops.origin.integration' => '集成',
+			'loops.iterationOf' => ({required Object n, required Object max}) => '${n} / ${max}',
+			'loops.action.pause' => '暂停',
+			'loops.action.resume' => '恢复',
+			'loops.action.stop' => '停止',
+			'loops.action.details' => '详情',
+			'loops.action.cancel' => '取消',
+			'loops.action.create' => '创建',
+			'loops.field.session' => 'Session ID',
+			'loops.field.sessionPlaceholder' => '该循环驱动的 session',
+			'loops.field.kind' => '类型',
+			'loops.field.goal' => '目标',
+			'loops.field.goalPlaceholder' => '循环要达成什么',
+			'loops.field.seedPrompt' => '初始 prompt',
+			'loops.field.prompt' => 'Prompt',
+			'loops.field.promptPlaceholder' => '发送给 agent 的指令',
+			'loops.field.intervalSeconds' => '间隔(秒)',
+			'loops.field.maxIterations' => '最大迭代数',
+			'loops.field.durationMinutes' => '截止(分钟)',
+			'loops.field.failureCap' => '失败上限',
+			'loops.runs.title' => '迭代记录',
+			'loops.runs.empty' => '还没有迭代。',
+			'loops.runs.iteration' => ({required Object n}) => '第 ${n} 轮',
 			_ => null,
 		};
 	}

--- a/app/mobile/lib/features/loops/loops_screen.dart
+++ b/app/mobile/lib/features/loops/loops_screen.dart
@@ -1,0 +1,562 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/api/loops_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+
+// Loops tab — the mobile mirror of the web Loops panel. Lists autonomous
+// agent loops, lets the operator create one, and pause/resume/stop a live
+// loop. Phase 1 has no per-loop WS, so the list polls every 4s (same cadence
+// as the web panel) on top of pull-to-refresh.
+class LoopsScreen extends ConsumerStatefulWidget {
+  const LoopsScreen({super.key});
+
+  @override
+  ConsumerState<LoopsScreen> createState() => _LoopsScreenState();
+}
+
+class _LoopsScreenState extends ConsumerState<LoopsScreen> {
+  Timer? _poll;
+
+  @override
+  void initState() {
+    super.initState();
+    _poll = Timer.periodic(const Duration(seconds: 4), (_) {
+      if (mounted) ref.invalidate(loopsListProvider);
+    });
+  }
+
+  @override
+  void dispose() {
+    _poll?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _act(
+    Future<LoopSummary> Function() action,
+  ) async {
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await action();
+      ref.invalidate(loopsListProvider);
+    } on Object catch (e) {
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(e.toString()),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final async = ref.watch(loopsListProvider);
+    return Scaffold(
+      appBar: AppBar(title: Text(t.loops.title)),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _openCreate,
+        icon: const Icon(Icons.add),
+        label: Text(t.loops.create),
+      ),
+      body: RefreshIndicator(
+        onRefresh: () => ref.refresh(loopsListProvider.future),
+        child: async.when(
+          data: (loops) {
+            if (loops.isEmpty) {
+              return ListView(
+                children: [
+                  const SizedBox(height: 120),
+                  Center(
+                    child: Padding(
+                      padding: const EdgeInsets.all(32),
+                      child: Text(
+                        t.loops.empty,
+                        textAlign: TextAlign.center,
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              color: Theme.of(context).colorScheme.outline,
+                            ),
+                      ),
+                    ),
+                  ),
+                ],
+              );
+            }
+            return ListView.builder(
+              padding: const EdgeInsets.all(12),
+              itemCount: loops.length,
+              itemBuilder: (_, i) => _LoopCard(
+                loop: loops[i],
+                onPause: () =>
+                    _act(() => ref.read(loopsApiProvider).pause(loops[i].id)),
+                onResume: () =>
+                    _act(() => ref.read(loopsApiProvider).resume(loops[i].id)),
+                onStop: () =>
+                    _act(() => ref.read(loopsApiProvider).stop(loops[i].id)),
+                onDetails: () => _openRuns(loops[i]),
+              ),
+            );
+          },
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => _ErrorView(
+            error: e.toString(),
+            onRetry: () => ref.invalidate(loopsListProvider),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openCreate() async {
+    final created = await showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => const _CreateLoopSheet(),
+    );
+    if (created ?? false) {
+      ref.invalidate(loopsListProvider);
+    }
+  }
+
+  Future<void> _openRuns(LoopSummary loop) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => _RunsSheet(loopId: loop.id),
+    );
+  }
+}
+
+Color _statusColor(BuildContext context, LoopStatus s) {
+  final scheme = Theme.of(context).colorScheme;
+  return switch (s) {
+    LoopStatus.running => Colors.green,
+    LoopStatus.paused => Colors.amber,
+    LoopStatus.done => Colors.blue,
+    LoopStatus.failed => scheme.error,
+    LoopStatus.escalated => Colors.orange,
+    _ => scheme.outline,
+  };
+}
+
+String _statusLabel(LoopStatus s) => switch (s) {
+      LoopStatus.pending => t.loops.status.pending,
+      LoopStatus.running => t.loops.status.running,
+      LoopStatus.paused => t.loops.status.paused,
+      LoopStatus.done => t.loops.status.done,
+      LoopStatus.stopped => t.loops.status.stopped,
+      LoopStatus.failed => t.loops.status.failed,
+      LoopStatus.escalated => t.loops.status.escalated,
+      LoopStatus.unknown => s.name,
+    };
+
+class _LoopCard extends StatelessWidget {
+  const _LoopCard({
+    required this.loop,
+    required this.onPause,
+    required this.onResume,
+    required this.onStop,
+    required this.onDetails,
+  });
+
+  final LoopSummary loop;
+  final VoidCallback onPause;
+  final VoidCallback onResume;
+  final VoidCallback onStop;
+  final VoidCallback onDetails;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final kindLabel =
+        loop.kind == LoopKind.goal ? t.loops.kind.goal : t.loops.kind.interval;
+    return Card(
+      margin: const EdgeInsets.only(bottom: 10),
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  loop.kind == LoopKind.goal ? Icons.flag_outlined : Icons.repeat,
+                  size: 18,
+                  color: theme.colorScheme.outline,
+                ),
+                const SizedBox(width: 6),
+                Text(kindLabel, style: theme.textTheme.titleSmall),
+                const SizedBox(width: 8),
+                _Chip(
+                  label: _statusLabel(loop.status),
+                  color: _statusColor(context, loop.status),
+                ),
+                const Spacer(),
+                Text(
+                  t.loops.iterationOf(
+                    n: loop.iteration.toString(),
+                    max: loop.maxIterations.toString(),
+                  ),
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: theme.colorScheme.outline),
+                ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            Text(
+              loop.sessionId,
+              style: theme.textTheme.bodySmall?.copyWith(
+                fontFamily: 'monospace',
+                color: theme.colorScheme.outline,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            if (loop.goal != null && loop.goal!.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(loop.goal!, maxLines: 2, overflow: TextOverflow.ellipsis),
+            ],
+            if (loop.lastReason != null && loop.lastReason!.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(
+                loop.lastVerdict != null && loop.lastVerdict!.isNotEmpty
+                    ? '${loop.lastVerdict} — ${loop.lastReason}'
+                    : loop.lastReason!,
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.outline),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              children: [
+                if (loop.status == LoopStatus.running)
+                  TextButton.icon(
+                    onPressed: onPause,
+                    icon: const Icon(Icons.pause, size: 18),
+                    label: Text(t.loops.action.pause),
+                  ),
+                if (loop.status == LoopStatus.paused)
+                  TextButton.icon(
+                    onPressed: onResume,
+                    icon: const Icon(Icons.play_arrow, size: 18),
+                    label: Text(t.loops.action.resume),
+                  ),
+                if (!loop.status.isTerminal)
+                  TextButton.icon(
+                    onPressed: onStop,
+                    icon: const Icon(Icons.stop, size: 18),
+                    label: Text(t.loops.action.stop),
+                  ),
+                TextButton.icon(
+                  onPressed: onDetails,
+                  icon: const Icon(Icons.list_alt, size: 18),
+                  label: Text(t.loops.action.details),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Chip extends StatelessWidget {
+  const _Chip({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(fontSize: 11, color: color, fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.error, required this.onRetry});
+
+  final String error;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      children: [
+        const SizedBox(height: 120),
+        Center(
+          child: Column(
+            children: [
+              Text(error, textAlign: TextAlign.center),
+              const SizedBox(height: 12),
+              OutlinedButton(onPressed: onRetry, child: Text(t.common.retry)),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CreateLoopSheet extends ConsumerStatefulWidget {
+  const _CreateLoopSheet();
+
+  @override
+  ConsumerState<_CreateLoopSheet> createState() => _CreateLoopSheetState();
+}
+
+class _CreateLoopSheetState extends ConsumerState<_CreateLoopSheet> {
+  final _session = TextEditingController();
+  final _prompt = TextEditingController();
+  final _goal = TextEditingController();
+  final _interval = TextEditingController(text: '60');
+  final _maxIter = TextEditingController(text: '20');
+  final _duration = TextEditingController(text: '60');
+  final _failCap = TextEditingController(text: '3');
+  LoopKind _kind = LoopKind.goal;
+  bool _busy = false;
+
+  @override
+  void dispose() {
+    _session.dispose();
+    _prompt.dispose();
+    _goal.dispose();
+    _interval.dispose();
+    _maxIter.dispose();
+    _duration.dispose();
+    _failCap.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+    final minutes = int.tryParse(_duration.text) ?? 60;
+    final req = CreateLoopRequest(
+      sessionId: _session.text.trim(),
+      kind: _kind,
+      prompt: _prompt.text.trim(),
+      maxIterations: int.tryParse(_maxIter.text) ?? 20,
+      deadlineAt: DateTime.now().add(Duration(minutes: minutes < 1 ? 1 : minutes)),
+      failureCap: int.tryParse(_failCap.text) ?? 3,
+      goal: _kind == LoopKind.goal ? _goal.text.trim() : null,
+      intervalSeconds:
+          _kind == LoopKind.interval ? int.tryParse(_interval.text) ?? 60 : null,
+    );
+    setState(() => _busy = true);
+    try {
+      await ref.read(loopsApiProvider).create(req);
+      navigator.pop(true);
+    } on Object catch (e) {
+      if (mounted) setState(() => _busy = false);
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(e.toString()),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final insets = MediaQuery.of(context).viewInsets.bottom;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(16, 16, 16, insets + 16),
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(t.loops.create, style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: 12),
+            SegmentedButton<LoopKind>(
+              segments: [
+                ButtonSegment(value: LoopKind.goal, label: Text(t.loops.kind.goal)),
+                ButtonSegment(
+                  value: LoopKind.interval,
+                  label: Text(t.loops.kind.interval),
+                ),
+              ],
+              selected: {_kind},
+              onSelectionChanged: (s) => setState(() => _kind = s.first),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _session,
+              decoration: InputDecoration(
+                labelText: t.loops.field.session,
+                hintText: t.loops.field.sessionPlaceholder,
+              ),
+            ),
+            if (_kind == LoopKind.goal) ...[
+              const SizedBox(height: 12),
+              TextField(
+                controller: _goal,
+                minLines: 2,
+                maxLines: 3,
+                decoration: InputDecoration(
+                  labelText: t.loops.field.goal,
+                  hintText: t.loops.field.goalPlaceholder,
+                ),
+              ),
+            ],
+            const SizedBox(height: 12),
+            TextField(
+              controller: _prompt,
+              minLines: 2,
+              maxLines: 3,
+              decoration: InputDecoration(
+                labelText: _kind == LoopKind.goal
+                    ? t.loops.field.seedPrompt
+                    : t.loops.field.prompt,
+                hintText: t.loops.field.promptPlaceholder,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                if (_kind == LoopKind.interval) ...[
+                  Expanded(
+                    child: TextField(
+                      controller: _interval,
+                      keyboardType: TextInputType.number,
+                      decoration: InputDecoration(
+                        labelText: t.loops.field.intervalSeconds,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                ],
+                Expanded(
+                  child: TextField(
+                    controller: _maxIter,
+                    keyboardType: TextInputType.number,
+                    decoration: InputDecoration(
+                      labelText: t.loops.field.maxIterations,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _duration,
+                    keyboardType: TextInputType.number,
+                    decoration: InputDecoration(
+                      labelText: t.loops.field.durationMinutes,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: TextField(
+                    controller: _failCap,
+                    keyboardType: TextInputType.number,
+                    decoration: InputDecoration(
+                      labelText: t.loops.field.failureCap,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+            FilledButton(
+              onPressed: _busy ? null : _submit,
+              child: _busy
+                  ? const SizedBox(
+                      height: 18,
+                      width: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Text(t.loops.action.create),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RunsSheet extends ConsumerWidget {
+  const _RunsSheet({required this.loopId});
+
+  final String loopId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(loopRunsProvider(loopId));
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(t.loops.runs.title, style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 12),
+          async.when(
+            data: (runs) {
+              if (runs.isEmpty) {
+                return Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 24),
+                  child: Center(child: Text(t.loops.runs.empty)),
+                );
+              }
+              return ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxHeight: MediaQuery.of(context).size.height * 0.6,
+                ),
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: runs.length,
+                  itemBuilder: (_, i) {
+                    final run = runs[i];
+                    return ListTile(
+                      dense: true,
+                      title: Text(t.loops.runs.iteration(n: run.iteration.toString())),
+                      subtitle: run.reason != null && run.reason!.isNotEmpty
+                          ? Text(run.reason!)
+                          : null,
+                      trailing: run.verdict != null
+                          ? Text(
+                              run.verdict!,
+                              style: Theme.of(context).textTheme.bodySmall,
+                            )
+                          : null,
+                    );
+                  },
+                ),
+              );
+            },
+            loading: () => const Padding(
+              padding: EdgeInsets.symmetric(vertical: 24),
+              child: Center(child: CircularProgressIndicator()),
+            ),
+            error: (e, _) => Padding(
+              padding: const EdgeInsets.symmetric(vertical: 24),
+              child: Center(child: Text(e.toString())),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/mobile/lib/features/more/more_screen.dart
+++ b/app/mobile/lib/features/more/more_screen.dart
@@ -10,6 +10,7 @@ import 'package:opendray/features/channels/channels_screen.dart';
 import 'package:opendray/features/custom_tasks/custom_tasks_screen.dart';
 import 'package:opendray/features/data_export/data_export_screen.dart';
 import 'package:opendray/features/githosts/githosts_screen.dart';
+import 'package:opendray/features/loops/loops_screen.dart';
 import 'package:opendray/features/mcp/mcp_screen.dart';
 import 'package:opendray/features/memory_archived/archived_screen.dart';
 import 'package:opendray/features/memory_quarantine/quarantine_screen.dart';
@@ -50,6 +51,12 @@ class MoreScreen extends ConsumerWidget {
           // Activity + Integrations are top-level bottom-nav tabs now; the
           // gateway section keeps the lower-frequency destinations.
           _SectionHeader(label: t.more.sections.gateway),
+          _MenuTile(
+            icon: Icons.repeat,
+            title: t.more.items.loops.title,
+            subtitle: t.more.items.loops.subtitle,
+            onTap: () => _push(context, const LoopsScreen()),
+          ),
           _MenuTile(
             icon: Icons.notifications_outlined,
             title: t.more.items.channels.title,

--- a/app/shared/src/lib/loops.ts
+++ b/app/shared/src/lib/loops.ts
@@ -1,0 +1,35 @@
+import { api } from './api'
+import type { CreateLoopRequest, Loop, LoopRun } from './types'
+
+// The Loop Engine REST surface. The gateway returns a bare array for the
+// list/runs endpoints and a bare object for a single loop (see
+// internal/autoloop/handler.go), so — unlike sessions — there is no wrapper
+// envelope to unwrap.
+
+export async function listLoops(): Promise<Loop[]> {
+  return (await api<Loop[]>('/api/v1/loops')) ?? []
+}
+
+export async function getLoop(id: string): Promise<Loop> {
+  return api<Loop>(`/api/v1/loops/${id}`)
+}
+
+export async function listLoopRuns(id: string): Promise<LoopRun[]> {
+  return (await api<LoopRun[]>(`/api/v1/loops/${id}/runs`)) ?? []
+}
+
+export async function createLoop(req: CreateLoopRequest): Promise<Loop> {
+  return api<Loop>('/api/v1/loops', { method: 'POST', body: req })
+}
+
+export async function pauseLoop(id: string): Promise<Loop> {
+  return api<Loop>(`/api/v1/loops/${id}/pause`, { method: 'POST' })
+}
+
+export async function resumeLoop(id: string): Promise<Loop> {
+  return api<Loop>(`/api/v1/loops/${id}/resume`, { method: 'POST' })
+}
+
+export async function stopLoop(id: string): Promise<Loop> {
+  return api<Loop>(`/api/v1/loops/${id}/stop`, { method: 'POST' })
+}

--- a/app/shared/src/lib/types.ts
+++ b/app/shared/src/lib/types.ts
@@ -39,6 +39,75 @@ export interface CreateSessionRequest {
   parent_session_id?: string
 }
 
+// ── Loops (autoloop — Loop Engine) ──────────────────────────
+
+export type LoopKind = 'interval' | 'goal'
+
+export type LoopStatus =
+  | 'pending'
+  | 'running'
+  | 'paused'
+  | 'done'
+  | 'stopped'
+  | 'failed'
+  | 'escalated'
+
+export const TERMINAL_LOOP_STATUSES: LoopStatus[] = [
+  'done',
+  'stopped',
+  'failed',
+  'escalated',
+]
+
+export function isTerminalLoopStatus(s: LoopStatus): boolean {
+  return TERMINAL_LOOP_STATUSES.includes(s)
+}
+
+export interface Loop {
+  id: string
+  session_id: string
+  origin: 'operator' | 'integration'
+  integration_id?: string
+  kind: LoopKind
+  status: LoopStatus
+  goal?: string
+  prompt: string
+  interval_seconds?: number
+  max_iterations: number
+  deadline_at?: string
+  failure_cap: number
+  judge_task?: string
+  iteration: number
+  last_verdict?: string
+  last_reason?: string
+  created_at: string
+  started_at?: string
+  ended_at?: string
+}
+
+export interface LoopRun {
+  id: number
+  loop_id: string
+  iteration: number
+  prompt: string
+  verdict?: string
+  reason?: string
+  started_at: string
+  ended_at?: string
+}
+
+export interface CreateLoopRequest {
+  session_id: string
+  kind: LoopKind
+  goal?: string
+  prompt: string
+  interval_seconds?: number
+  max_iterations?: number
+  deadline_at: string
+  failure_cap?: number
+  judge_task?: string
+}
+
 // ── Claude accounts (OAuth-token-on-disk model, mirrors v1) ─
 
 export interface ClaudeAccount {

--- a/app/web/src/components/SidebarNav.tsx
+++ b/app/web/src/components/SidebarNav.tsx
@@ -3,6 +3,7 @@ import { Link, useRouterState } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
 import {
   Layers,
+  Repeat,
   Cpu,
   MessageSquare,
   Plug,
@@ -43,6 +44,7 @@ interface NavItem {
 const groups: NavItem[][] = [
   [
     { to: '/sessions', icon: Layers, labelKey: 'nav.sessions', shortcut: 'g s' },
+    { to: '/loops', icon: Repeat, labelKey: 'nav.loops', shortcut: 'g o' },
     // Cortex — the unified Memory → Notes → Knowledge module. One
     // entry; the three rungs are layered inside (they are one loop,
     // not three silos).

--- a/app/web/src/pages/Loops.tsx
+++ b/app/web/src/pages/Loops.tsx
@@ -1,0 +1,507 @@
+import { useState, type FormEvent } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  Plus,
+  Loader2,
+  Pause,
+  Play,
+  Square,
+  ListTree,
+  Repeat,
+  Target,
+  RefreshCw,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import {
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import {
+  listLoops,
+  createLoop,
+  pauseLoop,
+  resumeLoop,
+  stopLoop,
+  listLoopRuns,
+} from '@/lib/loops'
+import {
+  isTerminalLoopStatus,
+  type CreateLoopRequest,
+  type Loop,
+  type LoopKind,
+  type LoopStatus,
+} from '@/lib/types'
+
+const STATUS_CLASS: Record<LoopStatus, string> = {
+  pending: 'bg-muted text-muted-foreground',
+  running: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+  paused: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
+  done: 'bg-sky-500/15 text-sky-600 dark:text-sky-400',
+  stopped: 'bg-muted text-muted-foreground',
+  failed: 'bg-destructive/15 text-destructive',
+  escalated: 'bg-orange-500/15 text-orange-600 dark:text-orange-400',
+}
+
+export function LoopsPage() {
+  const { t } = useTranslation()
+  const qc = useQueryClient()
+  const [createOpen, setCreateOpen] = useState(false)
+  const [runsFor, setRunsFor] = useState<Loop | null>(null)
+
+  const { data: loops, isLoading } = useQuery({
+    queryKey: ['loops'],
+    queryFn: listLoops,
+    // No per-loop WS in Phase 1 — poll for live status/iteration updates.
+    refetchInterval: 4_000,
+  })
+
+  const invalidate = () => qc.invalidateQueries({ queryKey: ['loops'] })
+
+  const pause = useMutation({
+    mutationFn: pauseLoop,
+    onSuccess: invalidate,
+    onError: (e: Error) => toast.error(e.message),
+  })
+  const resume = useMutation({
+    mutationFn: resumeLoop,
+    onSuccess: invalidate,
+    onError: (e: Error) => toast.error(e.message),
+  })
+  const stop = useMutation({
+    mutationFn: stopLoop,
+    onSuccess: invalidate,
+    onError: (e: Error) => toast.error(e.message),
+  })
+
+  return (
+    <div className="flex h-full flex-col bg-background">
+      <header className="flex items-center justify-between border-b border-border px-6 py-4">
+        <div>
+          <h1 className="text-lg font-semibold">{t('web.loops.title')}</h1>
+          <p className="text-sm text-muted-foreground">
+            {t('web.loops.subtitle')}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="icon" onClick={invalidate}>
+            <RefreshCw />
+          </Button>
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus />
+            {t('web.loops.create')}
+          </Button>
+        </div>
+      </header>
+
+      <ScrollArea className="flex-1">
+        <div className="mx-auto flex max-w-3xl flex-col gap-3 p-6">
+          {isLoading && (
+            <div className="flex justify-center py-12 text-muted-foreground">
+              <Loader2 className="animate-spin" />
+            </div>
+          )}
+          {!isLoading && (loops?.length ?? 0) === 0 && (
+            <div className="rounded-lg border border-dashed border-border py-16 text-center text-sm text-muted-foreground">
+              {t('web.loops.empty')}
+            </div>
+          )}
+          {loops?.map((loop) => (
+            <LoopCard
+              key={loop.id}
+              loop={loop}
+              onPause={() => pause.mutate(loop.id)}
+              onResume={() => resume.mutate(loop.id)}
+              onStop={() => stop.mutate(loop.id)}
+              onDetails={() => setRunsFor(loop)}
+            />
+          ))}
+        </div>
+      </ScrollArea>
+
+      <CreateLoopDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreated={() => {
+          invalidate()
+          setCreateOpen(false)
+        }}
+      />
+      <RunsDialog loop={runsFor} onClose={() => setRunsFor(null)} />
+    </div>
+  )
+}
+
+function LoopCard({
+  loop,
+  onPause,
+  onResume,
+  onStop,
+  onDetails,
+}: {
+  loop: Loop
+  onPause: () => void
+  onResume: () => void
+  onStop: () => void
+  onDetails: () => void
+}) {
+  const { t } = useTranslation()
+  const terminal = isTerminalLoopStatus(loop.status)
+  const KindIcon = loop.kind === 'goal' ? Target : Repeat
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <KindIcon className="size-4 shrink-0 text-muted-foreground" />
+            <span className="text-sm font-medium">
+              {t(`web.loops.kind.${loop.kind}`)}
+            </span>
+            <span
+              className={`rounded px-1.5 py-0.5 text-[11px] font-medium ${STATUS_CLASS[loop.status]}`}
+            >
+              {t(`web.loops.status.${loop.status}`)}
+            </span>
+            {loop.origin === 'integration' && (
+              <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                {t('web.loops.origin.integration')}
+              </span>
+            )}
+          </div>
+          <p className="mt-1 truncate font-mono text-xs text-muted-foreground">
+            {loop.session_id}
+          </p>
+          {loop.goal && (
+            <p className="mt-1 line-clamp-2 text-sm">{loop.goal}</p>
+          )}
+          {loop.last_reason && (
+            <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+              {loop.last_verdict ? `${loop.last_verdict} — ` : ''}
+              {loop.last_reason}
+            </p>
+          )}
+        </div>
+        <div className="shrink-0 text-right text-xs text-muted-foreground">
+          {t('web.loops.iterationOf', {
+            n: loop.iteration,
+            max: loop.max_iterations,
+          })}
+        </div>
+      </div>
+      <div className="mt-3 flex items-center gap-2">
+        {loop.status === 'running' && (
+          <Button variant="outline" size="sm" onClick={onPause}>
+            <Pause />
+            {t('web.loops.action.pause')}
+          </Button>
+        )}
+        {loop.status === 'paused' && (
+          <Button variant="outline" size="sm" onClick={onResume}>
+            <Play />
+            {t('web.loops.action.resume')}
+          </Button>
+        )}
+        {!terminal && (
+          <Button variant="outline" size="sm" onClick={onStop}>
+            <Square />
+            {t('web.loops.action.stop')}
+          </Button>
+        )}
+        <Button variant="ghost" size="sm" onClick={onDetails}>
+          <ListTree />
+          {t('web.loops.action.details')}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+const DEFAULTS = {
+  kind: 'goal' as LoopKind,
+  intervalSeconds: 60,
+  maxIterations: 20,
+  durationMinutes: 60,
+  failureCap: 3,
+}
+
+function CreateLoopDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: {
+  open: boolean
+  onOpenChange: (v: boolean) => void
+  onCreated: () => void
+}) {
+  const { t } = useTranslation()
+  const [sessionId, setSessionId] = useState('')
+  const [kind, setKind] = useState<LoopKind>(DEFAULTS.kind)
+  const [prompt, setPrompt] = useState('')
+  const [goal, setGoal] = useState('')
+  const [intervalSeconds, setIntervalSeconds] = useState(DEFAULTS.intervalSeconds)
+  const [maxIterations, setMaxIterations] = useState(DEFAULTS.maxIterations)
+  const [durationMinutes, setDurationMinutes] = useState(DEFAULTS.durationMinutes)
+  const [failureCap, setFailureCap] = useState(DEFAULTS.failureCap)
+
+  const create = useMutation({
+    mutationFn: createLoop,
+    onSuccess: () => {
+      toast.success(t('web.loops.createdToast'))
+      reset()
+      onCreated()
+    },
+    onError: (e: Error) => toast.error(e.message),
+  })
+
+  const reset = () => {
+    setSessionId('')
+    setKind(DEFAULTS.kind)
+    setPrompt('')
+    setGoal('')
+    setIntervalSeconds(DEFAULTS.intervalSeconds)
+    setMaxIterations(DEFAULTS.maxIterations)
+    setDurationMinutes(DEFAULTS.durationMinutes)
+    setFailureCap(DEFAULTS.failureCap)
+  }
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault()
+    const deadline = new Date(
+      Date.now() + Math.max(1, durationMinutes) * 60_000,
+    ).toISOString()
+    const req: CreateLoopRequest = {
+      session_id: sessionId.trim(),
+      kind,
+      prompt: prompt.trim(),
+      max_iterations: maxIterations,
+      deadline_at: deadline,
+      failure_cap: failureCap,
+    }
+    if (kind === 'goal') {
+      req.goal = goal.trim()
+    } else {
+      req.interval_seconds = intervalSeconds
+    }
+    create.mutate(req)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t('web.loops.create')}</DialogTitle>
+          <DialogDescription>{t('web.loops.createHint')}</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={submit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="loop-session">{t('web.loops.field.session')}</Label>
+            <Input
+              id="loop-session"
+              value={sessionId}
+              onChange={(e) => setSessionId(e.target.value)}
+              placeholder={t('web.loops.field.sessionPlaceholder')}
+              required
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label>{t('web.loops.field.kind')}</Label>
+            <Select value={kind} onValueChange={(v) => setKind(v as LoopKind)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="goal">
+                  {t('web.loops.kind.goal')} — {t('web.loops.kindHint.goal')}
+                </SelectItem>
+                <SelectItem value="interval">
+                  {t('web.loops.kind.interval')} —{' '}
+                  {t('web.loops.kindHint.interval')}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {kind === 'goal' && (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="loop-goal">{t('web.loops.field.goal')}</Label>
+              <Textarea
+                id="loop-goal"
+                value={goal}
+                onChange={(e) => setGoal(e.target.value)}
+                placeholder={t('web.loops.field.goalPlaceholder')}
+                rows={2}
+                required
+              />
+            </div>
+          )}
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="loop-prompt">
+              {kind === 'goal'
+                ? t('web.loops.field.seedPrompt')
+                : t('web.loops.field.prompt')}
+            </Label>
+            <Textarea
+              id="loop-prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder={t('web.loops.field.promptPlaceholder')}
+              rows={2}
+              required
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            {kind === 'interval' && (
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="loop-interval">
+                  {t('web.loops.field.intervalSeconds')}
+                </Label>
+                <Input
+                  id="loop-interval"
+                  type="number"
+                  min={30}
+                  value={intervalSeconds}
+                  onChange={(e) => setIntervalSeconds(Number(e.target.value))}
+                />
+              </div>
+            )}
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="loop-maxiter">
+                {t('web.loops.field.maxIterations')}
+              </Label>
+              <Input
+                id="loop-maxiter"
+                type="number"
+                min={1}
+                value={maxIterations}
+                onChange={(e) => setMaxIterations(Number(e.target.value))}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="loop-duration">
+                {t('web.loops.field.durationMinutes')}
+              </Label>
+              <Input
+                id="loop-duration"
+                type="number"
+                min={1}
+                value={durationMinutes}
+                onChange={(e) => setDurationMinutes(Number(e.target.value))}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="loop-failcap">
+                {t('web.loops.field.failureCap')}
+              </Label>
+              <Input
+                id="loop-failcap"
+                type="number"
+                min={1}
+                value={failureCap}
+                onChange={(e) => setFailureCap(Number(e.target.value))}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => onOpenChange(false)}
+            >
+              {t('web.loops.action.cancel')}
+            </Button>
+            <Button type="submit" disabled={create.isPending}>
+              {create.isPending && <Loader2 className="animate-spin" />}
+              {t('web.loops.action.create')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function RunsDialog({
+  loop,
+  onClose,
+}: {
+  loop: Loop | null
+  onClose: () => void
+}) {
+  const { t } = useTranslation()
+  const { data: runs, isLoading } = useQuery({
+    queryKey: ['loops', loop?.id, 'runs'],
+    queryFn: () => listLoopRuns(loop!.id),
+    enabled: !!loop,
+    refetchInterval: 4_000,
+  })
+
+  return (
+    <Dialog open={!!loop} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{t('web.loops.runs.title')}</DialogTitle>
+          <DialogDescription className="font-mono text-xs">
+            {loop?.id}
+          </DialogDescription>
+        </DialogHeader>
+        <ScrollArea className="max-h-[60vh]">
+          {isLoading && (
+            <div className="flex justify-center py-8 text-muted-foreground">
+              <Loader2 className="animate-spin" />
+            </div>
+          )}
+          {!isLoading && (runs?.length ?? 0) === 0 && (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              {t('web.loops.runs.empty')}
+            </p>
+          )}
+          <div className="flex flex-col gap-2">
+            {runs?.map((run) => (
+              <div
+                key={run.id}
+                className="rounded-md border border-border p-2.5 text-sm"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium">
+                    {t('web.loops.runs.iteration', { n: run.iteration })}
+                  </span>
+                  {run.verdict && (
+                    <span className="text-xs text-muted-foreground">
+                      {run.verdict}
+                    </span>
+                  )}
+                </div>
+                {run.reason && (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {run.reason}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/web/src/router.tsx
+++ b/app/web/src/router.tsx
@@ -8,6 +8,7 @@ import {
 import { AppShell } from '@/components/AppShell'
 import { LoginPage } from '@/pages/Login'
 import { SessionsPage } from '@/pages/Sessions'
+import { LoopsPage } from '@/pages/Loops'
 import { ProvidersPage } from '@/pages/Providers'
 import { ChannelsPage } from '@/pages/Channels'
 import { IntegrationsPage } from '@/pages/Integrations'
@@ -63,6 +64,12 @@ const sessionsRoute = createRoute({
   // param is stripped and the new session never gets focused.
   validateSearch: (search): { open?: string } =>
     typeof search.open === 'string' ? { open: search.open } : {},
+})
+
+const loopsRoute = createRoute({
+  getParentRoute: () => protectedRoute,
+  path: '/loops',
+  component: LoopsPage,
 })
 
 const providersRoute = createRoute({
@@ -247,6 +254,7 @@ const routeTree = rootRoute.addChildren([
   protectedRoute.addChildren([
     indexRoute,
     sessionsRoute,
+    loopsRoute,
     providersRoute,
     channelsRoute,
     integrationsRoute,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/opendray/opendray-v2/internal/audit"
+	"github.com/opendray/opendray-v2/internal/autoloop"
 	"github.com/opendray/opendray-v2/internal/auth"
 	"github.com/opendray/opendray-v2/internal/backup"
 	"github.com/opendray/opendray-v2/internal/catalog"
@@ -73,6 +74,7 @@ type App struct {
 	store           *store.Store
 	bus             *eventbus.Hub
 	sessions        *session.Manager
+	loopEngine      *autoloop.Engine // Loop Engine; cancels loop goroutines on shutdown (loops stay 'running' for reconcile)
 	channels        *channel.Hub
 	integrations    *integration.Service
 	healthCheck     *integration.HealthChecker
@@ -774,6 +776,21 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		st.Pool(), summarizerRegistry, cliacctSvc, log)
 	memoryWorkerHandlers := memworker.NewHandlers(memoryWorkerRegistry, log)
 
+	// Loop Engine (autoloop) — gateway-level Loop Engineering: drive a session
+	// repeatedly on a fixed interval, or until a judged goal is met. The engine
+	// drives sessions at the PTY layer, so it is provider-agnostic; sessionMgr
+	// satisfies autoloop.SessionDriver directly. Goal verification routes
+	// through the memory-worker registry (TaskLoopJudge, summarizer by default).
+	loopEngine := autoloop.New(
+		autoloop.NewPgStore(st.Pool()),
+		sessionMgr,
+		autoloop.NewWorkerJudge(memoryWorkerRegistry, 90*time.Second),
+		bus, log)
+	loopHandlers := autoloop.NewHandlers(loopEngine, log)
+	if err := loopEngine.ReconcileStartup(ctx); err != nil {
+		log.Warn("autoloop: reconcile re-arm failed", "err", err)
+	}
+
 	// M-PA — memory health dashboard. Aggregates "is the memory
 	// system actually working?" metrics across both subsystems
 	// (layer 5 + projectdoc) for one HTTP read.
@@ -1263,6 +1280,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 				r.Use(intgrCallLogger.Middleware)
 				authHandlers.MountProtected(r)
 				sessionHandlers.Mount(r)
+				loopHandlers.Mount(r)
 				catalogHandlers.Mount(r)
 				cliacctHandlers.Mount(r)
 				channelHandlers.Mount(r)
@@ -1288,6 +1306,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		log:                  log,
 		store:                st,
 		bus:                  bus,
+		loopEngine:           loopEngine,
 		sessions:             sessionMgr,
 		channels:             channelHub,
 		integrations:         intgrSvc,
@@ -1518,6 +1537,13 @@ func (a *App) Run(ctx context.Context) error {
 
 	if err := a.server.Shutdown(shutdownCtx); err != nil {
 		a.log.Error("http shutdown", "err", err)
+	}
+	// Stop loop goroutines before the sessions they drive. Loops keep their
+	// 'running' status in the DB so ReconcileStartup re-arms them next boot.
+	if a.loopEngine != nil {
+		if err := a.loopEngine.Shutdown(shutdownCtx); err != nil {
+			a.log.Error("autoloop shutdown", "err", err)
+		}
 	}
 	if err := a.sessions.Shutdown(shutdownCtx); err != nil {
 		a.log.Error("session shutdown", "err", err)

--- a/internal/autoloop/engine.go
+++ b/internal/autoloop/engine.go
@@ -1,0 +1,495 @@
+package autoloop
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/opendray/opendray-v2/internal/eventbus"
+)
+
+// Store is the persistence the engine depends on. *PgStore satisfies it; tests
+// use a fake. Defined here (at the point of use) per Go convention.
+type Store interface {
+	Create(ctx context.Context, l Loop) error
+	Get(ctx context.Context, id string) (Loop, error)
+	List(ctx context.Context) ([]Loop, error)
+	ListLive(ctx context.Context) ([]Loop, error)
+	ListRuns(ctx context.Context, loopID string) ([]Run, error)
+	MarkRunning(ctx context.Context, id string) error
+	SetStatus(ctx context.Context, id string, st Status, reason string) error
+	SaveProgress(ctx context.Context, id string, iteration int, verdict, reason string) error
+	AppendRun(ctx context.Context, loopID string, iteration int, prompt string) (int64, error)
+	FinishRun(ctx context.Context, runID int64, verdict, reason string) error
+}
+
+// SessionDriver is the slice of session.Manager the engine drives. PTY-level
+// and provider-agnostic: the same three calls drive any CLI opendray supports.
+type SessionDriver interface {
+	// ExpectTurn arms the session's turn watcher so the next settle fires
+	// session.turn_completed.
+	ExpectTurn(id string)
+	// Input writes bytes to the session's stdin.
+	Input(ctx context.Context, id string, data []byte) error
+	// RecentSnippet returns the session's recent visible output (fallback
+	// source for the judge when the turn_completed event carries none).
+	RecentSnippet(id string) string
+}
+
+// Judger verifies a goal-mode turn. *WorkerJudge satisfies it.
+type Judger interface {
+	Judge(ctx context.Context, loop Loop, turnOutput string) (Verdict, error)
+}
+
+// ErrClosed is returned when starting a loop on a shut-down engine.
+var ErrClosed = errors.New("autoloop: engine is shut down")
+
+// Engine orchestrates persistent loops: one goroutine per running loop, with
+// a registry so loops can be paused/stopped and re-armed after a restart.
+type Engine struct {
+	store  Store
+	driver SessionDriver
+	judge  Judger
+	bus    *eventbus.Hub
+	log    *slog.Logger
+
+	// Injected for deterministic tests; production uses the real defaults.
+	now          func() time.Time
+	intervalUnit time.Duration // IntervalSeconds is multiplied by this (real: 1s)
+	perRuneDelay time.Duration // inter-keystroke pause when submitting a prompt
+	submitDelay  time.Duration // settle pause before the Enter byte
+	turnTimeout  time.Duration // max wait for session.turn_completed per turn
+
+	mu     sync.Mutex
+	active map[string]context.CancelFunc
+	wg     sync.WaitGroup
+	closed bool
+}
+
+// Option configures an Engine.
+type Option func(*Engine)
+
+// WithClock overrides the time source (deadline checks).
+func WithClock(f func() time.Time) Option { return func(e *Engine) { e.now = f } }
+
+// WithIntervalUnit overrides the multiplier applied to IntervalSeconds (tests
+// set this to time.Millisecond to run interval loops fast).
+func WithIntervalUnit(d time.Duration) Option { return func(e *Engine) { e.intervalUnit = d } }
+
+// WithInputDelays overrides the per-rune + submit pauses (tests set 0).
+func WithInputDelays(perRune, submit time.Duration) Option {
+	return func(e *Engine) { e.perRuneDelay, e.submitDelay = perRune, submit }
+}
+
+// WithTurnTimeout overrides the per-turn wait for turn_completed.
+func WithTurnTimeout(d time.Duration) Option { return func(e *Engine) { e.turnTimeout = d } }
+
+// New wires an engine with production defaults.
+func New(store Store, driver SessionDriver, judge Judger, bus *eventbus.Hub, log *slog.Logger, opts ...Option) *Engine {
+	if log == nil {
+		log = slog.Default()
+	}
+	e := &Engine{
+		store:        store,
+		driver:       driver,
+		judge:        judge,
+		bus:          bus,
+		log:          log.With("component", "autoloop"),
+		now:          time.Now,
+		intervalUnit: time.Second,
+		perRuneDelay: 5 * time.Millisecond,
+		submitDelay:  40 * time.Millisecond,
+		turnTimeout:  5 * time.Minute,
+		active:       make(map[string]context.CancelFunc),
+	}
+	for _, o := range opts {
+		o(e)
+	}
+	return e
+}
+
+// Create validates, persists, and starts a loop.
+func (e *Engine) Create(ctx context.Context, req CreateRequest) (Loop, error) {
+	req = req.normalize()
+	if err := req.validate(e.now()); err != nil {
+		return Loop{}, err
+	}
+	l := newLoop(req, e.now())
+	if err := e.store.Create(ctx, l); err != nil {
+		return Loop{}, err
+	}
+	if err := e.start(ctx, l); err != nil {
+		return l, err
+	}
+	l.Status = StatusRunning
+	return l, nil
+}
+
+// Get / List / Runs are read-throughs for the API.
+func (e *Engine) Get(ctx context.Context, id string) (Loop, error) { return e.store.Get(ctx, id) }
+func (e *Engine) List(ctx context.Context) ([]Loop, error)         { return e.store.List(ctx) }
+func (e *Engine) Runs(ctx context.Context, id string) ([]Run, error) {
+	return e.store.ListRuns(ctx, id)
+}
+
+// Pause cancels the loop's goroutine and parks it as paused (resumable).
+func (e *Engine) Pause(ctx context.Context, id string) error {
+	l, err := e.store.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	if l.Status.IsTerminal() {
+		return ErrNotRunnable
+	}
+	e.cancel(id)
+	if err := e.store.SetStatus(ctx, id, StatusPaused, "paused by operator"); err != nil {
+		return err
+	}
+	l.Status = StatusPaused
+	e.publish("autoloop.paused", l, "paused by operator")
+	return nil
+}
+
+// Resume re-arms a paused loop from its persisted iteration.
+func (e *Engine) Resume(ctx context.Context, id string) error {
+	l, err := e.store.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	if l.Status != StatusPaused {
+		return ErrNotRunnable
+	}
+	if err := e.start(ctx, l); err != nil {
+		return err
+	}
+	e.publish("autoloop.resumed", l, "")
+	return nil
+}
+
+// Stop terminates a loop. The driven session is left running so an operator
+// can inspect it or take over.
+func (e *Engine) Stop(ctx context.Context, id string) error {
+	l, err := e.store.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	if l.Status.IsTerminal() {
+		return ErrNotRunnable
+	}
+	e.cancel(id)
+	if err := e.store.SetStatus(ctx, id, StatusStopped, "stopped by operator"); err != nil {
+		return err
+	}
+	l.Status = StatusStopped
+	e.publish("autoloop.stopped", l, "stopped by operator")
+	return nil
+}
+
+// ReconcileStartup re-arms loops that were running when the gateway last
+// stopped. Paused loops are left for an explicit Resume. Mirrors
+// session.Manager.ReconcileStartup.
+func (e *Engine) ReconcileStartup(ctx context.Context) error {
+	live, err := e.store.ListLive(ctx)
+	if err != nil {
+		return err
+	}
+	resumed := 0
+	for _, l := range live {
+		if l.Status != StatusRunning {
+			continue
+		}
+		if err := e.start(ctx, l); err != nil {
+			e.log.Warn("reconcile: failed to re-arm loop", "loop_id", l.ID, "err", err)
+			continue
+		}
+		resumed++
+	}
+	if resumed > 0 {
+		e.log.Info("reconcile: re-armed running loops", "count", resumed)
+	}
+	return nil
+}
+
+// Shutdown cancels every running goroutine WITHOUT changing DB status, so the
+// loops stay 'running' and ReconcileStartup resumes them on the next boot.
+func (e *Engine) Shutdown(ctx context.Context) error {
+	e.mu.Lock()
+	e.closed = true
+	for id, cancel := range e.active {
+		cancel()
+		delete(e.active, id)
+	}
+	e.mu.Unlock()
+	done := make(chan struct{})
+	go func() { e.wg.Wait(); close(done) }()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// start marks the loop running and launches its goroutine. Idempotent: a loop
+// already in the active set is left alone.
+func (e *Engine) start(ctx context.Context, l Loop) error {
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		return ErrClosed
+	}
+	if _, ok := e.active[l.ID]; ok {
+		e.mu.Unlock()
+		return nil
+	}
+	if err := e.store.MarkRunning(ctx, l.ID); err != nil {
+		e.mu.Unlock()
+		return err
+	}
+	// The loop must outlive the request ctx (an HTTP create returns
+	// immediately) — drive it from a background ctx we cancel ourselves.
+	runCtx, cancel := context.WithCancel(context.Background())
+	e.active[l.ID] = cancel
+	e.wg.Add(1)
+	e.mu.Unlock()
+
+	l.Status = StatusRunning
+	e.publish("autoloop.started", l, "")
+	go func() {
+		defer e.wg.Done()
+		e.run(runCtx, l)
+		e.mu.Lock()
+		delete(e.active, l.ID)
+		e.mu.Unlock()
+	}()
+	return nil
+}
+
+func (e *Engine) cancel(id string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if c, ok := e.active[id]; ok {
+		c()
+		delete(e.active, id)
+	}
+}
+
+func (e *Engine) run(ctx context.Context, l Loop) {
+	switch l.Kind {
+	case KindInterval:
+		e.runInterval(ctx, l)
+	case KindGoal:
+		e.runGoal(ctx, l)
+	}
+}
+
+// runInterval fires Prompt immediately, then once per interval, until a cap is
+// hit. Interval loops don't verify; reaching the budget is a clean 'done'.
+func (e *Engine) runInterval(ctx context.Context, l Loop) {
+	interval := time.Duration(l.IntervalSeconds) * e.intervalUnit
+	if interval <= 0 {
+		interval = time.Duration(MinIntervalSeconds) * e.intervalUnit
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		if done, reason := l.budgetExhausted(e.now()); done {
+			e.finish(ctx, &l, StatusDone, reason)
+			return
+		}
+		l.Iteration++
+		runID, _ := e.store.AppendRun(ctx, l.ID, l.Iteration, l.Prompt)
+		_ = e.store.SaveProgress(ctx, l.ID, l.Iteration, "", "")
+		e.publish("autoloop.iteration", l, "")
+		if err := e.submit(ctx, l.SessionID, l.Prompt, false); err != nil {
+			_ = e.store.FinishRun(ctx, runID, "", "input error: "+err.Error())
+			if ctx.Err() != nil {
+				return
+			}
+			e.finish(ctx, &l, StatusEscalated, "session input failed: "+err.Error())
+			return
+		}
+		_ = e.store.FinishRun(ctx, runID, "", "")
+		if done, reason := l.budgetExhausted(e.now()); done {
+			e.finish(ctx, &l, StatusDone, reason)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// runGoal feeds the seed prompt, waits for the turn to settle, judges it, and
+// continues with the judge's next prompt until done / escalate / a cap.
+func (e *Engine) runGoal(ctx context.Context, l Loop) {
+	sub, unsub := e.bus.Subscribe("session.turn_completed", 8)
+	defer unsub()
+	prompt := l.Prompt
+	failures := 0
+	for {
+		if done, reason := l.budgetExhausted(e.now()); done {
+			// budget gone without the goal being met: a stop, not a success.
+			e.finish(ctx, &l, StatusStopped, reason)
+			return
+		}
+		l.Iteration++
+		runID, _ := e.store.AppendRun(ctx, l.ID, l.Iteration, prompt)
+		e.publish("autoloop.iteration", l, "")
+		if err := e.submit(ctx, l.SessionID, prompt, true); err != nil {
+			_ = e.store.FinishRun(ctx, runID, "", "input error: "+err.Error())
+			if ctx.Err() != nil {
+				return
+			}
+			e.finish(ctx, &l, StatusEscalated, "session input failed: "+err.Error())
+			return
+		}
+
+		output, ok := e.waitTurn(ctx, sub, l.SessionID)
+		if !ok {
+			if ctx.Err() != nil {
+				_ = e.store.FinishRun(ctx, runID, "", "interrupted")
+				return
+			}
+			// turn timed out — treat as a failed iteration.
+			failures++
+			l.LastVerdict, l.LastReason = DecisionFail, "turn timed out"
+			_ = e.store.SaveProgress(ctx, l.ID, l.Iteration, l.LastVerdict, l.LastReason)
+			_ = e.store.FinishRun(ctx, runID, DecisionFail, "turn timed out")
+			if failures >= l.FailureCap {
+				e.finish(ctx, &l, StatusEscalated, "failure cap reached (turn timeouts)")
+				return
+			}
+			continue
+		}
+
+		verdict, _ := e.judge.Judge(ctx, l, output)
+		if ctx.Err() != nil {
+			_ = e.store.FinishRun(ctx, runID, "", "interrupted")
+			return
+		}
+		l.LastVerdict, l.LastReason = verdict.Decision, verdict.Reason
+		_ = e.store.SaveProgress(ctx, l.ID, l.Iteration, verdict.Decision, verdict.Reason)
+		_ = e.store.FinishRun(ctx, runID, verdict.Decision, verdict.Reason)
+		e.publish("autoloop.verdict", l, verdict.Reason)
+
+		switch verdict.Decision {
+		case DecisionDone:
+			e.finish(ctx, &l, StatusDone, verdict.Reason)
+			return
+		case DecisionEscalate:
+			e.finish(ctx, &l, StatusEscalated, verdict.Reason)
+			return
+		case DecisionFail:
+			failures++
+			if failures >= l.FailureCap {
+				e.finish(ctx, &l, StatusEscalated, "failure cap reached: "+verdict.Reason)
+				return
+			}
+			// retry the same prompt
+		case DecisionContinue:
+			failures = 0
+			if next := strings.TrimSpace(verdict.NextPrompt); next != "" {
+				prompt = next
+			}
+		}
+	}
+}
+
+// waitTurn blocks until session.turn_completed fires for sessionID, the turn
+// times out, or the loop is cancelled. Returns (output, true) on a real turn.
+func (e *Engine) waitTurn(ctx context.Context, sub <-chan eventbus.Event, sessionID string) (string, bool) {
+	timer := time.NewTimer(e.turnTimeout)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return "", false
+		case <-timer.C:
+			return "", false
+		case ev, ok := <-sub:
+			if !ok {
+				return "", false
+			}
+			data, _ := ev.Data.(map[string]any)
+			if data == nil {
+				continue
+			}
+			if sid, _ := data["session_id"].(string); sid != sessionID {
+				continue
+			}
+			out, _ := data["recent_output"].(string)
+			if out == "" {
+				out = e.driver.RecentSnippet(sessionID)
+			}
+			return out, true
+		}
+	}
+}
+
+// submit types text into the session rune-by-rune then sends Enter on its own
+// — the cross-CLI input pattern (a single text+\r write is misread as a paste
+// burst by Gemini's Ink input, swallowing the Enter). arm=true first arms the
+// turn watcher so the settle fires turn_completed (goal mode consumes it).
+func (e *Engine) submit(ctx context.Context, sid, text string, arm bool) error {
+	if arm {
+		e.driver.ExpectTurn(sid)
+	}
+	for _, r := range text {
+		if err := e.driver.Input(ctx, sid, []byte(string(r))); err != nil {
+			return err
+		}
+		if e.perRuneDelay > 0 {
+			select {
+			case <-time.After(e.perRuneDelay):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+	if e.submitDelay > 0 {
+		select {
+		case <-time.After(e.submitDelay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return e.driver.Input(ctx, sid, []byte{'\r'})
+}
+
+// finish persists a terminal status + publishes the matching event. Called
+// only on natural termination; cancellation (pause/stop/shutdown) returns
+// without touching status (the caller already set it, or shutdown leaves it
+// running for reconcile).
+func (e *Engine) finish(ctx context.Context, l *Loop, st Status, reason string) {
+	l.Status = st
+	l.LastReason = reason
+	wctx := ctx
+	if wctx.Err() != nil {
+		wctx = context.Background()
+	}
+	if err := e.store.SetStatus(wctx, l.ID, st, reason); err != nil {
+		e.log.Warn("finish: set status failed", "loop_id", l.ID, "status", st, "err", err)
+	}
+	e.publish("autoloop."+string(st), *l, reason)
+}
+
+func (e *Engine) publish(topic string, l Loop, reason string) {
+	e.bus.Publish(eventbus.Event{
+		Topic: topic,
+		Data: map[string]any{
+			"loop_id":    l.ID,
+			"session_id": l.SessionID,
+			"kind":       string(l.Kind),
+			"status":     string(l.Status),
+			"iteration":  l.Iteration,
+			"verdict":    l.LastVerdict,
+			"reason":     reason,
+		},
+	})
+}

--- a/internal/autoloop/engine_extra_test.go
+++ b/internal/autoloop/engine_extra_test.go
@@ -1,0 +1,96 @@
+package autoloop
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/opendray/opendray-v2/internal/eventbus"
+)
+
+func TestCreateRejectsInvalid(t *testing.T) {
+	bus := eventbus.New(nil)
+	defer bus.Close()
+	eng := testEngine(t, newFakeStore(), newFakeDriver(bus, ""), &fakeJudge{}, bus)
+	_, err := eng.Create(context.Background(), CreateRequest{
+		SessionID: "", Kind: KindGoal, Prompt: "p", DeadlineAt: futureDeadline(),
+	})
+	if !errors.Is(err, ErrEmptySession) {
+		t.Fatalf("err = %v, want ErrEmptySession", err)
+	}
+}
+
+func TestGetListRunsPassthrough(t *testing.T) {
+	bus := eventbus.New(nil)
+	defer bus.Close()
+	store := newFakeStore()
+	eng := New(store, newFakeDriver(bus, ""), &fakeJudge{}, bus, nil,
+		WithIntervalUnit(time.Second), WithInputDelays(0, 0)) // long interval: won't terminate
+	defer eng.Shutdown(context.Background())
+
+	l, err := eng.Create(context.Background(), CreateRequest{
+		SessionID: "s1", Kind: KindInterval, Prompt: "p",
+		IntervalSeconds: 3600, MaxIterations: 100, DeadlineAt: futureDeadline(),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := eng.Get(context.Background(), l.ID)
+	if err != nil || got.ID != l.ID {
+		t.Fatalf("Get = (%+v, %v)", got, err)
+	}
+	list, err := eng.List(context.Background())
+	if err != nil || len(list) != 1 {
+		t.Fatalf("List = (%d loops, %v)", len(list), err)
+	}
+	if _, err := eng.Runs(context.Background(), l.ID); err != nil {
+		t.Fatalf("Runs: %v", err)
+	}
+
+	// control ops on a missing loop surface ErrNotFound.
+	if err := eng.Pause(context.Background(), "nope"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Pause(missing) = %v, want ErrNotFound", err)
+	}
+	if err := eng.Resume(context.Background(), "nope"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Resume(missing) = %v, want ErrNotFound", err)
+	}
+}
+
+func TestWithClockUsedForDeadline(t *testing.T) {
+	bus := eventbus.New(nil)
+	defer bus.Close()
+	// Clock pinned to 2030; a deadline in 2026 is "past" relative to it.
+	fixed := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	eng := New(newFakeStore(), newFakeDriver(bus, ""), &fakeJudge{}, bus, nil,
+		WithClock(func() time.Time { return fixed }), WithInputDelays(0, 0))
+	dl := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	_, err := eng.Create(context.Background(), CreateRequest{
+		SessionID: "s1", Kind: KindGoal, Prompt: "p", DeadlineAt: &dl,
+	})
+	if !errors.Is(err, ErrPastDeadline) {
+		t.Fatalf("err = %v, want ErrPastDeadline (clock not applied?)", err)
+	}
+}
+
+func TestResumeRejectsNonPaused(t *testing.T) {
+	bus := eventbus.New(nil)
+	defer bus.Close()
+	store := newFakeStore()
+	eng := New(store, newFakeDriver(bus, ""), &fakeJudge{}, bus, nil,
+		WithIntervalUnit(time.Second), WithInputDelays(0, 0))
+	defer eng.Shutdown(context.Background())
+
+	l, err := eng.Create(context.Background(), CreateRequest{
+		SessionID: "s1", Kind: KindInterval, Prompt: "p",
+		IntervalSeconds: 3600, MaxIterations: 100, DeadlineAt: futureDeadline(),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// running (not paused) → resume rejected.
+	if err := eng.Resume(context.Background(), l.ID); !errors.Is(err, ErrNotRunnable) {
+		t.Fatalf("Resume(running) = %v, want ErrNotRunnable", err)
+	}
+}

--- a/internal/autoloop/engine_test.go
+++ b/internal/autoloop/engine_test.go
@@ -1,0 +1,440 @@
+package autoloop
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/opendray/opendray-v2/internal/eventbus"
+)
+
+// ─── fakes ──────────────────────────────────────────────────────────────
+
+type fakeStore struct {
+	mu     sync.Mutex
+	loops  map[string]*Loop
+	runs   map[string][]Run
+	nextID int64
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{loops: map[string]*Loop{}, runs: map[string][]Run{}}
+}
+
+func (s *fakeStore) Create(_ context.Context, l Loop) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := l
+	s.loops[l.ID] = &cp
+	return nil
+}
+func (s *fakeStore) Get(_ context.Context, id string) (Loop, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	l, ok := s.loops[id]
+	if !ok {
+		return Loop{}, ErrNotFound
+	}
+	return *l, nil
+}
+func (s *fakeStore) List(_ context.Context) ([]Loop, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []Loop
+	for _, l := range s.loops {
+		out = append(out, *l)
+	}
+	return out, nil
+}
+func (s *fakeStore) ListLive(_ context.Context) ([]Loop, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []Loop
+	for _, l := range s.loops {
+		if l.Status == StatusRunning || l.Status == StatusPaused {
+			out = append(out, *l)
+		}
+	}
+	return out, nil
+}
+func (s *fakeStore) ListRuns(_ context.Context, loopID string) ([]Run, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]Run(nil), s.runs[loopID]...), nil
+}
+func (s *fakeStore) MarkRunning(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if l, ok := s.loops[id]; ok {
+		l.Status = StatusRunning
+	}
+	return nil
+}
+func (s *fakeStore) SetStatus(_ context.Context, id string, st Status, reason string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if l, ok := s.loops[id]; ok {
+		l.Status = st
+		l.LastReason = reason
+	}
+	return nil
+}
+func (s *fakeStore) SaveProgress(_ context.Context, id string, it int, v, r string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if l, ok := s.loops[id]; ok {
+		l.Iteration = it
+		l.LastVerdict = v
+		l.LastReason = r
+	}
+	return nil
+}
+func (s *fakeStore) AppendRun(_ context.Context, loopID string, it int, prompt string) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextID++
+	id := s.nextID
+	s.runs[loopID] = append(s.runs[loopID], Run{ID: id, LoopID: loopID, Iteration: it, Prompt: prompt})
+	return id, nil
+}
+func (s *fakeStore) FinishRun(_ context.Context, runID int64, v, r string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for k := range s.runs {
+		for i := range s.runs[k] {
+			if s.runs[k][i].ID == runID {
+				s.runs[k][i].Verdict = v
+				s.runs[k][i].Reason = r
+			}
+		}
+	}
+	return nil
+}
+func (s *fakeStore) status(id string) Status {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if l, ok := s.loops[id]; ok {
+		return l.Status
+	}
+	return ""
+}
+func (s *fakeStore) iteration(id string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if l, ok := s.loops[id]; ok {
+		return l.Iteration
+	}
+	return -1
+}
+
+// fakeDriver records input and, when armed, fires session.turn_completed on
+// the bus as soon as the submit Enter arrives — simulating a CLI settling.
+type fakeDriver struct {
+	bus       *eventbus.Hub
+	output    string
+	failInput bool
+	silent    bool // armed but never fires turn_completed (timeout test)
+
+	mu    sync.Mutex
+	armed map[string]bool
+}
+
+func newFakeDriver(bus *eventbus.Hub, output string) *fakeDriver {
+	return &fakeDriver{bus: bus, output: output, armed: map[string]bool{}}
+}
+
+func (d *fakeDriver) ExpectTurn(id string) {
+	d.mu.Lock()
+	d.armed[id] = true
+	d.mu.Unlock()
+}
+func (d *fakeDriver) Input(_ context.Context, id string, data []byte) error {
+	if d.failInput {
+		return errors.New("fake input failure")
+	}
+	if len(data) == 1 && data[0] == '\r' {
+		d.mu.Lock()
+		armed := d.armed[id]
+		d.armed[id] = false
+		out := d.output
+		d.mu.Unlock()
+		if armed && !d.silent {
+			d.bus.Publish(eventbus.Event{
+				Topic: "session.turn_completed",
+				Data:  map[string]any{"session_id": id, "recent_output": out},
+			})
+		}
+	}
+	return nil
+}
+func (d *fakeDriver) RecentSnippet(string) string { return d.output }
+
+// fakeJudge returns programmed verdicts in order; the last one repeats.
+type fakeJudge struct {
+	mu       sync.Mutex
+	verdicts []Verdict
+	calls    int
+}
+
+func (j *fakeJudge) Judge(context.Context, Loop, string) (Verdict, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	i := j.calls
+	if i >= len(j.verdicts) {
+		i = len(j.verdicts) - 1
+	}
+	j.calls++
+	return j.verdicts[i], nil
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────
+
+func testEngine(t *testing.T, store Store, driver SessionDriver, judge Judger, bus *eventbus.Hub, opts ...Option) *Engine {
+	t.Helper()
+	base := []Option{
+		WithIntervalUnit(time.Millisecond),
+		WithInputDelays(0, 0),
+		WithTurnTimeout(2 * time.Second),
+	}
+	return New(store, driver, judge, bus, nil, append(base, opts...)...)
+}
+
+// awaitTerminal blocks until a terminal autoloop.* event for loopID arrives.
+func awaitTerminal(t *testing.T, bus *eventbus.Hub, loopID string, timeout time.Duration) Status {
+	t.Helper()
+	ch, unsub := bus.Subscribe("autoloop.*", 64)
+	defer unsub()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case ev := <-ch:
+			d, _ := ev.Data.(map[string]any)
+			if d == nil || d["loop_id"] != loopID {
+				continue
+			}
+			if st := Status(d["status"].(string)); st.IsTerminal() {
+				return st
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for terminal event for %s", loopID)
+			return ""
+		}
+	}
+}
+
+func futureDeadline() *time.Time { d := time.Now().Add(time.Hour); return &d }
+
+// ─── tests ──────────────────────────────────────────────────────────────
+
+func TestIntervalLoopRunsToBudget(t *testing.T) {
+	bus := eventbus.New(nil)
+	defer bus.Close()
+	store := newFakeStore()
+	driver := newFakeDriver(bus, "")
+	eng := testEngine(t, store, driver, &fakeJudge{}, bus)
+	defer eng.Shutdown(context.Background())
+
+	// subscribe before create so we never miss the terminal event.
+	done := make(chan Status, 1)
+	id := make(chan string, 1)
+	go func() { done <- awaitTerminal(t, bus, <-id, 5*time.Second) }()
+
+	l, err := eng.Create(context.Background(), CreateRequest{
+		SessionID: "s1", Kind: KindInterval, Prompt: "tick",
+		IntervalSeconds: MinIntervalSeconds, MaxIterations: 3, DeadlineAt: futureDeadline(),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	id <- l.ID
+
+	if st := <-done; st != StatusDone {
+		t.Fatalf("status = %q, want done", st)
+	}
+	if got := store.iteration(l.ID); got != 3 {
+		t.Errorf("iteration = %d, want 3", got)
+	}
+	runs, _ := store.ListRuns(context.Background(), l.ID)
+	if len(runs) != 3 {
+		t.Errorf("runs = %d, want 3", len(runs))
+	}
+}
+
+func TestGoalLoopReachesDone(t *testing.T) {
+	bus := eventbus.New(nil)
+	defer bus.Close()
+	store := newFakeStore()
+	driver := newFakeDriver(bus, "agent output")
+	judge := &fakeJudge{verdicts: []Verdict{
+		{Decision: DecisionContinue, NextPrompt: "keep going"},
+		{Decision: DecisionContinue, NextPrompt: "almost"},
+		{Decision: DecisionDone, Reason: "goal met"},
+	}}
+	eng := testEngine(t, store, driver, judge, bus)
+	defer eng.Shutdown(context.Background())
+
+	done := make(chan Status, 1)
+	id := make(chan string, 1)
+	go func() { done <- awaitTerminal(t, bus, <-id, 5*time.Second) }()
+
+	l, err := eng.Create(context.Background(), CreateRequest{
+		SessionID: "s1", Kind: KindGoal, Prompt: "start", Goal: "do the thing",
+		MaxIterations: 10, DeadlineAt: futureDeadline(),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	id <- l.ID
+
+	if st := <-done; st != StatusDone {
+		t.Fatalf("status = %q, want done", st)
+	}
+	if got := store.iteration(l.ID); got != 3 {
+		t.Errorf("iteration = %d, want 3", got)
+	}
+}
+
+func TestGoalLoopEscalatesOnFailureCap(t *testing.T) {
+	bus := eventbus.New(nil)
+	defer bus.Close()
+	store := newFakeStore()
+	driver := newFakeDriver(bus, "err")
+	judge := &fakeJudge{verdicts: []Verdict{{Decision: DecisionFail, Reason: "broken"}}}
+	eng := testEngine(t, store, driver, judge, bus)
+	defer eng.Shutdown(context.Background())
+
+	done := make(chan Status, 1)
+	id := make(chan string, 1)
+	go func() { done <- awaitTerminal(t, bus, <-id, 5*time.Second) }()
+
+	l, err := eng.Create(context.Background(), CreateRequest{
+		SessionID: "s1", Kind: KindGoal, Prompt: "start", Goal: "g",
+		MaxIterations: 10, FailureCap: 2, DeadlineAt: futureDeadline(),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	id <- l.ID
+
+	if st := <-done; st != StatusEscalated {
+		t.Fatalf("status = %q, want escalated", st)
+	}
+	if got := store.iteration(l.ID); got != 2 {
+		t.Errorf("iteration = %d, want 2 (failure cap)", got)
+	}
+}
+
+func TestGoalLoopEscalatesOnTurnTimeout(t *testing.T) {
+	bus := eventbus.New(nil)
+	defer bus.Close()
+	store := newFakeStore()
+	driver := newFakeDriver(bus, "")
+	driver.silent = true // never fires turn_completed
+	judge := &fakeJudge{verdicts: []Verdict{{Decision: DecisionContinue}}}
+	eng := testEngine(t, store, driver, judge, bus, WithTurnTimeout(50*time.Millisecond))
+	defer eng.Shutdown(context.Background())
+
+	done := make(chan Status, 1)
+	id := make(chan string, 1)
+	go func() { done <- awaitTerminal(t, bus, <-id, 5*time.Second) }()
+
+	l, err := eng.Create(context.Background(), CreateRequest{
+		SessionID: "s1", Kind: KindGoal, Prompt: "start", Goal: "g",
+		MaxIterations: 10, FailureCap: 2, DeadlineAt: futureDeadline(),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	id <- l.ID
+
+	if st := <-done; st != StatusEscalated {
+		t.Fatalf("status = %q, want escalated", st)
+	}
+}
+
+func TestStopHaltsLoop(t *testing.T) {
+	bus := eventbus.New(nil)
+	defer bus.Close()
+	store := newFakeStore()
+	driver := newFakeDriver(bus, "")
+	// big interval so it won't naturally terminate during the test.
+	eng := New(store, driver, &fakeJudge{}, bus, nil,
+		WithIntervalUnit(time.Second), WithInputDelays(0, 0))
+	defer eng.Shutdown(context.Background())
+
+	l, err := eng.Create(context.Background(), CreateRequest{
+		SessionID: "s1", Kind: KindInterval, Prompt: "p",
+		IntervalSeconds: 3600, MaxIterations: 100, DeadlineAt: futureDeadline(),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := eng.Stop(context.Background(), l.ID); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if st := store.status(l.ID); st != StatusStopped {
+		t.Fatalf("status = %q, want stopped", st)
+	}
+	// stopping a terminal loop is rejected.
+	if err := eng.Stop(context.Background(), l.ID); !errors.Is(err, ErrNotRunnable) {
+		t.Fatalf("second stop err = %v, want ErrNotRunnable", err)
+	}
+}
+
+func TestPauseResume(t *testing.T) {
+	bus := eventbus.New(nil)
+	defer bus.Close()
+	store := newFakeStore()
+	driver := newFakeDriver(bus, "")
+	eng := New(store, driver, &fakeJudge{}, bus, nil,
+		WithIntervalUnit(time.Second), WithInputDelays(0, 0))
+	defer eng.Shutdown(context.Background())
+
+	l, err := eng.Create(context.Background(), CreateRequest{
+		SessionID: "s1", Kind: KindInterval, Prompt: "p",
+		IntervalSeconds: 3600, MaxIterations: 100, DeadlineAt: futureDeadline(),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := eng.Pause(context.Background(), l.ID); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	if st := store.status(l.ID); st != StatusPaused {
+		t.Fatalf("status = %q, want paused", st)
+	}
+	if err := eng.Resume(context.Background(), l.ID); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if st := store.status(l.ID); st != StatusRunning {
+		t.Fatalf("status after resume = %q, want running", st)
+	}
+}
+
+func TestReconcileReArmsRunning(t *testing.T) {
+	bus := eventbus.New(nil)
+	defer bus.Close()
+	store := newFakeStore()
+	// a loop persisted as running (as if the gateway restarted mid-flight),
+	// at iteration 3 of 3 so it terminates on the first reconciled tick.
+	dl := time.Now().Add(time.Hour)
+	store.loops["lp_x"] = &Loop{
+		ID: "lp_x", SessionID: "s1", Kind: KindInterval, Status: StatusRunning,
+		Prompt: "p", IntervalSeconds: 1, MaxIterations: 3, Iteration: 3, DeadlineAt: &dl,
+	}
+	driver := newFakeDriver(bus, "")
+	eng := testEngine(t, store, driver, &fakeJudge{}, bus)
+	defer eng.Shutdown(context.Background())
+
+	done := make(chan Status, 1)
+	go func() { done <- awaitTerminal(t, bus, "lp_x", 5*time.Second) }()
+
+	if err := eng.ReconcileStartup(context.Background()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if st := <-done; st != StatusDone {
+		t.Fatalf("reconciled loop status = %q, want done", st)
+	}
+}

--- a/internal/autoloop/handler.go
+++ b/internal/autoloop/handler.go
@@ -1,0 +1,183 @@
+package autoloop
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/opendray/opendray-v2/internal/integration"
+)
+
+// LoopService is the engine surface the HTTP handlers need. *Engine satisfies
+// it; defined here so handlers are testable without a real engine.
+type LoopService interface {
+	Create(ctx context.Context, req CreateRequest) (Loop, error)
+	Get(ctx context.Context, id string) (Loop, error)
+	List(ctx context.Context) ([]Loop, error)
+	Runs(ctx context.Context, id string) ([]Run, error)
+	Pause(ctx context.Context, id string) error
+	Resume(ctx context.Context, id string) error
+	Stop(ctx context.Context, id string) error
+}
+
+// Handlers serves the loop REST API.
+type Handlers struct {
+	svc LoopService
+	log *slog.Logger
+}
+
+// NewHandlers wires the loop HTTP handlers.
+func NewHandlers(svc LoopService, log *slog.Logger) *Handlers {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Handlers{svc: svc, log: log.With("component", "autoloop.http")}
+}
+
+// Mount adds the loop routes. Caller mounts under /api/v1 in the combined-auth
+// group, so both an operator (admin bearer) and an integration (API key) can
+// drive loops; origin is derived from the authenticated principal, never the
+// request body.
+func (h *Handlers) Mount(r chi.Router) {
+	r.Route("/loops", func(r chi.Router) {
+		r.Get("/", h.list)
+		r.Post("/", h.create)
+		r.Route("/{id}", func(r chi.Router) {
+			r.Get("/", h.get)
+			r.Get("/runs", h.runs)
+			r.Post("/pause", h.pause)
+			r.Post("/resume", h.resume)
+			r.Post("/stop", h.stop)
+		})
+	})
+}
+
+// createBody is the JSON shape for POST /loops. origin / integration_id are
+// intentionally absent — they come from the principal.
+type createBody struct {
+	SessionID       string     `json:"session_id"`
+	Kind            string     `json:"kind"`
+	Goal            string     `json:"goal"`
+	Prompt          string     `json:"prompt"`
+	IntervalSeconds int        `json:"interval_seconds"`
+	MaxIterations   int        `json:"max_iterations"`
+	DeadlineAt      *time.Time `json:"deadline_at"`
+	FailureCap      int        `json:"failure_cap"`
+	JudgeTask       string     `json:"judge_task"`
+}
+
+func (h *Handlers) create(w http.ResponseWriter, r *http.Request) {
+	var body createBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	req := CreateRequest{
+		SessionID:       body.SessionID,
+		Origin:          OriginOperator,
+		Kind:            Kind(body.Kind),
+		Goal:            body.Goal,
+		Prompt:          body.Prompt,
+		IntervalSeconds: body.IntervalSeconds,
+		MaxIterations:   body.MaxIterations,
+		DeadlineAt:      body.DeadlineAt,
+		FailureCap:      body.FailureCap,
+		JudgeTask:       body.JudgeTask,
+	}
+	// Provenance from the authenticated principal — never the body.
+	if p, ok := integration.CurrentPrincipal(r.Context()); ok && p.Kind == integration.KindIntegration {
+		req.Origin = OriginIntegration
+		req.IntegrationID = p.ID
+	}
+	l, err := h.svc.Create(r.Context(), req)
+	if err != nil {
+		writeErr(w, statusForErr(err), err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, l)
+}
+
+func (h *Handlers) list(w http.ResponseWriter, r *http.Request) {
+	loops, err := h.svc.List(r.Context())
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+	if loops == nil {
+		loops = []Loop{}
+	}
+	writeJSON(w, http.StatusOK, loops)
+}
+
+func (h *Handlers) get(w http.ResponseWriter, r *http.Request) {
+	l, err := h.svc.Get(r.Context(), chi.URLParam(r, "id"))
+	if err != nil {
+		writeErr(w, statusForErr(err), err)
+		return
+	}
+	writeJSON(w, http.StatusOK, l)
+}
+
+func (h *Handlers) runs(w http.ResponseWriter, r *http.Request) {
+	rs, err := h.svc.Runs(r.Context(), chi.URLParam(r, "id"))
+	if err != nil {
+		writeErr(w, statusForErr(err), err)
+		return
+	}
+	if rs == nil {
+		rs = []Run{}
+	}
+	writeJSON(w, http.StatusOK, rs)
+}
+
+func (h *Handlers) pause(w http.ResponseWriter, r *http.Request)  { h.transition(w, r, h.svc.Pause) }
+func (h *Handlers) resume(w http.ResponseWriter, r *http.Request) { h.transition(w, r, h.svc.Resume) }
+func (h *Handlers) stop(w http.ResponseWriter, r *http.Request)   { h.transition(w, r, h.svc.Stop) }
+
+func (h *Handlers) transition(w http.ResponseWriter, r *http.Request, fn func(context.Context, string) error) {
+	id := chi.URLParam(r, "id")
+	if err := fn(r.Context(), id); err != nil {
+		writeErr(w, statusForErr(err), err)
+		return
+	}
+	l, err := h.svc.Get(r.Context(), id)
+	if err != nil {
+		writeErr(w, statusForErr(err), err)
+		return
+	}
+	writeJSON(w, http.StatusOK, l)
+}
+
+// statusForErr maps domain errors to HTTP codes.
+func statusForErr(err error) int {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		return http.StatusNotFound
+	case errors.Is(err, ErrNotRunnable):
+		return http.StatusConflict
+	case errors.Is(err, ErrEmptySession), errors.Is(err, ErrEmptyPrompt),
+		errors.Is(err, ErrBadKind), errors.Is(err, ErrBadOrigin),
+		errors.Is(err, ErrNoDeadline), errors.Is(err, ErrPastDeadline),
+		errors.Is(err, ErrBadInterval):
+		return http.StatusBadRequest
+	case errors.Is(err, ErrClosed):
+		return http.StatusServiceUnavailable
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeErr(w http.ResponseWriter, code int, err error) {
+	writeJSON(w, code, map[string]string{"error": err.Error()})
+}

--- a/internal/autoloop/handler.go
+++ b/internal/autoloop/handler.go
@@ -39,6 +39,31 @@ func NewHandlers(svc LoopService, log *slog.Logger) *Handlers {
 	return &Handlers{svc: svc, log: log.With("component", "autoloop.http")}
 }
 
+// Loop scopes. Enforced only for integration principals (admin and the
+// no-principal test path bypass). Not in defaultScopes — an operator grants
+// loop:* explicitly when registering an integration that should drive loops.
+const (
+	ScopeLoopCreate = "loop:create"
+	ScopeLoopRead   = "loop:read"
+	ScopeLoopWrite  = "loop:write"
+)
+
+// allow returns true when the request's principal may use scope. Admin
+// principals and an absent principal (unauthenticated test path) are allowed;
+// an integration principal must hold the scope, else allow writes a 403 and
+// returns false.
+func (h *Handlers) allow(w http.ResponseWriter, r *http.Request, scope string) bool {
+	p, ok := integration.CurrentPrincipal(r.Context())
+	if !ok || p.Kind != integration.KindIntegration {
+		return true
+	}
+	if integration.HasScope(p.Scopes, scope) {
+		return true
+	}
+	writeErr(w, http.StatusForbidden, integration.ErrInsufficientScope)
+	return false
+}
+
 // Mount adds the loop routes. Caller mounts under /api/v1 in the combined-auth
 // group, so both an operator (admin bearer) and an integration (API key) can
 // drive loops; origin is derived from the authenticated principal, never the
@@ -72,6 +97,9 @@ type createBody struct {
 }
 
 func (h *Handlers) create(w http.ResponseWriter, r *http.Request) {
+	if !h.allow(w, r, ScopeLoopCreate) {
+		return
+	}
 	var body createBody
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
@@ -103,6 +131,9 @@ func (h *Handlers) create(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handlers) list(w http.ResponseWriter, r *http.Request) {
+	if !h.allow(w, r, ScopeLoopRead) {
+		return
+	}
 	loops, err := h.svc.List(r.Context())
 	if err != nil {
 		writeErr(w, http.StatusInternalServerError, err)
@@ -115,6 +146,9 @@ func (h *Handlers) list(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handlers) get(w http.ResponseWriter, r *http.Request) {
+	if !h.allow(w, r, ScopeLoopRead) {
+		return
+	}
 	l, err := h.svc.Get(r.Context(), chi.URLParam(r, "id"))
 	if err != nil {
 		writeErr(w, statusForErr(err), err)
@@ -124,6 +158,9 @@ func (h *Handlers) get(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handlers) runs(w http.ResponseWriter, r *http.Request) {
+	if !h.allow(w, r, ScopeLoopRead) {
+		return
+	}
 	rs, err := h.svc.Runs(r.Context(), chi.URLParam(r, "id"))
 	if err != nil {
 		writeErr(w, statusForErr(err), err)
@@ -140,6 +177,9 @@ func (h *Handlers) resume(w http.ResponseWriter, r *http.Request) { h.transition
 func (h *Handlers) stop(w http.ResponseWriter, r *http.Request)   { h.transition(w, r, h.svc.Stop) }
 
 func (h *Handlers) transition(w http.ResponseWriter, r *http.Request, fn func(context.Context, string) error) {
+	if !h.allow(w, r, ScopeLoopWrite) {
+		return
+	}
 	id := chi.URLParam(r, "id")
 	if err := fn(r.Context(), id); err != nil {
 		writeErr(w, statusForErr(err), err)

--- a/internal/autoloop/handler_test.go
+++ b/internal/autoloop/handler_test.go
@@ -1,0 +1,159 @@
+package autoloop
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/opendray/opendray-v2/internal/integration"
+)
+
+type fakeSvc struct {
+	created   CreateRequest
+	createErr error
+	getErr    error
+	pauseErr  error
+	loop      Loop
+	runs      []Run
+}
+
+func (f *fakeSvc) Create(_ context.Context, req CreateRequest) (Loop, error) {
+	f.created = req
+	if f.createErr != nil {
+		return Loop{}, f.createErr
+	}
+	return Loop{ID: "lp_1", SessionID: req.SessionID, Kind: req.Kind, Origin: req.Origin, Status: StatusRunning}, nil
+}
+func (f *fakeSvc) Get(context.Context, string) (Loop, error)   { return f.loop, f.getErr }
+func (f *fakeSvc) List(context.Context) ([]Loop, error)        { return []Loop{f.loop}, nil }
+func (f *fakeSvc) Runs(context.Context, string) ([]Run, error) { return f.runs, nil }
+func (f *fakeSvc) Pause(context.Context, string) error         { return f.pauseErr }
+func (f *fakeSvc) Resume(context.Context, string) error        { return f.pauseErr }
+func (f *fakeSvc) Stop(context.Context, string) error          { return f.pauseErr }
+
+func testRouter(svc LoopService, p *integration.Principal) http.Handler {
+	r := chi.NewRouter()
+	if p != nil {
+		pr := *p
+		r.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				next.ServeHTTP(w, req.WithContext(integration.WithPrincipal(req.Context(), pr)))
+			})
+		})
+	}
+	NewHandlers(svc, nil).Mount(r)
+	return r
+}
+
+func do(t *testing.T, h http.Handler, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestCreateOperatorOrigin(t *testing.T) {
+	svc := &fakeSvc{}
+	h := testRouter(svc, nil) // no principal → operator
+	dl := time.Now().Add(time.Hour).Format(time.RFC3339)
+	body := `{"session_id":"s1","kind":"goal","goal":"g","prompt":"p","deadline_at":"` + dl + `"}`
+	rec := do(t, h, http.MethodPost, "/loops", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("code = %d, want 201 (%s)", rec.Code, rec.Body)
+	}
+	if svc.created.Origin != OriginOperator {
+		t.Errorf("origin = %q, want operator", svc.created.Origin)
+	}
+	if svc.created.SessionID != "s1" || svc.created.Kind != KindGoal {
+		t.Errorf("create req mismatch: %+v", svc.created)
+	}
+}
+
+func TestCreateIntegrationOrigin(t *testing.T) {
+	svc := &fakeSvc{}
+	p := &integration.Principal{Kind: integration.KindIntegration, ID: "intg_42"}
+	h := testRouter(svc, p)
+	dl := time.Now().Add(time.Hour).Format(time.RFC3339)
+	body := `{"session_id":"s1","kind":"interval","prompt":"p","interval_seconds":30,"deadline_at":"` + dl + `"}`
+	rec := do(t, h, http.MethodPost, "/loops", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("code = %d, want 201 (%s)", rec.Code, rec.Body)
+	}
+	if svc.created.Origin != OriginIntegration || svc.created.IntegrationID != "intg_42" {
+		t.Errorf("origin/integration = %q/%q, want integration/intg_42", svc.created.Origin, svc.created.IntegrationID)
+	}
+}
+
+func TestCreateBadJSON(t *testing.T) {
+	rec := do(t, testRouter(&fakeSvc{}, nil), http.MethodPost, "/loops", "{not json")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400", rec.Code)
+	}
+}
+
+func TestCreateValidationErrorMapsTo400(t *testing.T) {
+	svc := &fakeSvc{createErr: ErrNoDeadline}
+	rec := do(t, testRouter(svc, nil), http.MethodPost, "/loops", `{"session_id":"s1","kind":"goal","prompt":"p"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400", rec.Code)
+	}
+}
+
+func TestGetNotFound(t *testing.T) {
+	svc := &fakeSvc{getErr: ErrNotFound}
+	rec := do(t, testRouter(svc, nil), http.MethodGet, "/loops/nope", "")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("code = %d, want 404", rec.Code)
+	}
+}
+
+func TestListReturnsArray(t *testing.T) {
+	svc := &fakeSvc{loop: Loop{ID: "lp_1"}}
+	rec := do(t, testRouter(svc, nil), http.MethodGet, "/loops", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200", rec.Code)
+	}
+	var out []Loop
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil || len(out) != 1 {
+		t.Fatalf("list body = %s (err %v)", rec.Body, err)
+	}
+}
+
+func TestStopConflictWhenTerminal(t *testing.T) {
+	svc := &fakeSvc{pauseErr: ErrNotRunnable}
+	rec := do(t, testRouter(svc, nil), http.MethodPost, "/loops/lp_1/stop", "")
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("code = %d, want 409", rec.Code)
+	}
+}
+
+func TestPauseReturnsLoop(t *testing.T) {
+	svc := &fakeSvc{loop: Loop{ID: "lp_1", Status: StatusPaused}}
+	rec := do(t, testRouter(svc, nil), http.MethodPost, "/loops/lp_1/pause", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+	var l Loop
+	if err := json.Unmarshal(rec.Body.Bytes(), &l); err != nil || l.Status != StatusPaused {
+		t.Fatalf("pause body = %s (err %v)", rec.Body, err)
+	}
+}
+
+func TestRunsEndpoint(t *testing.T) {
+	svc := &fakeSvc{runs: []Run{{ID: 1, Iteration: 1, Prompt: "p"}}}
+	rec := do(t, testRouter(svc, nil), http.MethodGet, "/loops/lp_1/runs", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200", rec.Code)
+	}
+	var rs []Run
+	if err := json.Unmarshal(rec.Body.Bytes(), &rs); err != nil || len(rs) != 1 {
+		t.Fatalf("runs body = %s (err %v)", rec.Body, err)
+	}
+}

--- a/internal/autoloop/handler_test.go
+++ b/internal/autoloop/handler_test.go
@@ -78,7 +78,11 @@ func TestCreateOperatorOrigin(t *testing.T) {
 
 func TestCreateIntegrationOrigin(t *testing.T) {
 	svc := &fakeSvc{}
-	p := &integration.Principal{Kind: integration.KindIntegration, ID: "intg_42"}
+	p := &integration.Principal{
+		Kind:   integration.KindIntegration,
+		ID:     "intg_42",
+		Scopes: []string{ScopeLoopCreate},
+	}
 	h := testRouter(svc, p)
 	dl := time.Now().Add(time.Hour).Format(time.RFC3339)
 	body := `{"session_id":"s1","kind":"interval","prompt":"p","interval_seconds":30,"deadline_at":"` + dl + `"}`
@@ -155,5 +159,39 @@ func TestRunsEndpoint(t *testing.T) {
 	var rs []Run
 	if err := json.Unmarshal(rec.Body.Bytes(), &rs); err != nil || len(rs) != 1 {
 		t.Fatalf("runs body = %s (err %v)", rec.Body, err)
+	}
+}
+
+func TestIntegrationForbiddenWithoutScope(t *testing.T) {
+	// An integration principal missing the required scope is rejected; an
+	// admin / no principal (operator UI, tests) is not.
+	noScope := &integration.Principal{Kind: integration.KindIntegration, ID: "i1"}
+	dl := time.Now().Add(time.Hour).Format(time.RFC3339)
+	body := `{"session_id":"s1","kind":"goal","goal":"g","prompt":"p","deadline_at":"` + dl + `"}`
+
+	rec := do(t, testRouter(&fakeSvc{}, noScope), http.MethodPost, "/loops", body)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("create without loop:create = %d, want 403", rec.Code)
+	}
+	rec = do(t, testRouter(&fakeSvc{}, noScope), http.MethodGet, "/loops", "")
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("list without loop:read = %d, want 403", rec.Code)
+	}
+	rec = do(t, testRouter(&fakeSvc{}, noScope), http.MethodPost, "/loops/lp_1/stop", "")
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("stop without loop:write = %d, want 403", rec.Code)
+	}
+}
+
+func TestIntegrationAllowedWithScope(t *testing.T) {
+	reader := &integration.Principal{
+		Kind:   integration.KindIntegration,
+		ID:     "i1",
+		Scopes: []string{ScopeLoopRead},
+	}
+	svc := &fakeSvc{loop: Loop{ID: "lp_1"}}
+	rec := do(t, testRouter(svc, reader), http.MethodGet, "/loops", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list with loop:read = %d, want 200", rec.Code)
 	}
 }

--- a/internal/autoloop/judge.go
+++ b/internal/autoloop/judge.go
@@ -1,0 +1,144 @@
+package autoloop
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/opendray/opendray-v2/internal/memory/worker"
+)
+
+// Verdict is the strict response a goal-mode judge returns after inspecting
+// one turn's output. NextPrompt is only meaningful when Decision == continue.
+type Verdict struct {
+	Decision   string `json:"decision"` // continue | done | escalate | fail
+	Reason     string `json:"reason"`
+	NextPrompt string `json:"next_prompt"`
+}
+
+// validDecision normalises an unknown/blank decision to a safe escalate: when
+// the judge is unsure, pull a human in rather than loop blindly.
+func (v Verdict) normalise() Verdict {
+	switch v.Decision {
+	case DecisionContinue, DecisionDone, DecisionEscalate, DecisionFail:
+		return v
+	default:
+		out := v
+		out.Decision = DecisionEscalate
+		if out.Reason == "" {
+			out.Reason = "judge returned an unrecognised decision; escalating"
+		}
+		return out
+	}
+}
+
+// verdictJSONSchema is the OpenAI-spec response_format schema. Summarizer
+// workers translate it to response_format=json_schema; agent workers append
+// it to the system prompt. Mirrors the strict-schema pattern Cortex curation
+// already uses.
+const verdictJSONSchema = `{
+  "name": "loop_verdict",
+  "schema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "decision":    {"type": "string", "enum": ["continue", "done", "escalate", "fail"]},
+      "reason":      {"type": "string"},
+      "next_prompt": {"type": "string"}
+    },
+    "required": ["decision", "reason", "next_prompt"]
+  },
+  "strict": true
+}`
+
+const judgeSystemPrompt = `You are the verifier in an autonomous agent loop. You are given a GOAL and the OUTPUT of the agent's most recent turn. Decide one of:
+- "continue": the goal is not met yet and the agent should keep going. Put the concrete next instruction in "next_prompt".
+- "done": the goal is fully met. No further turns are needed.
+- "escalate": you are unsure, the agent appears stuck, or a human decision is needed. Prefer this over guessing.
+- "fail": this turn clearly failed or produced an error that the agent cannot recover from on its own.
+Be conservative: if you cannot positively confirm the goal is met, do NOT return "done". Reply ONLY with the structured JSON.`
+
+// WorkerJudge implements Judger over worker.Registry, routing to whichever
+// worker (summarizer by default, or an agent CLI) the operator configured for
+// the loop's JudgeTask. The judge is decoupled from the driven session's CLI,
+// so a goal loop over any provider can be verified by the same cheap worker.
+type WorkerJudge struct {
+	reg     *worker.Registry
+	timeout time.Duration
+}
+
+// NewWorkerJudge builds a judge. A zero timeout defaults to 90s — long enough
+// for a headless agent judge, bounded so a hung worker can't stall the loop.
+func NewWorkerJudge(reg *worker.Registry, timeout time.Duration) *WorkerJudge {
+	if timeout <= 0 {
+		timeout = 90 * time.Second
+	}
+	return &WorkerJudge{reg: reg, timeout: timeout}
+}
+
+// Judge runs the configured worker over the goal + turn output and parses the
+// structured verdict. A worker that isn't configured, errors, or returns
+// unparseable output yields an escalate verdict (never a silent continue).
+func (j *WorkerJudge) Judge(ctx context.Context, loop Loop, turnOutput string) (Verdict, error) {
+	task := worker.TaskKind(loop.JudgeTask)
+	if task == "" {
+		task = worker.TaskLoopJudge
+	}
+	resp, err := j.reg.Run(ctx, worker.Request{
+		Task:                     task,
+		SystemPrompt:             judgeSystemPrompt,
+		UserInput:                buildJudgeInput(loop, turnOutput),
+		MaxTokens:                500,
+		Timeout:                  j.timeout,
+		ResponseFormatJSONSchema: verdictJSONSchema,
+	})
+	if err != nil {
+		return Verdict{
+			Decision: DecisionEscalate,
+			Reason:   fmt.Sprintf("judge worker error: %v", err),
+		}, err
+	}
+	var v Verdict
+	if uerr := json.Unmarshal([]byte(extractJSON(resp.Content)), &v); uerr != nil {
+		return Verdict{
+			Decision: DecisionEscalate,
+			Reason:   "judge returned unparseable output; escalating",
+		}, nil
+	}
+	return v.normalise(), nil
+}
+
+func buildJudgeInput(loop Loop, turnOutput string) string {
+	var b strings.Builder
+	b.WriteString("GOAL:\n")
+	b.WriteString(strings.TrimSpace(loop.Goal))
+	b.WriteString("\n\nITERATION: ")
+	fmt.Fprintf(&b, "%d of %d", loop.Iteration, loop.MaxIterations)
+	if loop.LastReason != "" {
+		b.WriteString("\n\nPREVIOUS VERDICT: ")
+		b.WriteString(loop.LastVerdict)
+		b.WriteString(" — ")
+		b.WriteString(loop.LastReason)
+	}
+	b.WriteString("\n\nMOST RECENT TURN OUTPUT:\n")
+	if strings.TrimSpace(turnOutput) == "" {
+		b.WriteString("(the agent produced no visible output this turn)")
+	} else {
+		b.WriteString(turnOutput)
+	}
+	return b.String()
+}
+
+// extractJSON pulls the first {...} block out of a worker response. Agent
+// workers sometimes wrap JSON in prose or a ```json fence; summarizer workers
+// using response_format return clean JSON. Defensive either way.
+func extractJSON(s string) string {
+	start := strings.IndexByte(s, '{')
+	end := strings.LastIndexByte(s, '}')
+	if start >= 0 && end > start {
+		return s[start : end+1]
+	}
+	return s
+}

--- a/internal/autoloop/judge_test.go
+++ b/internal/autoloop/judge_test.go
@@ -1,0 +1,43 @@
+package autoloop
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractJSON(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		{"clean", `{"decision":"done"}`, `{"decision":"done"}`},
+		{"prose wrapped", "Here is my verdict: {\"decision\":\"done\"} hope that helps", `{"decision":"done"}`},
+		{"fenced", "```json\n{\"decision\":\"continue\"}\n```", `{"decision":"continue"}`},
+		{"no json", "nothing here", "nothing here"},
+		{"nested", `prefix {"a":{"b":1}} suffix`, `{"a":{"b":1}}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractJSON(tc.in); got != tc.want {
+				t.Errorf("extractJSON(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildJudgeInput(t *testing.T) {
+	l := Loop{Goal: "ship the feature", Iteration: 2, MaxIterations: 10,
+		LastVerdict: DecisionContinue, LastReason: "made progress"}
+	got := buildJudgeInput(l, "the agent did X")
+	for _, want := range []string{"ship the feature", "2 of 10", "made progress", "the agent did X"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("judge input missing %q\n--- got ---\n%s", want, got)
+		}
+	}
+}
+
+func TestBuildJudgeInputEmptyOutput(t *testing.T) {
+	got := buildJudgeInput(Loop{Goal: "g", MaxIterations: 5}, "   ")
+	if !strings.Contains(got, "no visible output") {
+		t.Errorf("empty output should be noted, got:\n%s", got)
+	}
+}

--- a/internal/autoloop/loop.go
+++ b/internal/autoloop/loop.go
@@ -1,0 +1,231 @@
+// Package autoloop is the Loop Engine: a gateway-level orchestration layer
+// that drives an agent session repeatedly — on a fixed interval, or until a
+// judged goal is met — turning opendray from a "tool you prompt" into a
+// "system that prompts the agent" (the 2026 Loop Engineering shift).
+//
+// A Loop is 1:1 with a session.Manager session. The engine drives that session
+// at the PTY layer (ExpectTurn + Input + the session.turn_completed event), so
+// a loop works identically over every provider opendray supports —
+// claude / codex / gemini / antigravity / opencode. Loop holds no provider
+// field; the bound session determines the CLI.
+package autoloop
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"time"
+)
+
+// Kind selects the loop's trigger + decision model. Both share one lifecycle.
+type Kind string
+
+const (
+	// KindInterval re-feeds Prompt every IntervalSeconds; it has no goal
+	// verification and ends when a cap (max iterations / deadline) is hit.
+	KindInterval Kind = "interval"
+	// KindGoal feeds Prompt as a seed, waits for the turn to settle, then
+	// runs the judge worker to decide continue|done|escalate|fail.
+	KindGoal Kind = "goal"
+)
+
+// ValidKind reports whether k is a recognised kind.
+func ValidKind(k Kind) bool { return k == KindInterval || k == KindGoal }
+
+// Status is the loop's lifecycle state, persisted in session_loops.status.
+type Status string
+
+const (
+	StatusPending   Status = "pending"
+	StatusRunning   Status = "running"
+	StatusPaused    Status = "paused"
+	StatusDone      Status = "done"      // ran its course / goal met
+	StatusStopped   Status = "stopped"   // operator stop, or budget exhausted without goal
+	StatusFailed    Status = "failed"    // unrecoverable
+	StatusEscalated Status = "escalated" // handed to a human (failure cap / judge escalate)
+)
+
+// IsTerminal reports whether the loop has finished and will not run again
+// without an explicit resume.
+func (s Status) IsTerminal() bool {
+	switch s {
+	case StatusDone, StatusStopped, StatusFailed, StatusEscalated:
+		return true
+	}
+	return false
+}
+
+// Origin mirrors session.Origin: who created the loop.
+type Origin string
+
+const (
+	OriginOperator    Origin = "operator"
+	OriginIntegration Origin = "integration"
+)
+
+// Verdict decisions returned by the goal-mode judge.
+const (
+	DecisionContinue = "continue"
+	DecisionDone     = "done"
+	DecisionEscalate = "escalate"
+	DecisionFail     = "fail"
+)
+
+// Guardrail defaults. The interval floor and a mandatory deadline are the
+// core "don't burn tokens forever" protections (verification + stopping
+// conditions are the hard part of loop engineering).
+const (
+	// MinIntervalSeconds floors interval loops so a misconfigured loop can't
+	// hammer a CLI dozens of times a second.
+	MinIntervalSeconds   = 30
+	DefaultMaxIterations = 20
+	DefaultFailureCap    = 3
+	// DefaultJudgeTask is the worker touchpoint a goal loop uses to verify a
+	// turn when the caller doesn't name one. Provider-agnostic summarizer.
+	DefaultJudgeTask = "loop_judge"
+)
+
+// Loop is one persistent autonomous loop.
+type Loop struct {
+	ID              string     `json:"id"`
+	SessionID       string     `json:"session_id"`
+	Origin          Origin     `json:"origin"`
+	IntegrationID   string     `json:"integration_id,omitempty"`
+	Kind            Kind       `json:"kind"`
+	Status          Status     `json:"status"`
+	Goal            string     `json:"goal,omitempty"`
+	Prompt          string     `json:"prompt"`
+	IntervalSeconds int        `json:"interval_seconds,omitempty"`
+	MaxIterations   int        `json:"max_iterations"`
+	DeadlineAt      *time.Time `json:"deadline_at,omitempty"`
+	FailureCap      int        `json:"failure_cap"`
+	JudgeTask       string     `json:"judge_task,omitempty"`
+	Iteration       int        `json:"iteration"`
+	LastVerdict     string     `json:"last_verdict,omitempty"`
+	LastReason      string     `json:"last_reason,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+	StartedAt       *time.Time `json:"started_at,omitempty"`
+	EndedAt         *time.Time `json:"ended_at,omitempty"`
+}
+
+// CreateRequest is the validated input for creating a loop.
+type CreateRequest struct {
+	SessionID       string
+	Origin          Origin
+	IntegrationID   string
+	Kind            Kind
+	Goal            string
+	Prompt          string
+	IntervalSeconds int
+	MaxIterations   int
+	DeadlineAt      *time.Time
+	FailureCap      int
+	JudgeTask       string
+}
+
+// Validation errors. Stable so handlers can map them to 4xx codes.
+var (
+	ErrEmptySession = errors.New("autoloop: session_id required")
+	ErrEmptyPrompt  = errors.New("autoloop: prompt required")
+	ErrBadKind      = errors.New("autoloop: kind must be 'interval' or 'goal'")
+	ErrBadOrigin    = errors.New("autoloop: origin must be 'operator' or 'integration'")
+	ErrNoDeadline   = errors.New("autoloop: deadline_at is required")
+	ErrPastDeadline = errors.New("autoloop: deadline_at must be in the future")
+	ErrBadInterval  = errors.New("autoloop: interval_seconds must be >= 30 for an interval loop")
+	ErrNotFound     = errors.New("autoloop: loop not found")
+	ErrNotRunnable  = errors.New("autoloop: loop is in a terminal state")
+)
+
+// normalize fills defaults that don't depend on validation. Pure: returns a
+// new request, never mutates the input (immutability).
+func (r CreateRequest) normalize() CreateRequest {
+	out := r
+	if out.Origin == "" {
+		out.Origin = OriginOperator
+	}
+	if out.MaxIterations <= 0 {
+		out.MaxIterations = DefaultMaxIterations
+	}
+	if out.FailureCap <= 0 {
+		out.FailureCap = DefaultFailureCap
+	}
+	if out.Kind == KindGoal && out.JudgeTask == "" {
+		out.JudgeTask = DefaultJudgeTask
+	}
+	if out.Kind == KindInterval {
+		// interval loops don't verify; clear any stray judge task.
+		out.JudgeTask = ""
+	}
+	return out
+}
+
+// validate checks the normalized request against the guardrails. now is
+// injected so the deadline check is deterministic in tests.
+func (r CreateRequest) validate(now time.Time) error {
+	if r.SessionID == "" {
+		return ErrEmptySession
+	}
+	if r.Prompt == "" {
+		return ErrEmptyPrompt
+	}
+	if !ValidKind(r.Kind) {
+		return ErrBadKind
+	}
+	if r.Origin != OriginOperator && r.Origin != OriginIntegration {
+		return ErrBadOrigin
+	}
+	// deadline_at is mandatory: guardrail-first. A loop with no deadline and
+	// only an iteration cap can still run for an unbounded wall-clock time.
+	if r.DeadlineAt == nil {
+		return ErrNoDeadline
+	}
+	if !r.DeadlineAt.After(now) {
+		return ErrPastDeadline
+	}
+	if r.Kind == KindInterval && r.IntervalSeconds < MinIntervalSeconds {
+		return ErrBadInterval
+	}
+	return nil
+}
+
+// newLoop builds a pending Loop from a normalized+validated request.
+func newLoop(r CreateRequest, now time.Time) Loop {
+	return Loop{
+		ID:              newID(),
+		SessionID:       r.SessionID,
+		Origin:          r.Origin,
+		IntegrationID:   r.IntegrationID,
+		Kind:            r.Kind,
+		Status:          StatusPending,
+		Goal:            r.Goal,
+		Prompt:          r.Prompt,
+		IntervalSeconds: r.IntervalSeconds,
+		MaxIterations:   r.MaxIterations,
+		DeadlineAt:      r.DeadlineAt,
+		FailureCap:      r.FailureCap,
+		JudgeTask:       r.JudgeTask,
+		CreatedAt:       now,
+	}
+}
+
+// budgetExhausted reports whether a loop has hit a stopping cap: it has run
+// at least MaxIterations turns, or passed its deadline. Returns the reason.
+func (l Loop) budgetExhausted(now time.Time) (bool, string) {
+	if l.MaxIterations > 0 && l.Iteration >= l.MaxIterations {
+		return true, "max_iterations reached"
+	}
+	if l.DeadlineAt != nil && !now.Before(*l.DeadlineAt) {
+		return true, "deadline reached"
+	}
+	return false, ""
+}
+
+func newID() string {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// rand.Read never fails on supported platforms; fall back to a
+		// time-seeded value so we still return a usable id.
+		return "lp_" + hex.EncodeToString([]byte(time.Now().Format("150405.000000")))
+	}
+	return "lp_" + hex.EncodeToString(b[:])
+}

--- a/internal/autoloop/loop_test.go
+++ b/internal/autoloop/loop_test.go
@@ -1,0 +1,130 @@
+package autoloop
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestCreateRequestValidate(t *testing.T) {
+	now := time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC)
+	future := now.Add(time.Hour)
+	past := now.Add(-time.Hour)
+
+	tests := []struct {
+		name string
+		req  CreateRequest
+		want error
+	}{
+		{
+			name: "valid interval",
+			req:  CreateRequest{SessionID: "s1", Kind: KindInterval, Prompt: "p", IntervalSeconds: 30, DeadlineAt: &future},
+			want: nil,
+		},
+		{
+			name: "valid goal",
+			req:  CreateRequest{SessionID: "s1", Kind: KindGoal, Prompt: "p", Goal: "g", DeadlineAt: &future},
+			want: nil,
+		},
+		{
+			name: "missing session",
+			req:  CreateRequest{Kind: KindGoal, Prompt: "p", DeadlineAt: &future},
+			want: ErrEmptySession,
+		},
+		{
+			name: "missing prompt",
+			req:  CreateRequest{SessionID: "s1", Kind: KindGoal, DeadlineAt: &future},
+			want: ErrEmptyPrompt,
+		},
+		{
+			name: "bad kind",
+			req:  CreateRequest{SessionID: "s1", Kind: "weird", Prompt: "p", DeadlineAt: &future},
+			want: ErrBadKind,
+		},
+		{
+			name: "missing deadline",
+			req:  CreateRequest{SessionID: "s1", Kind: KindGoal, Prompt: "p"},
+			want: ErrNoDeadline,
+		},
+		{
+			name: "past deadline",
+			req:  CreateRequest{SessionID: "s1", Kind: KindGoal, Prompt: "p", DeadlineAt: &past},
+			want: ErrPastDeadline,
+		},
+		{
+			name: "interval below floor",
+			req:  CreateRequest{SessionID: "s1", Kind: KindInterval, Prompt: "p", IntervalSeconds: 5, DeadlineAt: &future},
+			want: ErrBadInterval,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.req.normalize().validate(now)
+			if !errors.Is(got, tc.want) {
+				t.Fatalf("validate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeDefaults(t *testing.T) {
+	got := CreateRequest{SessionID: "s1", Kind: KindGoal, Prompt: "p"}.normalize()
+	if got.Origin != OriginOperator {
+		t.Errorf("origin = %q, want operator", got.Origin)
+	}
+	if got.MaxIterations != DefaultMaxIterations {
+		t.Errorf("max iterations = %d, want %d", got.MaxIterations, DefaultMaxIterations)
+	}
+	if got.FailureCap != DefaultFailureCap {
+		t.Errorf("failure cap = %d, want %d", got.FailureCap, DefaultFailureCap)
+	}
+	if got.JudgeTask != DefaultJudgeTask {
+		t.Errorf("judge task = %q, want %q", got.JudgeTask, DefaultJudgeTask)
+	}
+}
+
+func TestNormalizeIntervalClearsJudge(t *testing.T) {
+	got := CreateRequest{SessionID: "s1", Kind: KindInterval, Prompt: "p", JudgeTask: "loop_judge"}.normalize()
+	if got.JudgeTask != "" {
+		t.Errorf("interval judge task = %q, want empty", got.JudgeTask)
+	}
+}
+
+func TestBudgetExhausted(t *testing.T) {
+	now := time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC)
+	future := now.Add(time.Hour)
+	past := now.Add(-time.Minute)
+
+	if done, _ := (Loop{MaxIterations: 3, Iteration: 2, DeadlineAt: &future}).budgetExhausted(now); done {
+		t.Error("iteration 2 of 3 should not be exhausted")
+	}
+	if done, reason := (Loop{MaxIterations: 3, Iteration: 3, DeadlineAt: &future}).budgetExhausted(now); !done || reason == "" {
+		t.Errorf("iteration 3 of 3 should be exhausted, got done=%v reason=%q", done, reason)
+	}
+	if done, reason := (Loop{MaxIterations: 99, Iteration: 1, DeadlineAt: &past}).budgetExhausted(now); !done || reason == "" {
+		t.Errorf("past deadline should be exhausted, got done=%v reason=%q", done, reason)
+	}
+}
+
+func TestStatusIsTerminal(t *testing.T) {
+	terminal := []Status{StatusDone, StatusStopped, StatusFailed, StatusEscalated}
+	for _, s := range terminal {
+		if !s.IsTerminal() {
+			t.Errorf("%q should be terminal", s)
+		}
+	}
+	for _, s := range []Status{StatusPending, StatusRunning, StatusPaused} {
+		if s.IsTerminal() {
+			t.Errorf("%q should not be terminal", s)
+		}
+	}
+}
+
+func TestVerdictNormalise(t *testing.T) {
+	if got := (Verdict{Decision: "bogus"}).normalise(); got.Decision != DecisionEscalate {
+		t.Errorf("unknown decision should normalise to escalate, got %q", got.Decision)
+	}
+	if got := (Verdict{Decision: DecisionDone}).normalise(); got.Decision != DecisionDone {
+		t.Errorf("valid decision should pass through, got %q", got.Decision)
+	}
+}

--- a/internal/autoloop/store.go
+++ b/internal/autoloop/store.go
@@ -1,0 +1,218 @@
+package autoloop
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PgStore is the pgx-backed persistence for loops + their iteration audit.
+// It satisfies the Store interface the engine depends on. Loops are persisted
+// so they survive a gateway restart (ReconcileStartup re-arms running loops).
+type PgStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPgStore wraps a pool.
+func NewPgStore(pool *pgxpool.Pool) *PgStore { return &PgStore{pool: pool} }
+
+const loopColumns = `id, session_id, origin, COALESCE(integration_id, ''), kind, status,
+	goal, prompt, COALESCE(interval_seconds, 0), max_iterations, deadline_at,
+	failure_cap, COALESCE(judge_task, ''), iteration,
+	COALESCE(last_verdict, ''), COALESCE(last_reason, ''),
+	created_at, started_at, ended_at`
+
+func scanLoop(row pgx.Row) (Loop, error) {
+	var l Loop
+	err := row.Scan(
+		&l.ID, &l.SessionID, &l.Origin, &l.IntegrationID, &l.Kind, &l.Status,
+		&l.Goal, &l.Prompt, &l.IntervalSeconds, &l.MaxIterations, &l.DeadlineAt,
+		&l.FailureCap, &l.JudgeTask, &l.Iteration,
+		&l.LastVerdict, &l.LastReason,
+		&l.CreatedAt, &l.StartedAt, &l.EndedAt,
+	)
+	return l, err
+}
+
+// Create inserts a new loop row.
+func (s *PgStore) Create(ctx context.Context, l Loop) error {
+	var intervalSeconds *int
+	if l.Kind == KindInterval && l.IntervalSeconds > 0 {
+		v := l.IntervalSeconds
+		intervalSeconds = &v
+	}
+	var integrationID, judgeTask *string
+	if l.IntegrationID != "" {
+		integrationID = &l.IntegrationID
+	}
+	if l.JudgeTask != "" {
+		judgeTask = &l.JudgeTask
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO session_loops
+			(id, session_id, origin, integration_id, kind, status, goal, prompt,
+			 interval_seconds, max_iterations, deadline_at, failure_cap, judge_task,
+			 iteration, created_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+		l.ID, l.SessionID, l.Origin, integrationID, l.Kind, l.Status, l.Goal, l.Prompt,
+		intervalSeconds, l.MaxIterations, l.DeadlineAt, l.FailureCap, judgeTask,
+		l.Iteration, l.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("autoloop: create loop: %w", err)
+	}
+	return nil
+}
+
+// Get returns one loop by id, or ErrNotFound.
+func (s *PgStore) Get(ctx context.Context, id string) (Loop, error) {
+	row := s.pool.QueryRow(ctx, `SELECT `+loopColumns+` FROM session_loops WHERE id = $1`, id)
+	l, err := scanLoop(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Loop{}, ErrNotFound
+	}
+	if err != nil {
+		return Loop{}, fmt.Errorf("autoloop: get loop: %w", err)
+	}
+	return l, nil
+}
+
+// List returns all loops, newest first.
+func (s *PgStore) List(ctx context.Context) ([]Loop, error) {
+	rows, err := s.pool.Query(ctx, `SELECT `+loopColumns+` FROM session_loops ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("autoloop: list loops: %w", err)
+	}
+	defer rows.Close()
+	return collectLoops(rows)
+}
+
+// ListLive returns loops in a non-terminal state (running / paused). Used by
+// ReconcileStartup to re-arm loops after a gateway restart.
+func (s *PgStore) ListLive(ctx context.Context) ([]Loop, error) {
+	rows, err := s.pool.Query(ctx, `SELECT `+loopColumns+`
+		FROM session_loops WHERE status IN ('running','paused') ORDER BY created_at ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("autoloop: list live loops: %w", err)
+	}
+	defer rows.Close()
+	return collectLoops(rows)
+}
+
+func collectLoops(rows pgx.Rows) ([]Loop, error) {
+	var out []Loop
+	for rows.Next() {
+		l, err := scanLoop(rows)
+		if err != nil {
+			return nil, fmt.Errorf("autoloop: scan loop: %w", err)
+		}
+		out = append(out, l)
+	}
+	return out, rows.Err()
+}
+
+// MarkRunning flips a loop to running and stamps started_at (idempotent on
+// started_at: only set the first time).
+func (s *PgStore) MarkRunning(ctx context.Context, id string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE session_loops
+		   SET status = 'running', started_at = COALESCE(started_at, NOW())
+		 WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("autoloop: mark running: %w", err)
+	}
+	return nil
+}
+
+// SetStatus updates the loop status + last reason. Terminal states stamp
+// ended_at so the audit shows when the loop finished.
+func (s *PgStore) SetStatus(ctx context.Context, id string, st Status, reason string) error {
+	var endedAt *time.Time
+	if st.IsTerminal() {
+		now := time.Now()
+		endedAt = &now
+	}
+	_, err := s.pool.Exec(ctx, `
+		UPDATE session_loops
+		   SET status = $2,
+		       last_reason = NULLIF($3, ''),
+		       ended_at = COALESCE($4, ended_at)
+		 WHERE id = $1`, id, st, reason, endedAt)
+	if err != nil {
+		return fmt.Errorf("autoloop: set status: %w", err)
+	}
+	return nil
+}
+
+// SaveProgress records the loop's iteration count + latest verdict/reason.
+func (s *PgStore) SaveProgress(ctx context.Context, id string, iteration int, verdict, reason string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE session_loops
+		   SET iteration = $2, last_verdict = NULLIF($3, ''), last_reason = NULLIF($4, '')
+		 WHERE id = $1`, id, iteration, verdict, reason)
+	if err != nil {
+		return fmt.Errorf("autoloop: save progress: %w", err)
+	}
+	return nil
+}
+
+// AppendRun opens an audit row for one iteration and returns its id.
+func (s *PgStore) AppendRun(ctx context.Context, loopID string, iteration int, prompt string) (int64, error) {
+	var runID int64
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO session_loop_runs (loop_id, iteration, prompt)
+		VALUES ($1, $2, $3) RETURNING id`, loopID, iteration, prompt).Scan(&runID)
+	if err != nil {
+		return 0, fmt.Errorf("autoloop: append run: %w", err)
+	}
+	return runID, nil
+}
+
+// FinishRun closes an audit row with the iteration's verdict + reason.
+func (s *PgStore) FinishRun(ctx context.Context, runID int64, verdict, reason string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE session_loop_runs
+		   SET verdict = NULLIF($2, ''), reason = NULLIF($3, ''), ended_at = NOW()
+		 WHERE id = $1`, runID, verdict, reason)
+	if err != nil {
+		return fmt.Errorf("autoloop: finish run: %w", err)
+	}
+	return nil
+}
+
+// Run is one persisted iteration audit row (read side for the API).
+type Run struct {
+	ID        int64      `json:"id"`
+	LoopID    string     `json:"loop_id"`
+	Iteration int        `json:"iteration"`
+	Prompt    string     `json:"prompt"`
+	Verdict   string     `json:"verdict,omitempty"`
+	Reason    string     `json:"reason,omitempty"`
+	StartedAt time.Time  `json:"started_at"`
+	EndedAt   *time.Time `json:"ended_at,omitempty"`
+}
+
+// ListRuns returns the iteration audit for a loop, oldest first.
+func (s *PgStore) ListRuns(ctx context.Context, loopID string) ([]Run, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, loop_id, iteration, prompt,
+		       COALESCE(verdict, ''), COALESCE(reason, ''), started_at, ended_at
+		  FROM session_loop_runs WHERE loop_id = $1 ORDER BY iteration ASC, id ASC`, loopID)
+	if err != nil {
+		return nil, fmt.Errorf("autoloop: list runs: %w", err)
+	}
+	defer rows.Close()
+	var out []Run
+	for rows.Next() {
+		var r Run
+		if err := rows.Scan(&r.ID, &r.LoopID, &r.Iteration, &r.Prompt,
+			&r.Verdict, &r.Reason, &r.StartedAt, &r.EndedAt); err != nil {
+			return nil, fmt.Errorf("autoloop: scan run: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}

--- a/internal/autoloop/store_test.go
+++ b/internal/autoloop/store_test.go
@@ -1,0 +1,192 @@
+package autoloop
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// loopTestSchema is an isolated schema this test owns end-to-end: it is
+// dropped + recreated each run, so the test never touches the real public
+// tables even when OPENDRAY_DEV_DB_URL points at a populated database.
+const loopTestSchema = "autoloop_test"
+
+// loopTestDDL mirrors the table shape of migration 0069 (the memory_workers
+// ALTER in that migration is validated separately by the full ephemeral
+// migration run; PgStore itself never touches memory_workers).
+const loopTestDDL = `
+CREATE TABLE sessions (id TEXT PRIMARY KEY);
+CREATE TABLE integrations (id TEXT PRIMARY KEY);
+CREATE TABLE session_loops (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    origin TEXT NOT NULL DEFAULT 'operator',
+    integration_id TEXT REFERENCES integrations(id) ON DELETE SET NULL,
+    kind TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    goal TEXT NOT NULL DEFAULT '',
+    prompt TEXT NOT NULL,
+    interval_seconds INT,
+    max_iterations INT NOT NULL DEFAULT 20,
+    deadline_at TIMESTAMPTZ,
+    failure_cap INT NOT NULL DEFAULT 3,
+    judge_task TEXT,
+    iteration INT NOT NULL DEFAULT 0,
+    last_verdict TEXT,
+    last_reason TEXT,
+    config JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    started_at TIMESTAMPTZ,
+    ended_at TIMESTAMPTZ
+);
+CREATE TABLE session_loop_runs (
+    id BIGSERIAL PRIMARY KEY,
+    loop_id TEXT NOT NULL REFERENCES session_loops(id) ON DELETE CASCADE,
+    iteration INT NOT NULL,
+    prompt TEXT NOT NULL,
+    verdict TEXT,
+    reason TEXT,
+    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ended_at TIMESTAMPTZ
+);`
+
+func loopTestDB(t *testing.T) (*pgxpool.Pool, func()) {
+	t.Helper()
+	url := os.Getenv("OPENDRAY_DEV_DB_URL")
+	if url == "" {
+		t.Skip("OPENDRAY_DEV_DB_URL not set; export a writable Postgres DSN to run PgStore tests")
+	}
+	ctx := context.Background()
+	cfg, err := pgxpool.ParseConfig(url)
+	if err != nil {
+		t.Skipf("bad OPENDRAY_DEV_DB_URL: %v", err)
+	}
+	cfg.ConnConfig.RuntimeParams["search_path"] = loopTestSchema
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Skipf("dev DB unreachable, skipping: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("dev DB ping failed, skipping: %v", err)
+	}
+	for _, stmt := range []string{
+		"DROP SCHEMA IF EXISTS " + loopTestSchema + " CASCADE",
+		"CREATE SCHEMA " + loopTestSchema,
+	} {
+		if _, err := pool.Exec(ctx, stmt); err != nil {
+			pool.Close()
+			t.Fatalf("schema setup (%s): %v", stmt, err)
+		}
+	}
+	if _, err := pool.Exec(ctx, loopTestDDL); err != nil {
+		pool.Close()
+		t.Fatalf("ddl: %v", err)
+	}
+	// seed stub parents.
+	if _, err := pool.Exec(ctx, `INSERT INTO sessions(id) VALUES ('s1'); INSERT INTO integrations(id) VALUES ('i1');`); err != nil {
+		pool.Close()
+		t.Fatalf("seed parents: %v", err)
+	}
+	cleanup := func() {
+		_, _ = pool.Exec(context.Background(), "DROP SCHEMA IF EXISTS "+loopTestSchema+" CASCADE")
+		pool.Close()
+	}
+	return pool, cleanup
+}
+
+func TestPgStoreRoundTrip(t *testing.T) {
+	pool, cleanup := loopTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	s := NewPgStore(pool)
+	dl := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+
+	goal := Loop{
+		ID: "lp_goal", SessionID: "s1", Origin: OriginIntegration, IntegrationID: "i1",
+		Kind: KindGoal, Status: StatusPending, Goal: "do it", Prompt: "seed",
+		MaxIterations: 5, DeadlineAt: &dl, FailureCap: 2, JudgeTask: "loop_judge",
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := s.Create(ctx, goal); err != nil {
+		t.Fatalf("create goal: %v", err)
+	}
+	interval := Loop{
+		ID: "lp_int", SessionID: "s1", Origin: OriginOperator,
+		Kind: KindInterval, Status: StatusPending, Prompt: "tick",
+		IntervalSeconds: 30, MaxIterations: 3, DeadlineAt: &dl, FailureCap: 3,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := s.Create(ctx, interval); err != nil {
+		t.Fatalf("create interval: %v", err)
+	}
+
+	got, err := s.Get(ctx, "lp_goal")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Kind != KindGoal || got.IntegrationID != "i1" || got.JudgeTask != "loop_judge" {
+		t.Errorf("goal round-trip mismatch: %+v", got)
+	}
+	if got.DeadlineAt == nil || !got.DeadlineAt.Equal(dl) {
+		t.Errorf("deadline round-trip: got %v want %v", got.DeadlineAt, dl)
+	}
+	if gi, _ := s.Get(ctx, "lp_int"); gi.IntervalSeconds != 30 || gi.IntegrationID != "" {
+		t.Errorf("interval round-trip mismatch: %+v", gi)
+	}
+
+	if _, err := s.Get(ctx, "missing"); err != ErrNotFound {
+		t.Errorf("Get(missing) = %v, want ErrNotFound", err)
+	}
+
+	all, _ := s.List(ctx)
+	if len(all) != 2 {
+		t.Errorf("list = %d, want 2", len(all))
+	}
+
+	// lifecycle: run → progress → terminal.
+	if err := s.MarkRunning(ctx, "lp_goal"); err != nil {
+		t.Fatalf("mark running: %v", err)
+	}
+	live, _ := s.ListLive(ctx)
+	if len(live) != 1 || live[0].ID != "lp_goal" {
+		t.Errorf("listlive = %+v, want only lp_goal", live)
+	}
+	runID, err := s.AppendRun(ctx, "lp_goal", 1, "seed")
+	if err != nil {
+		t.Fatalf("append run: %v", err)
+	}
+	if err := s.SaveProgress(ctx, "lp_goal", 1, DecisionContinue, "progress"); err != nil {
+		t.Fatalf("save progress: %v", err)
+	}
+	if err := s.FinishRun(ctx, runID, DecisionContinue, "progress"); err != nil {
+		t.Fatalf("finish run: %v", err)
+	}
+	if err := s.SetStatus(ctx, "lp_goal", StatusDone, "goal met"); err != nil {
+		t.Fatalf("set status: %v", err)
+	}
+
+	done, _ := s.Get(ctx, "lp_goal")
+	if done.Status != StatusDone || done.Iteration != 1 || done.LastVerdict != DecisionContinue {
+		t.Errorf("post-lifecycle loop = %+v", done)
+	}
+	if done.EndedAt == nil {
+		t.Error("terminal status should stamp ended_at")
+	}
+
+	runs, _ := s.ListRuns(ctx, "lp_goal")
+	if len(runs) != 1 || runs[0].Verdict != DecisionContinue || runs[0].EndedAt == nil {
+		t.Errorf("runs = %+v", runs)
+	}
+
+	// FK cascade: deleting the session removes its loops + runs.
+	if _, err := pool.Exec(ctx, "DELETE FROM sessions WHERE id='s1'"); err != nil {
+		t.Fatalf("delete session: %v", err)
+	}
+	if remaining, _ := s.List(ctx); len(remaining) != 0 {
+		t.Errorf("loops after session delete = %d, want 0 (cascade)", len(remaining))
+	}
+}

--- a/internal/channel/hub.go
+++ b/internal/channel/hub.go
@@ -43,6 +43,15 @@ type Hub struct {
 	notifyMu    sync.Mutex
 	notifyState map[string]map[string]time.Time // channelID -> "topic|sessionID" -> sent-at
 
+	// loopSessions is the set of session ids currently driven by a Loop
+	// Engine (autoloop) loop. The hub suppresses routine per-turn idle
+	// cards for these sessions — a loop fires an idle every iteration as the
+	// agent settles, which would otherwise broadcast a card to every channel
+	// each turn. Loop milestones (escalated / failed) notify instead, via
+	// dispatchLoop. Maintained from autoloop.* lifecycle events.
+	loopMu       sync.Mutex
+	loopSessions map[string]bool
+
 	lastSessMu sync.RWMutex
 	lastSess   map[string]string // channelID -> session_id of the most-recent notification
 
@@ -134,6 +143,7 @@ func NewHub(pool *pgxpool.Pool, bus *eventbus.Hub, log *slog.Logger) *Hub {
 		cmds:          NewCommandRegistry(),
 		channels:      make(map[string]Channel),
 		notifyState:   make(map[string]map[string]time.Time),
+		loopSessions:  make(map[string]bool),
 		lastSess:      make(map[string]string),
 		outboundIndex: make(map[string]map[string]outboundEntry),
 		activeSess:    make(map[string]string),
@@ -976,6 +986,12 @@ func (h *Hub) runOutbound(ctx context.Context) {
 	defer unsubBF()
 	chVerifyFail, unsubVF := h.bus.Subscribe("backup.verify_failed", 32)
 	defer unsubVF()
+	// Loop Engine (autoloop) lifecycle. The wildcard catches started /
+	// resumed (which mark a session loop-driven, so its idle cards stay
+	// suppressed) and the milestone outcomes escalated / failed (which
+	// broadcast a "needs attention" card). See dispatchLoop.
+	chLoop, unsubLoop := h.bus.Subscribe("autoloop.*", 64)
+	defer unsubLoop()
 	for {
 		select {
 		case <-ctx.Done():
@@ -1026,6 +1042,11 @@ func (h *Hub) runOutbound(ctx context.Context) {
 				return
 			}
 			h.dispatch(ctx, ev)
+		case ev, ok := <-chLoop:
+			if !ok {
+				return
+			}
+			h.dispatchLoop(ctx, ev)
 		}
 	}
 }
@@ -1049,6 +1070,15 @@ func (h *Hub) dispatch(ctx context.Context, ev eventbus.Event) {
 	}
 
 	sessionID := sessionIDFromEvent(ev)
+
+	// A loop-driven session fires an idle every iteration as the agent
+	// settles between turns; broadcasting that as a card to every channel
+	// each turn is pure noise. Suppress routine idle cards for loop
+	// sessions — the loop's own milestones (escalated / failed) notify
+	// instead, via dispatchLoop.
+	if ev.Topic == "session.idle" && sessionID != "" && h.isLoopSession(sessionID) {
+		return
+	}
 
 	// The repeat-policy suppression key is the session id for session
 	// events. Non-session events (e.g. backup.*) carry no session_id, so

--- a/internal/channel/loops.go
+++ b/internal/channel/loops.go
@@ -1,0 +1,120 @@
+package channel
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/opendray/opendray-v2/internal/eventbus"
+)
+
+// dispatchLoop handles autoloop.* events. It maintains the set of
+// loop-driven sessions (so dispatch can suppress their routine idle cards)
+// and broadcasts a "needs attention" card for the milestone outcomes that an
+// operator actually wants pushed — escalated and failed. A clean done is
+// deliberately silent: success is visible in the Loops UI and doesn't earn a
+// chat ping.
+func (h *Hub) dispatchLoop(ctx context.Context, ev eventbus.Event) {
+	data, _ := ev.Data.(map[string]any)
+	if data == nil {
+		return
+	}
+	loopID, _ := data["loop_id"].(string)
+	sessionID, _ := data["session_id"].(string)
+	status, _ := data["status"].(string)
+	kind, _ := data["kind"].(string)
+	reason, _ := data["reason"].(string)
+
+	// Track which sessions are loop-driven so dispatch() can keep their
+	// per-turn idle cards suppressed.
+	switch ev.Topic {
+	case "autoloop.started", "autoloop.resumed":
+		h.markLoopSession(sessionID, true)
+	case "autoloop.done", "autoloop.failed", "autoloop.escalated", "autoloop.stopped":
+		h.markLoopSession(sessionID, false)
+	}
+
+	// Only the "needs a human" outcomes broadcast a card.
+	switch ev.Topic {
+	case "autoloop.escalated", "autoloop.failed":
+	default:
+		return
+	}
+
+	text := loopMilestoneText(status, kind, loopID, reason)
+
+	h.mu.RLock()
+	chs := make([]Channel, 0, len(h.channels))
+	for _, c := range h.channels {
+		chs = append(chs, c)
+	}
+	h.mu.RUnlock()
+
+	for _, c := range chs {
+		if h.isMuted(ctx, c.ID()) {
+			continue
+		}
+		// Dedup per loop+topic under the channel's repeat policy, so a
+		// flapping loop can't spam the same escalation.
+		if h.suppressByPolicy(ctx, c.ID(), ev.Topic, loopID) {
+			continue
+		}
+		msg := ChannelMessage{
+			ChannelID:      c.ID(),
+			Direction:      DirectionOutbound,
+			ConversationID: "default",
+			Text:           text,
+			Timestamp:      time.Now().UTC(),
+			Metadata:       map[string]any{"loop_id": loopID},
+		}
+		if err := h.sendWithFallback(ctx, c, msg, nil); err != nil {
+			h.log.Error("loop notify send failed", "id", c.ID(), "err", err)
+			continue
+		}
+		if _, err := h.store.InsertMessage(ctx, msg); err != nil {
+			h.log.Warn("loop notify persist failed", "id", c.ID(), "err", err)
+		}
+	}
+}
+
+// loopMilestoneText renders a concise chat line for a loop outcome.
+func loopMilestoneText(status, kind, loopID string, reason string) string {
+	var b strings.Builder
+	switch status {
+	case "escalated":
+		b.WriteString("🔁 Loop needs your attention")
+	case "failed":
+		b.WriteString("🔁 Loop failed")
+	default:
+		b.WriteString("🔁 Loop update")
+	}
+	if kind != "" {
+		fmt.Fprintf(&b, "\n%s loop %s", kind, loopID)
+	} else {
+		fmt.Fprintf(&b, "\nloop %s", loopID)
+	}
+	if strings.TrimSpace(reason) != "" {
+		fmt.Fprintf(&b, "\n%s", strings.TrimSpace(reason))
+	}
+	return b.String()
+}
+
+func (h *Hub) markLoopSession(sessionID string, driven bool) {
+	if sessionID == "" {
+		return
+	}
+	h.loopMu.Lock()
+	defer h.loopMu.Unlock()
+	if driven {
+		h.loopSessions[sessionID] = true
+	} else {
+		delete(h.loopSessions, sessionID)
+	}
+}
+
+func (h *Hub) isLoopSession(sessionID string) bool {
+	h.loopMu.Lock()
+	defer h.loopMu.Unlock()
+	return h.loopSessions[sessionID]
+}

--- a/internal/memory/worker/worker.go
+++ b/internal/memory/worker/worker.go
@@ -63,6 +63,13 @@ const (
 	// operator discusses a doc section or knowledge page with the AI
 	// and the AI produces a revision (apply or proposal).
 	TaskCuration TaskKind = "curation"
+	// TaskLoopJudge is the Loop Engine (autoloop) goal-mode verifier:
+	// given a goal and the latest turn's output, decide whether to
+	// continue (with a next prompt), the goal is done, it should
+	// escalate to a human, or it failed. Seeded summarizer by default
+	// so it is provider-agnostic — the judge is decoupled from whichever
+	// CLI the driven session runs.
+	TaskLoopJudge TaskKind = "loop_judge"
 )
 
 // AllTasks returns every recognised TaskKind in a stable order.
@@ -72,7 +79,7 @@ func AllTasks() []TaskKind {
 	return []TaskKind{
 		TaskGatekeeper, TaskCleaner, TaskGitActivity, TaskTranscript,
 		TaskPlanDrift, TaskConflictDetector, TaskCapture,
-		TaskBlueprint, TaskCuration,
+		TaskBlueprint, TaskCuration, TaskLoopJudge,
 	}
 }
 

--- a/internal/store/migrations/0069_session_loops.sql
+++ b/internal/store/migrations/0069_session_loops.sql
@@ -1,0 +1,97 @@
+-- 0069 — Loop Engine (autoloop): persistent autonomous agent loops.
+--
+-- "Loop Engineering" (2026) is the shift from hand-writing prompts to writing
+-- a system that drives the agent: a recursive goal, a way to find work, act,
+-- verify, remember, and a stopping condition. opendray already has every
+-- building block (PTY sessions to act, worker.Registry to verify, eventbus +
+-- channels to escalate, memory to remember) — this migration persists the
+-- orchestration layer (internal/autoloop) so loops survive a gateway restart.
+--
+-- A Loop is 1:1 with a session it drives. Two kinds share one lifecycle:
+--   - interval: re-feed `prompt` every `interval_seconds`; stop on caps.
+--   - goal:     feed `prompt` (seed), wait for turn_completed, run the
+--               `judge_task` worker → continue|done|escalate|fail.
+--
+-- Provider-agnostic: the engine drives sessions at the PTY layer
+-- (ExpectTurn/Input/turn_completed), so a loop works the same over
+-- claude/codex/gemini/antigravity/opencode — `Loop` holds no provider field;
+-- the bound session determines the CLI.
+
+CREATE TABLE session_loops (
+    id               TEXT PRIMARY KEY,
+    session_id       TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    -- origin mirrors session.Origin: who created the loop.
+    origin           TEXT NOT NULL DEFAULT 'operator'
+                     CHECK (origin IN ('operator', 'integration')),
+    integration_id   TEXT REFERENCES integrations(id) ON DELETE SET NULL,
+    kind             TEXT NOT NULL CHECK (kind IN ('interval', 'goal')),
+    status           TEXT NOT NULL DEFAULT 'pending'
+                     CHECK (status IN ('pending', 'running', 'paused',
+                                       'done', 'stopped', 'failed', 'escalated')),
+    -- goal mode: the recursive objective the judge evaluates against.
+    goal             TEXT NOT NULL DEFAULT '',
+    -- interval mode: re-fed each tick. goal mode: the seed prompt.
+    prompt           TEXT NOT NULL,
+    -- interval mode only; floored at 30s by the engine. NULL for goal loops.
+    interval_seconds INT,
+    -- hard caps (at least one of max_iterations / deadline_at is enforced at
+    -- creation; deadline_at is mandatory per the design's guardrail-first rule).
+    max_iterations   INT NOT NULL DEFAULT 20,
+    deadline_at      TIMESTAMPTZ,
+    -- consecutive judge=fail / turn-timeout count that flips the loop to
+    -- 'escalated' (hand it to a human) rather than retrying forever.
+    failure_cap      INT NOT NULL DEFAULT 3,
+    -- worker TaskKind used to verify a goal turn (e.g. 'loop_judge'); NULL =
+    -- no verification (interval loops, or a goal loop that only caps on count).
+    judge_task       TEXT,
+    iteration        INT NOT NULL DEFAULT 0,
+    last_verdict     TEXT,
+    last_reason      TEXT,
+    -- forward-compat spillover (e.g. future token/cost budget).
+    config           JSONB NOT NULL DEFAULT '{}',
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    started_at       TIMESTAMPTZ,
+    ended_at         TIMESTAMPTZ
+);
+
+-- ReconcileStartup scans only live loops; partial index keeps it cheap.
+CREATE INDEX idx_session_loops_live
+    ON session_loops (status)
+    WHERE status IN ('running', 'paused');
+CREATE INDEX idx_session_loops_session ON session_loops (session_id);
+
+-- Per-iteration audit. This is a SCOPED audit trail (one row per turn of a
+-- known loop), not a generic raw event stream — opendray deliberately avoids
+-- generic event-log viewers.
+CREATE TABLE session_loop_runs (
+    id         BIGSERIAL PRIMARY KEY,
+    loop_id    TEXT NOT NULL REFERENCES session_loops(id) ON DELETE CASCADE,
+    iteration  INT NOT NULL,
+    prompt     TEXT NOT NULL,
+    verdict    TEXT,
+    reason     TEXT,
+    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ended_at   TIMESTAMPTZ
+);
+CREATE INDEX idx_session_loop_runs_loop ON session_loop_runs (loop_id, iteration);
+
+-- Register 'loop_judge' as a memory-worker touchpoint: the goal-mode verifier
+-- that reads a turn's output and returns continue|done|escalate|fail. Seeded
+-- kind='summarizer' so it is provider-agnostic by default (an HTTP judge that
+-- works the same regardless of which CLI the driven session runs) and cheap;
+-- an operator can flip it to an agent worker later (subject to the per-CLI
+-- headless support matrix — opencode has no headless path).
+ALTER TABLE memory_workers
+    DROP CONSTRAINT IF EXISTS memory_workers_task_check;
+
+ALTER TABLE memory_workers
+    ADD CONSTRAINT memory_workers_task_check
+        CHECK (task IN (
+            'gatekeeper','cleaner','gitactivity','transcript',
+            'plan_drift','conflict_detector','capture',
+            'blueprint','curation','loop_judge'
+        ));
+
+INSERT INTO memory_workers (task, kind) VALUES
+    ('loop_judge', 'summarizer')
+ON CONFLICT (task) DO NOTHING;


### PR DESCRIPTION
## Summary

Implements **Loop Engineering** (the 2026 "write loops, not prompts" pattern) as a gateway-level capability: a new `internal/autoloop` orchestration layer that drives an agent session repeatedly — on a fixed **interval**, or until a judged **goal** is met — wiring opendray's existing session / worker / eventbus / memory pieces into a self-driving loop (find work → act → verify → remember → stop → escalate).

A `Loop` is 1:1 with a `session.Manager` session and is driven at the **PTY layer** (`ExpectTurn` + `Input` + the `session.turn_completed` event), so it is **provider-agnostic** — the same engine drives claude / codex / gemini / antigravity / opencode with no per-CLI branching. The engine arms `ExpectTurn` itself, so loops also work for integration-origin sessions (which otherwise never receive `turn_completed`).

Design doc: `Obsidiannote/Projects/OpenDray/loop-engine-design.md`.

## What's included

**Backend**
- `migration 0069` — `session_loops` + `session_loop_runs` (scoped iteration audit) tables; registers the `loop_judge` memory-worker task (summarizer by default, provider-agnostic).
- `internal/autoloop` — `loop` (entity + guardrail validation), `store` (pgx CRUD), `judge` (worker.Registry wrapper, strict-JSON verdict), `engine` (per-loop goroutine, interval/goal runs, reconcile-on-restart, pause/resume/stop), `handler` (REST `/api/v1/loops`, origin derived from the authenticated principal).
- `worker.TaskLoopJudge` + app wiring (construct over session.Manager + worker.Registry + eventbus, `ReconcileStartup` on boot, mount under the combined-auth group, `Shutdown` before sessions so loops stay `running` for restart reconcile).

**UI (web + mobile + i18n, per convention)**
- Web (React): shared `Loop` types + REST client, a Loops page (card list, create dialog with interval/goal toggle + guardrail fields, iteration-audit dialog, pause/resume/stop), `/loops` route + sidebar entry. Live via 4s polling (no per-loop WS in Phase 1).
- Mobile (Flutter): `LoopsApi` + models + Riverpod providers, a Loops screen (list + pull-to-refresh + 4s poll, create bottom sheet, iteration audit, controls), reached from the More tab.
- i18n in **en / zh / es**; `strings.g.dart` regenerated.

## Guardrails

Verification, stopping conditions, and human escalation are the hard part of loop engineering, so: a deadline is **mandatory**, interval has a **30s floor**, max-iteration + failure caps, the judge **escalates on uncertainty**, and every termination is logged + published on `autoloop.*` (no silent truncation).

## Test plan

- `go test -race ./internal/autoloop/...` — table-driven + httptest + a DB-backed store round-trip; **80.6%** coverage. Validated against an ephemeral pg17 (full migration chain through 0069).
- `go build ./...` clean; `go vet` clean.
- Web: `tsc -b` + `eslint` clean.
- Mobile: `flutter analyze` clean (whole app).

## Deferred (Phase 3)

Channel escalation/progress push + loop-origin notification suppression, scope enforcement, an MCP escalation-reply tool, and a token/cost budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)