### PR TITLE
fix(web/terminal): stop the input cursor drifting on iPad

### DIFF
--- a/app/web/src/components/sessions/Terminal.tsx
+++ b/app/web/src/components/sessions/Terminal.tsx
@@ -46,6 +46,17 @@ export interface TerminalHandle {
   getBufferText: () => string
 }
 
+// iPhone/iPad detection. iPadOS 13+ reports itself as "MacIntel", so
+// disambiguate a real iPad (multi-point touchscreen) from a desktop
+// Mac (maxTouchPoints 0). A trackpad-equipped iPad still has the
+// touchscreen, so maxTouchPoints stays >1. Used only to opt the
+// terminal into the composition-drift CSS workaround below — never for
+// feature gating, so a false negative just leaves stock behaviour.
+const IS_IOS =
+  typeof navigator !== 'undefined' &&
+  (/iP(hone|ad|od)/.test(navigator.platform) ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1))
+
 function readVar(name: string): string {
   return getComputedStyle(document.documentElement)
     .getPropertyValue(name)
@@ -511,7 +522,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
           and reliable RO timing across Safari/Chrome. */}
       <div
         ref={containerRef}
-        className="h-full w-full p-3 overflow-hidden"
+        className={`h-full w-full p-3 overflow-hidden${IS_IOS ? ' terminal-ios' : ''}`}
         style={{ contain: 'layout paint' }}
       />
       {dragActive && (

--- a/app/web/src/index.css
+++ b/app/web/src/index.css
@@ -163,6 +163,32 @@
   overscroll-behavior: contain;
 }
 
+/* iPad/iOS input-cursor drift. xterm parks its opacity:0 helper
+   textarea off-screen (left:-9999em) at rest, but during IME
+   composition CompositionHelper.updateCompositionElements() moves the
+   textarea AND the composition preview onto the terminal cursor
+   (buffer.x/y × cell) — and never restores them when composition
+   ends (see xterm's own "Composition position got messed up
+   somewhere" TODO). On iOS this is visible and destructive: the
+   system caret and QuickType candidate bar anchor to that focused
+   textarea, so in a busy, constantly-redrawing TUI (antigravity/agy)
+   they chase the jumping terminal cursor around the screen and cover
+   the real echo — "the typing cursor drifts and I can't see what I
+   typed." Desktop never draws a system caret over an opacity:0 field,
+   so it only bites on iPad. Pin both elements back to xterm's
+   off-screen rest position on iOS; the system keyboard's own
+   candidate UI plus the CLI's echo show what was typed. Scoped via a
+   `.terminal-ios` class the Terminal only adds on iPhone/iPad. */
+.terminal-ios .xterm-helper-textarea {
+  left: -9999em !important;
+  top: 0 !important;
+  width: 0 !important;
+  height: 0 !important;
+}
+.terminal-ios .composition-view {
+  display: none !important;
+}
+
 /* highlight.js theme — a compact mapping that uses palette-friendly
    colors for both light and dark modes. The Inspector's file viewer
    wraps lines into our own gutter, so only inline class colors are


### PR DESCRIPTION
## Problem

On iOS/iPadOS, typing into a live session terminal on the **web** client makes the input cursor drift across the screen — most visibly in a busy TUI like **antigravity/agy** — covering the real echo so you cannot see (or can only see wrongly) what you typed. Desktop and mobile (Flutter) are unaffected; the bug is specific to the iPad web experience.

## Root cause

In xterm.js the `opacity:0` helper textarea rests off-screen (`left:-9999em`). During IME **composition**, `CompositionHelper.updateCompositionElements()` moves the textarea **and** the composition preview onto the terminal cursor (`buffer.x/y × cell`) — and never restores them when composition ends (xterm's own `Composition position got messed up somewhere` TODO).

iOS anchors its **system caret** and **QuickType candidate bar** to that focused textarea. antigravity's TUI redraws its input area every frame, so `buffer.x/y` jumps and the iOS caret/candidate chase the cursor around the screen, sitting over the real echo. Desktop never paints a system caret over an `opacity:0` field, which is why it only bites on iPad.

## Fix

On iPhone/iPad only, pin the helper textarea back to xterm's off-screen rest position and hide the composition preview, via a `.terminal-ios` class the live `Terminal` adds only on iOS (iPadOS-13+-as-`MacIntel` disambiguated with `maxTouchPoints > 1`). The system keyboard's own candidate UI plus the CLI's echo already show what was typed, so nothing is lost.

Restoring the off-screen rest position is xterm's own default state at focus time, so iOS does not auto-scroll to chase it — this simply prevents the composition-time move on iOS.

## Scope

- **Web-only.** The read-only `EndedSessionView` terminal is `disableStdin` (never composes); mobile uses a separate Flutter terminal. No i18n strings touched.
- Provider-agnostic device-level fix — claude/codex/grok sessions on iPad benefit too; antigravity just made it most visible.

## Test plan

- `tsc --noEmit` green; eslint clean on the changed file (one pre-existing unrelated warning).
- Built locally, signed, installed, and **verified on a physical iPad**: input cursor no longer drifts in an antigravity session; typed content shows correctly. (Soft-keyboard QuickType composition cannot be reproduced in headless WebKit, so real-device verification was required.)
- Desktop behaviour unchanged (class not applied off iOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)