### PR TITLE
fix(integration): per-provider spawn parity — codex bypass, antigravity memory CLI, default-model guard

### DIFF
--- a/cmd/opendray/main.go
+++ b/cmd/opendray/main.go
@@ -69,6 +69,8 @@ func main() {
 		os.Exit(runMcp(args))
 	case "mcp-memory":
 		os.Exit(runMcpMemory(args))
+	case "memory":
+		os.Exit(runMemory(args))
 	case "hook":
 		os.Exit(runHook(args))
 	case "doctor":

--- a/cmd/opendray/mcp_memory.go
+++ b/cmd/opendray/mcp_memory.go
@@ -608,44 +608,8 @@ func (s *memMCPServer) handleToolCall(req rpcRequest) {
 		return
 	}
 
-	var (
-		result any
-		err    error
-	)
-	switch params.Name {
-	case "memory_search":
-		result, err = s.callSearch(params.Arguments)
-	case "memory_store":
-		result, err = s.callStore(params.Arguments)
-	case "memory_list":
-		result, err = s.callList(params.Arguments)
-	case "memory_load_context":
-		result, err = s.callLoadContext(params.Arguments)
-	case "memory_get_provenance":
-		result, err = s.callGetProvenance(params.Arguments)
-	case "project_goal_get":
-		result, err = s.callProjectDocGet("goal")
-	case "project_plan_get":
-		result, err = s.callProjectDocGet("plan")
-	case "current_objective_get":
-		result, err = s.callProjectDocGet("current_objective")
-	case "project_goal_set":
-		result, err = s.callProjectDocSet("goal", params.Arguments)
-	case "project_plan_set":
-		result, err = s.callProjectDocSet("plan", params.Arguments)
-	case "current_objective_set":
-		result, err = s.callProjectDocSet("current_objective", params.Arguments)
-	case "session_log_append":
-		result, err = s.callSessionLogAppend("manual", params.Arguments)
-	case "decision_record":
-		result, err = s.callSessionLogAppend("decision", params.Arguments)
-	case "doc_read":
-		result, err = s.callDocRead(params.Arguments)
-	case "skill_distill":
-		result, err = s.callSkillDistill(params.Arguments)
-	case "project_search":
-		result, err = s.callProjectSearch(params.Arguments)
-	default:
+	result, err, known := s.dispatchTool(params.Name, params.Arguments)
+	if !known {
 		s.respondErr(req.ID, -32601, "Unknown tool", params.Name)
 		return
 	}
@@ -663,6 +627,57 @@ func (s *memMCPServer) handleToolCall(req rpcRequest) {
 		return
 	}
 	s.respond(req.ID, result)
+}
+
+// dispatchTool routes one tool call to its handler and returns the MCP
+// tool result (a {"content":[...]} map), a tool-level error, and whether
+// the tool name was recognised. Shared by the stdio MCP frontend
+// (handleToolCall) and the argv frontend (`opendray memory call`), so the
+// two surfaces can never drift in which tools they expose or how each
+// forwards to the gateway. known=false means "no such tool".
+func (s *memMCPServer) dispatchTool(name string, args json.RawMessage) (result any, err error, known bool) {
+	if len(args) == 0 {
+		// argv callers may omit arguments for no-arg tools; the per-tool
+		// handlers unmarshal into a struct, which rejects empty input.
+		args = json.RawMessage("{}")
+	}
+	switch name {
+	case "memory_search":
+		result, err = s.callSearch(args)
+	case "memory_store":
+		result, err = s.callStore(args)
+	case "memory_list":
+		result, err = s.callList(args)
+	case "memory_load_context":
+		result, err = s.callLoadContext(args)
+	case "memory_get_provenance":
+		result, err = s.callGetProvenance(args)
+	case "project_goal_get":
+		result, err = s.callProjectDocGet("goal")
+	case "project_plan_get":
+		result, err = s.callProjectDocGet("plan")
+	case "current_objective_get":
+		result, err = s.callProjectDocGet("current_objective")
+	case "project_goal_set":
+		result, err = s.callProjectDocSet("goal", args)
+	case "project_plan_set":
+		result, err = s.callProjectDocSet("plan", args)
+	case "current_objective_set":
+		result, err = s.callProjectDocSet("current_objective", args)
+	case "session_log_append":
+		result, err = s.callSessionLogAppend("manual", args)
+	case "decision_record":
+		result, err = s.callSessionLogAppend("decision", args)
+	case "doc_read":
+		result, err = s.callDocRead(args)
+	case "skill_distill":
+		result, err = s.callSkillDistill(args)
+	case "project_search":
+		result, err = s.callProjectSearch(args)
+	default:
+		return nil, nil, false
+	}
+	return result, err, true
 }
 
 func (s *memMCPServer) callSearch(args json.RawMessage) (any, error) {

--- a/cmd/opendray/memory.go
+++ b/cmd/opendray/memory.go
@@ -1,0 +1,211 @@
+// Subcommand `opendray memory` — an argv frontend to opendray's shared
+// cross-agent memory, for agent CLIs that CANNOT load the stdio
+// `opendray mcp-memory` MCP server (notably antigravity/agy, whose MCP
+// is a closed plugin/protobuf system with no per-session config file).
+//
+// It reuses the exact same gateway-forwarding handlers as the MCP server
+// (memMCPServer.dispatchTool), so the two surfaces expose identical tools
+// and can never drift. The agent calls these through its Bash/shell tool:
+//
+//	opendray memory tools
+//	opendray memory call memory_search '{"query":"db url"}'
+//	opendray memory call memory_store  '{"text":"...","metadata":{"type":"project_fact"}}'
+//	opendray memory call session_log_append '{"content":"fixed X"}'
+//	opendray memory call current_objective_get
+//
+// Auth + scope come from the same env the MCP server reads
+// (OPENDRAY_BASE_URL / OPENDRAY_API_KEY / OPENDRAY_MEMORY_SCOPE /
+// OPENDRAY_MEMORY_SCOPE_KEY), which opendray exports into the session at
+// spawn time for non-MCP providers.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+)
+
+const memoryUsage = `opendray memory — call opendray's shared cross-agent memory from a shell.
+
+Usage:
+  opendray memory tools [--json]          List available tools.
+  opendray memory call <tool> [<json>]    Invoke a tool. <json> is the
+                                          arguments object; omit it for
+                                          no-arg tools, or pass '-' to read
+                                          the JSON from stdin.
+
+Auth/scope come from the environment (set automatically inside an
+opendray session):
+  OPENDRAY_BASE_URL, OPENDRAY_API_KEY                 (required)
+  OPENDRAY_MEMORY_SCOPE, OPENDRAY_MEMORY_SCOPE_KEY    (optional)
+Flags --scope / --scope-key override the env when given.
+
+Examples:
+  opendray memory call memory_search '{"query":"deploy topology"}'
+  opendray memory call memory_store '{"text":"deploys on LXC 86xx","metadata":{"type":"project_fact"}}'
+  opendray memory call session_log_append '{"content":"shipped codex bypass fix"}'
+  opendray memory call current_objective_get
+`
+
+func runMemory(args []string) int {
+	fs := flag.NewFlagSet("memory", flag.ContinueOnError)
+	scope := fs.String("scope", "", "override OPENDRAY_MEMORY_SCOPE (session|project|global)")
+	scopeKey := fs.String("scope-key", "", "override OPENDRAY_MEMORY_SCOPE_KEY (cwd / session id)")
+	asJSON := fs.Bool("json", false, "tools: emit JSON instead of text")
+	fs.Usage = func() { fmt.Fprint(os.Stderr, memoryUsage) }
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	rest := fs.Args()
+	if len(rest) == 0 {
+		fs.Usage()
+		return 2
+	}
+
+	switch rest[0] {
+	case "tools", "list":
+		return memoryListTools(*asJSON)
+	case "call":
+		return memoryCall(rest[1:], *scope, *scopeKey)
+	default:
+		fmt.Fprintf(os.Stderr, "opendray memory: unknown subcommand %q\n\n", rest[0])
+		fs.Usage()
+		return 2
+	}
+}
+
+// memoryListTools prints the shared tool catalogue (same toolDefs the MCP
+// server returns for tools/list) so an agent can discover what to call.
+func memoryListTools(asJSON bool) int {
+	if asJSON {
+		b, err := json.MarshalIndent(toolDefs, "", "  ")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		fmt.Println(string(b))
+		return 0
+	}
+	for _, t := range toolDefs {
+		name, _ := t["name"].(string)
+		desc, _ := t["description"].(string)
+		if i := strings.IndexByte(desc, '\n'); i >= 0 {
+			desc = desc[:i]
+		}
+		fmt.Printf("%-22s %s\n", name, desc)
+	}
+	return 0
+}
+
+// memoryCall invokes one tool by name with a JSON arguments object,
+// reusing the MCP server's gateway-forwarding dispatch. Result text goes
+// to stdout; a tool-level error (or isError result) exits non-zero so the
+// agent's shell sees the failure.
+func memoryCall(args []string, scopeOverride, scopeKeyOverride string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "opendray memory call: tool name required (try `opendray memory tools`)")
+		return 2
+	}
+	tool := args[0]
+
+	rawArgs := "{}"
+	if len(args) >= 2 {
+		if args[1] == "-" {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "opendray memory call: read stdin:", err)
+				return 2
+			}
+			if s := strings.TrimSpace(string(data)); s != "" {
+				rawArgs = s
+			}
+		} else if s := strings.TrimSpace(args[1]); s != "" {
+			rawArgs = s
+		}
+	}
+	if !json.Valid([]byte(rawArgs)) {
+		fmt.Fprintf(os.Stderr, "opendray memory call: arguments are not valid JSON: %s\n", rawArgs)
+		return 2
+	}
+
+	cfg, err := loadMemMCPConfig()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	if scopeOverride != "" {
+		cfg.scope = scopeOverride
+	}
+	if scopeKeyOverride != "" {
+		cfg.scopeKey = scopeKeyOverride
+	}
+	srv := &memMCPServer{
+		cfg:    cfg,
+		client: &http.Client{},
+		out:    os.Stdout,
+		outMu:  &sync.Mutex{},
+		errLog: os.Stderr,
+	}
+
+	result, callErr, known := srv.dispatchTool(tool, json.RawMessage(rawArgs))
+	if !known {
+		fmt.Fprintf(os.Stderr, "opendray memory call: unknown tool %q (try `opendray memory tools`)\n", tool)
+		return 2
+	}
+	if callErr != nil {
+		fmt.Fprintln(os.Stderr, "tool error:", callErr)
+		return 1
+	}
+	text, isErr := memoryResultText(result)
+	if isErr {
+		fmt.Fprintln(os.Stderr, text)
+		return 1
+	}
+	fmt.Println(text)
+	return 0
+}
+
+// memoryResultText flattens an MCP tool result ({"content":[{text}], ...})
+// into a single string, and reports whether the result was flagged
+// isError. Falls back to JSON for any unexpected shape.
+func memoryResultText(result any) (string, bool) {
+	m, ok := result.(map[string]any)
+	if !ok {
+		b, _ := json.Marshal(result)
+		return string(b), false
+	}
+	isErr, _ := m["isError"].(bool)
+
+	var b strings.Builder
+	appendText := func(c any) {
+		cm, ok := c.(map[string]any)
+		if !ok {
+			return
+		}
+		if t, ok := cm["text"].(string); ok {
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(t)
+		}
+	}
+	switch content := m["content"].(type) {
+	case []map[string]any:
+		for _, c := range content {
+			appendText(c)
+		}
+	case []any:
+		for _, c := range content {
+			appendText(c)
+		}
+	default:
+		raw, _ := json.Marshal(m)
+		return string(raw), isErr
+	}
+	return b.String(), isErr
+}

--- a/cmd/opendray/memory_test.go
+++ b/cmd/opendray/memory_test.go
@@ -1,0 +1,55 @@
+package main
+
+import "testing"
+
+func TestMemoryResultText(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   any
+		wantText string
+		wantErr  bool
+	}{
+		{
+			name: "single text content block ([]map form, as callX returns)",
+			result: map[string]any{
+				"content": []map[string]any{{"type": "text", "text": "hello"}},
+			},
+			wantText: "hello",
+		},
+		{
+			name: "multiple blocks joined by newline",
+			result: map[string]any{
+				"content": []map[string]any{
+					{"type": "text", "text": "line1"},
+					{"type": "text", "text": "line2"},
+				},
+			},
+			wantText: "line1\nline2",
+		},
+		{
+			name: "isError flagged ([]any form, as JSON round-trip yields)",
+			result: map[string]any{
+				"content": []any{map[string]any{"type": "text", "text": "tool error: boom"}},
+				"isError": true,
+			},
+			wantText: "tool error: boom",
+			wantErr:  true,
+		},
+		{
+			name:     "non-map result falls back to JSON",
+			result:   []string{"a", "b"},
+			wantText: `["a","b"]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, isErr := memoryResultText(tt.result)
+			if text != tt.wantText {
+				t.Errorf("text = %q, want %q", text, tt.wantText)
+			}
+			if isErr != tt.wantErr {
+				t.Errorf("isErr = %v, want %v", isErr, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -321,14 +321,19 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 	// via context) wins over the per-provider operator default.
 	args = append(args, modelArgs(p.Manifest, p.Config, session.ModelFromContext(ctx))...)
 	if p.Manifest.ID == "codex" {
-		// Skip the operator's approval policy when the integration asked
-		// for bypass: codex's full bypass flag (appended below) is
-		// mutually exclusive with an approval policy, so applying both
-		// would conflict.
-		if session.PermissionModeFromContext(ctx) != "bypass" {
-			if approval, ok := p.Config["approval"].(string); ok && approval != "" {
-				args = append(args, "-c", "approval_policy="+tomlString(approval))
-			}
+		if session.PermissionModeFromContext(ctx) == "bypass" {
+			// codex's full bypass flag (--dangerously-bypass-approvals-and-
+			// sandbox, appended below) is a clap ArgGroup mutually exclusive
+			// with --ask-for-approval (-a) and --sandbox (-s). Those land in
+			// args from the provider's saved config schema, so strip them
+			// here — otherwise codex rejects the combo and the session exits
+			// within seconds of spawn. dropConflictingFlags can't catch this
+			// because it only fires on USER-supplied trigger flags, but for
+			// integration sessions the bypass flag is provider-side.
+			args = stripFlagsWithValues(args, "--ask-for-approval", "-a", "--sandbox", "-s")
+		} else if approval, ok := p.Config["approval"].(string); ok && approval != "" {
+			// Non-bypass: apply the operator's approval policy.
+			args = append(args, "-c", "approval_policy="+tomlString(approval))
 		}
 	}
 	// Integration bypass: append the provider's unattended/auto-approve
@@ -380,7 +385,20 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 	// sessions are unaffected (project data is already cwd-scoped; the
 	// shared global/KB layer stays available to them).
 	isIntegration := session.OriginFromContext(ctx) == session.OriginIntegration
-	if sp.memory.Enabled && p.Manifest.Capabilities.SupportsMcp && !isIntegration {
+	// Two delivery modes for opendray-memory:
+	//   - MCP server (claude/codex/opencode): the agent calls memory_* as
+	//     native MCP tools, attached here.
+	//   - CLI shim (antigravity): agy CANNOT load opendray's stdio MCP
+	//     server — its MCP is a closed plugin/protobuf system with no
+	//     per-session config file (see renderMCP). Attaching the server
+	//     would write an invisible entry to .gemini/settings.json and the
+	//     agent would never see the tools. So for those providers we skip
+	//     the MCP attach and instead, in Prepare, export the gateway creds
+	//     into the session env + inject guidance to use the `opendray
+	//     memory` CLI through Bash. See memoryViaCLI / the Prepare branch.
+	wantMemory := sp.memory.Enabled && p.Manifest.Capabilities.SupportsMcp && !isIntegration
+	memoryCLIShim := wantMemory && memoryViaCLI(id)
+	if wantMemory && !memoryCLIShim {
 		servers = append(servers, MCPServer{
 			Name:    "opendray-memory",
 			Command: sp.memory.BinaryPath,
@@ -420,7 +438,7 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 	// no-Prepare fast path even when nothing else needs one.
 	hasIntegrationPrompt := session.IntegrationSystemPromptFromContext(ctx) != ""
 
-	if !wantClaudeAccount && !wantAgyAccount && !mcpEnabled && !skillsEnabled && len(configEnv) == 0 && !wantsOpenCodeConfig && !hasIntegrationPrompt {
+	if !wantClaudeAccount && !wantAgyAccount && !mcpEnabled && !skillsEnabled && len(configEnv) == 0 && !wantsOpenCodeConfig && !hasIntegrationPrompt && !memoryCLIShim {
 		return info, nil
 	}
 
@@ -516,14 +534,31 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 			}
 		}
 
-		// Inject memory-tool guidance into the agent's system prompt
-		// when the memory MCP is being attached. Without this nudge,
-		// Claude (and to a lesser extent Codex/Antigravity) tends to use
-		// its built-in markdown memory feature instead of our shared
-		// MCP store, defeating the cross-CLI value prop. Done here
-		// (after skills, before MCP rendering) so the message ordering
-		// stays predictable.
-		if sp.memory.Enabled && p.Manifest.Capabilities.SupportsMcp {
+		// Inject memory guidance into the agent's system prompt. Without
+		// this nudge, the CLI tends to use its built-in markdown memory
+		// instead of our shared store, defeating the cross-CLI value prop.
+		// Done here (after skills, before MCP rendering) so message
+		// ordering stays predictable. Two flavours:
+		//   - CLI shim (antigravity): the agent can't see MCP tools, so we
+		//     export the gateway creds into the session env and tell it to
+		//     use the `opendray memory` CLI through Bash.
+		//   - MCP (claude/codex/opencode): the native memory_* tool nudge.
+		if memoryCLIShim {
+			cwd := session.Cwd(prepareCtx)
+			out.Env["OPENDRAY_BASE_URL"] = sp.memory.BaseURL
+			out.Env["OPENDRAY_API_KEY"] = sp.memory.APIKey
+			out.Env["OPENDRAY_MEMORY_SCOPE"] = defaultStr(sp.memory.Scope, "project")
+			out.Env["OPENDRAY_MEMORY_SCOPE_KEY"] = cwd
+			// Absolute path to the opendray binary (os.Executable, resolved
+			// at startup — the same one that launches the MCP subprocess), so
+			// the agent can call the CLI even when `opendray` isn't on the
+			// session's PATH. Removes the only environmental dependency the
+			// shim would otherwise share with skill injection.
+			out.Env["OPENDRAY_BIN"] = sp.memory.BinaryPath
+			if err := injectMemoryCLIGuidanceFor(providerID, baseDir, sp.memory.BinaryPath, &out); err != nil {
+				return session.PrepareOutput{}, fmt.Errorf("inject memory CLI guidance: %w", err)
+			}
+		} else if sp.memory.Enabled && p.Manifest.Capabilities.SupportsMcp {
 			if err := injectMemoryGuidanceFor(providerID, baseDir, &out); err != nil {
 				return session.PrepareOutput{}, fmt.Errorf("inject memory guidance: %w", err)
 			}
@@ -1370,6 +1405,100 @@ func injectMemoryGuidanceFor(providerID, baseDir string, out *session.PrepareOut
 	return nil
 }
 
+// memoryViaCLI reports whether a provider must reach opendray-memory
+// through the `opendray memory` CLI shim instead of the stdio MCP server.
+// True for antigravity: agy can't load opendray's MCP server (its MCP is
+// a closed plugin/protobuf system with no per-session config file the
+// gateway can write — see renderMCP), so the only way to give it the
+// shared memory/project/journal tools is to export the gateway creds into
+// the session env and have it call the `opendray memory` CLI via Bash.
+func memoryViaCLI(providerID string) bool {
+	return providerID == "antigravity"
+}
+
+// injectMemoryCLIGuidanceFor injects the CLI-flavoured memory guidance
+// (use `opendray memory ...` through Bash) into the provider's
+// system-prompt surface. Used for providers in the memoryViaCLI bucket,
+// where the native MCP tools are unreachable. Same per-CLI dispatch shape
+// as injectMemoryGuidanceFor.
+func injectMemoryCLIGuidanceFor(providerID, baseDir, binPath string, out *session.PrepareOutput) error {
+	switch providerID {
+	case "antigravity":
+		return injectAgyContext(baseDir, "\n\n---\n\n"+memoryCLIGuidanceText(binPath), out)
+	}
+	// No other provider uses the CLI shim today; nothing to inject.
+	return nil
+}
+
+// memoryCLIGuidanceText returns the CLI memory guidance, appending a
+// concrete absolute-path fallback when binPath is known so the agent can
+// run the CLI even if `opendray` isn't on the session's PATH. binPath is
+// os.Executable() resolved at startup (the same binary that backs the MCP
+// server), exported to the session as OPENDRAY_BIN.
+func memoryCLIGuidanceText(binPath string) string {
+	if strings.TrimSpace(binPath) == "" {
+		return memoryGuidanceTextCLI
+	}
+	return memoryGuidanceTextCLI +
+		"\n\n> If your shell reports `opendray: command not found`, it isn't on " +
+		"PATH — use the absolute path, available in the `OPENDRAY_BIN` env var:\n" +
+		">  `\"$OPENDRAY_BIN\" memory call memory_search '{\"query\":\"...\"}'`\n" +
+		">  (it points to `" + binPath + "`)."
+}
+
+// memoryGuidanceTextCLI is the antigravity-flavoured memory guidance: same
+// shared store and the same when-to-store discipline as memoryGuidanceText,
+// but the agent reaches it through the `opendray memory` CLI (its Bash
+// tool) instead of MCP tool calls, because agy can't load opendray's MCP
+// server. Kept deliberately tighter than the MCP version — the agent only
+// needs the command shape + the core habits.
+const memoryGuidanceTextCLI = `## Persistent cross-agent memory (opendray)
+
+This session shares a cross-agent memory/knowledge store with every other
+opendray session in this project (Claude / Codex / others). You reach it
+through the ` + "`opendray memory`" + ` CLI via your shell/Bash tool — this
+CLI runtime cannot load it as MCP tools, so **do not** look for memory_*
+tools; run the command instead. Auth is already in your environment.
+
+### Commands
+
+- ` + "`opendray memory tools`" + ` — list every available tool + description.
+- ` + "`opendray memory call <tool> '<json-args>'`" + ` — invoke one. Examples:
+  - ` + "`opendray memory call memory_load_context '{\"query\":\"<task>\"}'`" + `
+  - ` + "`opendray memory call memory_search '{\"query\":\"db url\"}'`" + `
+  - ` + "`opendray memory call memory_store '{\"text\":\"...\",\"metadata\":{\"type\":\"project_fact\"}}'`" + `
+  - ` + "`opendray memory call session_log_append '{\"content\":\"what I just did\"}'`" + `
+  - ` + "`opendray memory call current_objective_set '{\"content\":\"...\"}'`" + `
+  - ` + "`opendray memory call current_objective_get`" + ` (no-arg tools omit the JSON)
+
+Arg keys per tool: memory_search/load_context use ` + "`query`" + `; memory_store
+uses ` + "`text`" + ` (+ ` + "`metadata`" + `); session_log_append / *_set use ` + "`content`" + `;
+doc_read uses ` + "`slug`" + ` (+ ` + "`section`" + `). Run ` + "`opendray memory tools`" + ` for the
+full schema if unsure.
+
+### Use this, not your built-in memory
+
+This shared store is the **only** memory you should write — not agy's own
+brain/notes. A fact you keep locally is invisible to the next Claude or
+Codex session in this project, which defeats the shared brain.
+
+### Habits (do these without being asked)
+
+1. **At start**: ` + "`memory_load_context`" + ` for the user's first ask, so you
+   don't repeat work prior sessions already did.
+2. **As you work**: ` + "`session_log_append`" + ` liberally — finished a step,
+   fixed a bug, hit a blocker, learned something the next session needs.
+   A session that ends with no journal taught the next agent nothing.
+3. **Keep ` + "`current_objective_set`" + ` live** — when the work establishes a
+   new immediate objective, finishes one, or shifts its steps.
+4. **Durable facts** → ` + "`memory_store`" + ` (user prefs, identifiers,
+   decisions, deploy topology). NOT transient "what I'm doing now" — that
+   is session_log_append / current_objective_set.
+5. **Before touching how OUR SYSTEM works** (opendray wiring, conventions,
+   a known pattern): ` + "`opendray memory call doc_read '{\"slug\":\"kb_integrations\",\"section\":\"...\"}'`" + `
+   — the kb_* pages are the source of truth and they update. Find them via
+   ` + "`opendray memory call project_search '{\"query\":\"...\"}'`" + `.`
+
 // injectAmbientMemoryFor injects the rendered "Recent project
 // memory" banner into the agent's system prompt. Same per-CLI
 // dispatch as injectMemoryGuidanceFor.
@@ -1410,6 +1539,44 @@ func bypassArgsFor(providerID string) []string {
 		return []string{"--dangerously-bypass-approvals-and-sandbox"}
 	}
 	return nil
+}
+
+// stripFlagsWithValues removes the named flags (and a following value
+// token when the flag takes one) from args. Both "--flag value" and
+// "--flag=value" forms are handled. Used to resolve codex's clap
+// ArgGroup conflict between the saved approval/sandbox config and the
+// integration bypass flag: both originate provider-side, so they escape
+// the user-triggered dropConflictingFlags pass in the session manager.
+func stripFlagsWithValues(args []string, flags ...string) []string {
+	if len(args) == 0 || len(flags) == 0 {
+		return args
+	}
+	drop := make(map[string]struct{}, len(flags))
+	for _, f := range flags {
+		drop[f] = struct{}{}
+	}
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		tok := args[i]
+		name := tok
+		if eq := strings.IndexByte(tok, '='); eq >= 0 {
+			name = tok[:eq]
+		}
+		if _, hit := drop[name]; !hit {
+			out = append(out, tok)
+			continue
+		}
+		// --flag=value is a single token — dropping it is enough.
+		if strings.Contains(tok, "=") {
+			continue
+		}
+		// --flag value: also skip the value token when present and not
+		// itself another flag.
+		if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+			i++
+		}
+	}
+	return out
 }
 
 func injectAmbientMemoryFor(providerID, baseDir, text string, out *session.PrepareOutput) error {

--- a/internal/catalog/mcp.go
+++ b/internal/catalog/mcp.go
@@ -77,12 +77,23 @@ func renderMCP(providerID, baseDir, cwd string, servers []MCPServer) ([]string, 
 	case "codex":
 		return renderCodexMCP(baseDir, servers)
 	case "antigravity":
-		// Antigravity (agy) is gemini-cli's successor and reads the
-		// workspace <cwd>/.gemini/settings.json mcpServers map (verified
-		// live; it starts servers lazily, on first tool need — a fake
-		// server + a non-forcing prompt won't trigger the spawn, which is
-		// why an earlier probe looked negative). The non-destructive merge
-		// attaches opendray-memory per-session, never globally.
+		// KNOWN LIMITATION (verified 2026-06-25 against agy 1.0.12): agy does
+		// NOT consume the gemini-cli-style <cwd>/.gemini/settings.json
+		// mcpServers map. Its own config (~/.gemini/antigravity-cli/
+		// settings.json) has no mcpServers key at all; MCP servers are
+		// registered through agy's plugin system (`agy plugin import` from
+		// gemini/claude EXTENSIONS, or `agy plugin install` from a
+		// marketplace) and materialise as a protobuf-backed internal
+		// registry + per-tool descriptors under
+		// ~/.gemini/antigravity-cli/mcp/<server>/. Proof: a server present in
+		// ~/.gemini/settings.json (e.g. "pencil") never appears in agy's
+		// plugin list. There is no clean per-session file opendray can write
+		// to inject an MCP server (especially an HTTP-transport one) into
+		// agy, so integration MCP injection does NOT reach antigravity agents
+		// today — steer MCP-dependent integrations at claude until agy
+		// exposes a --mcp-config-style flag. We still write the workspace
+		// file (harmless, non-destructive) so operator-driven gemini-cli
+		// fallbacks keep working, but DO NOT rely on agy reading it.
 		return renderGeminiMCP(cwd, servers)
 	case "opencode":
 		// OpenCode reads MCP from its JSON config's `mcp` block; we merge

--- a/internal/catalog/memory_cli_shim_test.go
+++ b/internal/catalog/memory_cli_shim_test.go
@@ -1,0 +1,71 @@
+package catalog
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/opendray/opendray-v2/internal/session"
+)
+
+func TestMemoryViaCLI(t *testing.T) {
+	// Only antigravity routes memory through the CLI shim today; everyone
+	// else loads the opendray-memory MCP server (or has no MCP surface).
+	cliBucket := map[string]bool{"antigravity": true}
+	for _, id := range []string{"claude", "codex", "opencode", "antigravity", "grok", "shell"} {
+		if got, want := memoryViaCLI(id), cliBucket[id]; got != want {
+			t.Errorf("memoryViaCLI(%q) = %v, want %v", id, got, want)
+		}
+	}
+}
+
+func TestInjectMemoryCLIGuidance_Antigravity(t *testing.T) {
+	base := t.TempDir()
+	out := &session.PrepareOutput{Env: map[string]string{}}
+	if err := injectMemoryCLIGuidanceFor("antigravity", base, "/abs/path/opendray", out); err != nil {
+		t.Fatal(err)
+	}
+	// agy guidance is appended to the --add-dir'd AGENTS.md.
+	body, err := os.ReadFile(filepath.Join(base, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	got := string(body)
+	// Must steer the agent at the CLI, not phantom MCP tools.
+	for _, want := range []string{
+		"opendray memory call",
+		"opendray memory tools",
+		"session_log_append",
+		"memory_load_context",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("agy CLI guidance missing %q; got:\n%s", want, got)
+		}
+	}
+	// It must NOT tell agy to call the MCP server (the old phantom bug).
+	if strings.Contains(got, "access to an MCP server named") {
+		t.Errorf("agy CLI guidance must not reference the MCP server it can't load")
+	}
+	// The absolute-path fallback (PATH-independent) must be present.
+	for _, want := range []string{"OPENDRAY_BIN", "/abs/path/opendray"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("agy CLI guidance missing PATH fallback %q", want)
+		}
+	}
+}
+
+func TestInjectMemoryCLIGuidance_NonShimProviderNoop(t *testing.T) {
+	// Providers not in the CLI-shim bucket get nothing from this path
+	// (they receive the MCP guidance elsewhere).
+	for _, id := range []string{"claude", "codex", "opencode"} {
+		base := t.TempDir()
+		out := &session.PrepareOutput{Env: map[string]string{}}
+		if err := injectMemoryCLIGuidanceFor(id, base, "/abs/path/opendray", out); err != nil {
+			t.Errorf("%s: should not error: %v", id, err)
+		}
+		if len(out.Args) != 0 {
+			t.Errorf("%s: should not mutate args; got %+v", id, out.Args)
+		}
+	}
+}

--- a/internal/catalog/strip_flags_test.go
+++ b/internal/catalog/strip_flags_test.go
@@ -1,0 +1,70 @@
+package catalog
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStripFlagsWithValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		args  []string
+		flags []string
+		want  []string
+	}{
+		{
+			name:  "codex bypass: strip approval+sandbox space-value forms",
+			args:  []string{"--ask-for-approval", "never", "--model", "gpt-5-codex", "-s", "workspace-write"},
+			flags: []string{"--ask-for-approval", "-a", "--sandbox", "-s"},
+			want:  []string{"--model", "gpt-5-codex"},
+		},
+		{
+			name:  "strip --flag=value single-token form",
+			args:  []string{"--ask-for-approval=never", "--model", "gpt-5-codex"},
+			flags: []string{"--ask-for-approval", "-a", "--sandbox", "-s"},
+			want:  []string{"--model", "gpt-5-codex"},
+		},
+		{
+			name:  "strip short-form -a with value",
+			args:  []string{"-a", "never", "--model", "x"},
+			flags: []string{"--ask-for-approval", "-a", "--sandbox", "-s"},
+			want:  []string{"--model", "x"},
+		},
+		{
+			name:  "flag at end with no following value",
+			args:  []string{"--model", "x", "--sandbox"},
+			flags: []string{"--sandbox", "-s"},
+			want:  []string{"--model", "x"},
+		},
+		{
+			name:  "value-less flag followed by another flag keeps that flag",
+			args:  []string{"--sandbox", "--model", "x"},
+			flags: []string{"--sandbox"},
+			want:  []string{"--model", "x"},
+		},
+		{
+			name:  "no matching flags is a passthrough",
+			args:  []string{"--model", "x", "--dangerously-bypass-approvals-and-sandbox"},
+			flags: []string{"--ask-for-approval", "-a", "--sandbox", "-s"},
+			want:  []string{"--model", "x", "--dangerously-bypass-approvals-and-sandbox"},
+		},
+		{
+			name:  "empty args",
+			args:  nil,
+			flags: []string{"--sandbox"},
+			want:  []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripFlagsWithValues(tt.args, tt.flags...)
+			// Normalise nil vs empty for comparison.
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("stripFlagsWithValues() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/session/handler.go
+++ b/internal/session/handler.go
@@ -249,7 +249,14 @@ func (h *Handlers) applyIntegrationDefaults(ctx context.Context, integrationID s
 	if req.ProviderID == "" {
 		req.ProviderID = provider
 	}
-	if req.Model == "" {
+	// default_model is a provider-specific string (e.g. an antigravity
+	// model name like "Gemini 3.5 Flash (Medium)"). Only inherit it when
+	// the session actually runs on the integration's default provider —
+	// otherwise a mismatched model would be passed to a different CLI
+	// (e.g. `claude --model "Gemini 3.5 Flash (Medium)"`), which fails to
+	// spawn. A session on another provider falls back to that provider's
+	// own default (no --model flag), which is always safe.
+	if req.Model == "" && req.ProviderID == provider {
 		req.Model = model
 	}
 	if req.ClaudeAccountID == "" {

--- a/internal/session/integration_defaults_test.go
+++ b/internal/session/integration_defaults_test.go
@@ -118,6 +118,38 @@ func TestCreate_RequestOverridesIntegrationDefaults(t *testing.T) {
 	}
 }
 
+func TestCreate_DefaultModelNotInheritedAcrossProviders(t *testing.T) {
+	// The integration default model is provider-specific (an antigravity
+	// model name). When the request explicitly picks a DIFFERENT provider
+	// but omits the model, opendray must NOT carry the mismatched model
+	// over — `claude --model "Gemini 3.5 Flash (Medium)"` would fail to
+	// spawn. The session falls back to claude's own default (empty model).
+	svc := newFakeSvc()
+	checker := &fakeAcctChecker{}
+	defs := &fakeDefaults{
+		id: "int_A", provider: "antigravity", model: "Gemini 3.5 Flash (Medium)",
+	}
+	body := `{"provider_id":"claude","cwd":"/tmp"}`
+	req := httptest.NewRequest(http.MethodPost, "/sessions", bytes.NewBufferString(body))
+	req = asIntegration(req, "int_A")
+	rr := httptest.NewRecorder()
+	newRouterWithDefaults(svc, checker, defs).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s; want 201", rr.Code, rr.Body)
+	}
+	var s Session
+	if err := json.Unmarshal(rr.Body.Bytes(), &s); err != nil {
+		t.Fatal(err)
+	}
+	if s.ProviderID != "claude" {
+		t.Errorf("provider: got %q, want request value 'claude'", s.ProviderID)
+	}
+	if s.Model != "" {
+		t.Errorf("model: got %q, want empty (antigravity model must not cross to claude)", s.Model)
+	}
+}
+
 func TestCreate_OperatorOriginIgnoresIntegrationDefaults(t *testing.T) {
 	// An admin/operator principal (or no integration principal) must not
 	// pick up any integration's defaults.


### PR DESCRIPTION
## Summary

Three per-provider integration spawn defects plus one comment correction, so integration sessions behave consistently across providers.

### 1. codex bypass crash (clap ArgGroup conflict)
`--dangerously-bypass-approvals-and-sandbox` is a clap ArgGroup mutually exclusive with `--ask-for-approval`/`-a` and `--sandbox`/`-s`. Those flags land in `args` from the provider's saved config schema, and `dropConflictingFlags` only fires on **user-supplied** trigger flags — so for integration sessions the provider-side bypass flag escapes it and codex exits within seconds of spawn. New helper `stripFlagsWithValues` strips the conflicting flags in bypass mode (handles both `--flag value` and `--flag=value`).

### 2. antigravity can't reach opendray-memory
`agy` cannot load opendray's stdio MCP server — its MCP is a closed plugin/protobuf system with no per-session config file the gateway can write. Added an `opendray memory` **argv CLI shim** that reuses the MCP server's gateway-forwarding dispatch (extracted as `memMCPServer.dispatchTool`, shared by both the stdio MCP frontend and the argv frontend so they can't drift). For antigravity, `Resolve` exports the gateway creds/scope + `OPENDRAY_BIN` into the session env and injects `opendray memory` CLI guidance into `AGENTS.md` instead of attaching the unreachable MCP server.

### 3. default_model leaking across providers
`default_model` is a provider-specific string (e.g. an antigravity model name). It is now only inherited when the session runs on the integration's default provider — otherwise a mismatched name reaches another CLI (e.g. `claude --model "Gemini 3.5 Flash (Medium)"`) and fails to spawn.

### 4. renderMCP comment correction
Corrected the antigravity comment to a verified KNOWN LIMITATION (agy 1.0.12 ignores `.gemini/settings.json` `mcpServers`; no clean per-session MCP injection path). Behaviour unchanged — still writes the harmless workspace file for operator-driven gemini-cli fallbacks.

## Test plan
- `go build ./...` — clean
- `go vet ./cmd/opendray/ ./internal/catalog/ ./internal/session/` — clean
- `go test -race ./cmd/opendray/ ./internal/catalog/ ./internal/session/` — all green
- New table-driven coverage:
  - `strip_flags_test.go` — codex bypass flag stripping (space/`=` forms, short flags, value-less trailing flags, passthrough)
  - `memory_cli_shim_test.go` — only antigravity routes via CLI; AGENTS.md guidance + `OPENDRAY_BIN` fallback; claude/codex/opencode are no-ops
  - `memory_test.go` — `memoryResultText` content flattening (`[]map`/`[]any`, multi-block, isError, JSON fallback)
  - `integration_defaults_test.go` — default_model not inherited across providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)