### PR TITLE
ci(release): auto-rebuild opendray.dev from the release job

### DIFF
--- a/.github/workflows/notify-site-on-release.yml
+++ b/.github/workflows/notify-site-on-release.yml
@@ -1,9 +1,15 @@
 name: Notify site on release
 
-# When a GitHub release is flipped from draft to published, ping
-# Opendray/opendray.dev so it rebuilds and the changelog/version card
-# updates immediately. Without this, opendray.dev only rebuilds on its
-# own push-to-main, so new releases can sit unseen on the site for days.
+# Pings Opendray/opendray.dev so it rebuilds and the changelog/version
+# card updates immediately.
+#
+# NOTE: the `release: published` trigger below does NOT fire for the
+# releases goreleaser cuts — GitHub suppresses workflow-triggering events
+# for releases created with the automatic GITHUB_TOKEN (loop prevention),
+# and goreleaser publishes as github-actions[bot]. Real releases are
+# therefore dispatched directly from release.yml's "Rebuild opendray.dev"
+# step. This workflow is kept for manual re-sync (workflow_dispatch) and
+# for releases published by a human/PAT (which do fire the event).
 #
 # Required secret:
 #   ODSITE_DISPATCH_PAT — fine-grained PAT scoped to Opendray/opendray.dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # ── Rebuild opendray.dev directly. The sibling notify-site-on-release
+      #    workflow listens on `release: published`, but that event never
+      #    fires here: GitHub suppresses workflow-triggering events for
+      #    releases created with the automatic GITHUB_TOKEN (loop
+      #    prevention), and goreleaser publishes as github-actions[bot].
+      #    So the site went stale for every goreleaser release. Dispatch
+      #    from inside the release job instead. Skipped for prerelease
+      #    ('-') tags — mirrors publish-npm — and no-ops if the PAT is unset.
+      - name: Rebuild opendray.dev
+        if: success() && !contains(env.TAG, '-')
+        env:
+          PAT: ${{ secrets.ODSITE_DISPATCH_PAT }}
+        run: |
+          if [ -z "$PAT" ]; then
+            echo "ODSITE_DISPATCH_PAT not set — skipping site rebuild."
+            exit 0
+          fi
+          curl -sSf -X POST \
+            -H "Authorization: token $PAT" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/Opendray/opendray.dev/dispatches" \
+            -d "{\"event_type\":\"opendray-release\",\"client_payload\":{\"tag\":\"$TAG\"}}"
+          echo "Dispatched opendray-release for $TAG"
+
   publish-npm:
     name: Publish to npm
     needs: release


### PR DESCRIPTION
**Fixes the stale-site root cause.** `notify-site-on-release` listens on `release: published`, but that event **never fires for goreleaser releases** — GitHub suppresses workflow-triggering events for releases created with the automatic `GITHUB_TOKEN`, and goreleaser publishes as `github-actions[bot]`. So the site hasn't been auto-pinged since **v2.7.1 (June 1)**; every release since (incl. v2.11.0's upload feature) only reached the site via its daily scheduled Cloudflare Pages build.

**Change:** add a `Rebuild opendray.dev` step at the end of the `release` job that dispatches the `opendray-release` `repository_dispatch` directly (using `ODSITE_DISPATCH_PAT`) — not relying on the suppressed event.
- `if: success() && !contains(env.TAG, '-')` — skips prerelease/test tags (mirrors `publish-npm`), so `v0.0.0-test` won't rebuild the site.
- No-ops cleanly if the PAT is unset.
- `notify-site-on-release.yml` is kept for manual re-sync (`workflow_dispatch`) and human/PAT-published releases; its header now documents the event-suppression caveat.

Verified the dispatch mechanism itself works — I triggered it manually today and opendray.dev completed a `repository_dispatch` deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)