### PR TITLE
docs(changelog): v2.11.0 — session file upload + database tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,23 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+## [v2.11.0] — 2026-07-08
+
 ### Added
 
+- **Upload files & folders into a session from the files sidebar.** The
+  session inspector's files panel can now create folders and upload files
+  or whole folders (recursively, preserving the subtree) via an upload
+  button or drag-and-drop — including dropping onto a specific folder row
+  to target it, or the panel background to target the session cwd.
+  Uploads land in the session's working directory where the AI model reads
+  them, streamed to disk (250 MiB per file) and confined to the session
+  cwd by the same `resolveWithinRoot` sandbox the download/zip endpoints
+  use — path traversal and symlinked-intermediate escapes are rejected.
+  Conflicting names auto-rename (`name-1.ext`) instead of overwriting what
+  the session produced. New admin-only endpoint `POST /api/v1/fs/upload`
+  on the existing `/fs` group; the tree refreshes to show new files
+  (including renames). (#420)
 - **Database tool — direct project database access.** opendray can now
   hold per-project (cwd-keyed) database connections and expose them like a
   JetBrains-style database tool: browse schemas/tables, read table data,
@@ -35,6 +50,33 @@ for the full rationale and what triggers a major bump.
   via `[dbtool]` (enabled by default; the feature is inert until a
   connection is registered). Migrations `0072` (schema) and `0073`
   (kb_integrations reseed).
+- **Mobile: antigravity multi-account parity with web.** The mobile app
+  gains the antigravity multi-account management already shipped on web
+  (#396). (#409)
+- **Mobile: Grok provider brand mark**, syncing the real Grok icon added
+  to web in #405. (#408)
+- **Memory search surfaces folded (deduped) variants** in `memory_search`
+  and `memory_load_context`, so callers see the merged form rather than
+  near-duplicate rows. (#414)
+
+### Fixed
+
+- **antigravity MCP injection now targets the real config surface**, so
+  injected servers actually reach antigravity sessions. (#416)
+- **Transcript overlay for CLIs with unscrollable TUIs** — the web
+  terminal can surface scrollback for tools whose full-screen TUI can't be
+  scrolled natively. (#415)
+- **`project_search` moved from admin-only to dual-auth + `memory:read`
+  scope**, so integrations can search project memory. (#413)
+- **Per-provider spawn parity** — codex bypass, antigravity memory CLI,
+  and a default-model guard for integration-originated sessions. (#412)
+- **Integration default-agent model is an explicit dropdown** rather than
+  a free-text datalist, on both web (#411) and mobile (#410).
+
+### Docs
+
+- **README refresh** — reworked hero, added comparison + FAQ, and synced
+  the 5-CLI provider list across all 10 translations. (#417)
 
 ## [v2.10.1] — 2026-06-22
 


### PR DESCRIPTION
Release bump for **v2.11.0**. Moves `[Unreleased]` → `[v2.11.0]` (2026-07-08) and documents everything merged since v2.10.1.

**Minor bump** (major=generation, minor=feature, patch=fix) — two features land in this release:
- **Files-sidebar upload** (#420) — create folders + upload files/whole-folders (button + drag-drop), confined to the session cwd, streamed, auto-rename.
- **Database tool** (#419) — per-project DB browse / row CRUD / SQL console + `opendray-dbtool` MCP.

Plus mobile parity (#408, #409), memory dedup surfacing (#414), and fixes (#410–#413, #415, #416) and the README refresh (#417).

Changelog-only change. On merge, I'll tag `v2.11.0` on the merge commit to trigger the goreleaser pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)