### PR TITLE
feat(knowledge): always inject the current objective + a proactive-write nudge

### DIFF
--- a/internal/projectdoc/projectdoc.go
+++ b/internal/projectdoc/projectdoc.go
@@ -1180,6 +1180,15 @@ func (s *Service) renderLeanSpawn(ctx context.Context, cwd string) (string, erro
 		for _, d := range docs {
 			filled[string(d.Kind)] = d
 		}
+		// The current objective is the live "what we're doing RIGHT NOW" — the
+		// single highest-signal piece of project state. Always inject its BODY
+		// (not just an index line) so the agent works to it without having to
+		// fetch it. Short by design, so the cost is a few hundred tokens.
+		if d, ok := filled[string(KindCurrentObjective)]; ok && strings.TrimSpace(d.Content) != "" {
+			b.WriteString("### Current objective — work to THIS\n\n")
+			b.WriteString(strings.TrimSpace(d.Content))
+			b.WriteString("\n\n")
+		}
 		b.WriteString("### Project doc index\n\n")
 		for _, sec := range sections {
 			d, has := filled[sec.Slug]
@@ -1223,11 +1232,17 @@ func (s *Service) renderLeanSpawn(ctx context.Context, cwd string) (string, erro
 		"If unsure which section, `project_search(\"<your task>\")` returns the best-matching " +
 		"section plus its `doc_read` pointer. `memory_search` covers episodic facts. " +
 		"Fetch ONLY what the task needs.\n\n" +
-		"Keep the project docs current. Use `current_objective_set` for the short-term " +
-		"objective we're working on right now — it writes the live doc directly (new " +
-		"objective set / current one finished / steps shift). For the long-term " +
-		"`project_goal_set` and medium-term `project_plan_set`, do **not** silently " +
-		"overwrite — those file a proposal the operator approves first.\n")
+		"**Maintain project state PROACTIVELY as you work — do not wait to be asked.** " +
+		"Treat the current objective shown above (if any) as your working brief and work to " +
+		"it; if none is set and the task is clear, set one. Call `current_objective_set` " +
+		"yourself whenever the situation changes — a new immediate objective is set, the " +
+		"current one is finished (roll to the next), or its steps shift; it writes the live " +
+		"doc directly, no approval. Use `session_log_append` every time you finish a " +
+		"meaningful step, make a decision, hit a blocker, or learn something the next session " +
+		"should know — a session that ends with no journal entries taught the next agent " +
+		"nothing. Save durable cross-session facts with `memory_store`. For the long-term " +
+		"`project_goal_set` and medium-term `project_plan_set`, do **not** silently overwrite " +
+		"— those file a proposal the operator approves first.\n")
 	return b.String(), nil
 }
 


### PR DESCRIPTION
## Why
Two gaps an op-spawned agent in **any** project hit — the same class as the KB on-demand gap, the operator's exact worry:
- **(b) "work to the current objective"**: in lean spawn mode the project docs are only **INDEXED**, never bodied — so the live `current_objective` (the single highest-signal *"what we're doing right now"*) was a one-line index entry the agent had to remember to `doc_read`. It often didn't.
- **(a) "proactively use the cortex note tools"**: the footer's write guidance was soft, so agents waited to be reminded instead of maintaining `current_objective` / journaling on their own.

(The note tools + their instructions already reach every op session via the auto-attached memory MCP — this PR makes the **current objective** and the **proactive-write** behaviour reliable.)

## Fix — both in `renderLeanSpawn`
1. **Always inject the `current_objective` BODY** (when non-empty) as a dedicated **`### Current objective — work to THIS`** block, right after the binding foundational rules and before the doc index. Short by design (~hundreds of tokens) → the agent gets its working brief without a fetch.
   - FULL mode already bodies `inject=true` sections, so this closes the **lean-mode** gap specifically (lean is the live mode).
2. **Strengthen the footer** into an imperative **PROACTIVE-maintenance** directive: work to the current objective; call `current_objective_set` yourself when it changes (new / done / steps shift — direct write, no approval); `session_log_append` on every meaningful step / decision / blocker; `memory_store` durable facts. `goal`/`plan` stay propose-only.

## Test plan
- [x] Verified on the **live lean renderer**: seed a temp `current_objective` for a throwaway cwd → the `### Current objective — work to THIS` body block appears (before the doc index) + the strengthened nudge ("PROACTIVELY as you work") is present; temp row cleaned up.
- [x] `go build` / `go vet` / `go test -race` green; full suite no failures.
- [ ] Post-deploy: set a real current_objective on a project, spawn a session, confirm the agent opens by working to it and updates it as work progresses.

## Notes
- Backend-only, no migration, no frontend/mobile change.
- Frozen projects inject no objective (the block is inside the `!frozen` branch); a project with no current_objective just shows the footer's "if none is set… set one".

🤖 Generated with [Claude Code](https://claude.com/claude-code)