### PR TITLE
feat(session): carry context by default on Claude account switch + failover

### DIFF
--- a/app/web/src/components/sessions/AccountSwitcher.tsx
+++ b/app/web/src/components/sessions/AccountSwitcher.tsx
@@ -45,7 +45,12 @@ export function AccountSwitcher({ session }: AccountSwitcherProps) {
   // Carry-over toggle. When on, the switch seeds the new account's
   // fresh session with a recap of the prior conversation (sent to the
   // provider under the new account — see the helper text / confirm).
-  const [carryContext, setCarryContext] = useState(false)
+  // Defaults ON: an account switch can't truly resume the old
+  // conversation across isolated accounts, so without a recap the new
+  // session starts blind — the common surprise was "I switched and lost
+  // everything". The confirm dialog uses the carry-consent copy so the
+  // cross-account data flow is still surfaced; untick for a clean slate.
+  const [carryContext, setCarryContext] = useState(true)
 
   const mutation = useMutation({
     mutationFn: (accountId: string) =>

--- a/internal/session/rate_limit_failover.go
+++ b/internal/session/rate_limit_failover.go
@@ -88,11 +88,12 @@ func (m *Manager) tryRateLimitFailover(rs *runningSession, now time.Time) {
 		return
 	}
 
-	// Automatic throttle failover keeps the clean-slate switch — no
-	// carry-context. The operator didn't opt in, and a rate-limit
-	// bounce shouldn't silently ship prior conversation to another
-	// account.
-	if _, err := m.SwitchClaudeAccount(ctx, sessID, target, false); err != nil {
+	// Automatic throttle failover carries context: a rate-limit bounce
+	// is involuntary, so dropping the conversation on the floor is worse
+	// than seeding the standby account with a recap. The target is one
+	// of the operator's own accounts (same trust domain), and the recap
+	// rides the same --append-system-prompt path as a manual carry.
+	if _, err := m.SwitchClaudeAccount(ctx, sessID, target, true); err != nil {
 		m.log.Warn("auto-failover switch failed",
 			"session", sessID,
 			"from_account", currentAccountID,


### PR DESCRIPTION
## Why

Switching a session to another Claude account was losing the conversation. Two reasons, both addressed here:

1. The **carry-context recap was opt-in (toggle OFF)** — a plain switch started the new session blind. The recurring report was *"I switched accounts and lost everything."*
2. **Rate-limit auto-failover** always passed `carryContext=false`, so an involuntary bounce silently dropped context too.

Account switches **cannot** `--resume` across accounts — each account is an isolated `CLAUDE_CONFIG_DIR` with its own session registry, so a UUID minted under account A doesn't exist under account B. A recap injected via `--append-system-prompt` is the best achievable continuity. This PR makes that recap the default.

## Changes

- **`AccountSwitcher.tsx`** — carry toggle now defaults **ON** (untick for a clean slate). The confirm dialog already uses the carry-consent copy, so the cross-account data flow stays surfaced.
- **`rate_limit_failover.go`** — auto-failover now carries context (target is one of the operator's own accounts; same `--append-system-prompt` path).

## Not changed

- Backend API default stays `carry_context omitted => false` (wire-protocol contract, covered by `handler_test.go`). The UI now sends an explicit value.

## Test

- `go test ./internal/session/...` ✅
- `tsc --noEmit` ✅