### PR TITLE
feat(session): concurrency-safe resume + persist interruption cause

### DIFF
--- a/docs/design/session-state-machine.md
+++ b/docs/design/session-state-machine.md
@@ -1,6 +1,6 @@
 # Session State Machine Hardening
 
-Status: **Phase 1 — design frozen, SSOT landed (guard not yet wired)**
+Status: **Phase 2 — SSOT wired; concurrency-safe resume + interrupt cause persisted**
 Owner: opendray gateway
 Last updated: 2026-07-14
 
@@ -45,34 +45,72 @@ flight) is distinct: it is terminatable but **not** startable — a second
 
 ---
 
-## 2. `interrupted` sub-states (frozen)
+## 2. `interrupted` sub-states (frozen) — and the architectural reality
 
-The single `interrupted` state conflated three genuinely different
-situations that need different recovery. Naming per antigravity, endorsed
-by all three reviewers. Modelled as `InterruptReason` refining
-`StateInterrupted` — **not** as new persisted enum values (so no migration
-is required to freeze the taxonomy; persisting the reason is a later,
-additive column).
+The single `interrupted` state conflated three situations that were
+*expected* to need different recovery. Naming per antigravity, endorsed by
+all three reviewers. Modelled as `InterruptReason` refining
+`StateInterrupted` — **not** as new persisted enum values.
 
-| Reason         | Observed reality | Recovery strategy |
+| Reason         | Observed reality | Intended recovery |
 |----------------|------------------|-------------------|
-| `disconnected` | WS transport dropped, **process healthy** | `wait_reattach`: silently buffer incremental output, wait for re-attach. **Do NOT respawn** — that abandons a live, working process. |
-| `orphaned`     | Gateway restarted, CLI left as an **orphan (still alive)** | `adopt_pid`: reconcile probes the OS for the recorded PID and **adopts** it if alive, rather than blindly respawning. |
-| `crashed`      | Process is **gone** | `rollback`: treat as failed, roll back to the last checkpoint (or respawn with `--resume` where the provider supports it). |
-
-### Classification is truth, not guess
+| `disconnected` | WS transport dropped, **process healthy** | `wait_reattach`: buffer output, wait for re-attach. Do NOT respawn. |
+| `orphaned`     | Gateway restarted, CLI left as an **orphan (still alive)** | `adopt_pid`: probe the recorded PID and adopt it if alive. |
+| `crashed`      | Process is **gone** | `rollback`: fail, roll back / respawn with `--resume`. |
 
 ```
 ClassifyInterrupt(procAlive, gatewayRestarted):
-    !procAlive               -> crashed      (a dead process is always crashed)
-    procAlive && gwRestarted -> orphaned     (adoptable)
-    procAlive && !gwRestarted-> disconnected (transport only)
+    !procAlive               -> crashed
+    procAlive && gwRestarted -> orphaned
+    procAlive && !gwRestarted-> disconnected
 ```
 
-**Reconcile = truth-check, not guess.** The DB row records *intent*; the
-OS process table / WS liveness / event stream are *reality*. Reconcile
-must observe the facts and write the truth back — never infer state from
-the stale DB value alone.
+### ⚠️ What the code investigation actually showed (2026-07-14)
+
+Two of these three collapse once you look at the real process model
+(`spawn` uses `pty.Start`, so the gateway holds the PTY **master fd**):
+
+- **`disconnected` is already correct with no state change.** A WS client
+  drop only calls `unsub()` (`handler.go`) → removes the subscriber channel
+  (`manager.go`). It does **not** touch the process: the session stays
+  `running`, the ring buffer keeps filling, and re-attach replays it. There
+  is nothing to persist or recover — the design's `wait_reattach` *is* the
+  current behaviour. `disconnected` is therefore a runtime transport state,
+  never a persisted one.
+
+- **`orphaned` / `adopt_pid` is infeasible for PTY-backed children.** When
+  the gateway dies, the kernel destroys the PTY pair as its master fd
+  closes; the orphan gets EIO/SIGHUP and is I/O-dead even if momentarily
+  alive, and a new gateway **cannot re-acquire the master fd**. Blindly
+  killing the recorded PID is also unsafe (PID reuse). So a gateway restart
+  collapses to a single achievable outcome: **process gone → respawn with
+  `--resume`** — which is what reconciliation already does.
+
+**Consequence:** at *startup* reconcile the only recovery-relevant class is
+effectively `crashed`. The genuinely useful, achievable hardening is
+therefore (a) making resume **concurrency-safe** so two resumes can't race
+the same cwd, and (b) recording the interruption **cause** for audit — not
+building an un-attachable "adopt" path.
+
+### Persisted cause vs. runtime recovery reason
+
+`InterruptReason` above (disconnected/orphaned/crashed) is the *runtime
+recovery* view. Persisted separately is the *audit cause* — why the row
+became interrupted, observable at the interruption point
+(`InterruptCause`, column `sessions.interrupt_reason`, migration 0077):
+
+| Cause              | Set by | Meaning |
+|--------------------|--------|---------|
+| `gateway_shutdown` | `waitExit` when `isClosing` (`pump.go`) | Graceful daemon exit (self-update / restart). |
+| `gateway_crash`    | `MarkRunningAsInterrupted` at next startup (`store.go`) | Daemon died hard; row was still live at boot. |
+
+Nullable and additive; cleared to NULL on resume (`Reactivate`). No
+backfill — historical rows have no observable cause.
+
+**Reconcile = truth-check, not guess** still holds: the DB row is intent;
+the OS process table / WS liveness are reality. The cause column records the
+reality we *can* observe; we do not guess an "orphan is adoptable" story the
+architecture cannot deliver.
 
 ---
 
@@ -141,10 +179,11 @@ Rules:
 - **Incremental replay** from the existing ring buffer (`ringbuf.go`);
   the open question is how much tail to replay vs. a full snapshot (see §6).
 
-For `orphaned`, the chain first runs an **adopt** probe: verify the
-recorded PID (and that it is our child / matches the expected argv) before
-deciding adopt-vs-respawn. For `crashed`, skip straight to rollback +
-resume.
+Note (per §2): `disconnected` already behaves exactly like this today —
+the process is never touched on a WS drop and re-attach replays the ring.
+The `orphaned` "adopt probe" is **not pursued** (PTY master fd dies with the
+gateway; see §2). For a gateway restart the chain is simply: interrupted
+(`gateway_shutdown` or `gateway_crash`) → concurrency-safe `start` → replay.
 
 ---
 
@@ -165,11 +204,12 @@ likely to corrupt state under failure:
 
 ---
 
-## 6. Open questions (carry into Phase 2)
+## 6. Open questions
 
-- **Persisting the interrupt reason**: an additive nullable
-  `interrupt_reason` column vs. keeping it purely runtime. Needed before
-  the audit panel can show *why* a session dropped.
+- ~~**Persisting the interrupt reason**~~ — **DONE** (migration 0077,
+  `InterruptCause` = `gateway_shutdown` / `gateway_crash`). See §2.
+- ~~**Concurrency-safe resume**~~ — **DONE** (`Manager.tryReserveStart`
+  reservation closes the check-then-spawn TOCTOU; see §7).
 - **Replay fidelity vs. cost**: antigravity wants context pruned /
   compressed on resume to cut token cost; that is in tension with the
   "full-context replay" goal. Reconcile the two — likely full **terminal**
@@ -182,23 +222,29 @@ likely to corrupt state under failure:
 
 ---
 
-## 7. Adoption plan (incremental, non-destructive)
+## 7. Adoption plan (incremental, non-destructive) — status
 
-`transitions.go` is a **pure SSOT** with no side effects; nothing in the
-running gateway calls it yet. It is landed first, fully tested, so the
-lifecycle mutation points can be migrated onto it one at a time without a
-big-bang rewrite:
+`transitions.go` is a **pure SSOT** with no side effects. It was landed
+first, fully tested, so the lifecycle mutation points migrate onto it one at
+a time without a big-bang rewrite:
 
-1. Route `Manager.Start`'s "already running" guard through
-   `CanTransition(state, EventStart)`.
-2. Route `waitExit`'s terminal classification through
-   `TerminationEvent` + `Next` (keeping `classifyExitState` as a thin
-   shim, already pinned equal by `TestTerminationEventPrecedence`).
-3. Add reconcile PID-liveness probing → `ClassifyInterrupt` →
-   `RecoveryStrategy` (this is where `orphaned`/`disconnected`/`crashed`
-   start driving behaviour).
-4. Only then: persist `interrupt_reason`, then build backup/checkpoint on
-   top.
+1. ✅ **Done (PR #450)** — `Manager.Start`'s "already running" guard routes
+   through `CanTransition(state, EventStart)`, pinned equal to
+   `!IsTerminal()` by `TestStartLegalIffTerminal`.
+2. ✅ **Done (PR #450)** — `waitExit`'s terminal classification goes through
+   `TerminationEvent` + `Next` (`classifyExitState` kept as a thin shim,
+   pinned equal by `TestTerminationEventPrecedence`).
+3. ✅ **Done (Phase 2)** — **concurrency-safe resume**:
+   `Manager.tryReserveStart` reserves the id under `mu` across the state
+   check *and* the spawn, closing the TOCTOU where two resumes could both
+   pass the guard and race the same cwd (`TestTryReserveStart*`).
+4. ✅ **Done (Phase 2)** — persist the interruption **cause**
+   (`gateway_shutdown` / `gateway_crash`) for audit (migration 0077).
+   Replaces the old plan item "reconcile PID-liveness probing → adopt",
+   which §2 showed is infeasible for PTY-backed children.
+5. ⬜ **Next** — backup / checkpoint format (cwd snapshot + uncommitted diff
+   + input history), then the audit/cost panel that surfaces
+   `interrupt_reason`. Orchestration remains parked.
 
-Each step is guarded by the existing matrix tests, so behaviour cannot
+Each step is guarded by the matrix + reservation tests, so behaviour cannot
 silently drift.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -208,6 +208,14 @@ type Manager struct {
 	mu       sync.RWMutex
 	closed   bool
 	sessions map[string]*runningSession
+	// starting holds the ids with a (re)spawn currently in flight,
+	// guarded by mu. It closes the check-then-spawn TOCTOU in Start: the
+	// in-memory state guard is released before spawn (which re-locks mu to
+	// insert into sessions), so without this reservation two concurrent
+	// resumes of the same terminal row would both pass the guard and spawn
+	// duplicate processes against the same cwd. Reserve under mu before
+	// spawning; release when spawn completes.
+	starting map[string]struct{}
 	wg       sync.WaitGroup
 
 	// stopRequested tracks session ids the user has explicitly asked
@@ -418,6 +426,7 @@ func NewManager(pool *pgxpool.Pool, bus *eventbus.Hub, providers ProviderResolve
 		store:         newStore(pool),
 		providers:     providers,
 		sessions:      make(map[string]*runningSession),
+		starting:      make(map[string]struct{}),
 		idleThreshold: defaultIdleThreshold,
 		idleInterval:  defaultIdleInterval,
 		turnThreshold: defaultTurnThreshold,
@@ -615,19 +624,16 @@ func (m *Manager) Start(ctx context.Context, id string) (Session, error) {
 	}
 	m.mu.RUnlock()
 
-	if rs := m.lookup(id); rs != nil {
-		rs.sessMu.RLock()
-		state := rs.sess.State
-		out := rs.sess
-		rs.sessMu.RUnlock()
-		// Guard via the transition matrix: EventStart is illegal from any
-		// live state (pending/running/idle), which is the SSOT form of
-		// ErrAlreadyRunning and stops two resumes racing the same cwd.
-		// Legal iff the row is terminal (see TestStartLegalIffTerminal).
-		if !CanTransition(state, EventStart) {
-			return out, fmt.Errorf("session %s is %s: %w", id, state, ErrAlreadyRunning)
-		}
+	// Atomically reject a resume of a live/already-resuming session and
+	// reserve the id for this spawn, so two concurrent Starts can't both
+	// spawn a duplicate process against the same cwd (the check-then-spawn
+	// TOCTOU the bare matrix guard can't close on its own).
+	release, blockedState, ok := m.tryReserveStart(id)
+	if !ok {
+		out, _ := m.snapshot(id)
+		return out, fmt.Errorf("session %s is %s: %w", id, blockedState, ErrAlreadyRunning)
 	}
+	defer release()
 
 	sess, err := m.store.Get(ctx, id)
 	if err != nil {
@@ -861,6 +867,53 @@ func (m *Manager) lookup(id string) *runningSession {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.sessions[id]
+}
+
+// snapshot returns the in-memory Session view for id, or the zero Session
+// and false when no live session is tracked. Used to build the error
+// payload when a resume is rejected.
+func (m *Manager) snapshot(id string) (Session, bool) {
+	rs := m.lookup(id)
+	if rs == nil {
+		return Session{}, false
+	}
+	rs.sessMu.RLock()
+	defer rs.sessMu.RUnlock()
+	return rs.sess, true
+}
+
+// tryReserveStart atomically decides whether a (re)spawn of id may proceed
+// and, if so, reserves the id so a concurrent Start cannot also spawn. It
+// returns ok=false — with blockedState describing why — when the session
+// is already live (EventStart illegal from its state) or another spawn is
+// already in flight. On ok=true the caller MUST call release exactly once
+// (defer) after the spawn attempt completes, success or failure.
+//
+// This is the concurrency-safe form of the ErrAlreadyRunning guard: it
+// holds mu across both the state check and the reservation, closing the
+// window between "guard passed" and "sessions[id] inserted" during which
+// two resumes could otherwise both proceed and race the same cwd.
+func (m *Manager) tryReserveStart(id string) (release func(), blockedState State, ok bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if rs := m.sessions[id]; rs != nil {
+		rs.sessMu.RLock()
+		state := rs.sess.State
+		rs.sessMu.RUnlock()
+		if !CanTransition(state, EventStart) {
+			return nil, state, false
+		}
+	}
+	if _, inFlight := m.starting[id]; inFlight {
+		// A spawn is mid-flight; report it as pending (spawn in flight).
+		return nil, StatePending, false
+	}
+	m.starting[id] = struct{}{}
+	return func() {
+		m.mu.Lock()
+		delete(m.starting, id)
+		m.mu.Unlock()
+	}, "", true
 }
 
 // RecentScreen returns the current visible screen of the session's

--- a/internal/session/pump.go
+++ b/internal/session/pump.go
@@ -222,14 +222,26 @@ func (m *Manager) waitExit(rs *runningSession) {
 
 		dbCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if err := m.store.MarkTerminal(dbCtx, rs.sess.ID, state, exitCode); err != nil {
-			m.log.Error("mark session terminal", "session", rs.sess.ID, "err", err)
+		// An interruption here is always the graceful path (the gateway is
+		// closing); a hard crash never runs waitExit and is instead flipped
+		// with cause gateway_crash by MarkRunningAsInterrupted at next boot.
+		var markErr error
+		if state == StateInterrupted {
+			markErr = m.store.MarkInterrupted(dbCtx, rs.sess.ID, exitCode, CauseGatewayShutdown)
+		} else {
+			markErr = m.store.MarkTerminal(dbCtx, rs.sess.ID, state, exitCode)
+		}
+		if markErr != nil {
+			m.log.Error("mark session terminal", "session", rs.sess.ID, "err", markErr)
 		}
 
 		now := time.Now().UTC()
 		ec := exitCode
 		rs.sessMu.Lock()
 		rs.sess.State = state
+		if state == StateInterrupted {
+			rs.sess.InterruptReason = CauseGatewayShutdown
+		}
 		rs.sess.EndedAt = &now
 		rs.sess.ExitCode = &ec
 		rs.sessMu.Unlock()

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -63,6 +63,22 @@ func classifyExitState(stopRequested, closing bool) State {
 	return state
 }
 
+// InterruptCause records WHY a session became interrupted, persisted in
+// sessions.interrupt_reason for audit. It is the interruption *cause*
+// (observable at the interruption point), distinct from the runtime
+// recovery *reason* in transitions.go (InterruptReason:
+// disconnected/orphaned/crashed) which classifies what to do next.
+type InterruptCause string
+
+const (
+	// CauseGatewayShutdown — the gateway exited gracefully (self-update /
+	// restart); recorded by waitExit when isClosing is true.
+	CauseGatewayShutdown InterruptCause = "gateway_shutdown"
+	// CauseGatewayCrash — the gateway died hard, so the row was still live
+	// at the next startup and reconciliation flipped it to interrupted.
+	CauseGatewayCrash InterruptCause = "gateway_crash"
+)
+
 // Session is the public view of a PTY-backed CLI session. Runtime
 // resources (PTY fd, ring buffer, subscribers) live on the Manager's
 // internal struct, not here.
@@ -101,10 +117,14 @@ type Session struct {
 	Origin Origin `json:"origin,omitempty"`
 	// IntegrationID is set when Origin == OriginIntegration: the id
 	// of the integration whose API key created the session.
-	IntegrationID string     `json:"integration_id,omitempty"`
-	StartedAt     time.Time  `json:"started_at"`
-	EndedAt       *time.Time `json:"ended_at,omitempty"`
-	ExitCode      *int       `json:"exit_code,omitempty"`
+	IntegrationID string `json:"integration_id,omitempty"`
+	// InterruptReason is the audit cause set only when State == interrupted
+	// (see InterruptCause); empty otherwise. Persisted in
+	// sessions.interrupt_reason, cleared on resume.
+	InterruptReason InterruptCause `json:"interrupt_reason,omitempty"`
+	StartedAt       time.Time      `json:"started_at"`
+	EndedAt         *time.Time     `json:"ended_at,omitempty"`
+	ExitCode        *int           `json:"exit_code,omitempty"`
 }
 
 // Origin identifies the kind of principal that created a session.

--- a/internal/session/start_reserve_test.go
+++ b/internal/session/start_reserve_test.go
@@ -1,0 +1,115 @@
+package session
+
+import (
+	"sync"
+	"testing"
+)
+
+// newBareManager builds a Manager with only the fields tryReserveStart
+// touches, so the reservation guard can be exercised without a DB or PTY.
+func newBareManager() *Manager {
+	return &Manager{
+		sessions: make(map[string]*runningSession),
+		starting: make(map[string]struct{}),
+	}
+}
+
+// TestTryReserveStartExclusive is the core of the double-spawn fix: when N
+// goroutines race to resume the same terminal row, exactly one may hold
+// the reservation at a time. Without release, the rest are rejected — so a
+// concurrent auto-resume + operator Restart cannot both spawn a process
+// against the same cwd.
+func TestTryReserveStartExclusive(t *testing.T) {
+	m := newBareManager()
+	const id = "ses_race"
+	const goroutines = 64
+
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		granted int
+	)
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start // release all at once to maximise contention
+			if release, _, ok := m.tryReserveStart(id); ok {
+				mu.Lock()
+				granted++
+				mu.Unlock()
+				// Hold the reservation; do NOT release. Simulates a spawn
+				// in flight — every other racer must be rejected.
+				_ = release
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if granted != 1 {
+		t.Fatalf("tryReserveStart granted %d concurrent reservations, want exactly 1", granted)
+	}
+}
+
+// TestTryReserveStartReleaseAllowsReuse verifies the reservation is not a
+// permanent lock: once the in-flight spawn releases, the id can be started
+// again (a later legitimate Restart after the first resume finished).
+func TestTryReserveStartReleaseAllowsReuse(t *testing.T) {
+	m := newBareManager()
+	const id = "ses_reuse"
+
+	release, _, ok := m.tryReserveStart(id)
+	if !ok {
+		t.Fatal("first reservation should succeed")
+	}
+	if _, _, ok := m.tryReserveStart(id); ok {
+		t.Fatal("second concurrent reservation must be rejected while first is in flight")
+	}
+	release()
+	if _, _, ok := m.tryReserveStart(id); !ok {
+		t.Fatal("reservation should be grantable again after release")
+	}
+}
+
+// TestTryReserveStartRejectsLiveSession pins that a session already live in
+// the map (non-terminal) is rejected with its real state, mirroring the
+// matrix guard — a resume of a running/idle session is ErrAlreadyRunning.
+func TestTryReserveStartRejectsLiveSession(t *testing.T) {
+	for _, state := range []State{StateRunning, StateIdle, StatePending} {
+		m := newBareManager()
+		const id = "ses_live"
+		m.sessions[id] = &runningSession{sess: Session{ID: id, State: state}}
+
+		release, blocked, ok := m.tryReserveStart(id)
+		if ok {
+			t.Fatalf("state %q: reservation must be rejected for a live session", state)
+		}
+		if blocked != state {
+			t.Errorf("state %q: blockedState = %q, want %q", state, blocked, state)
+		}
+		if release != nil {
+			t.Errorf("state %q: rejected reservation must not return a release func", state)
+		}
+	}
+}
+
+// TestTryReserveStartAllowsTerminalSession pins that a terminal row (the
+// normal resume case) is allowed through and reserved.
+func TestTryReserveStartAllowsTerminalSession(t *testing.T) {
+	for _, state := range []State{StateStopped, StateEnded, StateInterrupted} {
+		m := newBareManager()
+		const id = "ses_terminal"
+		m.sessions[id] = &runningSession{sess: Session{ID: id, State: state}}
+
+		release, _, ok := m.tryReserveStart(id)
+		if !ok {
+			t.Fatalf("state %q: terminal session should be startable", state)
+		}
+		if release == nil {
+			t.Fatalf("state %q: granted reservation must return a release func", state)
+		}
+		release()
+	}
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -24,6 +24,7 @@ const sessionSelect = `
            COALESCE(antigravity_account_id, ''),
            COALESCE(parent_session_id, ''),
            COALESCE(origin, 'operator'), COALESCE(integration_id, ''),
+           COALESCE(interrupt_reason, ''),
            started_at, ended_at, exit_code
     FROM sessions`
 
@@ -96,13 +97,31 @@ func (s *sessionStore) MarkTerminal(ctx context.Context, id string, state State,
 	return nil
 }
 
+// MarkInterrupted records a graceful-shutdown interruption for a live
+// session: state='interrupted' plus the audit cause (gateway_shutdown). Like
+// MarkTerminal it is idempotent against a row the user already stopped/ended.
+// The crash path (row still 'running' at next startup) is handled separately
+// by MarkRunningAsInterrupted, which stamps gateway_crash.
+func (s *sessionStore) MarkInterrupted(ctx context.Context, id string, exitCode int, cause InterruptCause) error {
+	_, err := s.pool.Exec(ctx, `
+        UPDATE sessions
+        SET state='interrupted', ended_at=NOW(), exit_code=$1, interrupt_reason=$2
+        WHERE id=$3 AND state NOT IN ('stopped', 'ended')`,
+		exitCode, string(cause), id)
+	if err != nil {
+		return fmt.Errorf("mark interrupted: %w", err)
+	}
+	return nil
+}
+
 // Reactivate transitions a terminal row back into running with a fresh
-// PID and started_at. Used by Manager.Start.
+// PID and started_at, clearing the prior run's exit/interrupt bookkeeping.
+// Used by Manager.Start.
 func (s *sessionStore) Reactivate(ctx context.Context, id string, pid int) error {
 	_, err := s.pool.Exec(ctx, `
         UPDATE sessions
         SET state='running', pid=$1, started_at=NOW(),
-            ended_at=NULL, exit_code=NULL
+            ended_at=NULL, exit_code=NULL, interrupt_reason=NULL
         WHERE id=$2`, pid, id)
 	if err != nil {
 		return fmt.Errorf("reactivate session: %w", err)
@@ -152,7 +171,8 @@ func (s *sessionStore) MarkAllRunningAsEnded(ctx context.Context) (int64, error)
 func (s *sessionStore) MarkRunningAsInterrupted(ctx context.Context) ([]string, error) {
 	rows, err := s.pool.Query(ctx, `
         UPDATE sessions
-        SET state='interrupted', ended_at=NOW(), exit_code=-1
+        SET state='interrupted', ended_at=NOW(), exit_code=-1,
+            interrupt_reason='gateway_crash'
         WHERE state IN ('pending', 'running', 'idle')
         RETURNING id`)
 	if err != nil {
@@ -245,17 +265,18 @@ type rowScanner interface {
 
 func scanSession(row rowScanner) (Session, error) {
 	var (
-		s         Session
-		argsJSON  []byte
-		endedAt   sql.NullTime
-		exitCode  sql.NullInt32
-		stateStr  string
-		originStr string
+		s          Session
+		argsJSON   []byte
+		endedAt    sql.NullTime
+		exitCode   sql.NullInt32
+		stateStr   string
+		originStr  string
+		interruptR string
 	)
 	err := row.Scan(&s.ID, &s.Name, &s.ProviderID, &s.Model, &s.Cwd, &argsJSON,
 		&stateStr, &s.PID, &s.ClaudeAccountID, &s.ClaudeSessionID,
 		&s.AntigravityAccountID, &s.ParentSessionID, &originStr, &s.IntegrationID,
-		&s.StartedAt, &endedAt, &exitCode)
+		&interruptR, &s.StartedAt, &endedAt, &exitCode)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Session{}, ErrNotFound
 	}
@@ -264,6 +285,7 @@ func scanSession(row rowScanner) (Session, error) {
 	}
 	s.State = State(stateStr)
 	s.Origin = Origin(originStr)
+	s.InterruptReason = InterruptCause(interruptR)
 	_ = json.Unmarshal(argsJSON, &s.Args)
 	if endedAt.Valid {
 		t := endedAt.Time

--- a/internal/store/migrations/0077_session_interrupt_reason.sql
+++ b/internal/store/migrations/0077_session_interrupt_reason.sql
@@ -1,0 +1,19 @@
+-- 0077_session_interrupt_reason — record WHY a session became interrupted,
+-- for audit/observability (Phase 2 of the session state-machine hardening).
+--
+-- The 'interrupted' state conflated two observable causes; this splits them
+-- so an operator / audit panel can tell a planned restart apart from a hard
+-- crash:
+--   'gateway_shutdown' — graceful daemon exit (self-update / restart);
+--                        recorded by waitExit when the gateway is closing.
+--   'gateway_crash'    — the daemon died hard, so the row was still live at
+--                        the next startup and reconciliation flipped it.
+--
+-- Nullable and additive: only interrupted rows carry a value; every other
+-- state (and every pre-existing interrupted row) stays NULL. A resume clears
+-- it back to NULL. No backfill — historical rows have no observable cause.
+--
+-- NOTE: this is the interruption *cause* (why it dropped), distinct from the
+-- runtime recovery *reason* (disconnected/orphaned/crashed) in
+-- internal/session/transitions.go, which classifies what to do next.
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS interrupt_reason TEXT;


### PR DESCRIPTION
## Summary

Phase 2 of the **session state-machine hardening** (builds on the SSOT from #450). Two concrete, achievable improvements plus a design-doc correction grounded in the real process model.

### 1. Concurrency-safe resume — fixes a real double-spawn race
`Manager.Start` checked its "already running" guard under `RLock`, then **released it before `spawn`** (which re-locks `mu` to insert into `sessions`). Two concurrent resumes of the same terminal row — e.g. **startup auto-resume racing an operator Restart**, or rate-limit failover — could both pass the guard and **spawn duplicate processes against the same cwd**, the second orphaning the first in the map.

- New `Manager.tryReserveStart` reserves the id **under `mu` across both the state check and the spawn**, so exactly one resume proceeds and the rest get `ErrAlreadyRunning`. This is the concurrency-safe form of the matrix guard and directly implements the plan's *"重复 resume 只生效一次，避免抢同一 cwd"*.
- `start_reserve_test.go`: 64-goroutine race test (exactly one reservation granted), release-allows-reuse, live-session rejection, terminal-allowed. Race-clean.

### 2. Persist the interruption cause for audit (migration 0077)
- Nullable `sessions.interrupt_reason` + `InterruptCause{gateway_shutdown, gateway_crash}`.
- `waitExit` stamps `gateway_shutdown` on the graceful path (`isClosing`); `MarkRunningAsInterrupted` stamps `gateway_crash` for rows still live at next startup; `Reactivate` clears it on resume. Surfaced on `Session.InterruptReason`.
- Validated on an **ephemeral pg17**: column added nullable; both writes and the resume-clear behave as intended.

### 3. Design-doc correction — the honest finding
Reading the actual process model (`spawn` uses `pty.Start`, gateway holds the PTY **master fd**) showed the group's assumed three-way recovery split partly collapses for PTY-backed children:
- **`disconnected` is already correct with no state change** — a WS drop only calls `unsub()`; the process keeps running and re-attach replays the ring buffer.
- **`orphaned`/`adopt_pid` is infeasible** — the PTY master fd dies with the gateway and cannot be re-acquired; killing by recorded PID is unsafe (PID reuse).

So a gateway restart collapses to *"process gone → `--resume`"*, and the useful hardening is concurrency-safe resume + the audit cause — not an un-attachable adopt path. `docs/design/session-state-machine.md` updated (§2, §6, §7).

## Test plan
- `go test -race ./internal/session/ ./internal/store/` — green.
- `go build ./...` ; `go vet` — clean; `gofmt` clean.
- Migration 0077 applied on ephemeral pg17; `gateway_crash` / `gateway_shutdown` / resume-clear verified.

## Next (deferred)
Backup / checkpoint format (cwd snapshot + uncommitted diff + input history), then the audit/cost panel that surfaces `interrupt_reason`. Orchestration remains parked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)