### PR TITLE
fix(memory-workers): allow grok + opencode as agent providers

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -510,6 +510,8 @@
       "modelBackToList": "List",
       "cliCodex": "Codex (codex exec)",
       "cliAntigravity": "Antigravity (agy --print)",
+      "cliGrok": "Grok (grok)",
+      "cliOpencode": "OpenCode (opencode run)",
       "infraGateOff": "{label} routing is saved, but its feature gate is OFF in Server Settings — nothing will run until you enable it there.",
       "infraGateOpen": "Enable it",
       "providerModel": "model:"
@@ -3952,6 +3954,8 @@
     "cliClaude": "Claude",
     "cliCodex": "Codex (codex exec)",
     "cliAntigravity": "Antigravity (agy --print)",
+    "cliGrok": "Grok (grok)",
+    "cliOpencode": "OpenCode (opencode run)",
     "modelLabel": "Model",
     "modelCliDefault": "CLI default (latest)",
     "modelCustom": "Custom…",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -510,6 +510,8 @@
       "modelBackToList": "Lista",
       "cliCodex": "Codex (codex exec)",
       "cliAntigravity": "Antigravity (agy --print)",
+      "cliGrok": "Grok (grok)",
+      "cliOpencode": "OpenCode (opencode run)",
       "infraGateOff": "El enrutado de {label} está guardado, pero su puerta de función está APAGADA en Server Settings — no se ejecutará nada hasta que la actives allí.",
       "infraGateOpen": "Activarla",
       "providerModel": "modelo:"
@@ -3952,6 +3954,8 @@
     "cliClaude": "Claude",
     "cliCodex": "Codex (codex exec)",
     "cliAntigravity": "Antigravity (agy --print)",
+    "cliGrok": "Grok (grok)",
+    "cliOpencode": "OpenCode (opencode run)",
     "modelLabel": "Modelo",
     "modelCliDefault": "Predeterminado del CLI (último)",
     "modelCustom": "Personalizado…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -510,6 +510,8 @@
       "modelBackToList": "返回列表",
       "cliCodex": "Codex（codex exec）",
       "cliAntigravity": "Antigravity（agy --print）",
+      "cliGrok": "Grok (grok)",
+      "cliOpencode": "OpenCode (opencode run)",
       "infraGateOff": "{label} 的路由已保存，但它的功能总开关在 Server Settings 中处于关闭状态——开启之前不会执行任何调用。",
       "infraGateOpen": "去开启",
       "providerModel": "模型："
@@ -3952,6 +3954,8 @@
     "cliClaude": "Claude",
     "cliCodex": "Codex（codex exec）",
     "cliAntigravity": "Antigravity（agy --print）",
+    "cliGrok": "Grok (grok)",
+    "cliOpencode": "OpenCode (opencode run)",
     "modelLabel": "模型",
     "modelCliDefault": "CLI 默认(最新)",
     "modelCustom": "自定义…",

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 12354 (4118 per locale)
+/// Strings: 12366 (4122 per locale)
 ///
-/// Built on 2026-07-17 at 07:25 UTC
+/// Built on 2026-07-17 at 07:46 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -814,6 +814,12 @@ class TranslationsMemoryWorkersEn {
 	/// en: 'Antigravity (agy --print)'
 	String get cliAntigravity => 'Antigravity (agy --print)';
 
+	/// en: 'Grok (grok)'
+	String get cliGrok => 'Grok (grok)';
+
+	/// en: 'OpenCode (opencode run)'
+	String get cliOpencode => 'OpenCode (opencode run)';
+
 	/// en: 'Model'
 	String get modelLabel => 'Model';
 
@@ -2759,6 +2765,12 @@ class TranslationsWebMemoryWorkersEn {
 
 	/// en: 'Antigravity (agy --print)'
 	String get cliAntigravity => 'Antigravity (agy --print)';
+
+	/// en: 'Grok (grok)'
+	String get cliGrok => 'Grok (grok)';
+
+	/// en: 'OpenCode (opencode run)'
+	String get cliOpencode => 'OpenCode (opencode run)';
 
 	/// en: '{label} routing is saved, but its feature gate is OFF in Server Settings — nothing will run until you enable it there.'
 	String infraGateOff({required Object label}) => '${label} routing is saved, but its feature gate is OFF in Server Settings — nothing will run until you enable it there.';
@@ -18196,6 +18208,8 @@ extension on Translations {
 			'web.memoryWorkers.modelBackToList' => 'List',
 			'web.memoryWorkers.cliCodex' => 'Codex (codex exec)',
 			'web.memoryWorkers.cliAntigravity' => 'Antigravity (agy --print)',
+			'web.memoryWorkers.cliGrok' => 'Grok (grok)',
+			'web.memoryWorkers.cliOpencode' => 'OpenCode (opencode run)',
 			'web.memoryWorkers.infraGateOff' => ({required Object label}) => '${label} routing is saved, but its feature gate is OFF in Server Settings — nothing will run until you enable it there.',
 			'web.memoryWorkers.infraGateOpen' => 'Enable it',
 			'web.memoryWorkers.providerModel' => 'model:',
@@ -18283,10 +18297,10 @@ extension on Translations {
 			'web.project.inbox.approvedToast' => ({required Object label}) => '${label} updated',
 			'web.project.inbox.approveFailedToast' => 'Approve failed',
 			'web.project.inbox.rejectedToast' => 'Rejected',
-			'web.project.inbox.rejectFailedToast' => 'Reject failed',
-			'web.project.inbox.sessionPrefix' => 'ses',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.inbox.rejectFailedToast' => 'Reject failed',
+			'web.project.inbox.sessionPrefix' => 'ses',
 			'web.project.inbox.warning' => ({required Object label}) => 'Approve will REPLACE the current ${label} entirely.',
 			'web.project.inbox.warningSuffix' => 'Review the diff below; this isn\'t a merge.',
 			'web.project.inbox.current' => 'Current',
@@ -18797,10 +18811,10 @@ extension on Translations {
 			'web.channels.toasts.deleted' => 'Channel deleted',
 			'web.channels.toasts.created' => 'Channel created',
 			'web.channels.toasts.updated' => 'Channel updated',
-			'web.channels.toasts.muted' => 'Channel muted',
-			'web.channels.toasts.unmuted' => 'Channel unmuted',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.toasts.muted' => 'Channel muted',
+			'web.channels.toasts.unmuted' => 'Channel unmuted',
 			'web.channels.dialog.editTitle' => 'Edit channel',
 			'web.channels.dialog.createTitle' => 'Register channel',
 			'web.channels.dialog.descriptionBridge' => 'External adapter (Python/Node/...) connects via WebSocket and presents this token.',
@@ -19311,10 +19325,10 @@ extension on Translations {
 			'web.backups.schedulesTab.columns.keep' => 'Keep',
 			'web.backups.schedulesTab.columns.nextRun' => 'Next run',
 			'web.backups.schedulesTab.columns.enabled' => 'Enabled',
-			'web.backups.schedulesTab.columns.actions' => 'Actions',
-			'web.backups.schedulesTab.keepCount' => ({required Object count}) => '${count} backups',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.schedulesTab.columns.actions' => 'Actions',
+			'web.backups.schedulesTab.keepCount' => ({required Object count}) => '${count} backups',
 			'web.backups.schedulesTab.deleteTooltip' => 'Delete',
 			'web.backups.newSchedule.title' => 'New backup schedule',
 			'web.backups.newSchedule.targetLabel' => 'Targets',
@@ -19825,10 +19839,10 @@ extension on Translations {
 			'web.memoryAmbient.rules.dialog.create' => 'Create',
 			'web.memoryAmbient.rules.dialog.nameRequiredToast' => 'Name is required',
 			'web.memoryAmbient.rules.dialog.createdToast' => ({required Object name}) => 'Rule ${name} created',
-			'web.memoryAmbient.rules.dialog.createFailedToast' => 'Create failed',
-			'web.memoryAmbient.profiles.title' => 'Injection profiles',
 			_ => null,
 		} ?? switch (path) {
+			'web.memoryAmbient.rules.dialog.createFailedToast' => 'Create failed',
+			'web.memoryAmbient.profiles.title' => 'Injection profiles',
 			'web.memoryAmbient.profiles.addButton' => 'Add profile',
 			'web.memoryAmbient.profiles.intro' => 'At spawn time opendray prepends a markdown banner of recent project memories to the agent\'s system prompt — IF a profile is configured. Without a profile, the model still uses memory_search on demand.',
 			'web.memoryAmbient.profiles.empty' => 'No injection profile. Memories are not auto-injected at spawn — model still uses memory_search.',
@@ -20339,10 +20353,10 @@ extension on Translations {
 			'web.roundTable.plan.running' => 'Running',
 			'web.roundTable.plan.done' => 'Done',
 			'web.roundTable.plan.pending' => 'Pending',
-			'web.roundTable.plan.openSession' => 'Open session',
-			'web.roundTable.plan.needProject' => 'Bind a project (cwd) to run steps.',
 			_ => null,
 		} ?? switch (path) {
+			'web.roundTable.plan.openSession' => 'Open session',
+			'web.roundTable.plan.needProject' => 'Bind a project (cwd) to run steps.',
 			'web.roundTable.plan.bindProject' => 'Bind',
 			'web.roundTable.plan.projectBound' => 'Project bound',
 			'web.roundTable.plan.runTitle' => 'Run step',
@@ -20853,10 +20867,10 @@ extension on Translations {
 			'integrations.detailLoadFailed' => ({required Object error}) => 'Failed to load integration: ${error}',
 			'integrations.callsLoadFailed' => 'Failed to load calls',
 			'integrations.noMatchingCalls' => 'No matching calls in the log yet.',
-			'integrations.directionAll' => 'All',
-			'integrations.directionInbound' => 'Inbound',
 			_ => null,
 		} ?? switch (path) {
+			'integrations.directionAll' => 'All',
+			'integrations.directionInbound' => 'Inbound',
 			'integrations.directionOutbound' => 'Outbound',
 			'integrations.form.validateRequired' => 'Name, base URL, and route prefix are required.',
 			'integrations.form.fieldName' => 'Name',
@@ -20895,6 +20909,8 @@ extension on Translations {
 			'memoryWorkers.cliClaude' => 'Claude',
 			'memoryWorkers.cliCodex' => 'Codex (codex exec)',
 			'memoryWorkers.cliAntigravity' => 'Antigravity (agy --print)',
+			'memoryWorkers.cliGrok' => 'Grok (grok)',
+			'memoryWorkers.cliOpencode' => 'OpenCode (opencode run)',
 			'memoryWorkers.modelLabel' => 'Model',
 			'memoryWorkers.modelCliDefault' => 'CLI default (latest)',
 			'memoryWorkers.modelCustom' => 'Custom…',
@@ -21365,12 +21381,12 @@ extension on Translations {
 			'channels.badges.muted' => 'muted',
 			'channels.capsLabel' => ({required Object list}) => '· caps: ${list}',
 			'channels.bridgeWebOnly' => 'Bridge channels stay web-only',
+			_ => null,
+		} ?? switch (path) {
 			'channels.bridgeEmptyAdd' => 'Add one from the web admin: Channels → New.',
 			'channels.deleteBody' => 'Stops the channel and removes its configuration. In-flight notifications addressed to it will be dropped silently.',
 			'channels.snacks.testDispatched' => 'Test message dispatched.',
 			'channels.snacks.channelEnabled' => 'Channel enabled.',
-			_ => null,
-		} ?? switch (path) {
 			'channels.snacks.channelDisabled' => 'Channel disabled.',
 			'channels.snacks.channelMuted' => 'Channel muted.',
 			'channels.snacks.channelUnmuted' => 'Channel unmuted.',
@@ -21879,12 +21895,12 @@ extension on Translations {
 			'cortexHub.memory' => 'Memory',
 			'cortexHub.memoryDesc' => 'Raw cross-session facts the agents store and recall.',
 			'cortexHub.notes' => 'Notes',
+			_ => null,
+		} ?? switch (path) {
 			'cortexHub.notesDesc' => 'Each project’s official goal / plan / journal.',
 			'cortexHub.knowledge' => 'Knowledge',
 			'cortexHub.knowledgeDesc' => 'Cross-project, distilled expertise.',
 			'cortexHub.quarantineBadge' => ({required Object count}) => '${count} to review',
-			_ => null,
-		} ?? switch (path) {
 			'cortexHub.pendingBadge' => ({required Object count}) => '${count} pending',
 			'cortexHub.disabled' => 'disabled',
 			'cortexHub.inboxTitle' => ({required Object count}) => 'Pending proposals (${count})',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -423,6 +423,8 @@ class _TranslationsMemoryWorkersEs extends TranslationsMemoryWorkersEn {
 	@override String get cliClaude => 'Claude';
 	@override String get cliCodex => 'Codex (codex exec)';
 	@override String get cliAntigravity => 'Antigravity (agy --print)';
+	@override String get cliGrok => 'Grok (grok)';
+	@override String get cliOpencode => 'OpenCode (opencode run)';
 	@override String get modelLabel => 'Modelo';
 	@override String get modelCliDefault => 'Predeterminado del CLI (último)';
 	@override String get modelCustom => 'Personalizado…';
@@ -1278,6 +1280,8 @@ class _TranslationsWebMemoryWorkersEs extends TranslationsWebMemoryWorkersEn {
 	@override String get modelBackToList => 'Lista';
 	@override String get cliCodex => 'Codex (codex exec)';
 	@override String get cliAntigravity => 'Antigravity (agy --print)';
+	@override String get cliGrok => 'Grok (grok)';
+	@override String get cliOpencode => 'OpenCode (opencode run)';
 	@override String infraGateOff({required Object label}) => 'El enrutado de ${label} está guardado, pero su puerta de función está APAGADA en Server Settings — no se ejecutará nada hasta que la actives allí.';
 	@override String get infraGateOpen => 'Activarla';
 	@override String get providerModel => 'modelo:';
@@ -9840,6 +9844,8 @@ extension on TranslationsEs {
 			'web.memoryWorkers.modelBackToList' => 'Lista',
 			'web.memoryWorkers.cliCodex' => 'Codex (codex exec)',
 			'web.memoryWorkers.cliAntigravity' => 'Antigravity (agy --print)',
+			'web.memoryWorkers.cliGrok' => 'Grok (grok)',
+			'web.memoryWorkers.cliOpencode' => 'OpenCode (opencode run)',
 			'web.memoryWorkers.infraGateOff' => ({required Object label}) => 'El enrutado de ${label} está guardado, pero su puerta de función está APAGADA en Server Settings — no se ejecutará nada hasta que la actives allí.',
 			'web.memoryWorkers.infraGateOpen' => 'Activarla',
 			'web.memoryWorkers.providerModel' => 'modelo:',
@@ -9927,10 +9933,10 @@ extension on TranslationsEs {
 			'web.project.inbox.approvedToast' => ({required Object label}) => '${label} actualizado',
 			'web.project.inbox.approveFailedToast' => 'Error al aprobar',
 			'web.project.inbox.rejectedToast' => 'Rechazado',
-			'web.project.inbox.rejectFailedToast' => 'Error al rechazar',
-			'web.project.inbox.sessionPrefix' => 'ses',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.inbox.rejectFailedToast' => 'Error al rechazar',
+			'web.project.inbox.sessionPrefix' => 'ses',
 			'web.project.inbox.warning' => ({required Object label}) => 'Aprobar REEMPLAZARÁ por completo el ${label} actual.',
 			'web.project.inbox.warningSuffix' => 'Revisa el diff de abajo; esto no es una fusión.',
 			'web.project.inbox.current' => 'Actual',
@@ -10441,10 +10447,10 @@ extension on TranslationsEs {
 			'web.channels.toasts.deleted' => 'Canal eliminado',
 			'web.channels.toasts.created' => 'Canal creado',
 			'web.channels.toasts.updated' => 'Canal actualizado',
-			'web.channels.toasts.muted' => 'Canal silenciado',
-			'web.channels.toasts.unmuted' => 'Canal reactivado',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.toasts.muted' => 'Canal silenciado',
+			'web.channels.toasts.unmuted' => 'Canal reactivado',
 			'web.channels.dialog.editTitle' => 'Editar canal',
 			'web.channels.dialog.createTitle' => 'Registrar canal',
 			'web.channels.dialog.descriptionBridge' => 'Un adaptador externo (Python/Node/...) se conecta vía WebSocket y presenta este token.',
@@ -10955,10 +10961,10 @@ extension on TranslationsEs {
 			'web.backups.schedulesTab.columns.keep' => 'Conservar',
 			'web.backups.schedulesTab.columns.nextRun' => 'Próxima ejecución',
 			'web.backups.schedulesTab.columns.enabled' => 'Habilitada',
-			'web.backups.schedulesTab.columns.actions' => 'Acciones',
-			'web.backups.schedulesTab.keepCount' => ({required Object count}) => '${count} copias de seguridad',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.schedulesTab.columns.actions' => 'Acciones',
+			'web.backups.schedulesTab.keepCount' => ({required Object count}) => '${count} copias de seguridad',
 			'web.backups.schedulesTab.deleteTooltip' => 'Eliminar',
 			'web.backups.newSchedule.title' => 'Nueva programación de copia de seguridad',
 			'web.backups.newSchedule.targetLabel' => 'Destinos',
@@ -11469,10 +11475,10 @@ extension on TranslationsEs {
 			'web.memoryAmbient.rules.dialog.create' => 'Crear',
 			'web.memoryAmbient.rules.dialog.nameRequiredToast' => 'El nombre es obligatorio',
 			'web.memoryAmbient.rules.dialog.createdToast' => ({required Object name}) => 'Regla ${name} creada',
-			'web.memoryAmbient.rules.dialog.createFailedToast' => 'La creación falló',
-			'web.memoryAmbient.profiles.title' => 'Perfiles de inyección',
 			_ => null,
 		} ?? switch (path) {
+			'web.memoryAmbient.rules.dialog.createFailedToast' => 'La creación falló',
+			'web.memoryAmbient.profiles.title' => 'Perfiles de inyección',
 			'web.memoryAmbient.profiles.addButton' => 'Añadir perfil',
 			'web.memoryAmbient.profiles.intro' => 'Al arrancar, opendray antepone un banner en markdown con las memorias recientes del proyecto al system prompt del agente, SI hay un perfil configurado. Sin un perfil, el modelo sigue usando memory_search bajo demanda.',
 			'web.memoryAmbient.profiles.empty' => 'No hay perfil de inyección. Las memorias no se inyectan automáticamente al arrancar; el modelo sigue usando memory_search.',
@@ -11983,10 +11989,10 @@ extension on TranslationsEs {
 			'web.roundTable.plan.running' => 'En curso',
 			'web.roundTable.plan.done' => 'Hecho',
 			'web.roundTable.plan.pending' => 'Pendiente',
-			'web.roundTable.plan.openSession' => 'Abrir sesión',
-			'web.roundTable.plan.needProject' => 'Vincula un proyecto (cwd) para ejecutar pasos.',
 			_ => null,
 		} ?? switch (path) {
+			'web.roundTable.plan.openSession' => 'Abrir sesión',
+			'web.roundTable.plan.needProject' => 'Vincula un proyecto (cwd) para ejecutar pasos.',
 			'web.roundTable.plan.bindProject' => 'Vincular',
 			'web.roundTable.plan.projectBound' => 'Proyecto vinculado',
 			'web.roundTable.plan.runTitle' => 'Ejecutar paso',
@@ -12497,10 +12503,10 @@ extension on TranslationsEs {
 			'integrations.detailLoadFailed' => ({required Object error}) => 'Error al cargar la integración: ${error}',
 			'integrations.callsLoadFailed' => 'Error al cargar las llamadas',
 			'integrations.noMatchingCalls' => 'Aún no hay llamadas coincidentes en el registro.',
-			'integrations.directionAll' => 'Todas',
-			'integrations.directionInbound' => 'Entrantes',
 			_ => null,
 		} ?? switch (path) {
+			'integrations.directionAll' => 'Todas',
+			'integrations.directionInbound' => 'Entrantes',
 			'integrations.directionOutbound' => 'Salientes',
 			'integrations.form.validateRequired' => 'El nombre, la URL base y el prefijo de ruta son obligatorios.',
 			'integrations.form.fieldName' => 'Nombre',
@@ -12539,6 +12545,8 @@ extension on TranslationsEs {
 			'memoryWorkers.cliClaude' => 'Claude',
 			'memoryWorkers.cliCodex' => 'Codex (codex exec)',
 			'memoryWorkers.cliAntigravity' => 'Antigravity (agy --print)',
+			'memoryWorkers.cliGrok' => 'Grok (grok)',
+			'memoryWorkers.cliOpencode' => 'OpenCode (opencode run)',
 			'memoryWorkers.modelLabel' => 'Modelo',
 			'memoryWorkers.modelCliDefault' => 'Predeterminado del CLI (último)',
 			'memoryWorkers.modelCustom' => 'Personalizado…',
@@ -13009,12 +13017,12 @@ extension on TranslationsEs {
 			'channels.badges.muted' => 'silenciado',
 			'channels.capsLabel' => ({required Object list}) => '· caps: ${list}',
 			'channels.bridgeWebOnly' => 'Los canales bridge solo están disponibles en la web',
+			_ => null,
+		} ?? switch (path) {
 			'channels.bridgeEmptyAdd' => 'Añade uno desde el admin web: Canales → Nuevo.',
 			'channels.deleteBody' => 'Detiene el canal y elimina su configuración. Las notificaciones en curso dirigidas a él se descartarán de forma silenciosa.',
 			'channels.snacks.testDispatched' => 'Mensaje de prueba enviado.',
 			'channels.snacks.channelEnabled' => 'Canal activado.',
-			_ => null,
-		} ?? switch (path) {
 			'channels.snacks.channelDisabled' => 'Canal desactivado.',
 			'channels.snacks.channelMuted' => 'Canal silenciado.',
 			'channels.snacks.channelUnmuted' => 'Sonido del canal reactivado.',
@@ -13523,12 +13531,12 @@ extension on TranslationsEs {
 			'cortexHub.memory' => 'Memoria',
 			'cortexHub.memoryDesc' => 'Hechos crudos entre sessions que los agentes guardan y recuerdan.',
 			'cortexHub.notes' => 'Notas',
+			_ => null,
+		} ?? switch (path) {
 			'cortexHub.notesDesc' => 'El objetivo / plan / diario oficial de cada proyecto.',
 			'cortexHub.knowledge' => 'Conocimiento',
 			'cortexHub.knowledgeDesc' => 'Experiencia destilada entre proyectos.',
 			'cortexHub.quarantineBadge' => ({required Object count}) => '${count} por revisar',
-			_ => null,
-		} ?? switch (path) {
 			'cortexHub.pendingBadge' => ({required Object count}) => '${count} pendientes',
 			'cortexHub.disabled' => 'desactivado',
 			'cortexHub.inboxTitle' => ({required Object count}) => 'Propuestas pendientes (${count})',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -423,6 +423,8 @@ class _TranslationsMemoryWorkersZh extends TranslationsMemoryWorkersEn {
 	@override String get cliClaude => 'Claude';
 	@override String get cliCodex => 'Codex（codex exec）';
 	@override String get cliAntigravity => 'Antigravity（agy --print）';
+	@override String get cliGrok => 'Grok (grok)';
+	@override String get cliOpencode => 'OpenCode (opencode run)';
 	@override String get modelLabel => '模型';
 	@override String get modelCliDefault => 'CLI 默认(最新)';
 	@override String get modelCustom => '自定义…';
@@ -1278,6 +1280,8 @@ class _TranslationsWebMemoryWorkersZh extends TranslationsWebMemoryWorkersEn {
 	@override String get modelBackToList => '返回列表';
 	@override String get cliCodex => 'Codex（codex exec）';
 	@override String get cliAntigravity => 'Antigravity（agy --print）';
+	@override String get cliGrok => 'Grok (grok)';
+	@override String get cliOpencode => 'OpenCode (opencode run)';
 	@override String infraGateOff({required Object label}) => '${label} 的路由已保存，但它的功能总开关在 Server Settings 中处于关闭状态——开启之前不会执行任何调用。';
 	@override String get infraGateOpen => '去开启';
 	@override String get providerModel => '模型：';
@@ -9840,6 +9844,8 @@ extension on TranslationsZh {
 			'web.memoryWorkers.modelBackToList' => '返回列表',
 			'web.memoryWorkers.cliCodex' => 'Codex（codex exec）',
 			'web.memoryWorkers.cliAntigravity' => 'Antigravity（agy --print）',
+			'web.memoryWorkers.cliGrok' => 'Grok (grok)',
+			'web.memoryWorkers.cliOpencode' => 'OpenCode (opencode run)',
 			'web.memoryWorkers.infraGateOff' => ({required Object label}) => '${label} 的路由已保存，但它的功能总开关在 Server Settings 中处于关闭状态——开启之前不会执行任何调用。',
 			'web.memoryWorkers.infraGateOpen' => '去开启',
 			'web.memoryWorkers.providerModel' => '模型：',
@@ -9927,10 +9933,10 @@ extension on TranslationsZh {
 			'web.project.inbox.approvedToast' => ({required Object label}) => '${label}已更新',
 			'web.project.inbox.approveFailedToast' => '批准失败',
 			'web.project.inbox.rejectedToast' => '已驳回',
-			'web.project.inbox.rejectFailedToast' => '驳回失败',
-			'web.project.inbox.sessionPrefix' => 'ses',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.inbox.rejectFailedToast' => '驳回失败',
+			'web.project.inbox.sessionPrefix' => 'ses',
 			'web.project.inbox.warning' => ({required Object label}) => '批准将完全替换当前${label}。',
 			'web.project.inbox.warningSuffix' => '请检查下方 diff；这不是合并。',
 			'web.project.inbox.current' => '当前',
@@ -10441,10 +10447,10 @@ extension on TranslationsZh {
 			'web.channels.toasts.deleted' => '频道已删除',
 			'web.channels.toasts.created' => '频道已创建',
 			'web.channels.toasts.updated' => '频道已更新',
-			'web.channels.toasts.muted' => '频道已静音',
-			'web.channels.toasts.unmuted' => '频道已取消静音',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.toasts.muted' => '频道已静音',
+			'web.channels.toasts.unmuted' => '频道已取消静音',
 			'web.channels.dialog.editTitle' => '编辑频道',
 			'web.channels.dialog.createTitle' => '注册频道',
 			'web.channels.dialog.descriptionBridge' => '外部适配器（Python/Node/...）通过 WebSocket 连接并出示此 token。',
@@ -10955,10 +10961,10 @@ extension on TranslationsZh {
 			'web.backups.schedulesTab.columns.keep' => '保留',
 			'web.backups.schedulesTab.columns.nextRun' => '下次运行',
 			'web.backups.schedulesTab.columns.enabled' => '启用',
-			'web.backups.schedulesTab.columns.actions' => '操作',
-			'web.backups.schedulesTab.keepCount' => ({required Object count}) => '${count} 个备份',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.schedulesTab.columns.actions' => '操作',
+			'web.backups.schedulesTab.keepCount' => ({required Object count}) => '${count} 个备份',
 			'web.backups.schedulesTab.deleteTooltip' => '删除',
 			'web.backups.newSchedule.title' => '新建备份计划',
 			'web.backups.newSchedule.targetLabel' => '目标',
@@ -11469,10 +11475,10 @@ extension on TranslationsZh {
 			'web.memoryAmbient.rules.dialog.create' => '创建',
 			'web.memoryAmbient.rules.dialog.nameRequiredToast' => '名称不能为空',
 			'web.memoryAmbient.rules.dialog.createdToast' => ({required Object name}) => '已创建规则 ${name}',
-			'web.memoryAmbient.rules.dialog.createFailedToast' => '创建失败',
-			'web.memoryAmbient.profiles.title' => 'Injection Profiles',
 			_ => null,
 		} ?? switch (path) {
+			'web.memoryAmbient.rules.dialog.createFailedToast' => '创建失败',
+			'web.memoryAmbient.profiles.title' => 'Injection Profiles',
 			'web.memoryAmbient.profiles.addButton' => '添加 profile',
 			'web.memoryAmbient.profiles.intro' => 'spawn 时，opendray 会把最近的项目记忆作为一段 markdown banner 拼接到 agent 的 system prompt — 前提是配置了 profile。没有 profile 时，模型仍可按需调用 memory_search。',
 			'web.memoryAmbient.profiles.empty' => '尚无 injection profile。spawn 时不会自动注入记忆 — 模型仍可使用 memory_search。',
@@ -11983,10 +11989,10 @@ extension on TranslationsZh {
 			'web.roundTable.plan.running' => '运行中',
 			'web.roundTable.plan.done' => '完成',
 			'web.roundTable.plan.pending' => '待运行',
-			'web.roundTable.plan.openSession' => '打开会话',
-			'web.roundTable.plan.needProject' => '运行步骤前需绑定项目(cwd)。',
 			_ => null,
 		} ?? switch (path) {
+			'web.roundTable.plan.openSession' => '打开会话',
+			'web.roundTable.plan.needProject' => '运行步骤前需绑定项目(cwd)。',
 			'web.roundTable.plan.bindProject' => '绑定',
 			'web.roundTable.plan.projectBound' => '项目已绑定',
 			'web.roundTable.plan.runTitle' => '运行此步',
@@ -12497,10 +12503,10 @@ extension on TranslationsZh {
 			'integrations.detailLoadFailed' => ({required Object error}) => '加载集成失败：${error}',
 			'integrations.callsLoadFailed' => '加载调用失败',
 			'integrations.noMatchingCalls' => '日志中暂无匹配的调用。',
-			'integrations.directionAll' => '全部',
-			'integrations.directionInbound' => '入站',
 			_ => null,
 		} ?? switch (path) {
+			'integrations.directionAll' => '全部',
+			'integrations.directionInbound' => '入站',
 			'integrations.directionOutbound' => '出站',
 			'integrations.form.validateRequired' => '名称、Base URL、路由前缀必填。',
 			'integrations.form.fieldName' => '名称',
@@ -12539,6 +12545,8 @@ extension on TranslationsZh {
 			'memoryWorkers.cliClaude' => 'Claude',
 			'memoryWorkers.cliCodex' => 'Codex（codex exec）',
 			'memoryWorkers.cliAntigravity' => 'Antigravity（agy --print）',
+			'memoryWorkers.cliGrok' => 'Grok (grok)',
+			'memoryWorkers.cliOpencode' => 'OpenCode (opencode run)',
 			'memoryWorkers.modelLabel' => '模型',
 			'memoryWorkers.modelCliDefault' => 'CLI 默认(最新)',
 			'memoryWorkers.modelCustom' => '自定义…',
@@ -13009,12 +13017,12 @@ extension on TranslationsZh {
 			'channels.badges.muted' => '已静音',
 			'channels.capsLabel' => ({required Object list}) => '· 能力：${list}',
 			'channels.bridgeWebOnly' => 'Bridge 通道仅 Web 端',
+			_ => null,
+		} ?? switch (path) {
 			'channels.bridgeEmptyAdd' => '在 Web 管理端添加：通道 → 新建。',
 			'channels.deleteBody' => '停止该通道并移除其配置。仍在传输中的通知会被静默丢弃。',
 			'channels.snacks.testDispatched' => '测试消息已发送。',
 			'channels.snacks.channelEnabled' => '通道已启用。',
-			_ => null,
-		} ?? switch (path) {
 			'channels.snacks.channelDisabled' => '通道已停用。',
 			'channels.snacks.channelMuted' => '通道已静音。',
 			'channels.snacks.channelUnmuted' => '通道已取消静音。',
@@ -13523,12 +13531,12 @@ extension on TranslationsZh {
 			'cortexHub.memory' => '记忆',
 			'cortexHub.memoryDesc' => '代理存取的跨会话原始事实。',
 			'cortexHub.notes' => '笔记',
+			_ => null,
+		} ?? switch (path) {
 			'cortexHub.notesDesc' => '每个项目的官方目标 / 计划 / 日志。',
 			'cortexHub.knowledge' => '知识',
 			'cortexHub.knowledgeDesc' => '跨项目沉淀的专业知识。',
 			'cortexHub.quarantineBadge' => ({required Object count}) => '${count} 条待审',
-			_ => null,
-		} ?? switch (path) {
 			'cortexHub.pendingBadge' => ({required Object count}) => '${count} 条待审',
 			'cortexHub.disabled' => '已禁用',
 			'cortexHub.inboxTitle' => ({required Object count}) => '待审提案（${count}）',

--- a/app/mobile/lib/features/memory_workers/memory_workers_screen.dart
+++ b/app/mobile/lib/features/memory_workers/memory_workers_screen.dart
@@ -474,6 +474,14 @@ class _WorkerCardState extends ConsumerState<_WorkerCard> {
           value: 'antigravity',
           child: Text(t.memoryWorkers.cliAntigravity),
         ),
+        DropdownMenuItem(
+          value: 'grok',
+          child: Text(t.memoryWorkers.cliGrok),
+        ),
+        DropdownMenuItem(
+          value: 'opencode',
+          child: Text(t.memoryWorkers.cliOpencode),
+        ),
       ],
       onChanged: (v) => setState(() {
         _providerId = v ?? '';

--- a/app/web/src/pages/MemoryWorkers.tsx
+++ b/app/web/src/pages/MemoryWorkers.tsx
@@ -809,6 +809,12 @@ function WorkerCard({
                     <SelectItem value="antigravity">
                       {t('web.memoryWorkers.cliAntigravity')}
                     </SelectItem>
+                    <SelectItem value="grok">
+                      {t('web.memoryWorkers.cliGrok')}
+                    </SelectItem>
+                    <SelectItem value="opencode">
+                      {t('web.memoryWorkers.cliOpencode')}
+                    </SelectItem>
                   </SelectContent>
                 </Select>
               </div>

--- a/internal/memory/worker/worker.go
+++ b/internal/memory/worker/worker.go
@@ -196,11 +196,12 @@ func (c Config) Valid() error {
 	case WorkerSummarizer:
 		return nil
 	case WorkerAgent:
+		// Must match AgentWorker.Run's headless provider switch.
 		switch c.ProviderID {
-		case "claude", "codex", "antigravity":
+		case "claude", "codex", "antigravity", "grok", "opencode":
 			return nil
 		default:
-			return errors.New("memory worker: agent provider_id required (claude, codex, or antigravity)")
+			return errors.New("memory worker: agent provider_id required (claude, codex, antigravity, grok, or opencode)")
 		}
 	default:
 		return errors.New("memory worker: invalid kind")


### PR DESCRIPTION
## Summary

In **Cortex → Memory Workers** settings, the agent-worker CLI dropdown only offered **claude / codex / antigravity** — grok and opencode were missing, and even if selected the backend `Config.Valid()` rejected them. Yet the worker fabric (`AgentWorker.Run`) already drives grok and opencode headlessly.

## What changed

- **Backend** (`internal/memory/worker/worker.go`): `Config.Valid()` now accepts `grok` + `opencode` for `WorkerAgent`, matching `AgentWorker.Run`'s provider switch; error text updated.
- **Web** (`MemoryWorkers.tsx`) + **Mobile** (`memory_workers_screen.dart`): add **Grok** / **OpenCode** to the CLI provider dropdown. The model picker already resolves per-provider models (grok/opencode included via the shared catalog from #467). Only claude shows an account picker (the rest use a single host login) — unchanged.
- **i18n**: `cliGrok` / `cliOpencode` in both the `web.memoryWorkers` and top-level `memoryWorkers` key sets; slang regenerated.

## Test plan
- [x] `go build ./...`, `go vet`, `go test ./internal/memory/worker` — green
- [x] web `tsc` clean; `flutter analyze lib/features/memory_workers` — no issues; i18n parity 100%
- [ ] **Local test:** in Memory Workers, set an agent worker (e.g. transcript) to Grok or OpenCode, pick a model, Save → accepted (no "provider unsupported" error); Test connection runs; web + mobile parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)