### PR TITLE
feat(knowledge): operator owns the form of the four global KB pages

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -217,18 +217,27 @@ func (a knowledgeJournalSource) ListJournal(ctx context.Context, scopeKey string
 type knowledgeDocSink struct{ pd *projectdoc.Service }
 
 func (a knowledgeDocSink) GetKBDoc(ctx context.Context, cwd, kind string) (knowledge.KBDoc, error) {
+	out := knowledge.KBDoc{}
 	d, err := a.pd.GetDoc(ctx, cwd, projectdoc.Kind(kind))
-	if errors.Is(err, projectdoc.ErrNotFound) {
-		return knowledge.KBDoc{}, nil
-	}
-	if err != nil {
+	switch {
+	case errors.Is(err, projectdoc.ErrNotFound):
+		// No content row yet — the blueprint meta below may still apply
+		// (an empty page can be operator-maintained).
+	case err != nil:
 		return knowledge.KBDoc{}, err
+	default:
+		out.Content = d.Content
+		out.HumanLocked = d.UpdatedBy == projectdoc.AuthorOperator
+		out.Exists = true
 	}
-	return knowledge.KBDoc{
-		Content:     d.Content,
-		HumanLocked: d.UpdatedBy == projectdoc.AuthorOperator,
-		Exists:      true,
-	}, nil
+	// Operator-owned-form controls from the page's blueprint section. Best
+	// effort: a missing section or lookup error just leaves the AI defaults
+	// (empty MaintainerMode → treated as "ai").
+	if sec, ok, serr := a.pd.GetSection(ctx, cwd, kind); serr == nil && ok {
+		out.MaintainerMode = sec.MaintainerMode
+		out.PromptHint = sec.PromptHint
+	}
+	return out, nil
 }
 
 func (a knowledgeDocSink) PutKBDoc(ctx context.Context, cwd, kind, content string) error {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -230,12 +230,17 @@ func (a knowledgeDocSink) GetKBDoc(ctx context.Context, cwd, kind string) (knowl
 		out.HumanLocked = d.UpdatedBy == projectdoc.AuthorOperator
 		out.Exists = true
 	}
-	// Operator-owned-form controls from the page's blueprint section. Best
-	// effort: a missing section or lookup error just leaves the AI defaults
-	// (empty MaintainerMode → treated as "ai").
-	if sec, ok, serr := a.pd.GetSection(ctx, cwd, kind); serr == nil && ok {
-		out.MaintainerMode = sec.MaintainerMode
-		out.PromptHint = sec.PromptHint
+	// Operator-owned-form controls from the page's blueprint section. Only the
+	// four global KB pages carry (and have the drafter consult) these controls;
+	// the Overview drafter shares this sink but ignores them, so skip the extra
+	// blueprint lookup for anything that is not a global KB page. Best effort: a
+	// missing section or lookup error just leaves the AI defaults (empty
+	// MaintainerMode → treated as "ai").
+	if cwd == projectdoc.GlobalCwd && projectdoc.IsGlobalKBKind(projectdoc.Kind(kind)) {
+		if sec, ok, serr := a.pd.GetSection(ctx, cwd, kind); serr == nil && ok {
+			out.MaintainerMode = sec.MaintainerMode
+			out.PromptHint = sec.PromptHint
+		}
 	}
 	return out, nil
 }

--- a/internal/knowledge/kb.go
+++ b/internal/knowledge/kb.go
@@ -36,6 +36,13 @@ type KBDoc struct {
 	Content     string
 	HumanLocked bool // a human edit (operator-authored) locks it from AI overwrite
 	Exists      bool
+	// MaintainerMode + PromptHint come from the page's blueprint section and
+	// let the OPERATOR own the page's form: "human" hands the page entirely to
+	// the operator (the drafter never touches it); PromptHint steers the AI
+	// maintainer's shape/scope when the mode is "ai". Empty MaintainerMode is
+	// treated as "ai" (the historical default).
+	MaintainerMode string
+	PromptHint     string
 }
 
 // DocSink persists curated KB pages into the note system (projectdoc-backed in
@@ -132,33 +139,39 @@ NEVER include secrets: passwords, API keys, tokens, certificates' private materi
 When information conflicts across time, describe only the CURRENT state — if something was renamed, deprecated, or replaced (e.g. an old tool/host/path superseded by a new one), present the current one and note the predecessor as deprecated; never present superseded state as current.
 Be concise and factual. No preamble, no "here is", no markdown code fences around the whole document.`
 
-// kbInfraSystem + kbConvSystem produce FOUNDATIONAL pages: standing ground
-// truth + the rules for using it. They are injected into every project as
-// BINDING constraints, so each page must end with an explicit, imperative
-// "## Rules (MUST follow)" section separated from the descriptive facts.
+// kbBaseSystem is the shared, FORM-NEUTRAL maintainer prompt for the four
+// global KB pages. It deliberately mandates NO section skeleton — the page's
+// shape belongs to the operator, expressed by editing the page itself and/or
+// its blueprint prompt_hint. The drafter only folds genuinely new, on-topic
+// evidence into whatever structure the operator has established. (Historically
+// each page had a hardcoded skeleton here — Databases/Domains/Rules/… — which
+// re-manufactured the same shape on every sweep and made operator curation
+// impossible to keep. That is intentionally gone.)
+const kbBaseSystem = `You maintain a long-lived, operator-owned knowledge page.
+You receive the page's CURRENT content and fresh EVIDENCE (facts / entities / playbooks) from recent work.
+Keep the page accurate by folding in genuinely new, on-topic evidence — nothing more.
+RULES:
+- PRESERVE the operator's existing structure, section headings, ordering, and voice EXACTLY. Never re-title, reorder, split, or merge sections the operator established, and never impose a template of your own.
+- Only ADD or CORRECT individual items the evidence supports; leave everything else as-is.
+- If (and only if) the current page is EMPTY, create a minimal, clean starting point — a short intro and a few obvious bullets. Do not pad it into an elaborate template.
+- The operator's maintainer hint (if present below) is AUTHORITATIVE on this page's form and scope.` + kbSafety
 
-const kbInfraSystem = `You curate the home-lab / ecosystem INFRASTRUCTURE reference from a developer's accumulated facts and entities.
-Organize the FACTS into sections such as: Hosts & network, Databases, Gateways & services, Credential stores (names/locations only), Build & deploy targets, Domains.
-Include concrete values that are NOT secrets (IPs, ports, hostnames, container names, paths, ID ranges).
-Then end with a "## Rules (MUST follow)" section: the imperative rules for USING this infrastructure (e.g. which account to connect as, where credentials must be stored, ID ranges to allocate from). These are binding — phrase them as commands.` + kbSafety
-
-const kbConvSystem = `You curate the DEVELOPMENT CONVENTIONS & policies the developer follows — the binding "how we work" rules.
-Organize into sections such as: Package manager & stack, Source control (commits / PR / branching), Coding rules, Release & deploy process, Naming, Workflow, Language & model preferences.
-Phrase every item as an imperative RULE the developer/agent must follow (not a description). End with a "## Rules (MUST follow)" section collecting the hardest must/never constraints.` + kbSafety
-
-const kbLessonsSystem = `You curate a LESSONS / playbooks reference from already-distilled playbooks.
-Group related playbooks under thematic "## " sections. For each, give a one-line how-to and the key pitfall. Keep it skimmable — this is the "what we learned the hard way" index.` + kbSafety
-
-const kbReusableSystem = `You curate a REUSABLE FEATURES catalog from what has been built across the developer's projects.
-List features / components / patterns / integrations that could be LIFTED into a NEW project, grouped under "## " themes. For each: what it is, which project it came from, and how to reuse it.
-Only include things genuinely reusable across projects — skip one-off project specifics.` + kbSafety
+// kbTopics is the one-line SCOPE descriptor per page — what the page is about,
+// NOT how it must be structured. Used only to tell the maintainer which
+// evidence is on-topic; the operator owns the actual form.
+var kbTopics = map[string]string{
+	KBKindInfrastructure: "PAGE TOPIC: infrastructure ground truth — hosts, networks, databases, gateways/services, and the binding rules for using them.",
+	KBKindConventions:    "PAGE TOPIC: the developer's binding development conventions & policies (how we work).",
+	KBKindLessons:        "PAGE TOPIC: distilled lessons and playbooks from past work — reference guidance.",
+	KBKindReusable:       "PAGE TOPIC: features / components / patterns / integrations reusable across projects.",
+}
 
 // KBDraftResult reports the outcome of drafting one KB page (returned by the
 // manual draft endpoint so failures are observable without log access).
 type KBDraftResult struct {
 	Kind   string `json:"kind"`
 	Cwd    string `json:"cwd"`
-	Status string `json:"status"` // written | proposed | skipped-empty | skipped-locked | skipped-pending | skipped-rejected | skipped-unchanged | error
+	Status string `json:"status"` // written | proposed | skipped-empty | skipped-human | skipped-locked | skipped-pending | skipped-rejected | skipped-unchanged | error
 	Bytes  int    `json:"bytes,omitempty"`
 	Err    string `json:"error,omitempty"`
 }
@@ -180,22 +193,44 @@ func (d *KBDrafter) DraftAll(ctx context.Context) ([]KBDraftResult, error) {
 	playbooks, _ := d.store.ListNodes(ctx, NodeFilter{Kind: KindPlaybook, Limit: 200})
 
 	var out []KBDraftResult
-	out = append(out, d.draftOne(ctx, GlobalKBCwd, KBKindInfrastructure, kbInfraSystem, buildInfraFeedstock(facts, entities)))
-	out = append(out, d.draftOne(ctx, GlobalKBCwd, KBKindConventions, kbConvSystem, buildConvFeedstock(facts)))
-	out = append(out, d.draftOne(ctx, GlobalKBCwd, KBKindLessons, kbLessonsSystem, buildLessonsFeedstock(playbooks)))
-	out = append(out, d.draftOne(ctx, GlobalKBCwd, KBKindReusable, kbReusableSystem, buildReusableFeedstock(playbooks, facts)))
+	out = append(out, d.draftOne(ctx, GlobalKBCwd, KBKindInfrastructure, buildInfraFeedstock(facts, entities)))
+	out = append(out, d.draftOne(ctx, GlobalKBCwd, KBKindConventions, buildConvFeedstock(facts)))
+	out = append(out, d.draftOne(ctx, GlobalKBCwd, KBKindLessons, buildLessonsFeedstock(playbooks)))
+	out = append(out, d.draftOne(ctx, GlobalKBCwd, KBKindReusable, buildReusableFeedstock(playbooks, facts)))
 	return out, nil
 }
 
-func (d *KBDrafter) draftOne(ctx context.Context, cwd, kind, system, feedstock string) KBDraftResult {
-	return draftOrPropose(ctx, d.llm, d.docs, d.proposals, d.log, cwd, kind, system, feedstock)
+// draftOne maintains one global KB page. The operator owns its form, so the
+// drafter honours the page's blueprint maintainer_mode (human → hands off),
+// steers on its prompt_hint, and PRESERVES the current content's structure —
+// it edits the page rather than regenerating it from a fixed skeleton.
+func (d *KBDrafter) draftOne(ctx context.Context, cwd, kind, feedstock string) KBDraftResult {
+	system := kbBaseSystem + "\n\n" + kbTopics[kind]
+	return draftOrPropose(ctx, d.llm, d.docs, d.proposals, d.log, cwd, kind, system, feedstock,
+		draftOpts{honorMaintainerMode: true, preserveCurrent: true, applyPromptHint: true})
+}
+
+// draftOpts turns on the operator-owned-form behaviours. They default OFF so
+// the Overview drafter (which shares this path) is unaffected; only the global
+// KB drafter opts in.
+type draftOpts struct {
+	// honorMaintainerMode: a page whose blueprint maintainer_mode is "human"
+	// is the operator's to write by hand — the drafter never touches it.
+	honorMaintainerMode bool
+	// preserveCurrent: feed the current page content to the LLM so it EDITS
+	// the operator's structure in place instead of regenerating from scratch.
+	preserveCurrent bool
+	// applyPromptHint: append the page's blueprint prompt_hint to the system
+	// prompt so the operator can steer form/scope without a code change.
+	applyPromptHint bool
 }
 
 // draftOrPropose is the shared lock-aware, dirty-checked draft path used by the
 // KB drafter and the Overview drafter. An unlocked page is rewritten in place;
 // a human-locked page whose feedstock diverged is filed as an update proposal
-// (B3 — Iterate) instead of overwritten.
-func draftOrPropose(ctx context.Context, llm LLM, docs DocSink, proposals ProposalSink, log *slog.Logger, cwd, kind, system, feedstock string) KBDraftResult {
+// (B3 — Iterate) instead of overwritten. opts enables the KB-only
+// operator-owned-form behaviours (Overview passes the zero value).
+func draftOrPropose(ctx context.Context, llm LLM, docs DocSink, proposals ProposalSink, log *slog.Logger, cwd, kind, system, feedstock string, opts draftOpts) KBDraftResult {
 	res := KBDraftResult{Kind: kind, Cwd: cwd}
 	if strings.TrimSpace(feedstock) == "" {
 		res.Status = "skipped-empty"
@@ -207,10 +242,24 @@ func draftOrPropose(ctx context.Context, llm LLM, docs DocSink, proposals Propos
 		res.Status, res.Err = "error", "get: "+err.Error()
 		return res
 	}
+	// The operator fully owns a human-maintained page — never draft or propose.
+	if opts.honorMaintainerMode && cur.MaintainerMode == "human" {
+		res.Status = "skipped-human"
+		return res
+	}
 	sig := kbSig(feedstock)
 	if cur.Exists && extractKBSig(cur.Content) == sig {
 		res.Status = "skipped-unchanged"
 		return res // feedstock unchanged since last draft — nothing to do
+	}
+	if opts.applyPromptHint {
+		if h := strings.TrimSpace(cur.PromptHint); h != "" {
+			system += "\n\nOPERATOR MAINTAINER HINT (authoritative on this page's form and scope):\n" + h
+		}
+	}
+	current := ""
+	if opts.preserveCurrent {
+		current = cur.Content
 	}
 	if cur.HumanLocked {
 		if proposals == nil {
@@ -236,7 +285,7 @@ func draftOrPropose(ctx context.Context, llm LLM, docs DocSink, proposals Propos
 				}
 			}
 		}
-		body, err := draftPageBody(ctx, llm, log, system, feedstock, sig)
+		body, err := draftPageBody(ctx, llm, log, system, current, feedstock, sig)
 		if err != nil {
 			res.Status, res.Err = "error", err.Error()
 			return res
@@ -251,7 +300,7 @@ func draftOrPropose(ctx context.Context, llm LLM, docs DocSink, proposals Propos
 		res.Status, res.Bytes = "proposed", len(body)
 		return res
 	}
-	body, err := draftPageBody(ctx, llm, log, system, feedstock, sig)
+	body, err := draftPageBody(ctx, llm, log, system, current, feedstock, sig)
 	if err != nil {
 		res.Status, res.Err = "error", err.Error()
 		return res
@@ -266,10 +315,24 @@ func draftOrPropose(ctx context.Context, llm LLM, docs DocSink, proposals Propos
 	return res
 }
 
+// draftUserMessage builds the LLM user turn. With no current content (Overview,
+// or a first-time KB page) it is just the feedstock — byte-identical to the
+// historical behaviour. When current content is supplied (KB edit-in-place) it
+// frames the current page as the structure to preserve and the feedstock as
+// new evidence to fold in.
+func draftUserMessage(current, feedstock string) string {
+	cur := stripKBSigText(strings.TrimSpace(current))
+	if cur == "" {
+		return feedstock
+	}
+	return "CURRENT PAGE (preserve this structure exactly; change only what the evidence updates):\n" +
+		cur + "\n\nNEW EVIDENCE (fold in only what is genuinely new and on-topic):\n" + feedstock
+}
+
 // draftPageBody runs the LLM and returns the cleaned page body with the
 // feedstock signature appended (so the next sweep's dirty-check can skip it).
-func draftPageBody(ctx context.Context, llm LLM, log *slog.Logger, system, feedstock, sig string) (string, error) {
-	body, err := llm.Complete(ctx, system, feedstock)
+func draftPageBody(ctx context.Context, llm LLM, log *slog.Logger, system, current, feedstock, sig string) (string, error) {
+	body, err := llm.Complete(ctx, system, draftUserMessage(current, feedstock))
 	if err != nil {
 		log.Warn("draft: llm failed", "err", err)
 		return "", fmt.Errorf("llm: %w", err)

--- a/internal/knowledge/kb.go
+++ b/internal/knowledge/kb.go
@@ -247,15 +247,25 @@ func draftOrPropose(ctx context.Context, llm LLM, docs DocSink, proposals Propos
 		res.Status = "skipped-human"
 		return res
 	}
+	// Fold the operator's prompt_hint into the dirty-check signature. The hint
+	// steers the page's form, so changing it must invalidate the cached draft —
+	// otherwise (sig keys on feedstock alone) a new hint would never take effect
+	// until the feedstock happened to diverge. Overview passes applyPromptHint
+	// off, so its signature stays feedstock-only (byte-identical behaviour).
+	hint := ""
+	if opts.applyPromptHint {
+		hint = strings.TrimSpace(cur.PromptHint)
+	}
 	sig := kbSig(feedstock)
+	if hint != "" {
+		sig = kbSig(feedstock + "\x00prompt_hint:" + hint)
+	}
 	if cur.Exists && extractKBSig(cur.Content) == sig {
 		res.Status = "skipped-unchanged"
-		return res // feedstock unchanged since last draft — nothing to do
+		return res // feedstock + hint unchanged since last draft — nothing to do
 	}
-	if opts.applyPromptHint {
-		if h := strings.TrimSpace(cur.PromptHint); h != "" {
-			system += "\n\nOPERATOR MAINTAINER HINT (authoritative on this page's form and scope):\n" + h
-		}
+	if hint != "" {
+		system += "\n\nOPERATOR MAINTAINER HINT (authoritative on this page's form and scope):\n" + hint
 	}
 	current := ""
 	if opts.preserveCurrent {

--- a/internal/knowledge/kb_draft_test.go
+++ b/internal/knowledge/kb_draft_test.go
@@ -4,14 +4,23 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 )
 
 // --- fakes ---------------------------------------------------------------
 
-type fakeLLM struct{ body string }
+type fakeLLM struct {
+	body       string
+	calls      int
+	lastSystem string
+	lastUser   string
+}
 
-func (f fakeLLM) Complete(_ context.Context, _, _ string) (string, error) {
+func (f *fakeLLM) Complete(_ context.Context, system, user string) (string, error) {
+	f.calls++
+	f.lastSystem = system
+	f.lastUser = user
 	return f.body, nil
 }
 
@@ -55,6 +64,13 @@ const (
 	testFeed = "ENTITIES:\nhost: kv01\n\nFACTS:\n- dev db at 192.168.3.88\n"
 )
 
+// kbOpts mirrors what the KB drafter passes (operator-owned-form on).
+var kbOpts = draftOpts{honorMaintainerMode: true, preserveCurrent: true, applyPromptHint: true}
+
+func run(llm *fakeLLM, docs *fakeDocSink, props *fakeProposalSink, opts draftOpts) KBDraftResult {
+	return draftOrPropose(context.Background(), llm, docs, props, discardLog(), testCwd, testKind, "SYS", testFeed, opts)
+}
+
 // --- tests ---------------------------------------------------------------
 
 // A locked page whose feedstock has diverged files a proposal (does not
@@ -62,8 +78,7 @@ const (
 func TestDraftOrPropose_LockedProposes(t *testing.T) {
 	docs := &fakeDocSink{doc: KBDoc{Content: "old\n<!-- kb-sig:0000000000000000 -->\n", HumanLocked: true, Exists: true}}
 	props := &fakeProposalSink{}
-
-	res := draftOrPropose(context.Background(), fakeLLM{body: "fresh body"}, docs, props, discardLog(), testCwd, testKind, "sys", testFeed)
+	res := run(&fakeLLM{body: "fresh body"}, docs, props, kbOpts)
 
 	if res.Status != "proposed" {
 		t.Fatalf("status = %q, want proposed", res.Status)
@@ -81,8 +96,7 @@ func TestDraftOrPropose_LockedProposes(t *testing.T) {
 func TestDraftOrPropose_LockedSkipsRejectedSig(t *testing.T) {
 	docs := &fakeDocSink{doc: KBDoc{Content: "old\n<!-- kb-sig:0000000000000000 -->\n", HumanLocked: true, Exists: true}}
 	props := &fakeProposalSink{rejected: []string{kbSig(testFeed)}}
-
-	res := draftOrPropose(context.Background(), fakeLLM{body: "fresh body"}, docs, props, discardLog(), testCwd, testKind, "sys", testFeed)
+	res := run(&fakeLLM{body: "fresh body"}, docs, props, kbOpts)
 
 	if res.Status != "skipped-rejected" {
 		t.Fatalf("status = %q, want skipped-rejected", res.Status)
@@ -97,8 +111,7 @@ func TestDraftOrPropose_LockedSkipsRejectedSig(t *testing.T) {
 func TestDraftOrPropose_LockedProposesWhenRejectionIsStale(t *testing.T) {
 	docs := &fakeDocSink{doc: KBDoc{Content: "old\n<!-- kb-sig:0000000000000000 -->\n", HumanLocked: true, Exists: true}}
 	props := &fakeProposalSink{rejected: []string{"deadbeefdeadbeef"}}
-
-	res := draftOrPropose(context.Background(), fakeLLM{body: "fresh body"}, docs, props, discardLog(), testCwd, testKind, "sys", testFeed)
+	res := run(&fakeLLM{body: "fresh body"}, docs, props, kbOpts)
 
 	if res.Status != "proposed" {
 		t.Fatalf("status = %q, want proposed", res.Status)
@@ -114,14 +127,14 @@ func TestDraftOrPropose_SkipsUnchanged(t *testing.T) {
 	content := "body\n<!-- kb-sig:" + kbSig(testFeed) + " -->\n"
 	docs := &fakeDocSink{doc: KBDoc{Content: content, HumanLocked: true, Exists: true}}
 	props := &fakeProposalSink{}
-
-	res := draftOrPropose(context.Background(), fakeLLM{body: "should not be used"}, docs, props, discardLog(), testCwd, testKind, "sys", testFeed)
+	llm := &fakeLLM{body: "should not be used"}
+	res := run(llm, docs, props, kbOpts)
 
 	if res.Status != "skipped-unchanged" {
 		t.Fatalf("status = %q, want skipped-unchanged", res.Status)
 	}
-	if props.proposeCalls != 0 || docs.putCalls != 0 {
-		t.Fatalf("unchanged page must be untouched (propose=%d put=%d)", props.proposeCalls, docs.putCalls)
+	if llm.calls != 0 || props.proposeCalls != 0 || docs.putCalls != 0 {
+		t.Fatalf("unchanged page must be untouched (llm=%d propose=%d put=%d)", llm.calls, props.proposeCalls, docs.putCalls)
 	}
 }
 
@@ -129,8 +142,7 @@ func TestDraftOrPropose_SkipsUnchanged(t *testing.T) {
 func TestDraftOrPropose_UnlockedWrites(t *testing.T) {
 	docs := &fakeDocSink{doc: KBDoc{Content: "old\n<!-- kb-sig:0000000000000000 -->\n", HumanLocked: false, Exists: true}}
 	props := &fakeProposalSink{}
-
-	res := draftOrPropose(context.Background(), fakeLLM{body: "fresh body"}, docs, props, discardLog(), testCwd, testKind, "sys", testFeed)
+	res := run(&fakeLLM{body: "fresh body"}, docs, props, kbOpts)
 
 	if res.Status != "written" {
 		t.Fatalf("status = %q, want written", res.Status)
@@ -140,5 +152,72 @@ func TestDraftOrPropose_UnlockedWrites(t *testing.T) {
 	}
 	if props.proposeCalls != 0 {
 		t.Fatalf("unlocked page must not propose (propose calls = %d)", props.proposeCalls)
+	}
+}
+
+// maintainer_mode=human hands the page entirely to the operator: the drafter
+// never calls the LLM, proposes, or writes.
+func TestDraftOrPropose_HumanModeSkips(t *testing.T) {
+	docs := &fakeDocSink{doc: KBDoc{Content: "operator's page", HumanLocked: true, Exists: true, MaintainerMode: "human"}}
+	props := &fakeProposalSink{}
+	llm := &fakeLLM{body: "should not be used"}
+	res := run(llm, docs, props, kbOpts)
+
+	if res.Status != "skipped-human" {
+		t.Fatalf("status = %q, want skipped-human", res.Status)
+	}
+	if llm.calls != 0 || props.proposeCalls != 0 || docs.putCalls != 0 {
+		t.Fatalf("human page must be untouched (llm=%d propose=%d put=%d)", llm.calls, props.proposeCalls, docs.putCalls)
+	}
+}
+
+// honorMaintainerMode is opt-in: with the zero opts (Overview), maintainer_mode
+// is ignored and the page is drafted as before.
+func TestDraftOrPropose_HumanModeIgnoredWithoutOpt(t *testing.T) {
+	docs := &fakeDocSink{doc: KBDoc{Content: "x\n<!-- kb-sig:0 -->\n", HumanLocked: false, Exists: true, MaintainerMode: "human"}}
+	res := run(&fakeLLM{body: "fresh"}, docs, &fakeProposalSink{}, draftOpts{})
+
+	if res.Status != "written" {
+		t.Fatalf("status = %q, want written (zero opts must ignore maintainer_mode)", res.Status)
+	}
+}
+
+// The operator's prompt_hint is appended to the system prompt so it can steer
+// the page's form without a code change.
+func TestDraftOrPropose_PromptHintSteersSystem(t *testing.T) {
+	docs := &fakeDocSink{doc: KBDoc{Content: "x\n<!-- kb-sig:0 -->\n", HumanLocked: false, Exists: true, PromptHint: "KEEP-IT-A-ONE-LINER"}}
+	llm := &fakeLLM{body: "fresh"}
+	run(llm, docs, &fakeProposalSink{}, kbOpts)
+
+	if !strings.Contains(llm.lastSystem, "KEEP-IT-A-ONE-LINER") {
+		t.Fatalf("system prompt did not include the operator hint; got:\n%s", llm.lastSystem)
+	}
+}
+
+// preserveCurrent feeds the current page into the LLM so it edits the operator's
+// structure rather than regenerating from scratch.
+func TestDraftOrPropose_PreservesCurrentContent(t *testing.T) {
+	docs := &fakeDocSink{doc: KBDoc{Content: "## OPERATORS-OWN-HEADING\n- keep me\n<!-- kb-sig:0 -->\n", HumanLocked: false, Exists: true}}
+	llm := &fakeLLM{body: "fresh"}
+	run(llm, docs, &fakeProposalSink{}, kbOpts)
+
+	if !strings.Contains(llm.lastUser, "OPERATORS-OWN-HEADING") {
+		t.Fatalf("current content not fed to the LLM for preservation; user turn:\n%s", llm.lastUser)
+	}
+	// The kb-sig marker must be stripped from the fed content, not echoed.
+	if strings.Contains(llm.lastUser, "kb-sig:") {
+		t.Fatalf("kb-sig marker leaked into the LLM user turn:\n%s", llm.lastUser)
+	}
+}
+
+// With no opts (Overview), the user turn is exactly the feedstock — current
+// content is NOT injected, preserving historical behaviour.
+func TestDraftOrPropose_OverviewUserTurnUnchanged(t *testing.T) {
+	docs := &fakeDocSink{doc: KBDoc{Content: "## SHOULD-NOT-APPEAR\n<!-- kb-sig:0 -->\n", HumanLocked: false, Exists: true}}
+	llm := &fakeLLM{body: "fresh"}
+	run(llm, docs, &fakeProposalSink{}, draftOpts{})
+
+	if llm.lastUser != testFeed {
+		t.Fatalf("zero-opts user turn must equal feedstock verbatim; got:\n%s", llm.lastUser)
 	}
 }

--- a/internal/knowledge/kb_draft_test.go
+++ b/internal/knowledge/kb_draft_test.go
@@ -194,6 +194,42 @@ func TestDraftOrPropose_PromptHintSteersSystem(t *testing.T) {
 	}
 }
 
+// Changing the prompt_hint alone (feedstock unchanged) must still trigger a
+// redraft: the hint is folded into the dirty-check signature, so a page that
+// carries the plain-feedstock sig is no longer "unchanged" once a hint is set.
+func TestDraftOrPropose_PromptHintChangeTriggersRedraft(t *testing.T) {
+	// Content carries the OLD signature (feedstock only), but a hint now exists.
+	content := "body\n<!-- kb-sig:" + kbSig(testFeed) + " -->\n"
+	docs := &fakeDocSink{doc: KBDoc{Content: content, HumanLocked: false, Exists: true, PromptHint: "NEW-HINT"}}
+	llm := &fakeLLM{body: "fresh"}
+	res := run(llm, docs, &fakeProposalSink{}, kbOpts)
+
+	if res.Status != "written" {
+		t.Fatalf("status = %q, want written (a hint change must trigger a redraft)", res.Status)
+	}
+	if llm.calls != 1 || !strings.Contains(llm.lastSystem, "NEW-HINT") {
+		t.Fatalf("hint not applied on redraft (llm calls=%d, system=%q)", llm.calls, llm.lastSystem)
+	}
+}
+
+// Once a hinted page has been redrafted, its signature includes the hint, so an
+// unchanged feedstock + unchanged hint is a no-op (converges, no re-draft loop).
+func TestDraftOrPropose_HintedPageConverges(t *testing.T) {
+	const hint = "KEEP-IT-A-ONE-LINER"
+	settledSig := kbSig(testFeed + "\x00prompt_hint:" + hint)
+	content := "body\n<!-- kb-sig:" + settledSig + " -->\n"
+	docs := &fakeDocSink{doc: KBDoc{Content: content, HumanLocked: false, Exists: true, PromptHint: hint}}
+	llm := &fakeLLM{body: "should not be used"}
+	res := run(llm, docs, &fakeProposalSink{}, kbOpts)
+
+	if res.Status != "skipped-unchanged" {
+		t.Fatalf("status = %q, want skipped-unchanged (hinted page must converge)", res.Status)
+	}
+	if llm.calls != 0 {
+		t.Fatalf("settled hinted page must not call the LLM (calls=%d)", llm.calls)
+	}
+}
+
 // preserveCurrent feeds the current page into the LLM so it edits the operator's
 // structure rather than regenerating from scratch.
 func TestDraftOrPropose_PreservesCurrentContent(t *testing.T) {

--- a/internal/knowledge/overview.go
+++ b/internal/knowledge/overview.go
@@ -116,7 +116,9 @@ func (o *OverviewDrafter) DraftAll(ctx context.Context) ([]KBDraftResult, error)
 			continue
 		}
 		feedstock := o.buildFeedstock(ctx, k)
-		out = append(out, draftOrPropose(ctx, o.llm, o.docs, o.proposals, o.log, k, OverviewKind, overviewSystem, feedstock))
+		// Overview keeps its historical behaviour: regenerate from the project
+		// feedstock (no operator-owned-form opts — those are KB-only).
+		out = append(out, draftOrPropose(ctx, o.llm, o.docs, o.proposals, o.log, k, OverviewKind, overviewSystem, feedstock, draftOpts{}))
 	}
 	return out, nil
 }

--- a/internal/projectdoc/blueprint.go
+++ b/internal/projectdoc/blueprint.go
@@ -350,9 +350,6 @@ func (s *Service) validateWriteTarget(ctx context.Context, cwd string, kind Kind
 	return nil
 }
 
-// HasSection reports whether the blueprint for cwd currently contains
-// slug with the given maintainer mode (mode "" = any). Used by the
-// scanners so a removed scanner section silently stops being written.
 // GetSection returns one blueprint section by slug (found=false when the cwd
 // has no such section). Used by the KB drafter to read a page's operator-owned
 // form controls (maintainer_mode, prompt_hint).
@@ -369,6 +366,9 @@ func (s *Service) GetSection(ctx context.Context, cwd, slug string) (Section, bo
 	return Section{}, false, nil
 }
 
+// HasSection reports whether the blueprint for cwd currently contains
+// slug with the given maintainer mode (mode "" = any). Used by the
+// scanners so a removed scanner section silently stops being written.
 func (s *Service) HasSection(ctx context.Context, cwd, slug, mode string) (bool, error) {
 	sections, err := s.ListSections(ctx, cwd)
 	if err != nil {

--- a/internal/projectdoc/blueprint.go
+++ b/internal/projectdoc/blueprint.go
@@ -353,6 +353,22 @@ func (s *Service) validateWriteTarget(ctx context.Context, cwd string, kind Kind
 // HasSection reports whether the blueprint for cwd currently contains
 // slug with the given maintainer mode (mode "" = any). Used by the
 // scanners so a removed scanner section silently stops being written.
+// GetSection returns one blueprint section by slug (found=false when the cwd
+// has no such section). Used by the KB drafter to read a page's operator-owned
+// form controls (maintainer_mode, prompt_hint).
+func (s *Service) GetSection(ctx context.Context, cwd, slug string) (Section, bool, error) {
+	sections, err := s.ListSections(ctx, cwd)
+	if err != nil {
+		return Section{}, false, err
+	}
+	for _, sec := range sections {
+		if sec.Slug == slug {
+			return sec, true, nil
+		}
+	}
+	return Section{}, false, nil
+}
+
 func (s *Service) HasSection(ctx context.Context, cwd, slug, mode string) (bool, error) {
 	sections, err := s.ListSections(ctx, cwd)
 	if err != nil {


### PR DESCRIPTION
## Problem

The four global KB pages (`kb_infrastructure`, `kb_conventions`, `kb_lessons`, `kb_reusable`) had their **shape hardcoded** in the drafter's system prompts. `kbInfraSystem`, for example, mandated `Databases / Gateways / Build & deploy / Domains` sections and told the model to include container names/paths — then ended with a required `## Rules` section.

Because every consolidation sweep regenerates these pages from the live memory feedstock through that prompt, operator curation could never stick: a slimmed page was always re-manufactured back into the fixed fat skeleton (proposed when locked, overwritten when not). This is the root cause behind the "kb_infrastructure keeps resetting" behaviour investigated in #475.

## Change — hand the form to the operator

The drafter now, **for the KB pages only** (Overview is untouched):

1. **honours `maintainer_mode`** — a page set to `human` is the operator's to write by hand; the drafter never drafts/proposes/writes it (`skipped-human`).
2. **preserves the current content** — the LLM *edits the operator's structure in place* (folding in only genuinely new, on-topic evidence) instead of regenerating from a skeleton. An empty page gets a minimal starting point, not a template.
3. **applies the page's `prompt_hint`** — appended to the system prompt so the operator can steer form/scope with no code change.

The four hardcoded skeleton prompts are replaced by a single **form-neutral `kbBaseSystem`** plus a one-line per-page *topic* (scope only, no structure).

### Bounded blast radius
`draftOrPropose` is shared with the Overview drafter. All new behaviour is gated behind a new `draftOpts` struct — the KB drafter opts in; Overview passes the zero value and stays **byte-identical** (there's a regression test asserting its user turn equals the feedstock verbatim).

## How the operator drives it

- `PUT /blueprint/{slug}` (cwd `__global__`) already accepts `maintainer_mode` + `prompt_hint` (validated `ai|human|scanner`; the four stay pinned). So the capability is reachable today via API.
- A web/mobile toggle for it is a sensible **follow-up** (UI change).
- **No migration**: the four keep `maintainer_mode=ai`, `prompt_hint=""` — identical defaults, but their form is now whatever the operator shapes (and preserved thereafter).

## Tests

`internal/knowledge/kb_draft_test.go` extended (fakes, no DB):
- `skipped-human` (+ ignored when opts are off)
- `prompt_hint` reaches the system prompt
- current content is fed to the LLM for preservation, with the `kb-sig` marker stripped
- **Overview** zero-opts: user turn is exactly the feedstock (no content injection)
- existing lock/propose/reject/unchanged/write cases still pass

`go build ./...`, `go vet`, and `go test ./internal/knowledge/... ./internal/projectdoc/... ./internal/app/...` all green; gofmt clean.

## Note

Removing the mandated `## Rules` skeleton means a *freshly created empty* foundational page won't auto-grow a Rules section — by design, the operator now owns that. Existing pages keep whatever structure they already have (preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)