### PR TITLE
feat(web): sidebar Updates drawer and resource links

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -42,7 +42,23 @@
     "knowledge": "Knowledge",
     "vault": "Vault",
     "cortex": "Cortex",
-    "updateAvailable": "Update available"
+    "updateAvailable": "Update available",
+    "resources": "Resources",
+    "docs": "Docs & Setup",
+    "community": "Community",
+    "sponsor": "Sponsor",
+    "updates": {
+      "title": "Updates",
+      "whatsNew": "What's new in {version}",
+      "loading": "Loading release notes…",
+      "loadFailed": "Couldn't load release notes ({error}).",
+      "noHighlights": "No short highlights for this release. Open the full changelog for details.",
+      "openFull": "Open full changelog",
+      "markRead": "Mark read",
+      "unread": "Unread release notes",
+      "badgeCount": "Updates · {count}",
+      "sourceChangelog": "Highlights from CHANGELOG.md (release body was a stub)."
+    }
   },
   "web": {
     "brand": "opendray",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -42,7 +42,23 @@
     "knowledge": "Conocimiento",
     "vault": "Bóveda",
     "cortex": "Cortex",
-    "updateAvailable": "Actualización disponible"
+    "updateAvailable": "Actualización disponible",
+    "resources": "Recursos",
+    "docs": "Docs y setup",
+    "community": "Comunidad",
+    "sponsor": "Patrocinar",
+    "updates": {
+      "title": "Actualizaciones",
+      "whatsNew": "Novedades en {version}",
+      "loading": "Cargando notas de la versión…",
+      "loadFailed": "No se pudieron cargar las notas ({error}).",
+      "noHighlights": "No hay highlights cortos para esta versión. Abre el changelog completo.",
+      "openFull": "Abrir changelog completo",
+      "markRead": "Marcar como leído",
+      "unread": "Notas de versión sin leer",
+      "badgeCount": "Actualizaciones · {count}",
+      "sourceChangelog": "Highlights desde CHANGELOG.md (el cuerpo del release era un stub)."
+    }
   },
   "web": {
     "brand": "opendray",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -42,7 +42,23 @@
     "knowledge": "知识",
     "vault": "文档库",
     "cortex": "心智中枢",
-    "updateAvailable": "有可用更新"
+    "updateAvailable": "有可用更新",
+    "resources": "资源",
+    "docs": "文档与安装",
+    "community": "社区",
+    "sponsor": "赞助",
+    "updates": {
+      "title": "更新",
+      "whatsNew": "{version} 新内容",
+      "loading": "正在加载更新说明…",
+      "loadFailed": "无法加载更新说明（{error}）。",
+      "noHighlights": "此版本没有简短亮点。请打开完整更新日志查看详情。",
+      "openFull": "打开完整更新日志",
+      "markRead": "标为已读",
+      "unread": "未读更新说明",
+      "badgeCount": "更新 · {count}",
+      "sourceChangelog": "亮点来自 CHANGELOG.md（GitHub Release 正文为占位）。"
+    }
   },
   "web": {
     "brand": "opendray",

--- a/app/shared/src/lib/releases.ts
+++ b/app/shared/src/lib/releases.ts
@@ -1,0 +1,236 @@
+// Release "what's new" feed for the admin sidebar Updates drawer.
+//
+// Source of truth order:
+//   1. GitHub Releases (latest) — freshest publish date + notes URL
+//   2. CHANGELOG.md on main — when the release body is a stub that
+//      only points at the changelog (common for this project)
+//
+// Read state is local-first (`opendray:lastReadRelease` in localStorage).
+// A later PR can sync that key per-user via the backend.
+
+const REPO = 'Opendray/opendray'
+const RELEASES_LATEST = `https://api.github.com/repos/${REPO}/releases/latest`
+const CHANGELOG_RAW = `https://raw.githubusercontent.com/${REPO}/main/CHANGELOG.md`
+const CHANGELOG_HTML = `https://github.com/${REPO}/blob/main/CHANGELOG.md`
+
+/** localStorage key for the last release the operator marked as read. */
+export const LAST_READ_RELEASE_KEY = 'opendray:lastReadRelease'
+
+export interface ReleaseInfo {
+  /** Tag as published, e.g. "v2.11.2". */
+  tag: string
+  /** Normalised without leading "v", e.g. "2.11.2". */
+  version: string
+  name: string
+  /** ISO publish date when known. */
+  publishedAt?: string
+  /** GitHub release page (or changelog section fallback). */
+  htmlUrl: string
+  /** 3–5 short highlight lines for the drawer. */
+  highlights: string[]
+  /** Where the highlights were parsed from. */
+  source: 'github-release' | 'changelog'
+}
+
+type GhRelease = {
+  tag_name?: string
+  name?: string
+  body?: string | null
+  published_at?: string
+  html_url?: string
+}
+
+export function normalizeReleaseVersion(v: string | undefined | null): string {
+  if (!v) return ''
+  let s = v.trim()
+  if (s.toLowerCase().startsWith('v')) s = s.slice(1)
+  const plus = s.indexOf('+')
+  if (plus >= 0) s = s.slice(0, plus)
+  return s
+}
+
+export function formatReleaseTag(version: string): string {
+  const n = normalizeReleaseVersion(version)
+  return n ? `v${n}` : ''
+}
+
+export function getLastReadRelease(): string | null {
+  if (typeof localStorage === 'undefined') return null
+  try {
+    const raw = localStorage.getItem(LAST_READ_RELEASE_KEY)
+    return raw ? normalizeReleaseVersion(raw) : null
+  } catch {
+    return null
+  }
+}
+
+export function setLastReadRelease(version: string): void {
+  if (typeof localStorage === 'undefined') return
+  const n = normalizeReleaseVersion(version)
+  if (!n) return
+  try {
+    localStorage.setItem(LAST_READ_RELEASE_KEY, formatReleaseTag(n))
+  } catch {
+    /* private mode / quota — ignore */
+  }
+}
+
+/** True when the latest release differs from the last one the operator read. */
+export function isReleaseUnread(latestVersion: string | undefined | null): boolean {
+  const latest = normalizeReleaseVersion(latestVersion)
+  if (!latest) return false
+  const read = getLastReadRelease()
+  if (!read) return true
+  return read !== latest
+}
+
+/**
+ * Pull short highlight lines from markdown (release body or CHANGELOG section).
+ * Prefers the bold title in `- **Title.** rest` bullets (CHANGELOG style);
+ * falls back to the first line of a plain list item. Continuation lines
+ * under a bullet are ignored — the drawer wants scannable titles, not
+ * full paragraphs.
+ */
+export function extractHighlights(markdown: string, limit = 5): string[] {
+  if (!markdown.trim()) return []
+  // Drop "Announce on X" / tweet blocks that ship in many release bodies.
+  const cleaned = markdown
+    .replace(/##\s*Announce on X[\s\S]*$/i, '')
+    .replace(/```[\s\S]*?```/g, '')
+
+  const lines = cleaned.split(/\r?\n/)
+  const out: string[] = []
+  for (const line of lines) {
+    // Only real list starters (not wrapped continuation indented with spaces).
+    const m = line.match(/^\s*[-*+]\s+(.+)$/)
+    if (!m) continue
+    const item = m[1]
+    const bold = item.match(/^\*\*(.+?)\*\*/)
+    let text = bold ? bold[1].trim() : item.trim()
+    text = text
+      .replace(/\*\*/g, '')
+      .replace(/`([^`]+)`/g, '$1')
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+      .replace(/\s+/g, ' ')
+      .replace(/[.:]+$/g, '')
+      .trim()
+    if (!text || text.length < 4) continue
+    // Cap length so the drawer stays scannable.
+    if (text.length > 120) text = text.slice(0, 117).trimEnd() + '…'
+    out.push(text)
+    if (out.length >= limit) break
+  }
+  return out
+}
+
+/** Extract the section under `## [vX.Y.Z]` (or unbracketed) from Keep-a-Changelog. */
+export function extractChangelogSection(changelog: string, version: string): string {
+  const v = normalizeReleaseVersion(version)
+  if (!v || !changelog) return ''
+  // Match ## [v2.11.2], ## [2.11.2], ## v2.11.2, with optional date suffix.
+  const re = new RegExp(
+    `^##\\s*\\[?v?${escapeRegExp(v)}\\]?\\s*(?:—|-|–).*$`,
+    'im',
+  )
+  const reAlt = new RegExp(`^##\\s*\\[?v?${escapeRegExp(v)}\\]?\\s*$`, 'im')
+  const startMatch = changelog.match(re) ?? changelog.match(reAlt)
+  if (!startMatch || startMatch.index === undefined) return ''
+  const from = startMatch.index + startMatch[0].length
+  const rest = changelog.slice(from)
+  const next = rest.search(/^##\s+/m)
+  return next >= 0 ? rest.slice(0, next) : rest
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function isStubBody(body: string): boolean {
+  const t = body.trim()
+  if (!t) return true
+  // Typical stub: "See CHANGELOG.md for the full release notes." + announce block.
+  const withoutAnnounce = t.replace(/##\s*Announce on X[\s\S]*$/i, '').trim()
+  if (withoutAnnounce.length < 80) return true
+  if (/see\s+\[?changelog/i.test(withoutAnnounce) && extractHighlights(withoutAnnounce).length === 0) {
+    return true
+  }
+  return false
+}
+
+async function fetchText(url: string): Promise<string> {
+  const resp = await fetch(url, {
+    headers: { Accept: 'text/plain, text/markdown, */*' },
+  })
+  if (!resp.ok) throw new Error(`fetch ${url}: ${resp.status}`)
+  return resp.text()
+}
+
+/**
+ * Load the latest release highlights for the Updates drawer.
+ * Prefer GitHub Releases; fall back to CHANGELOG.md for bullet text.
+ */
+export async function fetchLatestReleaseInfo(): Promise<ReleaseInfo> {
+  const resp = await fetch(RELEASES_LATEST, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+    },
+  })
+  if (!resp.ok) {
+    // Full fallback: no releases API — try changelog head only.
+    return fetchFromChangelogOnly()
+  }
+  const rel = (await resp.json()) as GhRelease
+  const tag = rel.tag_name?.trim() || ''
+  const version = normalizeReleaseVersion(tag)
+  if (!version) throw new Error('github release missing tag_name')
+
+  const body = rel.body ?? ''
+  let highlights = extractHighlights(body)
+  let source: ReleaseInfo['source'] = 'github-release'
+
+  if (isStubBody(body) || highlights.length === 0) {
+    try {
+      const changelog = await fetchText(CHANGELOG_RAW)
+      const section = extractChangelogSection(changelog, version)
+      const fromLog = extractHighlights(section)
+      if (fromLog.length > 0) {
+        highlights = fromLog
+        source = 'changelog'
+      }
+    } catch {
+      /* keep whatever we got from the release body */
+    }
+  }
+
+  return {
+    tag: tag.startsWith('v') ? tag : `v${version}`,
+    version,
+    name: rel.name?.trim() || tag || `v${version}`,
+    publishedAt: rel.published_at,
+    htmlUrl: rel.html_url || `https://github.com/${REPO}/releases/tag/v${version}`,
+    highlights,
+    source,
+  }
+}
+
+async function fetchFromChangelogOnly(): Promise<ReleaseInfo> {
+  const changelog = await fetchText(CHANGELOG_RAW)
+  // First version heading after Unreleased.
+  const m = changelog.match(/^##\s*\[?(v?\d+\.\d+\.\d+)\]?\s*(?:—|-|–)\s*(\d{4}-\d{2}-\d{2})?/m)
+  if (!m) throw new Error('changelog: no version heading found')
+  const tagRaw = m[1]
+  const version = normalizeReleaseVersion(tagRaw)
+  const section = extractChangelogSection(changelog, version)
+  const highlights = extractHighlights(section)
+  return {
+    tag: formatReleaseTag(version),
+    version,
+    name: formatReleaseTag(version),
+    publishedAt: m[2] ? `${m[2]}T00:00:00Z` : undefined,
+    htmlUrl: `${CHANGELOG_HTML}#v${version.replace(/\./g, '')}`,
+    highlights,
+    source: 'changelog',
+  }
+}
+
+

--- a/app/web/src/components/SidebarNav.tsx
+++ b/app/web/src/components/SidebarNav.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react'
+import { Fragment, useCallback, useState } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
 import {
@@ -12,6 +12,11 @@ import {
   BookText,
   Brain,
   Archive,
+  Sparkles,
+  BookOpen,
+  Send,
+  Heart,
+  ExternalLink,
   type LucideIcon,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -21,6 +26,11 @@ import { useLayout } from '@/stores/layout'
 import { useIsMobile } from '../lib/useIsMobile'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { getVersionInfo, type VersionInfo } from '@/lib/version'
+import {
+  isReleaseUnread,
+  normalizeReleaseVersion,
+} from '@/lib/releases'
+import { UpdatesDrawer, useLatestReleaseQuery } from './UpdatesDrawer'
 
 // 6 hours between background version checks — releases are weekly at
 // most, so anything more frequent burns server cycles for a state
@@ -28,6 +38,11 @@ import { getVersionInfo, type VersionInfo } from '@/lib/version'
 // Settings/About panel triggers, since both observers share the
 // `['version']` query cache.
 const UPDATE_POLL_INTERVAL_MS = 6 * 60 * 60 * 1000
+
+/** External community / docs links shown under Settings. */
+const DOCS_URL = 'https://opendray.dev/docs/'
+const COMMUNITY_URL = 'https://t.me/opendraycommunity'
+const SPONSOR_URL = 'https://opendray.dev/sponsors/'
 
 interface NavItem {
   to: string
@@ -62,6 +77,34 @@ const groups: NavItem[][] = [
   ],
 ]
 
+interface ExternalNavItem {
+  id: string
+  href: string
+  icon: LucideIcon
+  labelKey: string
+}
+
+const externalLinks: ExternalNavItem[] = [
+  {
+    id: 'docs',
+    href: DOCS_URL,
+    icon: BookOpen,
+    labelKey: 'nav.docs',
+  },
+  {
+    id: 'community',
+    href: COMMUNITY_URL,
+    icon: Send,
+    labelKey: 'nav.community',
+  },
+  {
+    id: 'sponsor',
+    href: SPONSOR_URL,
+    icon: Heart,
+    labelKey: 'nav.sponsor',
+  },
+]
+
 export function SidebarNav() {
   const { t } = useTranslation()
   const { location } = useRouterState()
@@ -70,19 +113,43 @@ export function SidebarNav() {
   // On mobile the nav is a full-width slide-over (positioned by AppShell),
   // so never collapse it to the icon rail there.
   const collapsed = collapsedState && !isMobile
-  // Background poll for available updates so the gear icon can carry
-  // a "new version waiting" dot without the operator having to open
-  // the About panel. Shares the `['version']` cache with AboutSection.
+
+  const [updatesOpen, setUpdatesOpen] = useState(false)
+  // Bumps when the operator marks a release read so the badge re-renders
+  // without waiting for a query refetch.
+  const [readEpoch, setReadEpoch] = useState(0)
+
+  // Background poll for available binary updates (About / self-update).
   const { data: version } = useQuery<VersionInfo>({
     queryKey: ['version'],
     queryFn: getVersionInfo,
     refetchInterval: UPDATE_POLL_INTERVAL_MS,
     staleTime: UPDATE_POLL_INTERVAL_MS,
   })
-  // Don't badge while an upgrade is already queued — the operator
-  // has already acted, the dot would just be noise until the daemon
-  // restarts and the version check resolves clean.
+  // Separate query: release notes body for the Updates drawer + unread
+  // badge. Shares cache with UpdatesDrawer via useLatestReleaseQuery.
+  const { data: release } = useLatestReleaseQuery()
+
   const updateAvailable = !!version?.updateAvailable && !version?.pending
+
+  // Unread = operator hasn't marked this release as read. Prefer the
+  // GitHub release version; fall back to the gateway's `latest` so a
+  // failed notes fetch still badges when a binary update exists.
+  const latestForUnread =
+    release?.version || normalizeReleaseVersion(version?.latest)
+  // readEpoch is intentionally read so mark-read re-evaluates isReleaseUnread.
+  void readEpoch
+  const notesUnread = isReleaseUnread(latestForUnread)
+  const showUpdatesBadge = notesUnread || updateAvailable
+  const highlightCount = release?.highlights.length ?? 0
+  // "Updates · 3" when we know highlight count and notes are unread;
+  // otherwise a plain dot is enough.
+  const showCountChip = notesUnread && highlightCount > 0 && !collapsed
+
+  const onMarkedRead = useCallback(() => {
+    setReadEpoch((n) => n + 1)
+  }, [])
+
   return (
     <nav
       className={cn(
@@ -113,14 +180,17 @@ export function SidebarNav() {
                 ? location.pathname.startsWith('/sessions') ||
                   location.pathname === '/'
                 : location.pathname.startsWith(to)
-            const showUpdateDot = to === '/settings' && updateAvailable
+            // Keep a quiet secondary cue on Settings when a binary
+            // update is waiting; the primary Updates row carries the
+            // "what's new" unread state.
+            const showSettingsDot = to === '/settings' && updateAvailable
             const updateLabel = t('nav.updateAvailable')
             const link = (
               <Link
                 key={to}
                 to={to}
                 aria-label={
-                  showUpdateDot ? `${label} — ${updateLabel}` : label
+                  showSettingsDot ? `${label} — ${updateLabel}` : label
                 }
                 className={cn(
                   'flex items-center h-7 rounded-md text-[13px] transition-all duration-100',
@@ -131,11 +201,7 @@ export function SidebarNav() {
               >
                 <span className="relative shrink-0">
                   <Icon className="size-3.5 shrink-0" />
-                  {showUpdateDot && (
-                    // Small accent dot anchored to the icon so it
-                    // reads as a badge on the gear, not a separate
-                    // chip — visible in both collapsed and expanded
-                    // sidebar without changing the row height.
+                  {showSettingsDot && (
                     <span
                       className="absolute -right-0.5 -top-0.5 size-1.5 rounded-full bg-accent ring-2 ring-card"
                       aria-hidden
@@ -159,7 +225,7 @@ export function SidebarNav() {
                 <TooltipContent side="right">
                   {label}
                   <span className="ml-2 text-muted-foreground">{shortcut}</span>
-                  {showUpdateDot && (
+                  {showSettingsDot && (
                     <span className="ml-2 text-accent">{updateLabel}</span>
                   )}
                 </TooltipContent>
@@ -168,6 +234,125 @@ export function SidebarNav() {
           })}
         </Fragment>
       ))}
+
+      {/* Community / docs / updates — under Settings, above the fold
+          bottom of the rail. mt-auto pins the block to the bottom when
+          the nav is tall enough. */}
+      <div
+        className={cn(
+          'mt-auto pt-2 border-t border-border/60',
+          collapsed ? 'mx-1.5' : 'mx-0',
+        )}
+      >
+        {!collapsed && (
+          <div className="px-2 pb-1.5 pt-1 text-[10px] uppercase tracking-wider text-muted-foreground/70 font-medium">
+            {t('nav.resources')}
+          </div>
+        )}
+
+        {/* Updates — native drawer, not an external link */}
+        {(() => {
+          const label = t('nav.updates.title')
+          const badgeLabel = showUpdatesBadge
+            ? showCountChip
+              ? t('nav.updates.badgeCount', { count: highlightCount })
+              : t('nav.updates.unread')
+            : label
+          const btn = (
+            <button
+              type="button"
+              onClick={() => setUpdatesOpen(true)}
+              aria-label={badgeLabel}
+              className={cn(
+                'w-full flex items-center h-7 rounded-md text-[13px] transition-all duration-100',
+                'text-muted-foreground hover:text-foreground hover:bg-card',
+                updatesOpen && 'bg-card text-foreground',
+                collapsed ? 'justify-center px-0' : 'gap-2.5 px-2.5',
+              )}
+            >
+              <span className="relative shrink-0">
+                <Sparkles className="size-3.5 shrink-0" />
+                {showUpdatesBadge && (
+                  // Accent (orange) when binary update is available;
+                  // primary (blue-ish) when only release notes are unread.
+                  <span
+                    className={cn(
+                      'absolute -right-0.5 -top-0.5 size-1.5 rounded-full ring-2 ring-card',
+                      updateAvailable ? 'bg-accent' : 'bg-primary',
+                    )}
+                    aria-hidden
+                  />
+                )}
+              </span>
+              {!collapsed && (
+                <>
+                  <span className="flex-1 text-left">{label}</span>
+                  {showCountChip && (
+                    <span className="text-[10px] tabular-nums text-muted-foreground">
+                      · {highlightCount}
+                    </span>
+                  )}
+                </>
+              )}
+            </button>
+          )
+          if (!collapsed) return btn
+          return (
+            <Tooltip>
+              <TooltipTrigger asChild>{btn}</TooltipTrigger>
+              <TooltipContent side="right">
+                {label}
+                {showUpdatesBadge && (
+                  <span className="ml-2 text-accent">
+                    {updateAvailable
+                      ? t('nav.updateAvailable')
+                      : t('nav.updates.unread')}
+                  </span>
+                )}
+              </TooltipContent>
+            </Tooltip>
+          )
+        })()}
+
+        {externalLinks.map(({ id, href, icon: Icon, labelKey }) => {
+          const label = t(labelKey)
+          const link = (
+            <a
+              key={id}
+              href={href}
+              target="_blank"
+              rel="noreferrer"
+              aria-label={label}
+              className={cn(
+                'flex items-center h-7 rounded-md text-[13px] transition-all duration-100',
+                'text-muted-foreground hover:text-foreground hover:bg-card',
+                collapsed ? 'justify-center px-0' : 'gap-2.5 px-2.5',
+              )}
+            >
+              <Icon className="size-3.5 shrink-0" />
+              {!collapsed && (
+                <>
+                  <span className="flex-1">{label}</span>
+                  <ExternalLink className="size-3 opacity-40" aria-hidden />
+                </>
+              )}
+            </a>
+          )
+          if (!collapsed) return link
+          return (
+            <Tooltip key={id}>
+              <TooltipTrigger asChild>{link}</TooltipTrigger>
+              <TooltipContent side="right">{label}</TooltipContent>
+            </Tooltip>
+          )
+        })}
+      </div>
+
+      <UpdatesDrawer
+        open={updatesOpen}
+        onClose={() => setUpdatesOpen(false)}
+        onMarkedRead={onMarkedRead}
+      />
     </nav>
   )
 }

--- a/app/web/src/components/UpdatesDrawer.tsx
+++ b/app/web/src/components/UpdatesDrawer.tsx
@@ -1,0 +1,204 @@
+// Right-side "What's new" drawer opened from the sidebar Updates row.
+// Fetches GitHub Releases (changelog fallback) and keeps read state in
+// localStorage — see app/shared/src/lib/releases.ts.
+
+import { useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { ExternalLink, Loader2, Sparkles, X } from 'lucide-react'
+import { format, parseISO } from 'date-fns'
+
+import {
+  fetchLatestReleaseInfo,
+  setLastReadRelease,
+  type ReleaseInfo,
+} from '@/lib/releases'
+import { cn } from '@/lib/utils'
+
+const POLL_MS = 6 * 60 * 60 * 1000
+
+export function useLatestReleaseQuery() {
+  return useQuery<ReleaseInfo>({
+    queryKey: ['release-whats-new'],
+    queryFn: fetchLatestReleaseInfo,
+    staleTime: POLL_MS,
+    refetchInterval: POLL_MS,
+    retry: 1,
+  })
+}
+
+export function UpdatesDrawer({
+  open,
+  onClose,
+  onMarkedRead,
+}: {
+  open: boolean
+  onClose: () => void
+  onMarkedRead: () => void
+}) {
+  const { t } = useTranslation()
+  const { data, isLoading, isError, error, refetch, isFetching } =
+    useLatestReleaseQuery()
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  function markRead() {
+    if (data?.version) {
+      setLastReadRelease(data.version)
+      onMarkedRead()
+    }
+    onClose()
+  }
+
+  const dateLabel = formatPublished(data?.publishedAt)
+
+  return createPortal(
+    <div className="fixed inset-0 z-[60] flex justify-end">
+      <div
+        aria-hidden
+        className="absolute inset-0 bg-black/40 backdrop-blur-[1px]"
+        onClick={onClose}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="updates-drawer-title"
+        className="relative h-full w-full max-w-md bg-background border-l border-border shadow-2xl flex flex-col"
+      >
+        <div className="flex items-start gap-2 px-4 py-3 border-b border-border">
+          <span className="mt-0.5 flex size-7 items-center justify-center rounded-md bg-accent/15 text-accent">
+            <Sparkles className="size-3.5" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <h2
+              id="updates-drawer-title"
+              className="text-[13px] font-medium leading-snug"
+            >
+              {data
+                ? t('nav.updates.whatsNew', { version: data.tag })
+                : t('nav.updates.title')}
+            </h2>
+            {dateLabel && (
+              <p className="text-[11px] text-muted-foreground mt-0.5">
+                {dateLabel}
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t('common.close')}
+            className="rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-card"
+          >
+            <X className="size-3.5" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-4 py-3">
+          {isLoading && (
+            <div className="flex items-center gap-2 text-[12px] text-muted-foreground py-6 justify-center">
+              <Loader2 className="size-3.5 animate-spin" />
+              {t('nav.updates.loading')}
+            </div>
+          )}
+
+          {isError && !data && (
+            <div className="space-y-3 py-4">
+              <p className="text-[12px] text-muted-foreground leading-relaxed">
+                {t('nav.updates.loadFailed', {
+                  error: (error as Error)?.message ?? 'unknown',
+                })}
+              </p>
+              <button
+                type="button"
+                onClick={() => void refetch()}
+                className="rounded border border-border px-2.5 py-1 text-[11px] hover:bg-card"
+              >
+                {t('common.retry')}
+              </button>
+            </div>
+          )}
+
+          {data && (
+            <div className="space-y-3">
+              {data.highlights.length === 0 ? (
+                <p className="text-[12px] text-muted-foreground leading-relaxed">
+                  {t('nav.updates.noHighlights')}
+                </p>
+              ) : (
+                <ul className="space-y-2.5">
+                  {data.highlights.map((h, i) => (
+                    <li
+                      key={i}
+                      className="flex gap-2 text-[12px] leading-relaxed text-foreground/90"
+                    >
+                      <span
+                        className="mt-1.5 size-1.5 shrink-0 rounded-full bg-accent"
+                        aria-hidden
+                      />
+                      <span>{h}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {data.source === 'changelog' && (
+                <p className="text-[10px] text-muted-foreground/80">
+                  {t('nav.updates.sourceChangelog')}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="border-t border-border px-4 py-3 flex flex-col gap-2">
+          <a
+            href={data?.htmlUrl ?? 'https://github.com/Opendray/opendray/releases'}
+            target="_blank"
+            rel="noreferrer"
+            className={cn(
+              'inline-flex items-center justify-center gap-1.5 rounded-md border border-border',
+              'px-3 py-1.5 text-[12px] font-medium hover:bg-card transition-colors',
+            )}
+          >
+            {t('nav.updates.openFull')}
+            <ExternalLink className="size-3 opacity-70" />
+          </a>
+          <button
+            type="button"
+            onClick={markRead}
+            disabled={!data}
+            className={cn(
+              'inline-flex items-center justify-center rounded-md bg-primary px-3 py-1.5',
+              'text-[12px] font-medium text-primary-foreground',
+              'disabled:opacity-50 hover:opacity-95 transition-opacity',
+            )}
+          >
+            {isFetching && !data
+              ? t('nav.updates.loading')
+              : t('nav.updates.markRead')}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+function formatPublished(iso: string | undefined): string | null {
+  if (!iso) return null
+  try {
+    return format(parseISO(iso), 'MMM d, yyyy')
+  } catch {
+    return iso.slice(0, 10)
+  }
+}


### PR DESCRIPTION
## Summary

Adds a **Resources** block at the bottom of the web admin left nav (under Settings):

- **Updates** — native right-side drawer with "What's new" from **GitHub Releases** first, falling back to **CHANGELOG.md** when the release body is a stub. Unread badge (dot / `· N` highlight count). **Mark read** stores `opendray:lastReadRelease` in `localStorage` (local-first; backend sync can come later).
- **Docs & Setup** → https://opendray.dev/docs/
- **Community** → https://t.me/opendraycommunity
- **Sponsor** → https://opendray.dev/sponsors/

Icons (Lucide): Sparkles, BookOpen, Send (Telegram), Heart.

Settings gear still shows the existing orange dot when a binary self-update is available; Updates uses accent (update available) or primary (notes unread only).

## Related issue

Refs #300 (roadmap surface area; no dedicated issue — UX contribution)

## Type of change

- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds capability)
- [ ] 💥 Breaking change (existing behaviour changes — bump VERSIONING.md if user-visible)
- [ ] 📖 Documentation only
- [ ] 🔧 CI / build / release pipeline
- [ ] 🧹 Chore (deps, refactor, repo housekeeping)

## Surface(s) touched

- [ ] Backend (Go) — `internal/*`, `cmd/*`
- [x] Web admin (React) — `app/web/`
- [ ] Mobile app (Flutter) — `app/mobile/`
- [ ] Channel adapter — `internal/channel/*`
- [ ] Memory subsystem — `internal/memory/*`
- [ ] Backup / restore — `internal/backup/*`
- [ ] Notes / vault — `internal/notes/*`, `internal/vaultgit/*`
- [ ] Integration API — `internal/integration/*`, `internal/gateway/*`
- [ ] DB migrations — `internal/store/migrations/*`
- [ ] Deploy artefacts — `deploy/`, `scripts/install*.sh`, `scripts/uninstall*.sh`
- [ ] Docs — `README*`, `docs/`, `CHANGELOG.md`
- Shared client lib: `app/shared/src/lib/releases.ts`
- i18n: `en` / `zh` / `es` (`nav.resources`, `nav.docs`, `nav.community`, `nav.sponsor`, `nav.updates.*`)

## Test plan

- [x] `pnpm --filter web build` (`tsc -b` + Vite prod) succeeds locally
- [x] Live fetch of `api.github.com/.../releases/latest` and raw CHANGELOG returns 200 from this environment
- [ ] Manual smoke: open web admin → bottom of left nav shows Updates / Docs & Setup / Community / Sponsor
- [ ] Click Updates → right drawer with title `What's new in v…`, date, 3–5 highlights, Open full changelog + Mark read
- [ ] Mark read → badge clears; refresh still clear (localStorage `opendray:lastReadRelease`)
- [ ] Clear localStorage key → badge returns
- [ ] Docs / Community / Sponsor open in new tab with correct URLs
- [ ] Collapsed sidebar: icons + tooltips still work; unread dot visible on Sparkles

## DB / config / operator impact

- [x] No DB migration
- [ ] Adds a new migration (`internal/store/migrations/NNNN_*.sql`) — idempotent + safe to re-run
- [ ] Changes existing user-facing config (env var rename, key removal, ...) — call out as **BREAKING** in CHANGELOG
- [ ] Adds new env vars / config keys — documented in `config.example.toml` and `docs/operator-guide.md`
- [x] None of the above

## Screenshots / before-after (UI changes)

Not captured in this environment (headless). Happy to add screenshots after a maintainer/dev run, or I can follow up.

## Anything else?

- Client-side GitHub API (unauthenticated, 6h poll) — same cadence as the existing version check. If rate limits become an issue on shared NAT, a later PR can proxy highlights through `GET /api/v1/version`.
- Read state is browser-local only for now, as suggested.
- First-time contribution — please flag any style nits against project conventions.