### PR TITLE
fix(web): explicit model dropdown in integration default-agent

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1361,6 +1361,7 @@
         "providerNone": "No default",
         "modelLabel": "Default model",
         "modelPlaceholder": "Provider default (e.g. opus)",
+        "modelPickAria": "Choose a known model",
         "accountLabel": "Default Claude account",
         "accountNone": "No default",
         "accountTokenMissing": "(token missing)",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -1361,6 +1361,7 @@
         "providerNone": "Sin predeterminado",
         "modelLabel": "Modelo predeterminado",
         "modelPlaceholder": "Predeterminado del proveedor (p. ej. opus)",
+        "modelPickAria": "Elegir un modelo conocido",
         "accountLabel": "Cuenta de Claude predeterminada",
         "accountNone": "Sin predeterminado",
         "accountTokenMissing": "(falta el token)",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -1361,6 +1361,7 @@
         "providerNone": "无默认",
         "modelLabel": "默认模型",
         "modelPlaceholder": "provider 默认(如 opus)",
+        "modelPickAria": "选择已知模型",
         "accountLabel": "默认 Claude 账号",
         "accountNone": "无默认",
         "accountTokenMissing": "(缺少 token)",

--- a/app/web/src/components/integrations/DefaultAgentFields.tsx
+++ b/app/web/src/components/integrations/DefaultAgentFields.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
+import { ChevronDown } from 'lucide-react'
 
 import {
   Select,
@@ -8,8 +9,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/utils'
 import { listProviders } from '@/lib/catalog'
 import { listClaudeAccounts } from '@/lib/claudeAccounts'
 
@@ -33,11 +42,13 @@ interface DefaultAgentFieldsProps {
 // register and edit dialogs. Fully controlled and immutable: every
 // change emits a fresh value object, never mutating the prop.
 //
-// The model field is a free-text input with a datalist of the selected
-// provider's known models — defaults shouldn't be locked to a curated
-// list (knownModels is only a suggestion source). The claude-account
-// selector applies only when the default provider is "claude"; it stays
-// visible (as an advisory) but the hint makes the scope clear.
+// The model field is a free-text input with an explicit dropdown of the
+// selected provider's known models (chevron button) — picking one fills
+// the field, while typing a custom value still wins (knownModels is only
+// a suggestion source, defaults shouldn't be locked to a curated list).
+// The claude-account selector applies only when the default provider is
+// "claude"; it stays visible (as an advisory) but the hint makes the
+// scope clear.
 export function DefaultAgentFields({ value, onChange }: DefaultAgentFieldsProps) {
   const { t } = useTranslation()
   const providers = useQuery({ queryKey: ['providers'], queryFn: listProviders })
@@ -50,7 +61,6 @@ export function DefaultAgentFields({ value, onChange }: DefaultAgentFieldsProps)
     (p) => p.manifest.id === value.providerId,
   )
   const knownModels = selectedProvider?.manifest.knownModels ?? []
-  const modelListId = 'default-agent-models'
   const isClaude = value.providerId === 'claude'
 
   return (
@@ -109,19 +119,44 @@ export function DefaultAgentFields({ value, onChange }: DefaultAgentFieldsProps)
         >
           {t('web.integrations.defaultAgent.modelLabel')}
         </Label>
-        <Input
-          id="default_model"
-          value={value.model}
-          onChange={(e) => onChange({ ...value, model: e.target.value })}
-          placeholder={t('web.integrations.defaultAgent.modelPlaceholder')}
-          className="font-mono"
-          list={modelListId}
-        />
-        <datalist id={modelListId}>
-          {knownModels.map((m) => (
-            <option key={m} value={m} />
-          ))}
-        </datalist>
+        <div className="relative">
+          <Input
+            id="default_model"
+            value={value.model}
+            onChange={(e) => onChange({ ...value, model: e.target.value })}
+            placeholder={t('web.integrations.defaultAgent.modelPlaceholder')}
+            className={cn('font-mono', knownModels.length > 0 && 'pr-9')}
+          />
+          {knownModels.length > 0 && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="absolute right-0 top-0 h-9 w-9 text-muted-foreground hover:text-foreground"
+                  aria-label={t('web.integrations.defaultAgent.modelPickAria')}
+                >
+                  <ChevronDown className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="end"
+                className="max-h-64 overflow-y-auto"
+              >
+                {knownModels.map((m) => (
+                  <DropdownMenuItem
+                    key={m}
+                    className="font-mono text-xs"
+                    onSelect={() => onChange({ ...value, model: m })}
+                  >
+                    {m}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
       </div>
 
       <div className="space-y-1.5">


### PR DESCRIPTION
## Problem

The integration "default model" field used an HTML `<datalist>`. That only surfaces the selected provider's `knownModels` as type-ahead suggestions *after* you click into the input — it doesn't look like a selectable dropdown, so operators couldn't tell non-Claude providers even had models to choose from. The ask: after selecting a provider, **dynamically show its models in an explicit dropdown to pick from** (not manual typing only).

## Fix (web)

Replace the `<datalist>` with an explicit dropdown — a chevron `Button` + `DropdownMenu` listing the selected provider's `manifest.knownModels`. This is the same affordance the **mobile** client now uses (`PopupMenuButton`, #410), so web and mobile match.

- Picking a model fills the field.
- Free text still wins (`knownModels` is only a suggestion source — defaults aren't locked to a curated list).
- The dropdown is hidden when the provider exposes no models (e.g. shell).
- Adds `web.integrations.defaultAgent.modelPickAria` (en/es/zh) for the trigger's aria-label.

The model data was already served by the gateway for every provider (`manifest.knownModels`); this is purely the picker affordance.

## Test plan

- `tsc -b` → exit 0; `pnpm --filter web build` → built clean.
- `node scripts/check-i18n-parity.mjs` → `missing:0 extra:0 token-mismatch:0`.
- Manual: integration register/edit → pick provider (Antigravity / Codex / Grok / Claude) → chevron dropdown lists that provider's models; selecting fills the field; typing a custom value still works; shell shows no dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)