### PR TITLE
feat(cli): systemctl-style health dashboard for `opendray status`

### DIFF
--- a/cmd/opendray/service.go
+++ b/cmd/opendray/service.go
@@ -36,7 +36,33 @@ const (
 func runStart(args []string) int   { return runServiceAction("start", args) }
 func runStop(args []string) int    { return runServiceAction("stop", args) }
 func runRestart(args []string) int { return runServiceAction("restart", args) }
-func runStatus(args []string) int  { return runServiceAction("status", args) }
+
+// runStatus renders a systemctl-style health summary by default; `--raw`
+// falls back to the native `launchctl print` / `systemctl status` dump.
+func runStatus(args []string) int {
+	fs := flag.NewFlagSet("status", flag.ExitOnError)
+	system := fs.Bool("system", false, "macOS only: target the system LaunchDaemon instead of the user LaunchAgent")
+	raw := fs.Bool("raw", false, "print the raw launchctl/systemctl output instead of the summary")
+	_ = fs.Parse(args)
+
+	if *raw {
+		return statusRaw(*system)
+	}
+	return renderStatusDashboard(*system)
+}
+
+// statusRaw shows the unfiltered platform-native service status.
+func statusRaw(system bool) int {
+	switch runtime.GOOS {
+	case "linux":
+		return linuxService("status")
+	case "darwin":
+		return macService("status", system)
+	default:
+		fmt.Fprintf(os.Stderr, "`opendray status` is not supported on %s.\n", runtime.GOOS)
+		return 1
+	}
+}
 
 func runServiceAction(action string, args []string) int {
 	fs := flag.NewFlagSet(action, flag.ExitOnError)

--- a/cmd/opendray/status.go
+++ b/cmd/opendray/status.go
@@ -1,0 +1,421 @@
+// `opendray status` — a systemctl-style health summary.
+//
+// The platform service managers speak in their own dialects: macOS'
+// `launchctl print` dumps ~80 lines of launchd internals, and `systemctl
+// status` is readable but still process-centric. Neither answers the
+// question an operator actually asks — "is opendray healthy right now?" —
+// because the process being alive says nothing about whether the gateway is
+// serving HTTP or can reach its database.
+//
+// This renders a compact checklist that fuses three sources:
+//
+//	launchd / systemd   → is the process up, pid, restart count, last exit
+//	GET /health         → version, uptime, DB reachability (the REAL liveness)
+//	config + TCC checks  → where config lives, privacy-folder gotchas
+//
+// `opendray status --raw` falls back to the native `launchctl print` /
+// `systemctl status` for when the low-level detail is actually wanted.
+//
+// Exit code mirrors severity so scripts can gate on it (like systemctl):
+// 0 = all green, 1 = degraded/warnings, 3 = not running / unreachable.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/opendray/opendray-v2/internal/config"
+	"github.com/opendray/opendray-v2/internal/version"
+)
+
+// checkState is the severity of a single dashboard row.
+type checkState int
+
+const (
+	stateOK checkState = iota
+	stateWarn
+	stateFail
+	stateUnknown
+)
+
+func (s checkState) icon() string {
+	switch s {
+	case stateOK:
+		return "✓"
+	case stateWarn:
+		return "⚠"
+	case stateFail:
+		return "✗"
+	default:
+		return "·"
+	}
+}
+
+// exitCode maps the worst row severity to a process exit code, matching
+// systemd's convention (3 = not running).
+func (s checkState) exitCode() int {
+	switch s {
+	case stateWarn:
+		return 1
+	case stateFail:
+		return 3
+	default:
+		return 0
+	}
+}
+
+// procInfo is the platform-agnostic view of the service process, distilled
+// from `launchctl print` (macOS) or `systemctl show` (Linux).
+type procInfo struct {
+	found    bool // the unit is loaded/bootstrapped at all
+	running  bool
+	pid      int
+	restarts int
+	lastExit int
+}
+
+// healthInfo is the parsed GET /health response; reachable=false means the
+// gateway did not answer HTTP (process may still exist but isn't serving).
+type healthInfo struct {
+	reachable bool
+	status    string
+	version   string
+	commit    string
+	uptime    time.Duration
+	dbOK      bool
+}
+
+// ── rendering ──────────────────────────────────────────────────────
+
+type statusRow struct {
+	label string
+	state checkState
+	text  string
+}
+
+func renderStatusDashboard(system bool) int {
+	home, _ := os.UserHomeDir()
+	cfgPath := activeConfigPath()
+
+	listen := "127.0.0.1:8770"
+	if cfgPath != "" {
+		if cfg, err := config.Load(cfgPath); err == nil && strings.TrimSpace(cfg.Listen) != "" {
+			listen = cfg.Listen
+		}
+	}
+
+	proc := gatherProc(system)
+	health := probeHealth(listen)
+
+	rows := buildStatusRows(proc, health, listen, cfgPath, home)
+
+	// Header: prefer the running gateway's self-reported version, fall back
+	// to this CLI binary's build info.
+	ver, commit := version.Version, version.Commit
+	if health.reachable && health.version != "" {
+		ver, commit = health.version, health.commit
+	}
+	fmt.Printf("opendray  %s (%s)\n", ver, shortCommit(commit))
+	fmt.Println(strings.Repeat("─", 42))
+
+	worst := stateOK
+	for _, r := range rows {
+		fmt.Printf("%-10s %s %s\n", r.label, r.state.icon(), r.text)
+		if r.state == stateWarn && worst < stateWarn {
+			worst = stateWarn
+		}
+		if r.state == stateFail {
+			worst = stateFail
+		}
+	}
+
+	for _, h := range statusHints(proc, health, cfgPath, home) {
+		fmt.Println()
+		fmt.Println(h)
+	}
+
+	return worst.exitCode()
+}
+
+// buildStatusRows is the pure heart of the dashboard: given the gathered
+// facts it decides each row's severity and text. Kept side-effect-free so
+// the severity logic is unit-testable without launchd/HTTP.
+func buildStatusRows(proc procInfo, health healthInfo, listen, cfgPath, home string) []statusRow {
+	var rows []statusRow
+
+	// Process.
+	switch {
+	case !proc.found:
+		rows = append(rows, statusRow{"Process", stateFail, "not loaded"})
+	case proc.running:
+		rows = append(rows, statusRow{"Process", stateOK, fmt.Sprintf("running   pid %d", proc.pid)})
+	default:
+		rows = append(rows, statusRow{"Process", stateFail, "stopped"})
+	}
+
+	// Health (the real liveness signal).
+	switch {
+	case !health.reachable:
+		rows = append(rows, statusRow{"Health", stateFail, "unreachable (no HTTP response)"})
+	case health.status == "ok":
+		rows = append(rows, statusRow{"Health", stateOK, "ok        up " + humanDuration(health.uptime)})
+	default:
+		label := health.status
+		if label == "" {
+			label = "degraded"
+		}
+		rows = append(rows, statusRow{"Health", stateWarn, label + "   up " + humanDuration(health.uptime)})
+	}
+
+	// Database.
+	switch {
+	case !health.reachable:
+		rows = append(rows, statusRow{"Database", stateUnknown, "— (gateway unreachable)"})
+	case health.dbOK:
+		rows = append(rows, statusRow{"Database", stateOK, "reachable"})
+	default:
+		rows = append(rows, statusRow{"Database", stateFail, "unreachable"})
+	}
+
+	// Listen.
+	switch {
+	case health.reachable:
+		rows = append(rows, statusRow{"Listen", stateOK, listen})
+	case proc.running:
+		rows = append(rows, statusRow{"Listen", stateWarn, listen + " (not answering)"})
+	default:
+		rows = append(rows, statusRow{"Listen", stateUnknown, listen})
+	}
+
+	// Restarts — only meaningful once the unit is loaded.
+	if proc.found {
+		text := strconv.Itoa(proc.restarts)
+		st := stateOK
+		if proc.lastExit != 0 {
+			st = stateWarn
+			text += fmt.Sprintf("  (last exit code %d)", proc.lastExit)
+		}
+		rows = append(rows, statusRow{"Restarts", st, text})
+	}
+
+	// Config.
+	switch {
+	case cfgPath == "":
+		rows = append(rows, statusRow{"Config", stateWarn, "(none found)"})
+	case isTCCProtectedPath(home, cfgPath):
+		rows = append(rows, statusRow{"Config", stateWarn, tildeAbbrev(home, cfgPath) + " (privacy-gated folder)"})
+	default:
+		rows = append(rows, statusRow{"Config", stateOK, tildeAbbrev(home, cfgPath)})
+	}
+
+	return rows
+}
+
+// statusHints returns actionable follow-up lines for anything not green.
+func statusHints(proc procInfo, health healthInfo, cfgPath, home string) []string {
+	var hints []string
+	errLog := "~/.opendray/logs/opendray.err"
+
+	if !proc.running || !health.reachable {
+		hints = append(hints, "Hint: service not fully up — see `opendray status --raw` for launchd/systemd\n"+
+			"      detail, and check "+errLog)
+	} else if proc.lastExit != 0 {
+		hints = append(hints, fmt.Sprintf("Hint: last exit was non-zero (code %d) — the service recovered, but\n"+
+			"      check %s if restarts keep climbing.", proc.lastExit, errLog))
+	}
+
+	if cfgPath != "" && isTCCProtectedPath(home, cfgPath) {
+		hints = append(hints, "Hint: config sits in a macOS privacy-gated folder — run `opendray doctor`\n"+
+			"      or move it under ~/.opendray/ so startup never blocks on a prompt.")
+	}
+	return hints
+}
+
+// ── gathering (side-effecting) ─────────────────────────────────────
+
+func gatherProc(system bool) procInfo {
+	switch runtime.GOOS {
+	case "darwin":
+		out, _ := exec.Command("launchctl", "print", launchdTarget(system)).CombinedOutput()
+		return parseLaunchctlPrint(string(out))
+	case "linux":
+		out, _ := exec.Command("systemctl", "show", systemdUnitName,
+			"--property=LoadState,ActiveState,SubState,MainPID,NRestarts,ExecMainStatus").CombinedOutput()
+		return parseSystemctlShow(string(out))
+	default:
+		return procInfo{}
+	}
+}
+
+func probeHealth(listen string) healthInfo {
+	url := normalizeHealthURL(listen)
+	if url == "" {
+		return healthInfo{}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return healthInfo{}
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return healthInfo{}
+	}
+	defer resp.Body.Close()
+
+	// The gateway answers /health with 200 (ok) or 503 (degraded). Anything
+	// else means we hit something that isn't our health endpoint (a 404, a
+	// stray proxy) — not a healthy gateway.
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusServiceUnavailable {
+		return healthInfo{}
+	}
+
+	var body struct {
+		Status    string `json:"status"`
+		Version   string `json:"version"`
+		Commit    string `json:"commit"`
+		UptimeSec int64  `json:"uptime_s"`
+		DBOK      bool   `json:"db_ok"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return healthInfo{}
+	}
+	return healthInfo{
+		reachable: true,
+		status:    body.Status,
+		version:   body.Version,
+		commit:    body.Commit,
+		uptime:    time.Duration(body.UptimeSec) * time.Second,
+		dbOK:      body.DBOK,
+	}
+}
+
+func launchdTarget(system bool) string {
+	if system {
+		return "system/" + launchdLabel
+	}
+	return fmt.Sprintf("gui/%d/%s", os.Getuid(), launchdLabel)
+}
+
+// ── pure helpers (unit-tested) ─────────────────────────────────────
+
+// parseLaunchctlPrint distills a `launchctl print <target>` dump into a
+// procInfo. The dump is `key = value` lines at varying indentation; we only
+// care about a handful of top-level fields.
+func parseLaunchctlPrint(out string) procInfo {
+	var p procInfo
+	sawState := false
+	for _, ln := range strings.Split(out, "\n") {
+		k, v, ok := strings.Cut(strings.TrimSpace(ln), " = ")
+		if !ok {
+			continue
+		}
+		k, v = strings.TrimSpace(k), strings.TrimSpace(v)
+		switch k {
+		case "state":
+			// The dump repeats `state = …` for nested coalitions; only the
+			// first (top-level) line is the service's own state.
+			if !sawState {
+				sawState = true
+				p.running = strings.HasPrefix(v, "running")
+			}
+		case "pid":
+			p.pid, _ = strconv.Atoi(v)
+		case "runs":
+			p.restarts, _ = strconv.Atoi(v)
+		case "last exit code":
+			p.lastExit, _ = strconv.Atoi(v)
+		}
+	}
+	p.found = sawState || p.pid > 0
+	return p
+}
+
+// parseSystemctlShow distills `systemctl show <unit> --property=...`
+// key=value output into a procInfo.
+func parseSystemctlShow(out string) procInfo {
+	m := map[string]string{}
+	for _, ln := range strings.Split(out, "\n") {
+		if k, v, ok := strings.Cut(strings.TrimSpace(ln), "="); ok {
+			m[k] = v
+		}
+	}
+	p := procInfo{
+		found:   m["LoadState"] == "loaded",
+		running: m["ActiveState"] == "active" && m["SubState"] == "running",
+	}
+	p.pid, _ = strconv.Atoi(m["MainPID"])
+	p.restarts, _ = strconv.Atoi(m["NRestarts"])
+	p.lastExit, _ = strconv.Atoi(m["ExecMainStatus"])
+	return p
+}
+
+// normalizeHealthURL turns a listen address into the /health URL to probe.
+// A wildcard/empty host is dialled on the loopback interface.
+func normalizeHealthURL(listen string) string {
+	listen = strings.TrimSpace(listen)
+	if listen == "" {
+		return ""
+	}
+	host, port, err := net.SplitHostPort(listen)
+	if err != nil {
+		return ""
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	return "http://" + net.JoinHostPort(host, port) + "/api/v1/health"
+}
+
+// humanDuration renders a duration the way systemctl/uptime do: the two most
+// significant units, e.g. "4h21m", "3d2h", "45s".
+func humanDuration(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	sec := int64(d.Seconds())
+	days := sec / 86400
+	hrs := (sec % 86400) / 3600
+	mins := (sec % 3600) / 60
+	secs := sec % 60
+	switch {
+	case days > 0:
+		return fmt.Sprintf("%dd%dh", days, hrs)
+	case hrs > 0:
+		return fmt.Sprintf("%dh%dm", hrs, mins)
+	case mins > 0:
+		return fmt.Sprintf("%dm%ds", mins, secs)
+	default:
+		return fmt.Sprintf("%ds", secs)
+	}
+}
+
+// shortCommit trims a git SHA to 7 chars for display.
+func shortCommit(c string) string {
+	if len(c) > 7 {
+		return c[:7]
+	}
+	if c == "" {
+		return "unknown"
+	}
+	return c
+}
+
+// tildeAbbrev replaces a leading home dir with "~" for compact display.
+func tildeAbbrev(home, p string) string {
+	if home != "" && (p == home || strings.HasPrefix(p, home+string(filepath.Separator))) {
+		return "~" + p[len(home):]
+	}
+	return p
+}

--- a/cmd/opendray/status_test.go
+++ b/cmd/opendray/status_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseLaunchctlPrint(t *testing.T) {
+	// Real dumps repeat `state = active` for nested coalitions after the
+	// top-level `state = running`; the parser must not let those override it.
+	running := `gui/501/com.opendray.opendray = {
+	active count = 1
+	state = running
+	program = /Users/linivek/.opendray/bin/opendray
+	pid = 46781
+	runs = 201
+	last exit code = 1
+	resource coalition = {
+		state = active
+	}
+	jetsam coalition = {
+		state = active
+	}
+}`
+	got := parseLaunchctlPrint(running)
+	if !got.found || !got.running {
+		t.Fatalf("expected found+running, got %+v", got)
+	}
+	if got.pid != 46781 || got.restarts != 201 || got.lastExit != 1 {
+		t.Fatalf("field mismatch: %+v", got)
+	}
+
+	// Not-loaded: launchctl prints an error, no fields.
+	empty := parseLaunchctlPrint("Could not find service \"com.opendray.opendray\"")
+	if empty.found || empty.running {
+		t.Fatalf("expected not-found, got %+v", empty)
+	}
+
+	// Loaded but stopped: state present, no pid line.
+	stopped := parseLaunchctlPrint("state = not running\nruns = 3\nlast exit code = 0")
+	if !stopped.found {
+		t.Fatalf("expected found (state seen), got %+v", stopped)
+	}
+	if stopped.running {
+		t.Fatalf("expected stopped, got %+v", stopped)
+	}
+}
+
+func TestParseSystemctlShow(t *testing.T) {
+	out := "LoadState=loaded\nActiveState=active\nSubState=running\nMainPID=1234\nNRestarts=2\nExecMainStatus=0"
+	got := parseSystemctlShow(out)
+	if !got.found || !got.running || got.pid != 1234 || got.restarts != 2 || got.lastExit != 0 {
+		t.Fatalf("mismatch: %+v", got)
+	}
+
+	dead := parseSystemctlShow("LoadState=loaded\nActiveState=failed\nSubState=failed\nMainPID=0\nNRestarts=5\nExecMainStatus=1")
+	if !dead.found || dead.running || dead.lastExit != 1 {
+		t.Fatalf("expected loaded+not-running+exit1, got %+v", dead)
+	}
+
+	notLoaded := parseSystemctlShow("LoadState=not-found\nActiveState=inactive")
+	if notLoaded.found {
+		t.Fatalf("expected not-found, got %+v", notLoaded)
+	}
+}
+
+func TestNormalizeHealthURL(t *testing.T) {
+	cases := map[string]string{
+		"127.0.0.1:8770": "http://127.0.0.1:8770/api/v1/health",
+		"0.0.0.0:8770":   "http://127.0.0.1:8770/api/v1/health",
+		":8770":          "http://127.0.0.1:8770/api/v1/health",
+		"192.168.3.1:80": "http://192.168.3.1:80/api/v1/health",
+		"":               "",
+		"garbage":        "",
+	}
+	for in, want := range cases {
+		if got := normalizeHealthURL(in); got != want {
+			t.Errorf("normalizeHealthURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestHumanDuration(t *testing.T) {
+	cases := map[time.Duration]string{
+		45 * time.Second:             "45s",
+		90 * time.Second:             "1m30s",
+		4*time.Hour + 21*time.Minute: "4h21m",
+		3*24*time.Hour + 2*time.Hour: "3d2h",
+		-5 * time.Second:             "0s",
+	}
+	for in, want := range cases {
+		if got := humanDuration(in); got != want {
+			t.Errorf("humanDuration(%v) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBuildStatusRowsSeverity(t *testing.T) {
+	home := "/Users/x"
+
+	// Healthy: process running, health ok, db ok.
+	healthy := buildStatusRows(
+		procInfo{found: true, running: true, pid: 100, restarts: 2, lastExit: 0},
+		healthInfo{reachable: true, status: "ok", dbOK: true, uptime: time.Hour},
+		"127.0.0.1:8770", "/Users/x/.opendray/config.toml", home,
+	)
+	for _, r := range healthy {
+		if r.state != stateOK {
+			t.Errorf("healthy row %q not OK: %+v", r.label, r)
+		}
+	}
+
+	// Non-zero last exit → Restarts row warns.
+	warned := buildStatusRows(
+		procInfo{found: true, running: true, pid: 100, restarts: 201, lastExit: 1},
+		healthInfo{reachable: true, status: "ok", dbOK: true},
+		"127.0.0.1:8770", "/Users/x/.opendray/config.toml", home,
+	)
+	if got := rowState(warned, "Restarts"); got != stateWarn {
+		t.Errorf("Restarts row = %v, want warn", got)
+	}
+
+	// Gateway unreachable → Health fails, DB unknown.
+	down := buildStatusRows(
+		procInfo{found: true, running: true, pid: 100},
+		healthInfo{reachable: false},
+		"127.0.0.1:8770", "/Users/x/.opendray/config.toml", home,
+	)
+	if got := rowState(down, "Health"); got != stateFail {
+		t.Errorf("Health row = %v, want fail", got)
+	}
+	if got := rowState(down, "Database"); got != stateUnknown {
+		t.Errorf("Database row = %v, want unknown", got)
+	}
+
+	// Not loaded → Process fails, no Restarts row.
+	off := buildStatusRows(
+		procInfo{found: false},
+		healthInfo{reachable: false},
+		"127.0.0.1:8770", "", home,
+	)
+	if got := rowState(off, "Process"); got != stateFail {
+		t.Errorf("Process row = %v, want fail", got)
+	}
+	if hasRow(off, "Restarts") {
+		t.Error("expected no Restarts row when unit not loaded")
+	}
+}
+
+func rowState(rows []statusRow, label string) checkState {
+	for _, r := range rows {
+		if r.label == label {
+			return r.state
+		}
+	}
+	return stateUnknown
+}
+
+func hasRow(rows []statusRow, label string) bool {
+	for _, r := range rows {
+		if r.label == label {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

`opendray status` on macOS dumped ~80 lines of raw `launchctl print` launchd internals, so an operator couldn't tell at a glance whether the service was actually healthy — the process being alive says nothing about whether the gateway is serving HTTP or can reach its database.

This replaces the default output with a `systemctl status`-style health checklist:

```
opendray  local-4e1ec88 (4e1ec88)
──────────────────────────────────────────
Process    ✓ running   pid 46781
Health     ✓ ok        up 9h24m
Database   ✓ reachable
Listen     ✓ 0.0.0.0:8770
Restarts   ⚠ 201  (last exit code 1)
Config     ✓ ~/.opendray/config.toml

Hint: last exit was non-zero (code 1) — the service recovered, but
      check ~/.opendray/logs/opendray.err if restarts keep climbing.
```

Fuses three sources:
- **launchd / systemd** → process up, pid, restart count, last exit code
- **GET /api/v1/health** → version, uptime, DB reachability (the *real* liveness signal)
- **config + TCC checks** → config location, macOS privacy-folder gotchas

`opendray status --raw` falls back to the native `launchctl print` / `systemctl status` dump. Exit code mirrors severity like systemctl — `0` all-green, `1` degraded/warnings, `3` not-running/unreachable — so scripts can gate on it.

## Bugs fixed (surfaced testing against a live service)

- `launchctl print` repeats `state = active` for nested resource/jetsam coalitions after the top-level `state = running`; the parser was letting those override it and misreporting a running service as **stopped**. First-line (top-level) state now wins.
- The health endpoint is `/api/v1/health`, not `/health`; a 404 was being treated as "healthy". The probe now validates the HTTP status code (only 200/503 count).

## Test plan

- `go test ./cmd/opendray/` — pure helpers unit-tested: launchctl parse (incl. nested-coalition regression case), systemctl parse, health-URL build, duration formatting, and per-row severity logic.
- `go vet ./cmd/opendray/` clean.
- Ran the built binary against the live gateway: healthy service renders all-green with the restart warning; verified `--raw` fallback and `-h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)