### PR TITLE
feat(grok): inject opendray MCP servers into Grok sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+### Added
+
+- **MCP servers reach Grok.** Grok Build sessions now receive opendray's
+  enabled MCP registry (HashiCorp Vault, etc.), per-provider `mcp_servers`,
+  integration-scoped servers, and the opendray-memory server — the same
+  injection every other MCP-capable provider gets. opendray writes them
+  into the project-scoped `<cwd>/.grok/config.toml` `[mcp_servers]` table,
+  which Grok union-merges with your global `~/.grok/config.toml` (your
+  personal servers are untouched). Previously Grok shipped with MCP
+  injection disabled, so it could not see Vault or any other shared server
+  the operator had configured.
+
 ## [v2.10.0] — 2026-06-21
 
 ### Added

--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -701,6 +701,19 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 			}
 		}
 
+		// Grok renders MCP into <cwd>/.grok/config.toml (project-scoped
+		// config). Mirror the antigravity cleanup so disabling MCP this
+		// spawn prunes stale managed entries (and their credentials).
+		if providerID == "grok" {
+			cwd := session.Cwd(prepareCtx)
+			if cwd != "" && !mcpEnabled {
+				if err := syncGrokWorkspaceMCP(cwd, nil); err != nil {
+					sp.log.Warn("workspace MCP cleanup failed",
+						"provider", providerID, "cwd", cwd, "err", err)
+				}
+			}
+		}
+
 		if providerID == "codex" && out.Env["CODEX_HOME"] != "" {
 			if err := ensureCodexScratchTrust(out.Env["CODEX_HOME"], session.Cwd(prepareCtx)); err != nil {
 				return session.PrepareOutput{}, fmt.Errorf("prepare codex config: %w", err)

--- a/internal/catalog/builtin/grok.json
+++ b/internal/catalog/builtin/grok.json
@@ -19,7 +19,7 @@
     "supportsResume": true,
     "supportsStream": true,
     "supportsImages": false,
-    "supportsMcp": false
+    "supportsMcp": true
   },
   "configSchema": [
     {

--- a/internal/catalog/mcp.go
+++ b/internal/catalog/mcp.go
@@ -1,12 +1,15 @@
 package catalog
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/BurntSushi/toml"
 )
 
 // MCPServer is one entry from a provider's user config under the
@@ -85,6 +88,13 @@ func renderMCP(providerID, baseDir, cwd string, servers []MCPServer) ([]string, 
 		// OpenCode reads MCP from its JSON config's `mcp` block; we merge
 		// into the per-session OPENCODE_CONFIG file opendray generates.
 		return renderOpenCodeMCP(baseDir, servers)
+	case "grok":
+		// Grok (xAI Build CLI) reads project-scoped MCP from
+		// <cwd>/.grok/config.toml (only its [mcp_servers] table) and
+		// union-merges it with the user's ~/.grok/config.toml — global-only
+		// servers stay untouched, so injecting here never disturbs the
+		// operator's personal Grok setup.
+		return renderGrokMCP(cwd, servers)
 	default:
 		// Provider declared supportsMcp=true but we have no renderer
 		// for it; surface as a no-op rather than failing the spawn.
@@ -255,6 +265,182 @@ func writeGeminiGitignore(dir string) {
 		geminiManagedFile + "\n" +
 		".gitignore\n"
 	_ = os.WriteFile(path, []byte(content), 0o644)
+}
+
+// grokManagedFile records which [mcp_servers] entries inside the
+// project config.toml are opendray-managed, so subsequent renders can
+// update / remove exactly those without touching user-authored ones.
+const grokManagedFile = ".opendray-managed.json"
+
+// renderGrokMCP merges the session's MCP servers into
+// <cwd>/.grok/config.toml — the project-scoped surface Grok honours.
+// Grok reads ONLY [mcp_servers] from project config and union-merges it
+// with the user's global ~/.grok/config.toml (same-named servers are
+// replaced, global-only servers untouched), so this never disturbs the
+// operator's global Grok setup. Merge is non-destructive: user-authored
+// entries in an existing project file are preserved.
+func renderGrokMCP(cwd string, servers []MCPServer) ([]string, map[string]string, error) {
+	if strings.TrimSpace(cwd) == "" {
+		return nil, nil, nil
+	}
+	entries := map[string]map[string]any{}
+	for _, s := range servers {
+		spec := grokMCPServerSpec(s)
+		if spec == nil {
+			continue
+		}
+		entries[s.Name] = spec
+	}
+	if err := syncGrokWorkspaceMCP(cwd, entries); err != nil {
+		return nil, nil, err
+	}
+	return nil, nil, nil
+}
+
+// syncGrokWorkspaceMCP applies the desired opendray-managed [mcp_servers]
+// entries to <cwd>/.grok/config.toml. An empty desired map removes every
+// previously managed entry (server disabled / removed from the registry)
+// and is a no-op when nothing was ever managed — so calling this on every
+// grok spawn keeps the project config converged with the registry without
+// churning untouched projects.
+func syncGrokWorkspaceMCP(cwd string, desired map[string]map[string]any) error {
+	dir := filepath.Join(cwd, ".grok")
+	managedPath := filepath.Join(dir, grokManagedFile)
+	prevManaged := readGrokManaged(managedPath)
+	if len(desired) == 0 && len(prevManaged) == 0 {
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir grok workspace dir: %w", err)
+	}
+
+	configPath := filepath.Join(dir, "config.toml")
+	config := map[string]any{}
+	if data, err := os.ReadFile(configPath); err == nil {
+		if err := toml.Unmarshal(data, &config); err != nil {
+			// Never risk rewriting a user-authored file we can't parse.
+			return fmt.Errorf("parse %s (fix or remove it to enable MCP injection): %w", configPath, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read grok config: %w", err)
+	}
+
+	mcpServers, _ := config["mcp_servers"].(map[string]any)
+	if mcpServers == nil {
+		mcpServers = map[string]any{}
+	}
+	// Drop entries we managed before that are no longer desired.
+	// User-authored entries are never in the managed list.
+	for _, name := range prevManaged {
+		if _, still := desired[name]; !still {
+			delete(mcpServers, name)
+		}
+	}
+	managed := make([]string, 0, len(desired))
+	for name, spec := range desired {
+		mcpServers[name] = spec
+		managed = append(managed, name)
+	}
+	sort.Strings(managed)
+	if len(mcpServers) == 0 {
+		delete(config, "mcp_servers")
+	} else {
+		config["mcp_servers"] = mcpServers
+	}
+
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(config); err != nil {
+		return fmt.Errorf("marshal grok config: %w", err)
+	}
+	// 0600: managed entries may embed resolved credentials (e.g. a Vault
+	// token). WriteFile keeps the existing mode when the file already exists.
+	if err := os.WriteFile(configPath, buf.Bytes(), 0o600); err != nil {
+		return fmt.Errorf("write grok config: %w", err)
+	}
+
+	if len(managed) == 0 {
+		_ = os.Remove(managedPath)
+	} else {
+		body, err := json.MarshalIndent(managed, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal grok managed list: %w", err)
+		}
+		if err := os.WriteFile(managedPath, append(body, '\n'), 0o600); err != nil {
+			return fmt.Errorf("write grok managed list: %w", err)
+		}
+	}
+	writeGrokGitignore(dir)
+	return nil
+}
+
+// readGrokManaged loads the managed-entry names from a prior render.
+// Missing / malformed → nil (treated as "nothing managed yet").
+func readGrokManaged(path string) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	if err := json.Unmarshal(data, &names); err != nil {
+		return nil
+	}
+	return names
+}
+
+// writeGrokGitignore drops a .gitignore next to the project config so the
+// opendray-managed config.toml — which can embed resolved credentials —
+// never lands in version control. Only created when missing: a
+// user-authored .grok/.gitignore always wins.
+func writeGrokGitignore(dir string) {
+	path := filepath.Join(dir, ".gitignore")
+	if _, err := os.Lstat(path); err == nil || !os.IsNotExist(err) {
+		return
+	}
+	content := "# Generated by opendray. config.toml carries opendray-managed MCP\n" +
+		"# server entries (may embed resolved credentials) — do not commit.\n" +
+		"config.toml\n" +
+		grokManagedFile + "\n" +
+		".gitignore\n"
+	_ = os.WriteFile(path, []byte(content), 0o644)
+}
+
+// grokMCPServerSpec converts one registry server into Grok's TOML
+// [mcp_servers.<name>] table shape. stdio uses command/args/env; sse uses
+// url + type="sse"; streamable HTTP uses url alone (Grok's default when no
+// type is set). Returns nil for entries missing their required field.
+func grokMCPServerSpec(s MCPServer) map[string]any {
+	switch s.Transport {
+	case "sse":
+		if s.URL == "" {
+			return nil
+		}
+		spec := map[string]any{"url": s.URL, "type": "sse"}
+		if len(s.Headers) > 0 {
+			spec["headers"] = s.Headers
+		}
+		return spec
+	case "http":
+		if s.URL == "" {
+			return nil
+		}
+		spec := map[string]any{"url": s.URL}
+		if len(s.Headers) > 0 {
+			spec["headers"] = s.Headers
+		}
+		return spec
+	default: // stdio
+		if s.Command == "" {
+			return nil
+		}
+		spec := map[string]any{"command": s.Command}
+		if len(s.Args) > 0 {
+			spec["args"] = s.Args
+		}
+		if len(s.Env) > 0 {
+			spec["env"] = s.Env
+		}
+		return spec
+	}
 }
 
 func stdioMCPServerSpec(s MCPServer) map[string]any {

--- a/internal/catalog/mcp_test.go
+++ b/internal/catalog/mcp_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/BurntSushi/toml"
 )
 
 func TestRenderClaudeMCP_StdioServer(t *testing.T) {
@@ -291,6 +293,155 @@ func TestRenderGeminiMCP_MalformedUserSettingsErrors(t *testing.T) {
 		{Name: "fs", Command: "npx"},
 	}); err == nil {
 		t.Fatal("expected error on malformed user settings.json (must not clobber)")
+	}
+}
+
+func readGrokConfig(t *testing.T, cwd string) map[string]any {
+	t.Helper()
+	var got map[string]any
+	if _, err := toml.DecodeFile(filepath.Join(cwd, ".grok", "config.toml"), &got); err != nil {
+		t.Fatalf("decode grok config.toml: %v", err)
+	}
+	return got
+}
+
+func TestRenderGrokMCP_WritesProjectConfig(t *testing.T) {
+	cwd := t.TempDir()
+	servers := []MCPServer{
+		{Name: "vault", Command: "vault-mcp", Args: []string{"--addr", "https://v"}, Env: map[string]string{"VAULT_TOKEN": "s.xxx"}},
+	}
+	args, env, err := renderMCP("grok", t.TempDir(), cwd, servers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(args) != 0 || len(env) != 0 {
+		t.Errorf("args=%v env=%v, want none (grok reads <cwd>/.grok/config.toml)", args, env)
+	}
+	mcps, ok := readGrokConfig(t, cwd)["mcp_servers"].(map[string]any)
+	if !ok {
+		t.Fatalf("mcp_servers table missing")
+	}
+	vault, ok := mcps["vault"].(map[string]any)
+	if !ok {
+		t.Fatalf("vault server missing: %v", mcps)
+	}
+	if vault["command"].(string) != "vault-mcp" {
+		t.Errorf("command=%v", vault["command"])
+	}
+	if vault["env"].(map[string]any)["VAULT_TOKEN"].(string) != "s.xxx" {
+		t.Errorf("env not rendered: %v", vault["env"])
+	}
+	// Managed ledger + gitignore so stale entries can be pruned and the
+	// credential-bearing config never lands in version control.
+	if _, err := os.Stat(filepath.Join(cwd, ".grok", grokManagedFile)); err != nil {
+		t.Errorf("managed ledger missing: %v", err)
+	}
+	gi, err := os.ReadFile(filepath.Join(cwd, ".grok", ".gitignore"))
+	if err != nil {
+		t.Fatalf("gitignore missing: %v", err)
+	}
+	if !strings.Contains(string(gi), "config.toml") {
+		t.Errorf("gitignore does not cover config.toml: %s", gi)
+	}
+}
+
+func TestRenderGrokMCP_RemoteTransports(t *testing.T) {
+	cwd := t.TempDir()
+	_, _, err := renderMCP("grok", t.TempDir(), cwd, []MCPServer{
+		{Name: "sse_srv", Transport: "sse", URL: "http://h/sse", Headers: map[string]string{"X-Key": "v"}},
+		{Name: "http_srv", Transport: "http", URL: "http://h/mcp"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mcps := readGrokConfig(t, cwd)["mcp_servers"].(map[string]any)
+	sse := mcps["sse_srv"].(map[string]any)
+	if sse["url"].(string) != "http://h/sse" || sse["type"].(string) != "sse" {
+		t.Errorf("sse render wrong: %v", sse)
+	}
+	if sse["headers"].(map[string]any)["X-Key"].(string) != "v" {
+		t.Errorf("sse headers wrong: %v", sse)
+	}
+	httpSrv := mcps["http_srv"].(map[string]any)
+	if httpSrv["url"].(string) != "http://h/mcp" {
+		t.Errorf("http url wrong: %v", httpSrv)
+	}
+	// Streamable HTTP is grok's default for a url with no type.
+	if _, hasType := httpSrv["type"]; hasType {
+		t.Errorf("http server should omit type (streamable default): %v", httpSrv)
+	}
+}
+
+func TestRenderGrokMCP_MergePreservesUserConfig(t *testing.T) {
+	cwd := t.TempDir()
+	dir := filepath.Join(cwd, ".grok")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	user := "[mcp_servers.user-server]\ncommand = \"uvx\"\nargs = [\"my-mcp\"]\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(user), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := renderMCP("grok", t.TempDir(), cwd, []MCPServer{
+		{Name: "vault", Command: "vault-mcp"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	mcps := readGrokConfig(t, cwd)["mcp_servers"].(map[string]any)
+	if _, ok := mcps["user-server"]; !ok {
+		t.Errorf("user mcp entry lost: %v", mcps)
+	}
+	if _, ok := mcps["vault"]; !ok {
+		t.Errorf("managed entry missing: %v", mcps)
+	}
+}
+
+func TestRenderGrokMCP_RemovesStaleManagedEntries(t *testing.T) {
+	cwd := t.TempDir()
+	if _, _, err := renderMCP("grok", t.TempDir(), cwd, []MCPServer{
+		{Name: "vault", Command: "vault-mcp"},
+		{Name: "old", Command: "node"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := renderMCP("grok", t.TempDir(), cwd, []MCPServer{
+		{Name: "vault", Command: "vault-mcp"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	mcps := readGrokConfig(t, cwd)["mcp_servers"].(map[string]any)
+	if _, ok := mcps["old"]; ok {
+		t.Errorf("stale managed entry survived: %v", mcps)
+	}
+	if _, ok := mcps["vault"]; !ok {
+		t.Errorf("live managed entry missing: %v", mcps)
+	}
+
+	// Full cleanup (MCP off this spawn).
+	if err := syncGrokWorkspaceMCP(cwd, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := readGrokConfig(t, cwd)["mcp_servers"]; ok {
+		t.Errorf("managed entries not cleaned up")
+	}
+	if _, err := os.Stat(filepath.Join(cwd, ".grok", grokManagedFile)); !os.IsNotExist(err) {
+		t.Errorf("managed ledger should be removed after cleanup, err=%v", err)
+	}
+}
+
+func TestRenderGrokMCP_MalformedUserConfigErrors(t *testing.T) {
+	cwd := t.TempDir()
+	dir := filepath.Join(cwd, ".grok")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte("[mcp_servers.x\nbroken"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := renderMCP("grok", t.TempDir(), cwd, []MCPServer{
+		{Name: "vault", Command: "vault-mcp"},
+	}); err == nil {
+		t.Fatal("expected error on malformed user config.toml (must not clobber)")
 	}
 }
 


### PR DESCRIPTION
## Why

A Grok Build session asked to *validate access to HashiCorp Vault* hangs forever — it "keeps checking and never answers." Root cause: **Grok never receives the Vault MCP at all.**

opendray gates MCP injection on `Manifest.Capabilities.SupportsMcp`. Grok was added (#397) with `supportsMcp: false`, so the daemon skips MCP rendering for it entirely. The only "vault"-named server the stuck session had was the user's own Obsidian `obsidian_vault` (whose SSE endpoint is independently broken). With no HC Vault tool to call, Grok just probes/searches and never converges.

The "other models that can see HC Vault" are Claude/Codex — they have `supportsMcp: true` **and** a renderer, so opendray writes the Vault MCP into them.

## What

Grok supports MCP natively (its GitHub server connects fine) and reads **project-scoped** MCP from `<cwd>/.grok/config.toml`'s `[mcp_servers]` table, which it **union-merges** with the user's global `~/.grok/config.toml` (per Grok docs: *"servers defined only in the global config are unaffected"*). That's the injection surface — analogous to the antigravity `<cwd>/.gemini/settings.json` renderer.

- Flip `supportsMcp: true` in `grok.json`.
- Add `renderGrokMCP` / `syncGrokWorkspaceMCP` + `grokMCPServerSpec` (stdio / sse / streamable-http) to the `renderMCP` switch.
- Non-destructive merge: managed-entry ledger + `.gitignore` (config can embed resolved secrets; 0600), mirroring the gemini renderer. User-authored project entries preserved.
- Prune stale managed entries when MCP is off this spawn (adapter cleanup, mirrors antigravity).

Once merged, Grok gets the same injection as every other provider: Vault registry, per-provider `mcp_servers`, integration-scoped servers, and opendray-memory.

## Tests

`internal/catalog/mcp_test.go`: project-config write, stdio + sse/http transports, user-config merge preservation, stale-entry pruning + full cleanup, malformed-config refusal.

## Live verification (real `grok` binary)

- `grok mcp list` → injected servers tagged `(project)`, loaded from the rendered config.
- `grok mcp doctor` → recognizes the `hashicorp_vault` stdio shape with its args (only `✗ command not found` for the deliberately-fake test binary) and parses the sse server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)