### PR TITLE
feat(sessions): grok bypass/YOLO toggle on session create

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -198,6 +198,7 @@
         "bypassCodex": "Bypass approvals & sandbox (--dangerously-bypass-approvals-and-sandbox)",
         "bypassAntigravity": "Bypass permissions / YOLO (--dangerously-skip-permissions)",
         "bypassOpencode": "Bypass permissions (--dangerously-skip-permissions)",
+        "bypassGrok": "Bypass permissions / YOLO (--always-approve)",
         "bypassOnHint": "This session will run with elevated autonomy.",
         "bypassOffHint": "Off — confirmations and prompts behave normally.",
         "errorPickProvider": "Pick a provider.",
@@ -3670,6 +3671,7 @@
         "labelCodex": "Bypass approvals & sandbox",
         "labelAntigravity": "Bypass permissions / YOLO",
         "labelOpencode": "Bypass permissions",
+        "labelGrok": "Bypass permissions / YOLO (--always-approve)",
         "subtitleOn": "This session will run with elevated autonomy.",
         "subtitleOff": "Off — confirmations and prompts behave normally."
       },

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -198,6 +198,7 @@
         "bypassCodex": "Omitir aprobaciones y sandbox (--dangerously-bypass-approvals-and-sandbox)",
         "bypassAntigravity": "Omitir permisos / YOLO (--dangerously-skip-permissions)",
         "bypassOpencode": "Omitir permisos (--dangerously-skip-permissions)",
+        "bypassGrok": "Saltar permisos / YOLO (--always-approve)",
         "bypassOnHint": "Esta session se ejecutará con autonomía elevada.",
         "bypassOffHint": "Desactivado. Las confirmaciones y los prompts se comportan con normalidad.",
         "errorPickProvider": "Elige un proveedor.",
@@ -3670,6 +3671,7 @@
         "labelCodex": "Omitir aprobaciones y sandbox",
         "labelAntigravity": "Omitir permisos / YOLO",
         "labelOpencode": "Omitir permisos",
+        "labelGrok": "Saltar permisos / YOLO (--always-approve)",
         "subtitleOn": "Esta session se ejecutará con autonomía elevada.",
         "subtitleOff": "Desactivado. Las confirmaciones y los prompts se comportan de forma normal."
       },

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -198,6 +198,7 @@
         "bypassCodex": "跳过所有批准与沙盒 (--dangerously-bypass-approvals-and-sandbox)",
         "bypassAntigravity": "跳过权限 / YOLO (--dangerously-skip-permissions)",
         "bypassOpencode": "跳过权限检查 (--dangerously-skip-permissions)",
+        "bypassGrok": "跳过权限 / YOLO（--always-approve）",
         "bypassOnHint": "本次会话将以更高的自主权运行。",
         "bypassOffHint": "关闭 — 确认与提示按正常流程处理。",
         "errorPickProvider": "请选择一个 Provider。",
@@ -3670,6 +3671,7 @@
         "labelCodex": "跳过批准与沙盒",
         "labelAntigravity": "跳过权限 / YOLO",
         "labelOpencode": "跳过权限检查",
+        "labelGrok": "跳过权限 / YOLO（--always-approve）",
         "subtitleOn": "此会话将以提升的自主权运行。",
         "subtitleOff": "关闭 — 确认和提示按正常方式处理。"
       },

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 12366 (4122 per locale)
+/// Strings: 12372 (4124 per locale)
 ///
-/// Built on 2026-07-17 at 07:46 UTC
+/// Built on 2026-07-17 at 08:59 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -6467,6 +6467,9 @@ class TranslationsWebSessionsSpawnEn {
 	/// en: 'Bypass permissions (--dangerously-skip-permissions)'
 	String get bypassOpencode => 'Bypass permissions (--dangerously-skip-permissions)';
 
+	/// en: 'Bypass permissions / YOLO (--always-approve)'
+	String get bypassGrok => 'Bypass permissions / YOLO (--always-approve)';
+
 	/// en: 'This session will run with elevated autonomy.'
 	String get bypassOnHint => 'This session will run with elevated autonomy.';
 
@@ -13143,6 +13146,9 @@ class TranslationsSessionsSpawnSheetBypassEn {
 	/// en: 'Bypass permissions'
 	String get labelOpencode => 'Bypass permissions';
 
+	/// en: 'Bypass permissions / YOLO (--always-approve)'
+	String get labelGrok => 'Bypass permissions / YOLO (--always-approve)';
+
 	/// en: 'This session will run with elevated autonomy.'
 	String get subtitleOn => 'This session will run with elevated autonomy.';
 
@@ -17957,6 +17963,7 @@ extension on Translations {
 			'web.sessions.spawn.bypassCodex' => 'Bypass approvals & sandbox (--dangerously-bypass-approvals-and-sandbox)',
 			'web.sessions.spawn.bypassAntigravity' => 'Bypass permissions / YOLO (--dangerously-skip-permissions)',
 			'web.sessions.spawn.bypassOpencode' => 'Bypass permissions (--dangerously-skip-permissions)',
+			'web.sessions.spawn.bypassGrok' => 'Bypass permissions / YOLO (--always-approve)',
 			'web.sessions.spawn.bypassOnHint' => 'This session will run with elevated autonomy.',
 			'web.sessions.spawn.bypassOffHint' => 'Off — confirmations and prompts behave normally.',
 			'web.sessions.spawn.errorPickProvider' => 'Pick a provider.',
@@ -18296,9 +18303,9 @@ extension on Translations {
 			'web.project.inbox.emptyHint' => 'Agents file proposals here via `project_goal_set` / `project_plan_set` MCP tools.',
 			'web.project.inbox.approvedToast' => ({required Object label}) => '${label} updated',
 			'web.project.inbox.approveFailedToast' => 'Approve failed',
-			'web.project.inbox.rejectedToast' => 'Rejected',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.inbox.rejectedToast' => 'Rejected',
 			'web.project.inbox.rejectFailedToast' => 'Reject failed',
 			'web.project.inbox.sessionPrefix' => 'ses',
 			'web.project.inbox.warning' => ({required Object label}) => 'Approve will REPLACE the current ${label} entirely.',
@@ -18810,9 +18817,9 @@ extension on Translations {
 			'web.channels.toasts.deleteConfirm' => ({required Object id}) => 'Delete channel ${id}?',
 			'web.channels.toasts.deleted' => 'Channel deleted',
 			'web.channels.toasts.created' => 'Channel created',
-			'web.channels.toasts.updated' => 'Channel updated',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.toasts.updated' => 'Channel updated',
 			'web.channels.toasts.muted' => 'Channel muted',
 			'web.channels.toasts.unmuted' => 'Channel unmuted',
 			'web.channels.dialog.editTitle' => 'Edit channel',
@@ -19324,9 +19331,9 @@ extension on Translations {
 			'web.backups.schedulesTab.columns.interval' => 'Interval',
 			'web.backups.schedulesTab.columns.keep' => 'Keep',
 			'web.backups.schedulesTab.columns.nextRun' => 'Next run',
-			'web.backups.schedulesTab.columns.enabled' => 'Enabled',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.schedulesTab.columns.enabled' => 'Enabled',
 			'web.backups.schedulesTab.columns.actions' => 'Actions',
 			'web.backups.schedulesTab.keepCount' => ({required Object count}) => '${count} backups',
 			'web.backups.schedulesTab.deleteTooltip' => 'Delete',
@@ -19838,9 +19845,9 @@ extension on Translations {
 			'web.memoryAmbient.rules.dialog.dedupHint' => 'Higher = stricter de-duplication. 0.85 is the recommended sweet spot.',
 			'web.memoryAmbient.rules.dialog.create' => 'Create',
 			'web.memoryAmbient.rules.dialog.nameRequiredToast' => 'Name is required',
-			'web.memoryAmbient.rules.dialog.createdToast' => ({required Object name}) => 'Rule ${name} created',
 			_ => null,
 		} ?? switch (path) {
+			'web.memoryAmbient.rules.dialog.createdToast' => ({required Object name}) => 'Rule ${name} created',
 			'web.memoryAmbient.rules.dialog.createFailedToast' => 'Create failed',
 			'web.memoryAmbient.profiles.title' => 'Injection profiles',
 			'web.memoryAmbient.profiles.addButton' => 'Add profile',
@@ -20352,9 +20359,9 @@ extension on Translations {
 			'web.roundTable.plan.rerun' => 'Re-run',
 			'web.roundTable.plan.running' => 'Running',
 			'web.roundTable.plan.done' => 'Done',
-			'web.roundTable.plan.pending' => 'Pending',
 			_ => null,
 		} ?? switch (path) {
+			'web.roundTable.plan.pending' => 'Pending',
 			'web.roundTable.plan.openSession' => 'Open session',
 			'web.roundTable.plan.needProject' => 'Bind a project (cwd) to run steps.',
 			'web.roundTable.plan.bindProject' => 'Bind',
@@ -20661,6 +20668,7 @@ extension on Translations {
 			'sessions.spawnSheet.bypass.labelCodex' => 'Bypass approvals & sandbox',
 			'sessions.spawnSheet.bypass.labelAntigravity' => 'Bypass permissions / YOLO',
 			'sessions.spawnSheet.bypass.labelOpencode' => 'Bypass permissions',
+			'sessions.spawnSheet.bypass.labelGrok' => 'Bypass permissions / YOLO (--always-approve)',
 			'sessions.spawnSheet.bypass.subtitleOn' => 'This session will run with elevated autonomy.',
 			'sessions.spawnSheet.bypass.subtitleOff' => 'Off — confirmations and prompts behave normally.',
 			'sessions.spawnSheet.noProviders.title' => 'No providers configured',
@@ -20865,10 +20873,10 @@ extension on Translations {
 			'integrations.kvCreated' => 'Created',
 			'integrations.kvKeyRotated' => 'Key rotated',
 			'integrations.detailLoadFailed' => ({required Object error}) => 'Failed to load integration: ${error}',
-			'integrations.callsLoadFailed' => 'Failed to load calls',
-			'integrations.noMatchingCalls' => 'No matching calls in the log yet.',
 			_ => null,
 		} ?? switch (path) {
+			'integrations.callsLoadFailed' => 'Failed to load calls',
+			'integrations.noMatchingCalls' => 'No matching calls in the log yet.',
 			'integrations.directionAll' => 'All',
 			'integrations.directionInbound' => 'Inbound',
 			'integrations.directionOutbound' => 'Outbound',
@@ -21379,10 +21387,10 @@ extension on Translations {
 			'channels.badges.starting' => 'starting…',
 			'channels.badges.disabled' => 'disabled',
 			'channels.badges.muted' => 'muted',
-			'channels.capsLabel' => ({required Object list}) => '· caps: ${list}',
-			'channels.bridgeWebOnly' => 'Bridge channels stay web-only',
 			_ => null,
 		} ?? switch (path) {
+			'channels.capsLabel' => ({required Object list}) => '· caps: ${list}',
+			'channels.bridgeWebOnly' => 'Bridge channels stay web-only',
 			'channels.bridgeEmptyAdd' => 'Add one from the web admin: Channels → New.',
 			'channels.deleteBody' => 'Stops the channel and removes its configuration. In-flight notifications addressed to it will be dropped silently.',
 			'channels.snacks.testDispatched' => 'Test message dispatched.',
@@ -21893,10 +21901,10 @@ extension on Translations {
 			'cortexHub.loopHint' => 'Sessions feed Memory → Memory distills into Notes → Notes compound into Knowledge → Knowledge guides every new session.',
 			'cortexHub.settings' => 'Settings',
 			'cortexHub.memory' => 'Memory',
-			'cortexHub.memoryDesc' => 'Raw cross-session facts the agents store and recall.',
-			'cortexHub.notes' => 'Notes',
 			_ => null,
 		} ?? switch (path) {
+			'cortexHub.memoryDesc' => 'Raw cross-session facts the agents store and recall.',
+			'cortexHub.notes' => 'Notes',
 			'cortexHub.notesDesc' => 'Each project’s official goal / plan / journal.',
 			'cortexHub.knowledge' => 'Knowledge',
 			'cortexHub.knowledgeDesc' => 'Cross-project, distilled expertise.',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -3281,6 +3281,7 @@ class _TranslationsWebSessionsSpawnEs extends TranslationsWebSessionsSpawnEn {
 	@override String get bypassCodex => 'Omitir aprobaciones y sandbox (--dangerously-bypass-approvals-and-sandbox)';
 	@override String get bypassAntigravity => 'Omitir permisos / YOLO (--dangerously-skip-permissions)';
 	@override String get bypassOpencode => 'Omitir permisos (--dangerously-skip-permissions)';
+	@override String get bypassGrok => 'Saltar permisos / YOLO (--always-approve)';
 	@override String get bypassOnHint => 'Esta session se ejecutará con autonomía elevada.';
 	@override String get bypassOffHint => 'Desactivado. Las confirmaciones y los prompts se comportan con normalidad.';
 	@override String get errorPickProvider => 'Elige un proveedor.';
@@ -6730,6 +6731,7 @@ class _TranslationsSessionsSpawnSheetBypassEs extends TranslationsSessionsSpawnS
 	@override String get labelCodex => 'Omitir aprobaciones y sandbox';
 	@override String get labelAntigravity => 'Omitir permisos / YOLO';
 	@override String get labelOpencode => 'Omitir permisos';
+	@override String get labelGrok => 'Saltar permisos / YOLO (--always-approve)';
 	@override String get subtitleOn => 'Esta session se ejecutará con autonomía elevada.';
 	@override String get subtitleOff => 'Desactivado. Las confirmaciones y los prompts se comportan de forma normal.';
 }
@@ -9593,6 +9595,7 @@ extension on TranslationsEs {
 			'web.sessions.spawn.bypassCodex' => 'Omitir aprobaciones y sandbox (--dangerously-bypass-approvals-and-sandbox)',
 			'web.sessions.spawn.bypassAntigravity' => 'Omitir permisos / YOLO (--dangerously-skip-permissions)',
 			'web.sessions.spawn.bypassOpencode' => 'Omitir permisos (--dangerously-skip-permissions)',
+			'web.sessions.spawn.bypassGrok' => 'Saltar permisos / YOLO (--always-approve)',
 			'web.sessions.spawn.bypassOnHint' => 'Esta session se ejecutará con autonomía elevada.',
 			'web.sessions.spawn.bypassOffHint' => 'Desactivado. Las confirmaciones y los prompts se comportan con normalidad.',
 			'web.sessions.spawn.errorPickProvider' => 'Elige un proveedor.',
@@ -9932,9 +9935,9 @@ extension on TranslationsEs {
 			'web.project.inbox.emptyHint' => 'Los agentes presentan propuestas aquí mediante las herramientas MCP `project_goal_set` / `project_plan_set`.',
 			'web.project.inbox.approvedToast' => ({required Object label}) => '${label} actualizado',
 			'web.project.inbox.approveFailedToast' => 'Error al aprobar',
-			'web.project.inbox.rejectedToast' => 'Rechazado',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.inbox.rejectedToast' => 'Rechazado',
 			'web.project.inbox.rejectFailedToast' => 'Error al rechazar',
 			'web.project.inbox.sessionPrefix' => 'ses',
 			'web.project.inbox.warning' => ({required Object label}) => 'Aprobar REEMPLAZARÁ por completo el ${label} actual.',
@@ -10446,9 +10449,9 @@ extension on TranslationsEs {
 			'web.channels.toasts.deleteConfirm' => ({required Object id}) => '¿Eliminar el canal ${id}?',
 			'web.channels.toasts.deleted' => 'Canal eliminado',
 			'web.channels.toasts.created' => 'Canal creado',
-			'web.channels.toasts.updated' => 'Canal actualizado',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.toasts.updated' => 'Canal actualizado',
 			'web.channels.toasts.muted' => 'Canal silenciado',
 			'web.channels.toasts.unmuted' => 'Canal reactivado',
 			'web.channels.dialog.editTitle' => 'Editar canal',
@@ -10960,9 +10963,9 @@ extension on TranslationsEs {
 			'web.backups.schedulesTab.columns.interval' => 'Intervalo',
 			'web.backups.schedulesTab.columns.keep' => 'Conservar',
 			'web.backups.schedulesTab.columns.nextRun' => 'Próxima ejecución',
-			'web.backups.schedulesTab.columns.enabled' => 'Habilitada',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.schedulesTab.columns.enabled' => 'Habilitada',
 			'web.backups.schedulesTab.columns.actions' => 'Acciones',
 			'web.backups.schedulesTab.keepCount' => ({required Object count}) => '${count} copias de seguridad',
 			'web.backups.schedulesTab.deleteTooltip' => 'Eliminar',
@@ -11474,9 +11477,9 @@ extension on TranslationsEs {
 			'web.memoryAmbient.rules.dialog.dedupHint' => 'Más alto = deduplicación más estricta. 0.85 es el punto óptimo recomendado.',
 			'web.memoryAmbient.rules.dialog.create' => 'Crear',
 			'web.memoryAmbient.rules.dialog.nameRequiredToast' => 'El nombre es obligatorio',
-			'web.memoryAmbient.rules.dialog.createdToast' => ({required Object name}) => 'Regla ${name} creada',
 			_ => null,
 		} ?? switch (path) {
+			'web.memoryAmbient.rules.dialog.createdToast' => ({required Object name}) => 'Regla ${name} creada',
 			'web.memoryAmbient.rules.dialog.createFailedToast' => 'La creación falló',
 			'web.memoryAmbient.profiles.title' => 'Perfiles de inyección',
 			'web.memoryAmbient.profiles.addButton' => 'Añadir perfil',
@@ -11988,9 +11991,9 @@ extension on TranslationsEs {
 			'web.roundTable.plan.rerun' => 'Re-ejecutar',
 			'web.roundTable.plan.running' => 'En curso',
 			'web.roundTable.plan.done' => 'Hecho',
-			'web.roundTable.plan.pending' => 'Pendiente',
 			_ => null,
 		} ?? switch (path) {
+			'web.roundTable.plan.pending' => 'Pendiente',
 			'web.roundTable.plan.openSession' => 'Abrir sesión',
 			'web.roundTable.plan.needProject' => 'Vincula un proyecto (cwd) para ejecutar pasos.',
 			'web.roundTable.plan.bindProject' => 'Vincular',
@@ -12297,6 +12300,7 @@ extension on TranslationsEs {
 			'sessions.spawnSheet.bypass.labelCodex' => 'Omitir aprobaciones y sandbox',
 			'sessions.spawnSheet.bypass.labelAntigravity' => 'Omitir permisos / YOLO',
 			'sessions.spawnSheet.bypass.labelOpencode' => 'Omitir permisos',
+			'sessions.spawnSheet.bypass.labelGrok' => 'Saltar permisos / YOLO (--always-approve)',
 			'sessions.spawnSheet.bypass.subtitleOn' => 'Esta session se ejecutará con autonomía elevada.',
 			'sessions.spawnSheet.bypass.subtitleOff' => 'Desactivado. Las confirmaciones y los prompts se comportan de forma normal.',
 			'sessions.spawnSheet.noProviders.title' => 'No hay proveedores configurados',
@@ -12501,10 +12505,10 @@ extension on TranslationsEs {
 			'integrations.kvCreated' => 'Creada',
 			'integrations.kvKeyRotated' => 'Key rotada',
 			'integrations.detailLoadFailed' => ({required Object error}) => 'Error al cargar la integración: ${error}',
-			'integrations.callsLoadFailed' => 'Error al cargar las llamadas',
-			'integrations.noMatchingCalls' => 'Aún no hay llamadas coincidentes en el registro.',
 			_ => null,
 		} ?? switch (path) {
+			'integrations.callsLoadFailed' => 'Error al cargar las llamadas',
+			'integrations.noMatchingCalls' => 'Aún no hay llamadas coincidentes en el registro.',
 			'integrations.directionAll' => 'Todas',
 			'integrations.directionInbound' => 'Entrantes',
 			'integrations.directionOutbound' => 'Salientes',
@@ -13015,10 +13019,10 @@ extension on TranslationsEs {
 			'channels.badges.starting' => 'iniciando…',
 			'channels.badges.disabled' => 'desactivado',
 			'channels.badges.muted' => 'silenciado',
-			'channels.capsLabel' => ({required Object list}) => '· caps: ${list}',
-			'channels.bridgeWebOnly' => 'Los canales bridge solo están disponibles en la web',
 			_ => null,
 		} ?? switch (path) {
+			'channels.capsLabel' => ({required Object list}) => '· caps: ${list}',
+			'channels.bridgeWebOnly' => 'Los canales bridge solo están disponibles en la web',
 			'channels.bridgeEmptyAdd' => 'Añade uno desde el admin web: Canales → Nuevo.',
 			'channels.deleteBody' => 'Detiene el canal y elimina su configuración. Las notificaciones en curso dirigidas a él se descartarán de forma silenciosa.',
 			'channels.snacks.testDispatched' => 'Mensaje de prueba enviado.',
@@ -13529,10 +13533,10 @@ extension on TranslationsEs {
 			'cortexHub.loopHint' => 'Las sesiones alimentan la Memoria → la Memoria se destila en Notas → las Notas se compilan en Conocimiento → el Conocimiento guía cada nueva sesión.',
 			'cortexHub.settings' => 'Ajustes',
 			'cortexHub.memory' => 'Memoria',
-			'cortexHub.memoryDesc' => 'Hechos crudos entre sessions que los agentes guardan y recuerdan.',
-			'cortexHub.notes' => 'Notas',
 			_ => null,
 		} ?? switch (path) {
+			'cortexHub.memoryDesc' => 'Hechos crudos entre sessions que los agentes guardan y recuerdan.',
+			'cortexHub.notes' => 'Notas',
 			'cortexHub.notesDesc' => 'El objetivo / plan / diario oficial de cada proyecto.',
 			'cortexHub.knowledge' => 'Conocimiento',
 			'cortexHub.knowledgeDesc' => 'Experiencia destilada entre proyectos.',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -3281,6 +3281,7 @@ class _TranslationsWebSessionsSpawnZh extends TranslationsWebSessionsSpawnEn {
 	@override String get bypassCodex => '跳过所有批准与沙盒 (--dangerously-bypass-approvals-and-sandbox)';
 	@override String get bypassAntigravity => '跳过权限 / YOLO (--dangerously-skip-permissions)';
 	@override String get bypassOpencode => '跳过权限检查 (--dangerously-skip-permissions)';
+	@override String get bypassGrok => '跳过权限 / YOLO（--always-approve）';
 	@override String get bypassOnHint => '本次会话将以更高的自主权运行。';
 	@override String get bypassOffHint => '关闭 — 确认与提示按正常流程处理。';
 	@override String get errorPickProvider => '请选择一个 Provider。';
@@ -6730,6 +6731,7 @@ class _TranslationsSessionsSpawnSheetBypassZh extends TranslationsSessionsSpawnS
 	@override String get labelCodex => '跳过批准与沙盒';
 	@override String get labelAntigravity => '跳过权限 / YOLO';
 	@override String get labelOpencode => '跳过权限检查';
+	@override String get labelGrok => '跳过权限 / YOLO（--always-approve）';
 	@override String get subtitleOn => '此会话将以提升的自主权运行。';
 	@override String get subtitleOff => '关闭 — 确认和提示按正常方式处理。';
 }
@@ -9593,6 +9595,7 @@ extension on TranslationsZh {
 			'web.sessions.spawn.bypassCodex' => '跳过所有批准与沙盒 (--dangerously-bypass-approvals-and-sandbox)',
 			'web.sessions.spawn.bypassAntigravity' => '跳过权限 / YOLO (--dangerously-skip-permissions)',
 			'web.sessions.spawn.bypassOpencode' => '跳过权限检查 (--dangerously-skip-permissions)',
+			'web.sessions.spawn.bypassGrok' => '跳过权限 / YOLO（--always-approve）',
 			'web.sessions.spawn.bypassOnHint' => '本次会话将以更高的自主权运行。',
 			'web.sessions.spawn.bypassOffHint' => '关闭 — 确认与提示按正常流程处理。',
 			'web.sessions.spawn.errorPickProvider' => '请选择一个 Provider。',
@@ -9932,9 +9935,9 @@ extension on TranslationsZh {
 			'web.project.inbox.emptyHint' => 'Agent 通过 `project_goal_set` / `project_plan_set` MCP 工具在这里提交提案。',
 			'web.project.inbox.approvedToast' => ({required Object label}) => '${label}已更新',
 			'web.project.inbox.approveFailedToast' => '批准失败',
-			'web.project.inbox.rejectedToast' => '已驳回',
 			_ => null,
 		} ?? switch (path) {
+			'web.project.inbox.rejectedToast' => '已驳回',
 			'web.project.inbox.rejectFailedToast' => '驳回失败',
 			'web.project.inbox.sessionPrefix' => 'ses',
 			'web.project.inbox.warning' => ({required Object label}) => '批准将完全替换当前${label}。',
@@ -10446,9 +10449,9 @@ extension on TranslationsZh {
 			'web.channels.toasts.deleteConfirm' => ({required Object id}) => '删除频道 ${id}?',
 			'web.channels.toasts.deleted' => '频道已删除',
 			'web.channels.toasts.created' => '频道已创建',
-			'web.channels.toasts.updated' => '频道已更新',
 			_ => null,
 		} ?? switch (path) {
+			'web.channels.toasts.updated' => '频道已更新',
 			'web.channels.toasts.muted' => '频道已静音',
 			'web.channels.toasts.unmuted' => '频道已取消静音',
 			'web.channels.dialog.editTitle' => '编辑频道',
@@ -10960,9 +10963,9 @@ extension on TranslationsZh {
 			'web.backups.schedulesTab.columns.interval' => '间隔',
 			'web.backups.schedulesTab.columns.keep' => '保留',
 			'web.backups.schedulesTab.columns.nextRun' => '下次运行',
-			'web.backups.schedulesTab.columns.enabled' => '启用',
 			_ => null,
 		} ?? switch (path) {
+			'web.backups.schedulesTab.columns.enabled' => '启用',
 			'web.backups.schedulesTab.columns.actions' => '操作',
 			'web.backups.schedulesTab.keepCount' => ({required Object count}) => '${count} 个备份',
 			'web.backups.schedulesTab.deleteTooltip' => '删除',
@@ -11474,9 +11477,9 @@ extension on TranslationsZh {
 			'web.memoryAmbient.rules.dialog.dedupHint' => '越高 = 去重越严格。0.85 是推荐的平衡点。',
 			'web.memoryAmbient.rules.dialog.create' => '创建',
 			'web.memoryAmbient.rules.dialog.nameRequiredToast' => '名称不能为空',
-			'web.memoryAmbient.rules.dialog.createdToast' => ({required Object name}) => '已创建规则 ${name}',
 			_ => null,
 		} ?? switch (path) {
+			'web.memoryAmbient.rules.dialog.createdToast' => ({required Object name}) => '已创建规则 ${name}',
 			'web.memoryAmbient.rules.dialog.createFailedToast' => '创建失败',
 			'web.memoryAmbient.profiles.title' => 'Injection Profiles',
 			'web.memoryAmbient.profiles.addButton' => '添加 profile',
@@ -11988,9 +11991,9 @@ extension on TranslationsZh {
 			'web.roundTable.plan.rerun' => '重跑',
 			'web.roundTable.plan.running' => '运行中',
 			'web.roundTable.plan.done' => '完成',
-			'web.roundTable.plan.pending' => '待运行',
 			_ => null,
 		} ?? switch (path) {
+			'web.roundTable.plan.pending' => '待运行',
 			'web.roundTable.plan.openSession' => '打开会话',
 			'web.roundTable.plan.needProject' => '运行步骤前需绑定项目(cwd)。',
 			'web.roundTable.plan.bindProject' => '绑定',
@@ -12297,6 +12300,7 @@ extension on TranslationsZh {
 			'sessions.spawnSheet.bypass.labelCodex' => '跳过批准与沙盒',
 			'sessions.spawnSheet.bypass.labelAntigravity' => '跳过权限 / YOLO',
 			'sessions.spawnSheet.bypass.labelOpencode' => '跳过权限检查',
+			'sessions.spawnSheet.bypass.labelGrok' => '跳过权限 / YOLO（--always-approve）',
 			'sessions.spawnSheet.bypass.subtitleOn' => '此会话将以提升的自主权运行。',
 			'sessions.spawnSheet.bypass.subtitleOff' => '关闭 — 确认和提示按正常方式处理。',
 			'sessions.spawnSheet.noProviders.title' => '未配置任何提供商',
@@ -12501,10 +12505,10 @@ extension on TranslationsZh {
 			'integrations.kvCreated' => '创建于',
 			'integrations.kvKeyRotated' => 'Key 轮换于',
 			'integrations.detailLoadFailed' => ({required Object error}) => '加载集成失败：${error}',
-			'integrations.callsLoadFailed' => '加载调用失败',
-			'integrations.noMatchingCalls' => '日志中暂无匹配的调用。',
 			_ => null,
 		} ?? switch (path) {
+			'integrations.callsLoadFailed' => '加载调用失败',
+			'integrations.noMatchingCalls' => '日志中暂无匹配的调用。',
 			'integrations.directionAll' => '全部',
 			'integrations.directionInbound' => '入站',
 			'integrations.directionOutbound' => '出站',
@@ -13015,10 +13019,10 @@ extension on TranslationsZh {
 			'channels.badges.starting' => '启动中…',
 			'channels.badges.disabled' => '已停用',
 			'channels.badges.muted' => '已静音',
-			'channels.capsLabel' => ({required Object list}) => '· 能力：${list}',
-			'channels.bridgeWebOnly' => 'Bridge 通道仅 Web 端',
 			_ => null,
 		} ?? switch (path) {
+			'channels.capsLabel' => ({required Object list}) => '· 能力：${list}',
+			'channels.bridgeWebOnly' => 'Bridge 通道仅 Web 端',
 			'channels.bridgeEmptyAdd' => '在 Web 管理端添加：通道 → 新建。',
 			'channels.deleteBody' => '停止该通道并移除其配置。仍在传输中的通知会被静默丢弃。',
 			'channels.snacks.testDispatched' => '测试消息已发送。',
@@ -13529,10 +13533,10 @@ extension on TranslationsZh {
 			'cortexHub.loopHint' => '会话喂养记忆 → 记忆提炼为笔记 → 笔记沉淀为知识 → 知识引导每个新会话。',
 			'cortexHub.settings' => '设置',
 			'cortexHub.memory' => '记忆',
-			'cortexHub.memoryDesc' => '代理存取的跨会话原始事实。',
-			'cortexHub.notes' => '笔记',
 			_ => null,
 		} ?? switch (path) {
+			'cortexHub.memoryDesc' => '代理存取的跨会话原始事实。',
+			'cortexHub.notes' => '笔记',
 			'cortexHub.notesDesc' => '每个项目的官方目标 / 计划 / 日志。',
 			'cortexHub.knowledge' => '知识',
 			'cortexHub.knowledgeDesc' => '跨项目沉淀的专业知识。',

--- a/app/mobile/lib/features/sessions/spawn_session_sheet.dart
+++ b/app/mobile/lib/features/sessions/spawn_session_sheet.dart
@@ -32,6 +32,8 @@ const Map<String, List<String>> _bypassFlagsByProvider = {
   'codex': ['--dangerously-bypass-approvals-and-sandbox'],
   'antigravity': ['--dangerously-skip-permissions'],
   'opencode': ['--dangerously-skip-permissions'],
+  // grok's documented auto-approve (manifest bypassPermissions → this flag).
+  'grok': ['--always-approve'],
 };
 
 // Per-provider label for the bypass toggle. Different CLIs name
@@ -43,6 +45,7 @@ String? _bypassLabelFor(String providerId) {
     'codex' => t.sessions.spawnSheet.bypass.labelCodex,
     'antigravity' => t.sessions.spawnSheet.bypass.labelAntigravity,
     'opencode' => t.sessions.spawnSheet.bypass.labelOpencode,
+    'grok' => t.sessions.spawnSheet.bypass.labelGrok,
     _ => null,
   };
 }

--- a/app/web/src/components/sessions/SpawnDialog.tsx
+++ b/app/web/src/components/sessions/SpawnDialog.tsx
@@ -45,6 +45,9 @@ const BYPASS_FLAGS: Record<string, string[]> = {
   codex: ['--dangerously-bypass-approvals-and-sandbox'],
   antigravity: ['--dangerously-skip-permissions'],
   opencode: ['--dangerously-skip-permissions'],
+  // grok's documented auto-approve (its manifest maps bypassPermissions →
+  // --always-approve): approve every tool execution, no prompts.
+  grok: ['--always-approve'],
 }
 
 // i18n key suffix per provider for the bypass toggle label. Different
@@ -55,6 +58,7 @@ const BYPASS_LABEL_KEY: Record<string, string> = {
   codex: 'web.sessions.spawn.bypassCodex',
   antigravity: 'web.sessions.spawn.bypassAntigravity',
   opencode: 'web.sessions.spawn.bypassOpencode',
+  grok: 'web.sessions.spawn.bypassGrok',
 }
 
 export function SpawnDialog({


### PR DESCRIPTION
## Summary

Creating a **grok** session had no bypass / YOLO toggle, unlike claude / codex / antigravity / opencode. grok was simply missing from the per-session bypass maps in both the web `SpawnDialog` and the mobile spawn sheet, so the toggle never rendered for grok.

## What changed

- **Web** (`SpawnDialog.tsx`) + **Mobile** (`spawn_session_sheet.dart`): add grok to the bypass-flags map and the label map, so the "Bypass permissions / YOLO" toggle shows for grok.
- Flag: **`--always-approve`** — grok's documented auto-approve (its manifest already maps the `bypassPermissions` config to `--always-approve`; also listed in `grok --help`).
- **i18n**: `web.sessions.spawn.bypassGrok` + `sessions.spawnSheet.bypass.labelGrok` (en/zh/es); slang regenerated.

## Notes
- Verified `grok --always-approve` spawns cleanly and composes with the `--trust` flag added in #471 (MCP) — a real spawn passes `grok … --trust --always-approve`.
- The toggle is per-session, opt-in, defaults OFF (same as the other providers).

## Test plan
- [x] web `tsc` clean; `flutter analyze lib/features/sessions` — no issues; i18n parity 100%; grok flag verified on the host
- [ ] **Local:** create a grok session → the "Bypass permissions / YOLO" toggle appears; enabling it spawns grok with `--always-approve` and the agent runs without permission prompts; web + mobile parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)