### PR TITLE
fix(catalog): let the Providers page update the Grok CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Grok now reports and applies CLI updates from the Providers page.** The
+  `grok` manifest carried an empty `npmPackage`, and the whole update path is
+  npm-gated: `CheckUpdate` returned early (no latest version, no
+  "update available" flag) and `Update` hard-errored with "not updatable via
+  npm". Grok is published as `@xai-official/grok` (maintainer
+  `xai-security@x.ai`), so the manifest now names it.
+- **A provider CLI installed outside npm can now be updated in place.** Grok's
+  documented installer (`curl -fsSL https://x.ai/cli/install.sh | bash`) drops
+  a symlink into the npm bin dir that npm does not own, and npm refuses to
+  clobber it — `EEXIST: file already exists`. Simply naming the package would
+  therefore have shipped a dashboard that advertises an update behind a button
+  that always fails. `Update` now preflights the bin path: an unmanaged
+  **symlink** is cleared so npm can take ownership (and the update output tells
+  the operator exactly which link was replaced), while a regular **file** is
+  never deleted — it is reported instead, mirroring the existing
+  `ErrUpdatePrefixReadonly` preflight. Grok's install note now recommends
+  `npm install -g @xai-official/grok`.
+
 ## [v2.11.6] — 2026-07-13
 
 ### Fixed

--- a/internal/catalog/builtin/grok.json
+++ b/internal/catalog/builtin/grok.json
@@ -9,7 +9,7 @@
   "version": "1.0.0",
   "kind": "cli",
   "executable": "grok",
-  "npmPackage": "",
+  "npmPackage": "@xai-official/grok",
   "modelFlag": "--model",
   "knownModels": [
     "grok-build",
@@ -28,8 +28,8 @@
       "label_zh": "认证",
       "type": "note",
       "group": "auth",
-      "description": "Grok signs in with your xAI account. Install the CLI on the gateway host with `curl -fsSL https://x.ai/cli/install.sh | bash`, then run `grok login` once as the opendray user (or set GROK_DEPLOYMENT_KEY). Credentials are written to ~/.grok/auth.json, which the daemon reads at spawn time. No API key is set here.",
-      "description_zh": "Grok 使用你的 xAI 账号登录。在网关主机上用 `curl -fsSL https://x.ai/cli/install.sh | bash` 安装 CLI，然后以 opendray 用户身份运行一次 `grok login`（或设置 GROK_DEPLOYMENT_KEY）。凭据写入 ~/.grok/auth.json，守护进程在启动会话时读取。此处无需填写 API 密钥。"
+      "description": "Grok signs in with your xAI account. Install the CLI on the gateway host with `npm install -g @xai-official/grok` (preferred — lets opendray check for and apply updates from the Providers page), then run `grok login` once as the opendray user (or set GROK_DEPLOYMENT_KEY). The x.ai installer script (`curl -fsSL https://x.ai/cli/install.sh | bash`) also works; opendray will migrate it to npm on the first update. Credentials are written to ~/.grok/auth.json, which the daemon reads at spawn time. No API key is set here.",
+      "description_zh": "Grok 使用你的 xAI 账号登录。在网关主机上用 `npm install -g @xai-official/grok` 安装 CLI（推荐 —— 这样 opendray 才能在「提供方」页面检查并应用更新），然后以 opendray 用户身份运行一次 `grok login`（或设置 GROK_DEPLOYMENT_KEY）。也可使用 x.ai 安装脚本（`curl -fsSL https://x.ai/cli/install.sh | bash`）；opendray 会在首次更新时将其迁移到 npm。凭据写入 ~/.grok/auth.json，守护进程在启动会话时读取。此处无需填写 API 密钥。"
     },
     {
       "key": "bypassPermissions",

--- a/internal/catalog/probe.go
+++ b/internal/catalog/probe.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -193,10 +194,35 @@ func (p *Prober) Update(ctx context.Context, m Manifest) (UpdateResult, error) {
 
 	before := p.Installed(ctx, m).InstalledVersion
 
-	// Preflight: if the npm global dir isn't writable by this (unprivileged)
-	// process, an install would just EACCES — report it cleanly instead.
-	if dir, derr := p.npmRoot(ctx); derr == nil && dir != "" && !dirWritable(dir) {
-		return UpdateResult{Package: m.NpmPackage, BeforeVersion: before}, ErrUpdatePrefixReadonly
+	var migrated string
+	if dir, derr := p.npmRoot(ctx); derr == nil && dir != "" {
+		// Preflight: if the npm global dir isn't writable by this (unprivileged)
+		// process, an install would just EACCES — report it cleanly instead.
+		if !dirWritable(dir) {
+			return UpdateResult{Package: m.NpmPackage, BeforeVersion: before}, ErrUpdatePrefixReadonly
+		}
+
+		// Preflight: a CLI installed by a vendor script rather than npm (grok's
+		// `curl -fsSL https://x.ai/cli/install.sh | bash`) leaves a symlink in
+		// the npm bin dir that npm does not own. npm refuses to clobber it —
+		// `EEXIST: file already exists` — so the install dies and the operator
+		// is left on the old binary with an Update button that never works.
+		// Clear the link so npm can take ownership; the CLI becomes npm-managed
+		// like every other provider. Only ever a symlink: a regular file there
+		// was put by a human or another package manager, and we refuse rather
+		// than delete it.
+		if link, isFile := unmanagedBinLink(dir, m.Executable); link != "" {
+			if isFile {
+				return UpdateResult{Package: m.NpmPackage, BeforeVersion: before}, fmt.Errorf(
+					"%s exists and was not installed by npm; remove it to let opendray manage %s updates",
+					link, m.ID)
+			}
+			if rmErr := os.Remove(link); rmErr != nil {
+				return UpdateResult{Package: m.NpmPackage, BeforeVersion: before}, fmt.Errorf(
+					"clearing non-npm %s link at %s: %w", m.ID, link, rmErr)
+			}
+			migrated = link
+		}
 	}
 
 	// Detach the install from the caller's cancellation. `ctx` here is the
@@ -218,6 +244,12 @@ func (p *Prober) Update(ctx context.Context, m Manifest) (UpdateResult, error) {
 	p.mu.Unlock()
 
 	res := UpdateResult{Package: m.NpmPackage, BeforeVersion: before, Output: tailLines(out, 40)}
+	if migrated != "" {
+		// Say what we replaced: the operator installed this CLI by hand, and
+		// silently repointing their binary would be a surprise.
+		res.Output = fmt.Sprintf("replaced non-npm %s at %s (now managed by npm)\n%s",
+			m.Executable, migrated, res.Output)
+	}
 	if err != nil {
 		return res, fmt.Errorf("npm install -g %s: %w", m.NpmPackage, err)
 	}
@@ -351,6 +383,43 @@ func defaultNpmRoot(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// unmanagedBinLink reports the npm-prefix bin entry for exe when that entry
+// exists but npm does not own it, so `npm install -g` would fail with EEXIST.
+//
+// npmRoot is `npm root -g` (<prefix>/lib/node_modules); the executables live
+// in <prefix>/bin. An entry is npm-owned when it resolves back inside
+// npmRoot — that is what npm's own bin shim looks like. Anything else was put
+// there by a vendor installer (grok's x.ai script points at ~/.grok/downloads).
+//
+// Returns ("", false) when the path is clear or already npm's. isFile is true
+// for a regular file, which the caller must refuse to delete rather than
+// silently replace someone's binary. A dangling symlink is reported as
+// replaceable — it is already broken.
+func unmanagedBinLink(npmRoot, exe string) (path string, isFile bool) {
+	if npmRoot == "" || exe == "" {
+		return "", false
+	}
+	// <prefix>/lib/node_modules -> <prefix> -> <prefix>/bin
+	binDir := filepath.Join(filepath.Dir(filepath.Dir(npmRoot)), "bin")
+	p := filepath.Join(binDir, exe)
+
+	fi, err := os.Lstat(p)
+	if err != nil {
+		return "", false // nothing there: npm installs cleanly
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		return p, true // a real file — report, never remove
+	}
+	dest, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		return p, false // dangling — safe to replace
+	}
+	if dest == npmRoot || strings.HasPrefix(dest, npmRoot+string(os.PathSeparator)) {
+		return "", false // npm's own shim
+	}
+	return p, false // vendor installer's link
 }
 
 // dirWritable reports whether dir exists and the current process can

--- a/internal/catalog/probe_binlink_test.go
+++ b/internal/catalog/probe_binlink_test.go
@@ -1,0 +1,194 @@
+package catalog
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// npmPrefix builds a realistic npm global layout under a temp dir and
+// returns (npmRoot, binDir). `npm root -g` reports <prefix>/lib/node_modules;
+// the executables live in <prefix>/bin.
+func npmPrefix(t *testing.T) (root, bin string) {
+	t.Helper()
+	prefix := t.TempDir()
+	root = filepath.Join(prefix, "lib", "node_modules")
+	bin = filepath.Join(prefix, "bin")
+	for _, d := range []string{root, bin} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root, bin
+}
+
+func TestUnmanagedBinLink_NothingInstalled(t *testing.T) {
+	root, _ := npmPrefix(t)
+	link, isFile := unmanagedBinLink(root, "grok")
+	if link != "" || isFile {
+		t.Errorf("empty bin dir must be clear for npm; got link=%q isFile=%v", link, isFile)
+	}
+}
+
+func TestUnmanagedBinLink_NpmOwnedLinkIsLeftAlone(t *testing.T) {
+	root, bin := npmPrefix(t)
+	// What npm itself creates: bin/grok -> ../lib/node_modules/<pkg>/bin/grok
+	target := filepath.Join(root, "@xai-official", "grok", "bin", "grok")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(bin, "grok")); err != nil {
+		t.Fatal(err)
+	}
+
+	link, isFile := unmanagedBinLink(root, "grok")
+	if link != "" || isFile {
+		t.Errorf("npm-owned link must not be reported as unmanaged; got link=%q isFile=%v", link, isFile)
+	}
+}
+
+// The grok case: `curl -fsSL https://x.ai/cli/install.sh | bash` drops a
+// symlink into the npm bin dir that points at its own download tree. npm
+// refuses to overwrite a bin entry it does not own (EEXIST), so the update
+// fails and silently leaves the old binary in place.
+func TestUnmanagedBinLink_VendorInstallerLinkIsReported(t *testing.T) {
+	root, bin := npmPrefix(t)
+	vendor := filepath.Join(t.TempDir(), "grok-downloads", "grok")
+	if err := os.MkdirAll(filepath.Dir(vendor), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(vendor, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(bin, "grok")
+	if err := os.Symlink(vendor, want); err != nil {
+		t.Fatal(err)
+	}
+
+	link, isFile := unmanagedBinLink(root, "grok")
+	if link != want {
+		t.Errorf("vendor symlink not reported: got %q, want %q", link, want)
+	}
+	if isFile {
+		t.Error("a symlink must not be reported as a regular file")
+	}
+}
+
+func TestUnmanagedBinLink_DanglingLinkIsReplaceable(t *testing.T) {
+	root, bin := npmPrefix(t)
+	want := filepath.Join(bin, "grok")
+	if err := os.Symlink(filepath.Join(t.TempDir(), "gone"), want); err != nil {
+		t.Fatal(err)
+	}
+
+	link, isFile := unmanagedBinLink(root, "grok")
+	if link != want || isFile {
+		t.Errorf("dangling link should be replaceable; got link=%q isFile=%v", link, isFile)
+	}
+}
+
+// A real file (not a symlink) is something a human or another package
+// manager put there deliberately. We must report it but never delete it.
+func TestUnmanagedBinLink_RegularFileIsFlaggedNotDeletable(t *testing.T) {
+	root, bin := npmPrefix(t)
+	want := filepath.Join(bin, "grok")
+	if err := os.WriteFile(want, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	link, isFile := unmanagedBinLink(root, "grok")
+	if link != want {
+		t.Errorf("regular file not reported: got %q, want %q", link, want)
+	}
+	if !isFile {
+		t.Error("a regular file must be flagged as such so Update refuses to remove it")
+	}
+}
+
+// End-to-end: Update must clear the vendor symlink so `npm install -g`
+// doesn't die with EEXIST, and must tell the operator it did so.
+func TestProber_UpdateReplacesVendorBinLink(t *testing.T) {
+	root, bin := npmPrefix(t)
+	vendor := filepath.Join(t.TempDir(), "grok")
+	if err := os.WriteFile(vendor, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(bin, "grok")
+	if err := os.Symlink(vendor, link); err != nil {
+		t.Fatal(err)
+	}
+
+	installs := 0
+	p := NewProber()
+	p.lookPath = func(string) (string, error) { return link, nil }
+	p.runVer = func(context.Context, string) (string, error) { return "grok 0.2.101 (5bc4b5dfad)", nil }
+	p.npmRoot = func(context.Context) (string, error) { return root, nil }
+	p.npmInstall = func(_ context.Context, pkg string) (string, error) {
+		installs++
+		if _, err := os.Lstat(link); !os.IsNotExist(err) {
+			t.Error("the unmanaged bin link must be gone BEFORE npm install runs (else EEXIST)")
+		}
+		return "added 3 packages", nil
+	}
+
+	res, err := p.Update(context.Background(),
+		Manifest{ID: "grok", Executable: "grok", NpmPackage: "@xai-official/grok"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installs != 1 {
+		t.Fatalf("expected one npm install, got %d", installs)
+	}
+	if !strings.Contains(res.Output, link) {
+		t.Errorf("operator must be told which unmanaged link was replaced; output=%q", res.Output)
+	}
+}
+
+func TestProber_UpdateRefusesToDeleteRegularBinFile(t *testing.T) {
+	root, bin := npmPrefix(t)
+	real := filepath.Join(bin, "grok")
+	if err := os.WriteFile(real, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	installed := false
+	p := NewProber()
+	p.lookPath = func(string) (string, error) { return real, nil }
+	p.runVer = func(context.Context, string) (string, error) { return "grok 0.2.101", nil }
+	p.npmRoot = func(context.Context) (string, error) { return root, nil }
+	p.npmInstall = func(context.Context, string) (string, error) { installed = true; return "", nil }
+
+	_, err := p.Update(context.Background(),
+		Manifest{ID: "grok", Executable: "grok", NpmPackage: "@xai-official/grok"})
+	if err == nil {
+		t.Fatal("Update must refuse when the bin entry is a real file it did not create")
+	}
+	if installed {
+		t.Error("npm install must not run when we cannot clear the bin path")
+	}
+	if _, statErr := os.Stat(real); statErr != nil {
+		t.Error("Update must never delete a regular file it did not create")
+	}
+}
+
+// grok ships as @xai-official/grok on npm (maintainer xai-security@x.ai).
+// Without the package name the whole update path is dead: CheckUpdate
+// returns early and the dashboard can never offer an update.
+func TestBuiltinGrokIsUpdatable(t *testing.T) {
+	manifests, _, err := LoadBuiltin()
+	if err != nil {
+		t.Fatalf("LoadBuiltin: %v", err)
+	}
+	m, ok := manifests["grok"]
+	if !ok {
+		t.Fatal("grok manifest not found in builtins")
+	}
+	if m.NpmPackage != "@xai-official/grok" {
+		t.Fatalf("grok manifest npmPackage = %q, want %q", m.NpmPackage, "@xai-official/grok")
+	}
+}


### PR DESCRIPTION
## The bug

Grok never shows an available update in the Providers page, and the operator has no way to update it from the dashboard.

`grok.json` carried an empty `npmPackage` — and opendray's **entire** update path is npm-gated:

```go
func (p *Prober) CheckUpdate(...) RuntimeInfo {
    info := p.Installed(ctx, m)
    if m.NpmPackage == "" { return info }   // ← grok exits here: no latest, no flag
    ...
}
func (p *Prober) Update(...) (UpdateResult, error) {
    if m.NpmPackage == "" {
        return UpdateResult{}, fmt.Errorf("provider %q is not updatable via npm", m.ID)
    }
```

So the dashboard could never surface an update, and the button could never work.

## Why the one-line fix would have been worse than nothing

Grok **is** on npm — `@xai-official/grok`, maintainer `xai-security@x.ai`, 21k downloads/week, `latest` matching the shipped binary. Naming it makes detection work.

But Grok's *documented* install is `curl -fsSL https://x.ai/cli/install.sh | bash`, which drops a symlink into the npm bin dir pointing at `~/.grok/downloads/…`. npm doesn't own that link and **refuses to clobber it**. Reproduced in a sandbox against the real registry:

```
npm error EEXIST: file already exists
npm error File exists: .../bin/grok
npm error Remove the existing file and try again, or run npm with --force
```

The install fails and the operator is **silently left on the old binary**. Setting `npmPackage` alone would have shipped a dashboard that advertises an update behind a button that always fails.

## The fix

1. `grok.json`: `npmPackage: "@xai-official/grok"` → update detection works.
2. `Update()` gains a bin-path preflight, sitting alongside the existing read-only-prefix check:
   - an unmanaged **symlink** is cleared so npm can take ownership, and the update output names the link that was replaced (the operator installed that binary by hand — silently repointing it would be a surprise);
   - a regular **file** is never deleted. It was put there deliberately, so we report it and refuse — mirroring `ErrUpdatePrefixReadonly` rather than inventing a new failure mode.
3. Grok's install note now recommends `npm install -g @xai-official/grok`, since the curl script is what creates the unmanaged link in the first place. The script still works — the first update migrates it to npm.

`extractSemver` already handles grok's `grok 0.2.101 (5bc4b5dfad)` format, so no version-parsing change was needed (covered by a test).

## Verification

- 8 new tests, written first and watched fail (TDD). They cover: empty bin dir, npm-owned shim (left alone), vendor symlink (reported), dangling symlink (replaceable), regular file (flagged, never deleted), the end-to-end migrate-then-install, the refuse-to-delete path, and the manifest itself.
- The end-to-end test asserts the link is gone **before** `npmInstall` runs — that's the EEXIST guarantee.
- Full suite green (45 packages), `gofmt`/`go vet` clean.
- Verified against the real npm registry in a sandbox prefix: `npm install -g @xai-official/grok` → working `grok 0.2.101 (5bc4b5dfad)`; and reproducing the curl-installed symlink reproduces EEXIST exactly.

## Note

`antigravity` also has an empty `npmPackage` and is therefore equally un-updatable — but `agy` isn't distributed on npm, so it needs a different mechanism. Left out of scope deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)