### PR TITLE
feat(keepawake): wake-on-demand mode so the host may sleep between bursts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+### Added
+
+- **Wake-on-demand: the host may sleep, and phone/web traffic wakes it.**
+  `[host] prevent_idle_sleep = "on_demand"` lets the gateway's Mac sleep
+  whenever things are quiet instead of being held awake around the clock.
+  Incoming traffic dark-wakes the machine (macOS "Wake for network
+  access"); the gateway then seizes a power assertion the moment a
+  request, live stream or mid-turn session shows up, extends the wake for
+  as long as serving actually takes, and lets go after a two-minute
+  linger so the host can sleep again. Running sessions count as activity,
+  so a turn started from a phone survives the phone locking. On-demand
+  warns at startup if `womp` is disabled, since without it a sleeping
+  host can't be woken remotely at all. The existing `"ac"` (default),
+  `"always"` and `"off"` behaviours are unchanged.
+
 ### Fixed
 
 - **The gateway keeps its host awake, so phone and web stay connected.**

--- a/config.example.toml
+++ b/config.example.toml
@@ -114,4 +114,11 @@ default = "project"
 # prevent_idle_sleep = "ac"   # "ac" (default) hold awake on wall power only,
 #                             # so a laptop on battery still sleeps;
 #                             # "always" hold awake on any power source;
+#                             # "on_demand" let the host sleep while the
+#                             #   gateway is quiet; incoming traffic wakes it
+#                             #   (requires Wake for network access: sudo
+#                             #   pmset -a womp 1, wired Ethernet is the
+#                             #   reliable path) and the gateway holds it
+#                             #   awake only while requests, live streams or
+#                             #   running sessions need it, +2min linger;
 #                             # "off" never touch host power state

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -629,7 +629,13 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 			"value", cfg.Host.PreventIdleSleep, "err", err)
 		awakeMode = keepawake.ModeAC
 	}
-	keepAwake := keepawake.New(log, awakeMode)
+	// Activity = an HTTP request/live stream in flight (awakeTracker
+	// wraps the root handler below) or a session mid-turn with nobody
+	// watching. Only on_demand mode consults it.
+	awakeTracker := keepawake.NewTracker()
+	keepAwake := keepawake.New(log, awakeMode, keepawake.WithActivity(func() bool {
+		return awakeTracker.Active() || sessionMgr.AnyMidTurn()
+	}))
 
 	auditSink := audit.NewSink(st.Pool(), bus, log)
 	auditSvc := audit.NewService(st.Pool())
@@ -1471,7 +1477,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 
 	srv := &http.Server{
 		Addr:              cfg.Listen,
-		Handler:           gw.Handler(),
+		Handler:           awakeTracker.Wrap(gw.Handler()),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
@@ -1564,7 +1570,9 @@ func (a *App) Run(ctx context.Context) error {
 		close(vaultSyncDone)
 	}()
 
-	// Hold the host awake for as long as we serve. Without this the
+	// Hold the host awake while we serve — continuously (ac/always) or
+	// only across activity bursts (on_demand, where the host may sleep
+	// when quiet and is dark-woken by incoming traffic). Without this the
 	// machine idle-sleeps, its network goes down, and the gateway is
 	// unreachable from phone and web until someone physically wakes it —
 	// which reads as "opendray is flaky" rather than "the Mac is asleep".

--- a/internal/keepawake/keepawake.go
+++ b/internal/keepawake/keepawake.go
@@ -12,8 +12,17 @@
 // symptom reads as "the gateway is flaky", which sends people reading
 // gateway code instead of `pmset -g log`.
 //
-// The fix is for the gateway to hold a power assertion for as long as it
-// serves. On macOS that is /usr/bin/caffeinate, spawned as a child
+// The fix is for the gateway to hold a power assertion while it serves —
+// either continuously (ModeAC / ModeAlways), or only while there is
+// something to serve (ModeOnDemand). On-demand relies on macOS waking
+// the machine when traffic arrives (Wake for network access programs the
+// NIC to wake on TCP data to listening ports); the gateway's job is then
+// to grab an assertion the moment a request or running session shows up,
+// so the short dark-wake window is extended long enough to actually
+// serve, and to let go once things quiet down so the host can sleep
+// again. Sleep itself is never fought — only slept-through requests are.
+//
+// On macOS the assertion is /usr/bin/caffeinate, spawned as a child
 // process rather than linked through IOKit: release binaries are
 // cross-compiled from a Linux runner with CGO disabled, so an
 // IOPMAssertionCreateWithName cgo call is not available to us.
@@ -51,6 +60,15 @@ const (
 	// operator who genuinely wants their laptop reachable on battery.
 	ModeAlways Mode = "always"
 
+	// ModeOnDemand lets the host sleep whenever the gateway is quiet and
+	// holds it awake only while there is activity — in-flight requests,
+	// attached live streams, or a session mid-turn. Reachability while
+	// asleep depends on the host waking for incoming traffic ("Wake for
+	// network access" on a wired interface, or a Bonjour sleep proxy);
+	// the on-demand keeper then extends that wake for as long as serving
+	// takes, plus a short linger.
+	ModeOnDemand Mode = "on_demand"
+
 	// ModeOff never touches host power state. The gateway then stops
 	// answering whenever the host sleeps — correct only if something
 	// else already keeps the machine up.
@@ -60,16 +78,19 @@ const (
 // ParseMode normalises a configured value. Empty means "unset", which
 // resolves to ModeAC.
 func ParseMode(s string) (Mode, error) {
-	switch Mode(strings.ToLower(strings.TrimSpace(s))) {
+	norm := strings.ReplaceAll(strings.ToLower(strings.TrimSpace(s)), "-", "_")
+	switch Mode(norm) {
 	case "", ModeAC:
 		return ModeAC, nil
 	case ModeAlways:
 		return ModeAlways, nil
+	case ModeOnDemand:
+		return ModeOnDemand, nil
 	case ModeOff:
 		return ModeOff, nil
 	default:
-		return "", fmt.Errorf("unknown mode %q (want %q, %q or %q)",
-			s, ModeAC, ModeAlways, ModeOff)
+		return "", fmt.Errorf("unknown mode %q (want %q, %q, %q or %q)",
+			s, ModeAC, ModeAlways, ModeOnDemand, ModeOff)
 	}
 }
 
@@ -83,6 +104,16 @@ const (
 	// healthyRun is how long a helper must survive before its next exit
 	// counts as a fresh failure rather than a continuing crash loop.
 	healthyRun = time.Minute
+
+	// pollInterval is how often on-demand mode re-samples the activity
+	// signal.
+	pollInterval = 15 * time.Second
+	// lingerAfterIdle is how long on-demand mode keeps holding the
+	// assertion after activity last read true. Long enough that a user
+	// tapping around a phone UI doesn't race the host back to sleep
+	// between screens; short enough that a quiet gateway lets the host
+	// sleep within a few minutes.
+	lingerAfterIdle = 2 * time.Minute
 )
 
 // Keeper supervises the platform helper that holds the power assertion.
@@ -94,29 +125,51 @@ type Keeper struct {
 	// no implementation, and is swapped out in tests.
 	newCmd func(ctx context.Context, mode Mode) *exec.Cmd
 
-	// Re-spawn pacing, fields rather than constants so tests can drive
-	// the supervisor loop without sleeping for real seconds.
+	// active reports whether the gateway is currently doing something a
+	// sleeping host would break. Only consulted by ModeOnDemand.
+	active func() bool
+
+	// Pacing knobs, fields rather than constants so tests can drive
+	// the loops without sleeping for real seconds.
 	baseBackoff time.Duration
 	maxBackoff  time.Duration
+	poll        time.Duration
+	linger      time.Duration
+}
+
+// Option customises a Keeper.
+type Option func(*Keeper)
+
+// WithActivity supplies the activity signal ModeOnDemand holds the host
+// awake for. The func must be cheap and safe to call from another
+// goroutine; it is sampled every poll interval.
+func WithActivity(f func() bool) Option {
+	return func(k *Keeper) { k.active = f }
 }
 
 // New returns a Keeper for the given mode. It starts nothing; call Run.
-func New(log *slog.Logger, mode Mode) *Keeper {
+func New(log *slog.Logger, mode Mode, opts ...Option) *Keeper {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &Keeper{
+	k := &Keeper{
 		log:         log.With("component", "keepawake"),
 		mode:        mode,
 		newCmd:      newInhibitCmd,
 		baseBackoff: baseBackoff,
 		maxBackoff:  maxBackoff,
+		poll:        pollInterval,
+		linger:      lingerAfterIdle,
 	}
+	for _, opt := range opts {
+		opt(k)
+	}
+	return k
 }
 
-// Run holds the assertion until ctx is cancelled, re-spawning the helper
-// if it dies. It returns as soon as there is nothing to supervise, so
-// callers can treat it as a plain background goroutine.
+// Run enforces the configured mode until ctx is cancelled. It returns as
+// soon as there is nothing to supervise, so callers can treat it as a
+// plain background goroutine.
 func (k *Keeper) Run(ctx context.Context) {
 	if k.mode == ModeOff {
 		k.log.Info("host idle-sleep inhibition disabled by config; " +
@@ -128,23 +181,119 @@ func (k *Keeper) Run(ctx context.Context) {
 			"mode", string(k.mode))
 		return
 	}
+	if k.mode == ModeOnDemand {
+		if k.active == nil {
+			// No activity signal means on-demand can never assert, which
+			// would silently be ModeOff. Fail towards reachability.
+			k.log.Warn("on_demand mode has no activity signal; " +
+				"holding the host awake continuously instead")
+			k.supervise(ctx)
+			return
+		}
+		k.runOnDemand(ctx)
+		return
+	}
+	k.supervise(ctx)
+}
 
+// runOnDemand lets the host sleep while the gateway is quiet and holds
+// the assertion only across bursts of activity. The host waking at all
+// when traffic hits a sleeping machine is the OS's job (Wake for network
+// access); ours is to keep it up long enough to serve.
+func (k *Keeper) runOnDemand(ctx context.Context) {
+	if wakePreflight != nil {
+		wakePreflight(ctx, k.log)
+	}
+	k.log.Info("holding the host awake on demand: it may sleep while the gateway is quiet",
+		"poll", k.poll, "linger", k.linger)
+	for ctx.Err() == nil {
+		if !k.waitForActivity(ctx) {
+			return
+		}
+		holdCtx, cancel := context.WithCancel(ctx)
+		superviseDone := make(chan bool, 1)
+		go func() {
+			superviseDone <- k.supervise(holdCtx)
+			// A supervisor that gave up permanently must also end the
+			// hold below, or Run would block on a signal that stays
+			// active with nothing left to supervise.
+			cancel()
+		}()
+		k.holdWhileActive(holdCtx)
+		cancel()
+		if gaveUp := <-superviseDone; gaveUp {
+			return
+		}
+	}
+}
+
+// waitForActivity blocks until the activity signal reads true. It
+// returns false when ctx ended first.
+func (k *Keeper) waitForActivity(ctx context.Context) bool {
+	if k.active() {
+		return true
+	}
+	ticker := time.NewTicker(k.poll)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ticker.C:
+			if k.active() {
+				return true
+			}
+		}
+	}
+}
+
+// holdWhileActive blocks while the activity signal stays warm, returning
+// once it has read false continuously for the linger window (or ctx
+// ended).
+func (k *Keeper) holdWhileActive(ctx context.Context) {
+	var idleSince time.Time
+	ticker := time.NewTicker(k.poll)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if k.active() {
+				idleSince = time.Time{}
+				continue
+			}
+			if idleSince.IsZero() {
+				idleSince = time.Now()
+				continue
+			}
+			if time.Since(idleSince) >= k.linger {
+				return
+			}
+		}
+	}
+}
+
+// supervise holds the assertion until ctx is cancelled, re-spawning the
+// helper if it dies. It reports true when the helper can never run
+// (missing binary) so on-demand mode stops re-attempting it forever.
+func (k *Keeper) supervise(ctx context.Context) (gaveUp bool) {
 	backoff := k.baseBackoff
 	for ctx.Err() == nil {
 		started := time.Now()
 		err := k.runOnce(ctx)
 		if ctx.Err() != nil {
-			// Expected: shutdown killed the helper. The assertion is
-			// released with it.
+			// Expected: shutdown (or the end of an on-demand hold)
+			// killed the helper. The assertion is released with it.
 			k.log.Debug("stopped holding the host awake")
-			return
+			return false
 		}
 		// A missing helper is not going to appear on retry.
 		if errors.Is(err, exec.ErrNotFound) || errors.Is(err, fs.ErrNotExist) {
 			k.log.Warn("cannot hold the host awake: power-assertion helper not found. "+
 				"The host may sleep out from under the gateway, making it unreachable "+
 				"from phone and web until someone wakes it.", "err", err)
-			return
+			return true
 		}
 		lived := time.Since(started)
 		if lived >= healthyRun {
@@ -154,11 +303,12 @@ func (k *Keeper) Run(ctx context.Context) {
 			"lived", lived.Round(time.Second), "retry_in", backoff, "err", err)
 		select {
 		case <-ctx.Done():
-			return
+			return false
 		case <-time.After(backoff):
 		}
 		backoff = min(backoff*2, k.maxBackoff)
 	}
+	return false
 }
 
 // runOnce spawns the helper and blocks until it exits.

--- a/internal/keepawake/keepawake_darwin.go
+++ b/internal/keepawake/keepawake_darwin.go
@@ -4,9 +4,12 @@ package keepawake
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
+	"time"
 )
 
 // caffeinatePath is macOS's built-in power-assertion helper. Referenced
@@ -21,7 +24,9 @@ const caffeinatePath = "/usr/bin/caffeinate"
 //	-s  assert against system sleep, but only while on wall power.
 //	    Exactly the ModeAC contract — a desk-bound Mac never idles out,
 //	    a laptop on battery is left alone.
-//	-i  assert against idle sleep on any power source (ModeAlways).
+//	-i  assert against idle sleep on any power source (ModeAlways, and
+//	    ModeOnDemand's holds — those exist only while a request or turn
+//	    is live, and active use should finish regardless of the plug).
 //	-w  wait on a pid: caffeinate exits — releasing the assertion — as
 //	    soon as that process is gone. Passing our own pid means a
 //	    SIGKILLed gateway cannot strand the host in a permanently awake
@@ -32,9 +37,33 @@ const caffeinatePath = "/usr/bin/caffeinate"
 // Sleep), so the operator keeps the last word on their own machine.
 func newInhibitCmd(ctx context.Context, mode Mode) *exec.Cmd {
 	assert := "-s"
-	if mode == ModeAlways {
+	if mode == ModeAlways || mode == ModeOnDemand {
 		assert = "-i"
 	}
 	return exec.CommandContext(ctx, caffeinatePath,
 		assert, "-w", strconv.Itoa(os.Getpid()))
+}
+
+// wakePreflight checks the one host setting on-demand mode cannot work
+// without: "Wake for network access" (womp). With it off, a sleeping
+// Mac never wakes for incoming traffic, so the gateway would simply be
+// unreachable between activity bursts — silently worse than ModeAC. We
+// can't fix it ourselves (pmset needs root), so warn loudly once.
+var wakePreflight = func(ctx context.Context, log *slog.Logger) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "/usr/bin/pmset", "-g", "custom").Output()
+	if err != nil {
+		log.Debug("could not read pmset settings to verify wake-on-network", "err", err)
+		return
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[0] == "womp" && fields[1] == "0" {
+			log.Warn("Wake for network access is off, so a sleeping host cannot be " +
+				"woken by phone or web traffic — on_demand mode will look like an " +
+				"unreachable gateway. Enable it with: sudo pmset -a womp 1")
+			return
+		}
+	}
 }

--- a/internal/keepawake/keepawake_darwin_test.go
+++ b/internal/keepawake/keepawake_darwin_test.go
@@ -23,6 +23,7 @@ func TestNewInhibitCmd_Flags(t *testing.T) {
 	}{
 		{"ac asserts only on wall power", ModeAC, "-s"},
 		{"always asserts on any power source", ModeAlways, "-i"},
+		{"on-demand holds assert on any power source", ModeOnDemand, "-i"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/keepawake/keepawake_other.go
+++ b/internal/keepawake/keepawake_other.go
@@ -4,6 +4,7 @@ package keepawake
 
 import (
 	"context"
+	"log/slog"
 	"os/exec"
 )
 
@@ -12,3 +13,6 @@ import (
 // install, so there is nothing to inhibit. Keeper.Run sees the nil and
 // returns immediately.
 var newInhibitCmd func(ctx context.Context, mode Mode) *exec.Cmd
+
+// wakePreflight has nothing to verify off macOS.
+var wakePreflight func(ctx context.Context, log *slog.Logger)

--- a/internal/keepawake/keepawake_test.go
+++ b/internal/keepawake/keepawake_test.go
@@ -41,6 +41,8 @@ func TestParseMode(t *testing.T) {
 		{"empty defaults to ac", "", ModeAC, false},
 		{"explicit ac", "ac", ModeAC, false},
 		{"always", "always", ModeAlways, false},
+		{"on_demand", "on_demand", ModeOnDemand, false},
+		{"on-demand hyphen spelling", "On-Demand", ModeOnDemand, false},
 		{"off", "off", ModeOff, false},
 		{"case and space insensitive", "  Always ", ModeAlways, false},
 		{"unknown value", "sometimes", "", true},

--- a/internal/keepawake/ondemand_test.go
+++ b/internal/keepawake/ondemand_test.go
@@ -1,0 +1,231 @@
+package keepawake
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestRun_OnDemandHoldsOnlyWhileActive(t *testing.T) {
+	var active atomic.Bool
+	var spawns atomic.Int32
+	pidFile := filepath.Join(t.TempDir(), "helper.pid")
+
+	k := New(quietLogger(), ModeOnDemand, WithActivity(active.Load))
+	k.baseBackoff = time.Millisecond
+	k.maxBackoff = 5 * time.Millisecond
+	k.poll = 2 * time.Millisecond
+	k.linger = 10 * time.Millisecond
+	k.newCmd = testHelperCmd(pidFile, &spawns)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		k.Run(ctx)
+		close(done)
+	}()
+
+	// Quiet gateway: no helper may be spawned.
+	time.Sleep(50 * time.Millisecond)
+	if got := spawns.Load(); got != 0 {
+		t.Fatalf("helper spawned %d times while inactive, want 0", got)
+	}
+
+	// Activity shows up: the helper must start and stay up.
+	active.Store(true)
+	pid := waitForHelperPid(t, pidFile)
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Fatalf("helper pid %d not alive while active: %v", pid, err)
+	}
+
+	// Activity ends: after the linger window the helper must be gone,
+	// releasing the assertion so the host can sleep again.
+	active.Store(false)
+	waitForProcessGone(t, pid)
+
+	// Activity returns: a fresh hold must start a fresh helper.
+	if err := os.Remove(pidFile); err != nil {
+		t.Fatalf("remove pid file: %v", err)
+	}
+	active.Store(true)
+	waitForHelperPid(t, pidFile)
+	if got := spawns.Load(); got < 2 {
+		t.Fatalf("helper spawned %d times after re-activation, want >= 2", got)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+// A cancel that lands while on-demand mode is idling (no helper up) must
+// end Run promptly, not leave a goroutine polling forever.
+func TestRun_OnDemandReturnsOnCancelWhileQuiet(t *testing.T) {
+	var active atomic.Bool // stays false
+	var spawns atomic.Int32
+	k := New(quietLogger(), ModeOnDemand, WithActivity(active.Load))
+	k.poll = 2 * time.Millisecond
+	k.linger = 10 * time.Millisecond
+	k.newCmd = testHelperCmd(filepath.Join(t.TempDir(), "helper.pid"), &spawns)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		k.Run(ctx)
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after cancel while quiet")
+	}
+	if got := spawns.Load(); got != 0 {
+		t.Fatalf("helper spawned %d times, want 0", got)
+	}
+}
+
+// A missing helper binary is permanent; on-demand mode must stop trying
+// rather than re-attempt it on every activity burst forever.
+func TestRun_OnDemandGivesUpWhenHelperIsMissing(t *testing.T) {
+	var active atomic.Bool
+	active.Store(true)
+	var spawns atomic.Int32
+	k := New(quietLogger(), ModeOnDemand, WithActivity(active.Load))
+	k.baseBackoff = time.Millisecond
+	k.maxBackoff = 5 * time.Millisecond
+	k.poll = 2 * time.Millisecond
+	k.linger = 10 * time.Millisecond
+	k.newCmd = func(ctx context.Context, _ Mode) *exec.Cmd {
+		spawns.Add(1)
+		return exec.CommandContext(ctx, "/nonexistent/opendray-keepawake-helper")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		k.Run(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run kept retrying a helper that does not exist")
+	}
+	if got := spawns.Load(); got != 1 {
+		t.Fatalf("attempted the missing helper %d times, want exactly 1", got)
+	}
+}
+
+// On-demand without an activity signal must fall back to holding the
+// host awake continuously — failing towards reachability, not ModeOff.
+func TestRun_OnDemandWithoutSignalHoldsContinuously(t *testing.T) {
+	var spawns atomic.Int32
+	k := newTestKeeper(t, ModeOnDemand, "sleep 30", &spawns)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		k.Run(ctx)
+		close(done)
+	}()
+	deadline := time.After(2 * time.Second)
+	for spawns.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("helper never spawned without an activity signal")
+		case <-time.After(time.Millisecond):
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+func TestTracker_ActiveDuringAndShortlyAfterRequests(t *testing.T) {
+	tr := NewTracker()
+	tr.recent = 80 * time.Millisecond
+	if tr.Active() {
+		t.Fatal("a tracker that has never served must be inactive")
+	}
+
+	release := make(chan struct{})
+	handled := make(chan struct{})
+	h := tr.Wrap(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		close(handled)
+		<-release
+	}))
+	go h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+	<-handled
+	if !tr.Active() {
+		t.Fatal("tracker must be active while a request is in flight")
+	}
+
+	close(release)
+	// Immediately after completion the recent window keeps it warm.
+	if !tr.Active() {
+		t.Fatal("tracker must stay active inside the recent window")
+	}
+	deadline := time.After(2 * time.Second)
+	for tr.Active() {
+		select {
+		case <-deadline:
+			t.Fatal("tracker never went inactive after the recent window")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+// testHelperCmd builds a newCmd whose process records its pid, so tests
+// can verify the assertion-holder's actual lifetime.
+func testHelperCmd(pidFile string, spawns *atomic.Int32) func(context.Context, Mode) *exec.Cmd {
+	script := "echo $$ > " + pidFile + " && sleep 30"
+	return func(ctx context.Context, _ Mode) *exec.Cmd {
+		spawns.Add(1)
+		return exec.CommandContext(ctx, "/bin/sh", "-c", script)
+	}
+}
+
+func waitForHelperPid(t *testing.T, pidFile string) int {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		if raw, err := os.ReadFile(pidFile); err == nil {
+			if pid, err := strconv.Atoi(strings.TrimSpace(string(raw))); err == nil && pid > 0 {
+				return pid
+			}
+		}
+		select {
+		case <-deadline:
+			t.Fatal("helper never wrote its pid file")
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+func waitForProcessGone(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for syscall.Kill(pid, 0) == nil {
+		select {
+		case <-deadline:
+			t.Fatalf("helper pid %d still alive after activity ended", pid)
+		case <-time.After(time.Millisecond):
+		}
+	}
+}

--- a/internal/keepawake/tracker.go
+++ b/internal/keepawake/tracker.go
@@ -1,0 +1,53 @@
+package keepawake
+
+import (
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// recentWindow is how long after a request completes the Tracker still
+// reports activity. The keeper samples on a poll grid, so without this
+// window a burst of fast requests — a phone loading a screen — could
+// start and finish entirely between two samples and never earn an
+// assertion, leaving the dark-woken host to sleep mid-browse.
+const recentWindow = 45 * time.Second
+
+// Tracker derives the gateway's HTTP activity signal for ModeOnDemand.
+// Wrap the root handler once; Active is then true while any request is
+// in flight or one completed within the recent window. WebSocket and
+// SSE handlers block inside ServeHTTP for the connection's lifetime, so
+// an attached live terminal or event feed counts as in flight too —
+// exactly right: a client streaming a PTY must keep the host up.
+type Tracker struct {
+	recent   time.Duration
+	inflight atomic.Int64
+	lastNano atomic.Int64
+}
+
+// NewTracker returns a Tracker with the default recent window.
+func NewTracker() *Tracker {
+	return &Tracker{recent: recentWindow}
+}
+
+// Wrap counts next's requests towards the activity signal.
+func (t *Tracker) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.inflight.Add(1)
+		defer func() {
+			t.lastNano.Store(time.Now().UnixNano())
+			t.inflight.Add(-1)
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+// Active reports whether the gateway is serving now or did within the
+// recent window.
+func (t *Tracker) Active() bool {
+	if t.inflight.Load() > 0 {
+		return true
+	}
+	last := t.lastNano.Load()
+	return last != 0 && time.Since(time.Unix(0, last)) < t.recent
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1095,6 +1095,26 @@ func (m *Manager) ActiveCountByProvider(providerID string) int {
 	return n
 }
 
+// AnyMidTurn reports whether any live session is currently producing
+// output (state running, before the idle detector flips it). This is
+// the keep-awake activity signal that stops the host sleeping out from
+// under a CLI that is mid-task with no client attached — a turn started
+// from a phone must survive the phone locking. Iterates the in-memory
+// map only, so it's lock-cheap and safe to poll.
+func (m *Manager) AnyMidTurn() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, rs := range m.sessions {
+		rs.sessMu.RLock()
+		running := rs.sess.State == StateRunning
+		rs.sessMu.RUnlock()
+		if running {
+			return true
+		}
+	}
+	return false
+}
+
 // Stop terminates the running process for a session but preserves
 // the DB row. The user can subsequently call Start to re-spawn.
 // For an already-terminal session it succeeds as a no-op.

--- a/internal/session/midturn_test.go
+++ b/internal/session/midturn_test.go
@@ -1,0 +1,30 @@
+package session
+
+import "testing"
+
+// AnyMidTurn is the keep-awake activity signal: it must fire only for a
+// session that is actively producing output, not for idle or terminal
+// ones sitting in the live map.
+func TestAnyMidTurn(t *testing.T) {
+	tests := []struct {
+		name   string
+		states []State
+		want   bool
+	}{
+		{"no live sessions", nil, false},
+		{"only idle sessions", []State{StateIdle, StateIdle}, false},
+		{"terminal states do not count", []State{StateEnded, StateStopped}, false},
+		{"one running among idle", []State{StateIdle, StateRunning, StateIdle}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Manager{sessions: make(map[string]*runningSession)}
+			for i, st := range tt.states {
+				m.sessions[string(rune('a'+i))] = &runningSession{sess: Session{State: st}}
+			}
+			if got := m.AnyMidTurn(); got != tt.want {
+				t.Fatalf("AnyMidTurn() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

#487 fixed phone/web unreachability by holding the host awake for as long as the gateway serves. That trades power for reachability around the clock. The operator's actual requirement is stronger: **the Mac should still sleep** when nothing is going on — the gateway just has to survive it.

The hardware path for that already works: with **Wake for network access** (`womp 1`) on a wired interface, incoming TCP data dark-wakes a sleeping Mac (visible as `DarkWake … Enet.TCPData` in `pmset -g log`). What's missing is the other half: the dark-wake window is ~45s, and nothing extends it while the gateway is actually serving, so the machine sleeps back mid-request.

## What

New `[host] prevent_idle_sleep = "on_demand"`:

- **Quiet gateway → no assertion.** The host sleeps per its own power settings.
- **Traffic arrives → the OS wakes the machine, we keep it up.** A `keepawake.Tracker` wraps the root handler; in-flight requests plus a 45s recent window (so fast request bursts can't slip between poll samples) form the HTTP signal. WebSocket/SSE handlers block inside `ServeHTTP`, so an attached live terminal counts as in-flight.
- **A mid-turn session counts as activity** (`session.Manager.AnyMidTurn`) — a turn started from a phone survives the phone locking and walking away.
- **Idle again → release after a 2-minute linger**, and the host may sleep.

Safety properties carried over from #487: assertion via `caffeinate -w <gateway pid>` (SIGKILL can't strand the host awake), deliberate sleep is never blocked. On-demand holds use `-i` — they only exist during active use, which should finish regardless of the power source. Startup preflight warns if `womp` is off, where on-demand would silently degrade into an unreachable gateway. `"ac"` stays the default; `"always"`/`"off"` unchanged.

Also fixes a liveness bug found by the new tests: a permanently missing helper binary now ends both the supervisor and the hold loop, instead of leaving `Run` blocked forever on an activity signal nobody consumes.

## Test plan

- [x] `go test -race ./internal/keepawake` — on-demand lifecycle observed against real processes (helper pid appears while active, is gone after linger, respawns on re-activation), cancel-while-quiet, missing-helper give-up, no-signal fallback to continuous hold, tracker in-flight/recent-window semantics, darwin flag pinning (`on_demand → -i -w <pid>`)
- [x] `go test -race ./internal/session` — `AnyMidTurn` table test (idle/terminal states don't count, one running does)
- [x] `go build ./...`, `go vet`, `gofmt` clean; full suite green except the pre-existing local-env `internal/catalog` npm bin-link failure (fails on clean main too)
- [x] Host prerequisites verified on the target Mac: wired `en0`, `womp 1`, `tcpkeepalive 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)