### PR TITLE
feat(sessions): let TUIs follow the opendray theme + scroll with the wheel

### DIFF
--- a/app/shared/src/lib/sessions.ts
+++ b/app/shared/src/lib/sessions.ts
@@ -1,4 +1,5 @@
 import { api } from './api'
+import { useTheme } from '@/stores/theme'
 import type { CreateSessionRequest, Session } from './types'
 
 export async function listSessions(): Promise<Session[]> {
@@ -15,7 +16,12 @@ export async function createSession(
 ): Promise<Session> {
   return api<Session>('/api/v1/sessions', {
     method: 'POST',
-    body: req,
+    // Stamp the operator's applied theme so the gateway can advertise the
+    // terminal's background to the CLI (COLORFGBG), letting a TUI pick a
+    // matching light/dark palette instead of always defaulting to dark.
+    // Done here rather than at each call site so every spawn path gets it.
+    // An explicit theme on the request still wins.
+    body: { theme: useTheme.getState().applied(), ...req },
   })
 }
 

--- a/app/shared/src/lib/types.ts
+++ b/app/shared/src/lib/types.ts
@@ -39,6 +39,10 @@ export interface CreateSessionRequest {
   args?: string[]
   claude_account_id?: string
   parent_session_id?: string
+  /** Operator's applied theme. The gateway advertises it to the CLI via
+      COLORFGBG so a TUI can pick a matching light/dark palette. Stamped
+      automatically by createSession(); callers rarely set it. */
+  theme?: 'light' | 'dark'
 }
 
 // ── Claude accounts (OAuth-token-on-disk model, mirrors v1) ─

--- a/app/web/src/components/sessions/Terminal.tsx
+++ b/app/web/src/components/sessions/Terminal.tsx
@@ -286,10 +286,40 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     const onTouchEnd = () => {
       touchActive = false
     }
+    // Alternate-scroll — what a real terminal does, and what opendray was
+    // missing. In the alternate screen there is no xterm scrollback to
+    // scroll; and when the app has NOT grabbed the mouse it never receives
+    // the wheel either. So the wheel silently did nothing and the
+    // conversation could not be scrolled at all (grok: its TUI ignores the
+    // mouse but honours PageUp/arrows). xterm/iTerm translate wheel notches
+    // into cursor Up/Down keys in exactly this situation — do the same, so
+    // any alt-screen TUI that honours arrows scrolls with the wheel.
+    //
+    // Apps that DO grab the mouse (Claude Code / Codex / Antigravity) are
+    // untouched: they already receive the wheel as SGR events, and the guard
+    // below leaves those alone. The normal (non-alt) buffer is untouched too
+    // — xterm's own scrollback already handles it.
+    const WHEEL_LINES = 3
+    const onWheel = (e: WheelEvent) => {
+      if (term.buffer.active.type !== 'alternate') return
+      if (term.modes.mouseTrackingMode !== 'none') return
+      if (e.deltaY === 0) return
+      e.preventDefault()
+      const seq = (e.deltaY < 0 ? '\x1b[A' : '\x1b[B').repeat(WHEEL_LINES)
+      const enc = new TextEncoder().encode(seq)
+      ws.send(
+        enc.buffer.slice(
+          enc.byteOffset,
+          enc.byteOffset + enc.byteLength,
+        ) as ArrayBuffer,
+      )
+    }
+
     touchHost?.addEventListener('touchstart', onTouchStart, { passive: true })
     touchHost?.addEventListener('touchmove', onTouchMove, { passive: false })
     touchHost?.addEventListener('touchend', onTouchEnd, { passive: true })
     touchHost?.addEventListener('touchcancel', onTouchEnd, { passive: true })
+    touchHost?.addEventListener('wheel', onWheel, { passive: false })
 
     // Coalesce resize bursts into one fit per animation frame. Calling
     // fit() synchronously inside the ResizeObserver callback mutates
@@ -344,6 +374,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       touchHost?.removeEventListener('touchmove', onTouchMove)
       touchHost?.removeEventListener('touchend', onTouchEnd)
       touchHost?.removeEventListener('touchcancel', onTouchEnd)
+      touchHost?.removeEventListener('wheel', onWheel)
       ro.disconnect()
       vv?.removeEventListener('resize', scheduleFit)
       vv?.removeEventListener('scroll', scheduleFit)

--- a/internal/session/color_term_test.go
+++ b/internal/session/color_term_test.go
@@ -34,3 +34,38 @@ func TestEnsureColorTerm(t *testing.T) {
 		}
 	})
 }
+
+// A TUI picks a light or dark palette by asking the terminal. Two routes
+// exist: the OSC 11 background query (xterm.js answers that already) and
+// the COLORFGBG environment variable. opendray never set COLORFGBG, so a
+// CLI that only reads the env (grok's `theme = "auto"`, vim, tmux, …) had
+// no way to know the operator was in light mode and defaulted to dark.
+func TestEnsureThemeEnv(t *testing.T) {
+	base := []string{"PATH=/bin"}
+
+	// COLORFGBG is "<fg>;<bg>" as colour indices; readers key off the
+	// trailing background field (0 = dark, 15 = light).
+	dark := ensureThemeEnv(base, "dark")
+	if !slices.Contains(dark, "COLORFGBG=15;0") {
+		t.Fatalf("dark theme should advertise a dark background, got %v", dark)
+	}
+
+	light := ensureThemeEnv(base, "light")
+	if !slices.Contains(light, "COLORFGBG=0;15") {
+		t.Fatalf("light theme should advertise a light background, got %v", light)
+	}
+
+	// Unknown/empty theme: say nothing, leave the CLI to its own default.
+	for _, theme := range []string{"", "solarized"} {
+		got := ensureThemeEnv(base, theme)
+		if len(got) != len(base) {
+			t.Fatalf("theme %q should not set COLORFGBG, got %v", theme, got)
+		}
+	}
+
+	// An explicit COLORFGBG already in the environment wins.
+	pinned := ensureThemeEnv([]string{"COLORFGBG=7;0"}, "light")
+	if slices.Contains(pinned, "COLORFGBG=0;15") {
+		t.Fatalf("an explicit COLORFGBG must not be overridden, got %v", pinned)
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -574,6 +574,7 @@ func (m *Manager) Create(ctx context.Context, req CreateRequest) (Session, error
 		Model:                req.Model,
 		Cwd:                  req.Cwd,
 		Args:                 req.Args,
+		Theme:                req.Theme,
 		State:                StateRunning,
 		ClaudeAccountID:      req.ClaudeAccountID,
 		AntigravityAccountID: req.AntigravityAccountID,
@@ -773,7 +774,7 @@ func (m *Manager) spawn(ctx context.Context, sess Session, reactivate bool) (*ru
 
 	cmd := exec.Command(p.Executable, args...)
 	cmd.Dir = sess.Cwd
-	cmd.Env = mergeEnv(ensureColorTerm(os.Environ()), extraEnv)
+	cmd.Env = mergeEnv(ensureThemeEnv(ensureColorTerm(os.Environ()), sess.Theme), extraEnv)
 
 	ptmx, err := pty.Start(cmd)
 	if err != nil {
@@ -921,6 +922,37 @@ func ensureColorTerm(env []string) []string {
 		env = append(env, "COLORTERM=truecolor")
 	}
 	return env
+}
+
+// ensureThemeEnv advertises the client terminal's background brightness so
+// a TUI can pick a matching light/dark palette.
+//
+// TUIs auto-detect this two ways: the OSC 11 background query (xterm.js
+// answers that for us already) and the COLORFGBG environment variable.
+// opendray only ever set TERM/COLORTERM, so a CLI that reads the env —
+// grok's `theme = "auto"`, vim, tmux, … — had no way to know the operator
+// was in light mode and fell back to dark. This closes that gap for every
+// provider, not just one.
+//
+// theme is the operator's applied opendray theme ("light"/"dark"); anything
+// else (including empty, e.g. an older client or an API caller that didn't
+// send one) sets nothing and leaves the CLI to its own default. An explicit
+// COLORFGBG already in the environment always wins.
+func ensureThemeEnv(env []string, theme string) []string {
+	if theme != "light" && theme != "dark" {
+		return env
+	}
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "COLORFGBG=") {
+			return env
+		}
+	}
+	// COLORFGBG is "<fg>;<bg>" as colour indices. Readers key off the
+	// trailing background field: 0 reads as a dark background, 15 as light.
+	if theme == "light" {
+		return append(env, "COLORFGBG=0;15")
+	}
+	return append(env, "COLORFGBG=15;0")
 }
 
 func mergeEnv(base []string, overrides map[string]string) []string {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -62,13 +62,17 @@ type Session struct {
 	// Model pins the model this session spawns against, applied at
 	// spawn via the provider's model flag. Empty falls back to the
 	// provider config default. See CreateRequest.Model.
-	Model           string   `json:"model,omitempty"`
-	Cwd             string   `json:"cwd"`
-	Args            []string `json:"args"`
-	State           State    `json:"state"`
-	PID             int      `json:"pid,omitempty"`
-	ClaudeAccountID string   `json:"claude_account_id,omitempty"`
-	ClaudeSessionID string   `json:"claude_session_id,omitempty"`
+	Model string   `json:"model,omitempty"`
+	Cwd   string   `json:"cwd"`
+	Args  []string `json:"args"`
+	// Theme is the operator's applied opendray theme ("light"/"dark") at
+	// spawn time. Advertised to the CLI via COLORFGBG so a TUI can pick a
+	// matching palette. Empty = unknown; the CLI keeps its own default.
+	Theme           string `json:"theme,omitempty"`
+	State           State  `json:"state"`
+	PID             int    `json:"pid,omitempty"`
+	ClaudeAccountID string `json:"claude_account_id,omitempty"`
+	ClaudeSessionID string `json:"claude_session_id,omitempty"`
 	// AntigravityAccountID is the agyacct account this session is pinned
 	// to (provider "antigravity"). Empty means the CLI's default HOME
 	// (~/.gemini). Mirrors ClaudeAccountID for the agy provider, whose
@@ -118,6 +122,10 @@ type CreateRequest struct {
 	ParentSessionID      string   `json:"parent_session_id,omitempty"`
 	Cwd                  string   `json:"cwd"`
 	Args                 []string `json:"args"`
+	// Theme is the client's applied theme ("light"/"dark"). Optional: an
+	// older client or an API caller may omit it, in which case opendray
+	// advertises nothing and the CLI keeps its own default.
+	Theme string `json:"theme,omitempty"`
 
 	// origin/integrationID are unexported on purpose: they are derived
 	// from the authenticated principal by the HTTP handler (SetOrigin)
@@ -139,6 +147,9 @@ func (r CreateRequest) Validate() error {
 	}
 	if r.Cwd == "" {
 		return errors.New("cwd is required")
+	}
+	if r.Theme != "" && r.Theme != "light" && r.Theme != "dark" {
+		return errors.New(`theme must be "light" or "dark"`)
 	}
 	return nil
 }


### PR DESCRIPTION
Two terminal gaps surfaced in a Grok session — but **neither is Grok-specific**, so both fixes are generic and every TUI benefits.

## 1. TUIs never learned the opendray theme

A TUI picks a light/dark palette by **asking the terminal**, two ways:
- the **OSC 11** background query — xterm.js already answers this ✅
- the **`COLORFGBG`** env var — opendray **never set it** ❌ (`manager.go` only ever injected `TERM`/`COLORTERM`)

So a CLI that reads the env had no way to know you were in light mode and defaulted to dark. Grok is a perfect example: it ships `theme = "auto"` with `auto_light_theme`/`auto_dark_theme`, and its binary reads **both** `COLORFGBG` and OSC 11 — but opendray told it nothing. Same for vim, tmux, and friends.

**Fix:** stamp the operator's applied theme on session create and advertise it at spawn via `COLORFGBG` (`0;15` light / `15;0` dark — readers key off the trailing background index).

- **Backward compatible:** theme is optional. No theme (older client, API caller, mobile) → nothing advertised, CLI keeps its own default.
- An explicit `COLORFGBG` already in the env **still wins**.
- Stamped inside the shared `createSession()`, so *every* spawn path gets it with no call-site changes.

## 2. The wheel did nothing in a full-screen TUI

In the **alternate screen** there's no xterm scrollback to scroll — and when the app hasn't grabbed the mouse, it never receives the wheel either. Net effect: **the wheel silently does nothing**, and a Grok conversation can't be scrolled at all. (Grok's TUI ignores the mouse but honours arrows/PageUp — it has a full scroll system: `scroll up/down`, `half page`, `page up/down`, `go to top/bottom`.)

**Fix:** implement **alternate-scroll**, exactly what xterm/iTerm do — translate wheel notches into cursor **Up/Down** keys when in the alt screen *and* the app hasn't grabbed the mouse.

- Apps that **do** grab the mouse (Claude Code, Codex, Antigravity) are **untouched** — they already get SGR wheel events.
- The **normal buffer** is untouched — xterm's own scrollback still handles it.

## Tests

`TestEnsureThemeEnv` covers light/dark advertisement, an unknown/empty theme staying silent, and an explicit `COLORFGBG` not being overridden. Full `internal/session` suite, `go vet`, `go build`, `gofmt` clean. Web compiles via CI.

> **Note:** the alt-scroll change is browser behaviour I can't exercise headlessly — worth an eyeball after merge (wheel should scroll Grok; Claude/Codex should behave exactly as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)