### PR TITLE
feat(mobile): session tool dock + More/settings grouped-card redesign

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -3266,6 +3266,8 @@
   },
   "more": {
     "title": "More",
+    "searchHint": "Search settings",
+    "noResults": "No settings match “{query}”",
     "identity": {
       "signedInAs": "Signed in as",
       "server": "Server",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -3266,8 +3266,6 @@
   },
   "more": {
     "title": "More",
-    "searchHint": "Search settings",
-    "noResults": "No settings match “{query}”",
     "identity": {
       "signedInAs": "Signed in as",
       "server": "Server",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -3415,6 +3415,14 @@
     "strategyUnknown": "Unknown"
   },
   "sessions": {
+    "dock": {
+      "more": "More"
+    },
+    "tools": {
+      "searchHint": "Search tools",
+      "inspectSection": "Inspect",
+      "sessionSection": "Session"
+    },
     "title": "Sessions",
     "refresh": "Refresh",
     "actions": "Actions",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -3266,6 +3266,8 @@
   },
   "more": {
     "title": "Más",
+    "searchHint": "Buscar ajustes",
+    "noResults": "Ningún ajuste coincide con «{query}»",
     "identity": {
       "signedInAs": "Sesión iniciada como",
       "server": "Servidor",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -3415,6 +3415,14 @@
     "strategyUnknown": "Desconocido"
   },
   "sessions": {
+    "dock": {
+      "more": "Más"
+    },
+    "tools": {
+      "searchHint": "Buscar herramientas",
+      "inspectSection": "Inspeccionar",
+      "sessionSection": "Sesión"
+    },
     "title": "Sesiones",
     "refresh": "Actualizar",
     "actions": "Acciones",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -3266,8 +3266,6 @@
   },
   "more": {
     "title": "Más",
-    "searchHint": "Buscar ajustes",
-    "noResults": "Ningún ajuste coincide con «{query}»",
     "identity": {
       "signedInAs": "Sesión iniciada como",
       "server": "Servidor",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -3266,6 +3266,8 @@
   },
   "more": {
     "title": "更多",
+    "searchHint": "搜索设置",
+    "noResults": "没有匹配“{query}”的设置",
     "identity": {
       "signedInAs": "登录账号",
       "server": "服务器",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -3415,6 +3415,14 @@
     "strategyUnknown": "未知"
   },
   "sessions": {
+    "dock": {
+      "more": "更多"
+    },
+    "tools": {
+      "searchHint": "搜索工具",
+      "inspectSection": "检查",
+      "sessionSection": "会话"
+    },
     "title": "会话",
     "refresh": "刷新",
     "actions": "操作",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -3266,8 +3266,6 @@
   },
   "more": {
     "title": "更多",
-    "searchHint": "搜索设置",
-    "noResults": "没有匹配“{query}”的设置",
     "identity": {
       "signedInAs": "登录账号",
       "server": "服务器",

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 12372 (4124 per locale)
+/// Strings: 12384 (4128 per locale)
 ///
-/// Built on 2026-07-17 at 08:59 UTC
+/// Built on 2026-07-22 at 04:04 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 12384 (4128 per locale)
+/// Strings: 12390 (4130 per locale)
 ///
-/// Built on 2026-07-22 at 04:04 UTC
+/// Built on 2026-07-22 at 09:39 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 12390 (4130 per locale)
+/// Strings: 12384 (4128 per locale)
 ///
-/// Built on 2026-07-22 at 09:39 UTC
+/// Built on 2026-07-22 at 04:04 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -419,6 +419,8 @@ class TranslationsSessionsEn {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
+	late final TranslationsSessionsDockEn dock = TranslationsSessionsDockEn.internal(_root);
+	late final TranslationsSessionsToolsEn tools = TranslationsSessionsToolsEn.internal(_root);
 
 	/// en: 'Sessions'
 	String get title => 'Sessions';
@@ -3666,6 +3668,36 @@ class TranslationsActivityDetailEn {
 
 	/// en: 'Timestamp'
 	String get timestamp => 'Timestamp';
+}
+
+// Path: sessions.dock
+class TranslationsSessionsDockEn {
+	TranslationsSessionsDockEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'More'
+	String get more => 'More';
+}
+
+// Path: sessions.tools
+class TranslationsSessionsToolsEn {
+	TranslationsSessionsToolsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Search tools'
+	String get searchHint => 'Search tools';
+
+	/// en: 'Inspect'
+	String get inspectSection => 'Inspect';
+
+	/// en: 'Session'
+	String get sessionSection => 'Session';
 }
 
 // Path: sessions.filters
@@ -20468,6 +20500,10 @@ extension on Translations {
 			'memoryAmbient.strategyManualOnly' => 'Manual only',
 			'memoryAmbient.strategyHybrid' => 'Hybrid summary',
 			'memoryAmbient.strategyUnknown' => 'Unknown',
+			'sessions.dock.more' => 'More',
+			'sessions.tools.searchHint' => 'Search tools',
+			'sessions.tools.inspectSection' => 'Inspect',
+			'sessions.tools.sessionSection' => 'Session',
 			'sessions.title' => 'Sessions',
 			'sessions.refresh' => 'Refresh',
 			'sessions.actions' => 'Actions',
@@ -20869,12 +20905,12 @@ extension on Translations {
 			'integrations.kvBaseUrl' => 'Base URL',
 			'integrations.kvScopes' => 'Scopes',
 			'integrations.kvVersion' => 'Version',
+			_ => null,
+		} ?? switch (path) {
 			'integrations.kvLastHealthPing' => 'Last health ping',
 			'integrations.kvCreated' => 'Created',
 			'integrations.kvKeyRotated' => 'Key rotated',
 			'integrations.detailLoadFailed' => ({required Object error}) => 'Failed to load integration: ${error}',
-			_ => null,
-		} ?? switch (path) {
 			'integrations.callsLoadFailed' => 'Failed to load calls',
 			'integrations.noMatchingCalls' => 'No matching calls in the log yet.',
 			'integrations.directionAll' => 'All',
@@ -21383,12 +21419,12 @@ extension on Translations {
 			'channels.popup.mute' => 'Mute',
 			'channels.popup.unmute' => 'Unmute',
 			'channels.popup.deleteLabel' => 'Delete',
+			_ => null,
+		} ?? switch (path) {
 			'channels.badges.running' => 'running',
 			'channels.badges.starting' => 'starting…',
 			'channels.badges.disabled' => 'disabled',
 			'channels.badges.muted' => 'muted',
-			_ => null,
-		} ?? switch (path) {
 			'channels.capsLabel' => ({required Object list}) => '· caps: ${list}',
 			'channels.bridgeWebOnly' => 'Bridge channels stay web-only',
 			'channels.bridgeEmptyAdd' => 'Add one from the web admin: Channels → New.',
@@ -21897,12 +21933,12 @@ extension on Translations {
 			'cortexHub.subtitle' => 'The experience flywheel: Memory → Notes → Knowledge, fed back into every session.',
 			'cortexHub.idleBadge' => ({required Object days}) => 'idle ${days}d',
 			'cortexHub.activeProjectsBadge' => ({required Object count}) => '${count} active',
+			_ => null,
+		} ?? switch (path) {
 			'cortexHub.activeProjectsTitle' => 'Active projects',
 			'cortexHub.loopHint' => 'Sessions feed Memory → Memory distills into Notes → Notes compound into Knowledge → Knowledge guides every new session.',
 			'cortexHub.settings' => 'Settings',
 			'cortexHub.memory' => 'Memory',
-			_ => null,
-		} ?? switch (path) {
 			'cortexHub.memoryDesc' => 'Raw cross-session facts the agents store and recall.',
 			'cortexHub.notes' => 'Notes',
 			'cortexHub.notesDesc' => 'Each project’s official goal / plan / journal.',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -293,6 +293,12 @@ class TranslationsMoreEn {
 	/// en: 'More'
 	String get title => 'More';
 
+	/// en: 'Search settings'
+	String get searchHint => 'Search settings';
+
+	/// en: 'No settings match “{query}”'
+	String noResults({required Object query}) => 'No settings match “${query}”';
+
 	late final TranslationsMoreIdentityEn identity = TranslationsMoreIdentityEn.internal(_root);
 	late final TranslationsMoreSectionsEn sections = TranslationsMoreSectionsEn.internal(_root);
 	late final TranslationsMoreItemsEn items = TranslationsMoreItemsEn.internal(_root);
@@ -20405,6 +20411,8 @@ extension on Translations {
 			'web.roundTable.plan.bypass' => 'Skip permissions (YOLO)',
 			'web.roundTable.plan.bypassHint' => 'Start the session with its bypass flag so it does not prompt for approvals.',
 			'more.title' => 'More',
+			'more.searchHint' => 'Search settings',
+			'more.noResults' => ({required Object query}) => 'No settings match “${query}”',
 			'more.identity.signedInAs' => 'Signed in as',
 			'more.identity.server' => 'Server',
 			'more.identity.tokenExpires' => 'Token expires',
@@ -20903,10 +20911,10 @@ extension on Translations {
 			'integrations.tooltipReadOnly' => 'System integration — read-only',
 			'integrations.kvRoutePrefix' => 'Route prefix',
 			'integrations.kvBaseUrl' => 'Base URL',
-			'integrations.kvScopes' => 'Scopes',
-			'integrations.kvVersion' => 'Version',
 			_ => null,
 		} ?? switch (path) {
+			'integrations.kvScopes' => 'Scopes',
+			'integrations.kvVersion' => 'Version',
 			'integrations.kvLastHealthPing' => 'Last health ping',
 			'integrations.kvCreated' => 'Created',
 			'integrations.kvKeyRotated' => 'Key rotated',
@@ -21417,10 +21425,10 @@ extension on Translations {
 			'channels.popup.enable' => 'Enable',
 			'channels.popup.disable' => 'Disable',
 			'channels.popup.mute' => 'Mute',
-			'channels.popup.unmute' => 'Unmute',
-			'channels.popup.deleteLabel' => 'Delete',
 			_ => null,
 		} ?? switch (path) {
+			'channels.popup.unmute' => 'Unmute',
+			'channels.popup.deleteLabel' => 'Delete',
 			'channels.badges.running' => 'running',
 			'channels.badges.starting' => 'starting…',
 			'channels.badges.disabled' => 'disabled',
@@ -21931,10 +21939,10 @@ extension on Translations {
 			'memoryQuarantine.countBadge' => ({required Object count}) => '${count} pending',
 			'cortexHub.title' => 'Cortex',
 			'cortexHub.subtitle' => 'The experience flywheel: Memory → Notes → Knowledge, fed back into every session.',
-			'cortexHub.idleBadge' => ({required Object days}) => 'idle ${days}d',
-			'cortexHub.activeProjectsBadge' => ({required Object count}) => '${count} active',
 			_ => null,
 		} ?? switch (path) {
+			'cortexHub.idleBadge' => ({required Object days}) => 'idle ${days}d',
+			'cortexHub.activeProjectsBadge' => ({required Object count}) => '${count} active',
 			'cortexHub.activeProjectsTitle' => 'Active projects',
 			'cortexHub.loopHint' => 'Sessions feed Memory → Memory distills into Notes → Notes compound into Knowledge → Knowledge guides every new session.',
 			'cortexHub.settings' => 'Settings',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -293,12 +293,6 @@ class TranslationsMoreEn {
 	/// en: 'More'
 	String get title => 'More';
 
-	/// en: 'Search settings'
-	String get searchHint => 'Search settings';
-
-	/// en: 'No settings match “{query}”'
-	String noResults({required Object query}) => 'No settings match “${query}”';
-
 	late final TranslationsMoreIdentityEn identity = TranslationsMoreIdentityEn.internal(_root);
 	late final TranslationsMoreSectionsEn sections = TranslationsMoreSectionsEn.internal(_root);
 	late final TranslationsMoreItemsEn items = TranslationsMoreItemsEn.internal(_root);
@@ -20411,8 +20405,6 @@ extension on Translations {
 			'web.roundTable.plan.bypass' => 'Skip permissions (YOLO)',
 			'web.roundTable.plan.bypassHint' => 'Start the session with its bypass flag so it does not prompt for approvals.',
 			'more.title' => 'More',
-			'more.searchHint' => 'Search settings',
-			'more.noResults' => ({required Object query}) => 'No settings match “${query}”',
 			'more.identity.signedInAs' => 'Signed in as',
 			'more.identity.server' => 'Server',
 			'more.identity.tokenExpires' => 'Token expires',
@@ -20911,10 +20903,10 @@ extension on Translations {
 			'integrations.tooltipReadOnly' => 'System integration — read-only',
 			'integrations.kvRoutePrefix' => 'Route prefix',
 			'integrations.kvBaseUrl' => 'Base URL',
-			_ => null,
-		} ?? switch (path) {
 			'integrations.kvScopes' => 'Scopes',
 			'integrations.kvVersion' => 'Version',
+			_ => null,
+		} ?? switch (path) {
 			'integrations.kvLastHealthPing' => 'Last health ping',
 			'integrations.kvCreated' => 'Created',
 			'integrations.kvKeyRotated' => 'Key rotated',
@@ -21425,10 +21417,10 @@ extension on Translations {
 			'channels.popup.enable' => 'Enable',
 			'channels.popup.disable' => 'Disable',
 			'channels.popup.mute' => 'Mute',
-			_ => null,
-		} ?? switch (path) {
 			'channels.popup.unmute' => 'Unmute',
 			'channels.popup.deleteLabel' => 'Delete',
+			_ => null,
+		} ?? switch (path) {
 			'channels.badges.running' => 'running',
 			'channels.badges.starting' => 'starting…',
 			'channels.badges.disabled' => 'disabled',
@@ -21939,10 +21931,10 @@ extension on Translations {
 			'memoryQuarantine.countBadge' => ({required Object count}) => '${count} pending',
 			'cortexHub.title' => 'Cortex',
 			'cortexHub.subtitle' => 'The experience flywheel: Memory → Notes → Knowledge, fed back into every session.',
-			_ => null,
-		} ?? switch (path) {
 			'cortexHub.idleBadge' => ({required Object days}) => 'idle ${days}d',
 			'cortexHub.activeProjectsBadge' => ({required Object count}) => '${count} active',
+			_ => null,
+		} ?? switch (path) {
 			'cortexHub.activeProjectsTitle' => 'Active projects',
 			'cortexHub.loopHint' => 'Sessions feed Memory → Memory distills into Notes → Notes compound into Knowledge → Knowledge guides every new session.',
 			'cortexHub.settings' => 'Settings',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -256,6 +256,8 @@ class _TranslationsSessionsEs extends TranslationsSessionsEn {
 	final TranslationsEs _root; // ignore: unused_field
 
 	// Translations
+	@override late final _TranslationsSessionsDockEs dock = _TranslationsSessionsDockEs._(_root);
+	@override late final _TranslationsSessionsToolsEs tools = _TranslationsSessionsToolsEs._(_root);
 	@override String get title => 'Sesiones';
 	@override String get refresh => 'Actualizar';
 	@override String get actions => 'Acciones';
@@ -1837,6 +1839,28 @@ class _TranslationsActivityDetailEs extends TranslationsActivityDetailEn {
 	@override String get requestId => 'ID de solicitud';
 	@override String get resource => 'Recurso';
 	@override String get timestamp => 'Marca de tiempo';
+}
+
+// Path: sessions.dock
+class _TranslationsSessionsDockEs extends TranslationsSessionsDockEn {
+	_TranslationsSessionsDockEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get more => 'Más';
+}
+
+// Path: sessions.tools
+class _TranslationsSessionsToolsEs extends TranslationsSessionsToolsEn {
+	_TranslationsSessionsToolsEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get searchHint => 'Buscar herramientas';
+	@override String get inspectSection => 'Inspeccionar';
+	@override String get sessionSection => 'Sesión';
 }
 
 // Path: sessions.filters
@@ -12100,6 +12124,10 @@ extension on TranslationsEs {
 			'memoryAmbient.strategyManualOnly' => 'Solo manual',
 			'memoryAmbient.strategyHybrid' => 'Resumen híbrido',
 			'memoryAmbient.strategyUnknown' => 'Desconocido',
+			'sessions.dock.more' => 'Más',
+			'sessions.tools.searchHint' => 'Buscar herramientas',
+			'sessions.tools.inspectSection' => 'Inspeccionar',
+			'sessions.tools.sessionSection' => 'Sesión',
 			'sessions.title' => 'Sesiones',
 			'sessions.refresh' => 'Actualizar',
 			'sessions.actions' => 'Acciones',
@@ -12501,12 +12529,12 @@ extension on TranslationsEs {
 			'integrations.kvBaseUrl' => 'URL base',
 			'integrations.kvScopes' => 'Ámbitos',
 			'integrations.kvVersion' => 'Versión',
+			_ => null,
+		} ?? switch (path) {
 			'integrations.kvLastHealthPing' => 'Último ping de estado',
 			'integrations.kvCreated' => 'Creada',
 			'integrations.kvKeyRotated' => 'Key rotada',
 			'integrations.detailLoadFailed' => ({required Object error}) => 'Error al cargar la integración: ${error}',
-			_ => null,
-		} ?? switch (path) {
 			'integrations.callsLoadFailed' => 'Error al cargar las llamadas',
 			'integrations.noMatchingCalls' => 'Aún no hay llamadas coincidentes en el registro.',
 			'integrations.directionAll' => 'Todas',
@@ -13015,12 +13043,12 @@ extension on TranslationsEs {
 			'channels.popup.mute' => 'Silenciar',
 			'channels.popup.unmute' => 'Reactivar sonido',
 			'channels.popup.deleteLabel' => 'Eliminar',
+			_ => null,
+		} ?? switch (path) {
 			'channels.badges.running' => 'en ejecución',
 			'channels.badges.starting' => 'iniciando…',
 			'channels.badges.disabled' => 'desactivado',
 			'channels.badges.muted' => 'silenciado',
-			_ => null,
-		} ?? switch (path) {
 			'channels.capsLabel' => ({required Object list}) => '· caps: ${list}',
 			'channels.bridgeWebOnly' => 'Los canales bridge solo están disponibles en la web',
 			'channels.bridgeEmptyAdd' => 'Añade uno desde el admin web: Canales → Nuevo.',
@@ -13529,12 +13557,12 @@ extension on TranslationsEs {
 			'cortexHub.subtitle' => 'El volante de experiencia: Memoria → Notas → Conocimiento, realimentado en cada session.',
 			'cortexHub.idleBadge' => ({required Object days}) => 'inactivo ${days}d',
 			'cortexHub.activeProjectsBadge' => ({required Object count}) => '${count} activos',
+			_ => null,
+		} ?? switch (path) {
 			'cortexHub.activeProjectsTitle' => 'Proyectos activos',
 			'cortexHub.loopHint' => 'Las sesiones alimentan la Memoria → la Memoria se destila en Notas → las Notas se compilan en Conocimiento → el Conocimiento guía cada nueva sesión.',
 			'cortexHub.settings' => 'Ajustes',
 			'cortexHub.memory' => 'Memoria',
-			_ => null,
-		} ?? switch (path) {
 			'cortexHub.memoryDesc' => 'Hechos crudos entre sessions que los agentes guardan y recuerdan.',
 			'cortexHub.notes' => 'Notas',
 			'cortexHub.notesDesc' => 'El objetivo / plan / diario oficial de cada proyecto.',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -193,8 +193,6 @@ class _TranslationsMoreEs extends TranslationsMoreEn {
 
 	// Translations
 	@override String get title => 'Más';
-	@override String get searchHint => 'Buscar ajustes';
-	@override String noResults({required Object query}) => 'Ningún ajuste coincide con «${query}»';
 	@override late final _TranslationsMoreIdentityEs identity = _TranslationsMoreIdentityEs._(_root);
 	@override late final _TranslationsMoreSectionsEs sections = _TranslationsMoreSectionsEs._(_root);
 	@override late final _TranslationsMoreItemsEs items = _TranslationsMoreItemsEs._(_root);
@@ -12031,8 +12029,6 @@ extension on TranslationsEs {
 			'web.roundTable.plan.bypass' => 'Omitir permisos (YOLO)',
 			'web.roundTable.plan.bypassHint' => 'Inicia la sesión con su indicador de bypass para no pedir aprobaciones.',
 			'more.title' => 'Más',
-			'more.searchHint' => 'Buscar ajustes',
-			'more.noResults' => ({required Object query}) => 'Ningún ajuste coincide con «${query}»',
 			'more.identity.signedInAs' => 'Sesión iniciada como',
 			'more.identity.server' => 'Servidor',
 			'more.identity.tokenExpires' => 'El token caduca',
@@ -12531,10 +12527,10 @@ extension on TranslationsEs {
 			'integrations.tooltipReadOnly' => 'Integración del sistema (solo lectura)',
 			'integrations.kvRoutePrefix' => 'Prefijo de ruta',
 			'integrations.kvBaseUrl' => 'URL base',
-			_ => null,
-		} ?? switch (path) {
 			'integrations.kvScopes' => 'Ámbitos',
 			'integrations.kvVersion' => 'Versión',
+			_ => null,
+		} ?? switch (path) {
 			'integrations.kvLastHealthPing' => 'Último ping de estado',
 			'integrations.kvCreated' => 'Creada',
 			'integrations.kvKeyRotated' => 'Key rotada',
@@ -13045,10 +13041,10 @@ extension on TranslationsEs {
 			'channels.popup.enable' => 'Activar',
 			'channels.popup.disable' => 'Desactivar',
 			'channels.popup.mute' => 'Silenciar',
-			_ => null,
-		} ?? switch (path) {
 			'channels.popup.unmute' => 'Reactivar sonido',
 			'channels.popup.deleteLabel' => 'Eliminar',
+			_ => null,
+		} ?? switch (path) {
 			'channels.badges.running' => 'en ejecución',
 			'channels.badges.starting' => 'iniciando…',
 			'channels.badges.disabled' => 'desactivado',
@@ -13559,10 +13555,10 @@ extension on TranslationsEs {
 			'memoryQuarantine.countBadge' => ({required Object count}) => '${count} pendientes',
 			'cortexHub.title' => 'Cortex',
 			'cortexHub.subtitle' => 'El volante de experiencia: Memoria → Notas → Conocimiento, realimentado en cada session.',
-			_ => null,
-		} ?? switch (path) {
 			'cortexHub.idleBadge' => ({required Object days}) => 'inactivo ${days}d',
 			'cortexHub.activeProjectsBadge' => ({required Object count}) => '${count} activos',
+			_ => null,
+		} ?? switch (path) {
 			'cortexHub.activeProjectsTitle' => 'Proyectos activos',
 			'cortexHub.loopHint' => 'Las sesiones alimentan la Memoria → la Memoria se destila en Notas → las Notas se compilan en Conocimiento → el Conocimiento guía cada nueva sesión.',
 			'cortexHub.settings' => 'Ajustes',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -193,6 +193,8 @@ class _TranslationsMoreEs extends TranslationsMoreEn {
 
 	// Translations
 	@override String get title => 'Más';
+	@override String get searchHint => 'Buscar ajustes';
+	@override String noResults({required Object query}) => 'Ningún ajuste coincide con «${query}»';
 	@override late final _TranslationsMoreIdentityEs identity = _TranslationsMoreIdentityEs._(_root);
 	@override late final _TranslationsMoreSectionsEs sections = _TranslationsMoreSectionsEs._(_root);
 	@override late final _TranslationsMoreItemsEs items = _TranslationsMoreItemsEs._(_root);
@@ -12029,6 +12031,8 @@ extension on TranslationsEs {
 			'web.roundTable.plan.bypass' => 'Omitir permisos (YOLO)',
 			'web.roundTable.plan.bypassHint' => 'Inicia la sesión con su indicador de bypass para no pedir aprobaciones.',
 			'more.title' => 'Más',
+			'more.searchHint' => 'Buscar ajustes',
+			'more.noResults' => ({required Object query}) => 'Ningún ajuste coincide con «${query}»',
 			'more.identity.signedInAs' => 'Sesión iniciada como',
 			'more.identity.server' => 'Servidor',
 			'more.identity.tokenExpires' => 'El token caduca',
@@ -12527,10 +12531,10 @@ extension on TranslationsEs {
 			'integrations.tooltipReadOnly' => 'Integración del sistema (solo lectura)',
 			'integrations.kvRoutePrefix' => 'Prefijo de ruta',
 			'integrations.kvBaseUrl' => 'URL base',
-			'integrations.kvScopes' => 'Ámbitos',
-			'integrations.kvVersion' => 'Versión',
 			_ => null,
 		} ?? switch (path) {
+			'integrations.kvScopes' => 'Ámbitos',
+			'integrations.kvVersion' => 'Versión',
 			'integrations.kvLastHealthPing' => 'Último ping de estado',
 			'integrations.kvCreated' => 'Creada',
 			'integrations.kvKeyRotated' => 'Key rotada',
@@ -13041,10 +13045,10 @@ extension on TranslationsEs {
 			'channels.popup.enable' => 'Activar',
 			'channels.popup.disable' => 'Desactivar',
 			'channels.popup.mute' => 'Silenciar',
-			'channels.popup.unmute' => 'Reactivar sonido',
-			'channels.popup.deleteLabel' => 'Eliminar',
 			_ => null,
 		} ?? switch (path) {
+			'channels.popup.unmute' => 'Reactivar sonido',
+			'channels.popup.deleteLabel' => 'Eliminar',
 			'channels.badges.running' => 'en ejecución',
 			'channels.badges.starting' => 'iniciando…',
 			'channels.badges.disabled' => 'desactivado',
@@ -13555,10 +13559,10 @@ extension on TranslationsEs {
 			'memoryQuarantine.countBadge' => ({required Object count}) => '${count} pendientes',
 			'cortexHub.title' => 'Cortex',
 			'cortexHub.subtitle' => 'El volante de experiencia: Memoria → Notas → Conocimiento, realimentado en cada session.',
-			'cortexHub.idleBadge' => ({required Object days}) => 'inactivo ${days}d',
-			'cortexHub.activeProjectsBadge' => ({required Object count}) => '${count} activos',
 			_ => null,
 		} ?? switch (path) {
+			'cortexHub.idleBadge' => ({required Object days}) => 'inactivo ${days}d',
+			'cortexHub.activeProjectsBadge' => ({required Object count}) => '${count} activos',
 			'cortexHub.activeProjectsTitle' => 'Proyectos activos',
 			'cortexHub.loopHint' => 'Las sesiones alimentan la Memoria → la Memoria se destila en Notas → las Notas se compilan en Conocimiento → el Conocimiento guía cada nueva sesión.',
 			'cortexHub.settings' => 'Ajustes',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -193,6 +193,8 @@ class _TranslationsMoreZh extends TranslationsMoreEn {
 
 	// Translations
 	@override String get title => '更多';
+	@override String get searchHint => '搜索设置';
+	@override String noResults({required Object query}) => '没有匹配“${query}”的设置';
 	@override late final _TranslationsMoreIdentityZh identity = _TranslationsMoreIdentityZh._(_root);
 	@override late final _TranslationsMoreSectionsZh sections = _TranslationsMoreSectionsZh._(_root);
 	@override late final _TranslationsMoreItemsZh items = _TranslationsMoreItemsZh._(_root);
@@ -12029,6 +12031,8 @@ extension on TranslationsZh {
 			'web.roundTable.plan.bypass' => '跳过权限 (YOLO)',
 			'web.roundTable.plan.bypassHint' => '用 bypass 标志启动会话,不再逐个请求批准。',
 			'more.title' => '更多',
+			'more.searchHint' => '搜索设置',
+			'more.noResults' => ({required Object query}) => '没有匹配“${query}”的设置',
 			'more.identity.signedInAs' => '登录账号',
 			'more.identity.server' => '服务器',
 			'more.identity.tokenExpires' => '令牌到期',
@@ -12527,10 +12531,10 @@ extension on TranslationsZh {
 			'integrations.tooltipReadOnly' => '系统集成 — 只读',
 			'integrations.kvRoutePrefix' => '路由前缀',
 			'integrations.kvBaseUrl' => 'Base URL',
-			'integrations.kvScopes' => '范围',
-			'integrations.kvVersion' => '版本',
 			_ => null,
 		} ?? switch (path) {
+			'integrations.kvScopes' => '范围',
+			'integrations.kvVersion' => '版本',
 			'integrations.kvLastHealthPing' => '最近健康检查',
 			'integrations.kvCreated' => '创建于',
 			'integrations.kvKeyRotated' => 'Key 轮换于',
@@ -13041,10 +13045,10 @@ extension on TranslationsZh {
 			'channels.popup.enable' => '启用',
 			'channels.popup.disable' => '停用',
 			'channels.popup.mute' => '静音',
-			'channels.popup.unmute' => '取消静音',
-			'channels.popup.deleteLabel' => '删除',
 			_ => null,
 		} ?? switch (path) {
+			'channels.popup.unmute' => '取消静音',
+			'channels.popup.deleteLabel' => '删除',
 			'channels.badges.running' => '运行中',
 			'channels.badges.starting' => '启动中…',
 			'channels.badges.disabled' => '已停用',
@@ -13555,10 +13559,10 @@ extension on TranslationsZh {
 			'memoryQuarantine.countBadge' => ({required Object count}) => '${count} 条待审',
 			'cortexHub.title' => 'Cortex',
 			'cortexHub.subtitle' => '经验飞轮：记忆 → 笔记 → 知识，回流到每个会话。',
-			'cortexHub.idleBadge' => ({required Object days}) => '闲置 ${days} 天',
-			'cortexHub.activeProjectsBadge' => ({required Object count}) => '${count} 个活跃',
 			_ => null,
 		} ?? switch (path) {
+			'cortexHub.idleBadge' => ({required Object days}) => '闲置 ${days} 天',
+			'cortexHub.activeProjectsBadge' => ({required Object count}) => '${count} 个活跃',
 			'cortexHub.activeProjectsTitle' => '活跃项目',
 			'cortexHub.loopHint' => '会话喂养记忆 → 记忆提炼为笔记 → 笔记沉淀为知识 → 知识引导每个新会话。',
 			'cortexHub.settings' => '设置',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -193,8 +193,6 @@ class _TranslationsMoreZh extends TranslationsMoreEn {
 
 	// Translations
 	@override String get title => '更多';
-	@override String get searchHint => '搜索设置';
-	@override String noResults({required Object query}) => '没有匹配“${query}”的设置';
 	@override late final _TranslationsMoreIdentityZh identity = _TranslationsMoreIdentityZh._(_root);
 	@override late final _TranslationsMoreSectionsZh sections = _TranslationsMoreSectionsZh._(_root);
 	@override late final _TranslationsMoreItemsZh items = _TranslationsMoreItemsZh._(_root);
@@ -12031,8 +12029,6 @@ extension on TranslationsZh {
 			'web.roundTable.plan.bypass' => '跳过权限 (YOLO)',
 			'web.roundTable.plan.bypassHint' => '用 bypass 标志启动会话,不再逐个请求批准。',
 			'more.title' => '更多',
-			'more.searchHint' => '搜索设置',
-			'more.noResults' => ({required Object query}) => '没有匹配“${query}”的设置',
 			'more.identity.signedInAs' => '登录账号',
 			'more.identity.server' => '服务器',
 			'more.identity.tokenExpires' => '令牌到期',
@@ -12531,10 +12527,10 @@ extension on TranslationsZh {
 			'integrations.tooltipReadOnly' => '系统集成 — 只读',
 			'integrations.kvRoutePrefix' => '路由前缀',
 			'integrations.kvBaseUrl' => 'Base URL',
-			_ => null,
-		} ?? switch (path) {
 			'integrations.kvScopes' => '范围',
 			'integrations.kvVersion' => '版本',
+			_ => null,
+		} ?? switch (path) {
 			'integrations.kvLastHealthPing' => '最近健康检查',
 			'integrations.kvCreated' => '创建于',
 			'integrations.kvKeyRotated' => 'Key 轮换于',
@@ -13045,10 +13041,10 @@ extension on TranslationsZh {
 			'channels.popup.enable' => '启用',
 			'channels.popup.disable' => '停用',
 			'channels.popup.mute' => '静音',
-			_ => null,
-		} ?? switch (path) {
 			'channels.popup.unmute' => '取消静音',
 			'channels.popup.deleteLabel' => '删除',
+			_ => null,
+		} ?? switch (path) {
 			'channels.badges.running' => '运行中',
 			'channels.badges.starting' => '启动中…',
 			'channels.badges.disabled' => '已停用',
@@ -13559,10 +13555,10 @@ extension on TranslationsZh {
 			'memoryQuarantine.countBadge' => ({required Object count}) => '${count} 条待审',
 			'cortexHub.title' => 'Cortex',
 			'cortexHub.subtitle' => '经验飞轮：记忆 → 笔记 → 知识，回流到每个会话。',
-			_ => null,
-		} ?? switch (path) {
 			'cortexHub.idleBadge' => ({required Object days}) => '闲置 ${days} 天',
 			'cortexHub.activeProjectsBadge' => ({required Object count}) => '${count} 个活跃',
+			_ => null,
+		} ?? switch (path) {
 			'cortexHub.activeProjectsTitle' => '活跃项目',
 			'cortexHub.loopHint' => '会话喂养记忆 → 记忆提炼为笔记 → 笔记沉淀为知识 → 知识引导每个新会话。',
 			'cortexHub.settings' => '设置',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -256,6 +256,8 @@ class _TranslationsSessionsZh extends TranslationsSessionsEn {
 	final TranslationsZh _root; // ignore: unused_field
 
 	// Translations
+	@override late final _TranslationsSessionsDockZh dock = _TranslationsSessionsDockZh._(_root);
+	@override late final _TranslationsSessionsToolsZh tools = _TranslationsSessionsToolsZh._(_root);
 	@override String get title => '会话';
 	@override String get refresh => '刷新';
 	@override String get actions => '操作';
@@ -1837,6 +1839,28 @@ class _TranslationsActivityDetailZh extends TranslationsActivityDetailEn {
 	@override String get requestId => '请求 ID';
 	@override String get resource => '资源';
 	@override String get timestamp => '时间';
+}
+
+// Path: sessions.dock
+class _TranslationsSessionsDockZh extends TranslationsSessionsDockEn {
+	_TranslationsSessionsDockZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get more => '更多';
+}
+
+// Path: sessions.tools
+class _TranslationsSessionsToolsZh extends TranslationsSessionsToolsEn {
+	_TranslationsSessionsToolsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get searchHint => '搜索工具';
+	@override String get inspectSection => '检查';
+	@override String get sessionSection => '会话';
 }
 
 // Path: sessions.filters
@@ -12100,6 +12124,10 @@ extension on TranslationsZh {
 			'memoryAmbient.strategyManualOnly' => '仅手动',
 			'memoryAmbient.strategyHybrid' => '混合摘要',
 			'memoryAmbient.strategyUnknown' => '未知',
+			'sessions.dock.more' => '更多',
+			'sessions.tools.searchHint' => '搜索工具',
+			'sessions.tools.inspectSection' => '检查',
+			'sessions.tools.sessionSection' => '会话',
 			'sessions.title' => '会话',
 			'sessions.refresh' => '刷新',
 			'sessions.actions' => '操作',
@@ -12501,12 +12529,12 @@ extension on TranslationsZh {
 			'integrations.kvBaseUrl' => 'Base URL',
 			'integrations.kvScopes' => '范围',
 			'integrations.kvVersion' => '版本',
+			_ => null,
+		} ?? switch (path) {
 			'integrations.kvLastHealthPing' => '最近健康检查',
 			'integrations.kvCreated' => '创建于',
 			'integrations.kvKeyRotated' => 'Key 轮换于',
 			'integrations.detailLoadFailed' => ({required Object error}) => '加载集成失败：${error}',
-			_ => null,
-		} ?? switch (path) {
 			'integrations.callsLoadFailed' => '加载调用失败',
 			'integrations.noMatchingCalls' => '日志中暂无匹配的调用。',
 			'integrations.directionAll' => '全部',
@@ -13015,12 +13043,12 @@ extension on TranslationsZh {
 			'channels.popup.mute' => '静音',
 			'channels.popup.unmute' => '取消静音',
 			'channels.popup.deleteLabel' => '删除',
+			_ => null,
+		} ?? switch (path) {
 			'channels.badges.running' => '运行中',
 			'channels.badges.starting' => '启动中…',
 			'channels.badges.disabled' => '已停用',
 			'channels.badges.muted' => '已静音',
-			_ => null,
-		} ?? switch (path) {
 			'channels.capsLabel' => ({required Object list}) => '· 能力：${list}',
 			'channels.bridgeWebOnly' => 'Bridge 通道仅 Web 端',
 			'channels.bridgeEmptyAdd' => '在 Web 管理端添加：通道 → 新建。',
@@ -13529,12 +13557,12 @@ extension on TranslationsZh {
 			'cortexHub.subtitle' => '经验飞轮：记忆 → 笔记 → 知识，回流到每个会话。',
 			'cortexHub.idleBadge' => ({required Object days}) => '闲置 ${days} 天',
 			'cortexHub.activeProjectsBadge' => ({required Object count}) => '${count} 个活跃',
+			_ => null,
+		} ?? switch (path) {
 			'cortexHub.activeProjectsTitle' => '活跃项目',
 			'cortexHub.loopHint' => '会话喂养记忆 → 记忆提炼为笔记 → 笔记沉淀为知识 → 知识引导每个新会话。',
 			'cortexHub.settings' => '设置',
 			'cortexHub.memory' => '记忆',
-			_ => null,
-		} ?? switch (path) {
 			'cortexHub.memoryDesc' => '代理存取的跨会话原始事实。',
 			'cortexHub.notes' => '笔记',
 			'cortexHub.notesDesc' => '每个项目的官方目标 / 计划 / 日志。',

--- a/app/mobile/lib/features/more/more_screen.dart
+++ b/app/mobile/lib/features/more/more_screen.dart
@@ -24,26 +24,44 @@ import 'package:opendray/features/settings/settings_screen.dart';
 import 'package:opendray/features/skills/skills_screen.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-// "More" tab — overflow menu for everything that doesn't earn its
-// own bottom-nav slot. Three sections: identity card, navigation
-// list, destructive sign-out. Sub-pages route via Navigator.push
-// (not go_router) because they're owned by this tab and don't need
-// deep-linking from outside.
+// "More" tab — the app's settings / overflow surface for everything that
+// doesn't earn its own bottom-nav slot.
 //
-// Sub-pages still ship as PlaceholderScreen until F8–F11 fill them
-// in — Integrations first (highest signal: every operator wants
-// "who's calling me right now"), then Channels, Providers, Backups,
-// About.
-// External Resources links — mirror app/web/src/components/SidebarNav.tsx.
+// Layout: a compact profile header + a pinned search field on top, then a
+// launcher-style 2-column grid of icon tiles grouped by section (Gateway /
+// Plugins / Memory / System / Resources). The search filters every tile
+// across all sections at once, so an 18-entry menu is one keystroke away.
+// Sub-pages route via Navigator.push (owned by this tab, no deep-linking).
 const _docsUrl = 'https://opendray.dev/docs/';
 const _communityUrl = 'https://t.me/opendraycommunity';
 const _sponsorUrl = 'https://opendray.dev/sponsors/';
 
-class MoreScreen extends ConsumerWidget {
+class MoreScreen extends ConsumerStatefulWidget {
   const MoreScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<MoreScreen> createState() => _MoreScreenState();
+}
+
+class _MoreScreenState extends ConsumerState<MoreScreen> {
+  String _query = '';
+
+  void _push(Widget page) {
+    Navigator.of(context).push(MaterialPageRoute<void>(builder: (_) => page));
+  }
+
+  Future<void> _openUrl(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    try {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } on Object {
+      // Best-effort convenience link.
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final auth = ref.watch(authControllerProvider);
     final version = ref.watch(versionInfoProvider).asData?.value;
     final updateAvailable = version?.updateAvailable ?? false;
@@ -60,218 +78,249 @@ class MoreScreen extends ConsumerWidget {
     if (auth is! AuthLoggedIn) {
       return const Scaffold(body: SizedBox.shrink());
     }
+
+    final sections = _buildSections(
+      updateAvailable: updateAvailable,
+      showUpdatesBadge: showUpdatesBadge,
+      notesUnread: notesUnread,
+      highlightCount: highlightCount,
+    );
+    final q = _query.trim().toLowerCase();
+    final visible = q.isEmpty
+        ? sections
+        : [
+            for (final s in sections)
+              if (s.items.any((it) => it.matches(q)))
+                _Section(
+                  s.label,
+                  s.items.where((it) => it.matches(q)).toList(),
+                ),
+          ];
+
     return Scaffold(
       appBar: AppBar(title: Text(t.more.title)),
-      body: ListView(
+      body: Column(
         children: [
-          _IdentityCard(auth: auth),
-          // Round Table + Integrations are top-level bottom-nav tabs now;
-          // Activity (per-call integration audit) lives here in the gateway
-          // section alongside the lower-frequency destinations.
-          _SectionHeader(label: t.more.sections.gateway),
-          _MenuGroup(children: [
-            _MenuTile(
-              icon: Icons.timeline_outlined,
-              title: t.more.items.activity.title,
-              subtitle: t.more.items.activity.subtitle,
-              onTap: () => _push(context, const ActivityScreen()),
-            ),
-            _MenuTile(
-              icon: Icons.notifications_outlined,
-              title: t.more.items.channels.title,
-              subtitle: t.more.items.channels.subtitle,
-              onTap: () => _push(context, const ChannelsScreen()),
-            ),
-            _MenuTile(
-              icon: Icons.psychology_outlined,
-              title: t.more.items.providers.title,
-              subtitle: t.more.items.providers.subtitle,
-              onTap: () => _push(context, const ProvidersScreen()),
-            ),
-          ]),
-          _SectionHeader(label: t.more.sections.plugins),
-          _MenuGroup(children: [
-            _MenuTile(
-              icon: Icons.extension_outlined,
-              title: t.more.items.mcp.title,
-              subtitle: t.more.items.mcp.subtitle,
-              onTap: () => _push(context, const McpScreen()),
-            ),
-            _MenuTile(
-              icon: Icons.auto_awesome_outlined,
-              title: t.more.items.skills.title,
-              subtitle: t.more.items.skills.subtitle,
-              onTap: () => _push(context, const SkillsScreen()),
-            ),
-            _MenuTile(
-              icon: Icons.account_tree_outlined,
-              title: t.more.items.gitHosts.title,
-              subtitle: t.more.items.gitHosts.subtitle,
-              onTap: () => _push(context, const GitHostsScreen()),
-            ),
-            _MenuTile(
-              icon: Icons.terminal_outlined,
-              title: t.more.items.customTasks.title,
-              subtitle: t.more.items.customTasks.subtitle,
-              onTap: () => _push(context, const CustomTasksScreen()),
-            ),
-          ]),
-          // Cortex hub is the bottom-nav "Cortex" tab and its ⚙ opens the
-          // unified Cortex settings (workers + capture/injection +
-          // providers) — so capture/injection no longer needs its own More
-          // entry. This section keeps the deeper, lower-frequency tools.
-          _SectionHeader(label: t.more.sections.memory),
-          _MenuGroup(children: [
-            _MenuTile(
-              icon: Icons.flag_outlined,
-              title: t.more.items.projectMemory.title,
-              subtitle: t.more.items.projectMemory.subtitle,
-              onTap: () => _push(context, const ProjectScreen()),
-            ),
-            _MenuTile(
-              icon: Icons.inventory_2_outlined,
-              title: t.more.items.archived.title,
-              subtitle: t.more.items.archived.subtitle,
-              onTap: () => _push(context, const ArchivedMemoriesScreen()),
-            ),
-            _MenuTile(
-              icon: Icons.shield_outlined,
-              title: t.more.items.quarantine.title,
-              subtitle: t.more.items.quarantine.subtitle,
-              onTap: () => _push(context, const QuarantineScreen()),
-            ),
-            _MenuTile(
-              icon: Icons.folder_outlined,
-              title: t.more.items.vault.title,
-              subtitle: t.more.items.vault.subtitle,
-              onTap: () => _push(context, const NotesVaultScreen()),
-            ),
-          ]),
-          _SectionHeader(label: t.more.sections.system),
-          _MenuGroup(children: [
-            _MenuTile(
-              icon: Icons.backup_outlined,
-              title: t.more.items.backups.title,
-              subtitle: t.more.items.backups.subtitle,
-              onTap: () => _push(context, const BackupsScreen()),
-            ),
-            _MenuTile(
-              icon: Icons.import_export_outlined,
-              title: t.more.items.dataExport.title,
-              subtitle: t.more.items.dataExport.subtitle,
-              onTap: () => _push(context, const DataExportScreen()),
-            ),
-            _MenuTile(
-              icon: Icons.tune_outlined,
-              title: t.more.items.settings.title,
-              subtitle: t.more.items.settings.subtitle,
-              badge: updateAvailable,
-              onTap: () => _push(context, const SettingsScreen()),
-            ),
-            _MenuTile(
-              icon: Icons.info_outline,
-              title: t.more.items.about.title,
-              subtitle: t.more.items.about.subtitle,
-              onTap: () => _push(context, const AboutScreen()),
-            ),
-          ]),
-          _SectionHeader(label: t.nav.resources),
-          _MenuGroup(children: [
-            _MenuTile(
-              icon: Icons.auto_awesome_outlined,
-              title: t.nav.updates.title,
-              badge: showUpdatesBadge,
-              // Accent-primary when only release notes are unread; the
-              // system error red is reserved for a waiting binary update
-              // (matches web's accent-vs-primary dot).
-              badgeColor: updateAvailable
-                  ? Theme.of(context).colorScheme.error
-                  : Theme.of(context).colorScheme.primary,
-              trailingText: (notesUnread && highlightCount > 0)
-                  ? '· $highlightCount'
-                  : null,
-              onTap: () => showUpdatesSheet(context),
-            ),
-            _MenuTile(
-              icon: Icons.menu_book_outlined,
-              title: t.nav.docs,
-              external: true,
-              onTap: () => _openUrl(_docsUrl),
-            ),
-            _MenuTile(
-              icon: Icons.forum_outlined,
-              title: t.nav.community,
-              external: true,
-              onTap: () => _openUrl(_communityUrl),
-            ),
-            _MenuTile(
-              icon: Icons.favorite_outline,
-              title: t.nav.sponsor,
-              external: true,
-              onTap: () => _openUrl(_sponsorUrl),
-            ),
-          ]),
-          const SizedBox(height: 24),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-            child: OutlinedButton.icon(
-              style: OutlinedButton.styleFrom(
-                foregroundColor: Theme.of(context).colorScheme.error,
-                side: BorderSide(
-                  color: Theme.of(
-                    context,
-                  ).colorScheme.error.withValues(alpha: 0.4),
-                ),
-                padding: const EdgeInsets.symmetric(vertical: 14),
-              ),
-              onPressed: () =>
-                  ref.read(authControllerProvider.notifier).logout(),
-              icon: const Icon(Icons.logout, size: 18),
-              label: Text(t.more.signOut),
-            ),
+          _ProfileHeader(auth: auth),
+          _SearchField(
+            onChanged: (v) => setState(() => _query = v),
           ),
-          // App version footer — a quiet, centred build stamp gives the
-          // page a finished bottom edge instead of trailing off.
-          if (version != null && version.current.isNotEmpty)
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 4, 16, 28),
-              child: Center(
-                child: Text(
-                  'opendray ${version.current}',
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Theme.of(context)
-                            .colorScheme
-                            .onSurface
-                            .withValues(alpha: 0.4),
-                      ),
-                ),
-              ),
-            ),
+          Expanded(
+            child: visible.isEmpty
+                ? _EmptyResults(query: _query.trim())
+                : ListView(
+                    padding: const EdgeInsets.only(top: 4, bottom: 8),
+                    children: [
+                      for (final section in visible) ...[
+                        _SectionHeader(label: section.label),
+                        _TileGrid(items: section.items),
+                      ],
+                      // Actions only belong on the full (unsearched) page.
+                      if (q.isEmpty) ...[
+                        const SizedBox(height: 20),
+                        _SignOutButton(
+                          onPressed: () => ref
+                              .read(authControllerProvider.notifier)
+                              .logout(),
+                        ),
+                        if (version != null && version.current.isNotEmpty)
+                          _VersionStamp(version: version.current),
+                      ],
+                    ],
+                  ),
+          ),
         ],
       ),
     );
   }
 
-  void _push(BuildContext context, Widget page) {
-    Navigator.of(context).push(MaterialPageRoute<void>(builder: (_) => page));
-  }
-
-  Future<void> _openUrl(String url) async {
-    final uri = Uri.tryParse(url);
-    if (uri == null) return;
-    try {
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
-    } on Object {
-      // Best-effort convenience link.
-    }
+  // The full menu, grouped by section. Built here (not const) because the
+  // Updates entry's badge/count depend on live release state.
+  List<_Section> _buildSections({
+    required bool updateAvailable,
+    required bool showUpdatesBadge,
+    required bool notesUnread,
+    required int highlightCount,
+  }) {
+    final scheme = Theme.of(context).colorScheme;
+    return [
+      _Section(t.more.sections.gateway, [
+        _MenuItem(
+          icon: Icons.timeline_outlined,
+          title: t.more.items.activity.title,
+          subtitle: t.more.items.activity.subtitle,
+          onTap: () => _push(const ActivityScreen()),
+        ),
+        _MenuItem(
+          icon: Icons.notifications_outlined,
+          title: t.more.items.channels.title,
+          subtitle: t.more.items.channels.subtitle,
+          onTap: () => _push(const ChannelsScreen()),
+        ),
+        _MenuItem(
+          icon: Icons.psychology_outlined,
+          title: t.more.items.providers.title,
+          subtitle: t.more.items.providers.subtitle,
+          onTap: () => _push(const ProvidersScreen()),
+        ),
+      ]),
+      _Section(t.more.sections.plugins, [
+        _MenuItem(
+          icon: Icons.extension_outlined,
+          title: t.more.items.mcp.title,
+          subtitle: t.more.items.mcp.subtitle,
+          onTap: () => _push(const McpScreen()),
+        ),
+        _MenuItem(
+          icon: Icons.auto_awesome_outlined,
+          title: t.more.items.skills.title,
+          subtitle: t.more.items.skills.subtitle,
+          onTap: () => _push(const SkillsScreen()),
+        ),
+        _MenuItem(
+          icon: Icons.account_tree_outlined,
+          title: t.more.items.gitHosts.title,
+          subtitle: t.more.items.gitHosts.subtitle,
+          onTap: () => _push(const GitHostsScreen()),
+        ),
+        _MenuItem(
+          icon: Icons.terminal_outlined,
+          title: t.more.items.customTasks.title,
+          subtitle: t.more.items.customTasks.subtitle,
+          onTap: () => _push(const CustomTasksScreen()),
+        ),
+      ]),
+      _Section(t.more.sections.memory, [
+        _MenuItem(
+          icon: Icons.flag_outlined,
+          title: t.more.items.projectMemory.title,
+          subtitle: t.more.items.projectMemory.subtitle,
+          onTap: () => _push(const ProjectScreen()),
+        ),
+        _MenuItem(
+          icon: Icons.inventory_2_outlined,
+          title: t.more.items.archived.title,
+          subtitle: t.more.items.archived.subtitle,
+          onTap: () => _push(const ArchivedMemoriesScreen()),
+        ),
+        _MenuItem(
+          icon: Icons.shield_outlined,
+          title: t.more.items.quarantine.title,
+          subtitle: t.more.items.quarantine.subtitle,
+          onTap: () => _push(const QuarantineScreen()),
+        ),
+        _MenuItem(
+          icon: Icons.folder_outlined,
+          title: t.more.items.vault.title,
+          subtitle: t.more.items.vault.subtitle,
+          onTap: () => _push(const NotesVaultScreen()),
+        ),
+      ]),
+      _Section(t.more.sections.system, [
+        _MenuItem(
+          icon: Icons.backup_outlined,
+          title: t.more.items.backups.title,
+          subtitle: t.more.items.backups.subtitle,
+          onTap: () => _push(const BackupsScreen()),
+        ),
+        _MenuItem(
+          icon: Icons.import_export_outlined,
+          title: t.more.items.dataExport.title,
+          subtitle: t.more.items.dataExport.subtitle,
+          onTap: () => _push(const DataExportScreen()),
+        ),
+        _MenuItem(
+          icon: Icons.tune_outlined,
+          title: t.more.items.settings.title,
+          subtitle: t.more.items.settings.subtitle,
+          badge: updateAvailable,
+          onTap: () => _push(const SettingsScreen()),
+        ),
+        _MenuItem(
+          icon: Icons.info_outline,
+          title: t.more.items.about.title,
+          subtitle: t.more.items.about.subtitle,
+          onTap: () => _push(const AboutScreen()),
+        ),
+      ]),
+      _Section(t.nav.resources, [
+        _MenuItem(
+          icon: Icons.auto_awesome_outlined,
+          title: t.nav.updates.title,
+          badge: showUpdatesBadge,
+          // Accent-primary when only release notes are unread; the system
+          // error red is reserved for a waiting binary update (matches
+          // web's accent-vs-primary dot).
+          badgeColor: updateAvailable ? scheme.error : scheme.primary,
+          trailingText:
+              (notesUnread && highlightCount > 0) ? '$highlightCount' : null,
+          onTap: () => showUpdatesSheet(context),
+        ),
+        _MenuItem(
+          icon: Icons.menu_book_outlined,
+          title: t.nav.docs,
+          external: true,
+          onTap: () => _openUrl(_docsUrl),
+        ),
+        _MenuItem(
+          icon: Icons.forum_outlined,
+          title: t.nav.community,
+          external: true,
+          onTap: () => _openUrl(_communityUrl),
+        ),
+        _MenuItem(
+          icon: Icons.favorite_outline,
+          title: t.nav.sponsor,
+          external: true,
+          onTap: () => _openUrl(_sponsorUrl),
+        ),
+      ]),
+    ];
   }
 }
 
-class _IdentityCard extends StatelessWidget {
-  const _IdentityCard({required this.auth});
+// ── data model ─────────────────────────────────────────────────────────
+
+class _MenuItem {
+  const _MenuItem({
+    required this.icon,
+    required this.title,
+    required this.onTap,
+    this.subtitle,
+    this.badge = false,
+    this.badgeColor,
+    this.trailingText,
+    this.external = false,
+  });
+
+  final IconData icon;
+  final String title;
+  final String? subtitle;
+  final VoidCallback onTap;
+  final bool badge;
+  final Color? badgeColor;
+  final String? trailingText;
+  final bool external;
+
+  bool matches(String q) =>
+      title.toLowerCase().contains(q) ||
+      (subtitle?.toLowerCase().contains(q) ?? false);
+}
+
+class _Section {
+  const _Section(this.label, this.items);
+  final String label;
+  final List<_MenuItem> items;
+}
+
+// ── header + search ────────────────────────────────────────────────────
+
+// Compact account block pinned above the grid: monogram avatar, username,
+// and server / token-expiry on muted meta lines.
+class _ProfileHeader extends StatelessWidget {
+  const _ProfileHeader({required this.auth});
   final AuthLoggedIn auth;
 
-  // First one or two letters of the username, for the avatar monogram.
   String get _initials {
     final name = auth.username.trim();
     if (name.isEmpty) return '?';
@@ -286,66 +335,55 @@ class _IdentityCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scheme = theme.colorScheme;
-    final muted = theme.textTheme.bodySmall
-        ?.copyWith(color: scheme.onSurface.withValues(alpha: 0.6));
+    final muted = scheme.onSurface.withValues(alpha: 0.6);
+    final expires = DateFormat.yMMMd().format(auth.expiresAt.toLocal());
     return Padding(
-      padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+      padding: const EdgeInsets.fromLTRB(12, 12, 12, 4),
       child: Card(
         child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+          padding: const EdgeInsets.all(14),
+          child: Row(
             children: [
-              // Profile row: monogram avatar + "signed in as" / username.
-              Row(
-                children: [
-                  Container(
-                    width: 44,
-                    height: 44,
-                    alignment: Alignment.center,
-                    decoration: BoxDecoration(
-                      color: scheme.primary.withValues(alpha: 0.14),
-                      shape: BoxShape.circle,
-                    ),
-                    child: Text(
-                      _initials,
-                      style: theme.textTheme.titleMedium?.copyWith(
-                        color: scheme.primary,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
+              Container(
+                width: 46,
+                height: 46,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: scheme.primary.withValues(alpha: 0.14),
+                  shape: BoxShape.circle,
+                ),
+                child: Text(
+                  _initials,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: scheme.primary,
+                    fontWeight: FontWeight.w700,
                   ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(t.more.identity.signedInAs, style: muted),
-                        Text(
-                          auth.username,
-                          style: theme.textTheme.titleMedium,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ],
+                ),
+              ),
+              const SizedBox(width: 13),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      auth.username,
+                      style: theme.textTheme.titleMedium
+                          ?.copyWith(fontWeight: FontWeight.w600),
+                      overflow: TextOverflow.ellipsis,
                     ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 14),
-              Divider(height: 1, color: theme.dividerColor),
-              const SizedBox(height: 12),
-              // Secondary detail rows: server + token expiry.
-              _DetailRow(
-                icon: Icons.dns_outlined,
-                label: t.more.identity.server,
-                value: auth.serverUrl,
-              ),
-              const SizedBox(height: 10),
-              _DetailRow(
-                icon: Icons.schedule_outlined,
-                label: t.more.identity.tokenExpires,
-                value:
-                    DateFormat.yMMMd().add_jm().format(auth.expiresAt.toLocal()),
+                    const SizedBox(height: 2),
+                    Text(
+                      auth.serverUrl,
+                      style: theme.textTheme.bodySmall?.copyWith(color: muted),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    Text(
+                      '${t.more.identity.tokenExpires} $expires',
+                      style: theme.textTheme.bodySmall?.copyWith(color: muted),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
               ),
             ],
           ),
@@ -355,44 +393,56 @@ class _IdentityCard extends StatelessWidget {
   }
 }
 
-// One muted label + value line in the identity card, prefixed by a small
-// glyph so server / token expiry read as distinct at a glance.
-class _DetailRow extends StatelessWidget {
-  const _DetailRow({
-    required this.icon,
-    required this.label,
-    required this.value,
-  });
+class _SearchField extends StatelessWidget {
+  const _SearchField({required this.onChanged});
+  final ValueChanged<String> onChanged;
 
-  final IconData icon;
-  final String label;
-  final String value;
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 4, 12, 8),
+      child: TextField(
+        onChanged: onChanged,
+        textInputAction: TextInputAction.search,
+        decoration: InputDecoration(
+          prefixIcon: const Icon(Icons.search, size: 20),
+          hintText: t.more.searchHint,
+          isDense: true,
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyResults extends StatelessWidget {
+  const _EmptyResults({required this.query});
+  final String query;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Icon(icon, size: 16, color: muted),
-        const SizedBox(width: 10),
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                label,
-                style: theme.textTheme.bodySmall?.copyWith(color: muted),
-              ),
-              Text(value, style: theme.textTheme.bodyMedium),
-            ],
-          ),
+    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.55);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.search_off, size: 40, color: muted),
+            const SizedBox(height: 12),
+            Text(
+              t.more.noResults(query: query),
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(color: muted),
+            ),
+          ],
         ),
-      ],
+      ),
     );
   }
 }
+
+// ── grid ───────────────────────────────────────────────────────────────
 
 class _SectionHeader extends StatelessWidget {
   const _SectionHeader({required this.label});
@@ -401,159 +451,173 @@ class _SectionHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(24, 20, 24, 8),
+      padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
       child: Text(
         label.toUpperCase(),
         style: Theme.of(context).textTheme.labelSmall?.copyWith(
-          letterSpacing: 0.8,
-          fontWeight: FontWeight.w600,
-          color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+              letterSpacing: 0.8,
+              fontWeight: FontWeight.w600,
+              color:
+                  Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
+      ),
+    );
+  }
+}
+
+class _TileGrid extends StatelessWidget {
+  const _TileGrid({required this.items});
+  final List<_MenuItem> items;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: GridView.builder(
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        padding: EdgeInsets.zero,
+        itemCount: items.length,
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 2,
+          mainAxisExtent: 96,
+          crossAxisSpacing: 10,
+          mainAxisSpacing: 10,
+        ),
+        itemBuilder: (_, i) => _GridTile(item: items[i]),
+      ),
+    );
+  }
+}
+
+// One launcher tile: tinted icon chip top-left (with an optional status
+// dot / external glyph), then title + one-line subtitle beneath. Kept on
+// the single gold accent so the grid reads as one system, not a mosaic.
+class _GridTile extends StatelessWidget {
+  const _GridTile({required this.item});
+  final _MenuItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: item.onTap,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(13, 12, 12, 12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Container(
+                    width: 34,
+                    height: 34,
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: scheme.primary.withValues(alpha: 0.12),
+                      borderRadius: BorderRadius.circular(9),
+                    ),
+                    child: Icon(item.icon, size: 19, color: scheme.primary),
+                  ),
+                  const Spacer(),
+                  if (item.trailingText != null)
+                    Padding(
+                      padding: const EdgeInsets.only(right: 2),
+                      child: Text(
+                        item.trailingText!,
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: scheme.onSurface.withValues(alpha: 0.55),
+                        ),
+                      ),
+                    ),
+                  if (item.badge)
+                    Container(
+                      width: 8,
+                      height: 8,
+                      decoration: BoxDecoration(
+                        color: item.badgeColor ?? scheme.error,
+                        shape: BoxShape.circle,
+                      ),
+                    )
+                  else if (item.external)
+                    Icon(Icons.open_in_new,
+                        size: 15,
+                        color: scheme.onSurface.withValues(alpha: 0.35)),
+                ],
+              ),
+              const Spacer(),
+              Text(
+                item.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodyMedium
+                    ?.copyWith(fontWeight: FontWeight.w600),
+              ),
+              if (item.subtitle != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 1),
+                  child: Text(
+                    item.subtitle!,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: scheme.onSurface.withValues(alpha: 0.55),
+                    ),
+                  ),
+                ),
+            ],
+          ),
         ),
       ),
     );
   }
 }
 
-// Wraps a section's tiles in one inset, bordered, rounded card with thin
-// dividers between rows — the standard grouped-settings look. Uses the
-// app-wide CardTheme (elevation 0, border, radius 12) so it matches the
-// identity card and every other card surface.
-class _MenuGroup extends StatelessWidget {
-  const _MenuGroup({required this.children});
-  final List<Widget> children;
+// ── footer ─────────────────────────────────────────────────────────────
 
-  @override
-  Widget build(BuildContext context) {
-    // Divider indented past the leading icon so it starts under the text,
-    // the way iOS/Material grouped lists separate rows.
-    final divider = Divider(
-      height: 1,
-      thickness: 1,
-      indent: 60,
-      color: Theme.of(context).dividerColor,
-    );
-    final rows = <Widget>[];
-    for (var i = 0; i < children.length; i++) {
-      if (i > 0) rows.add(divider);
-      rows.add(children[i]);
-    }
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 12),
-      child: Card(
-        clipBehavior: Clip.antiAlias,
-        child: Column(mainAxisSize: MainAxisSize.min, children: rows),
-      ),
-    );
-  }
-}
-
-class _MenuTile extends StatelessWidget {
-  const _MenuTile({
-    required this.icon,
-    required this.title,
-    required this.onTap,
-    this.subtitle,
-    this.badge = false,
-    this.badgeColor,
-    this.trailingText,
-    this.external = false,
-  });
-
-  final IconData icon;
-  final String title;
-  // Optional secondary line; Resources links render title-only.
-  final String? subtitle;
-  final VoidCallback onTap;
-  // When true, shows a status dot before the trailing icon.
-  final bool badge;
-  // Dot colour; defaults to the error colour (waiting binary update).
-  final Color? badgeColor;
-  // Small muted count chip (e.g. "· 3") shown before the trailing icon.
-  final String? trailingText;
-  // External links show an open-in-new glyph instead of a chevron.
-  final bool external;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
-    final subtitle = this.subtitle;
-    return ListTile(
-      onTap: onTap,
-      contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 4),
-      horizontalTitleGap: 12,
-      minLeadingWidth: 34,
-      leading: _IconChip(icon: icon),
-      title: Text(
-        title,
-        style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w500),
-      ),
-      subtitle: subtitle == null
-          ? null
-          : Padding(
-              padding: const EdgeInsets.only(top: 2),
-              child: Text(
-                subtitle,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: scheme.onSurface.withValues(alpha: 0.55),
-                  height: 1.25,
-                ),
-              ),
-            ),
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (trailingText != null)
-            Padding(
-              padding: const EdgeInsets.only(right: 8),
-              child: Text(
-                trailingText!,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: scheme.onSurface.withValues(alpha: 0.6),
-                ),
-              ),
-            ),
-          if (badge)
-            Container(
-              width: 8,
-              height: 8,
-              margin: const EdgeInsets.only(right: 8),
-              decoration: BoxDecoration(
-                color: badgeColor ?? scheme.error,
-                shape: BoxShape.circle,
-              ),
-            ),
-          Icon(
-            external ? Icons.open_in_new : Icons.chevron_right,
-            size: external ? 16 : 20,
-            color: scheme.onSurface.withValues(alpha: external ? 0.4 : 0.3),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-// Rounded-square tinted chip behind each menu icon — the signature
-// "app-icon" affordance of a polished settings page. Kept on the single
-// gold accent (primary) so the page stays on-brand rather than turning
-// into a rainbow of per-row colours.
-class _IconChip extends StatelessWidget {
-  const _IconChip({required this.icon});
-  final IconData icon;
+class _SignOutButton extends StatelessWidget {
+  const _SignOutButton({required this.onPressed});
+  final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
-    return Container(
-      width: 34,
-      height: 34,
-      alignment: Alignment.center,
-      decoration: BoxDecoration(
-        color: scheme.primary.withValues(alpha: 0.12),
-        borderRadius: BorderRadius.circular(9),
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+      child: OutlinedButton.icon(
+        style: OutlinedButton.styleFrom(
+          foregroundColor: scheme.error,
+          side: BorderSide(color: scheme.error.withValues(alpha: 0.4)),
+          padding: const EdgeInsets.symmetric(vertical: 14),
+        ),
+        onPressed: onPressed,
+        icon: const Icon(Icons.logout, size: 18),
+        label: Text(t.more.signOut),
       ),
-      child: Icon(icon, size: 19, color: scheme.primary),
+    );
+  }
+}
+
+class _VersionStamp extends StatelessWidget {
+  const _VersionStamp({required this.version});
+  final String version;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 28),
+      child: Center(
+        child: Text(
+          'opendray $version',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color:
+                    Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.4),
+              ),
+        ),
+      ),
     );
   }
 }

--- a/app/mobile/lib/features/more/more_screen.dart
+++ b/app/mobile/lib/features/more/more_screen.dart
@@ -24,44 +24,26 @@ import 'package:opendray/features/settings/settings_screen.dart';
 import 'package:opendray/features/skills/skills_screen.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-// "More" tab — the app's settings / overflow surface for everything that
-// doesn't earn its own bottom-nav slot.
+// "More" tab — overflow menu for everything that doesn't earn its
+// own bottom-nav slot. Three sections: identity card, navigation
+// list, destructive sign-out. Sub-pages route via Navigator.push
+// (not go_router) because they're owned by this tab and don't need
+// deep-linking from outside.
 //
-// Layout: a compact profile header + a pinned search field on top, then a
-// launcher-style 2-column grid of icon tiles grouped by section (Gateway /
-// Plugins / Memory / System / Resources). The search filters every tile
-// across all sections at once, so an 18-entry menu is one keystroke away.
-// Sub-pages route via Navigator.push (owned by this tab, no deep-linking).
+// Sub-pages still ship as PlaceholderScreen until F8–F11 fill them
+// in — Integrations first (highest signal: every operator wants
+// "who's calling me right now"), then Channels, Providers, Backups,
+// About.
+// External Resources links — mirror app/web/src/components/SidebarNav.tsx.
 const _docsUrl = 'https://opendray.dev/docs/';
 const _communityUrl = 'https://t.me/opendraycommunity';
 const _sponsorUrl = 'https://opendray.dev/sponsors/';
 
-class MoreScreen extends ConsumerStatefulWidget {
+class MoreScreen extends ConsumerWidget {
   const MoreScreen({super.key});
 
   @override
-  ConsumerState<MoreScreen> createState() => _MoreScreenState();
-}
-
-class _MoreScreenState extends ConsumerState<MoreScreen> {
-  String _query = '';
-
-  void _push(Widget page) {
-    Navigator.of(context).push(MaterialPageRoute<void>(builder: (_) => page));
-  }
-
-  Future<void> _openUrl(String url) async {
-    final uri = Uri.tryParse(url);
-    if (uri == null) return;
-    try {
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
-    } on Object {
-      // Best-effort convenience link.
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final auth = ref.watch(authControllerProvider);
     final version = ref.watch(versionInfoProvider).asData?.value;
     final updateAvailable = version?.updateAvailable ?? false;
@@ -78,249 +60,218 @@ class _MoreScreenState extends ConsumerState<MoreScreen> {
     if (auth is! AuthLoggedIn) {
       return const Scaffold(body: SizedBox.shrink());
     }
-
-    final sections = _buildSections(
-      updateAvailable: updateAvailable,
-      showUpdatesBadge: showUpdatesBadge,
-      notesUnread: notesUnread,
-      highlightCount: highlightCount,
-    );
-    final q = _query.trim().toLowerCase();
-    final visible = q.isEmpty
-        ? sections
-        : [
-            for (final s in sections)
-              if (s.items.any((it) => it.matches(q)))
-                _Section(
-                  s.label,
-                  s.items.where((it) => it.matches(q)).toList(),
-                ),
-          ];
-
     return Scaffold(
       appBar: AppBar(title: Text(t.more.title)),
-      body: Column(
+      body: ListView(
         children: [
-          _ProfileHeader(auth: auth),
-          _SearchField(
-            onChanged: (v) => setState(() => _query = v),
+          _IdentityCard(auth: auth),
+          // Round Table + Integrations are top-level bottom-nav tabs now;
+          // Activity (per-call integration audit) lives here in the gateway
+          // section alongside the lower-frequency destinations.
+          _SectionHeader(label: t.more.sections.gateway),
+          _MenuGroup(children: [
+            _MenuTile(
+              icon: Icons.timeline_outlined,
+              title: t.more.items.activity.title,
+              subtitle: t.more.items.activity.subtitle,
+              onTap: () => _push(context, const ActivityScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.notifications_outlined,
+              title: t.more.items.channels.title,
+              subtitle: t.more.items.channels.subtitle,
+              onTap: () => _push(context, const ChannelsScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.psychology_outlined,
+              title: t.more.items.providers.title,
+              subtitle: t.more.items.providers.subtitle,
+              onTap: () => _push(context, const ProvidersScreen()),
+            ),
+          ]),
+          _SectionHeader(label: t.more.sections.plugins),
+          _MenuGroup(children: [
+            _MenuTile(
+              icon: Icons.extension_outlined,
+              title: t.more.items.mcp.title,
+              subtitle: t.more.items.mcp.subtitle,
+              onTap: () => _push(context, const McpScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.auto_awesome_outlined,
+              title: t.more.items.skills.title,
+              subtitle: t.more.items.skills.subtitle,
+              onTap: () => _push(context, const SkillsScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.account_tree_outlined,
+              title: t.more.items.gitHosts.title,
+              subtitle: t.more.items.gitHosts.subtitle,
+              onTap: () => _push(context, const GitHostsScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.terminal_outlined,
+              title: t.more.items.customTasks.title,
+              subtitle: t.more.items.customTasks.subtitle,
+              onTap: () => _push(context, const CustomTasksScreen()),
+            ),
+          ]),
+          // Cortex hub is the bottom-nav "Cortex" tab and its ⚙ opens the
+          // unified Cortex settings (workers + capture/injection +
+          // providers) — so capture/injection no longer needs its own More
+          // entry. This section keeps the deeper, lower-frequency tools.
+          _SectionHeader(label: t.more.sections.memory),
+          _MenuGroup(children: [
+            _MenuTile(
+              icon: Icons.flag_outlined,
+              title: t.more.items.projectMemory.title,
+              subtitle: t.more.items.projectMemory.subtitle,
+              onTap: () => _push(context, const ProjectScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.inventory_2_outlined,
+              title: t.more.items.archived.title,
+              subtitle: t.more.items.archived.subtitle,
+              onTap: () => _push(context, const ArchivedMemoriesScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.shield_outlined,
+              title: t.more.items.quarantine.title,
+              subtitle: t.more.items.quarantine.subtitle,
+              onTap: () => _push(context, const QuarantineScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.folder_outlined,
+              title: t.more.items.vault.title,
+              subtitle: t.more.items.vault.subtitle,
+              onTap: () => _push(context, const NotesVaultScreen()),
+            ),
+          ]),
+          _SectionHeader(label: t.more.sections.system),
+          _MenuGroup(children: [
+            _MenuTile(
+              icon: Icons.backup_outlined,
+              title: t.more.items.backups.title,
+              subtitle: t.more.items.backups.subtitle,
+              onTap: () => _push(context, const BackupsScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.import_export_outlined,
+              title: t.more.items.dataExport.title,
+              subtitle: t.more.items.dataExport.subtitle,
+              onTap: () => _push(context, const DataExportScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.tune_outlined,
+              title: t.more.items.settings.title,
+              subtitle: t.more.items.settings.subtitle,
+              badge: updateAvailable,
+              onTap: () => _push(context, const SettingsScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.info_outline,
+              title: t.more.items.about.title,
+              subtitle: t.more.items.about.subtitle,
+              onTap: () => _push(context, const AboutScreen()),
+            ),
+          ]),
+          _SectionHeader(label: t.nav.resources),
+          _MenuGroup(children: [
+            _MenuTile(
+              icon: Icons.auto_awesome_outlined,
+              title: t.nav.updates.title,
+              badge: showUpdatesBadge,
+              // Accent-primary when only release notes are unread; the
+              // system error red is reserved for a waiting binary update
+              // (matches web's accent-vs-primary dot).
+              badgeColor: updateAvailable
+                  ? Theme.of(context).colorScheme.error
+                  : Theme.of(context).colorScheme.primary,
+              trailingText: (notesUnread && highlightCount > 0)
+                  ? '· $highlightCount'
+                  : null,
+              onTap: () => showUpdatesSheet(context),
+            ),
+            _MenuTile(
+              icon: Icons.menu_book_outlined,
+              title: t.nav.docs,
+              external: true,
+              onTap: () => _openUrl(_docsUrl),
+            ),
+            _MenuTile(
+              icon: Icons.forum_outlined,
+              title: t.nav.community,
+              external: true,
+              onTap: () => _openUrl(_communityUrl),
+            ),
+            _MenuTile(
+              icon: Icons.favorite_outline,
+              title: t.nav.sponsor,
+              external: true,
+              onTap: () => _openUrl(_sponsorUrl),
+            ),
+          ]),
+          const SizedBox(height: 24),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: OutlinedButton.icon(
+              style: OutlinedButton.styleFrom(
+                foregroundColor: Theme.of(context).colorScheme.error,
+                side: BorderSide(
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.error.withValues(alpha: 0.4),
+                ),
+                padding: const EdgeInsets.symmetric(vertical: 14),
+              ),
+              onPressed: () =>
+                  ref.read(authControllerProvider.notifier).logout(),
+              icon: const Icon(Icons.logout, size: 18),
+              label: Text(t.more.signOut),
+            ),
           ),
-          Expanded(
-            child: visible.isEmpty
-                ? _EmptyResults(query: _query.trim())
-                : ListView(
-                    padding: const EdgeInsets.only(top: 4, bottom: 8),
-                    children: [
-                      for (final section in visible) ...[
-                        _SectionHeader(label: section.label),
-                        _TileGrid(items: section.items),
-                      ],
-                      // Actions only belong on the full (unsearched) page.
-                      if (q.isEmpty) ...[
-                        const SizedBox(height: 20),
-                        _SignOutButton(
-                          onPressed: () => ref
-                              .read(authControllerProvider.notifier)
-                              .logout(),
-                        ),
-                        if (version != null && version.current.isNotEmpty)
-                          _VersionStamp(version: version.current),
-                      ],
-                    ],
-                  ),
-          ),
+          // App version footer — a quiet, centred build stamp gives the
+          // page a finished bottom edge instead of trailing off.
+          if (version != null && version.current.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 28),
+              child: Center(
+                child: Text(
+                  'opendray ${version.current}',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context)
+                            .colorScheme
+                            .onSurface
+                            .withValues(alpha: 0.4),
+                      ),
+                ),
+              ),
+            ),
         ],
       ),
     );
   }
 
-  // The full menu, grouped by section. Built here (not const) because the
-  // Updates entry's badge/count depend on live release state.
-  List<_Section> _buildSections({
-    required bool updateAvailable,
-    required bool showUpdatesBadge,
-    required bool notesUnread,
-    required int highlightCount,
-  }) {
-    final scheme = Theme.of(context).colorScheme;
-    return [
-      _Section(t.more.sections.gateway, [
-        _MenuItem(
-          icon: Icons.timeline_outlined,
-          title: t.more.items.activity.title,
-          subtitle: t.more.items.activity.subtitle,
-          onTap: () => _push(const ActivityScreen()),
-        ),
-        _MenuItem(
-          icon: Icons.notifications_outlined,
-          title: t.more.items.channels.title,
-          subtitle: t.more.items.channels.subtitle,
-          onTap: () => _push(const ChannelsScreen()),
-        ),
-        _MenuItem(
-          icon: Icons.psychology_outlined,
-          title: t.more.items.providers.title,
-          subtitle: t.more.items.providers.subtitle,
-          onTap: () => _push(const ProvidersScreen()),
-        ),
-      ]),
-      _Section(t.more.sections.plugins, [
-        _MenuItem(
-          icon: Icons.extension_outlined,
-          title: t.more.items.mcp.title,
-          subtitle: t.more.items.mcp.subtitle,
-          onTap: () => _push(const McpScreen()),
-        ),
-        _MenuItem(
-          icon: Icons.auto_awesome_outlined,
-          title: t.more.items.skills.title,
-          subtitle: t.more.items.skills.subtitle,
-          onTap: () => _push(const SkillsScreen()),
-        ),
-        _MenuItem(
-          icon: Icons.account_tree_outlined,
-          title: t.more.items.gitHosts.title,
-          subtitle: t.more.items.gitHosts.subtitle,
-          onTap: () => _push(const GitHostsScreen()),
-        ),
-        _MenuItem(
-          icon: Icons.terminal_outlined,
-          title: t.more.items.customTasks.title,
-          subtitle: t.more.items.customTasks.subtitle,
-          onTap: () => _push(const CustomTasksScreen()),
-        ),
-      ]),
-      _Section(t.more.sections.memory, [
-        _MenuItem(
-          icon: Icons.flag_outlined,
-          title: t.more.items.projectMemory.title,
-          subtitle: t.more.items.projectMemory.subtitle,
-          onTap: () => _push(const ProjectScreen()),
-        ),
-        _MenuItem(
-          icon: Icons.inventory_2_outlined,
-          title: t.more.items.archived.title,
-          subtitle: t.more.items.archived.subtitle,
-          onTap: () => _push(const ArchivedMemoriesScreen()),
-        ),
-        _MenuItem(
-          icon: Icons.shield_outlined,
-          title: t.more.items.quarantine.title,
-          subtitle: t.more.items.quarantine.subtitle,
-          onTap: () => _push(const QuarantineScreen()),
-        ),
-        _MenuItem(
-          icon: Icons.folder_outlined,
-          title: t.more.items.vault.title,
-          subtitle: t.more.items.vault.subtitle,
-          onTap: () => _push(const NotesVaultScreen()),
-        ),
-      ]),
-      _Section(t.more.sections.system, [
-        _MenuItem(
-          icon: Icons.backup_outlined,
-          title: t.more.items.backups.title,
-          subtitle: t.more.items.backups.subtitle,
-          onTap: () => _push(const BackupsScreen()),
-        ),
-        _MenuItem(
-          icon: Icons.import_export_outlined,
-          title: t.more.items.dataExport.title,
-          subtitle: t.more.items.dataExport.subtitle,
-          onTap: () => _push(const DataExportScreen()),
-        ),
-        _MenuItem(
-          icon: Icons.tune_outlined,
-          title: t.more.items.settings.title,
-          subtitle: t.more.items.settings.subtitle,
-          badge: updateAvailable,
-          onTap: () => _push(const SettingsScreen()),
-        ),
-        _MenuItem(
-          icon: Icons.info_outline,
-          title: t.more.items.about.title,
-          subtitle: t.more.items.about.subtitle,
-          onTap: () => _push(const AboutScreen()),
-        ),
-      ]),
-      _Section(t.nav.resources, [
-        _MenuItem(
-          icon: Icons.auto_awesome_outlined,
-          title: t.nav.updates.title,
-          badge: showUpdatesBadge,
-          // Accent-primary when only release notes are unread; the system
-          // error red is reserved for a waiting binary update (matches
-          // web's accent-vs-primary dot).
-          badgeColor: updateAvailable ? scheme.error : scheme.primary,
-          trailingText:
-              (notesUnread && highlightCount > 0) ? '$highlightCount' : null,
-          onTap: () => showUpdatesSheet(context),
-        ),
-        _MenuItem(
-          icon: Icons.menu_book_outlined,
-          title: t.nav.docs,
-          external: true,
-          onTap: () => _openUrl(_docsUrl),
-        ),
-        _MenuItem(
-          icon: Icons.forum_outlined,
-          title: t.nav.community,
-          external: true,
-          onTap: () => _openUrl(_communityUrl),
-        ),
-        _MenuItem(
-          icon: Icons.favorite_outline,
-          title: t.nav.sponsor,
-          external: true,
-          onTap: () => _openUrl(_sponsorUrl),
-        ),
-      ]),
-    ];
+  void _push(BuildContext context, Widget page) {
+    Navigator.of(context).push(MaterialPageRoute<void>(builder: (_) => page));
+  }
+
+  Future<void> _openUrl(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    try {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } on Object {
+      // Best-effort convenience link.
+    }
   }
 }
 
-// ── data model ─────────────────────────────────────────────────────────
-
-class _MenuItem {
-  const _MenuItem({
-    required this.icon,
-    required this.title,
-    required this.onTap,
-    this.subtitle,
-    this.badge = false,
-    this.badgeColor,
-    this.trailingText,
-    this.external = false,
-  });
-
-  final IconData icon;
-  final String title;
-  final String? subtitle;
-  final VoidCallback onTap;
-  final bool badge;
-  final Color? badgeColor;
-  final String? trailingText;
-  final bool external;
-
-  bool matches(String q) =>
-      title.toLowerCase().contains(q) ||
-      (subtitle?.toLowerCase().contains(q) ?? false);
-}
-
-class _Section {
-  const _Section(this.label, this.items);
-  final String label;
-  final List<_MenuItem> items;
-}
-
-// ── header + search ────────────────────────────────────────────────────
-
-// Compact account block pinned above the grid: monogram avatar, username,
-// and server / token-expiry on muted meta lines.
-class _ProfileHeader extends StatelessWidget {
-  const _ProfileHeader({required this.auth});
+class _IdentityCard extends StatelessWidget {
+  const _IdentityCard({required this.auth});
   final AuthLoggedIn auth;
 
+  // First one or two letters of the username, for the avatar monogram.
   String get _initials {
     final name = auth.username.trim();
     if (name.isEmpty) return '?';
@@ -335,55 +286,66 @@ class _ProfileHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scheme = theme.colorScheme;
-    final muted = scheme.onSurface.withValues(alpha: 0.6);
-    final expires = DateFormat.yMMMd().format(auth.expiresAt.toLocal());
+    final muted = theme.textTheme.bodySmall
+        ?.copyWith(color: scheme.onSurface.withValues(alpha: 0.6));
     return Padding(
-      padding: const EdgeInsets.fromLTRB(12, 12, 12, 4),
+      padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
       child: Card(
         child: Padding(
-          padding: const EdgeInsets.all(14),
-          child: Row(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Container(
-                width: 46,
-                height: 46,
-                alignment: Alignment.center,
-                decoration: BoxDecoration(
-                  color: scheme.primary.withValues(alpha: 0.14),
-                  shape: BoxShape.circle,
-                ),
-                child: Text(
-                  _initials,
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    color: scheme.primary,
-                    fontWeight: FontWeight.w700,
+              // Profile row: monogram avatar + "signed in as" / username.
+              Row(
+                children: [
+                  Container(
+                    width: 44,
+                    height: 44,
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: scheme.primary.withValues(alpha: 0.14),
+                      shape: BoxShape.circle,
+                    ),
+                    child: Text(
+                      _initials,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: scheme.primary,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
                   ),
-                ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(t.more.identity.signedInAs, style: muted),
+                        Text(
+                          auth.username,
+                          style: theme.textTheme.titleMedium,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
               ),
-              const SizedBox(width: 13),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      auth.username,
-                      style: theme.textTheme.titleMedium
-                          ?.copyWith(fontWeight: FontWeight.w600),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      auth.serverUrl,
-                      style: theme.textTheme.bodySmall?.copyWith(color: muted),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    Text(
-                      '${t.more.identity.tokenExpires} $expires',
-                      style: theme.textTheme.bodySmall?.copyWith(color: muted),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
-                ),
+              const SizedBox(height: 14),
+              Divider(height: 1, color: theme.dividerColor),
+              const SizedBox(height: 12),
+              // Secondary detail rows: server + token expiry.
+              _DetailRow(
+                icon: Icons.dns_outlined,
+                label: t.more.identity.server,
+                value: auth.serverUrl,
+              ),
+              const SizedBox(height: 10),
+              _DetailRow(
+                icon: Icons.schedule_outlined,
+                label: t.more.identity.tokenExpires,
+                value:
+                    DateFormat.yMMMd().add_jm().format(auth.expiresAt.toLocal()),
               ),
             ],
           ),
@@ -393,56 +355,44 @@ class _ProfileHeader extends StatelessWidget {
   }
 }
 
-class _SearchField extends StatelessWidget {
-  const _SearchField({required this.onChanged});
-  final ValueChanged<String> onChanged;
+// One muted label + value line in the identity card, prefixed by a small
+// glyph so server / token expiry read as distinct at a glance.
+class _DetailRow extends StatelessWidget {
+  const _DetailRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
 
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(12, 4, 12, 8),
-      child: TextField(
-        onChanged: onChanged,
-        textInputAction: TextInputAction.search,
-        decoration: InputDecoration(
-          prefixIcon: const Icon(Icons.search, size: 20),
-          hintText: t.more.searchHint,
-          isDense: true,
-        ),
-      ),
-    );
-  }
-}
-
-class _EmptyResults extends StatelessWidget {
-  const _EmptyResults({required this.query});
-  final String query;
+  final IconData icon;
+  final String label;
+  final String value;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.55);
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(32),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(Icons.search_off, size: 40, color: muted),
-            const SizedBox(height: 12),
-            Text(
-              t.more.noResults(query: query),
-              textAlign: TextAlign.center,
-              style: theme.textTheme.bodyMedium?.copyWith(color: muted),
-            ),
-          ],
+    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(icon, size: 16, color: muted),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label,
+                style: theme.textTheme.bodySmall?.copyWith(color: muted),
+              ),
+              Text(value, style: theme.textTheme.bodyMedium),
+            ],
+          ),
         ),
-      ),
+      ],
     );
   }
 }
-
-// ── grid ───────────────────────────────────────────────────────────────
 
 class _SectionHeader extends StatelessWidget {
   const _SectionHeader({required this.label});
@@ -451,173 +401,159 @@ class _SectionHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
+      padding: const EdgeInsets.fromLTRB(24, 20, 24, 8),
       child: Text(
         label.toUpperCase(),
         style: Theme.of(context).textTheme.labelSmall?.copyWith(
-              letterSpacing: 0.8,
-              fontWeight: FontWeight.w600,
-              color:
-                  Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
-            ),
+          letterSpacing: 0.8,
+          fontWeight: FontWeight.w600,
+          color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+        ),
       ),
     );
   }
 }
 
-class _TileGrid extends StatelessWidget {
-  const _TileGrid({required this.items});
-  final List<_MenuItem> items;
+// Wraps a section's tiles in one inset, bordered, rounded card with thin
+// dividers between rows — the standard grouped-settings look. Uses the
+// app-wide CardTheme (elevation 0, border, radius 12) so it matches the
+// identity card and every other card surface.
+class _MenuGroup extends StatelessWidget {
+  const _MenuGroup({required this.children});
+  final List<Widget> children;
 
   @override
   Widget build(BuildContext context) {
+    // Divider indented past the leading icon so it starts under the text,
+    // the way iOS/Material grouped lists separate rows.
+    final divider = Divider(
+      height: 1,
+      thickness: 1,
+      indent: 60,
+      color: Theme.of(context).dividerColor,
+    );
+    final rows = <Widget>[];
+    for (var i = 0; i < children.length; i++) {
+      if (i > 0) rows.add(divider);
+      rows.add(children[i]);
+    }
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12),
-      child: GridView.builder(
-        shrinkWrap: true,
-        physics: const NeverScrollableScrollPhysics(),
-        padding: EdgeInsets.zero,
-        itemCount: items.length,
-        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: 2,
-          mainAxisExtent: 96,
-          crossAxisSpacing: 10,
-          mainAxisSpacing: 10,
-        ),
-        itemBuilder: (_, i) => _GridTile(item: items[i]),
+      child: Card(
+        clipBehavior: Clip.antiAlias,
+        child: Column(mainAxisSize: MainAxisSize.min, children: rows),
       ),
     );
   }
 }
 
-// One launcher tile: tinted icon chip top-left (with an optional status
-// dot / external glyph), then title + one-line subtitle beneath. Kept on
-// the single gold accent so the grid reads as one system, not a mosaic.
-class _GridTile extends StatelessWidget {
-  const _GridTile({required this.item});
-  final _MenuItem item;
+class _MenuTile extends StatelessWidget {
+  const _MenuTile({
+    required this.icon,
+    required this.title,
+    required this.onTap,
+    this.subtitle,
+    this.badge = false,
+    this.badgeColor,
+    this.trailingText,
+    this.external = false,
+  });
+
+  final IconData icon;
+  final String title;
+  // Optional secondary line; Resources links render title-only.
+  final String? subtitle;
+  final VoidCallback onTap;
+  // When true, shows a status dot before the trailing icon.
+  final bool badge;
+  // Dot colour; defaults to the error colour (waiting binary update).
+  final Color? badgeColor;
+  // Small muted count chip (e.g. "· 3") shown before the trailing icon.
+  final String? trailingText;
+  // External links show an open-in-new glyph instead of a chevron.
+  final bool external;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scheme = theme.colorScheme;
-    return Card(
-      clipBehavior: Clip.antiAlias,
-      child: InkWell(
-        onTap: item.onTap,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(13, 12, 12, 12),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Container(
-                    width: 34,
-                    height: 34,
-                    alignment: Alignment.center,
-                    decoration: BoxDecoration(
-                      color: scheme.primary.withValues(alpha: 0.12),
-                      borderRadius: BorderRadius.circular(9),
-                    ),
-                    child: Icon(item.icon, size: 19, color: scheme.primary),
-                  ),
-                  const Spacer(),
-                  if (item.trailingText != null)
-                    Padding(
-                      padding: const EdgeInsets.only(right: 2),
-                      child: Text(
-                        item.trailingText!,
-                        style: theme.textTheme.labelSmall?.copyWith(
-                          color: scheme.onSurface.withValues(alpha: 0.55),
-                        ),
-                      ),
-                    ),
-                  if (item.badge)
-                    Container(
-                      width: 8,
-                      height: 8,
-                      decoration: BoxDecoration(
-                        color: item.badgeColor ?? scheme.error,
-                        shape: BoxShape.circle,
-                      ),
-                    )
-                  else if (item.external)
-                    Icon(Icons.open_in_new,
-                        size: 15,
-                        color: scheme.onSurface.withValues(alpha: 0.35)),
-                ],
-              ),
-              const Spacer(),
-              Text(
-                item.title,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: theme.textTheme.bodyMedium
-                    ?.copyWith(fontWeight: FontWeight.w600),
-              ),
-              if (item.subtitle != null)
-                Padding(
-                  padding: const EdgeInsets.only(top: 1),
-                  child: Text(
-                    item.subtitle!,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: scheme.onSurface.withValues(alpha: 0.55),
-                    ),
-                  ),
+    final subtitle = this.subtitle;
+    return ListTile(
+      onTap: onTap,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 4),
+      horizontalTitleGap: 12,
+      minLeadingWidth: 34,
+      leading: _IconChip(icon: icon),
+      title: Text(
+        title,
+        style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w500),
+      ),
+      subtitle: subtitle == null
+          ? null
+          : Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                subtitle,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: scheme.onSurface.withValues(alpha: 0.55),
+                  height: 1.25,
                 ),
-            ],
+              ),
+            ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (trailingText != null)
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: Text(
+                trailingText!,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: scheme.onSurface.withValues(alpha: 0.6),
+                ),
+              ),
+            ),
+          if (badge)
+            Container(
+              width: 8,
+              height: 8,
+              margin: const EdgeInsets.only(right: 8),
+              decoration: BoxDecoration(
+                color: badgeColor ?? scheme.error,
+                shape: BoxShape.circle,
+              ),
+            ),
+          Icon(
+            external ? Icons.open_in_new : Icons.chevron_right,
+            size: external ? 16 : 20,
+            color: scheme.onSurface.withValues(alpha: external ? 0.4 : 0.3),
           ),
-        ),
+        ],
       ),
     );
   }
 }
 
-// ── footer ─────────────────────────────────────────────────────────────
-
-class _SignOutButton extends StatelessWidget {
-  const _SignOutButton({required this.onPressed});
-  final VoidCallback onPressed;
+// Rounded-square tinted chip behind each menu icon — the signature
+// "app-icon" affordance of a polished settings page. Kept on the single
+// gold accent (primary) so the page stays on-brand rather than turning
+// into a rainbow of per-row colours.
+class _IconChip extends StatelessWidget {
+  const _IconChip({required this.icon});
+  final IconData icon;
 
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-      child: OutlinedButton.icon(
-        style: OutlinedButton.styleFrom(
-          foregroundColor: scheme.error,
-          side: BorderSide(color: scheme.error.withValues(alpha: 0.4)),
-          padding: const EdgeInsets.symmetric(vertical: 14),
-        ),
-        onPressed: onPressed,
-        icon: const Icon(Icons.logout, size: 18),
-        label: Text(t.more.signOut),
+    return Container(
+      width: 34,
+      height: 34,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: scheme.primary.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(9),
       ),
-    );
-  }
-}
-
-class _VersionStamp extends StatelessWidget {
-  const _VersionStamp({required this.version});
-  final String version;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 4, 16, 28),
-      child: Center(
-        child: Text(
-          'opendray $version',
-          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color:
-                    Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.4),
-              ),
-        ),
-      ),
+      child: Icon(icon, size: 19, color: scheme.primary),
     );
   }
 }

--- a/app/mobile/lib/features/more/more_screen.dart
+++ b/app/mobile/lib/features/more/more_screen.dart
@@ -65,147 +65,152 @@ class MoreScreen extends ConsumerWidget {
       body: ListView(
         children: [
           _IdentityCard(auth: auth),
-          const SizedBox(height: 8),
           // Round Table + Integrations are top-level bottom-nav tabs now;
           // Activity (per-call integration audit) lives here in the gateway
           // section alongside the lower-frequency destinations.
           _SectionHeader(label: t.more.sections.gateway),
-          _MenuTile(
-            icon: Icons.timeline_outlined,
-            title: t.more.items.activity.title,
-            subtitle: t.more.items.activity.subtitle,
-            onTap: () => _push(context, const ActivityScreen()),
-          ),
-          _MenuTile(
-            icon: Icons.notifications_outlined,
-            title: t.more.items.channels.title,
-            subtitle: t.more.items.channels.subtitle,
-            onTap: () => _push(context, const ChannelsScreen()),
-          ),
-          _MenuTile(
-            icon: Icons.psychology_outlined,
-            title: t.more.items.providers.title,
-            subtitle: t.more.items.providers.subtitle,
-            onTap: () => _push(context, const ProvidersScreen()),
-          ),
-          const SizedBox(height: 8),
+          _MenuGroup(children: [
+            _MenuTile(
+              icon: Icons.timeline_outlined,
+              title: t.more.items.activity.title,
+              subtitle: t.more.items.activity.subtitle,
+              onTap: () => _push(context, const ActivityScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.notifications_outlined,
+              title: t.more.items.channels.title,
+              subtitle: t.more.items.channels.subtitle,
+              onTap: () => _push(context, const ChannelsScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.psychology_outlined,
+              title: t.more.items.providers.title,
+              subtitle: t.more.items.providers.subtitle,
+              onTap: () => _push(context, const ProvidersScreen()),
+            ),
+          ]),
           _SectionHeader(label: t.more.sections.plugins),
-          _MenuTile(
-            icon: Icons.extension_outlined,
-            title: t.more.items.mcp.title,
-            subtitle: t.more.items.mcp.subtitle,
-            onTap: () => _push(context, const McpScreen()),
-          ),
-          _MenuTile(
-            icon: Icons.auto_awesome_outlined,
-            title: t.more.items.skills.title,
-            subtitle: t.more.items.skills.subtitle,
-            onTap: () => _push(context, const SkillsScreen()),
-          ),
-          _MenuTile(
-            icon: Icons.account_tree_outlined,
-            title: t.more.items.gitHosts.title,
-            subtitle: t.more.items.gitHosts.subtitle,
-            onTap: () => _push(context, const GitHostsScreen()),
-          ),
-          _MenuTile(
-            icon: Icons.terminal_outlined,
-            title: t.more.items.customTasks.title,
-            subtitle: t.more.items.customTasks.subtitle,
-            onTap: () => _push(context, const CustomTasksScreen()),
-          ),
-          const SizedBox(height: 8),
+          _MenuGroup(children: [
+            _MenuTile(
+              icon: Icons.extension_outlined,
+              title: t.more.items.mcp.title,
+              subtitle: t.more.items.mcp.subtitle,
+              onTap: () => _push(context, const McpScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.auto_awesome_outlined,
+              title: t.more.items.skills.title,
+              subtitle: t.more.items.skills.subtitle,
+              onTap: () => _push(context, const SkillsScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.account_tree_outlined,
+              title: t.more.items.gitHosts.title,
+              subtitle: t.more.items.gitHosts.subtitle,
+              onTap: () => _push(context, const GitHostsScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.terminal_outlined,
+              title: t.more.items.customTasks.title,
+              subtitle: t.more.items.customTasks.subtitle,
+              onTap: () => _push(context, const CustomTasksScreen()),
+            ),
+          ]),
           // Cortex hub is the bottom-nav "Cortex" tab and its ⚙ opens the
           // unified Cortex settings (workers + capture/injection +
           // providers) — so capture/injection no longer needs its own More
           // entry. This section keeps the deeper, lower-frequency tools.
           _SectionHeader(label: t.more.sections.memory),
-          _MenuTile(
-            icon: Icons.flag_outlined,
-            title: t.more.items.projectMemory.title,
-            subtitle: t.more.items.projectMemory.subtitle,
-            onTap: () => _push(context, const ProjectScreen()),
-          ),
-          _MenuTile(
-            icon: Icons.inventory_2_outlined,
-            title: t.more.items.archived.title,
-            subtitle: t.more.items.archived.subtitle,
-            onTap: () => _push(context, const ArchivedMemoriesScreen()),
-          ),
-          _MenuTile(
-            icon: Icons.shield_outlined,
-            title: t.more.items.quarantine.title,
-            subtitle: t.more.items.quarantine.subtitle,
-            onTap: () => _push(context, const QuarantineScreen()),
-          ),
-          _MenuTile(
-            icon: Icons.folder_outlined,
-            title: t.more.items.vault.title,
-            subtitle: t.more.items.vault.subtitle,
-            onTap: () => _push(context, const NotesVaultScreen()),
-          ),
-          const SizedBox(height: 8),
+          _MenuGroup(children: [
+            _MenuTile(
+              icon: Icons.flag_outlined,
+              title: t.more.items.projectMemory.title,
+              subtitle: t.more.items.projectMemory.subtitle,
+              onTap: () => _push(context, const ProjectScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.inventory_2_outlined,
+              title: t.more.items.archived.title,
+              subtitle: t.more.items.archived.subtitle,
+              onTap: () => _push(context, const ArchivedMemoriesScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.shield_outlined,
+              title: t.more.items.quarantine.title,
+              subtitle: t.more.items.quarantine.subtitle,
+              onTap: () => _push(context, const QuarantineScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.folder_outlined,
+              title: t.more.items.vault.title,
+              subtitle: t.more.items.vault.subtitle,
+              onTap: () => _push(context, const NotesVaultScreen()),
+            ),
+          ]),
           _SectionHeader(label: t.more.sections.system),
-          _MenuTile(
-            icon: Icons.backup_outlined,
-            title: t.more.items.backups.title,
-            subtitle: t.more.items.backups.subtitle,
-            onTap: () => _push(context, const BackupsScreen()),
-          ),
-          _MenuTile(
-            icon: Icons.import_export_outlined,
-            title: t.more.items.dataExport.title,
-            subtitle: t.more.items.dataExport.subtitle,
-            onTap: () => _push(context, const DataExportScreen()),
-          ),
-          _MenuTile(
-            icon: Icons.tune_outlined,
-            title: t.more.items.settings.title,
-            subtitle: t.more.items.settings.subtitle,
-            badge: updateAvailable,
-            onTap: () => _push(context, const SettingsScreen()),
-          ),
-          _MenuTile(
-            icon: Icons.info_outline,
-            title: t.more.items.about.title,
-            subtitle: t.more.items.about.subtitle,
-            onTap: () => _push(context, const AboutScreen()),
-          ),
-          const SizedBox(height: 8),
+          _MenuGroup(children: [
+            _MenuTile(
+              icon: Icons.backup_outlined,
+              title: t.more.items.backups.title,
+              subtitle: t.more.items.backups.subtitle,
+              onTap: () => _push(context, const BackupsScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.import_export_outlined,
+              title: t.more.items.dataExport.title,
+              subtitle: t.more.items.dataExport.subtitle,
+              onTap: () => _push(context, const DataExportScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.tune_outlined,
+              title: t.more.items.settings.title,
+              subtitle: t.more.items.settings.subtitle,
+              badge: updateAvailable,
+              onTap: () => _push(context, const SettingsScreen()),
+            ),
+            _MenuTile(
+              icon: Icons.info_outline,
+              title: t.more.items.about.title,
+              subtitle: t.more.items.about.subtitle,
+              onTap: () => _push(context, const AboutScreen()),
+            ),
+          ]),
           _SectionHeader(label: t.nav.resources),
-          _MenuTile(
-            icon: Icons.auto_awesome_outlined,
-            title: t.nav.updates.title,
-            badge: showUpdatesBadge,
-            // Accent-primary when only release notes are unread; the
-            // system error red is reserved for a waiting binary update
-            // (matches web's accent-vs-primary dot).
-            badgeColor: updateAvailable
-                ? Theme.of(context).colorScheme.error
-                : Theme.of(context).colorScheme.primary,
-            trailingText: (notesUnread && highlightCount > 0)
-                ? '· $highlightCount'
-                : null,
-            onTap: () => showUpdatesSheet(context),
-          ),
-          _MenuTile(
-            icon: Icons.menu_book_outlined,
-            title: t.nav.docs,
-            external: true,
-            onTap: () => _openUrl(_docsUrl),
-          ),
-          _MenuTile(
-            icon: Icons.forum_outlined,
-            title: t.nav.community,
-            external: true,
-            onTap: () => _openUrl(_communityUrl),
-          ),
-          _MenuTile(
-            icon: Icons.favorite_outline,
-            title: t.nav.sponsor,
-            external: true,
-            onTap: () => _openUrl(_sponsorUrl),
-          ),
+          _MenuGroup(children: [
+            _MenuTile(
+              icon: Icons.auto_awesome_outlined,
+              title: t.nav.updates.title,
+              badge: showUpdatesBadge,
+              // Accent-primary when only release notes are unread; the
+              // system error red is reserved for a waiting binary update
+              // (matches web's accent-vs-primary dot).
+              badgeColor: updateAvailable
+                  ? Theme.of(context).colorScheme.error
+                  : Theme.of(context).colorScheme.primary,
+              trailingText: (notesUnread && highlightCount > 0)
+                  ? '· $highlightCount'
+                  : null,
+              onTap: () => showUpdatesSheet(context),
+            ),
+            _MenuTile(
+              icon: Icons.menu_book_outlined,
+              title: t.nav.docs,
+              external: true,
+              onTap: () => _openUrl(_docsUrl),
+            ),
+            _MenuTile(
+              icon: Icons.forum_outlined,
+              title: t.nav.community,
+              external: true,
+              onTap: () => _openUrl(_communityUrl),
+            ),
+            _MenuTile(
+              icon: Icons.favorite_outline,
+              title: t.nav.sponsor,
+              external: true,
+              onTap: () => _openUrl(_sponsorUrl),
+            ),
+          ]),
           const Divider(height: 32),
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
@@ -248,9 +253,23 @@ class _IdentityCard extends StatelessWidget {
   const _IdentityCard({required this.auth});
   final AuthLoggedIn auth;
 
+  // First one or two letters of the username, for the avatar monogram.
+  String get _initials {
+    final name = auth.username.trim();
+    if (name.isEmpty) return '?';
+    final parts = name.split(RegExp(r'[\s._-]+')).where((p) => p.isNotEmpty);
+    if (parts.length >= 2) {
+      return (parts.first[0] + parts.elementAt(1)[0]).toUpperCase();
+    }
+    return name.substring(0, name.length >= 2 ? 2 : 1).toUpperCase();
+  }
+
   @override
   Widget build(BuildContext context) {
-    final muted = Theme.of(context).textTheme.bodySmall;
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final muted = theme.textTheme.bodySmall
+        ?.copyWith(color: scheme.onSurface.withValues(alpha: 0.6));
     return Padding(
       padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
       child: Card(
@@ -259,27 +278,100 @@ class _IdentityCard extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(t.more.identity.signedInAs, style: muted),
-              Text(
-                auth.username,
-                style: Theme.of(context).textTheme.titleMedium,
+              // Profile row: monogram avatar + "signed in as" / username.
+              Row(
+                children: [
+                  Container(
+                    width: 44,
+                    height: 44,
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: scheme.primary.withValues(alpha: 0.14),
+                      shape: BoxShape.circle,
+                    ),
+                    child: Text(
+                      _initials,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: scheme.primary,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(t.more.identity.signedInAs, style: muted),
+                        Text(
+                          auth.username,
+                          style: theme.textTheme.titleMedium,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
               ),
+              const SizedBox(height: 14),
+              Divider(height: 1, color: theme.dividerColor),
               const SizedBox(height: 12),
-              Text(t.more.identity.server, style: muted),
-              Text(
-                auth.serverUrl,
-                style: Theme.of(context).textTheme.bodyMedium,
+              // Secondary detail rows: server + token expiry.
+              _DetailRow(
+                icon: Icons.dns_outlined,
+                label: t.more.identity.server,
+                value: auth.serverUrl,
               ),
-              const SizedBox(height: 12),
-              Text(t.more.identity.tokenExpires, style: muted),
-              Text(
-                DateFormat.yMMMd().add_jm().format(auth.expiresAt.toLocal()),
-                style: Theme.of(context).textTheme.bodyMedium,
+              const SizedBox(height: 10),
+              _DetailRow(
+                icon: Icons.schedule_outlined,
+                label: t.more.identity.tokenExpires,
+                value:
+                    DateFormat.yMMMd().add_jm().format(auth.expiresAt.toLocal()),
               ),
             ],
           ),
         ),
       ),
+    );
+  }
+}
+
+// One muted label + value line in the identity card, prefixed by a small
+// glyph so server / token expiry read as distinct at a glance.
+class _DetailRow extends StatelessWidget {
+  const _DetailRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(icon, size: 16, color: muted),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label,
+                style: theme.textTheme.bodySmall?.copyWith(color: muted),
+              ),
+              Text(value, style: theme.textTheme.bodyMedium),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }
@@ -291,13 +383,47 @@ class _SectionHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(20, 12, 16, 6),
+      padding: const EdgeInsets.fromLTRB(24, 20, 24, 8),
       child: Text(
         label.toUpperCase(),
         style: Theme.of(context).textTheme.labelSmall?.copyWith(
           letterSpacing: 0.8,
+          fontWeight: FontWeight.w600,
           color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
         ),
+      ),
+    );
+  }
+}
+
+// Wraps a section's tiles in one inset, bordered, rounded card with thin
+// dividers between rows — the standard grouped-settings look. Uses the
+// app-wide CardTheme (elevation 0, border, radius 12) so it matches the
+// identity card and every other card surface.
+class _MenuGroup extends StatelessWidget {
+  const _MenuGroup({required this.children});
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    // Divider indented past the leading icon so it starts under the text,
+    // the way iOS/Material grouped lists separate rows.
+    final divider = Divider(
+      height: 1,
+      thickness: 1,
+      indent: 56,
+      color: Theme.of(context).dividerColor,
+    );
+    final rows = <Widget>[];
+    for (var i = 0; i < children.length; i++) {
+      if (i > 0) rows.add(divider);
+      rows.add(children[i]);
+    }
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: Card(
+        clipBehavior: Clip.antiAlias,
+        child: Column(mainAxisSize: MainAxisSize.min, children: rows),
       ),
     );
   }

--- a/app/mobile/lib/features/more/more_screen.dart
+++ b/app/mobile/lib/features/more/more_screen.dart
@@ -211,10 +211,10 @@ class MoreScreen extends ConsumerWidget {
               onTap: () => _openUrl(_sponsorUrl),
             ),
           ]),
-          const Divider(height: 32),
+          const SizedBox(height: 24),
           Padding(
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
-            child: OutlinedButton(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: OutlinedButton.icon(
               style: OutlinedButton.styleFrom(
                 foregroundColor: Theme.of(context).colorScheme.error,
                 side: BorderSide(
@@ -226,9 +226,27 @@ class MoreScreen extends ConsumerWidget {
               ),
               onPressed: () =>
                   ref.read(authControllerProvider.notifier).logout(),
-              child: Text(t.more.signOut),
+              icon: const Icon(Icons.logout, size: 18),
+              label: Text(t.more.signOut),
             ),
           ),
+          // App version footer — a quiet, centred build stamp gives the
+          // page a finished bottom edge instead of trailing off.
+          if (version != null && version.current.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 28),
+              child: Center(
+                child: Text(
+                  'opendray ${version.current}',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context)
+                            .colorScheme
+                            .onSurface
+                            .withValues(alpha: 0.4),
+                      ),
+                ),
+              ),
+            ),
         ],
       ),
     );
@@ -411,7 +429,7 @@ class _MenuGroup extends StatelessWidget {
     final divider = Divider(
       height: 1,
       thickness: 1,
-      indent: 56,
+      indent: 60,
       color: Theme.of(context).dividerColor,
     );
     final rows = <Widget>[];
@@ -458,14 +476,30 @@ class _MenuTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
     final subtitle = this.subtitle;
     return ListTile(
       onTap: onTap,
-      leading: Icon(icon, color: theme.colorScheme.primary),
-      title: Text(title),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 4),
+      horizontalTitleGap: 12,
+      minLeadingWidth: 34,
+      leading: _IconChip(icon: icon),
+      title: Text(
+        title,
+        style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w500),
+      ),
       subtitle: subtitle == null
           ? null
-          : Text(subtitle, style: theme.textTheme.bodySmall),
+          : Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                subtitle,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: scheme.onSurface.withValues(alpha: 0.55),
+                  height: 1.25,
+                ),
+              ),
+            ),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -475,7 +509,7 @@ class _MenuTile extends StatelessWidget {
               child: Text(
                 trailingText!,
                 style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                  color: scheme.onSurface.withValues(alpha: 0.6),
                 ),
               ),
             ),
@@ -485,17 +519,41 @@ class _MenuTile extends StatelessWidget {
               height: 8,
               margin: const EdgeInsets.only(right: 8),
               decoration: BoxDecoration(
-                color: badgeColor ?? theme.colorScheme.error,
+                color: badgeColor ?? scheme.error,
                 shape: BoxShape.circle,
               ),
             ),
-          Icon(external ? Icons.open_in_new : Icons.chevron_right,
-              size: external ? 18 : null,
-              color: external
-                  ? theme.colorScheme.onSurface.withValues(alpha: 0.4)
-                  : null),
+          Icon(
+            external ? Icons.open_in_new : Icons.chevron_right,
+            size: external ? 16 : 20,
+            color: scheme.onSurface.withValues(alpha: external ? 0.4 : 0.3),
+          ),
         ],
       ),
+    );
+  }
+}
+
+// Rounded-square tinted chip behind each menu icon — the signature
+// "app-icon" affordance of a polished settings page. Kept on the single
+// gold accent (primary) so the page stays on-brand rather than turning
+// into a rainbow of per-row colours.
+class _IconChip extends StatelessWidget {
+  const _IconChip({required this.icon});
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      width: 34,
+      height: 34,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: scheme.primary.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(9),
+      ),
+      child: Icon(icon, size: 19, color: scheme.primary),
     );
   }
 }

--- a/app/mobile/lib/features/sessions/session_detail_screen.dart
+++ b/app/mobile/lib/features/sessions/session_detail_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
 import 'package:opendray/core/api/antigravity_accounts_api.dart';
 import 'package:opendray/core/api/claude_accounts_api.dart';
@@ -10,19 +9,21 @@ import 'package:opendray/core/api/sessions_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/core/providers/provider_visual.dart';
 import 'package:opendray/core/widgets/brand_avatar.dart';
-import 'package:opendray/features/project/project_screen.dart';
 import 'package:opendray/features/sessions/account_switch_sheet.dart';
 import 'package:opendray/features/sessions/session_action_sheet.dart';
 import 'package:opendray/features/sessions/session_terminal_view.dart';
+import 'package:opendray/features/sessions/session_tool_dock.dart';
 
-// Session detail surface. The terminal eats most of the screen;
-// metadata sits in a collapsible header that defaults to one
-// compact row (provider + state badge), expanding on tap to show
-// the long fields (cwd, timestamps). The connection-state line
-// from earlier iterations is gone — its full strip now appears
-// only when the WS is *not* connected (handled inside
-// SessionTerminalView), so a healthy live session shows just a
-// thin colored accent.
+// Session detail surface.
+//
+// The terminal is the hero and now owns the full height of the body —
+// the old expandable metadata header is gone. Identity + lifecycle
+// state live in a compact two-line AppBar title (name on top, provider
+// + state beneath with a colour dot), and every cwd-scoped project tool
+// is one tap away on the SessionToolDock pinned under the terminal
+// (Files / Git / Tasks / Project memory / More). The AppBar "⋮" keeps
+// only the low-frequency, session-level actions (refresh, account
+// switch, lifecycle) — Inspector/Memory no longer hide in there.
 class SessionDetailScreen extends ConsumerStatefulWidget {
   const SessionDetailScreen({required this.sessionId, super.key});
 
@@ -34,39 +35,17 @@ class SessionDetailScreen extends ConsumerStatefulWidget {
 }
 
 class _SessionDetailScreenState extends ConsumerState<SessionDetailScreen> {
-  bool _metadataExpanded = false;
-
   @override
   Widget build(BuildContext context) {
     final async = ref.watch(sessionByIdProvider(widget.sessionId));
     return Scaffold(
       appBar: AppBar(
-        // Brand mark next to the title so the operator can tell at
-        // a glance which CLI is driving the session, matching the
-        // sessions list and the web admin's workbench header. Kept
-        // inside `title` (rather than the leading slot) so the
-        // system back arrow stays in place.
         titleSpacing: 0,
         title: async.when(
-          data: (s) => Row(
-            children: [
-              BrandAvatar(providerId: s.providerId, size: 28),
-              const SizedBox(width: 10),
-              Expanded(
-                child: Text(
-                  s.displayName,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            ],
-          ),
+          data: _TitleBar.new,
           loading: () => Text(t.sessions.detail.fallbackTitle),
           error: (_, __) => Text(t.sessions.detail.fallbackTitle),
         ),
-        // Phone bars are narrow and a row of unlabeled icons is easy to
-        // mis-tap — collapse every action into ONE labelled overflow menu so
-        // each item shows its name. The lifecycle actions (stop / restart /
-        // delete) keep their richer SessionActionSheet, opened from the menu.
         actions: [
           PopupMenuButton<String>(
             tooltip: MaterialLocalizations.of(context).showMenuTooltip,
@@ -79,40 +58,28 @@ class _SessionDetailScreenState extends ConsumerState<SessionDetailScreen> {
       body: async.when(
         data: (session) => Column(
           children: [
-            _MetadataHeader(
-              session: session,
-              expanded: _metadataExpanded,
-              onToggle: () =>
-                  setState(() => _metadataExpanded = !_metadataExpanded),
-            ),
             Expanded(child: SessionTerminalView(sessionId: widget.sessionId)),
+            SessionToolDock(session: session),
           ],
         ),
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => _ErrorView(
           error: e,
-          onRetry: () =>
-              ref.invalidate(sessionByIdProvider(widget.sessionId)),
+          onRetry: () => ref.invalidate(sessionByIdProvider(widget.sessionId)),
         ),
       ),
     );
   }
 
-  // Overflow-menu items. Session-dependent entries (project memory, account
-  // switch, lifecycle actions) only appear once the session has loaded; the
-  // account switcher is Claude/Antigravity-live only (nothing to rebind
-  // otherwise), mirroring the web header.
+  // Overflow menu — only the low-frequency, session-level actions now
+  // that the tools moved to the dock. The account switcher is
+  // Claude/Antigravity-live only (nothing to rebind otherwise).
   List<PopupMenuEntry<String>> _menuItems(SessionSummary? s) {
     final canAccount = s != null &&
         (s.providerId == 'claude' || s.providerId == 'antigravity') &&
         s.isLive;
     return [
       _menuItem('refresh', Icons.refresh, t.sessions.detail.refreshMetadata),
-      _menuItem('inspector', Icons.dashboard_customize_outlined,
-          t.sessions.detail.inspector),
-      if (s != null)
-        _menuItem(
-            'project', Icons.flag_outlined, t.sessions.detail.projectMemory),
       if (canAccount)
         _menuItem(
           'account',
@@ -145,16 +112,6 @@ class _SessionDetailScreenState extends ConsumerState<SessionDetailScreen> {
     switch (value) {
       case 'refresh':
         ref.invalidate(sessionByIdProvider(widget.sessionId));
-      case 'inspector':
-        context.push('/session/${widget.sessionId}/inspector');
-      case 'project':
-        if (s != null) {
-          Navigator.of(context).push(
-            MaterialPageRoute<void>(
-              builder: (_) => ProjectScreen(initialCwd: s.cwd),
-            ),
-          );
-        }
       case 'account':
         if (s != null) _switchAccount(s);
       case 'actions':
@@ -162,8 +119,6 @@ class _SessionDetailScreenState extends ConsumerState<SessionDetailScreen> {
     }
   }
 
-  // Rebind the running session to a different account (mirrors the web header
-  // AccountSwitcher).
   Future<void> _switchAccount(SessionSummary s) async {
     final isAgy = s.providerId == 'antigravity';
     final switched = await AccountSwitchSheet.show(context, session: s);
@@ -176,8 +131,6 @@ class _SessionDetailScreenState extends ConsumerState<SessionDetailScreen> {
       );
   }
 
-  // Lifecycle actions (stop / restart / delete) keep their richer sheet, which
-  // carries per-action descriptions and a delete confirmation.
   Future<void> _openActions(SessionSummary s) async {
     final result = await SessionActionSheet.show(context, session: s);
     if (result == null || !mounted) return;
@@ -192,139 +145,70 @@ class _SessionDetailScreenState extends ConsumerState<SessionDetailScreen> {
   }
 }
 
-class _MetadataHeader extends StatelessWidget {
-  const _MetadataHeader({
-    required this.session,
-    required this.expanded,
-    required this.onToggle,
-  });
-
+// Compact two-line AppBar title: brand mark + session name on top, and
+// "provider · state" with a lifecycle colour dot beneath.
+class _TitleBar extends StatelessWidget {
+  const _TitleBar(this.session);
   final SessionSummary session;
-  final bool expanded;
-  final VoidCallback onToggle;
 
   @override
   Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
+    final visual = providerVisualFor(session.providerId);
     final muted = Theme.of(context).textTheme.bodySmall;
-    return Material(
-      color: scheme.surface,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          // Always-visible compact row.
-          InkWell(
-            onTap: onToggle,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(14, 6, 8, 6),
-              child: Row(
+    return Row(
+      children: [
+        BrandAvatar(providerId: session.providerId, size: 28),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                session.displayName,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context)
+                    .textTheme
+                    .titleSmall
+                    ?.copyWith(fontWeight: FontWeight.w600),
+              ),
+              const SizedBox(height: 1),
+              Row(
                 children: [
-                  Text(
-                    providerVisualFor(session.providerId).label,
-                    style: muted?.copyWith(fontWeight: FontWeight.w600),
-                  ),
-                  const SizedBox(width: 8),
-                  _StateBadge(state: session.state),
-                  const Spacer(),
-                  Icon(
-                    expanded ? Icons.expand_less : Icons.expand_more,
-                    color: scheme.onSurface.withValues(alpha: 0.6),
-                    size: 20,
+                  _StateDot(state: session.state),
+                  const SizedBox(width: 6),
+                  Flexible(
+                    child: Text(
+                      '${visual.label} · ${session.state.wire}',
+                      overflow: TextOverflow.ellipsis,
+                      style: muted,
+                    ),
                   ),
                 ],
               ),
-            ),
+            ],
           ),
-          AnimatedSize(
-            duration: const Duration(milliseconds: 180),
-            curve: Curves.easeOut,
-            alignment: Alignment.topCenter,
-            child: expanded
-                ? _ExpandedDetail(session: session)
-                : const SizedBox(width: double.infinity),
-          ),
-          Divider(
-            height: 1,
-            thickness: 1,
-            color: Theme.of(context).dividerColor,
-          ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }
 
-class _ExpandedDetail extends StatelessWidget {
-  const _ExpandedDetail({required this.session});
-  final SessionSummary session;
-
-  @override
-  Widget build(BuildContext context) {
-    final muted = Theme.of(context).textTheme.bodySmall;
-    final started =
-        DateFormat.yMMMd().add_Hm().format(session.startedAt.toLocal());
-    final ended = session.endedAt != null
-        ? DateFormat.yMMMd().add_Hm().format(session.endedAt!.toLocal())
-        : null;
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(14, 0, 14, 8),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          SelectableText(session.cwd, style: muted),
-          const SizedBox(height: 2),
-          Text(
-            ended == null
-                ? t.sessions.detail.started(when: started)
-                : t.sessions.detail.startedEnded(
-                    started: started,
-                    ended: ended,
-                  ),
-            style: muted,
-          ),
-          const SizedBox(height: 2),
-          SelectableText(
-            t.sessions.detail.idPrefix(id: session.id),
-            style: muted,
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _StateBadge extends StatelessWidget {
-  const _StateBadge({required this.state});
+class _StateDot extends StatelessWidget {
+  const _StateDot({required this.state});
   final SessionState state;
 
   @override
   Widget build(BuildContext context) {
-    final (bg, fg) = switch (state) {
-      SessionState.running => (Colors.green.shade900, Colors.greenAccent),
-      SessionState.idle => (Colors.amber.shade900, Colors.amberAccent),
-      SessionState.pending => (Colors.grey.shade800, Colors.grey.shade300),
-      SessionState.stopped ||
-      SessionState.ended =>
-        (Colors.grey.shade800, Colors.grey.shade400),
-      SessionState.unknown => (Colors.grey.shade800, Colors.grey.shade400),
+    final color = switch (state) {
+      SessionState.running => Colors.greenAccent,
+      SessionState.idle => Colors.amberAccent,
+      _ => Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.4),
     };
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-      decoration: BoxDecoration(
-        color: bg.withValues(alpha: 0.45),
-        border: Border.all(color: fg.withValues(alpha: 0.4)),
-        borderRadius: BorderRadius.circular(999),
-      ),
-      child: Text(
-        state.wire,
-        style: TextStyle(
-          color: fg,
-          fontSize: 10,
-          fontWeight: FontWeight.w600,
-          letterSpacing: 0.5,
-        ),
-      ),
+      width: 8,
+      height: 8,
+      decoration: BoxDecoration(color: color, shape: BoxShape.circle),
     );
   }
 }

--- a/app/mobile/lib/features/sessions/session_tool_dock.dart
+++ b/app/mobile/lib/features/sessions/session_tool_dock.dart
@@ -2,20 +2,19 @@ import 'package:flutter/material.dart';
 
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
-import 'package:opendray/features/project/project_screen.dart';
 import 'package:opendray/features/sessions/session_tool_sheets.dart';
 import 'package:opendray/features/sessions/session_tools_sheet.dart';
 
 // Persistent tool dock shown directly under the live terminal on the
 // session detail screen. It promotes the four highest-traffic project
-// tools to a single tap — Files / Git / Tasks / Project memory — and
-// tucks the rest behind "More" (SessionToolsSheet). This replaces the
-// old flow where every one of those destinations was buried in the
+// tools to a single tap — Files / Git / Database / Vault — and tucks
+// the rest behind "More" (SessionToolsSheet). This replaces the old
+// flow where every one of those destinations was buried in the
 // AppBar's "⋮" overflow menu, two taps and a text list away.
 //
-// Files / Git / Tasks open as bottom sheets that float over the
-// terminal (see openSessionToolSheet); Project memory pushes its own
-// full workspace; More lifts the complete grid of tools.
+// Each of the four opens as a bottom sheet that floats over the
+// terminal (see openSessionToolSheet), so the terminal is never
+// unmounted; More lifts the complete grid of tools.
 class SessionToolDock extends StatelessWidget {
   const SessionToolDock({required this.session, super.key});
 
@@ -50,19 +49,16 @@ class SessionToolDock extends StatelessWidget {
                     openSessionToolSheet(context, session, SessionTool.git),
               ),
               _DockItem(
-                icon: sessionToolIcon(SessionTool.tasks),
-                label: sessionToolLabel(SessionTool.tasks),
-                onTap: () =>
-                    openSessionToolSheet(context, session, SessionTool.tasks),
+                icon: sessionToolIcon(SessionTool.database),
+                label: sessionToolLabel(SessionTool.database),
+                onTap: () => openSessionToolSheet(
+                    context, session, SessionTool.database),
               ),
               _DockItem(
-                icon: Icons.flag_outlined,
-                label: t.sessions.detail.projectMemory,
-                onTap: () => Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => ProjectScreen(initialCwd: session.cwd),
-                  ),
-                ),
+                icon: sessionToolIcon(SessionTool.vault),
+                label: sessionToolLabel(SessionTool.vault),
+                onTap: () =>
+                    openSessionToolSheet(context, session, SessionTool.vault),
               ),
               _DockItem(
                 icon: Icons.grid_view_outlined,

--- a/app/mobile/lib/features/sessions/session_tool_dock.dart
+++ b/app/mobile/lib/features/sessions/session_tool_dock.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+import 'package:opendray/core/api/models.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/project/project_screen.dart';
+import 'package:opendray/features/sessions/session_tool_sheets.dart';
+import 'package:opendray/features/sessions/session_tools_sheet.dart';
+
+// Persistent tool dock shown directly under the live terminal on the
+// session detail screen. It promotes the four highest-traffic project
+// tools to a single tap — Files / Git / Tasks / Project memory — and
+// tucks the rest behind "More" (SessionToolsSheet). This replaces the
+// old flow where every one of those destinations was buried in the
+// AppBar's "⋮" overflow menu, two taps and a text list away.
+//
+// Files / Git / Tasks open as bottom sheets that float over the
+// terminal (see openSessionToolSheet); Project memory pushes its own
+// full workspace; More lifts the complete grid of tools.
+class SessionToolDock extends StatelessWidget {
+  const SessionToolDock({required this.session, super.key});
+
+  final SessionSummary session;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Material(
+      color: scheme.surface,
+      child: SafeArea(
+        top: false,
+        child: Container(
+          decoration: BoxDecoration(
+            border: Border(
+              top: BorderSide(color: Theme.of(context).dividerColor),
+            ),
+          ),
+          padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+          child: Row(
+            children: [
+              _DockItem(
+                icon: sessionToolIcon(SessionTool.files),
+                label: sessionToolLabel(SessionTool.files),
+                onTap: () =>
+                    openSessionToolSheet(context, session, SessionTool.files),
+              ),
+              _DockItem(
+                icon: sessionToolIcon(SessionTool.git),
+                label: sessionToolLabel(SessionTool.git),
+                onTap: () =>
+                    openSessionToolSheet(context, session, SessionTool.git),
+              ),
+              _DockItem(
+                icon: sessionToolIcon(SessionTool.tasks),
+                label: sessionToolLabel(SessionTool.tasks),
+                onTap: () =>
+                    openSessionToolSheet(context, session, SessionTool.tasks),
+              ),
+              _DockItem(
+                icon: Icons.flag_outlined,
+                label: t.sessions.detail.projectMemory,
+                onTap: () => Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => ProjectScreen(initialCwd: session.cwd),
+                  ),
+                ),
+              ),
+              _DockItem(
+                icon: Icons.grid_view_outlined,
+                label: t.sessions.dock.more,
+                onTap: () => SessionToolsSheet.show(context, session),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DockItem extends StatelessWidget {
+  const _DockItem({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Expanded(
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 6),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 22, color: scheme.onSurface),
+              const SizedBox(height: 4),
+              Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: scheme.onSurface.withValues(alpha: 0.7),
+                      fontWeight: FontWeight.w500,
+                    ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/mobile/lib/features/sessions/session_tool_sheets.dart
+++ b/app/mobile/lib/features/sessions/session_tool_sheets.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+
+import 'package:opendray/core/api/models.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/database/database_tab.dart';
+import 'package:opendray/features/sessions/inspector/cortex_tab.dart';
+import 'package:opendray/features/sessions/inspector/files_tab.dart';
+import 'package:opendray/features/sessions/inspector/git_tab.dart';
+import 'package:opendray/features/sessions/inspector/history_tab.dart';
+import 'package:opendray/features/sessions/inspector/notes_tab.dart';
+import 'package:opendray/features/sessions/inspector/tasks_tab.dart';
+
+// Shared plumbing for the session "tool" surfaces used by both the
+// bottom dock (SessionToolDock) and the full "More" sheet
+// (SessionToolsSheet).
+//
+// Each cwd-scoped Inspector panel opens as a tall modal bottom sheet
+// that floats OVER the live terminal instead of replacing it — the
+// terminal stays the hero of the screen and the operator never loses
+// their place. The panel widgets themselves (FilesTab, GitTab, …) are
+// the exact same ones the full-screen SessionInspectorScreen hosts in
+// its TabBarView, so behaviour and state handling stay identical.
+
+/// The cwd-scoped project tools that can be opened over a session.
+enum SessionTool { files, git, tasks, history, vault, cortex, database }
+
+IconData sessionToolIcon(SessionTool tool) => switch (tool) {
+      SessionTool.files => Icons.folder_outlined,
+      SessionTool.git => Icons.account_tree_outlined,
+      SessionTool.tasks => Icons.play_circle_outline,
+      SessionTool.history => Icons.history,
+      SessionTool.vault => Icons.menu_book_outlined,
+      SessionTool.cortex => Icons.psychology_outlined,
+      SessionTool.database => Icons.storage_outlined,
+    };
+
+String sessionToolLabel(SessionTool tool) => switch (tool) {
+      SessionTool.files => t.sessions.inspector.shell.tabs.files,
+      SessionTool.git => t.sessions.inspector.shell.tabs.git,
+      SessionTool.tasks => t.sessions.inspector.shell.tabs.tasks,
+      SessionTool.history => t.sessions.inspector.shell.tabs.history,
+      SessionTool.vault => t.sessions.inspector.shell.tabs.vault,
+      SessionTool.cortex => t.sessions.inspector.shell.tabs.cortex,
+      SessionTool.database => t.sessions.inspector.shell.tabs.database,
+    };
+
+/// Open one project tool as a bottom sheet over the terminal.
+Future<void> openSessionToolSheet(
+  BuildContext context,
+  SessionSummary session,
+  SessionTool tool,
+) {
+  final child = switch (tool) {
+    SessionTool.files =>
+      FilesTab(sessionId: session.id, initialPath: session.cwd),
+    SessionTool.git => GitTab(sessionId: session.id, cwd: session.cwd),
+    SessionTool.tasks => TasksTab(sessionId: session.id, cwd: session.cwd),
+    SessionTool.history => HistoryTab(sessionId: session.id),
+    SessionTool.vault => NotesTab(sessionId: session.id, cwd: session.cwd),
+    SessionTool.cortex => CortexTab(cwd: session.cwd),
+    SessionTool.database => DatabaseTab(cwd: session.cwd),
+  };
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    builder: (_) => ToolSheetScaffold(
+      title: sessionToolLabel(tool),
+      child: child,
+    ),
+  );
+}
+
+/// Rounded, near-full-height sheet chrome: grabber + title bar + body.
+/// Reused by every tool sheet so they all share one look.
+class ToolSheetScaffold extends StatelessWidget {
+  const ToolSheetScaffold({required this.title, required this.child, super.key});
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return FractionallySizedBox(
+      heightFactor: 0.92,
+      child: Container(
+        decoration: BoxDecoration(
+          color: scheme.surface,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(22)),
+          border: Border.all(color: Theme.of(context).dividerColor),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: Column(
+          children: [
+            const SheetGrabber(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 2, 6, 8),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      title,
+                      style: Theme.of(context).textTheme.titleMedium,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    tooltip: MaterialLocalizations.of(context).closeButtonLabel,
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ],
+              ),
+            ),
+            Divider(height: 1, color: Theme.of(context).dividerColor),
+            Expanded(child: child),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The little drag handle at the top of every sheet.
+class SheetGrabber extends StatelessWidget {
+  const SheetGrabber({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 38,
+      height: 5,
+      margin: const EdgeInsets.only(top: 10, bottom: 8),
+      decoration: BoxDecoration(
+        color: Theme.of(context).dividerColor,
+        borderRadius: BorderRadius.circular(3),
+      ),
+    );
+  }
+}

--- a/app/mobile/lib/features/sessions/session_tools_sheet.dart
+++ b/app/mobile/lib/features/sessions/session_tools_sheet.dart
@@ -1,0 +1,271 @@
+import 'package:flutter/material.dart';
+
+import 'package:opendray/core/api/models.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/sessions/account_switch_sheet.dart';
+import 'package:opendray/features/sessions/session_action_sheet.dart';
+import 'package:opendray/features/sessions/session_tool_sheets.dart';
+
+// The full "More" tool sheet, lifted from the dock's More button. It
+// is the single home for every project + session tool that isn't hot
+// enough to earn a dock slot: all seven Inspector panels (Files, Git,
+// Tasks, History, Vault, Cortex, Database) plus the session actions
+// (account switch, lifecycle). Searchable, grouped and thumb-sized —
+// so nothing lives in an unlabelled overflow menu anymore.
+class SessionToolsSheet {
+  const SessionToolsSheet._();
+
+  static Future<void> show(BuildContext context, SessionSummary session) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (_) => _SessionToolsSheetBody(
+        session: session,
+        hostContext: context,
+      ),
+    );
+  }
+}
+
+class _SessionToolsSheetBody extends StatefulWidget {
+  const _SessionToolsSheetBody({
+    required this.session,
+    required this.hostContext,
+  });
+
+  final SessionSummary session;
+
+  /// The screen-level context that outlives this sheet — used to open a
+  /// follow-up sheet after this one is dismissed.
+  final BuildContext hostContext;
+
+  @override
+  State<_SessionToolsSheetBody> createState() => _SessionToolsSheetBodyState();
+}
+
+class _SessionToolsSheetBodyState extends State<_SessionToolsSheetBody> {
+  String _query = '';
+
+  bool get _canAccount {
+    final s = widget.session;
+    return (s.providerId == 'claude' || s.providerId == 'antigravity') &&
+        s.isLive;
+  }
+
+  List<SessionTool> get _visibleTools {
+    final q = _query.trim().toLowerCase();
+    const all = SessionTool.values;
+    if (q.isEmpty) return all;
+    return all
+        .where((tool) => sessionToolLabel(tool).toLowerCase().contains(q))
+        .toList();
+  }
+
+  void _openTool(SessionTool tool) {
+    Navigator.of(context).pop();
+    openSessionToolSheet(widget.hostContext, widget.session, tool);
+  }
+
+  Future<void> _account() async {
+    Navigator.of(context).pop();
+    await AccountSwitchSheet.show(widget.hostContext, session: widget.session);
+  }
+
+  Future<void> _actions() async {
+    Navigator.of(context).pop();
+    await SessionActionSheet.show(widget.hostContext, session: widget.session);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final tools = _visibleTools;
+    return FractionallySizedBox(
+      heightFactor: 0.92,
+      child: Container(
+        decoration: BoxDecoration(
+          color: scheme.surface,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(22)),
+          border: Border.all(color: Theme.of(context).dividerColor),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: Column(
+          children: [
+            const SheetGrabber(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 2, 16, 12),
+              child: TextField(
+                autofocus: false,
+                onChanged: (v) => setState(() => _query = v),
+                decoration: InputDecoration(
+                  prefixIcon: const Icon(Icons.search, size: 20),
+                  hintText: t.sessions.tools.searchHint,
+                  isDense: true,
+                ),
+              ),
+            ),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+                children: [
+                  _SectionLabel(
+                    t.sessions.tools.inspectSection,
+                    trailing: widget.session.displayName,
+                  ),
+                  const SizedBox(height: 10),
+                  GridView.count(
+                    crossAxisCount: 2,
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    mainAxisSpacing: 10,
+                    crossAxisSpacing: 10,
+                    childAspectRatio: 2.6,
+                    children: [
+                      for (final tool in tools)
+                        _ToolTile(
+                          icon: sessionToolIcon(tool),
+                          label: sessionToolLabel(tool),
+                          onTap: () => _openTool(tool),
+                        ),
+                    ],
+                  ),
+                  const SizedBox(height: 22),
+                  _SectionLabel(
+                    t.sessions.tools.sessionSection,
+                  ),
+                  const SizedBox(height: 10),
+                  Row(
+                    children: [
+                      if (_canAccount) ...[
+                        Expanded(
+                          child: _ActionButton(
+                            icon: Icons.manage_accounts_outlined,
+                            label: t.sessions.detail.accountSwitcher.tooltip,
+                            onTap: _account,
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                      ],
+                      Expanded(
+                        child: _ActionButton(
+                          icon: Icons.tune,
+                          label: t.sessions.detail.actions,
+                          onTap: _actions,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel(this.text, {this.trailing});
+  final String text;
+  final String? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            text,
+            style: theme.textTheme.labelSmall?.copyWith(
+              letterSpacing: 0.9,
+              fontWeight: FontWeight.w600,
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+            ),
+          ),
+        ),
+        if (trailing != null)
+          Text(
+            trailing!,
+            style: theme.textTheme.bodySmall?.copyWith(
+              fontFamily: 'monospace',
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _ToolTile extends StatelessWidget {
+  const _ToolTile({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Material(
+      color: scheme.surfaceContainerHighest.withValues(alpha: 0.35),
+      shape: RoundedRectangleBorder(
+        side: BorderSide(color: Theme.of(context).dividerColor),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: Row(
+            children: [
+              Icon(icon, size: 21, color: scheme.primary),
+              const SizedBox(width: 11),
+              Expanded(
+                child: Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodyMedium
+                      ?.copyWith(fontWeight: FontWeight.w600),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton.icon(
+      onPressed: onTap,
+      icon: Icon(icon, size: 18),
+      label: Text(label, overflow: TextOverflow.ellipsis),
+      style: OutlinedButton.styleFrom(
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        side: BorderSide(color: Theme.of(context).dividerColor),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Mobile UI pass on the session surface and the More/settings tab. Terminal
panel widgets and every destination are reused verbatim — this is layout,
navigation and visual work only.

## Session detail — tool dock
- Terminal owns the full body height; the old expandable metadata header
  is gone. Identity + lifecycle move into a compact two-line AppBar title
  (name on top; `provider · state` with a colour dot beneath).
- New **SessionToolDock** pinned under the terminal surfaces
  `Files · Git · Database · Vault · More` one tap away. Files/Git/Database/
  Vault open as tall bottom sheets that float over the still-live terminal
  (never unmounted); More lifts the full grid (SessionToolsSheet).
- AppBar ⋮ keeps only low-frequency session actions (refresh, account
  switch, lifecycle). Tasks stays reachable in the More grid; Project
  memory keeps its other entry points (global More tab, Cortex panel).

## More / settings tab — grouped-card redesign
- Flat full-bleed ListTile menu becomes the standard grouped-settings
  layout: each section (Gateway / Plugins / Memory / System / Resources)
  is one inset, bordered, rounded card with thin row dividers, using the
  app-wide CardTheme.
- Identity header reworked into an account block: monogram avatar +
  "signed in as" / username, with server and token-expiry as icon-prefixed
  detail rows.
- Each menu icon sits in a rounded, accent-tinted chip; tightened
  typography (title w500, muted subtitles), muted chevrons, a logout glyph
  on sign-out, and a quiet version stamp footer.

(A searchable launcher-grid variant was explored and reverted in-branch;
the net diff keeps the grouped-card version.)

## i18n
Adds `sessions.dock.more` and `sessions.tools.{searchHint,inspectSection,
sessionSection}` across en/zh/es (slang regenerated; parity 100%).

## Testing
- [x] `flutter analyze` clean on touched dirs
- [x] i18n parity 100% (en/zh/es)
- [x] CI green (Analyze / Backend / Lint / Frontend / i18n / CodeQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)