### PR TITLE
feat(opencode): spawn-time notice when local endpoint is unreachable / has no chat model

### DIFF
--- a/internal/catalog/opencode.go
+++ b/internal/catalog/opencode.go
@@ -119,7 +119,9 @@ func injectOpenCodeLocalProvider(ctx context.Context, baseDir string, cfg map[st
 
 	// Best-effort enumeration — a probe failure (endpoint down) just falls
 	// back to the explicitly named localModel, so a spawn is never blocked.
-	modelIDs := probeOpenCodeModels(ctx, baseURL, apiKey)
+	// probeErr distinguishes "unreachable" from "reached but no chat model"
+	// so the spawn-time notice below can be specific.
+	modelIDs, probeErr := probeOpenCodeModels(ctx, baseURL, apiKey)
 
 	models := map[string]any{}
 	for _, id := range modelIDs {
@@ -160,32 +162,60 @@ func injectOpenCodeLocalProvider(ctx context.Context, baseDir string, cfg map[st
 		return err
 	}
 	setOpenCodeConfigEnv(baseDir, out)
+
+	// Spawn-time diagnostics. The probe is best-effort and never blocks the
+	// spawn, so without this the operator only sees OpenCode's opaque
+	// "[buffer unavailable]" when the session can't produce a response.
+	// Surface a one-time hint in the session terminal (and transcript)
+	// describing the actual failure. Only fires when no chat model is
+	// available — a healthy enumeration stays silent.
+	if len(modelIDs) == 0 {
+		havePinned := localModel != "" || explicitModel
+		switch {
+		case probeErr != nil && !havePinned:
+			out.Notices = append(out.Notices, fmt.Sprintf(
+				"opendray: the OpenCode local endpoint %s is unreachable (%v), so this session has no local model and OpenCode will fail with \"[buffer unavailable]\". "+
+					"From the gateway host run:  curl %s/models  — check the URL ends in /v1, the endpoint serves on the LAN (not just localhost), and a chat model is loaded; then set a Default Local Model and start a new session.",
+				baseURL, probeErr, baseURL))
+		case probeErr != nil && havePinned:
+			out.Notices = append(out.Notices, fmt.Sprintf(
+				"opendray: couldn't reach the OpenCode local endpoint %s (%v) to verify models; falling back to your pinned model. If the session can't respond, confirm the endpoint is up and reachable from the gateway host.",
+				baseURL, probeErr))
+		case probeErr == nil && !havePinned:
+			out.Notices = append(out.Notices, fmt.Sprintf(
+				"opendray: the OpenCode local endpoint %s is reachable but served no chat-capable models (only embeddings/rerank, or none loaded), so this session has no local model and OpenCode will fail with \"[buffer unavailable]\". "+
+					"Load a chat model on the endpoint, or set a Default Local Model, then start a new session.",
+				baseURL))
+		}
+	}
 	return nil
 }
 
 // probeOpenCodeModels lists the chat/coding model ids served at an
 // OpenAI-compatible endpoint (GET <baseURL>/models). Embedding /
 // transcription / rerank ids are filtered out so they don't clutter
-// OpenCode's /model picker. Best-effort: any error returns nil so a spawn is
-// never blocked on an unreachable endpoint. A package var so tests can stub
-// it without a live endpoint.
-var probeOpenCodeModels = func(ctx context.Context, baseURL, apiKey string) []string {
+// OpenCode's /model picker. Best-effort: a non-nil error means the
+// endpoint was unreachable / refused / unparseable (the caller never
+// blocks a spawn on it, but surfaces a one-time notice). A nil error with
+// an empty slice means "reached it, but it served no chat-capable model".
+// A package var so tests can stub it without a live endpoint.
+var probeOpenCodeModels = func(ctx context.Context, baseURL, apiKey string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+"/models", nil)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	if apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil
+		return nil, fmt.Errorf("endpoint returned HTTP %d", resp.StatusCode)
 	}
 	var body struct {
 		Data []struct {
@@ -193,7 +223,7 @@ var probeOpenCodeModels = func(ctx context.Context, baseURL, apiKey string) []st
 		} `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return nil
+		return nil, fmt.Errorf("decode /models response: %w", err)
 	}
 	ids := make([]string, 0, len(body.Data))
 	for _, m := range body.Data {
@@ -201,7 +231,7 @@ var probeOpenCodeModels = func(ctx context.Context, baseURL, apiKey string) []st
 			ids = append(ids, id)
 		}
 	}
-	return ids
+	return ids, nil
 }
 
 // isOpenCodeChatModel drops obvious non-chat model ids (embeddings,

--- a/internal/catalog/opencode_test.go
+++ b/internal/catalog/opencode_test.go
@@ -3,7 +3,9 @@ package catalog
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/opendray/opendray-v2/internal/session"
@@ -13,8 +15,15 @@ import (
 // it on cleanup, so tests never depend on a running local endpoint.
 func stubOpenCodeProbe(t *testing.T, ids []string) {
 	t.Helper()
+	stubOpenCodeProbeResult(t, ids, nil)
+}
+
+// stubOpenCodeProbeResult lets a test drive both the returned model ids and
+// the probe error, to exercise the unreachable-endpoint notice path.
+func stubOpenCodeProbeResult(t *testing.T, ids []string, err error) {
+	t.Helper()
 	prev := probeOpenCodeModels
-	probeOpenCodeModels = func(context.Context, string, string) []string { return ids }
+	probeOpenCodeModels = func(context.Context, string, string) ([]string, error) { return ids, err }
 	t.Cleanup(func() { probeOpenCodeModels = prev })
 }
 
@@ -119,6 +128,45 @@ func TestInjectOpenCodeLocalProvider_EnumeratesProbedModels(t *testing.T) {
 	// Default-selects the first probed model when no localModel is pinned.
 	if got, _ := cfg["model"].(string); got != "opendray-local/qwen/qwen3-coder" {
 		t.Errorf("default model=%q, want opendray-local/qwen/qwen3-coder", got)
+	}
+}
+
+func TestInjectOpenCodeLocalProvider_SpawnNotice(t *testing.T) {
+	cfg := map[string]any{"localBaseUrl": "http://192.168.0.9:1234/v1"}
+	cases := []struct {
+		name       string
+		ids        []string
+		err        error
+		pinned     bool // set a localModel
+		wantNotice bool
+		wantSubstr string
+	}{
+		{"unreachable, no pinned model", nil, errors.New("connection refused"), false, true, "unreachable"},
+		{"unreachable but pinned model", nil, errors.New("connection refused"), true, true, "falling back"},
+		{"reachable but no chat models", nil, nil, false, true, "no chat-capable models"},
+		{"healthy enumeration stays silent", []string{"qwen/qwen3-coder"}, nil, false, false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stubOpenCodeProbeResult(t, tc.ids, tc.err)
+			c := map[string]any{}
+			for k, v := range cfg {
+				c[k] = v
+			}
+			if tc.pinned {
+				c["localModel"] = "qwen3-coder"
+			}
+			out := &session.PrepareOutput{Env: map[string]string{}}
+			if err := injectOpenCodeLocalProvider(context.Background(), t.TempDir(), c, out); err != nil {
+				t.Fatalf("inject: %v", err)
+			}
+			if got := len(out.Notices) > 0; got != tc.wantNotice {
+				t.Fatalf("notice present=%v, want %v (notices=%v)", got, tc.wantNotice, out.Notices)
+			}
+			if tc.wantNotice && !strings.Contains(out.Notices[0], tc.wantSubstr) {
+				t.Errorf("notice %q does not contain %q", out.Notices[0], tc.wantSubstr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Why
When an OpenCode session is bound to a local endpoint (LM Studio / Ollama / vLLM) that opendray can't use, OpenCode fails with an opaque **`[buffer unavailable]`** and the operator has no idea why. The model probe is best-effort (never blocks the spawn), so a misconfigured endpoint silently yields a provider with no usable model — exactly the dead-end hit while debugging LM Studio (missing `/v1`, endpoint bound to localhost, only an embedding model loaded, etc.).

## What
Surface the real cause as a one-time **⚠ notice at the top of the session terminal** (uses the existing prepare-notice banner the manager already renders before CLI output):

- **Unreachable + no pinned model** → `the OpenCode local endpoint <url> is unreachable (<err>) … curl <url>/models — check the URL ends in /v1, the endpoint serves on the LAN, and a chat model is loaded.`
- **Unreachable but a model is pinned** → soft `couldn't reach … falling back to your pinned model.`
- **Reachable but no chat-capable model** (only embeddings/rerank, or none loaded) → `load a chat model / set a Default Local Model.`
- **Healthy enumeration** → silent.

`probeOpenCodeModels` now returns `(ids, error)` so the notice distinguishes *unreachable* from *no chat models*. No spawn is ever blocked — this is purely diagnostic.

## Test
- New table test `TestInjectOpenCodeLocalProvider_SpawnNotice` covers all four paths; existing opencode tests updated for the new probe signature.
- `go build ./...` + catalog/session suites green; gofmt clean.

Independent of #396 / #397 (branched off main).