### PR TITLE
feat(dbtool): per-project cwd signing + bigint PK precision + TableMeta snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+### Security
+
+- **Database tool — cryptographic per-project isolation for the
+  auto-attached MCP.** The `opendray-dbtool` MCP now holds a `db:signed`
+  key and sends a per-session `X-OpenDray-Dbtool-Sig = HMAC(secret, cwd)`
+  header; the gateway rejects a signed-key call whose signature doesn't
+  match the `cwd`. An agent that extracts the injected key can no longer
+  forge another project's `cwd` — closing the residual the honest-path
+  check left open. Antigravity (whose MCP config is HOME-global and can't
+  carry a per-session signature — a Google limitation) and third-party
+  integration keys keep the plain `?cwd=` check via a separate honest-path
+  key. Migration `0074` reseeds the kb_integrations page.
+
+### Fixed
+
+- **Database tool — bigint primary keys stay exact.** Row update/delete
+  and filters decode JSON with `UseNumber`, so a 64-bit primary key above
+  2^53 is no longer rounded through `float64` (which could address the
+  wrong row or match none). Numbers beyond int64 keep their exact string.
+- **Database tool — consistent table metadata.** `TableMeta` runs its four
+  catalog queries (columns / PK / indexes / FKs) inside one read-only
+  transaction, so concurrent DDL can't produce a half-updated view.
+
 ## [v2.11.0] — 2026-07-08
 
 ### Added

--- a/cmd/opendray/mcp_dbtool.go
+++ b/cmd/opendray/mcp_dbtool.go
@@ -82,6 +82,10 @@ type dbtoolMCPConfig struct {
 	baseURL string
 	apiKey  string
 	cwd     string
+	// cwdSig is the HMAC(cwd) proof the gateway requires from signed keys
+	// (non-antigravity). Empty for antigravity (honest-path) or when the
+	// gateway didn't inject one.
+	cwdSig string
 }
 
 func loadDbtoolMCPConfig() (dbtoolMCPConfig, error) {
@@ -89,6 +93,7 @@ func loadDbtoolMCPConfig() (dbtoolMCPConfig, error) {
 		baseURL: strings.TrimRight(os.Getenv("OPENDRAY_BASE_URL"), "/"),
 		apiKey:  os.Getenv("OPENDRAY_API_KEY"),
 		cwd:     os.Getenv("OPENDRAY_DBTOOL_CWD"),
+		cwdSig:  os.Getenv("OPENDRAY_DBTOOL_CWD_SIG"),
 	}
 	if c.baseURL == "" {
 		return c, errors.New("mcp-dbtool: OPENDRAY_BASE_URL is required")
@@ -540,6 +545,11 @@ func (s *dbtoolMCPServer) gatewayGetJSON(path string, out any) error {
 }
 
 func (s *dbtoolMCPServer) doJSON(req *http.Request, path string, out any) error {
+	// Signed keys (non-antigravity) carry the per-cwd HMAC proof the
+	// gateway requires; header name must match dbtool's cwdSigHeader.
+	if s.cfg.cwdSig != "" {
+		req.Header.Set("X-OpenDray-Dbtool-Sig", s.cfg.cwdSig)
+	}
 	res, err := s.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("gateway %s: %w", path, err)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -814,6 +814,12 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 			[]string{"db:read", "db:write"}, dbtoolAgyKeyFile)
 		binPath, perr := os.Executable()
 		switch {
+		case secErr != nil:
+			// Fail closed: without the secret the gateway can't verify
+			// signatures, so a db:signed key would silently degrade to
+			// honest-path. Don't advertise a scope we can't enforce —
+			// leave the MCP unattached (the web UI still works).
+			log.Warn("dbtool MCP auto-attach disabled — signing secret unavailable", "err", secErr)
 		case err != nil:
 			log.Warn("dbtool MCP auto-attach disabled — could not mint signed key", "err", err)
 		case agyErr != nil:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,6 +8,8 @@ package app
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -792,24 +794,40 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 			PoolMaxConns: cfg.Dbtool.PoolMaxConns,
 			PoolIdleTTL:  cfg.Dbtool.PoolIdleTTLDuration(),
 		}, log)
-		dbtoolHandlers = dbtool.NewHandlers(dbtoolSvc, log)
+		// HMAC secret for the per-session cwd binding (server-side only).
+		signSecret, secErr := ensureDbtoolSignSecret()
+		if secErr != nil {
+			log.Warn("dbtool per-session cwd signing disabled — sign secret unavailable",
+				"err", secErr)
+		}
+		dbtoolHandlers = dbtool.NewHandlers(dbtoolSvc, signSecret, log)
 
-		// Mint the dedicated `opendray-dbtool` integration key and
-		// auto-attach the MCP server to spawned sessions — mirroring the
-		// memory auto-attach, but on its own key so the memory key never
-		// silently gains db scopes (and vice versa).
-		if key, err := ensureDbtoolIntegration(ctx, intgrSvc); err != nil {
-			log.Warn("dbtool MCP auto-attach disabled — could not mint integration key",
-				"err", err)
-		} else if binPath, perr := os.Executable(); perr != nil {
-			log.Warn("dbtool MCP auto-attach disabled — os.Executable failed",
-				"err", perr)
-		} else {
+		// Two auto-attach keys (see ensureDbtoolKey): the SIGNED key for
+		// providers whose MCP config is per-session (the gateway then
+		// requires an HMAC(cwd) proof, closing the "extract key + forge
+		// cwd" residual), and the ANTIGRAVITY key (honest-path) because
+		// antigravity's MCP config is HOME-global and cannot carry a
+		// per-session signature.
+		key, err := ensureDbtoolKey(ctx, intgrSvc, "opendray-dbtool",
+			[]string{"db:read", "db:write", "db:signed"}, dbtoolKeyFile)
+		agyKey, agyErr := ensureDbtoolKey(ctx, intgrSvc, "opendray-dbtool-agy",
+			[]string{"db:read", "db:write"}, dbtoolAgyKeyFile)
+		binPath, perr := os.Executable()
+		switch {
+		case err != nil:
+			log.Warn("dbtool MCP auto-attach disabled — could not mint signed key", "err", err)
+		case agyErr != nil:
+			log.Warn("dbtool MCP auto-attach disabled — could not mint antigravity key", "err", agyErr)
+		case perr != nil:
+			log.Warn("dbtool MCP auto-attach disabled — os.Executable failed", "err", perr)
+		default:
 			sessionProvider.WithDbtoolAutoAttach(catalog.DbtoolAutoAttach{
 				Enabled:    true,
 				BinaryPath: binPath,
 				BaseURL:    listenLoopback(cfg.Listen),
 				APIKey:     key,
+				AgyAPIKey:  agyKey,
+				SignSecret: signSecret,
 			})
 			mcpHandlers.AddBuiltins(mcpapi.Server{
 				ID:        "opendray-dbtool",
@@ -1887,23 +1905,15 @@ func ensureMemoryIntegration(ctx context.Context, svc *integration.Service) (str
 	return res.APIKey, nil
 }
 
-// ensureDbtoolIntegration guarantees an integration row named
-// "opendray-dbtool" exists with the db scopes and returns its plaintext
-// key, cached at ~/.opendray/dbtool.key. Same contract as
-// ensureMemoryIntegration: reuse cache when present, rotate once when
-// missing, reconcile scopes on upgrade.
-func ensureDbtoolIntegration(ctx context.Context, svc *integration.Service) (string, error) {
-	const name = "opendray-dbtool"
-	scopes := []string{
-		// The auto-attached mcp-dbtool subprocess authenticates as this
-		// key. db:write is included so db_execute / row CRUD work; the
-		// real write fence is per-connection (read_only flag) plus the
-		// gateway's statement classification — the operator decides per
-		// database whether agents may mutate it.
-		"db:read",
-		"db:write",
-	}
-
+// ensureDbtoolKey guarantees an integration row `name` with `scopes`
+// exists and returns its plaintext key, cached at keyFile. Same contract
+// as ensureMemoryIntegration: reuse cache when present, rotate once when
+// missing, reconcile scopes on upgrade. dbtool mints two keys through
+// this: the SIGNED key (carries db:signed — used by providers whose MCP
+// config is per-session, so the gateway can require an HMAC(cwd) proof),
+// and the ANTIGRAVITY key (honest-path, no db:signed — antigravity's MCP
+// config is HOME-global and cannot carry a per-session signature).
+func ensureDbtoolKey(ctx context.Context, svc *integration.Service, name string, scopes []string, keyFile string) (string, error) {
 	all, err := svc.List(ctx)
 	if err != nil {
 		return "", fmt.Errorf("list integrations: %w", err)
@@ -1925,7 +1935,7 @@ func ensureDbtoolIntegration(ctx context.Context, svc *integration.Service) (str
 		if err != nil {
 			return "", fmt.Errorf("register %s: %w", name, err)
 		}
-		_ = writeCachedKey(dbtoolKeyFile, res.APIKey)
+		_ = writeCachedKey(keyFile, res.APIKey)
 		return res.APIKey, nil
 	}
 	id := existing.ID
@@ -1936,7 +1946,7 @@ func ensureDbtoolIntegration(ctx context.Context, svc *integration.Service) (str
 		}
 	}
 
-	if cached, ok := readCachedKey(dbtoolKeyFile); ok {
+	if cached, ok := readCachedKey(keyFile); ok {
 		return cached, nil
 	}
 
@@ -1944,11 +1954,34 @@ func ensureDbtoolIntegration(ctx context.Context, svc *integration.Service) (str
 	if err != nil {
 		return "", fmt.Errorf("rotate %s: %w", name, err)
 	}
-	_ = writeCachedKey(dbtoolKeyFile, res.APIKey)
+	_ = writeCachedKey(keyFile, res.APIKey)
 	return res.APIKey, nil
 }
 
-const dbtoolKeyFile = "~/.opendray/dbtool.key"
+// ensureDbtoolSignSecret loads (or generates + caches) the HMAC secret
+// the gateway uses to sign/verify the per-session cwd binding. It lives
+// only on disk (~/.opendray/dbtool-sign.key), never in the DB and never
+// injected into a session — an agent that could read it could forge any
+// cwd, defeating the whole point.
+func ensureDbtoolSignSecret() ([]byte, error) {
+	if cached, ok := readCachedKey(dbtoolSignKeyFile); ok {
+		if raw, err := base64.StdEncoding.DecodeString(cached); err == nil && len(raw) >= 32 {
+			return raw, nil
+		}
+	}
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return nil, fmt.Errorf("generate dbtool sign secret: %w", err)
+	}
+	_ = writeCachedKey(dbtoolSignKeyFile, base64.StdEncoding.EncodeToString(b))
+	return b, nil
+}
+
+const (
+	dbtoolKeyFile     = "~/.opendray/dbtool.key"
+	dbtoolAgyKeyFile  = "~/.opendray/dbtool-agy.key"
+	dbtoolSignKeyFile = "~/.opendray/dbtool-sign.key"
+)
 
 // readCachedKey / writeCachedKey are the generic twins of
 // readMemoryKey / writeMemoryKey for additional system-integration

--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -2,6 +2,9 @@ package catalog
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"log/slog"
@@ -238,7 +241,16 @@ type DbtoolAutoAttach struct {
 	Enabled    bool
 	BinaryPath string
 	BaseURL    string
-	APIKey     string
+	// APIKey is the SIGNED key (db:signed) used by providers whose MCP
+	// config is per-session; those spawns also get a per-cwd HMAC
+	// signature the gateway verifies.
+	APIKey string
+	// AgyAPIKey is the honest-path key for antigravity, whose MCP config
+	// is HOME-global and can't carry a per-session signature.
+	AgyAPIKey string
+	// SignSecret signs the per-session cwd binding (HMAC-SHA256). Shared
+	// with the gateway's verifier; never injected into a session.
+	SignSecret []byte
 }
 
 // WithDbtoolAutoAttach enables auto-injection of the Database-tool MCP
@@ -246,6 +258,15 @@ type DbtoolAutoAttach struct {
 func (sp *SessionProvider) WithDbtoolAutoAttach(cfg DbtoolAutoAttach) *SessionProvider {
 	sp.dbtool = cfg
 	return sp
+}
+
+// signDbtoolCwd is hex HMAC-SHA256(secret, cwd) — the per-session cwd
+// proof injected for signed-key providers. It MUST stay byte-identical to
+// the gateway's verifier (internal/dbtool.verifyCwdSig).
+func signDbtoolCwd(secret []byte, cwd string) string {
+	m := hmac.New(sha256.New, secret)
+	m.Write([]byte(cwd))
+	return hex.EncodeToString(m.Sum(nil))
 }
 
 // WithAmbientInjector installs the ambient-memory injector — used
@@ -760,9 +781,19 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 					}
 				case "opendray-dbtool":
 					if providerID == "antigravity" {
+						// HOME-global MCP config: the honest-path key
+						// (no db:signed), no per-session signature — a
+						// shared config can't carry a per-cwd one.
+						servers[i].Env["OPENDRAY_API_KEY"] = sp.dbtool.AgyAPIKey
 						servers[i].Env["OPENDRAY_DBTOOL_CWD_FROM_CWD"] = "1"
 					} else {
+						// Per-session MCP config: the signed key plus a
+						// per-cwd HMAC proof the agent can't forge.
 						servers[i].Env["OPENDRAY_DBTOOL_CWD"] = cwd
+						if len(sp.dbtool.SignSecret) > 0 {
+							servers[i].Env["OPENDRAY_DBTOOL_CWD_SIG"] =
+								signDbtoolCwd(sp.dbtool.SignSecret, cwd)
+						}
 					}
 				}
 			}

--- a/internal/dbtool/handler.go
+++ b/internal/dbtool/handler.go
@@ -118,17 +118,10 @@ func (h *Handlers) requireConnCwd(w http.ResponseWriter, r *http.Request) bool {
 			errors.New("dbtool: cwd query parameter is required for non-admin callers"))
 		return false
 	}
-	// A db:signed key must prove the cwd binding with an HMAC signature:
-	// its sessions each get their own MCP config, so opendray injects a
-	// per-cwd signature the agent cannot forge (it has no signing secret).
-	// Keys without db:signed (antigravity — HOME-global MCP config) fall
-	// through to the honest-path cwd check below.
-	if integration.HasScope(p.Scopes, ScopeDBSigned) && len(h.signSecret) > 0 {
-		if !verifyCwdSig(h.signSecret, cwd, r.Header.Get(cwdSigHeader)) {
-			writeError(w, http.StatusForbidden,
-				errors.New("dbtool: missing or invalid cwd signature"))
-			return false
-		}
+	// A db:signed key must prove the cwd binding with an HMAC signature
+	// (shared with listConnections so no cwd-gated route can skip it).
+	if !h.enforceSignedCwd(w, r, p, cwd) {
+		return false
 	}
 	conn, err := h.svc.GetConnection(r.Context(), chi.URLParam(r, "id"))
 	if err != nil {
@@ -139,6 +132,23 @@ func (h *Handlers) requireConnCwd(w http.ResponseWriter, r *http.Request) bool {
 		// Do not reveal that the id exists under another project.
 		writeError(w, http.StatusNotFound, ErrNotFound)
 		return false
+	}
+	return true
+}
+
+// enforceSignedCwd verifies the per-session HMAC(cwd) signature when the
+// caller holds a db:signed key. Returns false (writing 403) on a missing
+// or invalid signature. Keys WITHOUT db:signed (antigravity, third-party
+// integrations) pass through — their weaker honest-path binding is the
+// cwd match at each call site. Every non-admin, cwd-gated route MUST run
+// this so a future route can't silently skip the proof.
+func (h *Handlers) enforceSignedCwd(w http.ResponseWriter, r *http.Request, p integration.Principal, cwd string) bool {
+	if integration.HasScope(p.Scopes, ScopeDBSigned) && len(h.signSecret) > 0 {
+		if !verifyCwdSig(h.signSecret, cwd, r.Header.Get(cwdSigHeader)) {
+			writeError(w, http.StatusForbidden,
+				errors.New("dbtool: missing or invalid cwd signature"))
+			return false
+		}
 	}
 	return true
 }
@@ -270,11 +280,20 @@ func (h *Handlers) listConnections(w http.ResponseWriter, r *http.Request) {
 	cwd := r.URL.Query().Get("cwd")
 	// Non-admin callers may only enumerate their own project's
 	// connections — never the whole cross-project registry. Admin (web
-	// UI) may omit cwd to list everything.
-	if p, _ := integration.CurrentPrincipal(r.Context()); p.Kind != integration.KindAdmin && cwd == "" {
-		writeError(w, http.StatusForbidden,
-			errors.New("dbtool: cwd query parameter is required for non-admin callers"))
-		return
+	// UI) may omit cwd to list everything. A db:signed key must also prove
+	// the cwd binding (same gate as the by-id routes) — otherwise it could
+	// enumerate another project's connection metadata with just a guessed
+	// cwd string.
+	p, _ := integration.CurrentPrincipal(r.Context())
+	if p.Kind != integration.KindAdmin {
+		if cwd == "" {
+			writeError(w, http.StatusForbidden,
+				errors.New("dbtool: cwd query parameter is required for non-admin callers"))
+			return
+		}
+		if !h.enforceSignedCwd(w, r, p, cwd) {
+			return
+		}
 	}
 	conns, err := h.svc.ListConnections(r.Context(), cwd)
 	if err != nil {

--- a/internal/dbtool/handler.go
+++ b/internal/dbtool/handler.go
@@ -1,12 +1,16 @@
 package dbtool
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 
@@ -23,21 +27,36 @@ import (
 const (
 	ScopeDBRead  = "db:read"
 	ScopeDBWrite = "db:write"
+	// ScopeDBSigned marks a key whose sessions each get their own MCP
+	// config, so the gateway can require an HMAC(cwd) signature — closing
+	// the "extract the shared key + forge cwd" residual. Keys without it
+	// (antigravity, whose MCP config is HOME-global and cannot carry a
+	// per-session signature) fall back to the honest-path cwd check.
+	ScopeDBSigned = "db:signed"
 )
+
+// cwdSigHeader carries the hex HMAC-SHA256(signSecret, cwd) that proves a
+// signed-key caller is bound to the cwd it claims.
+const cwdSigHeader = "X-OpenDray-Dbtool-Sig"
 
 // Handlers exposes the dbtool subsystem over HTTP under /dbtool/*.
 // Mount under the dual-auth route group (admin OR integration key).
 type Handlers struct {
 	svc *Service
-	log *slog.Logger
+	// signSecret verifies the per-session cwd signature from db:signed
+	// keys. Empty disables signature enforcement (all callers fall back to
+	// honest-path) — used in tests and if the secret can't be loaded.
+	signSecret []byte
+	log        *slog.Logger
 }
 
-// NewHandlers builds the HTTP wrapper around svc.
-func NewHandlers(svc *Service, log *slog.Logger) *Handlers {
+// NewHandlers builds the HTTP wrapper around svc. signSecret is the HMAC
+// secret shared with the catalog's per-session cwd signer (may be nil).
+func NewHandlers(svc *Service, signSecret []byte, log *slog.Logger) *Handlers {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &Handlers{svc: svc, log: log.With("component", "dbtool.http")}
+	return &Handlers{svc: svc, signSecret: signSecret, log: log.With("component", "dbtool.http")}
 }
 
 // requireScope allows admins, and integration keys holding `scope`.
@@ -77,11 +96,15 @@ func (h *Handlers) requireAdmin(next http.Handler) http.Handler {
 // touch another project's database by guessing an id. Admin principals
 // (the web UI) bypass so the operator can browse across projects.
 //
-// This is the honest-path boundary; it is NOT a cryptographic one — an
-// agent that extracts the injected system key from its rendered MCP
-// config could still call the REST API directly with a forged cwd. That
-// residual is identical to the memory MCP's shared-key model; a
-// per-project key would close it (tracked as a follow-up).
+// Two enforcement tiers by key type:
+//   - db:signed keys (providers whose MCP config is per-session) MUST also
+//     present a valid HMAC(cwd) signature — verified below. An agent that
+//     extracts the key still cannot forge a different cwd (it has no
+//     signing secret), so cross-project access is genuinely closed.
+//   - keys without db:signed (antigravity, whose MCP config is HOME-global
+//     and cannot carry a per-session signature) use the honest-path check
+//     only. That residual is inherent to antigravity's shared config
+//     (Google has an open per-workspace-config feature request).
 //
 // Returns false (and writes the response) when access is denied.
 func (h *Handlers) requireConnCwd(w http.ResponseWriter, r *http.Request) bool {
@@ -95,6 +118,18 @@ func (h *Handlers) requireConnCwd(w http.ResponseWriter, r *http.Request) bool {
 			errors.New("dbtool: cwd query parameter is required for non-admin callers"))
 		return false
 	}
+	// A db:signed key must prove the cwd binding with an HMAC signature:
+	// its sessions each get their own MCP config, so opendray injects a
+	// per-cwd signature the agent cannot forge (it has no signing secret).
+	// Keys without db:signed (antigravity — HOME-global MCP config) fall
+	// through to the honest-path cwd check below.
+	if integration.HasScope(p.Scopes, ScopeDBSigned) && len(h.signSecret) > 0 {
+		if !verifyCwdSig(h.signSecret, cwd, r.Header.Get(cwdSigHeader)) {
+			writeError(w, http.StatusForbidden,
+				errors.New("dbtool: missing or invalid cwd signature"))
+			return false
+		}
+	}
 	conn, err := h.svc.GetConnection(r.Context(), chi.URLParam(r, "id"))
 	if err != nil {
 		writeServiceError(w, err)
@@ -106,6 +141,22 @@ func (h *Handlers) requireConnCwd(w http.ResponseWriter, r *http.Request) bool {
 		return false
 	}
 	return true
+}
+
+// signCwd is hex HMAC-SHA256(secret, cwd) — the per-session cwd proof.
+// The catalog signer computes the identical value at spawn time.
+func signCwd(secret []byte, cwd string) string {
+	m := hmac.New(sha256.New, secret)
+	m.Write([]byte(cwd))
+	return hex.EncodeToString(m.Sum(nil))
+}
+
+// verifyCwdSig constant-time checks provided against HMAC(secret, cwd).
+func verifyCwdSig(secret []byte, cwd, provided string) bool {
+	if provided == "" {
+		return false
+	}
+	return hmac.Equal([]byte(signCwd(secret, cwd)), []byte(provided))
 }
 
 // Mount registers all /dbtool/* routes on r. r should already carry the
@@ -284,9 +335,12 @@ func (h *Handlers) tableData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req TableDataReq
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid JSON: %w", err))
 		return
+	}
+	for i := range req.Filters {
+		req.Filters[i].Value = normalizeNumber(req.Filters[i].Value)
 	}
 	rs, err := h.svc.TableData(r.Context(), chi.URLParam(r, "id"), req)
 	if err != nil {
@@ -301,7 +355,7 @@ func (h *Handlers) query(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req QueryReq
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid JSON: %w", err))
 		return
 	}
@@ -324,10 +378,11 @@ func (h *Handlers) insertRow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req RowInsertReq
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid JSON: %w", err))
 		return
 	}
+	req.Values = normalizeNumberMap(req.Values)
 	rs, err := h.svc.InsertRow(r.Context(), chi.URLParam(r, "id"), req)
 	if err != nil {
 		writeServiceError(w, err)
@@ -341,10 +396,12 @@ func (h *Handlers) updateRow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req RowUpdateReq
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid JSON: %w", err))
 		return
 	}
+	req.PK = normalizeNumberMap(req.PK)
+	req.Values = normalizeNumberMap(req.Values)
 	n, err := h.svc.UpdateRow(r.Context(), chi.URLParam(r, "id"), req)
 	if err != nil {
 		writeServiceError(w, err)
@@ -358,9 +415,12 @@ func (h *Handlers) deleteRows(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req RowDeleteReq
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid JSON: %w", err))
 		return
+	}
+	for i := range req.PKs {
+		req.PKs[i] = normalizeNumberMap(req.PKs[i])
 	}
 	n, err := h.svc.DeleteRows(r.Context(), chi.URLParam(r, "id"), req)
 	if err != nil {
@@ -368,6 +428,61 @@ func (h *Handlers) deleteRows(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"rows_affected": n})
+}
+
+// decodeJSON decodes the request body with UseNumber so large integers
+// (bigint primary keys above 2^53) survive as json.Number instead of
+// being rounded through float64 by the default decoder.
+func decodeJSON(r *http.Request, dst any) error {
+	dec := json.NewDecoder(r.Body)
+	dec.UseNumber()
+	return dec.Decode(dst)
+}
+
+// normalizeNumber turns json.Number values (from decodeJSON) into int64
+// when they fit — exact for bigint — else float64, recursing through the
+// maps/slices that become SQL parameters. Non-number values pass through.
+// This keeps a 64-bit primary key exact all the way to pgx.
+func normalizeNumber(v any) any {
+	switch x := v.(type) {
+	case json.Number:
+		s := x.String()
+		// Integer literal: keep it int64 when it fits (exact for bigint),
+		// else keep the exact string (numeric beyond int64) rather than
+		// lose precision through float64. Only fractional/exponent forms
+		// become float64.
+		if !strings.ContainsAny(s, ".eE") {
+			if i, err := x.Int64(); err == nil {
+				return i
+			}
+			return s
+		}
+		if f, err := x.Float64(); err == nil {
+			return f
+		}
+		return s
+	case map[string]any:
+		for k, vv := range x {
+			x[k] = normalizeNumber(vv)
+		}
+		return x
+	case []any:
+		for i, vv := range x {
+			x[i] = normalizeNumber(vv)
+		}
+		return x
+	default:
+		return v
+	}
+}
+
+// normalizeNumberMap applies normalizeNumber to every value in m and
+// returns it (nil-safe — a nil map ranges zero times).
+func normalizeNumberMap(m map[string]any) map[string]any {
+	for k, v := range m {
+		m[k] = normalizeNumber(v)
+	}
+	return m
 }
 
 // pathParam URL-decodes a chi path parameter (schema/table names may

--- a/internal/dbtool/handler_test.go
+++ b/internal/dbtool/handler_test.go
@@ -182,3 +182,23 @@ func TestRequireConnCwdSignatureEnforced(t *testing.T) {
 		})
 	}
 }
+
+// listConnections must also enforce the signature for db:signed keys —
+// otherwise a signed key could enumerate another project's connection
+// metadata with just a guessed cwd. Rejection happens before the service
+// is touched, so a nil svc is safe.
+func TestListConnectionsSignatureEnforced(t *testing.T) {
+	secret := []byte("sign-secret-abcdefghijklmnop")
+	h := NewHandlers(nil, secret, nil)
+	signed := integration.Principal{
+		Kind:   integration.KindIntegration,
+		Scopes: []string{ScopeDBRead, ScopeDBSigned},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/dbtool/connections?cwd=/proj", nil)
+	req = req.WithContext(integration.WithPrincipal(req.Context(), signed))
+	rec := httptest.NewRecorder()
+	h.listConnections(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("signed list without signature: status = %d, want 403", rec.Code)
+	}
+}

--- a/internal/dbtool/handler_test.go
+++ b/internal/dbtool/handler_test.go
@@ -1,6 +1,7 @@
 package dbtool
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -8,10 +9,38 @@ import (
 	"github.com/opendray/opendray-v2/internal/integration"
 )
 
+// A bigint primary key above 2^53 must survive JSON decoding exactly —
+// the default decoder rounds through float64, corrupting the WHERE that
+// addresses a row. decodeJSON uses UseNumber and normalizeNumber keeps it
+// an int64.
+func TestNormalizeNumber(t *testing.T) {
+	// 2^53 + 1 — the first integer float64 cannot represent exactly.
+	if got := normalizeNumber(json.Number("9007199254740993")); got != int64(9007199254740993) {
+		t.Fatalf("2^53+1 = %#v, want int64 9007199254740993", got)
+	}
+	// int64 max, nested in a map (the row-CRUD value path).
+	m := normalizeNumberMap(map[string]any{"id": json.Number("9223372036854775807")})
+	if m["id"] != int64(9223372036854775807) {
+		t.Fatalf("int64-max map value = %#v", m["id"])
+	}
+	// Fractional stays float64.
+	if got := normalizeNumber(json.Number("3.5")); got != 3.5 {
+		t.Fatalf("3.5 = %#v", got)
+	}
+	// Beyond int64 (e.g. numeric) falls back to the exact string.
+	if got := normalizeNumber(json.Number("99999999999999999999999999")); got != "99999999999999999999999999" {
+		t.Fatalf("huge = %#v", got)
+	}
+	// Non-numbers pass through untouched.
+	if got := normalizeNumber("alice"); got != "alice" {
+		t.Fatalf("string = %#v", got)
+	}
+}
+
 // The scope matrix: which principal passes which gate. The middlewares
 // run before any service code, so a nil Service is fine here.
 func TestScopeGates(t *testing.T) {
-	h := NewHandlers(nil, nil)
+	h := NewHandlers(nil, nil, nil)
 	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -58,7 +87,7 @@ func TestScopeGates(t *testing.T) {
 // admin bypasses, and a non-admin without a cwd param is rejected up
 // front (project-enumeration prevention).
 func TestRequireConnCwd(t *testing.T) {
-	h := NewHandlers(nil, nil)
+	h := NewHandlers(nil, nil, nil)
 
 	tests := []struct {
 		name    string
@@ -87,6 +116,68 @@ func TestRequireConnCwd(t *testing.T) {
 			got := h.requireConnCwd(rec, req)
 			if got != tt.allowed {
 				t.Fatalf("requireConnCwd = %v, want %v (status %d)", got, tt.allowed, rec.Code)
+			}
+		})
+	}
+}
+
+// The HMAC cwd proof: only a signature computed under the server secret
+// for that exact cwd verifies. This is what closes the "extract key +
+// forge cwd" residual for signed-key providers.
+func TestVerifyCwdSig(t *testing.T) {
+	secret := []byte("test-secret-0123456789abcdef")
+	cwd := "/Users/x/project"
+	sig := signCwd(secret, cwd)
+
+	if !verifyCwdSig(secret, cwd, sig) {
+		t.Fatal("valid signature rejected")
+	}
+	for name, bad := range map[string]string{
+		"empty":        "",
+		"tampered":     sig + "00",
+		"wrong length": sig[:len(sig)-2],
+		"not hex":      "zzzz",
+	} {
+		if verifyCwdSig(secret, cwd, bad) {
+			t.Fatalf("%s signature accepted", name)
+		}
+	}
+	if verifyCwdSig(secret, "/other/cwd", sig) {
+		t.Fatal("signature for a different cwd accepted")
+	}
+	if verifyCwdSig([]byte("a-different-secret-value"), cwd, sig) {
+		t.Fatal("signature under a different secret accepted")
+	}
+}
+
+// A db:signed key (per-session-config provider) MUST present a valid
+// signature; a missing or wrong one is rejected before the service is
+// touched (so a nil svc is safe here).
+func TestRequireConnCwdSignatureEnforced(t *testing.T) {
+	secret := []byte("sign-secret-abcdefghijklmnop")
+	h := NewHandlers(nil, secret, nil)
+	signed := integration.Principal{
+		Kind:   integration.KindIntegration,
+		Scopes: []string{ScopeDBRead, ScopeDBSigned},
+	}
+
+	cases := map[string]string{
+		"no signature":    "",
+		"wrong signature": "deadbeef",
+	}
+	for name, sig := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/x?cwd=/proj", nil)
+			if sig != "" {
+				req.Header.Set(cwdSigHeader, sig)
+			}
+			req = req.WithContext(integration.WithPrincipal(req.Context(), signed))
+			rec := httptest.NewRecorder()
+			if h.requireConnCwd(rec, req) {
+				t.Fatalf("%s: signed key was allowed", name)
+			}
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("%s: status = %d, want 403", name, rec.Code)
 			}
 		})
 	}

--- a/internal/dbtool/postgres.go
+++ b/internal/dbtool/postgres.go
@@ -178,7 +178,15 @@ func (postgresDriver) TableMeta(ctx context.Context, h Handle, schema, table str
 	defer cancel()
 	meta := TableMeta{Schema: schema, Table: table}
 
-	rows, err := pool.Query(ctx, `
+	// One read-only snapshot so the four catalog queries (columns / PK /
+	// indexes / FKs) see a consistent view even if DDL runs concurrently.
+	tx, err := pool.BeginTx(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly})
+	if err != nil {
+		return meta, fmt.Errorf("dbtool: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	rows, err := tx.Query(ctx, `
 		SELECT column_name, data_type, is_nullable = 'YES',
 		       COALESCE(column_default, ''), ordinal_position
 		FROM information_schema.columns
@@ -203,7 +211,7 @@ func (postgresDriver) TableMeta(ctx context.Context, h Handle, schema, table str
 		return meta, fmt.Errorf("dbtool: table %s.%s not found", schema, table)
 	}
 
-	pkRows, err := pool.Query(ctx, `
+	pkRows, err := tx.Query(ctx, `
 		SELECT a.attname
 		FROM pg_index i
 		JOIN pg_class c ON c.oid = i.indrelid
@@ -227,7 +235,7 @@ func (postgresDriver) TableMeta(ctx context.Context, h Handle, schema, table str
 		return meta, err
 	}
 
-	idxRows, err := pool.Query(ctx, `
+	idxRows, err := tx.Query(ctx, `
 		SELECT ci.relname, pg_get_indexdef(i.indexrelid), i.indisunique, i.indisprimary
 		FROM pg_index i
 		JOIN pg_class c  ON c.oid  = i.indrelid
@@ -251,7 +259,7 @@ func (postgresDriver) TableMeta(ctx context.Context, h Handle, schema, table str
 		return meta, err
 	}
 
-	fkRows, err := pool.Query(ctx, `
+	fkRows, err := tx.Query(ctx, `
 		SELECT con.conname,
 		       (SELECT array_agg(a.attname ORDER BY x.ord)
 		        FROM unnest(con.conkey) WITH ORDINALITY AS x(attnum, ord)

--- a/internal/store/migrations/0074_kb_integrations_dbtool_signing.sql
+++ b/internal/store/migrations/0074_kb_integrations_dbtool_signing.sql
@@ -1,3 +1,26 @@
+-- 0074 — kb_integrations refresh: the Database tool's per-session cwd
+-- binding is now cryptographic for opendray's own auto-attached MCP.
+-- The opendray-dbtool key is db:signed; per session opendray injects an
+-- X-OpenDray-Dbtool-Sig = HMAC(server-secret, cwd) header and the gateway
+-- rejects a signed-key call whose signature doesn't match cwd — closing
+-- the "extract key + forge cwd" residual for per-session-config providers.
+-- Antigravity (HOME-global MCP config) and third-party integration keys
+-- keep the plain ?cwd= check. New scope row: db:signed.
+--
+-- Why a new migration instead of editing 0073: the runner records applied
+-- versions by filename and never re-applies one. This force-updates the
+-- page (DO UPDATE), keeping updated_by='operator' so the AI KB drafter
+-- still treats it as human-locked.
+--
+-- Source of truth: docs/integrations/INTEGRATION_GUIDE.md — regenerated,
+-- do not hand-edit this heredoc.
+
+INSERT INTO project_docs (id, cwd, kind, content, updated_by, updated_at)
+VALUES (
+    'doc_global_kb_integrations',
+    '__global__',
+    'kb_integrations',
+    $ODGUIDE$
 # opendray Third-Party Integration Guide
 
 This is the canonical, forward-looking contract that **every** third-party app or website MUST follow to integrate with opendray. opendray is a self-hosted gateway that drives AI coding CLIs (Claude Code, Codex, OpenCode, antigravity) over a PTY behind a unified REST + WebSocket API. A third-party app integrates by being **registered by an operator** (admin-only), receiving a **one-time scoped API key**, and then spawning and driving agent sessions over REST while optionally proxying its own UI and subscribing to a live event stream. This document states the rules as explicit **MUST / SHOULD / NEVER**, documents the current reality honestly (including what is *not* enforced yet), and gives you a runnable end-to-end path.
@@ -865,3 +888,11 @@ This guide describes the opendray `/api/v1` integration contract as of **opendra
 - **Roadmap:** per-route scope enforcement for the still-unenforced `session:*` / `channel:*` / `provider:read`. Design your client now to handle `403` on any endpoint without breaking.
 
 When the code changes (new enforced scopes, spawn-profile fields, memory-zone semantics, or any endpoint addition), this guide MUST be updated in lockstep and re-seeded into the `kb_integrations` knowledge page (add a new `project_docs` upsert migration — the original seed migration is immutable once applied).
+$ODGUIDE$,
+    'operator',
+    NOW()
+)
+ON CONFLICT (cwd, kind) DO UPDATE
+    SET content    = EXCLUDED.content,
+        updated_by = EXCLUDED.updated_by,
+        updated_at = EXCLUDED.updated_at;


### PR DESCRIPTION
## Summary

Three backend follow-ups to the Database tool (#419), from that PR's review.

## 1. Cryptographic per-project isolation (security)

Closes the residual the honest-path `?cwd=` check left open: an agent that extracts the shared auto-attached dbtool key could otherwise forge another project's `cwd`.

- The `opendray-dbtool` MCP key is now **`db:signed`**. Per session, opendray injects `X-OpenDray-Dbtool-Sig = HMAC(server-secret, cwd)`; the gateway rejects a signed-key call whose signature doesn't match `cwd`. The agent has no signing secret, so it can't forge another cwd — cross-project access is genuinely closed.
- **Antigravity can't do this** — its MCP config is HOME-global (a documented Google limitation; there's an open per-workspace-config feature request on Google's forum), so it gets a **separate honest-path key** (`opendray-dbtool-agy`, no `db:signed`). Third-party integration keys likewise use the honest-path `?cwd=` check.
- Secret at `~/.opendray/dbtool-sign.key` (32 bytes) — server-side only, never in the DB, never injected into a session. HMAC compared constant-time (`hmac.Equal`).

> We verified the antigravity HOME-global limitation against Google's own docs + developer forum before designing the two-key split, rather than assuming it.

## 2. Bigint primary keys stay exact (fix)

Row update/delete/filter values decode JSON with `UseNumber` and normalize to `int64`, so a 64-bit PK above 2^53 is no longer rounded through `float64` (which could address the wrong row or match none). Integers beyond int64 keep their exact string; fractionals stay float64.

## 3. TableMeta snapshot (fix)

`TableMeta`'s four catalog queries (columns / PK / indexes / FKs) now run inside one read-only transaction, so concurrent DDL can't produce a half-updated view.

## Test plan

- [x] `go build ./...`, `go vet`, `golangci-lint` — all clean.
- [x] Unit: HMAC sign/verify round-trip + tamper / wrong-cwd / wrong-secret / non-hex rejection; a `db:signed` key is rejected without a valid signature; bigint normalization (2^53+1, int64-max in a map, beyond-int64 → exact string).
- [x] Integration tests against real PostgreSQL (introspection / CRUD / read-only-transaction fence) pass; `TableMeta` now transactional.
- [x] Migration `0074` applies + is idempotent on ephemeral pg17.

## Deploy note

On upgrade the existing signed key gains `db:signed` (scope reconcile), a new `opendray-dbtool-agy` key is minted, and the sign secret is generated on first boot — no operator action. CI has no PostgreSQL service, so DB-gated tests `t.Skip` there (validated locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
