### PR TITLE
docs(changelog): complete the v2.13.0 entry for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ iterate on, instead of describing a screen in prose and hoping it matches.
   the project's actual theme, or draw the system as a canvas.
 - **Full mobile parity** for all of the above: viewer, viewport switching,
   focus and precise marking from the phone.
+- **`opendray status` is now a systemctl-style health dashboard.** On macOS
+  the command used to dump ~80 lines of raw `launchctl print` internals —
+  a live process says nothing about whether the gateway is serving HTTP or
+  can reach its database. The default output is now a compact checklist:
+  process, HTTP health + uptime, database reachability, listen address,
+  restart count (with the last non-zero exit surfaced as a hint) and the
+  config path. The raw launchd/systemd dump moved behind `--raw`.
 
 ### Changed
 
@@ -85,6 +92,30 @@ iterate on, instead of describing a screen in prose and hoping it matches.
   these wheel-ignoring providers and sends arrow keys for both wheel and
   one-finger touch scroll, scoped by `providerId` so Claude/Codex/Antigravity
   (which genuinely consume the wheel) are untouched.
+- **Coming back to the mobile app after it slept no longer fails session
+  loads.** While the app is suspended the OS silently tears down its TCP
+  connections, but the HTTP client's pool didn't know — the next request
+  went out on a dead socket and stalled into a 30-second timeout and a
+  full-screen error, even on a LAN. Connection-level failures on GET/HEAD
+  are now replayed up to twice with backoff (a 4xx/5xx still passes
+  through untouched), the pool's idle timeout drops to 5 seconds so stale
+  sockets are rarely handed out at all, and returning from a suspension of
+  5+ seconds refetches the session list immediately instead of waiting for
+  the next tap.
+
+### Security
+
+- **Hardened the path-containment barrier behind `/fs/download`, `/fs/zip`
+  and `/fs/upload`.** The root-scoped filesystem endpoints now validate the
+  resolved path with `filepath.IsLocal` and refuse any residual `..`
+  sequence in the canonical path (which also means oddly-named entries like
+  `notes..md` are rejected inside these endpoints). Resolves all seven open
+  CodeQL `go/path-injection` alerts plus one allocation-size-overflow
+  finding.
+- **Bumped vulnerable transitive npm dependencies** in the web workspace
+  lockfile: seroval 1.6.2 (critical GHSA-mv8w-475r-vwqw), brace-expansion
+  5.0.9 (three DoS advisories), postcss 8.5.26 (path-traversal advisories)
+  and `@babel/core` 7.29.7. Lockfile-only; no manifest changes.
 
 ## [v2.12.2] — 2026-07-23
 

--- a/README.de.md
+++ b/README.de.md
@@ -579,7 +579,7 @@ opendray ist ein Self-hosted Gateway, das die AI-Coding-CLIs, die Sie bereits ve
 
 ### Welche AI-CLIs unterstützt opendray?
 
-Fünf erstklassige Provider ab v2.10.x: **Claude Code** (Anthropic), **Codex** (OpenAI), **Antigravity** (Google `agy`), **Grok Build** (xAI) und **OpenCode**. Dazu beliebige Shell für alles andere. Eine neue CLI hinzuzufügen ist ein JSON-Deskriptor unter `internal/catalog/builtin/`; für gängige Fälle ist kein Adapter-Code nötig.
+Fünf erstklassige Provider ab v2.13.x: **Claude Code** (Anthropic), **Codex** (OpenAI), **Antigravity** (Google `agy`), **Grok Build** (xAI) und **OpenCode**. Dazu beliebige Shell für alles andere. Eine neue CLI hinzuzufügen ist ein JSON-Deskriptor unter `internal/catalog/builtin/`; für gängige Fälle ist kein Adapter-Code nötig.
 
 ### Wie unterscheidet sich opendray von Claude Desktop oder ChatGPT Desktop?
 
@@ -630,7 +630,7 @@ Lesen Sie [`CONTRIBUTING.md`](CONTRIBUTING.md) und [`CODE_OF_CONDUCT.md`](CODE_O
 
 ## Status
 
-Aktuelle Generation: **v2.10.x**. Siehe [`CHANGELOG.md`](CHANGELOG.md) für die Release-Historie und [`VERSIONING.md`](VERSIONING.md) für die Major-als-Generation-Policy (Major = Produktgeneration, kein strikter SemVer-"Breaking Change").
+Aktuelle Generation: **v2.13.x**. Siehe [`CHANGELOG.md`](CHANGELOG.md) für die Release-Historie und [`VERSIONING.md`](VERSIONING.md) für die Major-als-Generation-Policy (Major = Produktgeneration, kein strikter SemVer-"Breaking Change").
 
 Diese Generation liefert:
 

--- a/README.es.md
+++ b/README.es.md
@@ -586,7 +586,7 @@ opendray es un gateway autohospedado que envuelve las CLIs de coding con IA que 
 
 ### ¿Qué CLIs de IA soporta opendray?
 
-Cinco proveedores de primera clase a día de v2.10.x: **Claude Code** (Anthropic), **Codex** (OpenAI), **Antigravity** (Google `agy`), **Grok Build** (xAI) y **OpenCode**. Más cualquier shell para cualquier otra cosa. Añadir una CLI nueva es un descriptor JSON bajo `internal/catalog/builtin/`; sin código de adaptador para los casos habituales.
+Cinco proveedores de primera clase a día de v2.13.x: **Claude Code** (Anthropic), **Codex** (OpenAI), **Antigravity** (Google `agy`), **Grok Build** (xAI) y **OpenCode**. Más cualquier shell para cualquier otra cosa. Añadir una CLI nueva es un descriptor JSON bajo `internal/catalog/builtin/`; sin código de adaptador para los casos habituales.
 
 ### ¿En qué se diferencia opendray de Claude Desktop o ChatGPT Desktop?
 
@@ -637,7 +637,7 @@ Lee [`CONTRIBUTING.md`](CONTRIBUTING.md) y [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUC
 
 ## Estado
 
-Generación actual: **v2.10.x**. Consulta [`CHANGELOG.md`](CHANGELOG.md) para el historial de releases y [`VERSIONING.md`](VERSIONING.md) para la política major-como-generación (major = generación de producto, no "breaking change" estricto al estilo SemVer).
+Generación actual: **v2.13.x**. Consulta [`CHANGELOG.md`](CHANGELOG.md) para el historial de releases y [`VERSIONING.md`](VERSIONING.md) para la política major-como-generación (major = generación de producto, no "breaking change" estricto al estilo SemVer).
 
 Esta generación incluye:
 

--- a/README.fa.md
+++ b/README.fa.md
@@ -535,7 +535,7 @@ opendray یک self-hosted gateway است که ابزارهای AI coding CLI ک�
 
 ### opendray چه AI CLIهایی را پشتیبانی می‌کند؟
 
-پنج provider first-class در نسخه v2.10.x: **Claude Code** (Anthropic)، **Codex** (OpenAI)، **Antigravity** (Google `agy`)، **Grok Build** (xAI) و **OpenCode**. به‌همراه shell دلخواه برای هر چیز دیگر. اضافه کردن یک CLI جدید، یک JSON descriptor زیر `internal/catalog/builtin/` است؛ در موارد رایج به کد adapter نیازی نیست.
+پنج provider first-class در نسخه v2.13.x: **Claude Code** (Anthropic)، **Codex** (OpenAI)، **Antigravity** (Google `agy`)، **Grok Build** (xAI) و **OpenCode**. به‌همراه shell دلخواه برای هر چیز دیگر. اضافه کردن یک CLI جدید، یک JSON descriptor زیر `internal/catalog/builtin/` است؛ در موارد رایج به کد adapter نیازی نیست.
 
 ### opendray در مقابل Claude Desktop یا ChatGPT Desktop چه فرقی دارد؟
 
@@ -586,7 +586,7 @@ Apache 2.0. برای همیشه رایگان. بدون paid tier، بدون tele
 
 ## Status
 
-نسل فعلی: **v2.10.x**. برای تاریخچه release به [`CHANGELOG.md`](CHANGELOG.md) و برای policy مربوط به major-as-generation به [`VERSIONING.md`](VERSIONING.md) نگاه کنید (major به معنای نسل محصول است، نه breaking change به معنای سخت‌گیرانه SemVer).
+نسل فعلی: **v2.13.x**. برای تاریخچه release به [`CHANGELOG.md`](CHANGELOG.md) و برای policy مربوط به major-as-generation به [`VERSIONING.md`](VERSIONING.md) نگاه کنید (major به معنای نسل محصول است، نه breaking change به معنای سخت‌گیرانه SemVer).
 
 این نسل شامل موارد زیر است:
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -569,7 +569,7 @@ opendray est un gateway self-hosted qui enveloppe les CLI de coding IA que vous 
 
 ### Quelles CLI d'IA opendray prend-il en charge ?
 
-Cinq providers de premier ordre en v2.10.x : **Claude Code** (Anthropic), **Codex** (OpenAI), **Antigravity** (Google `agy`), **Grok Build** (xAI) et **OpenCode**. Plus le shell arbitraire pour tout le reste. Ajouter une nouvelle CLI se fait via un descriptor JSON sous `internal/catalog/builtin/`, sans code d'adaptateur pour les cas courants.
+Cinq providers de premier ordre en v2.13.x : **Claude Code** (Anthropic), **Codex** (OpenAI), **Antigravity** (Google `agy`), **Grok Build** (xAI) et **OpenCode**. Plus le shell arbitraire pour tout le reste. Ajouter une nouvelle CLI se fait via un descriptor JSON sous `internal/catalog/builtin/`, sans code d'adaptateur pour les cas courants.
 
 ### En quoi opendray se distingue-t-il de Claude Desktop ou ChatGPT Desktop ?
 
@@ -620,7 +620,7 @@ Lisez [`CONTRIBUTING.md`](CONTRIBUTING.md) et [`CODE_OF_CONDUCT.md`](CODE_OF_CON
 
 ## État
 
-Génération actuelle : **v2.10.x**. Voir [`CHANGELOG.md`](CHANGELOG.md) pour l'historique des releases et [`VERSIONING.md`](VERSIONING.md) pour la politique major-comme-génération (major = génération de produit, pas un « breaking change » strict au sens SemVer).
+Génération actuelle : **v2.13.x**. Voir [`CHANGELOG.md`](CHANGELOG.md) pour l'historique des releases et [`VERSIONING.md`](VERSIONING.md) pour la politique major-comme-génération (major = génération de produit, pas un « breaking change » strict au sens SemVer).
 
 Cette génération embarque :
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -578,7 +578,7 @@ opendray は、あなたが普段使っている AI コーディング CLI（Cla
 
 ### opendray はどの AI CLI に対応していますか？
 
-v2.10.x 時点で、5 つのファーストクラスなプロバイダーに対応しています。**Claude Code**（Anthropic）、**Codex**（OpenAI）、**Antigravity**（Google の `agy`）、**Grok Build**（xAI）、そして **OpenCode** です。それ以外は任意の shell で対応できます。新しい CLI の追加は `internal/catalog/builtin/` 配下の JSON ディスクリプタで済み、一般的なケースであればアダプターコードは不要です。
+v2.13.x 時点で、5 つのファーストクラスなプロバイダーに対応しています。**Claude Code**（Anthropic）、**Codex**（OpenAI）、**Antigravity**（Google の `agy`）、**Grok Build**（xAI）、そして **OpenCode** です。それ以外は任意の shell で対応できます。新しい CLI の追加は `internal/catalog/builtin/` 配下の JSON ディスクリプタで済み、一般的なケースであればアダプターコードは不要です。
 
 ### opendray は Claude Desktop や ChatGPT Desktop とどう違いますか？
 
@@ -629,7 +629,7 @@ Apache 2.0 です。永久に無料です。有料ティアなし、テレメト
 
 ## ステータス
 
-現行世代: **v2.10.x**。リリース履歴については [`CHANGELOG.md`](CHANGELOG.md) を、major-as-generation 方針（major = 製品世代であり、厳密な SemVer の意味での「破壊的変更」ではない）については [`VERSIONING.md`](VERSIONING.md) を参照してください。
+現行世代: **v2.13.x**。リリース履歴については [`CHANGELOG.md`](CHANGELOG.md) を、major-as-generation 方針（major = 製品世代であり、厳密な SemVer の意味での「破壊的変更」ではない）については [`VERSIONING.md`](VERSIONING.md) を参照してください。
 
 この世代で提供される主な内容:
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -575,7 +575,7 @@ opendray는 이미 사용 중인 AI 코딩 CLI들(Claude Code, Codex, Antigravit
 
 ### opendray는 어떤 AI CLI를 지원하나요?
 
-v2.10.x 기준으로 5개의 first-class 프로바이더를 지원합니다: **Claude Code**(Anthropic), **Codex**(OpenAI), **Antigravity**(Google `agy`), **Grok Build**(xAI), **OpenCode**입니다. 그 외에는 임의의 shell로 대응할 수 있습니다. 새 CLI를 추가하는 작업은 `internal/catalog/builtin/` 아래의 JSON descriptor 하나로 끝나며, 일반적인 경우에는 어댑터 코드가 필요 없습니다.
+v2.13.x 기준으로 5개의 first-class 프로바이더를 지원합니다: **Claude Code**(Anthropic), **Codex**(OpenAI), **Antigravity**(Google `agy`), **Grok Build**(xAI), **OpenCode**입니다. 그 외에는 임의의 shell로 대응할 수 있습니다. 새 CLI를 추가하는 작업은 `internal/catalog/builtin/` 아래의 JSON descriptor 하나로 끝나며, 일반적인 경우에는 어댑터 코드가 필요 없습니다.
 
 ### opendray는 Claude Desktop이나 ChatGPT Desktop과 어떻게 다른가요?
 
@@ -626,7 +626,7 @@ Apache 2.0입니다. 영원히 무료입니다. 유료 티어도, 텔레메트�
 
 ## 현황
 
-현재 세대: **v2.10.x**. release 이력은 [`CHANGELOG.md`](CHANGELOG.md)에서, major-as-generation 정책(major = 제품 세대, 엄격한 SemVer "breaking change"가 아님)은 [`VERSIONING.md`](VERSIONING.md)에서 확인하세요.
+현재 세대: **v2.13.x**. release 이력은 [`CHANGELOG.md`](CHANGELOG.md)에서, major-as-generation 정책(major = 제품 세대, 엄격한 SemVer "breaking change"가 아님)은 [`VERSIONING.md`](VERSIONING.md)에서 확인하세요.
 
 이 세대에서 제공되는 것:
 

--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ opendray is a self-hosted gateway that wraps the AI coding CLIs you already use 
 
 ### Which AI CLIs does opendray support?
 
-Five first-class providers as of v2.10.x: **Claude Code** (Anthropic), **Codex** (OpenAI), **Antigravity** (Google `agy`), **Grok Build** (xAI), and **OpenCode**. Plus arbitrary shell for anything else. Adding a new CLI is a JSON descriptor under `internal/catalog/builtin/`; no adapter code required for common cases.
+Five first-class providers as of v2.13.x: **Claude Code** (Anthropic), **Codex** (OpenAI), **Antigravity** (Google `agy`), **Grok Build** (xAI), and **OpenCode**. Plus arbitrary shell for anything else. Adding a new CLI is a JSON descriptor under `internal/catalog/builtin/`; no adapter code required for common cases.
 
 ### How is opendray different from Claude Desktop or ChatGPT Desktop?
 
@@ -631,7 +631,7 @@ Read [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`CODE_OF_CONDUCT.md`](CODE_OF_CON
 
 ## Status
 
-Current generation: **v2.10.x**. See [`CHANGELOG.md`](CHANGELOG.md) for release history and [`VERSIONING.md`](VERSIONING.md) for the major-as-generation policy (major = product generation, not strict SemVer "breaking change").
+Current generation: **v2.13.x**. See [`CHANGELOG.md`](CHANGELOG.md) for release history and [`VERSIONING.md`](VERSIONING.md) for the major-as-generation policy (major = product generation, not strict SemVer "breaking change").
 
 This generation ships:
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -587,7 +587,7 @@ O opendray é um gateway self-hosted que encapsula as CLIs de coding com IA que 
 
 ### Quais CLIs de IA o opendray suporta?
 
-Cinco providers de primeira classe na v2.10.x: **Claude Code** (Anthropic), **Codex** (OpenAI), **Antigravity** (Google `agy`), **Grok Build** (xAI) e **OpenCode**. Mais shell arbitrário pra qualquer outra coisa. Adicionar uma nova CLI é um descritor JSON em `internal/catalog/builtin/`; sem código de adapter na maioria dos casos.
+Cinco providers de primeira classe na v2.13.x: **Claude Code** (Anthropic), **Codex** (OpenAI), **Antigravity** (Google `agy`), **Grok Build** (xAI) e **OpenCode**. Mais shell arbitrário pra qualquer outra coisa. Adicionar uma nova CLI é um descritor JSON em `internal/catalog/builtin/`; sem código de adapter na maioria dos casos.
 
 ### Qual a diferença entre o opendray e o Claude Desktop ou o ChatGPT Desktop?
 
@@ -638,7 +638,7 @@ Leia [`CONTRIBUTING.md`](CONTRIBUTING.md) e [`CODE_OF_CONDUCT.md`](CODE_OF_CONDU
 
 ## Status
 
-Geração atual: **v2.10.x**. Veja [`CHANGELOG.md`](CHANGELOG.md) pro histórico de releases e [`VERSIONING.md`](VERSIONING.md) pra política major-como-geração (major = geração de produto, não "breaking change" estrito ao estilo SemVer).
+Geração atual: **v2.13.x**. Veja [`CHANGELOG.md`](CHANGELOG.md) pro histórico de releases e [`VERSIONING.md`](VERSIONING.md) pra política major-como-geração (major = geração de produto, não "breaking change" estrito ao estilo SemVer).
 
 Esta geração entrega:
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -590,7 +590,7 @@ opendray это self-hosted шлюз, который оборачивает AI c
 
 ### Какие AI-CLI поддерживает opendray?
 
-Пять first-class-провайдеров на v2.10.x: **Claude Code** (Anthropic), **Codex** (OpenAI), **Antigravity** (Google `agy`), **Grok Build** (xAI) и **OpenCode**. Плюс произвольный shell для всего остального. Добавление нового CLI это JSON-дескриптор в `internal/catalog/builtin/`; в типовых случаях адаптерный код не нужен.
+Пять first-class-провайдеров на v2.13.x: **Claude Code** (Anthropic), **Codex** (OpenAI), **Antigravity** (Google `agy`), **Grok Build** (xAI) и **OpenCode**. Плюс произвольный shell для всего остального. Добавление нового CLI это JSON-дескриптор в `internal/catalog/builtin/`; в типовых случаях адаптерный код не нужен.
 
 ### Чем opendray отличается от Claude Desktop или ChatGPT Desktop?
 
@@ -641,7 +641,7 @@ Apache 2.0. Бесплатно навсегда. Никакого платног
 
 ## Статус
 
-Текущее поколение: **v2.10.x**. См. [`CHANGELOG.md`](CHANGELOG.md) для полной истории релизов и [`VERSIONING.md`](VERSIONING.md) для политики major-как-поколение (major = поколение продукта, а не строгий SemVer "breaking change").
+Текущее поколение: **v2.13.x**. См. [`CHANGELOG.md`](CHANGELOG.md) для полной истории релизов и [`VERSIONING.md`](VERSIONING.md) для политики major-как-поколение (major = поколение продукта, а не строгий SemVer "breaking change").
 
 В это поколение входит:
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -535,7 +535,7 @@ opendray 是一个自托管网关，把你已经在用的 AI 编程 CLI(Claude C
 
 ### opendray 支持哪些 AI CLI?
 
-截至 v2.10.x，共有五个一等公民级 provider：**Claude Code**(Anthropic)、**Codex**(OpenAI)、**Antigravity**(Google `agy`)、**Grok Build**(xAI)，以及 **OpenCode**。其余任何场景都可以用任意 shell 兜底。新增一个 CLI 只需在 `internal/catalog/builtin/` 下加一个 JSON 描述文件，常见场景不需要写适配代码。
+截至 v2.13.x，共有五个一等公民级 provider：**Claude Code**(Anthropic)、**Codex**(OpenAI)、**Antigravity**(Google `agy`)、**Grok Build**(xAI)，以及 **OpenCode**。其余任何场景都可以用任意 shell 兜底。新增一个 CLI 只需在 `internal/catalog/builtin/` 下加一个 JSON 描述文件，常见场景不需要写适配代码。
 
 ### opendray 跟 Claude Desktop 或 ChatGPT Desktop 有什么区别?
 
@@ -586,7 +586,7 @@ Apache 2.0。永久免费。没有付费档位，没有遥测，不 phone-home�
 
 ## 当前状态
 
-当前代号：**v2.10.x**。发布历史见 [`CHANGELOG.md`](CHANGELOG.md)，major-as-generation 版本策略(major = 产品代号，不是严格的 SemVer "破坏性变更")见 [`VERSIONING.md`](VERSIONING.md)。
+当前代号：**v2.13.x**。发布历史见 [`CHANGELOG.md`](CHANGELOG.md)，major-as-generation 版本策略(major = 产品代号，不是严格的 SemVer "破坏性变更")见 [`VERSIONING.md`](VERSIONING.md)。
 
 这一代产品包含:
 


### PR DESCRIPTION
## Summary

Prepares the v2.13.0 release per RELEASING.md (changelog must land on main before the tag).

The existing v2.13.0 section was written when Canvas (#483) merged and the release went on hold; three PRs have landed since. This PR completes the section:

- **Added**: `opendray status` systemctl-style health dashboard, raw dump behind `--raw` (#481)
- **Fixed**: mobile session loads failing on a suspended app's dead socket — narrow GET/HEAD retry, 5s pool idle timeout, refetch on resume (#484)
- **Security** (new subsection): path-containment hardening for the root-scoped `/fs/*` endpoints resolving all open CodeQL alerts, plus the npm transitive dependency bumps (#485)

Also bumps the `## Status` / FAQ version references in README.md and all translations from **v2.10.x** to **v2.13.x**.

No code changes. Tag `v2.13.0` will be pushed after this merges.

## Test plan

- [x] Changelog entries cross-checked against the actual PR implementations (#481 `--raw` flag verified in `cmd/opendray/service.go`; #484 retry/idle/resume behavior from the PR's What-changed section)
- [ ] CI green (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)