### PR TITLE
fix(checkpoint): make a clean-tree checkpoint self-explanatory (web + mobile)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -297,7 +297,9 @@
           "restoreConfirm": "Confirm restore",
           "restored": "Checkpoint restored",
           "restoredDetail": "diff applied: {diff} · {files} files restored · {skipped} skipped",
-          "deleteConfirm": "Delete this checkpoint?"
+          "deleteConfirm": "Delete this checkpoint?",
+          "clean": "clean — no changes captured",
+          "capturedClean": "Working tree was clean — no changes to back up"
         }
       },
       "ended": {
@@ -3545,7 +3547,9 @@
         "restored": "Restored · {files} files, {skipped} skipped",
         "delete": "Delete",
         "deleteTitle": "Delete checkpoint?",
-        "deleteConfirm": "This removes the checkpoint and its stored payload."
+        "deleteConfirm": "This removes the checkpoint and its stored payload.",
+        "clean": "clean — no changes",
+        "capturedClean": "Working tree was clean — nothing to back up"
       }
     },
     "spawnSheet": {

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -297,7 +297,9 @@
           "restoreConfirm": "Confirmar restauración",
           "restored": "Punto de control restaurado",
           "restoredDetail": "diff aplicado: {diff} · {files} archivos restaurados · {skipped} omitidos",
-          "deleteConfirm": "¿Eliminar este punto de control?"
+          "deleteConfirm": "¿Eliminar este punto de control?",
+          "clean": "limpio — sin cambios capturados",
+          "capturedClean": "El árbol de trabajo estaba limpio — no hay cambios que respaldar"
         }
       },
       "ended": {
@@ -3545,7 +3547,9 @@
         "restored": "Restaurado · {files} archivos, {skipped} omitidos",
         "delete": "Eliminar",
         "deleteTitle": "¿Eliminar punto de control?",
-        "deleteConfirm": "Esto elimina el punto de control y su contenido almacenado."
+        "deleteConfirm": "Esto elimina el punto de control y su contenido almacenado.",
+        "clean": "limpio — sin cambios",
+        "capturedClean": "El árbol de trabajo estaba limpio — nada que respaldar"
       }
     },
     "spawnSheet": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -297,7 +297,9 @@
           "restoreConfirm": "确认恢复",
           "restored": "检查点已恢复",
           "restoredDetail": "diff 应用:{diff} · 恢复 {files} 个文件 · 跳过 {skipped} 个",
-          "deleteConfirm": "删除此检查点?"
+          "deleteConfirm": "删除此检查点?",
+          "clean": "干净 · 无改动可捕获",
+          "capturedClean": "工作树干净 —— 没有可备份的改动"
         }
       },
       "ended": {
@@ -3545,7 +3547,9 @@
         "restored": "已恢复 · {files} 个文件,跳过 {skipped} 个",
         "delete": "删除",
         "deleteTitle": "删除检查点?",
-        "deleteConfirm": "将移除该检查点及其存储的内容。"
+        "deleteConfirm": "将移除该检查点及其存储的内容。",
+        "clean": "干净 · 无改动",
+        "capturedClean": "工作树干净 —— 没有可备份的改动"
       }
     },
     "spawnSheet": {

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 12102 (4034 per locale)
+/// Strings: 12114 (4038 per locale)
 ///
-/// Built on 2026-07-14 at 11:26 UTC
+/// Built on 2026-07-14 at 11:43 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -12786,6 +12786,12 @@ class TranslationsSessionsInspectorCheckpointsEn {
 
 	/// en: 'This removes the checkpoint and its stored payload.'
 	String get deleteConfirm => 'This removes the checkpoint and its stored payload.';
+
+	/// en: 'clean — no changes'
+	String get clean => 'clean — no changes';
+
+	/// en: 'Working tree was clean — nothing to back up'
+	String get capturedClean => 'Working tree was clean — nothing to back up';
 }
 
 // Path: sessions.spawnSheet.bypass
@@ -14030,6 +14036,12 @@ class TranslationsWebSessionsInspectorCheckpointsEn {
 
 	/// en: 'Delete this checkpoint?'
 	String get deleteConfirm => 'Delete this checkpoint?';
+
+	/// en: 'clean — no changes captured'
+	String get clean => 'clean — no changes captured';
+
+	/// en: 'Working tree was clean — no changes to back up'
+	String get capturedClean => 'Working tree was clean — no changes to back up';
 }
 
 // Path: web.memoryWorkers.tasks.gatekeeper
@@ -17708,6 +17720,8 @@ extension on Translations {
 			'web.sessions.inspector.checkpoints.restored' => 'Checkpoint restored',
 			'web.sessions.inspector.checkpoints.restoredDetail' => ({required Object diff, required Object files, required Object skipped}) => 'diff applied: ${diff} · ${files} files restored · ${skipped} skipped',
 			'web.sessions.inspector.checkpoints.deleteConfirm' => 'Delete this checkpoint?',
+			'web.sessions.inspector.checkpoints.clean' => 'clean — no changes captured',
+			'web.sessions.inspector.checkpoints.capturedClean' => 'Working tree was clean — no changes to back up',
 			'web.sessions.ended.bufferUnavailable' => '[buffer unavailable]',
 			'web.sessions.ended.readOnlyBanner' => '[session ended — read-only buffer]',
 			'web.sessions.fileBrowser.title' => 'Choose working directory',
@@ -17959,10 +17973,10 @@ extension on Translations {
 			'web.project.editor.save' => 'Save',
 			'web.project.editor.saveFailedToast' => 'Save failed',
 			'web.project.editor.savedToast' => ({required Object label}) => '${label} saved',
-			'web.project.editor.goalPlaceholder' => 'What are we building? One paragraph. Read by every agent on spawn.',
-			'web.project.editor.planPlaceholder' => 'Active plan — what we are doing right now and what is next. Updated as work progresses.',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.editor.goalPlaceholder' => 'What are we building? One paragraph. Read by every agent on spawn.',
+			'web.project.editor.planPlaceholder' => 'Active plan — what we are doing right now and what is next. Updated as work progresses.',
 			'web.project.editor.sectionPlaceholder' => 'Write this section in markdown…',
 			'web.project.readonly.tech_stack.label' => 'Tech stack & structure',
 			'web.project.readonly.tech_stack.empty' => 'Run a Claude session in this project — scanner refreshes on every spawn.',
@@ -18473,10 +18487,10 @@ extension on Translations {
 			'web.channels.card.channelIdLabel' => 'channel_id:',
 			'web.channels.card.webhookLabel' => 'webhook:',
 			'web.channels.card.copyWebhookTooltip' => 'Copy webhook URL',
-			'web.channels.card.webhookCopiedToast' => 'Webhook URL copied',
-			'web.channels.card.setup' => 'Setup',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.card.webhookCopiedToast' => 'Webhook URL copied',
+			'web.channels.card.setup' => 'Setup',
 			'web.channels.card.setupTooltip' => 'Show adapter connection details + sample code',
 			'web.channels.card.test' => 'Test',
 			'web.channels.card.testNotRunningTooltip' => 'Channel must be running',
@@ -18987,10 +19001,10 @@ extension on Translations {
 			'web.backups.recoveryKit.passphraseLabel' => 'Recovery passphrase (min 8 chars)',
 			'web.backups.recoveryKit.passphrasePlaceholder' => 'a strong passphrase you will not lose',
 			'web.backups.recoveryKit.confirmLabel' => 'Confirm recovery passphrase',
-			'web.backups.recoveryKit.mismatch' => 'Passphrases don\'t match',
-			'web.backups.recoveryKit.generating' => 'Generating…',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.recoveryKit.mismatch' => 'Passphrases don\'t match',
+			'web.backups.recoveryKit.generating' => 'Generating…',
 			'web.backups.recoveryKit.download' => 'Download kit',
 			'web.backups.recoveryKit.downloadedToast' => 'Recovery Kit downloaded — store it safely',
 			'web.backups.recoveryKit.failedToast' => 'Could not generate Recovery Kit',
@@ -19501,10 +19515,10 @@ extension on Translations {
 			'web.memoryAmbient.rules.row.runNowFailedToast' => 'Run-now failed',
 			'web.memoryAmbient.rules.row.deleteConfirm' => ({required Object name}) => 'Delete rule "${name}"?',
 			'web.memoryAmbient.rules.row.deletedToast' => 'Rule deleted',
-			'web.memoryAmbient.rules.row.deleteFailedToast' => 'Delete failed',
-			'web.memoryAmbient.rules.row.summary.afterMessages' => ({required Object n}) => 'every ${n} messages',
 			_ => null,
 		} ?? switch (path) {
+			'web.memoryAmbient.rules.row.deleteFailedToast' => 'Delete failed',
+			'web.memoryAmbient.rules.row.summary.afterMessages' => ({required Object n}) => 'every ${n} messages',
 			'web.memoryAmbient.rules.row.summary.onIdle' => ({required Object seconds}) => 'idle ≥ ${seconds}s',
 			'web.memoryAmbient.rules.row.summary.kChars' => ({required Object k}) => '≥ ${k} chars',
 			'web.memoryAmbient.rules.row.summary.manual' => 'manual only',
@@ -20015,10 +20029,10 @@ extension on Translations {
 			'memoryAmbient.strategyTopKRelevant' => 'Top-K relevant',
 			'memoryAmbient.strategyOnKeyword' => 'On keyword',
 			'memoryAmbient.strategyManualOnly' => 'Manual only',
-			'memoryAmbient.strategyHybrid' => 'Hybrid summary',
-			'memoryAmbient.strategyUnknown' => 'Unknown',
 			_ => null,
 		} ?? switch (path) {
+			'memoryAmbient.strategyHybrid' => 'Hybrid summary',
+			'memoryAmbient.strategyUnknown' => 'Unknown',
 			'sessions.title' => 'Sessions',
 			'sessions.refresh' => 'Refresh',
 			'sessions.actions' => 'Actions',
@@ -20219,6 +20233,8 @@ extension on Translations {
 			'sessions.inspector.checkpoints.delete' => 'Delete',
 			'sessions.inspector.checkpoints.deleteTitle' => 'Delete checkpoint?',
 			'sessions.inspector.checkpoints.deleteConfirm' => 'This removes the checkpoint and its stored payload.',
+			'sessions.inspector.checkpoints.clean' => 'clean — no changes',
+			'sessions.inspector.checkpoints.capturedClean' => 'Working tree was clean — nothing to back up',
 			'sessions.spawnSheet.title' => 'New session',
 			'sessions.spawnSheet.errorRequired' => 'Provider and working directory are required',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => 'Failed to spawn session: ${error}',
@@ -20527,12 +20543,12 @@ extension on Translations {
 			'memoryArchived.countBadge' => ({required Object count}) => '${count} archived',
 			'memoryArchived.restore' => 'Restore',
 			'memoryArchived.restoreAll' => 'Restore all',
+			_ => null,
+		} ?? switch (path) {
 			'memoryArchived.deleteAll' => 'Delete all',
 			'memoryArchived.restoreAllConfirm' => ({required Object count, required Object project}) => 'Restore all ${count} archived memories in ${project}?',
 			'memoryArchived.deleteAllConfirm' => ({required Object count, required Object project}) => 'Permanently delete all ${count} archived memories in ${project}? This skips the 30-day grace window and cannot be undone.',
 			'memoryArchived.deletePermanently' => 'Delete',
-			_ => null,
-		} ?? switch (path) {
 			'memoryArchived.deleteConfirm' => 'Permanently delete this memory now? This skips the 30-day grace window and cannot be undone.',
 			'memoryArchived.restoredToast' => 'Restored',
 			'memoryArchived.restoredAllToast' => ({required Object count}) => 'Restored ${count} memories',
@@ -21041,12 +21057,12 @@ extension on Translations {
 			'skills.saveFailedGeneric' => ({required Object error}) => 'Save failed: ${error}',
 			'skills.resetTitle' => 'Reset to built-in?',
 			'skills.deleteTitle' => 'Delete skill?',
+			_ => null,
+		} ?? switch (path) {
 			'skills.resetBody' => ({required Object id}) => 'Removes the vault override for ${id}. Sessions will fall back to the built-in body.',
 			'skills.resetButton' => 'Reset',
 			'skills.resetSnack' => ({required Object id}) => 'Reset ${id} to built-in.',
 			'skills.deletedSnack' => ({required Object id}) => 'Deleted ${id}.',
-			_ => null,
-		} ?? switch (path) {
 			'skills.deleteFailedApi' => ({required Object error}) => 'Delete failed: ${error}',
 			'skills.deleteFailedGeneric' => ({required Object error}) => 'Delete failed: ${error}',
 			'skills.deleteBody' => ({required Object id}) => 'Removes ${id} from the vault. Sessions that reference it will fail until restored.',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -6565,6 +6565,8 @@ class _TranslationsSessionsInspectorCheckpointsEs extends TranslationsSessionsIn
 	@override String get delete => 'Eliminar';
 	@override String get deleteTitle => '¿Eliminar punto de control?';
 	@override String get deleteConfirm => 'Esto elimina el punto de control y su contenido almacenado.';
+	@override String get clean => 'limpio — sin cambios';
+	@override String get capturedClean => 'El árbol de trabajo estaba limpio — nada que respaldar';
 }
 
 // Path: sessions.spawnSheet.bypass
@@ -7226,6 +7228,8 @@ class _TranslationsWebSessionsInspectorCheckpointsEs extends TranslationsWebSess
 	@override String get restored => 'Punto de control restaurado';
 	@override String restoredDetail({required Object diff, required Object files, required Object skipped}) => 'diff aplicado: ${diff} · ${files} archivos restaurados · ${skipped} omitidos';
 	@override String get deleteConfirm => '¿Eliminar este punto de control?';
+	@override String get clean => 'limpio — sin cambios capturados';
+	@override String get capturedClean => 'El árbol de trabajo estaba limpio — no hay cambios que respaldar';
 }
 
 // Path: web.memoryWorkers.tasks.gatekeeper
@@ -9522,6 +9526,8 @@ extension on TranslationsEs {
 			'web.sessions.inspector.checkpoints.restored' => 'Punto de control restaurado',
 			'web.sessions.inspector.checkpoints.restoredDetail' => ({required Object diff, required Object files, required Object skipped}) => 'diff aplicado: ${diff} · ${files} archivos restaurados · ${skipped} omitidos',
 			'web.sessions.inspector.checkpoints.deleteConfirm' => '¿Eliminar este punto de control?',
+			'web.sessions.inspector.checkpoints.clean' => 'limpio — sin cambios capturados',
+			'web.sessions.inspector.checkpoints.capturedClean' => 'El árbol de trabajo estaba limpio — no hay cambios que respaldar',
 			'web.sessions.ended.bufferUnavailable' => '[búfer no disponible]',
 			'web.sessions.ended.readOnlyBanner' => '[session finalizada. búfer de solo lectura]',
 			'web.sessions.fileBrowser.title' => 'Elige el directorio de trabajo',
@@ -9773,10 +9779,10 @@ extension on TranslationsEs {
 			'web.project.editor.save' => 'Guardar',
 			'web.project.editor.saveFailedToast' => 'Error al guardar',
 			'web.project.editor.savedToast' => ({required Object label}) => '${label} guardado',
-			'web.project.editor.goalPlaceholder' => '¿Qué estamos construyendo? Un párrafo. Lo lee cada agente al iniciarse.',
-			'web.project.editor.planPlaceholder' => 'Plan activo: qué estamos haciendo ahora mismo y qué viene después. Se actualiza a medida que avanza el trabajo.',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.editor.goalPlaceholder' => '¿Qué estamos construyendo? Un párrafo. Lo lee cada agente al iniciarse.',
+			'web.project.editor.planPlaceholder' => 'Plan activo: qué estamos haciendo ahora mismo y qué viene después. Se actualiza a medida que avanza el trabajo.',
 			'web.project.editor.sectionPlaceholder' => 'Escribe esta sección en markdown…',
 			'web.project.readonly.tech_stack.label' => 'Stack tecnológico y estructura',
 			'web.project.readonly.tech_stack.empty' => 'Ejecuta una session de Claude en este proyecto. El escáner se actualiza en cada inicio.',
@@ -10287,10 +10293,10 @@ extension on TranslationsEs {
 			'web.channels.card.channelIdLabel' => 'channel_id:',
 			'web.channels.card.webhookLabel' => 'webhook:',
 			'web.channels.card.copyWebhookTooltip' => 'Copiar la URL del webhook',
-			'web.channels.card.webhookCopiedToast' => 'URL del webhook copiada',
-			'web.channels.card.setup' => 'Configuración',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.card.webhookCopiedToast' => 'URL del webhook copiada',
+			'web.channels.card.setup' => 'Configuración',
 			'web.channels.card.setupTooltip' => 'Mostrar los detalles de conexión del adaptador y código de ejemplo',
 			'web.channels.card.test' => 'Probar',
 			'web.channels.card.testNotRunningTooltip' => 'El canal debe estar en ejecución',
@@ -10801,10 +10807,10 @@ extension on TranslationsEs {
 			'web.backups.recoveryKit.passphraseLabel' => 'Frase de recuperación (mín. 8 caracteres)',
 			'web.backups.recoveryKit.passphrasePlaceholder' => 'una frase fuerte que no perderás',
 			'web.backups.recoveryKit.confirmLabel' => 'Confirmar frase de recuperación',
-			'web.backups.recoveryKit.mismatch' => 'Las frases no coinciden',
-			'web.backups.recoveryKit.generating' => 'Generando…',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.recoveryKit.mismatch' => 'Las frases no coinciden',
+			'web.backups.recoveryKit.generating' => 'Generando…',
 			'web.backups.recoveryKit.download' => 'Descargar kit',
 			'web.backups.recoveryKit.downloadedToast' => 'Kit de recuperación descargado: guárdalo de forma segura',
 			'web.backups.recoveryKit.failedToast' => 'No se pudo generar el kit de recuperación',
@@ -11315,10 +11321,10 @@ extension on TranslationsEs {
 			'web.memoryAmbient.rules.row.runNowFailedToast' => 'La ejecución inmediata falló',
 			'web.memoryAmbient.rules.row.deleteConfirm' => ({required Object name}) => '¿Eliminar la regla "${name}"?',
 			'web.memoryAmbient.rules.row.deletedToast' => 'Regla eliminada',
-			'web.memoryAmbient.rules.row.deleteFailedToast' => 'La eliminación falló',
-			'web.memoryAmbient.rules.row.summary.afterMessages' => ({required Object n}) => 'cada ${n} mensajes',
 			_ => null,
 		} ?? switch (path) {
+			'web.memoryAmbient.rules.row.deleteFailedToast' => 'La eliminación falló',
+			'web.memoryAmbient.rules.row.summary.afterMessages' => ({required Object n}) => 'cada ${n} mensajes',
 			'web.memoryAmbient.rules.row.summary.onIdle' => ({required Object seconds}) => 'inactivo ≥ ${seconds}s',
 			'web.memoryAmbient.rules.row.summary.kChars' => ({required Object k}) => '≥ ${k} caracteres',
 			'web.memoryAmbient.rules.row.summary.manual' => 'solo manual',
@@ -11829,10 +11835,10 @@ extension on TranslationsEs {
 			'memoryAmbient.strategyTopKRelevant' => 'Top-K relevantes',
 			'memoryAmbient.strategyOnKeyword' => 'Por palabra clave',
 			'memoryAmbient.strategyManualOnly' => 'Solo manual',
-			'memoryAmbient.strategyHybrid' => 'Resumen híbrido',
-			'memoryAmbient.strategyUnknown' => 'Desconocido',
 			_ => null,
 		} ?? switch (path) {
+			'memoryAmbient.strategyHybrid' => 'Resumen híbrido',
+			'memoryAmbient.strategyUnknown' => 'Desconocido',
 			'sessions.title' => 'Sesiones',
 			'sessions.refresh' => 'Actualizar',
 			'sessions.actions' => 'Acciones',
@@ -12033,6 +12039,8 @@ extension on TranslationsEs {
 			'sessions.inspector.checkpoints.delete' => 'Eliminar',
 			'sessions.inspector.checkpoints.deleteTitle' => '¿Eliminar punto de control?',
 			'sessions.inspector.checkpoints.deleteConfirm' => 'Esto elimina el punto de control y su contenido almacenado.',
+			'sessions.inspector.checkpoints.clean' => 'limpio — sin cambios',
+			'sessions.inspector.checkpoints.capturedClean' => 'El árbol de trabajo estaba limpio — nada que respaldar',
 			'sessions.spawnSheet.title' => 'Nueva session',
 			'sessions.spawnSheet.errorRequired' => 'El proveedor y el directorio de trabajo son obligatorios',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => 'No se pudo crear la session: ${error}',
@@ -12341,12 +12349,12 @@ extension on TranslationsEs {
 			'memoryArchived.countBadge' => ({required Object count}) => '${count} archivadas',
 			'memoryArchived.restore' => 'Restaurar',
 			'memoryArchived.restoreAll' => 'Restaurar todo',
+			_ => null,
+		} ?? switch (path) {
 			'memoryArchived.deleteAll' => 'Eliminar todo',
 			'memoryArchived.restoreAllConfirm' => ({required Object count, required Object project}) => '¿Restaurar las ${count} memorias archivadas de ${project}?',
 			'memoryArchived.deleteAllConfirm' => ({required Object count, required Object project}) => '¿Eliminar permanentemente las ${count} memorias archivadas de ${project}? Omite la ventana de gracia de 30 días y no se puede deshacer.',
 			'memoryArchived.deletePermanently' => 'Eliminar',
-			_ => null,
-		} ?? switch (path) {
 			'memoryArchived.deleteConfirm' => '¿Eliminar permanentemente esta memoria ahora? Omite la ventana de gracia de 30 días y no se puede deshacer.',
 			'memoryArchived.restoredToast' => 'Restaurada',
 			'memoryArchived.restoredAllToast' => ({required Object count}) => '${count} memorias restauradas',
@@ -12855,12 +12863,12 @@ extension on TranslationsEs {
 			'skills.saveFailedGeneric' => ({required Object error}) => 'Error al guardar: ${error}',
 			'skills.resetTitle' => '¿Restablecer al integrado?',
 			'skills.deleteTitle' => '¿Eliminar skill?',
+			_ => null,
+		} ?? switch (path) {
 			'skills.resetBody' => ({required Object id}) => 'Elimina el override del vault para ${id}. Las sesiones recurrirán al cuerpo integrado.',
 			'skills.resetButton' => 'Restablecer',
 			'skills.resetSnack' => ({required Object id}) => '${id} restablecido al integrado.',
 			'skills.deletedSnack' => ({required Object id}) => '${id} eliminado.',
-			_ => null,
-		} ?? switch (path) {
 			'skills.deleteFailedApi' => ({required Object error}) => 'Error al eliminar: ${error}',
 			'skills.deleteFailedGeneric' => ({required Object error}) => 'Error al eliminar: ${error}',
 			'skills.deleteBody' => ({required Object id}) => 'Elimina ${id} del vault. Las sesiones que lo referencian fallarán hasta que se restaure.',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -6565,6 +6565,8 @@ class _TranslationsSessionsInspectorCheckpointsZh extends TranslationsSessionsIn
 	@override String get delete => '删除';
 	@override String get deleteTitle => '删除检查点?';
 	@override String get deleteConfirm => '将移除该检查点及其存储的内容。';
+	@override String get clean => '干净 · 无改动';
+	@override String get capturedClean => '工作树干净 —— 没有可备份的改动';
 }
 
 // Path: sessions.spawnSheet.bypass
@@ -7226,6 +7228,8 @@ class _TranslationsWebSessionsInspectorCheckpointsZh extends TranslationsWebSess
 	@override String get restored => '检查点已恢复';
 	@override String restoredDetail({required Object diff, required Object files, required Object skipped}) => 'diff 应用:${diff} · 恢复 ${files} 个文件 · 跳过 ${skipped} 个';
 	@override String get deleteConfirm => '删除此检查点?';
+	@override String get clean => '干净 · 无改动可捕获';
+	@override String get capturedClean => '工作树干净 —— 没有可备份的改动';
 }
 
 // Path: web.memoryWorkers.tasks.gatekeeper
@@ -9522,6 +9526,8 @@ extension on TranslationsZh {
 			'web.sessions.inspector.checkpoints.restored' => '检查点已恢复',
 			'web.sessions.inspector.checkpoints.restoredDetail' => ({required Object diff, required Object files, required Object skipped}) => 'diff 应用:${diff} · 恢复 ${files} 个文件 · 跳过 ${skipped} 个',
 			'web.sessions.inspector.checkpoints.deleteConfirm' => '删除此检查点?',
+			'web.sessions.inspector.checkpoints.clean' => '干净 · 无改动可捕获',
+			'web.sessions.inspector.checkpoints.capturedClean' => '工作树干净 —— 没有可备份的改动',
 			'web.sessions.ended.bufferUnavailable' => '[缓冲区不可用]',
 			'web.sessions.ended.readOnlyBanner' => '[会话已结束 — 只读缓冲区]',
 			'web.sessions.fileBrowser.title' => '选择工作目录',
@@ -9773,10 +9779,10 @@ extension on TranslationsZh {
 			'web.project.editor.save' => '保存',
 			'web.project.editor.saveFailedToast' => '保存失败',
 			'web.project.editor.savedToast' => ({required Object label}) => '${label}已保存',
-			'web.project.editor.goalPlaceholder' => '我们在做什么？一段文字。每个 agent 在 spawn 时都会读取。',
-			'web.project.editor.planPlaceholder' => '当前计划 — 现在在做什么、下一步是什么。随进度更新。',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.editor.goalPlaceholder' => '我们在做什么？一段文字。每个 agent 在 spawn 时都会读取。',
+			'web.project.editor.planPlaceholder' => '当前计划 — 现在在做什么、下一步是什么。随进度更新。',
 			'web.project.editor.sectionPlaceholder' => '以 markdown 撰写本章节…',
 			'web.project.readonly.tech_stack.label' => '技术栈与结构',
 			'web.project.readonly.tech_stack.empty' => '在该项目运行一次 Claude 会话 — scanner 会在每次 spawn 时刷新。',
@@ -10287,10 +10293,10 @@ extension on TranslationsZh {
 			'web.channels.card.channelIdLabel' => 'channel_id:',
 			'web.channels.card.webhookLabel' => 'webhook:',
 			'web.channels.card.copyWebhookTooltip' => '复制 webhook URL',
-			'web.channels.card.webhookCopiedToast' => '已复制 webhook URL',
-			'web.channels.card.setup' => '配置',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.card.webhookCopiedToast' => '已复制 webhook URL',
+			'web.channels.card.setup' => '配置',
 			'web.channels.card.setupTooltip' => '查看适配器连接信息和示例代码',
 			'web.channels.card.test' => '测试',
 			'web.channels.card.testNotRunningTooltip' => '频道必须处于运行状态',
@@ -10801,10 +10807,10 @@ extension on TranslationsZh {
 			'web.backups.recoveryKit.passphraseLabel' => '恢复口令（至少 8 位）',
 			'web.backups.recoveryKit.passphrasePlaceholder' => '一个你不会丢失的强口令',
 			'web.backups.recoveryKit.confirmLabel' => '确认恢复口令',
-			'web.backups.recoveryKit.mismatch' => '两次口令不一致',
-			'web.backups.recoveryKit.generating' => '生成中…',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.recoveryKit.mismatch' => '两次口令不一致',
+			'web.backups.recoveryKit.generating' => '生成中…',
 			'web.backups.recoveryKit.download' => '下载工具包',
 			'web.backups.recoveryKit.downloadedToast' => '恢复工具包已下载 —— 请妥善保存',
 			'web.backups.recoveryKit.failedToast' => '无法生成恢复工具包',
@@ -11315,10 +11321,10 @@ extension on TranslationsZh {
 			'web.memoryAmbient.rules.row.runNowFailedToast' => '立即运行失败',
 			'web.memoryAmbient.rules.row.deleteConfirm' => ({required Object name}) => '删除规则 "${name}"?',
 			'web.memoryAmbient.rules.row.deletedToast' => '规则已删除',
-			'web.memoryAmbient.rules.row.deleteFailedToast' => '删除失败',
-			'web.memoryAmbient.rules.row.summary.afterMessages' => ({required Object n}) => '每 ${n} 条消息',
 			_ => null,
 		} ?? switch (path) {
+			'web.memoryAmbient.rules.row.deleteFailedToast' => '删除失败',
+			'web.memoryAmbient.rules.row.summary.afterMessages' => ({required Object n}) => '每 ${n} 条消息',
 			'web.memoryAmbient.rules.row.summary.onIdle' => ({required Object seconds}) => 'idle ≥ ${seconds}s',
 			'web.memoryAmbient.rules.row.summary.kChars' => ({required Object k}) => '≥ ${k} 字符',
 			'web.memoryAmbient.rules.row.summary.manual' => '仅手动',
@@ -11829,10 +11835,10 @@ extension on TranslationsZh {
 			'memoryAmbient.strategyTopKRelevant' => '相关 Top-K',
 			'memoryAmbient.strategyOnKeyword' => '关键词触发',
 			'memoryAmbient.strategyManualOnly' => '仅手动',
-			'memoryAmbient.strategyHybrid' => '混合摘要',
-			'memoryAmbient.strategyUnknown' => '未知',
 			_ => null,
 		} ?? switch (path) {
+			'memoryAmbient.strategyHybrid' => '混合摘要',
+			'memoryAmbient.strategyUnknown' => '未知',
 			'sessions.title' => '会话',
 			'sessions.refresh' => '刷新',
 			'sessions.actions' => '操作',
@@ -12033,6 +12039,8 @@ extension on TranslationsZh {
 			'sessions.inspector.checkpoints.delete' => '删除',
 			'sessions.inspector.checkpoints.deleteTitle' => '删除检查点?',
 			'sessions.inspector.checkpoints.deleteConfirm' => '将移除该检查点及其存储的内容。',
+			'sessions.inspector.checkpoints.clean' => '干净 · 无改动',
+			'sessions.inspector.checkpoints.capturedClean' => '工作树干净 —— 没有可备份的改动',
 			'sessions.spawnSheet.title' => '新建会话',
 			'sessions.spawnSheet.errorRequired' => '需要指定提供商和工作目录',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => '创建会话失败：${error}',
@@ -12341,12 +12349,12 @@ extension on TranslationsZh {
 			'memoryArchived.countBadge' => ({required Object count}) => '${count} 条已归档',
 			'memoryArchived.restore' => '恢复',
 			'memoryArchived.restoreAll' => '全部恢复',
+			_ => null,
+		} ?? switch (path) {
 			'memoryArchived.deleteAll' => '全部删除',
 			'memoryArchived.restoreAllConfirm' => ({required Object project, required Object count}) => '恢复 ${project} 的全部 ${count} 条归档记忆？',
 			'memoryArchived.deleteAllConfirm' => ({required Object project, required Object count}) => '永久删除 ${project} 的全部 ${count} 条归档记忆？将跳过 30 天宽限期，且不可撤销。',
 			'memoryArchived.deletePermanently' => '删除',
-			_ => null,
-		} ?? switch (path) {
 			'memoryArchived.deleteConfirm' => '立即永久删除这条记忆？将跳过 30 天宽限期，且不可撤销。',
 			'memoryArchived.restoredToast' => '已恢复',
 			'memoryArchived.restoredAllToast' => ({required Object count}) => '已恢复 ${count} 条记忆',
@@ -12855,12 +12863,12 @@ extension on TranslationsZh {
 			'skills.saveFailedGeneric' => ({required Object error}) => '保存失败：${error}',
 			'skills.resetTitle' => '重置为内置？',
 			'skills.deleteTitle' => '删除技能？',
+			_ => null,
+		} ?? switch (path) {
 			'skills.resetBody' => ({required Object id}) => '移除 ${id} 的库覆盖。会话将回退到内置正文。',
 			'skills.resetButton' => '重置',
 			'skills.resetSnack' => ({required Object id}) => '已将 ${id} 重置为内置。',
 			'skills.deletedSnack' => ({required Object id}) => '已删除 ${id}。',
-			_ => null,
-		} ?? switch (path) {
 			'skills.deleteFailedApi' => ({required Object error}) => '删除失败：${error}',
 			'skills.deleteFailedGeneric' => ({required Object error}) => '删除失败：${error}',
 			'skills.deleteBody' => ({required Object id}) => '从库中移除 ${id}。引用它的会话在恢复前会失败。',

--- a/app/mobile/lib/features/sessions/inspector/checkpoints_tab.dart
+++ b/app/mobile/lib/features/sessions/inspector/checkpoints_tab.dart
@@ -51,16 +51,19 @@ class _CheckpointsTabState extends ConsumerState<CheckpointsTab>
     setState(() => _capturing = true);
     try {
       final cp = await ref.read(checkpointsApiProvider).capture(widget.sessionId);
+      final clean = cp.isGit && cp.diffBytes == 0 && cp.untrackedFiles == 0;
       messenger.showSnackBar(
         SnackBar(
           behavior: SnackBarBehavior.floating,
           content: Text(
-            cp.isGit
-                ? t.sessions.inspector.checkpoints.capturedGit(
-                    diff: cp.diffBytes,
-                    files: cp.untrackedFiles,
-                  )
-                : t.sessions.inspector.checkpoints.capturedNonGit,
+            !cp.isGit
+                ? t.sessions.inspector.checkpoints.capturedNonGit
+                : clean
+                    ? t.sessions.inspector.checkpoints.capturedClean
+                    : t.sessions.inspector.checkpoints.capturedGit(
+                        diff: cp.diffBytes,
+                        files: cp.untrackedFiles,
+                      ),
           ),
         ),
       );
@@ -294,14 +297,41 @@ class _CheckpointCardState extends State<_CheckpointCard> {
               ],
             ),
             const SizedBox(height: 6),
-            Text(
-              cp.isGit
-                  ? '${cp.gitHead != null ? cp.gitHead!.substring(0, cp.gitHead!.length < 8 ? cp.gitHead!.length : 8) : '—'}   Δ ${cp.diffBytes}B   +${cp.untrackedFiles}f   ⌨ ${cp.inputBytes}B'
-                  : '${t.sessions.inspector.checkpoints.nonGit}   ⌨ ${cp.inputBytes}B',
-              style: theme.textTheme.bodySmall?.copyWith(
-                fontFamily: 'monospace',
-                color: muted,
-              ),
+            Builder(
+              builder: (_) {
+                final head = cp.gitHead != null
+                    ? cp.gitHead!.substring(
+                        0, cp.gitHead!.length < 8 ? cp.gitHead!.length : 8)
+                    : '—';
+                // A git checkpoint with no diff and no untracked files
+                // captured nothing restorable — the tree was clean. Say so
+                // explicitly so an empty diff doesn't read as broken.
+                final clean =
+                    cp.isGit && cp.diffBytes == 0 && cp.untrackedFiles == 0;
+                if (clean) {
+                  return Row(
+                    children: [
+                      Icon(Icons.check_circle_outline,
+                          size: 14, color: Colors.green.shade600),
+                      const SizedBox(width: 4),
+                      Expanded(
+                        child: Text(
+                          '$head · ${t.sessions.inspector.checkpoints.clean}   ⌨ ${cp.inputBytes}B',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                              fontFamily: 'monospace', color: muted),
+                        ),
+                      ),
+                    ],
+                  );
+                }
+                return Text(
+                  cp.isGit
+                      ? '$head   Δ ${cp.diffBytes}B   +${cp.untrackedFiles}f   ⌨ ${cp.inputBytes}B'
+                      : '${t.sessions.inspector.checkpoints.nonGit}   ⌨ ${cp.inputBytes}B',
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(fontFamily: 'monospace', color: muted),
+                );
+              },
             ),
             if (cp.note != null) ...[
               const SizedBox(height: 4),

--- a/app/web/src/components/sessions/inspector/CheckpointsPanel.tsx
+++ b/app/web/src/components/sessions/inspector/CheckpointsPanel.tsx
@@ -8,6 +8,7 @@ import {
   GitCompare,
   AlertTriangle,
   FileWarning,
+  CheckCircle2,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
@@ -49,13 +50,17 @@ export function CheckpointsPanel({ session }: CheckpointsPanelProps) {
     mutationFn: () => captureCheckpoint(sessionId),
     onSuccess: (cp) => {
       qc.invalidateQueries({ queryKey: key })
+      const clean =
+        cp.is_git && cp.diff_bytes === 0 && cp.untracked_files === 0
       toast.success(t('web.sessions.inspector.checkpoints.captured'), {
-        description: cp.is_git
-          ? t('web.sessions.inspector.checkpoints.capturedGit', {
-              diff: cp.diff_bytes,
-              files: cp.untracked_files,
-            })
-          : t('web.sessions.inspector.checkpoints.capturedNonGit'),
+        description: !cp.is_git
+          ? t('web.sessions.inspector.checkpoints.capturedNonGit')
+          : clean
+            ? t('web.sessions.inspector.checkpoints.capturedClean')
+            : t('web.sessions.inspector.checkpoints.capturedGit', {
+                diff: cp.diff_bytes,
+                files: cp.untracked_files,
+              }),
       })
     },
     onError: (e: Error) => toast.error(e.message),
@@ -148,6 +153,11 @@ function CheckpointCard({
   })
 
   const when = new Date(cp.created_at).toLocaleString()
+  // A git checkpoint with no tracked diff and no untracked files captured
+  // nothing restorable — the working tree was clean. Surfaced explicitly so
+  // an empty diff doesn't read as "the feature didn't work".
+  const isClean =
+    cp.is_git && cp.diff_bytes === 0 && cp.untracked_files === 0
 
   return (
     <li className="rounded-md border border-border bg-card/30 px-2.5 py-2 flex flex-col gap-1.5">
@@ -176,13 +186,21 @@ function CheckpointCard({
         )}
       </div>
 
-      <div className="text-[11px] text-muted-foreground/85 font-mono flex flex-wrap gap-x-3 gap-y-0.5">
+      <div className="text-[11px] text-muted-foreground/85 font-mono flex flex-wrap items-center gap-x-3 gap-y-0.5">
         {cp.is_git ? (
-          <>
-            <span>{cp.git_head ? cp.git_head.slice(0, 8) : '—'}</span>
-            <span>Δ {cp.diff_bytes}B</span>
-            <span>+{cp.untracked_files}f</span>
-          </>
+          isClean ? (
+            <span className="flex items-center gap-1 text-muted-foreground/60">
+              {cp.git_head ? cp.git_head.slice(0, 8) : '—'}
+              <CheckCircle2 className="size-3 text-state-running/70" />
+              {t('web.sessions.inspector.checkpoints.clean')}
+            </span>
+          ) : (
+            <>
+              <span>{cp.git_head ? cp.git_head.slice(0, 8) : '—'}</span>
+              <span>Δ {cp.diff_bytes}B</span>
+              <span>+{cp.untracked_files}f</span>
+            </>
+          )
         ) : (
           <span className="text-muted-foreground/60">
             {t('web.sessions.inspector.checkpoints.nonGit')}


### PR DESCRIPTION
## Problem

A checkpoint of a working tree with **no uncommitted tracked changes and no untracked files** legitimately has an empty diff — but the panel showed a bare `Δ0B +0f` and no *View diff* button, which reads as *"the feature didn't work"*.

Verified it **does** work: capturing a repo with real uncommitted changes snapshots the diff correctly (`git_dirty:true, diff_bytes:163, untracked_files:1`, stored diff exact). Operators just commit everything via PRs, so their trees are usually clean → empty checkpoints → looked broken.

## Fix (web + mobile, kept in parity)

- **Card stats line**: when `is_git && diff_bytes==0 && untracked_files==0`, show `<head> ✓ clean — no changes captured` instead of `Δ0B +0f`.
- **Capture toast/snackbar**: a clean capture says *"working tree was clean — no changes to back up"* rather than diff/file counts.
- New i18n keys `clean` + `capturedClean` under both the web (`web.sessions.inspector.checkpoints`) and mobile (`sessions.inspector.checkpoints`) namespaces, en/zh/es; **slang regenerated**.

## Test plan
- `pnpm --filter web build` (tsc + vite) — green.
- `flutter analyze` — **No issues found** (full app).
- `scripts/check-i18n-parity.mjs` — 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)