### PR TITLE
feat(checkpoint): context-level session backup (git diff + untracked + input)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/opendray/opendray-v2/internal/channel/telegram" // register kind=telegram
 	_ "github.com/opendray/opendray-v2/internal/channel/wechat"   // register kind=wechat (wxpusher push)
 	_ "github.com/opendray/opendray-v2/internal/channel/wecom"    // register kind=wecom
+	"github.com/opendray/opendray-v2/internal/checkpoint"
 	"github.com/opendray/opendray-v2/internal/cliacct"
 	"github.com/opendray/opendray-v2/internal/config"
 	"github.com/opendray/opendray-v2/internal/cortex"
@@ -513,6 +514,13 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		// the sessions it creates (create AND reactivate).
 		session.WithIntegrationSpawnProfiles(&integrationDefaultsLookup{svc: intgrSvc}),
 	)
+	// Context-level checkpoints (priority ②): snapshot each live session's
+	// cwd diff + untracked files + input history on graceful shutdown (and
+	// on demand). The service takes its session source after the manager is
+	// built (SetSessions), breaking the construction cycle where the manager
+	// needs it as a recorder while it needs the manager for manual captures.
+	checkpointSvc := checkpoint.NewService(st.Pool(), nil, expandPath("~/.opendray/checkpoints"), log)
+	sessionOpts = append(sessionOpts, session.WithCheckpointRecorder(checkpointSvc))
 	sessionMgr := session.NewManager(
 		st.Pool(),
 		bus,
@@ -520,6 +528,8 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		log,
 		sessionOpts...,
 	)
+	checkpointSvc.SetSessions(sessionMgr)
+	checkpointHandlers := checkpoint.NewHandlers(checkpointSvc, log)
 	// Best-effort reconcile of leftover rows from a prior gateway
 	// process — their PTYs are gone, so flip them to 'ended' so the
 	// web UI can stop the WS reconnect loop and show EndedSessionView.
@@ -1290,6 +1300,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 				proxyHandlers.Mount(r)
 				fsHandlers.Mount(r)
 				gitHandlers.Mount(r)
+				checkpointHandlers.Mount(r)
 				gitHandlers.MountWrite(r)
 				gitHostHandlers.Mount(r)
 				customTaskHandlers.Mount(r)

--- a/internal/checkpoint/capture.go
+++ b/internal/checkpoint/capture.go
@@ -1,0 +1,219 @@
+package checkpoint
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// CaptureRequest is the input to Capture: everything needed to snapshot a
+// session's context, with no dependency on the session package.
+type CaptureRequest struct {
+	CheckpointID string  // pre-generated id (also the on-disk dir name)
+	SessionID    string  // owning session
+	Cwd          string  // working directory to snapshot
+	Trigger      Trigger // interrupted | manual
+	InputHistory []byte  // operator input tail (may be nil)
+	Note         string  // optional operator note
+	Now          time.Time
+}
+
+// gitTimeout bounds each git invocation so a wedged repo can't stall a
+// capture (which, for the interrupt trigger, runs during shutdown).
+const gitTimeout = 5 * time.Second
+
+// Capture snapshots the request's cwd into storageRoot/<checkpointID>/ and
+// returns the manifest. It never mutates the cwd. Capture is best-effort
+// within its caps: hitting a cap sets Truncated but still produces a valid
+// checkpoint. A capture-fatal error (cannot create the dir, cannot write
+// the manifest) returns a non-nil error and removes any partial dir.
+func Capture(ctx context.Context, storageRoot string, req CaptureRequest) (Checkpoint, error) {
+	if storageRoot == "" {
+		return Checkpoint{}, ErrNoStorageDir
+	}
+	if !req.Trigger.Valid() {
+		return Checkpoint{}, ErrInvalidTrigger
+	}
+	dir := filepath.Join(storageRoot, req.CheckpointID)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return Checkpoint{}, fmt.Errorf("checkpoint: mkdir: %w", err)
+	}
+
+	cp := Checkpoint{
+		ID:          req.CheckpointID,
+		SessionID:   req.SessionID,
+		CreatedAt:   req.Now.UTC(),
+		Trigger:     req.Trigger,
+		Cwd:         req.Cwd,
+		StoragePath: dir,
+		Note:        req.Note,
+	}
+
+	// Input history first — it's cheap and independent of the git state.
+	if len(req.InputHistory) > 0 {
+		if err := os.WriteFile(filepath.Join(dir, fileInput), req.InputHistory, 0o600); err != nil {
+			_ = os.RemoveAll(dir)
+			return Checkpoint{}, fmt.Errorf("checkpoint: write input history: %w", err)
+		}
+		cp.InputBytes = int64(len(req.InputHistory))
+	}
+
+	if isGitWorkTree(ctx, req.Cwd) {
+		cp.IsGit = true
+		if err := captureGit(ctx, dir, req.Cwd, &cp); err != nil {
+			// A git capture failure is non-fatal: keep the metadata-only
+			// checkpoint (input history is already written) and note why.
+			cp.Note = strings.TrimSpace(cp.Note + "\n[git capture error: " + err.Error() + "]")
+		}
+	} else {
+		cp.Note = strings.TrimSpace(cp.Note + "\n[cwd is not a git repository; file snapshot skipped]")
+	}
+
+	if err := writeManifest(dir, cp); err != nil {
+		_ = os.RemoveAll(dir)
+		return Checkpoint{}, err
+	}
+	return cp, nil
+}
+
+// captureGit writes the uncommitted diff and untracked (non-ignored) files
+// into dir, updating cp's git fields. Respects .gitignore via
+// --exclude-standard, so ignored paths (secrets, node_modules, build
+// output) are never copied.
+func captureGit(ctx context.Context, dir, cwd string, cp *Checkpoint) error {
+	cp.GitHead = strings.TrimSpace(gitOut(ctx, cwd, "rev-parse", "HEAD"))
+
+	// Uncommitted tracked changes. With a HEAD, diff against it (staged +
+	// unstaged); on an unborn branch (no commits yet) fall back to the
+	// worktree diff so a brand-new repo still captures something.
+	diffArgs := []string{"diff", "--no-color", "HEAD"}
+	if cp.GitHead == "" {
+		diffArgs = []string{"diff", "--no-color"}
+	}
+	diff := []byte(gitOut(ctx, cwd, diffArgs...))
+	if len(diff) > MaxDiffBytes {
+		diff = diff[:MaxDiffBytes]
+		cp.Truncated = true
+	}
+	if len(diff) > 0 {
+		if err := os.WriteFile(filepath.Join(dir, fileDiff), diff, 0o600); err != nil {
+			return fmt.Errorf("write diff: %w", err)
+		}
+		cp.DiffBytes = int64(len(diff))
+	}
+
+	// Untracked, non-ignored files (NUL-separated, so paths with spaces or
+	// newlines are handled). git already applied .gitignore + exclude rules.
+	out := gitOut(ctx, cwd, "ls-files", "--others", "--exclude-standard", "-z")
+	var copied int
+	var total int64
+	for _, rel := range strings.Split(out, "\x00") {
+		if rel == "" {
+			continue
+		}
+		if copied >= MaxUntrackedFiles || total >= MaxUntrackedTotalBytes {
+			cp.Truncated = true
+			break
+		}
+		n, skipped, err := copyUntracked(cwd, dir, rel, MaxUntrackedTotalBytes-total)
+		if err != nil {
+			continue // unreadable file: skip, don't fail the whole capture
+		}
+		if skipped {
+			cp.Truncated = true
+			continue
+		}
+		copied++
+		total += n
+	}
+	cp.UntrackedFiles = copied
+	cp.UntrackedBytes = total
+	cp.GitDirty = cp.DiffBytes > 0 || copied > 0
+	return nil
+}
+
+// copyUntracked copies cwd/rel into dir/untracked/rel, preserving the
+// relative path. Returns the bytes written, whether it was skipped by a cap
+// (too large, or would exceed remaining budget), and any hard error. rel
+// comes from `git ls-files` so it is repo-relative and clean, but we still
+// reject any path that would escape the untracked dir.
+func copyUntracked(cwd, dir, rel string, remaining int64) (int64, bool, error) {
+	if !safeRel(rel) {
+		return 0, true, nil
+	}
+	src := filepath.Join(cwd, rel)
+	info, err := os.Lstat(src)
+	if err != nil {
+		return 0, false, err
+	}
+	// Only regular files: skip symlinks (escape risk) and anything special.
+	if !info.Mode().IsRegular() {
+		return 0, true, nil
+	}
+	if info.Size() > MaxUntrackedFileBytes || info.Size() > remaining {
+		return 0, true, nil
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return 0, false, err
+	}
+	dst := filepath.Join(dir, dirUntracked, rel)
+	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+		return 0, false, err
+	}
+	if err := os.WriteFile(dst, data, 0o600); err != nil {
+		return 0, false, err
+	}
+	return int64(len(data)), false, nil
+}
+
+// safeRel rejects absolute paths and any path that escapes its root via
+// "..", defence-in-depth over git's already-clean output.
+func safeRel(rel string) bool {
+	if rel == "" || filepath.IsAbs(rel) {
+		return false
+	}
+	clean := filepath.Clean(rel)
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
+}
+
+func writeManifest(dir string, cp Checkpoint) error {
+	data, err := json.MarshalIndent(cp, "", "  ")
+	if err != nil {
+		return fmt.Errorf("checkpoint: marshal manifest: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, fileMeta), data, 0o600); err != nil {
+		return fmt.Errorf("checkpoint: write manifest: %w", err)
+	}
+	return nil
+}
+
+func isGitWorkTree(ctx context.Context, cwd string) bool {
+	out := strings.TrimSpace(gitOut(ctx, cwd, "rev-parse", "--is-inside-work-tree"))
+	return out == "true"
+}
+
+// gitOut runs `git <args>` in cwd and returns stdout (stderr discarded),
+// bounded by gitTimeout. Returns "" on any error — callers treat a git
+// failure as "no data", never fatal.
+func gitOut(ctx context.Context, cwd string, args ...string) string {
+	cctx, cancel := context.WithTimeout(ctx, gitTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, "git", args...)
+	cmd.Dir = cwd
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return ""
+	}
+	return out.String()
+}

--- a/internal/checkpoint/capture_test.go
+++ b/internal/checkpoint/capture_test.go
@@ -1,0 +1,192 @@
+package checkpoint
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// gitRepo initialises a temp git repo with one committed file and returns
+// its path. Skips the test if git is unavailable.
+func gitRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-q")
+	runGit(t, dir, "config", "user.email", "t@t.test")
+	runGit(t, dir, "config", "user.name", "t")
+	runGit(t, dir, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(dir, "tracked.txt"), []byte("original\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-q", "-m", "init")
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func capture(t *testing.T, cwd string, input []byte) (string, Checkpoint) {
+	t.Helper()
+	root := t.TempDir()
+	cp, err := Capture(context.Background(), root, CaptureRequest{
+		CheckpointID: "chk_test",
+		SessionID:    "ses_test",
+		Cwd:          cwd,
+		Trigger:      TriggerManual,
+		InputHistory: input,
+		Now:          time.Unix(1_700_000_000, 0),
+	})
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	return root, cp
+}
+
+// TestCaptureGitDiffAndUntracked is the core happy path: a modified tracked
+// file shows up in the diff, an untracked non-ignored file is copied, and a
+// .gitignore'd file is NOT copied (secrets/build output stay out).
+func TestCaptureGitDiffAndUntracked(t *testing.T) {
+	dir := gitRepo(t)
+	// Modify a tracked file.
+	if err := os.WriteFile(filepath.Join(dir, "tracked.txt"), []byte("CHANGED\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// One untracked file that should be captured...
+	if err := os.WriteFile(filepath.Join(dir, "new.txt"), []byte("brand new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// ...and one ignored file that must NOT be captured.
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("secret.env\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "secret.env"), []byte("TOKEN=abc\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root, cp := capture(t, dir, nil)
+
+	if !cp.IsGit {
+		t.Fatal("expected IsGit=true")
+	}
+	if !cp.GitDirty {
+		t.Error("expected GitDirty=true")
+	}
+	if cp.DiffBytes == 0 {
+		t.Error("expected a non-empty diff")
+	}
+	diff, err := os.ReadFile(filepath.Join(root, "chk_test", fileDiff))
+	if err != nil {
+		t.Fatalf("read diff: %v", err)
+	}
+	if !strings.Contains(string(diff), "CHANGED") {
+		t.Errorf("diff should mention the changed content, got:\n%s", diff)
+	}
+
+	// Untracked capture: new.txt + .gitignore are untracked-not-ignored (2),
+	// secret.env is ignored (0). So 2 files, and secret.env absent on disk.
+	if cp.UntrackedFiles != 2 {
+		t.Errorf("UntrackedFiles = %d, want 2 (new.txt + .gitignore)", cp.UntrackedFiles)
+	}
+	if _, err := os.Stat(filepath.Join(root, "chk_test", dirUntracked, "new.txt")); err != nil {
+		t.Errorf("new.txt should have been captured: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "chk_test", dirUntracked, "secret.env")); !os.IsNotExist(err) {
+		t.Error("ignored secret.env must NOT be captured")
+	}
+	// Manifest exists.
+	if _, err := os.Stat(filepath.Join(root, "chk_test", fileMeta)); err != nil {
+		t.Errorf("manifest missing: %v", err)
+	}
+}
+
+// TestCaptureNonGit: a non-git cwd records metadata only, with a note, and
+// no diff/untracked payload.
+func TestCaptureNonGit(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root, cp := capture(t, dir, nil)
+	if cp.IsGit {
+		t.Error("non-git cwd should have IsGit=false")
+	}
+	if cp.DiffBytes != 0 || cp.UntrackedFiles != 0 {
+		t.Error("non-git cwd should capture no diff/untracked payload")
+	}
+	if !strings.Contains(cp.Note, "not a git repository") {
+		t.Errorf("expected a not-a-repo note, got %q", cp.Note)
+	}
+	if _, err := os.Stat(filepath.Join(root, "chk_test", fileDiff)); !os.IsNotExist(err) {
+		t.Error("no diff file should be written for a non-git cwd")
+	}
+}
+
+// TestCaptureInputHistory: the input tail is written and sized.
+func TestCaptureInputHistory(t *testing.T) {
+	dir := t.TempDir()
+	input := []byte("ls -la\ngit status\n")
+	root, cp := capture(t, dir, input)
+	if cp.InputBytes != int64(len(input)) {
+		t.Errorf("InputBytes = %d, want %d", cp.InputBytes, len(input))
+	}
+	got, err := os.ReadFile(filepath.Join(root, "chk_test", fileInput))
+	if err != nil {
+		t.Fatalf("read input history: %v", err)
+	}
+	if string(got) != string(input) {
+		t.Errorf("input history = %q, want %q", got, input)
+	}
+}
+
+// TestCaptureUntrackedSizeCap: an untracked file larger than the per-file
+// cap is skipped and the checkpoint is flagged Truncated.
+func TestCaptureUntrackedSizeCap(t *testing.T) {
+	dir := gitRepo(t)
+	big := make([]byte, MaxUntrackedFileBytes+1)
+	for i := range big {
+		big[i] = 'x'
+	}
+	if err := os.WriteFile(filepath.Join(dir, "big.bin"), big, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root, cp := capture(t, dir, nil)
+	if cp.UntrackedFiles != 0 {
+		t.Errorf("oversized untracked file should be skipped, got UntrackedFiles=%d", cp.UntrackedFiles)
+	}
+	if !cp.Truncated {
+		t.Error("expected Truncated=true when a file is skipped by the size cap")
+	}
+	if _, err := os.Stat(filepath.Join(root, "chk_test", dirUntracked, "big.bin")); !os.IsNotExist(err) {
+		t.Error("oversized file must not be copied")
+	}
+}
+
+// TestSafeRel guards the path-escape defence.
+func TestSafeRel(t *testing.T) {
+	ok := []string{"a.txt", "dir/b.txt", "./c.txt"}
+	bad := []string{"", "/etc/passwd", "../escape", "../../x", "a/../../b"}
+	for _, p := range ok {
+		if !safeRel(p) {
+			t.Errorf("safeRel(%q) = false, want true", p)
+		}
+	}
+	for _, p := range bad {
+		if safeRel(p) {
+			t.Errorf("safeRel(%q) = true, want false", p)
+		}
+	}
+}

--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -1,0 +1,102 @@
+// Package checkpoint captures and restores the context-level state of a
+// session: the working tree's uncommitted git diff, untracked (non-ignored)
+// files, and the operator input history. It is priority ② of the
+// state-machine-hardening plan — context backup/restore layered on the now
+// concurrency-safe, audit-tracked session state machine.
+//
+// Design (frozen 2026-07-14, see docs/design/session-state-machine.md):
+//   - git-aware, .gitignore-respecting: only `git diff HEAD` (tracked
+//     changes) and untracked-but-not-ignored files are captured, so
+//     node_modules / build artifacts / secrets under .gitignore are never
+//     copied. A non-git cwd records metadata only.
+//   - filesystem + DB-metadata split: the heavy payload lands under a
+//     per-checkpoint dir on disk; the DB row is the queryable manifest.
+//   - triggers: on session interruption (gateway shutdown) and a manual API.
+package checkpoint
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"time"
+)
+
+// Trigger records what caused a checkpoint to be captured.
+type Trigger string
+
+const (
+	// TriggerInterrupted — captured because the gateway is shutting down
+	// and the session's live work is about to be interrupted.
+	TriggerInterrupted Trigger = "interrupted"
+	// TriggerManual — captured on an explicit operator/API request.
+	TriggerManual Trigger = "manual"
+)
+
+// Valid reports whether t is a known trigger.
+func (t Trigger) Valid() bool {
+	return t == TriggerInterrupted || t == TriggerManual
+}
+
+// Capture caps. Bound the on-disk payload so a checkpoint can never run
+// away with disk (a huge generated diff, a stray large untracked file, a
+// directory of thousands of untracked files). When a cap clips the capture
+// the checkpoint is still written and its Truncated flag is set.
+const (
+	// MaxDiffBytes bounds the stored `git diff HEAD` output.
+	MaxDiffBytes = 5 << 20 // 5 MiB
+	// MaxUntrackedFileBytes skips any single untracked file larger than this.
+	MaxUntrackedFileBytes = 1 << 20 // 1 MiB
+	// MaxUntrackedTotalBytes bounds the sum of copied untracked files.
+	MaxUntrackedTotalBytes = 20 << 20 // 20 MiB
+	// MaxUntrackedFiles bounds how many untracked files are copied.
+	MaxUntrackedFiles = 500
+	// InputHistoryRingBytes is the per-session input-history ring capacity
+	// the session manager keeps; the tail is what a checkpoint stores.
+	InputHistoryRingBytes = 64 << 10 // 64 KiB
+)
+
+// On-disk layout under a checkpoint's storage dir.
+const (
+	fileDiff     = "uncommitted.diff"
+	fileInput    = "input_history.log"
+	fileMeta     = "meta.json"
+	dirUntracked = "untracked"
+)
+
+// Checkpoint is the manifest for one captured context snapshot. The heavy
+// payload lives under StoragePath; this is the DB row.
+type Checkpoint struct {
+	ID             string    `json:"id"`
+	SessionID      string    `json:"session_id"`
+	CreatedAt      time.Time `json:"created_at"`
+	Trigger        Trigger   `json:"trigger"`
+	Cwd            string    `json:"cwd"`
+	IsGit          bool      `json:"is_git"`
+	GitHead        string    `json:"git_head,omitempty"`
+	GitDirty       bool      `json:"git_dirty"`
+	DiffBytes      int64     `json:"diff_bytes"`
+	UntrackedFiles int       `json:"untracked_files"`
+	UntrackedBytes int64     `json:"untracked_bytes"`
+	InputBytes     int64     `json:"input_bytes"`
+	Truncated      bool      `json:"truncated"`
+	StoragePath    string    `json:"-"`
+	Note           string    `json:"note,omitempty"`
+}
+
+// Errors surfaced by the service/handler layers.
+var (
+	ErrNotFound       = errors.New("checkpoint not found")
+	ErrInvalidTrigger = errors.New("invalid checkpoint trigger")
+	ErrNoStorageDir   = errors.New("checkpoint storage dir not configured")
+)
+
+func newID() string {
+	var b [9]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		t := time.Now().UnixNano()
+		for i := range b {
+			b[i] = byte(t >> (i * 8))
+		}
+	}
+	return "chk_" + base64.RawURLEncoding.EncodeToString(b[:])
+}

--- a/internal/checkpoint/handler.go
+++ b/internal/checkpoint/handler.go
@@ -1,0 +1,132 @@
+package checkpoint
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Handlers exposes the admin-facing checkpoint API. Capture is a mutating
+// action (snapshots the working tree to disk); list/get/diff are read-only.
+type Handlers struct {
+	svc *Service
+	log *slog.Logger
+}
+
+func NewHandlers(svc *Service, log *slog.Logger) *Handlers {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Handlers{svc: svc, log: log.With("component", "checkpoint.http")}
+}
+
+// Mount wires the routes. Session-scoped list/capture live under the
+// session id; per-checkpoint reads live under the checkpoint id.
+func (h *Handlers) Mount(r chi.Router) {
+	r.Route("/sessions/{id}/checkpoints", func(r chi.Router) {
+		r.Get("/", h.list)
+		r.Post("/", h.capture)
+	})
+	r.Route("/checkpoints/{cid}", func(r chi.Router) {
+		r.Get("/", h.get)
+		r.Get("/diff", h.diff)
+		r.Delete("/", h.delete)
+	})
+}
+
+func (h *Handlers) list(w http.ResponseWriter, r *http.Request) {
+	sessionID := chi.URLParam(r, "id")
+	cps, err := h.svc.List(r.Context(), sessionID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	if cps == nil {
+		cps = []Checkpoint{}
+	}
+	writeJSON(w, http.StatusOK, cps)
+}
+
+// captureRequest is the optional JSON body for POST .../checkpoints.
+type captureRequest struct {
+	Note string `json:"note,omitempty"`
+}
+
+func (h *Handlers) capture(w http.ResponseWriter, r *http.Request) {
+	sessionID := chi.URLParam(r, "id")
+	var req captureRequest
+	if r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&req) // body is optional
+	}
+	cp, err := h.svc.CaptureManual(r.Context(), sessionID, req.Note)
+	switch {
+	case errors.Is(err, ErrNotFound):
+		writeError(w, http.StatusNotFound, errors.New("session not found or not live"))
+		return
+	case errors.Is(err, ErrNoStorageDir):
+		writeError(w, http.StatusServiceUnavailable, errors.New("checkpoint storage not configured"))
+		return
+	case err != nil:
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, cp)
+}
+
+func (h *Handlers) get(w http.ResponseWriter, r *http.Request) {
+	cp, err := h.svc.Get(r.Context(), chi.URLParam(r, "cid"))
+	if errors.Is(err, ErrNotFound) {
+		writeError(w, http.StatusNotFound, err)
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, cp)
+}
+
+// diff returns the raw uncommitted diff as text/plain (empty body when the
+// working tree had no tracked changes).
+func (h *Handlers) diff(w http.ResponseWriter, r *http.Request) {
+	data, err := h.svc.ReadDiff(r.Context(), chi.URLParam(r, "cid"))
+	if errors.Is(err, ErrNotFound) {
+		writeError(w, http.StatusNotFound, err)
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+func (h *Handlers) delete(w http.ResponseWriter, r *http.Request) {
+	err := h.svc.Delete(r.Context(), chi.URLParam(r, "cid"))
+	if errors.Is(err, ErrNotFound) {
+		writeError(w, http.StatusNotFound, err)
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func writeJSON(w http.ResponseWriter, code int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, code int, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+}

--- a/internal/checkpoint/router_test.go
+++ b/internal/checkpoint/router_test.go
@@ -1,0 +1,59 @@
+package checkpoint
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// TestMountCoexistsWithSessionSubtree proves the checkpoint routes can be
+// mounted on the same router that already owns the /sessions/{id} subtree
+// (the real session handler) without a chi registration panic, and that
+// both the session-scoped and checkpoint-scoped routes still resolve. This
+// guards the app wiring where session.Handlers and checkpoint.Handlers
+// share one admin router.
+func TestMountCoexistsWithSessionSubtree(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("router assembly panicked: %v", r)
+		}
+	}()
+
+	r := chi.NewRouter()
+	// Stand in for session.Handlers.Mount: owns /sessions/{id}.
+	r.Route("/sessions", func(r chi.Router) {
+		r.Route("/{id}", func(r chi.Router) {
+			r.Get("/", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(299) })
+			r.Post("/input", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(298) })
+		})
+	})
+	// The real checkpoint handler on the same router (nil svc: routes must
+	// still register; we only assert routing resolves to the handler).
+	NewHandlers(NewService(nil, nil, "", nil), nil).Mount(r)
+
+	cases := []struct {
+		method, path string
+		wantCode     int
+	}{
+		{http.MethodGet, "/sessions/abc", 299},                                        // session subtree still works
+		{http.MethodPost, "/sessions/abc/input", 298},                                 // session subtree still works
+		{http.MethodGet, "/sessions/abc/checkpoints", http.StatusInternalServerError}, // reaches checkpoint list (nil pool -> 500)
+	}
+	for _, c := range cases {
+		req := httptest.NewRequest(c.method, c.path, nil)
+		rw := httptest.NewRecorder()
+		// The checkpoint list handler dereferences the DB pool; guard the
+		// nil-pool panic so we're asserting *routing*, not handler internals.
+		func() {
+			defer func() { _ = recover() }()
+			r.ServeHTTP(rw, req)
+		}()
+		// A 404 would mean the route didn't resolve at all — that's the
+		// failure we care about here.
+		if rw.Code == http.StatusNotFound {
+			t.Errorf("%s %s resolved to 404 (route not registered)", c.method, c.path)
+		}
+	}
+}

--- a/internal/checkpoint/service.go
+++ b/internal/checkpoint/service.go
@@ -1,0 +1,158 @@
+package checkpoint
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// SessionInfo is the minimal view of a session the checkpoint service needs
+// to capture context on demand (the manual trigger). The session manager
+// satisfies it without checkpoint importing the session package's types.
+type SessionInfo interface {
+	// CheckpointContext returns the working directory and the operator
+	// input-history tail for a session id, or ok=false if unknown.
+	CheckpointContext(id string) (cwd string, input []byte, ok bool)
+}
+
+// Service captures, lists, reads and reaps session checkpoints. It is safe
+// for concurrent use.
+type Service struct {
+	store       *store
+	sessions    SessionInfo
+	storageRoot string
+	log         *slog.Logger
+	now         func() time.Time
+}
+
+// NewService builds the checkpoint service. storageRoot is the base dir the
+// per-checkpoint payload dirs live under (e.g. ~/.opendray/checkpoints);
+// it is created on first capture. sessions may be nil (manual capture then
+// requires the caller to supply context explicitly via CaptureFor).
+func NewService(pool *pgxpool.Pool, sessions SessionInfo, storageRoot string, log *slog.Logger) *Service {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Service{
+		store:       newStore(pool),
+		sessions:    sessions,
+		storageRoot: storageRoot,
+		log:         log.With("component", "checkpoint"),
+		now:         time.Now,
+	}
+}
+
+// SetSessions wires the session source after construction, breaking the
+// startup cycle where the session manager needs this service as its
+// checkpoint recorder while this service needs the manager for manual
+// captures. Call once at startup before serving traffic.
+func (s *Service) SetSessions(sessions SessionInfo) {
+	s.sessions = sessions
+}
+
+// Capture snapshots a session's current context. cwd and input are supplied
+// by the caller (the session manager already holds them), so Capture has no
+// dependency on session internals. The metadata row is inserted on success.
+func (s *Service) Capture(ctx context.Context, sessionID, cwd string, trigger Trigger, input []byte, note string) (Checkpoint, error) {
+	if s.storageRoot == "" {
+		return Checkpoint{}, ErrNoStorageDir
+	}
+	if !trigger.Valid() {
+		return Checkpoint{}, ErrInvalidTrigger
+	}
+	cp, err := Capture(ctx, s.storageRoot, CaptureRequest{
+		CheckpointID: newID(),
+		SessionID:    sessionID,
+		Cwd:          cwd,
+		Trigger:      trigger,
+		InputHistory: input,
+		Note:         note,
+		Now:          s.now(),
+	})
+	if err != nil {
+		return Checkpoint{}, err
+	}
+	if err := s.store.insert(ctx, cp); err != nil {
+		// Don't leave an orphaned on-disk dir if the row didn't persist.
+		_ = os.RemoveAll(cp.StoragePath)
+		return Checkpoint{}, err
+	}
+	s.log.Info("captured session checkpoint",
+		"session_id", sessionID, "checkpoint_id", cp.ID, "trigger", trigger,
+		"is_git", cp.IsGit, "diff_bytes", cp.DiffBytes,
+		"untracked_files", cp.UntrackedFiles, "truncated", cp.Truncated)
+	return cp, nil
+}
+
+// CaptureManual captures via the SessionInfo lookup (the manual API path).
+func (s *Service) CaptureManual(ctx context.Context, sessionID, note string) (Checkpoint, error) {
+	if s.sessions == nil {
+		return Checkpoint{}, fmt.Errorf("checkpoint: no session source wired")
+	}
+	cwd, input, ok := s.sessions.CheckpointContext(sessionID)
+	if !ok {
+		return Checkpoint{}, ErrNotFound
+	}
+	return s.Capture(ctx, sessionID, cwd, TriggerManual, input, note)
+}
+
+// CaptureInterrupt is the session manager's hook: it snapshots a session
+// that is about to be interrupted by a gateway shutdown. Best-effort and
+// self-contained (its own timeout) so it can never wedge shutdown; errors
+// are logged, not returned.
+func (s *Service) CaptureInterrupt(sessionID, cwd string, input []byte) {
+	if s.storageRoot == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := s.Capture(ctx, sessionID, cwd, TriggerInterrupted, input, ""); err != nil {
+		s.log.Warn("interrupt checkpoint failed", "session_id", sessionID, "err", err)
+	}
+}
+
+// List returns a session's checkpoints, newest first.
+func (s *Service) List(ctx context.Context, sessionID string) ([]Checkpoint, error) {
+	return s.store.listForSession(ctx, sessionID)
+}
+
+// Get returns one checkpoint's manifest.
+func (s *Service) Get(ctx context.Context, id string) (Checkpoint, error) {
+	return s.store.get(ctx, id)
+}
+
+// ReadDiff returns the stored uncommitted diff for a checkpoint (empty when
+// the working tree had no tracked changes).
+func (s *Service) ReadDiff(ctx context.Context, id string) ([]byte, error) {
+	cp, err := s.store.get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(filepath.Join(cp.StoragePath, fileDiff))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("checkpoint: read diff: %w", err)
+	}
+	return data, nil
+}
+
+// Delete removes a checkpoint's metadata row and its on-disk payload.
+func (s *Service) Delete(ctx context.Context, id string) error {
+	path, err := s.store.delete(ctx, id)
+	if err != nil {
+		return err
+	}
+	if path != "" {
+		if err := os.RemoveAll(path); err != nil {
+			s.log.Warn("checkpoint payload reap failed", "checkpoint_id", id, "path", path, "err", err)
+		}
+	}
+	return nil
+}

--- a/internal/checkpoint/store.go
+++ b/internal/checkpoint/store.go
@@ -1,0 +1,114 @@
+package checkpoint
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// store is the package-private DB layer for session_checkpoints.
+type store struct{ pool *pgxpool.Pool }
+
+func newStore(pool *pgxpool.Pool) *store { return &store{pool: pool} }
+
+const checkpointSelect = `
+    SELECT id, session_id, created_at, trigger, cwd, is_git,
+           COALESCE(git_head, ''), git_dirty, diff_bytes,
+           untracked_files, untracked_bytes, input_bytes, truncated,
+           storage_path, COALESCE(note, '')
+    FROM session_checkpoints`
+
+func (s *store) insert(ctx context.Context, cp Checkpoint) error {
+	_, err := s.pool.Exec(ctx, `
+        INSERT INTO session_checkpoints
+            (id, session_id, created_at, trigger, cwd, is_git, git_head,
+             git_dirty, diff_bytes, untracked_files, untracked_bytes,
+             input_bytes, truncated, storage_path, note)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+		cp.ID, cp.SessionID, cp.CreatedAt, string(cp.Trigger), cp.Cwd, cp.IsGit,
+		nullableString(cp.GitHead), cp.GitDirty, cp.DiffBytes, cp.UntrackedFiles,
+		cp.UntrackedBytes, cp.InputBytes, cp.Truncated, cp.StoragePath,
+		nullableString(cp.Note))
+	if err != nil {
+		return fmt.Errorf("checkpoint: insert: %w", err)
+	}
+	return nil
+}
+
+func (s *store) get(ctx context.Context, id string) (Checkpoint, error) {
+	row := s.pool.QueryRow(ctx, checkpointSelect+` WHERE id=$1`, id)
+	return scanCheckpoint(row)
+}
+
+// listForSession returns a session's checkpoints, newest first.
+func (s *store) listForSession(ctx context.Context, sessionID string) ([]Checkpoint, error) {
+	rows, err := s.pool.Query(ctx, checkpointSelect+
+		` WHERE session_id=$1 ORDER BY created_at DESC`, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("checkpoint: list: %w", err)
+	}
+	defer rows.Close()
+	var out []Checkpoint
+	for rows.Next() {
+		cp, err := scanCheckpoint(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, cp)
+	}
+	return out, rows.Err()
+}
+
+// delete removes the metadata row and returns its storage_path so the
+// caller can reap the on-disk payload.
+func (s *store) delete(ctx context.Context, id string) (string, error) {
+	var path string
+	err := s.pool.QueryRow(ctx,
+		`DELETE FROM session_checkpoints WHERE id=$1 RETURNING storage_path`, id).
+		Scan(&path)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", ErrNotFound
+	}
+	if err != nil {
+		return "", fmt.Errorf("checkpoint: delete: %w", err)
+	}
+	return path, nil
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanCheckpoint(row rowScanner) (Checkpoint, error) {
+	var (
+		cp      Checkpoint
+		trigger string
+		gitHead string
+		storage string
+		note    string
+	)
+	err := row.Scan(&cp.ID, &cp.SessionID, &cp.CreatedAt, &trigger, &cp.Cwd,
+		&cp.IsGit, &gitHead, &cp.GitDirty, &cp.DiffBytes, &cp.UntrackedFiles,
+		&cp.UntrackedBytes, &cp.InputBytes, &cp.Truncated, &storage, &note)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Checkpoint{}, ErrNotFound
+	}
+	if err != nil {
+		return Checkpoint{}, fmt.Errorf("checkpoint: scan: %w", err)
+	}
+	cp.Trigger = Trigger(trigger)
+	cp.GitHead = gitHead
+	cp.StoragePath = storage
+	cp.Note = note
+	return cp, nil
+}
+
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/internal/session/checkpoint_context_test.go
+++ b/internal/session/checkpoint_context_test.go
@@ -1,0 +1,37 @@
+package session
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestCheckpointContextInputRing verifies the manager surfaces a live
+// session's cwd and the accumulated input-history tail (the data a context
+// checkpoint records), and returns ok=false for unknown sessions.
+func TestCheckpointContextInputRing(t *testing.T) {
+	m := newBareManager()
+	const id = "ses_cp"
+	rs := &runningSession{
+		sess:      Session{ID: id, State: StateRunning, Cwd: "/work/dir"},
+		inputRing: NewRing(inputRingSize),
+	}
+	// Simulate operator input flowing through Manager.Input's ring write.
+	_, _ = rs.inputRing.Write([]byte("git status\n"))
+	_, _ = rs.inputRing.Write([]byte("make test\n"))
+	m.sessions[id] = rs
+
+	cwd, input, ok := m.CheckpointContext(id)
+	if !ok {
+		t.Fatal("CheckpointContext(live) ok=false, want true")
+	}
+	if cwd != "/work/dir" {
+		t.Errorf("cwd = %q, want /work/dir", cwd)
+	}
+	if want := []byte("git status\nmake test\n"); !bytes.Equal(input, want) {
+		t.Errorf("input history = %q, want %q", input, want)
+	}
+
+	if _, _, ok := m.CheckpointContext("ses_missing"); ok {
+		t.Error("CheckpointContext(unknown) ok=true, want false")
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -23,9 +23,13 @@ import (
 const (
 	// DefaultRingSize is the per-session stdout ring buffer capacity.
 	DefaultRingSize = 1 << 20 // 1 MiB
-	fanoutBuffer    = 64
-	pumpBufSize     = 4096
-	terminateGrace  = 3 * time.Second
+	// inputRingSize is the per-session stdin (operator input) ring
+	// capacity kept for context checkpoints. Small: it's an input-history
+	// tail for recovery context, not a full transcript.
+	inputRingSize  = 64 << 10 // 64 KiB
+	fanoutBuffer   = 64
+	pumpBufSize    = 4096
+	terminateGrace = 3 * time.Second
 
 	// defaultIdleThreshold is deliberately generous: "idle" is only a
 	// soft notification/label — the session process keeps running and
@@ -136,6 +140,22 @@ func WithAutoFailoverEnabled(enabled bool) ManagerOption {
 	return func(m *Manager) { m.autoFailoverEnabled = enabled }
 }
 
+// CheckpointRecorder captures a session's context (cwd snapshot +
+// uncommitted diff + input history) when the gateway is about to interrupt
+// it. Wired as a small interface so session doesn't import the checkpoint
+// package. Nil disables checkpointing. CaptureInterrupt must be
+// self-contained (own timeout) and never block indefinitely — it runs
+// during shutdown.
+type CheckpointRecorder interface {
+	CaptureInterrupt(sessionID, cwd string, input []byte)
+}
+
+// WithCheckpointRecorder injects the context-checkpoint recorder invoked on
+// graceful shutdown (before processes are terminated). Defaults to nil.
+func WithCheckpointRecorder(r CheckpointRecorder) ManagerOption {
+	return func(m *Manager) { m.checkpoints = r }
+}
+
 // WithIntegrationSpawnProfiles wires the resolver the manager uses to
 // look up the provider-agnostic spawn profile (MCP servers + system
 // prompt + auto-approve) an integration declares, and apply it to every
@@ -195,6 +215,7 @@ type Manager struct {
 	antigravityAccounts AntigravityAccountResolver // optional; nil disables antigravity conversation resume/carry
 	autoFailoverEnabled bool                       // when true + claudeAccounts != nil, rate-limit scanner is hot
 	spawnProfiles       IntegrationSpawnProfiles   // optional; nil disables integration spawn-profile injection
+	checkpoints         CheckpointRecorder         // optional; nil disables context checkpoints on interrupt
 
 	idleThreshold time.Duration
 	idleInterval  time.Duration
@@ -268,6 +289,10 @@ type runningSession struct {
 	cmd  *exec.Cmd
 	pty  *os.File
 	ring *RingBuffer
+	// inputRing keeps a bounded tail of the operator input sent to the
+	// PTY, so a context checkpoint can record the recent input history.
+	// Output history lives in `ring`; this is the stdin side.
+	inputRing *RingBuffer
 	// vt is a virtual-terminal emulator fed in lockstep with `ring`.
 	// ring keeps the byte-stream history for client replay; vt keeps
 	// the *current screen* (post-redraw) for snapshots used by
@@ -825,6 +850,7 @@ func (m *Manager) spawn(ctx context.Context, sess Session, reactivate bool) (*ru
 		cmd:          cmd,
 		pty:          ptmx,
 		ring:         NewRing(DefaultRingSize),
+		inputRing:    NewRing(inputRingSize),
 		vt:           vt10x.New(vt10x.WithSize(defaultVTCols, defaultVTRows)),
 		tempDir:      tempDir,
 		subs:         make(map[chan []byte]struct{}),
@@ -867,6 +893,25 @@ func (m *Manager) lookup(id string) *runningSession {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.sessions[id]
+}
+
+// CheckpointContext returns a live session's working directory and its
+// operator input-history tail, for the checkpoint service's manual-capture
+// path. ok is false when the session isn't tracked in memory (only live
+// sessions can be checkpointed — a terminal row has no runtime context).
+// Implements checkpoint.SessionInfo without importing the checkpoint pkg.
+func (m *Manager) CheckpointContext(id string) (cwd string, input []byte, ok bool) {
+	rs := m.lookup(id)
+	if rs == nil {
+		return "", nil, false
+	}
+	rs.sessMu.RLock()
+	cwd = rs.sess.Cwd
+	rs.sessMu.RUnlock()
+	if rs.inputRing != nil {
+		input = rs.inputRing.Snapshot()
+	}
+	return cwd, input, true
 }
 
 // snapshot returns the in-memory Session view for id, or the zero Session
@@ -1405,6 +1450,11 @@ func (m *Manager) Input(_ context.Context, id string, data []byte) error {
 	if _, err := rs.pty.Write(data); err != nil {
 		return fmt.Errorf("pty write: %w", err)
 	}
+	// Record the input tail for context checkpoints. Best-effort; the ring
+	// is independently locked so this never blocks the PTY write path.
+	if rs.inputRing != nil {
+		_, _ = rs.inputRing.Write(data)
+	}
 	if rs.markActive(time.Now()) {
 		m.flipBackToRunning(rs)
 	}
@@ -1519,6 +1569,48 @@ func (m *Manager) History(ctx context.Context, id string, limit int) (HistoryRes
 
 // Shutdown signals SIGTERM to all live sessions, waits up to 5s, then
 // SIGKILL stragglers. Idempotent.
+// checkpointShutdownBudget bounds the total time the interrupt-checkpoint
+// pass may take during shutdown before we proceed to terminate processes.
+// Each capture also has its own internal timeout; this caps the aggregate.
+const checkpointShutdownBudget = 10 * time.Second
+
+// checkpointLiveOnShutdown snapshots the context of every live session
+// concurrently (bounded), waiting at most checkpointShutdownBudget before
+// returning so shutdown stays responsive. Best-effort: capture errors are
+// logged inside the recorder, never surfaced here.
+func (m *Manager) checkpointLiveOnShutdown(rss []*runningSession) {
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, autoResumeConcurrency)
+	for _, rs := range rss {
+		rs.sessMu.RLock()
+		terminal := rs.sess.State.IsTerminal()
+		id := rs.sess.ID
+		cwd := rs.sess.Cwd
+		rs.sessMu.RUnlock()
+		if terminal {
+			continue
+		}
+		var input []byte
+		if rs.inputRing != nil {
+			input = rs.inputRing.Snapshot()
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(id, cwd string, input []byte) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			m.checkpoints.CaptureInterrupt(id, cwd, input)
+		}(id, cwd, input)
+	}
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(checkpointShutdownBudget):
+		m.log.Warn("shutdown checkpoint capture exceeded budget; proceeding to terminate")
+	}
+}
+
 func (m *Manager) Shutdown(ctx context.Context) error {
 	m.mu.Lock()
 	if m.closed {
@@ -1531,6 +1623,13 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 		rss = append(rss, rs)
 	}
 	m.mu.Unlock()
+
+	// Capture context checkpoints for the live sessions BEFORE terminating
+	// them, while each cwd is still in its working state. Bounded so a
+	// wedged repo can't stall shutdown indefinitely.
+	if m.checkpoints != nil {
+		m.checkpointLiveOnShutdown(rss)
+	}
 
 	for _, rs := range rss {
 		rs.sessMu.RLock()

--- a/internal/store/migrations/0078_session_checkpoints.sql
+++ b/internal/store/migrations/0078_session_checkpoints.sql
@@ -1,0 +1,39 @@
+-- 0078_session_checkpoints — context-level checkpoints for sessions
+-- (priority ② of the state-machine-hardening plan: context backup/restore).
+--
+-- A checkpoint captures the recoverable *context* of a session at a point
+-- in time: the working tree's uncommitted git diff, untracked (non-ignored)
+-- files, and the operator input history. The heavy payload lives on disk
+-- under storage_path (filesystem + DB-metadata split, so large diffs/files
+-- don't bloat the DB); this row is the queryable manifest.
+--
+-- git-aware, .gitignore-respecting capture: only tracked changes (diff vs
+-- HEAD) and untracked-but-not-ignored files are snapshot, so node_modules /
+-- build artifacts / secrets under .gitignore are never copied. A non-git
+-- cwd records metadata only (is_git=false).
+--
+-- ON DELETE CASCADE: removing a session removes its checkpoint rows. The
+-- on-disk payload is reaped separately by the checkpoint service.
+CREATE TABLE IF NOT EXISTS session_checkpoints (
+    id              TEXT PRIMARY KEY,
+    session_id      TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- what triggered the capture: 'interrupted' (gateway shutdown) or 'manual'.
+    trigger         TEXT NOT NULL CHECK (trigger IN ('interrupted', 'manual')),
+    cwd             TEXT NOT NULL,
+    is_git          BOOLEAN NOT NULL DEFAULT FALSE,
+    git_head        TEXT,                        -- HEAD sha at capture ('' / NULL when none)
+    git_dirty       BOOLEAN NOT NULL DEFAULT FALSE,
+    diff_bytes      BIGINT NOT NULL DEFAULT 0,
+    untracked_files INTEGER NOT NULL DEFAULT 0,
+    untracked_bytes BIGINT NOT NULL DEFAULT 0,
+    input_bytes     BIGINT NOT NULL DEFAULT 0,
+    -- true when any cap (diff size / per-file / total / file count) clipped
+    -- the capture, so the UI can flag the checkpoint as partial.
+    truncated       BOOLEAN NOT NULL DEFAULT FALSE,
+    storage_path    TEXT NOT NULL,               -- on-disk checkpoint dir
+    note            TEXT
+);
+
+CREATE INDEX IF NOT EXISTS session_checkpoints_session_created_idx
+    ON session_checkpoints (session_id, created_at DESC);


### PR DESCRIPTION
## Summary

**Priority ②** of the state-machine-hardening plan: capture the recoverable **context** of a session — so a gateway restart / interruption no longer loses live work. Built on the now concurrency-safe, audit-tracked state machine from #450/#451.

Scope decisions (confirmed with the operator): **git-aware + respect `.gitignore`**, **filesystem + DB-metadata split**, **on-interrupt + manual trigger**.

### New `internal/checkpoint` package
- **Capture** (git-aware, `.gitignore`-respecting): snapshots `git diff HEAD` (tracked changes) + untracked-but-not-ignored files + operator input history into a per-checkpoint dir. `node_modules` / build output / secrets under `.gitignore` are **never** copied; a non-git cwd records metadata only. Bounded by caps (diff 5 MiB, per-file 1 MiB, total 20 MiB, 500 files) — hitting a cap sets `Truncated` but still yields a valid checkpoint. Never mutates the cwd; path-escape guarded.
- **Filesystem + DB-metadata split** (migration 0078 `session_checkpoints`): heavy payload on disk under `~/.opendray/checkpoints/<id>/`; queryable manifest row in the DB (`FK ON DELETE CASCADE`, `trigger` CHECK).
- **Admin REST**: `POST /sessions/{id}/checkpoints` (manual), `GET` list, `GET /checkpoints/{cid}`, `GET .../diff` (text/plain), `DELETE` (reaps disk).

### Session-manager integration (session does **not** import checkpoint)
- Per-session bounded **input ring** (64 KiB) records operator stdin; surfaced via `CheckpointContext(id)`.
- `CheckpointRecorder` interface + `WithCheckpointRecorder` option; **`Shutdown` captures every live session's context BEFORE terminating processes** (cwd still pristine), bounded by a 10s budget so a wedged repo can't stall shutdown.

### Deferred (documented)
Restore/apply (`git apply` + untracked restore), retention/pruning, and the web/mobile UI surfacing checkpoints + `interrupt_reason`.

## Test plan
- `go test -race ./internal/checkpoint/ ./internal/session/` — green: git diff+untracked capture, `.gitignore` exclusion, non-git metadata-only, size-cap truncation, input history, path-escape guard, and a **router coexistence test** proving `/sessions/{id}/checkpoints` mounts alongside the session handler's `/sessions/{id}` subtree without a chi panic.
- `go build ./...` ; `go vet` — clean; `gofmt` clean.
- Migration 0078 applied on **ephemeral pg17**: table/index/CHECK present, bad trigger rejected, `ON DELETE CASCADE` verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)