### PR TITLE
feat(tasks): pre-scope custom task creation to the current project

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -3456,7 +3456,8 @@
         "filterHint": "Filter tasks…",
         "noMatch": "No tasks match \"{query}\"",
         "emptyTitle": "No tasks in this folder",
-        "emptyHint": "Looking for package.json, Makefile, Taskfile, justfile, Cargo.toml, go.mod, pyproject.toml, or shell scripts"
+        "emptyHint": "Looking for package.json, Makefile, Taskfile, justfile, Cargo.toml, go.mod, pyproject.toml, or shell scripts",
+        "addCustomTask": "Add custom task"
       },
       "notes": {
         "insertedAt": "Inserted: @{path}",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -3456,7 +3456,8 @@
         "filterHint": "Filtrar tareas…",
         "noMatch": "Ninguna tarea coincide con \"{query}\"",
         "emptyTitle": "No hay tareas en esta carpeta",
-        "emptyHint": "Buscando package.json, Makefile, Taskfile, justfile, Cargo.toml, go.mod, pyproject.toml o scripts de shell"
+        "emptyHint": "Buscando package.json, Makefile, Taskfile, justfile, Cargo.toml, go.mod, pyproject.toml o scripts de shell",
+        "addCustomTask": "Añadir tarea personalizada"
       },
       "notes": {
         "insertedAt": "Insertado: @{path}",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -3456,7 +3456,8 @@
         "filterHint": "筛选任务…",
         "noMatch": "没有匹配“{query}”的任务",
         "emptyTitle": "此目录没有任务",
-        "emptyHint": "正在查找 package.json、Makefile、Taskfile、justfile、Cargo.toml、go.mod、pyproject.toml 或 shell 脚本"
+        "emptyHint": "正在查找 package.json、Makefile、Taskfile、justfile、Cargo.toml、go.mod、pyproject.toml 或 shell 脚本",
+        "addCustomTask": "添加自定义任务"
       },
       "notes": {
         "insertedAt": "已插入：@{path}",

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 11973 (3991 per locale)
+/// Strings: 11976 (3992 per locale)
 ///
-/// Built on 2026-07-10 at 11:04 UTC
+/// Built on 2026-07-12 at 02:22 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -12589,6 +12589,9 @@ class TranslationsSessionsInspectorTasksEn {
 
 	/// en: 'Looking for package.json, Makefile, Taskfile, justfile, Cargo.toml, go.mod, pyproject.toml, or shell scripts'
 	String get emptyHint => 'Looking for package.json, Makefile, Taskfile, justfile, Cargo.toml, go.mod, pyproject.toml, or shell scripts';
+
+	/// en: 'Add custom task'
+	String get addCustomTask => 'Add custom task';
 }
 
 // Path: sessions.inspector.notes
@@ -19978,6 +19981,7 @@ extension on Translations {
 			'sessions.inspector.tasks.noMatch' => ({required Object query}) => 'No tasks match "${query}"',
 			'sessions.inspector.tasks.emptyTitle' => 'No tasks in this folder',
 			'sessions.inspector.tasks.emptyHint' => 'Looking for package.json, Makefile, Taskfile, justfile, Cargo.toml, go.mod, pyproject.toml, or shell scripts',
+			'sessions.inspector.tasks.addCustomTask' => 'Add custom task',
 			'sessions.inspector.notes.insertedAt' => ({required Object path}) => 'Inserted: @${path}',
 			'sessions.inspector.notes.myNotes' => 'My notes',
 			'sessions.inspector.notes.projectDocs' => 'Project docs',
@@ -20370,9 +20374,9 @@ extension on Translations {
 			'project.conflicts.deleteNonFactOther' => ({required Object layer}) => '(${layer} entry — open the corresponding tab to inspect)',
 			'project.conflicts.deleteLoading' => 'Loading fact text…',
 			'project.conflicts.deleteFactLabel' => ({required Object side}) => 'Delete ${side}',
-			'project.conflicts.deletedFact' => 'Fact deleted and conflict accepted',
 			_ => null,
 		} ?? switch (path) {
+			'project.conflicts.deletedFact' => 'Fact deleted and conflict accepted',
 			'project.conflicts.openPlanEditor' => 'Open plan editor',
 			'project.conflicts.openGoalEditor' => 'Open goal editor',
 			'project.conflicts.severity.low' => 'low',
@@ -20884,9 +20888,9 @@ extension on Translations {
 			'customTasks.fieldCommand' => 'Command',
 			'customTasks.commandHelper' => 'The text inserted into the session when picked. Can be a CLI command or a Claude slash command.',
 			'customTasks.fieldDescription' => 'Description (optional)',
-			'customTasks.fieldScope' => 'Scope',
 			_ => null,
 		} ?? switch (path) {
+			'customTasks.fieldScope' => 'Scope',
 			'customTasks.globalScopeHint' => 'Visible from every session, regardless of cwd.',
 			'customTasks.projectScopeHint' => 'Visible only when a session\'s cwd matches the path below.',
 			'customTasks.fieldProjectCwd' => 'Project cwd',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -6486,6 +6486,7 @@ class _TranslationsSessionsInspectorTasksEs extends TranslationsSessionsInspecto
 	@override String noMatch({required Object query}) => 'Ninguna tarea coincide con "${query}"';
 	@override String get emptyTitle => 'No hay tareas en esta carpeta';
 	@override String get emptyHint => 'Buscando package.json, Makefile, Taskfile, justfile, Cargo.toml, go.mod, pyproject.toml o scripts de shell';
+	@override String get addCustomTask => 'Añadir tarea personalizada';
 }
 
 // Path: sessions.inspector.notes
@@ -11879,6 +11880,7 @@ extension on TranslationsEs {
 			'sessions.inspector.tasks.noMatch' => ({required Object query}) => 'Ninguna tarea coincide con "${query}"',
 			'sessions.inspector.tasks.emptyTitle' => 'No hay tareas en esta carpeta',
 			'sessions.inspector.tasks.emptyHint' => 'Buscando package.json, Makefile, Taskfile, justfile, Cargo.toml, go.mod, pyproject.toml o scripts de shell',
+			'sessions.inspector.tasks.addCustomTask' => 'Añadir tarea personalizada',
 			'sessions.inspector.notes.insertedAt' => ({required Object path}) => 'Insertado: @${path}',
 			'sessions.inspector.notes.myNotes' => 'Mis notas',
 			'sessions.inspector.notes.projectDocs' => 'Documentos del proyecto',
@@ -12271,9 +12273,9 @@ extension on TranslationsEs {
 			'project.conflicts.deleteNonFactOther' => ({required Object layer}) => '(entrada de ${layer}, abre la pestaña correspondiente para inspeccionar)',
 			'project.conflicts.deleteLoading' => 'Cargando el texto del hecho…',
 			'project.conflicts.deleteFactLabel' => ({required Object side}) => 'Eliminar ${side}',
-			'project.conflicts.deletedFact' => 'Hecho eliminado y conflicto aceptado',
 			_ => null,
 		} ?? switch (path) {
+			'project.conflicts.deletedFact' => 'Hecho eliminado y conflicto aceptado',
 			'project.conflicts.openPlanEditor' => 'Abrir el editor del plan',
 			'project.conflicts.openGoalEditor' => 'Abrir el editor del objetivo',
 			'project.conflicts.severity.low' => 'baja',
@@ -12785,9 +12787,9 @@ extension on TranslationsEs {
 			'customTasks.fieldCommand' => 'Comando',
 			'customTasks.commandHelper' => 'El texto que se inserta en la session al elegirlo. Puede ser un comando de CLI o un slash command de Claude.',
 			'customTasks.fieldDescription' => 'Descripción (opcional)',
-			'customTasks.fieldScope' => 'Ámbito',
 			_ => null,
 		} ?? switch (path) {
+			'customTasks.fieldScope' => 'Ámbito',
 			'customTasks.globalScopeHint' => 'Visible desde cualquier session, sin importar el cwd.',
 			'customTasks.projectScopeHint' => 'Visible solo cuando el cwd de una session coincide con la ruta de abajo.',
 			'customTasks.fieldProjectCwd' => 'cwd del proyecto',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -6486,6 +6486,7 @@ class _TranslationsSessionsInspectorTasksZh extends TranslationsSessionsInspecto
 	@override String noMatch({required Object query}) => '没有匹配“${query}”的任务';
 	@override String get emptyTitle => '此目录没有任务';
 	@override String get emptyHint => '正在查找 package.json、Makefile、Taskfile、justfile、Cargo.toml、go.mod、pyproject.toml 或 shell 脚本';
+	@override String get addCustomTask => '添加自定义任务';
 }
 
 // Path: sessions.inspector.notes
@@ -11879,6 +11880,7 @@ extension on TranslationsZh {
 			'sessions.inspector.tasks.noMatch' => ({required Object query}) => '没有匹配“${query}”的任务',
 			'sessions.inspector.tasks.emptyTitle' => '此目录没有任务',
 			'sessions.inspector.tasks.emptyHint' => '正在查找 package.json、Makefile、Taskfile、justfile、Cargo.toml、go.mod、pyproject.toml 或 shell 脚本',
+			'sessions.inspector.tasks.addCustomTask' => '添加自定义任务',
 			'sessions.inspector.notes.insertedAt' => ({required Object path}) => '已插入：@${path}',
 			'sessions.inspector.notes.myNotes' => '我的笔记',
 			'sessions.inspector.notes.projectDocs' => '项目文档',
@@ -12271,9 +12273,9 @@ extension on TranslationsZh {
 			'project.conflicts.deleteNonFactOther' => ({required Object layer}) => '（${layer} 条目 — 请打开对应 tab 查看）',
 			'project.conflicts.deleteLoading' => '加载中…',
 			'project.conflicts.deleteFactLabel' => ({required Object side}) => '删除 ${side}',
-			'project.conflicts.deletedFact' => '已删除 fact 并采纳冲突',
 			_ => null,
 		} ?? switch (path) {
+			'project.conflicts.deletedFact' => '已删除 fact 并采纳冲突',
 			'project.conflicts.openPlanEditor' => '打开计划编辑器',
 			'project.conflicts.openGoalEditor' => '打开目标编辑器',
 			'project.conflicts.severity.low' => '低',
@@ -12785,9 +12787,9 @@ extension on TranslationsZh {
 			'customTasks.fieldCommand' => '命令',
 			'customTasks.commandHelper' => '选择时插入到会话的文本。可以是 CLI 命令或 Claude 斜杠命令。',
 			'customTasks.fieldDescription' => '描述（可选）',
-			'customTasks.fieldScope' => '范围',
 			_ => null,
 		} ?? switch (path) {
+			'customTasks.fieldScope' => '范围',
 			'customTasks.globalScopeHint' => '从任何会话可见，不论 cwd。',
 			'customTasks.projectScopeHint' => '仅当会话的 cwd 匹配以下路径时可见。',
 			'customTasks.fieldProjectCwd' => '项目 cwd',

--- a/app/mobile/lib/features/custom_tasks/custom_tasks_screen.dart
+++ b/app/mobile/lib/features/custom_tasks/custom_tasks_screen.dart
@@ -21,6 +21,22 @@ import 'package:opendray/core/i18n/strings.g.dart' as i18n;
 class CustomTasksScreen extends ConsumerStatefulWidget {
   const CustomTasksScreen({super.key});
 
+  /// Opens the task editor directly in create mode, pre-scoped to
+  /// [initialCwd] (project scope). Used from the session inspector's
+  /// Tasks tab so operators don't have to retype the project path when
+  /// creating a task for the project they're already in. Returns true
+  /// if a task was saved.
+  static Future<bool?> pushCreate(
+    BuildContext context, {
+    String? initialCwd,
+  }) {
+    return Navigator.of(context).push<bool>(
+      MaterialPageRoute(
+        builder: (_) => _CustomTaskEditorScreen(initialCwd: initialCwd),
+      ),
+    );
+  }
+
   @override
   ConsumerState<CustomTasksScreen> createState() =>
       _CustomTasksScreenState();
@@ -253,8 +269,11 @@ class _CustomTasksScreenState extends ConsumerState<CustomTasksScreen> {
 enum _Scope { global, project }
 
 class _CustomTaskEditorScreen extends ConsumerStatefulWidget {
-  const _CustomTaskEditorScreen({this.existing});
+  const _CustomTaskEditorScreen({this.existing, this.initialCwd});
   final CustomTask? existing;
+  // When set (and not editing), the editor opens pre-scoped to this
+  // project cwd — scope defaults to project and the path is filled in.
+  final String? initialCwd;
 
   @override
   ConsumerState<_CustomTaskEditorScreen> createState() =>
@@ -283,6 +302,11 @@ class _CustomTaskEditorScreenState
       _descriptionCtrl.text = ex.description;
       _cwdCtrl.text = ex.cwd;
       _scope = ex.cwd.isEmpty ? _Scope.global : _Scope.project;
+    } else if (widget.initialCwd != null && widget.initialCwd!.isNotEmpty) {
+      // Creating from within a project: pre-scope to it so the operator
+      // doesn't have to switch to project scope and retype the path.
+      _cwdCtrl.text = widget.initialCwd!;
+      _scope = _Scope.project;
     }
   }
 

--- a/app/mobile/lib/features/custom_tasks/custom_tasks_screen.dart
+++ b/app/mobile/lib/features/custom_tasks/custom_tasks_screen.dart
@@ -37,6 +37,18 @@ class CustomTasksScreen extends ConsumerStatefulWidget {
     );
   }
 
+  /// Opens the task editor in edit mode for [task]. Used from the
+  /// session inspector's Tasks tab so operators can change a command or
+  /// scope without a trip to the global Custom Tasks screen. Returns
+  /// true if the task was saved.
+  static Future<bool?> pushEdit(BuildContext context, CustomTask task) {
+    return Navigator.of(context).push<bool>(
+      MaterialPageRoute(
+        builder: (_) => _CustomTaskEditorScreen(existing: task),
+      ),
+    );
+  }
+
   @override
   ConsumerState<CustomTasksScreen> createState() =>
       _CustomTasksScreenState();

--- a/app/mobile/lib/features/sessions/inspector/tasks_tab.dart
+++ b/app/mobile/lib/features/sessions/inspector/tasks_tab.dart
@@ -10,6 +10,7 @@ import 'package:opendray/core/api/fs_api.dart';
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/sessions_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/custom_tasks/custom_tasks_screen.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
@@ -269,6 +270,25 @@ class _TasksTabState extends ConsumerState<TasksTab>
     }
   }
 
+  // Create a custom task pre-scoped to this project's cwd, then reload
+  // so it shows up under the Custom group without a manual refresh.
+  Future<void> _addCustomTask() async {
+    final saved = await CustomTasksScreen.pushCreate(
+      context,
+      initialCwd: widget.cwd,
+    );
+    if ((saved ?? false) && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(t.customTasks.snackCreated),
+          duration: const Duration(seconds: 2),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      await _load();
+    }
+  }
+
   List<_TaskGroup> _applyFilter(List<_TaskGroup> groups) {
     final q = _filter.trim().toLowerCase();
     if (q.isEmpty) return groups;
@@ -405,13 +425,13 @@ class _TasksTabState extends ConsumerState<TasksTab>
     super.build(context);
     return Column(
       children: [
-        _Header(cwd: widget.cwd, onRefresh: _load),
+        _Header(cwd: widget.cwd, onRefresh: _load, onAdd: _addCustomTask),
         const Divider(height: 1),
         Expanded(
           child: _state.when(
             data: (groups) {
               if (groups.isEmpty) {
-                return _EmptyView(cwd: widget.cwd);
+                return _EmptyView(cwd: widget.cwd, onAdd: _addCustomTask);
               }
               final total =
                   groups.fold<int>(0, (n, g) => n + g.tasks.length);
@@ -488,9 +508,14 @@ class _TasksTabState extends ConsumerState<TasksTab>
 }
 
 class _Header extends StatelessWidget {
-  const _Header({required this.cwd, required this.onRefresh});
+  const _Header({
+    required this.cwd,
+    required this.onRefresh,
+    required this.onAdd,
+  });
   final String cwd;
   final VoidCallback onRefresh;
+  final VoidCallback onAdd;
 
   @override
   Widget build(BuildContext context) {
@@ -506,6 +531,11 @@ class _Header extends StatelessWidget {
                   ),
               overflow: TextOverflow.ellipsis,
             ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.add),
+            tooltip: t.sessions.inspector.tasks.addCustomTask,
+            onPressed: onAdd,
           ),
           IconButton(
             icon: const Icon(Icons.refresh),
@@ -618,8 +648,9 @@ class _GroupCard extends StatelessWidget {
 }
 
 class _EmptyView extends StatelessWidget {
-  const _EmptyView({required this.cwd});
+  const _EmptyView({required this.cwd, required this.onAdd});
   final String cwd;
+  final VoidCallback onAdd;
 
   @override
   Widget build(BuildContext context) {
@@ -641,6 +672,12 @@ class _EmptyView extends StatelessWidget {
               t.sessions.inspector.tasks.emptyHint,
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 16),
+            FilledButton.tonalIcon(
+              onPressed: onAdd,
+              icon: const Icon(Icons.add, size: 18),
+              label: Text(t.sessions.inspector.tasks.addCustomTask),
             ),
           ],
         ),

--- a/app/mobile/lib/features/sessions/inspector/tasks_tab.dart
+++ b/app/mobile/lib/features/sessions/inspector/tasks_tab.dart
@@ -143,6 +143,7 @@ class _TasksTabState extends ConsumerState<TasksTab>
                   name: t.name,
                   runCommand: t.command,
                   detail: t.description.isEmpty ? null : t.description,
+                  custom: t,
                 ),
             ],
           ));
@@ -313,7 +314,7 @@ class _TasksTabState extends ConsumerState<TasksTab>
   }
 
   Future<void> _onTaskTap(_Task task) async {
-    final confirmed = await showModalBottomSheet<bool>(
+    final action = await showModalBottomSheet<String>(
       context: context,
       backgroundColor: Theme.of(context).colorScheme.surface,
       shape: const RoundedRectangleBorder(
@@ -356,15 +357,119 @@ class _TasksTabState extends ConsumerState<TasksTab>
               leading: const Icon(Icons.play_arrow),
               title: Text(t.sessions.inspector.tasks.runCommand),
               subtitle: Text(t.sessions.inspector.tasks.runCommandSubtitle),
-              onTap: () => Navigator.of(sheetCtx).pop(true),
+              onTap: () => Navigator.of(sheetCtx).pop('run'),
             ),
+            // Custom tasks can be edited/deleted in place; discovered
+            // manifest/script tasks are read-only.
+            if (task.custom != null) ...[
+              ListTile(
+                leading: const Icon(Icons.edit_outlined),
+                title: Text(t.customTasks.popupEdit),
+                onTap: () => Navigator.of(sheetCtx).pop('edit'),
+              ),
+              ListTile(
+                leading: Icon(
+                  Icons.delete_outline,
+                  color: Theme.of(sheetCtx).colorScheme.error,
+                ),
+                title: Text(t.customTasks.popupDelete),
+                onTap: () => Navigator.of(sheetCtx).pop('delete'),
+              ),
+            ],
             const SizedBox(height: 4),
           ],
         ),
       ),
     );
-    if (confirmed != true || !mounted) return;
-    await _runInNewShell(task);
+    if (action == null || !mounted) return;
+    switch (action) {
+      case 'run':
+        await _runInNewShell(task);
+      case 'edit':
+        await _editCustomTask(task.custom!);
+      case 'delete':
+        await _deleteCustomTask(task.custom!);
+    }
+  }
+
+  // Edit a custom task in place, then reload so the change shows without
+  // a manual refresh.
+  Future<void> _editCustomTask(CustomTask task) async {
+    final saved = await CustomTasksScreen.pushEdit(context, task);
+    if ((saved ?? false) && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(t.customTasks.snackUpdated),
+          duration: const Duration(seconds: 2),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      await _load();
+    }
+  }
+
+  // Delete a custom task after a confirm, then reload.
+  Future<void> _deleteCustomTask(CustomTask task) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(t.customTasks.deleteTitle),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              task.name,
+              style: const TextStyle(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              t.customTasks.deleteBody,
+              style: Theme.of(ctx).textTheme.bodySmall,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(t.common.cancel),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(ctx).colorScheme.error,
+            ),
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(t.common.delete),
+          ),
+        ],
+      ),
+    );
+    if (ok != true || !mounted) return;
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref.read(customTasksApiProvider).delete(task.id);
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(t.customTasks.deletedSnack(name: task.name)),
+          duration: const Duration(seconds: 2),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      await _load();
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(content: Text(t.customTasks.deleteFailedApi(error: e.message))),
+      );
+    } on Object catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(t.customTasks.deleteFailedGeneric(error: e.toString())),
+        ),
+      );
+    }
   }
 
   // Run a task the way the web Task Runner does: spawn a fresh shell
@@ -748,7 +853,12 @@ enum _TaskSource {
 }
 
 class _Task {
-  const _Task({required this.name, required this.runCommand, this.detail});
+  const _Task({
+    required this.name,
+    required this.runCommand,
+    this.detail,
+    this.custom,
+  });
   // The task's identifier as it appears in the source file.
   final String name;
   // The command we'll paste into the terminal to run it.
@@ -756,6 +866,10 @@ class _Task {
   // Optional human-readable detail (the underlying script body, a
   // Taskfile `desc:`, a custom task's description, etc.).
   final String? detail;
+  // The backing custom task, set only for user-defined tasks. Manifest/
+  // script tasks are read-only and leave this null — that's what gates
+  // the inline edit/delete actions in the tap sheet.
+  final CustomTask? custom;
 }
 
 class _TaskGroup {

--- a/app/web/src/components/sessions/inspector/TaskRunnerPanel.tsx
+++ b/app/web/src/components/sessions/inspector/TaskRunnerPanel.tsx
@@ -12,13 +12,19 @@ import {
   Box,
   Coffee,
   Terminal,
+  Pencil,
+  Trash2,
 } from 'lucide-react'
 import { toast } from 'sonner'
 
 import { useQueryClient } from '@tanstack/react-query'
 
 import { listDir, readFile } from '@/lib/fs'
-import { listCustomTasks } from '@/lib/customTasks'
+import {
+  listCustomTasks,
+  deleteCustomTask,
+  type CustomTask,
+} from '@/lib/customTasks'
 import { createSession } from '@/lib/sessions'
 import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
@@ -37,6 +43,12 @@ interface DiscoveredTask {
   /** Origin manifest, e.g. "package.json" / "Custom" */
   source: string
   description?: string
+  /**
+   * The backing custom task, present only for user-defined tasks (the
+   * "Custom" group). Manifest/script tasks are read-only and leave this
+   * undefined — that's what gates the inline edit/delete affordances.
+   */
+  custom?: CustomTask
 }
 
 interface TaskGroup {
@@ -275,6 +287,9 @@ export function TaskRunnerPanel({ session }: TaskRunnerPanelProps) {
   // Create a custom task inline, pre-scoped to this session's project,
   // instead of bouncing to the Plugins page to type the cwd by hand.
   const [creatingTask, setCreatingTask] = useState(false)
+  // Edit a custom task inline (same reason — no trip to the Plugins page
+  // just to change a command). null = dialog closed.
+  const [editingTask, setEditingTask] = useState<CustomTask | null>(null)
 
   const dirEntries = useCwdEntries(session.cwd)
   const presentSet = useMemo(() => {
@@ -432,6 +447,7 @@ export function TaskRunnerPanel({ session }: TaskRunnerPanelProps) {
       command: t.command,
       source: t.cwd ? 'Custom · scoped' : 'Custom · global',
       description: t.description || undefined,
+      custom: t,
     }))
     return [{ source: 'Custom', icon: sourceIcon['Custom'], tasks: mapped }]
   }, [customQ.data])
@@ -498,6 +514,17 @@ export function TaskRunnerPanel({ session }: TaskRunnerPanelProps) {
     },
     onError: (err: Error) =>
       toast.error('Run failed', { description: err.message }),
+  })
+
+  const remove = useMutation({
+    mutationFn: deleteCustomTask,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['custom-tasks', session.cwd] })
+      qc.invalidateQueries({ queryKey: ['custom-tasks-all'] })
+      toast.success('Task removed')
+    },
+    onError: (err: Error) =>
+      toast.error('Delete failed', { description: err.message }),
   })
 
   const isLoading = dirEntries.isLoading || (presentSet.size > 0 && manifests.isLoading)
@@ -580,33 +607,64 @@ export function TaskRunnerPanel({ session }: TaskRunnerPanelProps) {
             </div>
             <div className="flex flex-col">
               {g.tasks.map((t) => (
-                <button
+                <div
                   key={`${g.source}/${t.name}`}
-                  type="button"
-                  disabled={disabled}
-                  onClick={() => runner_.mutate(t)}
                   className={cn(
-                    'group flex items-start gap-2 px-2 py-1.5 rounded-md text-left',
+                    'group flex items-stretch rounded-md',
                     'hover:bg-card border border-transparent hover:border-border/60',
-                    'disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:border-transparent',
                   )}
-                  title={t.description || t.command}
                 >
-                  <Play className="size-3 mt-0.5 text-muted-foreground/60 shrink-0 group-hover:text-foreground" />
-                  <div className="flex flex-col min-w-0 flex-1">
-                    <span className="text-[12px] font-medium truncate">
-                      {t.name}
-                    </span>
-                    <span className="text-[10px] text-muted-foreground/70 font-mono truncate">
-                      $ {t.command}
-                    </span>
-                    {t.description && (
-                      <span className="text-[10px] text-muted-foreground/60 truncate italic">
-                        {t.description}
+                  <button
+                    type="button"
+                    disabled={disabled}
+                    onClick={() => runner_.mutate(t)}
+                    className="flex items-start gap-2 px-2 py-1.5 text-left flex-1 min-w-0 disabled:opacity-50"
+                    title={t.description || t.command}
+                  >
+                    <Play className="size-3 mt-0.5 text-muted-foreground/60 shrink-0 group-hover:text-foreground" />
+                    <div className="flex flex-col min-w-0 flex-1">
+                      <span className="text-[12px] font-medium truncate">
+                        {t.name}
                       </span>
-                    )}
-                  </div>
-                </button>
+                      <span className="text-[10px] text-muted-foreground/70 font-mono truncate">
+                        $ {t.command}
+                      </span>
+                      {t.description && (
+                        <span className="text-[10px] text-muted-foreground/60 truncate italic">
+                          {t.description}
+                        </span>
+                      )}
+                    </div>
+                  </button>
+                  {/* Custom tasks get inline edit/delete; discovered
+                      manifest/script tasks are read-only. */}
+                  {t.custom && (
+                    <div className="flex items-center gap-0.5 pr-1 shrink-0 opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+                      <button
+                        type="button"
+                        onClick={() => setEditingTask(t.custom!)}
+                        className="p-1 rounded text-muted-foreground/70 hover:text-foreground hover:bg-muted"
+                        title="Edit task"
+                      >
+                        <Pencil className="size-3" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const task = t.custom!
+                          if (
+                            confirm(`Delete custom task "${task.name}"?`)
+                          )
+                            remove.mutate(task.id)
+                        }}
+                        className="p-1 rounded text-muted-foreground/70 hover:text-destructive hover:bg-muted"
+                        title="Delete task"
+                      >
+                        <Trash2 className="size-3" />
+                      </button>
+                    </div>
+                  )}
+                </div>
               ))}
             </div>
           </section>
@@ -628,6 +686,12 @@ export function TaskRunnerPanel({ session }: TaskRunnerPanelProps) {
         onOpenChange={setCreatingTask}
         mode="create"
         initialCwd={session.cwd}
+      />
+      <CustomTaskDialog
+        open={editingTask != null}
+        onOpenChange={(v) => !v && setEditingTask(null)}
+        mode="edit"
+        task={editingTask ?? undefined}
       />
     </div>
   )

--- a/app/web/src/components/sessions/inspector/TaskRunnerPanel.tsx
+++ b/app/web/src/components/sessions/inspector/TaskRunnerPanel.tsx
@@ -13,7 +13,6 @@ import {
   Coffee,
   Terminal,
 } from 'lucide-react'
-import { Link } from '@tanstack/react-router'
 import { toast } from 'sonner'
 
 import { useQueryClient } from '@tanstack/react-query'
@@ -25,6 +24,7 @@ import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
 import type { Session } from '@/lib/types'
 import { Input } from '@/components/ui/input'
+import { CustomTaskDialog } from '@/components/tasks/CustomTaskDialog'
 import { useSessionTabs } from '@/stores/sessionTabs'
 
 interface TaskRunnerPanelProps {
@@ -272,6 +272,9 @@ function iconFor(source: string): typeof FileCode {
 
 export function TaskRunnerPanel({ session }: TaskRunnerPanelProps) {
   const [filter, setFilter] = useState('')
+  // Create a custom task inline, pre-scoped to this session's project,
+  // instead of bouncing to the Plugins page to type the cwd by hand.
+  const [creatingTask, setCreatingTask] = useState(false)
 
   const dirEntries = useCwdEntries(session.cwd)
   const presentSet = useMemo(() => {
@@ -519,13 +522,19 @@ export function TaskRunnerPanel({ session }: TaskRunnerPanelProps) {
             <code>pyproject.toml</code> in the cwd, or define one below.
           </div>
         </div>
-        <Link
-          to="/plugins"
-          search={{ newTaskCwd: session.cwd }}
+        <button
+          type="button"
+          onClick={() => setCreatingTask(true)}
           className="text-[11px] text-state-running hover:underline self-center"
         >
           Add a custom task →
-        </Link>
+        </button>
+        <CustomTaskDialog
+          open={creatingTask}
+          onOpenChange={setCreatingTask}
+          mode="create"
+          initialCwd={session.cwd}
+        />
       </div>
     )
   }
@@ -605,14 +614,21 @@ export function TaskRunnerPanel({ session }: TaskRunnerPanelProps) {
       })}
 
       <div className="pt-1">
-        <Link
-          to="/plugins"
-          search={{ newTaskCwd: session.cwd }}
+        <button
+          type="button"
+          onClick={() => setCreatingTask(true)}
           className="text-[11px] text-muted-foreground/70 hover:text-foreground hover:underline"
         >
           + Add custom task
-        </Link>
+        </button>
       </div>
+
+      <CustomTaskDialog
+        open={creatingTask}
+        onOpenChange={setCreatingTask}
+        mode="create"
+        initialCwd={session.cwd}
+      />
     </div>
   )
 }

--- a/app/web/src/components/sessions/inspector/TaskRunnerPanel.tsx
+++ b/app/web/src/components/sessions/inspector/TaskRunnerPanel.tsx
@@ -521,6 +521,7 @@ export function TaskRunnerPanel({ session }: TaskRunnerPanelProps) {
         </div>
         <Link
           to="/plugins"
+          search={{ newTaskCwd: session.cwd }}
           className="text-[11px] text-state-running hover:underline self-center"
         >
           Add a custom task →
@@ -606,6 +607,7 @@ export function TaskRunnerPanel({ session }: TaskRunnerPanelProps) {
       <div className="pt-1">
         <Link
           to="/plugins"
+          search={{ newTaskCwd: session.cwd }}
           className="text-[11px] text-muted-foreground/70 hover:text-foreground hover:underline"
         >
           + Add custom task

--- a/app/web/src/components/tasks/CustomTaskDialog.tsx
+++ b/app/web/src/components/tasks/CustomTaskDialog.tsx
@@ -1,0 +1,186 @@
+// Shared create/edit dialog for custom tasks. Lives here (rather than
+// inside the Plugins page) so the session Task Runner can open it
+// inline — pre-scoped to the current project's cwd — instead of
+// bouncing the operator to the Plugins page to type the path by hand.
+import { useEffect, useState, type FormEvent } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  createCustomTask,
+  updateCustomTask,
+  type CustomTask,
+} from '@/lib/customTasks'
+
+interface CustomTaskDialogProps {
+  open: boolean
+  onOpenChange: (v: boolean) => void
+  mode: 'create' | 'edit'
+  task?: CustomTask
+  // Pre-fills the cwd field for a new task so operators creating a
+  // task from within a project don't have to retype its path.
+  initialCwd?: string
+}
+
+export function CustomTaskDialog({
+  open,
+  onOpenChange,
+  mode,
+  task,
+  initialCwd,
+}: CustomTaskDialogProps) {
+  const { t } = useTranslation()
+  const qc = useQueryClient()
+  const [name, setName] = useState(task?.name ?? '')
+  const [command, setCommand] = useState(task?.command ?? '')
+  const [description, setDescription] = useState(task?.description ?? '')
+  const [cwd, setCwd] = useState(task?.cwd ?? initialCwd ?? '')
+
+  useEffect(() => {
+    setName(task?.name ?? '')
+    setCommand(task?.command ?? '')
+    setDescription(task?.description ?? '')
+    setCwd(task?.cwd ?? initialCwd ?? '')
+  }, [task?.id, initialCwd])
+
+  const create = useMutation({
+    mutationFn: () =>
+      createCustomTask({ name, command, description, cwd: cwd || undefined }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['custom-tasks-all'] })
+      qc.invalidateQueries({ queryKey: ['custom-tasks'] })
+      toast.success(t('web.plugins.customTasks.dialog.addedToast'))
+      onOpenChange(false)
+    },
+    onError: (err: Error) =>
+      toast.error(t('web.plugins.customTasks.dialog.addFailedToast'), {
+        description: err.message,
+      }),
+  })
+
+  const update = useMutation({
+    mutationFn: () =>
+      updateCustomTask(task!.id, { name, command, description, cwd }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['custom-tasks-all'] })
+      qc.invalidateQueries({ queryKey: ['custom-tasks'] })
+      toast.success(t('web.plugins.customTasks.dialog.updatedToast'))
+      onOpenChange(false)
+    },
+    onError: (err: Error) =>
+      toast.error(t('web.plugins.customTasks.dialog.updateFailedToast'), {
+        description: err.message,
+      }),
+  })
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault()
+    if (mode === 'create') create.mutate()
+    else update.mutate()
+  }
+
+  const busy = create.isPending || update.isPending
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {mode === 'create'
+              ? t('web.plugins.customTasks.dialog.addTitle')
+              : t('web.plugins.customTasks.dialog.editTitle', { name: task?.name })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('web.plugins.customTasks.dialog.description')}
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={submit} className="flex flex-col gap-3 mt-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="task-name">
+              {t('web.plugins.customTasks.dialog.nameLabel')}
+            </Label>
+            <Input
+              id="task-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={t('web.plugins.customTasks.dialog.namePlaceholder')}
+              required
+              autoFocus
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="task-cmd">
+              {t('web.plugins.customTasks.dialog.commandLabel')}
+            </Label>
+            <Textarea
+              id="task-cmd"
+              value={command}
+              onChange={(e) => setCommand(e.target.value)}
+              placeholder={t('web.plugins.customTasks.dialog.commandPlaceholder')}
+              rows={2}
+              required
+              className="font-mono text-[12px]"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="task-desc">
+              {t('web.plugins.customTasks.dialog.descLabel')}
+            </Label>
+            <Input
+              id="task-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={t('web.plugins.customTasks.dialog.descPlaceholder')}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="task-cwd">
+              {t('web.plugins.customTasks.dialog.cwdLabel')}
+            </Label>
+            <Input
+              id="task-cwd"
+              value={cwd}
+              onChange={(e) => setCwd(e.target.value)}
+              placeholder={t('web.plugins.customTasks.dialog.cwdPlaceholder')}
+              className="font-mono text-[12px]"
+            />
+            <p className="text-[10.5px] text-muted-foreground/80">
+              {t('web.plugins.customTasks.dialog.cwdHint')}
+            </p>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => onOpenChange(false)}
+              disabled={busy}
+            >
+              {t('web.plugins.common.cancel')}
+            </Button>
+            <Button type="submit" variant="accent" size="sm" disabled={busy}>
+              {busy && <Loader2 className="size-3.5 animate-spin" />}
+              {mode === 'create'
+                ? t('web.plugins.common.add')
+                : t('web.plugins.common.save')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/web/src/pages/Plugins.tsx
+++ b/app/web/src/pages/Plugins.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type FormEvent, type ReactNode } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useNavigate, useSearch } from '@tanstack/react-router'
 import {
   Plus,
   Trash2,
@@ -1443,12 +1444,31 @@ function SkillEditor({ open, onOpenChange, mode, editingId }: SkillEditorProps) 
 function CustomTasksSection() {
   const { t } = useTranslation()
   const qc = useQueryClient()
+  const navigate = useNavigate()
+  const search = useSearch({ strict: false }) as { newTaskCwd?: string }
   const { data: tasks, isLoading } = useQuery({
     queryKey: ['custom-tasks-all'],
     queryFn: () => listCustomTasks({ all: true }),
   })
   const [editing, setEditing] = useState<CustomTask | null>(null)
-  const [creating, setCreating] = useState(false)
+  // Arriving from a project's "+ Add custom task" carries the project
+  // cwd on ?newTaskCwd — seed the create dialog open + pre-scoped from
+  // it (lazy initialisers so we capture the param before the effect
+  // below strips it from the URL).
+  const [creating, setCreating] = useState(() => Boolean(search.newTaskCwd))
+  // cwd to pre-scope a new task to; undefined = global.
+  const [createCwd, setCreateCwd] = useState<string | undefined>(
+    () => search.newTaskCwd,
+  )
+
+  // Strip ?newTaskCwd once consumed so a refresh or back-nav doesn't
+  // reopen the dialog. Side-effect only (no setState) — the open state
+  // was already captured by the initialisers above.
+  useEffect(() => {
+    if (search.newTaskCwd) {
+      navigate({ to: '/plugins', search: {}, replace: true })
+    }
+  }, [search.newTaskCwd, navigate])
 
   const remove = useMutation({
     mutationFn: deleteCustomTask,
@@ -1473,7 +1493,10 @@ function CustomTasksSection() {
         <Button
           variant="accent"
           size="sm"
-          onClick={() => setCreating(true)}
+          onClick={() => {
+            setCreateCwd(undefined)
+            setCreating(true)
+          }}
           className="gap-1"
         >
           <Plus className="size-3.5" />
@@ -1575,6 +1598,7 @@ function CustomTasksSection() {
         open={creating}
         onOpenChange={setCreating}
         mode="create"
+        initialCwd={createCwd}
       />
       <CustomTaskDialog
         open={editing != null}
@@ -1597,22 +1621,25 @@ interface CustomTaskDialogProps {
   onOpenChange: (v: boolean) => void
   mode: 'create' | 'edit'
   task?: CustomTask
+  // Pre-fills the cwd field for a new task so operators creating a
+  // task from within a project don't have to retype its path.
+  initialCwd?: string
 }
 
-function CustomTaskDialog({ open, onOpenChange, mode, task }: CustomTaskDialogProps) {
+function CustomTaskDialog({ open, onOpenChange, mode, task, initialCwd }: CustomTaskDialogProps) {
   const { t } = useTranslation()
   const qc = useQueryClient()
   const [name, setName] = useState(task?.name ?? '')
   const [command, setCommand] = useState(task?.command ?? '')
   const [description, setDescription] = useState(task?.description ?? '')
-  const [cwd, setCwd] = useState(task?.cwd ?? '')
+  const [cwd, setCwd] = useState(task?.cwd ?? initialCwd ?? '')
 
   useEffect(() => {
     setName(task?.name ?? '')
     setCommand(task?.command ?? '')
     setDescription(task?.description ?? '')
-    setCwd(task?.cwd ?? '')
-  }, [task?.id])
+    setCwd(task?.cwd ?? initialCwd ?? '')
+  }, [task?.id, initialCwd])
 
   const create = useMutation({
     mutationFn: () =>

--- a/app/web/src/pages/Plugins.tsx
+++ b/app/web/src/pages/Plugins.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState, type FormEvent, type ReactNode } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useNavigate, useSearch } from '@tanstack/react-router'
 import {
   Plus,
   Trash2,
@@ -38,7 +37,6 @@ import {
   SelectItem,
   SelectValue,
 } from '@/components/ui/select'
-import { Textarea } from '@/components/ui/textarea'
 import {
   listGitHosts,
   createGitHost,
@@ -49,11 +47,10 @@ import {
 } from '@/lib/githost'
 import {
   listCustomTasks,
-  createCustomTask,
-  updateCustomTask,
   deleteCustomTask,
   type CustomTask,
 } from '@/lib/customTasks'
+import { CustomTaskDialog } from '@/components/tasks/CustomTaskDialog'
 import {
   listSkills,
   getSkill,
@@ -1444,31 +1441,12 @@ function SkillEditor({ open, onOpenChange, mode, editingId }: SkillEditorProps) 
 function CustomTasksSection() {
   const { t } = useTranslation()
   const qc = useQueryClient()
-  const navigate = useNavigate()
-  const search = useSearch({ strict: false }) as { newTaskCwd?: string }
   const { data: tasks, isLoading } = useQuery({
     queryKey: ['custom-tasks-all'],
     queryFn: () => listCustomTasks({ all: true }),
   })
   const [editing, setEditing] = useState<CustomTask | null>(null)
-  // Arriving from a project's "+ Add custom task" carries the project
-  // cwd on ?newTaskCwd — seed the create dialog open + pre-scoped from
-  // it (lazy initialisers so we capture the param before the effect
-  // below strips it from the URL).
-  const [creating, setCreating] = useState(() => Boolean(search.newTaskCwd))
-  // cwd to pre-scope a new task to; undefined = global.
-  const [createCwd, setCreateCwd] = useState<string | undefined>(
-    () => search.newTaskCwd,
-  )
-
-  // Strip ?newTaskCwd once consumed so a refresh or back-nav doesn't
-  // reopen the dialog. Side-effect only (no setState) — the open state
-  // was already captured by the initialisers above.
-  useEffect(() => {
-    if (search.newTaskCwd) {
-      navigate({ to: '/plugins', search: {}, replace: true })
-    }
-  }, [search.newTaskCwd, navigate])
+  const [creating, setCreating] = useState(false)
 
   const remove = useMutation({
     mutationFn: deleteCustomTask,
@@ -1493,10 +1471,7 @@ function CustomTasksSection() {
         <Button
           variant="accent"
           size="sm"
-          onClick={() => {
-            setCreateCwd(undefined)
-            setCreating(true)
-          }}
+          onClick={() => setCreating(true)}
           className="gap-1"
         >
           <Plus className="size-3.5" />
@@ -1598,7 +1573,6 @@ function CustomTasksSection() {
         open={creating}
         onOpenChange={setCreating}
         mode="create"
-        initialCwd={createCwd}
       />
       <CustomTaskDialog
         open={editing != null}
@@ -1614,159 +1588,6 @@ function trimPath(p: string): string {
   const parts = p.split('/').filter(Boolean)
   if (parts.length <= 2) return p
   return '…/' + parts.slice(-2).join('/')
-}
-
-interface CustomTaskDialogProps {
-  open: boolean
-  onOpenChange: (v: boolean) => void
-  mode: 'create' | 'edit'
-  task?: CustomTask
-  // Pre-fills the cwd field for a new task so operators creating a
-  // task from within a project don't have to retype its path.
-  initialCwd?: string
-}
-
-function CustomTaskDialog({ open, onOpenChange, mode, task, initialCwd }: CustomTaskDialogProps) {
-  const { t } = useTranslation()
-  const qc = useQueryClient()
-  const [name, setName] = useState(task?.name ?? '')
-  const [command, setCommand] = useState(task?.command ?? '')
-  const [description, setDescription] = useState(task?.description ?? '')
-  const [cwd, setCwd] = useState(task?.cwd ?? initialCwd ?? '')
-
-  useEffect(() => {
-    setName(task?.name ?? '')
-    setCommand(task?.command ?? '')
-    setDescription(task?.description ?? '')
-    setCwd(task?.cwd ?? initialCwd ?? '')
-  }, [task?.id, initialCwd])
-
-  const create = useMutation({
-    mutationFn: () =>
-      createCustomTask({ name, command, description, cwd: cwd || undefined }),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['custom-tasks-all'] })
-      qc.invalidateQueries({ queryKey: ['custom-tasks'] })
-      toast.success(t('web.plugins.customTasks.dialog.addedToast'))
-      onOpenChange(false)
-    },
-    onError: (err: Error) =>
-      toast.error(t('web.plugins.customTasks.dialog.addFailedToast'), {
-        description: err.message,
-      }),
-  })
-
-  const update = useMutation({
-    mutationFn: () =>
-      updateCustomTask(task!.id, { name, command, description, cwd }),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['custom-tasks-all'] })
-      qc.invalidateQueries({ queryKey: ['custom-tasks'] })
-      toast.success(t('web.plugins.customTasks.dialog.updatedToast'))
-      onOpenChange(false)
-    },
-    onError: (err: Error) =>
-      toast.error(t('web.plugins.customTasks.dialog.updateFailedToast'), {
-        description: err.message,
-      }),
-  })
-
-  const submit = (e: FormEvent) => {
-    e.preventDefault()
-    if (mode === 'create') create.mutate()
-    else update.mutate()
-  }
-
-  const busy = create.isPending || update.isPending
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>
-            {mode === 'create'
-              ? t('web.plugins.customTasks.dialog.addTitle')
-              : t('web.plugins.customTasks.dialog.editTitle', { name: task?.name })}
-          </DialogTitle>
-          <DialogDescription>
-            {t('web.plugins.customTasks.dialog.description')}
-          </DialogDescription>
-        </DialogHeader>
-        <form onSubmit={submit} className="flex flex-col gap-3 mt-2">
-          <div className="space-y-1.5">
-            <Label htmlFor="task-name">
-              {t('web.plugins.customTasks.dialog.nameLabel')}
-            </Label>
-            <Input
-              id="task-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder={t('web.plugins.customTasks.dialog.namePlaceholder')}
-              required
-              autoFocus
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="task-cmd">
-              {t('web.plugins.customTasks.dialog.commandLabel')}
-            </Label>
-            <Textarea
-              id="task-cmd"
-              value={command}
-              onChange={(e) => setCommand(e.target.value)}
-              placeholder={t('web.plugins.customTasks.dialog.commandPlaceholder')}
-              rows={2}
-              required
-              className="font-mono text-[12px]"
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="task-desc">
-              {t('web.plugins.customTasks.dialog.descLabel')}
-            </Label>
-            <Input
-              id="task-desc"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder={t('web.plugins.customTasks.dialog.descPlaceholder')}
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="task-cwd">
-              {t('web.plugins.customTasks.dialog.cwdLabel')}
-            </Label>
-            <Input
-              id="task-cwd"
-              value={cwd}
-              onChange={(e) => setCwd(e.target.value)}
-              placeholder={t('web.plugins.customTasks.dialog.cwdPlaceholder')}
-              className="font-mono text-[12px]"
-            />
-            <p className="text-[10.5px] text-muted-foreground/80">
-              {t('web.plugins.customTasks.dialog.cwdHint')}
-            </p>
-          </div>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => onOpenChange(false)}
-              disabled={busy}
-            >
-              {t('web.plugins.common.cancel')}
-            </Button>
-            <Button type="submit" variant="accent" size="sm" disabled={busy}>
-              {busy && <Loader2 className="size-3.5 animate-spin" />}
-              {mode === 'create'
-                ? t('web.plugins.common.add')
-                : t('web.plugins.common.save')}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-  )
 }
 
 function GitHostsSection() {

--- a/app/web/src/router.tsx
+++ b/app/web/src/router.tsx
@@ -219,14 +219,6 @@ const pluginsRoute = createRoute({
   getParentRoute: () => protectedRoute,
   path: '/plugins',
   component: PluginsPage,
-  // When the "+ Add custom task" link fires from a project's Task
-  // Runner, the originating project cwd rides in on ?newTaskCwd so the
-  // create dialog can open pre-scoped to that project. Kept optional so
-  // the many other `<Link to="/plugins">` callers need no search prop.
-  validateSearch: (search): { newTaskCwd?: string } =>
-    typeof search.newTaskCwd === 'string'
-      ? { newTaskCwd: search.newTaskCwd }
-      : {},
 })
 
 const settingsRoute = createRoute({

--- a/app/web/src/router.tsx
+++ b/app/web/src/router.tsx
@@ -219,6 +219,14 @@ const pluginsRoute = createRoute({
   getParentRoute: () => protectedRoute,
   path: '/plugins',
   component: PluginsPage,
+  // When the "+ Add custom task" link fires from a project's Task
+  // Runner, the originating project cwd rides in on ?newTaskCwd so the
+  // create dialog can open pre-scoped to that project. Kept optional so
+  // the many other `<Link to="/plugins">` callers need no search prop.
+  validateSearch: (search): { newTaskCwd?: string } =>
+    typeof search.newTaskCwd === 'string'
+      ? { newTaskCwd: search.newTaskCwd }
+      : {},
 })
 
 const settingsRoute = createRoute({


### PR DESCRIPTION
## Problem

Creating a **project-scoped custom task** from inside a project was needlessly clunky on both surfaces:

- **Web** — the session Task Runner's blue "Add a custom task" button navigated you away to the **Plugins → Custom Tasks** page, where you then had to type (or paste) the project's absolute `cwd` by hand. Leaving it blank silently created a **global** task instead.
- **Mobile** — the only way in was More → Custom Tasks (the global list), then manually toggle scope to *project* and type the path.

Tasks are already scoped purely by `cwd` on the backend (empty = global, absolute path = project) — no backend change needed. This just removes the jump and the manual path entry.

## What changed

### Web
- The Task Runner's "Add a custom task" / "+ Add custom task" buttons now open a create dialog **inline**, pre-scoped to the session's project `cwd` — **no page jump, no typing the path**.
- Extracted `CustomTaskDialog` out of `Plugins.tsx` into a shared component (`components/tasks/CustomTaskDialog.tsx`) so both the Task Runner and the Plugins page reuse it. It gained an optional `initialCwd` prop.
- Creating a task invalidates the cwd-scoped query, so it appears in the panel immediately.
- The Plugins page keeps its plain global **Add task** flow unchanged.

### Mobile
- The session inspector **Tasks tab** gains an **Add custom task** action (header icon + empty-state button) that opens the editor **pre-scoped to the project** — scope defaults to *project*, path pre-filled.
- `CustomTasksScreen.pushCreate(context, initialCwd:)` opens the editor directly in create mode with the cwd seeded.
- New `sessions.inspector.tasks.addCustomTask` string added to `en`/`es`/`zh`; slang regenerated (i18n parity 100%).

## Test plan
- [x] `tsc -b` + `vite build` clean (web)
- [x] `eslint` — no net-new findings vs. `main`
- [x] `flutter analyze` clean on changed files
- [x] i18n parity check green (es/zh 100%)
- [ ] Manual (web): from a session's Tasks tab, the "Add custom task" button opens the dialog with the project path pre-filled; submitting creates a task visible only in that project — no navigation to Plugins.
- [ ] Manual (mobile): from a session's Tasks tab, "Add custom task" opens the editor pre-scoped to the project; the saved task shows under the Custom group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)