### PR TITLE
fix(catalog): don't let a client disconnect SIGKILL npm mid-install

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1139,6 +1139,7 @@
           "mcp": "mcp"
         },
         "notInstalled": "not installed",
+        "brokenCli": "Installed but not runnable",
         "updateAvailable": "update available → {version}",
         "upToDate": "up to date",
         "update": "Update to {version}",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -1139,6 +1139,7 @@
           "mcp": "mcp"
         },
         "notInstalled": "no instalado",
+        "brokenCli": "Instalado pero no ejecutable",
         "updateAvailable": "actualización disponible → {version}",
         "upToDate": "actualizado",
         "update": "Actualizar a {version}",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -1139,6 +1139,7 @@
           "mcp": "mcp"
         },
         "notInstalled": "未安装",
+        "brokenCli": "已安装但无法运行",
         "updateAvailable": "有可用更新 → {version}",
         "upToDate": "已是最新",
         "update": "更新到 {version}",

--- a/app/shared/src/lib/types.ts
+++ b/app/shared/src/lib/types.ts
@@ -184,6 +184,11 @@ export interface ProviderManifest {
 export interface ProviderRuntime {
   installed: boolean
   installedVersion?: string
+  // Set when the binary is on PATH but `--version` failed — installed, but
+  // not runnable (e.g. a broken npm install missing its platform binary).
+  // When set, never fall back to the manifest version: that would render a
+  // broken CLI as healthy.
+  versionError?: string
   path?: string
   latestVersion?: string
   updateAvailable: boolean

--- a/app/web/src/pages/Providers.tsx
+++ b/app/web/src/pages/Providers.tsx
@@ -23,6 +23,7 @@ import {
   checkProviderUpdate,
   updateProvider,
 } from '@/lib/catalog'
+import type { APIError } from '@/lib/api'
 import type { Provider } from '@/lib/types'
 import { cn } from '@/lib/utils'
 
@@ -218,10 +219,22 @@ function ProviderDetail({
       qc.invalidateQueries({ queryKey: ['providers'] })
       qc.invalidateQueries({ queryKey: ['provider-update', m.id] })
     },
-    onError: (e: Error) =>
+    onError: (e: Error) => {
+      // The 502 body carries npm's own output (result.output) — that's where
+      // the actionable line lives ("npm error ENOTEMPTY: directory not empty
+      // …"). e.message alone is just "npm install -g <pkg>: exit status 217",
+      // which tells the operator nothing about what to do.
+      const body = (e as APIError).body as
+        | { result?: { output?: string } }
+        | undefined
+      const npmErr = body?.result?.output
+        ?.split('\n')
+        .map((l) => l.trim())
+        .find((l) => l.toLowerCase().includes('error') && l.length > 12)
       toast.error(t('web.providers.detail.updateFailedToast'), {
-        description: e.message,
-      }),
+        description: npmErr ? `${e.message} — ${npmErr}` : e.message,
+      })
+    },
   })
   const caps: { key: keyof typeof m.capabilities; labelKey: string }[] = [
     { key: 'supportsResume', labelKey: 'web.providers.detail.caps.resume' },
@@ -253,6 +266,19 @@ function ProviderDetail({
                 className="font-mono normal-case text-muted-foreground"
               >
                 {t('web.providers.detail.notInstalled')}
+              </Badge>
+            ) : rt?.versionError ? (
+              // On PATH but won't run — e.g. a broken npm install whose
+              // platform binary never landed. Deliberately NOT falling back
+              // to the manifest version here: that renders a CLI that can't
+              // even launch as perfectly healthy. Hover for the CLI's own
+              // reason.
+              <Badge
+                variant="danger"
+                className="font-mono normal-case"
+                title={rt.versionError}
+              >
+                {t('web.providers.detail.brokenCli')}
               </Badge>
             ) : (
               <Badge variant="outline" className="font-mono normal-case">

--- a/internal/catalog/probe.go
+++ b/internal/catalog/probe.go
@@ -22,7 +22,14 @@ import (
 type RuntimeInfo struct {
 	Installed        bool   `json:"installed"`
 	InstalledVersion string `json:"installedVersion,omitempty"`
-	Path             string `json:"path,omitempty"`
+	// VersionError is set when the executable is on PATH but `--version`
+	// failed — i.e. installed, but not runnable. A broken npm install whose
+	// platform binary never landed looks exactly like this (codex threw
+	// "Missing optional dependency @openai/codex-linux-x64" on every launch).
+	// Surfaced so the operator sees "installed but broken" instead of a
+	// blank version that reads as fine.
+	VersionError string `json:"versionError,omitempty"`
+	Path         string `json:"path,omitempty"`
 	LatestVersion    string `json:"latestVersion,omitempty"`
 	UpdateAvailable  bool   `json:"updateAvailable"`
 	CheckedAt        string `json:"checkedAt,omitempty"` // RFC3339; when LatestVersion was fetched
@@ -113,6 +120,10 @@ func (p *Prober) Installed(ctx context.Context, m Manifest) RuntimeInfo {
 		info.Path = path
 		if v, err := p.runVer(ctx, m.Executable); err == nil {
 			info.InstalledVersion = v
+		} else {
+			// On PATH but won't run. Record why, so the UI can say
+			// "broken" rather than showing an empty version.
+			info.VersionError = err.Error()
 		}
 	}
 
@@ -188,7 +199,17 @@ func (p *Prober) Update(ctx context.Context, m Manifest) (UpdateResult, error) {
 		return UpdateResult{Package: m.NpmPackage, BeforeVersion: before}, ErrUpdatePrefixReadonly
 	}
 
-	out, err := p.npmInstall(ctx, m.NpmPackage)
+	// Detach the install from the caller's cancellation. `ctx` here is the
+	// HTTP request's: when the client disconnects (browser closed, navigated
+	// away, proxy timeout) it is cancelled, and exec.CommandContext would
+	// then SIGKILL npm *mid-install*. A half-killed `npm install -g` leaves
+	// a partial global tree behind — a stale `.<pkg>-XXXXXX` temp dir — after
+	// which EVERY later install fails with ENOTEMPTY, permanently wedging
+	// updates for that CLI (this is exactly how a codex update stayed broken
+	// for a week). npmInstall still applies its own timeout.
+	installCtx := context.WithoutCancel(ctx)
+
+	out, err := p.npmInstall(installCtx, m.NpmPackage)
 
 	// The install may have changed what's on disk even on partial
 	// failure, so always drop the cached install state.
@@ -200,7 +221,9 @@ func (p *Prober) Update(ctx context.Context, m Manifest) (UpdateResult, error) {
 	if err != nil {
 		return res, fmt.Errorf("npm install -g %s: %w", m.NpmPackage, err)
 	}
-	res.AfterVersion = p.Installed(ctx, m).InstalledVersion
+	// Re-probe on the detached ctx too, so we still report a real
+	// AfterVersion when the client has already gone away.
+	res.AfterVersion = p.Installed(installCtx, m).InstalledVersion
 	res.Changed = res.AfterVersion != before
 	return res, nil
 }
@@ -255,6 +278,27 @@ func semverLess(a, b string) bool {
 
 // ── default probes (shell out) ───────────────────────────────────────
 
+// versionErrDetail picks the actionable line out of a failed `--version`
+// run. Broken CLIs commonly dump a stack trace whose first line is a file
+// path; the line that matters is the one starting with "Error". Falls back
+// to the first non-empty line.
+func versionErrDetail(stderr string) string {
+	var first string
+	for _, ln := range strings.Split(stderr, "\n") {
+		ln = strings.TrimSpace(ln)
+		if ln == "" {
+			continue
+		}
+		if strings.HasPrefix(ln, "Error") {
+			return ln
+		}
+		if first == "" {
+			first = ln
+		}
+	}
+	return first
+}
+
 func defaultCliVersion(ctx context.Context, bin string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 8*time.Second)
 	defer cancel()
@@ -262,6 +306,16 @@ func defaultCliVersion(ctx context.Context, bin string) (string, error) {
 	cmd.Env = append(os.Environ(), "NO_COLOR=1")
 	out, err := cmd.Output()
 	if err != nil {
+		// cmd.Output() captures stderr into ExitError.Stderr. A CLI that is
+		// installed but broken prints the actionable reason there (codex:
+		// "Error: Missing optional dependency @openai/codex-linux-x64").
+		// Carry it up instead of a bare "exit status 1".
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			if detail := versionErrDetail(string(ee.Stderr)); detail != "" {
+				return "", fmt.Errorf("%w: %s", err, detail)
+			}
+		}
 		return "", err
 	}
 	sc := bufio.NewScanner(strings.NewReader(string(out)))

--- a/internal/catalog/probe.go
+++ b/internal/catalog/probe.go
@@ -28,11 +28,11 @@ type RuntimeInfo struct {
 	// "Missing optional dependency @openai/codex-linux-x64" on every launch).
 	// Surfaced so the operator sees "installed but broken" instead of a
 	// blank version that reads as fine.
-	VersionError string `json:"versionError,omitempty"`
-	Path         string `json:"path,omitempty"`
-	LatestVersion    string `json:"latestVersion,omitempty"`
-	UpdateAvailable  bool   `json:"updateAvailable"`
-	CheckedAt        string `json:"checkedAt,omitempty"` // RFC3339; when LatestVersion was fetched
+	VersionError    string `json:"versionError,omitempty"`
+	Path            string `json:"path,omitempty"`
+	LatestVersion   string `json:"latestVersion,omitempty"`
+	UpdateAvailable bool   `json:"updateAvailable"`
+	CheckedAt       string `json:"checkedAt,omitempty"` // RFC3339; when LatestVersion was fetched
 	// ActiveSessions is the number of non-terminal sessions currently
 	// using this provider's CLI. Populated by the handler from the
 	// session manager (0 when the counter isn't wired). Surfaced so the

--- a/internal/catalog/probe_test.go
+++ b/internal/catalog/probe_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -146,5 +147,61 @@ func TestProber_UpdateReadonlyPrefix(t *testing.T) {
 	}
 	if installed {
 		t.Error("npm install must NOT run when the prefix is read-only")
+	}
+}
+
+// Regression: the update handler passes the HTTP request's context down to
+// `npm install -g`. If the client disconnects mid-install (browser closed,
+// proxy timeout), cancelling that ctx SIGKILLs npm — which leaves a partial
+// global tree (a stale `.<pkg>-XXXXXX` temp dir) that makes EVERY later
+// install fail with ENOTEMPTY. That is exactly how a codex update wedged
+// itself for a week. The install must be detached from the caller's
+// cancellation.
+func TestProber_UpdateDetachesInstallFromCallerCancellation(t *testing.T) {
+	p := NewProber()
+	p.lookPath = func(string) (string, error) { return "/usr/bin/codex", nil }
+	p.runVer = func(context.Context, string) (string, error) { return "0.1.0", nil }
+	p.npmRoot = func(context.Context) (string, error) { return "", nil }
+
+	var installCtxErr error
+	p.npmInstall = func(ctx context.Context, _ string) (string, error) {
+		installCtxErr = ctx.Err()
+		return "ok", nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // client already gone
+
+	m := Manifest{ID: "codex", Executable: "codex", NpmPackage: "@openai/codex"}
+	if _, err := p.Update(ctx, m); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if installCtxErr != nil {
+		t.Fatalf("install ctx was cancelled by the caller (%v) — npm would be SIGKILLed mid-install", installCtxErr)
+	}
+}
+
+// Regression: a CLI can be on PATH but not runnable — a broken npm install
+// missing its platform binary (codex threw "Missing optional dependency
+// @openai/codex-linux-x64"). Installed() must surface that instead of
+// silently reporting a blank version, which reads as "fine" in the UI.
+func TestProber_InstalledSurfacesBrokenCLI(t *testing.T) {
+	p := NewProber()
+	p.lookPath = func(string) (string, error) { return "/usr/bin/codex", nil }
+	p.runVer = func(context.Context, string) (string, error) {
+		return "", errors.New("exit status 1: Error: Missing optional dependency @openai/codex-linux-x64")
+	}
+	info := p.Installed(context.Background(), Manifest{ID: "codex", Executable: "codex"})
+	if !info.Installed {
+		t.Fatal("expected Installed=true (the binary is on PATH)")
+	}
+	if info.InstalledVersion != "" {
+		t.Fatalf("expected empty version for a broken CLI, got %q", info.InstalledVersion)
+	}
+	if info.VersionError == "" {
+		t.Fatal("expected VersionError to surface the broken CLI, got empty")
+	}
+	if !strings.Contains(info.VersionError, "Missing optional dependency") {
+		t.Fatalf("VersionError should carry the CLI's own message, got %q", info.VersionError)
 	}
 }


### PR DESCRIPTION
## The bug (found while debugging a wedged codex)

A user's codex updates silently failed for a **week**, and codex sessions failed too. Root cause chain:

1. `handler.go` ran `prober.Update(r.Context(), …)` — so `npm install -g` was bound to the **HTTP request context**.
2. When the client went away (browser closed, navigated off, proxy timeout), that ctx cancelled and `exec.CommandContext` **SIGKILLed npm mid-install** (`provider update failed … err="npm install -g @openai/codex: signal: killed"` — straight from the gateway log).
3. A half-killed `npm install -g` leaves a partial global tree — a stale `.<pkg>-XXXXXX` temp dir. After that, **every** later install fails with `ENOTEMPTY: directory not empty, rename …` (exit 217). Updates for that CLI are permanently wedged.
4. Meanwhile the npm *wrapper* had advanced but its **platform binary never landed** (those ship as `optionalDependencies`, which npm fails **silently**), so `codex` threw `Missing optional dependency @openai/codex-linux-x64` on every launch → sessions broke.
5. And none of it was visible: the UI **fell back to the manifest version** for the broken CLI, and the failure toast showed `exit status 217` while npm's real error sat unused in the 502 body.

## Fixes

**1. Detach the install from the caller's cancellation** (the root cause) — `context.WithoutCancel(ctx)`, so a client disconnect can't SIGKILL npm and corrupt the global tree. `npmInstall` keeps its own timeout. *Regression test asserts the install ctx is not cancelled even when the caller's already is.*

**2. Surface a broken CLI.** New `RuntimeInfo.VersionError`, set when the binary is on PATH but `--version` fails, carrying the CLI's **own stderr reason** (`versionErrDetail` pulls the actionable `Error:` line — e.g. *"Missing optional dependency @openai/codex-linux-x64"*). The web **no longer falls back to the manifest version** in that case — that rendered a CLI which can't even launch as perfectly healthy. It now shows an **"Installed but not runnable"** badge (hover = the reason). *Regression test.*

**3. Show npm's actual error** in the update-failure toast — the 502 already carried `result.output`; the UI just dropped it. Now the operator sees `… — npm error ENOTEMPTY: directory not empty, rename …` instead of a bare `exit status 217`.

## Corrections to my own first read

Worth recording: two theories I had were **wrong**, and the code disproved them — the npm timeout is already 5 minutes (not too short), and update errors *are* already returned (502 + npm output). The real defect was the request-context binding.

## Tests

Two regression tests (cancelled-caller ctx; broken-CLI surfacing) — both RED before, GREEN after. Full `internal/catalog` suite, `go vet`, `go build` clean. i18n: new `brokenCli` key in en/es/zh, parity check passes. Web typecheck via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)