### PR TITLE
fix(web): show Grok logo in sessions list and header

### DIFF
--- a/app/shared/src/lib/providerIcons.ts
+++ b/app/shared/src/lib/providerIcons.ts
@@ -12,6 +12,7 @@ const MAP: Record<string, string> = {
 	codex: 'openai', // Codex CLI is OpenAI-branded
 	antigravity: 'antigravity',
 	opencode: 'opencode',
+	grok: 'grok',
 	shell: 'shell',
 }
 

--- a/app/shared/src/lib/providers.ts
+++ b/app/shared/src/lib/providers.ts
@@ -20,6 +20,7 @@ const palette: Record<string, Omit<ProviderVisual, 'letter'>> = {
   claude: { bg: 'bg-orange-600', fg: 'text-white', name: 'Claude Code' },
   codex: { bg: 'bg-emerald-600', fg: 'text-white', name: 'Codex' },
   shell: { bg: 'bg-slate-600', fg: 'text-white', name: 'Shell' },
+  grok: { bg: 'bg-neutral-900', fg: 'text-white', name: 'Grok' },
 }
 
 const fallback: Omit<ProviderVisual, 'letter'> = {

--- a/app/web/src/components/BrandIcon.tsx
+++ b/app/web/src/components/BrandIcon.tsx
@@ -114,6 +114,18 @@ const INLINE: Record<string, IconData> = {
 		path:
 			'M3 4h18a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1zm2 4l5 4-5 4v-2.5l2-1.5-2-1.5V8z',
 	},
+
+	// Grok (xAI) — the real mark renders from the curated SVG
+	// (public/icons/grok.svg); this entry only supplies the brand
+	// hex so the avatar disc tints correctly. The path is a
+	// simplified rendering of the mark and is never drawn for
+	// curated keys.
+	grok: {
+		title: 'Grok',
+		hex: '0A0A0A',
+		path:
+			'M4 15l8-6-8-6v3.5l4.5 3-4.5 3zm6 0l8-6-8-6v3.5l4.5 3-4.5 3z',
+	},
 }
 
 export type BrandIconKey = keyof typeof SIMPLE | keyof typeof INLINE
@@ -138,6 +150,7 @@ const CURATED = new Set([
 	'opencode',
 	'openai',
 	'shell',
+	'grok',
 	'slack',
 	'dingtalk',
 	'feishu',
@@ -152,6 +165,7 @@ const CURATED_MONOCHROME_DARK_INVERT = new Set([
 	'opencode',
 	'openai',
 	'shell',
+	'grok',
 	'dingtalk',
 	'feishu',
 ])


### PR DESCRIPTION
## Summary

Grok sessions showed a generic \"G\" letter disc instead of the Grok mark in the Sessions list and the workbench header, even though the curated `grok.svg` asset already ships and renders correctly in the Spawn dialog.

Root cause: the Spawn dialog uses `ProviderIcon.tsx`, which already had a `grok` entry — but the Sessions list / header use the older `BrandAvatar` → `BrandIcon` path, which resolves icons through two separate lookup tables that never got a `grok` entry added:

- `app/shared/src/lib/providerIcons.ts` — `providerIconKey('grok')` returned `undefined`, so `BrandAvatar` never even attempted to load the icon.
- `app/web/src/components/BrandIcon.tsx` — `grok` wasn't in the `CURATED` set (so the curated SVG was never used) or in the hex lookup (so `hasBrandIcon`/`brandHex` treated it as unknown).
- `app/shared/src/lib/providers.ts` — same gap in the `providerVisual` palette, which is why the session subtitle literally rendered the fallback text \"Provider\" instead of \"Grok\".

## Changes

- Add `grok: 'grok'` to `providerIconKey`'s map.
- Register `grok` in `BrandIcon`'s `CURATED` set, `CURATED_MONOCHROME_DARK_INVERT` (the asset is a monochrome black mark, same treatment as `openai`/`shell`/`opencode`), and add an `INLINE` entry so `hasBrandIcon`/`brandHex` resolve it (same pattern already used for `antigravity`/`opencode`).
- Add a `grok` entry to `providerVisual`'s palette (black tile, white text) so the header/list subtitle shows \"Grok\" instead of the generic \"Provider\" fallback.

## Test plan

- [x] `pnpm --filter web build` (`tsc -b` + Vite prod) succeeds locally
- [x] Traced both lookup paths (Spawn dialog vs. Sessions list/header) to confirm this was the only gap
- [ ] Manual smoke: open a Grok session, confirm the sidebar/header now show the Grok mark and \"Grok\" label instead of the \"G\" letter disc / \"Provider\" text

## Surface(s) touched

- Web admin (React) — `app/web/`
- Shared client lib — `app/shared/src/lib/`

## DB / config / operator impact

None — pure frontend lookup-table fix, no migration, no config changes.