### PR TITLE
fix(catalog): tolerate an empty gemini/agy MCP config file

### DIFF
--- a/internal/catalog/mcp.go
+++ b/internal/catalog/mcp.go
@@ -247,9 +247,14 @@ func syncAgyGlobalMCP(home string, desired map[string]map[string]any) error {
 	configPath := filepath.Join(dir, "mcp_config.json")
 	config := map[string]any{}
 	if data, err := os.ReadFile(configPath); err == nil {
-		if err := json.Unmarshal(data, &config); err != nil {
-			// Never risk rewriting a user-authored file we can't parse.
-			return fmt.Errorf("parse %s (fix or remove it to enable MCP injection): %w", configPath, err)
+		// An empty file (agy's first-run/migration writes one) is not a
+		// parse error — treat it as "no config yet" and let injection
+		// proceed. Only genuinely malformed content is refused.
+		if len(bytes.TrimSpace(data)) > 0 {
+			if err := json.Unmarshal(data, &config); err != nil {
+				// Never risk rewriting a user-authored file we can't parse.
+				return fmt.Errorf("parse %s (fix or remove it to enable MCP injection): %w", configPath, err)
+			}
 		}
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("read agy mcp_config: %w", err)
@@ -352,9 +357,12 @@ func syncGeminiWorkspaceMCP(cwd string, desired map[string]map[string]any) error
 	settingsPath := filepath.Join(dir, "settings.json")
 	settings := map[string]any{}
 	if data, err := os.ReadFile(settingsPath); err == nil {
-		if err := json.Unmarshal(data, &settings); err != nil {
-			// Never risk rewriting a user-authored file we can't parse.
-			return fmt.Errorf("parse %s (fix or remove it to enable MCP injection): %w", settingsPath, err)
+		// An empty settings.json is "no config yet", not a parse error.
+		if len(bytes.TrimSpace(data)) > 0 {
+			if err := json.Unmarshal(data, &settings); err != nil {
+				// Never risk rewriting a user-authored file we can't parse.
+				return fmt.Errorf("parse %s (fix or remove it to enable MCP injection): %w", settingsPath, err)
+			}
 		}
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("read agy settings: %w", err)

--- a/internal/catalog/mcp_test.go
+++ b/internal/catalog/mcp_test.go
@@ -597,3 +597,55 @@ func TestParseMCPServers_Missing(t *testing.T) {
 		t.Error("expected nil for missing key")
 	}
 }
+
+// Regression: antigravity's first-run/migration leaves an EMPTY
+// ~/.gemini/config/mcp_config.json. opendray must treat an empty file as
+// "no config yet", not a JSON parse error, or every agy spawn fails with
+// "unexpected end of JSON input". (Reported from the iPad spawn dialog.)
+func TestSyncAgyGlobalMCP_EmptyConfigFileTolerated(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".gemini", "config")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(dir, "mcp_config.json")
+	if err := os.WriteFile(cfgPath, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	desired := map[string]map[string]any{"vault": {"command": "vault-mcp"}}
+	if err := syncAgyGlobalMCP(home, desired); err != nil {
+		t.Fatalf("empty mcp_config.json should be tolerated, got: %v", err)
+	}
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("written config not valid JSON: %v", err)
+	}
+	servers, _ := got["mcpServers"].(map[string]any)
+	if _, ok := servers["vault"]; !ok {
+		t.Fatalf("expected injected 'vault' server, got: %v", got)
+	}
+}
+
+// Same empty-file tolerance for the gemini-workspace settings.json surface.
+func TestSyncGeminiWorkspaceMCP_EmptySettingsTolerated(t *testing.T) {
+	cwd := t.TempDir()
+	dir := filepath.Join(cwd, ".gemini")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settingsPath := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte("  \n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	desired := map[string]map[string]any{"vault": {"command": "vault-mcp"}}
+	if err := syncGeminiWorkspaceMCP(cwd, desired); err != nil {
+		t.Fatalf("empty settings.json should be tolerated, got: %v", err)
+	}
+	if _, err := os.ReadFile(settingsPath); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Bug

Spawning an **Antigravity** session failed with:

> provider prepare: parse `/…/.gemini/config/mcp_config.json` (fix or remove it to enable MCP injection): **unexpected end of JSON input**

**Root cause:** antigravity's own first-run/migration writes an **empty** `~/.gemini/config/mcp_config.json`. opendray's MCP-injection prep (`syncAgyGlobalMCP`) reads that file and runs `json.Unmarshal` unconditionally — an empty file is neither missing (already handled) nor valid JSON, so it errored and **blocked every antigravity spawn** on affected installs. (Reported from the iPad spawn dialog.)

## Fix

Treat an empty / whitespace-only file as "no config yet" (skip the `Unmarshal`, keep the initial `{}`) and let injection proceed — only genuinely malformed content is still refused. Applied to both JSON surfaces that had the identical flaw:
- `syncAgyGlobalMCP` → `.gemini/config/mcp_config.json` (the reported one)
- `syncGeminiWorkspaceMCP` → `.gemini/settings.json`

## Tests

Two regression tests that reproduce the exact failure (empty file → previously "unexpected end of JSON input") and now assert the spawn prep succeeds and injects the server. Full `internal/catalog` suite green; `go vet` + `go build` clean.

*Operational note:* the reporting host was unblocked immediately by writing `{}` into the empty file; this PR prevents recurrence for everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)