### PR TITLE
fix(grok): trust the spawn folder so its MCP servers start

### DIFF
--- a/internal/catalog/mcp.go
+++ b/internal/catalog/mcp.go
@@ -486,6 +486,16 @@ func renderGrokMCP(cwd string, servers []MCPServer) ([]string, map[string]string
 	if err := syncGrokWorkspaceMCP(cwd, entries); err != nil {
 		return nil, nil, err
 	}
+	// grok refuses to start repo-local (project-scoped) MCP servers in an
+	// UNTRUSTED folder — the memory/dbtool servers we just wrote to
+	// <cwd>/.grok/config.toml would be silently skipped otherwise (grok's own
+	// hint: "re-run with --trust"). opendray only spawns grok in the
+	// operator's own project dir, so mark it trusted: --trust persists the cwd
+	// to ~/.grok/trusted_folders.toml, the same gate that governs repo-local
+	// servers. Only when we actually injected servers.
+	if len(entries) > 0 {
+		return []string{"--trust"}, nil, nil
+	}
 	return nil, nil, nil
 }
 

--- a/internal/catalog/mcp_test.go
+++ b/internal/catalog/mcp_test.go
@@ -426,8 +426,10 @@ func TestRenderGrokMCP_WritesProjectConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(args) != 0 || len(env) != 0 {
-		t.Errorf("args=%v env=%v, want none (grok reads <cwd>/.grok/config.toml)", args, env)
+	// grok reads <cwd>/.grok/config.toml, but repo-local MCP servers only
+	// start in a TRUSTED folder — so we pass --trust (and no env).
+	if len(args) != 1 || args[0] != "--trust" || len(env) != 0 {
+		t.Errorf("args=%v env=%v, want [--trust] and no env", args, env)
 	}
 	mcps, ok := readGrokConfig(t, cwd)["mcp_servers"].(map[string]any)
 	if !ok {


### PR DESCRIPTION
## Summary

Grok sessions silently had **no memory / MCP tools**, unlike claude / codex / antigravity / opencode.

## Root cause (deep dive via `grok mcp doctor`)

opendray writes the memory (and dbtool) MCP servers into `<cwd>/.grok/config.toml` as **project-scoped ("repo-local")** entries — the location and TOML shape are correct (`grok mcp list` sees them). But grok **refuses to start repo-local MCP servers in an *untrusted* folder** as a supply-chain guard. `grok mcp doctor` spells it out:

```
opendray-memory (stdio: …)
  ✗ folder untrusted (repo-local (project-scoped) server not started for an untrusted folder)
  → re-run with --trust to allow repo-local servers
```

So the servers were written but never started → grok had zero MCP tools. (The manifest already declares `supportsMcp: true`, and `enabled` is not the blocker — trust is.)

## Fix

opendray only ever spawns grok in the operator's **own** project directory, so `renderGrokMCP` now returns **`--trust`** whenever it injected servers. grok persists the decision to `~/.grok/trusted_folders.toml` (the unified folder-trust store that gates repo-local MCP/LSP), and the project-scoped memory server starts on spawn — matching the other CLIs. Only emitted when servers were actually written (no servers → no flag).

## Verification (empirical)
- Reproduced the exact `grok mcp doctor` "folder untrusted → not started" for a project-scoped server.
- Confirmed grok's own `--trust` / `--trust-folder` writes `[folders."<path>"] trusted = true` and that the same server then **starts** (`✓ server started`).
- `go build ./...`, `go vet`, `go test ./internal/catalog -run Grok|MCP` — green. (The unrelated `TestUnmanagedBinLink` failure pre-exists on main — a grok bin-link env test.)

Backend-only. No web/mobile/i18n, no migration.

## Test plan
- [ ] **Local:** spawn a grok session in a project, `grok mcp doctor` (or the agent's tool list) shows `opendray-memory` started + tools discovered; ask grok to `memory_search` / `doc_read` and confirm it can. Folder appears in `~/.grok/trusted_folders.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)