### PR TITLE
feat(mobile): Resources section + Updates "what's new" sheet (#433 parity)

### DIFF
--- a/app/mobile/lib/core/api/releases_api.dart
+++ b/app/mobile/lib/core/api/releases_api.dart
@@ -1,0 +1,320 @@
+// Release "what's new" feed for the mobile More → Resources → Updates
+// sheet. Dart mirror of app/shared/src/lib/releases.ts — keep the two
+// in sync (highlight parsing, changelog fallback, read-state semantics).
+//
+// Source of truth order:
+//   1. GitHub Releases (latest) — freshest publish date + notes URL
+//   2. CHANGELOG.md on main — when the release body is a stub that
+//      only points at the changelog (common for this project)
+//
+// Read state is local-first (SharedPreferences), mirroring the web
+// `opendray:lastReadRelease` localStorage key. A later change can sync
+// it per-user via the backend.
+//
+// IMPORTANT: this talks to github.com, NOT the gateway, so it uses a
+// bare Dio() with no interceptors — never the shared `dioProvider`,
+// which would attach the operator's gateway bearer token to GitHub and
+// turn a GitHub 401/403 (rate limit) into a spurious forced sign-out.
+
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _repo = 'Opendray/opendray';
+const _releasesLatest = 'https://api.github.com/repos/$_repo/releases/latest';
+const _changelogRaw =
+    'https://raw.githubusercontent.com/$_repo/main/CHANGELOG.md';
+const _changelogHtml = 'https://github.com/$_repo/blob/main/CHANGELOG.md';
+
+/// SharedPreferences key for the last release the operator marked read.
+const lastReadReleaseKey = 'opendray.lastReadRelease';
+
+enum ReleaseSource { githubRelease, changelog }
+
+class ReleaseInfo {
+  const ReleaseInfo({
+    required this.tag,
+    required this.version,
+    required this.name,
+    required this.htmlUrl,
+    required this.highlights,
+    required this.source,
+    this.publishedAt,
+  });
+
+  /// Tag as published, e.g. "v2.11.2".
+  final String tag;
+
+  /// Normalised without leading "v", e.g. "2.11.2".
+  final String version;
+  final String name;
+
+  /// ISO publish date when known.
+  final String? publishedAt;
+
+  /// GitHub release page (or changelog section fallback).
+  final String htmlUrl;
+
+  /// 3–5 short highlight lines for the sheet.
+  final List<String> highlights;
+
+  /// Where the highlights were parsed from.
+  final ReleaseSource source;
+}
+
+String normalizeReleaseVersion(String? v) {
+  if (v == null) return '';
+  var s = v.trim();
+  if (s.toLowerCase().startsWith('v')) s = s.substring(1);
+  final plus = s.indexOf('+');
+  if (plus >= 0) s = s.substring(0, plus);
+  return s;
+}
+
+String formatReleaseTag(String version) {
+  final n = normalizeReleaseVersion(version);
+  return n.isNotEmpty ? 'v$n' : '';
+}
+
+/// True when [latestVersion] differs from the last one marked read.
+bool isReleaseUnread(String? latestVersion, String? lastRead) {
+  final latest = normalizeReleaseVersion(latestVersion);
+  if (latest.isEmpty) return false;
+  final read = normalizeReleaseVersion(lastRead);
+  if (read.isEmpty) return true;
+  return read != latest;
+}
+
+/// Pull short highlight lines from markdown (release body or CHANGELOG
+/// section). Prefers the bold title in `- **Title.** rest` bullets
+/// (CHANGELOG style); falls back to the first line of a plain list
+/// item. Continuation lines under a bullet are ignored.
+List<String> extractHighlights(String markdown, {int limit = 5}) {
+  if (markdown.trim().isEmpty) return const [];
+  // Drop "Announce on X" / tweet blocks that ship in many release bodies.
+  final cleaned = markdown
+      .replaceAll(
+        RegExp(r'##\s*Announce on X[\s\S]*$', caseSensitive: false),
+        '',
+      )
+      .replaceAll(RegExp(r'```[\s\S]*?```'), '');
+
+  final lines = cleaned.split(RegExp(r'\r?\n'));
+  final out = <String>[];
+  for (final line in lines) {
+    // Only real list starters (not wrapped continuation indented deeper).
+    final m = RegExp(r'^\s*[-*+]\s+(.+)$').firstMatch(line);
+    if (m == null) continue;
+    final item = m.group(1)!;
+    final bold = RegExp(r'^\*\*(.+?)\*\*').firstMatch(item);
+    var text = bold != null ? bold.group(1)!.trim() : item.trim();
+    text = text
+        .replaceAll('**', '')
+        .replaceAllMapped(RegExp('`([^`]+)`'), (mm) => mm.group(1)!)
+        .replaceAllMapped(
+          RegExp(r'\[([^\]]+)\]\([^)]+\)'),
+          (mm) => mm.group(1)!,
+        )
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .replaceAll(RegExp(r'[.:]+$'), '')
+        .trim();
+    if (text.length < 4) continue;
+    // Cap length so the sheet stays scannable.
+    if (text.length > 120) text = '${text.substring(0, 117).trimRight()}…';
+    out.add(text);
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+/// Extract the section under `## [vX.Y.Z]` from Keep-a-Changelog markdown.
+String extractChangelogSection(String changelog, String version) {
+  final v = normalizeReleaseVersion(version);
+  if (v.isEmpty || changelog.isEmpty) return '';
+  final esc = RegExp.escape(v);
+  // Match ## [v2.11.2], ## [2.11.2], ## v2.11.2, with optional date suffix.
+  final re = RegExp(
+    '^##\\s*\\[?v?$esc\\]?\\s*(?:—|-|–).*\$',
+    multiLine: true,
+    caseSensitive: false,
+  );
+  final reAlt = RegExp(
+    '^##\\s*\\[?v?$esc\\]?\\s*\$',
+    multiLine: true,
+    caseSensitive: false,
+  );
+  final startMatch = re.firstMatch(changelog) ?? reAlt.firstMatch(changelog);
+  if (startMatch == null) return '';
+  final from = startMatch.start + startMatch.group(0)!.length;
+  final rest = changelog.substring(from);
+  final next = RegExp(r'^##\s+', multiLine: true).firstMatch(rest);
+  return next != null ? rest.substring(0, next.start) : rest;
+}
+
+bool _isStubBody(String body) {
+  final t = body.trim();
+  if (t.isEmpty) return true;
+  // Typical stub: "See CHANGELOG.md for the full release notes." + announce.
+  final withoutAnnounce = t
+      .replaceAll(
+        RegExp(r'##\s*Announce on X[\s\S]*$', caseSensitive: false),
+        '',
+      )
+      .trim();
+  if (withoutAnnounce.length < 80) return true;
+  if (RegExp(r'see\s+\[?changelog', caseSensitive: false)
+          .hasMatch(withoutAnnounce) &&
+      extractHighlights(withoutAnnounce).isEmpty) {
+    return true;
+  }
+  return false;
+}
+
+class ReleasesApi {
+  ReleasesApi([Dio? dio])
+      : _dio = dio ??
+            Dio(
+              BaseOptions(
+                connectTimeout: const Duration(seconds: 8),
+                receiveTimeout: const Duration(seconds: 15),
+                // We parse the body ourselves (JSON for releases, plain
+                // text for the changelog) so keep Dio out of it.
+                responseType: ResponseType.plain,
+                validateStatus: (_) => true,
+              ),
+            );
+
+  final Dio _dio;
+
+  /// Load the latest release highlights. Prefer GitHub Releases; fall
+  /// back to CHANGELOG.md for bullet text.
+  Future<ReleaseInfo> fetchLatestReleaseInfo() async {
+    final res = await _dio.get<String>(
+      _releasesLatest,
+      options: Options(headers: {'Accept': 'application/vnd.github+json'}),
+    );
+    final status = res.statusCode ?? 0;
+    if (status < 200 || status >= 300) {
+      // No releases API (rate limit / offline) — try changelog head only.
+      return _fetchFromChangelogOnly();
+    }
+    final rel = jsonDecode(res.data ?? '{}') as Map<String, dynamic>;
+    final tag = (rel['tag_name'] as String?)?.trim() ?? '';
+    final version = normalizeReleaseVersion(tag);
+    if (version.isEmpty) throw Exception('github release missing tag_name');
+
+    final body = (rel['body'] as String?) ?? '';
+    var highlights = extractHighlights(body);
+    var source = ReleaseSource.githubRelease;
+
+    if (_isStubBody(body) || highlights.isEmpty) {
+      try {
+        final changelog = await _fetchText(_changelogRaw);
+        final section = extractChangelogSection(changelog, version);
+        final fromLog = extractHighlights(section);
+        if (fromLog.isNotEmpty) {
+          highlights = fromLog;
+          source = ReleaseSource.changelog;
+        }
+      } on Object {
+        // Keep whatever we got from the release body.
+      }
+    }
+
+    final name = (rel['name'] as String?)?.trim();
+    final htmlUrl = (rel['html_url'] as String?)?.trim();
+    return ReleaseInfo(
+      tag: tag.startsWith('v') ? tag : 'v$version',
+      version: version,
+      name: (name != null && name.isNotEmpty)
+          ? name
+          : (tag.isNotEmpty ? tag : 'v$version'),
+      publishedAt: rel['published_at'] as String?,
+      htmlUrl: (htmlUrl != null && htmlUrl.isNotEmpty)
+          ? htmlUrl
+          : 'https://github.com/$_repo/releases/tag/v$version',
+      highlights: highlights,
+      source: source,
+    );
+  }
+
+  Future<ReleaseInfo> _fetchFromChangelogOnly() async {
+    final changelog = await _fetchText(_changelogRaw);
+    // First version heading after Unreleased.
+    final m = RegExp(
+      r'^##\s*\[?(v?\d+\.\d+\.\d+)\]?\s*(?:—|-|–)\s*(\d{4}-\d{2}-\d{2})?',
+      multiLine: true,
+    ).firstMatch(changelog);
+    if (m == null) throw Exception('changelog: no version heading found');
+    final version = normalizeReleaseVersion(m.group(1));
+    final section = extractChangelogSection(changelog, version);
+    final highlights = extractHighlights(section);
+    final date = m.group(2);
+    return ReleaseInfo(
+      tag: formatReleaseTag(version),
+      version: version,
+      name: formatReleaseTag(version),
+      publishedAt: date != null ? '${date}T00:00:00Z' : null,
+      htmlUrl: '$_changelogHtml#v${version.replaceAll('.', '')}',
+      highlights: highlights,
+      source: ReleaseSource.changelog,
+    );
+  }
+
+  Future<String> _fetchText(String url) async {
+    final res = await _dio.get<String>(
+      url,
+      options: Options(headers: {'Accept': 'text/plain, text/markdown, */*'}),
+    );
+    final status = res.statusCode ?? 0;
+    if (status < 200 || status >= 300) {
+      throw Exception('fetch $url: $status');
+    }
+    return res.data ?? '';
+  }
+}
+
+final releasesApiProvider = Provider<ReleasesApi>((ref) => ReleasesApi());
+
+final latestReleaseProvider = FutureProvider.autoDispose<ReleaseInfo>((ref) {
+  return ref.watch(releasesApiProvider).fetchLatestReleaseInfo();
+});
+
+/// Last release the operator marked as read (normalised, e.g. "2.11.2";
+/// null when never marked). Persisted to SharedPreferences like the web
+/// localStorage key so the unread badge survives restarts.
+class LastReadReleaseController extends StateNotifier<String?> {
+  LastReadReleaseController() : super(null) {
+    _restore();
+  }
+
+  Future<void> _restore() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(lastReadReleaseKey);
+      final n = normalizeReleaseVersion(raw);
+      if (n.isNotEmpty) state = n;
+    } on Object {
+      // Best-effort; a null state simply badges the newest release.
+    }
+  }
+
+  Future<void> markRead(String version) async {
+    final n = normalizeReleaseVersion(version);
+    if (n.isEmpty) return;
+    state = n;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(lastReadReleaseKey, formatReleaseTag(n));
+    } on Object {
+      // Best-effort persistence; the badge still clears this run.
+    }
+  }
+}
+
+final lastReadReleaseProvider =
+    StateNotifierProvider<LastReadReleaseController, String?>(
+  (ref) => LastReadReleaseController(),
+);

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 11916 (3972 per locale)
+/// Strings: 11973 (3991 per locale)
 ///
-/// Built on 2026-07-09 at 00:05 UTC
+/// Built on 2026-07-10 at 11:04 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -215,6 +215,20 @@ class TranslationsNavEn {
 
 	/// en: 'Update available'
 	String get updateAvailable => 'Update available';
+
+	/// en: 'Resources'
+	String get resources => 'Resources';
+
+	/// en: 'Docs & Setup'
+	String get docs => 'Docs & Setup';
+
+	/// en: 'Community'
+	String get community => 'Community';
+
+	/// en: 'Sponsor'
+	String get sponsor => 'Sponsor';
+
+	late final TranslationsNavUpdatesEn updates = TranslationsNavUpdatesEn.internal(_root);
 }
 
 // Path: web
@@ -2253,6 +2267,45 @@ class TranslationsCortexSettingsEn {
 	String get defaultBadge => 'default';
 }
 
+// Path: nav.updates
+class TranslationsNavUpdatesEn {
+	TranslationsNavUpdatesEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Updates'
+	String get title => 'Updates';
+
+	/// en: 'What's new in {version}'
+	String whatsNew({required Object version}) => 'What\'s new in ${version}';
+
+	/// en: 'Loading release notes…'
+	String get loading => 'Loading release notes…';
+
+	/// en: 'Couldn't load release notes ({error}).'
+	String loadFailed({required Object error}) => 'Couldn\'t load release notes (${error}).';
+
+	/// en: 'No short highlights for this release. Open the full changelog for details.'
+	String get noHighlights => 'No short highlights for this release. Open the full changelog for details.';
+
+	/// en: 'Open full changelog'
+	String get openFull => 'Open full changelog';
+
+	/// en: 'Mark read'
+	String get markRead => 'Mark read';
+
+	/// en: 'Unread release notes'
+	String get unread => 'Unread release notes';
+
+	/// en: 'Updates · {count}'
+	String badgeCount({required Object count}) => 'Updates · ${count}';
+
+	/// en: 'Highlights from CHANGELOG.md (release body was a stub).'
+	String get sourceChangelog => 'Highlights from CHANGELOG.md (release body was a stub).';
+}
+
 // Path: web.topbar
 class TranslationsWebTopbarEn {
 	TranslationsWebTopbarEn.internal(this._root);
@@ -3672,6 +3725,7 @@ class TranslationsSessionsTerminalEn {
 	late final TranslationsSessionsTerminalSnackbarEn snackbar = TranslationsSessionsTerminalSnackbarEn.internal(_root);
 	late final TranslationsSessionsTerminalImageSourceEn imageSource = TranslationsSessionsTerminalImageSourceEn.internal(_root);
 	late final TranslationsSessionsTerminalKeyboardEn keyboard = TranslationsSessionsTerminalKeyboardEn.internal(_root);
+	late final TranslationsSessionsTerminalAttachmentsEn attachments = TranslationsSessionsTerminalAttachmentsEn.internal(_root);
 	late final TranslationsSessionsTerminalConnectionEn connection = TranslationsSessionsTerminalConnectionEn.internal(_root);
 	late final TranslationsSessionsTerminalSelectCopyEn selectCopy = TranslationsSessionsTerminalSelectCopyEn.internal(_root);
 }
@@ -6215,9 +6269,6 @@ class TranslationsWebSessionsTerminalEn {
 	/// en: 'Uploading image…'
 	String get uploadingToast => 'Uploading image…';
 
-	/// en: 'Image attached'
-	String get uploadedToast => 'Image attached';
-
 	/// en: 'Upload failed'
 	String get uploadFailedToast => 'Upload failed';
 
@@ -6226,6 +6277,15 @@ class TranslationsWebSessionsTerminalEn {
 
 	/// en: 'Drop image to attach'
 	String get dropToAttach => 'Drop image to attach';
+
+	/// en: 'Insert'
+	String get attachInsert => 'Insert';
+
+	/// en: 'Clear all'
+	String get attachClear => 'Clear all';
+
+	/// en: 'Remove {name}'
+	String attachRemove({required Object name}) => 'Remove ${name}';
 
 	/// en: 'Copied to clipboard'
 	String get copiedToast => 'Copied to clipboard';
@@ -12235,6 +12295,24 @@ class TranslationsSessionsTerminalKeyboardEn {
 	String get selectText => 'Select text';
 }
 
+// Path: sessions.terminal.attachments
+class TranslationsSessionsTerminalAttachmentsEn {
+	TranslationsSessionsTerminalAttachmentsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Insert'
+	String get insert => 'Insert';
+
+	/// en: 'Clear all'
+	String get clear => 'Clear all';
+
+	/// en: 'Remove {name}'
+	String remove({required Object name}) => 'Remove ${name}';
+}
+
 // Path: sessions.terminal.connection
 class TranslationsSessionsTerminalConnectionEn {
 	TranslationsSessionsTerminalConnectionEn.internal(this._root);
@@ -17250,6 +17328,20 @@ extension on Translations {
 			'nav.vault' => 'Vault',
 			'nav.cortex' => 'Cortex',
 			'nav.updateAvailable' => 'Update available',
+			'nav.resources' => 'Resources',
+			'nav.docs' => 'Docs & Setup',
+			'nav.community' => 'Community',
+			'nav.sponsor' => 'Sponsor',
+			'nav.updates.title' => 'Updates',
+			'nav.updates.whatsNew' => ({required Object version}) => 'What\'s new in ${version}',
+			'nav.updates.loading' => 'Loading release notes…',
+			'nav.updates.loadFailed' => ({required Object error}) => 'Couldn\'t load release notes (${error}).',
+			'nav.updates.noHighlights' => 'No short highlights for this release. Open the full changelog for details.',
+			'nav.updates.openFull' => 'Open full changelog',
+			'nav.updates.markRead' => 'Mark read',
+			'nav.updates.unread' => 'Unread release notes',
+			'nav.updates.badgeCount' => ({required Object count}) => 'Updates · ${count}',
+			'nav.updates.sourceChangelog' => 'Highlights from CHANGELOG.md (release body was a stub).',
 			'web.brand' => 'opendray',
 			'web.loading' => 'Loading…',
 			'web.topbar.expandSidebar' => 'Expand sidebar',
@@ -17326,10 +17418,12 @@ extension on Translations {
 			'web.sessions.header.transcript' => 'Transcript',
 			'web.sessions.header.transcriptTooltip' => 'Open the full session transcript (works for CLIs whose own scrollback is unreachable, e.g. Grok)',
 			'web.sessions.terminal.uploadingToast' => 'Uploading image…',
-			'web.sessions.terminal.uploadedToast' => 'Image attached',
 			'web.sessions.terminal.uploadFailedToast' => 'Upload failed',
 			'web.sessions.terminal.uploadInvalidTypeToast' => 'Only image files can be attached',
 			'web.sessions.terminal.dropToAttach' => 'Drop image to attach',
+			'web.sessions.terminal.attachInsert' => 'Insert',
+			'web.sessions.terminal.attachClear' => 'Clear all',
+			'web.sessions.terminal.attachRemove' => ({required Object name}) => 'Remove ${name}',
 			'web.sessions.terminal.copiedToast' => 'Copied to clipboard',
 			'web.sessions.terminal.copyFailedToast' => 'Couldn\'t copy to clipboard',
 			'web.sessions.terminal.selectCopyTitle' => 'Select & copy',
@@ -17707,6 +17801,8 @@ extension on Translations {
 			'web.project.inbox.sessionPrefix' => 'ses',
 			'web.project.inbox.warning' => ({required Object label}) => 'Approve will REPLACE the current ${label} entirely.',
 			'web.project.inbox.warningSuffix' => 'Review the diff below; this isn\'t a merge.',
+			_ => null,
+		} ?? switch (path) {
 			'web.project.inbox.current' => 'Current',
 			'web.project.inbox.proposed' => 'Proposed',
 			'web.project.inbox.emptyBody' => '(empty)',
@@ -17723,8 +17819,6 @@ extension on Translations {
 			'web.project.archived.restoredToast' => 'Restored',
 			'web.project.archived.restoreFailedToast' => 'Restore failed',
 			'web.project.reset.button' => 'Reset',
-			_ => null,
-		} ?? switch (path) {
 			'web.project.reset.dialogTitle' => 'Reset project memory?',
 			'web.project.reset.dialogDescription' => 'Deletes all stored project context for this cwd. This cannot be undone.',
 			'web.project.reset.alwaysDeleted' => 'Always deleted: goal, plan, proposals, journal, cleanup decisions.',
@@ -18221,6 +18315,8 @@ extension on Translations {
 			'web.channels.dialog.editTitle' => 'Edit channel',
 			'web.channels.dialog.createTitle' => 'Register channel',
 			'web.channels.dialog.descriptionBridge' => 'External adapter (Python/Node/...) connects via WebSocket and presents this token.',
+			_ => null,
+		} ?? switch (path) {
 			'web.channels.dialog.descriptionDefault' => 'Configure messaging integration.',
 			'web.channels.dialog.kindLabel' => 'Kind',
 			'web.channels.dialog.kindImmutable' => '(immutable — delete and recreate to change kind)',
@@ -18237,8 +18333,6 @@ extension on Translations {
 			'web.channels.dialog.nameRequired' => 'name is required',
 			'web.channels.dialog.tokenRequired' => 'token is required',
 			'web.channels.dialog.topicIdsNumeric' => ({required Object value}) => 'Topic IDs must be numeric (got ${value})',
-			_ => null,
-		} ?? switch (path) {
 			'web.channels.dialog.fieldRequired' => ({required Object label}) => '${label} is required',
 			'web.channels.dialog.cooldownInvalid' => 'Cooldown must be a non-negative number of seconds',
 			'web.channels.dialog.snippetCapInvalid' => 'Snippet cap must be a non-negative number',
@@ -18735,6 +18829,8 @@ extension on Translations {
 			'web.backups.schedulesTab.deleteTooltip' => 'Delete',
 			'web.backups.newSchedule.title' => 'New backup schedule',
 			'web.backups.newSchedule.targetLabel' => 'Targets',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.newSchedule.targetsHint' => 'Pick one or more — the same backup is written to each (3-2-1).',
 			'web.backups.newSchedule.everyHoursLabel' => 'Every (hours)',
 			'web.backups.newSchedule.keepLastNLabel' => 'Keep last N',
@@ -18751,8 +18847,6 @@ extension on Translations {
 			'web.backups.targetsTab.newTarget' => 'New target',
 			'web.backups.targetsTab.listFailedToast' => 'Failed to list targets',
 			'web.backups.targetsTab.deleteConfirm' => ({required Object id}) => 'Delete target ${id}? Schedules referencing it will block the delete.',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.targetsTab.deletedToast' => 'Target deleted',
 			'web.backups.targetsTab.deleteFailedToast' => 'Delete failed',
 			'web.backups.targetsTab.connectionOkToast' => 'Connection OK',
@@ -19249,6 +19343,8 @@ extension on Translations {
 			'web.memoryAmbient.profiles.addButton' => 'Add profile',
 			'web.memoryAmbient.profiles.intro' => 'At spawn time opendray prepends a markdown banner of recent project memories to the agent\'s system prompt — IF a profile is configured. Without a profile, the model still uses memory_search on demand.',
 			'web.memoryAmbient.profiles.empty' => 'No injection profile. Memories are not auto-injected at spawn — model still uses memory_search.',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryAmbient.profiles.row.globalDefault' => 'global default',
 			'web.memoryAmbient.profiles.row.delete' => 'Delete',
 			'web.memoryAmbient.profiles.row.deleteConfirm' => 'Delete this injection profile?',
@@ -19265,8 +19361,6 @@ extension on Translations {
 			'web.memoryAmbient.cost.intro' => 'Per-provider summary aggregated from <1>memory_summarizer_calls</1>. Local providers (Ollama, LM Studio, Integration) are priced as \$0 — operator owns hardware cost.',
 			'web.memoryAmbient.cost.empty' => 'No enabled providers — no cost data.',
 			'web.memoryAmbient.cost.columns.provider' => 'Provider',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryAmbient.cost.columns.calls' => 'Calls',
 			'web.memoryAmbient.cost.columns.inTokens' => 'In tokens',
 			'web.memoryAmbient.cost.columns.outTokens' => 'Out tokens',
@@ -19763,6 +19857,8 @@ extension on Translations {
 			'sessions.detail.refreshMetadata' => 'Refresh metadata',
 			'sessions.detail.inspector' => 'Inspector (Files / Git / Tasks / History / Notes)',
 			'sessions.detail.projectMemory' => 'Project memory (goal / plan / journal / inbox)',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.detail.actions' => 'Actions',
 			'sessions.detail.started' => ({required Object when}) => 'started ${when}',
 			'sessions.detail.startedEnded' => ({required Object started, required Object ended}) => 'started ${started}  ·  ended ${ended}',
@@ -19779,8 +19875,6 @@ extension on Translations {
 			'sessions.detail.accountSwitcher.confirmBody' => 'This restarts the CLI under the new account — the current in-CLI conversation context is lost (the session tab is kept).',
 			'sessions.detail.accountSwitcher.confirmAction' => 'Switch',
 			'sessions.detail.accountSwitcher.cancel' => 'Cancel',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.detail.accountSwitcher.switchedSnack' => ({required Object account}) => 'Switched to ${account}',
 			'sessions.detail.accountSwitcher.switchFailed' => ({required Object error}) => 'Switch failed: ${error}',
 			'sessions.detail.accountSwitcher.noneHint' => 'No Claude accounts configured. Add them in More → Providers → Claude.',
@@ -19799,6 +19893,9 @@ extension on Translations {
 			'sessions.terminal.keyboard.attachImage' => 'Attach image',
 			'sessions.terminal.keyboard.enter' => 'Enter',
 			'sessions.terminal.keyboard.selectText' => 'Select text',
+			'sessions.terminal.attachments.insert' => 'Insert',
+			'sessions.terminal.attachments.clear' => 'Clear all',
+			'sessions.terminal.attachments.remove' => ({required Object name}) => 'Remove ${name}',
 			'sessions.terminal.connection.connecting' => 'Connecting…',
 			'sessions.terminal.connection.connected' => 'Connected',
 			'sessions.terminal.connection.reconnecting' => 'Reconnecting…',
@@ -20274,6 +20371,8 @@ extension on Translations {
 			'project.conflicts.deleteLoading' => 'Loading fact text…',
 			'project.conflicts.deleteFactLabel' => ({required Object side}) => 'Delete ${side}',
 			'project.conflicts.deletedFact' => 'Fact deleted and conflict accepted',
+			_ => null,
+		} ?? switch (path) {
 			'project.conflicts.openPlanEditor' => 'Open plan editor',
 			'project.conflicts.openGoalEditor' => 'Open goal editor',
 			'project.conflicts.severity.low' => 'low',
@@ -20293,8 +20392,6 @@ extension on Translations {
 			'project.browseFolder' => 'Browse folder…',
 			'project.resetTooltip' => 'Reset project memory',
 			'project.append' => 'Append',
-			_ => null,
-		} ?? switch (path) {
 			'project.appendDialogTitle' => 'Append journal entry',
 			'project.titleFieldLabel' => 'Title (optional)',
 			'project.contentFieldLabel' => 'Content (markdown)',
@@ -20788,6 +20885,8 @@ extension on Translations {
 			'customTasks.commandHelper' => 'The text inserted into the session when picked. Can be a CLI command or a Claude slash command.',
 			'customTasks.fieldDescription' => 'Description (optional)',
 			'customTasks.fieldScope' => 'Scope',
+			_ => null,
+		} ?? switch (path) {
 			'customTasks.globalScopeHint' => 'Visible from every session, regardless of cwd.',
 			'customTasks.projectScopeHint' => 'Visible only when a session\'s cwd matches the path below.',
 			'customTasks.fieldProjectCwd' => 'Project cwd',
@@ -20807,8 +20906,6 @@ extension on Translations {
 			'notesPage.deleteTitle' => 'Delete note?',
 			'notesPage.deletedSnack' => ({required Object path}) => 'Deleted ${path}',
 			'notesPage.deleteFailedApi' => ({required Object error}) => 'Delete failed: ${error}',
-			_ => null,
-		} ?? switch (path) {
 			'notesPage.deleteFailedGeneric' => ({required Object error}) => 'Delete failed: ${error}',
 			'notesPage.createFailedApi' => ({required Object error}) => 'Create failed: ${error}',
 			'notesPage.createFailedGeneric' => ({required Object error}) => 'Create failed: ${error}',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -136,6 +136,11 @@ class _TranslationsNavEs extends TranslationsNavEn {
 	@override String get vault => 'Bóveda';
 	@override String get cortex => 'Cortex';
 	@override String get updateAvailable => 'Actualización disponible';
+	@override String get resources => 'Recursos';
+	@override String get docs => 'Docs y setup';
+	@override String get community => 'Comunidad';
+	@override String get sponsor => 'Patrocinar';
+	@override late final _TranslationsNavUpdatesEs updates = _TranslationsNavUpdatesEs._(_root);
 }
 
 // Path: web
@@ -1044,6 +1049,25 @@ class _TranslationsCortexSettingsEs extends TranslationsCortexSettingsEn {
 	@override String get defaultBadge => 'predeterminado';
 }
 
+// Path: nav.updates
+class _TranslationsNavUpdatesEs extends TranslationsNavUpdatesEn {
+	_TranslationsNavUpdatesEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Actualizaciones';
+	@override String whatsNew({required Object version}) => 'Novedades en ${version}';
+	@override String get loading => 'Cargando notas de la versión…';
+	@override String loadFailed({required Object error}) => 'No se pudieron cargar las notas (${error}).';
+	@override String get noHighlights => 'No hay highlights cortos para esta versión. Abre el changelog completo.';
+	@override String get openFull => 'Abrir changelog completo';
+	@override String get markRead => 'Marcar como leído';
+	@override String get unread => 'Notas de versión sin leer';
+	@override String badgeCount({required Object count}) => 'Actualizaciones · ${count}';
+	@override String get sourceChangelog => 'Highlights desde CHANGELOG.md (el cuerpo del release era un stub).';
+}
+
 // Path: web.topbar
 class _TranslationsWebTopbarEs extends TranslationsWebTopbarEn {
 	_TranslationsWebTopbarEs._(TranslationsEs root) : this._root = root, super.internal(root);
@@ -1861,6 +1885,7 @@ class _TranslationsSessionsTerminalEs extends TranslationsSessionsTerminalEn {
 	@override late final _TranslationsSessionsTerminalSnackbarEs snackbar = _TranslationsSessionsTerminalSnackbarEs._(_root);
 	@override late final _TranslationsSessionsTerminalImageSourceEs imageSource = _TranslationsSessionsTerminalImageSourceEs._(_root);
 	@override late final _TranslationsSessionsTerminalKeyboardEs keyboard = _TranslationsSessionsTerminalKeyboardEs._(_root);
+	@override late final _TranslationsSessionsTerminalAttachmentsEs attachments = _TranslationsSessionsTerminalAttachmentsEs._(_root);
 	@override late final _TranslationsSessionsTerminalConnectionEs connection = _TranslationsSessionsTerminalConnectionEs._(_root);
 	@override late final _TranslationsSessionsTerminalSelectCopyEs selectCopy = _TranslationsSessionsTerminalSelectCopyEs._(_root);
 }
@@ -3174,10 +3199,12 @@ class _TranslationsWebSessionsTerminalEs extends TranslationsWebSessionsTerminal
 
 	// Translations
 	@override String get uploadingToast => 'Subiendo imagen…';
-	@override String get uploadedToast => 'Imagen adjuntada';
 	@override String get uploadFailedToast => 'Error al subir';
 	@override String get uploadInvalidTypeToast => 'Solo se pueden adjuntar archivos de imagen';
 	@override String get dropToAttach => 'Suelta la imagen para adjuntarla';
+	@override String get attachInsert => 'Insertar';
+	@override String get attachClear => 'Quitar todo';
+	@override String attachRemove({required Object name}) => 'Quitar ${name}';
 	@override String get copiedToast => 'Copiado al portapapeles';
 	@override String get copyFailedToast => 'No se pudo copiar al portapapeles';
 	@override String get selectCopyTitle => 'Seleccionar y copiar';
@@ -6290,6 +6317,18 @@ class _TranslationsSessionsTerminalKeyboardEs extends TranslationsSessionsTermin
 	@override String get selectText => 'Seleccionar texto';
 }
 
+// Path: sessions.terminal.attachments
+class _TranslationsSessionsTerminalAttachmentsEs extends TranslationsSessionsTerminalAttachmentsEn {
+	_TranslationsSessionsTerminalAttachmentsEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get insert => 'Insertar';
+	@override String get clear => 'Quitar todo';
+	@override String remove({required Object name}) => 'Quitar ${name}';
+}
+
 // Path: sessions.terminal.connection
 class _TranslationsSessionsTerminalConnectionEs extends TranslationsSessionsTerminalConnectionEn {
 	_TranslationsSessionsTerminalConnectionEs._(TranslationsEs root) : this._root = root, super.internal(root);
@@ -9190,6 +9229,20 @@ extension on TranslationsEs {
 			'nav.vault' => 'Bóveda',
 			'nav.cortex' => 'Cortex',
 			'nav.updateAvailable' => 'Actualización disponible',
+			'nav.resources' => 'Recursos',
+			'nav.docs' => 'Docs y setup',
+			'nav.community' => 'Comunidad',
+			'nav.sponsor' => 'Patrocinar',
+			'nav.updates.title' => 'Actualizaciones',
+			'nav.updates.whatsNew' => ({required Object version}) => 'Novedades en ${version}',
+			'nav.updates.loading' => 'Cargando notas de la versión…',
+			'nav.updates.loadFailed' => ({required Object error}) => 'No se pudieron cargar las notas (${error}).',
+			'nav.updates.noHighlights' => 'No hay highlights cortos para esta versión. Abre el changelog completo.',
+			'nav.updates.openFull' => 'Abrir changelog completo',
+			'nav.updates.markRead' => 'Marcar como leído',
+			'nav.updates.unread' => 'Notas de versión sin leer',
+			'nav.updates.badgeCount' => ({required Object count}) => 'Actualizaciones · ${count}',
+			'nav.updates.sourceChangelog' => 'Highlights desde CHANGELOG.md (el cuerpo del release era un stub).',
 			'web.brand' => 'opendray',
 			'web.loading' => 'Cargando…',
 			'web.topbar.expandSidebar' => 'Expandir barra lateral',
@@ -9266,10 +9319,12 @@ extension on TranslationsEs {
 			'web.sessions.header.transcript' => 'Transcripción',
 			'web.sessions.header.transcriptTooltip' => 'Abre la transcripción completa de la sesión (útil para CLIs cuyo propio desplazamiento no funciona, p. ej. Grok)',
 			'web.sessions.terminal.uploadingToast' => 'Subiendo imagen…',
-			'web.sessions.terminal.uploadedToast' => 'Imagen adjuntada',
 			'web.sessions.terminal.uploadFailedToast' => 'Error al subir',
 			'web.sessions.terminal.uploadInvalidTypeToast' => 'Solo se pueden adjuntar archivos de imagen',
 			'web.sessions.terminal.dropToAttach' => 'Suelta la imagen para adjuntarla',
+			'web.sessions.terminal.attachInsert' => 'Insertar',
+			'web.sessions.terminal.attachClear' => 'Quitar todo',
+			'web.sessions.terminal.attachRemove' => ({required Object name}) => 'Quitar ${name}',
 			'web.sessions.terminal.copiedToast' => 'Copiado al portapapeles',
 			'web.sessions.terminal.copyFailedToast' => 'No se pudo copiar al portapapeles',
 			'web.sessions.terminal.selectCopyTitle' => 'Seleccionar y copiar',
@@ -9647,6 +9702,8 @@ extension on TranslationsEs {
 			'web.project.inbox.sessionPrefix' => 'ses',
 			'web.project.inbox.warning' => ({required Object label}) => 'Aprobar REEMPLAZARÁ por completo el ${label} actual.',
 			'web.project.inbox.warningSuffix' => 'Revisa el diff de abajo; esto no es una fusión.',
+			_ => null,
+		} ?? switch (path) {
 			'web.project.inbox.current' => 'Actual',
 			'web.project.inbox.proposed' => 'Propuesto',
 			'web.project.inbox.emptyBody' => '(vacío)',
@@ -9663,8 +9720,6 @@ extension on TranslationsEs {
 			'web.project.archived.restoredToast' => 'Restaurado',
 			'web.project.archived.restoreFailedToast' => 'Error al restaurar',
 			'web.project.reset.button' => 'Restablecer',
-			_ => null,
-		} ?? switch (path) {
 			'web.project.reset.dialogTitle' => '¿Restablecer la memoria del proyecto?',
 			'web.project.reset.dialogDescription' => 'Elimina todo el contexto de proyecto almacenado para este cwd. Esto no se puede deshacer.',
 			'web.project.reset.alwaysDeleted' => 'Siempre se elimina: objetivo, plan, propuestas, diario, decisiones de limpieza.',
@@ -10161,6 +10216,8 @@ extension on TranslationsEs {
 			'web.channels.dialog.editTitle' => 'Editar canal',
 			'web.channels.dialog.createTitle' => 'Registrar canal',
 			'web.channels.dialog.descriptionBridge' => 'Un adaptador externo (Python/Node/...) se conecta vía WebSocket y presenta este token.',
+			_ => null,
+		} ?? switch (path) {
 			'web.channels.dialog.descriptionDefault' => 'Configura la integración de mensajería.',
 			'web.channels.dialog.kindLabel' => 'Tipo',
 			'web.channels.dialog.kindImmutable' => '(inmutable, elimina y vuelve a crear para cambiar el tipo)',
@@ -10177,8 +10234,6 @@ extension on TranslationsEs {
 			'web.channels.dialog.nameRequired' => 'el nombre es obligatorio',
 			'web.channels.dialog.tokenRequired' => 'el token es obligatorio',
 			'web.channels.dialog.topicIdsNumeric' => ({required Object value}) => 'Los ID de tema deben ser numéricos (se recibió ${value})',
-			_ => null,
-		} ?? switch (path) {
 			'web.channels.dialog.fieldRequired' => ({required Object label}) => '${label} es obligatorio',
 			'web.channels.dialog.cooldownInvalid' => 'El cooldown debe ser un número de segundos no negativo',
 			'web.channels.dialog.snippetCapInvalid' => 'El límite del fragmento debe ser un número no negativo',
@@ -10675,6 +10730,8 @@ extension on TranslationsEs {
 			'web.backups.schedulesTab.deleteTooltip' => 'Eliminar',
 			'web.backups.newSchedule.title' => 'Nueva programación de copia de seguridad',
 			'web.backups.newSchedule.targetLabel' => 'Destinos',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.newSchedule.targetsHint' => 'Elige uno o más: la misma copia se escribe en cada destino (3-2-1).',
 			'web.backups.newSchedule.everyHoursLabel' => 'Cada (horas)',
 			'web.backups.newSchedule.keepLastNLabel' => 'Conservar las últimas N',
@@ -10691,8 +10748,6 @@ extension on TranslationsEs {
 			'web.backups.targetsTab.newTarget' => 'Nuevo destino',
 			'web.backups.targetsTab.listFailedToast' => 'No se pudieron listar los destinos',
 			'web.backups.targetsTab.deleteConfirm' => ({required Object id}) => '¿Eliminar el destino ${id}? Las programaciones que lo referencien bloquearán la eliminación.',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.targetsTab.deletedToast' => 'Destino eliminado',
 			'web.backups.targetsTab.deleteFailedToast' => 'Error al eliminar',
 			'web.backups.targetsTab.connectionOkToast' => 'Conexión correcta',
@@ -11189,6 +11244,8 @@ extension on TranslationsEs {
 			'web.memoryAmbient.profiles.addButton' => 'Añadir perfil',
 			'web.memoryAmbient.profiles.intro' => 'Al arrancar, opendray antepone un banner en markdown con las memorias recientes del proyecto al system prompt del agente, SI hay un perfil configurado. Sin un perfil, el modelo sigue usando memory_search bajo demanda.',
 			'web.memoryAmbient.profiles.empty' => 'No hay perfil de inyección. Las memorias no se inyectan automáticamente al arrancar; el modelo sigue usando memory_search.',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryAmbient.profiles.row.globalDefault' => 'predeterminado global',
 			'web.memoryAmbient.profiles.row.delete' => 'Eliminar',
 			'web.memoryAmbient.profiles.row.deleteConfirm' => '¿Eliminar este perfil de inyección?',
@@ -11205,8 +11262,6 @@ extension on TranslationsEs {
 			'web.memoryAmbient.cost.intro' => 'Resumen por proveedor agregado a partir de <1>memory_summarizer_calls</1>. Los proveedores locales (Ollama, LM Studio, Integración) tienen precio de \$0: el operador asume el coste del hardware.',
 			'web.memoryAmbient.cost.empty' => 'No hay proveedores habilitados: no hay datos de coste.',
 			'web.memoryAmbient.cost.columns.provider' => 'Proveedor',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryAmbient.cost.columns.calls' => 'Llamadas',
 			'web.memoryAmbient.cost.columns.inTokens' => 'Tokens de entrada',
 			'web.memoryAmbient.cost.columns.outTokens' => 'Tokens de salida',
@@ -11703,6 +11758,8 @@ extension on TranslationsEs {
 			'sessions.detail.refreshMetadata' => 'Actualizar metadatos',
 			'sessions.detail.inspector' => 'Inspector (Archivos / Git / Tareas / Historial / Notas)',
 			'sessions.detail.projectMemory' => 'Memoria del proyecto (objetivo / plan / diario / bandeja de entrada)',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.detail.actions' => 'Acciones',
 			'sessions.detail.started' => ({required Object when}) => 'iniciada ${when}',
 			'sessions.detail.startedEnded' => ({required Object started, required Object ended}) => 'iniciada ${started}  ·  finalizada ${ended}',
@@ -11719,8 +11776,6 @@ extension on TranslationsEs {
 			'sessions.detail.accountSwitcher.confirmBody' => 'Esto reinicia el CLI con la nueva cuenta — se pierde el contexto de conversación actual dentro del CLI (la pestaña de la sesión se conserva).',
 			'sessions.detail.accountSwitcher.confirmAction' => 'Cambiar',
 			'sessions.detail.accountSwitcher.cancel' => 'Cancelar',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.detail.accountSwitcher.switchedSnack' => ({required Object account}) => 'Cambiado a ${account}',
 			'sessions.detail.accountSwitcher.switchFailed' => ({required Object error}) => 'Cambio fallido: ${error}',
 			'sessions.detail.accountSwitcher.noneHint' => 'No hay cuentas de Claude configuradas. Agrégalas en Más → Providers → Claude.',
@@ -11739,6 +11794,9 @@ extension on TranslationsEs {
 			'sessions.terminal.keyboard.attachImage' => 'Adjuntar imagen',
 			'sessions.terminal.keyboard.enter' => 'Intro',
 			'sessions.terminal.keyboard.selectText' => 'Seleccionar texto',
+			'sessions.terminal.attachments.insert' => 'Insertar',
+			'sessions.terminal.attachments.clear' => 'Quitar todo',
+			'sessions.terminal.attachments.remove' => ({required Object name}) => 'Quitar ${name}',
 			'sessions.terminal.connection.connecting' => 'Conectando…',
 			'sessions.terminal.connection.connected' => 'Conectado',
 			'sessions.terminal.connection.reconnecting' => 'Reconectando…',
@@ -12214,6 +12272,8 @@ extension on TranslationsEs {
 			'project.conflicts.deleteLoading' => 'Cargando el texto del hecho…',
 			'project.conflicts.deleteFactLabel' => ({required Object side}) => 'Eliminar ${side}',
 			'project.conflicts.deletedFact' => 'Hecho eliminado y conflicto aceptado',
+			_ => null,
+		} ?? switch (path) {
 			'project.conflicts.openPlanEditor' => 'Abrir el editor del plan',
 			'project.conflicts.openGoalEditor' => 'Abrir el editor del objetivo',
 			'project.conflicts.severity.low' => 'baja',
@@ -12233,8 +12293,6 @@ extension on TranslationsEs {
 			'project.browseFolder' => 'Explorar carpeta…',
 			'project.resetTooltip' => 'Restablecer la memoria del proyecto',
 			'project.append' => 'Añadir',
-			_ => null,
-		} ?? switch (path) {
 			'project.appendDialogTitle' => 'Añadir entrada de diario',
 			'project.titleFieldLabel' => 'Título (opcional)',
 			'project.contentFieldLabel' => 'Contenido (markdown)',
@@ -12728,6 +12786,8 @@ extension on TranslationsEs {
 			'customTasks.commandHelper' => 'El texto que se inserta en la session al elegirlo. Puede ser un comando de CLI o un slash command de Claude.',
 			'customTasks.fieldDescription' => 'Descripción (opcional)',
 			'customTasks.fieldScope' => 'Ámbito',
+			_ => null,
+		} ?? switch (path) {
 			'customTasks.globalScopeHint' => 'Visible desde cualquier session, sin importar el cwd.',
 			'customTasks.projectScopeHint' => 'Visible solo cuando el cwd de una session coincide con la ruta de abajo.',
 			'customTasks.fieldProjectCwd' => 'cwd del proyecto',
@@ -12747,8 +12807,6 @@ extension on TranslationsEs {
 			'notesPage.deleteTitle' => '¿Eliminar nota?',
 			'notesPage.deletedSnack' => ({required Object path}) => 'Eliminado ${path}',
 			'notesPage.deleteFailedApi' => ({required Object error}) => 'Error al eliminar: ${error}',
-			_ => null,
-		} ?? switch (path) {
 			'notesPage.deleteFailedGeneric' => ({required Object error}) => 'Error al eliminar: ${error}',
 			'notesPage.createFailedApi' => ({required Object error}) => 'Error al crear: ${error}',
 			'notesPage.createFailedGeneric' => ({required Object error}) => 'Error al crear: ${error}',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -136,6 +136,11 @@ class _TranslationsNavZh extends TranslationsNavEn {
 	@override String get vault => '文档库';
 	@override String get cortex => '心智中枢';
 	@override String get updateAvailable => '有可用更新';
+	@override String get resources => '资源';
+	@override String get docs => '文档与安装';
+	@override String get community => '社区';
+	@override String get sponsor => '赞助';
+	@override late final _TranslationsNavUpdatesZh updates = _TranslationsNavUpdatesZh._(_root);
 }
 
 // Path: web
@@ -1044,6 +1049,25 @@ class _TranslationsCortexSettingsZh extends TranslationsCortexSettingsEn {
 	@override String get defaultBadge => '默认';
 }
 
+// Path: nav.updates
+class _TranslationsNavUpdatesZh extends TranslationsNavUpdatesEn {
+	_TranslationsNavUpdatesZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '更新';
+	@override String whatsNew({required Object version}) => '${version} 新内容';
+	@override String get loading => '正在加载更新说明…';
+	@override String loadFailed({required Object error}) => '无法加载更新说明（${error}）。';
+	@override String get noHighlights => '此版本没有简短亮点。请打开完整更新日志查看详情。';
+	@override String get openFull => '打开完整更新日志';
+	@override String get markRead => '标为已读';
+	@override String get unread => '未读更新说明';
+	@override String badgeCount({required Object count}) => '更新 · ${count}';
+	@override String get sourceChangelog => '亮点来自 CHANGELOG.md（GitHub Release 正文为占位）。';
+}
+
 // Path: web.topbar
 class _TranslationsWebTopbarZh extends TranslationsWebTopbarEn {
 	_TranslationsWebTopbarZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -1861,6 +1885,7 @@ class _TranslationsSessionsTerminalZh extends TranslationsSessionsTerminalEn {
 	@override late final _TranslationsSessionsTerminalSnackbarZh snackbar = _TranslationsSessionsTerminalSnackbarZh._(_root);
 	@override late final _TranslationsSessionsTerminalImageSourceZh imageSource = _TranslationsSessionsTerminalImageSourceZh._(_root);
 	@override late final _TranslationsSessionsTerminalKeyboardZh keyboard = _TranslationsSessionsTerminalKeyboardZh._(_root);
+	@override late final _TranslationsSessionsTerminalAttachmentsZh attachments = _TranslationsSessionsTerminalAttachmentsZh._(_root);
 	@override late final _TranslationsSessionsTerminalConnectionZh connection = _TranslationsSessionsTerminalConnectionZh._(_root);
 	@override late final _TranslationsSessionsTerminalSelectCopyZh selectCopy = _TranslationsSessionsTerminalSelectCopyZh._(_root);
 }
@@ -3174,10 +3199,12 @@ class _TranslationsWebSessionsTerminalZh extends TranslationsWebSessionsTerminal
 
 	// Translations
 	@override String get uploadingToast => '正在上传图片…';
-	@override String get uploadedToast => '图片已附加';
 	@override String get uploadFailedToast => '上传失败';
 	@override String get uploadInvalidTypeToast => '仅支持图片文件';
 	@override String get dropToAttach => '释放以附加图片';
+	@override String get attachInsert => '插入';
+	@override String get attachClear => '全部清除';
+	@override String attachRemove({required Object name}) => '移除 ${name}';
 	@override String get copiedToast => '已复制到剪贴板';
 	@override String get copyFailedToast => '无法复制到剪贴板';
 	@override String get selectCopyTitle => '选择并复制';
@@ -6290,6 +6317,18 @@ class _TranslationsSessionsTerminalKeyboardZh extends TranslationsSessionsTermin
 	@override String get selectText => '选择文本';
 }
 
+// Path: sessions.terminal.attachments
+class _TranslationsSessionsTerminalAttachmentsZh extends TranslationsSessionsTerminalAttachmentsEn {
+	_TranslationsSessionsTerminalAttachmentsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get insert => '插入';
+	@override String get clear => '全部清除';
+	@override String remove({required Object name}) => '移除 ${name}';
+}
+
 // Path: sessions.terminal.connection
 class _TranslationsSessionsTerminalConnectionZh extends TranslationsSessionsTerminalConnectionEn {
 	_TranslationsSessionsTerminalConnectionZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -9190,6 +9229,20 @@ extension on TranslationsZh {
 			'nav.vault' => '文档库',
 			'nav.cortex' => '心智中枢',
 			'nav.updateAvailable' => '有可用更新',
+			'nav.resources' => '资源',
+			'nav.docs' => '文档与安装',
+			'nav.community' => '社区',
+			'nav.sponsor' => '赞助',
+			'nav.updates.title' => '更新',
+			'nav.updates.whatsNew' => ({required Object version}) => '${version} 新内容',
+			'nav.updates.loading' => '正在加载更新说明…',
+			'nav.updates.loadFailed' => ({required Object error}) => '无法加载更新说明（${error}）。',
+			'nav.updates.noHighlights' => '此版本没有简短亮点。请打开完整更新日志查看详情。',
+			'nav.updates.openFull' => '打开完整更新日志',
+			'nav.updates.markRead' => '标为已读',
+			'nav.updates.unread' => '未读更新说明',
+			'nav.updates.badgeCount' => ({required Object count}) => '更新 · ${count}',
+			'nav.updates.sourceChangelog' => '亮点来自 CHANGELOG.md（GitHub Release 正文为占位）。',
 			'web.brand' => 'opendray',
 			'web.loading' => '加载中…',
 			'web.topbar.expandSidebar' => '展开侧边栏',
@@ -9266,10 +9319,12 @@ extension on TranslationsZh {
 			'web.sessions.header.transcript' => '完整记录',
 			'web.sessions.header.transcriptTooltip' => '打开整个会话的完整文本记录（适用于自身不支持滚动的 CLI，例如 Grok）',
 			'web.sessions.terminal.uploadingToast' => '正在上传图片…',
-			'web.sessions.terminal.uploadedToast' => '图片已附加',
 			'web.sessions.terminal.uploadFailedToast' => '上传失败',
 			'web.sessions.terminal.uploadInvalidTypeToast' => '仅支持图片文件',
 			'web.sessions.terminal.dropToAttach' => '释放以附加图片',
+			'web.sessions.terminal.attachInsert' => '插入',
+			'web.sessions.terminal.attachClear' => '全部清除',
+			'web.sessions.terminal.attachRemove' => ({required Object name}) => '移除 ${name}',
 			'web.sessions.terminal.copiedToast' => '已复制到剪贴板',
 			'web.sessions.terminal.copyFailedToast' => '无法复制到剪贴板',
 			'web.sessions.terminal.selectCopyTitle' => '选择并复制',
@@ -9647,6 +9702,8 @@ extension on TranslationsZh {
 			'web.project.inbox.sessionPrefix' => 'ses',
 			'web.project.inbox.warning' => ({required Object label}) => '批准将完全替换当前${label}。',
 			'web.project.inbox.warningSuffix' => '请检查下方 diff；这不是合并。',
+			_ => null,
+		} ?? switch (path) {
 			'web.project.inbox.current' => '当前',
 			'web.project.inbox.proposed' => '提议',
 			'web.project.inbox.emptyBody' => '(空)',
@@ -9663,8 +9720,6 @@ extension on TranslationsZh {
 			'web.project.archived.restoredToast' => '已恢复',
 			'web.project.archived.restoreFailedToast' => '恢复失败',
 			'web.project.reset.button' => '重置',
-			_ => null,
-		} ?? switch (path) {
 			'web.project.reset.dialogTitle' => '重置项目记忆?',
 			'web.project.reset.dialogDescription' => '删除该 cwd 下存储的所有项目上下文。不可撤销。',
 			'web.project.reset.alwaysDeleted' => '始终删除：目标、计划、提案、日志、清理决策。',
@@ -10161,6 +10216,8 @@ extension on TranslationsZh {
 			'web.channels.dialog.editTitle' => '编辑频道',
 			'web.channels.dialog.createTitle' => '注册频道',
 			'web.channels.dialog.descriptionBridge' => '外部适配器（Python/Node/...）通过 WebSocket 连接并出示此 token。',
+			_ => null,
+		} ?? switch (path) {
 			'web.channels.dialog.descriptionDefault' => '配置消息集成。',
 			'web.channels.dialog.kindLabel' => '类型',
 			'web.channels.dialog.kindImmutable' => '（不可更改 — 如需更换类型请删除后重建）',
@@ -10177,8 +10234,6 @@ extension on TranslationsZh {
 			'web.channels.dialog.nameRequired' => 'name 不能为空',
 			'web.channels.dialog.tokenRequired' => 'token 不能为空',
 			'web.channels.dialog.topicIdsNumeric' => ({required Object value}) => 'Topic ID 必须是数字（收到 ${value}）',
-			_ => null,
-		} ?? switch (path) {
 			'web.channels.dialog.fieldRequired' => ({required Object label}) => '${label} 不能为空',
 			'web.channels.dialog.cooldownInvalid' => 'Cooldown 必须是非负整数秒',
 			'web.channels.dialog.snippetCapInvalid' => 'Snippet cap 必须是非负数字',
@@ -10675,6 +10730,8 @@ extension on TranslationsZh {
 			'web.backups.schedulesTab.deleteTooltip' => '删除',
 			'web.backups.newSchedule.title' => '新建备份计划',
 			'web.backups.newSchedule.targetLabel' => '目标',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.newSchedule.targetsHint' => '选择一个或多个 —— 同一份备份会写入每个目标（3-2-1）。',
 			'web.backups.newSchedule.everyHoursLabel' => '每隔（小时）',
 			'web.backups.newSchedule.keepLastNLabel' => '保留最近 N 个',
@@ -10691,8 +10748,6 @@ extension on TranslationsZh {
 			'web.backups.targetsTab.newTarget' => '新建目标',
 			'web.backups.targetsTab.listFailedToast' => '加载目标列表失败',
 			'web.backups.targetsTab.deleteConfirm' => ({required Object id}) => '删除目标 ${id}? 引用它的计划会阻止删除。',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.targetsTab.deletedToast' => '目标已删除',
 			'web.backups.targetsTab.deleteFailedToast' => '删除失败',
 			'web.backups.targetsTab.connectionOkToast' => '连接成功',
@@ -11189,6 +11244,8 @@ extension on TranslationsZh {
 			'web.memoryAmbient.profiles.addButton' => '添加 profile',
 			'web.memoryAmbient.profiles.intro' => 'spawn 时，opendray 会把最近的项目记忆作为一段 markdown banner 拼接到 agent 的 system prompt — 前提是配置了 profile。没有 profile 时，模型仍可按需调用 memory_search。',
 			'web.memoryAmbient.profiles.empty' => '尚无 injection profile。spawn 时不会自动注入记忆 — 模型仍可使用 memory_search。',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryAmbient.profiles.row.globalDefault' => '全局默认',
 			'web.memoryAmbient.profiles.row.delete' => '删除',
 			'web.memoryAmbient.profiles.row.deleteConfirm' => '删除该 injection profile?',
@@ -11205,8 +11262,6 @@ extension on TranslationsZh {
 			'web.memoryAmbient.cost.intro' => '按 provider 聚合自 <1>memory_summarizer_calls</1>。本地 provider（Ollama、LM Studio、Integration）按 \$0 计价 — 硬件成本由运维承担。',
 			'web.memoryAmbient.cost.empty' => '暂无已启用的 provider — 没有成本数据。',
 			'web.memoryAmbient.cost.columns.provider' => 'Provider',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryAmbient.cost.columns.calls' => '调用',
 			'web.memoryAmbient.cost.columns.inTokens' => '输入 token',
 			'web.memoryAmbient.cost.columns.outTokens' => '输出 token',
@@ -11703,6 +11758,8 @@ extension on TranslationsZh {
 			'sessions.detail.refreshMetadata' => '刷新元数据',
 			'sessions.detail.inspector' => '检查器（文件 / Git / 任务 / 历史 / 笔记）',
 			'sessions.detail.projectMemory' => '项目记忆（目标 / 计划 / 日志 / 收件箱）',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.detail.actions' => '操作',
 			'sessions.detail.started' => ({required Object when}) => '${when} 启动',
 			'sessions.detail.startedEnded' => ({required Object started, required Object ended}) => '${started} 启动  ·  ${ended} 结束',
@@ -11719,8 +11776,6 @@ extension on TranslationsZh {
 			'sessions.detail.accountSwitcher.confirmBody' => '这会用新账号重启 CLI——当前 CLI 内的对话上下文会丢失（会话标签保留）。',
 			'sessions.detail.accountSwitcher.confirmAction' => '切换',
 			'sessions.detail.accountSwitcher.cancel' => '取消',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.detail.accountSwitcher.switchedSnack' => ({required Object account}) => '已切换到 ${account}',
 			'sessions.detail.accountSwitcher.switchFailed' => ({required Object error}) => '切换失败：${error}',
 			'sessions.detail.accountSwitcher.noneHint' => '未配置 Claude 账号。请在 更多 → Providers → Claude 中添加。',
@@ -11739,6 +11794,9 @@ extension on TranslationsZh {
 			'sessions.terminal.keyboard.attachImage' => '附加图片',
 			'sessions.terminal.keyboard.enter' => '回车',
 			'sessions.terminal.keyboard.selectText' => '选择文本',
+			'sessions.terminal.attachments.insert' => '插入',
+			'sessions.terminal.attachments.clear' => '全部清除',
+			'sessions.terminal.attachments.remove' => ({required Object name}) => '移除 ${name}',
 			'sessions.terminal.connection.connecting' => '连接中…',
 			'sessions.terminal.connection.connected' => '已连接',
 			'sessions.terminal.connection.reconnecting' => '重连中…',
@@ -12214,6 +12272,8 @@ extension on TranslationsZh {
 			'project.conflicts.deleteLoading' => '加载中…',
 			'project.conflicts.deleteFactLabel' => ({required Object side}) => '删除 ${side}',
 			'project.conflicts.deletedFact' => '已删除 fact 并采纳冲突',
+			_ => null,
+		} ?? switch (path) {
 			'project.conflicts.openPlanEditor' => '打开计划编辑器',
 			'project.conflicts.openGoalEditor' => '打开目标编辑器',
 			'project.conflicts.severity.low' => '低',
@@ -12233,8 +12293,6 @@ extension on TranslationsZh {
 			'project.browseFolder' => '浏览文件夹…',
 			'project.resetTooltip' => '重置项目记忆',
 			'project.append' => '追加',
-			_ => null,
-		} ?? switch (path) {
 			'project.appendDialogTitle' => '追加日志条目',
 			'project.titleFieldLabel' => '标题（可选）',
 			'project.contentFieldLabel' => '内容（Markdown）',
@@ -12728,6 +12786,8 @@ extension on TranslationsZh {
 			'customTasks.commandHelper' => '选择时插入到会话的文本。可以是 CLI 命令或 Claude 斜杠命令。',
 			'customTasks.fieldDescription' => '描述（可选）',
 			'customTasks.fieldScope' => '范围',
+			_ => null,
+		} ?? switch (path) {
 			'customTasks.globalScopeHint' => '从任何会话可见，不论 cwd。',
 			'customTasks.projectScopeHint' => '仅当会话的 cwd 匹配以下路径时可见。',
 			'customTasks.fieldProjectCwd' => '项目 cwd',
@@ -12747,8 +12807,6 @@ extension on TranslationsZh {
 			'notesPage.deleteTitle' => '删除笔记？',
 			'notesPage.deletedSnack' => ({required Object path}) => '已删除 ${path}',
 			'notesPage.deleteFailedApi' => ({required Object error}) => '删除失败：${error}',
-			_ => null,
-		} ?? switch (path) {
 			'notesPage.deleteFailedGeneric' => ({required Object error}) => '删除失败：${error}',
 			'notesPage.createFailedApi' => ({required Object error}) => '创建失败：${error}',
 			'notesPage.createFailedGeneric' => ({required Object error}) => '创建失败：${error}',

--- a/app/mobile/lib/features/more/more_screen.dart
+++ b/app/mobile/lib/features/more/more_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
+import 'package:opendray/core/api/releases_api.dart';
 import 'package:opendray/core/api/version_api.dart';
 import 'package:opendray/core/auth/auth_state.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
@@ -14,11 +15,13 @@ import 'package:opendray/features/mcp/mcp_screen.dart';
 import 'package:opendray/features/memory_archived/archived_screen.dart';
 import 'package:opendray/features/memory_quarantine/quarantine_screen.dart';
 import 'package:opendray/features/more/about_screen.dart';
+import 'package:opendray/features/more/updates_sheet.dart';
 import 'package:opendray/features/notes/notes_screen.dart';
 import 'package:opendray/features/project/project_screen.dart';
 import 'package:opendray/features/providers/providers_screen.dart';
 import 'package:opendray/features/settings/settings_screen.dart';
 import 'package:opendray/features/skills/skills_screen.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 // "More" tab — overflow menu for everything that doesn't earn its
 // own bottom-nav slot. Three sections: identity card, navigation
@@ -30,14 +33,29 @@ import 'package:opendray/features/skills/skills_screen.dart';
 // in — Integrations first (highest signal: every operator wants
 // "who's calling me right now"), then Channels, Providers, Backups,
 // About.
+// External Resources links — mirror app/web/src/components/SidebarNav.tsx.
+const _docsUrl = 'https://opendray.dev/docs/';
+const _communityUrl = 'https://t.me/opendraycommunity';
+const _sponsorUrl = 'https://opendray.dev/sponsors/';
+
 class MoreScreen extends ConsumerWidget {
   const MoreScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final auth = ref.watch(authControllerProvider);
-    final updateAvailable =
-        ref.watch(versionInfoProvider).asData?.value.updateAvailable ?? false;
+    final version = ref.watch(versionInfoProvider).asData?.value;
+    final updateAvailable = version?.updateAvailable ?? false;
+    // Updates "unread" badge — mirror the web sidebar: prefer the fetched
+    // GitHub release version, fall back to the gateway's `latest` so a
+    // failed notes fetch still badges when a binary update is waiting.
+    final release = ref.watch(latestReleaseProvider).asData?.value;
+    final lastRead = ref.watch(lastReadReleaseProvider);
+    final latestForUnread =
+        release?.version ?? normalizeReleaseVersion(version?.latest);
+    final notesUnread = isReleaseUnread(latestForUnread, lastRead);
+    final showUpdatesBadge = notesUnread || updateAvailable;
+    final highlightCount = release?.highlights.length ?? 0;
     if (auth is! AuthLoggedIn) {
       return const Scaffold(body: SizedBox.shrink());
     }
@@ -145,6 +163,41 @@ class MoreScreen extends ConsumerWidget {
             subtitle: t.more.items.about.subtitle,
             onTap: () => _push(context, const AboutScreen()),
           ),
+          const SizedBox(height: 8),
+          _SectionHeader(label: t.nav.resources),
+          _MenuTile(
+            icon: Icons.auto_awesome_outlined,
+            title: t.nav.updates.title,
+            badge: showUpdatesBadge,
+            // Accent-primary when only release notes are unread; the
+            // system error red is reserved for a waiting binary update
+            // (matches web's accent-vs-primary dot).
+            badgeColor: updateAvailable
+                ? Theme.of(context).colorScheme.error
+                : Theme.of(context).colorScheme.primary,
+            trailingText: (notesUnread && highlightCount > 0)
+                ? '· $highlightCount'
+                : null,
+            onTap: () => showUpdatesSheet(context),
+          ),
+          _MenuTile(
+            icon: Icons.menu_book_outlined,
+            title: t.nav.docs,
+            external: true,
+            onTap: () => _openUrl(_docsUrl),
+          ),
+          _MenuTile(
+            icon: Icons.forum_outlined,
+            title: t.nav.community,
+            external: true,
+            onTap: () => _openUrl(_communityUrl),
+          ),
+          _MenuTile(
+            icon: Icons.favorite_outline,
+            title: t.nav.sponsor,
+            external: true,
+            onTap: () => _openUrl(_sponsorUrl),
+          ),
           const Divider(height: 32),
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
@@ -170,6 +223,16 @@ class MoreScreen extends ConsumerWidget {
 
   void _push(BuildContext context, Widget page) {
     Navigator.of(context).push(MaterialPageRoute<void>(builder: (_) => page));
+  }
+
+  Future<void> _openUrl(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    try {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } on Object {
+      // Best-effort convenience link.
+    }
   }
 }
 
@@ -236,39 +299,67 @@ class _MenuTile extends StatelessWidget {
   const _MenuTile({
     required this.icon,
     required this.title,
-    required this.subtitle,
     required this.onTap,
+    this.subtitle,
     this.badge = false,
+    this.badgeColor,
+    this.trailingText,
+    this.external = false,
   });
 
   final IconData icon;
   final String title;
-  final String subtitle;
+  // Optional secondary line; Resources links render title-only.
+  final String? subtitle;
   final VoidCallback onTap;
-  // When true, shows an "update available" dot before the chevron.
+  // When true, shows a status dot before the trailing icon.
   final bool badge;
+  // Dot colour; defaults to the error colour (waiting binary update).
+  final Color? badgeColor;
+  // Small muted count chip (e.g. "· 3") shown before the trailing icon.
+  final String? trailingText;
+  // External links show an open-in-new glyph instead of a chevron.
+  final bool external;
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final subtitle = this.subtitle;
     return ListTile(
       onTap: onTap,
-      leading: Icon(icon, color: Theme.of(context).colorScheme.primary),
+      leading: Icon(icon, color: theme.colorScheme.primary),
       title: Text(title),
-      subtitle: Text(subtitle, style: Theme.of(context).textTheme.bodySmall),
+      subtitle: subtitle == null
+          ? null
+          : Text(subtitle, style: theme.textTheme.bodySmall),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
+          if (trailingText != null)
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: Text(
+                trailingText!,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                ),
+              ),
+            ),
           if (badge)
             Container(
               width: 8,
               height: 8,
               margin: const EdgeInsets.only(right: 8),
               decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.error,
+                color: badgeColor ?? theme.colorScheme.error,
                 shape: BoxShape.circle,
               ),
             ),
-          const Icon(Icons.chevron_right),
+          Icon(external ? Icons.open_in_new : Icons.chevron_right,
+              size: external ? 18 : null,
+              color: external
+                  ? theme.colorScheme.onSurface.withValues(alpha: 0.4)
+                  : null),
         ],
       ),
     );

--- a/app/mobile/lib/features/more/updates_sheet.dart
+++ b/app/mobile/lib/features/more/updates_sheet.dart
@@ -1,0 +1,275 @@
+// "What's new" bottom sheet — mobile mirror of the web sidebar
+// UpdatesDrawer (app/web/src/components/UpdatesDrawer.tsx). Fetches the
+// latest GitHub release (changelog fallback) via releases_api.dart and
+// keeps read state in SharedPreferences. Opened from More → Resources →
+// Updates.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:opendray/core/api/releases_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+const _releasesFallbackUrl = 'https://github.com/Opendray/opendray/releases';
+
+Future<void> showUpdatesSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    showDragHandle: true,
+    builder: (_) => const _UpdatesSheet(),
+  );
+}
+
+class _UpdatesSheet extends ConsumerWidget {
+  const _UpdatesSheet();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(latestReleaseProvider);
+    final maxHeight = MediaQuery.of(context).size.height * 0.7;
+    return SafeArea(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxHeight: maxHeight),
+        child: async.when(
+          loading: () => const _SheetPadding(child: _Loading()),
+          error: (e, _) => _SheetPadding(
+            child: _LoadError(
+              message: e.toString(),
+              onRetry: () => ref.invalidate(latestReleaseProvider),
+            ),
+          ),
+          data: (rel) => _Content(rel: rel),
+        ),
+      ),
+    );
+  }
+}
+
+class _SheetPadding extends StatelessWidget {
+  const _SheetPadding({required this.child});
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 8, 20, 28),
+      child: child,
+    );
+  }
+}
+
+class _Loading extends StatelessWidget {
+  const _Loading();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const SizedBox(
+          width: 18,
+          height: 18,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+        const SizedBox(width: 12),
+        Text(t.nav.updates.loading,
+            style: Theme.of(context).textTheme.bodyMedium),
+      ],
+    );
+  }
+}
+
+class _LoadError extends StatelessWidget {
+  const _LoadError({required this.message, required this.onRetry});
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          t.nav.updates.loadFailed(error: message),
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 12),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: OutlinedButton(
+            onPressed: onRetry,
+            child: Text(t.common.retry),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Content extends ConsumerWidget {
+  const _Content({required this.rel});
+  final ReleaseInfo rel;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final date = _formatPublished(rel.publishedAt);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Header
+        Padding(
+          padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 30,
+                height: 30,
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.primary.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                alignment: Alignment.center,
+                child: Icon(Icons.auto_awesome,
+                    size: 16, color: theme.colorScheme.primary),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      t.nav.updates.whatsNew(version: rel.tag),
+                      style: theme.textTheme.titleSmall,
+                    ),
+                    if (date != null)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 2),
+                        child: Text(date,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.onSurface
+                                  .withValues(alpha: 0.6),
+                            )),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+        const Divider(height: 1),
+        // Highlights
+        Flexible(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.fromLTRB(20, 12, 20, 12),
+            child: rel.highlights.isEmpty
+                ? Text(
+                    t.nav.updates.noHighlights,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color:
+                          theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                    ),
+                  )
+                : Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      for (final h in rel.highlights)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 10),
+                          child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.only(top: 6),
+                                child: Container(
+                                  width: 6,
+                                  height: 6,
+                                  decoration: BoxDecoration(
+                                    color: theme.colorScheme.primary,
+                                    shape: BoxShape.circle,
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(width: 10),
+                              Expanded(
+                                child: Text(h,
+                                    style: theme.textTheme.bodyMedium),
+                              ),
+                            ],
+                          ),
+                        ),
+                      if (rel.source == ReleaseSource.changelog)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 2),
+                          child: Text(
+                            t.nav.updates.sourceChangelog,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.onSurface
+                                  .withValues(alpha: 0.5),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+          ),
+        ),
+        const Divider(height: 1),
+        // Actions
+        Padding(
+          padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+          child: Column(
+            children: [
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  icon: const Icon(Icons.open_in_new, size: 16),
+                  label: Text(t.nav.updates.openFull),
+                  onPressed: () => _openUrl(
+                    rel.htmlUrl.isNotEmpty ? rel.htmlUrl : _releasesFallbackUrl,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 8),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed: () {
+                    ref
+                        .read(lastReadReleaseProvider.notifier)
+                        .markRead(rel.version);
+                    Navigator.of(context).pop();
+                  },
+                  child: Text(t.nav.updates.markRead),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  static String? _formatPublished(String? iso) {
+    if (iso == null || iso.isEmpty) return null;
+    try {
+      return DateFormat('MMM d, yyyy').format(DateTime.parse(iso).toLocal());
+    } on Object {
+      return iso.length >= 10 ? iso.substring(0, 10) : iso;
+    }
+  }
+
+  static Future<void> _openUrl(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    try {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } on Object {
+      // Best-effort convenience link.
+    }
+  }
+}

--- a/app/mobile/test/core/api/releases_api_test.dart
+++ b/app/mobile/test/core/api/releases_api_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opendray/core/api/releases_api.dart';
+
+// Guards the "what's new" parsing that mirrors app/shared/src/lib/
+// releases.ts. These pure functions must stay in lockstep with the web
+// version so mobile shows the same highlights / unread badge behaviour.
+void main() {
+  group('normalizeReleaseVersion', () {
+    test('strips leading v and build metadata', () {
+      expect(normalizeReleaseVersion('v2.11.2'), '2.11.2');
+      expect(normalizeReleaseVersion('2.11.2+47'), '2.11.2');
+      expect(normalizeReleaseVersion('  V2.12.0  '), '2.12.0');
+      expect(normalizeReleaseVersion(null), '');
+      expect(normalizeReleaseVersion(''), '');
+    });
+  });
+
+  group('formatReleaseTag', () {
+    test('re-adds the v prefix, empty stays empty', () {
+      expect(formatReleaseTag('2.11.2'), 'v2.11.2');
+      expect(formatReleaseTag('v2.11.2'), 'v2.11.2');
+      expect(formatReleaseTag(''), '');
+    });
+  });
+
+  group('isReleaseUnread', () {
+    test('unread when never marked and a latest exists', () {
+      expect(isReleaseUnread('2.12.0', null), isTrue);
+    });
+    test('read when marked version matches latest', () {
+      expect(isReleaseUnread('2.12.0', 'v2.12.0'), isFalse);
+    });
+    test('unread when marked version is older', () {
+      expect(isReleaseUnread('2.12.0', '2.11.2'), isTrue);
+    });
+    test('no badge when there is no latest version', () {
+      expect(isReleaseUnread('', '2.11.2'), isFalse);
+      expect(isReleaseUnread(null, null), isFalse);
+    });
+  });
+
+  group('extractHighlights', () {
+    test('prefers the bold title in CHANGELOG-style bullets', () {
+      const md = '''
+### Added
+
+- **Sidebar Updates drawer.** A new drawer pulling release highlights.
+- **Grok logo fix.** Sessions list now shows the mark.
+''';
+      expect(
+        extractHighlights(md),
+        ['Sidebar Updates drawer', 'Grok logo fix'],
+      );
+    });
+
+    test('falls back to the plain bullet text and strips markdown', () {
+      const md = '- Fixed a `race` in the [worker](http://x) loop.';
+      expect(extractHighlights(md), ['Fixed a race in the worker loop']);
+    });
+
+    test('ignores indented continuation lines and honours the limit', () {
+      // Titles must be >= 4 chars — the parser drops shorter fragments,
+      // matching releases.ts.
+      const md = '''
+- First item here
+  continuation line under first
+- Second item here
+- Third item here
+''';
+      expect(
+        extractHighlights(md, limit: 2),
+        ['First item here', 'Second item here'],
+      );
+    });
+
+    test('drops the Announce on X block and empty input', () {
+      const md = '''
+- Real highlight here
+## Announce on X
+- do not surface this tweet bullet
+''';
+      expect(extractHighlights(md), ['Real highlight here']);
+      expect(extractHighlights('   '), isEmpty);
+    });
+  });
+
+  group('extractChangelogSection', () {
+    const changelog = '''
+# Changelog
+
+## [Unreleased]
+
+## [v2.12.0] — 2026-07-09
+
+### Added
+
+- **Feature A.** Something new.
+
+## [v2.11.2] — 2026-07-01
+
+### Added
+
+- **Old feature.** Should not appear.
+''';
+
+    test('returns only the requested version section', () {
+      final section = extractChangelogSection(changelog, '2.12.0');
+      expect(section.contains('Feature A'), isTrue);
+      expect(section.contains('Old feature'), isFalse);
+      expect(extractHighlights(section), ['Feature A']);
+    });
+
+    test('empty when the version is missing', () {
+      expect(extractChangelogSection(changelog, '9.9.9'), '');
+      expect(extractChangelogSection('', '2.12.0'), '');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

#433 shipped the web sidebar **Resources** block (Updates drawer + Docs / Community / Sponsor links) as **web-only**. This brings the Flutter app to parity.

The web left-nav rail has no mobile analog, so the equivalent lands in the **More** tab rather than copying the sidebar UI: a new **Resources** section with an **Updates** entry (unread badge) plus **Docs**, **Community**, and **Sponsor** external links. Tapping Updates opens a "what's new" bottom sheet — the mobile form of the web right-side drawer.

## Changes

- **`core/api/releases_api.dart`** — Dart mirror of `app/shared/src/lib/releases.ts`: `ReleaseInfo` model, version normalisation, highlight + changelog-section parsing, GitHub Releases fetch with `CHANGELOG.md` fallback, and local-first read state via `SharedPreferences` (mirrors the web `opendray:lastReadRelease` localStorage key).
  - **Security:** uses a bare `Dio()`, **never** the gateway `dioProvider` — so the operator's bearer token is never attached to `github.com`, and a GitHub `403` rate-limit can't trip the `401 → forced sign-out` interceptor.
- **`features/more/updates_sheet.dart`** — "What's new" modal bottom sheet (mobile form of `UpdatesDrawer.tsx`): loading / error+retry / highlights list, changelog-source note, open-full-changelog, and mark-read.
- **`features/more/more_screen.dart`** — Resources section (Updates + Docs/Community/Sponsor via `url_launcher`). The unread badge reuses the web accent-vs-primary semantics: **primary** when only release notes are unread, **error** when a binary update is waiting.
- **i18n** — regenerated slang bindings for the shared `nav.updates.*` / `nav.resources` keys already present in `app/i18n` (added by #433). No new source strings; `es`/`zh` translations came with #433.
- **test** — 12 unit tests guarding the parsing / read-state parity with `releases.ts`.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test test/core/api/releases_api_test.dart` — 12/12 pass
- [x] i18n parity (`scripts/check-i18n-parity.mjs`) — es/zh 100%, 0 missing / 0 extra
- [ ] Manual smoke on device: More → Resources → Updates opens the sheet; mark-read clears the badge; Docs/Community/Sponsor open externally

## Surface(s) touched

- Mobile (Flutter) — `app/mobile/`

## DB / config / operator impact

None — client-only. No migration, no backend, no config.