### PR TITLE
feat(roundtable): read-only opendray-memory MCP for members

### DIFF
--- a/cmd/opendray/mcp_memory.go
+++ b/cmd/opendray/mcp_memory.go
@@ -105,6 +105,13 @@ type memMCPConfig struct {
 	// "KB Librarian" session by the session adapter; every other session's
 	// memory MCP omits it, so no ordinary session can rewrite the KB.
 	kbAdmin bool
+	// readOnly exposes ONLY the read/search tools and refuses every write
+	// tool (memory_store, *_set, session_log_append, decision_record,
+	// skill_distill). Set (OPENDRAY_MEMORY_READONLY=1) for headless callers
+	// that must observe but never mutate the store — e.g. Round Table
+	// discussion members, which run with permissions fully open and so rely
+	// on the server itself, not the CLI, to enforce the boundary.
+	readOnly bool
 }
 
 func loadMemMCPConfig() (memMCPConfig, error) {
@@ -114,6 +121,7 @@ func loadMemMCPConfig() (memMCPConfig, error) {
 		scope:    os.Getenv("OPENDRAY_MEMORY_SCOPE"),
 		scopeKey: os.Getenv("OPENDRAY_MEMORY_SCOPE_KEY"),
 		kbAdmin:  os.Getenv("OPENDRAY_KB_ADMIN") == "1",
+		readOnly: os.Getenv("OPENDRAY_MEMORY_READONLY") == "1",
 	}
 	if c.baseURL == "" {
 		return c, errors.New("mcp-memory: OPENDRAY_BASE_URL is required")
@@ -201,9 +209,20 @@ func (s *memMCPServer) handle(raw []byte) {
 		s.respond(req.ID, map[string]any{})
 	case "tools/list":
 		tools := toolDefs
-		// The KB Librarian session (OPENDRAY_KB_ADMIN=1) additionally sees
-		// the global-KB write tools; no other session does.
-		if s.cfg.kbAdmin {
+		// Read-only sessions never see any write tool (nor the KB admin
+		// write surface, which read-only implies is off).
+		if s.cfg.readOnly {
+			filtered := make([]map[string]any, 0, len(toolDefs))
+			for _, t := range toolDefs {
+				if name, _ := t["name"].(string); writeToolNames[name] {
+					continue
+				}
+				filtered = append(filtered, t)
+			}
+			tools = filtered
+		} else if s.cfg.kbAdmin {
+			// The KB Librarian session (OPENDRAY_KB_ADMIN=1) additionally sees
+			// the global-KB write tools; no other session does.
 			tools = append(append([]map[string]any{}, toolDefs...), kbAdminToolDefs...)
 		}
 		s.respond(req.ID, map[string]any{"tools": tools})
@@ -278,6 +297,21 @@ CRITICAL HABITS:
    doc_read(slug, section=…) the matching section. Do NOT infer
    our system's design or rules from memory; the kb_* pages are the
    source of truth and they update.`
+
+// writeToolNames is the set of tools that mutate the store (facts, project
+// docs, journal, distilled skills). Read-only sessions omit them from
+// tools/list and refuse them by name in dispatchTool. The KB admin write
+// tools are gated separately (kbAdmin) and are never listed for a read-only
+// session anyway. Keep this in sync with the write cases in dispatchTool.
+var writeToolNames = map[string]bool{
+	"memory_store":          true,
+	"project_goal_set":      true,
+	"project_plan_set":      true,
+	"current_objective_set": true,
+	"session_log_append":    true,
+	"decision_record":       true,
+	"skill_distill":         true,
+}
 
 // toolDefs is the static list returned for tools/list.
 var toolDefs = []map[string]any{
@@ -730,6 +764,12 @@ func (s *memMCPServer) dispatchTool(name string, args json.RawMessage) (result a
 		// argv callers may omit arguments for no-arg tools; the per-tool
 		// handlers unmarshal into a struct, which rejects empty input.
 		args = json.RawMessage("{}")
+	}
+	// Read-only sessions refuse every write tool by name, even though such
+	// tools aren't listed for them — a client can still call by name, and a
+	// read-only member runs with CLI permissions fully open.
+	if s.cfg.readOnly && writeToolNames[name] {
+		return nil, errors.New("this session is read-only; " + name + " is not permitted"), true
 	}
 	switch name {
 	case "memory_search":

--- a/cmd/opendray/mcp_memory_readonly_test.go
+++ b/cmd/opendray/mcp_memory_readonly_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"sync"
+	"testing"
+)
+
+// OPENDRAY_MEMORY_READONLY=1 flips the memory MCP into read-only mode.
+func TestLoadMemMCPConfig_ReadOnly(t *testing.T) {
+	t.Setenv("OPENDRAY_BASE_URL", "http://127.0.0.1:8770")
+	t.Setenv("OPENDRAY_API_KEY", "k")
+
+	t.Setenv("OPENDRAY_MEMORY_READONLY", "")
+	if cfg, err := loadMemMCPConfig(); err != nil || cfg.readOnly {
+		t.Fatalf("default should be read-write: readOnly=%v err=%v", cfg.readOnly, err)
+	}
+	t.Setenv("OPENDRAY_MEMORY_READONLY", "1")
+	if cfg, err := loadMemMCPConfig(); err != nil || !cfg.readOnly {
+		t.Fatalf("flag should enable read-only: readOnly=%v err=%v", cfg.readOnly, err)
+	}
+}
+
+// A read-only session's tools/list must omit every write tool while keeping
+// the read/search tools. A read-write session lists them all.
+func TestToolsList_ReadOnlyFiltersWriteTools(t *testing.T) {
+	list := func(readOnly bool) map[string]bool {
+		var buf bytes.Buffer
+		s := &memMCPServer{
+			cfg:   memMCPConfig{readOnly: readOnly},
+			out:   &buf,
+			outMu: &sync.Mutex{},
+		}
+		s.handle([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+
+		var resp struct {
+			Result struct {
+				Tools []struct {
+					Name string `json:"name"`
+				} `json:"tools"`
+			} `json:"result"`
+		}
+		if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal tools/list response: %v (raw: %s)", err, buf.String())
+		}
+		names := map[string]bool{}
+		for _, tl := range resp.Result.Tools {
+			names[tl.Name] = true
+		}
+		return names
+	}
+
+	ro := list(true)
+	if len(ro) == 0 {
+		t.Fatal("read-only tools/list returned nothing")
+	}
+	for name := range writeToolNames {
+		if ro[name] {
+			t.Errorf("read-only session must not list write tool %q", name)
+		}
+	}
+	// Read tools survive.
+	for _, want := range []string{"memory_search", "memory_list", "project_search", "doc_read"} {
+		if !ro[want] {
+			t.Errorf("read-only session must still list read tool %q", want)
+		}
+	}
+
+	// A normal session lists the write tools.
+	rw := list(false)
+	if !rw["memory_store"] {
+		t.Error("read-write session should list memory_store")
+	}
+}
+
+// Defense in depth: even called by name, a write tool is refused in read-only
+// mode — before any gateway HTTP call.
+func TestDispatchTool_ReadOnlyRefusesWrites(t *testing.T) {
+	s := &memMCPServer{cfg: memMCPConfig{readOnly: true}}
+	for name := range writeToolNames {
+		_, err, known := s.dispatchTool(name, nil)
+		if !known {
+			t.Errorf("%q should be a known tool name", name)
+		}
+		if err == nil {
+			t.Errorf("read-only mode must refuse write tool %q", name)
+		}
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -644,6 +644,10 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	// run the one-time M-U Phase 5 file-memory backfill import against
 	// it. Nil when memory is disabled or the mirror wasn't wired.
 	var memoryMirror *memory.Mirror
+	// memoryAutoAttach is hoisted so the Round Table wiring below can reuse
+	// the same memory-server config to attach read-only tools to members.
+	// Zero value (Enabled=false) → members run tool-less.
+	var memoryAutoAttach catalog.MemoryAutoAttach
 	if memorySvc != nil {
 		log.Info("memory ready",
 			"embedder", memorySvc.EmbedderName(),
@@ -677,13 +681,14 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 				log.Warn("memory MCP auto-attach disabled — os.Executable failed",
 					"err", perr)
 			} else {
-				sessionProvider.WithMemoryAutoAttach(catalog.MemoryAutoAttach{
+				memoryAutoAttach = catalog.MemoryAutoAttach{
 					Enabled:    true,
 					BinaryPath: binPath,
 					BaseURL:    listenLoopback(cfg.Listen),
 					APIKey:     key,
 					Scope:      cfg.Memory.Scope.Default,
-				})
+				}
+				sessionProvider.WithMemoryAutoAttach(memoryAutoAttach)
 				log.Info("memory MCP auto-attach enabled",
 					"bin", binPath,
 					"base_url", listenLoopback(cfg.Listen))
@@ -1211,6 +1216,17 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		WithSessionLauncher(&roundTableSessionLauncher{mgr: sessionMgr})
 	if memquerySvc != nil {
 		roundTableSvc.WithContextSource(&curationContextAdapter{mq: memquerySvc})
+	}
+	// Give members live, read-only opendray-memory tools (search / project_search
+	// / doc_read / …) scoped to the table's cwd — the same dynamic per-spawn
+	// injector interactive sessions use, so they can pull real facts instead of
+	// only the pre-injected snapshot. read-only=true: members run with tool
+	// permissions open, so the server is the write boundary.
+	if memoryAutoAttach.Enabled {
+		mem := memoryAutoAttach
+		roundTableSvc.WithMemoryMCP(func(providerID, baseDir, runCwd, scopeKey, home string) ([]string, map[string]string, error) {
+			return catalog.AttachMemoryMCP(mem, providerID, baseDir, runCwd, scopeKey, home, true)
+		})
 	}
 	roundTableHandlers := roundtable.NewHandlers(roundTableStore, roundTableSvc, log)
 	// ─── END ROUND TABLE ────────────────────────────────────────
@@ -2468,9 +2484,35 @@ func (a *curationContextAdapter) RelevantContext(ctx context.Context, cwd, query
 	return b.String(), nil
 }
 
+// Bracketed-paste markers. Wrapping a programmatically-injected seed in
+// these makes a CLI's input parser treat the whole (usually multi-line)
+// block as ONE pasted message: embedded newlines become soft line breaks,
+// not per-line submissions. This mirrors exactly what a human paste from the
+// web terminal delivers (xterm.js emits the same markers), so every provider
+// that already accepts pasted input handles it identically. Without it, TUIs
+// that read a raw '\n' as Enter (antigravity) submit a multi-paragraph
+// handoff seed as many separate turns — the round-table "full discussion
+// dribbled into the chat box as a conversation" bug. The submitting Enter
+// stays OUTSIDE the paste (inside, it would be a literal newline, not submit).
+const (
+	bracketedPasteStart = "\x1b[200~"
+	bracketedPasteEnd   = "\x1b[201~"
+)
+
+// seedIntoSession pastes a seed prompt into an already-booted session and
+// submits it with a single Enter, so a multi-line seed lands as one message
+// instead of one turn per line. Callers own the pre-boot delay + timeout ctx.
+func seedIntoSession(ctx context.Context, mgr *session.Manager, sid, prompt string) error {
+	if err := mgr.Input(ctx, sid, []byte(bracketedPasteStart+prompt+bracketedPasteEnd)); err != nil {
+		return err
+	}
+	time.Sleep(500 * time.Millisecond)
+	return mgr.Input(ctx, sid, []byte{'\r'})
+}
+
 // curationSessionLauncher implements cortex.SessionLauncher over the
 // session manager: spawn a claude session in cwd, give the CLI a
-// moment to boot, then type the seed prompt and submit it.
+// moment to boot, then paste the seed prompt and submit it.
 type curationSessionLauncher struct {
 	mgr *session.Manager
 }
@@ -2503,11 +2545,7 @@ func (l *curationSessionLauncher) Launch(ctx context.Context, spec cortex.Launch
 		time.Sleep(4 * time.Second)
 		bg, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		if err := l.mgr.Input(bg, sid, []byte(prompt)); err != nil {
-			return
-		}
-		time.Sleep(500 * time.Millisecond)
-		_ = l.mgr.Input(bg, sid, []byte{'\r'})
+		_ = seedIntoSession(bg, l.mgr, sid, prompt)
 	}(sess.ID, spec.SeedPrompt)
 	return sess.ID, nil
 }
@@ -2540,11 +2578,7 @@ func (l *roundTableSessionLauncher) Launch(ctx context.Context, spec roundtable.
 		time.Sleep(4 * time.Second)
 		bg, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		if err := l.mgr.Input(bg, sid, []byte(prompt)); err != nil {
-			return
-		}
-		time.Sleep(500 * time.Millisecond)
-		_ = l.mgr.Input(bg, sid, []byte{'\r'})
+		_ = seedIntoSession(bg, l.mgr, sid, prompt)
 	}(sess.ID, spec.SeedPrompt)
 	return sess.ID, nil
 }
@@ -2559,16 +2593,12 @@ func (l *roundTableSessionLauncher) Alive(ctx context.Context, sessionID string)
 	return !sess.State.IsTerminal()
 }
 
-// Deliver types a follow-up prompt into an existing (already booted) session.
+// Deliver pastes a follow-up prompt into an existing (already booted) session.
 func (l *roundTableSessionLauncher) Deliver(_ context.Context, sessionID, prompt string) error {
 	go func(sid, p string) {
 		bg, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		if err := l.mgr.Input(bg, sid, []byte(p)); err != nil {
-			return
-		}
-		time.Sleep(500 * time.Millisecond)
-		_ = l.mgr.Input(bg, sid, []byte{'\r'})
+		_ = seedIntoSession(bg, l.mgr, sid, p)
 	}(sessionID, prompt)
 	return nil
 }

--- a/internal/catalog/memory_mcp.go
+++ b/internal/catalog/memory_mcp.go
@@ -1,0 +1,102 @@
+package catalog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// AttachMemoryMCP renders the opendray-memory MCP server for one spawn of
+// providerID and returns the extra CLI args + env the CLI needs to pick it
+// up. It reuses the exact per-provider renderMCP machinery the interactive
+// session adapter uses, so every caller — interactive sessions, headless
+// Round Table members, any future out-of-band agent — injects memory the
+// same way. This is the single dynamic injection point: nothing is baked
+// into a provider at startup; the config is rendered per call.
+//
+// baseDir is a per-call scratch dir the renderer may write config files into
+// (claude-mcp.json, codex-home/, opencode config). runCwd is the working
+// directory the CLI itself will run in — grok reads project-scoped MCP from
+// <runCwd>/.grok, and antigravity derives the memory scope from the MCP
+// subprocess cwd, so for agy runCwd MUST be the project dir. scopeKey is the
+// memory scope (the project whose facts/journal to expose); it is baked into
+// the server env for every provider except antigravity (which derives it
+// from runCwd). home is the effective HOME — antigravity's mcp_config.json
+// surface; pass the operator's real HOME when the spawn isn't account-bound.
+//
+// readOnly attaches the server in read-only mode (OPENDRAY_MEMORY_READONLY=1):
+// only search/read tools, every write refused server-side. Callers that run
+// the CLI with tool permissions fully open (Round Table members) MUST pass
+// true — the server, not the CLI, is the boundary there.
+//
+// Returns (nil, nil, nil) when memory auto-attach is disabled or unconfigured,
+// so callers can wire it unconditionally and degrade to a tool-less spawn.
+func AttachMemoryMCP(mem MemoryAutoAttach, providerID, baseDir, runCwd, scopeKey, home string, readOnly bool) ([]string, map[string]string, error) {
+	if !mem.Enabled || mem.BinaryPath == "" {
+		return nil, nil, nil
+	}
+
+	env := map[string]string{
+		"OPENDRAY_BASE_URL":     mem.BaseURL,
+		"OPENDRAY_API_KEY":      mem.APIKey,
+		"OPENDRAY_MEMORY_SCOPE": defaultStr(mem.Scope, "project"),
+	}
+	if readOnly {
+		env["OPENDRAY_MEMORY_READONLY"] = "1"
+	}
+	// Scope key: antigravity's entry lands in a HOME-global mcp_config.json
+	// shared by every session under that HOME, so baking a per-call key in
+	// would leak it into (and clobber) concurrent sessions. Instead it opts
+	// into deriving the key from the MCP subprocess cwd (agy spawns MCP from
+	// its own workspace, which the caller sets to runCwd). Every other
+	// provider gets the key baked into its per-call entry.
+	//
+	// CAVEAT (antigravity only): because that file is shared, the read-only
+	// flag also lives in the shared entry. A concurrent NON-read-only agy
+	// spawn under the same HOME (e.g. an interactive session) converges the
+	// same entry and can momentarily flip it. Isolated providers (claude /
+	// codex / grok / opencode) each write a per-call config, so their
+	// read-only guarantee is airtight; only the default-account agy seat
+	// shares. Account-bound agy already has an isolated HOME and is unaffected.
+	if providerID == "antigravity" {
+		env["OPENDRAY_MEMORY_SCOPE_FROM_CWD"] = "1"
+	} else if scopeKey != "" {
+		env["OPENDRAY_MEMORY_SCOPE_KEY"] = scopeKey
+	}
+
+	server := MCPServer{
+		Name:    "opendray-memory",
+		Command: mem.BinaryPath,
+		Args:    []string{"mcp-memory"},
+		Env:     env,
+	}
+
+	args, mcpEnv, err := renderMCP(providerID, baseDir, runCwd, home, []MCPServer{server})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Codex reads MCP servers from <CODEX_HOME>/config.toml, so renderMCP
+	// points CODEX_HOME at a scratch codex-home — but that home has no
+	// auth.json, and codex would fail to authenticate. Mirror the minimal
+	// authenticated subset of the user's real codex home into it (same as
+	// the interactive adapter) and trust the run cwd so exec can start.
+	if providerID == "codex" && mcpEnv["CODEX_HOME"] != "" {
+		userHome := os.Getenv("CODEX_HOME")
+		if userHome == "" {
+			if h, herr := os.UserHomeDir(); herr == nil {
+				userHome = filepath.Join(h, ".codex")
+			}
+		}
+		if userHome != "" {
+			if err := mirrorCodexHome(userHome, mcpEnv["CODEX_HOME"]); err != nil {
+				return nil, nil, fmt.Errorf("mirror codex home for memory MCP: %w", err)
+			}
+		}
+		if err := ensureCodexScratchTrust(mcpEnv["CODEX_HOME"], runCwd); err != nil {
+			return nil, nil, fmt.Errorf("trust codex scratch cwd: %w", err)
+		}
+	}
+
+	return args, mcpEnv, nil
+}

--- a/internal/catalog/memory_mcp_test.go
+++ b/internal/catalog/memory_mcp_test.go
@@ -1,0 +1,111 @@
+package catalog
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Disabled / unconfigured memory auto-attach is a no-op so callers can wire it
+// unconditionally and degrade to a tool-less spawn.
+func TestAttachMemoryMCP_DisabledIsNoop(t *testing.T) {
+	args, env, err := AttachMemoryMCP(MemoryAutoAttach{}, "claude", t.TempDir(), "/cwd", "/cwd", "/home", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if args != nil || env != nil {
+		t.Fatalf("disabled attach must return nil args/env, got args=%v env=%v", args, env)
+	}
+}
+
+// For claude the helper writes claude-mcp.json (via --mcp-config) carrying the
+// opendray-memory server with the read-only flag + the scope key baked in.
+func TestAttachMemoryMCP_ClaudeReadOnly(t *testing.T) {
+	base := t.TempDir()
+	mem := MemoryAutoAttach{
+		Enabled:    true,
+		BinaryPath: "/usr/local/bin/opendray",
+		BaseURL:    "http://127.0.0.1:8770",
+		APIKey:     "secret-key",
+		Scope:      "project",
+	}
+	args, _, err := AttachMemoryMCP(mem, "claude", base, base, "/proj/foo", "/home/op", true)
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+
+	// --mcp-config <path> is returned and the file exists.
+	var cfgPath string
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "--mcp-config" {
+			cfgPath = args[i+1]
+		}
+	}
+	if cfgPath == "" {
+		t.Fatalf("expected --mcp-config in args, got %v", args)
+	}
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", cfgPath, err)
+	}
+
+	var parsed struct {
+		MCPServers map[string]struct {
+			Command string            `json:"command"`
+			Args    []string          `json:"args"`
+			Env     map[string]string `json:"env"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse claude-mcp.json: %v", err)
+	}
+	srv, ok := parsed.MCPServers["opendray-memory"]
+	if !ok {
+		t.Fatalf("opendray-memory server missing: %s", data)
+	}
+	if srv.Env["OPENDRAY_MEMORY_READONLY"] != "1" {
+		t.Errorf("read-only flag not set: %v", srv.Env)
+	}
+	if srv.Env["OPENDRAY_MEMORY_SCOPE_KEY"] != "/proj/foo" {
+		t.Errorf("scope key = %q, want /proj/foo", srv.Env["OPENDRAY_MEMORY_SCOPE_KEY"])
+	}
+	if srv.Env["OPENDRAY_API_KEY"] != "secret-key" {
+		t.Errorf("api key not propagated: %v", srv.Env)
+	}
+}
+
+// Antigravity derives its scope from the subprocess cwd (its entry lives in a
+// HOME-global file), so the helper opts into FROM_CWD instead of baking a key.
+func TestAttachMemoryMCP_AntigravityUsesFromCwd(t *testing.T) {
+	home := t.TempDir()
+	mem := MemoryAutoAttach{
+		Enabled: true, BinaryPath: "/bin/opendray",
+		BaseURL: "http://127.0.0.1:8770", APIKey: "k", Scope: "project",
+	}
+	if _, _, err := AttachMemoryMCP(mem, "antigravity", t.TempDir(), "/proj/foo", "/proj/foo", home, true); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".gemini", "config", "mcp_config.json"))
+	if err != nil {
+		t.Fatalf("read agy mcp_config: %v", err)
+	}
+	var parsed struct {
+		MCPServers map[string]struct {
+			Env map[string]string `json:"env"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	env := parsed.MCPServers["opendray-memory"].Env
+	if env["OPENDRAY_MEMORY_SCOPE_FROM_CWD"] != "1" {
+		t.Errorf("antigravity should derive scope from cwd, env=%v", env)
+	}
+	if _, baked := env["OPENDRAY_MEMORY_SCOPE_KEY"]; baked {
+		t.Errorf("antigravity must NOT bake a scope key (leaks across shared HOME file): %v", env)
+	}
+	if env["OPENDRAY_MEMORY_READONLY"] != "1" {
+		t.Errorf("read-only flag not set: %v", env)
+	}
+}

--- a/internal/memory/worker/agent.go
+++ b/internal/memory/worker/agent.go
@@ -114,13 +114,35 @@ func (w *AgentWorker) Run(ctx context.Context, req Request) (Response, error) {
 		return Response{}, err
 	}
 
+	// Optional MCP attach: render the provider's MCP config, apply the
+	// returned args + env, and add the per-provider flags that let the CLI
+	// execute the tools headless. runCwd is where the CLI runs — the scratch
+	// dir for every provider except antigravity, which derives the memory
+	// scope from its own cwd and so must run in the project dir.
+	runCwd := scratch
+	if req.MCP != nil && req.MCP.Provision != nil {
+		home := w.effectiveHome(runCtx)
+		if w.cfg.ProviderID == "antigravity" && strings.TrimSpace(req.MCP.Cwd) != "" {
+			runCwd = req.MCP.Cwd
+		}
+		mcpArgs, mcpEnv, perr := req.MCP.Provision(w.cfg.ProviderID, scratch, runCwd, req.MCP.Cwd, home)
+		if perr != nil {
+			return Response{}, fmt.Errorf("agent worker: provision mcp: %w", perr)
+		}
+		args = append(args, mcpArgs...)
+		for k, v := range mcpEnv {
+			env = append(env, k+"="+v)
+		}
+		args = append(args, mcpToolApprovalArgs(w.cfg.ProviderID)...)
+	}
+
 	binary := agentBinary(w.cfg.ProviderID)
 	if p, err := exec.LookPath(binary); err == nil {
 		binary = p
 	}
 
 	cmd := exec.CommandContext(runCtx, binary, args...)
-	cmd.Dir = scratch
+	cmd.Dir = runCwd
 	cmd.Env = append(os.Environ(), env...)
 
 	var stdout, stderr bytes.Buffer
@@ -204,6 +226,51 @@ func (w *AgentWorker) Run(ctx context.Context, req Request) (Response, error) {
 		// reliably. The metrics table records 0; cost UI will
 		// estimate from byte counts as a stopgap.
 	}, nil
+}
+
+// effectiveHome resolves the HOME the MCP renderer should target. For an
+// account-bound antigravity spawn that's the account's dedicated HOME (agy
+// keys its whole state — and its mcp_config.json — off HOME); everything
+// else uses the gateway user's real HOME. Mirrors buildCommand's agy account
+// resolution so the mcp_config.json lands where the CLI will read it.
+func (w *AgentWorker) effectiveHome(ctx context.Context) string {
+	if w.cfg.ProviderID == "antigravity" && w.cfg.AccountID != "" && w.agyAccounts != nil {
+		hctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		if home, err := w.agyAccounts.ResolveSpawnHome(hctx, w.cfg.AccountID); err == nil && home != "" {
+			return home
+		}
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return home
+	}
+	return ""
+}
+
+// mcpToolApprovalArgs returns the extra CLI flags a headless spawn needs to
+// actually EXECUTE MCP tools (not merely have them configured). Each CLI
+// gates tool use differently in non-interactive mode:
+//
+//   - claude allow-lists the memory server's tools so --print runs them with
+//     no prompt while every other tool (file writes, bash) stays unlisted and
+//     is auto-denied — this is both the tool gate and the file-safety boundary.
+//   - grok / opencode auto-DENY tool approvals in headless mode unless told to
+//     approve; the read-only memory server is the only tool source and the CLI
+//     runs in a throwaway scratch dir, so blanket approval is safe here.
+//   - antigravity already carries --dangerously-skip-permissions from
+//     buildCommand; codex exec auto-runs configured MCP tools while its
+//     read-only sandbox still blocks its own file/shell writes.
+func mcpToolApprovalArgs(providerID string) []string {
+	switch providerID {
+	case "claude":
+		return []string{"--allowedTools", "mcp__opendray-memory"}
+	case "grok":
+		return []string{"--always-approve"}
+	case "opencode":
+		return []string{"--dangerously-skip-permissions"}
+	default:
+		return nil
+	}
 }
 
 func (w *AgentWorker) buildCommand(req Request, sessionID, scratch string) ([]string, []string, error) {

--- a/internal/memory/worker/agent_mcp_test.go
+++ b/internal/memory/worker/agent_mcp_test.go
@@ -1,0 +1,34 @@
+package worker
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Each CLI enables headless MCP tool execution with a different flag; claude
+// uses an allow-list (also its file-safety boundary), grok/opencode need a
+// blanket approve, and antigravity/codex need nothing extra here.
+func TestMCPToolApprovalArgs(t *testing.T) {
+	cases := map[string][]string{
+		"claude":      {"--allowedTools", "mcp__opendray-memory"},
+		"grok":        {"--always-approve"},
+		"opencode":    {"--dangerously-skip-permissions"},
+		"antigravity": nil,
+		"codex":       nil,
+	}
+	for provider, want := range cases {
+		if got := mcpToolApprovalArgs(provider); !reflect.DeepEqual(got, want) {
+			t.Errorf("mcpToolApprovalArgs(%q) = %v, want %v", provider, got, want)
+		}
+	}
+}
+
+// The claude allow-list must name the memory server exactly so file/bash tools
+// stay unlisted (auto-denied in --print) — this is the read-only boundary for
+// claude members.
+func TestMCPToolApprovalArgs_ClaudeAllowlistIsScoped(t *testing.T) {
+	got := mcpToolApprovalArgs("claude")
+	if len(got) != 2 || got[0] != "--allowedTools" || got[1] != "mcp__opendray-memory" {
+		t.Fatalf("claude allow-list drifted: %v", got)
+	}
+}

--- a/internal/memory/worker/worker.go
+++ b/internal/memory/worker/worker.go
@@ -120,7 +120,36 @@ type Request struct {
 	// schema instructions to the system prompt instead (since
 	// agent CLIs don't natively support response_format).
 	ResponseFormatJSONSchema string
+
+	// MCP, when non-nil, attaches MCP tool servers to this headless call.
+	// The AgentWorker runs MCP.Provision after creating its scratch dir to
+	// render the provider-specific config, applies the returned args + env,
+	// and adds the per-provider flags that let the CLI execute the tools in
+	// headless mode. Nil (the default) keeps the deliberately tool-less
+	// one-shot behaviour every memory-touchpoint worker relies on.
+	MCP *MCPAttach
 }
+
+// MCPAttach carries the per-call MCP intent for an AgentWorker run. It holds
+// a caller-supplied closure rather than a concrete server list so the worker
+// package stays decoupled from the catalog rendering machinery (which owns
+// every provider's config-file format).
+type MCPAttach struct {
+	// Cwd is the memory scope key — the project whose facts / journal the
+	// agent should observe. It is also the working directory the CLI runs in
+	// for providers that derive scope from the subprocess cwd (antigravity);
+	// other providers run in the scratch dir and get the scope via env.
+	Cwd string
+	// Provision renders the MCP config for providerID into baseDir and
+	// returns the extra CLI args + env. It is catalog.AttachMemoryMCP bound
+	// to the memory config + read-only flag. runCwd is where the CLI will
+	// run; scopeKey is the memory scope; home is the effective HOME.
+	Provision MCPProvisionFunc
+}
+
+// MCPProvisionFunc renders a provider's MCP config and returns the extra CLI
+// args + env needed to load it. See catalog.AttachMemoryMCP.
+type MCPProvisionFunc func(providerID, baseDir, runCwd, scopeKey, home string) (args []string, env map[string]string, err error)
 
 // Response is what every Worker returns on success. Latency +
 // token counts are best-effort: AgentWorker can't always get

--- a/internal/roundtable/chat.go
+++ b/internal/roundtable/chat.go
@@ -38,8 +38,9 @@ type Service struct {
 	store    *Store
 	registry *worker.Registry
 	bus      *eventbus.Hub
-	context  ContextSource   // optional
-	sessions SessionLauncher // optional — Handoff 503s without it
+	context  ContextSource           // optional
+	sessions SessionLauncher         // optional — Handoff 503s without it
+	mcp      worker.MCPProvisionFunc // optional — attaches read-only opendray-memory to members
 	log      *slog.Logger
 }
 
@@ -59,6 +60,17 @@ func NewService(store *Store, reg *worker.Registry, bus *eventbus.Hub, log *slog
 // WithContextSource enables reply-prompt enrichment with relevant memories.
 func (s *Service) WithContextSource(c ContextSource) *Service {
 	s.context = c
+	return s
+}
+
+// WithMemoryMCP gives every member live, read-only access to the
+// opendray-memory MCP tools (memory_search / project_search / doc_read / …)
+// scoped to the table's cwd, so they can pull real facts on demand instead
+// of only seeing the pre-injected context snapshot. fn is
+// catalog.AttachMemoryMCP bound to the memory config + read-only=true. When
+// unset, members run tool-less as before.
+func (s *Service) WithMemoryMCP(fn worker.MCPProvisionFunc) *Service {
+	s.mcp = fn
 	return s
 }
 
@@ -129,7 +141,7 @@ func (s *Service) runReplies(id string, providers []string) {
 			if !ok {
 				continue
 			}
-			system := chatSystemPrompt(rt, seat)
+			system := chatSystemPrompt(rt, seat, s.mcp != nil && strings.TrimSpace(rt.Cwd) != "")
 			// Re-read the thread each turn so a member sees earlier replies
 			// (within this round and prior rounds).
 			rt, err = s.store.Get(ctx, id)
@@ -142,7 +154,7 @@ func (s *Service) runReplies(id string, providers []string) {
 				s.memberFailed(ctx, id, seat, err)
 				continue
 			}
-			resp, err := s.invokeSeat(ctx, seat, system, user, replyMaxTokens)
+			resp, err := s.invokeSeat(ctx, seat, system, user, replyMaxTokens, rt.Cwd)
 			if err != nil {
 				s.memberFailed(ctx, id, seat, err)
 				continue
@@ -300,7 +312,7 @@ func (s *Service) runSummary(id string, seat Seat) {
 		s.memberFailed(ctx, id, seat, err)
 		return
 	}
-	resp, err := s.invokeSeat(ctx, seat, summarySystemPrompt(rt), user, summaryMaxTokens)
+	resp, err := s.invokeSeat(ctx, seat, summarySystemPrompt(rt), user, summaryMaxTokens, rt.Cwd)
 	if err != nil {
 		s.memberFailed(ctx, id, seat, err)
 		return
@@ -319,7 +331,20 @@ func (s *Service) runSummary(id string, seat Seat) {
 // registry's per-call override path. TaskCuration is reused purely as the
 // metrics label (round table needs no memory_workers row of its own — see
 // ROLLBACK.md).
-func (s *Service) invokeSeat(ctx context.Context, seat Seat, system, user string, maxTokens int) (string, error) {
+func (s *Service) invokeSeat(ctx context.Context, seat Seat, system, user string, maxTokens int, cwd string) (string, error) {
+	req := worker.Request{
+		Task:         worker.TaskCuration,
+		SystemPrompt: system,
+		UserInput:    user,
+		MaxTokens:    maxTokens,
+		Timeout:      callTimeout,
+	}
+	// Attach read-only opendray-memory tools when configured and the table is
+	// bound to a project cwd (the memory scope). A table with no cwd, or a
+	// gateway without memory auto-attach, runs the member tool-less.
+	if s.mcp != nil && strings.TrimSpace(cwd) != "" {
+		req.MCP = &worker.MCPAttach{Cwd: cwd, Provision: s.mcp}
+	}
 	resp, err := s.registry.RunWith(ctx, worker.Config{
 		Task:       worker.TaskCuration,
 		Kind:       worker.WorkerAgent,
@@ -327,13 +352,7 @@ func (s *Service) invokeSeat(ctx context.Context, seat Seat, system, user string
 		Model:      seat.Model,
 		AccountID:  seat.AccountID,
 		Enabled:    true,
-	}, worker.Request{
-		Task:         worker.TaskCuration,
-		SystemPrompt: system,
-		UserInput:    user,
-		MaxTokens:    maxTokens,
-		Timeout:      callTimeout,
-	})
+	}, req)
 	if err != nil {
 		return "", err
 	}

--- a/internal/roundtable/plan.go
+++ b/internal/roundtable/plan.go
@@ -56,7 +56,7 @@ func (s *Service) runDraftPlan(id string, drafter Seat) {
 		s.memberFailed(ctx, id, drafter, err)
 		return
 	}
-	resp, err := s.invokeSeat(ctx, drafter, planSystemPrompt(rt), transcript, summaryMaxTokens)
+	resp, err := s.invokeSeat(ctx, drafter, planSystemPrompt(rt), transcript, summaryMaxTokens, rt.Cwd)
 	if err != nil {
 		s.memberFailed(ctx, id, drafter, err)
 		return

--- a/internal/roundtable/prompts.go
+++ b/internal/roundtable/prompts.go
@@ -30,7 +30,10 @@ func vendorLabel(provider string) string {
 
 // chatSystemPrompt is the persona for one member's reply turn. self is the
 // seat about to speak (its Persona, if set, becomes an extra role instruction).
-func chatSystemPrompt(rt RoundTable, self Seat) string {
+// hasMemoryTools tells the member whether the read-only opendray-memory MCP
+// tools are attached this turn, which flips the tool-use instruction from
+// "don't" to "ground your claims with them".
+func chatSystemPrompt(rt RoundTable, self Seat, hasMemoryTools bool) string {
 	selfProvider := self.Provider
 	var others []string
 	for _, seat := range rt.Seats {
@@ -73,7 +76,15 @@ func chatSystemPrompt(rt RoundTable, self Seat) string {
 	}
 	b.WriteString("- To bring another member into the discussion, @mention them (e.g. " + otherList + "); they'll get a turn to reply.\n")
 	b.WriteString("- Do NOT speak for the other members or the Operator. Do NOT prefix your message with your own name.\n")
-	b.WriteString("- Do NOT use tools, browse, or read files — answer from the conversation and any context provided.")
+	if hasMemoryTools {
+		b.WriteString("- You have READ-ONLY access to the team's shared opendray-memory through MCP tools " +
+			"(memory_search, project_search, doc_read, memory_list, and the project goal/plan getters). " +
+			"Before asserting anything about our setup, our past decisions, or our project docs, CALL these " +
+			"tools to ground it in the real store instead of guessing from the conversation. You cannot write " +
+			"memory — these are read-only, so use them freely to check facts, then answer in your own words.")
+	} else {
+		b.WriteString("- Do NOT use tools, browse, or read files — answer from the conversation and any context provided.")
+	}
 	return b.String()
 }
 

--- a/internal/roundtable/prompts_test.go
+++ b/internal/roundtable/prompts_test.go
@@ -35,13 +35,13 @@ func TestChatSystemPrompt_FramingAndPersona(t *testing.T) {
 	}
 
 	// Framing appears in every member's prompt.
-	claudePrompt := chatSystemPrompt(rt, rt.Seats[0])
+	claudePrompt := chatSystemPrompt(rt, rt.Seats[0], false)
 	if !strings.Contains(claudePrompt, "session tokens") {
 		t.Errorf("framing must be injected for all members; got:\n%s", claudePrompt)
 	}
 
 	// A seat's persona is injected as a directive lens for that seat.
-	codexPrompt := chatSystemPrompt(rt, rt.Seats[1])
+	codexPrompt := chatSystemPrompt(rt, rt.Seats[1], false)
 	if !strings.Contains(codexPrompt, "only hunt security holes") {
 		t.Errorf("persona must be injected for the seat; got:\n%s", codexPrompt)
 	}
@@ -51,8 +51,30 @@ func TestChatSystemPrompt_FramingAndPersona(t *testing.T) {
 	}
 
 	// No framing → no framing header.
-	noFraming := chatSystemPrompt(RoundTable{Seats: rt.Seats}, rt.Seats[0])
+	noFraming := chatSystemPrompt(RoundTable{Seats: rt.Seats}, rt.Seats[0], false)
 	if strings.Contains(noFraming, "DISCUSSION FRAMING") {
 		t.Errorf("empty framing must not emit a framing header")
+	}
+}
+
+// The tool-use instruction flips with hasMemoryTools: off tells members not to
+// use tools; on tells them they have read-only opendray-memory to ground claims.
+func TestChatSystemPrompt_MemoryToolsInstruction(t *testing.T) {
+	rt := RoundTable{Topic: "kb", Seats: []Seat{{Provider: "claude"}}}
+
+	off := chatSystemPrompt(rt, rt.Seats[0], false)
+	if !strings.Contains(off, "Do NOT use tools") {
+		t.Errorf("tool-less member must be told not to use tools; got:\n%s", off)
+	}
+	if strings.Contains(off, "memory_search") {
+		t.Errorf("tool-less member prompt must not advertise memory tools")
+	}
+
+	on := chatSystemPrompt(rt, rt.Seats[0], true)
+	if !strings.Contains(on, "memory_search") || !strings.Contains(on, "read-only") {
+		t.Errorf("tool-enabled member must be told about the read-only memory tools; got:\n%s", on)
+	}
+	if strings.Contains(on, "Do NOT use tools") {
+		t.Errorf("tool-enabled member must not carry the no-tools instruction")
 	}
 }

--- a/internal/session/terminal_capabilities_test.go
+++ b/internal/session/terminal_capabilities_test.go
@@ -140,3 +140,18 @@ func TestStripTerminalCapabilityResponses_MalformedSequencePassesThrough(t *test
 		t.Errorf("malformed bytes stripped: got %q want %q", got, in)
 	}
 }
+
+func TestStripTerminalCapabilityResponses_PreservesBracketedPaste(t *testing.T) {
+	// A programmatically-injected seed (round-table handoff / cortex
+	// escalation) is wrapped in bracketed-paste markers so a CLI treats
+	// the multi-line block as one pasted message. Those markers end in
+	// '~', not the c/R/n terminators this filter targets, so they MUST
+	// survive intact — otherwise the CLI never enters paste mode and
+	// embedded newlines submit line by line again.
+	seed := "line one\nline two\n\nfinal paragraph"
+	in := []byte("\x1b[200~" + seed + "\x1b[201~")
+	got := stripTerminalCapabilityResponses(in)
+	if !bytes.Equal(got, in) {
+		t.Errorf("bracketed-paste seed mutated by stripper:\n got %q\nwant %q", got, in)
+	}
+}


### PR DESCRIPTION
## Why

Round Table members answered purely from the conversation and guessed at our
setup, past decisions, and project docs. This gives every member live,
**read-only** access to the shared opendray-memory so they ground claims in
the real store instead of hallucinating.

## What

- **Read-only mcp-memory mode** (`OPENDRAY_MEMORY_READONLY=1`): `tools/list`
  exposes only the search/read tools and dispatch refuses every write by name
  (facts, project docs, journal, skill_distill; KB admin writes already gated).
  The **server** is the boundary — safe even when the member CLI runs with
  tool permissions fully open.
- **`catalog.AttachMemoryMCP`** — one per-provider dynamic injection point that
  renders the opendray-memory server config for any spawn (interactive session,
  headless worker, future agents) with a `readOnly` flag. Handles per-provider
  quirks (antigravity scope-from-cwd on its shared `mcp_config.json`, codex home
  mirroring + scratch-cwd trust).
- **memory/worker MCP attach** (`MCPAttach` / `MCPProvisionFunc`): render config,
  apply args+env, add per-provider tool-approval flags, resolve effective HOME.
- **`roundtable.Service.WithMemoryMCP`** wires it for members, scoped to the
  table cwd. A table with no cwd, or a gateway without memory auto-attach, runs
  members tool-less. The member system prompt flips accordingly ("ground your
  claims by calling these tools" vs "don't use tools").

## Testing

- [x] `go build ./...`
- [x] `go test -race` on affected packages (roundtable, memory/worker,
      cmd/opendray, session) — green. New unit tests cover the read-only tool
      gate, the attach renderer, the worker MCP path, and the prompt switch.
- [ ] CI

Follows up the Round Table feature — cross-vendor group chat now reads shared
memory on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)