### PR TITLE
feat(cortex): add a cross-page KB Librarian AI administrator

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -2835,6 +2835,16 @@
           "injectHint": "Off (recommended for most): the page stays out of the spawn banner and agents reach it on demand via memory search. On: foundational pages inject as binding rules, emergent pages as reference.",
           "create": "Create page",
           "createdToast": "Knowledge page created"
+        },
+        "librarian": {
+          "button": "Manage KB with AI",
+          "hint": "Launch a cross-page AI librarian that can organize, create and edit any knowledge page",
+          "launchedToast": "KB Librarian session started",
+          "title": "Launch KB Librarian",
+          "dialogHint": "Pick the cloud agent that will organize your knowledge base. It gets read + write tools across all KB pages.",
+          "provider": "Cloud agent",
+          "account": "Claude account",
+          "launch": "Launch"
         }
       },
       "kinds": {

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -2835,6 +2835,16 @@
           "injectHint": "Apagado (recomendado): la página queda fuera del banner de arranque y los agentes la alcanzan bajo demanda vía búsqueda. Encendido: las fundacionales se inyectan como reglas vinculantes, las emergentes como referencia.",
           "create": "Crear página",
           "createdToast": "Página de conocimiento creada"
+        },
+        "librarian": {
+          "button": "Gestionar KB con IA",
+          "hint": "Lanza un bibliotecario de IA que puede organizar, crear y editar cualquier página de conocimiento",
+          "launchedToast": "Sesión del bibliotecario de KB iniciada",
+          "title": "Lanzar bibliotecario de KB",
+          "dialogHint": "Elige el agente en la nube que organizará tu base de conocimiento. Tendrá herramientas de lectura y escritura en todas las páginas.",
+          "provider": "Agente en la nube",
+          "account": "Cuenta de Claude",
+          "launch": "Lanzar"
         }
       },
       "kinds": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -2835,6 +2835,16 @@
           "injectHint": "关闭（多数情况推荐）：页面不进启动横幅，AI 通过记忆搜索按需取用。开启：基础类页面作为强约束注入，经验类作为参考注入。",
           "create": "创建页面",
           "createdToast": "知识页已创建"
+        },
+        "librarian": {
+          "button": "用 AI 管理知识库",
+          "hint": "启动一个跨页面的 AI 图书管理员,可整理、创建、编辑任意知识页",
+          "launchedToast": "KB 图书管理员会话已启动",
+          "title": "启动 KB 图书管理员",
+          "dialogHint": "选择用来整理知识库的 cloud agent。它将获得对所有 KB 页面的读写工具。",
+          "provider": "Cloud agent",
+          "account": "Claude 账号",
+          "launch": "启动"
         }
       },
       "kinds": {

--- a/app/mobile/lib/core/api/cortex_api.dart
+++ b/app/mobile/lib/core/api/cortex_api.dart
@@ -264,6 +264,28 @@ class CortexApi {
     }
   }
 
+  // Launch the cross-page KB Librarian session (a knowledge-base admin agent
+  // whose memory MCP has the global-KB write tools). Returns the session id.
+  Future<String> launchLibrarian({
+    String provider = '',
+    String model = '',
+    String claudeAccountId = '',
+  }) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/cortex/librarian',
+        data: {
+          if (provider.isNotEmpty) 'provider': provider,
+          if (model.isNotEmpty) 'model': model,
+          if (claudeAccountId.isNotEmpty) 'claude_account_id': claudeAccountId,
+        },
+      );
+      return res.data?['session_id']?.toString() ?? '';
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
   Future<void> closeConversation(String id) async {
     try {
       await _dio.post<void>('/api/v1/cortex/conversations/$id/close');

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 12303 (4101 per locale)
+/// Strings: 12327 (4109 per locale)
 ///
-/// Built on 2026-07-16 at 10:18 UTC
+/// Built on 2026-07-17 at 00:31 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -11280,6 +11280,7 @@ class TranslationsWebKnowledgeKbEn {
 	String get pageRemovedToast => 'Page removed';
 
 	late final TranslationsWebKnowledgeKbNewPageEn newPage = TranslationsWebKnowledgeKbNewPageEn.internal(_root);
+	late final TranslationsWebKnowledgeKbLibrarianEn librarian = TranslationsWebKnowledgeKbLibrarianEn.internal(_root);
 }
 
 // Path: web.knowledge.kinds
@@ -17327,6 +17328,39 @@ class TranslationsWebKnowledgeKbNewPageEn {
 	String get createdToast => 'Knowledge page created';
 }
 
+// Path: web.knowledge.kb.librarian
+class TranslationsWebKnowledgeKbLibrarianEn {
+	TranslationsWebKnowledgeKbLibrarianEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Manage KB with AI'
+	String get button => 'Manage KB with AI';
+
+	/// en: 'Launch a cross-page AI librarian that can organize, create and edit any knowledge page'
+	String get hint => 'Launch a cross-page AI librarian that can organize, create and edit any knowledge page';
+
+	/// en: 'KB Librarian session started'
+	String get launchedToast => 'KB Librarian session started';
+
+	/// en: 'Launch KB Librarian'
+	String get title => 'Launch KB Librarian';
+
+	/// en: 'Pick the cloud agent that will organize your knowledge base. It gets read + write tools across all KB pages.'
+	String get dialogHint => 'Pick the cloud agent that will organize your knowledge base. It gets read + write tools across all KB pages.';
+
+	/// en: 'Cloud agent'
+	String get provider => 'Cloud agent';
+
+	/// en: 'Claude account'
+	String get account => 'Claude account';
+
+	/// en: 'Launch'
+	String get launch => 'Launch';
+}
+
 // Path: web.knowledge.distill.retirement
 class TranslationsWebKnowledgeDistillRetirementEn {
 	TranslationsWebKnowledgeDistillRetirementEn.internal(this._root);
@@ -19936,6 +19970,14 @@ extension on Translations {
 			'web.knowledge.kb.newPage.injectHint' => 'Off (recommended for most): the page stays out of the spawn banner and agents reach it on demand via memory search. On: foundational pages inject as binding rules, emergent pages as reference.',
 			'web.knowledge.kb.newPage.create' => 'Create page',
 			'web.knowledge.kb.newPage.createdToast' => 'Knowledge page created',
+			'web.knowledge.kb.librarian.button' => 'Manage KB with AI',
+			'web.knowledge.kb.librarian.hint' => 'Launch a cross-page AI librarian that can organize, create and edit any knowledge page',
+			'web.knowledge.kb.librarian.launchedToast' => 'KB Librarian session started',
+			'web.knowledge.kb.librarian.title' => 'Launch KB Librarian',
+			'web.knowledge.kb.librarian.dialogHint' => 'Pick the cloud agent that will organize your knowledge base. It gets read + write tools across all KB pages.',
+			'web.knowledge.kb.librarian.provider' => 'Cloud agent',
+			'web.knowledge.kb.librarian.account' => 'Claude account',
+			'web.knowledge.kb.librarian.launch' => 'Launch',
 			'web.knowledge.kinds.all' => 'All',
 			'web.knowledge.kinds.entity' => 'Entities',
 			'web.knowledge.kinds.fact' => 'Facts',
@@ -20262,6 +20304,8 @@ extension on Translations {
 			'web.roundTable.plan.bypass' => 'Skip permissions (YOLO)',
 			'web.roundTable.plan.bypassHint' => 'Start the session with its bypass flag so it does not prompt for approvals.',
 			'more.title' => 'More',
+			_ => null,
+		} ?? switch (path) {
 			'more.identity.signedInAs' => 'Signed in as',
 			'more.identity.server' => 'Server',
 			'more.identity.tokenExpires' => 'Token expires',
@@ -20270,8 +20314,6 @@ extension on Translations {
 			'more.sections.memory' => 'Memory',
 			'more.sections.system' => 'System',
 			'more.items.integrations.title' => 'Integrations',
-			_ => null,
-		} ?? switch (path) {
 			'more.items.integrations.subtitle' => 'API callers — recent activity & error rates',
 			'more.items.activity.title' => 'Activity',
 			'more.items.activity.subtitle' => 'Integration API call audit',
@@ -20776,6 +20818,8 @@ extension on Translations {
 			'integrations.form.routePrefixHelper' => 'Reachable as /api/v1/<prefix>/...',
 			'integrations.form.fieldVersion' => 'Version (optional)',
 			'integrations.form.validateBaseUrl' => 'Base URL is required.',
+			_ => null,
+		} ?? switch (path) {
 			'integrations.form.editFieldVersion' => 'Version',
 			'integrations.form.apiKeyWarn' => 'You won\'t see this key again.',
 			'integrations.form.copyCopied' => 'Copied',
@@ -20784,8 +20828,6 @@ extension on Translations {
 			'integrations.defaultAgent.description' => 'Applied to sessions this integration creates when its request omits the field. The request always wins.',
 			'integrations.defaultAgent.providerLabel' => 'Default provider',
 			'integrations.defaultAgent.providerNone' => 'No default',
-			_ => null,
-		} ?? switch (path) {
 			'integrations.defaultAgent.modelLabel' => 'Default model',
 			'integrations.defaultAgent.modelHint' => 'Provider default (e.g. opus)',
 			'integrations.defaultAgent.accountLabel' => 'Default Claude account',
@@ -21290,6 +21332,8 @@ extension on Translations {
 			'channels.errorPrefix.toggle' => 'Toggle failed',
 			'channels.errorPrefix.muteToggle' => 'Mute toggle failed',
 			'channels.errorPrefix.update' => 'Update failed',
+			_ => null,
+		} ?? switch (path) {
 			'channels.errorPrefix.delete' => 'Delete failed',
 			'channels.failedToLoad' => 'Failed to load channels',
 			'channels.kinds.telegram.description' => 'Bot via @BotFather. opendray long-polls getUpdates and sends via REST. Buttons + reply_to_message work natively.',
@@ -21298,8 +21342,6 @@ extension on Translations {
 			'channels.kinds.telegram.chatIdLabel' => 'Default chat ID',
 			'channels.kinds.telegram.chatIdPlaceholder' => '42 (optional — used when no ReplyCtx)',
 			'channels.kinds.telegram.ownerUserIdsLabel' => 'Owner Telegram user ID(s)',
-			_ => null,
-		} ?? switch (path) {
 			'channels.kinds.telegram.ownerUserIdsPlaceholder' => '123456789 (comma-separated for more than one)',
 			'channels.kinds.telegram.ownerUserIdsHint' => 'Only these numeric Telegram user IDs may drive sessions, run commands, or tap buttons; everyone else is ignored. Leave blank to allow anyone (not recommended for two-way chat). Get yours by DMing @userinfobot.',
 			'channels.kinds.telegram.chatEnabledLabel' => 'Two-way chat (route messages into the session)',
@@ -21804,6 +21846,8 @@ extension on Translations {
 			'cortexHub.hide' => 'Hide',
 			'cortexHub.approve' => 'Approve',
 			'cortexHub.reject' => 'Reject',
+			_ => null,
+		} ?? switch (path) {
 			'cortexHub.approvedToast' => 'Proposal approved',
 			'cortexHub.rejectedToast' => 'Proposal rejected',
 			'cortexHub.actionFailed' => ({required Object error}) => 'Action failed: ${error}',
@@ -21812,8 +21856,6 @@ extension on Translations {
 			'cortexSettings.tabWorkers' => 'Workers',
 			'cortexSettings.tabCapture' => 'Capture & injection',
 			'cortexSettings.tabProviders' => 'Providers',
-			_ => null,
-		} ?? switch (path) {
 			'cortexSettings.providersHint' => 'LLM endpoints that summarizer/agent workers route to.',
 			'cortexSettings.providersEmpty' => 'No providers configured.',
 			'cortexSettings.providersManageOnWeb' => 'Add or edit providers on the web admin.',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -5755,6 +5755,7 @@ class _TranslationsWebKnowledgeKbEs extends TranslationsWebKnowledgeKbEn {
 	@override String get removePageHint => 'Quita esta página de la base de conocimiento (su contenido se conserva y vuelve si se re-añade el slug)';
 	@override String get pageRemovedToast => 'Página quitada';
 	@override late final _TranslationsWebKnowledgeKbNewPageEs newPage = _TranslationsWebKnowledgeKbNewPageEs._(_root);
+	@override late final _TranslationsWebKnowledgeKbLibrarianEs librarian = _TranslationsWebKnowledgeKbLibrarianEs._(_root);
 }
 
 // Path: web.knowledge.kinds
@@ -9146,6 +9147,23 @@ class _TranslationsWebKnowledgeKbNewPageEs extends TranslationsWebKnowledgeKbNew
 	@override String get createdToast => 'Página de conocimiento creada';
 }
 
+// Path: web.knowledge.kb.librarian
+class _TranslationsWebKnowledgeKbLibrarianEs extends TranslationsWebKnowledgeKbLibrarianEn {
+	_TranslationsWebKnowledgeKbLibrarianEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get button => 'Gestionar KB con IA';
+	@override String get hint => 'Lanza un bibliotecario de IA que puede organizar, crear y editar cualquier página de conocimiento';
+	@override String get launchedToast => 'Sesión del bibliotecario de KB iniciada';
+	@override String get title => 'Lanzar bibliotecario de KB';
+	@override String get dialogHint => 'Elige el agente en la nube que organizará tu base de conocimiento. Tendrá herramientas de lectura y escritura en todas las páginas.';
+	@override String get provider => 'Agente en la nube';
+	@override String get account => 'Cuenta de Claude';
+	@override String get launch => 'Lanzar';
+}
+
 // Path: web.knowledge.distill.retirement
 class _TranslationsWebKnowledgeDistillRetirementEs extends TranslationsWebKnowledgeDistillRetirementEn {
 	_TranslationsWebKnowledgeDistillRetirementEs._(TranslationsEs root) : this._root = root, super.internal(root);
@@ -11614,6 +11632,14 @@ extension on TranslationsEs {
 			'web.knowledge.kb.newPage.injectHint' => 'Apagado (recomendado): la página queda fuera del banner de arranque y los agentes la alcanzan bajo demanda vía búsqueda. Encendido: las fundacionales se inyectan como reglas vinculantes, las emergentes como referencia.',
 			'web.knowledge.kb.newPage.create' => 'Crear página',
 			'web.knowledge.kb.newPage.createdToast' => 'Página de conocimiento creada',
+			'web.knowledge.kb.librarian.button' => 'Gestionar KB con IA',
+			'web.knowledge.kb.librarian.hint' => 'Lanza un bibliotecario de IA que puede organizar, crear y editar cualquier página de conocimiento',
+			'web.knowledge.kb.librarian.launchedToast' => 'Sesión del bibliotecario de KB iniciada',
+			'web.knowledge.kb.librarian.title' => 'Lanzar bibliotecario de KB',
+			'web.knowledge.kb.librarian.dialogHint' => 'Elige el agente en la nube que organizará tu base de conocimiento. Tendrá herramientas de lectura y escritura en todas las páginas.',
+			'web.knowledge.kb.librarian.provider' => 'Agente en la nube',
+			'web.knowledge.kb.librarian.account' => 'Cuenta de Claude',
+			'web.knowledge.kb.librarian.launch' => 'Lanzar',
 			'web.knowledge.kinds.all' => 'Todos',
 			'web.knowledge.kinds.entity' => 'Entidades',
 			'web.knowledge.kinds.fact' => 'Hechos',
@@ -11940,6 +11966,8 @@ extension on TranslationsEs {
 			'web.roundTable.plan.bypass' => 'Omitir permisos (YOLO)',
 			'web.roundTable.plan.bypassHint' => 'Inicia la sesión con su indicador de bypass para no pedir aprobaciones.',
 			'more.title' => 'Más',
+			_ => null,
+		} ?? switch (path) {
 			'more.identity.signedInAs' => 'Sesión iniciada como',
 			'more.identity.server' => 'Servidor',
 			'more.identity.tokenExpires' => 'El token caduca',
@@ -11948,8 +11976,6 @@ extension on TranslationsEs {
 			'more.sections.memory' => 'Memoria',
 			'more.sections.system' => 'Sistema',
 			'more.items.integrations.title' => 'Integraciones',
-			_ => null,
-		} ?? switch (path) {
 			'more.items.integrations.subtitle' => 'Llamadores de la API: actividad reciente y tasas de error',
 			'more.items.activity.title' => 'Actividad',
 			'more.items.activity.subtitle' => 'Auditoría de llamadas API de integraciones',
@@ -12454,6 +12480,8 @@ extension on TranslationsEs {
 			'integrations.form.routePrefixHelper' => 'Accesible como /api/v1/<prefix>/...',
 			'integrations.form.fieldVersion' => 'Versión (opcional)',
 			'integrations.form.validateBaseUrl' => 'La URL base es obligatoria.',
+			_ => null,
+		} ?? switch (path) {
 			'integrations.form.editFieldVersion' => 'Versión',
 			'integrations.form.apiKeyWarn' => 'No volverás a ver esta key.',
 			'integrations.form.copyCopied' => 'Copiado',
@@ -12462,8 +12490,6 @@ extension on TranslationsEs {
 			'integrations.defaultAgent.description' => 'Se aplica a las sesiones que crea esta integración cuando la petición omite el campo. La petición siempre prevalece.',
 			'integrations.defaultAgent.providerLabel' => 'Proveedor predeterminado',
 			'integrations.defaultAgent.providerNone' => 'Sin predeterminado',
-			_ => null,
-		} ?? switch (path) {
 			'integrations.defaultAgent.modelLabel' => 'Modelo predeterminado',
 			'integrations.defaultAgent.modelHint' => 'Predeterminado del proveedor (p. ej. opus)',
 			'integrations.defaultAgent.accountLabel' => 'Cuenta de Claude predeterminada',
@@ -12968,6 +12994,8 @@ extension on TranslationsEs {
 			'channels.errorPrefix.toggle' => 'Error al alternar',
 			'channels.errorPrefix.muteToggle' => 'Error al alternar el silencio',
 			'channels.errorPrefix.update' => 'Error al actualizar',
+			_ => null,
+		} ?? switch (path) {
 			'channels.errorPrefix.delete' => 'Error al eliminar',
 			'channels.failedToLoad' => 'Error al cargar los canales',
 			'channels.kinds.telegram.description' => 'Bot mediante @BotFather. opendray hace long-polling de getUpdates y envía vía REST. Los botones y reply_to_message funcionan de forma nativa.',
@@ -12976,8 +13004,6 @@ extension on TranslationsEs {
 			'channels.kinds.telegram.chatIdLabel' => 'Chat ID por defecto',
 			'channels.kinds.telegram.chatIdPlaceholder' => '42 (opcional, se usa cuando no hay ReplyCtx)',
 			'channels.kinds.telegram.ownerUserIdsLabel' => 'ID(s) de usuario de Telegram del propietario',
-			_ => null,
-		} ?? switch (path) {
 			'channels.kinds.telegram.ownerUserIdsPlaceholder' => '123456789 (separados por comas para más de uno)',
 			'channels.kinds.telegram.ownerUserIdsHint' => 'Solo estos IDs numéricos de usuario de Telegram pueden controlar sessions, ejecutar comandos o pulsar botones; el resto se ignora. Déjalo en blanco para permitir a cualquiera (no recomendado para chat bidireccional). Obtén el tuyo enviando un DM a @userinfobot.',
 			'channels.kinds.telegram.chatEnabledLabel' => 'Chat bidireccional (enrutar mensajes a la session)',
@@ -13482,6 +13508,8 @@ extension on TranslationsEs {
 			'cortexHub.hide' => 'Ocultar',
 			'cortexHub.approve' => 'Aprobar',
 			'cortexHub.reject' => 'Rechazar',
+			_ => null,
+		} ?? switch (path) {
 			'cortexHub.approvedToast' => 'Propuesta aprobada',
 			'cortexHub.rejectedToast' => 'Propuesta rechazada',
 			'cortexHub.actionFailed' => ({required Object error}) => 'La acción falló: ${error}',
@@ -13490,8 +13518,6 @@ extension on TranslationsEs {
 			'cortexSettings.tabWorkers' => 'Workers',
 			'cortexSettings.tabCapture' => 'Captura e inyección',
 			'cortexSettings.tabProviders' => 'Proveedores',
-			_ => null,
-		} ?? switch (path) {
 			'cortexSettings.providersHint' => 'Endpoints LLM a los que enrutan los workers de resumen/agente.',
 			'cortexSettings.providersEmpty' => 'Sin proveedores configurados.',
 			'cortexSettings.providersManageOnWeb' => 'Añade o edita proveedores en el panel web.',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -5755,6 +5755,7 @@ class _TranslationsWebKnowledgeKbZh extends TranslationsWebKnowledgeKbEn {
 	@override String get removePageHint => '从知识库移除此页（内容保留，重新添加同名标识即可恢复）';
 	@override String get pageRemovedToast => '页面已移除';
 	@override late final _TranslationsWebKnowledgeKbNewPageZh newPage = _TranslationsWebKnowledgeKbNewPageZh._(_root);
+	@override late final _TranslationsWebKnowledgeKbLibrarianZh librarian = _TranslationsWebKnowledgeKbLibrarianZh._(_root);
 }
 
 // Path: web.knowledge.kinds
@@ -9146,6 +9147,23 @@ class _TranslationsWebKnowledgeKbNewPageZh extends TranslationsWebKnowledgeKbNew
 	@override String get createdToast => '知识页已创建';
 }
 
+// Path: web.knowledge.kb.librarian
+class _TranslationsWebKnowledgeKbLibrarianZh extends TranslationsWebKnowledgeKbLibrarianEn {
+	_TranslationsWebKnowledgeKbLibrarianZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get button => '用 AI 管理知识库';
+	@override String get hint => '启动一个跨页面的 AI 图书管理员,可整理、创建、编辑任意知识页';
+	@override String get launchedToast => 'KB 图书管理员会话已启动';
+	@override String get title => '启动 KB 图书管理员';
+	@override String get dialogHint => '选择用来整理知识库的 cloud agent。它将获得对所有 KB 页面的读写工具。';
+	@override String get provider => 'Cloud agent';
+	@override String get account => 'Claude 账号';
+	@override String get launch => '启动';
+}
+
 // Path: web.knowledge.distill.retirement
 class _TranslationsWebKnowledgeDistillRetirementZh extends TranslationsWebKnowledgeDistillRetirementEn {
 	_TranslationsWebKnowledgeDistillRetirementZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -11614,6 +11632,14 @@ extension on TranslationsZh {
 			'web.knowledge.kb.newPage.injectHint' => '关闭（多数情况推荐）：页面不进启动横幅，AI 通过记忆搜索按需取用。开启：基础类页面作为强约束注入，经验类作为参考注入。',
 			'web.knowledge.kb.newPage.create' => '创建页面',
 			'web.knowledge.kb.newPage.createdToast' => '知识页已创建',
+			'web.knowledge.kb.librarian.button' => '用 AI 管理知识库',
+			'web.knowledge.kb.librarian.hint' => '启动一个跨页面的 AI 图书管理员,可整理、创建、编辑任意知识页',
+			'web.knowledge.kb.librarian.launchedToast' => 'KB 图书管理员会话已启动',
+			'web.knowledge.kb.librarian.title' => '启动 KB 图书管理员',
+			'web.knowledge.kb.librarian.dialogHint' => '选择用来整理知识库的 cloud agent。它将获得对所有 KB 页面的读写工具。',
+			'web.knowledge.kb.librarian.provider' => 'Cloud agent',
+			'web.knowledge.kb.librarian.account' => 'Claude 账号',
+			'web.knowledge.kb.librarian.launch' => '启动',
 			'web.knowledge.kinds.all' => '全部',
 			'web.knowledge.kinds.entity' => '实体',
 			'web.knowledge.kinds.fact' => '事实',
@@ -11940,6 +11966,8 @@ extension on TranslationsZh {
 			'web.roundTable.plan.bypass' => '跳过权限 (YOLO)',
 			'web.roundTable.plan.bypassHint' => '用 bypass 标志启动会话,不再逐个请求批准。',
 			'more.title' => '更多',
+			_ => null,
+		} ?? switch (path) {
 			'more.identity.signedInAs' => '登录账号',
 			'more.identity.server' => '服务器',
 			'more.identity.tokenExpires' => '令牌到期',
@@ -11948,8 +11976,6 @@ extension on TranslationsZh {
 			'more.sections.memory' => '记忆',
 			'more.sections.system' => '系统',
 			'more.items.integrations.title' => '集成',
-			_ => null,
-		} ?? switch (path) {
 			'more.items.integrations.subtitle' => 'API 调用方 — 近期活动与错误率',
 			'more.items.activity.title' => '活动',
 			'more.items.activity.subtitle' => '集成 API 调用审计',
@@ -12454,6 +12480,8 @@ extension on TranslationsZh {
 			'integrations.form.routePrefixHelper' => '可通过 /api/v1/<前缀>/... 访问',
 			'integrations.form.fieldVersion' => '版本（可选）',
 			'integrations.form.validateBaseUrl' => '必须填写 Base URL。',
+			_ => null,
+		} ?? switch (path) {
 			'integrations.form.editFieldVersion' => '版本',
 			'integrations.form.apiKeyWarn' => '此 key 只显示这一次。',
 			'integrations.form.copyCopied' => '已复制',
@@ -12462,8 +12490,6 @@ extension on TranslationsZh {
 			'integrations.defaultAgent.description' => '当该集成创建会话且请求未指定相应字段时套用。请求值始终优先。',
 			'integrations.defaultAgent.providerLabel' => '默认 provider',
 			'integrations.defaultAgent.providerNone' => '无默认',
-			_ => null,
-		} ?? switch (path) {
 			'integrations.defaultAgent.modelLabel' => '默认模型',
 			'integrations.defaultAgent.modelHint' => 'provider 默认(如 opus)',
 			'integrations.defaultAgent.accountLabel' => '默认 Claude 账号',
@@ -12968,6 +12994,8 @@ extension on TranslationsZh {
 			'channels.errorPrefix.toggle' => '切换失败',
 			'channels.errorPrefix.muteToggle' => '静音切换失败',
 			'channels.errorPrefix.update' => '更新失败',
+			_ => null,
+		} ?? switch (path) {
 			'channels.errorPrefix.delete' => '删除失败',
 			'channels.failedToLoad' => '加载通道失败',
 			'channels.kinds.telegram.description' => '通过 @BotFather 创建机器人。opendray 长轮询 getUpdates 并通过 REST 发送。原生支持按钮和 reply_to_message。',
@@ -12976,8 +13004,6 @@ extension on TranslationsZh {
 			'channels.kinds.telegram.chatIdLabel' => '默认 chat ID',
 			'channels.kinds.telegram.chatIdPlaceholder' => '42（可选 — 没有 ReplyCtx 时使用）',
 			'channels.kinds.telegram.ownerUserIdsLabel' => 'Telegram 拥有者用户 ID',
-			_ => null,
-		} ?? switch (path) {
 			'channels.kinds.telegram.ownerUserIdsPlaceholder' => '123456789（多个用逗号分隔）',
 			'channels.kinds.telegram.ownerUserIdsHint' => '只有这些数字 Telegram 用户 ID 才能驱动会话、运行命令或点击按钮；其他人一律忽略。留空则允许任何人（双向聊天不推荐）。私聊 @userinfobot 获取你的 ID。',
 			'channels.kinds.telegram.chatEnabledLabel' => '双向聊天（将消息路由进会话）',
@@ -13482,6 +13508,8 @@ extension on TranslationsZh {
 			'cortexHub.hide' => '收起',
 			'cortexHub.approve' => '批准',
 			'cortexHub.reject' => '拒绝',
+			_ => null,
+		} ?? switch (path) {
 			'cortexHub.approvedToast' => '提案已批准',
 			'cortexHub.rejectedToast' => '提案已拒绝',
 			'cortexHub.actionFailed' => ({required Object error}) => '操作失败：${error}',
@@ -13490,8 +13518,6 @@ extension on TranslationsZh {
 			'cortexSettings.tabWorkers' => '工作器',
 			'cortexSettings.tabCapture' => '捕获与注入',
 			'cortexSettings.tabProviders' => 'Provider',
-			_ => null,
-		} ?? switch (path) {
 			'cortexSettings.providersHint' => '总结/agent 工作器路由到的 LLM 端点。',
 			'cortexSettings.providersEmpty' => '未配置 provider。',
 			'cortexSettings.providersManageOnWeb' => '在 web 管理端添加或编辑 provider。',

--- a/app/mobile/lib/features/knowledge/knowledge_screen.dart
+++ b/app/mobile/lib/features/knowledge/knowledge_screen.dart
@@ -1,9 +1,14 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:opendray/core/api/api_exception.dart';
+import 'package:opendray/core/api/claude_accounts_api.dart';
 import 'package:opendray/core/api/cortex_api.dart';
 import 'package:opendray/core/api/knowledge_api.dart';
+import 'package:opendray/core/api/memory_workers_api.dart';
 import 'package:opendray/core/api/project_docs_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/cortex/curation_chat_screen.dart';
@@ -308,6 +313,30 @@ class _KbViewState extends ConsumerState<_KbView> {
     await _load();
   }
 
+  // Pick the cloud agent + model (+ Claude account) for the KB Librarian,
+  // then launch the session and open it.
+  Future<void> _launchLibrarian() async {
+    final choice = await _LibrarianLaunchSheet.show(context);
+    if (choice == null || !mounted) return;
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final sid = await ref.read(cortexApiProvider).launchLibrarian(
+            provider: choice.provider,
+            model: choice.model,
+            claudeAccountId: choice.account,
+          );
+      if (!mounted || sid.isEmpty) return;
+      messenger.showSnackBar(
+        SnackBar(content: Text(t.web.knowledge.kb.librarian.launchedToast)),
+      );
+      unawaited(context.push('/session/$sid'));
+    } on Object catch (e) {
+      messenger.showSnackBar(
+        SnackBar(content: Text('${t.web.knowledge.actionFailed}: $e')),
+      );
+    }
+  }
+
   @override
   void dispose() {
     _editCtrl.dispose();
@@ -496,6 +525,15 @@ class _KbViewState extends ConsumerState<_KbView> {
                     avatar: const Icon(Icons.add, size: 16),
                     label: Text(t.web.knowledge.kb.newPage.button),
                     onPressed: _newPage,
+                  ),
+                ),
+                // Cross-page KB admin — the Librarian agent session.
+                Padding(
+                  padding: const EdgeInsets.only(left: 4, top: 4),
+                  child: ActionChip(
+                    avatar: const Icon(Icons.auto_awesome, size: 16),
+                    label: Text(t.web.knowledge.kb.librarian.button),
+                    onPressed: _launchLibrarian,
                   ),
                 ),
               ],
@@ -1032,6 +1070,168 @@ class _NewKbPageDialogState extends ConsumerState<_NewKbPageDialog> {
           child: Text(t.web.knowledge.kb.newPage.create),
         ),
       ],
+    );
+  }
+}
+
+// _LibrarianLaunchSheet picks the cloud agent + model (+ Claude account) that
+// backs the KB Librarian session. Mirrors the web LaunchLibrarianDialog.
+typedef LibrarianChoice = ({String provider, String model, String account});
+
+class _LibrarianLaunchSheet extends ConsumerStatefulWidget {
+  const _LibrarianLaunchSheet();
+
+  static Future<LibrarianChoice?> show(BuildContext context) {
+    return showModalBottomSheet<LibrarianChoice>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (_) => const _LibrarianLaunchSheet(),
+    );
+  }
+
+  @override
+  ConsumerState<_LibrarianLaunchSheet> createState() =>
+      _LibrarianLaunchSheetState();
+}
+
+class _LibrarianLaunchSheetState
+    extends ConsumerState<_LibrarianLaunchSheet> {
+  // Every worker-backed CLI. grok/opencode use a single host login, so only
+  // claude shows an account picker.
+  static const _providers = <({String id, String label})>[
+    (id: 'claude', label: 'Claude'),
+    (id: 'codex', label: 'Codex'),
+    (id: 'antigravity', label: 'Antigravity'),
+    (id: 'grok', label: 'Grok'),
+    (id: 'opencode', label: 'OpenCode'),
+  ];
+  String _provider = 'claude';
+  String _model = '';
+  String _account = '';
+  List<ModelOption> _models = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadModels();
+  }
+
+  Future<void> _loadModels() async {
+    try {
+      final m =
+          await ref.read(memoryWorkersApiProvider).listAgentModels(_provider);
+      if (mounted) setState(() => _models = m);
+    } on Object {
+      if (mounted) setState(() => _models = const []);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final accounts = ref.watch(claudeAccountsListProvider).asData?.value
+            .where((a) => a.enabled)
+            .toList() ??
+        const [];
+    return Padding(
+      padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(t.web.knowledge.kb.librarian.title,
+                  style: theme.textTheme.titleMedium),
+              const SizedBox(height: 4),
+              Text(t.web.knowledge.kb.librarian.dialogHint,
+                  style: theme.textTheme.bodySmall),
+              const SizedBox(height: 16),
+              DropdownButtonFormField<String>(
+                initialValue: _provider,
+                isExpanded: true,
+                decoration: InputDecoration(
+                  labelText: t.web.knowledge.kb.librarian.provider,
+                  isDense: true,
+                  border: const OutlineInputBorder(),
+                ),
+                items: [
+                  for (final p in _providers)
+                    DropdownMenuItem(value: p.id, child: Text(p.label)),
+                ],
+                onChanged: (v) {
+                  if (v == null) return;
+                  setState(() {
+                    _provider = v;
+                    _model = '';
+                    _account = '';
+                    _models = const [];
+                  });
+                  _loadModels();
+                },
+              ),
+              const SizedBox(height: 12),
+              DropdownButtonFormField<String>(
+                initialValue: _models.any((m) => m.id == _model) ? _model : '',
+                isExpanded: true,
+                decoration: InputDecoration(
+                  labelText: t.web.cortex.chat.modelLabel,
+                  isDense: true,
+                  border: const OutlineInputBorder(),
+                ),
+                items: [
+                  DropdownMenuItem(
+                      value: '', child: Text(t.web.cortex.chat.modelCliDefault)),
+                  for (final m in _models)
+                    DropdownMenuItem(value: m.id, child: Text(m.label)),
+                ],
+                onChanged: (v) => setState(() => _model = v ?? ''),
+              ),
+              if (_provider == 'claude' && accounts.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                DropdownButtonFormField<String>(
+                  initialValue:
+                      accounts.any((a) => a.id == _account) ? _account : '',
+                  isExpanded: true,
+                  decoration: InputDecoration(
+                    labelText: t.web.knowledge.kb.librarian.account,
+                    isDense: true,
+                    border: const OutlineInputBorder(),
+                  ),
+                  items: [
+                    DropdownMenuItem(
+                        value: '',
+                        child: Text(t.web.cortex.chat.accountDefault)),
+                    for (final a in accounts)
+                      DropdownMenuItem(
+                          value: a.id, child: Text(a.displayName)),
+                  ],
+                  onChanged: (v) => setState(() => _account = v ?? ''),
+                ),
+              ],
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed: () => Navigator.of(context).pop((
+                    provider: _provider,
+                    model: _model,
+                    account: _provider == 'claude' ? _account : '',
+                  )),
+                  child: Text(t.web.knowledge.kb.librarian.launch),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/app/shared/src/lib/cortex.ts
+++ b/app/shared/src/lib/cortex.ts
@@ -236,6 +236,18 @@ export async function escalateConversation(
   )
 }
 
+// Launch the cross-page KB Librarian session (a knowledge-base admin agent
+// whose memory MCP has the global-KB write tools). Returns the new session id
+// so the UI can navigate to it. All fields optional; defaults to claude.
+export async function launchKBLibrarian(
+  input: { provider?: string; model?: string; claude_account_id?: string } = {},
+): Promise<{ session_id: string }> {
+  return api<{ session_id: string }>('/api/v1/cortex/librarian', {
+    method: 'POST',
+    body: input,
+  })
+}
+
 export async function closeConversation(id: string): Promise<void> {
   await api(`/api/v1/cortex/conversations/${id}/close`, { method: 'POST' })
 }

--- a/app/web/src/pages/Knowledge.tsx
+++ b/app/web/src/pages/Knowledge.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useRef, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Link } from '@tanstack/react-router'
+import { Link, useNavigate } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
+import { launchKBLibrarian } from '@/lib/cortex'
+import { listAgentModels, type AgentProviderID } from '@/lib/memoryWorkers'
+import { listClaudeAccounts } from '@/lib/claudeAccounts'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
@@ -36,7 +39,7 @@ import {
 } from '@/lib/projectDocs'
 import { CurationChat } from '@/components/cortex/CurationChat'
 import { Switch } from '@/components/ui/switch'
-import { Loader2, Plus } from 'lucide-react'
+import { Loader2, Plus, Sparkles } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -306,6 +309,7 @@ function KnowledgeBaseView() {
   const [showProposal, setShowProposal] = useState(false)
   const [chatOpen, setChatOpen] = useState(false)
   const [newPageOpen, setNewPageOpen] = useState(false)
+  const [librarianOpen, setLibrarianOpen] = useState(false)
 
   // The knowledge blueprint: the page set is data, not a constant.
   const blueprint = useQuery({
@@ -432,6 +436,16 @@ function KnowledgeBaseView() {
         >
           <Plus className="h-3 w-3" />
           {t('web.knowledge.kb.newPage.button')}
+        </button>
+        {/* Cross-page KB admin — launch the Librarian agent session that can
+            organize/create/edit any KB page (vs the per-page Discuss chat). */}
+        <button
+          onClick={() => setLibrarianOpen(true)}
+          className="text-muted-foreground hover:text-foreground flex items-center gap-1 rounded px-2 py-1.5 text-left text-xs"
+          title={t('web.knowledge.kb.librarian.hint')}
+        >
+          <Sparkles className="h-3 w-3" />
+          {t('web.knowledge.kb.librarian.button')}
         </button>
       </div>
 
@@ -619,7 +633,167 @@ function KnowledgeBaseView() {
         onOpenChange={setNewPageOpen}
         onCreated={(slug) => select(slug)}
       />
+
+      {librarianOpen && (
+        <LaunchLibrarianDialog onClose={() => setLibrarianOpen(false)} />
+      )}
     </div>
+  )
+}
+
+// LaunchLibrarianDialog picks the cloud agent + model (+ Claude account) that
+// backs the KB Librarian session, then spawns it and navigates to the session.
+// Mounted only while open so its state resets each time.
+function LaunchLibrarianDialog({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  // Provider is a plain string (not AgentProviderID) so the Librarian can
+  // offer every worker-backed CLI — grok/opencode included — independent of
+  // the discuss-chat's narrower union.
+  const [provider, setProvider] = useState('claude')
+  const [model, setModel] = useState('')
+  const [account, setAccount] = useState('')
+
+  const modelsQuery = useQuery({
+    queryKey: ['agent-models', provider],
+    queryFn: () => listAgentModels(provider as AgentProviderID),
+    staleTime: 60 * 60 * 1000,
+  })
+  const accountsQuery = useQuery({
+    queryKey: ['claude-accounts'],
+    queryFn: listClaudeAccounts,
+    enabled: provider === 'claude',
+  })
+  const accounts = (accountsQuery.data ?? []).filter((a) => a.enabled)
+
+  const launch = useMutation({
+    mutationFn: () =>
+      launchKBLibrarian({
+        provider,
+        model: model.trim() || undefined,
+        claude_account_id:
+          provider === 'claude' ? account.trim() || undefined : undefined,
+      }),
+    onSuccess: ({ session_id }) => {
+      toast.success(t('web.knowledge.kb.librarian.launchedToast'))
+      onClose()
+      navigate({ to: '/sessions', search: { open: session_id } })
+    },
+    onError: (e: Error) =>
+      toast.error(t('web.knowledge.actionFailed'), { description: e.message }),
+  })
+
+  // Every worker-backed CLI (matches the backend session providers + the
+  // memory MCP's KB tools attach to any of them). grok/opencode use a single
+  // host login, so no per-agent account picker — only claude is multi-account.
+  const LIB_PROVIDERS: { id: string; label: string }[] = [
+    { id: 'claude', label: 'Claude' },
+    { id: 'codex', label: 'Codex' },
+    { id: 'antigravity', label: 'Antigravity' },
+    { id: 'grok', label: 'Grok' },
+    { id: 'opencode', label: 'OpenCode' },
+  ]
+  const MODEL_DEFAULT = '__default__'
+  const ACCOUNT_DEFAULT = '__default__'
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('web.knowledge.kb.librarian.title')}</DialogTitle>
+          <DialogDescription>
+            {t('web.knowledge.kb.librarian.dialogHint')}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs text-muted-foreground">
+              {t('web.knowledge.kb.librarian.provider')}
+            </span>
+            <Select
+              value={provider}
+              onValueChange={(v) => {
+                setProvider(v)
+                setModel('')
+                setAccount('')
+              }}
+            >
+              <SelectTrigger className="h-8 text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {LIB_PROVIDERS.map((p) => (
+                  <SelectItem key={p.id} value={p.id}>
+                    {p.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs text-muted-foreground">
+              {t('web.cortex.chat.modelLabel')}
+            </span>
+            <Select
+              value={model === '' ? MODEL_DEFAULT : model}
+              onValueChange={(v) => setModel(v === MODEL_DEFAULT ? '' : v)}
+            >
+              <SelectTrigger className="h-8 text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={MODEL_DEFAULT}>
+                  {t('web.cortex.chat.modelCliDefault')}
+                </SelectItem>
+                {(modelsQuery.data ?? []).map((m) => (
+                  <SelectItem key={m.id} value={m.id}>
+                    {m.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {provider === 'claude' && accounts.length > 0 && (
+            <div className="flex flex-col gap-1.5">
+              <span className="text-xs text-muted-foreground">
+                {t('web.knowledge.kb.librarian.account')}
+              </span>
+              <Select
+                value={account === '' ? ACCOUNT_DEFAULT : account}
+                onValueChange={(v) =>
+                  setAccount(v === ACCOUNT_DEFAULT ? '' : v)
+                }
+              >
+                <SelectTrigger className="h-8 text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ACCOUNT_DEFAULT}>
+                    {t('web.cortex.chat.accountDefault')}
+                  </SelectItem>
+                  {accounts.map((a) => (
+                    <SelectItem key={a.id} value={a.id}>
+                      {a.display_name || a.name || a.id}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            {t('web.knowledge.kb.cancel')}
+          </Button>
+          <Button disabled={launch.isPending} onClick={() => launch.mutate()}>
+            {launch.isPending && <Loader2 className="mr-1 h-3 w-3 animate-spin" />}
+            {t('web.knowledge.kb.librarian.launch')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }
 

--- a/cmd/opendray/mcp_memory.go
+++ b/cmd/opendray/mcp_memory.go
@@ -100,6 +100,11 @@ type memMCPConfig struct {
 	apiKey   string
 	scope    string
 	scopeKey string
+	// kbAdmin lights up the global-KB write tools (kb_list/kb_page_upsert/
+	// kb_page_write/kb_page_delete). Set (OPENDRAY_KB_ADMIN=1) ONLY on the
+	// "KB Librarian" session by the session adapter; every other session's
+	// memory MCP omits it, so no ordinary session can rewrite the KB.
+	kbAdmin bool
 }
 
 func loadMemMCPConfig() (memMCPConfig, error) {
@@ -108,6 +113,7 @@ func loadMemMCPConfig() (memMCPConfig, error) {
 		apiKey:   os.Getenv("OPENDRAY_API_KEY"),
 		scope:    os.Getenv("OPENDRAY_MEMORY_SCOPE"),
 		scopeKey: os.Getenv("OPENDRAY_MEMORY_SCOPE_KEY"),
+		kbAdmin:  os.Getenv("OPENDRAY_KB_ADMIN") == "1",
 	}
 	if c.baseURL == "" {
 		return c, errors.New("mcp-memory: OPENDRAY_BASE_URL is required")
@@ -194,7 +200,13 @@ func (s *memMCPServer) handle(raw []byte) {
 	case "ping":
 		s.respond(req.ID, map[string]any{})
 	case "tools/list":
-		s.respond(req.ID, map[string]any{"tools": toolDefs})
+		tools := toolDefs
+		// The KB Librarian session (OPENDRAY_KB_ADMIN=1) additionally sees
+		// the global-KB write tools; no other session does.
+		if s.cfg.kbAdmin {
+			tools = append(append([]map[string]any{}, toolDefs...), kbAdminToolDefs...)
+		}
+		s.respond(req.ID, map[string]any{"tools": tools})
 	case "tools/call":
 		s.handleToolCall(req)
 	default:
@@ -609,6 +621,69 @@ var toolDefs = []map[string]any{
 	},
 }
 
+// kbAdminToolDefs are the global-KB curation tools, listed ONLY for the KB
+// Librarian session (OPENDRAY_KB_ADMIN=1). They let a cross-page admin agent
+// organize the whole knowledge base — unlike the per-page Discuss chat.
+var kbAdminToolDefs = []map[string]any{
+	{
+		"name": "kb_list",
+		"description": "List every global knowledge page (kb_* pages) with its " +
+			"config: slug, title, description, nature (foundational|emergent), " +
+			"inject flag, pinned flag, and lock state. Use this FIRST to see the " +
+			"whole knowledge base before creating, editing, or reorganizing pages.",
+		"inputSchema": map[string]any{"type": "object", "properties": map[string]any{}},
+	},
+	{
+		"name": "kb_page_upsert",
+		"description": "Create a new global knowledge page, or update an existing " +
+			"page's CONFIG (title, description, nature, inject). Slug is the primary " +
+			"key: a new kb_* slug creates the page; an existing slug edits its config " +
+			"(the body is written separately via kb_page_write). Fields not given are " +
+			"preserved on an existing page. Pinned/reserved flags are never changed.",
+		"inputSchema": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"slug":        map[string]any{"type": "string", "description": "kb_* slug, e.g. kb_network_topology. Lowercase, must start with kb_."},
+				"title":       map[string]any{"type": "string", "description": "Human title shown in the KB nav."},
+				"description": map[string]any{"type": "string", "description": "One sentence: what belongs on this page. Drives on-demand retrieval."},
+				"nature":      map[string]any{"type": "string", "description": "'foundational' (binding rule, injected in full) or 'emergent' (reference). Default emergent."},
+				"inject":      map[string]any{"type": "boolean", "description": "true = inject full body into every spawn; false (default) = index only, fetched on demand."},
+			},
+			"required": []string{"slug"},
+		},
+	},
+	{
+		"name": "kb_page_write",
+		"description": "Write/replace the BODY (markdown content) of a global " +
+			"knowledge page. Respects human locks: if the page was last edited by the " +
+			"operator it files a PROPOSAL for approval; otherwise it writes directly. " +
+			"Read the current body first (doc_read) so you edit rather than clobber.",
+		"inputSchema": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"slug":    map[string]any{"type": "string", "description": "Existing kb_* slug to write."},
+				"content": map[string]any{"type": "string", "description": "The full new markdown body for the page."},
+				"reason":  map[string]any{"type": "string", "description": "Short note on what changed (shown to the operator on a locked-page proposal)."},
+			},
+			"required": []string{"slug", "content"},
+		},
+	},
+	{
+		"name": "kb_page_delete",
+		"description": "Delete a global knowledge page. Pinned pages (the classic " +
+			"four + Integrations) are reserved and cannot be deleted — the gateway " +
+			"refuses and this returns that error. Deleting keeps the page's body row, " +
+			"which resurrects if the slug is re-added.",
+		"inputSchema": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"slug": map[string]any{"type": "string", "description": "kb_* slug to remove."},
+			},
+			"required": []string{"slug"},
+		},
+	},
+}
+
 // handleToolCall dispatches one MCP tools/call invocation to the
 // appropriate gateway endpoint. All tool calls share the same
 // scope/scope_key envelope coming from env so the agent never has
@@ -689,6 +764,23 @@ func (s *memMCPServer) dispatchTool(name string, args json.RawMessage) (result a
 		result, err = s.callSkillDistill(args)
 	case "project_search":
 		result, err = s.callProjectSearch(args)
+	case "kb_list", "kb_page_upsert", "kb_page_write", "kb_page_delete":
+		// KB Librarian write surface — refuse unless this session was
+		// spawned as the KB admin (defence in depth: the tools aren't even
+		// listed otherwise, but a client could still call by name).
+		if !s.cfg.kbAdmin {
+			return nil, errors.New("kb admin tools require the KB Librarian session"), true
+		}
+		switch name {
+		case "kb_list":
+			result, err = s.callKBList()
+		case "kb_page_upsert":
+			result, err = s.callKBPageUpsert(args)
+		case "kb_page_write":
+			result, err = s.callKBPageWrite(args)
+		case "kb_page_delete":
+			result, err = s.callKBPageDelete(args)
+		}
 	default:
 		return nil, nil, false
 	}
@@ -1099,6 +1191,206 @@ func (s *memMCPServer) callProjectDocSet(kind string, args json.RawMessage) (any
 	}, nil
 }
 
+// ── KB Librarian tools (OPENDRAY_KB_ADMIN sessions only) ─────────────
+
+const kbGlobalCwd = "__global__"
+
+// kbSection mirrors the blueprint Section fields the librarian needs.
+type kbSection struct {
+	Slug        string `json:"slug"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Position    int    `json:"position"`
+	Maintainer  string `json:"maintainer_mode"`
+	WritePolicy string `json:"write_policy"`
+	PromptHint  string `json:"prompt_hint"`
+	Pinned      bool   `json:"pinned"`
+	Inject      bool   `json:"inject"`
+	Nature      string `json:"nature"`
+}
+
+// kbListSections fetches the global knowledge blueprint (all kb_* pages).
+func (s *memMCPServer) kbListSections() ([]kbSection, error) {
+	var out struct {
+		Sections []kbSection `json:"sections"`
+	}
+	if err := s.gatewayGetJSON("/api/v1/project-docs/blueprint?cwd="+urlQuery(kbGlobalCwd), &out); err != nil {
+		return nil, err
+	}
+	return out.Sections, nil
+}
+
+// callKBList returns the whole knowledge base as a config table so the
+// librarian can plan cross-page work.
+func (s *memMCPServer) callKBList() (any, error) {
+	secs, err := s.kbListSections()
+	if err != nil {
+		return nil, err
+	}
+	var b strings.Builder
+	b.WriteString("Global knowledge pages:\n\n")
+	for _, sec := range secs {
+		if !strings.HasPrefix(sec.Slug, "kb_") {
+			continue
+		}
+		inject := "on-demand"
+		if sec.Inject {
+			inject = "injected"
+		}
+		nature := sec.Nature
+		if nature == "" {
+			nature = "emergent"
+		}
+		fmt.Fprintf(&b, "- %s (%s) — nature=%s, %s", sec.Title, sec.Slug, nature, inject)
+		if sec.Pinned {
+			b.WriteString(", pinned")
+		}
+		if d := strings.TrimSpace(sec.Description); d != "" {
+			b.WriteString(" — " + d)
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("\nRead a page's body with doc_read(slug). Edit config with " +
+		"kb_page_upsert, body with kb_page_write, remove with kb_page_delete.")
+	return textResult(b.String()), nil
+}
+
+// callKBPageUpsert creates a page (new slug) or edits an existing page's
+// config, preserving fields the caller omits + reserved flags.
+func (s *memMCPServer) callKBPageUpsert(args json.RawMessage) (any, error) {
+	var in struct {
+		Slug        string  `json:"slug"`
+		Title       *string `json:"title"`
+		Description *string `json:"description"`
+		Nature      *string `json:"nature"`
+		Inject      *bool   `json:"inject"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, fmt.Errorf("bad arguments: %w", err)
+	}
+	slug := strings.TrimSpace(in.Slug)
+	if !strings.HasPrefix(slug, "kb_") {
+		return nil, errors.New("slug must start with kb_")
+	}
+
+	// Start from the existing section (edit) or sensible defaults (create).
+	secs, err := s.kbListSections()
+	if err != nil {
+		return nil, err
+	}
+	sec := kbSection{
+		Slug: slug, Position: 99, Maintainer: "ai",
+		WritePolicy: "proposal", Nature: "emergent",
+	}
+	existing := false
+	for _, e := range secs {
+		if e.Slug == slug {
+			sec, existing = e, true
+			break
+		}
+	}
+	if in.Title != nil {
+		sec.Title = strings.TrimSpace(*in.Title)
+	}
+	if in.Description != nil {
+		sec.Description = strings.TrimSpace(*in.Description)
+	}
+	if in.Nature != nil {
+		n := strings.TrimSpace(*in.Nature)
+		if n != "foundational" && n != "emergent" {
+			return nil, errors.New("nature must be 'foundational' or 'emergent'")
+		}
+		sec.Nature = n
+	}
+	if in.Inject != nil {
+		sec.Inject = *in.Inject
+	}
+	if strings.TrimSpace(sec.Title) == "" {
+		return nil, errors.New("title is required when creating a page")
+	}
+
+	body := map[string]any{
+		"cwd": kbGlobalCwd, "slug": sec.Slug, "title": sec.Title,
+		"description": sec.Description, "position": sec.Position,
+		"maintainer_mode": sec.Maintainer, "write_policy": sec.WritePolicy,
+		"prompt_hint": sec.PromptHint, "pinned": sec.Pinned,
+		"inject": sec.Inject, "nature": sec.Nature,
+	}
+	if err := s.gatewayPutJSON("/api/v1/project-docs/blueprint/"+urlQuery(slug), body, nil); err != nil {
+		return nil, err
+	}
+	verb := "Created"
+	if existing {
+		verb = "Updated the config of"
+	}
+	return textResult(fmt.Sprintf("%s knowledge page %s (%q). Write its body with kb_page_write(slug=%q).", verb, slug, sec.Title, slug)), nil
+}
+
+// callKBPageWrite writes a page body, honouring human locks: an
+// operator-locked page files a proposal; an unlocked page writes directly.
+func (s *memMCPServer) callKBPageWrite(args json.RawMessage) (any, error) {
+	var in struct {
+		Slug    string `json:"slug"`
+		Content string `json:"content"`
+		Reason  string `json:"reason"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, fmt.Errorf("bad arguments: %w", err)
+	}
+	slug := strings.TrimSpace(in.Slug)
+	if !strings.HasPrefix(slug, "kb_") {
+		return nil, errors.New("slug must start with kb_")
+	}
+	if strings.TrimSpace(in.Content) == "" {
+		return nil, errors.New("content is required")
+	}
+	// Lock check: a page last written by the operator is human-locked.
+	var doc struct {
+		UpdatedBy string `json:"updated_by"`
+	}
+	if err := s.gatewayGetJSON("/api/v1/project-docs/"+urlQuery(slug)+"?cwd="+urlQuery(kbGlobalCwd), &doc); err != nil {
+		return nil, err
+	}
+	if doc.UpdatedBy == "operator" {
+		// Locked → file a proposal the operator approves in the inbox.
+		body := map[string]any{
+			"cwd": kbGlobalCwd, "kind": slug,
+			"proposed_content": in.Content, "reason": in.Reason,
+		}
+		var out struct {
+			ID string `json:"id"`
+		}
+		if err := s.gatewayPostJSON("/api/v1/project-doc-proposals/", body, &out); err != nil {
+			return nil, err
+		}
+		return textResult(fmt.Sprintf("Page %s is human-locked, so I filed proposal %s — the body is unchanged until the operator approves it in the inbox.", slug, out.ID)), nil
+	}
+	// Unlocked → write the live body directly (authored by the agent).
+	body := map[string]any{"cwd": kbGlobalCwd, "content": in.Content, "updated_by": "agent"}
+	if err := s.gatewayPutJSON("/api/v1/project-docs/"+urlQuery(slug), body, nil); err != nil {
+		return nil, err
+	}
+	return textResult(fmt.Sprintf("Wrote the body of %s directly (it was AI-maintained, not human-locked).", slug)), nil
+}
+
+// callKBPageDelete removes a page; the gateway refuses pinned/reserved ones.
+func (s *memMCPServer) callKBPageDelete(args json.RawMessage) (any, error) {
+	var in struct {
+		Slug string `json:"slug"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, fmt.Errorf("bad arguments: %w", err)
+	}
+	slug := strings.TrimSpace(in.Slug)
+	if !strings.HasPrefix(slug, "kb_") {
+		return nil, errors.New("slug must start with kb_")
+	}
+	if err := s.gatewayDelete("/api/v1/project-docs/blueprint/" + urlQuery(slug) + "?cwd=" + urlQuery(kbGlobalCwd)); err != nil {
+		return nil, err
+	}
+	return textResult(fmt.Sprintf("Removed knowledge page %s from the blueprint.", slug)), nil
+}
+
 // callSessionLogAppend writes one journal entry. Used by both
 // session_log_append (kind=manual) and decision_record (kind=
 // decision); the schema then tags it author=agent so the operator
@@ -1278,6 +1570,55 @@ func (s *memMCPServer) gatewayGetJSON(path string, out any) error {
 		if err := json.Unmarshal(rawRes, out); err != nil {
 			return fmt.Errorf("decode response: %w", err)
 		}
+	}
+	return nil
+}
+
+// gatewayPutJSON is the PUT twin of gatewayPostJSON (used by the KB
+// Librarian write tools: blueprint upsert + direct doc writes).
+func (s *memMCPServer) gatewayPutJSON(path string, body, out any) error {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("encode body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, s.cfg.baseURL+path, bytes.NewReader(raw))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+s.cfg.apiKey)
+	res, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("gateway %s: %w", path, err)
+	}
+	defer res.Body.Close()
+	rawRes, _ := io.ReadAll(res.Body)
+	if res.StatusCode/100 != 2 {
+		return fmt.Errorf("gateway %s returned %d: %s", path, res.StatusCode, string(rawRes))
+	}
+	if out != nil {
+		if err := json.Unmarshal(rawRes, out); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+	return nil
+}
+
+// gatewayDelete sends a DELETE to a gateway path (KB page removal).
+func (s *memMCPServer) gatewayDelete(path string) error {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, s.cfg.baseURL+path, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+s.cfg.apiKey)
+	res, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("gateway %s: %w", path, err)
+	}
+	defer res.Body.Close()
+	rawRes, _ := io.ReadAll(res.Body)
+	if res.StatusCode/100 != 2 {
+		return fmt.Errorf("gateway %s returned %d: %s", path, res.StatusCode, string(rawRes))
 	}
 	return nil
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2459,13 +2459,16 @@ func (l *curationSessionLauncher) Launch(ctx context.Context, spec cortex.Launch
 	if providerID == "" {
 		providerID = "claude"
 	}
-	sess, err := l.mgr.Create(ctx, session.CreateRequest{
+	req := session.CreateRequest{
 		Name:            spec.Name,
 		ProviderID:      providerID,
 		Model:           spec.Model,
 		ClaudeAccountID: spec.ClaudeAccountID,
 		Cwd:             spec.Cwd,
-	})
+	}
+	// KB Librarian spawns light up the global-KB write tools on the memory MCP.
+	req.SetKBAdmin(spec.KBAdmin)
+	sess, err := l.mgr.Create(ctx, req)
 	if err != nil {
 		return "", err
 	}

--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -457,22 +457,28 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 	// — that belief came from testing the wrong file; see the renderMCP
 	// antigravity arm.)
 	if sp.memory.Enabled && p.Manifest.Capabilities.SupportsMcp && !isIntegration {
+		memEnv := map[string]string{
+			"OPENDRAY_BASE_URL":     sp.memory.BaseURL,
+			"OPENDRAY_API_KEY":      sp.memory.APIKey,
+			"OPENDRAY_MEMORY_SCOPE": defaultStr(sp.memory.Scope, "project"),
+		}
+		// KB Librarian spawn only: light up the global-KB write tools
+		// (kb_page_upsert/write/delete). Every other operator/CLI session
+		// gets the same memory MCP without them, so no ordinary session can
+		// rewrite the knowledge base. Integrations never reach here at all.
+		if session.KBAdminFromContext(ctx) {
+			memEnv["OPENDRAY_KB_ADMIN"] = "1"
+		}
+		// Scope key is the cwd at spawn time — populated below inside
+		// Prepare since we need the live session.Cwd from context. (Except
+		// antigravity, whose entry lands in a HOME-global file shared across
+		// sessions: there the mcp-memory subprocess derives the scope from
+		// its own cwd, which agy sets to the session workspace.)
 		servers = append(servers, MCPServer{
 			Name:    "opendray-memory",
 			Command: sp.memory.BinaryPath,
 			Args:    []string{"mcp-memory"},
-			Env: map[string]string{
-				"OPENDRAY_BASE_URL":     sp.memory.BaseURL,
-				"OPENDRAY_API_KEY":      sp.memory.APIKey,
-				"OPENDRAY_MEMORY_SCOPE": defaultStr(sp.memory.Scope, "project"),
-				// Scope key is the cwd at spawn time — populated below
-				// inside Prepare since we need access to the live
-				// session.Cwd from context. (Except antigravity, whose
-				// entry lands in a HOME-global file shared across
-				// sessions: there the mcp-memory subprocess derives the
-				// scope from its own cwd, which agy sets to the session
-				// workspace.)
-			},
+			Env:     memEnv,
 		})
 	}
 	// Auto-attach the Database-tool MCP server under the same rules as

--- a/internal/cortex/conversation_handler.go
+++ b/internal/cortex/conversation_handler.go
@@ -162,6 +162,28 @@ func (h *Handlers) sendConversationMessage(w http.ResponseWriter, r *http.Reques
 	writeJSON(w, http.StatusAccepted, msg)
 }
 
+// launchLibrarian spawns the cross-page KB Librarian session and returns its
+// id so the UI can navigate to it. Body (all optional): {provider, model,
+// claude_account_id}. Defaults to the claude agent.
+func (h *Handlers) launchLibrarian(w http.ResponseWriter, r *http.Request) {
+	if !h.curationReady(w) {
+		return
+	}
+	var body struct {
+		Provider        string `json:"provider"`
+		Model           string `json:"model"`
+		ClaudeAccountID string `json:"claude_account_id"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	sid, err := h.curation.LaunchLibrarian(r.Context(), body.Provider, body.Model, body.ClaudeAccountID)
+	if err != nil {
+		h.log.Error("launch librarian failed", "err", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"session_id": sid})
+}
+
 func (h *Handlers) escalateConversation(w http.ResponseWriter, r *http.Request) {
 	if !h.curationReady(w) {
 		return

--- a/internal/cortex/conversation_worker.go
+++ b/internal/cortex/conversation_worker.go
@@ -34,6 +34,9 @@ type LaunchSpec struct {
 	ProviderID      string
 	Model           string
 	ClaudeAccountID string
+	// KBAdmin spawns the session as the KB Librarian: its memory MCP gets
+	// the global-KB write tools. Only the LaunchLibrarian path sets this.
+	KBAdmin bool
 }
 
 // SessionLauncher escalates a conversation into a full agent session.
@@ -407,6 +410,45 @@ func (s *CurationService) applyRevision(ctx context.Context, conv Conversation, 
 // Escalate promotes the conversation to a full agent session seeded
 // with the transcript + instructions to ground the revision in the
 // codebase and file changes through the standard proposal tools.
+// kbLibrarianSeed is the system brief for the cross-page KB administrator.
+const kbLibrarianSeed = `You are the **KB Librarian** — the operator's cross-page knowledge-base administrator for opendray's Cortex knowledge system. Unlike the per-page "Discuss with AI" chat, you can organize the WHOLE knowledge base.
+
+Your tools (opendray-memory MCP):
+- kb_list — see every global knowledge page with its config + lock state. **Call this FIRST.**
+- doc_read(slug) / project_search(query) — read a page's body / find relevant content.
+- kb_page_upsert(slug, title?, description?, nature?, inject?) — create a new kb_* page or edit an existing page's config.
+- kb_page_write(slug, content, reason?) — write a page's body. An operator-locked page files a PROPOSAL (the operator approves it); an AI-maintained page is written directly. Always doc_read first so you EDIT rather than clobber.
+- kb_page_delete(slug) — remove a page (pinned pages like the classic four + Integrations are reserved and refuse deletion).
+
+Guidelines:
+- Wait for the operator to tell you what to organize/create/fix. Then plan across pages, confirm anything destructive, and use the tools above.
+- Keep pages focused: prefer a new fine-grained kb_* page over bloating an existing one. Write a precise one-sentence description — it drives on-demand retrieval.
+- The classic four (kb_infrastructure/conventions/lessons/reusable) have i18n-managed titles and fixed natures — reconfigure/rewrite them carefully, and never expect to delete them.
+
+Start by calling kb_list and greeting the operator with a short summary of the current knowledge base, then ask what they'd like to do.`
+
+// LaunchLibrarian spawns the KB Librarian session — a cross-page knowledge
+// administrator whose memory MCP has the global-KB write tools. Runs in the
+// opendray workspace cwd (KB lives under the global sentinel, not a project).
+func (s *CurationService) LaunchLibrarian(ctx context.Context, providerID, model, claudeAccountID string) (string, error) {
+	if s.sessions == nil {
+		return "", errors.New("cortex: session launcher not configured")
+	}
+	cwd := strings.TrimSpace(s.workspaceCwd)
+	if cwd == "" {
+		return "", errors.New("cortex: no workspace cwd configured for the KB Librarian")
+	}
+	return s.sessions.Launch(ctx, LaunchSpec{
+		Cwd:             cwd,
+		Name:            "KB Librarian",
+		SeedPrompt:      kbLibrarianSeed,
+		ProviderID:      providerID,
+		Model:           model,
+		ClaudeAccountID: claudeAccountID,
+		KBAdmin:         true,
+	})
+}
+
 func (s *CurationService) Escalate(ctx context.Context, conversationID string) (Conversation, error) {
 	if s.sessions == nil {
 		return Conversation{}, errors.New("cortex: session launcher not configured")

--- a/internal/cortex/handler.go
+++ b/internal/cortex/handler.go
@@ -108,6 +108,8 @@ func (h *Handlers) Mount(r chi.Router) {
 		h.mountSettings(r)
 		// Curation conversations (Phase 4).
 		h.mountConversations(r)
+		// KB Librarian — launch a cross-page knowledge-base admin session.
+		r.Post("/librarian", h.launchLibrarian)
 		h.docs.Mount(r)
 		h.mem.Mount(r)
 		if h.know != nil {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -590,6 +590,7 @@ func (m *Manager) Create(ctx context.Context, req CreateRequest) (Session, error
 		ParentSessionID:      req.ParentSessionID,
 		Origin:               origin,
 		IntegrationID:        req.integrationID,
+		KBAdmin:              req.kbAdmin,
 		StartedAt:            time.Now().UTC(),
 	}
 	if sess.Args == nil {
@@ -682,7 +683,7 @@ func (m *Manager) spawn(ctx context.Context, sess Session, reactivate bool) (*ru
 	if sess.ProviderID == "antigravity" {
 		accountID = sess.AntigravityAccountID
 	}
-	resolveCtx := WithModel(WithOrigin(WithAccountID(ctx, accountID), sess.Origin), sess.Model)
+	resolveCtx := WithKBAdmin(WithModel(WithOrigin(WithAccountID(ctx, accountID), sess.Origin), sess.Model), sess.KBAdmin)
 	// Integration spawn profile: provider-agnostic MCP servers + system
 	// prompt + auto-approve declared on the creating integration, applied
 	// to every session it spawns (create AND reactivate). Best-effort: a

--- a/internal/session/provider.go
+++ b/internal/session/provider.go
@@ -166,6 +166,31 @@ func OriginFromContext(ctx context.Context) Origin {
 	return ""
 }
 
+// ── KB-admin propagation ───────────────────────────────────────────
+//
+// The "KB Librarian" session is the only one allowed to CREATE / EDIT /
+// DELETE global knowledge pages through the memory MCP. Prepare-time it
+// flips an env flag on the auto-attached memory MCP so its KB-write tools
+// light up ONLY for that session; every other operator/CLI session gets
+// the same MCP without those tools. Like origin/cwd, this rides context
+// because it isn't a Resolve() parameter.
+
+type kbAdminCtxKey struct{}
+
+// WithKBAdmin marks ctx as a KB-admin (Librarian) spawn. false is a no-op.
+func WithKBAdmin(ctx context.Context, on bool) context.Context {
+	if !on {
+		return ctx
+	}
+	return context.WithValue(ctx, kbAdminCtxKey{}, true)
+}
+
+// KBAdminFromContext reports whether WithKBAdmin marked this spawn.
+func KBAdminFromContext(ctx context.Context) bool {
+	v, _ := ctx.Value(kbAdminCtxKey{}).(bool)
+	return v
+}
+
 // sessionIDCtxKey + WithSessionID + SessionIDFromContext mirror the
 // cwd plumbing for the session.id, used by ambient-memory rendering
 // at spawn time. Defined here (alongside WithCwd) so callers don't

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -118,6 +118,10 @@ type Session struct {
 	// IntegrationID is set when Origin == OriginIntegration: the id
 	// of the integration whose API key created the session.
 	IntegrationID string `json:"integration_id,omitempty"`
+	// KBAdmin marks the "KB Librarian" spawn: the only session whose
+	// auto-attached memory MCP gets the global-KB write tools. Runtime-only
+	// (not persisted): a resumed Librarian loses it and must be relaunched.
+	KBAdmin bool `json:"-"`
 	// InterruptReason is the audit cause set only when State == interrupted
 	// (see InterruptCause); empty otherwise. Persisted in
 	// sessions.interrupt_reason, cleared on resume.
@@ -163,7 +167,16 @@ type CreateRequest struct {
 	// and must never be settable from the JSON body.
 	origin        Origin
 	integrationID string
+	// kbAdmin marks a KB Librarian spawn. Unexported + set only by the
+	// internal Librarian launcher (never from the JSON body), so a normal
+	// session can't grant itself global-KB write tools.
+	kbAdmin bool
 }
+
+// SetKBAdmin marks this request as a KB Librarian spawn (internal launcher
+// only). It rides a runtime flag onto the memory MCP so its KB-write tools
+// light up for this session alone.
+func (r *CreateRequest) SetKBAdmin(on bool) { r.kbAdmin = on }
 
 // SetOrigin stamps the provenance derived from the authenticated
 // principal. integrationID is only meaningful for OriginIntegration.


### PR DESCRIPTION
## Summary

The per-page **Discuss with AI** chat can only edit the single page it's bound to (good — precise). This adds the complementary piece the operator asked for: a **global KB administrator** — a real agent session (**"KB Librarian"**) that can organize, create, edit and delete **any** knowledge page across the whole base, driven conversationally.

## Security model

- The memory MCP is **never attached to third-party integration sessions** (existing `!isIntegration` gate), so the new KB-write tools can't leak to them.
- Among operator/CLI sessions, the write tools light up **only for the Librarian spawn** — gated by an `OPENDRAY_KB_ADMIN` env the session adapter sets when a spawn is marked KB-admin. No ordinary session can rewrite the KB (defence in depth: the tools aren't even listed, and dispatch refuses them, without the flag).

## What changed

**Backend**
- **session**: per-spawn KB-admin marker — `CreateRequest.SetKBAdmin()` (unexported field, internal launcher only) → `Session.KBAdmin` → `WithKBAdmin`/`KBAdminFromContext` context value, mirroring the existing origin/model plumbing. Runtime-only (a resumed Librarian relaunches).
- **catalog/adapter**: sets `OPENDRAY_KB_ADMIN=1` on the memory MCP env for KB-admin spawns only.
- **mcp-memory**: 4 tools listed + dispatched only under `OPENDRAY_KB_ADMIN`:
  - `kb_list` — the whole KB with config + lock state
  - `kb_page_upsert` — create a page / edit its config (preserves omitted + reserved fields)
  - `kb_page_write` — write the body; **operator-locked pages file a proposal**, unlocked pages write directly
  - `kb_page_delete` — pinned pages (classic four + Integrations) are refused by the store
  - They call the existing dual-auth `/project-docs` REST via the memory key.
- **cortex**: `LaunchLibrarian` spawns the session in the workspace cwd with a librarian system brief + `KBAdmin=true`; `POST /cortex/librarian` returns the session id.

**Frontend (web + mobile)**
- A **"Manage KB with AI"** action on the Knowledge page launches the Librarian and navigates to the session. + i18n (en/zh/es), slang regenerated.

## Authority (as chosen)
Full CRUD on all pages; **locked pages → proposals**, unlocked → direct writes. Pinned pages can be reconfigured/rewritten but not deleted (the store enforces this; the system re-seeds them).

## Test plan
- [x] `go build ./...`, `go vet`, `go test` for session/catalog/cortex (the one catalog failure — `TestUnmanagedBinLink` — pre-exists on main, a grok bin-link env test unrelated to this change)
- [x] web `tsc` + full build green; no new eslint errors in edited regions
- [x] `flutter analyze lib/features/knowledge` + cortex_api — no issues; slang regenerated; i18n parity 100%
- [ ] **Local manual test:** click "Manage KB with AI" → a KB Librarian session spawns; it calls `kb_list` and greets you; ask it to create a page / edit an unlocked page (direct) / edit a locked page (files a proposal in the inbox) / try to delete a pinned page (refused); confirm a NORMAL session does **not** have the kb_* tools; web + mobile parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)