### PR TITLE
fix(gateway): hold the host awake so phone and web stay connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The gateway keeps its host awake, so phone and web stay connected.**
+  A Mac left to itself idle-sleeps, and a sleeping host takes its network
+  with it: the gateway stops answering, a remote Postgres becomes
+  unreachable, and every phone or web request times out until someone
+  physically wakes the machine. Incoming traffic does dark-wake the host,
+  but the window is short and a user-session LaunchAgent isn't reliably
+  scheduled inside it, so the request has already timed out — which reads
+  as "opendray is flaky" and sends people reading gateway code instead of
+  `pmset -g log`. opendray now holds a power assertion for as long as it
+  serves. Default is wall-power only, so a laptop on battery still sleeps
+  normally; `[host] prevent_idle_sleep` takes `"always"` or `"off"`. A
+  deliberate sleep — lid close, Apple menu → Sleep — is never blocked, and
+  the assertion is tied to the gateway's pid so even a SIGKILL can't
+  strand the host awake. macOS only; accepted and ignored elsewhere.
+
 ## [v2.13.0] — 2026-08-07
 
 The Canvas: the agent renders a page you can actually see, mark up and

--- a/config.example.toml
+++ b/config.example.toml
@@ -103,3 +103,15 @@ default = "project"
 # max_rows = 500            # default result-row cap (requests may raise to 10000)
 # pool_max_conns = 3        # pgx pool cap per external connection
 # pool_idle_ttl = "5m"      # close external pools idle longer than this
+
+# Settings about the machine opendray runs on, rather than the gateway
+# process. A sleeping host takes its network down with it, so the gateway
+# is simply unreachable from phone and web until something wakes the
+# machine — which is why opendray holds a power assertion while serving.
+# macOS only (via caffeinate); accepted and ignored elsewhere. A
+# deliberate sleep — lid close, Apple menu -> Sleep — is never blocked.
+[host]
+# prevent_idle_sleep = "ac"   # "ac" (default) hold awake on wall power only,
+#                             # so a laptop on battery still sleeps;
+#                             # "always" hold awake on any power source;
+#                             # "off" never touch host power state

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -48,6 +48,7 @@ import (
 	"github.com/opendray/opendray-v2/internal/gitactivity"
 	githost "github.com/opendray/opendray-v2/internal/githost"
 	"github.com/opendray/opendray-v2/internal/integration"
+	"github.com/opendray/opendray-v2/internal/keepawake"
 	"github.com/opendray/opendray-v2/internal/knowledge"
 	mcpapi "github.com/opendray/opendray-v2/internal/mcp"
 	"github.com/opendray/opendray-v2/internal/memconflict"
@@ -85,6 +86,10 @@ type App struct {
 	audit           *audit.Sink
 	intgrCallLogger *integration.CallLogger
 	vaultSync       *vaultgit.Syncer
+	// keepAwake holds a host power assertion for as long as the gateway
+	// serves, so the machine can't idle-sleep and take the network — and
+	// every phone/web client — down with it.
+	keepAwake *keepawake.Keeper
 	// liveBackup owns the backup Service + scheduler. Always non-nil
 	// after New returns, but Service() returns nil when the feature
 	// is off. Disarm on shutdown to stop the scheduler goroutine.
@@ -614,6 +619,17 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	proxyHandlers := integration.NewProxyHandlers(intgrSvc, intgrCallLogger, log)
 	eventsHandler := integration.NewEventsHandler(bus, log)
 	healthCheck := integration.NewHealthChecker(intgrSvc, bus, log)
+
+	// Validated in config.Validate, so a parse failure here can only mean
+	// the config was built in-process rather than loaded; fall back to
+	// the default mode instead of refusing to start over a power setting.
+	awakeMode, err := keepawake.ParseMode(cfg.Host.PreventIdleSleep)
+	if err != nil {
+		log.Warn("host.prevent_idle_sleep is invalid; using the default",
+			"value", cfg.Host.PreventIdleSleep, "err", err)
+		awakeMode = keepawake.ModeAC
+	}
+	keepAwake := keepawake.New(log, awakeMode)
 
 	auditSink := audit.NewSink(st.Pool(), bus, log)
 	auditSvc := audit.NewService(st.Pool())
@@ -1471,6 +1487,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		audit:                auditSink,
 		intgrCallLogger:      intgrCallLogger,
 		vaultSync:            vaultSyncer,
+		keepAwake:            keepAwake,
 		liveBackup:           liveBackup,
 		captureEngine:        captureEngine,
 		journaler:            journaler,
@@ -1545,6 +1562,16 @@ func (a *App) Run(ctx context.Context) error {
 	go func() {
 		a.vaultSync.Run(ctx)
 		close(vaultSyncDone)
+	}()
+
+	// Hold the host awake for as long as we serve. Without this the
+	// machine idle-sleeps, its network goes down, and the gateway is
+	// unreachable from phone and web until someone physically wakes it —
+	// which reads as "opendray is flaky" rather than "the Mac is asleep".
+	keepAwakeDone := make(chan struct{})
+	go func() {
+		a.keepAwake.Run(ctx)
+		close(keepAwakeDone)
 	}()
 
 	// Backup scheduler lifecycle is owned by LiveBackup itself
@@ -1737,6 +1764,12 @@ func (a *App) Run(ctx context.Context) error {
 	case <-vaultSyncDone:
 	case <-time.After(5 * time.Second):
 		a.log.Warn("vault auto-sync shutdown timed out")
+	}
+
+	select {
+	case <-keepAwakeDone:
+	case <-time.After(2 * time.Second):
+		a.log.Warn("keep-awake shutdown timed out")
 	}
 
 	// Disarm idempotently stops the backup scheduler if it's

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+
+	"github.com/opendray/opendray-v2/internal/keepawake"
 )
 
 type Config struct {
@@ -26,6 +28,7 @@ type Config struct {
 	Backup    BackupConfig    `toml:"backup" json:"backup"`
 	Knowledge KnowledgeConfig `toml:"knowledge" json:"knowledge"`
 	Dbtool    DbtoolConfig    `toml:"dbtool" json:"dbtool"`
+	Host      HostConfig      `toml:"host" json:"host"`
 
 	// FilePath is the path config.toml was loaded from. Set by Load
 	// after a successful read so the runtime can find the same file
@@ -432,6 +435,25 @@ type DbtoolConfig struct {
 	PoolIdleTTL string `toml:"pool_idle_ttl" json:"pool_idle_ttl"`
 }
 
+// HostConfig covers the machine opendray runs on, rather than the
+// gateway process itself.
+type HostConfig struct {
+	// PreventIdleSleep stops the host idle-sleeping while the gateway is
+	// serving. A sleeping host takes its network with it, so phone and
+	// web clients simply cannot reach the gateway until something wakes
+	// the machine — the reason this defaults to on.
+	//
+	//   ""/"ac"  — hold the host awake only on wall power (default), so
+	//              a laptop on battery still sleeps normally
+	//   "always" — hold it awake on any power source
+	//   "off"    — never touch host power state
+	//
+	// A deliberate sleep (lid close, Apple menu → Sleep) is never
+	// blocked in any mode. Implemented on macOS only; elsewhere the
+	// setting is accepted and ignored.
+	PreventIdleSleep string `toml:"prevent_idle_sleep" json:"prevent_idle_sleep"`
+}
+
 // IsEnabled returns the effective feature state: nil pointer (omitted in
 // config) → true; explicit false → disabled.
 func (c DbtoolConfig) IsEnabled() bool {
@@ -582,6 +604,9 @@ func applyEnv(cfg *Config) {
 	if v := os.Getenv("OPENDRAY_VAULT_GIT_ROOT"); v != "" {
 		cfg.Vault.GitRoot = v
 	}
+	if v := os.Getenv("OPENDRAY_HOST_PREVENT_IDLE_SLEEP"); v != "" {
+		cfg.Host.PreventIdleSleep = v
+	}
 	if v := os.Getenv("OPENDRAY_MCP_ROOT"); v != "" {
 		cfg.MCP.Root = v
 	}
@@ -667,6 +692,9 @@ func (c Config) Validate() error {
 	}
 	if c.Dbtool.MaxRows < 0 || c.Dbtool.MaxRows > 10000 {
 		return fmt.Errorf("config: dbtool.max_rows must be 0..10000, got %d", c.Dbtool.MaxRows)
+	}
+	if _, err := keepawake.ParseMode(c.Host.PreventIdleSleep); err != nil {
+		return fmt.Errorf("config: host.prevent_idle_sleep: %w", err)
 	}
 	return nil
 }

--- a/internal/keepawake/keepawake.go
+++ b/internal/keepawake/keepawake.go
@@ -1,0 +1,176 @@
+// Package keepawake stops the host machine from idle-sleeping while the
+// gateway is serving.
+//
+// opendray exists so an operator can reach their AI CLI sessions from a
+// phone or another machine. That promise breaks the moment the host —
+// typically a Mac sitting on a desk — decides it has been idle long
+// enough to sleep: the network interface goes down, a remote Postgres
+// becomes unreachable, and every phone/web request times out. Incoming
+// traffic can dark-wake the machine, but the wake window is short and a
+// user-session LaunchAgent is not reliably scheduled inside it, so the
+// request has usually timed out before the listener runs again. The
+// symptom reads as "the gateway is flaky", which sends people reading
+// gateway code instead of `pmset -g log`.
+//
+// The fix is for the gateway to hold a power assertion for as long as it
+// serves. On macOS that is /usr/bin/caffeinate, spawned as a child
+// process rather than linked through IOKit: release binaries are
+// cross-compiled from a Linux runner with CGO disabled, so an
+// IOPMAssertionCreateWithName cgo call is not available to us.
+// caffeinate ships with the base system, and its -w flag ties the
+// assertion's lifetime to our pid — if opendray is SIGKILLed and never
+// reaches its shutdown path, the assertion is still released.
+//
+// Every other platform is a no-op. A Linux or BSD gateway is a server
+// that does not idle-suspend under any default install, and reaching
+// for logind inhibitors there would be solving a problem nobody has.
+package keepawake
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Mode selects how aggressively the gateway holds the host awake.
+type Mode string
+
+const (
+	// ModeAC holds the host awake only while it runs on wall power, so a
+	// laptop on battery still sleeps normally. The default: it fixes the
+	// desk-bound gateway without quietly draining someone's MacBook.
+	ModeAC Mode = "ac"
+
+	// ModeAlways holds the host awake on any power source. For an
+	// operator who genuinely wants their laptop reachable on battery.
+	ModeAlways Mode = "always"
+
+	// ModeOff never touches host power state. The gateway then stops
+	// answering whenever the host sleeps — correct only if something
+	// else already keeps the machine up.
+	ModeOff Mode = "off"
+)
+
+// ParseMode normalises a configured value. Empty means "unset", which
+// resolves to ModeAC.
+func ParseMode(s string) (Mode, error) {
+	switch Mode(strings.ToLower(strings.TrimSpace(s))) {
+	case "", ModeAC:
+		return ModeAC, nil
+	case ModeAlways:
+		return ModeAlways, nil
+	case ModeOff:
+		return ModeOff, nil
+	default:
+		return "", fmt.Errorf("unknown mode %q (want %q, %q or %q)",
+			s, ModeAC, ModeAlways, ModeOff)
+	}
+}
+
+const (
+	// baseBackoff is the pause before re-spawning a helper that died.
+	baseBackoff = 5 * time.Second
+	// maxBackoff caps the exponential growth: even in a hard crash loop
+	// we keep retrying, because the alternative is a gateway that
+	// silently stops being reachable.
+	maxBackoff = 5 * time.Minute
+	// healthyRun is how long a helper must survive before its next exit
+	// counts as a fresh failure rather than a continuing crash loop.
+	healthyRun = time.Minute
+)
+
+// Keeper supervises the platform helper that holds the power assertion.
+type Keeper struct {
+	log  *slog.Logger
+	mode Mode
+
+	// newCmd builds the inhibitor process. It is nil on platforms with
+	// no implementation, and is swapped out in tests.
+	newCmd func(ctx context.Context, mode Mode) *exec.Cmd
+
+	// Re-spawn pacing, fields rather than constants so tests can drive
+	// the supervisor loop without sleeping for real seconds.
+	baseBackoff time.Duration
+	maxBackoff  time.Duration
+}
+
+// New returns a Keeper for the given mode. It starts nothing; call Run.
+func New(log *slog.Logger, mode Mode) *Keeper {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Keeper{
+		log:         log.With("component", "keepawake"),
+		mode:        mode,
+		newCmd:      newInhibitCmd,
+		baseBackoff: baseBackoff,
+		maxBackoff:  maxBackoff,
+	}
+}
+
+// Run holds the assertion until ctx is cancelled, re-spawning the helper
+// if it dies. It returns as soon as there is nothing to supervise, so
+// callers can treat it as a plain background goroutine.
+func (k *Keeper) Run(ctx context.Context) {
+	if k.mode == ModeOff {
+		k.log.Info("host idle-sleep inhibition disabled by config; " +
+			"the gateway will stop answering whenever the host sleeps")
+		return
+	}
+	if k.newCmd == nil {
+		k.log.Debug("host idle-sleep inhibition is not implemented on this platform",
+			"mode", string(k.mode))
+		return
+	}
+
+	backoff := k.baseBackoff
+	for ctx.Err() == nil {
+		started := time.Now()
+		err := k.runOnce(ctx)
+		if ctx.Err() != nil {
+			// Expected: shutdown killed the helper. The assertion is
+			// released with it.
+			k.log.Debug("stopped holding the host awake")
+			return
+		}
+		// A missing helper is not going to appear on retry.
+		if errors.Is(err, exec.ErrNotFound) || errors.Is(err, fs.ErrNotExist) {
+			k.log.Warn("cannot hold the host awake: power-assertion helper not found. "+
+				"The host may sleep out from under the gateway, making it unreachable "+
+				"from phone and web until someone wakes it.", "err", err)
+			return
+		}
+		lived := time.Since(started)
+		if lived >= healthyRun {
+			backoff = k.baseBackoff
+		}
+		k.log.Warn("power-assertion helper exited; restarting",
+			"lived", lived.Round(time.Second), "retry_in", backoff, "err", err)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		backoff = min(backoff*2, k.maxBackoff)
+	}
+}
+
+// runOnce spawns the helper and blocks until it exits.
+func (k *Keeper) runOnce(ctx context.Context) error {
+	cmd := k.newCmd(ctx, k.mode)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start %s: %w", cmd.Path, err)
+	}
+	k.log.Info("holding the host awake while the gateway runs",
+		"mode", string(k.mode), "helper_pid", cmd.Process.Pid)
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("%s exited: %w", filepath.Base(cmd.Path), err)
+	}
+	return nil
+}

--- a/internal/keepawake/keepawake_darwin.go
+++ b/internal/keepawake/keepawake_darwin.go
@@ -1,0 +1,40 @@
+//go:build darwin
+
+package keepawake
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+// caffeinatePath is macOS's built-in power-assertion helper. Referenced
+// by absolute path rather than via $PATH so a session-inherited PATH
+// (the LaunchAgent copies the operator's) can't shadow it.
+const caffeinatePath = "/usr/bin/caffeinate"
+
+// newInhibitCmd builds the caffeinate invocation for a mode.
+//
+// The flags are load-bearing:
+//
+//	-s  assert against system sleep, but only while on wall power.
+//	    Exactly the ModeAC contract — a desk-bound Mac never idles out,
+//	    a laptop on battery is left alone.
+//	-i  assert against idle sleep on any power source (ModeAlways).
+//	-w  wait on a pid: caffeinate exits — releasing the assertion — as
+//	    soon as that process is gone. Passing our own pid means a
+//	    SIGKILLed gateway cannot strand the host in a permanently awake
+//	    state, which is the failure mode that would make this feature
+//	    worse than the bug it fixes.
+//
+// Neither flag blocks a deliberate sleep (lid close, Apple menu →
+// Sleep), so the operator keeps the last word on their own machine.
+func newInhibitCmd(ctx context.Context, mode Mode) *exec.Cmd {
+	assert := "-s"
+	if mode == ModeAlways {
+		assert = "-i"
+	}
+	return exec.CommandContext(ctx, caffeinatePath,
+		assert, "-w", strconv.Itoa(os.Getpid()))
+}

--- a/internal/keepawake/keepawake_darwin_test.go
+++ b/internal/keepawake/keepawake_darwin_test.go
@@ -1,0 +1,39 @@
+//go:build darwin
+
+package keepawake
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The caffeinate flags are the whole feature, so pin them: -s must not
+// drift to -i (that would keep a laptop awake on battery) and -w must
+// always carry our pid (without it a killed gateway strands the host
+// awake forever).
+func TestNewInhibitCmd_Flags(t *testing.T) {
+	self := strconv.Itoa(os.Getpid())
+	tests := []struct {
+		name     string
+		mode     Mode
+		wantFlag string
+	}{
+		{"ac asserts only on wall power", ModeAC, "-s"},
+		{"always asserts on any power source", ModeAlways, "-i"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newInhibitCmd(context.Background(), tt.mode)
+			if cmd.Path != caffeinatePath {
+				t.Fatalf("path = %q, want %q", cmd.Path, caffeinatePath)
+			}
+			args := strings.Join(cmd.Args[1:], " ")
+			if want := tt.wantFlag + " -w " + self; args != want {
+				t.Fatalf("args = %q, want %q", args, want)
+			}
+		})
+	}
+}

--- a/internal/keepawake/keepawake_other.go
+++ b/internal/keepawake/keepawake_other.go
@@ -1,0 +1,14 @@
+//go:build !darwin
+
+package keepawake
+
+import (
+	"context"
+	"os/exec"
+)
+
+// newInhibitCmd is deliberately nil off macOS: a Linux or BSD host
+// running a gateway does not idle-suspend under any default server
+// install, so there is nothing to inhibit. Keeper.Run sees the nil and
+// returns immediately.
+var newInhibitCmd func(ctx context.Context, mode Mode) *exec.Cmd

--- a/internal/keepawake/keepawake_test.go
+++ b/internal/keepawake/keepawake_test.go
@@ -1,0 +1,185 @@
+package keepawake
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os/exec"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// newTestKeeper builds a Keeper whose helper is a plain /bin/sh command,
+// so the supervisor loop can be exercised on any POSIX host — CI runs
+// Linux, where the real newInhibitCmd is nil by design.
+func newTestKeeper(t *testing.T, mode Mode, script string, spawns *atomic.Int32) *Keeper {
+	t.Helper()
+	k := New(quietLogger(), mode)
+	k.baseBackoff = time.Millisecond
+	k.maxBackoff = 5 * time.Millisecond
+	k.newCmd = func(ctx context.Context, _ Mode) *exec.Cmd {
+		if spawns != nil {
+			spawns.Add(1)
+		}
+		return exec.CommandContext(ctx, "/bin/sh", "-c", script)
+	}
+	return k
+}
+
+func TestParseMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    Mode
+		wantErr bool
+	}{
+		{"empty defaults to ac", "", ModeAC, false},
+		{"explicit ac", "ac", ModeAC, false},
+		{"always", "always", ModeAlways, false},
+		{"off", "off", ModeOff, false},
+		{"case and space insensitive", "  Always ", ModeAlways, false},
+		{"unknown value", "sometimes", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseMode(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseMode(%q) err = %v, wantErr = %v", tt.in, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseMode(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// Run must be safe to call as a bare goroutine on every configuration
+// that has nothing to supervise — it returns instead of spinning.
+func TestRun_ReturnsWhenThereIsNothingToSupervise(t *testing.T) {
+	tests := []struct {
+		name   string
+		keeper func() *Keeper
+	}{
+		{
+			name: "mode off",
+			keeper: func() *Keeper {
+				return newTestKeeper(t, ModeOff, "sleep 30", nil)
+			},
+		},
+		{
+			name: "platform without an implementation",
+			keeper: func() *Keeper {
+				k := New(quietLogger(), ModeAC)
+				k.newCmd = nil
+				return k
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			done := make(chan struct{})
+			go func() {
+				tt.keeper().Run(context.Background())
+				close(done)
+			}()
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("Run did not return")
+			}
+		})
+	}
+}
+
+func TestRun_RestartsHelperThatExitsEarly(t *testing.T) {
+	var spawns atomic.Int32
+	k := newTestKeeper(t, ModeAC, "exit 1", &spawns)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		k.Run(ctx)
+		close(done)
+	}()
+
+	deadline := time.After(5 * time.Second)
+	for spawns.Load() < 3 {
+		select {
+		case <-deadline:
+			t.Fatalf("helper respawned only %d times, want >= 3", spawns.Load())
+		case <-time.After(time.Millisecond):
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+func TestRun_StopsAndReleasesOnCancel(t *testing.T) {
+	var spawns atomic.Int32
+	k := newTestKeeper(t, ModeAC, "sleep 30", &spawns)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		k.Run(ctx)
+		close(done)
+	}()
+
+	// Wait for the helper to actually be running before cancelling, so
+	// this exercises the kill path rather than a pre-start return.
+	deadline := time.After(2 * time.Second)
+	for spawns.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("helper never spawned")
+		case <-time.After(time.Millisecond):
+		}
+	}
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+	if got := spawns.Load(); got != 1 {
+		t.Fatalf("helper spawned %d times, want exactly 1 (no respawn after cancel)", got)
+	}
+}
+
+// A helper binary that isn't there will never appear, so Run must give
+// up rather than retry forever.
+func TestRun_GivesUpWhenHelperIsMissing(t *testing.T) {
+	var spawns atomic.Int32
+	k := New(quietLogger(), ModeAC)
+	k.baseBackoff = time.Millisecond
+	k.maxBackoff = 5 * time.Millisecond
+	k.newCmd = func(ctx context.Context, _ Mode) *exec.Cmd {
+		spawns.Add(1)
+		return exec.CommandContext(ctx, "/nonexistent/opendray-keepawake-helper")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		k.Run(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run kept retrying a helper that does not exist")
+	}
+	if got := spawns.Load(); got != 1 {
+		t.Fatalf("attempted the missing helper %d times, want exactly 1", got)
+	}
+}


### PR DESCRIPTION
## The problem

Reported as "phone and web can't reach opendray when the Mac sleeps".

A gateway whose host idle-sleeps cannot do the one thing it exists for. Evidence from the affected host:

```
# pmset -g log
10:09:21  Sleep     Entering Sleep state due to 'Idle Sleep':TCPKeepAlive=active
10:14:37  DarkWake  ... Enet.TCPData ... 45 secs
10:15:22  Sleep     Entering Sleep state due to 'Maintenance Sleep'

# opendray.err, same window
10:15:37 ERROR insert audit_log ... dial tcp 192.168.3.88:5432: connect: network is down
10:19:02 ERROR list integrations ... connect: network is down
```

The host idle-sleeps, its network goes down, the listener stops answering and a remote Postgres becomes unreachable. Incoming requests *do* dark-wake the machine (`Enet.TCPData`), but the window is short and a user-session LaunchAgent isn't reliably scheduled inside it, so the client has already timed out. The symptom reads as "opendray is flaky", which sends people reading gateway code instead of `pmset -g log`.

**Not a Canvas regression**, though it surfaced around that release. `git show --stat b4d4c43` touches only `internal/canvas/**` — no deploy, service, plist or power code — and the repo had no sleep-prevention mechanism at all to regress. The likely reason it seemed fine before: Claude Code spawns `caffeinate -i -t 300` while a turn is running, so an operator with near-continuous sessions kept the host awake as a side effect. Longer idle gaps expose the host's 1-minute idle-sleep setting. Either way, relying on a CLI's incidental assertion is not a design — the gateway should hold its own.

## The fix

New `internal/keepawake`: a supervised power assertion held for as long as the gateway serves, started and stopped with the rest of the `App.Run` lifecycle.

- **macOS** spawns `/usr/bin/caffeinate`. A child process rather than an IOKit cgo call, because release binaries are cross-compiled from a Linux runner with `CGO_ENABLED=0`.
- **Everything else** is a no-op — a Linux/BSD gateway doesn't idle-suspend under a default server install.

Design points that matter:

| Decision | Why |
|---|---|
| `-w <our pid>` | Ties the assertion to the gateway process. A SIGKILLed opendray never runs its shutdown path, and without this the host would be stranded permanently awake — the failure mode that would make the feature worse than the bug. |
| Default `"ac"` → `-s` | Asserts only on wall power, so a laptop on battery still sleeps normally. Makes default-on safe. |
| Never blocks deliberate sleep | Lid close / Apple menu → Sleep still work in every mode. The operator keeps the last word on their own machine. |
| Capped exponential backoff | The helper is respawned if it dies; a *missing* binary ends the loop instead of spinning. |

Config (`[host] prevent_idle_sleep`, also `OPENDRAY_HOST_PREVENT_IDLE_SLEEP`): `"ac"` (default) / `"always"` (`-i`) / `"off"`. Validated at load, so a typo fails fast rather than silently disabling the protection.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt` clean
- [x] `go test -race` green: `internal/keepawake`, `internal/config`, `internal/settings`, `internal/app`
- [x] Cross-platform compile of the new package verified both ways (`GOOS=linux CGO_ENABLED=0 go build`, `GOOS=darwin go vet`) — the `!darwin` no-op path is what CI exercises
- [x] Table-driven tests for mode parsing, respawn-on-early-exit, stop-and-release on cancel, and give-up-on-missing-helper; a darwin-only test pins the exact `caffeinate` flags so `-s` can't silently drift to `-i`
- [x] Mechanism verified on the affected host: `caffeinate -s -w <pid>` registers `PreventSystemSleep` attributed to the caller's pid, and killing it releases the assertion immediately

No UI surface, so nothing to mirror on web/mobile or in i18n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)