### PR TITLE
fix(web/files): keep the download icon reachable in a deep/long file tree

### DIFF
--- a/app/web/src/components/sessions/InspectorPanel.tsx
+++ b/app/web/src/components/sessions/InspectorPanel.tsx
@@ -173,7 +173,14 @@ export function InspectorPanel({ session }: InspectorPanelProps) {
           </TabsList>
         </div>
 
-        <ScrollArea className="flex-1 min-h-0">
+        {/* Radix ScrollArea wraps content in an inner display:table div that
+            sizes to content width — so a long/deep Files tree overflows the
+            panel horizontally instead of truncating, which pushes the
+            hover-download icon (anchored to each row's right edge) off-screen.
+            Force that wrapper to block so children stay within the panel width
+            and `truncate` engages. Safe for the Database tab (its grid scrolls
+            in its own overflow-auto containers, not this viewport). */}
+        <ScrollArea className="flex-1 min-h-0 [&_[data-radix-scroll-area-viewport]>div]:!block">
           <TabsContent value="files" className="m-0 p-3">
             <FilesPanel cwd={session.cwd} />
           </TabsContent>


### PR DESCRIPTION
## Bug (reported from desktop)

Hovering a file in the inspector's **Files** sidebar showed no download icon on rows with long names / deep nesting.

## Root cause

The Files tree renders inside a Radix `ScrollArea` (only a *vertical* scrollbar). Radix wraps the viewport's children in an inner `display:table` div that **sizes to content width**. So a long/deep tree overflows the panel horizontally instead of truncating:
- filenames get **hard-cut with no `…`** (the ellipsis never engages because the row is wider than the panel), and
- the download icon — anchored `absolute right-1` to each **row's** right edge (`FilesPanel.tsx`) — is pushed **off the visible right edge**. The row still highlights on hover (`group-hover` works), but the icon is past the edge.

## Fix

One line: force Radix's inner wrapper to `display:block` on the inspector ScrollArea so children stay within the viewport width and `truncate` engages — the download icon then sits at the visible right edge.

```
[&_[data-radix-scroll-area-viewport]>div]:!block
```

**Safe across tabs:** the Database tab scrolls horizontally in its *own* `overflow-auto` containers (`DataGrid`, `ResultsTable`, `SQLConsole`, …), not this viewport; Git/Search/Tasks/etc. don't rely on horizontal scroll. So constraining the shared viewport to panel width only fixes overflow, doesn't remove any needed horizontal scroll.

## Verification

Pure className change → CI (`Frontend (web)`) compile-verifies it. **Visual confirmation needs a browser** (I can't render headlessly, and can't test on the live gateway without a deploy): after this ships, the Files tree should show `…`-truncated names and the download icon on hover at the right edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)