### PR TITLE
feat(knowledge): frame injected cortex as the authoritative source (cortex-first)

### DIFF
--- a/internal/projectdoc/projectdoc.go
+++ b/internal/projectdoc/projectdoc.go
@@ -1091,7 +1091,7 @@ func (s *Service) RenderForSpawnWithBudget(ctx context.Context, cwd string, rece
 	// drop human-courtesy framing (intro essays, "auto-generated"
 	// markers, last-scanned timestamps). Saves ~15-25% spawn tokens.
 	var b strings.Builder
-	header := "## Project context (cross-agent shared, read-only)\n\n"
+	header := "## Project context (cross-agent shared, read-only)\n\n" + cortexPrimacyPreamble
 	footer := "Keep the project docs current as you work. For the short-term objective we're working on right now, use `current_objective_set` — it writes the live doc directly: call it when a new immediate objective is set, when the current one is finished, or when its steps shift. For the long-term `project_goal_set` / medium-term `project_plan_set`, do **not** silently overwrite — those file a proposal the operator approves first.\n"
 	b.WriteString(header)
 
@@ -1147,6 +1147,19 @@ func (s *Service) RenderForSpawnWithBudget(ctx context.Context, cwd string, rece
 	return b.String(), nil
 }
 
+// cortexPrimacyPreamble frames the whole injected banner as op's authoritative
+// source, so an agent consults cortex FIRST and treats external/on-disk mirrors
+// (an Obsidian vault, a wiki, scattered notes) as a fallback. Fixes the case
+// where an agent went straight to Obsidian for infra/process knowledge that the
+// injected cortex already holds. Used by BOTH spawn-render modes.
+const cortexPrimacyPreamble = "This is op's authoritative cross-agent knowledge for this workspace: the " +
+	"foundational rules below plus the `kb_*` knowledge pages indexed further down are the source of " +
+	"truth. **Consult this cortex FIRST** — read the foundational rules, and `doc_read` / " +
+	"`project_search` the `kb_*` pages on demand. Treat any external or on-disk mirror (e.g. an " +
+	"Obsidian vault, a wiki, scattered README/notes) as a SECONDARY fallback: reach for it ONLY when " +
+	"cortex doesn't cover what you need, and prefer cortex when they disagree — it is the live, " +
+	"curated copy.\n\n"
+
 // renderLeanSpawn is the lean-mode banner: binding foundational rules
 // in full (they are the guardrails — never indexed away), then a
 // compact INDEX of the project's doc sections and the knowledge pages
@@ -1164,6 +1177,7 @@ func (s *Service) renderLeanSpawn(ctx context.Context, cwd string) (string, erro
 
 	var b strings.Builder
 	b.WriteString("## Project context (cross-agent shared, read-only)\n\n")
+	b.WriteString(cortexPrimacyPreamble)
 	if foundational != "" {
 		b.WriteString("### Foundational knowledge — RULES you MUST follow\n\n")
 		b.WriteString(foundational)


### PR DESCRIPTION
## Why
An agent in a project (Mathlandia) went straight to an external **Obsidian vault** for DB / infra process knowledge that op's injected cortex (`kb_infrastructure` / `kb_conventions` — foundational, full-body at spawn) **already held**. Nothing in the injected banner told it the cortex is the **primary** source, and the operator's own `CLAUDE.md` points at Obsidian as the SSOT — so the agent followed that.

The operator's ask: **consult op cortex FIRST; only fall back to Obsidian when cortex doesn't cover the topic.**

## Fix
A `cortexPrimacyPreamble` at the top of the spawn banner (**both** lean and full render modes) frames the whole injected block as op's authoritative cross-agent knowledge:
- **Consult cortex FIRST** — the foundational rules are already in-context; `doc_read` / `project_search` the `kb_*` pages on demand.
- Treat any external / on-disk mirror (Obsidian vault, wiki, scattered notes) as a **SECONDARY fallback**, used only when cortex doesn't cover the topic, and prefer cortex on conflict (it's the live, curated copy).

## Test plan
- [x] Verified on the **live lean renderer**: the preamble appears first, right after the `## Project context` header.
- [x] `go build` / `go test -race` green; full suite no failures.
- [ ] Post-deploy: spawn a session, ask for a DB/infra process → confirm it grounds in the injected cortex (and only reads Obsidian if cortex lacks the detail).

## Notes
- Backend-only, no migration, no frontend/mobile change.
- Does NOT touch the operator's `CLAUDE.md` — op declares its own source primacy; the two reconcile as "cortex first, external mirror as fallback."

🤖 Generated with [Claude Code](https://claude.com/claude-code)