### PR TITLE
docs(changelog): v2.11.4 — empty-MCP-config fix + mobile Updates parity + Grok icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+## [v2.11.4] — 2026-07-12
+
+### Added
+
+- **Mobile: Resources section + Updates "what's new" sheet.** The mobile
+  app gains the sidebar Resources block and the Updates/"what's new" sheet,
+  reaching parity with the web admin (#433). (#439)
+
+### Fixed
+
+- **Antigravity spawns no longer fail on an empty MCP config.** antigravity's
+  first-run migration writes an empty `~/.gemini/config/mcp_config.json`;
+  opendray's MCP-injection prep parsed it unconditionally and errored with
+  *"provider prepare: parse …/mcp_config.json … unexpected end of JSON
+  input"*, blocking every Antigravity session spawn. An empty (or
+  whitespace-only) file is now treated as "no config yet" rather than a parse
+  error, on both the `mcp_config.json` and gemini `settings.json` surfaces. (#440)
+- **Grok provider icon.** Grok is now registered in the web provider
+  icon/visual lookup tables so its brand mark renders. (#434)
+
 ## [v2.11.3] — 2026-07-09
 
 ### Added


### PR DESCRIPTION
Release bump for **v2.11.4** (patch). Moves `[Unreleased]` → `[v2.11.4]` (2026-07-12), bundling everything merged since v2.11.3:

- **Fix — antigravity spawn blocked by an empty MCP config** (#440): an empty `~/.gemini/config/mcp_config.json` (written by antigravity's own first-run migration) made MCP-injection prep fail with *"unexpected end of JSON input"*, blocking every Antigravity session. Empty files are now tolerated.
- **Mobile: Resources section + Updates sheet** (#439) — mobile parity with the web Updates drawer (#433).
- **Fix — Grok provider icon** (#434) — Grok registered in the web icon lookup.

Changelog-only change. On merge I'll tag `v2.11.4` to trigger goreleaser + the opendray.dev auto-rebuild (#431).

> Note: #439 is technically a feature (strict semver → v2.12.0), but cutting as v2.11.4 per request; the headline is the antigravity spawn fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)