### PR TITLE
feat(web/sessions): stage image uploads in a dismissable tray (Esc to cancel)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -153,7 +153,6 @@
       },
       "terminal": {
         "uploadingToast": "Uploading image…",
-        "uploadedToast": "Image attached",
         "uploadFailedToast": "Upload failed",
         "uploadInvalidTypeToast": "Only image files can be attached",
         "dropToAttach": "Drop image to attach",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -157,6 +157,9 @@
         "uploadFailedToast": "Upload failed",
         "uploadInvalidTypeToast": "Only image files can be attached",
         "dropToAttach": "Drop image to attach",
+        "attachInsert": "Insert",
+        "attachClear": "Clear all",
+        "attachRemove": "Remove {name}",
         "copiedToast": "Copied to clipboard",
         "copyFailedToast": "Couldn't copy to clipboard",
         "selectCopyTitle": "Select & copy",
@@ -3338,6 +3341,11 @@
         "attachImage": "Attach image",
         "enter": "Enter",
         "selectText": "Select text"
+      },
+      "attachments": {
+        "insert": "Insert",
+        "clear": "Clear all",
+        "remove": "Remove {name}"
       },
       "connection": {
         "connecting": "Connecting…",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -153,7 +153,6 @@
       },
       "terminal": {
         "uploadingToast": "Subiendo imagen…",
-        "uploadedToast": "Imagen adjuntada",
         "uploadFailedToast": "Error al subir",
         "uploadInvalidTypeToast": "Solo se pueden adjuntar archivos de imagen",
         "dropToAttach": "Suelta la imagen para adjuntarla",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -157,6 +157,9 @@
         "uploadFailedToast": "Error al subir",
         "uploadInvalidTypeToast": "Solo se pueden adjuntar archivos de imagen",
         "dropToAttach": "Suelta la imagen para adjuntarla",
+        "attachInsert": "Insertar",
+        "attachClear": "Quitar todo",
+        "attachRemove": "Quitar {name}",
         "copiedToast": "Copiado al portapapeles",
         "copyFailedToast": "No se pudo copiar al portapapeles",
         "selectCopyTitle": "Seleccionar y copiar",
@@ -3338,6 +3341,11 @@
         "attachImage": "Adjuntar imagen",
         "enter": "Intro",
         "selectText": "Seleccionar texto"
+      },
+      "attachments": {
+        "insert": "Insertar",
+        "clear": "Quitar todo",
+        "remove": "Quitar {name}"
       },
       "connection": {
         "connecting": "Conectando…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -157,6 +157,9 @@
         "uploadFailedToast": "上传失败",
         "uploadInvalidTypeToast": "仅支持图片文件",
         "dropToAttach": "释放以附加图片",
+        "attachInsert": "插入",
+        "attachClear": "全部清除",
+        "attachRemove": "移除 {name}",
         "copiedToast": "已复制到剪贴板",
         "copyFailedToast": "无法复制到剪贴板",
         "selectCopyTitle": "选择并复制",
@@ -3338,6 +3341,11 @@
         "attachImage": "附加图片",
         "enter": "回车",
         "selectText": "选择文本"
+      },
+      "attachments": {
+        "insert": "插入",
+        "clear": "全部清除",
+        "remove": "移除 {name}"
       },
       "connection": {
         "connecting": "连接中…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -153,7 +153,6 @@
       },
       "terminal": {
         "uploadingToast": "正在上传图片…",
-        "uploadedToast": "图片已附加",
         "uploadFailedToast": "上传失败",
         "uploadInvalidTypeToast": "仅支持图片文件",
         "dropToAttach": "释放以附加图片",

--- a/app/web/src/components/sessions/AttachmentTray.tsx
+++ b/app/web/src/components/sessions/AttachmentTray.tsx
@@ -1,0 +1,71 @@
+import { Paperclip, X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { cn } from '@/lib/utils'
+
+export interface AttachmentItem {
+  path: string
+  name: string
+}
+
+// A staging tray of pending image attachments, anchored to the bottom of
+// the terminal pane. Renders nothing when empty (no layout impact on the
+// xterm fit()). Esc-to-clear is owned by Terminal.tsx; this is presentational.
+export function AttachmentTray({
+  items,
+  onRemove,
+  onInsert,
+  onClear,
+}: {
+  items: AttachmentItem[]
+  onRemove: (index: number) => void
+  onInsert: () => void
+  onClear: () => void
+}) {
+  const { t } = useTranslation()
+  if (items.length === 0) return null
+  return (
+    <div className="absolute inset-x-0 bottom-0 z-10 flex items-center gap-2 overflow-x-auto border-t border-border bg-card/95 px-2 py-1.5 backdrop-blur">
+      <div className="flex min-w-0 items-center gap-1.5">
+        {items.map((item, i) => (
+          <span
+            key={`${item.path}-${i}`}
+            className="flex max-w-[180px] items-center gap-1 rounded-md border border-border bg-background px-1.5 py-0.5 text-[11px]"
+          >
+            <Paperclip className="size-3 shrink-0 text-muted-foreground" />
+            <span className="truncate">{item.name}</span>
+            <button
+              type="button"
+              onClick={() => onRemove(i)}
+              aria-label={t('web.sessions.terminal.attachRemove', {
+                name: item.name,
+              })}
+              className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-card hover:text-foreground"
+            >
+              <X className="size-3" />
+            </button>
+          </span>
+        ))}
+      </div>
+      <div className="ml-auto flex shrink-0 items-center gap-1.5">
+        <button
+          type="button"
+          onClick={onClear}
+          className="rounded-md px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-background hover:text-foreground"
+        >
+          {t('web.sessions.terminal.attachClear')}
+        </button>
+        <button
+          type="button"
+          onClick={onInsert}
+          className={cn(
+            'rounded-md bg-primary px-2.5 py-0.5 text-[11px] font-medium text-primary-foreground',
+            'hover:opacity-95',
+          )}
+        >
+          {t('web.sessions.terminal.attachInsert')}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/app/web/src/components/sessions/Terminal.tsx
+++ b/app/web/src/components/sessions/Terminal.tsx
@@ -448,16 +448,19 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
   }, [themeApplied])
 
   // While attachments are staged, Esc clears them instead of reaching the
-  // CLI. Capture phase so we win before xterm's own key handling (same
-  // pattern WikiLinkSuggestions uses).
+  // CLI. Capture-phase window listener wins before xterm's own key handling.
   useEffect(() => {
     if (pendingAttachments.length === 0) return
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault()
-        e.stopPropagation()
-        setPendingAttachments([])
-      }
+      if (e.key !== 'Escape') return
+      // Only swallow Esc when focus is inside the terminal pane. Otherwise an
+      // open dialog (Radix closes on a document bubble-phase Esc) would be
+      // robbed of its Escape and the staged tray cleared unexpectedly.
+      const root = rootRef.current
+      if (root && !root.contains(e.target as Node)) return
+      e.preventDefault()
+      e.stopPropagation()
+      setPendingAttachments([])
     }
     window.addEventListener('keydown', onKey, true)
     return () => window.removeEventListener('keydown', onKey, true)

--- a/app/web/src/components/sessions/Terminal.tsx
+++ b/app/web/src/components/sessions/Terminal.tsx
@@ -18,6 +18,7 @@ import { useTheme } from '@/stores/theme'
 import { BinaryWS, wsURL } from '@/lib/ws'
 import { resizeSession, uploadSessionFile } from '@/lib/sessions'
 import { terminalBufferText } from './terminal-text'
+import { AttachmentTray, type AttachmentItem } from './AttachmentTray'
 
 interface TerminalProps {
   sessionId: string
@@ -94,6 +95,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
   const themeApplied = useTheme((s) => s.applied())
   const { t } = useTranslation()
   const [dragActive, setDragActive] = useState(false)
+  const [pendingAttachments, setPendingAttachments] = useState<AttachmentItem[]>([])
   const rootRef = useRef<HTMLDivElement>(null)
 
   const sendInput = useCallback((data: string) => {
@@ -124,11 +126,8 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       toast.loading(t('web.sessions.terminal.uploadingToast'), { id: toastId })
       try {
         const res = await uploadSessionFile(sessionId, file)
-        sendInput(res.path)
-        toast.success(t('web.sessions.terminal.uploadedToast'), {
-          id: toastId,
-          description: res.path,
-        })
+        setPendingAttachments((a) => [...a, { path: res.path, name: file.name }])
+        toast.dismiss(toastId)
       } catch (err) {
         toast.error(t('web.sessions.terminal.uploadFailedToast'), {
           id: toastId,
@@ -136,8 +135,20 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         })
       }
     },
-    [sessionId, sendInput, t],
+    [sessionId, t],
   )
+
+  const insertAttachments = useCallback(() => {
+    if (pendingAttachments.length === 0) return
+    sendInput(pendingAttachments.map((a) => a.path).join(' ') + ' ')
+    setPendingAttachments([])
+  }, [pendingAttachments, sendInput])
+
+  const removeAttachment = useCallback((index: number) => {
+    setPendingAttachments((a) => a.filter((_, i) => i !== index))
+  }, [])
+
+  const clearAttachments = useCallback(() => setPendingAttachments([]), [])
 
   const getBufferText = useCallback(() => terminalBufferText(xtermRef.current), [])
 
@@ -436,6 +447,22 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     fitRef.current?.fit()
   }, [themeApplied])
 
+  // While attachments are staged, Esc clears them instead of reaching the
+  // CLI. Capture phase so we win before xterm's own key handling (same
+  // pattern WikiLinkSuggestions uses).
+  useEffect(() => {
+    if (pendingAttachments.length === 0) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        e.stopPropagation()
+        setPendingAttachments([])
+      }
+    }
+    window.addEventListener('keydown', onKey, true)
+    return () => window.removeEventListener('keydown', onKey, true)
+  }, [pendingAttachments.length])
+
   return (
     <div ref={rootRef} className="h-full w-full bg-background relative overflow-hidden">
       {/* `contain: layout` + `overflow-hidden` isolate xterm's inner
@@ -460,6 +487,12 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
           </div>
         </div>
       )}
+      <AttachmentTray
+        items={pendingAttachments}
+        onRemove={removeAttachment}
+        onInsert={insertAttachments}
+        onClear={clearAttachments}
+      />
     </div>
   )
 })

--- a/docs/superpowers/plans/2026-07-09-attachment-tray.md
+++ b/docs/superpowers/plans/2026-07-09-attachment-tray.md
@@ -1,0 +1,507 @@
+# Image-attachment staging tray Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stage uploaded images as dismissable chips (Esc/✕ to cancel, explicit Insert to commit) instead of typing the path straight into the PTY, on web and mobile.
+
+**Architecture:** No backend change. Web: a presentational `AttachmentTray` + pending-state in `Terminal.tsx`; upload stages instead of `sendInput`, a capture-phase window `keydown` swallows `Esc` to clear the tray. Mobile: pending-state in `_SessionTerminalViewState`, a chip row above the keyboard bar, and the keyboard-bar `Esc` key clears the tray when non-empty. All strings come from the shared `app/i18n` layer.
+
+**Tech Stack:** React 19 + TypeScript + Tailwind (`cn`) + lucide (web); Flutter + slang i18n (mobile); react-i18next (web i18n). No JS test runner; no Go change.
+
+## Global Constraints
+
+- **No backend change**, no new endpoint. Reuse `uploadSessionFile` / `sessionsApiProvider.uploadFile` + `sendInput` (web) / `_terminal.paste` (mobile). The text delivered to the CLI is **unchanged**: the bare server path, multiples space-separated with a trailing space.
+- **All new copy via `app/i18n/{en,es,zh}.json`** — web under `web.sessions.terminal.*`, mobile under `sessions.terminal.attachments.*`. **No literal English in components.**
+- **Placeholders use single braces `{name}`** (both slang and this repo's react-i18next are single-brace); the SAME placeholder tokens must appear in all three locales (i18n-parity CI fails on token mismatch).
+- After editing the JSON, **regenerate mobile slang**: `cd app/mobile && dart run slang` (rewrites `lib/core/i18n/strings.g.dart` + per-locale files).
+- **`Esc` semantics:** clears ALL staged chips and is swallowed (never reaches the CLI) — web via capture-phase `window` listener active only while the tray is non-empty; mobile via the keyboard-bar `Esc` key. Empty tray → `Esc`/`\x1b` behaves exactly as today.
+- **Styling** via Tailwind tokens + `cn` (web) and `Theme.of(context).colorScheme` (mobile) — no hardcoded colors.
+- **Verify:** web `pnpm --filter web exec tsc -b` + file-scoped `pnpm --filter web exec eslint <paths>` (the full `pnpm build:web` is blocked by a pre-existing root-owned `internal/web/dist` EACCES); mobile `cd app/mobile && flutter analyze`. No unit-test runner on either surface — the gate is typecheck/analyze/lint + a manual pass.
+- Commit per task. Open the PR only after all tasks pass and the operator approves; this feature **bundles with #433 into v2.11.3**.
+
+---
+
+### Task 1: i18n keys (shared) + slang codegen
+
+**Files:**
+- Modify: `app/i18n/en.json`, `app/i18n/es.json`, `app/i18n/zh.json`
+- Regenerate: `app/mobile/lib/core/i18n/strings*.g.dart` (via slang)
+
+**Interfaces:**
+- Produces (web, under `web.sessions.terminal`): `attachInsert`, `attachClear`, `attachRemove` (has `{name}`).
+- Produces (mobile, under `sessions.terminal.attachments`): `insert`, `clear`, `remove` (has `{name}`).
+
+- [ ] **Step 1: Add the web keys** to the `web.sessions.terminal` object in each locale (place after `dropToAttach`).
+
+`en.json`:
+```json
+    "attachInsert": "Insert",
+    "attachClear": "Clear all",
+    "attachRemove": "Remove {name}",
+```
+`es.json`:
+```json
+    "attachInsert": "Insertar",
+    "attachClear": "Quitar todo",
+    "attachRemove": "Quitar {name}",
+```
+`zh.json`:
+```json
+    "attachInsert": "插入",
+    "attachClear": "全部清除",
+    "attachRemove": "移除 {name}",
+```
+
+- [ ] **Step 2: Add the mobile keys** as a new `attachments` object inside `sessions.terminal` in each locale (place after the `keyboard` object).
+
+`en.json`:
+```json
+    "attachments": {
+      "insert": "Insert",
+      "clear": "Clear all",
+      "remove": "Remove {name}"
+    },
+```
+`es.json`:
+```json
+    "attachments": {
+      "insert": "Insertar",
+      "clear": "Quitar todo",
+      "remove": "Quitar {name}"
+    },
+```
+`zh.json`:
+```json
+    "attachments": {
+      "insert": "插入",
+      "clear": "全部清除",
+      "remove": "移除 {name}"
+    },
+```
+
+- [ ] **Step 3: Validate JSON + placeholder parity**
+
+Run:
+```bash
+cd "$(git rev-parse --show-toplevel)"
+for f in en es zh; do python3 -c "import json;json.load(open('app/i18n/$f.json'));print('$f OK')"; done
+node scripts/check-i18n-parity.mjs
+```
+Expected: `en OK` / `es OK` / `zh OK`, and the parity script exits 0 (every locale has the same `{name}` tokens).
+
+- [ ] **Step 4: Regenerate slang**
+
+Run: `cd app/mobile && dart run slang`
+Expected: it reports writing `lib/core/i18n/strings.g.dart` (+ `strings_en.g.dart`, `strings_es.g.dart`, `strings_zh.g.dart`) with the new `attachments` keys. Confirm no errors about `{{` interpolation.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/i18n app/mobile/lib/core/i18n
+git commit -m "i18n(attachments): staging-tray strings (web + mobile) + slang codegen
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Web — AttachmentTray + Terminal staging
+
+**Files:**
+- Create: `app/web/src/components/sessions/AttachmentTray.tsx`
+- Modify: `app/web/src/components/sessions/Terminal.tsx`
+
+**Interfaces:**
+- Consumes: i18n keys `web.sessions.terminal.attach{Insert,Clear,Remove}` (Task 1); existing `sendInput`, `uploadSessionFile`.
+- Produces: `interface AttachmentItem { path: string; name: string }` (exported from `AttachmentTray.tsx`); `<AttachmentTray items onRemove onInsert onClear />`.
+
+- [ ] **Step 1: Create `AttachmentTray.tsx`**
+
+```tsx
+import { Paperclip, X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { cn } from '@/lib/utils'
+
+export interface AttachmentItem {
+  path: string
+  name: string
+}
+
+// A staging tray of pending image attachments, anchored to the bottom of
+// the terminal pane. Renders nothing when empty (no layout impact on the
+// xterm fit()). Esc-to-clear is owned by Terminal.tsx; this is presentational.
+export function AttachmentTray({
+  items,
+  onRemove,
+  onInsert,
+  onClear,
+}: {
+  items: AttachmentItem[]
+  onRemove: (index: number) => void
+  onInsert: () => void
+  onClear: () => void
+}) {
+  const { t } = useTranslation()
+  if (items.length === 0) return null
+  return (
+    <div className="absolute inset-x-0 bottom-0 z-10 flex items-center gap-2 overflow-x-auto border-t border-border bg-card/95 px-2 py-1.5 backdrop-blur">
+      <div className="flex min-w-0 items-center gap-1.5">
+        {items.map((item, i) => (
+          <span
+            key={`${item.path}-${i}`}
+            className="flex max-w-[180px] items-center gap-1 rounded-md border border-border bg-background px-1.5 py-0.5 text-[11px]"
+          >
+            <Paperclip className="size-3 shrink-0 text-muted-foreground" />
+            <span className="truncate">{item.name}</span>
+            <button
+              type="button"
+              onClick={() => onRemove(i)}
+              aria-label={t('web.sessions.terminal.attachRemove', {
+                name: item.name,
+              })}
+              className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-card hover:text-foreground"
+            >
+              <X className="size-3" />
+            </button>
+          </span>
+        ))}
+      </div>
+      <div className="ml-auto flex shrink-0 items-center gap-1.5">
+        <button
+          type="button"
+          onClick={onClear}
+          className="rounded-md px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-background hover:text-foreground"
+        >
+          {t('web.sessions.terminal.attachClear')}
+        </button>
+        <button
+          type="button"
+          onClick={onInsert}
+          className={cn(
+            'rounded-md bg-primary px-2.5 py-0.5 text-[11px] font-medium text-primary-foreground',
+            'hover:opacity-95',
+          )}
+        >
+          {t('web.sessions.terminal.attachInsert')}
+        </button>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Add pending state + handlers in `Terminal.tsx`**
+
+Add the import near the other local imports (after `import { terminalBufferText } from './terminal-text'`):
+```ts
+import { AttachmentTray, type AttachmentItem } from './AttachmentTray'
+```
+
+Add state next to the existing `const [dragActive, setDragActive] = useState(false)` (~L96):
+```ts
+  const [pendingAttachments, setPendingAttachments] = useState<AttachmentItem[]>([])
+```
+
+- [ ] **Step 3: Stage instead of inserting, in `uploadFile`**
+
+In `uploadFile` (~L125-131), replace the success branch:
+```ts
+        const res = await uploadSessionFile(sessionId, file)
+        sendInput(res.path)
+        toast.success(t('web.sessions.terminal.uploadedToast'), {
+          id: toastId,
+          description: res.path,
+        })
+```
+with:
+```ts
+        const res = await uploadSessionFile(sessionId, file)
+        setPendingAttachments((a) => [...a, { path: res.path, name: file.name }])
+        toast.dismiss(toastId)
+```
+(The chip is now the feedback; the loading + error toasts stay.)
+
+- [ ] **Step 4: Add insert / remove / clear + Esc handling in `Terminal.tsx`**
+
+Add these callbacks after `uploadFile` (they can go right before `getBufferText`):
+```ts
+  const insertAttachments = useCallback(() => {
+    if (pendingAttachments.length === 0) return
+    sendInput(pendingAttachments.map((a) => a.path).join(' ') + ' ')
+    setPendingAttachments([])
+  }, [pendingAttachments, sendInput])
+
+  const removeAttachment = useCallback((index: number) => {
+    setPendingAttachments((a) => a.filter((_, i) => i !== index))
+  }, [])
+
+  const clearAttachments = useCallback(() => setPendingAttachments([]), [])
+```
+
+Add an Esc effect (place it near the other `useEffect`s, e.g. after the theme-refresh effect ~L437). It only registers while the tray is non-empty, so an empty tray leaves `Esc` untouched for the CLI:
+```ts
+  // While attachments are staged, Esc clears them instead of reaching the
+  // CLI. Capture phase so we win before xterm's own key handling (same
+  // pattern WikiLinkSuggestions uses).
+  useEffect(() => {
+    if (pendingAttachments.length === 0) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        e.stopPropagation()
+        setPendingAttachments([])
+      }
+    }
+    window.addEventListener('keydown', onKey, true)
+    return () => window.removeEventListener('keydown', onKey, true)
+  }, [pendingAttachments.length])
+```
+
+- [ ] **Step 5: Render the tray**
+
+In the `return` (~L439), inside the root `<div ref={rootRef} …>`, add the tray right after the `{dragActive && …}` overlay block (still inside the relative root so it anchors to the bottom):
+```tsx
+      <AttachmentTray
+        items={pendingAttachments}
+        onRemove={removeAttachment}
+        onInsert={insertAttachments}
+        onClear={clearAttachments}
+      />
+```
+
+- [ ] **Step 6: Typecheck + lint**
+
+Run:
+```bash
+cd "$(git rev-parse --show-toplevel)"
+pnpm --filter web exec tsc -b
+pnpm --filter web exec eslint src/components/sessions/Terminal.tsx src/components/sessions/AttachmentTray.tsx
+```
+Expected: `tsc -b` 0 errors; eslint clean.
+
+- [ ] **Step 7: Manual verification**
+
+In a session's terminal: attach an image (button / paste / drag-drop) → a chip appears in a bottom tray, and the path is **NOT** yet in the terminal. Press **Esc** → tray clears and nothing is sent to the CLI. Attach again → click **✕** → that chip is removed. Attach one or more → click **Insert** → the path(s) are typed into the terminal and the tray clears. With an empty tray, **Esc** still reaches the CLI as before.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/web/src/components/sessions/AttachmentTray.tsx app/web/src/components/sessions/Terminal.tsx
+git commit -m "feat(web/sessions): stage image uploads in a dismissable tray
+
+Upload no longer types the path straight into the PTY; it stages a chip
+(Esc/✕ to cancel, Insert to commit). Esc is swallowed only while staged.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Mobile — staging tray + keyboard-bar Esc
+
+**Files:**
+- Modify: `app/mobile/lib/features/sessions/session_terminal_view.dart`
+
+**Interfaces:**
+- Consumes: slang keys `sessions.terminal.attachments.{insert,clear,remove}` (Task 1); existing `_terminal.paste`, `sessionsApiProvider.uploadFile`.
+- Produces: `_PendingAttachment{path,name}`; `_AttachmentTray` widget; `_MobileKeyboardBar` gains `hasPendingAttachments` + `onEscClearPending`.
+
+- [ ] **Step 1: Add the model + state**
+
+Near the top of the file's private types (e.g. just above `class _ConnectionAccent`), add:
+```dart
+class _PendingAttachment {
+  const _PendingAttachment({required this.path, required this.name});
+  final String path;
+  final String name;
+}
+```
+In `_SessionTerminalViewState` (after `late final Terminal _terminal;` ~L39), add:
+```dart
+  final List<_PendingAttachment> _pending = [];
+```
+
+- [ ] **Step 2: Stage instead of pasting, in `_attachImage`**
+
+In `_attachImage` (~L352-368), replace:
+```dart
+      _terminal.paste(remotePath);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            t.sessions.terminal.snackbar.imageAttached(path: remotePath),
+          ),
+          behavior: SnackBarBehavior.floating,
+          duration: const Duration(seconds: 3),
+        ),
+      );
+```
+with:
+```dart
+      if (!mounted) return;
+      final attachmentName = file.name; // promoted non-null here (outside closure)
+      setState(() => _pending.add(
+            _PendingAttachment(path: remotePath, name: attachmentName),
+          ));
+```
+(`file` is promoted to non-null after the earlier `if (file == null) return;`; capturing `attachmentName` outside the `setState` closure avoids Dart's closure-promotion ambiguity, so no `!` is needed.)
+
+- [ ] **Step 3: Add insert / clear / remove methods**
+
+Add to `_SessionTerminalViewState` (near `_attachImage`):
+```dart
+  void _insertAttachments() {
+    if (_pending.isEmpty) return;
+    _terminal.paste('${_pending.map((a) => a.path).join(' ')} ');
+    setState(() => _pending.clear());
+  }
+
+  void _clearAttachments() => setState(() => _pending.clear());
+
+  void _removeAttachment(int index) =>
+      setState(() => _pending.removeAt(index));
+```
+
+- [ ] **Step 4: Add the `_AttachmentTray` widget**
+
+Add near the other private widgets (e.g. above `_MobileKeyboardBar`'s class):
+```dart
+class _AttachmentTray extends StatelessWidget {
+  const _AttachmentTray({
+    required this.items,
+    required this.onRemove,
+    required this.onInsert,
+    required this.onClear,
+  });
+  final List<_PendingAttachment> items;
+  final void Function(int index) onRemove;
+  final VoidCallback onInsert;
+  final VoidCallback onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) return const SizedBox.shrink();
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      color: scheme.surface,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+      child: Row(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: [
+                  for (var i = 0; i < items.length; i++)
+                    Padding(
+                      padding: const EdgeInsets.only(right: 6),
+                      child: Chip(
+                        avatar: const Icon(Icons.attach_file, size: 14),
+                        label: Text(
+                          items[i].name,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        deleteIcon: const Icon(Icons.close, size: 14),
+                        deleteButtonTooltipMessage: t
+                            .sessions.terminal.attachments
+                            .remove(name: items[i].name),
+                        onDeleted: () => onRemove(i),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+          TextButton(
+            onPressed: onClear,
+            child: Text(t.sessions.terminal.attachments.clear),
+          ),
+          const SizedBox(width: 4),
+          FilledButton(
+            onPressed: onInsert,
+            child: Text(t.sessions.terminal.attachments.insert),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+(`t` is the slang global — it's already imported and used throughout this file.)
+
+- [ ] **Step 5: Render the tray + wire the keyboard bar**
+
+In the parent `build` (~L490-497), insert the tray directly before `_MobileKeyboardBar(...)` and add the two new props to the bar:
+```dart
+        _AttachmentTray(
+          items: _pending,
+          onRemove: _removeAttachment,
+          onInsert: _insertAttachments,
+          onClear: _clearAttachments,
+        ),
+        _MobileKeyboardBar(
+          onKey: _sendKey,
+          onSelectText: _openSelectSheet,
+          onPaste: _pasteFromClipboard,
+          onAttachImage: _attachImage,
+          hasPendingAttachments: _pending.isNotEmpty,
+          onEscClearPending: _clearAttachments,
+        ),
+```
+
+- [ ] **Step 6: Add the props to `_MobileKeyboardBar` + conditional Esc**
+
+On the `_MobileKeyboardBar` widget class, add the fields + constructor params:
+```dart
+  final bool hasPendingAttachments;
+  final VoidCallback onEscClearPending;
+```
+(and `required this.hasPendingAttachments, required this.onEscClearPending,` in its constructor).
+
+In its `build`, change the `Esc` `_Key` (~L656-662) to:
+```dart
+            _Key(
+              label: 'Esc',
+              onTap: () {
+                _haptic();
+                if (widget.hasPendingAttachments) {
+                  widget.onEscClearPending();
+                } else {
+                  _send('\x1b');
+                }
+              },
+            ),
+```
+
+- [ ] **Step 7: Analyze**
+
+Run: `cd app/mobile && flutter analyze`
+Expected: "No issues found!" (or no new issues attributable to these files).
+
+- [ ] **Step 8: Manual verification**
+
+In a mobile session: attach an image → a chip appears above the keyboard bar; the path is **not** in the terminal. Tap the keyboard bar's **Esc** → the tray clears (and no escape is sent). Attach again → tap the chip's **✕** → it's removed. Tap **Insert** → the path is pasted into the terminal and the tray clears. With no chips, **Esc** sends `\x1b` as before.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/mobile/lib/features/sessions/session_terminal_view.dart
+git commit -m "feat(mobile/sessions): stage image uploads in a dismissable tray
+
+Parity with web: uploads stage as chips; keyboard-bar Esc clears the tray
+when staged, else sends escape.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Notes for the implementer
+
+- **Do not change** what the CLI receives — Insert sends the same bare path(s) that `sendInput`/`_terminal.paste` sent before, just deferred and space-joined.
+- **Do not add** a delete-on-cancel endpoint, thumbnails, or a composer — all out of scope.
+- The only literal escape sequence (`'\x1b'`) is pre-existing protocol, not a hardcoding-rule concern.
+- No JS/Go test runner is added; the gate is `tsc -b` + `eslint` (web), `flutter analyze` (mobile), plus the manual passes.
+- After all three tasks pass, this branch is ready to bundle with #433 for the **v2.11.3** release (changelog entry added at release time).

--- a/docs/superpowers/specs/2026-07-09-attachment-tray-design.md
+++ b/docs/superpowers/specs/2026-07-09-attachment-tray-design.md
@@ -1,0 +1,111 @@
+# Image-attachment staging tray (Esc-to-dismiss)
+
+**Date:** 2026-07-09
+**Status:** Approved design — ready for implementation plan
+**Surfaces:** web (`app/web`) + mobile (`app/mobile`). No backend change.
+
+## Problem
+
+When a user uploads an image to a session, opendray immediately types the returned
+server path (`/tmp/opendray-uploads/{sessionId}/{hex}.jpg`) straight into the PTY —
+web via `sendInput(res.path)` (`Terminal.tsx`), mobile via `_terminal.paste(...)`
+(`session_terminal_view.dart`). There is no attachment UI: the path lands directly
+in the running CLI's input line. So pressing **Esc** sends the escape byte to the
+CLI, not to opendray, and the user cannot cancel/dismiss the attachment — which is
+what they expect, since opendray's other overlays close on Esc.
+
+## Decisions (from brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Commit model | **Chip + explicit insert** — upload stages a chip; nothing reaches the PTY until the user clicks **Insert**. |
+| Count | **Multiple** pending chips (a tray). |
+| Chip content | Image icon + filename + **✕**. **No thumbnail** → no new backend endpoint. |
+| `Esc` (tray non-empty) | **Clears all** staged chips and is **swallowed** (never reaches the CLI). Empty tray → Esc passes through as today. |
+| `✕` | Removes that one chip. |
+| Insert | Explicit button — types all staged paths into the terminal (bare `res.path`, space-separated + trailing space), then clears the tray. Content delivered to the CLI is **unchanged** from today. |
+| Backend | **None.** Reuses `/api/v1/sessions/{id}/uploads` + `sendInput`/`paste`. |
+| Strings | **All new copy via the shared `app/i18n` layer** — web `t()`, mobile slang `t.` (see i18n section). No hardcoded copy. |
+| Orphaned upload on cancel | Accepted — the already-uploaded `/tmp/opendray-uploads` file is left unreferenced, same as today. A delete-on-cancel endpoint is out of scope. |
+
+## Architecture & no-hardcoding alignment
+
+- **Shared i18n source.** `app/mobile/slang.yaml` sets `input_directory: ../i18n`, so
+  both web (react-i18next) and mobile (slang codegen → `app/mobile/lib/core/i18n/strings_*.g.dart`)
+  read from the same `app/i18n/{en,es,zh}.json`. New strings are added there once.
+- **Styling** uses Tailwind design tokens (`bg-card`, `accent`, `text-muted-foreground`)
+  via `cn`, never literal colors — matching the surrounding code.
+- **Esc handling** uses the capture-phase `window` `keydown` pattern already used by
+  `WikiLinkSuggestions.tsx`.
+- No new hardcoded paths, formats, or magic values; the inserted text is the existing
+  `res.path`. The only literal is the mobile Esc byte `'\x1b'` (an escape sequence
+  already present in the code).
+
+### Unit 1 — Web: `AttachmentTray.tsx` (new, presentational)
+
+`app/web/src/components/sessions/AttachmentTray.tsx`. Pure, no state:
+
+```
+interface AttachmentItem { path: string; name: string }
+function AttachmentTray(props: {
+  items: AttachmentItem[]
+  onRemove: (index: number) => void
+  onInsert: () => void
+  onClear: () => void
+}): JSX.Element | null   // renders null when items is empty
+```
+
+Renders a chip row (icon + truncated `name` + `✕` per chip) plus an **Insert**
+button. All labels via `t()`. Styled with `cn` + tokens, lucide icons
+(`ImageIcon`/`Paperclip`, `X`).
+
+### Unit 2 — Web: `Terminal.tsx` wiring
+
+- Add state `pendingAttachments: AttachmentItem[]` (`useState`).
+- Render `<AttachmentTray items={pendingAttachments} … />` directly below the xterm
+  container.
+- Rewire the three upload paths — `uploadFile` (~L115-140), paste (~L356-374), drop
+  (~L398-411): replace `sendInput(res.path)` with
+  `setPendingAttachments(a => [...a, { path: res.path, name: file.name }])`.
+  Remove the current path-echoing toast (the chip is the feedback); keep error toasts.
+- **Insert:** `sendInput(pendingAttachments.map(a => a.path).join(' ') + ' ')`, then
+  `setPendingAttachments([])`.
+- **`Esc`:** a `useEffect` registers a **capture-phase** `window` `keydown` listener;
+  when `e.key === 'Escape'` and `pendingAttachments.length > 0`, call
+  `e.preventDefault()` + `e.stopPropagation()` and clear the tray. Cleanup on unmount.
+
+### Unit 3 — Mobile: `session_terminal_view.dart`
+
+- Add widget state `List<_PendingAttachment>` (`{path, name}`).
+- `_attachImage`: replace `_terminal.paste(remotePath)` with appending to the list.
+- Render a chip row above the keyboard bar (✕ per chip + **Insert** action).
+- **Keyboard-bar `Esc`** (currently `_send('\x1b')`, ~L657-663): becomes conditional —
+  if the tray is non-empty, clear it; else `_send('\x1b')` as today.
+- **Insert:** `_terminal.paste(path)` for each (space-separated), then clear.
+- Strings via slang `t.` accessors (see i18n).
+
+### i18n keys (add to `app/i18n/{en,es,zh}.json`)
+
+Under an appropriate group (e.g. `sessions.terminal.attachments` for mobile parity;
+web reads the same tree via its own namespace). Keys: `insert`, `clear`,
+`removeOne` (✕ aria-label, e.g. "Remove {name}"), `attached` (feedback, e.g.
+"Attached {name}"), `title`/`hint` if a tray header is shown. English base plus es/zh
+translations, placeholders (`{name}`) identical across locales (i18n-parity CI). After
+editing the JSON, **run the mobile slang codegen** (`dart run slang` or build_runner)
+so `strings_*.g.dart` regenerates.
+
+## Testing
+
+- **Web:** no JS test runner (repo condition) → `pnpm --filter web exec tsc -b` +
+  file-scoped `eslint` on the touched files + a manual pass (upload → chip appears →
+  `Esc` clears / `✕` removes one / **Insert** types the path; empty-tray Esc still
+  reaches the CLI).
+- **Mobile:** `flutter analyze` (after slang codegen) + manual pass mirroring the web
+  checks.
+- **Backend:** none.
+
+## Out of scope (YAGNI)
+
+- Delete-on-cancel of the orphaned `/tmp/opendray-uploads` file (a follow-up endpoint).
+- Thumbnail previews (would need a new image-serving endpoint).
+- A full message composer above the terminal.


### PR DESCRIPTION
## What & why

A user reported that after attaching an image to a session, the `/tmp/opendray-uploads/…jpg` path "should dismiss with **Esc** but doesn't." Root cause: opendray never created a cancellable attachment — on upload it typed the server path **straight into the PTY** (`sendInput`), so `Esc` went to the running CLI, not to opendray. There was nothing to dismiss.

This makes image uploads **stage** instead:

- Uploading (button / clipboard paste / drag-drop) now shows a **dismissable chip** in a tray at the bottom of the terminal — nothing reaches the CLI yet.
- **✕** removes one chip · **Esc** clears all (only while the tray is non-empty; empty tray → `Esc` passes to the CLI as before) · **Insert** types the path(s) into the terminal and clears the tray.
- The text delivered to the CLI is **unchanged** (bare path, multiples space-joined) — just deferred from upload-time to Insert-click.

## Scope

**Web + i18n only.** The **mobile (Flutter)** half is a deliberate follow-up (no Flutter toolchain on the build host + no mobile CI), matching how mobile parity has landed before (#422/#425). The mobile i18n keys are added to the shared `app/i18n` source now (inert until the mobile PR runs slang codegen). Design + plan committed under `docs/superpowers/`.

## How it works

- **No backend change.** Reuses `uploadSessionFile` + `sendInput`; paste/drop already funnel through the single `uploadFile` choke point, so only its success branch changed (stage instead of send).
- **`Esc` handling:** a capture-phase `window` `keydown` listener registered *only* while the tray is non-empty, **scoped to the terminal** (`rootRef.contains(e.target)`) so it can't steal Escape from an open Radix dialog. `AttachmentTray` renders `null` when empty (no xterm layout impact).
- **i18n:** all copy via the shared `app/i18n/{en,es,zh}.json` (single-brace `{name}`), consumed by `t()` — no hardcoded strings.

## Process & review

Brainstorm → spec → plan → subagent-driven TDD-style execution (per-task spec+quality reviews) → whole-branch review. The whole-branch review caught a cross-component bug — the `Esc` listener could hijack Escape from an open dialog while attachments were staged — which is fixed here (focus-scoped to the terminal). It also flagged an orphaned `uploadedToast` i18n key, removed here.

## Testing / verification

- **i18n:** JSON valid in all 3 locales; `check-i18n-parity.mjs` exits 0.
- **Web:** file-scoped `tsc` (0 errors in the two changed files) + `eslint` (clean). Note: the build host can't run a clean `pnpm install` (pre-existing root-owned `node_modules`/`dist` perms), so the full `tsc -b`/`vite build` is left to **CI**, which installs fresh.
- No JS test runner exists in the repo (pre-existing).

Bundles with #433 for **v2.11.3** (changelog added at release time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
