### PR TITLE
docs(changelog): v2.12.0 — sidebar Updates drawer + resource links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+## [v2.12.0] — 2026-07-09
+
+### Added
+
+- **Sidebar Updates drawer + resource links.** A new "Resources" block at
+  the bottom of the web admin left nav (under Settings) adds a native
+  "What's new" drawer — pulling release highlights from GitHub Releases,
+  falling back to CHANGELOG.md when the release body is a stub — with an
+  unread badge and local "mark read" state, plus quick links to Docs &
+  Setup, Community, and Sponsor. (#433)
+
 ## [v2.11.2] — 2026-07-09
 
 ### Added


### PR DESCRIPTION
## Summary

PR #433 (sidebar Updates drawer + resource links) merged to \`main\` without a CHANGELOG entry, so \`## [Unreleased]\` is currently empty and nothing has been tagged since v2.11.2. \`opendray update\` only picks up published GitHub Releases, so operators who merged #433 can't see it yet.

This is the CHANGELOG-bump PR — the review gate per \`release.yml\`'s comment (\"The CHANGELOG bump PR is the review gate\"). Per [VERSIONING.md](./VERSIONING.md), #433 is additive/non-breaking (\"New feature\" per its own PR checklist), so this is a **minor** bump: v2.11.2 → v2.12.0.

## What happens after this merges

This PR only edits \`CHANGELOG.md\` — it does not cut the release. Someone with push access needs to tag \`v2.12.0\` on \`main\` (or run the \"Release\" workflow via \`workflow_dispatch\`) to actually trigger goreleaser and publish the GitHub Release that \`opendray update\` will pick up.

## Surface(s) touched

- Docs — \`CHANGELOG.md\`

## DB / config / operator impact

None — changelog only, no code changes.