### PR TITLE
docs(changelog): v2.11.3 — attachment tray + Updates drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+## [v2.11.3] — 2026-07-09
+
+### Added
+
+- **Session terminal: staged image attachments.** Uploading an image to a
+  session (attach button, clipboard paste, or drag-and-drop) now stages it
+  as a dismissable chip in a tray at the bottom of the terminal instead of
+  typing the server path straight into the running CLI. **Esc** (or the
+  chip's ✕) cancels it — an empty tray still passes Esc through to the CLI —
+  and an **Insert** button commits the path(s) when you're ready. Fixes the
+  long-standing "the uploaded path can't be dismissed" surprise. Web for
+  now; mobile parity to follow. (#436)
+- **Sidebar Resources block + Updates drawer.** The web admin's left nav
+  gains a Resources section under Settings: an **Updates** drawer that shows
+  "what's new" from GitHub Releases (falling back to CHANGELOG.md) with an
+  unread badge and "mark read", plus **Docs**, **Community**, and
+  **Sponsor** links. (#433)
+
 ## [v2.11.2] — 2026-07-09
 
 ### Added


### PR DESCRIPTION
Release bump for **v2.11.3**. Moves `[Unreleased]` → `[v2.11.3]` (2026-07-09), bundling the two features merged since v2.11.2:

- **Staged image attachments** in the session terminal (#436) — uploads stage as a dismissable chip (Esc/✕ to cancel, Insert to commit) instead of typing the path straight into the CLI. Web; mobile parity to follow.
- **Sidebar Resources block + Updates drawer** (#433) — "what's new" from GitHub Releases with an unread badge, plus Docs/Community/Sponsor links.

Changelog-only change. On merge I'll tag `v2.11.3` to trigger goreleaser; with the #431 fix in place it also auto-rebuilds opendray.dev.

> Note: both are features, so strict semver would be v2.12.0 — cutting as v2.11.3 per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)