### PR TITLE
feat(dbtool): MySQL, MariaDB and SQLite support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+### Added
+
+- **Database tool — MySQL, MariaDB and SQLite.** The Database tool now
+  connects to MySQL and MariaDB (host/port/username like PostgreSQL; a
+  MySQL "schema" is a database) and SQLite in addition to PostgreSQL. The
+  connection form (web and mobile) gains an engine picker with per-engine
+  default ports. **SQLite is a file-path connection**: the path is fenced
+  to the connection's project `cwd` (a path escaping it via `../` or a
+  symlink is rejected) and extension loading is disabled. Reads run behind
+  the same read-only fence on every engine (SQLite via a dedicated
+  read-only connection pool). All engines are pure-Go drivers
+  (`go-sql-driver/mysql`, `modernc.org/sqlite`), so the binary still
+  cross-compiles without cgo. Migration `0075` widens the driver
+  constraint; `0076` reseeds the kb_integrations page.
+
 ## [v2.11.1] — 2026-07-09
 
 ### Added

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -3032,10 +3032,19 @@
         "test": "Test",
         "save": "Save",
         "testFailed": "Connection test failed",
-        "testOk": "Connected — PostgreSQL {version} ({ms} ms)",
+        "testOk": "Connected — {version} ({ms} ms)",
         "savedCreate": "Connection added",
         "savedEdit": "Connection updated",
-        "missingFields": "Name, host, database and username are required"
+        "missingFields": "Name and database are required (plus host and username for server engines)",
+        "driver": "Database engine",
+        "drivers": {
+          "postgres": "PostgreSQL",
+          "mysql": "MySQL",
+          "mariadb": "MariaDB",
+          "sqlite": "SQLite"
+        },
+        "filePath": "Database file",
+        "filePathHint": "Path to a SQLite file, inside the project directory."
       },
       "results": {
         "noColumns": "{command} — {rows} row(s) affected"

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -3032,10 +3032,19 @@
         "test": "Probar",
         "save": "Guardar",
         "testFailed": "La prueba de conexión falló",
-        "testOk": "Conectado — PostgreSQL {version} ({ms} ms)",
+        "testOk": "Conectado — {version} ({ms} ms)",
         "savedCreate": "Conexión añadida",
         "savedEdit": "Conexión actualizada",
-        "missingFields": "Nombre, host, base de datos y usuario son obligatorios"
+        "missingFields": "El nombre y la base de datos son obligatorios (más host y usuario para motores de servidor)",
+        "driver": "Motor de base de datos",
+        "drivers": {
+          "postgres": "PostgreSQL",
+          "mysql": "MySQL",
+          "mariadb": "MariaDB",
+          "sqlite": "SQLite"
+        },
+        "filePath": "Archivo de base de datos",
+        "filePathHint": "Ruta a un archivo SQLite, dentro del directorio del proyecto."
       },
       "results": {
         "noColumns": "{command} — {rows} fila(s) afectada(s)"

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -3032,10 +3032,19 @@
         "test": "测试",
         "save": "保存",
         "testFailed": "连接测试失败",
-        "testOk": "已连接 —— PostgreSQL {version}({ms} 毫秒)",
+        "testOk": "已连接 — {version}（{ms} ms）",
         "savedCreate": "连接已添加",
         "savedEdit": "连接已更新",
-        "missingFields": "名称、主机、数据库和用户名为必填项"
+        "missingFields": "需要填写名称和数据库（服务器引擎还需主机和用户名）",
+        "driver": "数据库类型",
+        "drivers": {
+          "postgres": "PostgreSQL",
+          "mysql": "MySQL",
+          "mariadb": "MariaDB",
+          "sqlite": "SQLite"
+        },
+        "filePath": "数据库文件",
+        "filePathHint": "项目目录内的 SQLite 文件路径。"
       },
       "results": {
         "noColumns": "{command} —— 影响 {rows} 行"

--- a/app/mobile/lib/core/api/dbtool_api.dart
+++ b/app/mobile/lib/core/api/dbtool_api.dart
@@ -264,12 +264,14 @@ class DbConnectionInput {
     required this.dbName,
     required this.username,
     required this.password,
+    this.driver = 'postgres',
     this.sslMode = 'prefer',
     this.readOnly = false,
   });
 
   final String cwd;
   final String name;
+  final String driver;
   final String host;
   final int port;
   final String dbName;
@@ -281,7 +283,7 @@ class DbConnectionInput {
   Map<String, dynamic> toJson() => {
     'cwd': cwd,
     'name': name,
-    'driver': 'postgres',
+    'driver': driver,
     'host': host,
     'port': port,
     'db_name': dbName,

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 11895 (3965 per locale)
+/// Strings: 11916 (3972 per locale)
 ///
-/// Built on 2026-07-08 at 15:00 UTC
+/// Built on 2026-07-09 at 00:05 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -11638,8 +11638,8 @@ class TranslationsWebDatabaseDialogEn {
 	/// en: 'Connection test failed'
 	String get testFailed => 'Connection test failed';
 
-	/// en: 'Connected — PostgreSQL {version} ({ms} ms)'
-	String testOk({required Object version, required Object ms}) => 'Connected — PostgreSQL ${version} (${ms} ms)';
+	/// en: 'Connected — {version} ({ms} ms)'
+	String testOk({required Object version, required Object ms}) => 'Connected — ${version} (${ms} ms)';
 
 	/// en: 'Connection added'
 	String get savedCreate => 'Connection added';
@@ -11647,8 +11647,19 @@ class TranslationsWebDatabaseDialogEn {
 	/// en: 'Connection updated'
 	String get savedEdit => 'Connection updated';
 
-	/// en: 'Name, host, database and username are required'
-	String get missingFields => 'Name, host, database and username are required';
+	/// en: 'Name and database are required (plus host and username for server engines)'
+	String get missingFields => 'Name and database are required (plus host and username for server engines)';
+
+	/// en: 'Database engine'
+	String get driver => 'Database engine';
+
+	late final TranslationsWebDatabaseDialogDriversEn drivers = TranslationsWebDatabaseDialogDriversEn.internal(_root);
+
+	/// en: 'Database file'
+	String get filePath => 'Database file';
+
+	/// en: 'Path to a SQLite file, inside the project directory.'
+	String get filePathHint => 'Path to a SQLite file, inside the project directory.';
 }
 
 // Path: web.database.results
@@ -17058,6 +17069,27 @@ class TranslationsWebCortexSettingsInjectionEn {
 	String get note => 'Per-section and per-page inject flags (blueprint editor / knowledge pages) still apply in full mode; in lean mode foundational rules always inject and everything else is indexed.';
 }
 
+// Path: web.database.dialog.drivers
+class TranslationsWebDatabaseDialogDriversEn {
+	TranslationsWebDatabaseDialogDriversEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'PostgreSQL'
+	String get postgres => 'PostgreSQL';
+
+	/// en: 'MySQL'
+	String get mysql => 'MySQL';
+
+	/// en: 'MariaDB'
+	String get mariadb => 'MariaDB';
+
+	/// en: 'SQLite'
+	String get sqlite => 'SQLite';
+}
+
 // Path: sessions.inspector.shell.tabs
 class TranslationsSessionsInspectorShellTabsEn {
 	TranslationsSessionsInspectorShellTabsEn.internal(this._root);
@@ -19565,10 +19597,17 @@ extension on Translations {
 			'web.database.dialog.test' => 'Test',
 			'web.database.dialog.save' => 'Save',
 			'web.database.dialog.testFailed' => 'Connection test failed',
-			'web.database.dialog.testOk' => ({required Object version, required Object ms}) => 'Connected — PostgreSQL ${version} (${ms} ms)',
+			'web.database.dialog.testOk' => ({required Object version, required Object ms}) => 'Connected — ${version} (${ms} ms)',
 			'web.database.dialog.savedCreate' => 'Connection added',
 			'web.database.dialog.savedEdit' => 'Connection updated',
-			'web.database.dialog.missingFields' => 'Name, host, database and username are required',
+			'web.database.dialog.missingFields' => 'Name and database are required (plus host and username for server engines)',
+			'web.database.dialog.driver' => 'Database engine',
+			'web.database.dialog.drivers.postgres' => 'PostgreSQL',
+			'web.database.dialog.drivers.mysql' => 'MySQL',
+			'web.database.dialog.drivers.mariadb' => 'MariaDB',
+			'web.database.dialog.drivers.sqlite' => 'SQLite',
+			'web.database.dialog.filePath' => 'Database file',
+			'web.database.dialog.filePathHint' => 'Path to a SQLite file, inside the project directory.',
 			'web.database.results.noColumns' => ({required Object command, required Object rows}) => '${command} — ${rows} row(s) affected',
 			'web.database.tree.loading' => 'Loading schemas…',
 			'web.database.tree.noSchemas' => 'No schemas visible to this user',
@@ -19740,6 +19779,8 @@ extension on Translations {
 			'sessions.detail.accountSwitcher.confirmBody' => 'This restarts the CLI under the new account — the current in-CLI conversation context is lost (the session tab is kept).',
 			'sessions.detail.accountSwitcher.confirmAction' => 'Switch',
 			'sessions.detail.accountSwitcher.cancel' => 'Cancel',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.detail.accountSwitcher.switchedSnack' => ({required Object account}) => 'Switched to ${account}',
 			'sessions.detail.accountSwitcher.switchFailed' => ({required Object error}) => 'Switch failed: ${error}',
 			'sessions.detail.accountSwitcher.noneHint' => 'No Claude accounts configured. Add them in More → Providers → Claude.',
@@ -19747,8 +19788,6 @@ extension on Translations {
 			'sessions.detail.accountSwitcher.sheetTitleAgy' => 'Switch Antigravity account',
 			'sessions.detail.accountSwitcher.confirmBodyAgy' => 'This restarts the Antigravity CLI under a fresh conversation — the in-CLI history doesn\'t carry across accounts (the session tab is kept).',
 			'sessions.detail.accountSwitcher.noneHintAgy' => 'No Antigravity accounts configured. Add them in More → Providers → Antigravity.',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.terminal.snackbar.imagePickerFailed' => ({required Object error}) => 'Image picker failed: ${error}',
 			'sessions.terminal.snackbar.uploadingImage' => 'Uploading image…',
 			'sessions.terminal.snackbar.imageAttached' => ({required Object path}) => 'Image attached: ${path}',
@@ -20254,6 +20293,8 @@ extension on Translations {
 			'project.browseFolder' => 'Browse folder…',
 			'project.resetTooltip' => 'Reset project memory',
 			'project.append' => 'Append',
+			_ => null,
+		} ?? switch (path) {
 			'project.appendDialogTitle' => 'Append journal entry',
 			'project.titleFieldLabel' => 'Title (optional)',
 			'project.contentFieldLabel' => 'Content (markdown)',
@@ -20261,8 +20302,6 @@ extension on Translations {
 			'project.approveFailed' => ({required Object error}) => 'Approve failed: ${error}',
 			'project.rejectFailed' => ({required Object error}) => 'Reject failed: ${error}',
 			'project.resetConfirmTitle' => 'Reset project memory?',
-			_ => null,
-		} ?? switch (path) {
 			'project.alsoDeleteScanner' => 'Also delete scanner docs',
 			'project.alsoDeletePgvector' => 'Also delete pgvector memories',
 			'project.deleteForever' => 'Delete forever',
@@ -20768,6 +20807,8 @@ extension on Translations {
 			'notesPage.deleteTitle' => 'Delete note?',
 			'notesPage.deletedSnack' => ({required Object path}) => 'Deleted ${path}',
 			'notesPage.deleteFailedApi' => ({required Object error}) => 'Delete failed: ${error}',
+			_ => null,
+		} ?? switch (path) {
 			'notesPage.deleteFailedGeneric' => ({required Object error}) => 'Delete failed: ${error}',
 			'notesPage.createFailedApi' => ({required Object error}) => 'Create failed: ${error}',
 			'notesPage.createFailedGeneric' => ({required Object error}) => 'Create failed: ${error}',
@@ -20775,8 +20816,6 @@ extension on Translations {
 			'notesPage.pathHint' => 'personal/scratch.md',
 			'notesPage.create' => 'Create',
 			'notesPage.popupDelete' => 'Delete',
-			_ => null,
-		} ?? switch (path) {
 			'notesPage.deleteBody' => 'This is irreversible. Vault git sync will remove the file on the gateway host too.',
 			'notesPage.emptyFilterMatch' => ({required Object query}) => 'No notes match "${query}".',
 			'notesPage.emptyVault' => 'Vault is empty. Tap + to create your first note.',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -5915,10 +5915,14 @@ class _TranslationsWebDatabaseDialogEs extends TranslationsWebDatabaseDialogEn {
 	@override String get test => 'Probar';
 	@override String get save => 'Guardar';
 	@override String get testFailed => 'La prueba de conexión falló';
-	@override String testOk({required Object version, required Object ms}) => 'Conectado — PostgreSQL ${version} (${ms} ms)';
+	@override String testOk({required Object version, required Object ms}) => 'Conectado — ${version} (${ms} ms)';
 	@override String get savedCreate => 'Conexión añadida';
 	@override String get savedEdit => 'Conexión actualizada';
-	@override String get missingFields => 'Nombre, host, base de datos y usuario son obligatorios';
+	@override String get missingFields => 'El nombre y la base de datos son obligatorios (más host y usuario para motores de servidor)';
+	@override String get driver => 'Motor de base de datos';
+	@override late final _TranslationsWebDatabaseDialogDriversEs drivers = _TranslationsWebDatabaseDialogDriversEs._(_root);
+	@override String get filePath => 'Archivo de base de datos';
+	@override String get filePathHint => 'Ruta a un archivo SQLite, dentro del directorio del proyecto.';
 }
 
 // Path: web.database.results
@@ -9051,6 +9055,19 @@ class _TranslationsWebCortexSettingsInjectionEs extends TranslationsWebCortexSet
 	@override String get note => 'En modo completo siguen aplicando los flags de inyección por sección/página; en modo ligero las reglas fundacionales siempre se inyectan y el resto va al índice.';
 }
 
+// Path: web.database.dialog.drivers
+class _TranslationsWebDatabaseDialogDriversEs extends TranslationsWebDatabaseDialogDriversEn {
+	_TranslationsWebDatabaseDialogDriversEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get postgres => 'PostgreSQL';
+	@override String get mysql => 'MySQL';
+	@override String get mariadb => 'MariaDB';
+	@override String get sqlite => 'SQLite';
+}
+
 // Path: sessions.inspector.shell.tabs
 class _TranslationsSessionsInspectorShellTabsEs extends TranslationsSessionsInspectorShellTabsEn {
 	_TranslationsSessionsInspectorShellTabsEs._(TranslationsEs root) : this._root = root, super.internal(root);
@@ -11520,10 +11537,17 @@ extension on TranslationsEs {
 			'web.database.dialog.test' => 'Probar',
 			'web.database.dialog.save' => 'Guardar',
 			'web.database.dialog.testFailed' => 'La prueba de conexión falló',
-			'web.database.dialog.testOk' => ({required Object version, required Object ms}) => 'Conectado — PostgreSQL ${version} (${ms} ms)',
+			'web.database.dialog.testOk' => ({required Object version, required Object ms}) => 'Conectado — ${version} (${ms} ms)',
 			'web.database.dialog.savedCreate' => 'Conexión añadida',
 			'web.database.dialog.savedEdit' => 'Conexión actualizada',
-			'web.database.dialog.missingFields' => 'Nombre, host, base de datos y usuario son obligatorios',
+			'web.database.dialog.missingFields' => 'El nombre y la base de datos son obligatorios (más host y usuario para motores de servidor)',
+			'web.database.dialog.driver' => 'Motor de base de datos',
+			'web.database.dialog.drivers.postgres' => 'PostgreSQL',
+			'web.database.dialog.drivers.mysql' => 'MySQL',
+			'web.database.dialog.drivers.mariadb' => 'MariaDB',
+			'web.database.dialog.drivers.sqlite' => 'SQLite',
+			'web.database.dialog.filePath' => 'Archivo de base de datos',
+			'web.database.dialog.filePathHint' => 'Ruta a un archivo SQLite, dentro del directorio del proyecto.',
 			'web.database.results.noColumns' => ({required Object command, required Object rows}) => '${command} — ${rows} fila(s) afectada(s)',
 			'web.database.tree.loading' => 'Cargando esquemas…',
 			'web.database.tree.noSchemas' => 'No hay esquemas visibles para este usuario',
@@ -11695,6 +11719,8 @@ extension on TranslationsEs {
 			'sessions.detail.accountSwitcher.confirmBody' => 'Esto reinicia el CLI con la nueva cuenta — se pierde el contexto de conversación actual dentro del CLI (la pestaña de la sesión se conserva).',
 			'sessions.detail.accountSwitcher.confirmAction' => 'Cambiar',
 			'sessions.detail.accountSwitcher.cancel' => 'Cancelar',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.detail.accountSwitcher.switchedSnack' => ({required Object account}) => 'Cambiado a ${account}',
 			'sessions.detail.accountSwitcher.switchFailed' => ({required Object error}) => 'Cambio fallido: ${error}',
 			'sessions.detail.accountSwitcher.noneHint' => 'No hay cuentas de Claude configuradas. Agrégalas en Más → Providers → Claude.',
@@ -11702,8 +11728,6 @@ extension on TranslationsEs {
 			'sessions.detail.accountSwitcher.sheetTitleAgy' => 'Cambiar de cuenta de Antigravity',
 			'sessions.detail.accountSwitcher.confirmBodyAgy' => 'Esto reinicia el CLI de Antigravity con una conversación nueva — el historial dentro del CLI no se traslada entre cuentas (la pestaña de la sesión se conserva).',
 			'sessions.detail.accountSwitcher.noneHintAgy' => 'No hay cuentas de Antigravity configuradas. Agrégalas en Más → Providers → Antigravity.',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.terminal.snackbar.imagePickerFailed' => ({required Object error}) => 'Falló el selector de imágenes: ${error}',
 			'sessions.terminal.snackbar.uploadingImage' => 'Subiendo imagen…',
 			'sessions.terminal.snackbar.imageAttached' => ({required Object path}) => 'Imagen adjuntada: ${path}',
@@ -12209,6 +12233,8 @@ extension on TranslationsEs {
 			'project.browseFolder' => 'Explorar carpeta…',
 			'project.resetTooltip' => 'Restablecer la memoria del proyecto',
 			'project.append' => 'Añadir',
+			_ => null,
+		} ?? switch (path) {
 			'project.appendDialogTitle' => 'Añadir entrada de diario',
 			'project.titleFieldLabel' => 'Título (opcional)',
 			'project.contentFieldLabel' => 'Contenido (markdown)',
@@ -12216,8 +12242,6 @@ extension on TranslationsEs {
 			'project.approveFailed' => ({required Object error}) => 'Error al aprobar: ${error}',
 			'project.rejectFailed' => ({required Object error}) => 'Error al rechazar: ${error}',
 			'project.resetConfirmTitle' => '¿Restablecer la memoria del proyecto?',
-			_ => null,
-		} ?? switch (path) {
 			'project.alsoDeleteScanner' => 'Eliminar también los documentos del scanner',
 			'project.alsoDeletePgvector' => 'Eliminar también las memorias de pgvector',
 			'project.deleteForever' => 'Eliminar para siempre',
@@ -12723,6 +12747,8 @@ extension on TranslationsEs {
 			'notesPage.deleteTitle' => '¿Eliminar nota?',
 			'notesPage.deletedSnack' => ({required Object path}) => 'Eliminado ${path}',
 			'notesPage.deleteFailedApi' => ({required Object error}) => 'Error al eliminar: ${error}',
+			_ => null,
+		} ?? switch (path) {
 			'notesPage.deleteFailedGeneric' => ({required Object error}) => 'Error al eliminar: ${error}',
 			'notesPage.createFailedApi' => ({required Object error}) => 'Error al crear: ${error}',
 			'notesPage.createFailedGeneric' => ({required Object error}) => 'Error al crear: ${error}',
@@ -12730,8 +12756,6 @@ extension on TranslationsEs {
 			'notesPage.pathHint' => 'personal/scratch.md',
 			'notesPage.create' => 'Crear',
 			'notesPage.popupDelete' => 'Eliminar',
-			_ => null,
-		} ?? switch (path) {
 			'notesPage.deleteBody' => 'Esto es irreversible. La sincronización git del vault también eliminará el archivo en el host del gateway.',
 			'notesPage.emptyFilterMatch' => ({required Object query}) => 'Ninguna nota coincide con "${query}".',
 			'notesPage.emptyVault' => 'El vault está vacío. Toca + para crear tu primera nota.',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -5915,10 +5915,14 @@ class _TranslationsWebDatabaseDialogZh extends TranslationsWebDatabaseDialogEn {
 	@override String get test => '测试';
 	@override String get save => '保存';
 	@override String get testFailed => '连接测试失败';
-	@override String testOk({required Object version, required Object ms}) => '已连接 —— PostgreSQL ${version}(${ms} 毫秒)';
+	@override String testOk({required Object version, required Object ms}) => '已连接 — ${version}（${ms} ms）';
 	@override String get savedCreate => '连接已添加';
 	@override String get savedEdit => '连接已更新';
-	@override String get missingFields => '名称、主机、数据库和用户名为必填项';
+	@override String get missingFields => '需要填写名称和数据库（服务器引擎还需主机和用户名）';
+	@override String get driver => '数据库类型';
+	@override late final _TranslationsWebDatabaseDialogDriversZh drivers = _TranslationsWebDatabaseDialogDriversZh._(_root);
+	@override String get filePath => '数据库文件';
+	@override String get filePathHint => '项目目录内的 SQLite 文件路径。';
 }
 
 // Path: web.database.results
@@ -9051,6 +9055,19 @@ class _TranslationsWebCortexSettingsInjectionZh extends TranslationsWebCortexSet
 	@override String get note => '完整模式下章节/知识页各自的注入开关（蓝图编辑器 / 知识页）仍然生效；精简模式下基础方针始终注入，其余一律走索引。';
 }
 
+// Path: web.database.dialog.drivers
+class _TranslationsWebDatabaseDialogDriversZh extends TranslationsWebDatabaseDialogDriversEn {
+	_TranslationsWebDatabaseDialogDriversZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get postgres => 'PostgreSQL';
+	@override String get mysql => 'MySQL';
+	@override String get mariadb => 'MariaDB';
+	@override String get sqlite => 'SQLite';
+}
+
 // Path: sessions.inspector.shell.tabs
 class _TranslationsSessionsInspectorShellTabsZh extends TranslationsSessionsInspectorShellTabsEn {
 	_TranslationsSessionsInspectorShellTabsZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -11520,10 +11537,17 @@ extension on TranslationsZh {
 			'web.database.dialog.test' => '测试',
 			'web.database.dialog.save' => '保存',
 			'web.database.dialog.testFailed' => '连接测试失败',
-			'web.database.dialog.testOk' => ({required Object version, required Object ms}) => '已连接 —— PostgreSQL ${version}(${ms} 毫秒)',
+			'web.database.dialog.testOk' => ({required Object version, required Object ms}) => '已连接 — ${version}（${ms} ms）',
 			'web.database.dialog.savedCreate' => '连接已添加',
 			'web.database.dialog.savedEdit' => '连接已更新',
-			'web.database.dialog.missingFields' => '名称、主机、数据库和用户名为必填项',
+			'web.database.dialog.missingFields' => '需要填写名称和数据库（服务器引擎还需主机和用户名）',
+			'web.database.dialog.driver' => '数据库类型',
+			'web.database.dialog.drivers.postgres' => 'PostgreSQL',
+			'web.database.dialog.drivers.mysql' => 'MySQL',
+			'web.database.dialog.drivers.mariadb' => 'MariaDB',
+			'web.database.dialog.drivers.sqlite' => 'SQLite',
+			'web.database.dialog.filePath' => '数据库文件',
+			'web.database.dialog.filePathHint' => '项目目录内的 SQLite 文件路径。',
 			'web.database.results.noColumns' => ({required Object command, required Object rows}) => '${command} —— 影响 ${rows} 行',
 			'web.database.tree.loading' => '正在加载 schema…',
 			'web.database.tree.noSchemas' => '该用户无可见 schema',
@@ -11695,6 +11719,8 @@ extension on TranslationsZh {
 			'sessions.detail.accountSwitcher.confirmBody' => '这会用新账号重启 CLI——当前 CLI 内的对话上下文会丢失（会话标签保留）。',
 			'sessions.detail.accountSwitcher.confirmAction' => '切换',
 			'sessions.detail.accountSwitcher.cancel' => '取消',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.detail.accountSwitcher.switchedSnack' => ({required Object account}) => '已切换到 ${account}',
 			'sessions.detail.accountSwitcher.switchFailed' => ({required Object error}) => '切换失败：${error}',
 			'sessions.detail.accountSwitcher.noneHint' => '未配置 Claude 账号。请在 更多 → Providers → Claude 中添加。',
@@ -11702,8 +11728,6 @@ extension on TranslationsZh {
 			'sessions.detail.accountSwitcher.sheetTitleAgy' => '切换 Antigravity 账号',
 			'sessions.detail.accountSwitcher.confirmBodyAgy' => '这会用全新对话重启 Antigravity CLI——CLI 内的历史不会在账号间保留（会话标签保留）。',
 			'sessions.detail.accountSwitcher.noneHintAgy' => '未配置 Antigravity 账号。请在 更多 → Providers → Antigravity 中添加。',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.terminal.snackbar.imagePickerFailed' => ({required Object error}) => '图片选择失败：${error}',
 			'sessions.terminal.snackbar.uploadingImage' => '正在上传图片…',
 			'sessions.terminal.snackbar.imageAttached' => ({required Object path}) => '已附加图片：${path}',
@@ -12209,6 +12233,8 @@ extension on TranslationsZh {
 			'project.browseFolder' => '浏览文件夹…',
 			'project.resetTooltip' => '重置项目记忆',
 			'project.append' => '追加',
+			_ => null,
+		} ?? switch (path) {
 			'project.appendDialogTitle' => '追加日志条目',
 			'project.titleFieldLabel' => '标题（可选）',
 			'project.contentFieldLabel' => '内容（Markdown）',
@@ -12216,8 +12242,6 @@ extension on TranslationsZh {
 			'project.approveFailed' => ({required Object error}) => '批准失败：${error}',
 			'project.rejectFailed' => ({required Object error}) => '拒绝失败：${error}',
 			'project.resetConfirmTitle' => '重置项目记忆？',
-			_ => null,
-		} ?? switch (path) {
 			'project.alsoDeleteScanner' => '同时删除扫描器文档',
 			'project.alsoDeletePgvector' => '同时删除 pgvector 记忆',
 			'project.deleteForever' => '永久删除',
@@ -12723,6 +12747,8 @@ extension on TranslationsZh {
 			'notesPage.deleteTitle' => '删除笔记？',
 			'notesPage.deletedSnack' => ({required Object path}) => '已删除 ${path}',
 			'notesPage.deleteFailedApi' => ({required Object error}) => '删除失败：${error}',
+			_ => null,
+		} ?? switch (path) {
 			'notesPage.deleteFailedGeneric' => ({required Object error}) => '删除失败：${error}',
 			'notesPage.createFailedApi' => ({required Object error}) => '创建失败：${error}',
 			'notesPage.createFailedGeneric' => ({required Object error}) => '创建失败：${error}',
@@ -12730,8 +12756,6 @@ extension on TranslationsZh {
 			'notesPage.pathHint' => 'personal/scratch.md',
 			'notesPage.create' => '创建',
 			'notesPage.popupDelete' => '删除',
-			_ => null,
-		} ?? switch (path) {
 			'notesPage.deleteBody' => '此操作不可撤销。仓库的 git 同步会同时移除网关主机上的文件。',
 			'notesPage.emptyFilterMatch' => ({required Object query}) => '未找到匹配「${query}」的笔记。',
 			'notesPage.emptyVault' => '仓库为空。点击 + 创建第一条笔记。',

--- a/app/mobile/lib/features/database/database_tab.dart
+++ b/app/mobile/lib/features/database/database_tab.dart
@@ -128,9 +128,14 @@ class _DatabaseTabState extends ConsumerState<DatabaseTab> {
         ),
         trailing: PopupMenuButton<String>(
           onSelected: (v) {
+            if (v == 'edit') _openEditSheet(c);
             if (v == 'delete') _confirmDelete(c);
           },
           itemBuilder: (context) => [
+            PopupMenuItem(
+              value: 'edit',
+              child: Text(t.web.database.panel.edit),
+            ),
             PopupMenuItem(
               value: 'delete',
               child: Text(t.web.database.panel.delete),
@@ -184,19 +189,30 @@ class _DatabaseTabState extends ConsumerState<DatabaseTab> {
     if ((saved ?? false) && mounted) await _refresh();
   }
 
+  Future<void> _openEditSheet(DbConnection c) async {
+    final saved = await showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => _ConnectionForm(cwd: widget.cwd, existing: c),
+    );
+    if ((saved ?? false) && mounted) await _refresh();
+  }
+
   void _snack(String msg) {
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
   }
 }
 
-// _ConnectionForm is the add-connection bottom sheet: the minimal fields
-// plus a Test button. Editing an existing connection is web-only; mobile
-// stays add/delete for now.
+// _ConnectionForm is the add/edit-connection bottom sheet: the minimal
+// fields plus a Test button. When `existing` is set it edits that
+// connection (driver locked, password kept if left blank), mirroring the
+// web ConnectionDialog; otherwise it creates a new one.
 class _ConnectionForm extends ConsumerStatefulWidget {
-  const _ConnectionForm({required this.cwd});
+  const _ConnectionForm({required this.cwd, this.existing});
 
   final String cwd;
+  final DbConnection? existing;
 
   @override
   ConsumerState<_ConnectionForm> createState() => _ConnectionFormState();
@@ -223,6 +239,23 @@ class _ConnectionFormState extends ConsumerState<_ConnectionForm> {
   };
 
   bool get _isSqlite => _driver == 'sqlite';
+  bool get _editing => widget.existing != null;
+
+  @override
+  void initState() {
+    super.initState();
+    final e = widget.existing;
+    if (e != null) {
+      _name.text = e.name;
+      _driver = e.driver;
+      _host.text = e.host;
+      _port.text = e.driver == 'sqlite' ? '' : '${e.port}';
+      _db.text = e.dbName;
+      _user.text = e.username;
+      _readOnly = e.readOnly;
+      // password left blank — kept unless the user types a new one
+    }
+  }
 
   // Switching engine resets the port to that engine's default (SQLite is a
   // file path, no port) and clears the last ping.
@@ -281,11 +314,43 @@ class _ConnectionFormState extends ConsumerState<_ConnectionForm> {
     }
   }
 
+  // Edit patch mirrors the web dialog: SQLite carries only name / path /
+  // read_only; server engines carry host/port/user/ssl/read_only, and the
+  // password only when the user typed a new one (blank keeps the stored
+  // secret). ssl_mode is preserved from the existing connection (the mobile
+  // form has no ssl field).
+  Map<String, dynamic> _patch() {
+    if (_isSqlite) {
+      return {
+        'name': _name.text.trim(),
+        'db_name': _db.text.trim(),
+        'read_only': _readOnly,
+      };
+    }
+    final p = <String, dynamic>{
+      'name': _name.text.trim(),
+      'host': _host.text.trim(),
+      'port':
+          int.tryParse(_port.text.trim()) ?? (_defaultPorts[_driver] ?? 5432),
+      'db_name': _db.text.trim(),
+      'username': _user.text.trim(),
+      'ssl_mode': widget.existing!.sslMode,
+      'read_only': _readOnly,
+    };
+    if (_pass.text.isNotEmpty) p['password'] = _pass.text;
+    return p;
+  }
+
   Future<void> _save() async {
     if (!_valid) return;
     setState(() => _busy = true);
     try {
-      await ref.read(dbtoolApiProvider).createConnection(_input());
+      final api = ref.read(dbtoolApiProvider);
+      if (widget.existing != null) {
+        await api.updateConnection(widget.existing!.id, _patch());
+      } else {
+        await api.createConnection(_input());
+      }
       if (mounted) Navigator.of(context).pop(true);
     } on ApiException catch (e) {
       if (mounted) {
@@ -314,7 +379,7 @@ class _ConnectionFormState extends ConsumerState<_ConnectionForm> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Text(d.createTitle,
+            Text(_editing ? d.editTitle : d.createTitle,
                 style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 12),
             _field(_name, d.name, onChanged: () => setState(() {})),
@@ -336,7 +401,7 @@ class _ConnectionFormState extends ConsumerState<_ConnectionForm> {
                   };
                   return DropdownMenuItem(value: v, child: Text(label));
                 }).toList(),
-                onChanged: _onDriver,
+                onChanged: _editing ? null : _onDriver,
               ),
             ),
             if (!_isSqlite) ...[
@@ -358,7 +423,14 @@ class _ConnectionFormState extends ConsumerState<_ConnectionForm> {
               ),
             if (!_isSqlite) ...[
               _field(_user, d.username, onChanged: () => setState(() {})),
-              _field(_pass, d.password, obscure: true),
+              _field(
+                _pass,
+                d.password,
+                obscure: true,
+                hint: _editing && widget.existing!.hasPassword
+                    ? d.passwordKept
+                    : null,
+              ),
             ],
             SwitchListTile(
               contentPadding: EdgeInsets.zero,
@@ -408,6 +480,7 @@ class _ConnectionFormState extends ConsumerState<_ConnectionForm> {
     bool obscure = false,
     TextInputType? keyboard,
     VoidCallback? onChanged,
+    String? hint,
   }) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
@@ -418,6 +491,7 @@ class _ConnectionFormState extends ConsumerState<_ConnectionForm> {
         onChanged: onChanged == null ? null : (_) => onChanged(),
         decoration: InputDecoration(
           labelText: label,
+          hintText: hint,
           isDense: true,
           border: const OutlineInputBorder(),
         ),

--- a/app/mobile/lib/features/database/database_tab.dart
+++ b/app/mobile/lib/features/database/database_tab.dart
@@ -120,7 +120,9 @@ class _DatabaseTabState extends ConsumerState<DatabaseTab> {
         ),
         title: Text(c.name),
         subtitle: Text(
-          '${c.driver} · ${c.host}:${c.port}/${c.dbName}',
+          c.driver == 'sqlite'
+              ? '${c.driver} · ${c.dbName}'
+              : '${c.driver} · ${c.host}:${c.port}/${c.dbName}',
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
@@ -210,6 +212,28 @@ class _ConnectionFormState extends ConsumerState<_ConnectionForm> {
   bool _readOnly = false;
   bool _busy = false;
   DbPingResult? _ping;
+  String _driver = 'postgres';
+
+  static const _drivers = ['postgres', 'mysql', 'mariadb', 'sqlite'];
+  static const _defaultPorts = <String, int>{
+    'postgres': 5432,
+    'mysql': 3306,
+    'mariadb': 3306,
+    'sqlite': 0,
+  };
+
+  bool get _isSqlite => _driver == 'sqlite';
+
+  // Switching engine resets the port to that engine's default (SQLite is a
+  // file path, no port) and clears the last ping.
+  void _onDriver(String? v) {
+    if (v == null) return;
+    setState(() {
+      _driver = v;
+      _port.text = v == 'sqlite' ? '' : '${_defaultPorts[v] ?? 5432}';
+      _ping = null;
+    });
+  }
 
   @override
   void dispose() {
@@ -222,19 +246,22 @@ class _ConnectionFormState extends ConsumerState<_ConnectionForm> {
   DbConnectionInput _input() => DbConnectionInput(
     cwd: widget.cwd,
     name: _name.text.trim(),
-    host: _host.text.trim(),
-    port: int.tryParse(_port.text.trim()) ?? 5432,
+    driver: _driver,
+    host: _isSqlite ? '' : _host.text.trim(),
+    port: _isSqlite
+        ? 0
+        : (int.tryParse(_port.text.trim()) ?? (_defaultPorts[_driver] ?? 5432)),
     dbName: _db.text.trim(),
-    username: _user.text.trim(),
-    password: _pass.text,
+    username: _isSqlite ? '' : _user.text.trim(),
+    password: _isSqlite ? '' : _pass.text,
     readOnly: _readOnly,
   );
 
   bool get _valid =>
       _name.text.trim().isNotEmpty &&
-      _host.text.trim().isNotEmpty &&
       _db.text.trim().isNotEmpty &&
-      _user.text.trim().isNotEmpty;
+      (_isSqlite ||
+          (_host.text.trim().isNotEmpty && _user.text.trim().isNotEmpty));
 
   Future<void> _test() async {
     setState(() => _busy = true);
@@ -291,11 +318,48 @@ class _ConnectionFormState extends ConsumerState<_ConnectionForm> {
                 style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 12),
             _field(_name, d.name, onChanged: () => setState(() {})),
-            _field(_host, d.host),
-            _field(_port, d.port, keyboard: TextInputType.number),
-            _field(_db, d.database, onChanged: () => setState(() {})),
-            _field(_user, d.username, onChanged: () => setState(() {})),
-            _field(_pass, d.password, obscure: true),
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: DropdownButtonFormField<String>(
+                initialValue: _driver,
+                decoration: InputDecoration(
+                  labelText: d.driver,
+                  isDense: true,
+                  border: const OutlineInputBorder(),
+                ),
+                items: _drivers.map((v) {
+                  final label = switch (v) {
+                    'mysql' => d.drivers.mysql,
+                    'mariadb' => d.drivers.mariadb,
+                    'sqlite' => d.drivers.sqlite,
+                    _ => d.drivers.postgres,
+                  };
+                  return DropdownMenuItem(value: v, child: Text(label));
+                }).toList(),
+                onChanged: _onDriver,
+              ),
+            ),
+            if (!_isSqlite) ...[
+              _field(_host, d.host),
+              _field(_port, d.port, keyboard: TextInputType.number),
+            ],
+            _field(
+              _db,
+              _isSqlite ? d.filePath : d.database,
+              onChanged: () => setState(() {}),
+            ),
+            if (_isSqlite)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Text(
+                  d.filePathHint,
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ),
+            if (!_isSqlite) ...[
+              _field(_user, d.username, onChanged: () => setState(() {})),
+              _field(_pass, d.password, obscure: true),
+            ],
             SwitchListTile(
               contentPadding: EdgeInsets.zero,
               title: Text(d.readOnly),

--- a/app/shared/src/lib/database.ts
+++ b/app/shared/src/lib/database.ts
@@ -3,7 +3,29 @@
 // Wraps the /api/v1/dbtool/* endpoints via the shared api<T>() helper.
 import { api } from './api'
 
-export type DBDriver = 'postgres'
+export type DBDriver = 'postgres' | 'mysql' | 'mariadb' | 'sqlite'
+
+// Drivers offered in the connection form, in display order.
+export const DB_DRIVERS: readonly DBDriver[] = [
+  'postgres',
+  'mysql',
+  'mariadb',
+  'sqlite',
+]
+
+// Well-known default port per driver (0 for the file-based SQLite).
+export const DB_DEFAULT_PORTS: Record<DBDriver, number> = {
+  postgres: 5432,
+  mysql: 3306,
+  mariadb: 3306,
+  sqlite: 0,
+}
+
+// SQLite is a file-path connection (db_name is the path); the others use
+// host/port/username/password/ssl.
+export function driverUsesServer(driver: DBDriver): boolean {
+  return driver !== 'sqlite'
+}
 
 export interface DBConnection {
   id: string
@@ -150,6 +172,13 @@ export const DB_FILTER_OPS = [
 
 // Operators that don't take a value (the value input is hidden).
 export const DB_VALUELESS_OPS = new Set(['IS NULL', 'IS NOT NULL'])
+
+// Filter operators available for a given driver. ILIKE is PostgreSQL-only;
+// MySQL/SQLite reject it, so they get the shared subset.
+export function dbFilterOps(driver: DBDriver): readonly string[] {
+  if (driver === 'postgres') return DB_FILTER_OPS
+  return DB_FILTER_OPS.filter((op) => op !== 'ILIKE' && op !== 'NOT ILIKE')
+}
 
 export async function listConnections(cwd: string): Promise<DBConnection[]> {
   const res = await api<{ connections: DBConnection[] }>(

--- a/app/web/src/components/database/ConnectionDialog.tsx
+++ b/app/web/src/components/database/ConnectionDialog.tsx
@@ -27,8 +27,12 @@ import {
   createConnection,
   updateConnection,
   testConnectionParams,
+  DB_DRIVERS,
+  DB_DEFAULT_PORTS,
+  driverUsesServer,
   type DBConnection,
   type DBConnectionInput,
+  type DBDriver,
   type DBPingResult,
 } from '@/lib/database'
 
@@ -44,6 +48,7 @@ const SSL_MODES = ['disable', 'prefer', 'require', 'verify-ca', 'verify-full']
 
 interface FormState {
   name: string
+  driver: DBDriver
   host: string
   port: string
   db_name: string
@@ -55,6 +60,7 @@ interface FormState {
 
 const EMPTY: FormState = {
   name: '',
+  driver: 'postgres',
   host: '',
   port: '5432',
   db_name: '',
@@ -87,6 +93,7 @@ export function ConnectionDialog({
     if (connection) {
       setForm({
         name: connection.name,
+        driver: connection.driver,
         host: connection.host,
         port: String(connection.port),
         db_name: connection.db_name,
@@ -103,16 +110,29 @@ export function ConnectionDialog({
   const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
     setForm((f) => ({ ...f, [key]: value }))
 
+  // Switching driver resets the port to that engine's default (file-based
+  // SQLite has none) and clears the last ping.
+  const onDriverChange = (driver: DBDriver) => {
+    setPing(null)
+    setForm((f) => ({
+      ...f,
+      driver,
+      port: driverUsesServer(driver) ? String(DB_DEFAULT_PORTS[driver]) : '',
+    }))
+  }
+
+  const isSqlite = form.driver === 'sqlite'
+
   const toInput = (): DBConnectionInput => ({
     cwd,
     name: form.name.trim(),
-    driver: 'postgres',
-    host: form.host.trim(),
-    port: Number(form.port) || 5432,
+    driver: form.driver,
+    host: isSqlite ? '' : form.host.trim(),
+    port: isSqlite ? 0 : Number(form.port) || DB_DEFAULT_PORTS[form.driver],
     db_name: form.db_name.trim(),
-    username: form.username.trim(),
-    password: form.password,
-    ssl_mode: form.ssl_mode,
+    username: isSqlite ? '' : form.username.trim(),
+    password: isSqlite ? '' : form.password,
+    ssl_mode: isSqlite ? '' : form.ssl_mode,
     read_only: form.read_only,
   })
 
@@ -129,16 +149,22 @@ export function ConnectionDialog({
     mutationFn: () => {
       if (connection) {
         // Omit password when left blank so the stored secret is kept.
-        const patch = {
-          name: form.name.trim(),
-          host: form.host.trim(),
-          port: Number(form.port) || 5432,
-          db_name: form.db_name.trim(),
-          username: form.username.trim(),
-          ssl_mode: form.ssl_mode,
-          read_only: form.read_only,
-          ...(form.password ? { password: form.password } : {}),
-        }
+        const patch = isSqlite
+          ? {
+              name: form.name.trim(),
+              db_name: form.db_name.trim(),
+              read_only: form.read_only,
+            }
+          : {
+              name: form.name.trim(),
+              host: form.host.trim(),
+              port: Number(form.port) || DB_DEFAULT_PORTS[form.driver],
+              db_name: form.db_name.trim(),
+              username: form.username.trim(),
+              ssl_mode: form.ssl_mode,
+              read_only: form.read_only,
+              ...(form.password ? { password: form.password } : {}),
+            }
         return updateConnection(connection.id, patch)
       }
       return createConnection(toInput())
@@ -157,7 +183,11 @@ export function ConnectionDialog({
 
   const onSubmit = (e: FormEvent) => {
     e.preventDefault()
-    if (!form.name.trim() || !form.host.trim() || !form.db_name.trim() || !form.username.trim()) {
+    if (
+      !form.name.trim() ||
+      !form.db_name.trim() ||
+      (!isSqlite && (!form.host.trim() || !form.username.trim()))
+    ) {
       toast.error(t('web.database.dialog.missingFields'))
       return
     }
@@ -192,76 +222,117 @@ export function ConnectionDialog({
                 placeholder="prod-db"
               />
             </div>
-            <div className="col-span-2 sm:col-span-1">
-              <Label htmlFor="db-host">{t('web.database.dialog.host')}</Label>
-              <Input
-                id="db-host"
-                value={form.host}
-                onChange={(e) => set('host', e.target.value)}
-                placeholder="192.168.3.88"
-              />
-            </div>
-            <div>
-              <Label htmlFor="db-port">{t('web.database.dialog.port')}</Label>
-              <Input
-                id="db-port"
-                value={form.port}
-                onChange={(e) => set('port', e.target.value)}
-                inputMode="numeric"
-              />
-            </div>
-            <div>
-              <Label htmlFor="db-database">
-                {t('web.database.dialog.database')}
-              </Label>
-              <Input
-                id="db-database"
-                value={form.db_name}
-                onChange={(e) => set('db_name', e.target.value)}
-              />
-            </div>
-            <div>
-              <Label htmlFor="db-user">{t('web.database.dialog.username')}</Label>
-              <Input
-                id="db-user"
-                value={form.username}
-                onChange={(e) => set('username', e.target.value)}
-              />
-            </div>
-            <div className="col-span-2 sm:col-span-1">
-              <Label htmlFor="db-pass">
-                {t('web.database.dialog.password')}
-              </Label>
-              <Input
-                id="db-pass"
-                type="password"
-                value={form.password}
-                onChange={(e) => set('password', e.target.value)}
-                placeholder={
-                  editing && connection?.has_password
-                    ? t('web.database.dialog.passwordKept')
-                    : ''
-                }
-              />
-            </div>
-            <div>
-              <Label>{t('web.database.dialog.sslMode')}</Label>
+            <div className="col-span-2">
+              <Label>{t('web.database.dialog.driver')}</Label>
               <Select
-                value={form.ssl_mode}
-                onValueChange={(v) => set('ssl_mode', v)}
+                value={form.driver}
+                onValueChange={(v) => onDriverChange(v as DBDriver)}
+                disabled={editing}
               >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {SSL_MODES.map((m) => (
-                    <SelectItem key={m} value={m}>
-                      {m}
+                  {DB_DRIVERS.map((d) => (
+                    <SelectItem key={d} value={d}>
+                      {t(`web.database.dialog.drivers.${d}`)}
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
             </div>
+            {driverUsesServer(form.driver) && (
+              <>
+                <div className="col-span-2 sm:col-span-1">
+                  <Label htmlFor="db-host">
+                    {t('web.database.dialog.host')}
+                  </Label>
+                  <Input
+                    id="db-host"
+                    value={form.host}
+                    onChange={(e) => set('host', e.target.value)}
+                    placeholder="192.168.3.88"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="db-port">
+                    {t('web.database.dialog.port')}
+                  </Label>
+                  <Input
+                    id="db-port"
+                    value={form.port}
+                    onChange={(e) => set('port', e.target.value)}
+                    inputMode="numeric"
+                  />
+                </div>
+              </>
+            )}
+            <div className={isSqlite ? 'col-span-2' : ''}>
+              <Label htmlFor="db-database">
+                {isSqlite
+                  ? t('web.database.dialog.filePath')
+                  : t('web.database.dialog.database')}
+              </Label>
+              <Input
+                id="db-database"
+                value={form.db_name}
+                onChange={(e) => set('db_name', e.target.value)}
+                placeholder={isSqlite ? 'data/app.db' : ''}
+              />
+              {isSqlite && (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {t('web.database.dialog.filePathHint')}
+                </p>
+              )}
+            </div>
+            {driverUsesServer(form.driver) && (
+              <>
+                <div>
+                  <Label htmlFor="db-user">
+                    {t('web.database.dialog.username')}
+                  </Label>
+                  <Input
+                    id="db-user"
+                    value={form.username}
+                    onChange={(e) => set('username', e.target.value)}
+                  />
+                </div>
+                <div className="col-span-2 sm:col-span-1">
+                  <Label htmlFor="db-pass">
+                    {t('web.database.dialog.password')}
+                  </Label>
+                  <Input
+                    id="db-pass"
+                    type="password"
+                    value={form.password}
+                    onChange={(e) => set('password', e.target.value)}
+                    placeholder={
+                      editing && connection?.has_password
+                        ? t('web.database.dialog.passwordKept')
+                        : ''
+                    }
+                  />
+                </div>
+                <div>
+                  <Label>{t('web.database.dialog.sslMode')}</Label>
+                  <Select
+                    value={form.ssl_mode}
+                    onValueChange={(v) => set('ssl_mode', v)}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {SSL_MODES.map((m) => (
+                        <SelectItem key={m} value={m}>
+                          {m}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </>
+            )}
           </div>
 
           <div className="flex items-center gap-2">

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/daulet/tokenizers v1.27.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-chi/chi/v5 v5.2.5
+	github.com/go-sql-driver/mysql v1.10.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
@@ -24,6 +25,7 @@ require (
 )
 
 require (
+	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
+filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -22,6 +24,8 @@ github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
 github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
+github.com/go-sql-driver/mysql v1.10.0 h1:Q+1LV8DkHJvSYAdR83XzuhDaTykuDx0l6fkXxoWCWfw=
+github.com/go-sql-driver/mysql v1.10.0/go.mod h1:M+cqaI7+xxXGG9swrdeUIoPG3Y3KCkF0pZej+SK+nWk=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/internal/dbtool/classify.go
+++ b/internal/dbtool/classify.go
@@ -31,10 +31,12 @@ var ErrTxnControl = errors.New("dbtool: transaction control statements are not a
 
 // readLeaders are first keywords that make a statement a read on their own.
 var readLeaders = map[string]bool{
-	"SELECT": true,
-	"VALUES": true,
-	"TABLE":  true,
-	"SHOW":   true,
+	"SELECT":   true,
+	"VALUES":   true,
+	"TABLE":    true,
+	"SHOW":     true,
+	"DESCRIBE": true, // MySQL: describe a table (read-only introspection)
+	"DESC":     true,
 }
 
 // txnKeywords are rejected outright.
@@ -218,6 +220,23 @@ func tokenize(sql string) []string {
 			for i < n {
 				if src[i] == '"' {
 					if i+1 < n && src[i+1] == '"' {
+						i += 2
+						continue
+					}
+					i++
+					break
+				}
+				i++
+			}
+			tokens = append(tokens, `"ident"`)
+		case c == '`':
+			// MySQL/SQLite backtick identifier (doubled backtick escapes an
+			// inner one). Emitted as a placeholder so a backticked word like
+			// `update` never looks like a keyword to the classifier.
+			i++
+			for i < n {
+				if src[i] == '`' {
+					if i+1 < n && src[i+1] == '`' {
 						i += 2
 						continue
 					}

--- a/internal/dbtool/classify_test.go
+++ b/internal/dbtool/classify_test.go
@@ -19,6 +19,8 @@ func TestClassify(t *testing.T) {
 		{"values", "VALUES (1), (2)", ClassRead, nil},
 		{"table", "TABLE users", ClassRead, nil},
 		{"show", "SHOW search_path", ClassRead, nil},
+		{"describe", "DESCRIBE users", ClassRead, nil},
+		{"desc", "DESC users", ClassRead, nil},
 
 		{"line comment then select", "-- hi\nSELECT 1", ClassRead, nil},
 		{"block comment then select", "/* multi\nline */ SELECT 1", ClassRead, nil},
@@ -37,6 +39,7 @@ func TestClassify(t *testing.T) {
 		{"with delete tail", "WITH x AS (SELECT 1) DELETE FROM t", ClassWrite, nil},
 		{"with update in string literal", "WITH x AS (SELECT * FROM audit WHERE action = 'update') SELECT * FROM x", ClassRead, nil},
 		{"with quoted identifier named update", `WITH x AS (SELECT "update" FROM t) SELECT * FROM x`, ClassRead, nil},
+		{"with backtick identifier named update", "WITH x AS (SELECT `update` FROM t) SELECT * FROM x", ClassRead, nil},
 		{"with dollar-quoted insert text", "WITH x AS (SELECT $tag$INSERT INTO$tag$) SELECT * FROM x", ClassRead, nil},
 
 		{"explain select", "EXPLAIN SELECT 1", ClassRead, nil},

--- a/internal/dbtool/dbtool.go
+++ b/internal/dbtool/dbtool.go
@@ -354,6 +354,7 @@ func (s *Service) TestParams(ctx context.Context, p CreateParams) PingResult {
 		return PingResult{OK: false, Error: err.Error()}
 	}
 	c := Connection{
+		Cwd: p.Cwd, Driver: p.Driver,
 		Host: p.Host, Port: p.Port, DBName: p.DBName,
 		Username: p.Username, Password: p.Password, SSLMode: p.SSLMode,
 	}

--- a/internal/dbtool/dbtool.go
+++ b/internal/dbtool/dbtool.go
@@ -86,17 +86,17 @@ func NewService(store *Store, opts Options, log *slog.Logger) *Service {
 		log = slog.Default()
 	}
 	s := &Service{
-		store:   store,
-		opts:    opts,
-		log:     log.With("component", "dbtool"),
+		store: store,
+		opts:  opts,
+		log:   log.With("component", "dbtool"),
 		drivers: map[string]Driver{
 			"postgres": postgresDriver{},
 			"mysql":    mysqlDriver{},
 			"mariadb":  mysqlDriver{}, // same wire protocol as MySQL
 			"sqlite":   sqliteDriver{},
 		},
-		pools:   map[string]*poolEntry{},
-		stop:    make(chan struct{}),
+		pools: map[string]*poolEntry{},
+		stop:  make(chan struct{}),
 	}
 	go s.evictLoop()
 	return s

--- a/internal/dbtool/dbtool.go
+++ b/internal/dbtool/dbtool.go
@@ -25,8 +25,8 @@ var ErrWriteScope = errors.New("dbtool: statement modifies data — requires the
 // without a primary key.
 var ErrNoPrimaryKey = errors.New("dbtool: table has no primary key — row editing is disabled")
 
-// ErrUnsupportedDriver is returned for a driver name v1 doesn't ship.
-var ErrUnsupportedDriver = errors.New("dbtool: unsupported driver (v1 supports \"postgres\")")
+// ErrUnsupportedDriver is returned for a driver name we don't ship.
+var ErrUnsupportedDriver = errors.New("dbtool: unsupported driver (supported: postgres, mysql, mariadb, sqlite)")
 
 // Options are the service's runtime knobs, resolved from [dbtool] config.
 type Options struct {
@@ -89,7 +89,12 @@ func NewService(store *Store, opts Options, log *slog.Logger) *Service {
 		store:   store,
 		opts:    opts,
 		log:     log.With("component", "dbtool"),
-		drivers: map[string]Driver{"postgres": postgresDriver{}},
+		drivers: map[string]Driver{
+			"postgres": postgresDriver{},
+			"mysql":    mysqlDriver{},
+			"mariadb":  mysqlDriver{}, // same wire protocol as MySQL
+			"sqlite":   sqliteDriver{},
+		},
 		pools:   map[string]*poolEntry{},
 		stop:    make(chan struct{}),
 	}
@@ -223,6 +228,15 @@ func (p CreateParams) validate() error {
 	if strings.TrimSpace(p.Name) == "" {
 		return errors.New("dbtool: name is required")
 	}
+	// SQLite is a file-path connection: db_name holds the path (validated
+	// against the project cwd by the driver at Open time); there is no
+	// host / port / username.
+	if p.Driver == "sqlite" {
+		if strings.TrimSpace(p.DBName) == "" {
+			return errors.New("dbtool: sqlite requires a database file path")
+		}
+		return nil
+	}
 	if strings.TrimSpace(p.Host) == "" {
 		return errors.New("dbtool: host is required")
 	}
@@ -244,13 +258,26 @@ func (p *CreateParams) normalize() {
 		p.Driver = "postgres"
 	}
 	if p.Port == 0 {
-		p.Port = 5432
+		p.Port = defaultPort(p.Driver)
 	}
 	if p.SSLMode == "" {
 		p.SSLMode = "prefer"
 	}
 	if p.Options == nil {
 		p.Options = map[string]any{}
+	}
+}
+
+// defaultPort is the well-known port for a driver (0 for the file-based
+// SQLite, which has no port).
+func defaultPort(driver string) int {
+	switch driver {
+	case "mysql", "mariadb":
+		return 3306
+	case "sqlite":
+		return 0
+	default:
+		return 5432
 	}
 }
 

--- a/internal/dbtool/dialect.go
+++ b/internal/dbtool/dialect.go
@@ -56,8 +56,8 @@ type pgDialect struct{}
 func (pgDialect) QuoteIdent(parts ...string) string { return pgx.Identifier(parts).Sanitize() }
 func (pgDialect) Placeholder(n int) string          { return "$" + strconv.Itoa(n) }
 func (pgDialect) NullSafeEq() string                { return "IS NOT DISTINCT FROM" }
-func (pgDialect) SupportsReturning() bool            { return true }
-func (pgDialect) FilterOps() map[string]bool         { return pgFilterOps }
+func (pgDialect) SupportsReturning() bool           { return true }
+func (pgDialect) FilterOps() map[string]bool        { return pgFilterOps }
 
 // mysqlDialect — MySQL and MariaDB. Backtick identifiers, "?" params,
 // "<=>" null-safe equality. MySQL 8 has no RETURNING; MariaDB 10.5+ does,
@@ -67,8 +67,8 @@ type mysqlDialect struct{ returning bool }
 func (mysqlDialect) QuoteIdent(parts ...string) string { return quoteJoin(parts, '`') }
 func (mysqlDialect) Placeholder(int) string            { return "?" }
 func (mysqlDialect) NullSafeEq() string                { return "<=>" }
-func (d mysqlDialect) SupportsReturning() bool          { return d.returning }
-func (mysqlDialect) FilterOps() map[string]bool         { return sqlFilterOps }
+func (d mysqlDialect) SupportsReturning() bool         { return d.returning }
+func (mysqlDialect) FilterOps() map[string]bool        { return sqlFilterOps }
 
 // sqliteDialect — SQLite. Standard double-quoted identifiers, "?" params,
 // "IS" null-safe equality, RETURNING (3.35+, satisfied by modernc v1.47).
@@ -77,8 +77,8 @@ type sqliteDialect struct{}
 func (sqliteDialect) QuoteIdent(parts ...string) string { return quoteJoin(parts, '"') }
 func (sqliteDialect) Placeholder(int) string            { return "?" }
 func (sqliteDialect) NullSafeEq() string                { return "IS" }
-func (sqliteDialect) SupportsReturning() bool            { return true }
-func (sqliteDialect) FilterOps() map[string]bool         { return sqlFilterOps }
+func (sqliteDialect) SupportsReturning() bool           { return true }
+func (sqliteDialect) FilterOps() map[string]bool        { return sqlFilterOps }
 
 // quoteJoin quotes each part with q, escaping an embedded quote by
 // doubling it, and joins with ".". This is the standard SQL identifier

--- a/internal/dbtool/dialect.go
+++ b/internal/dbtool/dialect.go
@@ -1,0 +1,93 @@
+package dbtool
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// Dialect captures the per-engine SQL surface the shared statement
+// builders (sqlbuild.go) need: how identifiers are quoted, how bind
+// parameters are spelled, the NULL-safe equality operator, whether
+// INSERT … RETURNING is available, and which filter operators are legal.
+//
+// The builders are engine-agnostic; only these five knobs differ between
+// PostgreSQL, MySQL/MariaDB and SQLite. Values are always positional
+// parameters and identifiers always quoted+escaped, so a Dialect never
+// widens the injection surface — it only changes the spelling.
+type Dialect interface {
+	// QuoteIdent quotes and escapes a (possibly dotted) identifier, e.g.
+	// schema+table → "public"."users" (pg/sqlite) or `db`.`users` (mysql).
+	QuoteIdent(parts ...string) string
+	// Placeholder renders the n-th (1-based) bind parameter: "$n" for
+	// postgres, "?" for mysql/sqlite (n ignored).
+	Placeholder(n int) string
+	// NullSafeEq is the operator that treats NULL = NULL as true, used for
+	// primary-key WHERE clauses so a NULL PK column still matches its row.
+	NullSafeEq() string
+	// SupportsReturning reports whether INSERT … RETURNING * works.
+	SupportsReturning() bool
+	// FilterOps whitelists table-data filter operators → whether each takes
+	// a value parameter.
+	FilterOps() map[string]bool
+}
+
+// pgFilterOps is the PostgreSQL filter whitelist — includes ILIKE.
+var pgFilterOps = map[string]bool{
+	"=": true, "!=": true, "<>": true, "<": true, ">": true, "<=": true, ">=": true,
+	"LIKE": true, "ILIKE": true, "NOT LIKE": true, "NOT ILIKE": true,
+	"IS NULL": false, "IS NOT NULL": false,
+}
+
+// sqlFilterOps is the MySQL/SQLite whitelist — no ILIKE (neither engine
+// has it; MySQL LIKE is case-insensitive by collation, SQLite LIKE is
+// case-insensitive for ASCII).
+var sqlFilterOps = map[string]bool{
+	"=": true, "!=": true, "<>": true, "<": true, ">": true, "<=": true, ">=": true,
+	"LIKE": true, "NOT LIKE": true,
+	"IS NULL": false, "IS NOT NULL": false,
+}
+
+// pgDialect — PostgreSQL. QuoteIdent delegates to pgx.Identifier.Sanitize
+// so quoting stays byte-identical to the original hand-rolled builders.
+type pgDialect struct{}
+
+func (pgDialect) QuoteIdent(parts ...string) string { return pgx.Identifier(parts).Sanitize() }
+func (pgDialect) Placeholder(n int) string          { return "$" + strconv.Itoa(n) }
+func (pgDialect) NullSafeEq() string                { return "IS NOT DISTINCT FROM" }
+func (pgDialect) SupportsReturning() bool            { return true }
+func (pgDialect) FilterOps() map[string]bool         { return pgFilterOps }
+
+// mysqlDialect — MySQL and MariaDB. Backtick identifiers, "?" params,
+// "<=>" null-safe equality. MySQL 8 has no RETURNING; MariaDB 10.5+ does,
+// so `returning` is set per connection.
+type mysqlDialect struct{ returning bool }
+
+func (mysqlDialect) QuoteIdent(parts ...string) string { return quoteJoin(parts, '`') }
+func (mysqlDialect) Placeholder(int) string            { return "?" }
+func (mysqlDialect) NullSafeEq() string                { return "<=>" }
+func (d mysqlDialect) SupportsReturning() bool          { return d.returning }
+func (mysqlDialect) FilterOps() map[string]bool         { return sqlFilterOps }
+
+// sqliteDialect — SQLite. Standard double-quoted identifiers, "?" params,
+// "IS" null-safe equality, RETURNING (3.35+, satisfied by modernc v1.47).
+type sqliteDialect struct{}
+
+func (sqliteDialect) QuoteIdent(parts ...string) string { return quoteJoin(parts, '"') }
+func (sqliteDialect) Placeholder(int) string            { return "?" }
+func (sqliteDialect) NullSafeEq() string                { return "IS" }
+func (sqliteDialect) SupportsReturning() bool            { return true }
+func (sqliteDialect) FilterOps() map[string]bool         { return sqlFilterOps }
+
+// quoteJoin quotes each part with q, escaping an embedded quote by
+// doubling it, and joins with ".". This is the standard SQL identifier
+// escape for both backtick (MySQL) and double-quote (SQLite) styles.
+func quoteJoin(parts []string, q byte) string {
+	esc := string(q) + string(q)
+	out := make([]string, len(parts))
+	for i, p := range parts {
+		out[i] = string(q) + strings.ReplaceAll(p, string(q), esc) + string(q)
+	}
+	return strings.Join(out, ".")
+}

--- a/internal/dbtool/dialect_test.go
+++ b/internal/dbtool/dialect_test.go
@@ -1,0 +1,100 @@
+package dbtool
+
+import "testing"
+
+func TestDialects(t *testing.T) {
+	tests := []struct {
+		name      string
+		d         Dialect
+		wantQuote string // QuoteIdent("a", "b")
+		wantPlace string // Placeholder(3)
+		wantNull  string
+		wantRet   bool
+	}{
+		{"postgres", pgDialect{}, `"a"."b"`, "$3", "IS NOT DISTINCT FROM", true},
+		{"mysql", mysqlDialect{returning: false}, "`a`.`b`", "?", "<=>", false},
+		{"mariadb", mysqlDialect{returning: true}, "`a`.`b`", "?", "<=>", true},
+		{"sqlite", sqliteDialect{}, `"a"."b"`, "?", "IS", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.d.QuoteIdent("a", "b"); got != tt.wantQuote {
+				t.Errorf("QuoteIdent = %q, want %q", got, tt.wantQuote)
+			}
+			if got := tt.d.Placeholder(3); got != tt.wantPlace {
+				t.Errorf("Placeholder(3) = %q, want %q", got, tt.wantPlace)
+			}
+			if got := tt.d.NullSafeEq(); got != tt.wantNull {
+				t.Errorf("NullSafeEq = %q, want %q", got, tt.wantNull)
+			}
+			if got := tt.d.SupportsReturning(); got != tt.wantRet {
+				t.Errorf("SupportsReturning = %v, want %v", got, tt.wantRet)
+			}
+		})
+	}
+}
+
+// Identifier quoting must escape the quote char by doubling it — the
+// injection barrier for every generated statement.
+func TestDialectQuoteEscaping(t *testing.T) {
+	if got := (mysqlDialect{}).QuoteIdent("a`b"); got != "`a``b`" {
+		t.Errorf("mysql escape = %q", got)
+	}
+	if got := (sqliteDialect{}).QuoteIdent(`a"b`); got != `"a""b"` {
+		t.Errorf("sqlite escape = %q", got)
+	}
+	if got := (pgDialect{}).QuoteIdent(`a"b`); got != `"a""b"` {
+		t.Errorf("pg escape = %q", got)
+	}
+}
+
+// Filter operators differ: ILIKE is PostgreSQL-only.
+func TestDialectFilterOps(t *testing.T) {
+	if !(pgDialect{}).FilterOps()["ILIKE"] {
+		t.Error("pg should allow ILIKE")
+	}
+	if _, ok := (mysqlDialect{}).FilterOps()["ILIKE"]; ok {
+		t.Error("mysql must not allow ILIKE")
+	}
+	if _, ok := (sqliteDialect{}).FilterOps()["ILIKE"]; ok {
+		t.Error("sqlite must not allow ILIKE")
+	}
+}
+
+// The shared builders must honour a non-postgres dialect: "?" params,
+// engine-specific quoting and null-safe operator, and RETURNING only when
+// supported.
+func TestBuildWithMySQLDialect(t *testing.T) {
+	d := mysqlDialect{returning: false}
+	sql, args, err := buildTableDataSQL(TableDataReq{
+		Schema: "app", Table: "users", Limit: 10,
+		Filters: []Filter{{Column: "status", Op: "=", Value: "open"}},
+		Sort:    []Sort{{Column: "id", Desc: true}},
+	}, d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "SELECT * FROM `app`.`users` WHERE `status` = ? ORDER BY `id` DESC LIMIT ?"
+	if sql != want {
+		t.Fatalf("sql = %q\nwant  %q", sql, want)
+	}
+	if len(args) != 2 {
+		t.Fatalf("args = %#v", args)
+	}
+
+	ins, _, err := buildInsertSQL(RowInsertReq{Schema: "app", Table: "t", Values: map[string]any{"a": 1}}, d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "INSERT INTO `app`.`t` (`a`) VALUES (?)"; ins != want {
+		t.Fatalf("insert = %q, want %q (no RETURNING for mysql)", ins, want)
+	}
+
+	upd, _, err := buildUpdateSQL(RowUpdateReq{Schema: "app", Table: "t", PK: map[string]any{"id": 1}, Values: map[string]any{"a": 2}}, d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "UPDATE `app`.`t` SET `a` = ? WHERE `id` <=> ?"; upd != want {
+		t.Fatalf("update = %q, want %q", upd, want)
+	}
+}

--- a/internal/dbtool/injection_test.go
+++ b/internal/dbtool/injection_test.go
@@ -1,0 +1,111 @@
+package dbtool
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// These tests are the executable proof behind the CodeQL go/sql-injection
+// findings on the identifier-concatenation sites (PRAGMA args can't be
+// bound; generated SELECT/INSERT/UPDATE quote identifiers). They pin the
+// escaping so a future refactor of QuoteIdent — or a new dialect — can't
+// silently reintroduce a real injection at those sinks.
+
+// Injection-safety property for a quoted identifier: after stripping the
+// outer quotes, every inner quote char must belong to a doubled ("") pair —
+// no lone quote survives, so an attacker's quote can never terminate the
+// identifier early and start a second statement. (Byte-for-byte round-trip
+// is stronger, but pgx.Identifier strips NUL bytes — still safe, since a
+// removed byte can't inject; this checks the property that actually matters.)
+func TestQuoteIdentNoBreakout(t *testing.T) {
+	payloads := []string{
+		`t") ; DROP TABLE secret; --`,
+		`a"b"c`,
+		"back`tick",
+		`); DROP TABLE x;--`,
+		"line\nbreak",
+		"tab\there",
+		"nul\x00byte",
+		`" OR 1=1 --`,
+		`"" UNION SELECT * FROM secret --`,
+		"plain",
+		"",
+	}
+	check := func(name, quoted string, q byte) {
+		if len(quoted) < 2 || quoted[0] != q || quoted[len(quoted)-1] != q {
+			t.Errorf("%s: %q not wrapped in %c", name, quoted, q)
+			return
+		}
+		inner := quoted[1 : len(quoted)-1]
+		stripped := strings.ReplaceAll(inner, string([]byte{q, q}), "")
+		if strings.IndexByte(stripped, q) >= 0 {
+			t.Errorf("%s: %q has an unpaired %c — identifier breakout possible", name, quoted, q)
+		}
+	}
+	for _, p := range payloads {
+		check("sqlite", sqliteDialect{}.QuoteIdent(p), '"')
+		check("pg", pgDialect{}.QuoteIdent(p), '"')
+		check("mysql", mysqlDialect{}.QuoteIdent(p), '`')
+	}
+}
+
+// A hostile filter operator must be rejected by the whitelist, never
+// concatenated into SQL (operators are the one non-identifier,
+// non-parameter token in buildTableDataSQL).
+func TestFilterOperatorWhitelistRejectsInjection(t *testing.T) {
+	for _, d := range []Dialect{pgDialect{}, mysqlDialect{}, sqliteDialect{}} {
+		_, _, err := buildTableDataSQL(TableDataReq{
+			Schema: "s", Table: "t",
+			Filters: []Filter{{Column: "a", Op: "= 1 OR 1=1 --", Value: 1}},
+		}, d)
+		if err == nil {
+			t.Errorf("%T: injection via operator was not rejected", d)
+		}
+	}
+}
+
+// Live proof: firing crafted identifiers at the real PRAGMA path
+// (TableMeta) and the generated-INSERT path must not execute a smuggled
+// second statement — a target table survives untouched.
+func TestSQLiteInjectionResistanceLive(t *testing.T) {
+	dir := t.TempDir()
+	c := Connection{Driver: "sqlite", Cwd: dir, DBName: "t.db"}
+	d := sqliteDriver{}
+	ctx := context.Background()
+	to := 10 * time.Second
+
+	h, err := d.Open(ctx, c, DriverOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer h.Close()
+
+	mustExec := func(sql string, class StatementClass) {
+		if _, err := d.Query(ctx, h, QueryReq{SQL: sql}, class, 100, to); err != nil {
+			t.Fatalf("setup %q: %v", sql, err)
+		}
+	}
+	mustExec(`CREATE TABLE secret (id INTEGER PRIMARY KEY)`, ClassDDL)
+	mustExec(`INSERT INTO secret VALUES (1)`, ClassWrite)
+	mustExec(`CREATE TABLE t (a INTEGER)`, ClassDDL)
+
+	evil := `secret"); DROP TABLE secret; --`
+	// Hostile table name down the PRAGMA path — errors or empties, never drops.
+	_, _ = d.TableMeta(ctx, h, "main", evil, to)
+	// Hostile column name down the generated-INSERT path.
+	_, _ = d.InsertRow(ctx, h, RowInsertReq{
+		Schema: "main", Table: "t",
+		Values: map[string]any{`a"); DROP TABLE secret; --`: 1},
+	}, to)
+
+	// secret must still exist with its row.
+	rs, err := d.Query(ctx, h, QueryReq{SQL: `SELECT count(*) FROM secret`}, ClassRead, 100, to)
+	if err != nil {
+		t.Fatalf("secret table was dropped by an injection: %v", err)
+	}
+	if len(rs.Rows) != 1 {
+		t.Fatalf("unexpected result shape: %#v", rs.Rows)
+	}
+}

--- a/internal/dbtool/mysql.go
+++ b/internal/dbtool/mysql.go
@@ -1,0 +1,378 @@
+package dbtool
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// mysqlDriver implements Driver over database/sql + go-sql-driver/mysql
+// (pure Go, no cgo). It serves both MySQL and MariaDB — the wire protocol
+// is identical; only the version string and RETURNING support differ, and
+// this driver takes the conservative no-RETURNING path for both so row
+// inserts behave the same everywhere.
+//
+// In MySQL a "schema" IS a database, so Schemas lists databases and every
+// table query is qualified `db`.`table`. Every identifier goes through the
+// backtick-quoting mysqlDialect; every value is a "?" placeholder. Reads
+// run inside a READ ONLY transaction (the second fence behind the
+// classifier).
+type mysqlDriver struct{}
+
+func (mysqlDriver) dialect() Dialect { return mysqlDialect{returning: false} }
+
+// dsn builds a go-sql-driver DSN via its Config so special characters in
+// the password survive without hand-escaping.
+func (mysqlDriver) dsn(c Connection, opts DriverOpts) string {
+	cfg := mysql.NewConfig()
+	cfg.User = c.Username
+	cfg.Passwd = c.Password
+	cfg.Net = "tcp"
+	cfg.Addr = net.JoinHostPort(c.Host, strconv.Itoa(c.Port))
+	cfg.DBName = c.DBName
+	cfg.ParseTime = true // DATETIME/TIMESTAMP → time.Time
+	ct := opts.ConnectTimeout
+	if ct <= 0 {
+		ct = 5 * time.Second
+	}
+	cfg.Timeout = ct
+	switch c.SSLMode {
+	case "disable":
+		cfg.TLSConfig = "false"
+	case "require":
+		cfg.TLSConfig = "skip-verify" // encrypt, don't verify the cert
+	case "verify-ca", "verify-full":
+		cfg.TLSConfig = "true" // encrypt and verify
+	default: // prefer / empty
+		cfg.TLSConfig = "preferred"
+	}
+	return cfg.FormatDSN()
+}
+
+func (d mysqlDriver) Open(ctx context.Context, c Connection, opts DriverOpts) (Handle, error) {
+	db, err := sql.Open("mysql", d.dsn(c, opts))
+	if err != nil {
+		return nil, fmt.Errorf("dbtool: open mysql: %w", err)
+	}
+	maxConns := opts.MaxConns
+	if maxConns <= 0 {
+		maxConns = 3
+	}
+	db.SetMaxOpenConns(maxConns)
+	db.SetConnMaxIdleTime(2 * time.Minute)
+	return &sqlHandle{db: db}, nil
+}
+
+func (d mysqlDriver) Ping(ctx context.Context, c Connection, opts DriverOpts) PingResult {
+	start := time.Now()
+	db, err := sql.Open("mysql", d.dsn(c, opts))
+	if err != nil {
+		return PingResult{OK: false, Error: err.Error(), LatencyMs: time.Since(start).Milliseconds()}
+	}
+	defer func() { _ = db.Close() }()
+	var version string
+	if err := db.QueryRowContext(ctx, "SELECT VERSION()").Scan(&version); err != nil {
+		return PingResult{OK: false, Error: err.Error(), LatencyMs: time.Since(start).Milliseconds()}
+	}
+	return PingResult{
+		OK:            true,
+		ServerVersion: version,
+		IsSuperuser:   mysqlIsSuper(ctx, db),
+		LatencyMs:     time.Since(start).Milliseconds(),
+	}
+}
+
+// mysqlIsSuper powers the superuser warning banner: a role holding
+// `ALL PRIVILEGES ON *.*` or `SUPER` is server-admin-grade (operator rule:
+// never run project work as such an account).
+func mysqlIsSuper(ctx context.Context, db *sql.DB) bool {
+	rows, err := db.QueryContext(ctx, "SHOW GRANTS FOR CURRENT_USER()")
+	if err != nil {
+		return false
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var g string
+		if rows.Scan(&g) != nil {
+			continue
+		}
+		up := strings.ToUpper(g)
+		if strings.Contains(up, "ALL PRIVILEGES ON *.*") || strings.Contains(up, "SUPER") {
+			return true
+		}
+	}
+	return false
+}
+
+func (mysqlDriver) Schemas(ctx context.Context, h Handle, timeout time.Duration) ([]Schema, error) {
+	db, err := sqlDB(h)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	rows, err := db.QueryContext(ctx, `
+		SELECT schema_name FROM information_schema.schemata
+		WHERE schema_name NOT IN ('mysql','performance_schema','information_schema','sys')
+		ORDER BY schema_name`)
+	if err != nil {
+		return nil, fmt.Errorf("dbtool: list schemas: %w", err)
+	}
+	defer rows.Close()
+	var out []Schema
+	for rows.Next() {
+		var s Schema
+		if err := rows.Scan(&s.Name); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+func (mysqlDriver) Tables(ctx context.Context, h Handle, schema string, timeout time.Duration) ([]Table, error) {
+	db, err := sqlDB(h)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	rows, err := db.QueryContext(ctx, `
+		SELECT table_name, table_type, COALESCE(table_rows, 0)
+		FROM information_schema.tables
+		WHERE table_schema = ?
+		ORDER BY table_name`, schema)
+	if err != nil {
+		return nil, fmt.Errorf("dbtool: list tables: %w", err)
+	}
+	defer rows.Close()
+	var out []Table
+	for rows.Next() {
+		var t Table
+		var tType string
+		if err := rows.Scan(&t.Name, &tType, &t.RowEstimate); err != nil {
+			return nil, err
+		}
+		if strings.EqualFold(tType, "VIEW") {
+			t.Kind = "view"
+		} else {
+			t.Kind = "table"
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+func (mysqlDriver) TableMeta(ctx context.Context, h Handle, schema, table string, timeout time.Duration) (TableMeta, error) {
+	db, err := sqlDB(h)
+	if err != nil {
+		return TableMeta{}, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	meta := TableMeta{Schema: schema, Table: table, PrimaryKey: []string{}, Indexes: []Index{}, ForeignKeys: []ForeignKey{}}
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return meta, fmt.Errorf("dbtool: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	colRows, err := tx.QueryContext(ctx, `
+		SELECT column_name, column_type, is_nullable = 'YES',
+		       COALESCE(column_default, ''), ordinal_position
+		FROM information_schema.columns
+		WHERE table_schema = ? AND table_name = ?
+		ORDER BY ordinal_position`, schema, table)
+	if err != nil {
+		return meta, fmt.Errorf("dbtool: table columns: %w", err)
+	}
+	for colRows.Next() {
+		var c Column
+		if err := colRows.Scan(&c.Name, &c.DataType, &c.Nullable, &c.Default, &c.Position); err != nil {
+			colRows.Close()
+			return meta, err
+		}
+		meta.Columns = append(meta.Columns, c)
+	}
+	colRows.Close()
+	if err := colRows.Err(); err != nil {
+		return meta, err
+	}
+	if len(meta.Columns) == 0 {
+		return meta, fmt.Errorf("dbtool: table %s.%s not found", schema, table)
+	}
+
+	// Primary key columns in key order.
+	pkRows, err := tx.QueryContext(ctx, `
+		SELECT column_name FROM information_schema.statistics
+		WHERE table_schema = ? AND table_name = ? AND index_name = 'PRIMARY'
+		ORDER BY seq_in_index`, schema, table)
+	if err != nil {
+		return meta, fmt.Errorf("dbtool: table primary key: %w", err)
+	}
+	for pkRows.Next() {
+		var col string
+		if err := pkRows.Scan(&col); err != nil {
+			pkRows.Close()
+			return meta, err
+		}
+		meta.PrimaryKey = append(meta.PrimaryKey, col)
+	}
+	pkRows.Close()
+	if err := pkRows.Err(); err != nil {
+		return meta, err
+	}
+
+	// Indexes: one row per index, columns concatenated in order.
+	idxRows, err := tx.QueryContext(ctx, `
+		SELECT index_name, MAX(non_unique) = 0,
+		       GROUP_CONCAT(column_name ORDER BY seq_in_index SEPARATOR ', ')
+		FROM information_schema.statistics
+		WHERE table_schema = ? AND table_name = ?
+		GROUP BY index_name
+		ORDER BY index_name`, schema, table)
+	if err != nil {
+		return meta, fmt.Errorf("dbtool: table indexes: %w", err)
+	}
+	for idxRows.Next() {
+		var ix Index
+		var cols string
+		if err := idxRows.Scan(&ix.Name, &ix.Unique, &cols); err != nil {
+			idxRows.Close()
+			return meta, err
+		}
+		ix.Primary = ix.Name == "PRIMARY"
+		ix.Definition = fmt.Sprintf("(%s)", cols)
+		meta.Indexes = append(meta.Indexes, ix)
+	}
+	idxRows.Close()
+	if err := idxRows.Err(); err != nil {
+		return meta, err
+	}
+
+	// Foreign keys, grouped by constraint.
+	fkRows, err := tx.QueryContext(ctx, `
+		SELECT constraint_name, column_name,
+		       referenced_table_schema, referenced_table_name, referenced_column_name
+		FROM information_schema.key_column_usage
+		WHERE table_schema = ? AND table_name = ? AND referenced_table_name IS NOT NULL
+		ORDER BY constraint_name, ordinal_position`, schema, table)
+	if err != nil {
+		return meta, fmt.Errorf("dbtool: table foreign keys: %w", err)
+	}
+	fkByName := map[string]*ForeignKey{}
+	var fkOrder []string
+	for fkRows.Next() {
+		var name, col, refSchema, refTable, refCol string
+		if err := fkRows.Scan(&name, &col, &refSchema, &refTable, &refCol); err != nil {
+			fkRows.Close()
+			return meta, err
+		}
+		fk, ok := fkByName[name]
+		if !ok {
+			fk = &ForeignKey{Name: name, RefSchema: refSchema, RefTable: refTable}
+			fkByName[name] = fk
+			fkOrder = append(fkOrder, name)
+		}
+		fk.Columns = append(fk.Columns, col)
+		fk.RefColumns = append(fk.RefColumns, refCol)
+	}
+	fkRows.Close()
+	if err := fkRows.Err(); err != nil {
+		return meta, err
+	}
+	for _, name := range fkOrder {
+		meta.ForeignKeys = append(meta.ForeignKeys, *fkByName[name])
+	}
+	return meta, nil
+}
+
+func (d mysqlDriver) TableData(ctx context.Context, h Handle, req TableDataReq, timeout time.Duration) (*ResultSet, error) {
+	db, err := sqlDB(h)
+	if err != nil {
+		return nil, err
+	}
+	sqlText, args, err := buildTableDataSQL(req, d.dialect())
+	if err != nil {
+		return nil, err
+	}
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	return sqlExecute(ctx, db, sqlText, args, true, true, limit, timeout)
+}
+
+// InsertRow takes the no-RETURNING path (MySQL 8 has no RETURNING). It
+// reports rows affected; the grid refreshes from the server afterwards.
+func (d mysqlDriver) InsertRow(ctx context.Context, h Handle, req RowInsertReq, timeout time.Duration) (*ResultSet, error) {
+	db, err := sqlDB(h)
+	if err != nil {
+		return nil, err
+	}
+	sqlText, args, err := buildInsertSQL(req, d.dialect()) // returning=false → bare INSERT
+	if err != nil {
+		return nil, err
+	}
+	return sqlExecute(ctx, db, sqlText, args, false, false, 1, timeout)
+}
+
+func (d mysqlDriver) UpdateRow(ctx context.Context, h Handle, req RowUpdateReq, timeout time.Duration) (int64, error) {
+	db, err := sqlDB(h)
+	if err != nil {
+		return 0, err
+	}
+	sqlText, args, err := buildUpdateSQL(req, d.dialect())
+	if err != nil {
+		return 0, err
+	}
+	return sqlExecuteAffected(ctx, db, sqlText, args, timeout)
+}
+
+func (d mysqlDriver) DeleteRows(ctx context.Context, h Handle, req RowDeleteReq, timeout time.Duration) (int64, error) {
+	if req.Schema == "" || req.Table == "" {
+		return 0, fmt.Errorf("dbtool: schema and table are required")
+	}
+	if len(req.PKs) == 0 {
+		return 0, fmt.Errorf("dbtool: delete requires at least one primary key")
+	}
+	db, err := sqlDB(h)
+	if err != nil {
+		return 0, err
+	}
+	dl := d.dialect()
+	var total int64
+	for _, pk := range req.PKs {
+		if len(pk) == 0 {
+			return 0, fmt.Errorf("dbtool: delete requires the row's primary key")
+		}
+		var sb strings.Builder
+		var args []any
+		sb.WriteString("DELETE FROM ")
+		sb.WriteString(dl.QuoteIdent(req.Schema, req.Table))
+		sb.WriteString(" WHERE ")
+		writePKWhere(&sb, &args, pk, dl)
+		n, err := sqlExecuteAffected(ctx, db, sb.String(), args, timeout)
+		if err != nil {
+			return 0, err
+		}
+		total += n
+	}
+	return total, nil
+}
+
+func (d mysqlDriver) Query(ctx context.Context, h Handle, req QueryReq, class StatementClass, maxRows int, timeout time.Duration) (*ResultSet, error) {
+	db, err := sqlDB(h)
+	if err != nil {
+		return nil, err
+	}
+	readOnly := class == ClassRead
+	return sqlExecute(ctx, db, req.SQL, nil, readOnly, readOnly, maxRows, timeout)
+}

--- a/internal/dbtool/mysql.go
+++ b/internal/dbtool/mysql.go
@@ -96,7 +96,7 @@ func mysqlIsSuper(ctx context.Context, db *sql.DB) bool {
 	if err != nil {
 		return false
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var g string
 		if rows.Scan(&g) != nil {
@@ -124,7 +124,7 @@ func (mysqlDriver) Schemas(ctx context.Context, h Handle, timeout time.Duration)
 	if err != nil {
 		return nil, fmt.Errorf("dbtool: list schemas: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var out []Schema
 	for rows.Next() {
 		var s Schema
@@ -151,7 +151,7 @@ func (mysqlDriver) Tables(ctx context.Context, h Handle, schema string, timeout 
 	if err != nil {
 		return nil, fmt.Errorf("dbtool: list tables: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var out []Table
 	for rows.Next() {
 		var t Table
@@ -196,12 +196,12 @@ func (mysqlDriver) TableMeta(ctx context.Context, h Handle, schema, table string
 	for colRows.Next() {
 		var c Column
 		if err := colRows.Scan(&c.Name, &c.DataType, &c.Nullable, &c.Default, &c.Position); err != nil {
-			colRows.Close()
+			_ = colRows.Close()
 			return meta, err
 		}
 		meta.Columns = append(meta.Columns, c)
 	}
-	colRows.Close()
+	_ = colRows.Close()
 	if err := colRows.Err(); err != nil {
 		return meta, err
 	}
@@ -220,12 +220,12 @@ func (mysqlDriver) TableMeta(ctx context.Context, h Handle, schema, table string
 	for pkRows.Next() {
 		var col string
 		if err := pkRows.Scan(&col); err != nil {
-			pkRows.Close()
+			_ = pkRows.Close()
 			return meta, err
 		}
 		meta.PrimaryKey = append(meta.PrimaryKey, col)
 	}
-	pkRows.Close()
+	_ = pkRows.Close()
 	if err := pkRows.Err(); err != nil {
 		return meta, err
 	}
@@ -245,14 +245,14 @@ func (mysqlDriver) TableMeta(ctx context.Context, h Handle, schema, table string
 		var ix Index
 		var cols string
 		if err := idxRows.Scan(&ix.Name, &ix.Unique, &cols); err != nil {
-			idxRows.Close()
+			_ = idxRows.Close()
 			return meta, err
 		}
 		ix.Primary = ix.Name == "PRIMARY"
 		ix.Definition = fmt.Sprintf("(%s)", cols)
 		meta.Indexes = append(meta.Indexes, ix)
 	}
-	idxRows.Close()
+	_ = idxRows.Close()
 	if err := idxRows.Err(); err != nil {
 		return meta, err
 	}
@@ -272,7 +272,7 @@ func (mysqlDriver) TableMeta(ctx context.Context, h Handle, schema, table string
 	for fkRows.Next() {
 		var name, col, refSchema, refTable, refCol string
 		if err := fkRows.Scan(&name, &col, &refSchema, &refTable, &refCol); err != nil {
-			fkRows.Close()
+			_ = fkRows.Close()
 			return meta, err
 		}
 		fk, ok := fkByName[name]
@@ -284,7 +284,7 @@ func (mysqlDriver) TableMeta(ctx context.Context, h Handle, schema, table string
 		fk.Columns = append(fk.Columns, col)
 		fk.RefColumns = append(fk.RefColumns, refCol)
 	}
-	fkRows.Close()
+	_ = fkRows.Close()
 	if err := fkRows.Err(); err != nil {
 		return meta, err
 	}

--- a/internal/dbtool/postgres.go
+++ b/internal/dbtool/postgres.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -305,76 +304,8 @@ func (postgresDriver) TableMeta(ctx context.Context, h Handle, schema, table str
 	return meta, nil
 }
 
-// filterOps whitelists the operators a table-data filter may use and
-// whether each takes a value parameter.
-var filterOps = map[string]bool{
-	"=": true, "!=": true, "<>": true, "<": true, ">": true, "<=": true, ">=": true,
-	"LIKE": true, "ILIKE": true, "NOT LIKE": true, "NOT ILIKE": true,
-	"IS NULL": false, "IS NOT NULL": false,
-}
-
-// buildTableDataSQL renders the paged SELECT for req. Split out (and
-// exported to tests) so identifier quoting and parameter numbering can be
-// unit-tested without a live database.
-func buildTableDataSQL(req TableDataReq) (string, []any, error) {
-	if req.Schema == "" || req.Table == "" {
-		return "", nil, errors.New("dbtool: schema and table are required")
-	}
-	var sb strings.Builder
-	var args []any
-	sb.WriteString("SELECT * FROM ")
-	sb.WriteString(pgx.Identifier{req.Schema, req.Table}.Sanitize())
-	for i, f := range req.Filters {
-		op := strings.ToUpper(strings.TrimSpace(f.Op))
-		takesValue, ok := filterOps[op]
-		if !ok {
-			return "", nil, fmt.Errorf("dbtool: unsupported filter operator %q", f.Op)
-		}
-		if f.Column == "" {
-			return "", nil, errors.New("dbtool: filter column is required")
-		}
-		if i == 0 {
-			sb.WriteString(" WHERE ")
-		} else {
-			sb.WriteString(" AND ")
-		}
-		sb.WriteString(pgx.Identifier{f.Column}.Sanitize())
-		sb.WriteString(" ")
-		sb.WriteString(op)
-		if takesValue {
-			args = append(args, f.Value)
-			fmt.Fprintf(&sb, " $%d", len(args))
-		}
-	}
-	for i, s := range req.Sort {
-		if s.Column == "" {
-			return "", nil, errors.New("dbtool: sort column is required")
-		}
-		if i == 0 {
-			sb.WriteString(" ORDER BY ")
-		} else {
-			sb.WriteString(", ")
-		}
-		sb.WriteString(pgx.Identifier{s.Column}.Sanitize())
-		if s.Desc {
-			sb.WriteString(" DESC")
-		}
-	}
-	limit := req.Limit
-	if limit <= 0 {
-		limit = 100
-	}
-	args = append(args, limit+1) // +1 row to detect truncation
-	fmt.Fprintf(&sb, " LIMIT $%d", len(args))
-	if req.Offset > 0 {
-		args = append(args, req.Offset)
-		fmt.Fprintf(&sb, " OFFSET $%d", len(args))
-	}
-	return sb.String(), args, nil
-}
-
 func (d postgresDriver) TableData(ctx context.Context, h Handle, req TableDataReq, timeout time.Duration) (*ResultSet, error) {
-	sqlText, args, err := buildTableDataSQL(req)
+	sqlText, args, err := buildTableDataSQL(req, pgDialect{})
 	if err != nil {
 		return nil, err
 	}
@@ -385,79 +316,16 @@ func (d postgresDriver) TableData(ctx context.Context, h Handle, req TableDataRe
 	return d.execute(ctx, h, sqlText, args, true, limit, timeout)
 }
 
-// buildInsertSQL renders INSERT … RETURNING *. Column order is made
-// deterministic for testability.
-func buildInsertSQL(req RowInsertReq) (string, []any, error) {
-	if req.Schema == "" || req.Table == "" {
-		return "", nil, errors.New("dbtool: schema and table are required")
-	}
-	if len(req.Values) == 0 {
-		return "", nil, errors.New("dbtool: insert requires at least one column value")
-	}
-	cols := sortedKeys(req.Values)
-	var sb strings.Builder
-	var args []any
-	sb.WriteString("INSERT INTO ")
-	sb.WriteString(pgx.Identifier{req.Schema, req.Table}.Sanitize())
-	sb.WriteString(" (")
-	for i, c := range cols {
-		if i > 0 {
-			sb.WriteString(", ")
-		}
-		sb.WriteString(pgx.Identifier{c}.Sanitize())
-	}
-	sb.WriteString(") VALUES (")
-	for i, c := range cols {
-		if i > 0 {
-			sb.WriteString(", ")
-		}
-		args = append(args, req.Values[c])
-		fmt.Fprintf(&sb, "$%d", len(args))
-	}
-	sb.WriteString(") RETURNING *")
-	return sb.String(), args, nil
-}
-
 func (d postgresDriver) InsertRow(ctx context.Context, h Handle, req RowInsertReq, timeout time.Duration) (*ResultSet, error) {
-	sqlText, args, err := buildInsertSQL(req)
+	sqlText, args, err := buildInsertSQL(req, pgDialect{})
 	if err != nil {
 		return nil, err
 	}
 	return d.execute(ctx, h, sqlText, args, false, 10, timeout)
 }
 
-// buildUpdateSQL renders UPDATE … WHERE <full pk>. The service validates
-// that req.PK covers the table's actual primary key before calling this.
-func buildUpdateSQL(req RowUpdateReq) (string, []any, error) {
-	if req.Schema == "" || req.Table == "" {
-		return "", nil, errors.New("dbtool: schema and table are required")
-	}
-	if len(req.Values) == 0 {
-		return "", nil, errors.New("dbtool: update requires at least one column value")
-	}
-	if len(req.PK) == 0 {
-		return "", nil, errors.New("dbtool: update requires the row's primary key")
-	}
-	var sb strings.Builder
-	var args []any
-	sb.WriteString("UPDATE ")
-	sb.WriteString(pgx.Identifier{req.Schema, req.Table}.Sanitize())
-	sb.WriteString(" SET ")
-	for i, c := range sortedKeys(req.Values) {
-		if i > 0 {
-			sb.WriteString(", ")
-		}
-		args = append(args, req.Values[c])
-		sb.WriteString(pgx.Identifier{c}.Sanitize())
-		fmt.Fprintf(&sb, " = $%d", len(args))
-	}
-	sb.WriteString(" WHERE ")
-	writePKWhere(&sb, &args, req.PK)
-	return sb.String(), args, nil
-}
-
 func (d postgresDriver) UpdateRow(ctx context.Context, h Handle, req RowUpdateReq, timeout time.Duration) (int64, error) {
-	sqlText, args, err := buildUpdateSQL(req)
+	sqlText, args, err := buildUpdateSQL(req, pgDialect{})
 	if err != nil {
 		return 0, err
 	}
@@ -495,7 +363,7 @@ func (d postgresDriver) DeleteRows(ctx context.Context, h Handle, req RowDeleteR
 		sb.WriteString("DELETE FROM ")
 		sb.WriteString(pgx.Identifier{req.Schema, req.Table}.Sanitize())
 		sb.WriteString(" WHERE ")
-		writePKWhere(&sb, &args, pk)
+		writePKWhere(&sb, &args, pk, pgDialect{})
 		tag, err := tx.Exec(ctx, sb.String(), args...)
 		if err != nil {
 			return 0, fmt.Errorf("dbtool: delete row: %w", err)
@@ -510,28 +378,6 @@ func (d postgresDriver) DeleteRows(ctx context.Context, h Handle, req RowDeleteR
 
 func (d postgresDriver) Query(ctx context.Context, h Handle, req QueryReq, class StatementClass, maxRows int, timeout time.Duration) (*ResultSet, error) {
 	return d.execute(ctx, h, req.SQL, nil, class == ClassRead, maxRows, timeout)
-}
-
-// writePKWhere appends "pk1 = $n AND pk2 = $m" (NULL-safe via IS NOT
-// DISTINCT FROM) for the pk map, in deterministic column order.
-func writePKWhere(sb *strings.Builder, args *[]any, pk map[string]any) {
-	for i, c := range sortedKeys(pk) {
-		if i > 0 {
-			sb.WriteString(" AND ")
-		}
-		*args = append(*args, pk[c])
-		sb.WriteString(pgx.Identifier{c}.Sanitize())
-		fmt.Fprintf(sb, " IS NOT DISTINCT FROM $%d", len(*args))
-	}
-}
-
-func sortedKeys(m map[string]any) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
 }
 
 func setLocalTimeout(ctx context.Context, tx pgx.Tx, timeout time.Duration) error {

--- a/internal/dbtool/sqlbuild.go
+++ b/internal/dbtool/sqlbuild.go
@@ -1,0 +1,168 @@
+package dbtool
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Engine-agnostic SQL builders shared by every driver. Identifier quoting,
+// bind-parameter spelling and the null-safe operator come from the passed
+// Dialect; every value is a positional parameter and every identifier is
+// quoted+escaped, so these builders never widen the injection surface.
+
+// buildTableDataSQL renders the paged SELECT for req.
+func buildTableDataSQL(req TableDataReq, d Dialect) (string, []any, error) {
+	if req.Schema == "" || req.Table == "" {
+		return "", nil, errors.New("dbtool: schema and table are required")
+	}
+	var sb strings.Builder
+	var args []any
+	sb.WriteString("SELECT * FROM ")
+	sb.WriteString(d.QuoteIdent(req.Schema, req.Table))
+	ops := d.FilterOps()
+	for i, f := range req.Filters {
+		op := strings.ToUpper(strings.TrimSpace(f.Op))
+		takesValue, ok := ops[op]
+		if !ok {
+			return "", nil, fmt.Errorf("dbtool: unsupported filter operator %q", f.Op)
+		}
+		if f.Column == "" {
+			return "", nil, errors.New("dbtool: filter column is required")
+		}
+		if i == 0 {
+			sb.WriteString(" WHERE ")
+		} else {
+			sb.WriteString(" AND ")
+		}
+		sb.WriteString(d.QuoteIdent(f.Column))
+		sb.WriteString(" ")
+		sb.WriteString(op)
+		if takesValue {
+			args = append(args, f.Value)
+			sb.WriteString(" ")
+			sb.WriteString(d.Placeholder(len(args)))
+		}
+	}
+	for i, s := range req.Sort {
+		if s.Column == "" {
+			return "", nil, errors.New("dbtool: sort column is required")
+		}
+		if i == 0 {
+			sb.WriteString(" ORDER BY ")
+		} else {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(d.QuoteIdent(s.Column))
+		if s.Desc {
+			sb.WriteString(" DESC")
+		}
+	}
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	args = append(args, limit+1) // +1 row to detect truncation
+	sb.WriteString(" LIMIT ")
+	sb.WriteString(d.Placeholder(len(args)))
+	if req.Offset > 0 {
+		args = append(args, req.Offset)
+		sb.WriteString(" OFFSET ")
+		sb.WriteString(d.Placeholder(len(args)))
+	}
+	return sb.String(), args, nil
+}
+
+// buildInsertSQL renders INSERT … [RETURNING *]. Column order is made
+// deterministic for testability. RETURNING is emitted only when the
+// dialect supports it (MySQL 8 does not — its driver re-selects instead).
+func buildInsertSQL(req RowInsertReq, d Dialect) (string, []any, error) {
+	if req.Schema == "" || req.Table == "" {
+		return "", nil, errors.New("dbtool: schema and table are required")
+	}
+	if len(req.Values) == 0 {
+		return "", nil, errors.New("dbtool: insert requires at least one column value")
+	}
+	cols := sortedKeys(req.Values)
+	var sb strings.Builder
+	var args []any
+	sb.WriteString("INSERT INTO ")
+	sb.WriteString(d.QuoteIdent(req.Schema, req.Table))
+	sb.WriteString(" (")
+	for i, c := range cols {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(d.QuoteIdent(c))
+	}
+	sb.WriteString(") VALUES (")
+	for i, c := range cols {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		args = append(args, req.Values[c])
+		sb.WriteString(d.Placeholder(len(args)))
+	}
+	sb.WriteString(")")
+	if d.SupportsReturning() {
+		sb.WriteString(" RETURNING *")
+	}
+	return sb.String(), args, nil
+}
+
+// buildUpdateSQL renders UPDATE … WHERE <full pk>. The service validates
+// that req.PK covers the table's actual primary key before calling this.
+func buildUpdateSQL(req RowUpdateReq, d Dialect) (string, []any, error) {
+	if req.Schema == "" || req.Table == "" {
+		return "", nil, errors.New("dbtool: schema and table are required")
+	}
+	if len(req.Values) == 0 {
+		return "", nil, errors.New("dbtool: update requires at least one column value")
+	}
+	if len(req.PK) == 0 {
+		return "", nil, errors.New("dbtool: update requires the row's primary key")
+	}
+	var sb strings.Builder
+	var args []any
+	sb.WriteString("UPDATE ")
+	sb.WriteString(d.QuoteIdent(req.Schema, req.Table))
+	sb.WriteString(" SET ")
+	for i, c := range sortedKeys(req.Values) {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		args = append(args, req.Values[c])
+		sb.WriteString(d.QuoteIdent(c))
+		sb.WriteString(" = ")
+		sb.WriteString(d.Placeholder(len(args)))
+	}
+	sb.WriteString(" WHERE ")
+	writePKWhere(&sb, &args, req.PK, d)
+	return sb.String(), args, nil
+}
+
+// writePKWhere appends "pk1 <eq> $n AND pk2 <eq> $m" (NULL-safe equality
+// via the dialect) for the pk map, in deterministic column order.
+func writePKWhere(sb *strings.Builder, args *[]any, pk map[string]any, d Dialect) {
+	for i, c := range sortedKeys(pk) {
+		if i > 0 {
+			sb.WriteString(" AND ")
+		}
+		*args = append(*args, pk[c])
+		sb.WriteString(d.QuoteIdent(c))
+		sb.WriteString(" ")
+		sb.WriteString(d.NullSafeEq())
+		sb.WriteString(" ")
+		sb.WriteString(d.Placeholder(len(*args)))
+	}
+}
+
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/dbtool/sqlbuild_test.go
+++ b/internal/dbtool/sqlbuild_test.go
@@ -67,7 +67,7 @@ func TestBuildTableDataSQL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sql, args, err := buildTableDataSQL(tt.req)
+			sql, args, err := buildTableDataSQL(tt.req, pgDialect{})
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got sql %q", sql)
@@ -91,7 +91,7 @@ func TestBuildInsertSQL(t *testing.T) {
 	sql, args, err := buildInsertSQL(RowInsertReq{
 		Schema: "public", Table: "users",
 		Values: map[string]any{"name": "bob", "age": 42},
-	})
+	}, pgDialect{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestBuildInsertSQL(t *testing.T) {
 		t.Fatalf("args = %#v", args)
 	}
 
-	if _, _, err := buildInsertSQL(RowInsertReq{Schema: "s", Table: "t"}); err == nil {
+	if _, _, err := buildInsertSQL(RowInsertReq{Schema: "s", Table: "t"}, pgDialect{}); err == nil {
 		t.Fatal("expected error for empty values")
 	}
 }
@@ -114,7 +114,7 @@ func TestBuildUpdateSQL(t *testing.T) {
 		Schema: "public", Table: "users",
 		PK:     map[string]any{"id": 7},
 		Values: map[string]any{"name": "alice"},
-	})
+	}, pgDialect{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -126,10 +126,10 @@ func TestBuildUpdateSQL(t *testing.T) {
 		t.Fatalf("args = %#v", args)
 	}
 
-	if _, _, err := buildUpdateSQL(RowUpdateReq{Schema: "s", Table: "t", Values: map[string]any{"a": 1}}); err == nil {
+	if _, _, err := buildUpdateSQL(RowUpdateReq{Schema: "s", Table: "t", Values: map[string]any{"a": 1}}, pgDialect{}); err == nil {
 		t.Fatal("expected error for missing pk")
 	}
-	if _, _, err := buildUpdateSQL(RowUpdateReq{Schema: "s", Table: "t", PK: map[string]any{"id": 1}}); err == nil {
+	if _, _, err := buildUpdateSQL(RowUpdateReq{Schema: "s", Table: "t", PK: map[string]any{"id": 1}}, pgDialect{}); err == nil {
 		t.Fatal("expected error for empty values")
 	}
 }
@@ -139,7 +139,7 @@ func TestBuildUpdateSQLCompositePK(t *testing.T) {
 		Schema: "s", Table: "t",
 		PK:     map[string]any{"b": 2, "a": 1},
 		Values: map[string]any{"v": "x"},
-	})
+	}, pgDialect{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/dbtool/sqldriver.go
+++ b/internal/dbtool/sqldriver.go
@@ -95,7 +95,7 @@ func sqlExecute(ctx context.Context, db *sql.DB, sqlText string, args []any, rea
 	}
 	cols, err := rows.Columns()
 	if err != nil {
-		rows.Close()
+		_ = rows.Close()
 		return nil, err
 	}
 	colTypes, _ := rows.ColumnTypes()
@@ -119,7 +119,7 @@ func sqlExecute(ctx context.Context, db *sql.DB, sqlText string, args []any, rea
 			ptrs[i] = &holders[i]
 		}
 		if err := rows.Scan(ptrs...); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return nil, fmt.Errorf("dbtool: read row: %w", err)
 		}
 		row := make([]any, len(cols))
@@ -128,7 +128,7 @@ func sqlExecute(ctx context.Context, db *sql.DB, sqlText string, args []any, rea
 		}
 		rs.Rows = append(rs.Rows, row)
 	}
-	rows.Close()
+	_ = rows.Close()
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/dbtool/sqldriver.go
+++ b/internal/dbtool/sqldriver.go
@@ -1,0 +1,173 @@
+package dbtool
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Shared database/sql plumbing for the MySQL/MariaDB and SQLite drivers.
+// PostgreSQL keeps its own pgx-based path (postgres.go); these two ride
+// database/sql, so they share the handle type, row rendering and the
+// read-only / affected-rows execution helpers here.
+
+// sqlHandle wraps a database/sql pool as a dbtool Handle.
+type sqlHandle struct{ db *sql.DB }
+
+func (h *sqlHandle) Close() { _ = h.db.Close() }
+
+func sqlDB(h Handle) (*sql.DB, error) {
+	sh, ok := h.(*sqlHandle)
+	if !ok || sh.db == nil {
+		return nil, errors.New("dbtool: handle is not a database/sql pool")
+	}
+	return sh.db, nil
+}
+
+// binaryTypeNames are the column DatabaseTypeName()s whose []byte payload
+// is genuinely binary and must be base64-encoded. Everything else that
+// scans as []byte (VARCHAR/TEXT/JSON/DECIMAL/…) is UTF-8 text and is
+// returned as a string — database/sql hands back []byte for text columns,
+// so a blanket base64 (like pgx's bytea path) would corrupt normal text.
+var binaryTypeNames = map[string]bool{
+	"BLOB": true, "TINYBLOB": true, "MEDIUMBLOB": true, "LONGBLOB": true,
+	"BINARY": true, "VARBINARY": true, "BYTEA": true,
+}
+
+// sqlCell renders one database/sql cell JSON-safe. []byte is text unless
+// the column type is binary; other types defer to the shared jsonSafe.
+func sqlCell(v any, binary bool) any {
+	if b, ok := v.([]byte); ok {
+		if binary {
+			return base64.StdEncoding.EncodeToString(b)
+		}
+		return string(b)
+	}
+	return jsonSafe(v)
+}
+
+// sqlExecute runs one statement over database/sql.
+//   - readOnly wraps it in a read-only transaction (the second fence behind
+//     the classifier): MySQL issues START TRANSACTION READ ONLY, SQLite sets
+//     PRAGMA query_only — both via database/sql's TxOptions.ReadOnly.
+//   - wantRows collects a result set (SELECT, or INSERT … RETURNING); when
+//     false the statement is a bare write and only RowsAffected/Command are
+//     returned.
+func sqlExecute(ctx context.Context, db *sql.DB, sqlText string, args []any, readOnly, wantRows bool, maxRows int, timeout time.Duration) (*ResultSet, error) {
+	if maxRows <= 0 {
+		maxRows = 500
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: readOnly})
+	if err != nil {
+		return nil, fmt.Errorf("dbtool: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	start := time.Now()
+	rs := &ResultSet{Columns: []ColumnMeta{}, Rows: [][]any{}}
+
+	if !wantRows {
+		res, err := tx.ExecContext(ctx, sqlText, args...)
+		if err != nil {
+			return nil, err
+		}
+		if n, err := res.RowsAffected(); err == nil {
+			rs.RowsAffected = n
+		}
+		rs.Command = firstWord(sqlText)
+		if err := tx.Commit(); err != nil {
+			return nil, err
+		}
+		rs.DurationMs = time.Since(start).Milliseconds()
+		return rs, nil
+	}
+
+	rows, err := tx.QueryContext(ctx, sqlText, args...)
+	if err != nil {
+		return nil, err
+	}
+	cols, err := rows.Columns()
+	if err != nil {
+		rows.Close()
+		return nil, err
+	}
+	colTypes, _ := rows.ColumnTypes()
+	binary := make([]bool, len(cols))
+	for i, name := range cols {
+		typeName := ""
+		if i < len(colTypes) && colTypes[i] != nil {
+			typeName = strings.ToUpper(colTypes[i].DatabaseTypeName())
+			binary[i] = binaryTypeNames[typeName]
+		}
+		rs.Columns = append(rs.Columns, ColumnMeta{Name: name, Type: typeName})
+	}
+	for rows.Next() {
+		if len(rs.Rows) >= maxRows {
+			rs.Truncated = true
+			break
+		}
+		holders := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range holders {
+			ptrs[i] = &holders[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("dbtool: read row: %w", err)
+		}
+		row := make([]any, len(cols))
+		for i, v := range holders {
+			row[i] = sqlCell(v, binary[i])
+		}
+		rs.Rows = append(rs.Rows, row)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	rs.Command = firstWord(sqlText)
+	rs.RowsAffected = int64(len(rs.Rows))
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	rs.DurationMs = time.Since(start).Milliseconds()
+	return rs, nil
+}
+
+// sqlExecuteAffected runs a write statement and returns rows affected
+// (row update/delete). Always a read-write transaction.
+func sqlExecuteAffected(ctx context.Context, db *sql.DB, sqlText string, args []any, timeout time.Duration) (int64, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("dbtool: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	res, err := tx.ExecContext(ctx, sqlText, args...)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// firstWord returns the upper-cased leading keyword of a statement (its
+// command tag: INSERT / UPDATE / DELETE / SELECT …).
+func firstWord(sqlText string) string {
+	fields := strings.Fields(strings.TrimSpace(sqlText))
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.ToUpper(fields[0])
+}

--- a/internal/dbtool/sqlite.go
+++ b/internal/dbtool/sqlite.go
@@ -167,7 +167,7 @@ func (sqliteDriver) Tables(ctx context.Context, h Handle, schema string, timeout
 	if err != nil {
 		return nil, fmt.Errorf("dbtool: list tables: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var out []Table
 	for rows.Next() {
 		var t Table
@@ -211,7 +211,7 @@ func (d sqliteDriver) TableMeta(ctx context.Context, h Handle, schema, table str
 		var name, ctype string
 		var dflt sql.NullString
 		if err := colRows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
-			colRows.Close()
+			_ = colRows.Close()
 			return meta, err
 		}
 		meta.Columns = append(meta.Columns, Column{
@@ -222,7 +222,7 @@ func (d sqliteDriver) TableMeta(ctx context.Context, h Handle, schema, table str
 			pks = append(pks, pkCol{name: name, ord: pk})
 		}
 	}
-	colRows.Close()
+	_ = colRows.Close()
 	if err := colRows.Err(); err != nil {
 		return meta, err
 	}
@@ -251,12 +251,12 @@ func (d sqliteDriver) TableMeta(ctx context.Context, h Handle, schema, table str
 		var seq, unique, partial int
 		var name, origin string
 		if err := idxRows.Scan(&seq, &name, &unique, &origin, &partial); err != nil {
-			idxRows.Close()
+			_ = idxRows.Close()
 			return meta, err
 		}
 		idxList = append(idxList, idxInfo{name: name, unique: unique == 1})
 	}
-	idxRows.Close()
+	_ = idxRows.Close()
 	if err := idxRows.Err(); err != nil {
 		return meta, err
 	}
@@ -282,7 +282,7 @@ func (d sqliteDriver) TableMeta(ctx context.Context, h Handle, schema, table str
 		var id, seq int
 		var refTable, from, to, onUpdate, onDelete, match string
 		if err := fkRows.Scan(&id, &seq, &refTable, &from, &to, &onUpdate, &onDelete, &match); err != nil {
-			fkRows.Close()
+			_ = fkRows.Close()
 			return meta, err
 		}
 		fk, ok := fkByID[id]
@@ -294,7 +294,7 @@ func (d sqliteDriver) TableMeta(ctx context.Context, h Handle, schema, table str
 		fk.Columns = append(fk.Columns, from)
 		fk.RefColumns = append(fk.RefColumns, to)
 	}
-	fkRows.Close()
+	_ = fkRows.Close()
 	if err := fkRows.Err(); err != nil {
 		return meta, err
 	}
@@ -310,7 +310,7 @@ func sqliteIndexColumns(ctx context.Context, db *sql.DB, index string) ([]string
 	if err != nil {
 		return nil, fmt.Errorf("dbtool: index columns: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	var cols []string
 	for rows.Next() {
 		var seqno, cid int

--- a/internal/dbtool/sqlite.go
+++ b/internal/dbtool/sqlite.go
@@ -1,0 +1,413 @@
+package dbtool
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite" // pure-Go SQLite; registers the "sqlite" driver
+)
+
+// sqliteDriver implements Driver over modernc.org/sqlite (pure Go, no cgo,
+// so it cross-compiles under CGO_ENABLED=0 like the rest of the binary).
+//
+// A SQLite "connection" is a FILE PATH on the gateway host, not host/port.
+// Two safety fences apply: the file path must resolve inside the
+// connection's project cwd (sqliteResolvePath — rejects "../" and
+// symlinked-intermediate escapes), and extension loading is never enabled
+// (modernc keeps it off; the DSN carries only a busy_timeout pragma). SQLite
+// has no schemas, so Schemas reports the single "main" namespace.
+type sqliteDriver struct{}
+
+func (sqliteDriver) dialect() Dialect { return sqliteDialect{} }
+
+// sqliteResolvePath validates a SQLite file path against the project cwd.
+// A relative path is taken relative to cwd; the result must stay within
+// cwd after symlink resolution. This is the SQLite analogue of fs's
+// resolveWithinRoot — the per-project isolation fence.
+func sqliteResolvePath(dbPath, cwd string) (string, error) {
+	if strings.TrimSpace(cwd) == "" {
+		return "", errors.New("dbtool: sqlite connection requires a project cwd")
+	}
+	if strings.TrimSpace(dbPath) == "" {
+		return "", errors.New("dbtool: sqlite requires a database file path")
+	}
+	cwdAbs, err := filepath.Abs(cwd)
+	if err != nil {
+		return "", fmt.Errorf("dbtool: invalid cwd: %w", err)
+	}
+	// Resolve the cwd's own symlinks first (e.g. macOS /var → /private/var)
+	// so the containment check compares like with like.
+	rootResolved := cwdAbs
+	if r, rerr := filepath.EvalSymlinks(cwdAbs); rerr == nil {
+		rootResolved = r
+	}
+	p := dbPath
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(rootResolved, p)
+	}
+	p = filepath.Clean(p)
+	// Resolve symlinks on the path — or, for a not-yet-created file, on its
+	// existing parent — so a symlinked intermediate can't point outside cwd.
+	resolved := p
+	if r, rerr := filepath.EvalSymlinks(p); rerr == nil {
+		resolved = r
+	} else if r, rerr := filepath.EvalSymlinks(filepath.Dir(p)); rerr == nil {
+		resolved = filepath.Join(r, filepath.Base(p))
+	}
+	rel, err := filepath.Rel(rootResolved, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", errors.New("dbtool: sqlite path escapes the project directory")
+	}
+	return resolved, nil
+}
+
+// sqliteHandle keeps two pools: a read-write pool (rwc) and a read-only
+// pool (mode=ro). Reads go through the ro pool, whose connections SQLite
+// refuses writes on at the file layer — that is the read-only fence, since
+// modernc does NOT honour database/sql's TxOptions.ReadOnly.
+type sqliteHandle struct {
+	rw *sql.DB
+	ro *sql.DB
+}
+
+func (h *sqliteHandle) Close() {
+	_ = h.rw.Close()
+	_ = h.ro.Close()
+}
+
+func sqlitePools(h Handle) (*sqliteHandle, error) {
+	sh, ok := h.(*sqliteHandle)
+	if !ok || sh.rw == nil || sh.ro == nil {
+		return nil, errors.New("dbtool: handle is not a sqlite handle")
+	}
+	return sh, nil
+}
+
+func sqliteDSN(path string, readOnly bool) string {
+	// Only a busy_timeout pragma — no extension loading, no writable schema
+	// toggles. modernc leaves load_extension disabled by default. mode=ro
+	// opens read-only; the default rwc creates the file if needed.
+	mode := "rwc"
+	if readOnly {
+		mode = "ro"
+	}
+	return fmt.Sprintf("file:%s?mode=%s&_pragma=busy_timeout(5000)", path, mode)
+}
+
+func (sqliteDriver) Open(ctx context.Context, c Connection, opts DriverOpts) (Handle, error) {
+	path, err := sqliteResolvePath(c.DBName, c.Cwd)
+	if err != nil {
+		return nil, err
+	}
+	rw, err := sql.Open("sqlite", sqliteDSN(path, false))
+	if err != nil {
+		return nil, fmt.Errorf("dbtool: open sqlite: %w", err)
+	}
+	// Materialize the file up front so the read-only pool can open it.
+	if err := rw.PingContext(ctx); err != nil {
+		_ = rw.Close()
+		return nil, fmt.Errorf("dbtool: open sqlite: %w", err)
+	}
+	rw.SetMaxOpenConns(1) // SQLite is single-writer; avoids SQLITE_BUSY churn
+	rw.SetConnMaxIdleTime(2 * time.Minute)
+	ro, err := sql.Open("sqlite", sqliteDSN(path, true))
+	if err != nil {
+		_ = rw.Close()
+		return nil, fmt.Errorf("dbtool: open sqlite (ro): %w", err)
+	}
+	ro.SetConnMaxIdleTime(2 * time.Minute)
+	return &sqliteHandle{rw: rw, ro: ro}, nil
+}
+
+func (d sqliteDriver) Ping(ctx context.Context, c Connection, opts DriverOpts) PingResult {
+	start := time.Now()
+	path, err := sqliteResolvePath(c.DBName, c.Cwd)
+	if err != nil {
+		return PingResult{OK: false, Error: err.Error(), LatencyMs: time.Since(start).Milliseconds()}
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(path, false))
+	if err != nil {
+		return PingResult{OK: false, Error: err.Error(), LatencyMs: time.Since(start).Milliseconds()}
+	}
+	defer func() { _ = db.Close() }()
+	var version string
+	if err := db.QueryRowContext(ctx, "SELECT sqlite_version()").Scan(&version); err != nil {
+		return PingResult{OK: false, Error: err.Error(), LatencyMs: time.Since(start).Milliseconds()}
+	}
+	return PingResult{
+		OK:            true,
+		ServerVersion: "SQLite " + version,
+		IsSuperuser:   false, // no role concept; the cwd fence is the guard
+		LatencyMs:     time.Since(start).Milliseconds(),
+	}
+}
+
+func (sqliteDriver) Schemas(ctx context.Context, h Handle, timeout time.Duration) ([]Schema, error) {
+	// SQLite has no schemas; report the single default namespace so the
+	// tree/UI has a node to expand.
+	return []Schema{{Name: "main"}}, nil
+}
+
+func (sqliteDriver) Tables(ctx context.Context, h Handle, schema string, timeout time.Duration) ([]Table, error) {
+	sh, err := sqlitePools(h)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	rows, err := sh.ro.QueryContext(ctx, `
+		SELECT name, type FROM sqlite_master
+		WHERE type IN ('table','view') AND name NOT LIKE 'sqlite_%'
+		ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("dbtool: list tables: %w", err)
+	}
+	defer rows.Close()
+	var out []Table
+	for rows.Next() {
+		var t Table
+		var tType string
+		if err := rows.Scan(&t.Name, &tType); err != nil {
+			return nil, err
+		}
+		if tType == "view" {
+			t.Kind = "view"
+		} else {
+			t.Kind = "table"
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+func (d sqliteDriver) TableMeta(ctx context.Context, h Handle, schema, table string, timeout time.Duration) (TableMeta, error) {
+	sh, err := sqlitePools(h)
+	if err != nil {
+		return TableMeta{}, err
+	}
+	db := sh.ro
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	meta := TableMeta{Schema: schema, Table: table, PrimaryKey: []string{}, Indexes: []Index{}, ForeignKeys: []ForeignKey{}}
+	q := sqliteDialect{}.QuoteIdent(table) // "t" — PRAGMA args can't be bound
+
+	// Columns + PK order via table_info: pk>0 gives the key ordinal.
+	colRows, err := db.QueryContext(ctx, "PRAGMA table_info("+q+")")
+	if err != nil {
+		return meta, fmt.Errorf("dbtool: table columns: %w", err)
+	}
+	type pkCol struct {
+		name string
+		ord  int
+	}
+	var pks []pkCol
+	for colRows.Next() {
+		var cid, notnull, pk int
+		var name, ctype string
+		var dflt sql.NullString
+		if err := colRows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			colRows.Close()
+			return meta, err
+		}
+		meta.Columns = append(meta.Columns, Column{
+			Name: name, DataType: ctype, Nullable: notnull == 0,
+			Default: dflt.String, Position: cid + 1,
+		})
+		if pk > 0 {
+			pks = append(pks, pkCol{name: name, ord: pk})
+		}
+	}
+	colRows.Close()
+	if err := colRows.Err(); err != nil {
+		return meta, err
+	}
+	if len(meta.Columns) == 0 {
+		return meta, fmt.Errorf("dbtool: table %s not found", table)
+	}
+	for i := 1; i <= len(pks); i++ {
+		for _, p := range pks {
+			if p.ord == i {
+				meta.PrimaryKey = append(meta.PrimaryKey, p.name)
+			}
+		}
+	}
+
+	// Indexes via index_list, columns via index_info per index.
+	idxRows, err := db.QueryContext(ctx, "PRAGMA index_list("+q+")")
+	if err != nil {
+		return meta, fmt.Errorf("dbtool: table indexes: %w", err)
+	}
+	type idxInfo struct {
+		name   string
+		unique bool
+	}
+	var idxList []idxInfo
+	for idxRows.Next() {
+		var seq, unique, partial int
+		var name, origin string
+		if err := idxRows.Scan(&seq, &name, &unique, &origin, &partial); err != nil {
+			idxRows.Close()
+			return meta, err
+		}
+		idxList = append(idxList, idxInfo{name: name, unique: unique == 1})
+	}
+	idxRows.Close()
+	if err := idxRows.Err(); err != nil {
+		return meta, err
+	}
+	for _, ii := range idxList {
+		cols, err := sqliteIndexColumns(ctx, db, ii.name)
+		if err != nil {
+			return meta, err
+		}
+		meta.Indexes = append(meta.Indexes, Index{
+			Name: ii.name, Unique: ii.unique, Primary: false,
+			Definition: fmt.Sprintf("(%s)", strings.Join(cols, ", ")),
+		})
+	}
+
+	// Foreign keys via foreign_key_list, grouped by id.
+	fkRows, err := db.QueryContext(ctx, "PRAGMA foreign_key_list("+q+")")
+	if err != nil {
+		return meta, fmt.Errorf("dbtool: table foreign keys: %w", err)
+	}
+	fkByID := map[int]*ForeignKey{}
+	var fkOrder []int
+	for fkRows.Next() {
+		var id, seq int
+		var refTable, from, to, onUpdate, onDelete, match string
+		if err := fkRows.Scan(&id, &seq, &refTable, &from, &to, &onUpdate, &onDelete, &match); err != nil {
+			fkRows.Close()
+			return meta, err
+		}
+		fk, ok := fkByID[id]
+		if !ok {
+			fk = &ForeignKey{Name: fmt.Sprintf("fk_%d", id), RefSchema: "main", RefTable: refTable}
+			fkByID[id] = fk
+			fkOrder = append(fkOrder, id)
+		}
+		fk.Columns = append(fk.Columns, from)
+		fk.RefColumns = append(fk.RefColumns, to)
+	}
+	fkRows.Close()
+	if err := fkRows.Err(); err != nil {
+		return meta, err
+	}
+	for _, id := range fkOrder {
+		meta.ForeignKeys = append(meta.ForeignKeys, *fkByID[id])
+	}
+	return meta, nil
+}
+
+func sqliteIndexColumns(ctx context.Context, db *sql.DB, index string) ([]string, error) {
+	q := sqliteDialect{}.QuoteIdent(index)
+	rows, err := db.QueryContext(ctx, "PRAGMA index_info("+q+")")
+	if err != nil {
+		return nil, fmt.Errorf("dbtool: index columns: %w", err)
+	}
+	defer rows.Close()
+	var cols []string
+	for rows.Next() {
+		var seqno, cid int
+		var name sql.NullString
+		if err := rows.Scan(&seqno, &cid, &name); err != nil {
+			return nil, err
+		}
+		if name.Valid {
+			cols = append(cols, name.String)
+		}
+	}
+	return cols, rows.Err()
+}
+
+func (d sqliteDriver) TableData(ctx context.Context, h Handle, req TableDataReq, timeout time.Duration) (*ResultSet, error) {
+	sh, err := sqlitePools(h)
+	if err != nil {
+		return nil, err
+	}
+	sqlText, args, err := buildTableDataSQL(req, d.dialect())
+	if err != nil {
+		return nil, err
+	}
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	return sqlExecute(ctx, sh.ro, sqlText, args, true, true, limit, timeout)
+}
+
+func (d sqliteDriver) InsertRow(ctx context.Context, h Handle, req RowInsertReq, timeout time.Duration) (*ResultSet, error) {
+	sh, err := sqlitePools(h)
+	if err != nil {
+		return nil, err
+	}
+	sqlText, args, err := buildInsertSQL(req, d.dialect()) // RETURNING * (SQLite 3.35+)
+	if err != nil {
+		return nil, err
+	}
+	return sqlExecute(ctx, sh.rw, sqlText, args, false, true, 10, timeout)
+}
+
+func (d sqliteDriver) UpdateRow(ctx context.Context, h Handle, req RowUpdateReq, timeout time.Duration) (int64, error) {
+	sh, err := sqlitePools(h)
+	if err != nil {
+		return 0, err
+	}
+	sqlText, args, err := buildUpdateSQL(req, d.dialect())
+	if err != nil {
+		return 0, err
+	}
+	return sqlExecuteAffected(ctx, sh.rw, sqlText, args, timeout)
+}
+
+func (d sqliteDriver) DeleteRows(ctx context.Context, h Handle, req RowDeleteReq, timeout time.Duration) (int64, error) {
+	if req.Schema == "" || req.Table == "" {
+		return 0, fmt.Errorf("dbtool: schema and table are required")
+	}
+	if len(req.PKs) == 0 {
+		return 0, fmt.Errorf("dbtool: delete requires at least one primary key")
+	}
+	sh, err := sqlitePools(h)
+	if err != nil {
+		return 0, err
+	}
+	dl := d.dialect()
+	var total int64
+	for _, pk := range req.PKs {
+		if len(pk) == 0 {
+			return 0, fmt.Errorf("dbtool: delete requires the row's primary key")
+		}
+		var sb strings.Builder
+		var args []any
+		sb.WriteString("DELETE FROM ")
+		sb.WriteString(dl.QuoteIdent(req.Schema, req.Table))
+		sb.WriteString(" WHERE ")
+		writePKWhere(&sb, &args, pk, dl)
+		n, err := sqlExecuteAffected(ctx, sh.rw, sb.String(), args, timeout)
+		if err != nil {
+			return 0, err
+		}
+		total += n
+	}
+	return total, nil
+}
+
+func (d sqliteDriver) Query(ctx context.Context, h Handle, req QueryReq, class StatementClass, maxRows int, timeout time.Duration) (*ResultSet, error) {
+	sh, err := sqlitePools(h)
+	if err != nil {
+		return nil, err
+	}
+	readOnly := class == ClassRead
+	// Reads go through the ro pool (write-refusing at the file layer);
+	// writes/DDL through the rw pool.
+	db := sh.rw
+	if readOnly {
+		db = sh.ro
+	}
+	return sqlExecute(ctx, db, req.SQL, nil, readOnly, readOnly, maxRows, timeout)
+}

--- a/internal/dbtool/sqlite_test.go
+++ b/internal/dbtool/sqlite_test.go
@@ -133,3 +133,19 @@ func TestSQLiteResolvePath(t *testing.T) {
 		t.Fatalf("resolved = %q, want %q", got, want)
 	}
 }
+
+// TestParams (the "Test" button on an unsaved connection) must carry the
+// cwd through to the driver — SQLite's Ping needs it for the file-path
+// fence. Regression: TestParams built the Connection without Cwd, so every
+// SQLite Test failed with "requires a project cwd".
+func TestTestParamsSQLiteCarriesCwd(t *testing.T) {
+	dir := t.TempDir()
+	svc := NewService(nil, Options{}, nil)
+	defer svc.Close()
+	res := svc.TestParams(context.Background(), CreateParams{
+		Cwd: dir, Name: "probe", Driver: "sqlite", DBName: "probe.db",
+	})
+	if !res.OK {
+		t.Fatalf("sqlite TestParams failed: %s", res.Error)
+	}
+}

--- a/internal/dbtool/sqlite_test.go
+++ b/internal/dbtool/sqlite_test.go
@@ -1,0 +1,135 @@
+package dbtool
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// SQLite runs entirely on a local temp file (pure-Go modernc, no external
+// service), so this full round-trip executes in CI — unlike the postgres /
+// mysql integration tests that skip without a live server.
+func TestSQLiteDriverRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	c := Connection{Driver: "sqlite", Cwd: dir, DBName: "test.db"}
+	d := sqliteDriver{}
+	ctx := context.Background()
+	to := 10 * time.Second
+
+	if pr := d.Ping(ctx, c, DriverOpts{}); !pr.OK {
+		t.Fatalf("ping failed: %s", pr.Error)
+	}
+	h, err := d.Open(ctx, c, DriverOpts{})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer h.Close()
+
+	if _, err := d.Query(ctx, h, QueryReq{
+		SQL: `CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL, note TEXT)`,
+	}, ClassDDL, 100, to); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	rs, err := d.InsertRow(ctx, h, RowInsertReq{
+		Schema: "main", Table: "users",
+		Values: map[string]any{"id": 1, "name": "alice"},
+	}, to)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	// SQLite supports RETURNING, so the inserted row comes back.
+	if len(rs.Rows) != 1 {
+		t.Fatalf("insert RETURNING gave %d rows, want 1", len(rs.Rows))
+	}
+
+	schemas, err := d.Schemas(ctx, h, to)
+	if err != nil || len(schemas) != 1 || schemas[0].Name != "main" {
+		t.Fatalf("schemas = %#v, err %v", schemas, err)
+	}
+
+	tables, err := d.Tables(ctx, h, "main", to)
+	if err != nil || len(tables) != 1 || tables[0].Name != "users" {
+		t.Fatalf("tables = %#v, err %v", tables, err)
+	}
+
+	meta, err := d.TableMeta(ctx, h, "main", "users", to)
+	if err != nil {
+		t.Fatalf("meta: %v", err)
+	}
+	if len(meta.PrimaryKey) != 1 || meta.PrimaryKey[0] != "id" {
+		t.Fatalf("primary key = %#v, want [id]", meta.PrimaryKey)
+	}
+	if len(meta.Columns) != 3 {
+		t.Fatalf("columns = %d, want 3", len(meta.Columns))
+	}
+
+	td, err := d.TableData(ctx, h, TableDataReq{Schema: "main", Table: "users", Limit: 10}, to)
+	if err != nil {
+		t.Fatalf("table data: %v", err)
+	}
+	if len(td.Rows) != 1 {
+		t.Fatalf("table data rows = %d, want 1", len(td.Rows))
+	}
+
+	// Read-only fence: a write forced down the read path (readOnly tx via
+	// PRAGMA query_only) must be refused by SQLite, not silently applied.
+	if _, err := d.Query(ctx, h, QueryReq{
+		SQL: `UPDATE users SET name = 'x' WHERE id = 1`,
+	}, ClassRead, 100, to); err == nil {
+		t.Fatal("read-only transaction allowed a write")
+	}
+
+	n, err := d.UpdateRow(ctx, h, RowUpdateReq{
+		Schema: "main", Table: "users",
+		PK:     map[string]any{"id": 1},
+		Values: map[string]any{"name": "bob"},
+	}, to)
+	if err != nil || n != 1 {
+		t.Fatalf("update affected %d, err %v", n, err)
+	}
+
+	del, err := d.DeleteRows(ctx, h, RowDeleteReq{
+		Schema: "main", Table: "users",
+		PKs:    []map[string]any{{"id": 1}},
+	}, to)
+	if err != nil || del != 1 {
+		t.Fatalf("delete affected %d, err %v", del, err)
+	}
+}
+
+// The cwd fence is the SQLite isolation guard — a path escaping the
+// project directory (via "..", an absolute path, or a symlink) must be
+// rejected before any file is opened.
+func TestSQLiteResolvePath(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := sqliteResolvePath("../evil.db", dir); err == nil {
+		t.Error("`..` escape was allowed")
+	}
+	if _, err := sqliteResolvePath("/etc/passwd", dir); err == nil {
+		t.Error("absolute out-of-cwd path was allowed")
+	}
+	if _, err := sqliteResolvePath("app.db", ""); err == nil {
+		t.Error("empty cwd was allowed")
+	}
+	if _, err := sqliteResolvePath("", dir); err == nil {
+		t.Error("empty path was allowed")
+	}
+
+	got, err := sqliteResolvePath("sub/app.db", dir)
+	if err != nil {
+		t.Fatalf("in-cwd relative path rejected: %v", err)
+	}
+	want := filepath.Join(dir, "sub", "app.db")
+	// dir may itself be a symlink (macOS /var → /private/var); compare the
+	// resolved forms.
+	if rd, e := filepath.EvalSymlinks(dir); e == nil {
+		want = filepath.Join(rd, "sub", "app.db")
+	}
+	if got != want && !strings.HasSuffix(got, filepath.Join("sub", "app.db")) {
+		t.Fatalf("resolved = %q, want %q", got, want)
+	}
+}

--- a/internal/dbtool/sqlite_test.go
+++ b/internal/dbtool/sqlite_test.go
@@ -93,7 +93,7 @@ func TestSQLiteDriverRoundTrip(t *testing.T) {
 
 	del, err := d.DeleteRows(ctx, h, RowDeleteReq{
 		Schema: "main", Table: "users",
-		PKs:    []map[string]any{{"id": 1}},
+		PKs: []map[string]any{{"id": 1}},
 	}, to)
 	if err != nil || del != 1 {
 		t.Fatalf("delete affected %d, err %v", del, err)

--- a/internal/dbtool/sqlite_test.go
+++ b/internal/dbtool/sqlite_test.go
@@ -74,12 +74,25 @@ func TestSQLiteDriverRoundTrip(t *testing.T) {
 		t.Fatalf("table data rows = %d, want 1", len(td.Rows))
 	}
 
-	// Read-only fence: a write forced down the read path (readOnly tx via
-	// PRAGMA query_only) must be refused by SQLite, not silently applied.
+	// Read-only fence: a write forced down the read path must be refused.
+	// SQLite reads go through a separate mode=ro connection pool that
+	// rejects writes at the file layer (modernc has no read-only
+	// transaction). Assert BOTH that the write errors AND that the row is
+	// genuinely unchanged — so the test can't pass on an unrelated error.
 	if _, err := d.Query(ctx, h, QueryReq{
 		SQL: `UPDATE users SET name = 'x' WHERE id = 1`,
 	}, ClassRead, 100, to); err == nil {
-		t.Fatal("read-only transaction allowed a write")
+		t.Fatal("read path allowed a write")
+	}
+	guard, err := d.TableData(ctx, h,
+		TableDataReq{Schema: "main", Table: "users", Limit: 10}, to)
+	if err != nil {
+		t.Fatalf("post-fence read: %v", err)
+	}
+	// Columns are id(0), name(1), note(2): the refused UPDATE tried to set
+	// name='x'; it must still be 'alice'.
+	if len(guard.Rows) != 1 || guard.Rows[0][1] != "alice" {
+		t.Fatalf("read-only fence let a write through: rows = %#v", guard.Rows)
 	}
 
 	n, err := d.UpdateRow(ctx, h, RowUpdateReq{

--- a/internal/store/migrations/0075_db_connections_drivers.sql
+++ b/internal/store/migrations/0075_db_connections_drivers.sql
@@ -1,0 +1,12 @@
+-- 0075_db_connections_drivers — widen the Database tool from PostgreSQL
+-- only to MySQL, MariaDB and SQLite.
+--
+-- 0072 created the driver column with an inline (anonymous) CHECK, which
+-- PostgreSQL named db_connections_driver_check. Drop and re-add it with the
+-- wider engine set. host / username stay NOT NULL: a SQLite connection
+-- stores '' for both — its "connection" is a file path in db_name, fenced
+-- to the project cwd by the driver at open time — while MySQL/MariaDB use
+-- host/port/username like PostgreSQL.
+ALTER TABLE db_connections DROP CONSTRAINT IF EXISTS db_connections_driver_check;
+ALTER TABLE db_connections ADD CONSTRAINT db_connections_driver_check
+    CHECK (driver IN ('postgres', 'mysql', 'mariadb', 'sqlite'));

--- a/internal/store/migrations/0076_kb_integrations_multidriver.sql
+++ b/internal/store/migrations/0076_kb_integrations_multidriver.sql
@@ -1,3 +1,21 @@
+-- 0076_kb_integrations_multidriver — kb_integrations refresh: the Database
+-- tool now supports MySQL, MariaDB and SQLite alongside PostgreSQL. MySQL
+-- and MariaDB use host/port/username like PostgreSQL; SQLite is a file-path
+-- connection fenced to the project cwd (path escapes rejected) with
+-- extension loading disabled. See the INTEGRATION_GUIDE "The Database tool"
+-- section for the supported-engines note.
+--
+-- Why a new migration instead of editing 0074: the runner records applied
+-- versions by filename and never re-applies one. This force-updates the
+-- page (DO UPDATE), keeping updated_by='operator' so the AI KB drafter
+-- treats it as human-locked.
+
+INSERT INTO project_docs (id, cwd, kind, content, updated_by, updated_at)
+VALUES (
+    'doc_global_kb_integrations',
+    '__global__',
+    'kb_integrations',
+    $ODGUIDE$
 # opendray Third-Party Integration Guide
 
 This is the canonical, forward-looking contract that **every** third-party app or website MUST follow to integrate with opendray. opendray is a self-hosted gateway that drives AI coding CLIs (Claude Code, Codex, OpenCode, antigravity) over a PTY behind a unified REST + WebSocket API. A third-party app integrates by being **registered by an operator** (admin-only), receiving a **one-time scoped API key**, and then spawning and driving agent sessions over REST while optionally proxying its own UI and subscribing to a live event stream. This document states the rules as explicit **MUST / SHOULD / NEVER**, documents the current reality honestly (including what is *not* enforced yet), and gives you a runnable end-to-end path.
@@ -867,3 +885,11 @@ This guide describes the opendray `/api/v1` integration contract as of **opendra
 - **Roadmap:** per-route scope enforcement for the still-unenforced `session:*` / `channel:*` / `provider:read`. Design your client now to handle `403` on any endpoint without breaking.
 
 When the code changes (new enforced scopes, spawn-profile fields, memory-zone semantics, or any endpoint addition), this guide MUST be updated in lockstep and re-seeded into the `kb_integrations` knowledge page (add a new `project_docs` upsert migration — the original seed migration is immutable once applied).
+$ODGUIDE$,
+    'operator',
+    NOW()
+)
+ON CONFLICT (cwd, kind) DO UPDATE
+    SET content    = EXCLUDED.content,
+        updated_by = EXCLUDED.updated_by,
+        updated_at = EXCLUDED.updated_at;


### PR DESCRIPTION
## Summary

Extends the Database tool beyond PostgreSQL to **MySQL, MariaDB and SQLite** — web, mobile and the auto-attached MCP all inherit it, since the change lives behind the existing `Driver` interface (service / handler / MCP layers untouched).

## Design

- **Dialect abstraction** (`dialect.go`) — identifier quoting, bind-param spelling (`$n` vs `?`), null-safe equality (`IS NOT DISTINCT FROM` / `<=>` / `IS`), RETURNING support and filter operators. The postgres SQL builders move to `sqlbuild.go` and take a `Dialect`; **pg output is byte-identical** (guarded by the existing `sqlbuild_test`).
- **MySQL/MariaDB** (`mysql.go`, `go-sql-driver/mysql`) — shared implementation (MariaDB = same wire protocol); schema == database; `information_schema` introspection; `READ ONLY` transaction read fence; no-RETURNING insert path.
- **SQLite** (`sqlite.go`, `modernc.org/sqlite`) — **file-path connection fenced to the project `cwd`** (rejects `../` and symlink escapes), extension loading disabled. Read fence via a dedicated `mode=ro` connection pool (modernc ignores `TxOptions.ReadOnly`). PRAGMA introspection.
- **Pure Go, no cgo** — both new drivers cross-compile under `CGO_ENABLED=0`, so goreleaser's 4-platform build is unaffected.
- **Web + mobile** connection forms gain an engine picker; SQLite switches to a single file-path field with an in-cwd hint. i18n (en/zh/es), slang regenerated.
- **Classifier** — backtick-identifier tokenizing + `DESCRIBE`/`DESC` read leaders.
- **Migrations** — `0075` widens the driver CHECK; `0076` reseeds the kb_integrations page. Both validated on an ephemeral pg17.

## Test plan

- [x] `go test -race ./internal/dbtool/`, `go vet`, `go build ./...` — green. Includes a **full SQLite round-trip that runs in CI** (local temp file): introspect / CRUD / read-only fence / cwd-escape rejection; plus dialect + mysql-builder unit tests.
- [x] `pnpm build:web` (tsc + vite) green; i18n parity green; `flutter analyze` clean.
- [x] Migration `0075` (mysql/sqlite accepted, oracle rejected, empty host/user for sqlite) and `0076` (idempotent reseed) validated on ephemeral pg17.
- [ ] **Operator, on a deployed build**: register a MySQL connection → test → browse / page / row CRUD; register a SQLite connection with an in-cwd file → browse / CRUD; a SQLite path outside cwd is rejected; writes on a read-only connection are refused. MySQL integration test runs with `OPENDRAY_DEV_MYSQL_URL` set.

> No changes to the Driver/service/handler/MCP contracts. MySQL integration tests skip without a live server (CI has none); SQLite tests run unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)