### PR TITLE
feat(session): frozen state-machine transition matrix (SSOT) + guard wiring

### DIFF
--- a/docs/design/session-state-machine.md
+++ b/docs/design/session-state-machine.md
@@ -1,0 +1,204 @@
+# Session State Machine Hardening
+
+Status: **Phase 1 — design frozen, SSOT landed (guard not yet wired)**
+Owner: opendray gateway
+Last updated: 2026-07-14
+
+This is the load-bearing first step of the "harden the foundation before
+orchestration" plan. Context-level backup/restore, the audit/cost panel,
+and any future multi-model orchestration all depend on a **trustworthy**
+session state, so the state machine is hardened first.
+
+Priority order for the whole plan (orchestration is explicitly deferred):
+
+1. **Session state-machine hardening** ← this document
+2. Context-level backup / restore (cwd snapshot + uncommitted diff + input history)
+3. Audit panel (cost / quota stats + multimodal Artifacts tracking)
+4. _(parked)_ Multi-model orchestration (fan-out one task to N models, merge)
+
+---
+
+## 1. States
+
+Persisted in `sessions.state` (TEXT). Unchanged by this phase — the enum
+values below already exist in `internal/session/session.go`.
+
+| State         | Terminal | Meaning |
+|---------------|:--------:|---------|
+| `pending`     | no  | Row created, PTY not yet live (transient). |
+| `running`     | no  | PTY live, agent active. |
+| `idle`        | no  | PTY live, no activity past the idle threshold. |
+| `stopped`     | yes | Operator explicitly stopped it (`Manager.Stop` / DELETE-as-stop). Restartable. |
+| `ended`       | yes | Process exited on its own (clean exit or child crash). Restartable. |
+| `interrupted` | yes | Was live when the **gateway** process exited; PTY died with the daemon. Auto-resumed on next startup. |
+
+`interrupted` is the ambiguous one. This phase **refines** it into three
+recovery classes (below) without adding new persisted enum values.
+
+### Zero State
+
+`""` is the pre-persistence State of a freshly-constructed session. Only
+`start` is legal from it; you cannot stop / exit / interrupt a session
+that never spawned. Note `pending` (a *persisted* row whose spawn is in
+flight) is distinct: it is terminatable but **not** startable — a second
+`start` would race the first spawn for the same cwd.
+
+---
+
+## 2. `interrupted` sub-states (frozen)
+
+The single `interrupted` state conflated three genuinely different
+situations that need different recovery. Naming per antigravity, endorsed
+by all three reviewers. Modelled as `InterruptReason` refining
+`StateInterrupted` — **not** as new persisted enum values (so no migration
+is required to freeze the taxonomy; persisting the reason is a later,
+additive column).
+
+| Reason         | Observed reality | Recovery strategy |
+|----------------|------------------|-------------------|
+| `disconnected` | WS transport dropped, **process healthy** | `wait_reattach`: silently buffer incremental output, wait for re-attach. **Do NOT respawn** — that abandons a live, working process. |
+| `orphaned`     | Gateway restarted, CLI left as an **orphan (still alive)** | `adopt_pid`: reconcile probes the OS for the recorded PID and **adopts** it if alive, rather than blindly respawning. |
+| `crashed`      | Process is **gone** | `rollback`: treat as failed, roll back to the last checkpoint (or respawn with `--resume` where the provider supports it). |
+
+### Classification is truth, not guess
+
+```
+ClassifyInterrupt(procAlive, gatewayRestarted):
+    !procAlive               -> crashed      (a dead process is always crashed)
+    procAlive && gwRestarted -> orphaned     (adoptable)
+    procAlive && !gwRestarted-> disconnected (transport only)
+```
+
+**Reconcile = truth-check, not guess.** The DB row records *intent*; the
+OS process table / WS liveness / event stream are *reality*. Reconcile
+must observe the facts and write the truth back — never infer state from
+the stale DB value alone.
+
+---
+
+## 3. Transition matrix (frozen)
+
+Encoded as the single source of truth in
+`internal/session/transitions.go` (`Next(state, event) (State, error)`)
+and pinned cell-by-cell in `transitions_test.go`. `-` = **illegal**
+(`Next` returns `ErrIllegalTransition`, State unchanged). Cells equal to
+the row State are **idempotent no-ops**.
+
+| from \ event   | `start`     | `idle`  | `resume`  | `user_stop`   | `exit`        | `gateway_shutdown` |
+|----------------|-------------|---------|-----------|---------------|---------------|--------------------|
+| `""` (zero)    | running     | –       | –         | –             | –             | –                  |
+| `pending`      | – (spawning)| –       | –         | stopped       | ended         | interrupted        |
+| `running`      | – (already) | idle    | running·  | stopped       | ended         | interrupted        |
+| `idle`         | – (already) | idle·   | running   | stopped       | ended         | interrupted        |
+| `stopped`      | running     | –       | –         | stopped·      | stopped·      | stopped·           |
+| `ended`        | running     | –       | –         | ended·        | ended·        | ended·             |
+| `interrupted`  | running     | –       | –         | interrupted·  | interrupted·  | interrupted·       |
+
+`·` marks an idempotent no-op.
+
+### Guard + idempotency guarantees
+
+- **Guarded**: illegal jumps are rejected (`ended -> running` via `idle`;
+  `start` on an already-running session, i.e. `ErrAlreadyRunning`; any
+  `idle`/`resume` on a terminal row).
+- **Idempotent**: repeat exit-detector wakeups, a double `Stop`, or a
+  `gateway_shutdown` racing a session that already exited are all no-ops.
+  The termination precedence (user stop ▷ gateway shutdown ▷ spontaneous
+  exit) means a user stop is **never** overwritten by a later shutdown —
+  this reproduces the historical `classifyExitState` precedence, which
+  `TerminationEvent(stopRequested, closing)` now maps into the matrix.
+- **No two resumes race the same cwd**: `start` is illegal from
+  `running`/`idle`, so a second resume attempt is rejected rather than
+  spawning a duplicate process against the same working directory.
+
+---
+
+## 4. The `disconnected -> resuming -> running` reconnect chain (design)
+
+`resuming` is a **transient in-memory phase**, not a persisted state: a
+terminal (`interrupted`) row is being brought back live via `start`. The
+alignment focus is **incremental log buffering & replay** so a re-attach
+does not lose or duplicate output.
+
+```
+running ──WS drop──▶ interrupted(disconnected)
+                         │  (process still alive; ring buffer keeps filling)
+                         ▼
+                     [resuming]  ← client re-attaches
+                         │  1. replay buffered tail from the ring buffer
+                         │  2. queue new input until replay drains (input guard)
+                         │  3. release the input queue
+                         ▼
+                     running
+```
+
+Rules:
+- **Buffer, don't respawn** for `disconnected`: the PTY is healthy; only
+  the transport was lost. Respawning would kill live work.
+- **Input guard during `resuming`**: client input is queued, not sent to
+  the PTY, until buffered output has been replayed — so the operator never
+  types into a half-replayed screen.
+- **Incremental replay** from the existing ring buffer (`ringbuf.go`);
+  the open question is how much tail to replay vs. a full snapshot (see §6).
+
+For `orphaned`, the chain first runs an **adopt** probe: verify the
+recorded PID (and that it is our child / matches the expected argv) before
+deciding adopt-vs-respawn. For `crashed`, skip straight to rollback +
+resume.
+
+---
+
+## 5. Highest-risk transitions (tests first)
+
+Written test-first in `transitions_test.go`; these are the cells most
+likely to corrupt state under failure:
+
+1. **Gateway restart** (`running/idle/pending -> interrupted`) then
+   `start -> running` (auto-resume).
+2. **Disconnect** (`running -> interrupted(disconnected)`), process stays
+   alive — must NOT respawn.
+3. **Abnormal child exit** (`running -> ended`) vs. gateway shutdown —
+   precedence must not misclassify a crash as an interruption.
+4. **Resume failure**: `start` from `interrupted` fails → row must remain
+   `interrupted` (recoverable next boot), never a phantom `running`.
+5. **Double stop / repeat exit wakeup**: idempotent no-ops.
+
+---
+
+## 6. Open questions (carry into Phase 2)
+
+- **Persisting the interrupt reason**: an additive nullable
+  `interrupt_reason` column vs. keeping it purely runtime. Needed before
+  the audit panel can show *why* a session dropped.
+- **Replay fidelity vs. cost**: antigravity wants context pruned /
+  compressed on resume to cut token cost; that is in tension with the
+  "full-context replay" goal. Reconcile the two — likely full **terminal**
+  replay (ring buffer) but pruned **model-context** replay.
+- **Checkpoint definition** for `crashed` rollback: what exactly is a
+  checkpoint, when is it taken, where stored.
+- **Backup scope** (Phase 2): cwd key-file snapshot + uncommitted diff +
+  input history — depends on this state machine being solid first.
+- **Audit multimodal / Artifacts diff tracking**: Phase 3 vs. later.
+
+---
+
+## 7. Adoption plan (incremental, non-destructive)
+
+`transitions.go` is a **pure SSOT** with no side effects; nothing in the
+running gateway calls it yet. It is landed first, fully tested, so the
+lifecycle mutation points can be migrated onto it one at a time without a
+big-bang rewrite:
+
+1. Route `Manager.Start`'s "already running" guard through
+   `CanTransition(state, EventStart)`.
+2. Route `waitExit`'s terminal classification through
+   `TerminationEvent` + `Next` (keeping `classifyExitState` as a thin
+   shim, already pinned equal by `TestTerminationEventPrecedence`).
+3. Add reconcile PID-liveness probing → `ClassifyInterrupt` →
+   `RecoveryStrategy` (this is where `orphaned`/`disconnected`/`crashed`
+   start driving behaviour).
+4. Only then: persist `interrupt_reason`, then build backup/checkpoint on
+   top.
+
+Each step is guarded by the existing matrix tests, so behaviour cannot
+silently drift.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -620,7 +620,11 @@ func (m *Manager) Start(ctx context.Context, id string) (Session, error) {
 		state := rs.sess.State
 		out := rs.sess
 		rs.sessMu.RUnlock()
-		if !state.IsTerminal() {
+		// Guard via the transition matrix: EventStart is illegal from any
+		// live state (pending/running/idle), which is the SSOT form of
+		// ErrAlreadyRunning and stops two resumes racing the same cwd.
+		// Legal iff the row is terminal (see TestStartLegalIffTerminal).
+		if !CanTransition(state, EventStart) {
 			return out, fmt.Errorf("session %s is %s: %w", id, state, ErrAlreadyRunning)
 		}
 	}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -41,15 +41,26 @@ func (s State) IsTerminal() bool {
 // whose process just exited. Precedence: an explicit user stop wins;
 // otherwise a gateway shutdown makes it 'interrupted' (so startup
 // reconciliation resumes it); a spontaneous exit is a normal 'ended'.
+//
+// This now delegates to the transition matrix (Next) via TerminationEvent
+// so the precedence lives in exactly one place; TestTerminationEventPrecedence
+// pins the two in lock-step. A thin shim is kept for the existing call site.
 func classifyExitState(stopRequested, closing bool) State {
-	switch {
-	case stopRequested:
-		return StateStopped
-	case closing:
-		return StateInterrupted
-	default:
-		return StateEnded
+	// A running session always has a legal terminal transition, so the
+	// error is unreachable; fall back to the prior explicit precedence
+	// defensively rather than propagate it into the exit path.
+	state, err := Next(StateRunning, TerminationEvent(stopRequested, closing))
+	if err != nil {
+		switch {
+		case stopRequested:
+			return StateStopped
+		case closing:
+			return StateInterrupted
+		default:
+			return StateEnded
+		}
 	}
+	return state
 }
 
 // Session is the public view of a PTY-backed CLI session. Runtime

--- a/internal/session/transitions.go
+++ b/internal/session/transitions.go
@@ -1,0 +1,237 @@
+package session
+
+import "errors"
+
+// This file is the single source of truth for the session lifecycle
+// state machine. It encodes the transition matrix agreed in the
+// 2026-07 state-machine hardening design (docs/design/session-state-machine.md):
+// every (State, Event) pair either maps to a well-defined next State or
+// is rejected as an illegal transition.
+//
+// It is intentionally PURE and side-effect free — no DB, no PTY, no
+// locks — so it can be exhaustively table-tested and adopted incrementally
+// by the Manager/store as the authoritative guard. Persisted states are
+// unchanged (session.go still owns the State enum and the sessions.state
+// column); the three interrupted sub-states are modelled here as a
+// refinement layer (InterruptReason), not as new persisted enum values.
+
+// Event enumerates the lifecycle signals that drive a session between
+// States. A transition is legal iff Next(state, event) returns a nil
+// error. See docs/design/session-state-machine.md for the full matrix.
+type Event string
+
+const (
+	// EventStart — a PTY is (re)spawned for a row that is not currently
+	// running: initial Create, operator Restart, or startup auto-resume.
+	// Legal from the zero State ("", fresh) and any terminal State;
+	// rejected from running/idle (that is ErrAlreadyRunning).
+	EventStart Event = "start"
+	// EventIdle — the idle detector observed no activity past threshold.
+	EventIdle Event = "idle"
+	// EventResume — input/output activity resumed a previously idle
+	// session (a no-op while already running).
+	EventResume Event = "resume"
+	// EventUserStop — the operator explicitly stopped the session
+	// (Manager.Stop / DELETE-as-stop). Highest precedence terminator.
+	EventUserStop Event = "user_stop"
+	// EventExit — the CLI process exited on its own (clean exit or a
+	// spontaneous crash of the child).
+	EventExit Event = "exit"
+	// EventGatewayShutdown — the gateway process itself is exiting, so
+	// the PTY dies with it. Distinct from EventExit so reconciliation can
+	// tell "the daemon killed this" apart from "the agent exited" and
+	// auto-resume it.
+	EventGatewayShutdown Event = "gateway_shutdown"
+)
+
+// ErrIllegalTransition is returned by Next when the (State, Event) pair
+// is not a permitted transition (e.g. ended -> running via EventIdle, or
+// EventStart on an already-running session).
+var ErrIllegalTransition = errors.New("illegal session state transition")
+
+// terminationEvents are the three ways a live session can leave the
+// running set. Applied to an already-terminal State they are idempotent
+// no-ops (the State is preserved), mirroring the store's
+// `state NOT IN ('stopped','ended')` guard: a user stop is never
+// overwritten by a later gateway shutdown, etc.
+var terminationEvents = map[Event]State{
+	EventUserStop:        StateStopped,
+	EventExit:            StateEnded,
+	EventGatewayShutdown: StateInterrupted,
+}
+
+// liveTransitions is the transition table for the non-terminal States
+// (plus the zero State, which represents a not-yet-persisted session).
+// A missing (State, Event) entry is an illegal transition, UNLESS the
+// State is terminatable (see terminatableStates), in which case the
+// termination events fold in from terminationEvents so the precedence
+// lives in one place.
+var liveTransitions = map[State]map[Event]State{
+	// Zero State: a fresh session that has not been spawned yet. It is
+	// NOT terminatable — you cannot stop/exit/interrupt a session that
+	// never started — so only a spawn is legal here.
+	"": {
+		EventStart: StateRunning,
+	},
+	// StatePending: a spawn is already in flight. It is terminatable
+	// (a mid-spawn session can still be stopped / die / be interrupted)
+	// but NOT startable — a second start would race the first spawn for
+	// the same cwd. Only running/terminal rows are restartable.
+	StatePending: {},
+	StateRunning: {
+		EventIdle:   StateIdle,
+		EventResume: StateRunning, // no-op: already running
+	},
+	StateIdle: {
+		EventIdle:   StateIdle, // no-op: already idle
+		EventResume: StateRunning,
+	},
+}
+
+// terminatableStates are the live States that hold a real PTY and can
+// therefore receive a termination event (user stop / exit / gateway
+// shutdown). The zero State is excluded on purpose.
+var terminatableStates = map[State]bool{
+	StatePending: true,
+	StateRunning: true,
+	StateIdle:    true,
+}
+
+// Next applies event to from and returns the resulting State. It is the
+// guarded, idempotent transition function every lifecycle mutation should
+// route through:
+//
+//   - Illegal transitions return (from, ErrIllegalTransition) and MUST be
+//     rejected by the caller (no state change, surface an error).
+//   - Idempotent no-ops (re-applying the event that produced the current
+//     State) return (from, nil) so repeat exit-detector wakeups or a
+//     double Stop are harmless.
+//
+// Next never mutates anything; it only computes the target State.
+func Next(from State, event Event) (State, error) {
+	if from.IsTerminal() {
+		// From any terminal State only a (re)start is legal; the three
+		// termination events are idempotent no-ops that preserve the
+		// existing terminal State (a stopped session stays stopped even
+		// if the process is later observed to have exited).
+		switch {
+		case event == EventStart:
+			return StateRunning, nil
+		case isTerminationEvent(event):
+			return from, nil
+		default:
+			return from, ErrIllegalTransition
+		}
+	}
+
+	if next, ok := liveTransitions[from][event]; ok {
+		return next, nil
+	}
+	if next, ok := terminationEvents[event]; ok && terminatableStates[from] {
+		return next, nil
+	}
+	return from, ErrIllegalTransition
+}
+
+// CanTransition reports whether event is a legal transition from state
+// (including idempotent no-ops). Convenience wrapper over Next for guard
+// checks that do not need the resulting State.
+func CanTransition(from State, event Event) bool {
+	_, err := Next(from, event)
+	return err == nil
+}
+
+func isTerminationEvent(event Event) bool {
+	_, ok := terminationEvents[event]
+	return ok
+}
+
+// TerminationEvent maps the two booleans the exit detector already tracks
+// (an explicit user stop; the gateway closing) to the lifecycle Event
+// that drives the terminal transition. Precedence matches the historical
+// classifyExitState: a user stop wins over a gateway shutdown, which wins
+// over a spontaneous exit. Provided so callers can converge on Next as the
+// single transition point instead of duplicating this precedence.
+func TerminationEvent(stopRequested, closing bool) Event {
+	switch {
+	case stopRequested:
+		return EventUserStop
+	case closing:
+		return EventGatewayShutdown
+	default:
+		return EventExit
+	}
+}
+
+// InterruptReason refines StateInterrupted into the three recovery classes
+// frozen in the 2026-07 design. The persisted state stays "interrupted";
+// this is the "why", derived from OBSERVED facts (process liveness, gateway
+// restart) rather than guessed — the "reconcile = truth" contract, where
+// the DB row is only intent and the OS process table / WS / event stream
+// are the reality written back.
+type InterruptReason string
+
+const (
+	// InterruptDisconnected — the WS transport dropped but the CLI process
+	// is healthy. Recovery: silently buffer output and wait for re-attach;
+	// do NOT respawn (that would abandon a live, working process).
+	InterruptDisconnected InterruptReason = "disconnected"
+	// InterruptOrphaned — the gateway restarted and left the CLI running
+	// as an orphan. Recovery: reconcile probes the OS for the recorded PID
+	// and adopts it if still alive, rather than blindly respawning.
+	InterruptOrphaned InterruptReason = "orphaned"
+	// InterruptCrashed — the process is gone. Recovery: treat as failed and
+	// roll back to the last checkpoint (or respawn with --resume where the
+	// provider supports it).
+	InterruptCrashed InterruptReason = "crashed"
+)
+
+// ClassifyInterrupt derives the InterruptReason from observed facts, not
+// from the DB's stale intent:
+//
+//   - procAlive: is the OS process for the recorded PID still running?
+//   - gatewayRestarted: did the gateway process itself restart (vs. only
+//     the WS client disconnecting)?
+//
+// Precedence: a dead process is always "crashed" regardless of why we are
+// looking; a live process after a gateway restart is "orphaned" (adoptable);
+// a live process with only the transport gone is "disconnected".
+func ClassifyInterrupt(procAlive, gatewayRestarted bool) InterruptReason {
+	switch {
+	case !procAlive:
+		return InterruptCrashed
+	case gatewayRestarted:
+		return InterruptOrphaned
+	default:
+		return InterruptDisconnected
+	}
+}
+
+// RecoveryStrategy names the action reconciliation should take for a given
+// InterruptReason. Kept separate from the reason so the "what happened"
+// (classification) and the "what to do" (policy) can evolve independently.
+type RecoveryStrategy string
+
+const (
+	// RecoveryWaitReattach — buffer incremental output and wait for the
+	// client to re-attach; the process is healthy (InterruptDisconnected).
+	RecoveryWaitReattach RecoveryStrategy = "wait_reattach"
+	// RecoveryAdoptPID — verify the recorded PID and adopt the live orphan
+	// instead of respawning (InterruptOrphaned).
+	RecoveryAdoptPID RecoveryStrategy = "adopt_pid"
+	// RecoveryRollback — the process is gone; fail and restore the last
+	// checkpoint / respawn with resume (InterruptCrashed).
+	RecoveryRollback RecoveryStrategy = "rollback"
+)
+
+// Recovery returns the recovery strategy for this interrupt reason.
+func (r InterruptReason) Recovery() RecoveryStrategy {
+	switch r {
+	case InterruptDisconnected:
+		return RecoveryWaitReattach
+	case InterruptOrphaned:
+		return RecoveryAdoptPID
+	default: // InterruptCrashed and any unknown reason: safest is rollback
+		return RecoveryRollback
+	}
+}

--- a/internal/session/transitions_test.go
+++ b/internal/session/transitions_test.go
@@ -1,0 +1,209 @@
+package session
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestNextMatrix is the frozen State x Event -> State transition matrix
+// from docs/design/session-state-machine.md. Every legal cell and every
+// rejected illegal cell is pinned here; new lifecycle code MUST route
+// through Next and keep this matrix green. `-` means illegal (Next returns
+// ErrIllegalTransition and leaves the State unchanged).
+func TestNextMatrix(t *testing.T) {
+	const illegal = State("-")
+
+	events := []Event{
+		EventStart, EventIdle, EventResume,
+		EventUserStop, EventExit, EventGatewayShutdown,
+	}
+
+	// want[from][event]; illegal marks a rejected transition.
+	want := map[State]map[Event]State{
+		// Zero State: only a spawn is legal.
+		"": {
+			EventStart: StateRunning, EventIdle: illegal, EventResume: illegal,
+			EventUserStop: illegal, EventExit: illegal, EventGatewayShutdown: illegal,
+		},
+		StatePending: {
+			EventStart: illegal, EventIdle: illegal, EventResume: illegal,
+			EventUserStop: StateStopped, EventExit: StateEnded, EventGatewayShutdown: StateInterrupted,
+		},
+		StateRunning: {
+			EventStart: illegal, EventIdle: StateIdle, EventResume: StateRunning,
+			EventUserStop: StateStopped, EventExit: StateEnded, EventGatewayShutdown: StateInterrupted,
+		},
+		StateIdle: {
+			EventStart: illegal, EventIdle: StateIdle, EventResume: StateRunning,
+			EventUserStop: StateStopped, EventExit: StateEnded, EventGatewayShutdown: StateInterrupted,
+		},
+		// Terminal States: only a restart re-enters running; the three
+		// termination events are idempotent no-ops preserving the State.
+		StateStopped: {
+			EventStart: StateRunning, EventIdle: illegal, EventResume: illegal,
+			EventUserStop: StateStopped, EventExit: StateStopped, EventGatewayShutdown: StateStopped,
+		},
+		StateEnded: {
+			EventStart: StateRunning, EventIdle: illegal, EventResume: illegal,
+			EventUserStop: StateEnded, EventExit: StateEnded, EventGatewayShutdown: StateEnded,
+		},
+		StateInterrupted: {
+			EventStart: StateRunning, EventIdle: illegal, EventResume: illegal,
+			EventUserStop: StateInterrupted, EventExit: StateInterrupted, EventGatewayShutdown: StateInterrupted,
+		},
+	}
+
+	for from, row := range want {
+		for _, ev := range events {
+			expected := row[ev]
+			got, err := Next(from, ev)
+			if expected == illegal {
+				if !errors.Is(err, ErrIllegalTransition) {
+					t.Errorf("Next(%q, %q): want ErrIllegalTransition, got (%q, %v)", from, ev, got, err)
+				}
+				// Illegal transitions must not change the State.
+				if got != from {
+					t.Errorf("Next(%q, %q): illegal transition must return unchanged State, got %q", from, ev, got)
+				}
+				if CanTransition(from, ev) {
+					t.Errorf("CanTransition(%q, %q) = true, want false", from, ev)
+				}
+				continue
+			}
+			if err != nil {
+				t.Errorf("Next(%q, %q): unexpected error %v (want -> %q)", from, ev, err, expected)
+				continue
+			}
+			if got != expected {
+				t.Errorf("Next(%q, %q) = %q, want %q", from, ev, got, expected)
+			}
+			if !CanTransition(from, ev) {
+				t.Errorf("CanTransition(%q, %q) = false, want true", from, ev)
+			}
+		}
+	}
+}
+
+// TestNextIdempotent covers the highest-risk operational hazards the
+// design calls out: a double Stop, repeat exit-detector wakeups, and a
+// gateway shutdown racing a session that already exited. Each must be a
+// harmless no-op, never a state flip.
+func TestNextIdempotent(t *testing.T) {
+	cases := []struct {
+		name  string
+		from  State
+		event Event
+	}{
+		{"double user stop", StateStopped, EventUserStop},
+		{"repeat exit wakeup", StateEnded, EventExit},
+		{"shutdown after user stop keeps stopped", StateStopped, EventGatewayShutdown},
+		{"exit after user stop keeps stopped", StateStopped, EventExit},
+		{"shutdown after natural end keeps ended", StateEnded, EventGatewayShutdown},
+		{"resume while running is a no-op", StateRunning, EventResume},
+		{"idle while idle is a no-op", StateIdle, EventIdle},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := Next(c.from, c.event)
+			if err != nil {
+				t.Fatalf("Next(%q, %q) errored: %v", c.from, c.event, err)
+			}
+			if got != c.from {
+				t.Errorf("Next(%q, %q) = %q, want unchanged %q", c.from, c.event, got, c.from)
+			}
+		})
+	}
+}
+
+// TestNextRejectsRestartOfLiveSession pins the guard that a session which
+// is already running/idle cannot be spawned again — the SSOT form of
+// ErrAlreadyRunning, and the guard that stops two resumes racing for the
+// same cwd.
+func TestNextRejectsRestartOfLiveSession(t *testing.T) {
+	for _, from := range []State{StateRunning, StateIdle} {
+		if _, err := Next(from, EventStart); !errors.Is(err, ErrIllegalTransition) {
+			t.Errorf("Next(%q, EventStart): want ErrIllegalTransition, got %v", from, err)
+		}
+	}
+}
+
+// TestStartLegalIffTerminal pins the invariant that makes routing
+// Manager.Start's guard through CanTransition behaviour-identical to the
+// historical `!state.IsTerminal()` check: EventStart is legal from exactly
+// the terminal States (restart/resume), and rejected from every live
+// State (pending/running/idle) — the SSOT form of ErrAlreadyRunning and
+// the guard against two resumes racing the same cwd.
+func TestStartLegalIffTerminal(t *testing.T) {
+	for _, s := range []State{StatePending, StateRunning, StateIdle, StateStopped, StateEnded, StateInterrupted} {
+		if got, want := CanTransition(s, EventStart), s.IsTerminal(); got != want {
+			t.Errorf("CanTransition(%q, EventStart) = %v, want IsTerminal() = %v", s, got, want)
+		}
+	}
+}
+
+// TestTerminationEventPrecedence pins that TerminationEvent reproduces the
+// historical classifyExitState precedence, and that feeding the resulting
+// Event through Next from a running session reaches the same terminal
+// State classifyExitState would have chosen. This keeps the new SSOT and
+// the legacy classifier in lock-step during incremental adoption.
+func TestTerminationEventPrecedence(t *testing.T) {
+	cases := []struct {
+		name          string
+		stop, closing bool
+		wantEvent     Event
+		wantState     State
+	}{
+		{"user stop beats shutdown", true, true, EventUserStop, StateStopped},
+		{"user stop", true, false, EventUserStop, StateStopped},
+		{"shutdown -> interrupted", false, true, EventGatewayShutdown, StateInterrupted},
+		{"spontaneous exit -> ended", false, false, EventExit, StateEnded},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ev := TerminationEvent(c.stop, c.closing)
+			if ev != c.wantEvent {
+				t.Fatalf("TerminationEvent(%v,%v) = %q, want %q", c.stop, c.closing, ev, c.wantEvent)
+			}
+			got, err := Next(StateRunning, ev)
+			if err != nil {
+				t.Fatalf("Next(running, %q) errored: %v", ev, err)
+			}
+			if got != c.wantState {
+				t.Errorf("Next(running, %q) = %q, want %q", ev, got, c.wantState)
+			}
+			// Must agree with the legacy classifier still in session.go.
+			if legacy := classifyExitState(c.stop, c.closing); legacy != c.wantState {
+				t.Errorf("classifyExitState(%v,%v) = %q, diverged from matrix %q", c.stop, c.closing, legacy, c.wantState)
+			}
+		})
+	}
+}
+
+// TestClassifyInterrupt freezes the interrupted sub-state classifier: the
+// three recovery classes are derived from observed facts (process
+// liveness, gateway restart), not from stale DB intent.
+func TestClassifyInterrupt(t *testing.T) {
+	cases := []struct {
+		name             string
+		procAlive        bool
+		gatewayRestarted bool
+		wantReason       InterruptReason
+		wantRecovery     RecoveryStrategy
+	}{
+		{"WS drop, process healthy", true, false, InterruptDisconnected, RecoveryWaitReattach},
+		{"gateway restart, orphan alive", true, true, InterruptOrphaned, RecoveryAdoptPID},
+		{"process dead", false, false, InterruptCrashed, RecoveryRollback},
+		{"process dead beats gateway restart", false, true, InterruptCrashed, RecoveryRollback},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotReason := ClassifyInterrupt(c.procAlive, c.gatewayRestarted)
+			if gotReason != c.wantReason {
+				t.Errorf("ClassifyInterrupt(%v,%v) = %q, want %q", c.procAlive, c.gatewayRestarted, gotReason, c.wantReason)
+			}
+			if gotRecovery := gotReason.Recovery(); gotRecovery != c.wantRecovery {
+				t.Errorf("%q.Recovery() = %q, want %q", gotReason, gotRecovery, c.wantRecovery)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of the **session state-machine hardening** plan — harden the foundation before building backup/restore, the audit panel, or multi-model orchestration on top. The load-bearing first step is a *trustworthy* session state: today the ambiguous `interrupted` state conflates three genuinely different failure modes, and the transition/idempotency rules live scattered across the manager.

This PR introduces the state machine as a **single source of truth** and wires the existing transition points onto it **without any behaviour change**. It is intentionally non-destructive: no persisted-enum change, no DB migration.

## What's in it

- **`internal/session/transitions.go`** — pure, side-effect-free SSOT:
  - `Next(State, Event) (State, error)` — **guarded** (illegal jumps like `ended→running` via idle, or `start` on a live session, return `ErrIllegalTransition` and leave the state unchanged) and **idempotent** (repeat exit-detector wakeups / double stop are no-ops; user-stop precedence preserved).
  - The `interrupted` state is **frozen into three recovery classes** as a refinement layer — `InterruptReason{disconnected, orphaned, crashed}` via `ClassifyInterrupt(procAlive, gatewayRestarted)` + `Recovery()` → `wait_reattach` / `adopt_pid` / `rollback`. This encodes the **"reconcile = truth, not guess"** contract (DB row is intent; OS process table / WS / event stream are reality).
- **Guard wiring (behaviour-identical)**:
  - `Manager.Start`'s already-running guard now routes through `CanTransition(state, EventStart)` — pinned equal to the old `!IsTerminal()` check by `TestStartLegalIffTerminal`.
  - `classifyExitState` delegates to the matrix via `TerminationEvent` — pinned equal to the legacy precedence by `TestTerminationEventPrecedence`.
- **`internal/session/transitions_test.go`** — table-driven full `State × Event` matrix, the highest-risk idempotency hazards, the start-legal-iff-terminal invariant, and the interrupt classifier.
- **`docs/design/session-state-machine.md`** — the frozen states, sub-state taxonomy, transition matrix, the `disconnected → resuming → running` reconnect chain (incremental log buffering/replay + input guard), the highest-risk transitions, open questions, and an incremental adoption plan for the remaining phases.

## Test plan

- `go test -race ./internal/session/` — green (new matrix/idempotency/classifier tests + existing suite).
- `go build ./...` — green; `go vet ./internal/session/` — clean; `gofmt` clean.
- Behaviour-preservation is enforced *in tests*: `TestStartLegalIffTerminal` and `TestTerminationEventPrecedence` pin the wired call sites equal to their prior logic, so this PR cannot silently drift.

## Deferred (see design doc)

Reconcile PID-probe + orphan adoption (driving `disconnected`/`orphaned`/`crashed` behaviour), persisting `interrupt_reason` (additive column), and the backup/checkpoint format are follow-up phases. The audit/cost panel and orchestration layer remain parked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)