### PR TITLE
fix(web/files): show the download icon on touch devices (iPad)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ for the full rationale and what triggers a major bump.
 
 ### Fixed
 
+- **The Files-tree download icon is now reachable on touch devices (iPad,
+  phones).** The per-row download button was revealed only on hover
+  (`group-hover`) or keyboard focus. Tailwind v4 gates `group-hover` behind
+  `@media (hover: hover)`, so on a touch device — which can neither hover nor
+  focus a row — the icon stayed at `opacity-0` and was impossible to tap. It
+  now pins visible under `@media (hover: none)`, so touch users get a
+  permanently-shown download control while pointer users keep the clean
+  hover-reveal. (Follow-up to the v2.11.6 positioning fix, which addressed
+  *where* the icon sits but not *whether* it ever appears without a mouse.)
 - **Two MCP servers sharing a display name no longer brick Codex sessions.**
   Every provider renderer keys its generated config on a server's display
   name, not its unique id. Two enabled servers with the same name therefore

--- a/app/web/src/components/sessions/inspector/FilesPanel.tsx
+++ b/app/web/src/components/sessions/inspector/FilesPanel.tsx
@@ -401,11 +401,12 @@ function FsNode({
 }
 
 // DownloadIconButton overlays a small Download icon on the right edge
-// of a tree row. Visible-on-hover (or always on touch via the row's
-// group-hover and active fallbacks) so the tree stays scannable when
-// the operator isn't reaching for a file. Anchored absolutely so the
-// row's text isn't truncated to make space — the button sits over the
-// row's right padding.
+// of a tree row. On pointer devices it is hover-revealed so the tree
+// stays scannable; on touch devices (which can't hover — and where
+// Tailwind gates group-hover behind @media (hover: hover), so it never
+// fires) it is shown unconditionally, otherwise the icon is unreachable
+// on iPad/phones. Anchored absolutely so the row's text isn't truncated
+// to make space — the button sits over the row's right padding.
 function DownloadIconButton({
   ariaLabel,
   onActivate,
@@ -430,6 +431,9 @@ function DownloadIconButton({
         'size-5 flex items-center justify-center rounded-sm',
         'text-muted-foreground/70 hover:text-foreground hover:bg-border',
         'opacity-0 group-hover:opacity-100 focus-visible:opacity-100',
+        // Touch devices can't hover, so the hover-reveal above never
+        // triggers — pin the icon visible wherever hover is unavailable.
+        '[@media(hover:none)]:opacity-100',
         'transition-opacity',
       )}
     >


### PR DESCRIPTION
## Symptom

On iPad (and phones) the Files inspector shows **no download icon** on any file row — reported with a screenshot where every row is bare.

## Root cause

The per-row `DownloadIconButton` is revealed only on hover or keyboard focus:

```
opacity-0 group-hover:opacity-100 focus-visible:opacity-100
```

Tailwind v4 gates `group-hover` behind `@media (hover: hover)`, so on a touch device — which can neither hover a row nor keyboard-focus it — the icon stays `opacity-0` and is impossible to tap. The code comment even claimed a touch fallback existed ("always on touch via … active fallbacks") but there was none.

This is distinct from the v2.11.6 fix (#443/#448), which corrected *where* the icon sits in deep/long trees but not *whether* it appears without a mouse.

## Fix

Pin the icon visible under `@media (hover: none)`:

```
opacity-0 group-hover:opacity-100 focus-visible:opacity-100
[@media(hover:none)]:opacity-100
```

- Touch (hover: none) → icon always visible and tappable.
- Pointer (hover: hover) → unchanged hover-reveal, tree stays scannable.

One component change covers both the root "download folder as zip" button and every per-file button (both render `DownloadIconButton`). Comment corrected to describe the real behavior.

## Testing

app/web has no component test harness (no vitest/testing-library), so this is verified by the Frontend (web) CI build + the fix being a single, standard Tailwind v4 arbitrary at-rule variant. Local build wasn't possible (root-owned node_modules); relying on CI's clean `pnpm install --frozen-lockfile && pnpm --filter web build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)