### PR TITLE
refactor(mobile/knowledge): scalable list → detail KB for phones

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -2822,6 +2822,8 @@
         "discuss": "Discuss with AI",
         "discussHint": "Re-draft this policy page in conversation with the AI — locked pages get proposals, never overwrites",
         "onDemand": "on-demand",
+        "searchHint": "Search knowledge pages",
+        "searchEmpty": "No pages match your search",
         "removePage": "Remove page",
         "removePageHint": "Remove this page from the knowledge base (its content is kept and resurrects if the slug is re-added)",
         "pageRemovedToast": "Page removed",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -12,7 +12,8 @@
     "copy": "Copy",
     "enabled": "Enabled",
     "refresh": "Refresh",
-    "clear": "Clear"
+    "clear": "Clear",
+    "more": "More"
   },
   "auth": {
     "signInTitle": "Sign in",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -12,7 +12,8 @@
     "copy": "Copiar",
     "enabled": "Activado",
     "refresh": "Actualizar",
-    "clear": "Limpiar"
+    "clear": "Limpiar",
+    "more": "Más"
   },
   "auth": {
     "signInTitle": "Iniciar sesión",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -2822,6 +2822,8 @@
         "discuss": "Hablar con la IA",
         "discussHint": "Redacta de nuevo esta política conversando con la IA — las páginas bloqueadas reciben propuestas, nunca sobrescrituras",
         "onDemand": "bajo demanda",
+        "searchHint": "Buscar páginas de conocimiento",
+        "searchEmpty": "Ninguna página coincide con tu búsqueda",
         "removePage": "Quitar página",
         "removePageHint": "Quita esta página de la base de conocimiento (su contenido se conserva y vuelve si se re-añade el slug)",
         "pageRemovedToast": "Página quitada",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -2822,6 +2822,8 @@
         "discuss": "与 AI 讨论",
         "discussHint": "与 AI 对话重新制定这页方针——已锁定的页面只会产生提案，绝不覆写",
         "onDemand": "按需",
+        "searchHint": "搜索知识页",
+        "searchEmpty": "没有匹配的知识页",
         "removePage": "移除页面",
         "removePageHint": "从知识库移除此页（内容保留，重新添加同名标识即可恢复）",
         "pageRemovedToast": "页面已移除",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -12,7 +12,8 @@
     "copy": "复制",
     "enabled": "已启用",
     "refresh": "刷新",
-    "clear": "清除"
+    "clear": "清除",
+    "more": "更多"
   },
   "auth": {
     "signInTitle": "登录",

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 12345 (4115 per locale)
+/// Strings: 12348 (4116 per locale)
 ///
-/// Built on 2026-07-17 at 05:17 UTC
+/// Built on 2026-07-17 at 06:59 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 12348 (4116 per locale)
+/// Strings: 12354 (4118 per locale)
 ///
-/// Built on 2026-07-17 at 06:59 UTC
+/// Built on 2026-07-17 at 07:25 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -11273,6 +11273,12 @@ class TranslationsWebKnowledgeKbEn {
 	/// en: 'on-demand'
 	String get onDemand => 'on-demand';
 
+	/// en: 'Search knowledge pages'
+	String get searchHint => 'Search knowledge pages';
+
+	/// en: 'No pages match your search'
+	String get searchEmpty => 'No pages match your search';
+
 	/// en: 'Remove page'
 	String get removePage => 'Remove page';
 
@@ -19989,6 +19995,8 @@ extension on Translations {
 			'web.knowledge.kb.discuss' => 'Discuss with AI',
 			'web.knowledge.kb.discussHint' => 'Re-draft this policy page in conversation with the AI — locked pages get proposals, never overwrites',
 			'web.knowledge.kb.onDemand' => 'on-demand',
+			'web.knowledge.kb.searchHint' => 'Search knowledge pages',
+			'web.knowledge.kb.searchEmpty' => 'No pages match your search',
 			'web.knowledge.kb.removePage' => 'Remove page',
 			'web.knowledge.kb.removePageHint' => 'Remove this page from the knowledge base (its content is kept and resurrects if the slug is re-added)',
 			'web.knowledge.kb.pageRemovedToast' => 'Page removed',
@@ -20333,10 +20341,10 @@ extension on Translations {
 			'web.roundTable.plan.pending' => 'Pending',
 			'web.roundTable.plan.openSession' => 'Open session',
 			'web.roundTable.plan.needProject' => 'Bind a project (cwd) to run steps.',
-			'web.roundTable.plan.bindProject' => 'Bind',
-			'web.roundTable.plan.projectBound' => 'Project bound',
 			_ => null,
 		} ?? switch (path) {
+			'web.roundTable.plan.bindProject' => 'Bind',
+			'web.roundTable.plan.projectBound' => 'Project bound',
 			'web.roundTable.plan.runTitle' => 'Run step',
 			'web.roundTable.plan.runStep' => 'Run',
 			'web.roundTable.plan.account' => 'Account',
@@ -20847,10 +20855,10 @@ extension on Translations {
 			'integrations.noMatchingCalls' => 'No matching calls in the log yet.',
 			'integrations.directionAll' => 'All',
 			'integrations.directionInbound' => 'Inbound',
-			'integrations.directionOutbound' => 'Outbound',
-			'integrations.form.validateRequired' => 'Name, base URL, and route prefix are required.',
 			_ => null,
 		} ?? switch (path) {
+			'integrations.directionOutbound' => 'Outbound',
+			'integrations.form.validateRequired' => 'Name, base URL, and route prefix are required.',
 			'integrations.form.fieldName' => 'Name',
 			'integrations.form.fieldNameHint' => 'My Bot',
 			'integrations.form.fieldBaseUrl' => 'Base URL',
@@ -21361,10 +21369,10 @@ extension on Translations {
 			'channels.deleteBody' => 'Stops the channel and removes its configuration. In-flight notifications addressed to it will be dropped silently.',
 			'channels.snacks.testDispatched' => 'Test message dispatched.',
 			'channels.snacks.channelEnabled' => 'Channel enabled.',
-			'channels.snacks.channelDisabled' => 'Channel disabled.',
-			'channels.snacks.channelMuted' => 'Channel muted.',
 			_ => null,
 		} ?? switch (path) {
+			'channels.snacks.channelDisabled' => 'Channel disabled.',
+			'channels.snacks.channelMuted' => 'Channel muted.',
 			'channels.snacks.channelUnmuted' => 'Channel unmuted.',
 			'channels.snacks.configUpdated' => 'Channel config updated.',
 			'channels.snacks.channelDeleted' => 'Channel deleted.',
@@ -21875,10 +21883,10 @@ extension on Translations {
 			'cortexHub.knowledge' => 'Knowledge',
 			'cortexHub.knowledgeDesc' => 'Cross-project, distilled expertise.',
 			'cortexHub.quarantineBadge' => ({required Object count}) => '${count} to review',
-			'cortexHub.pendingBadge' => ({required Object count}) => '${count} pending',
-			'cortexHub.disabled' => 'disabled',
 			_ => null,
 		} ?? switch (path) {
+			'cortexHub.pendingBadge' => ({required Object count}) => '${count} pending',
+			'cortexHub.disabled' => 'disabled',
 			'cortexHub.inboxTitle' => ({required Object count}) => 'Pending proposals (${count})',
 			'cortexHub.inboxHint' => 'AI-proposed updates to project notes and KB pages. Approve to publish, reject to drop.',
 			'cortexHub.kbLabel' => 'Knowledge Base',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -119,6 +119,9 @@ class TranslationsCommonEn {
 
 	/// en: 'Clear'
 	String get clear => 'Clear';
+
+	/// en: 'More'
+	String get more => 'More';
 }
 
 // Path: auth
@@ -17777,6 +17780,7 @@ extension on Translations {
 			'common.enabled' => 'Enabled',
 			'common.refresh' => 'Refresh',
 			'common.clear' => 'Clear',
+			'common.more' => 'More',
 			'auth.signInTitle' => 'Sign in',
 			'auth.changeServer' => 'Change',
 			'auth.username' => 'Username',
@@ -18275,9 +18279,9 @@ extension on Translations {
 			'web.project.inbox.rejectedToast' => 'Rejected',
 			'web.project.inbox.rejectFailedToast' => 'Reject failed',
 			'web.project.inbox.sessionPrefix' => 'ses',
-			'web.project.inbox.warning' => ({required Object label}) => 'Approve will REPLACE the current ${label} entirely.',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.inbox.warning' => ({required Object label}) => 'Approve will REPLACE the current ${label} entirely.',
 			'web.project.inbox.warningSuffix' => 'Review the diff below; this isn\'t a merge.',
 			'web.project.inbox.current' => 'Current',
 			'web.project.inbox.proposed' => 'Proposed',
@@ -18789,9 +18793,9 @@ extension on Translations {
 			'web.channels.toasts.updated' => 'Channel updated',
 			'web.channels.toasts.muted' => 'Channel muted',
 			'web.channels.toasts.unmuted' => 'Channel unmuted',
-			'web.channels.dialog.editTitle' => 'Edit channel',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.dialog.editTitle' => 'Edit channel',
 			'web.channels.dialog.createTitle' => 'Register channel',
 			'web.channels.dialog.descriptionBridge' => 'External adapter (Python/Node/...) connects via WebSocket and presents this token.',
 			'web.channels.dialog.descriptionDefault' => 'Configure messaging integration.',
@@ -19303,9 +19307,9 @@ extension on Translations {
 			'web.backups.schedulesTab.columns.enabled' => 'Enabled',
 			'web.backups.schedulesTab.columns.actions' => 'Actions',
 			'web.backups.schedulesTab.keepCount' => ({required Object count}) => '${count} backups',
-			'web.backups.schedulesTab.deleteTooltip' => 'Delete',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.schedulesTab.deleteTooltip' => 'Delete',
 			'web.backups.newSchedule.title' => 'New backup schedule',
 			'web.backups.newSchedule.targetLabel' => 'Targets',
 			'web.backups.newSchedule.targetsHint' => 'Pick one or more — the same backup is written to each (3-2-1).',
@@ -19817,9 +19821,9 @@ extension on Translations {
 			'web.memoryAmbient.rules.dialog.createdToast' => ({required Object name}) => 'Rule ${name} created',
 			'web.memoryAmbient.rules.dialog.createFailedToast' => 'Create failed',
 			'web.memoryAmbient.profiles.title' => 'Injection profiles',
-			'web.memoryAmbient.profiles.addButton' => 'Add profile',
 			_ => null,
 		} ?? switch (path) {
+			'web.memoryAmbient.profiles.addButton' => 'Add profile',
 			'web.memoryAmbient.profiles.intro' => 'At spawn time opendray prepends a markdown banner of recent project memories to the agent\'s system prompt — IF a profile is configured. Without a profile, the model still uses memory_search on demand.',
 			'web.memoryAmbient.profiles.empty' => 'No injection profile. Memories are not auto-injected at spawn — model still uses memory_search.',
 			'web.memoryAmbient.profiles.row.globalDefault' => 'global default',
@@ -20331,9 +20335,9 @@ extension on Translations {
 			'web.roundTable.plan.needProject' => 'Bind a project (cwd) to run steps.',
 			'web.roundTable.plan.bindProject' => 'Bind',
 			'web.roundTable.plan.projectBound' => 'Project bound',
-			'web.roundTable.plan.runTitle' => 'Run step',
 			_ => null,
 		} ?? switch (path) {
+			'web.roundTable.plan.runTitle' => 'Run step',
 			'web.roundTable.plan.runStep' => 'Run',
 			'web.roundTable.plan.account' => 'Account',
 			'web.roundTable.plan.accountDefault' => 'Default',
@@ -20845,9 +20849,9 @@ extension on Translations {
 			'integrations.directionInbound' => 'Inbound',
 			'integrations.directionOutbound' => 'Outbound',
 			'integrations.form.validateRequired' => 'Name, base URL, and route prefix are required.',
-			'integrations.form.fieldName' => 'Name',
 			_ => null,
 		} ?? switch (path) {
+			'integrations.form.fieldName' => 'Name',
 			'integrations.form.fieldNameHint' => 'My Bot',
 			'integrations.form.fieldBaseUrl' => 'Base URL',
 			'integrations.form.fieldRoutePrefix' => 'Route prefix',
@@ -21359,9 +21363,9 @@ extension on Translations {
 			'channels.snacks.channelEnabled' => 'Channel enabled.',
 			'channels.snacks.channelDisabled' => 'Channel disabled.',
 			'channels.snacks.channelMuted' => 'Channel muted.',
-			'channels.snacks.channelUnmuted' => 'Channel unmuted.',
 			_ => null,
 		} ?? switch (path) {
+			'channels.snacks.channelUnmuted' => 'Channel unmuted.',
 			'channels.snacks.configUpdated' => 'Channel config updated.',
 			'channels.snacks.channelDeleted' => 'Channel deleted.',
 			'channels.errorPrefix.test' => 'Test failed',
@@ -21873,9 +21877,9 @@ extension on Translations {
 			'cortexHub.quarantineBadge' => ({required Object count}) => '${count} to review',
 			'cortexHub.pendingBadge' => ({required Object count}) => '${count} pending',
 			'cortexHub.disabled' => 'disabled',
-			'cortexHub.inboxTitle' => ({required Object count}) => 'Pending proposals (${count})',
 			_ => null,
 		} ?? switch (path) {
+			'cortexHub.inboxTitle' => ({required Object count}) => 'Pending proposals (${count})',
 			'cortexHub.inboxHint' => 'AI-proposed updates to project notes and KB pages. Approve to publish, reject to drop.',
 			'cortexHub.kbLabel' => 'Knowledge Base',
 			'cortexHub.preview' => 'Preview',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -92,6 +92,7 @@ class _TranslationsCommonEs extends TranslationsCommonEn {
 	@override String get enabled => 'Activado';
 	@override String get refresh => 'Actualizar';
 	@override String get clear => 'Limpiar';
+	@override String get more => 'Más';
 }
 
 // Path: auth
@@ -9427,6 +9428,7 @@ extension on TranslationsEs {
 			'common.enabled' => 'Activado',
 			'common.refresh' => 'Actualizar',
 			'common.clear' => 'Limpiar',
+			'common.more' => 'Más',
 			'auth.signInTitle' => 'Iniciar sesión',
 			'auth.changeServer' => 'Cambiar',
 			'auth.username' => 'Usuario',
@@ -9925,9 +9927,9 @@ extension on TranslationsEs {
 			'web.project.inbox.rejectedToast' => 'Rechazado',
 			'web.project.inbox.rejectFailedToast' => 'Error al rechazar',
 			'web.project.inbox.sessionPrefix' => 'ses',
-			'web.project.inbox.warning' => ({required Object label}) => 'Aprobar REEMPLAZARÁ por completo el ${label} actual.',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.inbox.warning' => ({required Object label}) => 'Aprobar REEMPLAZARÁ por completo el ${label} actual.',
 			'web.project.inbox.warningSuffix' => 'Revisa el diff de abajo; esto no es una fusión.',
 			'web.project.inbox.current' => 'Actual',
 			'web.project.inbox.proposed' => 'Propuesto',
@@ -10439,9 +10441,9 @@ extension on TranslationsEs {
 			'web.channels.toasts.updated' => 'Canal actualizado',
 			'web.channels.toasts.muted' => 'Canal silenciado',
 			'web.channels.toasts.unmuted' => 'Canal reactivado',
-			'web.channels.dialog.editTitle' => 'Editar canal',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.dialog.editTitle' => 'Editar canal',
 			'web.channels.dialog.createTitle' => 'Registrar canal',
 			'web.channels.dialog.descriptionBridge' => 'Un adaptador externo (Python/Node/...) se conecta vía WebSocket y presenta este token.',
 			'web.channels.dialog.descriptionDefault' => 'Configura la integración de mensajería.',
@@ -10953,9 +10955,9 @@ extension on TranslationsEs {
 			'web.backups.schedulesTab.columns.enabled' => 'Habilitada',
 			'web.backups.schedulesTab.columns.actions' => 'Acciones',
 			'web.backups.schedulesTab.keepCount' => ({required Object count}) => '${count} copias de seguridad',
-			'web.backups.schedulesTab.deleteTooltip' => 'Eliminar',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.schedulesTab.deleteTooltip' => 'Eliminar',
 			'web.backups.newSchedule.title' => 'Nueva programación de copia de seguridad',
 			'web.backups.newSchedule.targetLabel' => 'Destinos',
 			'web.backups.newSchedule.targetsHint' => 'Elige uno o más: la misma copia se escribe en cada destino (3-2-1).',
@@ -11467,9 +11469,9 @@ extension on TranslationsEs {
 			'web.memoryAmbient.rules.dialog.createdToast' => ({required Object name}) => 'Regla ${name} creada',
 			'web.memoryAmbient.rules.dialog.createFailedToast' => 'La creación falló',
 			'web.memoryAmbient.profiles.title' => 'Perfiles de inyección',
-			'web.memoryAmbient.profiles.addButton' => 'Añadir perfil',
 			_ => null,
 		} ?? switch (path) {
+			'web.memoryAmbient.profiles.addButton' => 'Añadir perfil',
 			'web.memoryAmbient.profiles.intro' => 'Al arrancar, opendray antepone un banner en markdown con las memorias recientes del proyecto al system prompt del agente, SI hay un perfil configurado. Sin un perfil, el modelo sigue usando memory_search bajo demanda.',
 			'web.memoryAmbient.profiles.empty' => 'No hay perfil de inyección. Las memorias no se inyectan automáticamente al arrancar; el modelo sigue usando memory_search.',
 			'web.memoryAmbient.profiles.row.globalDefault' => 'predeterminado global',
@@ -11981,9 +11983,9 @@ extension on TranslationsEs {
 			'web.roundTable.plan.needProject' => 'Vincula un proyecto (cwd) para ejecutar pasos.',
 			'web.roundTable.plan.bindProject' => 'Vincular',
 			'web.roundTable.plan.projectBound' => 'Proyecto vinculado',
-			'web.roundTable.plan.runTitle' => 'Ejecutar paso',
 			_ => null,
 		} ?? switch (path) {
+			'web.roundTable.plan.runTitle' => 'Ejecutar paso',
 			'web.roundTable.plan.runStep' => 'Ejecutar',
 			'web.roundTable.plan.account' => 'Cuenta',
 			'web.roundTable.plan.accountDefault' => 'Predeterminada',
@@ -12495,9 +12497,9 @@ extension on TranslationsEs {
 			'integrations.directionInbound' => 'Entrantes',
 			'integrations.directionOutbound' => 'Salientes',
 			'integrations.form.validateRequired' => 'El nombre, la URL base y el prefijo de ruta son obligatorios.',
-			'integrations.form.fieldName' => 'Nombre',
 			_ => null,
 		} ?? switch (path) {
+			'integrations.form.fieldName' => 'Nombre',
 			'integrations.form.fieldNameHint' => 'Mi Bot',
 			'integrations.form.fieldBaseUrl' => 'URL base',
 			'integrations.form.fieldRoutePrefix' => 'Prefijo de ruta',
@@ -13009,9 +13011,9 @@ extension on TranslationsEs {
 			'channels.snacks.channelEnabled' => 'Canal activado.',
 			'channels.snacks.channelDisabled' => 'Canal desactivado.',
 			'channels.snacks.channelMuted' => 'Canal silenciado.',
-			'channels.snacks.channelUnmuted' => 'Sonido del canal reactivado.',
 			_ => null,
 		} ?? switch (path) {
+			'channels.snacks.channelUnmuted' => 'Sonido del canal reactivado.',
 			'channels.snacks.configUpdated' => 'Configuración del canal actualizada.',
 			'channels.snacks.channelDeleted' => 'Canal eliminado.',
 			'channels.errorPrefix.test' => 'Error en la prueba',
@@ -13523,9 +13525,9 @@ extension on TranslationsEs {
 			'cortexHub.quarantineBadge' => ({required Object count}) => '${count} por revisar',
 			'cortexHub.pendingBadge' => ({required Object count}) => '${count} pendientes',
 			'cortexHub.disabled' => 'desactivado',
-			'cortexHub.inboxTitle' => ({required Object count}) => 'Propuestas pendientes (${count})',
 			_ => null,
 		} ?? switch (path) {
+			'cortexHub.inboxTitle' => ({required Object count}) => 'Propuestas pendientes (${count})',
 			'cortexHub.inboxHint' => 'Actualizaciones propuestas por la IA para notas y páginas KB. Aprueba para publicar, rechaza para descartar.',
 			'cortexHub.kbLabel' => 'Base de conocimiento',
 			'cortexHub.preview' => 'Vista previa',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -5752,6 +5752,8 @@ class _TranslationsWebKnowledgeKbEs extends TranslationsWebKnowledgeKbEn {
 	@override String get discuss => 'Hablar con la IA';
 	@override String get discussHint => 'Redacta de nuevo esta política conversando con la IA — las páginas bloqueadas reciben propuestas, nunca sobrescrituras';
 	@override String get onDemand => 'bajo demanda';
+	@override String get searchHint => 'Buscar páginas de conocimiento';
+	@override String get searchEmpty => 'Ninguna página coincide con tu búsqueda';
 	@override String get removePage => 'Quitar página';
 	@override String get removePageHint => 'Quita esta página de la base de conocimiento (su contenido se conserva y vuelve si se re-añade el slug)';
 	@override String get pageRemovedToast => 'Página quitada';
@@ -11637,6 +11639,8 @@ extension on TranslationsEs {
 			'web.knowledge.kb.discuss' => 'Hablar con la IA',
 			'web.knowledge.kb.discussHint' => 'Redacta de nuevo esta política conversando con la IA — las páginas bloqueadas reciben propuestas, nunca sobrescrituras',
 			'web.knowledge.kb.onDemand' => 'bajo demanda',
+			'web.knowledge.kb.searchHint' => 'Buscar páginas de conocimiento',
+			'web.knowledge.kb.searchEmpty' => 'Ninguna página coincide con tu búsqueda',
 			'web.knowledge.kb.removePage' => 'Quitar página',
 			'web.knowledge.kb.removePageHint' => 'Quita esta página de la base de conocimiento (su contenido se conserva y vuelve si se re-añade el slug)',
 			'web.knowledge.kb.pageRemovedToast' => 'Página quitada',
@@ -11981,10 +11985,10 @@ extension on TranslationsEs {
 			'web.roundTable.plan.pending' => 'Pendiente',
 			'web.roundTable.plan.openSession' => 'Abrir sesión',
 			'web.roundTable.plan.needProject' => 'Vincula un proyecto (cwd) para ejecutar pasos.',
-			'web.roundTable.plan.bindProject' => 'Vincular',
-			'web.roundTable.plan.projectBound' => 'Proyecto vinculado',
 			_ => null,
 		} ?? switch (path) {
+			'web.roundTable.plan.bindProject' => 'Vincular',
+			'web.roundTable.plan.projectBound' => 'Proyecto vinculado',
 			'web.roundTable.plan.runTitle' => 'Ejecutar paso',
 			'web.roundTable.plan.runStep' => 'Ejecutar',
 			'web.roundTable.plan.account' => 'Cuenta',
@@ -12495,10 +12499,10 @@ extension on TranslationsEs {
 			'integrations.noMatchingCalls' => 'Aún no hay llamadas coincidentes en el registro.',
 			'integrations.directionAll' => 'Todas',
 			'integrations.directionInbound' => 'Entrantes',
-			'integrations.directionOutbound' => 'Salientes',
-			'integrations.form.validateRequired' => 'El nombre, la URL base y el prefijo de ruta son obligatorios.',
 			_ => null,
 		} ?? switch (path) {
+			'integrations.directionOutbound' => 'Salientes',
+			'integrations.form.validateRequired' => 'El nombre, la URL base y el prefijo de ruta son obligatorios.',
 			'integrations.form.fieldName' => 'Nombre',
 			'integrations.form.fieldNameHint' => 'Mi Bot',
 			'integrations.form.fieldBaseUrl' => 'URL base',
@@ -13009,10 +13013,10 @@ extension on TranslationsEs {
 			'channels.deleteBody' => 'Detiene el canal y elimina su configuración. Las notificaciones en curso dirigidas a él se descartarán de forma silenciosa.',
 			'channels.snacks.testDispatched' => 'Mensaje de prueba enviado.',
 			'channels.snacks.channelEnabled' => 'Canal activado.',
-			'channels.snacks.channelDisabled' => 'Canal desactivado.',
-			'channels.snacks.channelMuted' => 'Canal silenciado.',
 			_ => null,
 		} ?? switch (path) {
+			'channels.snacks.channelDisabled' => 'Canal desactivado.',
+			'channels.snacks.channelMuted' => 'Canal silenciado.',
 			'channels.snacks.channelUnmuted' => 'Sonido del canal reactivado.',
 			'channels.snacks.configUpdated' => 'Configuración del canal actualizada.',
 			'channels.snacks.channelDeleted' => 'Canal eliminado.',
@@ -13523,10 +13527,10 @@ extension on TranslationsEs {
 			'cortexHub.knowledge' => 'Conocimiento',
 			'cortexHub.knowledgeDesc' => 'Experiencia destilada entre proyectos.',
 			'cortexHub.quarantineBadge' => ({required Object count}) => '${count} por revisar',
-			'cortexHub.pendingBadge' => ({required Object count}) => '${count} pendientes',
-			'cortexHub.disabled' => 'desactivado',
 			_ => null,
 		} ?? switch (path) {
+			'cortexHub.pendingBadge' => ({required Object count}) => '${count} pendientes',
+			'cortexHub.disabled' => 'desactivado',
 			'cortexHub.inboxTitle' => ({required Object count}) => 'Propuestas pendientes (${count})',
 			'cortexHub.inboxHint' => 'Actualizaciones propuestas por la IA para notas y páginas KB. Aprueba para publicar, rechaza para descartar.',
 			'cortexHub.kbLabel' => 'Base de conocimiento',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -92,6 +92,7 @@ class _TranslationsCommonZh extends TranslationsCommonEn {
 	@override String get enabled => '已启用';
 	@override String get refresh => '刷新';
 	@override String get clear => '清除';
+	@override String get more => '更多';
 }
 
 // Path: auth
@@ -9427,6 +9428,7 @@ extension on TranslationsZh {
 			'common.enabled' => '已启用',
 			'common.refresh' => '刷新',
 			'common.clear' => '清除',
+			'common.more' => '更多',
 			'auth.signInTitle' => '登录',
 			'auth.changeServer' => '更换',
 			'auth.username' => '用户名',
@@ -9925,9 +9927,9 @@ extension on TranslationsZh {
 			'web.project.inbox.rejectedToast' => '已驳回',
 			'web.project.inbox.rejectFailedToast' => '驳回失败',
 			'web.project.inbox.sessionPrefix' => 'ses',
-			'web.project.inbox.warning' => ({required Object label}) => '批准将完全替换当前${label}。',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.inbox.warning' => ({required Object label}) => '批准将完全替换当前${label}。',
 			'web.project.inbox.warningSuffix' => '请检查下方 diff；这不是合并。',
 			'web.project.inbox.current' => '当前',
 			'web.project.inbox.proposed' => '提议',
@@ -10439,9 +10441,9 @@ extension on TranslationsZh {
 			'web.channels.toasts.updated' => '频道已更新',
 			'web.channels.toasts.muted' => '频道已静音',
 			'web.channels.toasts.unmuted' => '频道已取消静音',
-			'web.channels.dialog.editTitle' => '编辑频道',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.dialog.editTitle' => '编辑频道',
 			'web.channels.dialog.createTitle' => '注册频道',
 			'web.channels.dialog.descriptionBridge' => '外部适配器（Python/Node/...）通过 WebSocket 连接并出示此 token。',
 			'web.channels.dialog.descriptionDefault' => '配置消息集成。',
@@ -10953,9 +10955,9 @@ extension on TranslationsZh {
 			'web.backups.schedulesTab.columns.enabled' => '启用',
 			'web.backups.schedulesTab.columns.actions' => '操作',
 			'web.backups.schedulesTab.keepCount' => ({required Object count}) => '${count} 个备份',
-			'web.backups.schedulesTab.deleteTooltip' => '删除',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.schedulesTab.deleteTooltip' => '删除',
 			'web.backups.newSchedule.title' => '新建备份计划',
 			'web.backups.newSchedule.targetLabel' => '目标',
 			'web.backups.newSchedule.targetsHint' => '选择一个或多个 —— 同一份备份会写入每个目标（3-2-1）。',
@@ -11467,9 +11469,9 @@ extension on TranslationsZh {
 			'web.memoryAmbient.rules.dialog.createdToast' => ({required Object name}) => '已创建规则 ${name}',
 			'web.memoryAmbient.rules.dialog.createFailedToast' => '创建失败',
 			'web.memoryAmbient.profiles.title' => 'Injection Profiles',
-			'web.memoryAmbient.profiles.addButton' => '添加 profile',
 			_ => null,
 		} ?? switch (path) {
+			'web.memoryAmbient.profiles.addButton' => '添加 profile',
 			'web.memoryAmbient.profiles.intro' => 'spawn 时，opendray 会把最近的项目记忆作为一段 markdown banner 拼接到 agent 的 system prompt — 前提是配置了 profile。没有 profile 时，模型仍可按需调用 memory_search。',
 			'web.memoryAmbient.profiles.empty' => '尚无 injection profile。spawn 时不会自动注入记忆 — 模型仍可使用 memory_search。',
 			'web.memoryAmbient.profiles.row.globalDefault' => '全局默认',
@@ -11981,9 +11983,9 @@ extension on TranslationsZh {
 			'web.roundTable.plan.needProject' => '运行步骤前需绑定项目(cwd)。',
 			'web.roundTable.plan.bindProject' => '绑定',
 			'web.roundTable.plan.projectBound' => '项目已绑定',
-			'web.roundTable.plan.runTitle' => '运行此步',
 			_ => null,
 		} ?? switch (path) {
+			'web.roundTable.plan.runTitle' => '运行此步',
 			'web.roundTable.plan.runStep' => '运行',
 			'web.roundTable.plan.account' => '账号',
 			'web.roundTable.plan.accountDefault' => '默认',
@@ -12495,9 +12497,9 @@ extension on TranslationsZh {
 			'integrations.directionInbound' => '入站',
 			'integrations.directionOutbound' => '出站',
 			'integrations.form.validateRequired' => '名称、Base URL、路由前缀必填。',
-			'integrations.form.fieldName' => '名称',
 			_ => null,
 		} ?? switch (path) {
+			'integrations.form.fieldName' => '名称',
 			'integrations.form.fieldNameHint' => 'My Bot',
 			'integrations.form.fieldBaseUrl' => 'Base URL',
 			'integrations.form.fieldRoutePrefix' => '路由前缀',
@@ -13009,9 +13011,9 @@ extension on TranslationsZh {
 			'channels.snacks.channelEnabled' => '通道已启用。',
 			'channels.snacks.channelDisabled' => '通道已停用。',
 			'channels.snacks.channelMuted' => '通道已静音。',
-			'channels.snacks.channelUnmuted' => '通道已取消静音。',
 			_ => null,
 		} ?? switch (path) {
+			'channels.snacks.channelUnmuted' => '通道已取消静音。',
 			'channels.snacks.configUpdated' => '通道配置已更新。',
 			'channels.snacks.channelDeleted' => '通道已删除。',
 			'channels.errorPrefix.test' => '测试失败',
@@ -13523,9 +13525,9 @@ extension on TranslationsZh {
 			'cortexHub.quarantineBadge' => ({required Object count}) => '${count} 条待审',
 			'cortexHub.pendingBadge' => ({required Object count}) => '${count} 条待审',
 			'cortexHub.disabled' => '已禁用',
-			'cortexHub.inboxTitle' => ({required Object count}) => '待审提案（${count}）',
 			_ => null,
 		} ?? switch (path) {
+			'cortexHub.inboxTitle' => ({required Object count}) => '待审提案（${count}）',
 			'cortexHub.inboxHint' => 'AI 对项目笔记与知识库页面提出的更新。批准即发布，拒绝即丢弃。',
 			'cortexHub.kbLabel' => '知识库',
 			'cortexHub.preview' => '预览',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -5752,6 +5752,8 @@ class _TranslationsWebKnowledgeKbZh extends TranslationsWebKnowledgeKbEn {
 	@override String get discuss => '与 AI 讨论';
 	@override String get discussHint => '与 AI 对话重新制定这页方针——已锁定的页面只会产生提案，绝不覆写';
 	@override String get onDemand => '按需';
+	@override String get searchHint => '搜索知识页';
+	@override String get searchEmpty => '没有匹配的知识页';
 	@override String get removePage => '移除页面';
 	@override String get removePageHint => '从知识库移除此页（内容保留，重新添加同名标识即可恢复）';
 	@override String get pageRemovedToast => '页面已移除';
@@ -11637,6 +11639,8 @@ extension on TranslationsZh {
 			'web.knowledge.kb.discuss' => '与 AI 讨论',
 			'web.knowledge.kb.discussHint' => '与 AI 对话重新制定这页方针——已锁定的页面只会产生提案，绝不覆写',
 			'web.knowledge.kb.onDemand' => '按需',
+			'web.knowledge.kb.searchHint' => '搜索知识页',
+			'web.knowledge.kb.searchEmpty' => '没有匹配的知识页',
 			'web.knowledge.kb.removePage' => '移除页面',
 			'web.knowledge.kb.removePageHint' => '从知识库移除此页（内容保留，重新添加同名标识即可恢复）',
 			'web.knowledge.kb.pageRemovedToast' => '页面已移除',
@@ -11981,10 +11985,10 @@ extension on TranslationsZh {
 			'web.roundTable.plan.pending' => '待运行',
 			'web.roundTable.plan.openSession' => '打开会话',
 			'web.roundTable.plan.needProject' => '运行步骤前需绑定项目(cwd)。',
-			'web.roundTable.plan.bindProject' => '绑定',
-			'web.roundTable.plan.projectBound' => '项目已绑定',
 			_ => null,
 		} ?? switch (path) {
+			'web.roundTable.plan.bindProject' => '绑定',
+			'web.roundTable.plan.projectBound' => '项目已绑定',
 			'web.roundTable.plan.runTitle' => '运行此步',
 			'web.roundTable.plan.runStep' => '运行',
 			'web.roundTable.plan.account' => '账号',
@@ -12495,10 +12499,10 @@ extension on TranslationsZh {
 			'integrations.noMatchingCalls' => '日志中暂无匹配的调用。',
 			'integrations.directionAll' => '全部',
 			'integrations.directionInbound' => '入站',
-			'integrations.directionOutbound' => '出站',
-			'integrations.form.validateRequired' => '名称、Base URL、路由前缀必填。',
 			_ => null,
 		} ?? switch (path) {
+			'integrations.directionOutbound' => '出站',
+			'integrations.form.validateRequired' => '名称、Base URL、路由前缀必填。',
 			'integrations.form.fieldName' => '名称',
 			'integrations.form.fieldNameHint' => 'My Bot',
 			'integrations.form.fieldBaseUrl' => 'Base URL',
@@ -13009,10 +13013,10 @@ extension on TranslationsZh {
 			'channels.deleteBody' => '停止该通道并移除其配置。仍在传输中的通知会被静默丢弃。',
 			'channels.snacks.testDispatched' => '测试消息已发送。',
 			'channels.snacks.channelEnabled' => '通道已启用。',
-			'channels.snacks.channelDisabled' => '通道已停用。',
-			'channels.snacks.channelMuted' => '通道已静音。',
 			_ => null,
 		} ?? switch (path) {
+			'channels.snacks.channelDisabled' => '通道已停用。',
+			'channels.snacks.channelMuted' => '通道已静音。',
 			'channels.snacks.channelUnmuted' => '通道已取消静音。',
 			'channels.snacks.configUpdated' => '通道配置已更新。',
 			'channels.snacks.channelDeleted' => '通道已删除。',
@@ -13523,10 +13527,10 @@ extension on TranslationsZh {
 			'cortexHub.knowledge' => '知识',
 			'cortexHub.knowledgeDesc' => '跨项目沉淀的专业知识。',
 			'cortexHub.quarantineBadge' => ({required Object count}) => '${count} 条待审',
-			'cortexHub.pendingBadge' => ({required Object count}) => '${count} 条待审',
-			'cortexHub.disabled' => '已禁用',
 			_ => null,
 		} ?? switch (path) {
+			'cortexHub.pendingBadge' => ({required Object count}) => '${count} 条待审',
+			'cortexHub.disabled' => '已禁用',
 			'cortexHub.inboxTitle' => ({required Object count}) => '待审提案（${count}）',
 			'cortexHub.inboxHint' => 'AI 对项目笔记与知识库页面提出的更新。批准即发布，拒绝即丢弃。',
 			'cortexHub.kbLabel' => '知识库',

--- a/app/mobile/lib/features/knowledge/knowledge_screen.dart
+++ b/app/mobile/lib/features/knowledge/knowledge_screen.dart
@@ -258,53 +258,78 @@ class _KbView extends ConsumerStatefulWidget {
   ConsumerState<_KbView> createState() => _KbViewState();
 }
 
+// The KB tab is a scalable, searchable LIST of knowledge pages — it grows
+// gracefully as the operator/AI create more kb_* docs, unlike the old
+// horizontal chip strip that ran out of room. Tapping a page opens a
+// full-screen detail (_KbPageScreen). New page / Librarian live on a FAB.
 class _KbViewState extends ConsumerState<_KbView> {
   static const _global = '__global__';
-  static const _foundational = ['kb_infrastructure', 'kb_conventions'];
-  static const _emergent = ['kb_lessons', 'kb_reusable'];
-  String _kind = 'kb_infrastructure';
-  final _editCtrl = TextEditingController();
-  bool _editing = false;
-  bool _busy = false;
-  bool _showProposal = false;
-  AsyncValue<ProjectDoc> _doc = const AsyncValue.loading();
-  List<DocProposal> _proposals = const [];
-  // Custom kb_* pages beyond the four classics, pulled from the global
-  // blueprint so operator/AI-added pages show up + are selectable.
-  List<BlueprintSection> _extra = const [];
-
   static const _classic = {
     'kb_infrastructure',
     'kb_conventions',
     'kb_lessons',
     'kb_reusable',
   };
-
-  bool get _isFoundational =>
-      _foundational.contains(_kind) ||
-      _extra.any((s) => s.slug == _kind && s.nature == 'foundational');
+  AsyncValue<List<BlueprintSection>> _sections = const AsyncValue.loading();
+  final _searchCtrl = TextEditingController();
+  String _query = '';
 
   @override
   void initState() {
     super.initState();
-    _load();
     _loadSections();
+  }
+
+  @override
+  void dispose() {
+    _searchCtrl.dispose();
+    super.dispose();
   }
 
   Future<void> _loadSections() async {
     try {
       final secs = await ref.read(cortexApiProvider).listSections(_global);
-      if (!mounted) return;
-      setState(() => _extra =
-          secs.where((s) => !_classic.contains(s.slug)).toList()
-            ..sort((a, b) => a.position.compareTo(b.position)));
-    } on Object catch (_) {
-      // Non-fatal: the four classics still render without the extras.
+      final kb = secs.where((s) => s.slug.startsWith('kb_')).toList()
+        ..sort((a, b) => a.position.compareTo(b.position));
+      if (mounted) setState(() => _sections = AsyncValue.data(kb));
+    } on Object catch (e, st) {
+      if (mounted) setState(() => _sections = AsyncValue.error(e, st));
     }
   }
 
-  // Create a new kb_* knowledge page (a global blueprint section), then
-  // select it. Mirrors the web PageSettingsDialog (create mode).
+  // Localized display name: the classic four use i18n labels; custom pages
+  // use their stored title (slug minus kb_ as a last resort).
+  String _label(BlueprintSection s) {
+    switch (s.slug) {
+      case 'kb_conventions':
+        return t.web.knowledge.kb.kinds.kb_conventions;
+      case 'kb_lessons':
+        return t.web.knowledge.kb.kinds.kb_lessons;
+      case 'kb_reusable':
+        return t.web.knowledge.kb.kinds.kb_reusable;
+      case 'kb_infrastructure':
+        return t.web.knowledge.kb.kinds.kb_infrastructure;
+      default:
+        return s.title.isNotEmpty ? s.title : s.slug.replaceFirst('kb_', '');
+    }
+  }
+
+  Future<void> _openPage(BlueprintSection s) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => _KbPageScreen(
+          slug: s.slug,
+          title: _label(s),
+          section: s,
+          editable: !_classic.contains(s.slug),
+          isFoundational: s.nature == 'foundational',
+        ),
+      ),
+    );
+    // The detail may have changed a body / config; refresh the list.
+    if (mounted) unawaited(_loadSections());
+  }
+
   Future<void> _newPage() async {
     final created = await showDialog<BlueprintSection>(
       context: context,
@@ -312,45 +337,7 @@ class _KbViewState extends ConsumerState<_KbView> {
     );
     if (created == null || !mounted) return;
     await _loadSections();
-    if (!mounted) return;
-    setState(() => _kind = created.slug);
-    await _load();
-  }
-
-  // Edit the selected custom page's config (title/description/nature/inject).
-  // Only offered for operator-added pages (the classic four aren't editable
-  // here). Mirrors the web PageSettingsDialog (edit mode).
-  Future<void> _editPageSettings(BlueprintSection section) async {
-    final saved = await showDialog<BlueprintSection>(
-      context: context,
-      builder: (_) => _KbPageDialog(section: section),
-    );
-    if (saved == null || !mounted) return;
-    await _loadSections();
-    if (mounted) setState(() {});
-  }
-
-  // Dispatch a ⋮ overflow-menu action for the current page.
-  void _onKbAction(_KbAction action, ProjectDoc d, BlueprintSection? custom) {
-    switch (action) {
-      case _KbAction.discuss:
-        Navigator.of(context).push(
-          MaterialPageRoute<void>(
-            builder: (_) => CurationChatScreen(
-              targetKind: 'kb_page',
-              targetCwd: _global,
-              targetSlug: _kind,
-              onRevision: _load,
-            ),
-          ),
-        );
-      case _KbAction.unlock:
-        _unlock(d);
-      case _KbAction.regenerate:
-        _regen();
-      case _KbAction.settings:
-        if (custom != null) _editPageSettings(custom);
-    }
+    if (mounted) unawaited(_openPage(created));
   }
 
   // Pick the cloud agent + model (+ Claude account) for the KB Librarian,
@@ -377,6 +364,220 @@ class _KbViewState extends ConsumerState<_KbView> {
     }
   }
 
+  // FAB → a small sheet with the two global actions (kept off the list so it
+  // stays a clean, single-purpose browse surface).
+  void _openActions() {
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (sheetCtx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.add),
+              title: Text(t.web.knowledge.kb.newPage.button),
+              onTap: () {
+                Navigator.of(sheetCtx).pop();
+                _newPage();
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.auto_awesome),
+              title: Text(t.web.knowledge.kb.librarian.button),
+              onTap: () {
+                Navigator.of(sheetCtx).pop();
+                _launchLibrarian();
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      floatingActionButton: FloatingActionButton(
+        onPressed: _openActions,
+        tooltip: t.common.more,
+        child: const Icon(Icons.add),
+      ),
+      body: Column(
+        children: [
+          // Search — the key affordance once there are many pages.
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+            child: TextField(
+              controller: _searchCtrl,
+              onChanged: (v) => setState(() => _query = v.trim().toLowerCase()),
+              decoration: InputDecoration(
+                prefixIcon: const Icon(Icons.search, size: 20),
+                hintText: t.web.knowledge.kb.searchHint,
+                isDense: true,
+                border: const OutlineInputBorder(),
+                suffixIcon: _query.isEmpty
+                    ? null
+                    : IconButton(
+                        icon: const Icon(Icons.close, size: 18),
+                        onPressed: () {
+                          _searchCtrl.clear();
+                          setState(() => _query = '');
+                        },
+                      ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: _sections.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (e, _) => Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Text('$e', textAlign: TextAlign.center),
+                ),
+              ),
+              data: (all) {
+                bool match(BlueprintSection s) =>
+                    _query.isEmpty ||
+                    _label(s).toLowerCase().contains(_query) ||
+                    s.description.toLowerCase().contains(_query);
+                final found = [
+                  for (final s in all)
+                    if (s.nature == 'foundational' && match(s)) s
+                ];
+                final emergent = [
+                  for (final s in all)
+                    if (s.nature != 'foundational' && match(s)) s
+                ];
+                if (found.isEmpty && emergent.isEmpty) {
+                  return Center(
+                    child: Text(
+                      _query.isEmpty
+                          ? t.web.knowledge.empty
+                          : t.web.knowledge.kb.searchEmpty,
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  );
+                }
+                return RefreshIndicator(
+                  onRefresh: _loadSections,
+                  child: ListView(
+                    padding: const EdgeInsets.only(bottom: 88),
+                    children: [
+                      if (found.isNotEmpty)
+                        _groupHeader(t.web.knowledge.kb.foundational),
+                      for (final s in found) _pageTile(s),
+                      if (emergent.isNotEmpty)
+                        _groupHeader(t.web.knowledge.kb.emergent),
+                      for (final s in emergent) _pageTile(s),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _groupHeader(String text) => Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+        child: Text(
+          text.toUpperCase(),
+          style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                letterSpacing: 0.5,
+              ),
+        ),
+      );
+
+  Widget _pageTile(BlueprintSection s) {
+    final scheme = Theme.of(context).colorScheme;
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 3),
+      child: ListTile(
+        title: Text(_label(s), style: const TextStyle(fontWeight: FontWeight.w600)),
+        subtitle: s.description.isNotEmpty
+            ? Text(s.description, maxLines: 2, overflow: TextOverflow.ellipsis)
+            : null,
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (!s.inject)
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: scheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  t.web.knowledge.kb.onDemand,
+                  style: TextStyle(
+                    fontSize: 9,
+                    color: scheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            const SizedBox(width: 4),
+            Icon(Icons.chevron_right, color: scheme.onSurfaceVariant),
+          ],
+        ),
+        onTap: () => _openPage(s),
+      ),
+    );
+  }
+}
+
+// _KbPageScreen — the full-screen reader/editor for one knowledge page.
+// Splitting browse (the list) from read/edit (this screen) is what makes the
+// KB usable on a phone when there are many pages.
+class _KbPageScreen extends ConsumerStatefulWidget {
+  const _KbPageScreen({
+    required this.slug,
+    required this.title,
+    required this.section,
+    required this.editable,
+    required this.isFoundational,
+  });
+
+  final String slug;
+  final String title;
+  final BlueprintSection section;
+  // editable == the operator may change this page's config (non-classic).
+  final bool editable;
+  final bool isFoundational;
+
+  @override
+  ConsumerState<_KbPageScreen> createState() => _KbPageScreenState();
+}
+
+class _KbPageScreenState extends ConsumerState<_KbPageScreen> {
+  static const _global = '__global__';
+  final _editCtrl = TextEditingController();
+  bool _editing = false;
+  bool _busy = false;
+  bool _showProposal = false;
+  AsyncValue<ProjectDoc> _doc = const AsyncValue.loading();
+  List<DocProposal> _proposals = const [];
+  late String _title = widget.title;
+  late BlueprintSection _section = widget.section;
+
+  String get _kind => widget.slug;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
   @override
   void dispose() {
     _editCtrl.dispose();
@@ -385,27 +586,6 @@ class _KbViewState extends ConsumerState<_KbView> {
 
   String _stripSig(String s) =>
       s.split('\n').where((l) => !l.contains('kb-sig:')).join('\n').trim();
-
-  String _kindLabel(String k) {
-    switch (k) {
-      case 'kb_conventions':
-        return t.web.knowledge.kb.kinds.kb_conventions;
-      case 'kb_lessons':
-        return t.web.knowledge.kb.kinds.kb_lessons;
-      case 'kb_reusable':
-        return t.web.knowledge.kb.kinds.kb_reusable;
-      case 'kb_infrastructure':
-        return t.web.knowledge.kb.kinds.kb_infrastructure;
-      default:
-        // Custom page → its blueprint title (slug minus kb_ as fallback).
-        for (final s in _extra) {
-          if (s.slug == k) {
-            return s.title.isNotEmpty ? s.title : k.replaceFirst('kb_', '');
-          }
-        }
-        return k.replaceFirst('kb_', '');
-    }
-  }
 
   Future<void> _load() async {
     setState(() {
@@ -433,11 +613,6 @@ class _KbViewState extends ConsumerState<_KbView> {
       if (p.kind == _kind) return p;
     }
     return null;
-  }
-
-  void _select(String kind) {
-    setState(() => _kind = kind);
-    _load();
   }
 
   Future<void> _save() async {
@@ -519,281 +694,225 @@ class _KbViewState extends ConsumerState<_KbView> {
     }
   }
 
-  Widget _sectionLabel(String text) => Padding(
-        padding: const EdgeInsets.only(right: 6, left: 2),
-        child: Text(
-          text,
-          style: TextStyle(
-            fontSize: 10,
-            color: Theme.of(context).colorScheme.onSurfaceVariant,
-          ),
-        ),
-      );
+  Future<void> _editPageSettings() async {
+    final saved = await showDialog<BlueprintSection>(
+      context: context,
+      builder: (_) => _KbPageDialog(section: _section),
+    );
+    if (saved == null || !mounted) return;
+    setState(() {
+      _section = saved;
+      _title = saved.title.isNotEmpty ? saved.title : _title;
+    });
+  }
 
-  Widget _chip(String k) => Padding(
-        padding: const EdgeInsets.only(right: 6),
-        child: ChoiceChip(
-          label: Text(_kindLabel(k)),
-          selected: _kind == k,
-          onSelected: (_) => _select(k),
-        ),
-      );
+  void _onAction(_KbAction action, ProjectDoc d) {
+    switch (action) {
+      case _KbAction.discuss:
+        Navigator.of(context).push(
+          MaterialPageRoute<void>(
+            builder: (_) => CurationChatScreen(
+              targetKind: 'kb_page',
+              targetCwd: _global,
+              targetSlug: _kind,
+              onRevision: _load,
+            ),
+          ),
+        );
+      case _KbAction.unlock:
+        _unlock(d);
+      case _KbAction.regenerate:
+        _regen();
+      case _KbAction.settings:
+        _editPageSettings();
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
-    return Column(
-      children: [
-        // Page navigation: a horizontal scroll of section chips (nav only),
-        // with the two global actions (new page / Librarian) as trailing
-        // icon buttons so their long labels don't crowd out the chips on a
-        // narrow screen.
-        SizedBox(
-          height: 48,
-          child: Row(
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_title, overflow: TextOverflow.ellipsis),
+        actions: _doc.maybeWhen(
+          data: (d) {
+            final locked = d.updatedBy == 'operator';
+            if (_editing) {
+              return [
+                TextButton(
+                  onPressed: () => setState(() => _editing = false),
+                  child: Text(t.web.knowledge.kb.cancel),
+                ),
+                FilledButton(
+                  onPressed: _busy ? null : _save,
+                  child: Text(t.web.knowledge.kb.save),
+                ),
+                const SizedBox(width: 8),
+              ];
+            }
+            return [
+              IconButton(
+                icon: const Icon(Icons.edit_outlined),
+                tooltip: t.web.knowledge.kb.edit,
+                onPressed: () {
+                  _editCtrl.text = _stripSig(d.content);
+                  setState(() => _editing = true);
+                },
+              ),
+              PopupMenuButton<_KbAction>(
+                tooltip: t.common.more,
+                onSelected: (a) => _onAction(a, d),
+                itemBuilder: (_) => [
+                  PopupMenuItem(
+                    value: _KbAction.discuss,
+                    child: Text(t.web.cortex.chat.show),
+                  ),
+                  if (locked)
+                    PopupMenuItem(
+                      value: _KbAction.unlock,
+                      child: Text(t.web.knowledge.kb.unlock),
+                    ),
+                  PopupMenuItem(
+                    value: _KbAction.regenerate,
+                    child: Text(t.web.knowledge.kb.regenerate),
+                  ),
+                  if (widget.editable)
+                    PopupMenuItem(
+                      value: _KbAction.settings,
+                      child: Text(t.web.knowledge.kb.pageSettings.button),
+                    ),
+                ],
+              ),
+            ];
+          },
+          orElse: () => const [],
+        ),
+      ),
+      body: _doc.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text('$e', textAlign: TextAlign.center),
+          ),
+        ),
+        data: (d) {
+          final content = _stripSig(d.content);
+          final locked = d.updatedBy == 'operator';
+          final pending = _pending;
+          if (_editing) {
+            return Padding(
+              padding: const EdgeInsets.all(12),
+              child: TextField(
+                controller: _editCtrl,
+                maxLines: null,
+                expands: true,
+                textAlignVertical: TextAlignVertical.top,
+                style: const TextStyle(fontFamily: 'monospace', fontSize: 13),
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  alignLabelWithHint: true,
+                ),
+              ),
+            );
+          }
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Expanded(
-                child: SingleChildScrollView(
-                  scrollDirection: Axis.horizontal,
-                  padding: const EdgeInsets.only(left: 12),
-                  child: Row(
+              // Badges: nature + lock state.
+              Padding(
+                padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+                child: Wrap(
+                  spacing: 6,
+                  runSpacing: 4,
+                  children: [
+                    Chip(
+                      label: Text(
+                        widget.isFoundational
+                            ? t.web.knowledge.kb.bindingBadge
+                            : t.web.knowledge.kb.referenceBadge,
+                        style: const TextStyle(fontSize: 10),
+                      ),
+                      backgroundColor: widget.isFoundational
+                          ? scheme.tertiaryContainer
+                          : scheme.secondaryContainer,
+                      visualDensity: VisualDensity.compact,
+                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                    if (d.isPersisted)
+                      Chip(
+                        label: Text(
+                          locked
+                              ? t.web.knowledge.kb.locked
+                              : t.web.knowledge.kb.aiDrafted,
+                          style: const TextStyle(fontSize: 10),
+                        ),
+                        visualDensity: VisualDensity.compact,
+                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                  ],
+                ),
+              ),
+              if (pending != null)
+                Container(
+                  margin: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+                  padding: const EdgeInsets.all(10),
+                  decoration: BoxDecoration(
+                    color: scheme.tertiaryContainer,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      _sectionLabel(t.web.knowledge.kb.foundational),
-                      for (final k in _foundational) _chip(k),
-                      for (final s in _extra)
-                        if (s.nature == 'foundational') _chip(s.slug),
-                      _sectionLabel(t.web.knowledge.kb.emergent),
-                      for (final k in _emergent) _chip(k),
-                      for (final s in _extra)
-                        if (s.nature != 'foundational') _chip(s.slug),
+                      Text(t.web.knowledge.kb.proposal.text,
+                          style: const TextStyle(fontSize: 12)),
+                      Row(
+                        children: [
+                          TextButton(
+                            onPressed: () => setState(
+                                () => _showProposal = !_showProposal),
+                            child: Text(_showProposal
+                                ? t.web.knowledge.kb.proposal.hide
+                                : t.web.knowledge.kb.proposal.preview),
+                          ),
+                          const Spacer(),
+                          TextButton(
+                            onPressed: _busy ? null : () => _decide(false),
+                            child: Text(t.web.knowledge.kb.proposal.reject),
+                          ),
+                          FilledButton(
+                            onPressed: _busy ? null : () => _decide(true),
+                            child: Text(t.web.knowledge.kb.proposal.approve),
+                          ),
+                        ],
+                      ),
+                      if (_showProposal)
+                        Container(
+                          constraints: const BoxConstraints(maxHeight: 240),
+                          margin: const EdgeInsets.only(top: 6),
+                          child: SingleChildScrollView(
+                            child: SelectableText(
+                              _stripSig(pending.proposedContent),
+                              style: const TextStyle(fontSize: 12),
+                            ),
+                          ),
+                        ),
                     ],
                   ),
                 ),
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+                  child: SelectableText(
+                    content.isEmpty ? t.web.knowledge.kb.empty : content,
+                    style: const TextStyle(fontSize: 14, height: 1.5),
+                  ),
+                ),
               ),
-              IconButton(
-                icon: const Icon(Icons.add, size: 22),
-                tooltip: t.web.knowledge.kb.newPage.button,
-                onPressed: _newPage,
-              ),
-              IconButton(
-                icon: const Icon(Icons.auto_awesome, size: 20),
-                tooltip: t.web.knowledge.kb.librarian.button,
-                onPressed: _launchLibrarian,
-              ),
-              const SizedBox(width: 4),
             ],
-          ),
-        ),
-        Expanded(
-          child: _doc.when(
-            loading: () => const Center(child: CircularProgressIndicator()),
-            error: (e, _) => Center(
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Text('$e', textAlign: TextAlign.center),
-              ),
-            ),
-            data: (d) {
-              final content = _stripSig(d.content);
-              final locked = d.updatedBy == 'operator';
-              final pending = _pending;
-              // The custom (non-classic) page for the current selection, if any
-              // — drives whether "Settings" is offered.
-              BlueprintSection? custom;
-              for (final s in _extra) {
-                if (s.slug == _kind) {
-                  custom = s;
-                  break;
-                }
-              }
-              return Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  // Compact action bar: the page's nature + lock badges on the
-                  // left, then the primary Edit action + a ⋮ menu for the rest
-                  // (Discuss / Unlock / Regenerate / Settings). Keeps everything
-                  // on one line instead of a wrapping button pile.
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(12, 4, 4, 0),
-                    child: Row(
-                      children: [
-                        Expanded(
-                          child: Wrap(
-                            spacing: 6,
-                            runSpacing: 4,
-                            crossAxisAlignment: WrapCrossAlignment.center,
-                            children: [
-                              Chip(
-                                label: Text(
-                                  _isFoundational
-                                      ? t.web.knowledge.kb.bindingBadge
-                                      : t.web.knowledge.kb.referenceBadge,
-                                  style: const TextStyle(fontSize: 10),
-                                ),
-                                backgroundColor: _isFoundational
-                                    ? scheme.tertiaryContainer
-                                    : scheme.secondaryContainer,
-                                visualDensity: VisualDensity.compact,
-                                materialTapTargetSize:
-                                    MaterialTapTargetSize.shrinkWrap,
-                              ),
-                              if (d.isPersisted)
-                                Chip(
-                                  label: Text(
-                                    locked
-                                        ? t.web.knowledge.kb.locked
-                                        : t.web.knowledge.kb.aiDrafted,
-                                    style: const TextStyle(fontSize: 10),
-                                  ),
-                                  visualDensity: VisualDensity.compact,
-                                  materialTapTargetSize:
-                                      MaterialTapTargetSize.shrinkWrap,
-                                ),
-                            ],
-                          ),
-                        ),
-                        if (!_editing) ...[
-                          TextButton(
-                            onPressed: () {
-                              _editCtrl.text = content;
-                              setState(() => _editing = true);
-                            },
-                            child: Text(t.web.knowledge.kb.edit),
-                          ),
-                          PopupMenuButton<_KbAction>(
-                            icon: const Icon(Icons.more_vert, size: 20),
-                            tooltip: t.common.more,
-                            onSelected: (a) => _onKbAction(a, d, custom),
-                            itemBuilder: (_) => [
-                              PopupMenuItem(
-                                value: _KbAction.discuss,
-                                child: Text(t.web.cortex.chat.show),
-                              ),
-                              if (locked)
-                                PopupMenuItem(
-                                  value: _KbAction.unlock,
-                                  child: Text(t.web.knowledge.kb.unlock),
-                                ),
-                              PopupMenuItem(
-                                value: _KbAction.regenerate,
-                                child: Text(t.web.knowledge.kb.regenerate),
-                              ),
-                              if (custom != null)
-                                PopupMenuItem(
-                                  value: _KbAction.settings,
-                                  child:
-                                      Text(t.web.knowledge.kb.pageSettings.button),
-                                ),
-                            ],
-                          ),
-                        ],
-                      ],
-                    ),
-                  ),
-                  if (pending != null && !_editing)
-                    Container(
-                      margin: const EdgeInsets.fromLTRB(12, 6, 12, 0),
-                      padding: const EdgeInsets.all(10),
-                      decoration: BoxDecoration(
-                        color: scheme.tertiaryContainer,
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            t.web.knowledge.kb.proposal.text,
-                            style: const TextStyle(fontSize: 12),
-                          ),
-                          Row(
-                            children: [
-                              TextButton(
-                                onPressed: () => setState(
-                                    () => _showProposal = !_showProposal),
-                                child: Text(_showProposal
-                                    ? t.web.knowledge.kb.proposal.hide
-                                    : t.web.knowledge.kb.proposal.preview),
-                              ),
-                              const Spacer(),
-                              TextButton(
-                                onPressed: _busy ? null : () => _decide(false),
-                                child: Text(t.web.knowledge.kb.proposal.reject),
-                              ),
-                              FilledButton(
-                                onPressed: _busy ? null : () => _decide(true),
-                                child: Text(t.web.knowledge.kb.proposal.approve),
-                              ),
-                            ],
-                          ),
-                          if (_showProposal)
-                            Container(
-                              constraints: const BoxConstraints(maxHeight: 240),
-                              margin: const EdgeInsets.only(top: 6),
-                              child: SingleChildScrollView(
-                                child: SelectableText(
-                                  _stripSig(pending.proposedContent),
-                                  style: const TextStyle(fontSize: 12),
-                                ),
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
-                  Expanded(
-                    child: _editing
-                        ? Padding(
-                            padding: const EdgeInsets.all(12),
-                            child: Column(
-                              children: [
-                                Expanded(
-                                  child: TextField(
-                                    controller: _editCtrl,
-                                    maxLines: null,
-                                    expands: true,
-                                    textAlignVertical: TextAlignVertical.top,
-                                    style: const TextStyle(
-                                      fontFamily: 'monospace',
-                                      fontSize: 13,
-                                    ),
-                                    decoration: const InputDecoration(
-                                      border: OutlineInputBorder(),
-                                      alignLabelWithHint: true,
-                                    ),
-                                  ),
-                                ),
-                                const SizedBox(height: 8),
-                                Row(
-                                  children: [
-                                    FilledButton(
-                                      onPressed: _busy ? null : _save,
-                                      child: Text(t.web.knowledge.kb.save),
-                                    ),
-                                    const SizedBox(width: 8),
-                                    TextButton(
-                                      onPressed: () =>
-                                          setState(() => _editing = false),
-                                      child: Text(t.web.knowledge.kb.cancel),
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                          )
-                        : SingleChildScrollView(
-                            padding: const EdgeInsets.all(12),
-                            child: SelectableText(
-                              content.isEmpty
-                                  ? t.web.knowledge.kb.empty
-                                  : content,
-                            ),
-                          ),
-                  ),
-                ],
-              );
-            },
-          ),
-        ),
-      ],
+          );
+        },
+      ),
     );
   }
 }

--- a/app/mobile/lib/features/knowledge/knowledge_screen.dart
+++ b/app/mobile/lib/features/knowledge/knowledge_screen.dart
@@ -244,6 +244,10 @@ class _KindChip extends StatelessWidget {
   }
 }
 
+// Secondary per-page actions, collapsed into a ⋮ overflow menu so the KB
+// header stays compact on a phone screen (Edit is the visible primary).
+enum _KbAction { discuss, unlock, regenerate, settings }
+
 // _KbView — the curated Knowledge Base pages (the human-readable surface),
 // fused with the note system (projectdoc kb_* docs). Global pages + per-project
 // handbook; AI-drafted, human edit locks a page from AI overwrite.
@@ -324,6 +328,29 @@ class _KbViewState extends ConsumerState<_KbView> {
     if (saved == null || !mounted) return;
     await _loadSections();
     if (mounted) setState(() {});
+  }
+
+  // Dispatch a ⋮ overflow-menu action for the current page.
+  void _onKbAction(_KbAction action, ProjectDoc d, BlueprintSection? custom) {
+    switch (action) {
+      case _KbAction.discuss:
+        Navigator.of(context).push(
+          MaterialPageRoute<void>(
+            builder: (_) => CurationChatScreen(
+              targetKind: 'kb_page',
+              targetCwd: _global,
+              targetSlug: _kind,
+              onRevision: _load,
+            ),
+          ),
+        );
+      case _KbAction.unlock:
+        _unlock(d);
+      case _KbAction.regenerate:
+        _regen();
+      case _KbAction.settings:
+        if (custom != null) _editPageSettings(custom);
+    }
   }
 
   // Pick the cloud agent + model (+ Claude account) for the KB Librarian,
@@ -517,40 +544,44 @@ class _KbViewState extends ConsumerState<_KbView> {
     final scheme = Theme.of(context).colorScheme;
     return Column(
       children: [
+        // Page navigation: a horizontal scroll of section chips (nav only),
+        // with the two global actions (new page / Librarian) as trailing
+        // icon buttons so their long labels don't crowd out the chips on a
+        // narrow screen.
         SizedBox(
-          height: 44,
-          child: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: 12),
-            child: Row(
-              children: [
-                _sectionLabel(t.web.knowledge.kb.foundational),
-                for (final k in _foundational) _chip(k),
-                for (final s in _extra)
-                  if (s.nature == 'foundational') _chip(s.slug),
-                _sectionLabel(t.web.knowledge.kb.emergent),
-                for (final k in _emergent) _chip(k),
-                for (final s in _extra)
-                  if (s.nature != 'foundational') _chip(s.slug),
-                Padding(
-                  padding: const EdgeInsets.only(left: 4, top: 4),
-                  child: ActionChip(
-                    avatar: const Icon(Icons.add, size: 16),
-                    label: Text(t.web.knowledge.kb.newPage.button),
-                    onPressed: _newPage,
+          height: 48,
+          child: Row(
+            children: [
+              Expanded(
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  padding: const EdgeInsets.only(left: 12),
+                  child: Row(
+                    children: [
+                      _sectionLabel(t.web.knowledge.kb.foundational),
+                      for (final k in _foundational) _chip(k),
+                      for (final s in _extra)
+                        if (s.nature == 'foundational') _chip(s.slug),
+                      _sectionLabel(t.web.knowledge.kb.emergent),
+                      for (final k in _emergent) _chip(k),
+                      for (final s in _extra)
+                        if (s.nature != 'foundational') _chip(s.slug),
+                    ],
                   ),
                 ),
-                // Cross-page KB admin — the Librarian agent session.
-                Padding(
-                  padding: const EdgeInsets.only(left: 4, top: 4),
-                  child: ActionChip(
-                    avatar: const Icon(Icons.auto_awesome, size: 16),
-                    label: Text(t.web.knowledge.kb.librarian.button),
-                    onPressed: _launchLibrarian,
-                  ),
-                ),
-              ],
-            ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.add, size: 22),
+                tooltip: t.web.knowledge.kb.newPage.button,
+                onPressed: _newPage,
+              ),
+              IconButton(
+                icon: const Icon(Icons.auto_awesome, size: 20),
+                tooltip: t.web.knowledge.kb.librarian.button,
+                onPressed: _launchLibrarian,
+              ),
+              const SizedBox(width: 4),
+            ],
           ),
         ),
         Expanded(
@@ -566,57 +597,62 @@ class _KbViewState extends ConsumerState<_KbView> {
               final content = _stripSig(d.content);
               final locked = d.updatedBy == 'operator';
               final pending = _pending;
+              // The custom (non-classic) page for the current selection, if any
+              // — drives whether "Settings" is offered.
+              BlueprintSection? custom;
+              for (final s in _extra) {
+                if (s.slug == _kind) {
+                  custom = s;
+                  break;
+                }
+              }
               return Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
+                  // Compact action bar: the page's nature + lock badges on the
+                  // left, then the primary Edit action + a ⋮ menu for the rest
+                  // (Discuss / Unlock / Regenerate / Settings). Keeps everything
+                  // on one line instead of a wrapping button pile.
                   Padding(
-                    padding: const EdgeInsets.fromLTRB(12, 4, 12, 0),
-                    child: Wrap(
-                      spacing: 6,
-                      runSpacing: 4,
-                      crossAxisAlignment: WrapCrossAlignment.center,
+                    padding: const EdgeInsets.fromLTRB(12, 4, 4, 0),
+                    child: Row(
                       children: [
-                        Chip(
-                          label: Text(
-                            _isFoundational
-                                ? t.web.knowledge.kb.bindingBadge
-                                : t.web.knowledge.kb.referenceBadge,
-                            style: const TextStyle(fontSize: 10),
-                          ),
-                          backgroundColor: _isFoundational
-                              ? scheme.tertiaryContainer
-                              : scheme.secondaryContainer,
-                          visualDensity: VisualDensity.compact,
-                          materialTapTargetSize:
-                              MaterialTapTargetSize.shrinkWrap,
-                        ),
-                        if (d.isPersisted)
-                          Chip(
-                            label: Text(
-                              locked
-                                  ? t.web.knowledge.kb.locked
-                                  : t.web.knowledge.kb.aiDrafted,
-                              style: const TextStyle(fontSize: 10),
-                            ),
-                            visualDensity: VisualDensity.compact,
-                            materialTapTargetSize:
-                                MaterialTapTargetSize.shrinkWrap,
-                          ),
-                        if (!_editing) ...[
-                          TextButton(
-                            onPressed: () =>
-                                Navigator.of(context).push(
-                                  MaterialPageRoute<void>(
-                                    builder: (_) => CurationChatScreen(
-                                      targetKind: 'kb_page',
-                                      targetCwd: _global,
-                                      targetSlug: _kind,
-                                      onRevision: _load,
-                                    ),
-                                  ),
+                        Expanded(
+                          child: Wrap(
+                            spacing: 6,
+                            runSpacing: 4,
+                            crossAxisAlignment: WrapCrossAlignment.center,
+                            children: [
+                              Chip(
+                                label: Text(
+                                  _isFoundational
+                                      ? t.web.knowledge.kb.bindingBadge
+                                      : t.web.knowledge.kb.referenceBadge,
+                                  style: const TextStyle(fontSize: 10),
                                 ),
-                            child: Text(t.web.cortex.chat.show),
+                                backgroundColor: _isFoundational
+                                    ? scheme.tertiaryContainer
+                                    : scheme.secondaryContainer,
+                                visualDensity: VisualDensity.compact,
+                                materialTapTargetSize:
+                                    MaterialTapTargetSize.shrinkWrap,
+                              ),
+                              if (d.isPersisted)
+                                Chip(
+                                  label: Text(
+                                    locked
+                                        ? t.web.knowledge.kb.locked
+                                        : t.web.knowledge.kb.aiDrafted,
+                                    style: const TextStyle(fontSize: 10),
+                                  ),
+                                  visualDensity: VisualDensity.compact,
+                                  materialTapTargetSize:
+                                      MaterialTapTargetSize.shrinkWrap,
+                                ),
+                            ],
                           ),
+                        ),
+                        if (!_editing) ...[
                           TextButton(
                             onPressed: () {
                               _editCtrl.text = content;
@@ -624,28 +660,32 @@ class _KbViewState extends ConsumerState<_KbView> {
                             },
                             child: Text(t.web.knowledge.kb.edit),
                           ),
-                          if (locked)
-                            TextButton(
-                              onPressed: () => _unlock(d),
-                              child: Text(t.web.knowledge.kb.unlock),
-                            ),
-                          TextButton(
-                            onPressed: _regen,
-                            child: Text(t.web.knowledge.kb.regenerate),
-                          ),
-                          // Config editor for every non-classic page (_extra
-                          // already excludes the classic four). Seeded pages
-                          // like Integrations (pinned but non-classic) are
-                          // configurable too — wider than delete, which stays
-                          // pinned-gated. The classics keep i18n titles/fixed
-                          // natures, so they're not editable here.
-                          for (final s in _extra)
-                            if (s.slug == _kind)
-                              TextButton(
-                                onPressed: () => _editPageSettings(s),
-                                child: Text(
-                                    t.web.knowledge.kb.pageSettings.button),
+                          PopupMenuButton<_KbAction>(
+                            icon: const Icon(Icons.more_vert, size: 20),
+                            tooltip: t.common.more,
+                            onSelected: (a) => _onKbAction(a, d, custom),
+                            itemBuilder: (_) => [
+                              PopupMenuItem(
+                                value: _KbAction.discuss,
+                                child: Text(t.web.cortex.chat.show),
                               ),
+                              if (locked)
+                                PopupMenuItem(
+                                  value: _KbAction.unlock,
+                                  child: Text(t.web.knowledge.kb.unlock),
+                                ),
+                              PopupMenuItem(
+                                value: _KbAction.regenerate,
+                                child: Text(t.web.knowledge.kb.regenerate),
+                              ),
+                              if (custom != null)
+                                PopupMenuItem(
+                                  value: _KbAction.settings,
+                                  child:
+                                      Text(t.web.knowledge.kb.pageSettings.button),
+                                ),
+                            ],
+                          ),
                         ],
                       ],
                     ),


### PR DESCRIPTION
## Summary

The mobile **Cortex → Knowledge (KB)** page didn't scale: page navigation was a single horizontal chip strip, which runs out of room and becomes unusable once the operator/AI create many `kb_*` documents. Rebuilt the KB tab as a **mobile-native browse-then-read flow**.

## What changed (mobile-only)

**KB tab → a searchable, grouped list**
- Every `kb_*` page renders as a list row (title + description + an *on-demand* tag), grouped into **Foundational / Emergent** sections. The list grows gracefully however many pages exist.
- A **search box** filters by title/description — the key affordance once there are many pages. Pull-to-refresh reloads.
- **New page / Librarian** move onto a **FAB** (single-hand reach) that opens a small action sheet, off the browse surface.

**Tap a page → full-screen `_KbPageScreen`**
- The body reads in a clean scroll (larger text, 1.5 line-height).
- **Edit** is a primary AppBar action; **Discuss / Unlock / Regenerate / Settings** live in the AppBar **⋮** menu.
- The pending-proposal banner and lock/nature badges live here too.

Web is unchanged (its sidebar layout already works on wide screens). Adds `web.knowledge.kb.searchHint` / `searchEmpty` (+ a generic `common.more`); slang regenerated.

## Test plan
- [x] `flutter analyze lib/features/knowledge` — no issues; slang regenerated; i18n parity 100%
- [ ] **Device test:** create several kb pages → the list stays usable + searchable; tap opens a full-screen reader; Edit / ⋮ actions work; FAB → New page / Librarian; pending proposals + lock badges show on the detail screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)