### PR TITLE
fix(backup): attach admin token to download URL

### DIFF
--- a/app/shared/src/lib/backup.ts
+++ b/app/shared/src/lib/backup.ts
@@ -260,10 +260,13 @@ export async function deleteBackup(id: string): Promise<void> {
   })
 }
 
-/** Browser-friendly download URL — admin token rides via cookie/auth header
- *  on the underlying fetch the browser issues when the user clicks. */
-export function backupDownloadURL(id: string): string {
-  return `/api/v1/backups/${encodeURIComponent(id)}/download`
+/** Browser-friendly download URL. Auth rides in the query string — a
+ *  browser anchor navigation can't set an Authorization header, and there
+ *  is no auth cookie, so the admin bearer must go via the `?token=`
+ *  fallback the gateway middleware accepts (same path fs/export downloads
+ *  use). Without it the endpoint returns {"error":"unauthorized"}. */
+export function backupDownloadURL(id: string, token: string): string {
+  return `/api/v1/backups/${encodeURIComponent(id)}/download?token=${encodeURIComponent(token)}`
 }
 
 export async function listTargets(): Promise<TargetSpec[]> {

--- a/app/web/src/components/backup/BackupsView.tsx
+++ b/app/web/src/components/backup/BackupsView.tsx
@@ -75,6 +75,7 @@ import {
 } from '@/lib/backup'
 import { TargetEditor, targetSummary } from './TargetEditor'
 import { APIError } from '@/lib/api'
+import { useAuth } from '@/stores/auth'
 import { cn } from '@/lib/utils'
 
 export function BackupsView() {
@@ -1051,6 +1052,7 @@ function BackupTable({
   onDelete: (id: string) => void | Promise<void>
 }) {
   const { t } = useTranslation()
+  const token = useAuth((s) => s.token)
   if (rows === null) {
     return <div className="text-muted-foreground text-sm">{t('web.backups.loading')}</div>
   }
@@ -1132,7 +1134,7 @@ function BackupTable({
                 <div className="flex justify-end gap-1">
                   {b.status === 'succeeded' && (
                     <a
-                      href={backupDownloadURL(b.id)}
+                      href={backupDownloadURL(b.id, token ?? '')}
                       className="inline-flex items-center justify-center h-7 w-7 rounded-md border border-border hover:bg-card"
                       title={t('web.backups.backupsTab.downloadTooltip')}
                     >


### PR DESCRIPTION
## Problem

Downloading a backup from the web **Backups** tab fails with `{"error":"unauthorized"}`.

## Root cause

`backupDownloadURL()` (`app/shared/src/lib/backup.ts`) returned a bare
`/api/v1/backups/{id}/download` with no auth. Its comment claimed *"admin token rides via cookie/auth header"* — but that is wrong:

- opendray authenticates with **bearer tokens** (`Authorization: Bearer` from the `useAuth` store), **not cookies**.
- The Backups tab triggers the download through an `<a href>` **anchor navigation** (`BackupsView.tsx`), and browsers **cannot attach an `Authorization` header** to an anchor navigation.

So the request reached `authSvc.Middleware` with no credentials → `unauthorized`.

## Fix

Append the admin bearer via the `?token=` query fallback that the gateway middleware already accepts (`bearerToken()` reads `Authorization: Bearer` **or** `?token=`). This is the exact pattern the sibling helpers `fsDownloadURL` and `exportDownloadURL` already use.

- `backupDownloadURL(id, token)` now appends `?token=<encoded>` and the misleading comment is corrected.
- `BackupTable` reads the token from the `useAuth` store and passes it through.

Web-only: mobile exposes no backup-file download (only export download), so there is no parity gap.

## Test plan

- [x] `pnpm --filter web build` (tsc -b + vite) passes
- [x] `tsc --noEmit` passes
- [x] `eslint` introduces no new problems on the changed file (pre-existing warnings on unrelated lines only)
- [ ] Manual: click the download icon on a succeeded backup → file downloads instead of `unauthorized`

🤖 Generated with [Claude Code](https://claude.com/claude-code)