### PR TITLE
feat(knowledge): un-starve the experience compiler's episode feedstock

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1433,6 +1433,20 @@ func (a *App) Run(ctx context.Context) error {
 		close(docEmbedBackfillDone)
 	}()
 
+	// One-shot: recover the session OUTCOME for historical session_summary
+	// rows (migration 0070) by parsing their bodies, so the experience
+	// compiler's episode feedstock includes the whole journal instead of the
+	// ~2 rows whose ephemeral sessions row survived. Best-effort.
+	go func() {
+		if n, err := a.projectDocSvc.BackfillLogOutcomes(ctx); err != nil {
+			a.log.Warn("session-log outcome backfill failed", "err", err)
+		} else if n > 0 {
+			a.log.Info("session-log outcome backfill complete", "rows_recovered", n)
+		} else {
+			a.log.Debug("session-log outcome backfill: nothing to recover")
+		}
+	}()
+
 	// M-U Phase 5 — one-time import of pre-existing Claude file memories
 	// into the single DB store, so an upgrading operator lands them
 	// immediately rather than only after each project's next spawn. The

--- a/internal/app/knowledge_experience.go
+++ b/internal/app/knowledge_experience.go
@@ -24,12 +24,14 @@ func (e knowledgeEpisodeSource) ListEpisodes(ctx context.Context, since time.Tim
 	if limit <= 0 {
 		limit = 400
 	}
+	// Read the outcome straight off session_logs (denormalized by the
+	// journaler, migration 0070) — NO JOIN to the ephemeral `sessions` table,
+	// which is pruned and used to silently drop ~all historical episodes.
 	rows, err := e.pool.Query(ctx, `
 		SELECT l.session_id, l.cwd, l.title, l.content, l.created_at,
 		       COALESCE(l.embedding::text, ''), COALESCE(l.embedder, ''),
-		       s.started_at, s.ended_at, s.exit_code, s.state
+		       l.started_at, l.ended_at, l.exit_code, COALESCE(l.outcome_state, '')
 		  FROM session_logs l
-		  JOIN sessions s ON s.id = l.session_id
 		 WHERE l.kind = 'session_summary'
 		   AND l.session_id IS NOT NULL
 		   AND l.created_at >= $1
@@ -44,7 +46,7 @@ func (e knowledgeEpisodeSource) ListEpisodes(ctx context.Context, since time.Tim
 		var (
 			ep        knowledge.Episode
 			vecText   string
-			startedAt time.Time
+			startedAt *time.Time // nullable now (un-backfilled rows)
 			endedAt   *time.Time
 			exitCode  *int
 			state     string
@@ -58,10 +60,13 @@ func (e knowledgeEpisodeSource) ListEpisodes(ctx context.Context, since time.Tim
 			continue
 		}
 		ep.Embedding = knowledge.ParseVector(vecText)
-		if endedAt != nil {
-			ep.Duration = endedAt.Sub(startedAt)
+		if startedAt != nil && endedAt != nil {
+			ep.Duration = endedAt.Sub(*startedAt)
 		}
 		// Same heuristic the journaler applies to the skill-outcome loop.
+		// An unknown outcome (NULL state + NULL exit, e.g. an un-backfilled
+		// legacy row) is treated as success — lenient on purpose so the
+		// recovered corpus feeds the compiler rather than being dropped.
 		ep.Success = state == "stopped" || exitCode == nil || *exitCode == 0
 		out = append(out, ep)
 	}

--- a/internal/projectdoc/journaler.go
+++ b/internal/projectdoc/journaler.go
@@ -267,14 +267,7 @@ func (j *Journaler) process(ctx context.Context, ev eventbus.Event, state string
 		}
 	}
 
-	entry := LogEntry{
-		Cwd:       sess.Cwd,
-		SessionID: sess.ID,
-		Kind:      LogKindSessionSummary,
-		Title:     title,
-		Content:   body,
-		UpdatedBy: AuthorSummarizer,
-	}
+	entry := newSessionSummaryEntry(sess, state, title, body)
 	if _, err := j.docs.AppendLog(ctx, entry); err != nil {
 		j.log.Warn("journaler: append failed", "session_id", sessionID, "cwd", sess.Cwd, "err", err)
 		return
@@ -407,6 +400,27 @@ func (j *Journaler) maybeProposeDocDrift(sess SessionInfo, transcriptSummary str
 	}
 	j.log.Info("journaler: drift proposal filed",
 		"cwd", sess.Cwd, "kind", kind, "session_id", sess.ID, "proposal_id", proposal.ID)
+}
+
+// newSessionSummaryEntry builds the session_summary LogEntry, denormalizing
+// the session OUTCOME onto the durable row so the experience compiler's
+// episode source survives `sessions` pruning (migration 0070). state is the
+// terminal event kind ("ended"/"stopped"). StartedAt is always set on a
+// spawned session, so &sess.StartedAt never points at a zero value; EndedAt
+// is already *time.Time (nil for a session with no recorded end).
+func newSessionSummaryEntry(sess SessionInfo, state, title, body string) LogEntry {
+	return LogEntry{
+		Cwd:          sess.Cwd,
+		SessionID:    sess.ID,
+		Kind:         LogKindSessionSummary,
+		Title:        title,
+		Content:      body,
+		UpdatedBy:    AuthorSummarizer,
+		OutcomeState: state,
+		ExitCode:     sess.ExitCode,
+		StartedAt:    &sess.StartedAt,
+		EndedAt:      sess.EndedAt,
+	}
 }
 
 // SessionSucceeded is the shared "did this session end well" heuristic:

--- a/internal/projectdoc/journaler_test.go
+++ b/internal/projectdoc/journaler_test.go
@@ -66,6 +66,42 @@ func TestBuildJournalBody_NoHistory(t *testing.T) {
 	}
 }
 
+func TestNewSessionSummaryEntry_StampsOutcome(t *testing.T) {
+	exit := 0
+	started := time.Date(2026, 6, 20, 9, 18, 37, 0, time.UTC)
+	ended := started.Add(5 * time.Minute)
+	sess := SessionInfo{ID: "ses_x", Cwd: "/proj", ExitCode: &exit, StartedAt: started, EndedAt: &ended}
+
+	e := newSessionSummaryEntry(sess, "stopped", "the title", "the body")
+
+	if e.Kind != LogKindSessionSummary || e.UpdatedBy != AuthorSummarizer {
+		t.Fatalf("kind/author = %q/%q", e.Kind, e.UpdatedBy)
+	}
+	if e.OutcomeState != "stopped" {
+		t.Errorf("OutcomeState = %q, want stopped", e.OutcomeState)
+	}
+	if e.ExitCode == nil || *e.ExitCode != 0 {
+		t.Errorf("ExitCode = %v, want 0", e.ExitCode)
+	}
+	if e.StartedAt == nil || !e.StartedAt.Equal(started) {
+		t.Errorf("StartedAt = %v, want %v", e.StartedAt, started)
+	}
+	if e.EndedAt == nil || !e.EndedAt.Equal(ended) {
+		t.Errorf("EndedAt = %v, want %v", e.EndedAt, ended)
+	}
+}
+
+func TestNewSessionSummaryEntry_NilEndAndExit(t *testing.T) {
+	sess := SessionInfo{ID: "ses_y", Cwd: "/p", StartedAt: time.Now().UTC()}
+	e := newSessionSummaryEntry(sess, "ended", "t", "b")
+	if e.ExitCode != nil || e.EndedAt != nil {
+		t.Errorf("expected nil exit/end, got %v/%v", e.ExitCode, e.EndedAt)
+	}
+	if e.StartedAt == nil {
+		t.Error("StartedAt should always be set")
+	}
+}
+
 func TestCompactOneLine(t *testing.T) {
 	for _, tc := range []struct {
 		in, want string

--- a/internal/projectdoc/log_outcome_backfill.go
+++ b/internal/projectdoc/log_outcome_backfill.go
@@ -1,0 +1,117 @@
+package projectdoc
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// log_outcome_backfill.go recovers the session OUTCOME for historical
+// session_summary rows (migration 0070) so the experience compiler's episode
+// feedstock includes the whole journal — not just the ~2 rows whose ephemeral
+// `sessions` row happens to survive. The outcome was always serialized into
+// the summary by buildJournalBody (state in the title, started/ended/exit_code
+// in the body), so we parse it back out. Forward-written rows already carry
+// the columns; this is a one-shot for the legacy backlog.
+
+// parseLogOutcome extracts the outcome a journaler-written session_summary
+// encodes in its title + body:
+//
+//	title: "Session <id> — <provider> — <state>"
+//	body:  "- started: <RFC3339>" / "- ended: <RFC3339>" / "- exit_code: <int>"
+//
+// NOTE: the title separator is an EM DASH (U+2014, " — "), matching
+// buildJournalBody — do NOT "fix" it to an ASCII hyphen or state extraction
+// silently breaks. Returns zero values for anything it can't find; callers
+// default state to "ended" (a session_summary means the session terminated).
+func parseLogOutcome(title, content string) (state string, exitCode *int, startedAt, endedAt *time.Time) {
+	if parts := strings.Split(title, " — "); len(parts) >= 2 {
+		if s := strings.TrimSpace(parts[len(parts)-1]); s == "ended" || s == "stopped" {
+			state = s
+		}
+	}
+	for _, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(raw)
+		switch {
+		case strings.HasPrefix(line, "- started:"):
+			if t, err := time.Parse(time.RFC3339, strings.TrimSpace(strings.TrimPrefix(line, "- started:"))); err == nil {
+				startedAt = &t
+			}
+		case strings.HasPrefix(line, "- ended:"):
+			if t, err := time.Parse(time.RFC3339, strings.TrimSpace(strings.TrimPrefix(line, "- ended:"))); err == nil {
+				endedAt = &t
+			}
+		case strings.HasPrefix(line, "- exit_code:"):
+			if n, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(line, "- exit_code:"))); err == nil {
+				exitCode = &n
+			}
+		}
+	}
+	return state, exitCode, startedAt, endedAt
+}
+
+// BackfillLogOutcomes is a one-shot, idempotent pass that fills the outcome
+// columns for every session_summary row that still has a NULL outcome_state,
+// by parsing the row's own body. Returns the number of rows updated. Runs at
+// boot, best-effort: every recovered row becomes experience-compiler feedstock
+// it was previously invisible to.
+func (s *Service) BackfillLogOutcomes(ctx context.Context) (int, error) {
+	// LIMIT bounds memory + connection-hold time. Realistic journals are tiny
+	// (~100s of rows); if a backlog ever exceeds this, each boot drains
+	// another batch (recovered rows get a non-NULL outcome_state, so they drop
+	// out of the predicate) until it converges.
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, title, content
+		  FROM session_logs
+		 WHERE kind = 'session_summary' AND outcome_state IS NULL
+		 LIMIT 50000`)
+	if err != nil {
+		return 0, fmt.Errorf("backfill outcomes: query: %w", err)
+	}
+	type patch struct {
+		id        string
+		state     string
+		exitCode  *int
+		startedAt *time.Time
+		endedAt   *time.Time
+	}
+	var patches []patch
+	for rows.Next() {
+		var id, title, content string
+		if err := rows.Scan(&id, &title, &content); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("backfill outcomes: scan: %w", err)
+		}
+		state, exitCode, startedAt, endedAt := parseLogOutcome(title, content)
+		if state == "" {
+			// A session_summary always means the session terminated; default
+			// to the lenient terminal state so the row is marked processed
+			// (won't re-scan next boot) and counts as success-eligible.
+			state = "ended"
+		}
+		patches = append(patches, patch{id, state, exitCode, startedAt, endedAt})
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return 0, fmt.Errorf("backfill outcomes: rows: %w", err)
+	}
+	// Close the cursor (release the pooled conn) BEFORE the UPDATE loop — do
+	// NOT convert this to `defer rows.Close()`, which would hold the cursor's
+	// connection open across every UPDATE below.
+	rows.Close()
+
+	n := 0
+	for _, p := range patches {
+		if _, err := s.pool.Exec(ctx, `
+			UPDATE session_logs
+			   SET outcome_state = $1, exit_code = $2, started_at = $3, ended_at = $4
+			 WHERE id = $5`, p.state, p.exitCode, p.startedAt, p.endedAt, p.id); err != nil {
+			s.log.Warn("backfill outcomes: update failed", "id", p.id, "err", err)
+			continue
+		}
+		n++
+	}
+	return n, nil
+}

--- a/internal/projectdoc/log_outcome_backfill_test.go
+++ b/internal/projectdoc/log_outcome_backfill_test.go
@@ -1,0 +1,65 @@
+package projectdoc
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseLogOutcome(t *testing.T) {
+	// Mirrors buildJournalBody's real output shape.
+	body := "**Session metadata**\n\n" +
+		"- id: `ses_abc123`\n" +
+		"- provider: Claude\n" +
+		"- cwd: `/home/proj`\n" +
+		"- started: 2026-06-20T09:18:37Z\n" +
+		"- ended: 2026-06-20T09:42:10Z\n" +
+		"- duration: 23m33s\n" +
+		"- exit_code: 0\n\n"
+
+	state, exit, started, ended := parseLogOutcome("Session abc123 — Claude — ended", body)
+	if state != "ended" {
+		t.Errorf("state = %q, want ended", state)
+	}
+	if exit == nil || *exit != 0 {
+		t.Errorf("exit = %v, want 0", exit)
+	}
+	if started == nil || !started.Equal(time.Date(2026, 6, 20, 9, 18, 37, 0, time.UTC)) {
+		t.Errorf("started = %v", started)
+	}
+	if ended == nil || !ended.Equal(time.Date(2026, 6, 20, 9, 42, 10, 0, time.UTC)) {
+		t.Errorf("ended = %v", ended)
+	}
+}
+
+func TestParseLogOutcome_StoppedNoExit(t *testing.T) {
+	// An operator-stopped session: state from title, no exit_code line, no end.
+	body := "- started: 2026-06-19T08:00:00Z\n"
+	state, exit, started, ended := parseLogOutcome("Session zz — Codex — stopped", body)
+	if state != "stopped" {
+		t.Errorf("state = %q, want stopped", state)
+	}
+	if exit != nil {
+		t.Errorf("exit = %v, want nil", exit)
+	}
+	if started == nil {
+		t.Error("started should parse")
+	}
+	if ended != nil {
+		t.Errorf("ended = %v, want nil", ended)
+	}
+}
+
+func TestParseLogOutcome_NonZeroExit(t *testing.T) {
+	_, exit, _, _ := parseLogOutcome("Session q — Claude — ended", "- exit_code: 1\n")
+	if exit == nil || *exit != 1 {
+		t.Errorf("exit = %v, want 1", exit)
+	}
+}
+
+func TestParseLogOutcome_Unparseable(t *testing.T) {
+	// Title without the " — state" suffix and a body with no metadata lines.
+	state, exit, started, ended := parseLogOutcome("freeform note", "just some text\n")
+	if state != "" || exit != nil || started != nil || ended != nil {
+		t.Errorf("expected all-zero, got state=%q exit=%v started=%v ended=%v", state, exit, started, ended)
+	}
+}

--- a/internal/projectdoc/projectdoc.go
+++ b/internal/projectdoc/projectdoc.go
@@ -184,6 +184,15 @@ type LogEntry struct {
 	Content   string    `json:"content"`
 	UpdatedBy Author    `json:"updated_by"`
 	CreatedAt time.Time `json:"created_at"`
+
+	// Outcome fields — set by the journaler on session_summary rows so the
+	// experience compiler's episode source reads success/timing straight off
+	// the durable log instead of JOINing the pruned `sessions` table. Nil/
+	// empty on non-summary rows (manual / decision).
+	OutcomeState string     `json:"outcome_state,omitempty"` // "ended" | "stopped"
+	ExitCode     *int       `json:"exit_code,omitempty"`
+	StartedAt    *time.Time `json:"started_at,omitempty"`
+	EndedAt      *time.Time `json:"ended_at,omitempty"`
 }
 
 // Sentinel errors.
@@ -646,11 +655,20 @@ func (s *Service) AppendLog(ctx context.Context, e LogEntry) (LogEntry, error) {
 	if e.SessionID != "" {
 		sessID = e.SessionID
 	}
+	var outcomeState any
+	if e.OutcomeState != "" {
+		outcomeState = e.OutcomeState
+	}
+	// Outcome columns are populated only for session_summary rows (by the
+	// journaler); they stay NULL for manual/decision logs. Not in RETURNING —
+	// callers don't read them back, so scanLog is untouched.
 	row := s.pool.QueryRow(ctx, `
-		INSERT INTO session_logs (id, cwd, session_id, kind, title, content, updated_by)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		INSERT INTO session_logs (id, cwd, session_id, kind, title, content, updated_by,
+		                          outcome_state, exit_code, started_at, ended_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 		RETURNING id, cwd, COALESCE(session_id, ''), kind, title, content, updated_by, created_at`,
-		id, e.Cwd, sessID, string(e.Kind), e.Title, e.Content, string(e.UpdatedBy))
+		id, e.Cwd, sessID, string(e.Kind), e.Title, e.Content, string(e.UpdatedBy),
+		outcomeState, e.ExitCode, e.StartedAt, e.EndedAt)
 	out, err := scanLog(row)
 	if err == nil {
 		s.mirrorBestEffort(ctx, out.Cwd)

--- a/internal/store/migrations/0070_session_logs_outcome.sql
+++ b/internal/store/migrations/0070_session_logs_outcome.sql
@@ -1,0 +1,29 @@
+-- Denormalize session OUTCOME onto session_logs so the experience compiler's
+-- episode feedstock survives session pruning.
+--
+-- The compiler distils cross-project skills only from procedures that
+-- SUCCEEDED in >=2 sessions, and it reads that success signal (exit_code /
+-- state / timing) from the `sessions` table via
+--   session_logs l JOIN sessions s ON s.id = l.session_id.
+-- But `sessions` is ephemeral (rows are DELETEd on prune), so the JOIN
+-- silently drops every session_summary whose session row is gone — measured
+-- at 112 summaries -> 2 surviving the JOIN. The compiler therefore never sees
+-- enough recurrence and distils nothing.
+--
+-- Fix: the journaler already KNOWS the outcome when it writes the
+-- session_summary (SessionSucceeded + ExitCode + Started/Ended), so persist it
+-- here on the durable row. The episode source then reads session_logs alone
+-- (no JOIN) and the whole journal corpus becomes feedstock. Columns are
+-- nullable — only session_summary rows carry them; a boot-time backfill
+-- recovers the values for historical rows by parsing the summary body.
+ALTER TABLE session_logs
+    ADD COLUMN IF NOT EXISTS outcome_state TEXT,        -- 'ended' | 'stopped' (NULL = non-summary / not backfilled)
+    ADD COLUMN IF NOT EXISTS exit_code     INT,         -- process exit code; NULL when unknown / still running
+    ADD COLUMN IF NOT EXISTS started_at    TIMESTAMPTZ, -- session start (duration / time-cost proxy)
+    ADD COLUMN IF NOT EXISTS ended_at      TIMESTAMPTZ; -- session end
+
+-- The compiler scans recent session_summary rows; a partial index keeps that
+-- scan cheap as the journal grows.
+CREATE INDEX IF NOT EXISTS session_logs_episode_idx
+    ON session_logs (created_at)
+    WHERE kind = 'session_summary';


### PR DESCRIPTION
## Why
op's cross-project **experience compiler** distils a skill only from a procedure that **SUCCEEDED in ≥2 sessions**. It read that success signal (`exit_code` / `state` / timing) from the `sessions` table via:
```
session_logs l JOIN sessions s ON s.id = l.session_id
```
But `sessions` is **ephemeral (pruned)**, so the JOIN silently dropped every `session_summary` whose session row was gone — measured live at **112 summaries → only 2 survive the JOIN**. The compiler (running every 15m for weeks) therefore never saw enough recurrence and distilled **nothing** — `KindSkill = 0`, and 0 global playbooks, despite 112 entities + 47 playbooks from the per-project path.

This is the **supply-side root cause** of "op's distillation doesn't apply."

## Fix — denormalize the outcome onto the durable `session_logs` row
1. **migration `0070`** — `session_logs` gains `outcome_state` / `exit_code` / `started_at` / `ended_at` + a partial index on `session_summary` rows.
2. **journaler** stamps the outcome on every `session_summary` it writes (it already computes `SessionSucceeded`); extracted into `newSessionSummaryEntry` (unit-tested).
3. **episode source** (`knowledge_experience.go ListEpisodes`) drops the JOIN and reads the outcome straight off `session_logs` → the whole journal corpus becomes feedstock.
4. **boot-time one-shot backfill** recovers the outcome for historical rows by parsing the summary body — `buildJournalBody` already serialized `state` into the title and `started`/`ended`/`exit_code` into the body. **Dry-run over the live 112 rows recovered state + exit + timing for 112/112.**

## Effect
Feedstock goes from **2 → 112 episodes (56×)**. The compiler can now find cross-project recurrence and produce **global playbooks**, which **auto-inject at spawn** (`RenderForSpawn`) — so cross-project distilled knowledge applies to every project **without manual promotion**.

> `skillify` (promote a playbook → an *invocable* skill on the **skills page**) stays a deliberate **follow-up** — playbook injection already delivers the knowledge; skillify adds the click-runnable `run.sh` form.

## Test plan
- [x] migration `0070` validated on **ephemeral pg17** (ADD COLUMN + partial index; idempotent)
- [x] `parseLogOutcome` TDD (full / stopped-no-exit / non-zero-exit / unparseable)
- [x] `newSessionSummaryEntry` TDD (outcome stamped; nil end/exit)
- [x] **read-only dry-run** over the live 112 `session_summary` rows → 112/112 recovered
- [x] `go build`/`go vet`/`go test -race` green; full suite no failures
- [ ] Post-deploy: confirm boot log `session-log outcome backfill complete rows_recovered=…`, then watch a 15m compile cycle produce global playbook candidates

## Adversarial review (go-reviewer) — applied
No blockers. Applied: `LIMIT` guard on backfill, `IF NOT EXISTS` on ADD COLUMN, em-dash separator note, explicit close-before-update comment, `n==0` debug log, journaler-stamp test, StartedAt-never-nil note.

## Notes
- Forward-only for genuinely-deleted sessions, but the historical corpus is fully recovered from journal bodies, so there's no data loss in practice.
- Migration `0070` (0069 is `antigravity_accounts`; the loop-engine `0069_session_loops` reservation is void — that work was shelved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)