### PR TITLE
fix(memquery): project_search was admin-only — move to dual-auth + memory:read scope

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1255,7 +1255,6 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 				summarizerHandlers.Mount(r)
 				memoryWorkerHandlers.Mount(r)
 				memhealthHandlers.Mount(r)
-				memqueryHandlers.Mount(r)
 				conflictHandlers.Mount(r)
 				captureHandlers.Mount(r)
 				injectorHandlers.Mount(r)
@@ -1284,6 +1283,12 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 				channelHandlers.Mount(r)
 				memoryHandlers.Mount(r)
 				projectDocHandlers.Mount(r)
+				// project-search (cross-layer recall) is an MCP tool driven
+				// by the scoped-key memory subprocess, so it belongs on the
+				// dual-auth path next to /memory/search, not the admin-only
+				// group above (where it 401'd for every agent). Its own
+				// requireRead gate enforces the memory:read scope.
+				memqueryHandlers.Mount(r)
 				if knowledgeHandlers != nil {
 					knowledgeHandlers.Mount(r)
 				}

--- a/internal/memquery/handler.go
+++ b/internal/memquery/handler.go
@@ -7,14 +7,23 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/opendray/opendray-v2/internal/integration"
+	"github.com/opendray/opendray-v2/internal/memory"
 )
 
 // Handlers exposes cross-layer search over HTTP.
 //
 //	GET /api/v1/project-search?cwd=<cwd>&q=<query>&top_k=<N>
 //
-// Mount under admin auth — results expose every layer including
-// goal/plan content which can include private project context.
+// Mount under the dual-auth group (admin OR integration key) and gate
+// each route with the memory:read scope — the same bar as
+// /memory/search. project_search is an MCP tool driven by the
+// scoped-key `opendray mcp-memory` subprocess, so it must accept the
+// same credential path the other memory tools do; mounting it admin-only
+// made the advertised tool 401 for every agent. Results expose goal/plan
+// content, but no more than doc_read (also dual-auth + memory:read), and
+// scope_key already confines results to the caller's project.
 type Handlers struct {
 	svc *Service
 	log *slog.Logger
@@ -28,7 +37,26 @@ func NewHandlers(svc *Service, log *slog.Logger) *Handlers {
 }
 
 func (h *Handlers) Mount(r chi.Router) {
-	r.Get("/project-search", h.search)
+	r.With(h.requireRead).Get("/project-search", h.search)
+}
+
+// requireRead admits an admin principal or an integration key carrying
+// memory:read, matching memory.Handlers' read gate. Mirrored here (rather
+// than reused) because the route lives in a different package; the scope
+// constant is shared so the two surfaces stay in lockstep.
+func (h *Handlers) requireRead(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p, ok := integration.CurrentPrincipal(r.Context())
+		if !ok {
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		if p.Kind == integration.KindAdmin || integration.HasScope(p.Scopes, memory.ScopeMemoryRead) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		writeError(w, http.StatusForbidden, "requires admin or the memory:read scope")
+	})
 }
 
 func (h *Handlers) search(w http.ResponseWriter, r *http.Request) {

--- a/internal/memquery/handler_test.go
+++ b/internal/memquery/handler_test.go
@@ -1,0 +1,56 @@
+package memquery
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/opendray/opendray-v2/internal/integration"
+	"github.com/opendray/opendray-v2/internal/memory"
+)
+
+// TestRequireRead_Gate verifies the project-search read gate: it accepts an
+// admin principal or an integration key carrying memory:read, mirroring the
+// /memory/search bar — so the project_search MCP tool (driven by the
+// scoped-key memory subprocess) is actually reachable, not admin-only 401.
+func TestRequireRead_Gate(t *testing.T) {
+	h := NewHandlers(nil, nil) // the gate never touches svc
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	gate := h.requireRead(next)
+
+	cases := []struct {
+		name  string
+		princ *integration.Principal // nil → no principal in context
+		want  int
+	}{
+		{"no principal", nil, http.StatusUnauthorized},
+		{"admin", &integration.Principal{Kind: integration.KindAdmin}, http.StatusOK},
+		{
+			"integration with memory:read",
+			&integration.Principal{Kind: integration.KindIntegration, Scopes: []string{memory.ScopeMemoryRead}},
+			http.StatusOK,
+		},
+		{
+			"integration without the scope",
+			&integration.Principal{Kind: integration.KindIntegration, Scopes: []string{"session:read"}},
+			http.StatusForbidden,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/project-search?cwd=/x&q=y", nil)
+			if c.princ != nil {
+				req = req.WithContext(integration.WithPrincipal(req.Context(), *c.princ))
+			}
+			rec := httptest.NewRecorder()
+			gate.ServeHTTP(rec, req)
+			if rec.Code != c.want {
+				t.Errorf("status = %d, want %d", rec.Code, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`project_search` is advertised to every agent (it's in the `opendray mcp-memory` tool catalogue), but its backing endpoint `GET /api/v1/project-search` was mounted under the **admin-only** route group (`authSvc.Middleware`). The memory MCP subprocess forwards with a **scoped key**, which that group rejects — so agents got **401** on a tool they were told they had, while `memory_search` and `doc_read` (dual-auth group) worked from the *same* key.

## How it was found

The black-box memory test (operator-origin cloud agents per provider, no source access): claude's `project_search` returned `401 unauthorized` while `doc_read` on identical credentials succeeded. Classic "advertised but unreachable" — exactly the kind of gap codebase-aware tests miss.

## Fix

- Move `memqueryHandlers.Mount` from the admin-only group into the **dual-auth group** (admin OR integration key), next to `/memory/search` and `/project-docs`.
- Gate the route with a `requireRead` middleware admitting an admin principal **or** an integration key carrying `memory:read` — mirroring `memory.Handlers`' read gate, reusing the shared `memory.ScopeMemoryRead` constant so the two surfaces stay in lockstep.

## Exposure note

No broader than `doc_read`, which is already dual-auth + `memory:read` and can read the same goal/plan content. `scope_key` already confines results to the caller's project. An integration only reaches it if the operator granted `memory:read`.

## Test plan
- `go build ./...`, `go vet ./internal/memquery/ ./internal/app/` — clean
- `go test -race ./internal/memquery/ ./internal/app/` — green
- New table-driven gate test: no principal → 401, admin → 200, integration w/ `memory:read` → 200, integration without it → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)