### PR TITLE
fix(mobile): integration default-model picker for all providers

### DIFF
--- a/app/mobile/lib/core/api/models.dart
+++ b/app/mobile/lib/core/api/models.dart
@@ -151,6 +151,7 @@ class ProviderSummary {
     required this.manifestHash,
     required this.enabled,
     this.icon = '',
+    this.knownModels = const [],
   });
 
   factory ProviderSummary.fromGatewayJson(Map<String, dynamic> json) {
@@ -171,6 +172,10 @@ class ProviderSummary {
       manifestHash: json['manifest_hash'] as String? ?? '',
       enabled: json['enabled'] as bool? ?? false,
       icon: manifest['icon'] as String? ?? '',
+      knownModels: (manifest['knownModels'] as List?)
+              ?.whereType<String>()
+              .toList() ??
+          const [],
     );
   }
 
@@ -181,6 +186,12 @@ class ProviderSummary {
   // Manifest emoji glyph (🪐 Antigravity, 🟣 Claude, …). Rendered as the
   // mobile provider avatar; the web uses brand SVGs.
   final String icon;
+  // Suggested model names from the manifest (knownModels). The CLIs
+  // expose no live model-list, so this curated list is what the
+  // integration default-model picker offers as suggestions. Empty for
+  // providers with no model concept (e.g. shell). Mirrors web's
+  // manifest.knownModels datalist source.
+  final List<String> knownModels;
 }
 
 // One row from the gateway's audit log. Mirrors

--- a/app/mobile/lib/features/integrations/default_agent_fields.dart
+++ b/app/mobile/lib/features/integrations/default_agent_fields.dart
@@ -40,6 +40,21 @@ class DefaultAgentFields extends ConsumerWidget {
     final isClaude = providerId == 'claude';
     final theme = Theme.of(context);
 
+    // Suggested models for the selected provider (manifest knownModels).
+    // Drives the model field's dropdown — mirrors the web datalist so any
+    // provider (not just Claude) can pick from its models. Empty for an
+    // unselected provider or one with no model concept (e.g. shell), in
+    // which case the field stays free-text only.
+    final knownModels = providers.maybeWhen(
+      data: (list) {
+        for (final p in list) {
+          if (p.id == providerId) return p.knownModels;
+        }
+        return const <String>[];
+      },
+      orElse: () => const <String>[],
+    );
+
     return Container(
       margin: const EdgeInsets.only(bottom: 12),
       padding: const EdgeInsets.all(12),
@@ -90,7 +105,11 @@ class DefaultAgentFields extends ConsumerWidget {
           ),
           const SizedBox(height: 12),
 
-          // Model free-text field (controller owned by parent).
+          // Model field (controller owned by parent). Free text, plus a
+          // dropdown of the selected provider's known models so any
+          // provider — not just Claude — can pick a model. knownModels is
+          // only a suggestion source, so a typed custom value still wins;
+          // the dropdown is hidden when the provider exposes no models.
           TextField(
             controller: modelController,
             autocorrect: false,
@@ -98,6 +117,19 @@ class DefaultAgentFields extends ConsumerWidget {
               labelText: t.integrations.defaultAgent.modelLabel,
               hintText: t.integrations.defaultAgent.modelHint,
               border: const OutlineInputBorder(),
+              suffixIcon: knownModels.isEmpty
+                  ? null
+                  : PopupMenuButton<String>(
+                      icon: const Icon(Icons.arrow_drop_down),
+                      onSelected: (m) => modelController.text = m,
+                      itemBuilder: (menuCtx) => [
+                        for (final m in knownModels)
+                          PopupMenuItem<String>(
+                            value: m,
+                            child: Text(m),
+                          ),
+                      ],
+                    ),
             ),
           ),
           const SizedBox(height: 12),


### PR DESCRIPTION
## Problem

In the integration edit form (screenshot: mobile, editing "PDAweb" with provider = Antigravity), the **default model** field offered nothing to select for non-Claude providers — operators had to know and type the exact model string. The web admin already shows the selected provider's `manifest.knownModels` as a datalist for **any** provider, so this was a mobile-only gap.

**Root cause:** mobile's `ProviderSummary.fromGatewayJson` dropped `manifest.knownModels` when projecting the `/api/v1/providers` response, so the form had no model data to offer — the field was a bare free-text input for every provider.

(The web "only Claude shows models" symptom was a separate, already-resolved issue: the gateway was running a stale binary whose embedded `antigravity.json` / `grok.json` predated their `knownModels`. The gateway now runs current code — `local-cd4f829` — so the providers API serves `knownModels` for all providers and the web datalist works.)

## Fix (mobile only)

- `ProviderSummary` now parses `manifest.knownModels`.
- `DefaultAgentFields` resolves the selected provider's `knownModels` and adds a dropdown (`PopupMenuButton`) to the model field listing them. Free text still wins (knownModels is only a suggestion source), and the dropdown is hidden when the provider exposes no models (e.g. shell). Mirrors the web `<datalist>` semantics.

No backend change (gateway already serves `knownModels` for every provider); no i18n change.

## Test plan

- `flutter analyze` (changed files) → No issues found.
- Manual: integration edit → set default provider to Antigravity/Codex/Grok → the model field's dropdown lists that provider's known models; selecting one fills the field; typing a custom value still works; shell shows no dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)