### PR TITLE
docs(changelog): v2.11.6 — files-tree download icon reachable again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+## [v2.11.6] — 2026-07-13
+
+### Fixed
+
+- **The download icon is reachable again in a deep or long file tree.** The
+  session inspector's Files tree renders inside a scroll area whose inner
+  wrapper sizes to its content, so long filenames and deep nesting pushed
+  rows wider than the panel: names were hard-cut with no ellipsis, and the
+  hover-download icon — anchored to each row's right edge — sat beyond the
+  visible edge, so hovering a file appeared to do nothing. The tree is now
+  constrained to the panel width, so names truncate with an ellipsis and the
+  download icon sits at the visible right edge. The Database tab is
+  unaffected (its grid scrolls in its own containers). (#443)
+
 ## [v2.11.5] — 2026-07-13
 
 ### Added


### PR DESCRIPTION
Release bump for **v2.11.6** (patch). Moves `[Unreleased]` → `[v2.11.6]` (2026-07-13).

**Fixed**
- **Files-sidebar download icon reachable in a deep/long tree** (#443) — the tree overflowed the panel horizontally (names hard-cut, no ellipsis), pushing the hover-download icon past the visible right edge. Now constrained to the panel width so names truncate and the icon is visible. Database tab unaffected.

Changelog-only change. On merge I'll tag `v2.11.6` → goreleaser + opendray.dev auto-rebuild.

> Shipping so the reporter can visually confirm the fix on their gateway — the layout change couldn't be verified headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)