### PR TITLE
feat(mobile): checkpoints tab in the session inspector (web parity)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -3430,7 +3430,8 @@
           "history": "History",
           "vault": "Vault",
           "cortex": "Cortex",
-          "database": "Database"
+          "database": "Database",
+          "checkpoints": "Checkpoints"
         }
       },
       "cortex": {
@@ -3524,6 +3525,27 @@
         "noProjectMapping2": "(no project mapping)",
         "clearOverride": "Clear override",
         "save": "Save"
+      },
+      "checkpoints": {
+        "blurb": "Snapshot this session's uncommitted diff, untracked files and input history.",
+        "capture": "Capture",
+        "capturedGit": "diff {diff}B · {files} untracked files",
+        "capturedNonGit": "Metadata only (not a git repo)",
+        "empty": "No checkpoints yet. Capture one now, or it happens automatically when the gateway shuts down.",
+        "triggerManual": "Manual",
+        "triggerInterrupted": "Interrupted",
+        "truncatedHint": "A size/count cap clipped this capture; it is partial.",
+        "nonGit": "Not a git repository",
+        "viewDiff": "View diff",
+        "hideDiff": "Hide diff",
+        "restore": "Restore",
+        "restoreTitle": "Restore checkpoint?",
+        "restoreWarn": "Re-applies this snapshot onto the working directory. Runs only if HEAD matches and there are no uncommitted tracked changes; untracked files are never overwritten.",
+        "restoreConfirm": "Restore",
+        "restored": "Restored · {files} files, {skipped} skipped",
+        "delete": "Delete",
+        "deleteTitle": "Delete checkpoint?",
+        "deleteConfirm": "This removes the checkpoint and its stored payload."
       }
     },
     "spawnSheet": {

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -3430,7 +3430,8 @@
           "history": "Historial",
           "vault": "Bóveda",
           "cortex": "Cortex",
-          "database": "BD"
+          "database": "BD",
+          "checkpoints": "Puntos de control"
         }
       },
       "cortex": {
@@ -3524,6 +3525,27 @@
         "noProjectMapping2": "(sin asignación de proyecto)",
         "clearOverride": "Borrar anulación",
         "save": "Guardar"
+      },
+      "checkpoints": {
+        "blurb": "Captura el diff sin confirmar, los archivos sin seguimiento y el historial de entrada de esta sesión.",
+        "capture": "Capturar",
+        "capturedGit": "diff {diff}B · {files} archivos sin seguimiento",
+        "capturedNonGit": "Solo metadatos (no es un repo git)",
+        "empty": "Aún no hay puntos de control. Captura uno ahora, o se crea automáticamente al apagar el gateway.",
+        "triggerManual": "Manual",
+        "triggerInterrupted": "Interrumpido",
+        "truncatedHint": "Un límite de tamaño/cantidad recortó esta captura; es parcial.",
+        "nonGit": "No es un repositorio git",
+        "viewDiff": "Ver diff",
+        "hideDiff": "Ocultar diff",
+        "restore": "Restaurar",
+        "restoreTitle": "¿Restaurar punto de control?",
+        "restoreWarn": "Reaplica esta captura sobre el directorio de trabajo. Solo se ejecuta si HEAD coincide y no hay cambios rastreados sin confirmar; los archivos sin seguimiento nunca se sobrescriben.",
+        "restoreConfirm": "Restaurar",
+        "restored": "Restaurado · {files} archivos, {skipped} omitidos",
+        "delete": "Eliminar",
+        "deleteTitle": "¿Eliminar punto de control?",
+        "deleteConfirm": "Esto elimina el punto de control y su contenido almacenado."
       }
     },
     "spawnSheet": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -3430,7 +3430,8 @@
           "history": "历史",
           "vault": "文档库",
           "cortex": "心智中枢",
-          "database": "数据库"
+          "database": "数据库",
+          "checkpoints": "检查点"
         }
       },
       "cortex": {
@@ -3524,6 +3525,27 @@
         "noProjectMapping2": "（无项目映射）",
         "clearOverride": "清除覆盖",
         "save": "保存"
+      },
+      "checkpoints": {
+        "blurb": "快照本会话的未提交 diff、未跟踪文件与输入历史。",
+        "capture": "捕获",
+        "capturedGit": "diff {diff}B · {files} 个未跟踪文件",
+        "capturedNonGit": "仅元数据(非 git 仓库)",
+        "empty": "还没有检查点。可以现在捕获一个,或在网关关闭时自动生成。",
+        "triggerManual": "手动",
+        "triggerInterrupted": "中断",
+        "truncatedHint": "大小/数量上限裁剪了本次捕获,内容不完整。",
+        "nonGit": "非 git 仓库",
+        "viewDiff": "查看 diff",
+        "hideDiff": "隐藏 diff",
+        "restore": "恢复",
+        "restoreTitle": "恢复检查点?",
+        "restoreWarn": "将此快照重新应用到工作目录。仅当 HEAD 一致且无未提交的已跟踪改动时执行;未跟踪文件绝不覆盖。",
+        "restoreConfirm": "恢复",
+        "restored": "已恢复 · {files} 个文件,跳过 {skipped} 个",
+        "delete": "删除",
+        "deleteTitle": "删除检查点?",
+        "deleteConfirm": "将移除该检查点及其存储的内容。"
       }
     },
     "spawnSheet": {

--- a/app/mobile/lib/core/api/checkpoints_api.dart
+++ b/app/mobile/lib/core/api/checkpoints_api.dart
@@ -1,0 +1,160 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/api/dio_provider.dart';
+
+// Context checkpoint — one captured snapshot of a session's working dir
+// (uncommitted git diff + untracked files + input history). Mirrors the Go
+// checkpoint.Checkpoint JSON. Manual fromJson to match the rest of models.
+class Checkpoint {
+  Checkpoint({
+    required this.id,
+    required this.sessionId,
+    required this.createdAt,
+    required this.trigger,
+    required this.cwd,
+    required this.isGit,
+    required this.gitDirty,
+    required this.diffBytes,
+    required this.untrackedFiles,
+    required this.untrackedBytes,
+    required this.inputBytes,
+    required this.truncated,
+    this.gitHead,
+    this.note,
+  });
+
+  factory Checkpoint.fromJson(Map<String, dynamic> json) => Checkpoint(
+        id: json['id'] as String? ?? '',
+        sessionId: json['session_id'] as String? ?? '',
+        createdAt: DateTime.tryParse(json['created_at'] as String? ?? '') ??
+            DateTime.now().toUtc(),
+        trigger: json['trigger'] as String? ?? 'manual',
+        cwd: json['cwd'] as String? ?? '',
+        isGit: json['is_git'] as bool? ?? false,
+        gitHead: (json['git_head'] as String?)?.isNotEmpty ?? false
+            ? json['git_head'] as String
+            : null,
+        gitDirty: json['git_dirty'] as bool? ?? false,
+        diffBytes: (json['diff_bytes'] as num?)?.toInt() ?? 0,
+        untrackedFiles: (json['untracked_files'] as num?)?.toInt() ?? 0,
+        untrackedBytes: (json['untracked_bytes'] as num?)?.toInt() ?? 0,
+        inputBytes: (json['input_bytes'] as num?)?.toInt() ?? 0,
+        truncated: json['truncated'] as bool? ?? false,
+        note: (json['note'] as String?)?.isNotEmpty ?? false
+            ? json['note'] as String
+            : null,
+      );
+
+  final String id;
+  final String sessionId;
+  final DateTime createdAt;
+  final String trigger; // 'interrupted' | 'manual'
+  final String cwd;
+  final bool isGit;
+  final String? gitHead;
+  final bool gitDirty;
+  final int diffBytes;
+  final int untrackedFiles;
+  final int untrackedBytes;
+  final int inputBytes;
+  final bool truncated;
+  final String? note;
+}
+
+// RestoreResult reports what a restore actually did (mirrors Go).
+class RestoreResult {
+  RestoreResult({
+    required this.checkpointId,
+    required this.diffApplied,
+    required this.untrackedRestored,
+    required this.untrackedSkipped,
+  });
+
+  factory RestoreResult.fromJson(Map<String, dynamic> json) => RestoreResult(
+        checkpointId: json['checkpoint_id'] as String? ?? '',
+        diffApplied: json['diff_applied'] as bool? ?? false,
+        untrackedRestored: (json['untracked_restored'] as num?)?.toInt() ?? 0,
+        untrackedSkipped: (json['untracked_skipped'] as List<dynamic>?)
+                ?.whereType<String>()
+                .toList() ??
+            const [],
+      );
+
+  final String checkpointId;
+  final bool diffApplied;
+  final int untrackedRestored;
+  final List<String> untrackedSkipped;
+}
+
+// CheckpointsApi maps /api/v1/sessions/{id}/checkpoints and
+// /api/v1/checkpoints/{id}. Capture snapshots the working tree; restore
+// re-applies it under the gateway's strict guards (a 409 guard failure
+// surfaces as an ApiException whose message carries the reason).
+class CheckpointsApi {
+  CheckpointsApi(this._dio);
+  final Dio _dio;
+
+  Future<List<Checkpoint>> list(String sessionId) async {
+    try {
+      final res = await _dio
+          .get<List<dynamic>>('/api/v1/sessions/$sessionId/checkpoints');
+      return (res.data ?? [])
+          .whereType<Map<String, dynamic>>()
+          .map(Checkpoint.fromJson)
+          .toList();
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  Future<Checkpoint> capture(String sessionId, {String? note}) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/sessions/$sessionId/checkpoints',
+        data: {if (note != null && note.isNotEmpty) 'note': note},
+      );
+      return Checkpoint.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  Future<String> diff(String checkpointId) async {
+    try {
+      final res = await _dio.get<String>(
+        '/api/v1/checkpoints/$checkpointId/diff',
+        options: Options(
+          responseType: ResponseType.plain,
+          headers: {'Accept': 'text/plain'},
+        ),
+      );
+      return res.data ?? '';
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  Future<RestoreResult> restore(String checkpointId) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/checkpoints/$checkpointId/restore',
+      );
+      return RestoreResult.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  Future<void> delete(String checkpointId) async {
+    try {
+      await _dio.delete<void>('/api/v1/checkpoints/$checkpointId');
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+}
+
+final checkpointsApiProvider = Provider<CheckpointsApi>((ref) {
+  return CheckpointsApi(ref.watch(dioProvider));
+});

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 11976 (3992 per locale)
+/// Strings: 12102 (4034 per locale)
 ///
-/// Built on 2026-07-12 at 02:22 UTC
+/// Built on 2026-07-14 at 11:26 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -3815,6 +3815,7 @@ class TranslationsSessionsInspectorEn {
 	late final TranslationsSessionsInspectorGitEn git = TranslationsSessionsInspectorGitEn.internal(_root);
 	late final TranslationsSessionsInspectorTasksEn tasks = TranslationsSessionsInspectorTasksEn.internal(_root);
 	late final TranslationsSessionsInspectorNotesEn notes = TranslationsSessionsInspectorNotesEn.internal(_root);
+	late final TranslationsSessionsInspectorCheckpointsEn checkpoints = TranslationsSessionsInspectorCheckpointsEn.internal(_root);
 }
 
 // Path: sessions.spawnSheet
@@ -6502,6 +6503,7 @@ class TranslationsWebSessionsInspectorEn {
 	late final TranslationsWebSessionsInspectorTabsEn tabs = TranslationsWebSessionsInspectorTabsEn.internal(_root);
 	late final TranslationsWebSessionsInspectorVaultPanelEn vaultPanel = TranslationsWebSessionsInspectorVaultPanelEn.internal(_root);
 	late final TranslationsWebSessionsInspectorCortexPanelEn cortexPanel = TranslationsWebSessionsInspectorCortexPanelEn.internal(_root);
+	late final TranslationsWebSessionsInspectorCheckpointsEn checkpoints = TranslationsWebSessionsInspectorCheckpointsEn.internal(_root);
 }
 
 // Path: web.sessions.ended
@@ -8141,6 +8143,9 @@ class TranslationsWebProvidersDetailEn {
 
 	/// en: 'not installed'
 	String get notInstalled => 'not installed';
+
+	/// en: 'Installed but not runnable'
+	String get brokenCli => 'Installed but not runnable';
 
 	/// en: 'update available → {version}'
 	String updateAvailable({required Object version}) => 'update available → ${version}';
@@ -12717,6 +12722,72 @@ class TranslationsSessionsInspectorNotesEn {
 	String get save => 'Save';
 }
 
+// Path: sessions.inspector.checkpoints
+class TranslationsSessionsInspectorCheckpointsEn {
+	TranslationsSessionsInspectorCheckpointsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Snapshot this session's uncommitted diff, untracked files and input history.'
+	String get blurb => 'Snapshot this session\'s uncommitted diff, untracked files and input history.';
+
+	/// en: 'Capture'
+	String get capture => 'Capture';
+
+	/// en: 'diff {diff}B · {files} untracked files'
+	String capturedGit({required Object diff, required Object files}) => 'diff ${diff}B · ${files} untracked files';
+
+	/// en: 'Metadata only (not a git repo)'
+	String get capturedNonGit => 'Metadata only (not a git repo)';
+
+	/// en: 'No checkpoints yet. Capture one now, or it happens automatically when the gateway shuts down.'
+	String get empty => 'No checkpoints yet. Capture one now, or it happens automatically when the gateway shuts down.';
+
+	/// en: 'Manual'
+	String get triggerManual => 'Manual';
+
+	/// en: 'Interrupted'
+	String get triggerInterrupted => 'Interrupted';
+
+	/// en: 'A size/count cap clipped this capture; it is partial.'
+	String get truncatedHint => 'A size/count cap clipped this capture; it is partial.';
+
+	/// en: 'Not a git repository'
+	String get nonGit => 'Not a git repository';
+
+	/// en: 'View diff'
+	String get viewDiff => 'View diff';
+
+	/// en: 'Hide diff'
+	String get hideDiff => 'Hide diff';
+
+	/// en: 'Restore'
+	String get restore => 'Restore';
+
+	/// en: 'Restore checkpoint?'
+	String get restoreTitle => 'Restore checkpoint?';
+
+	/// en: 'Re-applies this snapshot onto the working directory. Runs only if HEAD matches and there are no uncommitted tracked changes; untracked files are never overwritten.'
+	String get restoreWarn => 'Re-applies this snapshot onto the working directory. Runs only if HEAD matches and there are no uncommitted tracked changes; untracked files are never overwritten.';
+
+	/// en: 'Restore'
+	String get restoreConfirm => 'Restore';
+
+	/// en: 'Restored · {files} files, {skipped} skipped'
+	String restored({required Object files, required Object skipped}) => 'Restored · ${files} files, ${skipped} skipped';
+
+	/// en: 'Delete'
+	String get delete => 'Delete';
+
+	/// en: 'Delete checkpoint?'
+	String get deleteTitle => 'Delete checkpoint?';
+
+	/// en: 'This removes the checkpoint and its stored payload.'
+	String get deleteConfirm => 'This removes the checkpoint and its stored payload.';
+}
+
 // Path: sessions.spawnSheet.bypass
 class TranslationsSessionsSpawnSheetBypassEn {
 	TranslationsSessionsSpawnSheetBypassEn.internal(this._root);
@@ -13774,6 +13845,9 @@ class TranslationsWebSessionsInspectorTabsEn {
 
 	/// en: 'Database'
 	String get database => 'Database';
+
+	/// en: 'Checkpoints'
+	String get checkpoints => 'Checkpoints';
 }
 
 // Path: web.sessions.inspector.vaultPanel
@@ -13891,6 +13965,71 @@ class TranslationsWebSessionsInspectorCortexPanelEn {
 
 	/// en: 'No Cortex memory captured yet for this project. Spawn a session or set a goal to populate.'
 	String get empty => 'No Cortex memory captured yet for this project. Spawn a session or set a goal to populate.';
+}
+
+// Path: web.sessions.inspector.checkpoints
+class TranslationsWebSessionsInspectorCheckpointsEn {
+	TranslationsWebSessionsInspectorCheckpointsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Loading…'
+	String get loading => 'Loading…';
+
+	/// en: 'Snapshot this session's uncommitted diff, untracked files and input history — restore it later.'
+	String get blurb => 'Snapshot this session\'s uncommitted diff, untracked files and input history — restore it later.';
+
+	/// en: 'Capture'
+	String get capture => 'Capture';
+
+	/// en: 'Checkpoint captured'
+	String get captured => 'Checkpoint captured';
+
+	/// en: 'diff {diff}B · {files} untracked files'
+	String capturedGit({required Object diff, required Object files}) => 'diff ${diff}B · ${files} untracked files';
+
+	/// en: 'Metadata only (not a git repo)'
+	String get capturedNonGit => 'Metadata only (not a git repo)';
+
+	/// en: 'No checkpoints yet. Capture one now, or it happens automatically when the gateway shuts down.'
+	String get empty => 'No checkpoints yet. Capture one now, or it happens automatically when the gateway shuts down.';
+
+	late final TranslationsWebSessionsInspectorCheckpointsTriggerEn trigger = TranslationsWebSessionsInspectorCheckpointsTriggerEn.internal(_root);
+
+	/// en: 'Truncated'
+	String get truncated => 'Truncated';
+
+	/// en: 'A size/count cap clipped this capture; it is partial.'
+	String get truncatedHint => 'A size/count cap clipped this capture; it is partial.';
+
+	/// en: 'Not a git repository'
+	String get nonGit => 'Not a git repository';
+
+	/// en: 'Hide diff'
+	String get hideDiff => 'Hide diff';
+
+	/// en: 'View diff'
+	String get viewDiff => 'View diff';
+
+	/// en: 'Restore'
+	String get restore => 'Restore';
+
+	/// en: 'Re-applies this snapshot onto the working directory. Runs only if HEAD matches and there are no uncommitted tracked changes; untracked files are never overwritten.'
+	String get restoreWarn => 'Re-applies this snapshot onto the working directory. Runs only if HEAD matches and there are no uncommitted tracked changes; untracked files are never overwritten.';
+
+	/// en: 'Confirm restore'
+	String get restoreConfirm => 'Confirm restore';
+
+	/// en: 'Checkpoint restored'
+	String get restored => 'Checkpoint restored';
+
+	/// en: 'diff applied: {diff} · {files} files restored · {skipped} skipped'
+	String restoredDetail({required Object diff, required Object files, required Object skipped}) => 'diff applied: ${diff} · ${files} files restored · ${skipped} skipped';
+
+	/// en: 'Delete this checkpoint?'
+	String get deleteConfirm => 'Delete this checkpoint?';
 }
 
 // Path: web.memoryWorkers.tasks.gatekeeper
@@ -17199,6 +17338,24 @@ class TranslationsSessionsInspectorShellTabsEn {
 
 	/// en: 'Database'
 	String get database => 'Database';
+
+	/// en: 'Checkpoints'
+	String get checkpoints => 'Checkpoints';
+}
+
+// Path: web.sessions.inspector.checkpoints.trigger
+class TranslationsWebSessionsInspectorCheckpointsTriggerEn {
+	TranslationsWebSessionsInspectorCheckpointsTriggerEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Manual'
+	String get manual => 'Manual';
+
+	/// en: 'Interrupted'
+	String get interrupted => 'Interrupted';
 }
 
 // Path: web.notes.vaultSync.conflict.kinds
@@ -17497,6 +17654,7 @@ extension on Translations {
 			'web.sessions.inspector.tabs.vault' => 'Vault',
 			'web.sessions.inspector.tabs.cortex' => 'Cortex',
 			'web.sessions.inspector.tabs.database' => 'Database',
+			'web.sessions.inspector.tabs.checkpoints' => 'Checkpoints',
 			'web.sessions.inspector.vaultPanel.open' => 'Open Vault',
 			'web.sessions.inspector.vaultPanel.projectDocs' => 'Project docs',
 			'web.sessions.inspector.vaultPanel.projectDocsHint' => 'Agent-authored project docs in the vault. Re-bind the folder if this project\'s notes live elsewhere.',
@@ -17530,6 +17688,26 @@ extension on Translations {
 			'web.sessions.inspector.cortexPanel.plan' => 'Plan',
 			'web.sessions.inspector.cortexPanel.latestJournal' => 'Latest journal',
 			'web.sessions.inspector.cortexPanel.empty' => 'No Cortex memory captured yet for this project. Spawn a session or set a goal to populate.',
+			'web.sessions.inspector.checkpoints.loading' => 'Loading…',
+			'web.sessions.inspector.checkpoints.blurb' => 'Snapshot this session\'s uncommitted diff, untracked files and input history — restore it later.',
+			'web.sessions.inspector.checkpoints.capture' => 'Capture',
+			'web.sessions.inspector.checkpoints.captured' => 'Checkpoint captured',
+			'web.sessions.inspector.checkpoints.capturedGit' => ({required Object diff, required Object files}) => 'diff ${diff}B · ${files} untracked files',
+			'web.sessions.inspector.checkpoints.capturedNonGit' => 'Metadata only (not a git repo)',
+			'web.sessions.inspector.checkpoints.empty' => 'No checkpoints yet. Capture one now, or it happens automatically when the gateway shuts down.',
+			'web.sessions.inspector.checkpoints.trigger.manual' => 'Manual',
+			'web.sessions.inspector.checkpoints.trigger.interrupted' => 'Interrupted',
+			'web.sessions.inspector.checkpoints.truncated' => 'Truncated',
+			'web.sessions.inspector.checkpoints.truncatedHint' => 'A size/count cap clipped this capture; it is partial.',
+			'web.sessions.inspector.checkpoints.nonGit' => 'Not a git repository',
+			'web.sessions.inspector.checkpoints.hideDiff' => 'Hide diff',
+			'web.sessions.inspector.checkpoints.viewDiff' => 'View diff',
+			'web.sessions.inspector.checkpoints.restore' => 'Restore',
+			'web.sessions.inspector.checkpoints.restoreWarn' => 'Re-applies this snapshot onto the working directory. Runs only if HEAD matches and there are no uncommitted tracked changes; untracked files are never overwritten.',
+			'web.sessions.inspector.checkpoints.restoreConfirm' => 'Confirm restore',
+			'web.sessions.inspector.checkpoints.restored' => 'Checkpoint restored',
+			'web.sessions.inspector.checkpoints.restoredDetail' => ({required Object diff, required Object files, required Object skipped}) => 'diff applied: ${diff} · ${files} files restored · ${skipped} skipped',
+			'web.sessions.inspector.checkpoints.deleteConfirm' => 'Delete this checkpoint?',
 			'web.sessions.ended.bufferUnavailable' => '[buffer unavailable]',
 			'web.sessions.ended.readOnlyBanner' => '[session ended — read-only buffer]',
 			'web.sessions.fileBrowser.title' => 'Choose working directory',
@@ -17783,6 +17961,8 @@ extension on Translations {
 			'web.project.editor.savedToast' => ({required Object label}) => '${label} saved',
 			'web.project.editor.goalPlaceholder' => 'What are we building? One paragraph. Read by every agent on spawn.',
 			'web.project.editor.planPlaceholder' => 'Active plan — what we are doing right now and what is next. Updated as work progresses.',
+			_ => null,
+		} ?? switch (path) {
 			'web.project.editor.sectionPlaceholder' => 'Write this section in markdown…',
 			'web.project.readonly.tech_stack.label' => 'Tech stack & structure',
 			'web.project.readonly.tech_stack.empty' => 'Run a Claude session in this project — scanner refreshes on every spawn.',
@@ -17804,8 +17984,6 @@ extension on Translations {
 			'web.project.inbox.sessionPrefix' => 'ses',
 			'web.project.inbox.warning' => ({required Object label}) => 'Approve will REPLACE the current ${label} entirely.',
 			'web.project.inbox.warningSuffix' => 'Review the diff below; this isn\'t a merge.',
-			_ => null,
-		} ?? switch (path) {
 			'web.project.inbox.current' => 'Current',
 			'web.project.inbox.proposed' => 'Proposed',
 			'web.project.inbox.emptyBody' => '(empty)',
@@ -18211,6 +18389,7 @@ extension on Translations {
 			'web.providers.detail.caps.images' => 'images',
 			'web.providers.detail.caps.mcp' => 'mcp',
 			'web.providers.detail.notInstalled' => 'not installed',
+			'web.providers.detail.brokenCli' => 'Installed but not runnable',
 			'web.providers.detail.updateAvailable' => ({required Object version}) => 'update available → ${version}',
 			'web.providers.detail.upToDate' => 'up to date',
 			'web.providers.detail.update' => ({required Object version}) => 'Update to ${version}',
@@ -18296,6 +18475,8 @@ extension on Translations {
 			'web.channels.card.copyWebhookTooltip' => 'Copy webhook URL',
 			'web.channels.card.webhookCopiedToast' => 'Webhook URL copied',
 			'web.channels.card.setup' => 'Setup',
+			_ => null,
+		} ?? switch (path) {
 			'web.channels.card.setupTooltip' => 'Show adapter connection details + sample code',
 			'web.channels.card.test' => 'Test',
 			'web.channels.card.testNotRunningTooltip' => 'Channel must be running',
@@ -18318,8 +18499,6 @@ extension on Translations {
 			'web.channels.dialog.editTitle' => 'Edit channel',
 			'web.channels.dialog.createTitle' => 'Register channel',
 			'web.channels.dialog.descriptionBridge' => 'External adapter (Python/Node/...) connects via WebSocket and presents this token.',
-			_ => null,
-		} ?? switch (path) {
 			'web.channels.dialog.descriptionDefault' => 'Configure messaging integration.',
 			'web.channels.dialog.kindLabel' => 'Kind',
 			'web.channels.dialog.kindImmutable' => '(immutable — delete and recreate to change kind)',
@@ -18810,6 +18989,8 @@ extension on Translations {
 			'web.backups.recoveryKit.confirmLabel' => 'Confirm recovery passphrase',
 			'web.backups.recoveryKit.mismatch' => 'Passphrases don\'t match',
 			'web.backups.recoveryKit.generating' => 'Generating…',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.recoveryKit.download' => 'Download kit',
 			'web.backups.recoveryKit.downloadedToast' => 'Recovery Kit downloaded — store it safely',
 			'web.backups.recoveryKit.failedToast' => 'Could not generate Recovery Kit',
@@ -18832,8 +19013,6 @@ extension on Translations {
 			'web.backups.schedulesTab.deleteTooltip' => 'Delete',
 			'web.backups.newSchedule.title' => 'New backup schedule',
 			'web.backups.newSchedule.targetLabel' => 'Targets',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.newSchedule.targetsHint' => 'Pick one or more — the same backup is written to each (3-2-1).',
 			'web.backups.newSchedule.everyHoursLabel' => 'Every (hours)',
 			'web.backups.newSchedule.keepLastNLabel' => 'Keep last N',
@@ -19324,6 +19503,8 @@ extension on Translations {
 			'web.memoryAmbient.rules.row.deletedToast' => 'Rule deleted',
 			'web.memoryAmbient.rules.row.deleteFailedToast' => 'Delete failed',
 			'web.memoryAmbient.rules.row.summary.afterMessages' => ({required Object n}) => 'every ${n} messages',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryAmbient.rules.row.summary.onIdle' => ({required Object seconds}) => 'idle ≥ ${seconds}s',
 			'web.memoryAmbient.rules.row.summary.kChars' => ({required Object k}) => '≥ ${k} chars',
 			'web.memoryAmbient.rules.row.summary.manual' => 'manual only',
@@ -19346,8 +19527,6 @@ extension on Translations {
 			'web.memoryAmbient.profiles.addButton' => 'Add profile',
 			'web.memoryAmbient.profiles.intro' => 'At spawn time opendray prepends a markdown banner of recent project memories to the agent\'s system prompt — IF a profile is configured. Without a profile, the model still uses memory_search on demand.',
 			'web.memoryAmbient.profiles.empty' => 'No injection profile. Memories are not auto-injected at spawn — model still uses memory_search.',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryAmbient.profiles.row.globalDefault' => 'global default',
 			'web.memoryAmbient.profiles.row.delete' => 'Delete',
 			'web.memoryAmbient.profiles.row.deleteConfirm' => 'Delete this injection profile?',
@@ -19838,6 +20017,8 @@ extension on Translations {
 			'memoryAmbient.strategyManualOnly' => 'Manual only',
 			'memoryAmbient.strategyHybrid' => 'Hybrid summary',
 			'memoryAmbient.strategyUnknown' => 'Unknown',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.title' => 'Sessions',
 			'sessions.refresh' => 'Refresh',
 			'sessions.actions' => 'Actions',
@@ -19860,8 +20041,6 @@ extension on Translations {
 			'sessions.detail.refreshMetadata' => 'Refresh metadata',
 			'sessions.detail.inspector' => 'Inspector (Files / Git / Tasks / History / Notes)',
 			'sessions.detail.projectMemory' => 'Project memory (goal / plan / journal / inbox)',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.detail.actions' => 'Actions',
 			'sessions.detail.started' => ({required Object when}) => 'started ${when}',
 			'sessions.detail.startedEnded' => ({required Object started, required Object ended}) => 'started ${started}  ·  ended ${ended}',
@@ -19942,6 +20121,7 @@ extension on Translations {
 			'sessions.inspector.shell.tabs.vault' => 'Vault',
 			'sessions.inspector.shell.tabs.cortex' => 'Cortex',
 			'sessions.inspector.shell.tabs.database' => 'Database',
+			'sessions.inspector.shell.tabs.checkpoints' => 'Checkpoints',
 			'sessions.inspector.cortex.title' => 'Cortex workspace',
 			'sessions.inspector.cortex.blurb' => 'Goal, plan, journal, inbox and memory hygiene for this project — the AI-maintained Cortex.',
 			'sessions.inspector.cortex.open' => 'Open Cortex workspace',
@@ -20020,6 +20200,25 @@ extension on Translations {
 			'sessions.inspector.notes.noProjectMapping2' => '(no project mapping)',
 			'sessions.inspector.notes.clearOverride' => 'Clear override',
 			'sessions.inspector.notes.save' => 'Save',
+			'sessions.inspector.checkpoints.blurb' => 'Snapshot this session\'s uncommitted diff, untracked files and input history.',
+			'sessions.inspector.checkpoints.capture' => 'Capture',
+			'sessions.inspector.checkpoints.capturedGit' => ({required Object diff, required Object files}) => 'diff ${diff}B · ${files} untracked files',
+			'sessions.inspector.checkpoints.capturedNonGit' => 'Metadata only (not a git repo)',
+			'sessions.inspector.checkpoints.empty' => 'No checkpoints yet. Capture one now, or it happens automatically when the gateway shuts down.',
+			'sessions.inspector.checkpoints.triggerManual' => 'Manual',
+			'sessions.inspector.checkpoints.triggerInterrupted' => 'Interrupted',
+			'sessions.inspector.checkpoints.truncatedHint' => 'A size/count cap clipped this capture; it is partial.',
+			'sessions.inspector.checkpoints.nonGit' => 'Not a git repository',
+			'sessions.inspector.checkpoints.viewDiff' => 'View diff',
+			'sessions.inspector.checkpoints.hideDiff' => 'Hide diff',
+			'sessions.inspector.checkpoints.restore' => 'Restore',
+			'sessions.inspector.checkpoints.restoreTitle' => 'Restore checkpoint?',
+			'sessions.inspector.checkpoints.restoreWarn' => 'Re-applies this snapshot onto the working directory. Runs only if HEAD matches and there are no uncommitted tracked changes; untracked files are never overwritten.',
+			'sessions.inspector.checkpoints.restoreConfirm' => 'Restore',
+			'sessions.inspector.checkpoints.restored' => ({required Object files, required Object skipped}) => 'Restored · ${files} files, ${skipped} skipped',
+			'sessions.inspector.checkpoints.delete' => 'Delete',
+			'sessions.inspector.checkpoints.deleteTitle' => 'Delete checkpoint?',
+			'sessions.inspector.checkpoints.deleteConfirm' => 'This removes the checkpoint and its stored payload.',
 			'sessions.spawnSheet.title' => 'New session',
 			'sessions.spawnSheet.errorRequired' => 'Provider and working directory are required',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => 'Failed to spawn session: ${error}',
@@ -20332,6 +20531,8 @@ extension on Translations {
 			'memoryArchived.restoreAllConfirm' => ({required Object count, required Object project}) => 'Restore all ${count} archived memories in ${project}?',
 			'memoryArchived.deleteAllConfirm' => ({required Object count, required Object project}) => 'Permanently delete all ${count} archived memories in ${project}? This skips the 30-day grace window and cannot be undone.',
 			'memoryArchived.deletePermanently' => 'Delete',
+			_ => null,
+		} ?? switch (path) {
 			'memoryArchived.deleteConfirm' => 'Permanently delete this memory now? This skips the 30-day grace window and cannot be undone.',
 			'memoryArchived.restoredToast' => 'Restored',
 			'memoryArchived.restoredAllToast' => ({required Object count}) => 'Restored ${count} memories',
@@ -20374,8 +20575,6 @@ extension on Translations {
 			'project.conflicts.deleteNonFactOther' => ({required Object layer}) => '(${layer} entry — open the corresponding tab to inspect)',
 			'project.conflicts.deleteLoading' => 'Loading fact text…',
 			'project.conflicts.deleteFactLabel' => ({required Object side}) => 'Delete ${side}',
-			_ => null,
-		} ?? switch (path) {
 			'project.conflicts.deletedFact' => 'Fact deleted and conflict accepted',
 			'project.conflicts.openPlanEditor' => 'Open plan editor',
 			'project.conflicts.openGoalEditor' => 'Open goal editor',
@@ -20846,6 +21045,8 @@ extension on Translations {
 			'skills.resetButton' => 'Reset',
 			'skills.resetSnack' => ({required Object id}) => 'Reset ${id} to built-in.',
 			'skills.deletedSnack' => ({required Object id}) => 'Deleted ${id}.',
+			_ => null,
+		} ?? switch (path) {
 			'skills.deleteFailedApi' => ({required Object error}) => 'Delete failed: ${error}',
 			'skills.deleteFailedGeneric' => ({required Object error}) => 'Delete failed: ${error}',
 			'skills.deleteBody' => ({required Object id}) => 'Removes ${id} from the vault. Sessions that reference it will fail until restored.',
@@ -20888,8 +21089,6 @@ extension on Translations {
 			'customTasks.fieldCommand' => 'Command',
 			'customTasks.commandHelper' => 'The text inserted into the session when picked. Can be a CLI command or a Claude slash command.',
 			'customTasks.fieldDescription' => 'Description (optional)',
-			_ => null,
-		} ?? switch (path) {
 			'customTasks.fieldScope' => 'Scope',
 			'customTasks.globalScopeHint' => 'Visible from every session, regardless of cwd.',
 			'customTasks.projectScopeHint' => 'Visible only when a session\'s cwd matches the path below.',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -1941,6 +1941,7 @@ class _TranslationsSessionsInspectorEs extends TranslationsSessionsInspectorEn {
 	@override late final _TranslationsSessionsInspectorGitEs git = _TranslationsSessionsInspectorGitEs._(_root);
 	@override late final _TranslationsSessionsInspectorTasksEs tasks = _TranslationsSessionsInspectorTasksEs._(_root);
 	@override late final _TranslationsSessionsInspectorNotesEs notes = _TranslationsSessionsInspectorNotesEs._(_root);
+	@override late final _TranslationsSessionsInspectorCheckpointsEs checkpoints = _TranslationsSessionsInspectorCheckpointsEs._(_root);
 }
 
 // Path: sessions.spawnSheet
@@ -3297,6 +3298,7 @@ class _TranslationsWebSessionsInspectorEs extends TranslationsWebSessionsInspect
 	@override late final _TranslationsWebSessionsInspectorTabsEs tabs = _TranslationsWebSessionsInspectorTabsEs._(_root);
 	@override late final _TranslationsWebSessionsInspectorVaultPanelEs vaultPanel = _TranslationsWebSessionsInspectorVaultPanelEs._(_root);
 	@override late final _TranslationsWebSessionsInspectorCortexPanelEs cortexPanel = _TranslationsWebSessionsInspectorCortexPanelEs._(_root);
+	@override late final _TranslationsWebSessionsInspectorCheckpointsEs checkpoints = _TranslationsWebSessionsInspectorCheckpointsEs._(_root);
 }
 
 // Path: web.sessions.ended
@@ -4167,6 +4169,7 @@ class _TranslationsWebProvidersDetailEs extends TranslationsWebProvidersDetailEn
 	@override String get toggleFailedToast => 'Error al alternar';
 	@override late final _TranslationsWebProvidersDetailCapsEs caps = _TranslationsWebProvidersDetailCapsEs._(_root);
 	@override String get notInstalled => 'no instalado';
+	@override String get brokenCli => 'Instalado pero no ejecutable';
 	@override String updateAvailable({required Object version}) => 'actualización disponible → ${version}';
 	@override String get upToDate => 'actualizado';
 	@override String update({required Object version}) => 'Actualizar a ${version}';
@@ -6536,6 +6539,34 @@ class _TranslationsSessionsInspectorNotesEs extends TranslationsSessionsInspecto
 	@override String get save => 'Guardar';
 }
 
+// Path: sessions.inspector.checkpoints
+class _TranslationsSessionsInspectorCheckpointsEs extends TranslationsSessionsInspectorCheckpointsEn {
+	_TranslationsSessionsInspectorCheckpointsEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get blurb => 'Captura el diff sin confirmar, los archivos sin seguimiento y el historial de entrada de esta sesión.';
+	@override String get capture => 'Capturar';
+	@override String capturedGit({required Object diff, required Object files}) => 'diff ${diff}B · ${files} archivos sin seguimiento';
+	@override String get capturedNonGit => 'Solo metadatos (no es un repo git)';
+	@override String get empty => 'Aún no hay puntos de control. Captura uno ahora, o se crea automáticamente al apagar el gateway.';
+	@override String get triggerManual => 'Manual';
+	@override String get triggerInterrupted => 'Interrumpido';
+	@override String get truncatedHint => 'Un límite de tamaño/cantidad recortó esta captura; es parcial.';
+	@override String get nonGit => 'No es un repositorio git';
+	@override String get viewDiff => 'Ver diff';
+	@override String get hideDiff => 'Ocultar diff';
+	@override String get restore => 'Restaurar';
+	@override String get restoreTitle => '¿Restaurar punto de control?';
+	@override String get restoreWarn => 'Reaplica esta captura sobre el directorio de trabajo. Solo se ejecuta si HEAD coincide y no hay cambios rastreados sin confirmar; los archivos sin seguimiento nunca se sobrescriben.';
+	@override String get restoreConfirm => 'Restaurar';
+	@override String restored({required Object files, required Object skipped}) => 'Restaurado · ${files} archivos, ${skipped} omitidos';
+	@override String get delete => 'Eliminar';
+	@override String get deleteTitle => '¿Eliminar punto de control?';
+	@override String get deleteConfirm => 'Esto elimina el punto de control y su contenido almacenado.';
+}
+
 // Path: sessions.spawnSheet.bypass
 class _TranslationsSessionsSpawnSheetBypassEs extends TranslationsSessionsSpawnSheetBypassEn {
 	_TranslationsSessionsSpawnSheetBypassEs._(TranslationsEs root) : this._root = root, super.internal(root);
@@ -7115,6 +7146,7 @@ class _TranslationsWebSessionsInspectorTabsEs extends TranslationsWebSessionsIns
 	@override String get vault => 'Bóveda';
 	@override String get cortex => 'Cortex';
 	@override String get database => 'BD';
+	@override String get checkpoints => 'Puntos de control';
 }
 
 // Path: web.sessions.inspector.vaultPanel
@@ -7166,6 +7198,34 @@ class _TranslationsWebSessionsInspectorCortexPanelEs extends TranslationsWebSess
 	@override String get plan => 'Plan';
 	@override String get latestJournal => 'Último diario';
 	@override String get empty => 'Aún no se ha capturado memoria de Cortex para este proyecto. Inicia una sesión o define un objetivo para poblarla.';
+}
+
+// Path: web.sessions.inspector.checkpoints
+class _TranslationsWebSessionsInspectorCheckpointsEs extends TranslationsWebSessionsInspectorCheckpointsEn {
+	_TranslationsWebSessionsInspectorCheckpointsEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get loading => 'Cargando…';
+	@override String get blurb => 'Captura el diff sin confirmar, los archivos sin seguimiento y el historial de entrada de esta sesión — restáuralo después.';
+	@override String get capture => 'Capturar';
+	@override String get captured => 'Punto de control capturado';
+	@override String capturedGit({required Object diff, required Object files}) => 'diff ${diff}B · ${files} archivos sin seguimiento';
+	@override String get capturedNonGit => 'Solo metadatos (no es un repo git)';
+	@override String get empty => 'Aún no hay puntos de control. Captura uno ahora, o se crea automáticamente al apagar el gateway.';
+	@override late final _TranslationsWebSessionsInspectorCheckpointsTriggerEs trigger = _TranslationsWebSessionsInspectorCheckpointsTriggerEs._(_root);
+	@override String get truncated => 'Truncado';
+	@override String get truncatedHint => 'Un límite de tamaño/cantidad recortó esta captura; es parcial.';
+	@override String get nonGit => 'No es un repositorio git';
+	@override String get hideDiff => 'Ocultar diff';
+	@override String get viewDiff => 'Ver diff';
+	@override String get restore => 'Restaurar';
+	@override String get restoreWarn => 'Reaplica esta captura sobre el directorio de trabajo. Solo se ejecuta si HEAD coincide y no hay cambios rastreados sin confirmar; los archivos sin seguimiento nunca se sobrescriben.';
+	@override String get restoreConfirm => 'Confirmar restauración';
+	@override String get restored => 'Punto de control restaurado';
+	@override String restoredDetail({required Object diff, required Object files, required Object skipped}) => 'diff aplicado: ${diff} · ${files} archivos restaurados · ${skipped} omitidos';
+	@override String get deleteConfirm => '¿Eliminar este punto de control?';
 }
 
 // Path: web.memoryWorkers.tasks.gatekeeper
@@ -9122,6 +9182,18 @@ class _TranslationsSessionsInspectorShellTabsEs extends TranslationsSessionsInsp
 	@override String get vault => 'Bóveda';
 	@override String get cortex => 'Cortex';
 	@override String get database => 'BD';
+	@override String get checkpoints => 'Puntos de control';
+}
+
+// Path: web.sessions.inspector.checkpoints.trigger
+class _TranslationsWebSessionsInspectorCheckpointsTriggerEs extends TranslationsWebSessionsInspectorCheckpointsTriggerEn {
+	_TranslationsWebSessionsInspectorCheckpointsTriggerEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get manual => 'Manual';
+	@override String get interrupted => 'Interrumpido';
 }
 
 // Path: web.notes.vaultSync.conflict.kinds
@@ -9396,6 +9468,7 @@ extension on TranslationsEs {
 			'web.sessions.inspector.tabs.vault' => 'Bóveda',
 			'web.sessions.inspector.tabs.cortex' => 'Cortex',
 			'web.sessions.inspector.tabs.database' => 'BD',
+			'web.sessions.inspector.tabs.checkpoints' => 'Puntos de control',
 			'web.sessions.inspector.vaultPanel.open' => 'Abrir Bóveda',
 			'web.sessions.inspector.vaultPanel.projectDocs' => 'Docs del proyecto',
 			'web.sessions.inspector.vaultPanel.projectDocsHint' => 'Docs del proyecto escritos por el agente en la bóveda. Revincula la carpeta si las notas de este proyecto viven en otro sitio.',
@@ -9429,6 +9502,26 @@ extension on TranslationsEs {
 			'web.sessions.inspector.cortexPanel.plan' => 'Plan',
 			'web.sessions.inspector.cortexPanel.latestJournal' => 'Último diario',
 			'web.sessions.inspector.cortexPanel.empty' => 'Aún no se ha capturado memoria de Cortex para este proyecto. Inicia una sesión o define un objetivo para poblarla.',
+			'web.sessions.inspector.checkpoints.loading' => 'Cargando…',
+			'web.sessions.inspector.checkpoints.blurb' => 'Captura el diff sin confirmar, los archivos sin seguimiento y el historial de entrada de esta sesión — restáuralo después.',
+			'web.sessions.inspector.checkpoints.capture' => 'Capturar',
+			'web.sessions.inspector.checkpoints.captured' => 'Punto de control capturado',
+			'web.sessions.inspector.checkpoints.capturedGit' => ({required Object diff, required Object files}) => 'diff ${diff}B · ${files} archivos sin seguimiento',
+			'web.sessions.inspector.checkpoints.capturedNonGit' => 'Solo metadatos (no es un repo git)',
+			'web.sessions.inspector.checkpoints.empty' => 'Aún no hay puntos de control. Captura uno ahora, o se crea automáticamente al apagar el gateway.',
+			'web.sessions.inspector.checkpoints.trigger.manual' => 'Manual',
+			'web.sessions.inspector.checkpoints.trigger.interrupted' => 'Interrumpido',
+			'web.sessions.inspector.checkpoints.truncated' => 'Truncado',
+			'web.sessions.inspector.checkpoints.truncatedHint' => 'Un límite de tamaño/cantidad recortó esta captura; es parcial.',
+			'web.sessions.inspector.checkpoints.nonGit' => 'No es un repositorio git',
+			'web.sessions.inspector.checkpoints.hideDiff' => 'Ocultar diff',
+			'web.sessions.inspector.checkpoints.viewDiff' => 'Ver diff',
+			'web.sessions.inspector.checkpoints.restore' => 'Restaurar',
+			'web.sessions.inspector.checkpoints.restoreWarn' => 'Reaplica esta captura sobre el directorio de trabajo. Solo se ejecuta si HEAD coincide y no hay cambios rastreados sin confirmar; los archivos sin seguimiento nunca se sobrescriben.',
+			'web.sessions.inspector.checkpoints.restoreConfirm' => 'Confirmar restauración',
+			'web.sessions.inspector.checkpoints.restored' => 'Punto de control restaurado',
+			'web.sessions.inspector.checkpoints.restoredDetail' => ({required Object diff, required Object files, required Object skipped}) => 'diff aplicado: ${diff} · ${files} archivos restaurados · ${skipped} omitidos',
+			'web.sessions.inspector.checkpoints.deleteConfirm' => '¿Eliminar este punto de control?',
 			'web.sessions.ended.bufferUnavailable' => '[búfer no disponible]',
 			'web.sessions.ended.readOnlyBanner' => '[session finalizada. búfer de solo lectura]',
 			'web.sessions.fileBrowser.title' => 'Elige el directorio de trabajo',
@@ -9682,6 +9775,8 @@ extension on TranslationsEs {
 			'web.project.editor.savedToast' => ({required Object label}) => '${label} guardado',
 			'web.project.editor.goalPlaceholder' => '¿Qué estamos construyendo? Un párrafo. Lo lee cada agente al iniciarse.',
 			'web.project.editor.planPlaceholder' => 'Plan activo: qué estamos haciendo ahora mismo y qué viene después. Se actualiza a medida que avanza el trabajo.',
+			_ => null,
+		} ?? switch (path) {
 			'web.project.editor.sectionPlaceholder' => 'Escribe esta sección en markdown…',
 			'web.project.readonly.tech_stack.label' => 'Stack tecnológico y estructura',
 			'web.project.readonly.tech_stack.empty' => 'Ejecuta una session de Claude en este proyecto. El escáner se actualiza en cada inicio.',
@@ -9703,8 +9798,6 @@ extension on TranslationsEs {
 			'web.project.inbox.sessionPrefix' => 'ses',
 			'web.project.inbox.warning' => ({required Object label}) => 'Aprobar REEMPLAZARÁ por completo el ${label} actual.',
 			'web.project.inbox.warningSuffix' => 'Revisa el diff de abajo; esto no es una fusión.',
-			_ => null,
-		} ?? switch (path) {
 			'web.project.inbox.current' => 'Actual',
 			'web.project.inbox.proposed' => 'Propuesto',
 			'web.project.inbox.emptyBody' => '(vacío)',
@@ -10110,6 +10203,7 @@ extension on TranslationsEs {
 			'web.providers.detail.caps.images' => 'images',
 			'web.providers.detail.caps.mcp' => 'mcp',
 			'web.providers.detail.notInstalled' => 'no instalado',
+			'web.providers.detail.brokenCli' => 'Instalado pero no ejecutable',
 			'web.providers.detail.updateAvailable' => ({required Object version}) => 'actualización disponible → ${version}',
 			'web.providers.detail.upToDate' => 'actualizado',
 			'web.providers.detail.update' => ({required Object version}) => 'Actualizar a ${version}',
@@ -10195,6 +10289,8 @@ extension on TranslationsEs {
 			'web.channels.card.copyWebhookTooltip' => 'Copiar la URL del webhook',
 			'web.channels.card.webhookCopiedToast' => 'URL del webhook copiada',
 			'web.channels.card.setup' => 'Configuración',
+			_ => null,
+		} ?? switch (path) {
 			'web.channels.card.setupTooltip' => 'Mostrar los detalles de conexión del adaptador y código de ejemplo',
 			'web.channels.card.test' => 'Probar',
 			'web.channels.card.testNotRunningTooltip' => 'El canal debe estar en ejecución',
@@ -10217,8 +10313,6 @@ extension on TranslationsEs {
 			'web.channels.dialog.editTitle' => 'Editar canal',
 			'web.channels.dialog.createTitle' => 'Registrar canal',
 			'web.channels.dialog.descriptionBridge' => 'Un adaptador externo (Python/Node/...) se conecta vía WebSocket y presenta este token.',
-			_ => null,
-		} ?? switch (path) {
 			'web.channels.dialog.descriptionDefault' => 'Configura la integración de mensajería.',
 			'web.channels.dialog.kindLabel' => 'Tipo',
 			'web.channels.dialog.kindImmutable' => '(inmutable, elimina y vuelve a crear para cambiar el tipo)',
@@ -10709,6 +10803,8 @@ extension on TranslationsEs {
 			'web.backups.recoveryKit.confirmLabel' => 'Confirmar frase de recuperación',
 			'web.backups.recoveryKit.mismatch' => 'Las frases no coinciden',
 			'web.backups.recoveryKit.generating' => 'Generando…',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.recoveryKit.download' => 'Descargar kit',
 			'web.backups.recoveryKit.downloadedToast' => 'Kit de recuperación descargado: guárdalo de forma segura',
 			'web.backups.recoveryKit.failedToast' => 'No se pudo generar el kit de recuperación',
@@ -10731,8 +10827,6 @@ extension on TranslationsEs {
 			'web.backups.schedulesTab.deleteTooltip' => 'Eliminar',
 			'web.backups.newSchedule.title' => 'Nueva programación de copia de seguridad',
 			'web.backups.newSchedule.targetLabel' => 'Destinos',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.newSchedule.targetsHint' => 'Elige uno o más: la misma copia se escribe en cada destino (3-2-1).',
 			'web.backups.newSchedule.everyHoursLabel' => 'Cada (horas)',
 			'web.backups.newSchedule.keepLastNLabel' => 'Conservar las últimas N',
@@ -11223,6 +11317,8 @@ extension on TranslationsEs {
 			'web.memoryAmbient.rules.row.deletedToast' => 'Regla eliminada',
 			'web.memoryAmbient.rules.row.deleteFailedToast' => 'La eliminación falló',
 			'web.memoryAmbient.rules.row.summary.afterMessages' => ({required Object n}) => 'cada ${n} mensajes',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryAmbient.rules.row.summary.onIdle' => ({required Object seconds}) => 'inactivo ≥ ${seconds}s',
 			'web.memoryAmbient.rules.row.summary.kChars' => ({required Object k}) => '≥ ${k} caracteres',
 			'web.memoryAmbient.rules.row.summary.manual' => 'solo manual',
@@ -11245,8 +11341,6 @@ extension on TranslationsEs {
 			'web.memoryAmbient.profiles.addButton' => 'Añadir perfil',
 			'web.memoryAmbient.profiles.intro' => 'Al arrancar, opendray antepone un banner en markdown con las memorias recientes del proyecto al system prompt del agente, SI hay un perfil configurado. Sin un perfil, el modelo sigue usando memory_search bajo demanda.',
 			'web.memoryAmbient.profiles.empty' => 'No hay perfil de inyección. Las memorias no se inyectan automáticamente al arrancar; el modelo sigue usando memory_search.',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryAmbient.profiles.row.globalDefault' => 'predeterminado global',
 			'web.memoryAmbient.profiles.row.delete' => 'Eliminar',
 			'web.memoryAmbient.profiles.row.deleteConfirm' => '¿Eliminar este perfil de inyección?',
@@ -11737,6 +11831,8 @@ extension on TranslationsEs {
 			'memoryAmbient.strategyManualOnly' => 'Solo manual',
 			'memoryAmbient.strategyHybrid' => 'Resumen híbrido',
 			'memoryAmbient.strategyUnknown' => 'Desconocido',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.title' => 'Sesiones',
 			'sessions.refresh' => 'Actualizar',
 			'sessions.actions' => 'Acciones',
@@ -11759,8 +11855,6 @@ extension on TranslationsEs {
 			'sessions.detail.refreshMetadata' => 'Actualizar metadatos',
 			'sessions.detail.inspector' => 'Inspector (Archivos / Git / Tareas / Historial / Notas)',
 			'sessions.detail.projectMemory' => 'Memoria del proyecto (objetivo / plan / diario / bandeja de entrada)',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.detail.actions' => 'Acciones',
 			'sessions.detail.started' => ({required Object when}) => 'iniciada ${when}',
 			'sessions.detail.startedEnded' => ({required Object started, required Object ended}) => 'iniciada ${started}  ·  finalizada ${ended}',
@@ -11841,6 +11935,7 @@ extension on TranslationsEs {
 			'sessions.inspector.shell.tabs.vault' => 'Bóveda',
 			'sessions.inspector.shell.tabs.cortex' => 'Cortex',
 			'sessions.inspector.shell.tabs.database' => 'BD',
+			'sessions.inspector.shell.tabs.checkpoints' => 'Puntos de control',
 			'sessions.inspector.cortex.title' => 'Espacio Cortex',
 			'sessions.inspector.cortex.blurb' => 'Objetivo, plan, diario, bandeja y limpieza de memoria de este proyecto — el Cortex mantenido por IA.',
 			'sessions.inspector.cortex.open' => 'Abrir espacio Cortex',
@@ -11919,6 +12014,25 @@ extension on TranslationsEs {
 			'sessions.inspector.notes.noProjectMapping2' => '(sin asignación de proyecto)',
 			'sessions.inspector.notes.clearOverride' => 'Borrar anulación',
 			'sessions.inspector.notes.save' => 'Guardar',
+			'sessions.inspector.checkpoints.blurb' => 'Captura el diff sin confirmar, los archivos sin seguimiento y el historial de entrada de esta sesión.',
+			'sessions.inspector.checkpoints.capture' => 'Capturar',
+			'sessions.inspector.checkpoints.capturedGit' => ({required Object diff, required Object files}) => 'diff ${diff}B · ${files} archivos sin seguimiento',
+			'sessions.inspector.checkpoints.capturedNonGit' => 'Solo metadatos (no es un repo git)',
+			'sessions.inspector.checkpoints.empty' => 'Aún no hay puntos de control. Captura uno ahora, o se crea automáticamente al apagar el gateway.',
+			'sessions.inspector.checkpoints.triggerManual' => 'Manual',
+			'sessions.inspector.checkpoints.triggerInterrupted' => 'Interrumpido',
+			'sessions.inspector.checkpoints.truncatedHint' => 'Un límite de tamaño/cantidad recortó esta captura; es parcial.',
+			'sessions.inspector.checkpoints.nonGit' => 'No es un repositorio git',
+			'sessions.inspector.checkpoints.viewDiff' => 'Ver diff',
+			'sessions.inspector.checkpoints.hideDiff' => 'Ocultar diff',
+			'sessions.inspector.checkpoints.restore' => 'Restaurar',
+			'sessions.inspector.checkpoints.restoreTitle' => '¿Restaurar punto de control?',
+			'sessions.inspector.checkpoints.restoreWarn' => 'Reaplica esta captura sobre el directorio de trabajo. Solo se ejecuta si HEAD coincide y no hay cambios rastreados sin confirmar; los archivos sin seguimiento nunca se sobrescriben.',
+			'sessions.inspector.checkpoints.restoreConfirm' => 'Restaurar',
+			'sessions.inspector.checkpoints.restored' => ({required Object files, required Object skipped}) => 'Restaurado · ${files} archivos, ${skipped} omitidos',
+			'sessions.inspector.checkpoints.delete' => 'Eliminar',
+			'sessions.inspector.checkpoints.deleteTitle' => '¿Eliminar punto de control?',
+			'sessions.inspector.checkpoints.deleteConfirm' => 'Esto elimina el punto de control y su contenido almacenado.',
 			'sessions.spawnSheet.title' => 'Nueva session',
 			'sessions.spawnSheet.errorRequired' => 'El proveedor y el directorio de trabajo son obligatorios',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => 'No se pudo crear la session: ${error}',
@@ -12231,6 +12345,8 @@ extension on TranslationsEs {
 			'memoryArchived.restoreAllConfirm' => ({required Object count, required Object project}) => '¿Restaurar las ${count} memorias archivadas de ${project}?',
 			'memoryArchived.deleteAllConfirm' => ({required Object count, required Object project}) => '¿Eliminar permanentemente las ${count} memorias archivadas de ${project}? Omite la ventana de gracia de 30 días y no se puede deshacer.',
 			'memoryArchived.deletePermanently' => 'Eliminar',
+			_ => null,
+		} ?? switch (path) {
 			'memoryArchived.deleteConfirm' => '¿Eliminar permanentemente esta memoria ahora? Omite la ventana de gracia de 30 días y no se puede deshacer.',
 			'memoryArchived.restoredToast' => 'Restaurada',
 			'memoryArchived.restoredAllToast' => ({required Object count}) => '${count} memorias restauradas',
@@ -12273,8 +12389,6 @@ extension on TranslationsEs {
 			'project.conflicts.deleteNonFactOther' => ({required Object layer}) => '(entrada de ${layer}, abre la pestaña correspondiente para inspeccionar)',
 			'project.conflicts.deleteLoading' => 'Cargando el texto del hecho…',
 			'project.conflicts.deleteFactLabel' => ({required Object side}) => 'Eliminar ${side}',
-			_ => null,
-		} ?? switch (path) {
 			'project.conflicts.deletedFact' => 'Hecho eliminado y conflicto aceptado',
 			'project.conflicts.openPlanEditor' => 'Abrir el editor del plan',
 			'project.conflicts.openGoalEditor' => 'Abrir el editor del objetivo',
@@ -12745,6 +12859,8 @@ extension on TranslationsEs {
 			'skills.resetButton' => 'Restablecer',
 			'skills.resetSnack' => ({required Object id}) => '${id} restablecido al integrado.',
 			'skills.deletedSnack' => ({required Object id}) => '${id} eliminado.',
+			_ => null,
+		} ?? switch (path) {
 			'skills.deleteFailedApi' => ({required Object error}) => 'Error al eliminar: ${error}',
 			'skills.deleteFailedGeneric' => ({required Object error}) => 'Error al eliminar: ${error}',
 			'skills.deleteBody' => ({required Object id}) => 'Elimina ${id} del vault. Las sesiones que lo referencian fallarán hasta que se restaure.',
@@ -12787,8 +12903,6 @@ extension on TranslationsEs {
 			'customTasks.fieldCommand' => 'Comando',
 			'customTasks.commandHelper' => 'El texto que se inserta en la session al elegirlo. Puede ser un comando de CLI o un slash command de Claude.',
 			'customTasks.fieldDescription' => 'Descripción (opcional)',
-			_ => null,
-		} ?? switch (path) {
 			'customTasks.fieldScope' => 'Ámbito',
 			'customTasks.globalScopeHint' => 'Visible desde cualquier session, sin importar el cwd.',
 			'customTasks.projectScopeHint' => 'Visible solo cuando el cwd de una session coincide con la ruta de abajo.',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -1941,6 +1941,7 @@ class _TranslationsSessionsInspectorZh extends TranslationsSessionsInspectorEn {
 	@override late final _TranslationsSessionsInspectorGitZh git = _TranslationsSessionsInspectorGitZh._(_root);
 	@override late final _TranslationsSessionsInspectorTasksZh tasks = _TranslationsSessionsInspectorTasksZh._(_root);
 	@override late final _TranslationsSessionsInspectorNotesZh notes = _TranslationsSessionsInspectorNotesZh._(_root);
+	@override late final _TranslationsSessionsInspectorCheckpointsZh checkpoints = _TranslationsSessionsInspectorCheckpointsZh._(_root);
 }
 
 // Path: sessions.spawnSheet
@@ -3297,6 +3298,7 @@ class _TranslationsWebSessionsInspectorZh extends TranslationsWebSessionsInspect
 	@override late final _TranslationsWebSessionsInspectorTabsZh tabs = _TranslationsWebSessionsInspectorTabsZh._(_root);
 	@override late final _TranslationsWebSessionsInspectorVaultPanelZh vaultPanel = _TranslationsWebSessionsInspectorVaultPanelZh._(_root);
 	@override late final _TranslationsWebSessionsInspectorCortexPanelZh cortexPanel = _TranslationsWebSessionsInspectorCortexPanelZh._(_root);
+	@override late final _TranslationsWebSessionsInspectorCheckpointsZh checkpoints = _TranslationsWebSessionsInspectorCheckpointsZh._(_root);
 }
 
 // Path: web.sessions.ended
@@ -4167,6 +4169,7 @@ class _TranslationsWebProvidersDetailZh extends TranslationsWebProvidersDetailEn
 	@override String get toggleFailedToast => '切换失败';
 	@override late final _TranslationsWebProvidersDetailCapsZh caps = _TranslationsWebProvidersDetailCapsZh._(_root);
 	@override String get notInstalled => '未安装';
+	@override String get brokenCli => '已安装但无法运行';
 	@override String updateAvailable({required Object version}) => '有可用更新 → ${version}';
 	@override String get upToDate => '已是最新';
 	@override String update({required Object version}) => '更新到 ${version}';
@@ -6536,6 +6539,34 @@ class _TranslationsSessionsInspectorNotesZh extends TranslationsSessionsInspecto
 	@override String get save => '保存';
 }
 
+// Path: sessions.inspector.checkpoints
+class _TranslationsSessionsInspectorCheckpointsZh extends TranslationsSessionsInspectorCheckpointsEn {
+	_TranslationsSessionsInspectorCheckpointsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get blurb => '快照本会话的未提交 diff、未跟踪文件与输入历史。';
+	@override String get capture => '捕获';
+	@override String capturedGit({required Object diff, required Object files}) => 'diff ${diff}B · ${files} 个未跟踪文件';
+	@override String get capturedNonGit => '仅元数据(非 git 仓库)';
+	@override String get empty => '还没有检查点。可以现在捕获一个,或在网关关闭时自动生成。';
+	@override String get triggerManual => '手动';
+	@override String get triggerInterrupted => '中断';
+	@override String get truncatedHint => '大小/数量上限裁剪了本次捕获,内容不完整。';
+	@override String get nonGit => '非 git 仓库';
+	@override String get viewDiff => '查看 diff';
+	@override String get hideDiff => '隐藏 diff';
+	@override String get restore => '恢复';
+	@override String get restoreTitle => '恢复检查点?';
+	@override String get restoreWarn => '将此快照重新应用到工作目录。仅当 HEAD 一致且无未提交的已跟踪改动时执行;未跟踪文件绝不覆盖。';
+	@override String get restoreConfirm => '恢复';
+	@override String restored({required Object files, required Object skipped}) => '已恢复 · ${files} 个文件,跳过 ${skipped} 个';
+	@override String get delete => '删除';
+	@override String get deleteTitle => '删除检查点?';
+	@override String get deleteConfirm => '将移除该检查点及其存储的内容。';
+}
+
 // Path: sessions.spawnSheet.bypass
 class _TranslationsSessionsSpawnSheetBypassZh extends TranslationsSessionsSpawnSheetBypassEn {
 	_TranslationsSessionsSpawnSheetBypassZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -7115,6 +7146,7 @@ class _TranslationsWebSessionsInspectorTabsZh extends TranslationsWebSessionsIns
 	@override String get vault => '文档库';
 	@override String get cortex => '心智中枢';
 	@override String get database => '数据库';
+	@override String get checkpoints => '检查点';
 }
 
 // Path: web.sessions.inspector.vaultPanel
@@ -7166,6 +7198,34 @@ class _TranslationsWebSessionsInspectorCortexPanelZh extends TranslationsWebSess
 	@override String get plan => '计划';
 	@override String get latestJournal => '最新日志';
 	@override String get empty => '该项目尚未捕获任何心智中枢记忆。启动会话或设定目标以填充。';
+}
+
+// Path: web.sessions.inspector.checkpoints
+class _TranslationsWebSessionsInspectorCheckpointsZh extends TranslationsWebSessionsInspectorCheckpointsEn {
+	_TranslationsWebSessionsInspectorCheckpointsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get loading => '加载中…';
+	@override String get blurb => '快照本会话的未提交 diff、未跟踪文件与输入历史——之后可恢复。';
+	@override String get capture => '捕获';
+	@override String get captured => '检查点已捕获';
+	@override String capturedGit({required Object diff, required Object files}) => 'diff ${diff}B · ${files} 个未跟踪文件';
+	@override String get capturedNonGit => '仅元数据(非 git 仓库)';
+	@override String get empty => '还没有检查点。可以现在捕获一个,或在网关关闭时自动生成。';
+	@override late final _TranslationsWebSessionsInspectorCheckpointsTriggerZh trigger = _TranslationsWebSessionsInspectorCheckpointsTriggerZh._(_root);
+	@override String get truncated => '已截断';
+	@override String get truncatedHint => '大小/数量上限裁剪了本次捕获,内容不完整。';
+	@override String get nonGit => '非 git 仓库';
+	@override String get hideDiff => '隐藏 diff';
+	@override String get viewDiff => '查看 diff';
+	@override String get restore => '恢复';
+	@override String get restoreWarn => '将此快照重新应用到工作目录。仅当 HEAD 一致且无未提交的已跟踪改动时执行;未跟踪文件绝不覆盖。';
+	@override String get restoreConfirm => '确认恢复';
+	@override String get restored => '检查点已恢复';
+	@override String restoredDetail({required Object diff, required Object files, required Object skipped}) => 'diff 应用:${diff} · 恢复 ${files} 个文件 · 跳过 ${skipped} 个';
+	@override String get deleteConfirm => '删除此检查点?';
 }
 
 // Path: web.memoryWorkers.tasks.gatekeeper
@@ -9122,6 +9182,18 @@ class _TranslationsSessionsInspectorShellTabsZh extends TranslationsSessionsInsp
 	@override String get vault => '文档库';
 	@override String get cortex => '心智中枢';
 	@override String get database => '数据库';
+	@override String get checkpoints => '检查点';
+}
+
+// Path: web.sessions.inspector.checkpoints.trigger
+class _TranslationsWebSessionsInspectorCheckpointsTriggerZh extends TranslationsWebSessionsInspectorCheckpointsTriggerEn {
+	_TranslationsWebSessionsInspectorCheckpointsTriggerZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get manual => '手动';
+	@override String get interrupted => '中断';
 }
 
 // Path: web.notes.vaultSync.conflict.kinds
@@ -9396,6 +9468,7 @@ extension on TranslationsZh {
 			'web.sessions.inspector.tabs.vault' => '文档库',
 			'web.sessions.inspector.tabs.cortex' => '心智中枢',
 			'web.sessions.inspector.tabs.database' => '数据库',
+			'web.sessions.inspector.tabs.checkpoints' => '检查点',
 			'web.sessions.inspector.vaultPanel.open' => '打开文档库',
 			'web.sessions.inspector.vaultPanel.projectDocs' => '项目文档',
 			'web.sessions.inspector.vaultPanel.projectDocsHint' => '文档库中由 AI 撰写的项目文档。若本项目笔记在别处，可重新绑定文件夹。',
@@ -9429,6 +9502,26 @@ extension on TranslationsZh {
 			'web.sessions.inspector.cortexPanel.plan' => '计划',
 			'web.sessions.inspector.cortexPanel.latestJournal' => '最新日志',
 			'web.sessions.inspector.cortexPanel.empty' => '该项目尚未捕获任何心智中枢记忆。启动会话或设定目标以填充。',
+			'web.sessions.inspector.checkpoints.loading' => '加载中…',
+			'web.sessions.inspector.checkpoints.blurb' => '快照本会话的未提交 diff、未跟踪文件与输入历史——之后可恢复。',
+			'web.sessions.inspector.checkpoints.capture' => '捕获',
+			'web.sessions.inspector.checkpoints.captured' => '检查点已捕获',
+			'web.sessions.inspector.checkpoints.capturedGit' => ({required Object diff, required Object files}) => 'diff ${diff}B · ${files} 个未跟踪文件',
+			'web.sessions.inspector.checkpoints.capturedNonGit' => '仅元数据(非 git 仓库)',
+			'web.sessions.inspector.checkpoints.empty' => '还没有检查点。可以现在捕获一个,或在网关关闭时自动生成。',
+			'web.sessions.inspector.checkpoints.trigger.manual' => '手动',
+			'web.sessions.inspector.checkpoints.trigger.interrupted' => '中断',
+			'web.sessions.inspector.checkpoints.truncated' => '已截断',
+			'web.sessions.inspector.checkpoints.truncatedHint' => '大小/数量上限裁剪了本次捕获,内容不完整。',
+			'web.sessions.inspector.checkpoints.nonGit' => '非 git 仓库',
+			'web.sessions.inspector.checkpoints.hideDiff' => '隐藏 diff',
+			'web.sessions.inspector.checkpoints.viewDiff' => '查看 diff',
+			'web.sessions.inspector.checkpoints.restore' => '恢复',
+			'web.sessions.inspector.checkpoints.restoreWarn' => '将此快照重新应用到工作目录。仅当 HEAD 一致且无未提交的已跟踪改动时执行;未跟踪文件绝不覆盖。',
+			'web.sessions.inspector.checkpoints.restoreConfirm' => '确认恢复',
+			'web.sessions.inspector.checkpoints.restored' => '检查点已恢复',
+			'web.sessions.inspector.checkpoints.restoredDetail' => ({required Object diff, required Object files, required Object skipped}) => 'diff 应用:${diff} · 恢复 ${files} 个文件 · 跳过 ${skipped} 个',
+			'web.sessions.inspector.checkpoints.deleteConfirm' => '删除此检查点?',
 			'web.sessions.ended.bufferUnavailable' => '[缓冲区不可用]',
 			'web.sessions.ended.readOnlyBanner' => '[会话已结束 — 只读缓冲区]',
 			'web.sessions.fileBrowser.title' => '选择工作目录',
@@ -9682,6 +9775,8 @@ extension on TranslationsZh {
 			'web.project.editor.savedToast' => ({required Object label}) => '${label}已保存',
 			'web.project.editor.goalPlaceholder' => '我们在做什么？一段文字。每个 agent 在 spawn 时都会读取。',
 			'web.project.editor.planPlaceholder' => '当前计划 — 现在在做什么、下一步是什么。随进度更新。',
+			_ => null,
+		} ?? switch (path) {
 			'web.project.editor.sectionPlaceholder' => '以 markdown 撰写本章节…',
 			'web.project.readonly.tech_stack.label' => '技术栈与结构',
 			'web.project.readonly.tech_stack.empty' => '在该项目运行一次 Claude 会话 — scanner 会在每次 spawn 时刷新。',
@@ -9703,8 +9798,6 @@ extension on TranslationsZh {
 			'web.project.inbox.sessionPrefix' => 'ses',
 			'web.project.inbox.warning' => ({required Object label}) => '批准将完全替换当前${label}。',
 			'web.project.inbox.warningSuffix' => '请检查下方 diff；这不是合并。',
-			_ => null,
-		} ?? switch (path) {
 			'web.project.inbox.current' => '当前',
 			'web.project.inbox.proposed' => '提议',
 			'web.project.inbox.emptyBody' => '(空)',
@@ -10110,6 +10203,7 @@ extension on TranslationsZh {
 			'web.providers.detail.caps.images' => 'images',
 			'web.providers.detail.caps.mcp' => 'mcp',
 			'web.providers.detail.notInstalled' => '未安装',
+			'web.providers.detail.brokenCli' => '已安装但无法运行',
 			'web.providers.detail.updateAvailable' => ({required Object version}) => '有可用更新 → ${version}',
 			'web.providers.detail.upToDate' => '已是最新',
 			'web.providers.detail.update' => ({required Object version}) => '更新到 ${version}',
@@ -10195,6 +10289,8 @@ extension on TranslationsZh {
 			'web.channels.card.copyWebhookTooltip' => '复制 webhook URL',
 			'web.channels.card.webhookCopiedToast' => '已复制 webhook URL',
 			'web.channels.card.setup' => '配置',
+			_ => null,
+		} ?? switch (path) {
 			'web.channels.card.setupTooltip' => '查看适配器连接信息和示例代码',
 			'web.channels.card.test' => '测试',
 			'web.channels.card.testNotRunningTooltip' => '频道必须处于运行状态',
@@ -10217,8 +10313,6 @@ extension on TranslationsZh {
 			'web.channels.dialog.editTitle' => '编辑频道',
 			'web.channels.dialog.createTitle' => '注册频道',
 			'web.channels.dialog.descriptionBridge' => '外部适配器（Python/Node/...）通过 WebSocket 连接并出示此 token。',
-			_ => null,
-		} ?? switch (path) {
 			'web.channels.dialog.descriptionDefault' => '配置消息集成。',
 			'web.channels.dialog.kindLabel' => '类型',
 			'web.channels.dialog.kindImmutable' => '（不可更改 — 如需更换类型请删除后重建）',
@@ -10709,6 +10803,8 @@ extension on TranslationsZh {
 			'web.backups.recoveryKit.confirmLabel' => '确认恢复口令',
 			'web.backups.recoveryKit.mismatch' => '两次口令不一致',
 			'web.backups.recoveryKit.generating' => '生成中…',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.recoveryKit.download' => '下载工具包',
 			'web.backups.recoveryKit.downloadedToast' => '恢复工具包已下载 —— 请妥善保存',
 			'web.backups.recoveryKit.failedToast' => '无法生成恢复工具包',
@@ -10731,8 +10827,6 @@ extension on TranslationsZh {
 			'web.backups.schedulesTab.deleteTooltip' => '删除',
 			'web.backups.newSchedule.title' => '新建备份计划',
 			'web.backups.newSchedule.targetLabel' => '目标',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.newSchedule.targetsHint' => '选择一个或多个 —— 同一份备份会写入每个目标（3-2-1）。',
 			'web.backups.newSchedule.everyHoursLabel' => '每隔（小时）',
 			'web.backups.newSchedule.keepLastNLabel' => '保留最近 N 个',
@@ -11223,6 +11317,8 @@ extension on TranslationsZh {
 			'web.memoryAmbient.rules.row.deletedToast' => '规则已删除',
 			'web.memoryAmbient.rules.row.deleteFailedToast' => '删除失败',
 			'web.memoryAmbient.rules.row.summary.afterMessages' => ({required Object n}) => '每 ${n} 条消息',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryAmbient.rules.row.summary.onIdle' => ({required Object seconds}) => 'idle ≥ ${seconds}s',
 			'web.memoryAmbient.rules.row.summary.kChars' => ({required Object k}) => '≥ ${k} 字符',
 			'web.memoryAmbient.rules.row.summary.manual' => '仅手动',
@@ -11245,8 +11341,6 @@ extension on TranslationsZh {
 			'web.memoryAmbient.profiles.addButton' => '添加 profile',
 			'web.memoryAmbient.profiles.intro' => 'spawn 时，opendray 会把最近的项目记忆作为一段 markdown banner 拼接到 agent 的 system prompt — 前提是配置了 profile。没有 profile 时，模型仍可按需调用 memory_search。',
 			'web.memoryAmbient.profiles.empty' => '尚无 injection profile。spawn 时不会自动注入记忆 — 模型仍可使用 memory_search。',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryAmbient.profiles.row.globalDefault' => '全局默认',
 			'web.memoryAmbient.profiles.row.delete' => '删除',
 			'web.memoryAmbient.profiles.row.deleteConfirm' => '删除该 injection profile?',
@@ -11737,6 +11831,8 @@ extension on TranslationsZh {
 			'memoryAmbient.strategyManualOnly' => '仅手动',
 			'memoryAmbient.strategyHybrid' => '混合摘要',
 			'memoryAmbient.strategyUnknown' => '未知',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.title' => '会话',
 			'sessions.refresh' => '刷新',
 			'sessions.actions' => '操作',
@@ -11759,8 +11855,6 @@ extension on TranslationsZh {
 			'sessions.detail.refreshMetadata' => '刷新元数据',
 			'sessions.detail.inspector' => '检查器（文件 / Git / 任务 / 历史 / 笔记）',
 			'sessions.detail.projectMemory' => '项目记忆（目标 / 计划 / 日志 / 收件箱）',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.detail.actions' => '操作',
 			'sessions.detail.started' => ({required Object when}) => '${when} 启动',
 			'sessions.detail.startedEnded' => ({required Object started, required Object ended}) => '${started} 启动  ·  ${ended} 结束',
@@ -11841,6 +11935,7 @@ extension on TranslationsZh {
 			'sessions.inspector.shell.tabs.vault' => '文档库',
 			'sessions.inspector.shell.tabs.cortex' => '心智中枢',
 			'sessions.inspector.shell.tabs.database' => '数据库',
+			'sessions.inspector.shell.tabs.checkpoints' => '检查点',
 			'sessions.inspector.cortex.title' => '心智中枢工作区',
 			'sessions.inspector.cortex.blurb' => '本项目的目标、计划、日志、收件箱与记忆整理 —— 由 AI 维护的心智中枢。',
 			'sessions.inspector.cortex.open' => '打开心智中枢工作区',
@@ -11919,6 +12014,25 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.noProjectMapping2' => '（无项目映射）',
 			'sessions.inspector.notes.clearOverride' => '清除覆盖',
 			'sessions.inspector.notes.save' => '保存',
+			'sessions.inspector.checkpoints.blurb' => '快照本会话的未提交 diff、未跟踪文件与输入历史。',
+			'sessions.inspector.checkpoints.capture' => '捕获',
+			'sessions.inspector.checkpoints.capturedGit' => ({required Object diff, required Object files}) => 'diff ${diff}B · ${files} 个未跟踪文件',
+			'sessions.inspector.checkpoints.capturedNonGit' => '仅元数据(非 git 仓库)',
+			'sessions.inspector.checkpoints.empty' => '还没有检查点。可以现在捕获一个,或在网关关闭时自动生成。',
+			'sessions.inspector.checkpoints.triggerManual' => '手动',
+			'sessions.inspector.checkpoints.triggerInterrupted' => '中断',
+			'sessions.inspector.checkpoints.truncatedHint' => '大小/数量上限裁剪了本次捕获,内容不完整。',
+			'sessions.inspector.checkpoints.nonGit' => '非 git 仓库',
+			'sessions.inspector.checkpoints.viewDiff' => '查看 diff',
+			'sessions.inspector.checkpoints.hideDiff' => '隐藏 diff',
+			'sessions.inspector.checkpoints.restore' => '恢复',
+			'sessions.inspector.checkpoints.restoreTitle' => '恢复检查点?',
+			'sessions.inspector.checkpoints.restoreWarn' => '将此快照重新应用到工作目录。仅当 HEAD 一致且无未提交的已跟踪改动时执行;未跟踪文件绝不覆盖。',
+			'sessions.inspector.checkpoints.restoreConfirm' => '恢复',
+			'sessions.inspector.checkpoints.restored' => ({required Object files, required Object skipped}) => '已恢复 · ${files} 个文件,跳过 ${skipped} 个',
+			'sessions.inspector.checkpoints.delete' => '删除',
+			'sessions.inspector.checkpoints.deleteTitle' => '删除检查点?',
+			'sessions.inspector.checkpoints.deleteConfirm' => '将移除该检查点及其存储的内容。',
 			'sessions.spawnSheet.title' => '新建会话',
 			'sessions.spawnSheet.errorRequired' => '需要指定提供商和工作目录',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => '创建会话失败：${error}',
@@ -12231,6 +12345,8 @@ extension on TranslationsZh {
 			'memoryArchived.restoreAllConfirm' => ({required Object project, required Object count}) => '恢复 ${project} 的全部 ${count} 条归档记忆？',
 			'memoryArchived.deleteAllConfirm' => ({required Object project, required Object count}) => '永久删除 ${project} 的全部 ${count} 条归档记忆？将跳过 30 天宽限期，且不可撤销。',
 			'memoryArchived.deletePermanently' => '删除',
+			_ => null,
+		} ?? switch (path) {
 			'memoryArchived.deleteConfirm' => '立即永久删除这条记忆？将跳过 30 天宽限期，且不可撤销。',
 			'memoryArchived.restoredToast' => '已恢复',
 			'memoryArchived.restoredAllToast' => ({required Object count}) => '已恢复 ${count} 条记忆',
@@ -12273,8 +12389,6 @@ extension on TranslationsZh {
 			'project.conflicts.deleteNonFactOther' => ({required Object layer}) => '（${layer} 条目 — 请打开对应 tab 查看）',
 			'project.conflicts.deleteLoading' => '加载中…',
 			'project.conflicts.deleteFactLabel' => ({required Object side}) => '删除 ${side}',
-			_ => null,
-		} ?? switch (path) {
 			'project.conflicts.deletedFact' => '已删除 fact 并采纳冲突',
 			'project.conflicts.openPlanEditor' => '打开计划编辑器',
 			'project.conflicts.openGoalEditor' => '打开目标编辑器',
@@ -12745,6 +12859,8 @@ extension on TranslationsZh {
 			'skills.resetButton' => '重置',
 			'skills.resetSnack' => ({required Object id}) => '已将 ${id} 重置为内置。',
 			'skills.deletedSnack' => ({required Object id}) => '已删除 ${id}。',
+			_ => null,
+		} ?? switch (path) {
 			'skills.deleteFailedApi' => ({required Object error}) => '删除失败：${error}',
 			'skills.deleteFailedGeneric' => ({required Object error}) => '删除失败：${error}',
 			'skills.deleteBody' => ({required Object id}) => '从库中移除 ${id}。引用它的会话在恢复前会失败。',
@@ -12787,8 +12903,6 @@ extension on TranslationsZh {
 			'customTasks.fieldCommand' => '命令',
 			'customTasks.commandHelper' => '选择时插入到会话的文本。可以是 CLI 命令或 Claude 斜杠命令。',
 			'customTasks.fieldDescription' => '描述（可选）',
-			_ => null,
-		} ?? switch (path) {
 			'customTasks.fieldScope' => '范围',
 			'customTasks.globalScopeHint' => '从任何会话可见，不论 cwd。',
 			'customTasks.projectScopeHint' => '仅当会话的 cwd 匹配以下路径时可见。',

--- a/app/mobile/lib/features/sessions/inspector/checkpoints_tab.dart
+++ b/app/mobile/lib/features/sessions/inspector/checkpoints_tab.dart
@@ -1,0 +1,487 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import 'package:opendray/core/api/api_exception.dart';
+import 'package:opendray/core/api/checkpoints_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+
+// Checkpoints surface inside the session inspector — the mobile mirror of
+// the web CheckpointsPanel. Lists a session's context checkpoints
+// (uncommitted git diff + untracked files + input history), can capture one
+// on demand, and per checkpoint can view the stored diff or restore it back
+// onto the cwd under the gateway's strict guards (a 409 guard failure shows
+// its reason verbatim).
+class CheckpointsTab extends ConsumerStatefulWidget {
+  const CheckpointsTab({required this.sessionId, super.key});
+
+  final String sessionId;
+
+  @override
+  ConsumerState<CheckpointsTab> createState() => _CheckpointsTabState();
+}
+
+class _CheckpointsTabState extends ConsumerState<CheckpointsTab>
+    with AutomaticKeepAliveClientMixin {
+  AsyncValue<List<Checkpoint>> _state = const AsyncValue.loading();
+  bool _capturing = false;
+
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _state = const AsyncValue.loading());
+    try {
+      final res = await ref.read(checkpointsApiProvider).list(widget.sessionId);
+      if (!mounted) return;
+      setState(() => _state = AsyncValue.data(res));
+    } on Object catch (e, st) {
+      if (mounted) setState(() => _state = AsyncValue.error(e, st));
+    }
+  }
+
+  Future<void> _capture() async {
+    final messenger = ScaffoldMessenger.of(context);
+    setState(() => _capturing = true);
+    try {
+      final cp = await ref.read(checkpointsApiProvider).capture(widget.sessionId);
+      messenger.showSnackBar(
+        SnackBar(
+          behavior: SnackBarBehavior.floating,
+          content: Text(
+            cp.isGit
+                ? t.sessions.inspector.checkpoints.capturedGit(
+                    diff: cp.diffBytes,
+                    files: cp.untrackedFiles,
+                  )
+                : t.sessions.inspector.checkpoints.capturedNonGit,
+          ),
+        ),
+      );
+      await _load();
+    } on ApiException catch (e) {
+      messenger.showSnackBar(
+        SnackBar(behavior: SnackBarBehavior.floating, content: Text(e.message)),
+      );
+    } finally {
+      if (mounted) setState(() => _capturing = false);
+    }
+  }
+
+  Future<void> _delete(Checkpoint cp) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(t.sessions.inspector.checkpoints.deleteTitle),
+        content: Text(t.sessions.inspector.checkpoints.deleteConfirm),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(t.common.cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(t.sessions.inspector.checkpoints.delete),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    try {
+      await ref.read(checkpointsApiProvider).delete(cp.id);
+      await _load();
+    } on ApiException catch (e) {
+      messenger.showSnackBar(
+        SnackBar(behavior: SnackBarBehavior.floating, content: Text(e.message)),
+      );
+    }
+  }
+
+  Future<void> _restore(Checkpoint cp) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(t.sessions.inspector.checkpoints.restoreTitle),
+        content: Text(t.sessions.inspector.checkpoints.restoreWarn),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(t.common.cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(t.sessions.inspector.checkpoints.restoreConfirm),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    try {
+      final res = await ref.read(checkpointsApiProvider).restore(cp.id);
+      messenger.showSnackBar(
+        SnackBar(
+          behavior: SnackBarBehavior.floating,
+          content: Text(
+            t.sessions.inspector.checkpoints.restored(
+              files: res.untrackedRestored,
+              skipped: res.untrackedSkipped.length,
+            ),
+          ),
+        ),
+      );
+    } on ApiException catch (e) {
+      // Guard failures (409) carry their reason in the message.
+      messenger.showSnackBar(
+        SnackBar(behavior: SnackBarBehavior.floating, content: Text(e.message)),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  t.sessions.inspector.checkpoints.blurb,
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ),
+              const SizedBox(width: 8),
+              FilledButton.tonalIcon(
+                onPressed: _capturing ? null : _capture,
+                icon: _capturing
+                    ? const SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.camera_alt_outlined, size: 18),
+                label: Text(t.sessions.inspector.checkpoints.capture),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: _state.when(
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (e, _) => _ErrorView(
+              message: e is ApiException ? e.message : e.toString(),
+              onRetry: _load,
+            ),
+            data: (list) => list.isEmpty
+                ? _EmptyView(onRefresh: _load)
+                : RefreshIndicator(
+                    onRefresh: _load,
+                    child: ListView.separated(
+                      padding: const EdgeInsets.fromLTRB(12, 4, 12, 24),
+                      itemCount: list.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 8),
+                      itemBuilder: (_, i) => _CheckpointCard(
+                        cp: list[i],
+                        onRestore: () => _restore(list[i]),
+                        onDelete: () => _delete(list[i]),
+                        loadDiff: () =>
+                            ref.read(checkpointsApiProvider).diff(list[i].id),
+                      ),
+                    ),
+                  ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CheckpointCard extends StatefulWidget {
+  const _CheckpointCard({
+    required this.cp,
+    required this.onRestore,
+    required this.onDelete,
+    required this.loadDiff,
+  });
+
+  final Checkpoint cp;
+  final VoidCallback onRestore;
+  final VoidCallback onDelete;
+  final Future<String> Function() loadDiff;
+
+  @override
+  State<_CheckpointCard> createState() => _CheckpointCardState();
+}
+
+class _CheckpointCardState extends State<_CheckpointCard> {
+  bool _showDiff = false;
+  AsyncValue<String>? _diff;
+
+  Future<void> _toggleDiff() async {
+    if (_showDiff) {
+      setState(() => _showDiff = false);
+      return;
+    }
+    setState(() {
+      _showDiff = true;
+      _diff = const AsyncValue.loading();
+    });
+    try {
+      final text = await widget.loadDiff();
+      if (mounted) setState(() => _diff = AsyncValue.data(text));
+    } on Object catch (e, st) {
+      if (mounted) setState(() => _diff = AsyncValue.error(e, st));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cp = widget.cp;
+    final theme = Theme.of(context);
+    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    final isManual = cp.trigger == 'manual';
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 10, 8, 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: (isManual ? theme.colorScheme.primary : Colors.amber)
+                        .withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Text(
+                    isManual
+                        ? t.sessions.inspector.checkpoints.triggerManual
+                        : t.sessions.inspector.checkpoints.triggerInterrupted,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color:
+                          isManual ? theme.colorScheme.primary : Colors.amber,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    DateFormat.yMMMd().add_Hm().format(cp.createdAt.toLocal()),
+                    style: theme.textTheme.bodySmall,
+                  ),
+                ),
+                if (cp.truncated)
+                  Tooltip(
+                    message: t.sessions.inspector.checkpoints.truncatedHint,
+                    child: const Icon(Icons.warning_amber_rounded,
+                        size: 16, color: Colors.amber),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            Text(
+              cp.isGit
+                  ? '${cp.gitHead != null ? cp.gitHead!.substring(0, cp.gitHead!.length < 8 ? cp.gitHead!.length : 8) : '—'}   Δ ${cp.diffBytes}B   +${cp.untrackedFiles}f   ⌨ ${cp.inputBytes}B'
+                  : '${t.sessions.inspector.checkpoints.nonGit}   ⌨ ${cp.inputBytes}B',
+              style: theme.textTheme.bodySmall?.copyWith(
+                fontFamily: 'monospace',
+                color: muted,
+              ),
+            ),
+            if (cp.note != null) ...[
+              const SizedBox(height: 4),
+              Text(
+                cp.note!.split('\n').first,
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(fontStyle: FontStyle.italic, color: muted),
+              ),
+            ],
+            Row(
+              children: [
+                if (cp.diffBytes > 0)
+                  TextButton.icon(
+                    onPressed: _toggleDiff,
+                    icon: const Icon(Icons.difference_outlined, size: 16),
+                    label: Text(
+                      _showDiff
+                          ? t.sessions.inspector.checkpoints.hideDiff
+                          : t.sessions.inspector.checkpoints.viewDiff,
+                    ),
+                  ),
+                if (cp.isGit)
+                  TextButton.icon(
+                    onPressed: widget.onRestore,
+                    icon: const Icon(Icons.restore, size: 16),
+                    label: Text(t.sessions.inspector.checkpoints.restore),
+                  ),
+                const Spacer(),
+                IconButton(
+                  onPressed: widget.onDelete,
+                  icon: Icon(Icons.delete_outline,
+                      size: 18, color: theme.colorScheme.error),
+                  tooltip: t.sessions.inspector.checkpoints.delete,
+                ),
+              ],
+            ),
+            if (_showDiff && cp.diffBytes > 0)
+              Container(
+                width: double.infinity,
+                constraints: const BoxConstraints(maxHeight: 260),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.surfaceContainerHighest
+                      .withValues(alpha: 0.4),
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: (_diff ?? const AsyncValue<String>.loading()).when(
+                  loading: () => const Padding(
+                    padding: EdgeInsets.all(12),
+                    child: Center(
+                      child: SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    ),
+                  ),
+                  error: (e, _) => Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: Text(
+                      e is ApiException ? e.message : e.toString(),
+                      style: TextStyle(color: theme.colorScheme.error),
+                    ),
+                  ),
+                  data: (text) => SingleChildScrollView(
+                    padding: const EdgeInsets.all(8),
+                    child: _DiffText(text: text),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// _DiffText renders a unified diff with per-line color coding, prefix-only.
+class _DiffText extends StatelessWidget {
+  const _DiffText({required this.text});
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    const maxLines = 2000;
+    final all = text.split('\n');
+    final lines = all.length > maxLines ? all.sublist(0, maxLines) : all;
+    final theme = Theme.of(context);
+    Color? colorFor(String line) {
+      if (line.startsWith('+++') || line.startsWith('---')) return null;
+      if (line.startsWith('@@')) return Colors.blue;
+      if (line.startsWith('+')) return Colors.green.shade600;
+      if (line.startsWith('-')) return theme.colorScheme.error;
+      return null;
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final line in lines)
+          Text(
+            line.isEmpty ? ' ' : line,
+            softWrap: false,
+            style: TextStyle(
+              fontFamily: 'monospace',
+              fontSize: 11,
+              height: 1.4,
+              color: colorFor(line),
+            ),
+          ),
+        if (all.length > maxLines)
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
+              '… ${all.length - maxLines} more lines',
+              style: theme.textTheme.labelSmall,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _EmptyView extends StatelessWidget {
+  const _EmptyView({required this.onRefresh});
+  final Future<void> Function() onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    return RefreshIndicator(
+      onRefresh: onRefresh,
+      child: ListView(
+        children: [
+          const SizedBox(height: 80),
+          Icon(Icons.archive_outlined,
+              size: 48,
+              color:
+                  Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.4)),
+          const SizedBox(height: 12),
+          Center(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: Text(
+                t.sessions.inspector.checkpoints.empty,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.message, required this.onRetry});
+  final String message;
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodySmall
+                  ?.copyWith(color: Theme.of(context).colorScheme.error),
+            ),
+            const SizedBox(height: 12),
+            OutlinedButton(onPressed: onRetry, child: Text(t.common.retry)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/mobile/lib/features/sessions/inspector/session_inspector_screen.dart
+++ b/app/mobile/lib/features/sessions/inspector/session_inspector_screen.dart
@@ -4,6 +4,7 @@ import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/sessions_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/database/database_tab.dart';
+import 'package:opendray/features/sessions/inspector/checkpoints_tab.dart';
 import 'package:opendray/features/sessions/inspector/cortex_tab.dart';
 import 'package:opendray/features/sessions/inspector/files_tab.dart';
 import 'package:opendray/features/sessions/inspector/git_tab.dart';
@@ -43,7 +44,7 @@ class _Body extends StatelessWidget {
   Widget build(BuildContext context) {
     final lastSegment = p.basename(session.cwd);
     return DefaultTabController(
-      length: 7,
+      length: 8,
       child: Scaffold(
         appBar: AppBar(
           title: Column(
@@ -93,6 +94,10 @@ class _Body extends StatelessWidget {
                 icon: const Icon(Icons.storage_outlined),
                 text: t.sessions.inspector.shell.tabs.database,
               ),
+              Tab(
+                icon: const Icon(Icons.archive_outlined),
+                text: t.sessions.inspector.shell.tabs.checkpoints,
+              ),
             ],
           ),
         ),
@@ -105,6 +110,7 @@ class _Body extends StatelessWidget {
             NotesTab(sessionId: session.id, cwd: session.cwd),
             CortexTab(cwd: session.cwd),
             DatabaseTab(cwd: session.cwd),
+            CheckpointsTab(sessionId: session.id),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary

Brings the **mobile** app in line with the web checkpoints panel (#455), so the context backup/restore feature (#452/#453/#454) is usable from the phone too. Closes the mobile-parity gap from this arc.

## What's in it
- **New Checkpoints tab** (8th, Archive icon) in the session inspector:
  - Lists checkpoints: trigger badge (manual/interrupted), capture time, short git HEAD, diff / untracked / input sizes, truncated warning, note.
  - **Capture** button; per checkpoint **View diff** (inline colored unified diff, fetched on demand), **Restore**, **Delete**.
  - **Restore/Delete** gated behind an `AlertDialog` confirm; the restore dialog spells out the strict server guards, and a **409** guard failure (HEAD moved / dirty tree / patch won't apply) surfaces **verbatim** (via the Dio error interceptor) as a SnackBar.
- **New Dio API client** `core/api/checkpoints_api.dart` (`Checkpoint` + `RestoreResult` models, list / capture / diff / restore / delete + provider) — same endpoints the web client uses.
- **i18n** under `sessions.inspector.checkpoints` + `shell.tabs.checkpoints` for en/zh/es; **slang regenerated**.

## Test plan
- `flutter analyze` — **No issues found** (full app).
- `scripts/check-i18n-parity.mjs` — 100%.
- CI has no mobile build, so `flutter analyze` is the local gate (per project convention).

## Note
Backend (state-machine hardening #450/#451 + checkpoint capture/restore/input-fix #452–#454) is provider-agnostic and already served by the same gateway — this PR is purely the mobile UI to reach parity with web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)