### PR TITLE
feat(web): checkpoints panel in the session Inspector

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -235,7 +235,8 @@
           "history": "History",
           "vault": "Vault",
           "cortex": "Cortex",
-          "database": "Database"
+          "database": "Database",
+          "checkpoints": "Checkpoints"
         },
         "vaultPanel": {
           "open": "Open Vault",
@@ -273,6 +274,30 @@
           "plan": "Plan",
           "latestJournal": "Latest journal",
           "empty": "No Cortex memory captured yet for this project. Spawn a session or set a goal to populate."
+        },
+        "checkpoints": {
+          "loading": "Loading…",
+          "blurb": "Snapshot this session's uncommitted diff, untracked files and input history — restore it later.",
+          "capture": "Capture",
+          "captured": "Checkpoint captured",
+          "capturedGit": "diff {diff}B · {files} untracked files",
+          "capturedNonGit": "Metadata only (not a git repo)",
+          "empty": "No checkpoints yet. Capture one now, or it happens automatically when the gateway shuts down.",
+          "trigger": {
+            "manual": "Manual",
+            "interrupted": "Interrupted"
+          },
+          "truncated": "Truncated",
+          "truncatedHint": "A size/count cap clipped this capture; it is partial.",
+          "nonGit": "Not a git repository",
+          "hideDiff": "Hide diff",
+          "viewDiff": "View diff",
+          "restore": "Restore",
+          "restoreWarn": "Re-applies this snapshot onto the working directory. Runs only if HEAD matches and there are no uncommitted tracked changes; untracked files are never overwritten.",
+          "restoreConfirm": "Confirm restore",
+          "restored": "Checkpoint restored",
+          "restoredDetail": "diff applied: {diff} · {files} files restored · {skipped} skipped",
+          "deleteConfirm": "Delete this checkpoint?"
         }
       },
       "ended": {

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -235,7 +235,8 @@
           "history": "Historial",
           "vault": "Bóveda",
           "cortex": "Cortex",
-          "database": "BD"
+          "database": "BD",
+          "checkpoints": "Puntos de control"
         },
         "vaultPanel": {
           "open": "Abrir Bóveda",
@@ -273,6 +274,30 @@
           "plan": "Plan",
           "latestJournal": "Último diario",
           "empty": "Aún no se ha capturado memoria de Cortex para este proyecto. Inicia una sesión o define un objetivo para poblarla."
+        },
+        "checkpoints": {
+          "loading": "Cargando…",
+          "blurb": "Captura el diff sin confirmar, los archivos sin seguimiento y el historial de entrada de esta sesión — restáuralo después.",
+          "capture": "Capturar",
+          "captured": "Punto de control capturado",
+          "capturedGit": "diff {diff}B · {files} archivos sin seguimiento",
+          "capturedNonGit": "Solo metadatos (no es un repo git)",
+          "empty": "Aún no hay puntos de control. Captura uno ahora, o se crea automáticamente al apagar el gateway.",
+          "trigger": {
+            "manual": "Manual",
+            "interrupted": "Interrumpido"
+          },
+          "truncated": "Truncado",
+          "truncatedHint": "Un límite de tamaño/cantidad recortó esta captura; es parcial.",
+          "nonGit": "No es un repositorio git",
+          "hideDiff": "Ocultar diff",
+          "viewDiff": "Ver diff",
+          "restore": "Restaurar",
+          "restoreWarn": "Reaplica esta captura sobre el directorio de trabajo. Solo se ejecuta si HEAD coincide y no hay cambios rastreados sin confirmar; los archivos sin seguimiento nunca se sobrescriben.",
+          "restoreConfirm": "Confirmar restauración",
+          "restored": "Punto de control restaurado",
+          "restoredDetail": "diff aplicado: {diff} · {files} archivos restaurados · {skipped} omitidos",
+          "deleteConfirm": "¿Eliminar este punto de control?"
         }
       },
       "ended": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -235,7 +235,8 @@
           "history": "历史",
           "vault": "文档库",
           "cortex": "心智中枢",
-          "database": "数据库"
+          "database": "数据库",
+          "checkpoints": "检查点"
         },
         "vaultPanel": {
           "open": "打开文档库",
@@ -273,6 +274,30 @@
           "plan": "计划",
           "latestJournal": "最新日志",
           "empty": "该项目尚未捕获任何心智中枢记忆。启动会话或设定目标以填充。"
+        },
+        "checkpoints": {
+          "loading": "加载中…",
+          "blurb": "快照本会话的未提交 diff、未跟踪文件与输入历史——之后可恢复。",
+          "capture": "捕获",
+          "captured": "检查点已捕获",
+          "capturedGit": "diff {diff}B · {files} 个未跟踪文件",
+          "capturedNonGit": "仅元数据(非 git 仓库)",
+          "empty": "还没有检查点。可以现在捕获一个,或在网关关闭时自动生成。",
+          "trigger": {
+            "manual": "手动",
+            "interrupted": "中断"
+          },
+          "truncated": "已截断",
+          "truncatedHint": "大小/数量上限裁剪了本次捕获,内容不完整。",
+          "nonGit": "非 git 仓库",
+          "hideDiff": "隐藏 diff",
+          "viewDiff": "查看 diff",
+          "restore": "恢复",
+          "restoreWarn": "将此快照重新应用到工作目录。仅当 HEAD 一致且无未提交的已跟踪改动时执行;未跟踪文件绝不覆盖。",
+          "restoreConfirm": "确认恢复",
+          "restored": "检查点已恢复",
+          "restoredDetail": "diff 应用:{diff} · 恢复 {files} 个文件 · 跳过 {skipped} 个",
+          "deleteConfirm": "删除此检查点?"
         }
       },
       "ended": {

--- a/app/shared/src/lib/checkpoints.ts
+++ b/app/shared/src/lib/checkpoints.ts
@@ -1,0 +1,68 @@
+import { api } from './api'
+
+// Checkpoint is one captured context snapshot of a session's working dir
+// (uncommitted git diff + untracked files + input history). Mirrors the Go
+// checkpoint.Checkpoint JSON. The heavy payload lives on the gateway's disk;
+// this is the manifest.
+export interface Checkpoint {
+  id: string
+  session_id: string
+  created_at: string
+  trigger: 'interrupted' | 'manual'
+  cwd: string
+  is_git: boolean
+  git_head?: string
+  git_dirty: boolean
+  diff_bytes: number
+  untracked_files: number
+  untracked_bytes: number
+  input_bytes: number
+  truncated: boolean
+  note?: string
+}
+
+// RestoreResult reports what a restore actually did (mirrors Go).
+export interface RestoreResult {
+  checkpoint_id: string
+  diff_applied: boolean
+  untracked_restored: number
+  untracked_skipped?: string[]
+}
+
+export async function listCheckpoints(
+  sessionId: string,
+): Promise<Checkpoint[]> {
+  return (
+    (await api<Checkpoint[]>(`/api/v1/sessions/${sessionId}/checkpoints`)) ?? []
+  )
+}
+
+export async function captureCheckpoint(
+  sessionId: string,
+  note?: string,
+): Promise<Checkpoint> {
+  return api<Checkpoint>(`/api/v1/sessions/${sessionId}/checkpoints`, {
+    method: 'POST',
+    body: note ? { note } : {},
+  })
+}
+
+// readCheckpointDiff returns the raw uncommitted diff (text/plain; empty when
+// the working tree had no tracked changes at capture time).
+export async function readCheckpointDiff(id: string): Promise<string> {
+  return api<string>(`/api/v1/checkpoints/${id}/diff`)
+}
+
+// restoreCheckpoint re-applies a checkpoint onto its cwd. The gateway
+// enforces strict guards (HEAD match, clean tracked tree, dry-run) and
+// returns 409 on any guard failure — surfaced here as an APIError whose
+// message is git's/the guard's explanation.
+export async function restoreCheckpoint(id: string): Promise<RestoreResult> {
+  return api<RestoreResult>(`/api/v1/checkpoints/${id}/restore`, {
+    method: 'POST',
+  })
+}
+
+export async function deleteCheckpoint(id: string): Promise<void> {
+  await api(`/api/v1/checkpoints/${id}`, { method: 'DELETE' })
+}

--- a/app/web/src/components/sessions/InspectorPanel.tsx
+++ b/app/web/src/components/sessions/InspectorPanel.tsx
@@ -8,6 +8,7 @@ import {
   Search,
   Play,
   History as HistoryIcon,
+  Archive,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -28,6 +29,7 @@ import { CortexPanel } from './inspector/CortexPanel'
 import { VaultPanel } from './inspector/VaultPanel'
 import { SearchPanel } from './inspector/SearchPanel'
 import { TaskRunnerPanel } from './inspector/TaskRunnerPanel'
+import { CheckpointsPanel } from './inspector/CheckpointsPanel'
 import { DatabasePanel } from '@/components/database/DatabasePanel'
 
 interface InspectorPanelProps {
@@ -170,6 +172,13 @@ export function InspectorPanel({ session }: InspectorPanelProps) {
               <Database className="size-3" />
               {t('web.sessions.inspector.tabs.database')}
             </TabsTrigger>
+            <TabsTrigger
+              value="checkpoints"
+              className="flex items-center justify-center gap-1.5 col-span-4 data-[state=active]:bg-card"
+            >
+              <Archive className="size-3" />
+              {t('web.sessions.inspector.tabs.checkpoints')}
+            </TabsTrigger>
           </TabsList>
         </div>
 
@@ -204,6 +213,9 @@ export function InspectorPanel({ session }: InspectorPanelProps) {
           </TabsContent>
           <TabsContent value="database" className="m-0 p-3">
             <DatabasePanel cwd={session.cwd} />
+          </TabsContent>
+          <TabsContent value="checkpoints" className="m-0 p-3">
+            <CheckpointsPanel session={session} />
           </TabsContent>
         </ScrollArea>
       </Tabs>

--- a/app/web/src/components/sessions/inspector/CheckpointsPanel.tsx
+++ b/app/web/src/components/sessions/inspector/CheckpointsPanel.tsx
@@ -1,0 +1,324 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Loader2,
+  Camera,
+  RotateCcw,
+  Trash2,
+  GitCompare,
+  AlertTriangle,
+  FileWarning,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import {
+  listCheckpoints,
+  captureCheckpoint,
+  readCheckpointDiff,
+  restoreCheckpoint,
+  deleteCheckpoint,
+  type Checkpoint,
+} from '@/lib/checkpoints'
+import type { Session } from '@/lib/types'
+
+interface CheckpointsPanelProps {
+  session: Session
+}
+
+// CheckpointsPanel surfaces a session's context checkpoints (uncommitted
+// git diff + untracked files + input history). It can capture one on demand
+// and, per checkpoint, view the stored diff or restore it back onto the cwd
+// under the gateway's strict guards (HEAD match, clean tracked tree, dry-run
+// — a guard failure comes back as a 409 the panel shows verbatim).
+export function CheckpointsPanel({ session }: CheckpointsPanelProps) {
+  const { t } = useTranslation()
+  const qc = useQueryClient()
+  const sessionId = session.id
+  const key = ['checkpoints', sessionId]
+
+  const list = useQuery({
+    queryKey: key,
+    queryFn: () => listCheckpoints(sessionId),
+    refetchInterval: 15_000,
+  })
+
+  const capture = useMutation({
+    mutationFn: () => captureCheckpoint(sessionId),
+    onSuccess: (cp) => {
+      qc.invalidateQueries({ queryKey: key })
+      toast.success(t('web.sessions.inspector.checkpoints.captured'), {
+        description: cp.is_git
+          ? t('web.sessions.inspector.checkpoints.capturedGit', {
+              diff: cp.diff_bytes,
+              files: cp.untracked_files,
+            })
+          : t('web.sessions.inspector.checkpoints.capturedNonGit'),
+      })
+    },
+    onError: (e: Error) => toast.error(e.message),
+  })
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <p className="text-[11px] text-muted-foreground/80 leading-snug pr-2">
+          {t('web.sessions.inspector.checkpoints.blurb')}
+        </p>
+        <Button
+          size="sm"
+          variant="secondary"
+          className="h-7 shrink-0 gap-1.5 text-[12px]"
+          disabled={capture.isPending}
+          onClick={() => capture.mutate()}
+        >
+          {capture.isPending ? (
+            <Loader2 className="size-3 animate-spin" />
+          ) : (
+            <Camera className="size-3" />
+          )}
+          {t('web.sessions.inspector.checkpoints.capture')}
+        </Button>
+      </div>
+
+      {list.isLoading ? (
+        <div className="flex items-center gap-2 text-[12px] text-muted-foreground py-3">
+          <Loader2 className="size-3 animate-spin" />
+          {t('web.sessions.inspector.checkpoints.loading')}
+        </div>
+      ) : list.error ? (
+        <div className="text-[12px] text-state-failed py-3">
+          {(list.error as Error).message}
+        </div>
+      ) : (list.data?.length ?? 0) === 0 ? (
+        <div className="text-[12px] text-muted-foreground/70 py-6 text-center">
+          {t('web.sessions.inspector.checkpoints.empty')}
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {list.data!.map((cp) => (
+            <CheckpointCard key={cp.id} cp={cp} invalidate={key} />
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function CheckpointCard({
+  cp,
+  invalidate,
+}: {
+  cp: Checkpoint
+  invalidate: unknown[]
+}) {
+  const { t } = useTranslation()
+  const qc = useQueryClient()
+  const [showDiff, setShowDiff] = useState(false)
+  const [confirmRestore, setConfirmRestore] = useState(false)
+
+  const diff = useQuery({
+    queryKey: ['checkpoint-diff', cp.id],
+    queryFn: () => readCheckpointDiff(cp.id),
+    enabled: showDiff && cp.diff_bytes > 0,
+  })
+
+  const restore = useMutation({
+    mutationFn: () => restoreCheckpoint(cp.id),
+    onSuccess: (res) => {
+      setConfirmRestore(false)
+      toast.success(t('web.sessions.inspector.checkpoints.restored'), {
+        description: t('web.sessions.inspector.checkpoints.restoredDetail', {
+          diff: res.diff_applied ? 1 : 0,
+          files: res.untracked_restored,
+          skipped: res.untracked_skipped?.length ?? 0,
+        }),
+      })
+    },
+    // Guard failures come back as 409 with git's explanation — show it.
+    onError: (e: Error) => toast.error(e.message),
+  })
+
+  const remove = useMutation({
+    mutationFn: () => deleteCheckpoint(cp.id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: invalidate }),
+    onError: (e: Error) => toast.error(e.message),
+  })
+
+  const when = new Date(cp.created_at).toLocaleString()
+
+  return (
+    <li className="rounded-md border border-border bg-card/30 px-2.5 py-2 flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            'text-[10px] font-medium px-1.5 py-0.5 rounded uppercase tracking-wide',
+            cp.trigger === 'manual'
+              ? 'bg-primary/10 text-primary'
+              : 'bg-amber-500/10 text-amber-500',
+          )}
+        >
+          {t(`web.sessions.inspector.checkpoints.trigger.${cp.trigger}`)}
+        </span>
+        <span className="text-[11px] text-muted-foreground font-mono truncate">
+          {when}
+        </span>
+        {cp.truncated && (
+          <span
+            title={t('web.sessions.inspector.checkpoints.truncatedHint')}
+            className="ml-auto flex items-center gap-1 text-[10px] text-amber-500"
+          >
+            <FileWarning className="size-3" />
+            {t('web.sessions.inspector.checkpoints.truncated')}
+          </span>
+        )}
+      </div>
+
+      <div className="text-[11px] text-muted-foreground/85 font-mono flex flex-wrap gap-x-3 gap-y-0.5">
+        {cp.is_git ? (
+          <>
+            <span>{cp.git_head ? cp.git_head.slice(0, 8) : '—'}</span>
+            <span>Δ {cp.diff_bytes}B</span>
+            <span>+{cp.untracked_files}f</span>
+          </>
+        ) : (
+          <span className="text-muted-foreground/60">
+            {t('web.sessions.inspector.checkpoints.nonGit')}
+          </span>
+        )}
+        <span>⌨ {cp.input_bytes}B</span>
+      </div>
+
+      {cp.note && (
+        <p className="text-[11px] text-muted-foreground/70 italic break-words">
+          {cp.note.split('\n')[0]}
+        </p>
+      )}
+
+      <div className="flex items-center gap-1.5 pt-0.5">
+        {cp.diff_bytes > 0 && (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-6 px-2 gap-1 text-[11px]"
+            onClick={() => setShowDiff((s) => !s)}
+          >
+            <GitCompare className="size-3" />
+            {showDiff
+              ? t('web.sessions.inspector.checkpoints.hideDiff')
+              : t('web.sessions.inspector.checkpoints.viewDiff')}
+          </Button>
+        )}
+        {cp.is_git && (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-6 px-2 gap-1 text-[11px]"
+            disabled={restore.isPending}
+            onClick={() => setConfirmRestore((c) => !c)}
+          >
+            {restore.isPending ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : (
+              <RotateCcw className="size-3" />
+            )}
+            {t('web.sessions.inspector.checkpoints.restore')}
+          </Button>
+        )}
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-6 px-2 gap-1 text-[11px] text-state-failed hover:text-state-failed ml-auto"
+          disabled={remove.isPending}
+          onClick={() => {
+            if (window.confirm(t('web.sessions.inspector.checkpoints.deleteConfirm')))
+              remove.mutate()
+          }}
+        >
+          <Trash2 className="size-3" />
+        </Button>
+      </div>
+
+      {confirmRestore && (
+        <div className="rounded border border-amber-500/30 bg-amber-500/5 px-2 py-1.5 flex flex-col gap-1.5">
+          <p className="text-[11px] text-amber-600 dark:text-amber-400 flex items-start gap-1.5">
+            <AlertTriangle className="size-3 mt-0.5 shrink-0" />
+            {t('web.sessions.inspector.checkpoints.restoreWarn')}
+          </p>
+          <div className="flex items-center gap-1.5">
+            <Button
+              size="sm"
+              variant="secondary"
+              className="h-6 px-2 text-[11px]"
+              disabled={restore.isPending}
+              onClick={() => restore.mutate()}
+            >
+              {t('web.sessions.inspector.checkpoints.restoreConfirm')}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-6 px-2 text-[11px]"
+              onClick={() => setConfirmRestore(false)}
+            >
+              {t('common.cancel')}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {showDiff && cp.diff_bytes > 0 && (
+        <div className="rounded border border-border bg-background/60 overflow-auto max-h-72">
+          {diff.isLoading ? (
+            <div className="flex items-center gap-2 text-[11px] text-muted-foreground p-2">
+              <Loader2 className="size-3 animate-spin" />
+              {t('web.sessions.inspector.checkpoints.loading')}
+            </div>
+          ) : diff.error ? (
+            <div className="text-[11px] text-state-failed p-2">
+              {(diff.error as Error).message}
+            </div>
+          ) : (
+            <DiffText text={diff.data ?? ''} />
+          )}
+        </div>
+      )}
+    </li>
+  )
+}
+
+// DiffText renders a unified diff with per-line color coding — a compact
+// inline variant of DiffViewer's DiffBody, prefix-classified only.
+function DiffText({ text }: { text: string }) {
+  const MAX = 4000
+  const all = text.split('\n')
+  const lines = all.length > MAX ? all.slice(0, MAX) : all
+  return (
+    <div className="font-mono text-[11px] leading-[1.5] py-1">
+      {lines.map((line, i) => {
+        let clsName = 'text-foreground/85'
+        if (line.startsWith('+++') || line.startsWith('---'))
+          clsName = 'text-muted-foreground/70 font-medium'
+        else if (line.startsWith('@@')) clsName = 'text-sky-400/90 bg-sky-500/5'
+        else if (line.startsWith('diff --git') || line.startsWith('index '))
+          clsName = 'text-muted-foreground/60'
+        else if (line.startsWith('+'))
+          clsName = 'text-state-running bg-state-running/5'
+        else if (line.startsWith('-'))
+          clsName = 'text-state-failed bg-state-failed/5'
+        return (
+          <div key={i} className={cn('px-2 whitespace-pre', clsName)}>
+            {line || ' '}
+          </div>
+        )
+      })}
+      {all.length > MAX && (
+        <div className="px-2 text-[10px] text-muted-foreground/60 py-1">
+          … {all.length - MAX} more lines
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Surfaces the context-checkpoint backend (#452 capture / #453 restore / #454 input-history fix) in the **web** UI. Web only for now, per request — mobile parity deferred.

## What's in it
- **New Inspector tab "Checkpoints"** (full-width row) → `CheckpointsPanel`:
  - Lists a session's checkpoints: trigger badge (manual/interrupted), capture time, short git HEAD, diff / untracked / input sizes, `truncated` flag, note.
  - **Capture** button → manual snapshot (`POST /sessions/{id}/checkpoints`).
  - Per checkpoint: **View diff** (inline colored unified diff, fetched on demand), **Restore**, delete.
  - **Restore** is gated behind an inline confirm that spells out the strict server-side guards; a **409** guard failure (HEAD moved / dirty tree / patch won't apply) is surfaced **verbatim** as a toast.
- **New shared API client** `app/shared/src/lib/checkpoints.ts` (list / capture / diff / restore / delete).
- **i18n** keys added to en/zh/es (single-brace interpolation); parity 100%.

## Test plan
- `pnpm --filter web build` (`tsc -b` + vite) — green, no type errors.
- `scripts/check-i18n-parity.mjs` — 100%, no missing/extra/token-mismatch.
- New `.tsx` files lint clean.

## Screenshots
Panel renders in the right-hand Inspector, scoped to the session's cwd. (Verified by build; live verification after the operator rebuilds + restarts.)

## Deferred
Mobile parity for this panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)