### PR TITLE
fix(web/terminal): scroll grok/opencode with the wheel and touch swipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The mouse wheel (and touch swipe) now scrolls grok and opencode
+  sessions.** These TUIs enable mouse tracking — so xterm hands them the
+  wheel instead of scrolling its own viewport — but then ignore wheel events,
+  scrolling only on arrow keys. opendray's wheel→arrow fallback was gated
+  behind "app hasn't grabbed the mouse", so it never ran for them and the
+  wheel did nothing (verified live: grok sets `?1000/1002/1003/1006` at
+  startup yet does nothing on button-64/65). The web terminal now recognises
+  these wheel-ignoring providers and sends arrow keys for both wheel and
+  one-finger touch scroll, scoped by `providerId` so Claude/Codex/Antigravity
+  (which genuinely consume the wheel) are untouched.
+
 ## [v2.12.2] — 2026-07-23
 
 Round Table members gain live, grounded memory, the mobile session screen

--- a/app/web/src/components/sessions/Terminal.tsx
+++ b/app/web/src/components/sessions/Terminal.tsx
@@ -22,6 +22,13 @@ import { AttachmentTray, type AttachmentItem } from './AttachmentTray'
 
 interface TerminalProps {
   sessionId: string
+  /**
+   * The session's provider (e.g. 'grok', 'opencode'). Used to work around
+   * TUIs that grab the mouse but ignore wheel events — they scroll only on
+   * arrow keys, so the wheel/touch handlers send arrows instead of an SGR
+   * wheel report for them.
+   */
+  providerId?: string
 }
 
 export interface TerminalHandle {
@@ -95,7 +102,7 @@ function buildTheme(applied: 'light' | 'dark') {
 }
 
 export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Terminal(
-  { sessionId },
+  { sessionId, providerId },
   ref,
 ) {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -258,17 +265,30 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     let touchActive = false
     let lastTouchY = 0
     let touchAccum = 0
+    const sendKeys = (seq: string) => {
+      const enc = new TextEncoder().encode(seq)
+      ws.send(
+        enc.buffer.slice(enc.byteOffset, enc.byteOffset + enc.byteLength) as ArrayBuffer,
+      )
+    }
+    // grok / opencode enable mouse tracking (so xterm hands them the wheel
+    // instead of scrolling its own viewport) but their TUIs then IGNORE wheel
+    // events — they scroll only on arrow keys. For those providers, send an
+    // arrow instead of an SGR wheel report; every other provider keeps the
+    // native wheel path. Verified live: grok sets ?1000/1002/1003/1006 at
+    // startup yet does nothing on button-64/65.
+    const wheelIgnorer = providerId === 'grok' || providerId === 'opencode'
     const sendWheel = (up: boolean) => {
+      if (wheelIgnorer) {
+        sendKeys(up ? '\x1b[A' : '\x1b[B')
+        return
+      }
       // SGR mouse: button 64 = wheel up, 65 = wheel down; press ('M').
       // Report the pointer at screen centre so the app treats it as a
       // scroll over its content region.
       const col = Math.max(1, Math.floor(term.cols / 2))
       const row = Math.max(1, Math.floor(term.rows / 2))
-      const seq = `\x1b[<${up ? 64 : 65};${col};${row}M`
-      const enc = new TextEncoder().encode(seq)
-      ws.send(
-        enc.buffer.slice(enc.byteOffset, enc.byteOffset + enc.byteLength) as ArrayBuffer,
-      )
+      sendKeys(`\x1b[<${up ? 64 : 65};${col};${row}M`)
     }
     const onTouchStart = (e: TouchEvent) => {
       if (e.touches.length !== 1 || term.modes.mouseTrackingMode === 'none') {
@@ -313,17 +333,15 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     const WHEEL_LINES = 3
     const onWheel = (e: WheelEvent) => {
       if (term.buffer.active.type !== 'alternate') return
-      if (term.modes.mouseTrackingMode !== 'none') return
+      // Normally only translate when the app has NOT grabbed the mouse (apps
+      // that grabbed it receive the wheel as SGR and scroll themselves). The
+      // wheelIgnorer providers grabbed it but drop the wheel, so translate for
+      // them too — they get a harmless duplicate SGR wheel from xterm plus the
+      // arrows below, which they honour.
+      if (term.modes.mouseTrackingMode !== 'none' && !wheelIgnorer) return
       if (e.deltaY === 0) return
       e.preventDefault()
-      const seq = (e.deltaY < 0 ? '\x1b[A' : '\x1b[B').repeat(WHEEL_LINES)
-      const enc = new TextEncoder().encode(seq)
-      ws.send(
-        enc.buffer.slice(
-          enc.byteOffset,
-          enc.byteOffset + enc.byteLength,
-        ) as ArrayBuffer,
-      )
+      sendKeys((e.deltaY < 0 ? '\x1b[A' : '\x1b[B').repeat(WHEEL_LINES))
     }
 
     touchHost?.addEventListener('touchstart', onTouchStart, { passive: true })
@@ -395,7 +413,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       fitRef.current = null
       wsRef.current = null
     }
-  }, [sessionId, token])
+  }, [sessionId, token, providerId])
 
   // Clipboard + drag-and-drop image attach. Browsers don't expose
   // clipboard images through xterm's default paste hook (which only

--- a/app/web/src/pages/Sessions.tsx
+++ b/app/web/src/pages/Sessions.tsx
@@ -331,6 +331,7 @@ export function SessionsPage() {
                   // pump goroutine, so we must reconnect from scratch.
                   key={`${currentId}:${currentSession?.pid ?? 0}`}
                   sessionId={currentId}
+                  providerId={currentSession?.provider_id}
                 />
               )}
             </div>


### PR DESCRIPTION
## Symptom
The mouse wheel and one-finger touch swipe do nothing in **grok** and **opencode** sessions — you can't scroll the conversation. Claude/Codex/Antigravity scroll fine.

## Root cause (verified live)
Captured grok's startup in a controlled PTY: it enables full mouse tracking — `?1000` (click), `?1002` (drag), `?1003` (any-motion), `?1006` (SGR). So xterm.js hands grok the wheel as SGR events instead of scrolling its own viewport — **but grok's TUI ignores wheel events** (it only scrolls on arrow keys).

opendray's wheel→arrow-key fallback for alt-screen TUIs was gated behind `term.modes.mouseTrackingMode === 'none'` — i.e. only for apps that *didn't* grab the mouse. grok/opencode grabbed it but drop the wheel, so the fallback never ran and the wheel landed in a dead zone. Same for the touch-swipe path, which translated swipes into SGR wheel reports grok ignores.

## Fix
Thread the session's `providerId` into `Terminal`, and for wheel-ignoring providers (`grok`, `opencode`) send **arrow keys** instead of an SGR wheel report — from both the wheel handler and the touch-swipe handler. Scoped by provider so Claude/Codex/Antigravity (which consume the wheel natively) are untouched. A shared `sendKeys` helper replaces the duplicated encode/`ws.send` blocks.

## Testing
No web component test harness exists in `app/web`, so this is validated by the Frontend (web) CI build/typecheck plus the live mode-capture that confirmed the mechanism. grok's mouse-mode set was observed directly; opencode is included on the same reported symptom (safe either way — if it doesn't grab the mouse, the existing path already handled it and arrows are harmless; the user reports it can't scroll, same as grok).

Ships in a future 2.12.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)