### PR TITLE
ci: bump goreleaser-action to v7.2.3 (node24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,11 +125,10 @@ jobs:
       # ── Goreleaser: archives + checksums in ./dist, published release on GH.
       #    --release-notes overrides the static header in .goreleaser.yml
       #    with the extracted CHANGELOG section. SHA-pinned for supply-
-      #    chain integrity. Intentionally pinned on v6 (not v7) to
-      #    avoid the v7 ESM/Node 24 breaking change until we explicitly
-      #    validate it.
+      #    chain integrity. On v7 (node24) — validated end-to-end against a
+      #    v0.0.0-test prerelease tag before this landed.
       - name: Run goreleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a  # v6
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3
         with:
           version: latest
           args: release --clean --release-notes=${{ runner.temp }}/release-notes.md


### PR DESCRIPTION
Clears the last remaining Node-20 deprecation warning — the one on the release-critical `goreleaser-action`, which was previously pinned on v6 deliberately (v7 carries an ESM/Node-24 change) until validated.

- `goreleaser/goreleaser-action@e435ccd…` (v6, node20) → `@f06c13b…` (**v7.2.3**, node24), SHA-pinned.

### Validated end-to-end before this PR
Pushed a `v0.0.0-test` prerelease tag at this commit and ran the real Release pipeline with v7:
- ✅ goreleaser built all 8 release assets (4 platform tarballs + SBOM + `SHA256SUMS` + `.sig` + `.pem`) — identical to a real release.
- ✅ cosign keyless signing + SBOM upload succeeded.
- ✅ **No Node-20 annotation** on the run (only the pre-existing "goreleaser version: latest" note).
- ✅ `publish-npm` correctly **skipped** (the `!contains(tag, '-')` guard), so no package pollution.
- ✅ Release marked Pre-release; `v2.11.x` stayed "Latest".

Test release + tag were deleted after validation. Combined with #429, this clears **every** Node-20 warning across CI and Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)