### PR TITLE
feat(dbtool): mobile Database — session inspector + row editing (web parity)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -3371,7 +3371,8 @@
           "tasks": "Tasks",
           "history": "History",
           "vault": "Vault",
-          "cortex": "Cortex"
+          "cortex": "Cortex",
+          "database": "Database"
         }
       },
       "cortex": {

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -3371,7 +3371,8 @@
           "tasks": "Tareas",
           "history": "Historial",
           "vault": "Bóveda",
-          "cortex": "Cortex"
+          "cortex": "Cortex",
+          "database": "BD"
         }
       },
       "cortex": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -3371,7 +3371,8 @@
           "tasks": "任务",
           "history": "历史",
           "vault": "文档库",
-          "cortex": "心智中枢"
+          "cortex": "心智中枢",
+          "database": "数据库"
         }
       },
       "cortex": {

--- a/app/mobile/lib/core/api/dbtool_api.dart
+++ b/app/mobile/lib/core/api/dbtool_api.dart
@@ -144,6 +144,73 @@ class DbtoolApi {
       throw toApiException(e);
     }
   }
+
+  // Table metadata — columns + primary key — needed to edit rows (the
+  // primary key addresses the row; a table with no PK can't be edited).
+  Future<DbTableMeta> tableMeta(String id, String schema, String table) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/dbtool/connections/$id/schemas/'
+        '${Uri.encodeComponent(schema)}/tables/'
+        '${Uri.encodeComponent(table)}/meta',
+      );
+      return DbTableMeta.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  Future<DbResultSet> insertRow(
+    String id, {
+    required String schema,
+    required String table,
+    required Map<String, dynamic> values,
+  }) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/dbtool/connections/$id/rows/insert',
+        data: {'schema': schema, 'table': table, 'values': values},
+      );
+      return DbResultSet.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  Future<int> updateRow(
+    String id, {
+    required String schema,
+    required String table,
+    required Map<String, dynamic> pk,
+    required Map<String, dynamic> values,
+  }) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/dbtool/connections/$id/rows/update',
+        data: {'schema': schema, 'table': table, 'pk': pk, 'values': values},
+      );
+      return (res.data?['rows_affected'] as num?)?.toInt() ?? 0;
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  Future<int> deleteRows(
+    String id, {
+    required String schema,
+    required String table,
+    required List<Map<String, dynamic>> pks,
+  }) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/dbtool/connections/$id/rows/delete',
+        data: {'schema': schema, 'table': table, 'pks': pks},
+      );
+      return (res.data?['rows_affected'] as num?)?.toInt() ?? 0;
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
 }
 
 class DbConnection {
@@ -273,6 +340,65 @@ class DbColumnMeta {
 
   final String name;
   final String type;
+}
+
+// DbColumn is one column of a table's structure (distinct from
+// DbColumnMeta, which is a result-set column). Used by the row editor.
+class DbColumn {
+  DbColumn({
+    required this.name,
+    required this.dataType,
+    required this.nullable,
+  });
+
+  factory DbColumn.fromJson(Map<String, dynamic> j) => DbColumn(
+    name: j['name']?.toString() ?? '',
+    dataType: j['data_type']?.toString() ?? '',
+    nullable: j['nullable'] == true,
+  );
+
+  final String name;
+  final String dataType;
+  final bool nullable;
+}
+
+// DbTableMeta describes a table's columns and primary key — enough to
+// render the row editor and address a row for update/delete.
+class DbTableMeta {
+  DbTableMeta({
+    required this.schema,
+    required this.table,
+    required this.columns,
+    required this.primaryKey,
+  });
+
+  factory DbTableMeta.fromJson(Map<String, dynamic> j) {
+    final cols = <DbColumn>[];
+    final rawCols = j['columns'];
+    if (rawCols is List) {
+      for (final c in rawCols.whereType<Map<String, dynamic>>()) {
+        cols.add(DbColumn.fromJson(c));
+      }
+    }
+    final pk = <String>[];
+    final rawPk = j['primary_key'];
+    if (rawPk is List) {
+      for (final k in rawPk) {
+        if (k != null) pk.add(k.toString());
+      }
+    }
+    return DbTableMeta(
+      schema: j['schema']?.toString() ?? '',
+      table: j['table']?.toString() ?? '',
+      columns: cols,
+      primaryKey: pk,
+    );
+  }
+
+  final String schema;
+  final String table;
+  final List<DbColumn> columns;
+  final List<String> primaryKey;
 }
 
 class DbResultSet {

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 11877 (3959 per locale)
+/// Strings: 11886 (3962 per locale)
 ///
-/// Built on 2026-07-07 at 06:40 UTC
+/// Built on 2026-07-08 at 11:36 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -3405,6 +3405,7 @@ class TranslationsWebDatabaseEn {
 	late final TranslationsWebDatabaseGridEn grid = TranslationsWebDatabaseGridEn.internal(_root);
 	late final TranslationsWebDatabaseConsoleEn console = TranslationsWebDatabaseConsoleEn.internal(_root);
 	late final TranslationsWebDatabasePanelEn panel = TranslationsWebDatabasePanelEn.internal(_root);
+	late final TranslationsWebDatabaseWorkbenchEn workbench = TranslationsWebDatabaseWorkbenchEn.internal(_root);
 }
 
 // Path: more.identity
@@ -6816,9 +6817,6 @@ class TranslationsWebProjectTabsEn {
 
 	/// en: 'Hygiene'
 	String get hygiene => 'Hygiene';
-
-	/// en: 'Database'
-	String get database => 'Database';
 }
 
 // Path: web.project.docLabel
@@ -11816,6 +11814,21 @@ class TranslationsWebDatabasePanelEn {
 
 	/// en: 'SQL console'
 	String get console => 'SQL console';
+
+	/// en: 'Open workbench'
+	String get openWorkbench => 'Open workbench';
+}
+
+// Path: web.database.workbench
+class TranslationsWebDatabaseWorkbenchEn {
+	TranslationsWebDatabaseWorkbenchEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Database workbench'
+	String get title => 'Database workbench';
 }
 
 // Path: more.items.integrations
@@ -13657,6 +13670,9 @@ class TranslationsWebSessionsInspectorTabsEn {
 
 	/// en: 'Cortex'
 	String get cortex => 'Cortex';
+
+	/// en: 'Database'
+	String get database => 'Database';
 }
 
 // Path: web.sessions.inspector.vaultPanel
@@ -17058,6 +17074,9 @@ class TranslationsSessionsInspectorShellTabsEn {
 
 	/// en: 'Cortex'
 	String get cortex => 'Cortex';
+
+	/// en: 'Database'
+	String get database => 'Database';
 }
 
 // Path: web.notes.vaultSync.conflict.kinds
@@ -17339,6 +17358,7 @@ extension on Translations {
 			'web.sessions.inspector.tabs.history' => 'History',
 			'web.sessions.inspector.tabs.vault' => 'Vault',
 			'web.sessions.inspector.tabs.cortex' => 'Cortex',
+			'web.sessions.inspector.tabs.database' => 'Database',
 			'web.sessions.inspector.vaultPanel.open' => 'Open Vault',
 			'web.sessions.inspector.vaultPanel.projectDocs' => 'Project docs',
 			'web.sessions.inspector.vaultPanel.projectDocsHint' => 'Agent-authored project docs in the vault. Re-bind the folder if this project\'s notes live elsewhere.',
@@ -17613,7 +17633,6 @@ extension on Translations {
 			'web.project.tabs.archived' => 'Archived',
 			'web.project.tabs.overview' => 'Overview',
 			'web.project.tabs.hygiene' => 'Hygiene',
-			'web.project.tabs.database' => 'Database',
 			'web.project.docLabel.goal' => 'Goal',
 			'web.project.docLabel.plan' => 'Plan',
 			'web.project.docLabel.current_objective' => 'Current objective',
@@ -19578,6 +19597,8 @@ extension on Translations {
 			'web.database.panel.deleted' => 'Connection deleted',
 			'web.database.panel.confirmDelete' => 'Delete this connection?',
 			'web.database.panel.console' => 'SQL console',
+			'web.database.panel.openWorkbench' => 'Open workbench',
+			'web.database.workbench.title' => 'Database workbench',
 			'more.title' => 'More',
 			'more.identity.signedInAs' => 'Signed in as',
 			'more.identity.server' => 'Server',
@@ -19717,10 +19738,10 @@ extension on Translations {
 			'sessions.detail.accountSwitcher.sheetTitleAgy' => 'Switch Antigravity account',
 			'sessions.detail.accountSwitcher.confirmBodyAgy' => 'This restarts the Antigravity CLI under a fresh conversation — the in-CLI history doesn\'t carry across accounts (the session tab is kept).',
 			'sessions.detail.accountSwitcher.noneHintAgy' => 'No Antigravity accounts configured. Add them in More → Providers → Antigravity.',
-			'sessions.terminal.snackbar.imagePickerFailed' => ({required Object error}) => 'Image picker failed: ${error}',
-			'sessions.terminal.snackbar.uploadingImage' => 'Uploading image…',
 			_ => null,
 		} ?? switch (path) {
+			'sessions.terminal.snackbar.imagePickerFailed' => ({required Object error}) => 'Image picker failed: ${error}',
+			'sessions.terminal.snackbar.uploadingImage' => 'Uploading image…',
 			'sessions.terminal.snackbar.imageAttached' => ({required Object path}) => 'Image attached: ${path}',
 			'sessions.terminal.snackbar.uploadFailed' => ({required Object status, required Object message}) => 'Upload failed (${status}): ${message}',
 			'sessions.terminal.snackbar.uploadFailedGeneric' => ({required Object error}) => 'Upload failed: ${error}',
@@ -19772,6 +19793,7 @@ extension on Translations {
 			'sessions.inspector.shell.tabs.history' => 'History',
 			'sessions.inspector.shell.tabs.vault' => 'Vault',
 			'sessions.inspector.shell.tabs.cortex' => 'Cortex',
+			'sessions.inspector.shell.tabs.database' => 'Database',
 			'sessions.inspector.cortex.title' => 'Cortex workspace',
 			'sessions.inspector.cortex.blurb' => 'Goal, plan, journal, inbox and memory hygiene for this project — the AI-maintained Cortex.',
 			'sessions.inspector.cortex.open' => 'Open Cortex workspace',
@@ -20230,11 +20252,11 @@ extension on Translations {
 			'project.alsoDeleteScanner' => 'Also delete scanner docs',
 			'project.alsoDeletePgvector' => 'Also delete pgvector memories',
 			'project.deleteForever' => 'Delete forever',
+			_ => null,
+		} ?? switch (path) {
 			'project.resetDoneSnack' => ({required Object parts}) => 'Reset: ${parts}',
 			'project.resetFailed' => ({required Object error}) => 'Reset failed: ${error}',
 			'project.docSavedSnack' => ({required Object kind}) => '${kind} saved',
-			_ => null,
-		} ?? switch (path) {
 			'project.docSaveFailed' => ({required Object error}) => 'Save failed: ${error}',
 			'project.docHintTemplate' => ({required Object kind}) => 'Write the ${kind} as markdown…',
 			'project.deleteEntryTooltip' => 'Delete entry',
@@ -20744,11 +20766,11 @@ extension on Translations {
 			'notesPage.deleteBody' => 'This is irreversible. Vault git sync will remove the file on the gateway host too.',
 			'notesPage.emptyFilterMatch' => ({required Object query}) => 'No notes match "${query}".',
 			'notesPage.emptyVault' => 'Vault is empty. Tap + to create your first note.',
+			_ => null,
+		} ?? switch (path) {
 			'notesPage.emptyFolder' => ({required Object path}) => 'Folder "${path}" is empty.',
 			'notesPage.validatePath' => 'Path is required',
 			'notesPage.validatePathDots' => 'Path cannot contain ".."',
-			_ => null,
-		} ?? switch (path) {
 			'notesPage.pathHelper' => 'Auto-appends .md if missing.',
 			'notesPage.editor.markdownHint' => 'Markdown…',
 			'notesPage.editor.saving' => 'Saving…',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -1691,6 +1691,7 @@ class _TranslationsWebDatabaseEs extends TranslationsWebDatabaseEn {
 	@override late final _TranslationsWebDatabaseGridEs grid = _TranslationsWebDatabaseGridEs._(_root);
 	@override late final _TranslationsWebDatabaseConsoleEs console = _TranslationsWebDatabaseConsoleEs._(_root);
 	@override late final _TranslationsWebDatabasePanelEs panel = _TranslationsWebDatabasePanelEs._(_root);
+	@override late final _TranslationsWebDatabaseWorkbenchEs workbench = _TranslationsWebDatabaseWorkbenchEs._(_root);
 }
 
 // Path: more.identity
@@ -3478,7 +3479,6 @@ class _TranslationsWebProjectTabsEs extends TranslationsWebProjectTabsEn {
 	@override String get archived => 'Archivadas';
 	@override String get overview => 'Resumen';
 	@override String get hygiene => 'Higiene';
-	@override String get database => 'Base de datos';
 }
 
 // Path: web.project.docLabel
@@ -6010,6 +6010,17 @@ class _TranslationsWebDatabasePanelEs extends TranslationsWebDatabasePanelEn {
 	@override String get deleted => 'Conexión eliminada';
 	@override String get confirmDelete => '¿Eliminar esta conexión?';
 	@override String get console => 'Consola SQL';
+	@override String get openWorkbench => 'Abrir banco de trabajo';
+}
+
+// Path: web.database.workbench
+class _TranslationsWebDatabaseWorkbenchEs extends TranslationsWebDatabaseWorkbenchEn {
+	_TranslationsWebDatabaseWorkbenchEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Banco de trabajo de BD';
 }
 
 // Path: more.items.integrations
@@ -7056,6 +7067,7 @@ class _TranslationsWebSessionsInspectorTabsEs extends TranslationsWebSessionsIns
 	@override String get history => 'Historial';
 	@override String get vault => 'Bóveda';
 	@override String get cortex => 'Cortex';
+	@override String get database => 'BD';
 }
 
 // Path: web.sessions.inspector.vaultPanel
@@ -9049,6 +9061,7 @@ class _TranslationsSessionsInspectorShellTabsEs extends TranslationsSessionsInsp
 	@override String get history => 'Historial';
 	@override String get vault => 'Bóveda';
 	@override String get cortex => 'Cortex';
+	@override String get database => 'BD';
 }
 
 // Path: web.notes.vaultSync.conflict.kinds
@@ -9306,6 +9319,7 @@ extension on TranslationsEs {
 			'web.sessions.inspector.tabs.history' => 'Historial',
 			'web.sessions.inspector.tabs.vault' => 'Bóveda',
 			'web.sessions.inspector.tabs.cortex' => 'Cortex',
+			'web.sessions.inspector.tabs.database' => 'BD',
 			'web.sessions.inspector.vaultPanel.open' => 'Abrir Bóveda',
 			'web.sessions.inspector.vaultPanel.projectDocs' => 'Docs del proyecto',
 			'web.sessions.inspector.vaultPanel.projectDocsHint' => 'Docs del proyecto escritos por el agente en la bóveda. Revincula la carpeta si las notas de este proyecto viven en otro sitio.',
@@ -9580,7 +9594,6 @@ extension on TranslationsEs {
 			'web.project.tabs.archived' => 'Archivadas',
 			'web.project.tabs.overview' => 'Resumen',
 			'web.project.tabs.hygiene' => 'Higiene',
-			'web.project.tabs.database' => 'Base de datos',
 			'web.project.docLabel.goal' => 'Objetivo',
 			'web.project.docLabel.plan' => 'Plan',
 			'web.project.docLabel.current_objective' => 'Objetivo actual',
@@ -11545,6 +11558,8 @@ extension on TranslationsEs {
 			'web.database.panel.deleted' => 'Conexión eliminada',
 			'web.database.panel.confirmDelete' => '¿Eliminar esta conexión?',
 			'web.database.panel.console' => 'Consola SQL',
+			'web.database.panel.openWorkbench' => 'Abrir banco de trabajo',
+			'web.database.workbench.title' => 'Banco de trabajo de BD',
 			'more.title' => 'Más',
 			'more.identity.signedInAs' => 'Sesión iniciada como',
 			'more.identity.server' => 'Servidor',
@@ -11684,10 +11699,10 @@ extension on TranslationsEs {
 			'sessions.detail.accountSwitcher.sheetTitleAgy' => 'Cambiar de cuenta de Antigravity',
 			'sessions.detail.accountSwitcher.confirmBodyAgy' => 'Esto reinicia el CLI de Antigravity con una conversación nueva — el historial dentro del CLI no se traslada entre cuentas (la pestaña de la sesión se conserva).',
 			'sessions.detail.accountSwitcher.noneHintAgy' => 'No hay cuentas de Antigravity configuradas. Agrégalas en Más → Providers → Antigravity.',
-			'sessions.terminal.snackbar.imagePickerFailed' => ({required Object error}) => 'Falló el selector de imágenes: ${error}',
-			'sessions.terminal.snackbar.uploadingImage' => 'Subiendo imagen…',
 			_ => null,
 		} ?? switch (path) {
+			'sessions.terminal.snackbar.imagePickerFailed' => ({required Object error}) => 'Falló el selector de imágenes: ${error}',
+			'sessions.terminal.snackbar.uploadingImage' => 'Subiendo imagen…',
 			'sessions.terminal.snackbar.imageAttached' => ({required Object path}) => 'Imagen adjuntada: ${path}',
 			'sessions.terminal.snackbar.uploadFailed' => ({required Object status, required Object message}) => 'Falló la subida (${status}): ${message}',
 			'sessions.terminal.snackbar.uploadFailedGeneric' => ({required Object error}) => 'Falló la subida: ${error}',
@@ -11739,6 +11754,7 @@ extension on TranslationsEs {
 			'sessions.inspector.shell.tabs.history' => 'Historial',
 			'sessions.inspector.shell.tabs.vault' => 'Bóveda',
 			'sessions.inspector.shell.tabs.cortex' => 'Cortex',
+			'sessions.inspector.shell.tabs.database' => 'BD',
 			'sessions.inspector.cortex.title' => 'Espacio Cortex',
 			'sessions.inspector.cortex.blurb' => 'Objetivo, plan, diario, bandeja y limpieza de memoria de este proyecto — el Cortex mantenido por IA.',
 			'sessions.inspector.cortex.open' => 'Abrir espacio Cortex',
@@ -12197,11 +12213,11 @@ extension on TranslationsEs {
 			'project.alsoDeleteScanner' => 'Eliminar también los documentos del scanner',
 			'project.alsoDeletePgvector' => 'Eliminar también las memorias de pgvector',
 			'project.deleteForever' => 'Eliminar para siempre',
+			_ => null,
+		} ?? switch (path) {
 			'project.resetDoneSnack' => ({required Object parts}) => 'Restablecido: ${parts}',
 			'project.resetFailed' => ({required Object error}) => 'Error al restablecer: ${error}',
 			'project.docSavedSnack' => ({required Object kind}) => '${kind} guardado',
-			_ => null,
-		} ?? switch (path) {
 			'project.docSaveFailed' => ({required Object error}) => 'Error al guardar: ${error}',
 			'project.docHintTemplate' => ({required Object kind}) => 'Escribe el ${kind} como markdown…',
 			'project.deleteEntryTooltip' => 'Eliminar entrada',
@@ -12711,11 +12727,11 @@ extension on TranslationsEs {
 			'notesPage.deleteBody' => 'Esto es irreversible. La sincronización git del vault también eliminará el archivo en el host del gateway.',
 			'notesPage.emptyFilterMatch' => ({required Object query}) => 'Ninguna nota coincide con "${query}".',
 			'notesPage.emptyVault' => 'El vault está vacío. Toca + para crear tu primera nota.',
+			_ => null,
+		} ?? switch (path) {
 			'notesPage.emptyFolder' => ({required Object path}) => 'La carpeta "${path}" está vacía.',
 			'notesPage.validatePath' => 'La ruta es obligatoria',
 			'notesPage.validatePathDots' => 'La ruta no puede contener ".."',
-			_ => null,
-		} ?? switch (path) {
 			'notesPage.pathHelper' => 'Añade .md automáticamente si falta.',
 			'notesPage.editor.markdownHint' => 'Markdown…',
 			'notesPage.editor.saving' => 'Guardando…',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -1691,6 +1691,7 @@ class _TranslationsWebDatabaseZh extends TranslationsWebDatabaseEn {
 	@override late final _TranslationsWebDatabaseGridZh grid = _TranslationsWebDatabaseGridZh._(_root);
 	@override late final _TranslationsWebDatabaseConsoleZh console = _TranslationsWebDatabaseConsoleZh._(_root);
 	@override late final _TranslationsWebDatabasePanelZh panel = _TranslationsWebDatabasePanelZh._(_root);
+	@override late final _TranslationsWebDatabaseWorkbenchZh workbench = _TranslationsWebDatabaseWorkbenchZh._(_root);
 }
 
 // Path: more.identity
@@ -3478,7 +3479,6 @@ class _TranslationsWebProjectTabsZh extends TranslationsWebProjectTabsEn {
 	@override String get archived => '已归档';
 	@override String get overview => '概览';
 	@override String get hygiene => '记忆卫生';
-	@override String get database => '数据库';
 }
 
 // Path: web.project.docLabel
@@ -6010,6 +6010,17 @@ class _TranslationsWebDatabasePanelZh extends TranslationsWebDatabasePanelEn {
 	@override String get deleted => '连接已删除';
 	@override String get confirmDelete => '删除此连接?';
 	@override String get console => 'SQL 控制台';
+	@override String get openWorkbench => '展开工作台';
+}
+
+// Path: web.database.workbench
+class _TranslationsWebDatabaseWorkbenchZh extends TranslationsWebDatabaseWorkbenchEn {
+	_TranslationsWebDatabaseWorkbenchZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '数据库工作台';
 }
 
 // Path: more.items.integrations
@@ -7056,6 +7067,7 @@ class _TranslationsWebSessionsInspectorTabsZh extends TranslationsWebSessionsIns
 	@override String get history => '历史';
 	@override String get vault => '文档库';
 	@override String get cortex => '心智中枢';
+	@override String get database => '数据库';
 }
 
 // Path: web.sessions.inspector.vaultPanel
@@ -9049,6 +9061,7 @@ class _TranslationsSessionsInspectorShellTabsZh extends TranslationsSessionsInsp
 	@override String get history => '历史';
 	@override String get vault => '文档库';
 	@override String get cortex => '心智中枢';
+	@override String get database => '数据库';
 }
 
 // Path: web.notes.vaultSync.conflict.kinds
@@ -9306,6 +9319,7 @@ extension on TranslationsZh {
 			'web.sessions.inspector.tabs.history' => '历史',
 			'web.sessions.inspector.tabs.vault' => '文档库',
 			'web.sessions.inspector.tabs.cortex' => '心智中枢',
+			'web.sessions.inspector.tabs.database' => '数据库',
 			'web.sessions.inspector.vaultPanel.open' => '打开文档库',
 			'web.sessions.inspector.vaultPanel.projectDocs' => '项目文档',
 			'web.sessions.inspector.vaultPanel.projectDocsHint' => '文档库中由 AI 撰写的项目文档。若本项目笔记在别处，可重新绑定文件夹。',
@@ -9580,7 +9594,6 @@ extension on TranslationsZh {
 			'web.project.tabs.archived' => '已归档',
 			'web.project.tabs.overview' => '概览',
 			'web.project.tabs.hygiene' => '记忆卫生',
-			'web.project.tabs.database' => '数据库',
 			'web.project.docLabel.goal' => '目标',
 			'web.project.docLabel.plan' => '计划',
 			'web.project.docLabel.current_objective' => '当前目标',
@@ -11545,6 +11558,8 @@ extension on TranslationsZh {
 			'web.database.panel.deleted' => '连接已删除',
 			'web.database.panel.confirmDelete' => '删除此连接?',
 			'web.database.panel.console' => 'SQL 控制台',
+			'web.database.panel.openWorkbench' => '展开工作台',
+			'web.database.workbench.title' => '数据库工作台',
 			'more.title' => '更多',
 			'more.identity.signedInAs' => '登录账号',
 			'more.identity.server' => '服务器',
@@ -11684,10 +11699,10 @@ extension on TranslationsZh {
 			'sessions.detail.accountSwitcher.sheetTitleAgy' => '切换 Antigravity 账号',
 			'sessions.detail.accountSwitcher.confirmBodyAgy' => '这会用全新对话重启 Antigravity CLI——CLI 内的历史不会在账号间保留（会话标签保留）。',
 			'sessions.detail.accountSwitcher.noneHintAgy' => '未配置 Antigravity 账号。请在 更多 → Providers → Antigravity 中添加。',
-			'sessions.terminal.snackbar.imagePickerFailed' => ({required Object error}) => '图片选择失败：${error}',
-			'sessions.terminal.snackbar.uploadingImage' => '正在上传图片…',
 			_ => null,
 		} ?? switch (path) {
+			'sessions.terminal.snackbar.imagePickerFailed' => ({required Object error}) => '图片选择失败：${error}',
+			'sessions.terminal.snackbar.uploadingImage' => '正在上传图片…',
 			'sessions.terminal.snackbar.imageAttached' => ({required Object path}) => '已附加图片：${path}',
 			'sessions.terminal.snackbar.uploadFailed' => ({required Object status, required Object message}) => '上传失败（${status}）：${message}',
 			'sessions.terminal.snackbar.uploadFailedGeneric' => ({required Object error}) => '上传失败：${error}',
@@ -11739,6 +11754,7 @@ extension on TranslationsZh {
 			'sessions.inspector.shell.tabs.history' => '历史',
 			'sessions.inspector.shell.tabs.vault' => '文档库',
 			'sessions.inspector.shell.tabs.cortex' => '心智中枢',
+			'sessions.inspector.shell.tabs.database' => '数据库',
 			'sessions.inspector.cortex.title' => '心智中枢工作区',
 			'sessions.inspector.cortex.blurb' => '本项目的目标、计划、日志、收件箱与记忆整理 —— 由 AI 维护的心智中枢。',
 			'sessions.inspector.cortex.open' => '打开心智中枢工作区',
@@ -12197,11 +12213,11 @@ extension on TranslationsZh {
 			'project.alsoDeleteScanner' => '同时删除扫描器文档',
 			'project.alsoDeletePgvector' => '同时删除 pgvector 记忆',
 			'project.deleteForever' => '永久删除',
+			_ => null,
+		} ?? switch (path) {
 			'project.resetDoneSnack' => ({required Object parts}) => '已重置：${parts}',
 			'project.resetFailed' => ({required Object error}) => '重置失败：${error}',
 			'project.docSavedSnack' => ({required Object kind}) => '${kind} 已保存',
-			_ => null,
-		} ?? switch (path) {
 			'project.docSaveFailed' => ({required Object error}) => '保存失败：${error}',
 			'project.docHintTemplate' => ({required Object kind}) => '以 Markdown 编写 ${kind}…',
 			'project.deleteEntryTooltip' => '删除条目',
@@ -12711,11 +12727,11 @@ extension on TranslationsZh {
 			'notesPage.deleteBody' => '此操作不可撤销。仓库的 git 同步会同时移除网关主机上的文件。',
 			'notesPage.emptyFilterMatch' => ({required Object query}) => '未找到匹配「${query}」的笔记。',
 			'notesPage.emptyVault' => '仓库为空。点击 + 创建第一条笔记。',
+			_ => null,
+		} ?? switch (path) {
 			'notesPage.emptyFolder' => ({required Object path}) => '文件夹「${path}」为空。',
 			'notesPage.validatePath' => '必须填写路径',
 			'notesPage.validatePathDots' => '路径不能包含「..」',
-			_ => null,
-		} ?? switch (path) {
 			'notesPage.pathHelper' => '缺失时自动追加 .md。',
 			'notesPage.editor.markdownHint' => 'Markdown…',
 			'notesPage.editor.saving' => '保存中…',

--- a/app/mobile/lib/features/database/database_tab.dart
+++ b/app/mobile/lib/features/database/database_tab.dart
@@ -8,7 +8,7 @@ import 'package:opendray/features/database/schema_browser.dart';
 
 // DatabaseTab is the mobile Database surface (simplified vs web): manage
 // per-project connections, then drill into a connection to browse its
-// schema and run read-only queries. Row-level editing is web-only.
+// schema, edit rows, and run SQL (reads + writes on writable connections).
 class DatabaseTab extends ConsumerStatefulWidget {
   const DatabaseTab({required this.cwd, super.key});
 

--- a/app/mobile/lib/features/database/query_screen.dart
+++ b/app/mobile/lib/features/database/query_screen.dart
@@ -6,9 +6,10 @@ import 'package:opendray/core/api/dbtool_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 
 // QueryScreen is the mobile SQL console: a multiline field plus a
-// read-only results grid. Write statements are rejected server-side
-// unless the connection is writable and the key carries db:write — the
-// mobile client only surfaces the outcome.
+// results grid. One statement per run — reads (SELECT/EXPLAIN/SHOW…)
+// render a grid; writes (INSERT/UPDATE/DELETE/DDL) run against a writable
+// connection and report rows affected. A write on a read-only connection
+// is rejected server-side and shown as an error.
 class QueryScreen extends ConsumerStatefulWidget {
   const QueryScreen({required this.connection, super.key});
 
@@ -65,6 +66,16 @@ class _QueryScreenState extends ConsumerState<QueryScreen> {
       ),
       body: Column(
         children: [
+          if (widget.connection.readOnly)
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              color: Theme.of(context).colorScheme.surfaceContainerHighest,
+              child: Text(
+                t.web.database.grid.readOnlyHint,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ),
           Padding(
             padding: const EdgeInsets.all(12),
             child: TextField(

--- a/app/mobile/lib/features/database/schema_browser.dart
+++ b/app/mobile/lib/features/database/schema_browser.dart
@@ -154,12 +154,25 @@ class _TableDataScreen extends ConsumerStatefulWidget {
 class _TableDataScreenState extends ConsumerState<_TableDataScreen> {
   static const _pageSize = 50;
   int _page = 0;
+  DbTableMeta? _meta;
   late Future<DbResultSet> _future;
 
   @override
   void initState() {
     super.initState();
+    _loadMeta();
     _load();
+  }
+
+  Future<void> _loadMeta() async {
+    try {
+      final m = await ref
+          .read(dbtoolApiProvider)
+          .tableMeta(widget.connection.id, widget.schema, widget.table);
+      if (mounted) setState(() => _meta = m);
+    } on Object {
+      // Metadata is best-effort; without it, editing stays disabled.
+    }
   }
 
   void _load() {
@@ -172,6 +185,8 @@ class _TableDataScreenState extends ConsumerState<_TableDataScreen> {
         );
   }
 
+  void _reload() => setState(_load);
+
   void _go(int delta) {
     setState(() {
       _page = (_page + delta).clamp(0, 1 << 30);
@@ -179,10 +194,89 @@ class _TableDataScreenState extends ConsumerState<_TableDataScreen> {
     });
   }
 
+  // Editing needs a writable connection AND a primary key to address rows.
+  bool get _editable =>
+      !widget.connection.readOnly && (_meta?.primaryKey.isNotEmpty ?? false);
+
+  Map<String, dynamic> _rowMap(DbResultSet rs, List<dynamic> row) {
+    final m = <String, dynamic>{};
+    for (var i = 0; i < rs.columns.length && i < row.length; i++) {
+      m[rs.columns[i].name] = row[i];
+    }
+    return m;
+  }
+
+  Future<void> _openEditor({Map<String, dynamic>? row}) async {
+    final meta = _meta;
+    if (meta == null) return;
+    final saved = await showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) =>
+          _RowEditorSheet(connection: widget.connection, meta: meta, row: row),
+    );
+    if (saved ?? false) _reload();
+  }
+
+  Future<void> _deleteRow(Map<String, dynamic> rowMap) async {
+    final meta = _meta;
+    if (meta == null) return;
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(t.web.database.grid.confirmDelete),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(t.common.cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(t.web.database.grid.delete),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    final pk = <String, dynamic>{};
+    for (final k in meta.primaryKey) {
+      pk[k] = rowMap[k];
+    }
+    try {
+      await ref.read(dbtoolApiProvider).deleteRows(
+            widget.connection.id,
+            schema: widget.schema,
+            table: widget.table,
+            pks: [pk],
+          );
+      if (mounted) {
+        _reload();
+        _snack(t.web.database.grid.deleted);
+      }
+    } on ApiException catch (e) {
+      _snack(e.message);
+    }
+  }
+
+  void _snack(String msg) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('${widget.schema}.${widget.table}')),
+      appBar: AppBar(
+        title: Text('${widget.schema}.${widget.table}'),
+        actions: [
+          if (_editable)
+            IconButton(
+              icon: const Icon(Icons.add),
+              tooltip: t.web.database.grid.insert,
+              onPressed: _openEditor,
+            ),
+        ],
+      ),
       body: FutureBuilder<DbResultSet>(
         future: _future,
         builder: (context, snap) {
@@ -201,6 +295,10 @@ class _TableDataScreenState extends ConsumerState<_TableDataScreen> {
           }
           return Column(
             children: [
+              if (widget.connection.readOnly)
+                _hint(t.web.database.grid.readOnlyHint)
+              else if (_meta != null && _meta!.primaryKey.isEmpty)
+                _hint(t.web.database.grid.noPkHint),
               Expanded(child: _grid(rs)),
               _pager(rs),
             ],
@@ -210,18 +308,40 @@ class _TableDataScreenState extends ConsumerState<_TableDataScreen> {
     );
   }
 
+  Widget _hint(String text) => Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        child: Text(text, style: Theme.of(context).textTheme.bodySmall),
+      );
+
   Widget _grid(DbResultSet rs) {
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       child: SingleChildScrollView(
         child: DataTable(
           columns: [
+            if (_editable) const DataColumn(label: Text('')),
             for (final c in rs.columns) DataColumn(label: Text(c.name)),
           ],
           rows: [
             for (final row in rs.rows)
               DataRow(
                 cells: [
+                  if (_editable)
+                    DataCell(Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        IconButton(
+                          icon: const Icon(Icons.edit_outlined, size: 18),
+                          onPressed: () => _openEditor(row: _rowMap(rs, row)),
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.delete_outline, size: 18),
+                          onPressed: () => _deleteRow(_rowMap(rs, row)),
+                        ),
+                      ],
+                    )),
                   for (final cell in row) DataCell(Text(_cell(cell))),
                 ],
               ),
@@ -266,4 +386,205 @@ class _TableDataScreenState extends ConsumerState<_TableDataScreen> {
     if (v is Map || v is List) return v.toString();
     return '$v';
   }
+}
+
+// _RowEditorSheet is the insert/edit form for one row. Every column gets
+// a text field plus a NULL toggle (nullable columns). On edit, the
+// primary key addresses the row; on insert, non-empty / explicit-NULL
+// fields are sent. Mirrors the web row dialog.
+class _RowEditorSheet extends ConsumerStatefulWidget {
+  const _RowEditorSheet({
+    required this.connection,
+    required this.meta,
+    this.row,
+  });
+
+  final DbConnection connection;
+  final DbTableMeta meta;
+  final Map<String, dynamic>? row; // null = insert
+
+  @override
+  ConsumerState<_RowEditorSheet> createState() => _RowEditorSheetState();
+}
+
+class _RowEditorSheetState extends ConsumerState<_RowEditorSheet> {
+  final _controllers = <String, TextEditingController>{};
+  final _isNull = <String, bool>{};
+  bool _busy = false;
+
+  bool get _editing => widget.row != null;
+
+  @override
+  void initState() {
+    super.initState();
+    for (final c in widget.meta.columns) {
+      final v = widget.row?[c.name];
+      _controllers[c.name] =
+          TextEditingController(text: v == null ? '' : _cellToInput(v));
+      _isNull[c.name] = _editing && v == null;
+    }
+  }
+
+  @override
+  void dispose() {
+    for (final c in _controllers.values) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  Map<String, dynamic> _buildValues() {
+    final out = <String, dynamic>{};
+    for (final c in widget.meta.columns) {
+      final isNull = _isNull[c.name] ?? false;
+      final text = _controllers[c.name]!.text;
+      final newVal = isNull ? null : _coerce(text);
+      if (_editing) {
+        final orig = widget.row![c.name];
+        if (orig != newVal) out[c.name] = newVal;
+      } else if (isNull) {
+        out[c.name] = null;
+      } else if (text.isNotEmpty) {
+        out[c.name] = newVal;
+      }
+    }
+    return out;
+  }
+
+  Future<void> _save() async {
+    setState(() => _busy = true);
+    try {
+      final api = ref.read(dbtoolApiProvider);
+      if (_editing) {
+        final pk = <String, dynamic>{};
+        for (final k in widget.meta.primaryKey) {
+          pk[k] = widget.row![k];
+        }
+        await api.updateRow(
+          widget.connection.id,
+          schema: widget.meta.schema,
+          table: widget.meta.table,
+          pk: pk,
+          values: _buildValues(),
+        );
+      } else {
+        await api.insertRow(
+          widget.connection.id,
+          schema: widget.meta.schema,
+          table: widget.meta.table,
+          values: _buildValues(),
+        );
+      }
+      if (mounted) Navigator.of(context).pop(true);
+    } on ApiException catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text(e.message)));
+        setState(() => _busy = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final pkSet = widget.meta.primaryKey.toSet();
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 16,
+        right: 16,
+        top: 16,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 16,
+      ),
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              _editing
+                  ? t.web.database.row.editTitle
+                  : t.web.database.row.insertTitle,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            Text(
+              '${widget.meta.schema}.${widget.meta.table}',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 12),
+            for (final col in widget.meta.columns)
+              _field(col, isPk: pkSet.contains(col.name)),
+            const SizedBox(height: 12),
+            FilledButton(
+              onPressed: _busy ? null : _save,
+              child: _busy
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Text(t.web.database.row.save),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _field(DbColumn col, {required bool isPk}) {
+    final isNull = _isNull[col.name] ?? false;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextField(
+            controller: _controllers[col.name],
+            enabled: !isNull,
+            style: const TextStyle(fontFamily: 'monospace', fontSize: 13),
+            decoration: InputDecoration(
+              labelText: isPk ? '${col.name}  (PK)' : col.name,
+              hintText: col.dataType,
+              isDense: true,
+              border: const OutlineInputBorder(),
+            ),
+          ),
+          if (col.nullable)
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                Text(
+                  t.web.database.row.setNull,
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+                Checkbox(
+                  value: isNull,
+                  onChanged: (v) =>
+                      setState(() => _isNull[col.name] = v ?? false),
+                ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+// _cellToInput renders a stored value for the text field.
+String _cellToInput(dynamic v) {
+  if (v is Map || v is List) return v.toString();
+  return '$v';
+}
+
+// _coerce turns the raw input text into a JSON value so numbers/bools
+// reach Postgres as the right type (mirrors the web row editor).
+dynamic _coerce(String text) {
+  final trimmed = text.trim();
+  if (trimmed.isEmpty) return '';
+  if (trimmed == 'true') return true;
+  if (trimmed == 'false') return false;
+  final asInt = int.tryParse(trimmed);
+  if (asInt != null) return asInt;
+  final asDouble = double.tryParse(trimmed);
+  if (asDouble != null) return asDouble;
+  return text;
 }

--- a/app/mobile/lib/features/project/project_screen.dart
+++ b/app/mobile/lib/features/project/project_screen.dart
@@ -12,7 +12,6 @@ import 'package:opendray/core/api/project_docs_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/cortex/blueprint_editor_screen.dart';
 import 'package:opendray/features/cortex/curation_chat_screen.dart';
-import 'package:opendray/features/database/database_tab.dart';
 import 'package:opendray/features/sessions/directory_picker_sheet.dart';
 import 'package:path/path.dart' as p;
 
@@ -162,7 +161,7 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
       setState(() {
         _sections = secs;
         _blueprintError = null;
-        _ensureTabController(secs.length + 4);
+        _ensureTabController(secs.length + 3);
       });
     } on ApiException catch (e) {
       // Web parity: NEVER substitute a hardcoded section set on failure —
@@ -173,7 +172,7 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
       if (!mounted) return;
       setState(() {
         _blueprintError = e;
-        _ensureTabController(_sections.length + 4);
+        _ensureTabController(_sections.length + 3);
       });
     }
     try {
@@ -371,7 +370,6 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
                   Tab(text: t.web.project.tabs.journal),
                   Tab(text: t.web.project.tabs.inbox),
                   Tab(text: t.web.project.tabs.hygiene),
-                  Tab(text: t.web.project.tabs.database),
                 ],
               ),
       ),
@@ -395,7 +393,6 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
                       _journalTab(),
                       _inboxTab(),
                       _hygieneTab(),
-                      _databaseTab(),
                     ],
                   ),
           ),
@@ -1304,17 +1301,6 @@ class _ProjectScreenState extends ConsumerState<ProjectScreen>
         ],
       ),
     );
-  }
-
-  // _databaseTab hosts the per-project Database tool (connections,
-  // schema browse, read-only query). Keyed by the selected cwd so it
-  // reloads when the operator switches projects.
-  Widget _databaseTab() {
-    final cwd = _selectedKey;
-    if (cwd == null || cwd.isEmpty) {
-      return Center(child: Text(t.project.pickFirst));
-    }
-    return DatabaseTab(key: ValueKey(cwd), cwd: cwd);
   }
 
   Widget _healthTab() {

--- a/app/mobile/lib/features/sessions/inspector/session_inspector_screen.dart
+++ b/app/mobile/lib/features/sessions/inspector/session_inspector_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/sessions_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/database/database_tab.dart';
 import 'package:opendray/features/sessions/inspector/cortex_tab.dart';
 import 'package:opendray/features/sessions/inspector/files_tab.dart';
 import 'package:opendray/features/sessions/inspector/git_tab.dart';
@@ -42,7 +43,7 @@ class _Body extends StatelessWidget {
   Widget build(BuildContext context) {
     final lastSegment = p.basename(session.cwd);
     return DefaultTabController(
-      length: 6,
+      length: 7,
       child: Scaffold(
         appBar: AppBar(
           title: Column(
@@ -88,6 +89,10 @@ class _Body extends StatelessWidget {
                 icon: const Icon(Icons.psychology_outlined),
                 text: t.sessions.inspector.shell.tabs.cortex,
               ),
+              Tab(
+                icon: const Icon(Icons.storage_outlined),
+                text: t.sessions.inspector.shell.tabs.database,
+              ),
             ],
           ),
         ),
@@ -99,6 +104,7 @@ class _Body extends StatelessWidget {
             HistoryTab(sessionId: session.id),
             NotesTab(sessionId: session.id, cwd: session.cwd),
             CortexTab(cwd: session.cwd),
+            DatabaseTab(cwd: session.cwd),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary

Mobile parity for the Database tool (follow-up to #419). Two parts:

1. **IA move** — Database moves from the Project screen to the **Session inspector** (7th tab, beside Files/Git/Tasks/History/Notes/Cortex), auto-scoped to `session.cwd` — matching web.
2. **Row editing (CRUD parity)** — mobile can now **edit** data, not just browse.

## Changes

### IA move
- `session_inspector_screen.dart` — Database as the 7th inspector tab (`DatabaseTab(cwd: session.cwd)`).
- `project_screen.dart` — removed the Database tab (controller length +4 → +3).

### Row editing
- `dbtool_api.dart` — added `tableMeta` / `insertRow` / `updateRow` / `deleteRows` (+ `DbColumn` / `DbTableMeta` models).
- `schema_browser.dart` — the table view loads metadata and, on a **writable connection with a primary key**, shows per-row **edit / delete** and an **insert** action via a bottom-sheet row editor (a field per column, NULL toggle, type coercion, PK-addressed) — mirroring the web row dialog. `read_only` connections / PK-less tables show a hint and stay read-only.
- `query_screen.dart` — the SQL console already executed writes server-side; clarified its docs and added a read-only hint.
- Reuses the `web.database.*` i18n (no new keys).

## Test plan

- [x] `flutter analyze` (whole `lib`) — No issues found.
- [x] APK built + uploaded to UNAS: `opendray-v2_v2.4.0_b52_20260708.apk`.
- [ ] **Operator on device**: session → inspector → Database tab → open a table → edit a cell / insert / delete a row on a writable connection; confirm a read-only connection stays read-only; run a write in the SQL console.

> Backend unchanged — the `rows/*` endpoints have existed since #419. Mobile-only; CI has no mobile build, so `flutter analyze` is the local gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
