### PR TITLE
feat(checkpoint): strict, dry-run-first checkpoint restore + retention

### DIFF
--- a/docs/design/session-state-machine.md
+++ b/docs/design/session-state-machine.md
@@ -1,6 +1,6 @@
 # Session State Machine Hardening
 
-Status: **Phase 2 — SSOT wired; concurrency-safe resume + interrupt cause persisted**
+Status: **Priority ② — context checkpoint capture + restore landed (SSOT wired; concurrency-safe resume; interrupt cause persisted)**
 Owner: opendray gateway
 Last updated: 2026-07-14
 
@@ -242,9 +242,19 @@ a time without a big-bang rewrite:
    (`gateway_shutdown` / `gateway_crash`) for audit (migration 0077).
    Replaces the old plan item "reconcile PID-liveness probing → adopt",
    which §2 showed is infeasible for PTY-backed children.
-5. ⬜ **Next** — backup / checkpoint format (cwd snapshot + uncommitted diff
-   + input history), then the audit/cost panel that surfaces
-   `interrupt_reason`. Orchestration remains parked.
+5. ✅ **Done (priority ②, PR #452)** — context checkpoint **capture**:
+   git-aware (`git diff HEAD` + untracked-not-ignored files + input history),
+   `.gitignore`-respecting, bounded caps, filesystem + DB-metadata split
+   (migration 0078), captured on graceful shutdown and via a manual API.
+   Lives in `internal/checkpoint`.
+6. ✅ **Done (priority ②)** — checkpoint **restore** (strict, dry-run-first):
+   `applyCheckpoint` re-applies a checkpoint onto its cwd only when HEAD
+   matches and there are no uncommitted tracked changes, `git apply --check`
+   passes, and untracked files are restored without overwriting
+   (`POST /checkpoints/{cid}/restore`, 409 on any guard). Plus retention
+   (`RetainPerSession`) reaping old checkpoints after each capture.
+7. ⬜ **Next** — the audit/cost panel that surfaces `interrupt_reason` +
+   checkpoints, and the web/mobile UI. Orchestration remains parked.
 
-Each step is guarded by the matrix + reservation tests, so behaviour cannot
-silently drift.
+Each step is guarded by the matrix + reservation + capture/restore tests, so
+behaviour cannot silently drift.

--- a/internal/checkpoint/handler.go
+++ b/internal/checkpoint/handler.go
@@ -33,6 +33,7 @@ func (h *Handlers) Mount(r chi.Router) {
 	r.Route("/checkpoints/{cid}", func(r chi.Router) {
 		r.Get("/", h.get)
 		r.Get("/diff", h.diff)
+		r.Post("/restore", h.restore)
 		r.Delete("/", h.delete)
 	})
 }
@@ -104,6 +105,29 @@ func (h *Handlers) diff(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(data)
+}
+
+// restore re-applies a checkpoint onto its cwd under the strict guards in
+// Service.Restore. A guard failure is a 409 Conflict (the operator must
+// resolve the working-tree state first), a bad/absent checkpoint is 404.
+func (h *Handlers) restore(w http.ResponseWriter, r *http.Request) {
+	res, err := h.svc.Restore(r.Context(), chi.URLParam(r, "cid"))
+	switch {
+	case errors.Is(err, ErrNotFound):
+		writeError(w, http.StatusNotFound, err)
+		return
+	case errors.Is(err, ErrNotGitCheckpoint),
+		errors.Is(err, ErrNotWorkTree),
+		errors.Is(err, ErrHeadMismatch),
+		errors.Is(err, ErrDirtyWorktree),
+		errors.Is(err, ErrApplyCheckFailed):
+		writeError(w, http.StatusConflict, err)
+		return
+	case err != nil:
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
 }
 
 func (h *Handlers) delete(w http.ResponseWriter, r *http.Request) {

--- a/internal/checkpoint/restore.go
+++ b/internal/checkpoint/restore.go
@@ -1,0 +1,193 @@
+package checkpoint
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// RestoreResult reports what a Restore actually did.
+type RestoreResult struct {
+	CheckpointID      string   `json:"checkpoint_id"`
+	DiffApplied       bool     `json:"diff_applied"`
+	UntrackedRestored int      `json:"untracked_restored"`
+	UntrackedSkipped  []string `json:"untracked_skipped,omitempty"` // target already existed
+}
+
+// Restore errors. All are pre-write guards except a failure mid-apply,
+// which git apply makes atomic (it applies all hunks or none).
+var (
+	// ErrNotGitCheckpoint — the checkpoint captured a non-git cwd (metadata
+	// only), so there is nothing to apply.
+	ErrNotGitCheckpoint = errors.New("checkpoint has no git payload to restore")
+	// ErrNotWorkTree — the target cwd is no longer a git working tree.
+	ErrNotWorkTree = errors.New("target cwd is not a git working tree")
+	// ErrHeadMismatch — HEAD moved since capture; applying the diff would
+	// be against a different base. Refused (strict posture).
+	ErrHeadMismatch = errors.New("HEAD has moved since the checkpoint; refusing to restore")
+	// ErrDirtyWorktree — there are uncommitted tracked changes; restoring
+	// could clobber them or conflict. Refused (strict posture).
+	ErrDirtyWorktree = errors.New("working tree has uncommitted changes; commit or stash them first")
+	// ErrApplyCheckFailed — the stored diff does not apply cleanly to the
+	// current tree (git apply --check dry-run failed). Refused before any
+	// write. The wrapped message carries git's explanation.
+	ErrApplyCheckFailed = errors.New("stored diff does not apply cleanly")
+)
+
+// Restore re-applies a checkpoint's captured context onto its cwd, under a
+// strict, dry-run-first posture:
+//
+//  1. the cwd must be a git work tree whose HEAD equals the checkpoint's,
+//  2. it must have no uncommitted tracked changes,
+//  3. the stored diff must pass `git apply --check` (dry-run),
+//
+// only then is the diff applied. Untracked files are restored only where
+// the target does not already exist (never overwriting). Any guard failing
+// returns before a single byte is written.
+func (s *Service) Restore(ctx context.Context, id string) (RestoreResult, error) {
+	cp, err := s.store.get(ctx, id)
+	if err != nil {
+		return RestoreResult{}, err
+	}
+	res, err := applyCheckpoint(ctx, cp)
+	if err == nil {
+		s.log.Info("restored session checkpoint", "checkpoint_id", id, "cwd", cp.Cwd,
+			"diff_applied", res.DiffApplied, "untracked_restored", res.UntrackedRestored,
+			"untracked_skipped", len(res.UntrackedSkipped))
+	}
+	return res, err
+}
+
+// applyCheckpoint is the DB-free core of Restore: it enforces the strict
+// guards and applies cp's payload onto cp.Cwd. Split out so the restore
+// logic is testable without a database.
+func applyCheckpoint(ctx context.Context, cp Checkpoint) (RestoreResult, error) {
+	res := RestoreResult{CheckpointID: cp.ID}
+	if !cp.IsGit {
+		return res, ErrNotGitCheckpoint
+	}
+	cwd := cp.Cwd
+	if !isGitWorkTree(ctx, cwd) {
+		return res, ErrNotWorkTree
+	}
+
+	// Guard 1: HEAD must match the capture point.
+	head := strings.TrimSpace(gitOut(ctx, cwd, "rev-parse", "HEAD"))
+	if head != cp.GitHead {
+		return res, fmt.Errorf("%w (checkpoint %s, now %s)", ErrHeadMismatch, shortSHA(cp.GitHead), shortSHA(head))
+	}
+
+	// Guard 2: no uncommitted *tracked* changes (untracked files are fine —
+	// they don't conflict with the tracked-changes patch, and the untracked
+	// restore below never overwrites).
+	if dirty := strings.TrimSpace(gitOut(ctx, cwd, "status", "--porcelain", "--untracked-files=no")); dirty != "" {
+		return res, ErrDirtyWorktree
+	}
+
+	// Apply the diff (if any) — dry-run first, then for real.
+	diffPath := filepath.Join(cp.StoragePath, fileDiff)
+	if fileExists(diffPath) {
+		if out, err := gitRunCombined(ctx, cwd, "apply", "--check", diffPath); err != nil {
+			return res, fmt.Errorf("%w: %s", ErrApplyCheckFailed, strings.TrimSpace(out))
+		}
+		if out, err := gitRunCombined(ctx, cwd, "apply", diffPath); err != nil {
+			return res, fmt.Errorf("git apply: %s", strings.TrimSpace(out))
+		}
+		res.DiffApplied = true
+	}
+
+	// Restore untracked files without overwriting anything present.
+	restored, skipped, err := restoreUntracked(filepath.Join(cp.StoragePath, dirUntracked), cwd)
+	if err != nil {
+		// The diff (if any) is already applied; report partial success with
+		// the error so the operator knows the untracked restore was cut.
+		res.UntrackedRestored = restored
+		res.UntrackedSkipped = skipped
+		return res, fmt.Errorf("restore untracked files: %w", err)
+	}
+	res.UntrackedRestored = restored
+	res.UntrackedSkipped = skipped
+	return res, nil
+}
+
+// restoreUntracked copies files from untrackedDir back into cwd at their
+// captured relative paths, skipping any whose target already exists (no
+// overwrite). Returns the restored count and the skipped relpaths.
+func restoreUntracked(untrackedDir, cwd string) (int, []string, error) {
+	info, err := os.Stat(untrackedDir)
+	if os.IsNotExist(err) || (err == nil && !info.IsDir()) {
+		return 0, nil, nil
+	}
+	var restored int
+	var skipped []string
+	walkErr := filepath.WalkDir(untrackedDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(untrackedDir, path)
+		if err != nil {
+			return err
+		}
+		if !safeRel(rel) {
+			skipped = append(skipped, rel)
+			return nil
+		}
+		target := filepath.Join(cwd, rel)
+		if fileExists(target) {
+			skipped = append(skipped, rel)
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(target, data, 0o644); err != nil {
+			return err
+		}
+		restored++
+		return nil
+	})
+	return restored, skipped, walkErr
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+func shortSHA(s string) string {
+	if len(s) > 8 {
+		return s[:8]
+	}
+	if s == "" {
+		return "(none)"
+	}
+	return s
+}
+
+// gitRunCombined runs `git <args>` in cwd and returns combined stdout+stderr
+// plus any error, so restore can surface git's explanation on failure.
+// Unlike gitOut it does NOT swallow errors.
+func gitRunCombined(ctx context.Context, cwd string, args ...string) (string, error) {
+	cctx, cancel := context.WithTimeout(ctx, gitTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, "git", args...)
+	cmd.Dir = cwd
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}

--- a/internal/checkpoint/restore_test.go
+++ b/internal/checkpoint/restore_test.go
@@ -1,0 +1,140 @@
+package checkpoint
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// captureRepo captures cwd and returns the resulting Checkpoint, so the
+// DB-free applyCheckpoint core can be exercised directly.
+func captureRepo(t *testing.T, cwd string) Checkpoint {
+	t.Helper()
+	root := t.TempDir()
+	cp, err := Capture(context.Background(), root, CaptureRequest{
+		CheckpointID: "chk_r",
+		SessionID:    "ses_r",
+		Cwd:          cwd,
+		Trigger:      TriggerManual,
+		Now:          time.Unix(1_700_000_000, 0),
+	})
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	return cp
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFile(t *testing.T, dir, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, name))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}
+
+// TestRestoreHappyPath: capture a dirty repo, revert the working tree, then
+// restore — the tracked diff is re-applied and untracked files come back.
+func TestRestoreHappyPath(t *testing.T) {
+	dir := gitRepo(t)
+	writeFile(t, dir, "tracked.txt", "CHANGED\n")
+	writeFile(t, dir, "new.txt", "fresh\n")
+	cp := captureRepo(t, dir)
+
+	// Revert the working tree to the committed state + remove the untracked.
+	runGit(t, dir, "checkout", "--", "tracked.txt")
+	if err := os.Remove(filepath.Join(dir, "new.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := applyCheckpoint(context.Background(), cp)
+	if err != nil {
+		t.Fatalf("applyCheckpoint: %v", err)
+	}
+	if !res.DiffApplied {
+		t.Error("expected DiffApplied=true")
+	}
+	if res.UntrackedRestored != 1 {
+		t.Errorf("UntrackedRestored = %d, want 1", res.UntrackedRestored)
+	}
+	if got := readFile(t, dir, "tracked.txt"); got != "CHANGED\n" {
+		t.Errorf("tracked.txt = %q, want CHANGED", got)
+	}
+	if got := readFile(t, dir, "new.txt"); got != "fresh\n" {
+		t.Errorf("new.txt = %q, want fresh", got)
+	}
+}
+
+// TestRestoreRefusesHeadMismatch: a commit after capture moves HEAD, so
+// restore refuses before touching the tree.
+func TestRestoreRefusesHeadMismatch(t *testing.T) {
+	dir := gitRepo(t)
+	writeFile(t, dir, "tracked.txt", "CHANGED\n")
+	cp := captureRepo(t, dir)
+
+	runGit(t, dir, "checkout", "--", "tracked.txt")
+	writeFile(t, dir, "another.txt", "x\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-q", "-m", "second")
+
+	if _, err := applyCheckpoint(context.Background(), cp); !errors.Is(err, ErrHeadMismatch) {
+		t.Fatalf("want ErrHeadMismatch, got %v", err)
+	}
+}
+
+// TestRestoreRefusesDirtyWorktree: uncommitted tracked changes block restore.
+func TestRestoreRefusesDirtyWorktree(t *testing.T) {
+	dir := gitRepo(t)
+	writeFile(t, dir, "tracked.txt", "CHANGED\n")
+	cp := captureRepo(t, dir)
+	// Leave the tree dirty (tracked.txt still modified).
+
+	if _, err := applyCheckpoint(context.Background(), cp); !errors.Is(err, ErrDirtyWorktree) {
+		t.Fatalf("want ErrDirtyWorktree, got %v", err)
+	}
+}
+
+// TestRestoreUntrackedNoOverwrite: an existing target untracked file is
+// skipped, not clobbered.
+func TestRestoreUntrackedNoOverwrite(t *testing.T) {
+	dir := gitRepo(t)
+	writeFile(t, dir, "new.txt", "fresh\n")
+	cp := captureRepo(t, dir)
+
+	// Clean tracked tree; pre-create new.txt with content that must survive.
+	writeFile(t, dir, "new.txt", "LOCAL EDIT\n")
+
+	res, err := applyCheckpoint(context.Background(), cp)
+	if err != nil {
+		t.Fatalf("applyCheckpoint: %v", err)
+	}
+	if res.UntrackedRestored != 0 {
+		t.Errorf("UntrackedRestored = %d, want 0 (target existed)", res.UntrackedRestored)
+	}
+	if len(res.UntrackedSkipped) != 1 {
+		t.Errorf("UntrackedSkipped = %v, want 1 entry", res.UntrackedSkipped)
+	}
+	if got := readFile(t, dir, "new.txt"); got != "LOCAL EDIT\n" {
+		t.Errorf("new.txt was clobbered: %q", got)
+	}
+}
+
+// TestRestoreNonGit: a metadata-only (non-git) checkpoint has nothing to
+// restore.
+func TestRestoreNonGit(t *testing.T) {
+	dir := t.TempDir()
+	cp := captureRepo(t, dir)
+	if _, err := applyCheckpoint(context.Background(), cp); !errors.Is(err, ErrNotGitCheckpoint) {
+		t.Fatalf("want ErrNotGitCheckpoint, got %v", err)
+	}
+}

--- a/internal/checkpoint/service.go
+++ b/internal/checkpoint/service.go
@@ -86,7 +86,29 @@ func (s *Service) Capture(ctx context.Context, sessionID, cwd string, trigger Tr
 		"session_id", sessionID, "checkpoint_id", cp.ID, "trigger", trigger,
 		"is_git", cp.IsGit, "diff_bytes", cp.DiffBytes,
 		"untracked_files", cp.UntrackedFiles, "truncated", cp.Truncated)
+	s.pruneForSession(ctx, sessionID)
 	return cp, nil
+}
+
+// RetainPerSession bounds how many checkpoints a session keeps; older ones
+// are reaped (metadata + on-disk payload) after each capture.
+const RetainPerSession = 10
+
+// pruneForSession enforces RetainPerSession, best-effort: a prune failure is
+// logged, never surfaced to the capture caller (the checkpoint succeeded).
+func (s *Service) pruneForSession(ctx context.Context, sessionID string) {
+	paths, err := s.store.pruneForSession(ctx, sessionID, RetainPerSession)
+	if err != nil {
+		s.log.Warn("checkpoint prune failed", "session_id", sessionID, "err", err)
+		return
+	}
+	for _, p := range paths {
+		if p != "" {
+			if err := os.RemoveAll(p); err != nil {
+				s.log.Warn("checkpoint prune reap failed", "path", p, "err", err)
+			}
+		}
+	}
 }
 
 // CaptureManual captures via the SessionInfo lookup (the manual API path).

--- a/internal/checkpoint/store.go
+++ b/internal/checkpoint/store.go
@@ -62,6 +62,37 @@ func (s *store) listForSession(ctx context.Context, sessionID string) ([]Checkpo
 	return out, rows.Err()
 }
 
+// pruneForSession deletes all but the newest `keep` checkpoints of a
+// session and returns the storage paths of the removed rows so the caller
+// can reap them from disk. keep <= 0 is treated as "no retention" (no-op).
+func (s *store) pruneForSession(ctx context.Context, sessionID string, keep int) ([]string, error) {
+	if keep <= 0 {
+		return nil, nil
+	}
+	rows, err := s.pool.Query(ctx, `
+        DELETE FROM session_checkpoints
+        WHERE id IN (
+            SELECT id FROM session_checkpoints
+            WHERE session_id=$1
+            ORDER BY created_at DESC
+            OFFSET $2
+        )
+        RETURNING storage_path`, sessionID, keep)
+	if err != nil {
+		return nil, fmt.Errorf("checkpoint: prune: %w", err)
+	}
+	defer rows.Close()
+	var paths []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return nil, fmt.Errorf("checkpoint: scan prune path: %w", err)
+		}
+		paths = append(paths, p)
+	}
+	return paths, rows.Err()
+}
+
 // delete removes the metadata row and returns its storage_path so the
 // caller can reap the on-disk payload.
 func (s *store) delete(ctx context.Context, id string) (string, error) {


### PR DESCRIPTION
## Summary

Completes **priority ②** (context backup/restore): the **restore** half on top of the capture landed in #452.

### Restore — strict, dry-run-first (operator-chosen posture)
`applyCheckpoint` re-applies a checkpoint onto its cwd only when every guard passes, **refusing before any write**:
1. cwd is a git work tree whose **HEAD equals the checkpoint's** (else `409 ErrHeadMismatch`),
2. **no uncommitted tracked changes** (else `409 ErrDirtyWorktree`; untracked files may coexist),
3. the stored diff passes **`git apply --check`** dry-run (else `409 ErrApplyCheckFailed` with git's explanation).

Only then is the diff applied. **Untracked files are restored without ever overwriting** an existing target (skipped ones reported). A non-git checkpoint has nothing to apply (`409 ErrNotGitCheckpoint`).

- `POST /checkpoints/{cid}/restore` → `RestoreResult`; guard failures map to **409 Conflict** so the operator resolves the working-tree state first.
- DB lookup (`Service.Restore`) split from the restore core (`applyCheckpoint`) so the logic is unit-testable without a database.

### Retention
`RetainPerSession` (10) reaps older checkpoints (metadata + on-disk payload) after each capture; best-effort, never fails the capture.

## Test plan
- `go test -race ./internal/checkpoint/` — green: restore happy path (diff re-applied + untracked restored), and each guard refused (HEAD mismatch, dirty tree, untracked no-overwrite, non-git).
- `go build ./...` ; `go vet` — clean; `gofmt` clean.

## Deferred
The audit panel surfacing `interrupt_reason` + checkpoints, and the web/mobile UI. Orchestration remains parked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)