### PR TITLE
docs(changelog): v2.11.2 — dbtool multi-driver + backup fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+## [v2.11.2] — 2026-07-09
+
 ### Added
 
 - **Database tool — MySQL, MariaDB and SQLite.** The Database tool now
@@ -24,6 +26,12 @@ for the full rationale and what triggers a major bump.
   (`go-sql-driver/mysql`, `modernc.org/sqlite`), so the binary still
   cross-compiles without cgo. Migration `0075` widens the driver
   constraint; `0076` reseeds the kb_integrations page.
+
+### Fixed
+
+- **Backup download link authorises correctly.** The backup download URL
+  now carries the admin token, so downloading a backup from the web UI no
+  longer fails auth. (#428)
 
 ## [v2.11.1] — 2026-07-09
 


### PR DESCRIPTION
Release bump for **v2.11.2**. Moves `[Unreleased]` → `[v2.11.2]` (2026-07-09).

**Added**
- Database tool: **MySQL, MariaDB, and SQLite** support (#427) — engine picker, per-engine defaults, SQLite path fenced to project cwd, pure-Go drivers (still cgo-free).

**Fixed**
- Backup download link now carries the admin token (#428).

CI/infra changes since v2.11.1 (node24 action bumps, goreleaser v7, site auto-rebuild) are intentionally omitted from the user-facing changelog.

Changelog-only change. On merge I'll tag `v2.11.2` to trigger goreleaser — and this is the first release with the #431 fix, so it should also auto-rebuild opendray.dev.

> Note: multi-driver DB support is arguably a *minor* (v2.12.0) per the versioning policy; releasing as v2.11.2 per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)