### PR TITLE
feat(memory): surface deduped (folded) variants in search + load_context

### DIFF
--- a/cmd/opendray/mcp_memory.go
+++ b/cmd/opendray/mcp_memory.go
@@ -703,8 +703,10 @@ func (s *memMCPServer) callSearch(args json.RawMessage) (any, error) {
 	} else {
 		fmt.Fprintf(&b, "Found %d memory hit(s):\n\n", len(out.Hits))
 		for i, h := range out.Hits {
-			fmt.Fprintf(&b, "[%d] %s\n  similarity=%.3f id=%v\n\n",
+			fmt.Fprintf(&b, "[%d] %s\n  similarity=%.3f id=%v\n",
 				i+1, stringField(h.Memory, "text"), h.Similarity, h.Memory["id"])
+			b.WriteString(foldedVariantsBlock(h.Memory, "  "))
+			b.WriteByte('\n')
 		}
 	}
 	return map[string]any{
@@ -839,6 +841,7 @@ func (s *memMCPServer) callLoadContext(args json.RawMessage) (any, error) {
 				text = text[:i]
 			}
 			fmt.Fprintf(&b, "- %s\n", text)
+			b.WriteString(foldedVariantsBlock(memory, "  "))
 		}
 	}
 	return map[string]any{
@@ -1267,6 +1270,54 @@ func (s *memMCPServer) write(resp rpcResponse) {
 	defer s.outMu.Unlock()
 	_, _ = s.out.Write(raw)
 	_, _ = s.out.Write([]byte{'\n'})
+}
+
+// mergedFromTexts extracts the absorbed variant texts from a memory's
+// metadata.merged_from audit list (oldest first), or nil when the row was
+// never folded. Write-time dedup (memory.Service.Store) overwrites the
+// canonical text with the newest write and parks the superseded text here —
+// lossless in the DB, but invisible to search until we surface it. Two facts
+// that differ only in a critical token (a port, a provider tag, a version)
+// embed as near-duplicates and fold, so without this the distinguishing one
+// silently vanishes from recall.
+func mergedFromTexts(memory map[string]any) []string {
+	meta, ok := memory["metadata"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	raw, ok := meta["merged_from"].([]any)
+	if !ok || len(raw) == 0 {
+		return nil
+	}
+	var out []string
+	for _, e := range raw {
+		em, ok := e.(map[string]any)
+		if !ok {
+			continue
+		}
+		if t, ok := em["text"].(string); ok && strings.TrimSpace(t) != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// foldedVariantsBlock renders the "folded in N earlier writes" suffix for a
+// search / load_context hit, or "" when the row was never deduped (the common
+// case, so normal output is unchanged). indent is prepended to every line so
+// it nests under the hit. Each variant is collapsed to a single line.
+func foldedVariantsBlock(memory map[string]any, indent string) string {
+	texts := mergedFromTexts(memory)
+	if len(texts) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s↳ folded in %d earlier write(s) (deduped, kept for recall):\n", indent, len(texts))
+	for _, t := range texts {
+		oneLine := strings.Join(strings.Fields(t), " ")
+		fmt.Fprintf(&b, "%s    • %s\n", indent, oneLine)
+	}
+	return b.String()
 }
 
 func stringField(m map[string]any, key string) string {

--- a/cmd/opendray/mcp_memory_fold_test.go
+++ b/cmd/opendray/mcp_memory_fold_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// mem builds a search-hit memory map shaped like /api/v1/memory/search returns
+// (memory object with an optional metadata.merged_from audit list).
+func mem(text string, mergedFrom ...string) map[string]any {
+	m := map[string]any{"id": "mem_x", "text": text}
+	if len(mergedFrom) > 0 {
+		var arr []any
+		for _, t := range mergedFrom {
+			arr = append(arr, map[string]any{"text": t, "similarity": 0.9})
+		}
+		m["metadata"] = map[string]any{"merged_from": arr}
+	}
+	return m
+}
+
+func TestMergedFromTexts(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]any
+		want []string
+	}{
+		{"no metadata", map[string]any{"text": "a"}, nil},
+		{"metadata but no merged_from", map[string]any{"text": "a", "metadata": map[string]any{"type": "fact"}}, nil},
+		{"two variants", mem("canonical", "from=antigravity", "from=codex"), []string{"from=antigravity", "from=codex"}},
+		{
+			"skips malformed entries",
+			map[string]any{"metadata": map[string]any{"merged_from": []any{
+				map[string]any{"text": "keep"},
+				map[string]any{"nope": 1},    // no text
+				"raw-string",                 // not a map
+				map[string]any{"text": "  "}, // blank
+			}}},
+			[]string{"keep"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := mergedFromTexts(c.in)
+			if len(got) != len(c.want) {
+				t.Fatalf("got %v, want %v", got, c.want)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Errorf("[%d] got %q, want %q", i, got[i], c.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFoldedVariantsBlock(t *testing.T) {
+	// No fold → empty suffix (unchanged output for the common case).
+	if got := foldedVariantsBlock(mem("solo"), "  "); got != "" {
+		t.Errorf("expected empty block for un-folded memory, got %q", got)
+	}
+
+	// Folded → surfaces count + every absorbed variant, indented, newlines
+	// collapsed so each variant stays on one line.
+	block := foldedVariantsBlock(mem("canonical", "port 8770", "port 9090\nextra line"), "  ")
+	for _, want := range []string{"2 earlier", "port 8770", "port 9090 extra line"} {
+		if !strings.Contains(block, want) {
+			t.Errorf("block missing %q\n--- block ---\n%s", want, block)
+		}
+	}
+	if strings.Contains(block, "port 9090\nextra line") {
+		t.Errorf("variant newline not collapsed:\n%s", block)
+	}
+	if !strings.HasPrefix(block, "  ") {
+		t.Errorf("block not indented with the given prefix:\n%s", block)
+	}
+}


### PR DESCRIPTION
## Summary

Write-time dedup (`memory.Service.Store`, on by default since the M-U redesign) folds a near-duplicate write into the canonical row: it overwrites the canonical text with the newest write and parks the superseded text in `metadata.merged_from`. That's **lossless in the DB but invisible to recall** — `memory_search` / `memory_load_context` only ever rendered the canonical text. Two facts that differ only in a critical token (a port, a provider tag, a version) embed as near-duplicates and fold, so the distinguishing one silently vanished from search.

## How it was found

The black-box memory test: every test `memory_store` across three providers folded into one id (`mem_zfGsgNbm-QdF`); the cross-provider beacons (`…from=antigravity` / `…from=codex` / `…from=claude`) collapsed to the last writer's, so no agent could see the others'. It *looked* like broken cross-provider sharing but was actually the dedup eating the distinguishing tag — sharing itself works (the seeded canary was visible to all three providers).

## Fix

Keep dedup (the intended anti-bloat behaviour) and make it **transparent**: `callSearch` and `callLoadContext` now render the absorbed variants under each hit:

```
[1] OPENDRAY-XCHECK … beacon from=claude
  similarity=0.901 id=mem_…
  ↳ folded in 2 earlier write(s) (deduped, kept for recall):
      • OPENDRAY-XCHECK … beacon from=antigravity
      • OPENDRAY-XCHECK … beacon from=codex
```

Un-folded rows are byte-for-byte unchanged (the helper returns `""`), so the common case is untouched.

## Test plan
- `go build ./...`, `go vet ./cmd/opendray/` — clean
- `go test -race ./cmd/opendray/` — green
- Table-driven tests: `mergedFromTexts` (no metadata / no merged_from / multiple variants / malformed entries — no panic on bad shapes) and `foldedVariantsBlock` (empty for un-folded; count + every variant, indented, newlines collapsed)

## Notes
- This is a separate, pre-existing concern from PR #412 (integration provider parity) and PR #413 (project_search auth). All three were surfaced by the same black-box run.
- Follow-up worth considering (not in this PR): the web/mobile Memory UI could surface folds the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)