### PR TITLE
fix(checkpoint): filter terminal back-channel noise from input history

### DIFF
--- a/internal/session/input_history.go
+++ b/internal/session/input_history.go
@@ -56,8 +56,8 @@ func scanInputNoise(data []byte, start int) (int, bool) {
 		if i >= len(data) {
 			return start, false
 		}
-		switch {
-		case data[i] == '<':
+		switch data[i] {
+		case '<':
 			// SGR mouse: ESC [ < digits;digits;digits (M|m).
 			j := i + 1
 			for j < len(data) && ((data[j] >= '0' && data[j] <= '9') || data[j] == ';') {
@@ -67,14 +67,14 @@ func scanInputNoise(data []byte, start int) (int, bool) {
 				return j + 1, true
 			}
 			return start, false
-		case data[i] == 'M':
+		case 'M':
 			// X10/UTF-8 mouse: ESC [ M followed by exactly 3 bytes. Only
 			// strip when all 3 are present; a truncated tail is left intact.
 			if i+3 < len(data) {
 				return i + 4, true
 			}
 			return start, false
-		case data[i] == 'I' || data[i] == 'O':
+		case 'I', 'O':
 			// Focus-in / focus-out. Distinct from arrow keys, which are
 			// ESC [ A..D and fall through untouched.
 			return i + 1, true

--- a/internal/session/input_history.go
+++ b/internal/session/input_history.go
@@ -1,0 +1,98 @@
+package session
+
+import "bytes"
+
+// stripInputHistoryNoise removes machine-generated terminal back-channel
+// sequences from a COPY of session input before it is recorded in the
+// input-history ring used by context checkpoints. These bytes are valid
+// input to a TUI — so they still reach the PTY untouched — but they are
+// noise for a human or agent reading "what the operator actually did":
+// mouse-motion reports dominate the stream and bury the real keystrokes.
+//
+// Stripped (all emulator-emitted, never typed by a human):
+//
+//	SGR mouse       ESC [ < <params> (M|m)
+//	X10/UTF-8 mouse ESC [ M <3 coordinate bytes>
+//	Focus in/out    ESC [ I  ,  ESC [ O
+//	OSC response    ESC ] <...> (BEL | ESC \)      e.g. color-query answers
+//
+// Everything else is preserved verbatim: printable text, Enter / Ctrl keys,
+// arrow-key CSI (ESC [ A..D), bracketed-paste markers and their content.
+// Applied on top of stripTerminalCapabilityResponses, which already removed
+// DA / CPR / DSR answers.
+func stripInputHistoryNoise(data []byte) []byte {
+	// Fast path: no ESC means nothing to strip; typed text is unaffected
+	// and allocation-free.
+	if !bytes.Contains(data, []byte{escByte}) {
+		return data
+	}
+	out := make([]byte, 0, len(data))
+	i := 0
+	for i < len(data) {
+		if data[i] == escByte {
+			if end, ok := scanInputNoise(data, i); ok {
+				i = end
+				continue
+			}
+		}
+		out = append(out, data[i])
+		i++
+	}
+	return out
+}
+
+// scanInputNoise inspects a putative escape sequence at data[start] (where
+// data[start]==ESC) and, when it matches one of the emulator back-channel
+// shapes above, returns the index immediately after it and true. A partial
+// or unrecognised sequence returns (start, false) so the caller emits the
+// ESC normally — we never eat bytes we're unsure about.
+func scanInputNoise(data []byte, start int) (int, bool) {
+	if start+1 >= len(data) {
+		return start, false
+	}
+	switch data[start+1] {
+	case '[':
+		i := start + 2
+		if i >= len(data) {
+			return start, false
+		}
+		switch {
+		case data[i] == '<':
+			// SGR mouse: ESC [ < digits;digits;digits (M|m).
+			j := i + 1
+			for j < len(data) && ((data[j] >= '0' && data[j] <= '9') || data[j] == ';') {
+				j++
+			}
+			if j < len(data) && (data[j] == 'M' || data[j] == 'm') {
+				return j + 1, true
+			}
+			return start, false
+		case data[i] == 'M':
+			// X10/UTF-8 mouse: ESC [ M followed by exactly 3 bytes. Only
+			// strip when all 3 are present; a truncated tail is left intact.
+			if i+3 < len(data) {
+				return i + 4, true
+			}
+			return start, false
+		case data[i] == 'I' || data[i] == 'O':
+			// Focus-in / focus-out. Distinct from arrow keys, which are
+			// ESC [ A..D and fall through untouched.
+			return i + 1, true
+		}
+		return start, false
+	case ']':
+		// OSC: ESC ] ... terminated by BEL (0x07) or ST (ESC \).
+		j := start + 2
+		for j < len(data) {
+			if data[j] == 0x07 {
+				return j + 1, true
+			}
+			if data[j] == escByte && j+1 < len(data) && data[j+1] == '\\' {
+				return j + 2, true
+			}
+			j++
+		}
+		return start, false // unterminated: leave intact
+	}
+	return start, false
+}

--- a/internal/session/input_history_test.go
+++ b/internal/session/input_history_test.go
@@ -1,0 +1,64 @@
+package session
+
+import "testing"
+
+// TestStripInputHistoryNoise pins that emulator back-channel sequences are
+// removed from recorded input while real keystrokes — including arrow keys
+// and bracketed paste — survive verbatim. The polluting shapes are the ones
+// observed live in a real captured input_history.log (SGR mouse, focus, OSC).
+func TestStripInputHistoryNoise(t *testing.T) {
+	esc := "\x1b"
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain text untouched", "git status\n", "git status\n"},
+		{"empty", "", ""},
+		{"SGR mouse motion stripped", esc + "[<35;66;2M", ""},
+		{"SGR mouse release stripped", esc + "[<0;12;7m", ""},
+		{"focus in/out stripped", esc + "[I" + esc + "[O", ""},
+		{"OSC color response (BEL) stripped", esc + "]11;rgb:0606/0707/0c0c\x07", ""},
+		{"OSC color response (ST) stripped", esc + "]11;rgb:06/07/0c" + esc + "\\", ""},
+		{"X10 mouse stripped", esc + "[Mabc", ""},           // ESC [ M + exactly 3 coord bytes "abc"
+		{"X10 mouse then text", esc + "[Mabc" + "hi", "hi"}, // 3 coord bytes consumed, "hi" survives
+		{
+			name: "real keystrokes survive around mouse noise",
+			in:   esc + "[<35;66;2M" + "ls -la\r" + esc + "[<35;65;2M",
+			want: "ls -la\r",
+		},
+		{"arrow keys preserved", esc + "[A" + esc + "[B" + esc + "[C" + esc + "[D", esc + "[A" + esc + "[B" + esc + "[C" + esc + "[D"},
+		{"Ctrl-C preserved", "\x03", "\x03"},
+		{
+			name: "bracketed paste markers + content preserved",
+			in:   esc + "[200~pasted text" + esc + "[201~",
+			want: esc + "[200~pasted text" + esc + "[201~",
+		},
+		{"unterminated OSC left intact", esc + "]11;rgb:incomplete", esc + "]11;rgb:incomplete"},
+		{"truncated SGR mouse left intact", esc + "[<35;66", esc + "[<35;66"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := string(stripInputHistoryNoise([]byte(c.in)))
+			if got != c.want {
+				t.Errorf("stripInputHistoryNoise(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestStripInputHistoryNoiseRealSample feeds a burst shaped like the actual
+// polluted capture (leading OSC + focus + a long run of SGR mouse motion,
+// with one real command buried inside) and asserts only the command remains.
+func TestStripInputHistoryNoiseRealSample(t *testing.T) {
+	esc := "\x1b"
+	sample := esc + "[O" +
+		esc + "]11;rgb:0606/0707/0c0c\x07" +
+		esc + "[<35;66;2M" + esc + "[<35;65;2M" + esc + "[<35;64;2M" +
+		"make test\r" +
+		esc + "[<35;61;2M" + esc + "[I"
+	got := string(stripInputHistoryNoise([]byte(sample)))
+	if got != "make test\r" {
+		t.Errorf("real-sample filter = %q, want %q", got, "make test\r")
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1450,10 +1450,15 @@ func (m *Manager) Input(_ context.Context, id string, data []byte) error {
 	if _, err := rs.pty.Write(data); err != nil {
 		return fmt.Errorf("pty write: %w", err)
 	}
-	// Record the input tail for context checkpoints. Best-effort; the ring
-	// is independently locked so this never blocks the PTY write path.
+	// Record the input tail for context checkpoints. The PTY got the full
+	// bytes above (a TUI needs mouse/focus events); the history ring gets a
+	// noise-filtered copy so it reads as real operator input, not a stream
+	// of mouse-motion reports. Best-effort; the ring is independently locked
+	// so this never blocks the PTY write path.
 	if rs.inputRing != nil {
-		_, _ = rs.inputRing.Write(data)
+		if filtered := stripInputHistoryNoise(data); len(filtered) > 0 {
+			_, _ = rs.inputRing.Write(filtered)
+		}
 	}
 	if rs.markActive(time.Now()) {
 		m.flipBackToRunning(rs)


### PR DESCRIPTION
## Summary

A **live capture after deploying** the checkpoint feature (#452) surfaced a real quality gap: the input-history component of a checkpoint was dominated by emulator **back-channel bytes** — SGR mouse-motion reports, focus in/out, OSC color-query answers — burying the actual operator keystrokes. A captured 1057-byte `input_history.log` was ~all mouse noise:

```
\x1b[O \x1b]11;rgb:0606/0707/0c0c\x07 \x1b[<35;66;2M \x1b[<35;65;2M … \x1b[I
```

## Fix

`Manager.Input` records the bytes sent to the PTY, and a TUI legitimately needs mouse/focus events — so they can't be stripped from the PTY stream. Instead, **filter only the copy written to the input-history ring**:

- `stripInputHistoryNoise` removes: SGR mouse (`ESC [ < … M/m`), X10/UTF-8 mouse (`ESC [ M` + 3 bytes), focus (`ESC [ I` / `ESC [ O`), and OSC responses (`ESC ] … BEL/ST`). **Preserves** printable text, Enter/Ctrl keys, arrow-key CSI (`ESC [ A..D`), and bracketed-paste markers + content verbatim. Applied on top of `stripTerminalCapabilityResponses` (DA/CPR/DSR).
- `Manager.Input` writes the filtered copy to `inputRing`; the PTY still gets the full bytes.

## Test plan
- `go test -race ./internal/session/` — green. Table-driven cases cover each stripped shape, real keystrokes surviving around mouse noise, arrow keys / Ctrl-C / bracketed paste preserved, partial/unterminated sequences left intact, and a **real-sample burst** (the shape observed live) that reduces to just the command.
- `go build ./...` ; `go vet` — clean; gofmt clean.

Follow-up to #452; found by testing the deployed build end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)