### PR TITLE
feat(mobile): antigravity multi-account parity with web (#396)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -3202,7 +3202,11 @@
         "cancel": "Cancel",
         "switchedSnack": "Switched to {account}",
         "switchFailed": "Switch failed: {error}",
-        "noneHint": "No Claude accounts configured. Add them in More → Providers → Claude."
+        "noneHint": "No Claude accounts configured. Add them in More → Providers → Claude.",
+        "tooltipAgy": "Switch Antigravity account",
+        "sheetTitleAgy": "Switch Antigravity account",
+        "confirmBodyAgy": "This restarts the Antigravity CLI under a fresh conversation — the in-CLI history doesn't carry across accounts (the session tab is kept).",
+        "noneHintAgy": "No Antigravity accounts configured. Add them in More → Providers → Antigravity."
       }
     },
     "terminal": {
@@ -3566,6 +3570,17 @@
       "acceptIdentity": "Accept",
       "identityAcceptedSnack": "Identity change accepted",
       "identityAcceptFailed": "Accept failed"
+    },
+    "antigravityAccounts": {
+      "addHint": "Adding a new account is gateway-host only.",
+      "addBody": "Give each account its own HOME on the gateway host (HOME=~/.antigravity-accounts/<name> agy), finish the Google sign-in, then tap Import local.",
+      "intro": "Sessions spawned with the Antigravity provider pick from these accounts (or fall back to the gateway default HOME).",
+      "empty": "No Antigravity accounts yet. Run HOME=~/.antigravity-accounts/<name> agy on the gateway host, finish the Google sign-in, then tap Import local.",
+      "deleteTitle": "Remove account?",
+      "deleteBody": "Removes the account from opendray. The on-disk HOME directory is left untouched; sessions already using it stay running.",
+      "importSyncedSnack": "Already in sync — gateway has no new accounts.",
+      "noTokenYet": "not logged in",
+      "homeDir": "home: {dir}"
     },
     "configFallbackTitle": "Provider config",
     "saving": "Saving…",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -3202,7 +3202,11 @@
         "cancel": "Cancelar",
         "switchedSnack": "Cambiado a {account}",
         "switchFailed": "Cambio fallido: {error}",
-        "noneHint": "No hay cuentas de Claude configuradas. Agrégalas en Más → Providers → Claude."
+        "noneHint": "No hay cuentas de Claude configuradas. Agrégalas en Más → Providers → Claude.",
+        "tooltipAgy": "Cambiar de cuenta de Antigravity",
+        "sheetTitleAgy": "Cambiar de cuenta de Antigravity",
+        "confirmBodyAgy": "Esto reinicia el CLI de Antigravity con una conversación nueva — el historial dentro del CLI no se traslada entre cuentas (la pestaña de la sesión se conserva).",
+        "noneHintAgy": "No hay cuentas de Antigravity configuradas. Agrégalas en Más → Providers → Antigravity."
       }
     },
     "terminal": {
@@ -3566,6 +3570,17 @@
       "acceptIdentity": "Aceptar",
       "identityAcceptedSnack": "Cambio de identidad aceptado",
       "identityAcceptFailed": "Error al aceptar"
+    },
+    "antigravityAccounts": {
+      "addHint": "Añadir una cuenta nueva solo se puede hacer en el host del gateway.",
+      "addBody": "Dale a cada cuenta su propio HOME en el host del gateway (HOME=~/.antigravity-accounts/<nombre> agy), completa el inicio de sesión de Google y luego toca Importar locales.",
+      "intro": "Las sessions creadas con el proveedor Antigravity eligen entre estas cuentas (o recurren al HOME predeterminado del gateway).",
+      "empty": "Aún no hay cuentas de Antigravity. Ejecuta HOME=~/.antigravity-accounts/<nombre> agy en el host del gateway, completa el inicio de sesión de Google y luego toca Importar locales.",
+      "deleteTitle": "¿Quitar la cuenta?",
+      "deleteBody": "Quita la cuenta de opendray. El directorio HOME en disco no se modifica; las sessions que ya lo usan siguen funcionando.",
+      "importSyncedSnack": "Ya está sincronizado, el gateway no tiene cuentas nuevas.",
+      "noTokenYet": "sin iniciar sesión",
+      "homeDir": "home: {dir}"
     },
     "configFallbackTitle": "Configuración del proveedor",
     "saving": "Guardando…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -3202,7 +3202,11 @@
         "cancel": "取消",
         "switchedSnack": "已切换到 {account}",
         "switchFailed": "切换失败：{error}",
-        "noneHint": "未配置 Claude 账号。请在 更多 → Providers → Claude 中添加。"
+        "noneHint": "未配置 Claude 账号。请在 更多 → Providers → Claude 中添加。",
+        "tooltipAgy": "切换 Antigravity 账号",
+        "sheetTitleAgy": "切换 Antigravity 账号",
+        "confirmBodyAgy": "这会用全新对话重启 Antigravity CLI——CLI 内的历史不会在账号间保留（会话标签保留）。",
+        "noneHintAgy": "未配置 Antigravity 账号。请在 更多 → Providers → Antigravity 中添加。"
       }
     },
     "terminal": {
@@ -3566,6 +3570,17 @@
       "acceptIdentity": "接受",
       "identityAcceptedSnack": "已接受身份变更",
       "identityAcceptFailed": "接受失败"
+    },
+    "antigravityAccounts": {
+      "addHint": "添加新账号仅可在网关主机上操作。",
+      "addBody": "在网关主机上为每个账号分配独立的 HOME（HOME=~/.antigravity-accounts/<name> agy），完成 Google 登录后点按“导入本地”。",
+      "intro": "以 Antigravity 提供商启动的会话会从这些账号中选择（或回退到网关默认 HOME）。",
+      "empty": "尚无 Antigravity 账号。在网关主机上运行 HOME=~/.antigravity-accounts/<name> agy，完成 Google 登录后点按“导入本地”。",
+      "deleteTitle": "移除账号？",
+      "deleteBody": "从 opendray 移除该账号。磁盘上的 HOME 目录保持不变；已使用它的会话保持运行。",
+      "importSyncedSnack": "已同步 — 网关没有新账号。",
+      "noTokenYet": "未登录",
+      "homeDir": "home：{dir}"
     },
     "configFallbackTitle": "提供商配置",
     "saving": "保存中…",

--- a/app/mobile/lib/core/api/antigravity_accounts_api.dart
+++ b/app/mobile/lib/core/api/antigravity_accounts_api.dart
@@ -1,0 +1,82 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/api/dio_provider.dart';
+import 'package:opendray/core/api/models.dart';
+
+// /api/v1/antigravity-accounts — multi-account support for the
+// Antigravity (agy) provider. Unlike Claude, agy keys all of its state
+// off $HOME, so an "account" is just a per-account HOME directory the
+// operator logs into on the gateway host. There is no token-paste flow:
+// rows are surfaced by import-local (the gateway scans
+// ~/.antigravity-accounts/) and removed/toggled from here. Mirrors web
+// app/shared/src/lib/antigravityAccounts.ts.
+class AntigravityAccountsApi {
+  AntigravityAccountsApi(this._dio);
+  final Dio _dio;
+
+  Future<List<AntigravityAccountSummary>> list() async {
+    try {
+      final res = await _dio
+          .get<Map<String, dynamic>>('/api/v1/antigravity-accounts');
+      final raw = res.data?['accounts'];
+      if (raw is! List) return [];
+      return raw
+          .whereType<Map<String, dynamic>>()
+          .map(AntigravityAccountSummary.fromJson)
+          .where((a) => a.id.isNotEmpty)
+          .toList();
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // PATCH /antigravity-accounts/{id}/toggle. Enables/disables an account
+  // without touching its on-disk HOME; the spawn picker and switcher
+  // filter out disabled accounts.
+  Future<void> setEnabled(String id, {required bool enabled}) async {
+    try {
+      await _dio.patch<Map<String, dynamic>>(
+        '/api/v1/antigravity-accounts/$id/toggle',
+        data: {'enabled': enabled},
+      );
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  Future<void> delete(String id) async {
+    try {
+      await _dio.delete<void>('/api/v1/antigravity-accounts/$id');
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // POST /antigravity-accounts/import-local — gateway scans
+  // ~/.antigravity-accounts/ (and the gateway user's ~) on its own host
+  // and registers any logged-in account dir that doesn't already have a
+  // matching DB row. Returns the count of newly-created accounts so the
+  // UI can toast "imported N" vs "already in sync".
+  Future<int> importLocal() async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/antigravity-accounts/import-local',
+      );
+      final c = res.data?['count'];
+      if (c is num) return c.toInt();
+      return 0;
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+}
+
+final antigravityAccountsApiProvider = Provider<AntigravityAccountsApi>((ref) {
+  return AntigravityAccountsApi(ref.watch(dioProvider));
+});
+
+final antigravityAccountsListProvider =
+    FutureProvider.autoDispose<List<AntigravityAccountSummary>>((ref) {
+  return ref.watch(antigravityAccountsApiProvider).list();
+});

--- a/app/mobile/lib/core/api/models.dart
+++ b/app/mobile/lib/core/api/models.dart
@@ -90,6 +90,7 @@ class SessionSummary {
     this.name,
     this.endedAt,
     this.claudeAccountId,
+    this.antigravityAccountId,
   });
 
   factory SessionSummary.fromJson(Map<String, dynamic> json) => SessionSummary(
@@ -107,6 +108,10 @@ class SessionSummary {
             (json['claude_account_id'] as String?)?.isNotEmpty ?? false
                 ? json['claude_account_id'] as String
                 : null,
+        antigravityAccountId:
+            (json['antigravity_account_id'] as String?)?.isNotEmpty ?? false
+                ? json['antigravity_account_id'] as String
+                : null,
       );
 
   final String id;
@@ -120,6 +125,10 @@ class SessionSummary {
   // CLI's system-default credential). Only meaningful for Claude
   // sessions; drives the in-session account switcher.
   final String? claudeAccountId;
+  // Which Antigravity (agy) account HOME this session is bound to
+  // (null = the gateway default HOME). Only meaningful for antigravity
+  // sessions; drives the in-session account switcher.
+  final String? antigravityAccountId;
 
   String get displayName => name?.isNotEmpty ?? false ? name! : id;
 
@@ -540,6 +549,64 @@ class ClaudeAccountSummary {
   final String? oauthEmail; // current Anthropic account email
   final String? previousEmail; // prior email when drift detected
   final bool identityDrift; // oauth_email differs from baseline
+
+  bool get isUsable => enabled && tokenFilled;
+}
+
+// One Antigravity (agy) account. Mirrors web app/shared/src/lib/types.ts
+// AntigravityAccount. Simpler than Claude: an account is a per-account
+// HOME directory (config_dir) the operator logs into on the gateway
+// host — there is no token-paste, rename, or identity-drift concept.
+class AntigravityAccountSummary {
+  AntigravityAccountSummary({
+    required this.id,
+    required this.name,
+    required this.displayName,
+    required this.configDir,
+    required this.enabled,
+    required this.tokenFilled,
+    this.description,
+    this.lastUsedAt,
+    this.activeSessions,
+  });
+
+  factory AntigravityAccountSummary.fromJson(Map<String, dynamic> json) {
+    final id = json['id'] as String? ?? '';
+    final name = json['name'] as String? ?? '';
+    final display = json['display_name'] as String? ?? '';
+    String? str(String key) {
+      final v = json[key];
+      return v is String && v.isNotEmpty ? v : null;
+    }
+
+    return AntigravityAccountSummary(
+      id: id,
+      name: name,
+      // Fall back through display_name → name → id so the picker never
+      // shows a blank row.
+      displayName:
+          display.isNotEmpty ? display : (name.isNotEmpty ? name : id),
+      configDir: json['config_dir'] as String? ?? '',
+      enabled: json['enabled'] as bool? ?? false,
+      // True once the per-account HOME holds an OAuth token (i.e. the
+      // Google sign-in completed). Disabled/empty accounts can't spawn.
+      tokenFilled: json['token_filled'] as bool? ?? false,
+      description: str('description'),
+      // Decorated metadata — optional; older gateways omit these.
+      lastUsedAt: str('last_used_at'),
+      activeSessions: (json['active_sessions'] as num?)?.toInt(),
+    );
+  }
+
+  final String id;
+  final String name;
+  final String displayName;
+  final String configDir; // per-account HOME directory
+  final bool enabled;
+  final bool tokenFilled;
+  final String? description;
+  final String? lastUsedAt; // ISO timestamp
+  final int? activeSessions;
 
   bool get isUsable => enabled && tokenFilled;
 }

--- a/app/mobile/lib/core/api/sessions_api.dart
+++ b/app/mobile/lib/core/api/sessions_api.dart
@@ -138,6 +138,28 @@ class SessionsApi {
     }
   }
 
+  // PATCH /api/v1/sessions/:id/antigravity-account — rebind a running
+  // Antigravity session to a different account HOME. Like the Claude
+  // switch, the gateway restarts the agy child under a fresh conversation
+  // (in-CLI history doesn't carry across accounts); the session id / tab
+  // is preserved. `accountId == ''` clears the binding (gateway default
+  // HOME). Mirrors web switchAntigravityAccount
+  // (app/shared/src/lib/sessions.ts).
+  Future<SessionSummary> switchAntigravityAccount(
+    String id,
+    String accountId,
+  ) async {
+    try {
+      final res = await _dio.patch<Map<String, dynamic>>(
+        '/api/v1/sessions/$id/antigravity-account',
+        data: {'account_id': accountId},
+      );
+      return SessionSummary.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
   // Upload a file (typically an image) and let the gateway hand
   // back the absolute path it landed at on the server's tempdir.
   // The caller pastes that path into the live PTY so the running

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 11568 (3856 per locale)
+/// Strings: 11676 (3892 per locale)
 ///
-/// Built on 2026-06-20 at 13:44 UTC
+/// Built on 2026-06-24 at 22:36 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -559,6 +559,7 @@ class TranslationsProvidersEn {
 
 	late final TranslationsProvidersUpdateCheckEn updateCheck = TranslationsProvidersUpdateCheckEn.internal(_root);
 	late final TranslationsProvidersAccountsEn accounts = TranslationsProvidersAccountsEn.internal(_root);
+	late final TranslationsProvidersAntigravityAccountsEn antigravityAccounts = TranslationsProvidersAntigravityAccountsEn.internal(_root);
 
 	/// en: 'Provider config'
 	String get configFallbackTitle => 'Provider config';
@@ -2912,6 +2913,7 @@ class TranslationsWebProvidersEn {
 	late final TranslationsWebProvidersDetailEn detail = TranslationsWebProvidersDetailEn.internal(_root);
 	late final TranslationsWebProvidersConfigFormEn configForm = TranslationsWebProvidersConfigFormEn.internal(_root);
 	late final TranslationsWebProvidersClaudeAccountsEn claudeAccounts = TranslationsWebProvidersClaudeAccountsEn.internal(_root);
+	late final TranslationsWebProvidersAntigravityAccountsEn antigravityAccounts = TranslationsWebProvidersAntigravityAccountsEn.internal(_root);
 	late final TranslationsWebProvidersModelsEn models = TranslationsWebProvidersModelsEn.internal(_root);
 }
 
@@ -4154,6 +4156,42 @@ class TranslationsProvidersAccountsEn {
 
 	/// en: 'Accept failed'
 	String get identityAcceptFailed => 'Accept failed';
+}
+
+// Path: providers.antigravityAccounts
+class TranslationsProvidersAntigravityAccountsEn {
+	TranslationsProvidersAntigravityAccountsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Adding a new account is gateway-host only.'
+	String get addHint => 'Adding a new account is gateway-host only.';
+
+	/// en: 'Give each account its own HOME on the gateway host (HOME=~/.antigravity-accounts/<name> agy), finish the Google sign-in, then tap Import local.'
+	String get addBody => 'Give each account its own HOME on the gateway host (HOME=~/.antigravity-accounts/<name> agy), finish the Google sign-in, then tap Import local.';
+
+	/// en: 'Sessions spawned with the Antigravity provider pick from these accounts (or fall back to the gateway default HOME).'
+	String get intro => 'Sessions spawned with the Antigravity provider pick from these accounts (or fall back to the gateway default HOME).';
+
+	/// en: 'No Antigravity accounts yet. Run HOME=~/.antigravity-accounts/<name> agy on the gateway host, finish the Google sign-in, then tap Import local.'
+	String get empty => 'No Antigravity accounts yet. Run HOME=~/.antigravity-accounts/<name> agy on the gateway host, finish the Google sign-in, then tap Import local.';
+
+	/// en: 'Remove account?'
+	String get deleteTitle => 'Remove account?';
+
+	/// en: 'Removes the account from opendray. The on-disk HOME directory is left untouched; sessions already using it stay running.'
+	String get deleteBody => 'Removes the account from opendray. The on-disk HOME directory is left untouched; sessions already using it stay running.';
+
+	/// en: 'Already in sync — gateway has no new accounts.'
+	String get importSyncedSnack => 'Already in sync — gateway has no new accounts.';
+
+	/// en: 'not logged in'
+	String get noTokenYet => 'not logged in';
+
+	/// en: 'home: {dir}'
+	String homeDir({required Object dir}) => 'home: ${dir}';
 }
 
 // Path: integrations.form
@@ -6303,11 +6341,20 @@ class TranslationsWebSessionsAccountSwitcherEn {
 	/// en: 'Switch Claude account (restarts the CLI process)'
 	String get tooltip => 'Switch Claude account (restarts the CLI process)';
 
+	/// en: 'Switch Antigravity account (restarts the CLI process)'
+	String get tooltipAgy => 'Switch Antigravity account (restarts the CLI process)';
+
 	/// en: 'default'
 	String get currentDefault => 'default';
 
 	/// en: 'Switch Claude account'
 	String get menuTitle => 'Switch Claude account';
+
+	/// en: 'Switch Antigravity account'
+	String get menuTitleAgy => 'Switch Antigravity account';
+
+	/// en: 'Switching account restarts the Antigravity CLI under a fresh conversation — the in-CLI history doesn't carry across accounts. Any in-flight tool execution or unsent input is lost. Continue?'
+	String get confirmSwitchAgy => 'Switching account restarts the Antigravity CLI under a fresh conversation — the in-CLI history doesn\'t carry across accounts. Any in-flight tool execution or unsent input is lost. Continue?';
 
 	/// en: 'Default'
 	String get defaultName => 'Default';
@@ -8124,6 +8171,75 @@ class TranslationsWebProvidersClaudeAccountsEn {
 
 	/// en: 'Could not accept identity'
 	String get identityAcceptFailedToast => 'Could not accept identity';
+}
+
+// Path: web.providers.antigravityAccounts
+class TranslationsWebProvidersAntigravityAccountsEn {
+	TranslationsWebProvidersAntigravityAccountsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Antigravity accounts'
+	String get title => 'Antigravity accounts';
+
+	/// en: 'Import local'
+	String get importLocal => 'Import local';
+
+	/// en: 'Scan ~/.antigravity-accounts/ (and the gateway user's ~) on the host and register any logged-in account dirs. Gateway-host only.'
+	String get importLocalTooltip => 'Scan ~/.antigravity-accounts/ (and the gateway user\'s ~) on the host and register any logged-in account dirs. Gateway-host only.';
+
+	/// en: 'Nothing to import — accounts already in sync.'
+	String get importedNothingToast => 'Nothing to import — accounts already in sync.';
+
+	/// en: 'Imported {count} account from ~/.antigravity-accounts'
+	String importedToast_one({required Object count}) => 'Imported ${count} account from ~/.antigravity-accounts';
+
+	/// en: 'Imported {count} accounts from ~/.antigravity-accounts'
+	String importedToast_other({required Object count}) => 'Imported ${count} accounts from ~/.antigravity-accounts';
+
+	/// en: 'Import failed'
+	String get importFailedToast => 'Import failed';
+
+	/// en: 'Adding a new account.'
+	String get addingTitle => 'Adding a new account.';
+
+	/// en: 'Antigravity keys all state off $HOME. Give each account its own HOME and log in there on the gateway host:'
+	String get addingBodyPrefix => 'Antigravity keys all state off \$HOME. Give each account its own HOME and log in there on the gateway host:';
+
+	/// en: 'Then click <1>Import local</1> to register it. The directory only counts as an account once the Google sign-in has written its OAuth token.'
+	String get addingBodySuffix => 'Then click <1>Import local</1> to register it. The directory only counts as an account once the Google sign-in has written its OAuth token.';
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'No Antigravity accounts yet. Run <1>HOME=~/.antigravity-accounts/&lt;name&gt; agy</1> on the gateway host, complete the Google sign-in, then click Import local.'
+	String get empty => 'No Antigravity accounts yet. Run <1>HOME=~/.antigravity-accounts/&lt;name&gt; agy</1> on the gateway host, complete the Google sign-in, then click Import local.';
+
+	/// en: 'not logged in'
+	String get noTokenYet => 'not logged in';
+
+	/// en: 'home:'
+	String get homeDir => 'home:';
+
+	/// en: 'Toggle failed'
+	String get toggleFailedToast => 'Toggle failed';
+
+	/// en: 'Remove account "{name}"?'
+	String removeConfirm({required Object name}) => 'Remove account "${name}"?';
+
+	/// en: 'Account removed'
+	String get removedToast => 'Account removed';
+
+	/// en: 'Remove failed'
+	String get removeFailedToast => 'Remove failed';
+
+	/// en: 'Toggle {name}'
+	String toggleAria({required Object name}) => 'Toggle ${name}';
+
+	/// en: 'Remove {name}'
+	String removeAria({required Object name}) => 'Remove ${name}';
 }
 
 // Path: web.providers.models
@@ -11740,6 +11856,18 @@ class TranslationsSessionsDetailAccountSwitcherEn {
 
 	/// en: 'No Claude accounts configured. Add them in More → Providers → Claude.'
 	String get noneHint => 'No Claude accounts configured. Add them in More → Providers → Claude.';
+
+	/// en: 'Switch Antigravity account'
+	String get tooltipAgy => 'Switch Antigravity account';
+
+	/// en: 'Switch Antigravity account'
+	String get sheetTitleAgy => 'Switch Antigravity account';
+
+	/// en: 'This restarts the Antigravity CLI under a fresh conversation — the in-CLI history doesn't carry across accounts (the session tab is kept).'
+	String get confirmBodyAgy => 'This restarts the Antigravity CLI under a fresh conversation — the in-CLI history doesn\'t carry across accounts (the session tab is kept).';
+
+	/// en: 'No Antigravity accounts configured. Add them in More → Providers → Antigravity.'
+	String get noneHintAgy => 'No Antigravity accounts configured. Add them in More → Providers → Antigravity.';
 }
 
 // Path: sessions.terminal.snackbar
@@ -16899,8 +17027,11 @@ extension on Translations {
 			'web.sessions.spawn.spawnedDescription' => ({required Object provider, required Object pid}) => '${provider} · pid ${pid}',
 			'web.sessions.spawn.pidFallback' => '—',
 			'web.sessions.accountSwitcher.tooltip' => 'Switch Claude account (restarts the CLI process)',
+			'web.sessions.accountSwitcher.tooltipAgy' => 'Switch Antigravity account (restarts the CLI process)',
 			'web.sessions.accountSwitcher.currentDefault' => 'default',
 			'web.sessions.accountSwitcher.menuTitle' => 'Switch Claude account',
+			'web.sessions.accountSwitcher.menuTitleAgy' => 'Switch Antigravity account',
+			'web.sessions.accountSwitcher.confirmSwitchAgy' => 'Switching account restarts the Antigravity CLI under a fresh conversation — the in-CLI history doesn\'t carry across accounts. Any in-flight tool execution or unsent input is lost. Continue?',
 			'web.sessions.accountSwitcher.defaultName' => 'Default',
 			'web.sessions.accountSwitcher.defaultSubtitle' => 'CLI\'s system keychain / env',
 			'web.sessions.accountSwitcher.tokenEmpty' => '·empty',
@@ -17251,11 +17382,11 @@ extension on Translations {
 			'web.project.reset.alsoDeleteMemoriesLabel' => 'Also delete pgvector memories',
 			'web.project.reset.alsoDeleteMemoriesSuffix' => 'for this scope_key.',
 			'web.project.reset.alsoDeleteMemoriesHint' => 'Long-term facts the agent stored (user preferences, project facts). Cannot be recovered.',
+			_ => null,
+		} ?? switch (path) {
 			'web.project.reset.cancel' => 'Cancel',
 			'web.project.reset.deleteForever' => 'Delete forever',
 			'web.project.reset.successToast' => ({required Object summary}) => 'Reset: deleted ${summary}',
-			_ => null,
-		} ?? switch (path) {
 			'web.project.reset.summary.docs_one' => ({required Object count}) => '${count} doc',
 			'web.project.reset.summary.docs_other' => ({required Object count}) => '${count} docs',
 			'web.project.reset.summary.journal' => ({required Object count}) => '${count} journal',
@@ -17671,6 +17802,26 @@ extension on Translations {
 			'web.providers.claudeAccounts.removeAria' => ({required Object name}) => 'Remove ${name}',
 			'web.providers.claudeAccounts.identityAcceptedToast' => 'New identity recorded',
 			'web.providers.claudeAccounts.identityAcceptFailedToast' => 'Could not accept identity',
+			'web.providers.antigravityAccounts.title' => 'Antigravity accounts',
+			'web.providers.antigravityAccounts.importLocal' => 'Import local',
+			'web.providers.antigravityAccounts.importLocalTooltip' => 'Scan ~/.antigravity-accounts/ (and the gateway user\'s ~) on the host and register any logged-in account dirs. Gateway-host only.',
+			'web.providers.antigravityAccounts.importedNothingToast' => 'Nothing to import — accounts already in sync.',
+			'web.providers.antigravityAccounts.importedToast_one' => ({required Object count}) => 'Imported ${count} account from ~/.antigravity-accounts',
+			'web.providers.antigravityAccounts.importedToast_other' => ({required Object count}) => 'Imported ${count} accounts from ~/.antigravity-accounts',
+			'web.providers.antigravityAccounts.importFailedToast' => 'Import failed',
+			'web.providers.antigravityAccounts.addingTitle' => 'Adding a new account.',
+			'web.providers.antigravityAccounts.addingBodyPrefix' => 'Antigravity keys all state off \$HOME. Give each account its own HOME and log in there on the gateway host:',
+			'web.providers.antigravityAccounts.addingBodySuffix' => 'Then click <1>Import local</1> to register it. The directory only counts as an account once the Google sign-in has written its OAuth token.',
+			'web.providers.antigravityAccounts.loading' => 'Loading…',
+			'web.providers.antigravityAccounts.empty' => 'No Antigravity accounts yet. Run <1>HOME=~/.antigravity-accounts/&lt;name&gt; agy</1> on the gateway host, complete the Google sign-in, then click Import local.',
+			'web.providers.antigravityAccounts.noTokenYet' => 'not logged in',
+			'web.providers.antigravityAccounts.homeDir' => 'home:',
+			'web.providers.antigravityAccounts.toggleFailedToast' => 'Toggle failed',
+			'web.providers.antigravityAccounts.removeConfirm' => ({required Object name}) => 'Remove account "${name}"?',
+			'web.providers.antigravityAccounts.removedToast' => 'Account removed',
+			'web.providers.antigravityAccounts.removeFailedToast' => 'Remove failed',
+			'web.providers.antigravityAccounts.toggleAria' => ({required Object name}) => 'Toggle ${name}',
+			'web.providers.antigravityAccounts.removeAria' => ({required Object name}) => 'Remove ${name}',
 			'web.providers.models.title' => 'Models',
 			'web.providers.models.help' => 'Models offered for this provider. The default is passed to every session via the model flag; sessions can still override it.',
 			'web.providers.models.empty' => 'No models configured yet.',
@@ -17745,6 +17896,8 @@ extension on Translations {
 			'web.channels.notifications.onceReplyHint' => 'Replying with non-command text in this chat resets the suppression — opendray forwards your reply to the session\'s stdin and re-arms the notifier.',
 			'web.channels.notifications.terminalSnippetLabel' => 'Terminal snippet',
 			'web.channels.notifications.embedSnippetLabel' => 'Embed the recent terminal screen in idle notifications',
+			_ => null,
+		} ?? switch (path) {
 			'web.channels.notifications.snippetExplainer' => 'When enabled, the idle card includes a code-block snippet of what the user would see in the live web terminal — Claude TUI chrome (status spinner, "bypass permissions" hint, separator lines) is filtered out automatically.',
 			'web.channels.notifications.modes.onceLabel' => 'Once per session (recommended)',
 			'web.channels.notifications.modes.onceHint' => 'Fire once when a session goes idle, then stay silent until either the session ends or you reply via this channel.',
@@ -17768,8 +17921,6 @@ extension on Translations {
 			'web.channels.bridge.tokenLabel' => 'Adapter token',
 			'web.channels.bridge.regenerateTooltip' => 'Regenerate',
 			'web.channels.bridge.copyTooltip' => 'Copy',
-			_ => null,
-		} ?? switch (path) {
 			'web.channels.bridge.tokenCopiedToast' => 'Token copied',
 			'web.channels.bridge.tokenHint' => 'Adapter authenticates by sending this in the WS register frame (or as <1>X-Bridge-Token</1> header).',
 			'web.channels.bridge.capsLabel' => 'Accept capabilities (optional whitelist)',
@@ -18259,6 +18410,8 @@ extension on Translations {
 			'web.backups.targetsTab.columns.config' => 'Config',
 			'web.backups.targetsTab.columns.enabled' => 'Enabled',
 			'web.backups.targetsTab.columns.actions' => 'Actions',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.targetsTab.on' => 'on',
 			'web.backups.targetsTab.off' => 'off',
 			'web.backups.targetsTab.test' => 'Test',
@@ -18282,8 +18435,6 @@ extension on Translations {
 			'web.backups.targetEditor.smb.shareLabel' => 'Share',
 			'web.backups.targetEditor.smb.shareHint' => 'Top-level share name on the SMB server',
 			'web.backups.targetEditor.smb.sharePlaceholder' => 'Claude_Workspace',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.targetEditor.smb.userLabel' => 'User',
 			'web.backups.targetEditor.smb.passwordLabel' => 'Password',
 			'web.backups.targetEditor.smb.pathPrefixLabel' => 'Path prefix',
@@ -18773,6 +18924,8 @@ extension on Translations {
 			'web.noteEditor.tagTitle' => ({required Object tag}) => 'tag #${tag}',
 			'web.noteEditor.emptyNote' => 'Empty note. Switch to Source to start writing.',
 			'web.noteEditor.saveFailedToast' => 'Save failed',
+			_ => null,
+		} ?? switch (path) {
 			'web.noteEditor.status.saveFailed' => 'save failed',
 			'web.noteEditor.status.saving' => 'saving…',
 			'web.noteEditor.status.unsaved' => 'unsaved',
@@ -18796,8 +18949,6 @@ extension on Translations {
 			'web.export.form.integrationOptions.plaintext' => 'Include plaintext API keys',
 			'web.export.form.integrationOptions.plaintextHint' => 'v1 bcrypt-only: no recoverable plaintext exists. Manifest documents this; nothing leaks.',
 			'web.export.form.confirmWarning' => 'Type <1>I understand</1> to confirm. opendray currently stores only bcrypt hashes — selecting plaintext does NOT export any plaintext (the feature is reserved for a future release that keeps plaintext caches).',
-			_ => null,
-		} ?? switch (path) {
 			'web.export.form.confirmPlaceholder' => 'I understand',
 			'web.export.form.confirmSentinel' => 'i understand',
 			'web.export.form.footnote' => 'Audit logs and session transcripts are out of scope — covered by /backups (operator dump) instead.',
@@ -19214,6 +19365,10 @@ extension on Translations {
 			'sessions.detail.accountSwitcher.switchedSnack' => ({required Object account}) => 'Switched to ${account}',
 			'sessions.detail.accountSwitcher.switchFailed' => ({required Object error}) => 'Switch failed: ${error}',
 			'sessions.detail.accountSwitcher.noneHint' => 'No Claude accounts configured. Add them in More → Providers → Claude.',
+			'sessions.detail.accountSwitcher.tooltipAgy' => 'Switch Antigravity account',
+			'sessions.detail.accountSwitcher.sheetTitleAgy' => 'Switch Antigravity account',
+			'sessions.detail.accountSwitcher.confirmBodyAgy' => 'This restarts the Antigravity CLI under a fresh conversation — the in-CLI history doesn\'t carry across accounts (the session tab is kept).',
+			'sessions.detail.accountSwitcher.noneHintAgy' => 'No Antigravity accounts configured. Add them in More → Providers → Antigravity.',
 			'sessions.terminal.snackbar.imagePickerFailed' => ({required Object error}) => 'Image picker failed: ${error}',
 			'sessions.terminal.snackbar.uploadingImage' => 'Uploading image…',
 			'sessions.terminal.snackbar.imageAttached' => ({required Object path}) => 'Image attached: ${path}',
@@ -19283,6 +19438,8 @@ extension on Translations {
 			'sessions.inspector.files.readContent' => 'Read content',
 			'sessions.inspector.files.readContentSubtitle' => 'Up to 256 KiB plain text',
 			'sessions.inspector.files.readFailedApi' => ({required Object status, required Object message}) => 'Read failed (${status}): ${message}',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.files.readFailedGeneric' => ({required Object error}) => 'Read failed: ${error}',
 			'sessions.inspector.files.parent' => 'Parent',
 			'sessions.inspector.files.backToCwd' => 'Back to session cwd',
@@ -19310,8 +19467,6 @@ extension on Translations {
 			'sessions.inspector.notes.insertAtRefShort' => 'Insert @reference',
 			'sessions.inspector.notes.draftHint' => ({required Object project}) => '# ${project}\n\nThoughts, todos, context for the agent…',
 			'sessions.inspector.notes.createFailed' => ({required Object error}) => 'Create failed: ${error}',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.saveFailed' => ({required Object error}) => 'Save failed: ${error}',
 			'sessions.inspector.notes.changeLocationTooltip' => 'Change project docs location',
 			'sessions.inspector.notes.filenameHint' => 'filename (e.g. spec or design.md)',
@@ -19508,6 +19663,15 @@ extension on Translations {
 			'providers.accounts.acceptIdentity' => 'Accept',
 			'providers.accounts.identityAcceptedSnack' => 'Identity change accepted',
 			'providers.accounts.identityAcceptFailed' => 'Accept failed',
+			'providers.antigravityAccounts.addHint' => 'Adding a new account is gateway-host only.',
+			'providers.antigravityAccounts.addBody' => 'Give each account its own HOME on the gateway host (HOME=~/.antigravity-accounts/<name> agy), finish the Google sign-in, then tap Import local.',
+			'providers.antigravityAccounts.intro' => 'Sessions spawned with the Antigravity provider pick from these accounts (or fall back to the gateway default HOME).',
+			'providers.antigravityAccounts.empty' => 'No Antigravity accounts yet. Run HOME=~/.antigravity-accounts/<name> agy on the gateway host, finish the Google sign-in, then tap Import local.',
+			'providers.antigravityAccounts.deleteTitle' => 'Remove account?',
+			'providers.antigravityAccounts.deleteBody' => 'Removes the account from opendray. The on-disk HOME directory is left untouched; sessions already using it stay running.',
+			'providers.antigravityAccounts.importSyncedSnack' => 'Already in sync — gateway has no new accounts.',
+			'providers.antigravityAccounts.noTokenYet' => 'not logged in',
+			'providers.antigravityAccounts.homeDir' => ({required Object dir}) => 'home: ${dir}',
 			'providers.configFallbackTitle' => 'Provider config',
 			'providers.saving' => 'Saving…',
 			'providers.save' => 'Save',
@@ -19788,6 +19952,8 @@ extension on Translations {
 			'backups.emptyMissingDeps.headline' => 'Backups can\'t run yet',
 			'backups.emptyMissingDeps.body' => 'Install postgresql-client and restart opendray.',
 			'backups.emptyNoTargets.headline' => 'No backup targets configured',
+			_ => null,
+		} ?? switch (path) {
 			'backups.emptyNoTargets.body' => 'Open the More menu → Targets to add a destination (local / S3 / SMB / SFTP / WebDAV / rclone). Then come back and tap "Run now".',
 			'backups.emptyNoBackups.headline' => 'No backups yet',
 			'backups.emptyNoBackups.body' => 'Tap "Run now" to take a fresh snapshot, or open Schedules to set up recurring runs.',
@@ -19824,8 +19990,6 @@ extension on Translations {
 			'backups.encryption.generate' => 'Generate',
 			'backups.encryption.paste' => 'Paste',
 			'backups.encryption.random256bit' => '256-bit random key',
-			_ => null,
-		} ?? switch (path) {
 			'backups.encryption.passphraseLabel' => 'Your passphrase',
 			'backups.encryption.passphraseHint' => 'At least 20 characters',
 			'backups.encryption.passphraseCopied' => 'Passphrase copied to clipboard',
@@ -20302,6 +20466,8 @@ extension on Translations {
 			'dataExport.import.importing' => 'Importing…',
 			'dataExport.import.pickFileToast' => 'Pick a bundle file first.',
 			'dataExport.import.doneToast' => 'Import done',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.import.finishedWithErrors' => 'Import finished with errors',
 			'dataExport.import.failedToast' => ({required Object error}) => 'Import failed: ${error}',
 			'dataExport.import.summaryCard.memories' => 'Memories',
@@ -20338,8 +20504,6 @@ extension on Translations {
 			'memory.status.dimensions' => ({required Object dim, required Object state}) => '${dim}-dim · ${state}',
 			'memory.status.enabled' => 'enabled',
 			'memory.status.disabled' => 'disabled',
-			_ => null,
-		} ?? switch (path) {
 			'memory.status.floorNoModel' => 'Keyword (BM25) retrieval only — no embedding model configured. Configure a dense endpoint in Settings to enable semantic memory.',
 			'memory.status.denseConfiguredPendingRestart' => ({required Object model}) => 'Configured ${model} (dense) — restart the gateway to activate semantic memory and re-embed existing memories.',
 			'memory.status.denseUnreachableFloor' => ({required Object model}) => 'Configured ${model} (dense) but the endpoint is unreachable — using the keyword floor until it responds (auto-upgrades on restart).',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -323,6 +323,7 @@ class _TranslationsProvidersEs extends TranslationsProvidersEn {
 	@override String errorWithMessage({required Object prefix, required Object error}) => '${prefix}: ${error}';
 	@override late final _TranslationsProvidersUpdateCheckEs updateCheck = _TranslationsProvidersUpdateCheckEs._(_root);
 	@override late final _TranslationsProvidersAccountsEs accounts = _TranslationsProvidersAccountsEs._(_root);
+	@override late final _TranslationsProvidersAntigravityAccountsEs antigravityAccounts = _TranslationsProvidersAntigravityAccountsEs._(_root);
 	@override String get configFallbackTitle => 'Configuración del proveedor';
 	@override String get saving => 'Guardando…';
 	@override String get save => 'Guardar';
@@ -1384,6 +1385,7 @@ class _TranslationsWebProvidersEs extends TranslationsWebProvidersEn {
 	@override late final _TranslationsWebProvidersDetailEs detail = _TranslationsWebProvidersDetailEs._(_root);
 	@override late final _TranslationsWebProvidersConfigFormEs configForm = _TranslationsWebProvidersConfigFormEs._(_root);
 	@override late final _TranslationsWebProvidersClaudeAccountsEs claudeAccounts = _TranslationsWebProvidersClaudeAccountsEs._(_root);
+	@override late final _TranslationsWebProvidersAntigravityAccountsEs antigravityAccounts = _TranslationsWebProvidersAntigravityAccountsEs._(_root);
 	@override late final _TranslationsWebProvidersModelsEs models = _TranslationsWebProvidersModelsEs._(_root);
 }
 
@@ -2090,6 +2092,24 @@ class _TranslationsProvidersAccountsEs extends TranslationsProvidersAccountsEn {
 	@override String get acceptIdentity => 'Aceptar';
 	@override String get identityAcceptedSnack => 'Cambio de identidad aceptado';
 	@override String get identityAcceptFailed => 'Error al aceptar';
+}
+
+// Path: providers.antigravityAccounts
+class _TranslationsProvidersAntigravityAccountsEs extends TranslationsProvidersAntigravityAccountsEn {
+	_TranslationsProvidersAntigravityAccountsEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get addHint => 'Añadir una cuenta nueva solo se puede hacer en el host del gateway.';
+	@override String get addBody => 'Dale a cada cuenta su propio HOME en el host del gateway (HOME=~/.antigravity-accounts/<nombre> agy), completa el inicio de sesión de Google y luego toca Importar locales.';
+	@override String get intro => 'Las sessions creadas con el proveedor Antigravity eligen entre estas cuentas (o recurren al HOME predeterminado del gateway).';
+	@override String get empty => 'Aún no hay cuentas de Antigravity. Ejecuta HOME=~/.antigravity-accounts/<nombre> agy en el host del gateway, completa el inicio de sesión de Google y luego toca Importar locales.';
+	@override String get deleteTitle => '¿Quitar la cuenta?';
+	@override String get deleteBody => 'Quita la cuenta de opendray. El directorio HOME en disco no se modifica; las sessions que ya lo usan siguen funcionando.';
+	@override String get importSyncedSnack => 'Ya está sincronizado, el gateway no tiene cuentas nuevas.';
+	@override String get noTokenYet => 'sin iniciar sesión';
+	@override String homeDir({required Object dir}) => 'home: ${dir}';
 }
 
 // Path: integrations.form
@@ -3196,8 +3216,11 @@ class _TranslationsWebSessionsAccountSwitcherEs extends TranslationsWebSessionsA
 
 	// Translations
 	@override String get tooltip => 'Cambiar de cuenta de Claude (reinicia el proceso de la CLI)';
+	@override String get tooltipAgy => 'Cambiar de cuenta de Antigravity (reinicia el proceso de la CLI)';
 	@override String get currentDefault => 'predeterminada';
 	@override String get menuTitle => 'Cambiar de cuenta de Claude';
+	@override String get menuTitleAgy => 'Cambiar de cuenta de Antigravity';
+	@override String get confirmSwitchAgy => 'Cambiar de cuenta reinicia la CLI de Antigravity con una conversación nueva: el historial dentro de la CLI no se transfiere entre cuentas. Se pierde cualquier ejecución de herramienta en curso o entrada sin enviar. ¿Continuar?';
 	@override String get defaultName => 'Predeterminada';
 	@override String get defaultSubtitle => 'keychain del sistema / env de la CLI';
 	@override String get tokenEmpty => '·vacío';
@@ -4147,6 +4170,35 @@ class _TranslationsWebProvidersClaudeAccountsEs extends TranslationsWebProviders
 	@override String removeAria({required Object name}) => 'Quitar ${name}';
 	@override String get identityAcceptedToast => 'Nueva identidad registrada';
 	@override String get identityAcceptFailedToast => 'No se pudo aceptar la identidad';
+}
+
+// Path: web.providers.antigravityAccounts
+class _TranslationsWebProvidersAntigravityAccountsEs extends TranslationsWebProvidersAntigravityAccountsEn {
+	_TranslationsWebProvidersAntigravityAccountsEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Cuentas de Antigravity';
+	@override String get importLocal => 'Importar locales';
+	@override String get importLocalTooltip => 'Escanea ~/.antigravity-accounts/ (y el ~ del usuario del gateway) en el host y registra los directorios de cuentas con sesión iniciada. Solo en el host del gateway.';
+	@override String get importedNothingToast => 'Nada que importar: las cuentas ya están sincronizadas.';
+	@override String importedToast_one({required Object count}) => 'Se importó ${count} cuenta de ~/.antigravity-accounts';
+	@override String importedToast_other({required Object count}) => 'Se importaron ${count} cuentas de ~/.antigravity-accounts';
+	@override String get importFailedToast => 'Error al importar';
+	@override String get addingTitle => 'Añadir una cuenta nueva.';
+	@override String get addingBodyPrefix => 'Antigravity guarda todo su estado en \$HOME. Da a cada cuenta su propio HOME e inicia sesión allí en el host del gateway:';
+	@override String get addingBodySuffix => 'Luego haz clic en <1>Importar locales</1> para registrarla. El directorio solo cuenta como cuenta cuando el inicio de sesión de Google ha escrito su token OAuth.';
+	@override String get loading => 'Cargando…';
+	@override String get empty => 'Aún no hay cuentas de Antigravity. Ejecuta <1>HOME=~/.antigravity-accounts/&lt;nombre&gt; agy</1> en el host del gateway, completa el inicio de sesión de Google y luego haz clic en Importar locales.';
+	@override String get noTokenYet => 'sin sesión iniciada';
+	@override String get homeDir => 'home:';
+	@override String get toggleFailedToast => 'Error al alternar';
+	@override String removeConfirm({required Object name}) => '¿Quitar la cuenta "${name}"?';
+	@override String get removedToast => 'Cuenta eliminada';
+	@override String get removeFailedToast => 'Error al eliminar';
+	@override String toggleAria({required Object name}) => 'Alternar ${name}';
+	@override String removeAria({required Object name}) => 'Quitar ${name}';
 }
 
 // Path: web.providers.models
@@ -6032,6 +6084,10 @@ class _TranslationsSessionsDetailAccountSwitcherEs extends TranslationsSessionsD
 	@override String switchedSnack({required Object account}) => 'Cambiado a ${account}';
 	@override String switchFailed({required Object error}) => 'Cambio fallido: ${error}';
 	@override String get noneHint => 'No hay cuentas de Claude configuradas. Agrégalas en Más → Providers → Claude.';
+	@override String get tooltipAgy => 'Cambiar de cuenta de Antigravity';
+	@override String get sheetTitleAgy => 'Cambiar de cuenta de Antigravity';
+	@override String get confirmBodyAgy => 'Esto reinicia el CLI de Antigravity con una conversación nueva — el historial dentro del CLI no se traslada entre cuentas (la pestaña de la sesión se conserva).';
+	@override String get noneHintAgy => 'No hay cuentas de Antigravity configuradas. Agrégalas en Más → Providers → Antigravity.';
 }
 
 // Path: sessions.terminal.snackbar
@@ -9072,8 +9128,11 @@ extension on TranslationsEs {
 			'web.sessions.spawn.spawnedDescription' => ({required Object provider, required Object pid}) => '${provider} · pid ${pid}',
 			'web.sessions.spawn.pidFallback' => '—',
 			'web.sessions.accountSwitcher.tooltip' => 'Cambiar de cuenta de Claude (reinicia el proceso de la CLI)',
+			'web.sessions.accountSwitcher.tooltipAgy' => 'Cambiar de cuenta de Antigravity (reinicia el proceso de la CLI)',
 			'web.sessions.accountSwitcher.currentDefault' => 'predeterminada',
 			'web.sessions.accountSwitcher.menuTitle' => 'Cambiar de cuenta de Claude',
+			'web.sessions.accountSwitcher.menuTitleAgy' => 'Cambiar de cuenta de Antigravity',
+			'web.sessions.accountSwitcher.confirmSwitchAgy' => 'Cambiar de cuenta reinicia la CLI de Antigravity con una conversación nueva: el historial dentro de la CLI no se transfiere entre cuentas. Se pierde cualquier ejecución de herramienta en curso o entrada sin enviar. ¿Continuar?',
 			'web.sessions.accountSwitcher.defaultName' => 'Predeterminada',
 			'web.sessions.accountSwitcher.defaultSubtitle' => 'keychain del sistema / env de la CLI',
 			'web.sessions.accountSwitcher.tokenEmpty' => '·vacío',
@@ -9424,11 +9483,11 @@ extension on TranslationsEs {
 			'web.project.reset.alsoDeleteMemoriesLabel' => 'Eliminar también las memorias de pgvector',
 			'web.project.reset.alsoDeleteMemoriesSuffix' => 'para este scope_key.',
 			'web.project.reset.alsoDeleteMemoriesHint' => 'Hechos a largo plazo que el agente almacenó (preferencias del usuario, datos del proyecto). No se pueden recuperar.',
+			_ => null,
+		} ?? switch (path) {
 			'web.project.reset.cancel' => 'Cancelar',
 			'web.project.reset.deleteForever' => 'Eliminar para siempre',
 			'web.project.reset.successToast' => ({required Object summary}) => 'Restablecido: se eliminó ${summary}',
-			_ => null,
-		} ?? switch (path) {
 			'web.project.reset.summary.docs_one' => ({required Object count}) => '${count} documento',
 			'web.project.reset.summary.docs_other' => ({required Object count}) => '${count} documentos',
 			'web.project.reset.summary.journal' => ({required Object count}) => '${count} diario',
@@ -9844,6 +9903,26 @@ extension on TranslationsEs {
 			'web.providers.claudeAccounts.removeAria' => ({required Object name}) => 'Quitar ${name}',
 			'web.providers.claudeAccounts.identityAcceptedToast' => 'Nueva identidad registrada',
 			'web.providers.claudeAccounts.identityAcceptFailedToast' => 'No se pudo aceptar la identidad',
+			'web.providers.antigravityAccounts.title' => 'Cuentas de Antigravity',
+			'web.providers.antigravityAccounts.importLocal' => 'Importar locales',
+			'web.providers.antigravityAccounts.importLocalTooltip' => 'Escanea ~/.antigravity-accounts/ (y el ~ del usuario del gateway) en el host y registra los directorios de cuentas con sesión iniciada. Solo en el host del gateway.',
+			'web.providers.antigravityAccounts.importedNothingToast' => 'Nada que importar: las cuentas ya están sincronizadas.',
+			'web.providers.antigravityAccounts.importedToast_one' => ({required Object count}) => 'Se importó ${count} cuenta de ~/.antigravity-accounts',
+			'web.providers.antigravityAccounts.importedToast_other' => ({required Object count}) => 'Se importaron ${count} cuentas de ~/.antigravity-accounts',
+			'web.providers.antigravityAccounts.importFailedToast' => 'Error al importar',
+			'web.providers.antigravityAccounts.addingTitle' => 'Añadir una cuenta nueva.',
+			'web.providers.antigravityAccounts.addingBodyPrefix' => 'Antigravity guarda todo su estado en \$HOME. Da a cada cuenta su propio HOME e inicia sesión allí en el host del gateway:',
+			'web.providers.antigravityAccounts.addingBodySuffix' => 'Luego haz clic en <1>Importar locales</1> para registrarla. El directorio solo cuenta como cuenta cuando el inicio de sesión de Google ha escrito su token OAuth.',
+			'web.providers.antigravityAccounts.loading' => 'Cargando…',
+			'web.providers.antigravityAccounts.empty' => 'Aún no hay cuentas de Antigravity. Ejecuta <1>HOME=~/.antigravity-accounts/&lt;nombre&gt; agy</1> en el host del gateway, completa el inicio de sesión de Google y luego haz clic en Importar locales.',
+			'web.providers.antigravityAccounts.noTokenYet' => 'sin sesión iniciada',
+			'web.providers.antigravityAccounts.homeDir' => 'home:',
+			'web.providers.antigravityAccounts.toggleFailedToast' => 'Error al alternar',
+			'web.providers.antigravityAccounts.removeConfirm' => ({required Object name}) => '¿Quitar la cuenta "${name}"?',
+			'web.providers.antigravityAccounts.removedToast' => 'Cuenta eliminada',
+			'web.providers.antigravityAccounts.removeFailedToast' => 'Error al eliminar',
+			'web.providers.antigravityAccounts.toggleAria' => ({required Object name}) => 'Alternar ${name}',
+			'web.providers.antigravityAccounts.removeAria' => ({required Object name}) => 'Quitar ${name}',
 			'web.providers.models.title' => 'Modelos',
 			'web.providers.models.help' => 'Modelos ofrecidos para este proveedor. El predeterminado se pasa a cada session mediante el flag de modelo; las sessions aún pueden sobrescribirlo.',
 			'web.providers.models.empty' => 'Aún no hay modelos configurados.',
@@ -9918,6 +9997,8 @@ extension on TranslationsEs {
 			'web.channels.notifications.onceReplyHint' => 'Responder con texto que no sea un comando en este chat restablece la supresión, opendray reenvía tu respuesta al stdin de la session y rearma el notificador.',
 			'web.channels.notifications.terminalSnippetLabel' => 'Fragmento de terminal',
 			'web.channels.notifications.embedSnippetLabel' => 'Incrustar la pantalla reciente del terminal en las notificaciones de inactividad',
+			_ => null,
+		} ?? switch (path) {
 			'web.channels.notifications.snippetExplainer' => 'Cuando está activado, la tarjeta de inactividad incluye un fragmento en bloque de código de lo que el usuario vería en el terminal web en vivo, los elementos de la interfaz del TUI de Claude (indicador de estado, aviso de "bypass permissions", líneas separadoras) se filtran automáticamente.',
 			'web.channels.notifications.modes.onceLabel' => 'Una vez por session (recomendado)',
 			'web.channels.notifications.modes.onceHint' => 'Se dispara una vez cuando una session queda inactiva, luego permanece en silencio hasta que la session termine o respondas por este canal.',
@@ -9941,8 +10022,6 @@ extension on TranslationsEs {
 			'web.channels.bridge.tokenLabel' => 'Token del adaptador',
 			'web.channels.bridge.regenerateTooltip' => 'Regenerar',
 			'web.channels.bridge.copyTooltip' => 'Copiar',
-			_ => null,
-		} ?? switch (path) {
 			'web.channels.bridge.tokenCopiedToast' => 'Token copiado',
 			'web.channels.bridge.tokenHint' => 'El adaptador se autentica enviándolo en el frame de registro de WS (o como cabecera <1>X-Bridge-Token</1>).',
 			'web.channels.bridge.capsLabel' => 'Aceptar capacidades (lista blanca opcional)',
@@ -10432,6 +10511,8 @@ extension on TranslationsEs {
 			'web.backups.targetsTab.columns.config' => 'Config',
 			'web.backups.targetsTab.columns.enabled' => 'Habilitado',
 			'web.backups.targetsTab.columns.actions' => 'Acciones',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.targetsTab.on' => 'activado',
 			'web.backups.targetsTab.off' => 'desactivado',
 			'web.backups.targetsTab.test' => 'Probar',
@@ -10455,8 +10536,6 @@ extension on TranslationsEs {
 			'web.backups.targetEditor.smb.shareLabel' => 'Recurso compartido',
 			'web.backups.targetEditor.smb.shareHint' => 'Nombre del recurso compartido de nivel superior en el servidor SMB',
 			'web.backups.targetEditor.smb.sharePlaceholder' => 'Claude_Workspace',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.targetEditor.smb.userLabel' => 'Usuario',
 			'web.backups.targetEditor.smb.passwordLabel' => 'Contraseña',
 			'web.backups.targetEditor.smb.pathPrefixLabel' => 'Prefijo de ruta',
@@ -10946,6 +11025,8 @@ extension on TranslationsEs {
 			'web.noteEditor.tagTitle' => ({required Object tag}) => 'etiqueta #${tag}',
 			'web.noteEditor.emptyNote' => 'Nota vacía. Cambia a Origen para empezar a escribir.',
 			'web.noteEditor.saveFailedToast' => 'Error al guardar',
+			_ => null,
+		} ?? switch (path) {
 			'web.noteEditor.status.saveFailed' => 'error al guardar',
 			'web.noteEditor.status.saving' => 'guardando…',
 			'web.noteEditor.status.unsaved' => 'sin guardar',
@@ -10969,8 +11050,6 @@ extension on TranslationsEs {
 			'web.export.form.integrationOptions.plaintext' => 'Incluir las API keys en texto plano',
 			'web.export.form.integrationOptions.plaintextHint' => 'v1 solo con bcrypt: no existe texto plano recuperable. El manifiesto lo documenta; no se filtra nada.',
 			'web.export.form.confirmWarning' => 'Escribe <1>Lo entiendo</1> para confirmar. opendray actualmente almacena solo hashes bcrypt, así que seleccionar texto plano NO exporta ningún texto plano (la función está reservada para una versión futura que mantenga cachés de texto plano).',
-			_ => null,
-		} ?? switch (path) {
 			'web.export.form.confirmPlaceholder' => 'Lo entiendo',
 			'web.export.form.confirmSentinel' => 'lo entiendo',
 			'web.export.form.footnote' => 'Los logs de auditoría y los transcripts de session quedan fuera del alcance; en su lugar los cubre /backups (volcado del operador).',
@@ -11387,6 +11466,10 @@ extension on TranslationsEs {
 			'sessions.detail.accountSwitcher.switchedSnack' => ({required Object account}) => 'Cambiado a ${account}',
 			'sessions.detail.accountSwitcher.switchFailed' => ({required Object error}) => 'Cambio fallido: ${error}',
 			'sessions.detail.accountSwitcher.noneHint' => 'No hay cuentas de Claude configuradas. Agrégalas en Más → Providers → Claude.',
+			'sessions.detail.accountSwitcher.tooltipAgy' => 'Cambiar de cuenta de Antigravity',
+			'sessions.detail.accountSwitcher.sheetTitleAgy' => 'Cambiar de cuenta de Antigravity',
+			'sessions.detail.accountSwitcher.confirmBodyAgy' => 'Esto reinicia el CLI de Antigravity con una conversación nueva — el historial dentro del CLI no se traslada entre cuentas (la pestaña de la sesión se conserva).',
+			'sessions.detail.accountSwitcher.noneHintAgy' => 'No hay cuentas de Antigravity configuradas. Agrégalas en Más → Providers → Antigravity.',
 			'sessions.terminal.snackbar.imagePickerFailed' => ({required Object error}) => 'Falló el selector de imágenes: ${error}',
 			'sessions.terminal.snackbar.uploadingImage' => 'Subiendo imagen…',
 			'sessions.terminal.snackbar.imageAttached' => ({required Object path}) => 'Imagen adjuntada: ${path}',
@@ -11456,6 +11539,8 @@ extension on TranslationsEs {
 			'sessions.inspector.files.readContent' => 'Leer contenido',
 			'sessions.inspector.files.readContentSubtitle' => 'Hasta 256 KiB de texto plano',
 			'sessions.inspector.files.readFailedApi' => ({required Object status, required Object message}) => 'Falló la lectura (${status}): ${message}',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.files.readFailedGeneric' => ({required Object error}) => 'Falló la lectura: ${error}',
 			'sessions.inspector.files.parent' => 'Superior',
 			'sessions.inspector.files.backToCwd' => 'Volver al cwd de la session',
@@ -11483,8 +11568,6 @@ extension on TranslationsEs {
 			'sessions.inspector.notes.insertAtRefShort' => 'Insertar @referencia',
 			'sessions.inspector.notes.draftHint' => ({required Object project}) => '# ${project}\n\nIdeas, tareas pendientes, contexto para el agente…',
 			'sessions.inspector.notes.createFailed' => ({required Object error}) => 'Falló al crear: ${error}',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.saveFailed' => ({required Object error}) => 'Falló al guardar: ${error}',
 			'sessions.inspector.notes.changeLocationTooltip' => 'Cambiar la ubicación de los documentos del proyecto',
 			'sessions.inspector.notes.filenameHint' => 'nombre de archivo (p. ej. spec o design.md)',
@@ -11681,6 +11764,15 @@ extension on TranslationsEs {
 			'providers.accounts.acceptIdentity' => 'Aceptar',
 			'providers.accounts.identityAcceptedSnack' => 'Cambio de identidad aceptado',
 			'providers.accounts.identityAcceptFailed' => 'Error al aceptar',
+			'providers.antigravityAccounts.addHint' => 'Añadir una cuenta nueva solo se puede hacer en el host del gateway.',
+			'providers.antigravityAccounts.addBody' => 'Dale a cada cuenta su propio HOME en el host del gateway (HOME=~/.antigravity-accounts/<nombre> agy), completa el inicio de sesión de Google y luego toca Importar locales.',
+			'providers.antigravityAccounts.intro' => 'Las sessions creadas con el proveedor Antigravity eligen entre estas cuentas (o recurren al HOME predeterminado del gateway).',
+			'providers.antigravityAccounts.empty' => 'Aún no hay cuentas de Antigravity. Ejecuta HOME=~/.antigravity-accounts/<nombre> agy en el host del gateway, completa el inicio de sesión de Google y luego toca Importar locales.',
+			'providers.antigravityAccounts.deleteTitle' => '¿Quitar la cuenta?',
+			'providers.antigravityAccounts.deleteBody' => 'Quita la cuenta de opendray. El directorio HOME en disco no se modifica; las sessions que ya lo usan siguen funcionando.',
+			'providers.antigravityAccounts.importSyncedSnack' => 'Ya está sincronizado, el gateway no tiene cuentas nuevas.',
+			'providers.antigravityAccounts.noTokenYet' => 'sin iniciar sesión',
+			'providers.antigravityAccounts.homeDir' => ({required Object dir}) => 'home: ${dir}',
 			'providers.configFallbackTitle' => 'Configuración del proveedor',
 			'providers.saving' => 'Guardando…',
 			'providers.save' => 'Guardar',
@@ -11961,6 +12053,8 @@ extension on TranslationsEs {
 			'backups.emptyMissingDeps.headline' => 'Las copias de seguridad aún no pueden ejecutarse',
 			'backups.emptyMissingDeps.body' => 'Instala postgresql-client y reinicia opendray.',
 			'backups.emptyNoTargets.headline' => 'No hay destinos de copia de seguridad configurados',
+			_ => null,
+		} ?? switch (path) {
 			'backups.emptyNoTargets.body' => 'Abre el menú Más → Destinos para añadir un destino (local / S3 / SMB / SFTP / WebDAV / rclone). Luego vuelve y toca "Ejecutar ahora".',
 			'backups.emptyNoBackups.headline' => 'Aún no hay copias de seguridad',
 			'backups.emptyNoBackups.body' => 'Toca "Ejecutar ahora" para tomar una nueva instantánea, o abre Programaciones para configurar ejecuciones periódicas.',
@@ -11997,8 +12091,6 @@ extension on TranslationsEs {
 			'backups.encryption.generate' => 'Generar',
 			'backups.encryption.paste' => 'Pegar',
 			'backups.encryption.random256bit' => 'Clave aleatoria de 256 bits',
-			_ => null,
-		} ?? switch (path) {
 			'backups.encryption.passphraseLabel' => 'Tu passphrase',
 			'backups.encryption.passphraseHint' => 'Al menos 20 caracteres',
 			'backups.encryption.passphraseCopied' => 'Passphrase copiada al portapapeles',
@@ -12475,6 +12567,8 @@ extension on TranslationsEs {
 			'dataExport.import.importing' => 'Importando…',
 			'dataExport.import.pickFileToast' => 'Elige primero un archivo de paquete.',
 			'dataExport.import.doneToast' => 'Importación completada',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.import.finishedWithErrors' => 'Importación finalizada con errores',
 			'dataExport.import.failedToast' => ({required Object error}) => 'Error en la importación: ${error}',
 			'dataExport.import.summaryCard.memories' => 'Memorias',
@@ -12511,8 +12605,6 @@ extension on TranslationsEs {
 			'memory.status.dimensions' => ({required Object dim, required Object state}) => '${dim}-dim · ${state}',
 			'memory.status.enabled' => 'habilitado',
 			'memory.status.disabled' => 'deshabilitado',
-			_ => null,
-		} ?? switch (path) {
 			'memory.status.floorNoModel' => 'Solo recuperación por palabras clave (BM25) — no hay modelo de embedding configurado. Configura un endpoint denso en Settings para habilitar la memoria semántica.',
 			'memory.status.denseConfiguredPendingRestart' => ({required Object model}) => 'Configurado ${model} (denso) — reinicia el gateway para activar la memoria semántica y re-embeber las memorias existentes.',
 			'memory.status.denseUnreachableFloor' => ({required Object model}) => 'Configurado ${model} (denso) pero el endpoint está inalcanzable — se usa el piso de palabras clave hasta que responda (se actualiza al reiniciar).',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -323,6 +323,7 @@ class _TranslationsProvidersZh extends TranslationsProvidersEn {
 	@override String errorWithMessage({required Object prefix, required Object error}) => '${prefix}：${error}';
 	@override late final _TranslationsProvidersUpdateCheckZh updateCheck = _TranslationsProvidersUpdateCheckZh._(_root);
 	@override late final _TranslationsProvidersAccountsZh accounts = _TranslationsProvidersAccountsZh._(_root);
+	@override late final _TranslationsProvidersAntigravityAccountsZh antigravityAccounts = _TranslationsProvidersAntigravityAccountsZh._(_root);
 	@override String get configFallbackTitle => '提供商配置';
 	@override String get saving => '保存中…';
 	@override String get save => '保存';
@@ -1384,6 +1385,7 @@ class _TranslationsWebProvidersZh extends TranslationsWebProvidersEn {
 	@override late final _TranslationsWebProvidersDetailZh detail = _TranslationsWebProvidersDetailZh._(_root);
 	@override late final _TranslationsWebProvidersConfigFormZh configForm = _TranslationsWebProvidersConfigFormZh._(_root);
 	@override late final _TranslationsWebProvidersClaudeAccountsZh claudeAccounts = _TranslationsWebProvidersClaudeAccountsZh._(_root);
+	@override late final _TranslationsWebProvidersAntigravityAccountsZh antigravityAccounts = _TranslationsWebProvidersAntigravityAccountsZh._(_root);
 	@override late final _TranslationsWebProvidersModelsZh models = _TranslationsWebProvidersModelsZh._(_root);
 }
 
@@ -2090,6 +2092,24 @@ class _TranslationsProvidersAccountsZh extends TranslationsProvidersAccountsEn {
 	@override String get acceptIdentity => '接受';
 	@override String get identityAcceptedSnack => '已接受身份变更';
 	@override String get identityAcceptFailed => '接受失败';
+}
+
+// Path: providers.antigravityAccounts
+class _TranslationsProvidersAntigravityAccountsZh extends TranslationsProvidersAntigravityAccountsEn {
+	_TranslationsProvidersAntigravityAccountsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get addHint => '添加新账号仅可在网关主机上操作。';
+	@override String get addBody => '在网关主机上为每个账号分配独立的 HOME（HOME=~/.antigravity-accounts/<name> agy），完成 Google 登录后点按“导入本地”。';
+	@override String get intro => '以 Antigravity 提供商启动的会话会从这些账号中选择（或回退到网关默认 HOME）。';
+	@override String get empty => '尚无 Antigravity 账号。在网关主机上运行 HOME=~/.antigravity-accounts/<name> agy，完成 Google 登录后点按“导入本地”。';
+	@override String get deleteTitle => '移除账号？';
+	@override String get deleteBody => '从 opendray 移除该账号。磁盘上的 HOME 目录保持不变；已使用它的会话保持运行。';
+	@override String get importSyncedSnack => '已同步 — 网关没有新账号。';
+	@override String get noTokenYet => '未登录';
+	@override String homeDir({required Object dir}) => 'home：${dir}';
 }
 
 // Path: integrations.form
@@ -3196,8 +3216,11 @@ class _TranslationsWebSessionsAccountSwitcherZh extends TranslationsWebSessionsA
 
 	// Translations
 	@override String get tooltip => '切换 Claude 账号（将重启 CLI 进程）';
+	@override String get tooltipAgy => '切换 Antigravity 账号（将重启 CLI 进程）';
 	@override String get currentDefault => '默认';
 	@override String get menuTitle => '切换 Claude 账号';
+	@override String get menuTitleAgy => '切换 Antigravity 账号';
+	@override String get confirmSwitchAgy => '切换账号会以全新对话重启 Antigravity CLI——CLI 内的历史记录不会在账号间保留。任何进行中的工具执行或未发送的输入都会丢失。是否继续？';
 	@override String get defaultName => '默认';
 	@override String get defaultSubtitle => 'CLI 的系统 keychain / 环境变量';
 	@override String get tokenEmpty => '·未填';
@@ -4147,6 +4170,35 @@ class _TranslationsWebProvidersClaudeAccountsZh extends TranslationsWebProviders
 	@override String removeAria({required Object name}) => '移除 ${name}';
 	@override String get identityAcceptedToast => '已接受新身份';
 	@override String get identityAcceptFailedToast => '无法接受新身份';
+}
+
+// Path: web.providers.antigravityAccounts
+class _TranslationsWebProvidersAntigravityAccountsZh extends TranslationsWebProvidersAntigravityAccountsEn {
+	_TranslationsWebProvidersAntigravityAccountsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Antigravity 账号';
+	@override String get importLocal => '导入本地';
+	@override String get importLocalTooltip => '扫描主机上的 ~/.antigravity-accounts/（以及网关用户的 ~），注册已登录的账号目录。仅限网关主机。';
+	@override String get importedNothingToast => '无可导入——账号已同步。';
+	@override String importedToast_one({required Object count}) => '已从 ~/.antigravity-accounts 导入 ${count} 个账号';
+	@override String importedToast_other({required Object count}) => '已从 ~/.antigravity-accounts 导入 ${count} 个账号';
+	@override String get importFailedToast => '导入失败';
+	@override String get addingTitle => '添加新账号。';
+	@override String get addingBodyPrefix => 'Antigravity 的所有状态都基于 \$HOME。为每个账号分配独立的 HOME，并在网关主机上登录：';
+	@override String get addingBodySuffix => '然后点击 <1>导入本地</1> 进行注册。只有当 Google 登录写入 OAuth 令牌后，该目录才会被视为账号。';
+	@override String get loading => '加载中…';
+	@override String get empty => '尚无 Antigravity 账号。在网关主机上运行 <1>HOME=~/.antigravity-accounts/&lt;name&gt; agy</1>，完成 Google 登录，然后点击“导入本地”。';
+	@override String get noTokenYet => '未登录';
+	@override String get homeDir => 'home：';
+	@override String get toggleFailedToast => '切换失败';
+	@override String removeConfirm({required Object name}) => '移除账号“${name}”？';
+	@override String get removedToast => '账号已移除';
+	@override String get removeFailedToast => '移除失败';
+	@override String toggleAria({required Object name}) => '切换 ${name}';
+	@override String removeAria({required Object name}) => '移除 ${name}';
 }
 
 // Path: web.providers.models
@@ -6032,6 +6084,10 @@ class _TranslationsSessionsDetailAccountSwitcherZh extends TranslationsSessionsD
 	@override String switchedSnack({required Object account}) => '已切换到 ${account}';
 	@override String switchFailed({required Object error}) => '切换失败：${error}';
 	@override String get noneHint => '未配置 Claude 账号。请在 更多 → Providers → Claude 中添加。';
+	@override String get tooltipAgy => '切换 Antigravity 账号';
+	@override String get sheetTitleAgy => '切换 Antigravity 账号';
+	@override String get confirmBodyAgy => '这会用全新对话重启 Antigravity CLI——CLI 内的历史不会在账号间保留（会话标签保留）。';
+	@override String get noneHintAgy => '未配置 Antigravity 账号。请在 更多 → Providers → Antigravity 中添加。';
 }
 
 // Path: sessions.terminal.snackbar
@@ -9072,8 +9128,11 @@ extension on TranslationsZh {
 			'web.sessions.spawn.spawnedDescription' => ({required Object provider, required Object pid}) => '${provider} · pid ${pid}',
 			'web.sessions.spawn.pidFallback' => '—',
 			'web.sessions.accountSwitcher.tooltip' => '切换 Claude 账号（将重启 CLI 进程）',
+			'web.sessions.accountSwitcher.tooltipAgy' => '切换 Antigravity 账号（将重启 CLI 进程）',
 			'web.sessions.accountSwitcher.currentDefault' => '默认',
 			'web.sessions.accountSwitcher.menuTitle' => '切换 Claude 账号',
+			'web.sessions.accountSwitcher.menuTitleAgy' => '切换 Antigravity 账号',
+			'web.sessions.accountSwitcher.confirmSwitchAgy' => '切换账号会以全新对话重启 Antigravity CLI——CLI 内的历史记录不会在账号间保留。任何进行中的工具执行或未发送的输入都会丢失。是否继续？',
 			'web.sessions.accountSwitcher.defaultName' => '默认',
 			'web.sessions.accountSwitcher.defaultSubtitle' => 'CLI 的系统 keychain / 环境变量',
 			'web.sessions.accountSwitcher.tokenEmpty' => '·未填',
@@ -9424,11 +9483,11 @@ extension on TranslationsZh {
 			'web.project.reset.alsoDeleteMemoriesLabel' => '同时删除 pgvector 记忆',
 			'web.project.reset.alsoDeleteMemoriesSuffix' => '（该 scope_key 下的）。',
 			'web.project.reset.alsoDeleteMemoriesHint' => 'Agent 存储的长期事实（用户偏好、项目事实）。无法恢复。',
+			_ => null,
+		} ?? switch (path) {
 			'web.project.reset.cancel' => '取消',
 			'web.project.reset.deleteForever' => '永久删除',
 			'web.project.reset.successToast' => ({required Object summary}) => '重置：已删除 ${summary}',
-			_ => null,
-		} ?? switch (path) {
 			'web.project.reset.summary.docs_one' => ({required Object count}) => '${count} 份文档',
 			'web.project.reset.summary.docs_other' => ({required Object count}) => '${count} 份文档',
 			'web.project.reset.summary.journal' => ({required Object count}) => '${count} 条日志',
@@ -9844,6 +9903,26 @@ extension on TranslationsZh {
 			'web.providers.claudeAccounts.removeAria' => ({required Object name}) => '移除 ${name}',
 			'web.providers.claudeAccounts.identityAcceptedToast' => '已接受新身份',
 			'web.providers.claudeAccounts.identityAcceptFailedToast' => '无法接受新身份',
+			'web.providers.antigravityAccounts.title' => 'Antigravity 账号',
+			'web.providers.antigravityAccounts.importLocal' => '导入本地',
+			'web.providers.antigravityAccounts.importLocalTooltip' => '扫描主机上的 ~/.antigravity-accounts/（以及网关用户的 ~），注册已登录的账号目录。仅限网关主机。',
+			'web.providers.antigravityAccounts.importedNothingToast' => '无可导入——账号已同步。',
+			'web.providers.antigravityAccounts.importedToast_one' => ({required Object count}) => '已从 ~/.antigravity-accounts 导入 ${count} 个账号',
+			'web.providers.antigravityAccounts.importedToast_other' => ({required Object count}) => '已从 ~/.antigravity-accounts 导入 ${count} 个账号',
+			'web.providers.antigravityAccounts.importFailedToast' => '导入失败',
+			'web.providers.antigravityAccounts.addingTitle' => '添加新账号。',
+			'web.providers.antigravityAccounts.addingBodyPrefix' => 'Antigravity 的所有状态都基于 \$HOME。为每个账号分配独立的 HOME，并在网关主机上登录：',
+			'web.providers.antigravityAccounts.addingBodySuffix' => '然后点击 <1>导入本地</1> 进行注册。只有当 Google 登录写入 OAuth 令牌后，该目录才会被视为账号。',
+			'web.providers.antigravityAccounts.loading' => '加载中…',
+			'web.providers.antigravityAccounts.empty' => '尚无 Antigravity 账号。在网关主机上运行 <1>HOME=~/.antigravity-accounts/&lt;name&gt; agy</1>，完成 Google 登录，然后点击“导入本地”。',
+			'web.providers.antigravityAccounts.noTokenYet' => '未登录',
+			'web.providers.antigravityAccounts.homeDir' => 'home：',
+			'web.providers.antigravityAccounts.toggleFailedToast' => '切换失败',
+			'web.providers.antigravityAccounts.removeConfirm' => ({required Object name}) => '移除账号“${name}”？',
+			'web.providers.antigravityAccounts.removedToast' => '账号已移除',
+			'web.providers.antigravityAccounts.removeFailedToast' => '移除失败',
+			'web.providers.antigravityAccounts.toggleAria' => ({required Object name}) => '切换 ${name}',
+			'web.providers.antigravityAccounts.removeAria' => ({required Object name}) => '移除 ${name}',
 			'web.providers.models.title' => '模型',
 			'web.providers.models.help' => '该提供方可用的模型。默认模型会通过 model 参数传给每个会话；会话仍可覆盖。',
 			'web.providers.models.empty' => '尚未配置任何模型。',
@@ -9918,6 +9997,8 @@ extension on TranslationsZh {
 			'web.channels.notifications.onceReplyHint' => '在该聊天中以非命令文本回复会重置抑制 — opendray 会把你的回复转发到会话的 stdin 并重新启用通知。',
 			'web.channels.notifications.terminalSnippetLabel' => '终端片段',
 			'web.channels.notifications.embedSnippetLabel' => '在 idle 通知中嵌入最近的终端画面',
+			_ => null,
+		} ?? switch (path) {
 			'web.channels.notifications.snippetExplainer' => '开启后，idle 卡片会包含一段代码块片段，呈现用户在网页终端中会看到的内容 — Claude TUI 自身的装饰（状态 spinner、"bypass permissions" 提示、分隔线）会被自动过滤。',
 			'web.channels.notifications.modes.onceLabel' => '每个会话仅一次（推荐）',
 			'web.channels.notifications.modes.onceHint' => '当会话变为 idle 时通知一次，然后保持静默，直到会话结束或你通过该频道回复。',
@@ -9941,8 +10022,6 @@ extension on TranslationsZh {
 			'web.channels.bridge.tokenLabel' => '适配器 token',
 			'web.channels.bridge.regenerateTooltip' => '重新生成',
 			'web.channels.bridge.copyTooltip' => '复制',
-			_ => null,
-		} ?? switch (path) {
 			'web.channels.bridge.tokenCopiedToast' => '已复制 token',
 			'web.channels.bridge.tokenHint' => '适配器通过 WS register 帧发送此 token（也可作为 <1>X-Bridge-Token</1> header）。',
 			'web.channels.bridge.capsLabel' => '接受的能力（可选白名单）',
@@ -10432,6 +10511,8 @@ extension on TranslationsZh {
 			'web.backups.targetsTab.columns.config' => '配置',
 			'web.backups.targetsTab.columns.enabled' => '启用',
 			'web.backups.targetsTab.columns.actions' => '操作',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.targetsTab.on' => '开',
 			'web.backups.targetsTab.off' => '关',
 			'web.backups.targetsTab.test' => '测试',
@@ -10455,8 +10536,6 @@ extension on TranslationsZh {
 			'web.backups.targetEditor.smb.shareLabel' => 'Share',
 			'web.backups.targetEditor.smb.shareHint' => 'SMB 服务器上的顶层共享名',
 			'web.backups.targetEditor.smb.sharePlaceholder' => 'Claude_Workspace',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.targetEditor.smb.userLabel' => '用户',
 			'web.backups.targetEditor.smb.passwordLabel' => '密码',
 			'web.backups.targetEditor.smb.pathPrefixLabel' => '路径前缀',
@@ -10946,6 +11025,8 @@ extension on TranslationsZh {
 			'web.noteEditor.tagTitle' => ({required Object tag}) => '标签 #${tag}',
 			'web.noteEditor.emptyNote' => '空白笔记。切换到源码标签开始书写。',
 			'web.noteEditor.saveFailedToast' => '保存失败',
+			_ => null,
+		} ?? switch (path) {
 			'web.noteEditor.status.saveFailed' => '保存失败',
 			'web.noteEditor.status.saving' => '保存中…',
 			'web.noteEditor.status.unsaved' => '未保存',
@@ -10969,8 +11050,6 @@ extension on TranslationsZh {
 			'web.export.form.integrationOptions.plaintext' => '包含明文 API key',
 			'web.export.form.integrationOptions.plaintextHint' => 'v1 仅 bcrypt：不存在可恢复的明文。Manifest 会记录此事实；不会泄露任何内容。',
 			'web.export.form.confirmWarning' => '输入 <1>I understand</1> 以确认。opendray 当前只存 bcrypt 哈希 — 选择明文也不会导出任何明文（该选项为将来保留明文缓存的版本而预留）。',
-			_ => null,
-		} ?? switch (path) {
 			'web.export.form.confirmPlaceholder' => 'I understand',
 			'web.export.form.confirmSentinel' => 'i understand',
 			'web.export.form.footnote' => '审计日志与会话记录不在范围内 — 由 /backups（运维 dump）覆盖。',
@@ -11387,6 +11466,10 @@ extension on TranslationsZh {
 			'sessions.detail.accountSwitcher.switchedSnack' => ({required Object account}) => '已切换到 ${account}',
 			'sessions.detail.accountSwitcher.switchFailed' => ({required Object error}) => '切换失败：${error}',
 			'sessions.detail.accountSwitcher.noneHint' => '未配置 Claude 账号。请在 更多 → Providers → Claude 中添加。',
+			'sessions.detail.accountSwitcher.tooltipAgy' => '切换 Antigravity 账号',
+			'sessions.detail.accountSwitcher.sheetTitleAgy' => '切换 Antigravity 账号',
+			'sessions.detail.accountSwitcher.confirmBodyAgy' => '这会用全新对话重启 Antigravity CLI——CLI 内的历史不会在账号间保留（会话标签保留）。',
+			'sessions.detail.accountSwitcher.noneHintAgy' => '未配置 Antigravity 账号。请在 更多 → Providers → Antigravity 中添加。',
 			'sessions.terminal.snackbar.imagePickerFailed' => ({required Object error}) => '图片选择失败：${error}',
 			'sessions.terminal.snackbar.uploadingImage' => '正在上传图片…',
 			'sessions.terminal.snackbar.imageAttached' => ({required Object path}) => '已附加图片：${path}',
@@ -11456,6 +11539,8 @@ extension on TranslationsZh {
 			'sessions.inspector.files.readContent' => '读取内容',
 			'sessions.inspector.files.readContentSubtitle' => '最多 256 KiB 纯文本',
 			'sessions.inspector.files.readFailedApi' => ({required Object status, required Object message}) => '读取失败（${status}）：${message}',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.files.readFailedGeneric' => ({required Object error}) => '读取失败：${error}',
 			'sessions.inspector.files.parent' => '上级',
 			'sessions.inspector.files.backToCwd' => '返回会话目录',
@@ -11483,8 +11568,6 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.insertAtRefShort' => '插入 @引用',
 			'sessions.inspector.notes.draftHint' => ({required Object project}) => '# ${project}\n\n想法、待办、为 agent 提供的上下文…',
 			'sessions.inspector.notes.createFailed' => ({required Object error}) => '创建失败：${error}',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.notes.saveFailed' => ({required Object error}) => '保存失败：${error}',
 			'sessions.inspector.notes.changeLocationTooltip' => '更改项目文档位置',
 			'sessions.inspector.notes.filenameHint' => '文件名（例如：spec 或 design.md）',
@@ -11681,6 +11764,15 @@ extension on TranslationsZh {
 			'providers.accounts.acceptIdentity' => '接受',
 			'providers.accounts.identityAcceptedSnack' => '已接受身份变更',
 			'providers.accounts.identityAcceptFailed' => '接受失败',
+			'providers.antigravityAccounts.addHint' => '添加新账号仅可在网关主机上操作。',
+			'providers.antigravityAccounts.addBody' => '在网关主机上为每个账号分配独立的 HOME（HOME=~/.antigravity-accounts/<name> agy），完成 Google 登录后点按“导入本地”。',
+			'providers.antigravityAccounts.intro' => '以 Antigravity 提供商启动的会话会从这些账号中选择（或回退到网关默认 HOME）。',
+			'providers.antigravityAccounts.empty' => '尚无 Antigravity 账号。在网关主机上运行 HOME=~/.antigravity-accounts/<name> agy，完成 Google 登录后点按“导入本地”。',
+			'providers.antigravityAccounts.deleteTitle' => '移除账号？',
+			'providers.antigravityAccounts.deleteBody' => '从 opendray 移除该账号。磁盘上的 HOME 目录保持不变；已使用它的会话保持运行。',
+			'providers.antigravityAccounts.importSyncedSnack' => '已同步 — 网关没有新账号。',
+			'providers.antigravityAccounts.noTokenYet' => '未登录',
+			'providers.antigravityAccounts.homeDir' => ({required Object dir}) => 'home：${dir}',
 			'providers.configFallbackTitle' => '提供商配置',
 			'providers.saving' => '保存中…',
 			'providers.save' => '保存',
@@ -11961,6 +12053,8 @@ extension on TranslationsZh {
 			'backups.emptyMissingDeps.headline' => '备份暂时无法运行',
 			'backups.emptyMissingDeps.body' => '安装 postgresql-client 并重启 opendray。',
 			'backups.emptyNoTargets.headline' => '未配置任何备份目标',
+			_ => null,
+		} ?? switch (path) {
 			'backups.emptyNoTargets.body' => '打开「更多」菜单 → 目标，添加一个目的地（本地 / S3 / SMB / SFTP / WebDAV / rclone）。然后返回并点击「立即运行」。',
 			'backups.emptyNoBackups.headline' => '暂无备份',
 			'backups.emptyNoBackups.body' => '点击「立即运行」生成一次新快照，或打开「计划」设置定期运行。',
@@ -11997,8 +12091,6 @@ extension on TranslationsZh {
 			'backups.encryption.generate' => '生成',
 			'backups.encryption.paste' => '粘贴',
 			'backups.encryption.random256bit' => '256 位随机密钥',
-			_ => null,
-		} ?? switch (path) {
 			'backups.encryption.passphraseLabel' => '你的密语',
 			'backups.encryption.passphraseHint' => '至少 20 个字符',
 			'backups.encryption.passphraseCopied' => '密语已复制到剪贴板',
@@ -12475,6 +12567,8 @@ extension on TranslationsZh {
 			'dataExport.import.importing' => '导入中…',
 			'dataExport.import.pickFileToast' => '请先选择数据包文件。',
 			'dataExport.import.doneToast' => '导入完成',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.import.finishedWithErrors' => '导入完成但有错误',
 			'dataExport.import.failedToast' => ({required Object error}) => '导入失败：${error}',
 			'dataExport.import.summaryCard.memories' => '记忆',
@@ -12511,8 +12605,6 @@ extension on TranslationsZh {
 			'memory.status.dimensions' => ({required Object dim, required Object state}) => '${dim} 维 · ${state}',
 			'memory.status.enabled' => '已启用',
 			'memory.status.disabled' => '已禁用',
-			_ => null,
-		} ?? switch (path) {
 			'memory.status.floorNoModel' => '仅关键词（BM25）检索 — 未配置 embedding 模型。在 Settings 配置 dense 端点即可启用语义记忆。',
 			'memory.status.denseConfiguredPendingRestart' => ({required Object model}) => '已配置 ${model}（dense）— 重启网关即启用语义记忆并自动重嵌历史记忆。',
 			'memory.status.denseUnreachableFloor' => ({required Object model}) => '已配置 ${model}（dense）但端点当前不可达 — 暂用关键词 floor，端点恢复后重启会自动升级。',

--- a/app/mobile/lib/features/providers/antigravity_accounts_section.dart
+++ b/app/mobile/lib/features/providers/antigravity_accounts_section.dart
@@ -1,0 +1,554 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/api/antigravity_accounts_api.dart';
+import 'package:opendray/core/api/api_exception.dart';
+import 'package:opendray/core/api/models.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+
+// Self-contained widget that owns the Antigravity accounts list (fetch +
+// per-row actions). Lives inside the Antigravity provider's config page
+// because accounts are scoped to that provider. Mirrors the web
+// AntigravityAccountsPanel — and the mobile ClaudeAccountsSection — but
+// is import-only: agy accounts are per-account HOME dirs surfaced by
+// import-local, so there is no token-paste, rename, or identity-drift
+// flow. Per-row actions are just enable/disable + remove.
+class AntigravityAccountsSection extends ConsumerStatefulWidget {
+  const AntigravityAccountsSection({super.key});
+
+  @override
+  ConsumerState<AntigravityAccountsSection> createState() =>
+      _AntigravityAccountsSectionState();
+}
+
+class _AntigravityAccountsSectionState
+    extends ConsumerState<AntigravityAccountsSection> {
+  AsyncValue<List<AntigravityAccountSummary>> _state =
+      const AsyncValue.loading();
+  final Set<String> _busy = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final list = await ref.read(antigravityAccountsApiProvider).list();
+      if (!mounted) return;
+      list.sort((a, b) {
+        if (a.isUsable != b.isUsable) return a.isUsable ? -1 : 1;
+        return a.displayName
+            .toLowerCase()
+            .compareTo(b.displayName.toLowerCase());
+      });
+      setState(() => _state = AsyncValue.data(list));
+    } on ApiException catch (e) {
+      if (mounted) {
+        setState(() => _state = AsyncValue.error(e, StackTrace.current));
+      }
+    } on Object catch (e, st) {
+      if (mounted) setState(() => _state = AsyncValue.error(e, st));
+    }
+  }
+
+  Future<void> _runOp({
+    required String key,
+    required String okMsg,
+    required String failPrefix,
+    required Future<void> Function() op,
+  }) async {
+    setState(() => _busy.add(key));
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await op();
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(okMsg),
+          duration: const Duration(seconds: 2),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      await _load();
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.providers.errorWithMessage(prefix: failPrefix, error: e.message),
+          ),
+        ),
+      );
+    } on Object catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.providers
+                .errorWithMessage(prefix: failPrefix, error: e.toString()),
+          ),
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _busy.remove(key));
+    }
+  }
+
+  Future<void> _openActions(AntigravityAccountSummary a) async {
+    final action = await showModalBottomSheet<_AccountAction>(
+      context: context,
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (sheetCtx) => SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 14, 16, 8),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(a.displayName,
+                      style: Theme.of(sheetCtx).textTheme.titleSmall),
+                  Text(
+                    a.name,
+                    style: Theme.of(sheetCtx)
+                        .textTheme
+                        .bodySmall
+                        ?.copyWith(fontFamily: 'monospace'),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+            ListTile(
+              leading: Icon(
+                a.enabled
+                    ? Icons.pause_circle_outline
+                    : Icons.play_circle_outline,
+              ),
+              title: Text(a.enabled
+                  ? t.providers.accounts.disable
+                  : t.providers.accounts.enable),
+              onTap: () =>
+                  Navigator.of(sheetCtx).pop(_AccountAction.toggleEnabled),
+            ),
+            const Divider(height: 1),
+            ListTile(
+              leading: Icon(
+                Icons.delete_outline,
+                color: Theme.of(sheetCtx).colorScheme.error,
+              ),
+              title: Text(
+                t.providers.accounts.deleteLabel,
+                style: TextStyle(color: Theme.of(sheetCtx).colorScheme.error),
+              ),
+              onTap: () => Navigator.of(sheetCtx).pop(_AccountAction.delete),
+            ),
+            const SizedBox(height: 4),
+          ],
+        ),
+      ),
+    );
+    if (action == null || !mounted) return;
+    switch (action) {
+      case _AccountAction.toggleEnabled:
+        final next = !a.enabled;
+        await _runOp(
+          key: 'a:${a.id}',
+          okMsg: next
+              ? t.providers.accounts.enabledSnack(name: a.displayName)
+              : t.providers.accounts.disabledSnack(name: a.displayName),
+          failPrefix: t.providers.errorPrefix.toggle,
+          op: () => ref
+              .read(antigravityAccountsApiProvider)
+              .setEnabled(a.id, enabled: next),
+        );
+      case _AccountAction.delete:
+        final ok = await showDialog<bool>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: Text(t.providers.antigravityAccounts.deleteTitle),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '${a.displayName} (${a.name})',
+                  style: Theme.of(ctx).textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  t.providers.antigravityAccounts.deleteBody,
+                  style: Theme.of(ctx).textTheme.bodySmall,
+                ),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(false),
+                child: Text(t.common.cancel),
+              ),
+              FilledButton(
+                style: FilledButton.styleFrom(
+                  backgroundColor: Theme.of(ctx).colorScheme.error,
+                ),
+                onPressed: () => Navigator.of(ctx).pop(true),
+                child: Text(t.common.delete),
+              ),
+            ],
+          ),
+        );
+        if (ok != true || !mounted) return;
+        await _runOp(
+          key: 'a:${a.id}',
+          okMsg: t.providers.accounts.deletedSnack(name: a.name),
+          failPrefix: t.providers.errorPrefix.delete,
+          op: () => ref.read(antigravityAccountsApiProvider).delete(a.id),
+        );
+    }
+  }
+
+  Future<void> _importLocal() async {
+    setState(() => _busy.add('import'));
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final n = await ref.read(antigravityAccountsApiProvider).importLocal();
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            n == 0
+                ? t.providers.antigravityAccounts.importSyncedSnack
+                : (n == 1
+                    ? t.providers.accounts.importedSnackOne(n: n.toString())
+                    : t.providers.accounts.importedSnackOther(n: n.toString())),
+          ),
+          duration: const Duration(seconds: 2),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      await _load();
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.providers.accounts.importFailedApi(error: e.message),
+          ),
+        ),
+      );
+    } on Object catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            t.providers.accounts.importFailedGeneric(error: e.toString()),
+          ),
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _busy.remove('import'));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final muted = Theme.of(context).textTheme.bodySmall;
+    final importing = _busy.contains('import');
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(4, 14, 0, 6),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'ACCOUNTS',
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        letterSpacing: 0.8,
+                        color: Theme.of(context)
+                            .colorScheme
+                            .onSurface
+                            .withValues(alpha: 0.6),
+                      ),
+                ),
+              ),
+              TextButton.icon(
+                icon: importing
+                    ? const SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.cloud_sync_outlined, size: 16),
+                label: Text(importing
+                    ? t.providers.accounts.importing
+                    : t.providers.accounts.importLocal),
+                onPressed: importing ? null : _importLocal,
+              ),
+            ],
+          ),
+        ),
+        Container(
+          padding: const EdgeInsets.all(10),
+          margin: const EdgeInsets.only(bottom: 6),
+          decoration: BoxDecoration(
+            color: Theme.of(context)
+                .colorScheme
+                .tertiary
+                .withValues(alpha: 0.08),
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                t.providers.antigravityAccounts.addHint,
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  color: Theme.of(context).colorScheme.tertiary,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                t.providers.antigravityAccounts.addBody,
+                style: TextStyle(
+                  fontSize: 11,
+                  height: 1.4,
+                  color: Theme.of(context)
+                      .colorScheme
+                      .onSurface
+                      .withValues(alpha: 0.75),
+                ),
+              ),
+            ],
+          ),
+        ),
+        _state.when(
+          data: _buildList,
+          loading: () => const Padding(
+            padding: EdgeInsets.symmetric(vertical: 16),
+            child: Center(
+              child: SizedBox(
+                width: 18,
+                height: 18,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            ),
+          ),
+          error: (e, _) => Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  t.providers.accounts.loadFailed(error: e.toString()),
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.error,
+                    fontSize: 12,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                OutlinedButton(
+                  onPressed: _load,
+                  child: Text(t.common.retry),
+                ),
+              ],
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.only(top: 6, left: 4),
+          child: Text(
+            t.providers.antigravityAccounts.intro,
+            style: muted,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildList(List<AntigravityAccountSummary> list) {
+    if (list.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+        child: Text(
+          t.providers.antigravityAccounts.empty,
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+      );
+    }
+    return Column(
+      children: [
+        for (final a in list)
+          _AccountTile(
+            account: a,
+            busy: _busy.contains('a:${a.id}'),
+            onTap: () => _openActions(a),
+          ),
+      ],
+    );
+  }
+}
+
+enum _AccountAction { toggleEnabled, delete }
+
+class _AccountTile extends StatelessWidget {
+  const _AccountTile({
+    required this.account,
+    required this.busy,
+    required this.onTap,
+  });
+
+  final AntigravityAccountSummary account;
+  final bool busy;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final usable = account.isUsable;
+    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        ListTile(
+          onTap: busy ? null : onTap,
+          contentPadding: EdgeInsets.zero,
+          leading: Icon(
+            usable ? Icons.vpn_key : Icons.vpn_key_outlined,
+            color: usable
+                ? theme.colorScheme.primary
+                : theme.colorScheme.onSurface.withValues(alpha: 0.4),
+          ),
+          title: Row(
+            children: [
+              Flexible(
+                child: Text(
+                  account.displayName,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: account.enabled
+                        ? null
+                        : theme.colorScheme.onSurface.withValues(alpha: 0.55),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 6),
+              if (!account.enabled)
+                _MiniBadge(label: 'disabled', color: theme.colorScheme.error),
+              if (!account.tokenFilled) ...[
+                const SizedBox(width: 4),
+                _MiniBadge(
+                  label: t.providers.antigravityAccounts.noTokenYet,
+                  color: theme.colorScheme.error,
+                ),
+              ],
+            ],
+          ),
+          subtitle: Text(
+            account.id,
+            style:
+                theme.textTheme.bodySmall?.copyWith(fontFamily: 'monospace'),
+          ),
+          trailing: busy
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.more_vert),
+        ),
+        // Metadata chips live below the ListTile (not in its subtitle
+        // slot, which clips to a fixed height) so the HOME path + chips
+        // never get cut off on a phone row.
+        if (_hasMeta)
+          Padding(
+            padding: const EdgeInsets.only(left: 40, bottom: 8),
+            child: _metaChips(context, muted),
+          ),
+      ],
+    );
+  }
+
+  bool get _hasMeta =>
+      account.configDir.isNotEmpty ||
+      account.activeSessions != null ||
+      account.lastUsedAt != null;
+
+  // Capacity-at-a-glance metadata, wrapped so it never overflows a phone
+  // row. Mirrors the inline chips in web's AntigravityAccountsPanel.
+  Widget _metaChips(BuildContext context, Color muted) {
+    final theme = Theme.of(context);
+    final used = _relTime(account.lastUsedAt);
+    return Wrap(
+      spacing: 6,
+      runSpacing: 4,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        if (account.activeSessions != null)
+          _MiniBadge(
+            label: t.providers.accounts
+                .activeSessions(count: account.activeSessions!.toString()),
+            color: muted,
+          ),
+        if (used != null)
+          Text(
+            t.providers.accounts.usedAgo(when: used),
+            style: theme.textTheme.bodySmall?.copyWith(color: muted),
+          ),
+        if (account.configDir.isNotEmpty)
+          Text(
+            t.providers.antigravityAccounts.homeDir(dir: account.configDir),
+            style: theme.textTheme.bodySmall
+                ?.copyWith(color: muted, fontFamily: 'monospace'),
+          ),
+      ],
+    );
+  }
+
+  // Coarse relative time for last_used_at; null when absent/unparseable.
+  static String? _relTime(String? iso) {
+    if (iso == null) return null;
+    final t = DateTime.tryParse(iso);
+    if (t == null) return null;
+    final d = DateTime.now().difference(t);
+    if (d.inDays > 365) return '${(d.inDays / 365).floor()}y ago';
+    if (d.inDays > 30) return '${(d.inDays / 30).floor()}mo ago';
+    if (d.inDays > 0) return '${d.inDays}d ago';
+    if (d.inHours > 0) return '${d.inHours}h ago';
+    if (d.inMinutes > 0) return '${d.inMinutes}m ago';
+    return 'just now';
+  }
+}
+
+class _MiniBadge extends StatelessWidget {
+  const _MiniBadge({required this.label, required this.color});
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: color.withValues(alpha: 0.6), width: 0.5),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(color: color, fontSize: 10),
+      ),
+    );
+  }
+}

--- a/app/mobile/lib/features/providers/provider_config_screen.dart
+++ b/app/mobile/lib/features/providers/provider_config_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/providers_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/providers/antigravity_accounts_section.dart';
 import 'package:opendray/features/providers/claude_accounts_section.dart';
 
 // Provider config editor — schema-driven so we don't carry per-
@@ -170,6 +171,7 @@ class _ProviderConfigScreenState
 
   Widget _buildEditor(ProviderDetail p) {
     final isClaude = p.id == 'claude';
+    final isAntigravity = p.id == 'antigravity';
     final groups = <String, List<ConfigField>>{};
     for (final f in p.configSchema) {
       if (!_shouldShow(f)) continue;
@@ -177,7 +179,7 @@ class _ProviderConfigScreenState
       groups.putIfAbsent(g, () => []).add(f);
     }
     final hasFields = groups.isNotEmpty;
-    if (!hasFields && !isClaude) {
+    if (!hasFields && !isClaude && !isAntigravity) {
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(24),
@@ -222,6 +224,11 @@ class _ProviderConfigScreenState
           const Padding(
             padding: EdgeInsets.fromLTRB(16, 8, 16, 0),
             child: ClaudeAccountsSection(),
+          ),
+        if (isAntigravity)
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 8, 16, 0),
+            child: AntigravityAccountsSection(),
           ),
       ],
     );

--- a/app/mobile/lib/features/sessions/account_switch_sheet.dart
+++ b/app/mobile/lib/features/sessions/account_switch_sheet.dart
@@ -1,18 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:opendray/core/api/antigravity_accounts_api.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/claude_accounts_api.dart';
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/sessions_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 
-// AccountSwitchSheet rebinds a *running* Claude session to a different
-// OAuth account — the mobile mirror of the web header AccountSwitcher
-// (app/web/src/components/sessions/AccountSwitcher.tsx). The gateway
-// terminates the current child process and respawns it under the new
-// credential, so the in-CLI conversation context is lost (the session
-// id / tab is preserved). A confirm dialog gates the switch.
+// AccountSwitchSheet rebinds a *running* session to a different account —
+// the mobile mirror of the web header AccountSwitcher
+// (app/web/src/components/sessions/AccountSwitcher.tsx). It serves both
+// the Claude (OAuth account) and Antigravity (per-account HOME) flows:
+// the gateway terminates the current child process and respawns it under
+// the new credential, so the in-CLI conversation context is lost (the
+// session id / tab is preserved). A confirm dialog gates the switch.
 //
 // Returns true via the modal result when a switch succeeded, so the
 // caller can refresh the session + accounts views.
@@ -38,15 +40,42 @@ class AccountSwitchSheet extends ConsumerStatefulWidget {
   ConsumerState<AccountSwitchSheet> createState() => _AccountSwitchSheetState();
 }
 
+// A provider-agnostic view of a switchable account, projected from
+// either ClaudeAccountSummary or AntigravityAccountSummary so the sheet
+// renders one list regardless of provider.
+class _AccountOption {
+  const _AccountOption({
+    required this.id,
+    required this.title,
+    required this.subtitle,
+    required this.enabled,
+    required this.tokenFilled,
+  });
+
+  final String id;
+  final String title;
+  final String subtitle;
+  final bool enabled;
+  final bool tokenFilled;
+}
+
 class _AccountSwitchSheetState extends ConsumerState<AccountSwitchSheet> {
   bool _busy = false;
 
   Translations get _t => Translations.of(context);
 
+  bool get _isAgy => widget.session.providerId == 'antigravity';
+
+  String get _currentId =>
+      (_isAgy
+          ? widget.session.antigravityAccountId
+          : widget.session.claudeAccountId) ??
+      '';
+
   Future<void> _pick(String accountId, String label) async {
     final tr = _t.sessions.detail.accountSwitcher;
     // No-op when picking the already-bound account.
-    if (accountId == (widget.session.claudeAccountId ?? '')) {
+    if (accountId == _currentId) {
       Navigator.of(context).pop(false);
       return;
     }
@@ -54,7 +83,7 @@ class _AccountSwitchSheetState extends ConsumerState<AccountSwitchSheet> {
       context: context,
       builder: (ctx) => AlertDialog(
         title: Text(tr.confirmTitle),
-        content: Text(tr.confirmBody),
+        content: Text(_isAgy ? tr.confirmBodyAgy : tr.confirmBody),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(false),
@@ -73,9 +102,12 @@ class _AccountSwitchSheetState extends ConsumerState<AccountSwitchSheet> {
     final messenger = ScaffoldMessenger.of(context);
     final navigator = Navigator.of(context);
     try {
-      await ref
-          .read(sessionsApiProvider)
-          .switchClaudeAccount(widget.session.id, accountId);
+      final api = ref.read(sessionsApiProvider);
+      if (_isAgy) {
+        await api.switchAntigravityAccount(widget.session.id, accountId);
+      } else {
+        await api.switchClaudeAccount(widget.session.id, accountId);
+      }
       if (!mounted) return;
       messenger.showSnackBar(
         SnackBar(
@@ -103,7 +135,34 @@ class _AccountSwitchSheetState extends ConsumerState<AccountSwitchSheet> {
   @override
   Widget build(BuildContext context) {
     final tr = _t.sessions.detail.accountSwitcher;
-    final accountsAsync = ref.watch(claudeAccountsListProvider);
+    // Project the right provider's accounts into a common option list so
+    // the body below is provider-agnostic.
+    final optionsAsync = _isAgy
+        ? ref.watch(antigravityAccountsListProvider).whenData(
+              (list) => [
+                for (final a in list)
+                  _AccountOption(
+                    id: a.id,
+                    title: a.displayName,
+                    subtitle: a.tokenFilled ? a.name : tr.tokenEmpty,
+                    enabled: a.enabled,
+                    tokenFilled: a.tokenFilled,
+                  ),
+              ],
+            )
+        : ref.watch(claudeAccountsListProvider).whenData(
+              (list) => [
+                for (final a in list)
+                  _AccountOption(
+                    id: a.id,
+                    title: a.displayName,
+                    subtitle:
+                        a.tokenFilled ? (a.oauthEmail ?? a.name) : tr.tokenEmpty,
+                    enabled: a.enabled,
+                    tokenFilled: a.tokenFilled,
+                  ),
+              ],
+            );
     final theme = Theme.of(context);
     return SafeArea(
       child: Padding(
@@ -114,17 +173,20 @@ class _AccountSwitchSheetState extends ConsumerState<AccountSwitchSheet> {
           children: [
             Padding(
               padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
-              child: Text(tr.sheetTitle, style: theme.textTheme.titleMedium),
+              child: Text(
+                _isAgy ? tr.sheetTitleAgy : tr.sheetTitle,
+                style: theme.textTheme.titleMedium,
+              ),
             ),
             if (_busy) const LinearProgressIndicator(minHeight: 2),
-            accountsAsync.when(
-              data: (accounts) {
-                final enabled = accounts.where((a) => a.enabled).toList();
+            optionsAsync.when(
+              data: (options) {
+                final enabled = options.where((a) => a.enabled).toList();
                 return Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     _AccountRow(
-                      selected: widget.session.claudeAccountId == null,
+                      selected: _currentId.isEmpty,
                       title: tr.defaultName,
                       subtitle: tr.defaultSubtitle,
                       enabled: !_busy,
@@ -133,19 +195,17 @@ class _AccountSwitchSheetState extends ConsumerState<AccountSwitchSheet> {
                     if (enabled.isNotEmpty) const Divider(height: 1),
                     for (final a in enabled)
                       _AccountRow(
-                        selected: widget.session.claudeAccountId == a.id,
-                        title: a.displayName,
-                        subtitle: a.tokenFilled
-                            ? (a.oauthEmail ?? a.name)
-                            : tr.tokenEmpty,
+                        selected: _currentId == a.id,
+                        title: a.title,
+                        subtitle: a.subtitle,
                         enabled: !_busy && a.tokenFilled,
-                        onTap: () => _pick(a.id, a.displayName),
+                        onTap: () => _pick(a.id, a.title),
                       ),
-                    if (accounts.isEmpty)
+                    if (options.isEmpty)
                       Padding(
                         padding: const EdgeInsets.fromLTRB(20, 12, 20, 4),
                         child: Text(
-                          tr.noneHint,
+                          _isAgy ? tr.noneHintAgy : tr.noneHint,
                           style: theme.textTheme.bodySmall,
                         ),
                       ),

--- a/app/mobile/lib/features/sessions/session_detail_screen.dart
+++ b/app/mobile/lib/features/sessions/session_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 
+import 'package:opendray/core/api/antigravity_accounts_api.dart';
 import 'package:opendray/core/api/claude_accounts_api.dart';
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/sessions_api.dart';
@@ -93,29 +94,40 @@ class _SessionDetailScreenState extends ConsumerState<SessionDetailScreen> {
             ),
             orElse: SizedBox.shrink,
           ),
-          // Account switcher — Claude live sessions only. Rebinds the
-          // running session to a different OAuth account (mirrors the
-          // web header AccountSwitcher). Hidden for non-Claude providers
+          // Account switcher — Claude and Antigravity live sessions only.
+          // Rebinds the running session to a different account (mirrors
+          // the web header AccountSwitcher). Hidden for other providers
           // (no account concept) and terminated sessions (nothing to
           // rebind — /resume first).
           async.maybeWhen(
-            data: (s) => (s.providerId == 'claude' && s.isLive)
-                ? IconButton(
-                    icon: const Icon(Icons.manage_accounts_outlined),
-                    tooltip: t.sessions.detail.accountSwitcher.tooltip,
-                    onPressed: () async {
-                      final switched = await AccountSwitchSheet.show(
-                        context,
-                        session: s,
-                      );
-                      if (!switched || !context.mounted) return;
-                      ref
-                        ..invalidate(sessionByIdProvider(widget.sessionId))
-                        ..invalidate(sessionsListProvider)
-                        ..invalidate(claudeAccountsListProvider);
-                    },
-                  )
-                : const SizedBox.shrink(),
+            data: (s) {
+              final isClaude = s.providerId == 'claude';
+              final isAgy = s.providerId == 'antigravity';
+              if (!(isClaude || isAgy) || !s.isLive) {
+                return const SizedBox.shrink();
+              }
+              return IconButton(
+                icon: const Icon(Icons.manage_accounts_outlined),
+                tooltip: isAgy
+                    ? t.sessions.detail.accountSwitcher.tooltipAgy
+                    : t.sessions.detail.accountSwitcher.tooltip,
+                onPressed: () async {
+                  final switched = await AccountSwitchSheet.show(
+                    context,
+                    session: s,
+                  );
+                  if (!switched || !context.mounted) return;
+                  ref
+                    ..invalidate(sessionByIdProvider(widget.sessionId))
+                    ..invalidate(sessionsListProvider)
+                    ..invalidate(
+                      isAgy
+                          ? antigravityAccountsListProvider
+                          : claudeAccountsListProvider,
+                    );
+                },
+              );
+            },
             orElse: SizedBox.shrink,
           ),
           async.maybeWhen(


### PR DESCRIPTION
## Why

PR #396 shipped **Antigravity (agy) multi-account** support across web + shared + backend, but touched **zero mobile files**. As a result the iOS/Android client had no way to manage agy accounts or switch a running agy session's account, while the web admin had the full feature — a violation of the "web + mobile + i18n move together" rule. This was found while auditing the recent batch of provider PRs (the Grok icon gap fixed in #408 was the smaller sibling of this one).

The backend was already complete in #396 (`agyacct` service, REST routes, `session.antigravity_account_id`, migration 0069). **This is a pure client port — no Go changes.** It mirrors the existing mobile Claude multi-account implementation as the template.

## What

**Added**
- `core/api/antigravity_accounts_api.dart` — `list` / `setEnabled` / `delete` / `importLocal` against `/api/v1/antigravity-accounts`. Import-only: agy accounts are per-account `$HOME` dirs, so there's no token-paste / rename / identity-drift flow (unlike Claude).
- `features/providers/antigravity_accounts_section.dart` — the provider config panel (import-local + per-row enable/disable + remove), shown under the Antigravity provider exactly as `ClaudeAccountsSection` is shown under Claude.

**Changed**
- `models.dart` — new `AntigravityAccountSummary`; `SessionSummary` now parses `antigravity_account_id`.
- `sessions_api.dart` — `switchAntigravityAccount` → `PATCH /sessions/{id}/antigravity-account`.
- `account_switch_sheet.dart` — made provider-aware (Claude **or** Antigravity) via a common `_AccountOption` projection: picks the right list provider, current binding, switch call, and confirm/title strings per provider.
- `session_detail_screen.dart` — the in-session account switcher now also renders for live **antigravity** sessions and invalidates the right account list on success.
- `provider_config_screen.dart` — renders `AntigravityAccountsSection` for the antigravity provider (and no longer treats its config page as "no settings").

**i18n**
- Added `providers.antigravityAccounts.*` (9 keys) + `sessions.detail.accountSwitcher.*Agy` (4 keys) to `en` / `es` / `zh`, regenerated slang.

## Endpoint parity (mobile ↔ backend, both from #396)

| Mobile call | Backend route |
|---|---|
| `list()` | `GET /api/v1/antigravity-accounts` |
| `setEnabled()` | `PATCH /antigravity-accounts/{id}/toggle` |
| `delete()` | `DELETE /antigravity-accounts/{id}` |
| `importLocal()` | `POST /antigravity-accounts/import-local` |
| `switchAntigravityAccount()` | `PATCH /sessions/{id}/antigravity-account` |

## Test plan

- `node scripts/check-i18n-parity.mjs` → `OK: no blocking issues` (es/zh `missing:0 extra:0 token-mismatch:0`).
- `flutter analyze` (full app) → **No issues found**.
- Manual flow (gateway with ≥1 agy account): Providers → Antigravity shows the accounts panel; Import local registers a logged-in HOME dir; toggle/remove work; a live agy session's header shows the account switcher and rebinds to the chosen account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)