### PR TITLE
fix(mcp): reject duplicate server display names before they break sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ for the full rationale and what triggers a major bump.
 
 ### Fixed
 
+- **Two MCP servers sharing a display name no longer brick Codex sessions.**
+  Every provider renderer keys its generated config on a server's display
+  name, not its unique id. Two enabled servers with the same name therefore
+  collided on that key: Codex emitted a duplicate `[mcp_servers."…"]` TOML
+  table and died with `duplicate key` at startup — before printing a byte, so
+  the session flipped straight to the read-only "[buffer unavailable]" view —
+  while Claude's map-based renderer silently dropped one of them. `renderMCP`
+  now rejects a duplicate name up front (for every provider, before any config
+  file is written), and the Plugins create/update endpoints return `409` when
+  a new or edited server would reuse a name already taken by a different id.
+  Grok's manifest gap and this collision are unrelated; a stray second Notion
+  entry sharing the name `Notion API` is what exposed it.
 - **Grok now reports and applies CLI updates from the Providers page.** The
   `grok` manifest carried an empty `npmPackage`, and the whole update path is
   npm-gated: `CheckUpdate` returned early (no latest version, no

--- a/internal/catalog/mcp.go
+++ b/internal/catalog/mcp.go
@@ -72,6 +72,16 @@ func renderMCP(providerID, baseDir, cwd, home string, servers []MCPServer) ([]st
 	if len(servers) == 0 {
 		return nil, nil, nil
 	}
+	// Every renderer keys its per-provider config on the server's display
+	// name. Two servers sharing a name collide on that key: Claude's map
+	// silently drops one, Codex emits a duplicate TOML table that fails to
+	// parse and bricks the session before it can print a single byte. Reject
+	// the collision here, once, so the failure is a clear operator error
+	// rather than a provider-specific mystery — and before any renderer
+	// writes a half-formed config file to disk.
+	if dup, ok := duplicateServerName(servers); ok {
+		return nil, nil, fmt.Errorf("two MCP servers share the name %q; names must be unique", dup)
+	}
 	switch providerID {
 	case "claude":
 		return renderClaudeMCP(baseDir, servers)
@@ -707,6 +717,24 @@ func codexBaseConfigForScratch() string {
 		return ""
 	}
 	return string(data)
+}
+
+// duplicateServerName reports the first display name shared by two
+// renderable servers (those that would actually be emitted — i.e. carry a
+// command or URL). Servers dropped for being invalid can't collide, so
+// they're ignored.
+func duplicateServerName(servers []MCPServer) (string, bool) {
+	seen := make(map[string]bool, len(servers))
+	for _, s := range servers {
+		if s.Command == "" && s.URL == "" {
+			continue
+		}
+		if seen[s.Name] {
+			return s.Name, true
+		}
+		seen[s.Name] = true
+	}
+	return "", false
 }
 
 func codexServerBlock(s MCPServer) string {

--- a/internal/catalog/mcp_test.go
+++ b/internal/catalog/mcp_test.go
@@ -649,3 +649,44 @@ func TestSyncGeminiWorkspaceMCP_EmptySettingsTolerated(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// Two servers sharing a display name collide on the config key every
+// renderer uses (Claude's map silently drops one; Codex emits a duplicate
+// TOML table that fails to parse and bricks the session before it prints
+// anything). renderMCP must reject the collision up front, for every
+// provider, so the operator sees a clear error instead of a dead session.
+func TestRenderMCP_DuplicateNameRejected(t *testing.T) {
+	servers := []MCPServer{
+		{Name: "Notion API", Command: "npx", Args: []string{"-y", "a"}},
+		{Name: "Notion API", Command: "npx", Args: []string{"-y", "b"}},
+	}
+	for _, provider := range []string{"claude", "codex", "opencode", "grok", "antigravity"} {
+		t.Run(provider, func(t *testing.T) {
+			_, _, err := renderMCP(provider, t.TempDir(), t.TempDir(), t.TempDir(), servers)
+			if err == nil {
+				t.Fatalf("%s: expected an error for duplicate server name, got nil", provider)
+			}
+			if !strings.Contains(err.Error(), "Notion API") {
+				t.Errorf("%s: error should name the colliding server; got %q", provider, err)
+			}
+		})
+	}
+}
+
+// A collision must never leave a half-written, unparseable config on disk:
+// Codex reads config.toml at startup, so a broken file is worse than none.
+func TestRenderMCP_DuplicateNameWritesNoCodexConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", home)
+	dir := t.TempDir()
+	servers := []MCPServer{
+		{Name: "dup", Command: "npx", Args: []string{"-y", "a"}},
+		{Name: "dup", Command: "npx", Args: []string{"-y", "b"}},
+	}
+	if _, _, err := renderMCP("codex", dir, "", "", servers); err == nil {
+		t.Fatal("expected duplicate-name error, got nil")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "codex-home", "config.toml")); err == nil {
+		t.Error("a broken config.toml must not be written on collision")
+	}
+}

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -208,6 +208,11 @@ func (h *Handlers) create(w http.ResponseWriter, r *http.Request) {
 	if strings.TrimSpace(srv.Name) == "" {
 		srv.Name = id
 	}
+	if other, taken := h.loader.NameTaken(srv.Name, id); taken {
+		writeError(w, http.StatusConflict, fmt.Errorf(
+			"display name %q is already used by MCP server %q; names must be unique or sessions break", srv.Name, other))
+		return
+	}
 	if err := prepareServerForWrite(&srv); err != nil {
 		writeError(w, http.StatusBadRequest, err)
 		return
@@ -258,6 +263,11 @@ func (h *Handlers) update(w http.ResponseWriter, r *http.Request) {
 	srv.ID = id
 	if strings.TrimSpace(srv.Name) == "" {
 		srv.Name = id
+	}
+	if other, taken := h.loader.NameTaken(srv.Name, id); taken {
+		writeError(w, http.StatusConflict, fmt.Errorf(
+			"display name %q is already used by MCP server %q; names must be unique or sessions break", srv.Name, other))
+		return
 	}
 	if err := prepareServerForWrite(&srv); err != nil {
 		writeError(w, http.StatusBadRequest, err)

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -121,6 +121,29 @@ func (l *Loader) ListEnabled() ([]Server, error) {
 	return out, nil
 }
 
+// NameTaken reports whether some OTHER server already uses display name
+// `name`, returning that server's id. Every provider renderer keys its
+// config on the display name, so two servers sharing one collide — Codex
+// emits a duplicate TOML table and won't start, Claude silently drops one.
+// Create/update guards call this to reject the collision at write time.
+// Comparison is trimmed but case-sensitive (names are exact TOML/JSON keys).
+func (l *Loader) NameTaken(name, selfID string) (string, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", false
+	}
+	all, err := l.List()
+	if err != nil {
+		return "", false
+	}
+	for _, s := range all {
+		if s.ID != selfID && strings.TrimSpace(s.Name) == name {
+			return s.ID, true
+		}
+	}
+	return "", false
+}
+
 // Get returns one server by id. Returns os.ErrNotExist when the
 // directory doesn't exist so callers can disambiguate 404s.
 func (l *Loader) Get(id string) (Server, error) {

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -2,8 +2,12 @@ package mcp
 
 import (
 	"encoding/json"
+	"github.com/go-chi/chi/v5"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -68,5 +72,63 @@ func TestPrepareServerForWriteRejectsRemoteCommand(t *testing.T) {
 	}
 	if err := prepareServerForWrite(&srv); err == nil {
 		t.Fatal("expected remote server without URL to be rejected")
+	}
+}
+
+// Two servers with different ids but the same display name break Codex
+// (duplicate TOML table) and silently drop in Claude. The loader must be
+// able to report that a name is already taken by a *different* id so the
+// create/update handlers can reject it before it ever reaches a session.
+func TestLoader_NameTakenByAnother(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "notion")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "mcp.json"),
+		[]byte(`{"name":"Notion API","command":"npx","enabled":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	l := NewLoader(root)
+
+	if other, taken := l.NameTaken("Notion API", "motion"); !taken || other != "notion" {
+		t.Errorf("a new id reusing an existing name must be reported taken; got other=%q taken=%v", other, taken)
+	}
+	if _, taken := l.NameTaken("Notion API", "notion"); taken {
+		t.Error("the same id keeping its own name must not report a collision")
+	}
+	if _, taken := l.NameTaken("Something Else", "motion"); taken {
+		t.Error("an unused name must be free")
+	}
+}
+
+// End-to-end guard: creating a second server whose display name matches an
+// existing one (the motion/notion bug) must be refused with 409, not
+// written to disk — otherwise Codex sessions die on a duplicate TOML key.
+func TestCreate_RejectsDuplicateDisplayName(t *testing.T) {
+	root := t.TempDir()
+	existing := filepath.Join(root, "notion")
+	if err := os.MkdirAll(existing, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(existing, "mcp.json"),
+		[]byte(`{"name":"Notion API","command":"npx","enabled":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewHandlers(NewLoader(root), "", nil)
+	r := chi.NewRouter()
+	h.Mount(r)
+
+	body := `{"id":"motion","server":{"name":"Notion API","command":"npx","enabled":true}}`
+	req := httptest.NewRequest(http.MethodPost, "/mcps/", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("want 409 Conflict on duplicate display name, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(root, "motion", "mcp.json")); err == nil {
+		t.Error("colliding server must not be written to disk")
 	}
 }

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -2,13 +2,14 @@ package mcp
 
 import (
 	"encoding/json"
-	"github.com/go-chi/chi/v5"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/go-chi/chi/v5"
 )
 
 func TestLoadOneNormalizesRemoteCommandURL(t *testing.T) {


### PR DESCRIPTION
## What

Two enabled MCP servers sharing a **display name** made Codex sessions
unstartable. Every provider renderer keys its generated config on the
display name (not the unique vault id), so a duplicate name collides on
that key:

- **Codex** concatenates TOML blocks → emits `[mcp_servers."Notion API"]`
  twice → `config.toml` fails to parse with `duplicate key` → Codex exits
  ~100 ms after spawn, before writing a byte to the PTY, so the UI shows
  the ended-session `[buffer unavailable]` view with no error.
- **Claude** builds a map (`entries[s.Name]`) → the duplicate silently
  collapses to one server → no crash, but one server is invisibly dropped.

This was found in the wild: a stray `motion` vault entry shared the name
`Notion API` with the real `notion` entry, and every Codex restart died on
it. (That entry also had a raw token pasted where a `${SECRET}` placeholder
belongs — handled operationally, out of scope here.)

## Fix

- `renderMCP` rejects a duplicate display name up front — for **every**
  provider, before any config file is written to disk (a half-written,
  unparseable `config.toml` is worse than none).
- The Plugins **create/update** endpoints (`POST`/`PUT /mcps`) return `409
  Conflict` when a new or edited server would reuse a name already held by a
  different id, so the collision can't be persisted in the first place.

Display-name keying is kept deliberately: switching to id-keying would
rename live tool namespaces (`mcp__opendray_memory__*` → `mcp__memory__*`,
`mcp__obsidian_vault__*` → `mcp__obsidian__*`) and break the cross-agent
memory instructions every session receives.

## Tests (TDD, RED→GREEN)

- `TestRenderMCP_DuplicateNameRejected` — all five providers error, message
  names the colliding server.
- `TestRenderMCP_DuplicateNameWritesNoCodexConfig` — no broken TOML left on
  disk.
- `TestLoader_NameTakenByAnother` — collision detected only across *different*
  ids.
- `TestCreate_RejectsDuplicateDisplayName` — end-to-end `409`, nothing
  written (verified it returns `201` with the guard removed).

`gofmt`/`go vet` clean; `go build ./...` green; `internal/catalog` +
`internal/mcp` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)