### PR TITLE
fix(knowledge): keep operator lock on approve; stop re-proposing rejected KB refreshes

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -273,6 +273,30 @@ func (a knowledgeProposalSink) ProposeKBDoc(ctx context.Context, cwd, kind, cont
 	return err
 }
 
+// RejectedSigs recovers the feedstock signature of each rejected proposal for
+// a page (the sig lives in the proposed content's trailing kb-sig marker), so
+// the drafter won't re-file a refresh the operator already declined.
+func (a knowledgeProposalSink) RejectedSigs(ctx context.Context, cwd, kind string) ([]string, error) {
+	contents, err := a.pd.RejectedProposalContents(ctx, cwd, projectdoc.Kind(kind))
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{}, len(contents))
+	out := make([]string, 0, len(contents))
+	for _, c := range contents {
+		sig := knowledge.ExtractKBSig(c)
+		if sig == "" {
+			continue
+		}
+		if _, ok := seen[sig]; ok {
+			continue
+		}
+		seen[sig] = struct{}{}
+		out = append(out, sig)
+	}
+	return out, nil
+}
+
 // knowledgeLLM adapts the memory worker registry to knowledge.LLM so the
 // Phase 1B entity extractor gets a general completion path. It borrows the
 // TaskCapture worker config (the closest existing touchpoint: extract

--- a/internal/knowledge/kb.go
+++ b/internal/knowledge/kb.go
@@ -52,6 +52,12 @@ type DocSink interface {
 type ProposalSink interface {
 	HasPendingKBProposal(ctx context.Context, cwd, kind string) (bool, error)
 	ProposeKBDoc(ctx context.Context, cwd, kind, content, reason string) error
+	// RejectedSigs returns the feedstock signatures of proposals the
+	// operator has already REJECTED for this page. The drafter uses them to
+	// avoid re-proposing an identical refresh every cycle: a rejection with
+	// no memory would otherwise resurface the same draft on the next sweep
+	// (the ~15m consolidation interval), nagging the operator forever.
+	RejectedSigs(ctx context.Context, cwd, kind string) ([]string, error)
 }
 
 // KBDrafter distils Memory + the graph into the global Knowledge pages.
@@ -152,7 +158,7 @@ Only include things genuinely reusable across projects — skip one-off project 
 type KBDraftResult struct {
 	Kind   string `json:"kind"`
 	Cwd    string `json:"cwd"`
-	Status string `json:"status"` // written | skipped-empty | skipped-locked | skipped-unchanged | error
+	Status string `json:"status"` // written | proposed | skipped-empty | skipped-locked | skipped-pending | skipped-rejected | skipped-unchanged | error
 	Bytes  int    `json:"bytes,omitempty"`
 	Err    string `json:"error,omitempty"`
 }
@@ -214,6 +220,21 @@ func draftOrPropose(ctx context.Context, llm LLM, docs DocSink, proposals Propos
 		if pending, _ := proposals.HasPendingKBProposal(ctx, cwd, kind); pending {
 			res.Status = "skipped-pending"
 			return res
+		}
+		// A rejected refresh must stay rejected: if the operator already said
+		// no to the draft for THIS feedstock, don't re-file it. Otherwise the
+		// same proposal resurfaces every consolidation cycle. On lookup error
+		// we fail open (proceed to propose) rather than silently drop a real
+		// divergence.
+		if rejected, err := proposals.RejectedSigs(ctx, cwd, kind); err != nil {
+			log.Warn("draft: rejected-sig lookup failed", "kind", kind, "cwd", cwd, "err", err)
+		} else {
+			for _, rs := range rejected {
+				if rs == sig {
+					res.Status = "skipped-rejected"
+					return res
+				}
+			}
 		}
 		body, err := draftPageBody(ctx, llm, log, system, feedstock, sig)
 		if err != nil {
@@ -357,6 +378,12 @@ func kbSig(feedstock string) string {
 	sum := sha256.Sum256([]byte(feedstock))
 	return hex.EncodeToString(sum[:])[:16]
 }
+
+// ExtractKBSig reads the feedstock signature a drafted page carries in its
+// trailing `<!-- kb-sig:… -->` marker, or "" if absent. Exported so the app's
+// proposal sink can recover the signature of a rejected proposal's content
+// (which was produced by draftPageBody and therefore carries the marker).
+func ExtractKBSig(content string) string { return extractKBSig(content) }
 
 func extractKBSig(content string) string {
 	const marker = "<!-- kb-sig:"

--- a/internal/knowledge/kb_draft_test.go
+++ b/internal/knowledge/kb_draft_test.go
@@ -1,0 +1,144 @@
+package knowledge
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// --- fakes ---------------------------------------------------------------
+
+type fakeLLM struct{ body string }
+
+func (f fakeLLM) Complete(_ context.Context, _, _ string) (string, error) {
+	return f.body, nil
+}
+
+type fakeDocSink struct {
+	doc        KBDoc
+	putCalls   int
+	putContent string
+}
+
+func (f *fakeDocSink) GetKBDoc(_ context.Context, _, _ string) (KBDoc, error) { return f.doc, nil }
+func (f *fakeDocSink) PutKBDoc(_ context.Context, _, _, content string) error {
+	f.putCalls++
+	f.putContent = content
+	return nil
+}
+
+type fakeProposalSink struct {
+	pending      bool
+	rejected     []string
+	proposeCalls int
+	proposed     string
+}
+
+func (f *fakeProposalSink) HasPendingKBProposal(_ context.Context, _, _ string) (bool, error) {
+	return f.pending, nil
+}
+func (f *fakeProposalSink) ProposeKBDoc(_ context.Context, _, _, content, _ string) error {
+	f.proposeCalls++
+	f.proposed = content
+	return nil
+}
+func (f *fakeProposalSink) RejectedSigs(_ context.Context, _, _ string) ([]string, error) {
+	return f.rejected, nil
+}
+
+func discardLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+const (
+	testCwd  = "__global__"
+	testKind = "kb_infrastructure"
+	testFeed = "ENTITIES:\nhost: kv01\n\nFACTS:\n- dev db at 192.168.3.88\n"
+)
+
+// --- tests ---------------------------------------------------------------
+
+// A locked page whose feedstock has diverged files a proposal (does not
+// overwrite) when the draft has not been rejected before.
+func TestDraftOrPropose_LockedProposes(t *testing.T) {
+	docs := &fakeDocSink{doc: KBDoc{Content: "old\n<!-- kb-sig:0000000000000000 -->\n", HumanLocked: true, Exists: true}}
+	props := &fakeProposalSink{}
+
+	res := draftOrPropose(context.Background(), fakeLLM{body: "fresh body"}, docs, props, discardLog(), testCwd, testKind, "sys", testFeed)
+
+	if res.Status != "proposed" {
+		t.Fatalf("status = %q, want proposed", res.Status)
+	}
+	if props.proposeCalls != 1 {
+		t.Fatalf("propose calls = %d, want 1", props.proposeCalls)
+	}
+	if docs.putCalls != 0 {
+		t.Fatalf("locked page must not be overwritten (put calls = %d)", docs.putCalls)
+	}
+}
+
+// Bug 2 regression: a draft the operator already rejected (same feedstock
+// signature) must NOT be re-proposed on the next sweep.
+func TestDraftOrPropose_LockedSkipsRejectedSig(t *testing.T) {
+	docs := &fakeDocSink{doc: KBDoc{Content: "old\n<!-- kb-sig:0000000000000000 -->\n", HumanLocked: true, Exists: true}}
+	props := &fakeProposalSink{rejected: []string{kbSig(testFeed)}}
+
+	res := draftOrPropose(context.Background(), fakeLLM{body: "fresh body"}, docs, props, discardLog(), testCwd, testKind, "sys", testFeed)
+
+	if res.Status != "skipped-rejected" {
+		t.Fatalf("status = %q, want skipped-rejected", res.Status)
+	}
+	if props.proposeCalls != 0 {
+		t.Fatalf("a rejected draft must not be re-proposed (propose calls = %d)", props.proposeCalls)
+	}
+}
+
+// A rejection for a DIFFERENT feedstock signature does not suppress a genuinely
+// new divergence.
+func TestDraftOrPropose_LockedProposesWhenRejectionIsStale(t *testing.T) {
+	docs := &fakeDocSink{doc: KBDoc{Content: "old\n<!-- kb-sig:0000000000000000 -->\n", HumanLocked: true, Exists: true}}
+	props := &fakeProposalSink{rejected: []string{"deadbeefdeadbeef"}}
+
+	res := draftOrPropose(context.Background(), fakeLLM{body: "fresh body"}, docs, props, discardLog(), testCwd, testKind, "sys", testFeed)
+
+	if res.Status != "proposed" {
+		t.Fatalf("status = %q, want proposed", res.Status)
+	}
+	if props.proposeCalls != 1 {
+		t.Fatalf("propose calls = %d, want 1", props.proposeCalls)
+	}
+}
+
+// When the page already carries the current feedstock signature, the sweep is a
+// no-op — no LLM call, no proposal, no overwrite.
+func TestDraftOrPropose_SkipsUnchanged(t *testing.T) {
+	content := "body\n<!-- kb-sig:" + kbSig(testFeed) + " -->\n"
+	docs := &fakeDocSink{doc: KBDoc{Content: content, HumanLocked: true, Exists: true}}
+	props := &fakeProposalSink{}
+
+	res := draftOrPropose(context.Background(), fakeLLM{body: "should not be used"}, docs, props, discardLog(), testCwd, testKind, "sys", testFeed)
+
+	if res.Status != "skipped-unchanged" {
+		t.Fatalf("status = %q, want skipped-unchanged", res.Status)
+	}
+	if props.proposeCalls != 0 || docs.putCalls != 0 {
+		t.Fatalf("unchanged page must be untouched (propose=%d put=%d)", props.proposeCalls, docs.putCalls)
+	}
+}
+
+// An unlocked (agent-owned) page whose feedstock diverged is rewritten in place.
+func TestDraftOrPropose_UnlockedWrites(t *testing.T) {
+	docs := &fakeDocSink{doc: KBDoc{Content: "old\n<!-- kb-sig:0000000000000000 -->\n", HumanLocked: false, Exists: true}}
+	props := &fakeProposalSink{}
+
+	res := draftOrPropose(context.Background(), fakeLLM{body: "fresh body"}, docs, props, discardLog(), testCwd, testKind, "sys", testFeed)
+
+	if res.Status != "written" {
+		t.Fatalf("status = %q, want written", res.Status)
+	}
+	if docs.putCalls != 1 {
+		t.Fatalf("put calls = %d, want 1", docs.putCalls)
+	}
+	if props.proposeCalls != 0 {
+		t.Fatalf("unlocked page must not propose (propose calls = %d)", props.proposeCalls)
+	}
+}

--- a/internal/projectdoc/projectdoc.go
+++ b/internal/projectdoc/projectdoc.go
@@ -524,6 +524,34 @@ func (s *Service) ListPendingProposals(ctx context.Context, cwd string) ([]Propo
 	return out, rows.Err()
 }
 
+// RejectedProposalContents returns the proposed_content of every REJECTED
+// proposal for one page, newest first (bounded — a page accrues at most a
+// handful of distinct rejected drafts). The knowledge drafter maps these to
+// feedstock signatures so it never re-files a refresh the operator already
+// declined. Kept content-only (no Proposal decode) so the layer stays generic:
+// projectdoc knows nothing about kb-sig markers.
+func (s *Service) RejectedProposalContents(ctx context.Context, cwd string, kind Kind) ([]string, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT proposed_content
+		  FROM project_doc_proposals
+		 WHERE cwd = $1 AND kind = $2 AND decision = 'rejected'
+		 ORDER BY created_at DESC
+		 LIMIT 100`, cwd, string(kind))
+	if err != nil {
+		return nil, fmt.Errorf("projectdoc: list rejected proposals: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var c string
+		if err := rows.Scan(&c); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
 // ApproveProposal merges the proposed content into project_docs
 // and stamps the proposal row 'approved' with the prior content
 // captured for audit. Idempotent in the sense that re-approving an
@@ -562,13 +590,18 @@ func (s *Service) ApproveProposal(ctx context.Context, id string) (Doc, error) {
 		`SELECT content FROM project_docs WHERE cwd=$1 AND kind=$2`,
 		p.Cwd, string(p.Kind)).Scan(&prior)
 
+	// Approving is an operator decision, so the resulting doc is
+	// operator-authored — this PRESERVES the human-lock (updated_by=operator).
+	// Stamping 'agent' here would silently un-lock the page: the next time the
+	// feedstock diverged, the drafter would overwrite it directly instead of
+	// proposing, making the lock a one-shot that any approval throws away.
 	newDocID := newID("pd_")
 	docRow := tx.QueryRow(ctx, `
 		INSERT INTO project_docs (id, cwd, kind, content, updated_by)
-		VALUES ($1, $2, $3, $4, 'agent')
+		VALUES ($1, $2, $3, $4, 'operator')
 		ON CONFLICT (cwd, kind) DO UPDATE
 		   SET content      = EXCLUDED.content,
-		       updated_by   = 'agent',
+		       updated_by   = 'operator',
 		       updated_at   = NOW(),
 		       embedding    = NULL,
 		       embedder     = NULL,

--- a/internal/projectdoc/proposal_lock_test.go
+++ b/internal/projectdoc/proposal_lock_test.go
@@ -1,0 +1,107 @@
+package projectdoc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestApproveProposalPreservesOperatorLock is the Bug 1 regression: approving a
+// proposal is an operator decision, so the resulting doc must stay
+// operator-authored (HumanLocked). Stamping 'agent' would silently un-lock the
+// page, turning the human-lock into a one-shot any approval throws away.
+//
+// DB-gated (skips without OPENDRAY_DEV_DB_URL). Uses an isolated throwaway cwd
+// and cleans up after itself so it never touches real project or global data.
+func TestApproveProposalPreservesOperatorLock(t *testing.T) {
+	pool := devDB(t)
+	defer pool.Close()
+	svc := NewService(pool, nil)
+	svc.DisableMirror()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	uniq := time.Now().UnixNano()
+	cwd := fmt.Sprintf("/__opendray_test__/approve-lock-%d", uniq)
+	kind := string(KindGoal)
+	docID := fmt.Sprintf("pd_test_%d", uniq)
+	propID := fmt.Sprintf("pdp_test_%d", uniq)
+
+	// Registered after `defer pool.Close()` so LIFO runs the deletes FIRST,
+	// while the pool is still open (t.Cleanup would run after pool.Close).
+	defer func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM project_doc_proposals WHERE cwd=$1`, cwd)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM project_docs WHERE cwd=$1`, cwd)
+	}()
+
+	// Seed an operator-locked doc + a pending proposal directly. Raw INSERTs
+	// bypass blueprint validation, which is irrelevant to what we're testing.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO project_docs (id,cwd,kind,content,updated_by) VALUES ($1,$2,$3,$4,'operator')`,
+		docID, cwd, kind, "locked body"); err != nil {
+		t.Fatalf("seed doc: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO project_doc_proposals (id,cwd,kind,proposed_content,reason) VALUES ($1,$2,$3,$4,$5)`,
+		propID, cwd, kind, "refreshed body", "test"); err != nil {
+		t.Fatalf("seed proposal: %v", err)
+	}
+
+	doc, err := svc.ApproveProposal(ctx, propID)
+	if err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if doc.UpdatedBy != AuthorOperator {
+		t.Fatalf("approved doc author = %q, want %q (approving must preserve the operator lock)",
+			doc.UpdatedBy, AuthorOperator)
+	}
+	if doc.Content != "refreshed body" {
+		t.Fatalf("approved content = %q, want %q", doc.Content, "refreshed body")
+	}
+}
+
+// TestRejectedProposalContents verifies the query the drafter uses to suppress
+// re-proposing rejected refreshes (Bug 2) returns only rejected rows.
+func TestRejectedProposalContents(t *testing.T) {
+	pool := devDB(t)
+	defer pool.Close()
+	svc := NewService(pool, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	uniq := time.Now().UnixNano()
+	cwd := fmt.Sprintf("/__opendray_test__/rejected-%d", uniq)
+	kind := string(KindInfrastructure)
+
+	// defer (not t.Cleanup) so the delete runs before `defer pool.Close()`.
+	defer func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM project_doc_proposals WHERE cwd=$1`, cwd)
+	}()
+
+	seedDecided := func(id, content, decision string) {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO project_doc_proposals (id,cwd,kind,proposed_content,reason,decision,decided_at) VALUES ($1,$2,$3,$4,'r',$5,NOW())`,
+			id, cwd, kind, content, decision); err != nil {
+			t.Fatalf("seed %s: %v", decision, err)
+		}
+	}
+	seedPending := func(id, content string) {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO project_doc_proposals (id,cwd,kind,proposed_content,reason) VALUES ($1,$2,$3,$4,'r')`,
+			id, cwd, kind, content); err != nil {
+			t.Fatalf("seed pending: %v", err)
+		}
+	}
+	seedDecided(fmt.Sprintf("pdp_r_%d", uniq), "REJECTED body", "rejected")
+	seedPending(fmt.Sprintf("pdp_p_%d", uniq+1), "PENDING body")
+	seedDecided(fmt.Sprintf("pdp_a_%d", uniq+2), "APPROVED body", "approved")
+
+	got, err := svc.RejectedProposalContents(ctx, cwd, KindInfrastructure)
+	if err != nil {
+		t.Fatalf("rejected contents: %v", err)
+	}
+	if len(got) != 1 || got[0] != "REJECTED body" {
+		t.Fatalf("got %v, want [REJECTED body]", got)
+	}
+}


### PR DESCRIPTION
## Problem

A human-locked global KB page (e.g. `kb_infrastructure`) could not be made to converge from the web/mobile UI. Two bugs in the proposal flow fought each other:

**Bug 1 — approving a proposal silently drops the operator lock.**
`ApproveProposal` wrote the merged content back as `updated_by='agent'` (internal/projectdoc/projectdoc.go). Since `HumanLocked == (updated_by == 'operator')`, the page became agent-owned again, so the *next* feedstock divergence overwrote it **directly instead of proposing**. The human-lock was a one-shot that any approval threw away.

**Bug 2 — rejecting a proposal doesn't stick.**
`RejectProposal` only stamped the row `rejected`. `HasPendingKBProposal` counts only `decided_at IS NULL`, and nothing recorded the rejected feedstock signature — so the drafter re-generated and re-filed the *identical* refresh on the next consolidation cycle (~15m interval), nagging the operator forever.

Net effect: approve → lose the lock → silent overwrites; reject → the same proposal returns every sweep. No stable resolution via the UI.

## Fix

- **Bug 1:** approving is an operator decision, so the resulting doc is now `updated_by='operator'` — the lock is preserved (future divergences propose, not overwrite).
- **Bug 2:** the drafter skips a locked page whose *current* feedstock signature matches an already-rejected proposal. New `ProposalSink.RejectedSigs`, backed by `projectdoc.RejectedProposalContents` (the sig lives in the proposed content's trailing `<!-- kb-sig:… -->` marker; extraction stays in the `knowledge` layer via the newly-exported `ExtractKBSig`). `RejectProposal` stays side-effect-free. A rejection for a *different* (stale) signature still lets a genuinely new divergence through.

## Tests

- `internal/knowledge/kb_draft_test.go` — drafter decision table with fakes, **no DB**: proposes when not rejected, `skipped-rejected` for a matching rejected sig, still proposes for a stale rejection, `skipped-unchanged`, and unlocked-writes.
- `internal/projectdoc/proposal_lock_test.go` — **DB-gated** (skips without `OPENDRAY_DEV_DB_URL`): approve preserves the operator author + content, and the rejected-contents query returns only rejected rows. Runs on an isolated throwaway cwd with cleanup.

All green locally (`go test ./internal/knowledge/... ./internal/projectdoc/...`, including the DB-gated tests against the dev DB); gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)