### PR TITLE
feat(settings): expose host power mode on web and mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ for the full rationale and what triggers a major bump.
 
 ### Added
 
+- **Host power is now a setting you can see, on web and mobile.** The
+  choice between "stay reachable" and "let the machine sleep" was only
+  reachable by hand-editing `config.toml`, which meant nobody found it.
+  Server settings gain a **Host power** section listing all four modes
+  with what each one costs — web renders them as annotated cards, mobile
+  as a labelled picker — plus a note that a deliberate sleep is never
+  blocked and that non-macOS hosts ignore the setting. Translated across
+  English, 中文 and Español.
+
 - **Wake-on-demand: the host may sleep, and phone/web traffic wakes it.**
   `[host] prevent_idle_sleep = "on_demand"` lets the gateway's Mac sleep
   whenever things are quiet instead of being held awake around the clock.
@@ -26,6 +35,14 @@ for the full rationale and what triggers a major bump.
   `"always"` and `"off"` behaviours are unchanged.
 
 ### Fixed
+
+- **Saving invalid server settings no longer bricks the next restart.**
+  `PUT /admin/settings` wrote whatever it was given. Since the loader
+  validates on every startup, a bad value — an unparseable duration, an
+  unknown mode — saved cleanly and then stopped the gateway from coming
+  back up, with nothing naming the offending field. The write path now
+  validates exactly what is about to hit disk and answers 400 instead,
+  leaving the stored config untouched.
 
 - **The gateway keeps its host awake, so phone and web stay connected.**
   A Mac left to itself idle-sleeps, and a sleeping host takes its network

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -2118,6 +2118,10 @@
           "title": "General",
           "desc": "Listen address, operator account, token TTL."
         },
+        "host": {
+          "title": "Host power",
+          "desc": "Keep the machine reachable from phone and web while it is idle."
+        },
         "logging": {
           "title": "Logging",
           "desc": "Verbosity, format, and live tail."
@@ -2488,7 +2492,32 @@
         "defaultOff": "Default (off)"
       },
       "memoryRuntimeBanner": "Runtime AI behaviour — workers, capture rules, injection profiles and spawn mode — lives in Cortex settings and applies instantly. This section is the infrastructure half: embedder, storage and background governance (restart required).",
-      "memoryRuntimeBannerButton": "Open Cortex settings"
+      "memoryRuntimeBannerButton": "Open Cortex settings",
+      "host": {
+        "intro": "A sleeping Mac takes its network down with it, so the gateway simply stops answering — from phone, from web, and to its database. It reads as \"opendray is flaky\" when the machine is really just asleep. Pick how opendray should handle that.",
+        "platformNote": "macOS only. On Linux and Windows this setting is accepted and ignored — those hosts do not idle-suspend under a normal server install. A deliberate sleep (lid close, Apple menu → Sleep) is never blocked, and the assertion is released if opendray exits or is killed.",
+        "modes": {
+          "ac": {
+            "label": "Stay awake on wall power",
+            "desc": "The machine never idle-sleeps while plugged in, so phone and web connect instantly. On battery it sleeps normally. The screen still turns off as usual."
+          },
+          "always": {
+            "label": "Stay awake on any power",
+            "desc": "Never idle-sleeps, including on battery.",
+            "caveat": "Will drain a laptop battery left unplugged."
+          },
+          "on_demand": {
+            "label": "Sleep when idle, wake on traffic",
+            "desc": "The machine sleeps whenever the gateway is quiet. An incoming request wakes it, and opendray holds it awake while serving, then lets it sleep again.",
+            "caveat": "Needs \"Wake for network access\" (sudo pmset -a womp 1), reliably wired Ethernet. The first request after a sleep takes a few seconds and may need one retry."
+          },
+          "off": {
+            "label": "Never touch power settings",
+            "desc": "opendray leaves the machine alone entirely.",
+            "caveat": "The gateway is unreachable whenever the host sleeps, unless something else keeps it awake."
+          }
+        }
+      }
     },
     "settings": {
       "title": "Settings",
@@ -5202,6 +5231,7 @@
       "loadFailed": "Failed to load server settings",
       "sections": {
         "general": "General",
+        "host": "Host power",
         "logging": "Logging",
         "sessions": "Sessions",
         "vault": "Vault",
@@ -5214,6 +5244,7 @@
       },
       "sectionDescriptions": {
         "general": "Listen address, operator account, token TTL.",
+        "host": "Keep this machine reachable while it is idle.",
         "logging": "Verbosity, format, and on-disk log path.",
         "sessions": "Idle detection thresholds.",
         "vault": "Notes, skills, and git-versioned root.",
@@ -5288,7 +5319,13 @@
         "cleanerEnabled": "Cleaner",
         "cleanerHelper": "Periodic auto-librarian that soft-archives stale / duplicate memories.",
         "knowledgeEnabled": "Knowledge graph",
-        "knowledgeHelper": "The structured entities/playbooks/skills layer on top of memory."
+        "knowledgeHelper": "The structured entities/playbooks/skills layer on top of memory.",
+        "preventIdleSleep": "Idle sleep",
+        "preventIdleSleepHelper": "A sleeping Mac takes its network down, so the gateway stops answering from phone and web. \"Stay awake on wall power\" is the default and keeps it reachable (the screen still turns off). \"Sleep, wake on traffic\" saves power but needs Wake for network access, and the first request after a sleep is slow. macOS only.",
+        "sleepModeAc": "Stay awake on wall power",
+        "sleepModeAlways": "Stay awake on any power",
+        "sleepModeOnDemand": "Sleep, wake on traffic",
+        "sleepModeOff": "Don't touch power"
       },
       "validateInteger": "\"{field}\" must be an integer",
       "validateNumber": "\"{field}\" must be a number",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -2118,6 +2118,10 @@
           "title": "General",
           "desc": "Dirección de escucha, cuenta de operador, TTL del token."
         },
+        "host": {
+          "title": "Energía del host",
+          "desc": "Mantén la máquina accesible desde el móvil y la web mientras está inactiva."
+        },
         "logging": {
           "title": "Registro",
           "desc": "Verbosidad, formato y seguimiento en vivo."
@@ -2488,7 +2492,32 @@
         "defaultOff": "Por defecto (off)"
       },
       "memoryRuntimeBanner": "El comportamiento de IA en runtime — workers, reglas de captura, perfiles de inyección y modo de spawn — vive en los ajustes de Cortex y se aplica al instante. Esta sección es la mitad de infraestructura: embedder, almacenamiento y gobernanza de fondo (requiere reinicio).",
-      "memoryRuntimeBannerButton": "Abrir ajustes de Cortex"
+      "memoryRuntimeBannerButton": "Abrir ajustes de Cortex",
+      "host": {
+        "intro": "Un Mac dormido apaga también su red, así que la pasarela deja de responder: desde el móvil, desde la web y hacia su base de datos. Parece que «opendray falla» cuando en realidad la máquina solo está dormida. Elige cómo debe gestionarlo opendray.",
+        "platformNote": "Solo macOS. En Linux y Windows este ajuste se acepta y se ignora: esos hosts no se suspenden por inactividad en una instalación de servidor normal. Nunca se bloquea una suspensión deliberada (cerrar la tapa, menú Apple → Reposo), y la aserción se libera si opendray termina o es forzado a cerrar.",
+        "modes": {
+          "ac": {
+            "label": "Despierto con corriente",
+            "desc": "La máquina no se duerme por inactividad mientras está enchufada, así que el móvil y la web conectan al instante. Con batería duerme con normalidad. La pantalla se sigue apagando igual."
+          },
+          "always": {
+            "label": "Despierto con cualquier alimentación",
+            "desc": "Nunca se duerme por inactividad, tampoco con batería.",
+            "caveat": "Agotará la batería de un portátil desenchufado."
+          },
+          "on_demand": {
+            "label": "Duerme inactivo, despierta con tráfico",
+            "desc": "La máquina duerme siempre que la pasarela está en calma. Una petición entrante la despierta y opendray la mantiene despierta mientras sirve; después vuelve a dormir.",
+            "caveat": "Requiere «Activar por acceso de red» (sudo pmset -a womp 1); Ethernet por cable es lo fiable. La primera petición tras dormir tarda unos segundos y puede necesitar un reintento."
+          },
+          "off": {
+            "label": "No tocar la energía",
+            "desc": "opendray no interviene en absoluto en la máquina.",
+            "caveat": "La pasarela será inaccesible cuando el host duerma, salvo que otra cosa lo mantenga despierto."
+          }
+        }
+      }
     },
     "settings": {
       "title": "Ajustes",
@@ -5202,6 +5231,7 @@
       "loadFailed": "No se pudieron cargar los ajustes del servidor",
       "sections": {
         "general": "General",
+        "host": "Energía del host",
         "logging": "Registro",
         "sessions": "Sessions",
         "vault": "Vault",
@@ -5214,6 +5244,7 @@
       },
       "sectionDescriptions": {
         "general": "Dirección de escucha, cuenta del operador, TTL del token.",
+        "host": "Mantén esta máquina accesible mientras está inactiva.",
         "logging": "Verbosidad, formato y ruta del log en disco.",
         "sessions": "Umbrales de detección de inactividad.",
         "vault": "Notas, skills y raíz versionada con git.",
@@ -5288,7 +5319,13 @@
         "cleanerEnabled": "Cleaner",
         "cleanerHelper": "Auto-bibliotecario periódico que archiva memorias obsoletas / duplicadas.",
         "knowledgeEnabled": "Grafo de conocimiento",
-        "knowledgeHelper": "La capa estructurada de entidades/playbooks/skills sobre la memoria."
+        "knowledgeHelper": "La capa estructurada de entidades/playbooks/skills sobre la memoria.",
+        "preventIdleSleep": "Reposo por inactividad",
+        "preventIdleSleepHelper": "Un Mac dormido apaga su red, así que la pasarela deja de responder desde el móvil y la web. «Despierto con corriente» es lo predeterminado y lo mantiene accesible (la pantalla se sigue apagando). «Dormir y despertar con tráfico» ahorra energía pero requiere Activar por acceso de red, y la primera petición tras dormir es lenta. Solo macOS.",
+        "sleepModeAc": "Despierto con corriente",
+        "sleepModeAlways": "Despierto con cualquier alimentación",
+        "sleepModeOnDemand": "Dormir, despertar con tráfico",
+        "sleepModeOff": "No tocar la energía"
       },
       "validateInteger": "\"{field}\" debe ser un entero",
       "validateNumber": "\"{field}\" debe ser un número",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -2118,6 +2118,10 @@
           "title": "通用",
           "desc": "监听地址、操作员账号、令牌 TTL。"
         },
+        "host": {
+          "title": "主机电源",
+          "desc": "让这台机器在闲置时仍能被手机和网页访问。"
+        },
         "logging": {
           "title": "日志",
           "desc": "日志级别、格式与实时跟踪。"
@@ -2488,7 +2492,32 @@
         "defaultOff": "默认（关）"
       },
       "memoryRuntimeBanner": "运行时 AI 行为——工作器、捕获规则、注入策略与 spawn 模式——位于 Cortex 设置，保存即生效。本区块是基础设施的一半：嵌入后端、存储与后台治理（需重启生效）。",
-      "memoryRuntimeBannerButton": "打开 Cortex 设置"
+      "memoryRuntimeBannerButton": "打开 Cortex 设置",
+      "host": {
+        "intro": "睡眠中的 Mac 会一并关掉网络,网关随即停止应答 —— 手机连不上、网页连不上、连数据库也断开。表面看像\"opendray 不稳定\",实际只是机器睡着了。请选择 opendray 的应对方式。",
+        "platformNote": "仅 macOS 生效。Linux 与 Windows 会接受但忽略此设置 —— 常规服务器安装下这些主机不会空闲休眠。主动睡眠(合盖、苹果菜单 → 睡眠)永不被阻止;opendray 退出或被强制结束时,电源断言会立即释放。",
+        "modes": {
+          "ac": {
+            "label": "插电时保持唤醒",
+            "desc": "插电状态下机器不会空闲休眠,手机与网页随时秒连;使用电池时照常休眠。屏幕仍会正常熄灭。"
+          },
+          "always": {
+            "label": "任何供电下都保持唤醒",
+            "desc": "包括使用电池时也不会空闲休眠。",
+            "caveat": "笔记本拔掉电源后会持续耗电。"
+          },
+          "on_demand": {
+            "label": "闲时休眠,有请求时唤醒",
+            "desc": "网关空闲时机器正常入睡;收到请求时被唤醒,opendray 在服务期间保持唤醒,结束后让它继续休眠。",
+            "caveat": "需要开启\"网络访问唤醒\"(sudo pmset -a womp 1),有线以太网最可靠。休眠后的第一个请求会有几秒延迟,偶尔需要重试一次。"
+          },
+          "off": {
+            "label": "完全不干预电源",
+            "desc": "opendray 不对机器电源做任何操作。",
+            "caveat": "主机一旦休眠即无法连接,除非另有程序让它保持唤醒。"
+          }
+        }
+      }
     },
     "settings": {
       "title": "设置",
@@ -5202,6 +5231,7 @@
       "loadFailed": "加载服务器设置失败",
       "sections": {
         "general": "通用",
+        "host": "主机电源",
         "logging": "日志",
         "sessions": "会话",
         "vault": "凭据库",
@@ -5214,6 +5244,7 @@
       },
       "sectionDescriptions": {
         "general": "监听地址、管理员账号、令牌 TTL。",
+        "host": "让这台机器在闲置时仍可被访问。",
         "logging": "详细程度、格式、磁盘日志路径。",
         "sessions": "空闲检测阈值。",
         "vault": "笔记、技能、git 版本化的根目录。",
@@ -5288,7 +5319,13 @@
         "cleanerEnabled": "Cleaner",
         "cleanerHelper": "周期性自动馆员，软归档过期/重复记忆。",
         "knowledgeEnabled": "知识图谱",
-        "knowledgeHelper": "建立在记忆之上的结构化实体/手册/技能层。"
+        "knowledgeHelper": "建立在记忆之上的结构化实体/手册/技能层。",
+        "preventIdleSleep": "空闲休眠",
+        "preventIdleSleepHelper": "睡眠中的 Mac 会关掉网络,网关便无法从手机和网页应答。默认的\"插电时保持唤醒\"能确保随时可连(屏幕仍会正常熄灭)。\"闲时休眠,有请求时唤醒\"更省电,但需开启网络访问唤醒,且休眠后的第一个请求会较慢。仅 macOS 生效。",
+        "sleepModeAc": "插电时保持唤醒",
+        "sleepModeAlways": "任何供电下保持唤醒",
+        "sleepModeOnDemand": "闲时休眠,有请求时唤醒",
+        "sleepModeOff": "不干预电源"
       },
       "validateInteger": "「{field}」必须是整数",
       "validateNumber": "「{field}」必须是数字",

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 12891 (4297 per locale)
+/// Strings: 12960 (4320 per locale)
 ///
-/// Built on 2026-08-06 at 09:06 UTC
+/// Built on 2026-08-07 at 08:42 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -3202,6 +3202,8 @@ class TranslationsWebServerSettingsEn {
 
 	/// en: 'Open Cortex settings'
 	String get memoryRuntimeBannerButton => 'Open Cortex settings';
+
+	late final TranslationsWebServerSettingsHostEn host = TranslationsWebServerSettingsHostEn.internal(_root);
 }
 
 // Path: web.settings
@@ -10193,6 +10195,7 @@ class TranslationsWebServerSettingsSectionsEn {
 
 	// Translations
 	late final TranslationsWebServerSettingsSectionsGeneralEn general = TranslationsWebServerSettingsSectionsGeneralEn.internal(_root);
+	late final TranslationsWebServerSettingsSectionsHostEn host = TranslationsWebServerSettingsSectionsHostEn.internal(_root);
 	late final TranslationsWebServerSettingsSectionsLoggingEn logging = TranslationsWebServerSettingsSectionsLoggingEn.internal(_root);
 	late final TranslationsWebServerSettingsSectionsSessionsEn sessions = TranslationsWebServerSettingsSectionsSessionsEn.internal(_root);
 	late final TranslationsWebServerSettingsSectionsVaultEn vault = TranslationsWebServerSettingsSectionsVaultEn.internal(_root);
@@ -10603,6 +10606,23 @@ class TranslationsWebServerSettingsToggleEn {
 
 	/// en: 'Default (off)'
 	String get defaultOff => 'Default (off)';
+}
+
+// Path: web.serverSettings.host
+class TranslationsWebServerSettingsHostEn {
+	TranslationsWebServerSettingsHostEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'A sleeping Mac takes its network down with it, so the gateway simply stops answering — from phone, from web, and to its database. It reads as "opendray is flaky" when the machine is really just asleep. Pick how opendray should handle that.'
+	String get intro => 'A sleeping Mac takes its network down with it, so the gateway simply stops answering — from phone, from web, and to its database. It reads as "opendray is flaky" when the machine is really just asleep. Pick how opendray should handle that.';
+
+	/// en: 'macOS only. On Linux and Windows this setting is accepted and ignored — those hosts do not idle-suspend under a normal server install. A deliberate sleep (lid close, Apple menu → Sleep) is never blocked, and the assertion is released if opendray exits or is killed.'
+	String get platformNote => 'macOS only. On Linux and Windows this setting is accepted and ignored — those hosts do not idle-suspend under a normal server install. A deliberate sleep (lid close, Apple menu → Sleep) is never blocked, and the assertion is released if opendray exits or is killed.';
+
+	late final TranslationsWebServerSettingsHostModesEn modes = TranslationsWebServerSettingsHostModesEn.internal(_root);
 }
 
 // Path: web.settings.groups
@@ -14104,6 +14124,9 @@ class TranslationsSettingsServerSettingsSectionsEn {
 	/// en: 'General'
 	String get general => 'General';
 
+	/// en: 'Host power'
+	String get host => 'Host power';
+
 	/// en: 'Logging'
 	String get logging => 'Logging';
 
@@ -14142,6 +14165,9 @@ class TranslationsSettingsServerSettingsSectionDescriptionsEn {
 
 	/// en: 'Listen address, operator account, token TTL.'
 	String get general => 'Listen address, operator account, token TTL.';
+
+	/// en: 'Keep this machine reachable while it is idle.'
+	String get host => 'Keep this machine reachable while it is idle.';
 
 	/// en: 'Verbosity, format, and on-disk log path.'
 	String get logging => 'Verbosity, format, and on-disk log path.';
@@ -14370,6 +14396,24 @@ class TranslationsSettingsServerSettingsFieldsEn {
 
 	/// en: 'The structured entities/playbooks/skills layer on top of memory.'
 	String get knowledgeHelper => 'The structured entities/playbooks/skills layer on top of memory.';
+
+	/// en: 'Idle sleep'
+	String get preventIdleSleep => 'Idle sleep';
+
+	/// en: 'A sleeping Mac takes its network down, so the gateway stops answering from phone and web. "Stay awake on wall power" is the default and keeps it reachable (the screen still turns off). "Sleep, wake on traffic" saves power but needs Wake for network access, and the first request after a sleep is slow. macOS only.'
+	String get preventIdleSleepHelper => 'A sleeping Mac takes its network down, so the gateway stops answering from phone and web. "Stay awake on wall power" is the default and keeps it reachable (the screen still turns off). "Sleep, wake on traffic" saves power but needs Wake for network access, and the first request after a sleep is slow. macOS only.';
+
+	/// en: 'Stay awake on wall power'
+	String get sleepModeAc => 'Stay awake on wall power';
+
+	/// en: 'Stay awake on any power'
+	String get sleepModeAlways => 'Stay awake on any power';
+
+	/// en: 'Sleep, wake on traffic'
+	String get sleepModeOnDemand => 'Sleep, wake on traffic';
+
+	/// en: 'Don't touch power'
+	String get sleepModeOff => 'Don\'t touch power';
 }
 
 // Path: settings.serverSettings.embedderModel
@@ -16440,6 +16484,21 @@ class TranslationsWebServerSettingsSectionsGeneralEn {
 	String get desc => 'Listen address, operator account, token TTL.';
 }
 
+// Path: web.serverSettings.sections.host
+class TranslationsWebServerSettingsSectionsHostEn {
+	TranslationsWebServerSettingsSectionsHostEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Host power'
+	String get title => 'Host power';
+
+	/// en: 'Keep the machine reachable from phone and web while it is idle.'
+	String get desc => 'Keep the machine reachable from phone and web while it is idle.';
+}
+
 // Path: web.serverSettings.sections.logging
 class TranslationsWebServerSettingsSectionsLoggingEn {
 	TranslationsWebServerSettingsSectionsLoggingEn.internal(this._root);
@@ -17356,6 +17415,19 @@ class TranslationsWebServerSettingsBackupScheduleHeadersEn {
 
 	/// en: 'State'
 	String get state => 'State';
+}
+
+// Path: web.serverSettings.host.modes
+class TranslationsWebServerSettingsHostModesEn {
+	TranslationsWebServerSettingsHostModesEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsWebServerSettingsHostModesAcEn ac = TranslationsWebServerSettingsHostModesAcEn.internal(_root);
+	late final TranslationsWebServerSettingsHostModesAlwaysEn always = TranslationsWebServerSettingsHostModesAlwaysEn.internal(_root);
+	late final TranslationsWebServerSettingsHostModesOnDemandEn on_demand = TranslationsWebServerSettingsHostModesOnDemandEn.internal(_root);
+	late final TranslationsWebServerSettingsHostModesOffEn off = TranslationsWebServerSettingsHostModesOffEn.internal(_root);
 }
 
 // Path: web.settings.appearance.options
@@ -18278,6 +18350,75 @@ class TranslationsWebNotesVaultSyncConflictKindsEn {
 
 	/// en: 'operation'
 	String get operation => 'operation';
+}
+
+// Path: web.serverSettings.host.modes.ac
+class TranslationsWebServerSettingsHostModesAcEn {
+	TranslationsWebServerSettingsHostModesAcEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Stay awake on wall power'
+	String get label => 'Stay awake on wall power';
+
+	/// en: 'The machine never idle-sleeps while plugged in, so phone and web connect instantly. On battery it sleeps normally. The screen still turns off as usual.'
+	String get desc => 'The machine never idle-sleeps while plugged in, so phone and web connect instantly. On battery it sleeps normally. The screen still turns off as usual.';
+}
+
+// Path: web.serverSettings.host.modes.always
+class TranslationsWebServerSettingsHostModesAlwaysEn {
+	TranslationsWebServerSettingsHostModesAlwaysEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Stay awake on any power'
+	String get label => 'Stay awake on any power';
+
+	/// en: 'Never idle-sleeps, including on battery.'
+	String get desc => 'Never idle-sleeps, including on battery.';
+
+	/// en: 'Will drain a laptop battery left unplugged.'
+	String get caveat => 'Will drain a laptop battery left unplugged.';
+}
+
+// Path: web.serverSettings.host.modes.on_demand
+class TranslationsWebServerSettingsHostModesOnDemandEn {
+	TranslationsWebServerSettingsHostModesOnDemandEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Sleep when idle, wake on traffic'
+	String get label => 'Sleep when idle, wake on traffic';
+
+	/// en: 'The machine sleeps whenever the gateway is quiet. An incoming request wakes it, and opendray holds it awake while serving, then lets it sleep again.'
+	String get desc => 'The machine sleeps whenever the gateway is quiet. An incoming request wakes it, and opendray holds it awake while serving, then lets it sleep again.';
+
+	/// en: 'Needs "Wake for network access" (sudo pmset -a womp 1), reliably wired Ethernet. The first request after a sleep takes a few seconds and may need one retry.'
+	String get caveat => 'Needs "Wake for network access" (sudo pmset -a womp 1), reliably wired Ethernet. The first request after a sleep takes a few seconds and may need one retry.';
+}
+
+// Path: web.serverSettings.host.modes.off
+class TranslationsWebServerSettingsHostModesOffEn {
+	TranslationsWebServerSettingsHostModesOffEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Never touch power settings'
+	String get label => 'Never touch power settings';
+
+	/// en: 'opendray leaves the machine alone entirely.'
+	String get desc => 'opendray leaves the machine alone entirely.';
+
+	/// en: 'The gateway is unreachable whenever the host sleeps, unless something else keeps it awake.'
+	String get caveat => 'The gateway is unreachable whenever the host sleeps, unless something else keeps it awake.';
 }
 
 // Path: web.memoryAmbient.rules.row.summary
@@ -20100,6 +20241,8 @@ extension on Translations {
 			'web.backups.targetEditor.rclone.configPathPlaceholder' => 'leave blank for rclone default',
 			'web.serverSettings.sections.general.title' => 'General',
 			'web.serverSettings.sections.general.desc' => 'Listen address, operator account, token TTL.',
+			'web.serverSettings.sections.host.title' => 'Host power',
+			'web.serverSettings.sections.host.desc' => 'Keep the machine reachable from phone and web while it is idle.',
 			'web.serverSettings.sections.logging.title' => 'Logging',
 			'web.serverSettings.sections.logging.desc' => 'Verbosity, format, and live tail.',
 			'web.serverSettings.sections.sessions.title' => 'Sessions',
@@ -20328,6 +20471,19 @@ extension on Translations {
 			'web.serverSettings.toggle.defaultOff' => 'Default (off)',
 			'web.serverSettings.memoryRuntimeBanner' => 'Runtime AI behaviour — workers, capture rules, injection profiles and spawn mode — lives in Cortex settings and applies instantly. This section is the infrastructure half: embedder, storage and background governance (restart required).',
 			'web.serverSettings.memoryRuntimeBannerButton' => 'Open Cortex settings',
+			'web.serverSettings.host.intro' => 'A sleeping Mac takes its network down with it, so the gateway simply stops answering — from phone, from web, and to its database. It reads as "opendray is flaky" when the machine is really just asleep. Pick how opendray should handle that.',
+			'web.serverSettings.host.platformNote' => 'macOS only. On Linux and Windows this setting is accepted and ignored — those hosts do not idle-suspend under a normal server install. A deliberate sleep (lid close, Apple menu → Sleep) is never blocked, and the assertion is released if opendray exits or is killed.',
+			'web.serverSettings.host.modes.ac.label' => 'Stay awake on wall power',
+			'web.serverSettings.host.modes.ac.desc' => 'The machine never idle-sleeps while plugged in, so phone and web connect instantly. On battery it sleeps normally. The screen still turns off as usual.',
+			'web.serverSettings.host.modes.always.label' => 'Stay awake on any power',
+			'web.serverSettings.host.modes.always.desc' => 'Never idle-sleeps, including on battery.',
+			'web.serverSettings.host.modes.always.caveat' => 'Will drain a laptop battery left unplugged.',
+			'web.serverSettings.host.modes.on_demand.label' => 'Sleep when idle, wake on traffic',
+			'web.serverSettings.host.modes.on_demand.desc' => 'The machine sleeps whenever the gateway is quiet. An incoming request wakes it, and opendray holds it awake while serving, then lets it sleep again.',
+			'web.serverSettings.host.modes.on_demand.caveat' => 'Needs "Wake for network access" (sudo pmset -a womp 1), reliably wired Ethernet. The first request after a sleep takes a few seconds and may need one retry.',
+			'web.serverSettings.host.modes.off.label' => 'Never touch power settings',
+			'web.serverSettings.host.modes.off.desc' => 'opendray leaves the machine alone entirely.',
+			'web.serverSettings.host.modes.off.caveat' => 'The gateway is unreachable whenever the host sleeps, unless something else keeps it awake.',
 			'web.settings.title' => 'Settings',
 			'web.settings.subtitle' => 'Workspace, account, and gateway config.',
 			'web.settings.groups.workspace' => 'Workspace',
@@ -20389,6 +20545,8 @@ extension on Translations {
 			'web.settings.about.updateAvailable' => ({required Object version}) => 'Update available: ${version}',
 			'web.settings.about.releaseNotes' => 'Release notes ↗',
 			'web.settings.about.updateNow' => 'Update now',
+			_ => null,
+		} ?? switch (path) {
 			'web.settings.about.upgradingShort' => 'Upgrading…',
 			'web.settings.about.confirmRestart' => 'This restarts the service; running sessions reconnect.',
 			'web.settings.about.confirmUpgrade' => 'Upgrade & restart',
@@ -20404,8 +20562,6 @@ extension on Translations {
 			'web.settings.about.forcePrompt' => ({required Object count}) => '${count} live session(s) will be interrupted by the restart (they auto-resume afterward).',
 			'web.settings.about.upgradeAnyway' => 'Upgrade anyway',
 			'web.logViewer.filterPlaceholder' => 'Filter…',
-			_ => null,
-		} ?? switch (path) {
 			'web.logViewer.debugTooltip' => 'Debug count',
 			'web.logViewer.infoTooltip' => 'Info count',
 			'web.logViewer.warnTooltip' => 'Warn count',
@@ -20903,6 +21059,8 @@ extension on Translations {
 			'web.database.console.run' => 'Run',
 			'web.database.console.runHint' => 'Cmd/Ctrl+Enter to run',
 			'web.database.console.stats' => ({required Object command, required Object rows, required Object ms}) => '${command} · ${rows} row(s) · ${ms} ms',
+			_ => null,
+		} ?? switch (path) {
 			'web.database.console.truncated' => 'truncated',
 			'web.database.console.empty' => 'Run a query to see results.',
 			'web.database.console.truncatedNote' => 'results truncated',
@@ -20918,8 +21076,6 @@ extension on Translations {
 			'web.database.panel.console' => 'SQL console',
 			'web.database.panel.openWorkbench' => 'Open workbench',
 			'web.database.workbench.title' => 'Database workbench',
-			_ => null,
-		} ?? switch (path) {
 			'web.roundTable.title' => 'Round Table',
 			'web.roundTable.experimental' => 'Experimental',
 			'web.roundTable.subtitle' => 'A cross-vendor AI group chat. @mention claude, codex or antigravity and they reply in the thread — like a Telegram group, with a different vendor\'s model behind each member.',
@@ -21417,6 +21573,8 @@ extension on Translations {
 			'sessions.spawnSheet.claudeAccount.disabledSuffix' => ' (disabled)',
 			'sessions.spawnSheet.claudeAccount.noTokenSuffix' => ' (no token)',
 			'sessions.spawnSheet.claudeAccount.noneHint' => 'No Claude accounts configured — the gateway will use the system ANTHROPIC_API_KEY. Add accounts under Settings → Accounts on the web admin.',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.spawnSheet.claudeAccount.errorHint' => ({required Object error}) => 'Could not load Claude accounts (${error}). The session will spawn with the gateway default.',
 			'mcp.title' => 'MCP',
 			'mcp.newServer' => 'New server',
@@ -21432,8 +21590,6 @@ extension on Translations {
 			'mcp.errorPrefix.update' => 'Update failed',
 			'mcp.errorPrefix.toggle' => 'Toggle failed',
 			'mcp.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}: ${error}',
-			_ => null,
-		} ?? switch (path) {
 			'mcp.editor.nameHint' => 'my-mcp-server',
 			'mcp.editor.jsonHint' => 'JSON config — name, transport: stdio, command, args…',
 			'mcp.editor.descriptionPlaceholder' => 'Optional one-liner',
@@ -21931,6 +22087,8 @@ extension on Translations {
 			'backups.inventory.summary' => ({required Object rows, required Object tables}) => '${rows} rows · ${tables} tables',
 			'backups.inventory.description' => 'Live row counts from opendray\'s Postgres database. Backups capture every row below; binary artifacts on disk are not included.',
 			'backups.inventory.rowsLabel' => 'rows',
+			_ => null,
+		} ?? switch (path) {
 			'backups.inventory.loadFailedToast' => 'Failed to load inventory',
 			'backups.inventory.loading' => 'Loading…',
 			'backups.inventory.tap' => 'Tap to expand',
@@ -21946,8 +22104,6 @@ extension on Translations {
 			'backupSchedules.newButton' => 'New',
 			'backupSchedules.deleteTitle' => 'Delete schedule?',
 			'backupSchedules.targetLabel' => 'Targets',
-			_ => null,
-		} ?? switch (path) {
 			'backupSchedules.targetsHint' => 'Pick one or more — the same backup is written to each (3-2-1).',
 			'backupSchedules.intervalLabel' => 'Interval',
 			'backupSchedules.retentionLabel' => 'Retention (keep N most recent)',
@@ -22445,6 +22601,8 @@ extension on Translations {
 			'about.fields.app' => 'App',
 			'about.fields.version' => 'Version',
 			'about.fields.versionFormat' => ({required Object version, required Object build}) => '${version} (build ${build})',
+			_ => null,
+		} ?? switch (path) {
 			'about.fields.package' => 'Package',
 			'about.fields.url' => 'URL',
 			'about.fields.signedInAs' => 'Signed in as',
@@ -22460,8 +22618,6 @@ extension on Translations {
 			'about.gateway.upToDate' => 'Up to date',
 			'about.gateway.updateAvailable' => ({required Object version}) => 'Update available: ${version}',
 			'about.gateway.releaseNotes' => 'Release notes',
-			_ => null,
-		} ?? switch (path) {
 			'about.gateway.checkFailed' => 'Update check unavailable',
 			'settings.title' => 'Settings',
 			'settings.language.section' => 'Language',
@@ -22526,6 +22682,7 @@ extension on Translations {
 			'settings.serverSettings.changesNeedRestart' => 'Changes to this section need a gateway restart.',
 			'settings.serverSettings.loadFailed' => 'Failed to load server settings',
 			'settings.serverSettings.sections.general' => 'General',
+			'settings.serverSettings.sections.host' => 'Host power',
 			'settings.serverSettings.sections.logging' => 'Logging',
 			'settings.serverSettings.sections.sessions' => 'Sessions',
 			'settings.serverSettings.sections.vault' => 'Vault',
@@ -22536,6 +22693,7 @@ extension on Translations {
 			'settings.serverSettings.sections.storageCodex' => 'Storage · Codex',
 			'settings.serverSettings.sections.storageAntigravity' => 'Storage · Antigravity',
 			'settings.serverSettings.sectionDescriptions.general' => 'Listen address, operator account, token TTL.',
+			'settings.serverSettings.sectionDescriptions.host' => 'Keep this machine reachable while it is idle.',
 			'settings.serverSettings.sectionDescriptions.logging' => 'Verbosity, format, and on-disk log path.',
 			'settings.serverSettings.sectionDescriptions.sessions' => 'Idle detection thresholds.',
 			'settings.serverSettings.sectionDescriptions.vault' => 'Notes, skills, and git-versioned root.',
@@ -22609,6 +22767,12 @@ extension on Translations {
 			'settings.serverSettings.fields.cleanerHelper' => 'Periodic auto-librarian that soft-archives stale / duplicate memories.',
 			'settings.serverSettings.fields.knowledgeEnabled' => 'Knowledge graph',
 			'settings.serverSettings.fields.knowledgeHelper' => 'The structured entities/playbooks/skills layer on top of memory.',
+			'settings.serverSettings.fields.preventIdleSleep' => 'Idle sleep',
+			'settings.serverSettings.fields.preventIdleSleepHelper' => 'A sleeping Mac takes its network down, so the gateway stops answering from phone and web. "Stay awake on wall power" is the default and keeps it reachable (the screen still turns off). "Sleep, wake on traffic" saves power but needs Wake for network access, and the first request after a sleep is slow. macOS only.',
+			'settings.serverSettings.fields.sleepModeAc' => 'Stay awake on wall power',
+			'settings.serverSettings.fields.sleepModeAlways' => 'Stay awake on any power',
+			'settings.serverSettings.fields.sleepModeOnDemand' => 'Sleep, wake on traffic',
+			'settings.serverSettings.fields.sleepModeOff' => 'Don\'t touch power',
 			'settings.serverSettings.validateInteger' => ({required Object field}) => '"${field}" must be an integer',
 			'settings.serverSettings.validateNumber' => ({required Object field}) => '"${field}" must be a number',
 			'settings.serverSettings.embedderModel.reprobe' => 'Re-check endpoint',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -1554,6 +1554,7 @@ class _TranslationsWebServerSettingsEs extends TranslationsWebServerSettingsEn {
 	@override late final _TranslationsWebServerSettingsToggleEs toggle = _TranslationsWebServerSettingsToggleEs._(_root);
 	@override String get memoryRuntimeBanner => 'El comportamiento de IA en runtime — workers, reglas de captura, perfiles de inyección y modo de spawn — vive en los ajustes de Cortex y se aplica al instante. Esta sección es la mitad de infraestructura: embedder, almacenamiento y gobernanza de fondo (requiere reinicio).';
 	@override String get memoryRuntimeBannerButton => 'Abrir ajustes de Cortex';
+	@override late final _TranslationsWebServerSettingsHostEs host = _TranslationsWebServerSettingsHostEs._(_root);
 }
 
 // Path: web.settings
@@ -5157,6 +5158,7 @@ class _TranslationsWebServerSettingsSectionsEs extends TranslationsWebServerSett
 
 	// Translations
 	@override late final _TranslationsWebServerSettingsSectionsGeneralEs general = _TranslationsWebServerSettingsSectionsGeneralEs._(_root);
+	@override late final _TranslationsWebServerSettingsSectionsHostEs host = _TranslationsWebServerSettingsSectionsHostEs._(_root);
 	@override late final _TranslationsWebServerSettingsSectionsLoggingEs logging = _TranslationsWebServerSettingsSectionsLoggingEs._(_root);
 	@override late final _TranslationsWebServerSettingsSectionsSessionsEs sessions = _TranslationsWebServerSettingsSectionsSessionsEs._(_root);
 	@override late final _TranslationsWebServerSettingsSectionsVaultEs vault = _TranslationsWebServerSettingsSectionsVaultEs._(_root);
@@ -5399,6 +5401,18 @@ class _TranslationsWebServerSettingsToggleEs extends TranslationsWebServerSettin
 	@override String get off => 'Desactivado';
 	@override String get defaultOn => 'Por defecto (on)';
 	@override String get defaultOff => 'Por defecto (off)';
+}
+
+// Path: web.serverSettings.host
+class _TranslationsWebServerSettingsHostEs extends TranslationsWebServerSettingsHostEn {
+	_TranslationsWebServerSettingsHostEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get intro => 'Un Mac dormido apaga también su red, así que la pasarela deja de responder: desde el móvil, desde la web y hacia su base de datos. Parece que «opendray falla» cuando en realidad la máquina solo está dormida. Elige cómo debe gestionarlo opendray.';
+	@override String get platformNote => 'Solo macOS. En Linux y Windows este ajuste se acepta y se ignora: esos hosts no se suspenden por inactividad en una instalación de servidor normal. Nunca se bloquea una suspensión deliberada (cerrar la tapa, menú Apple → Reposo), y la aserción se libera si opendray termina o es forzado a cerrar.';
+	@override late final _TranslationsWebServerSettingsHostModesEs modes = _TranslationsWebServerSettingsHostModesEs._(_root);
 }
 
 // Path: web.settings.groups
@@ -7263,6 +7277,7 @@ class _TranslationsSettingsServerSettingsSectionsEs extends TranslationsSettings
 
 	// Translations
 	@override String get general => 'General';
+	@override String get host => 'Energía del host';
 	@override String get logging => 'Registro';
 	@override String get sessions => 'Sessions';
 	@override String get vault => 'Vault';
@@ -7282,6 +7297,7 @@ class _TranslationsSettingsServerSettingsSectionDescriptionsEs extends Translati
 
 	// Translations
 	@override String get general => 'Dirección de escucha, cuenta del operador, TTL del token.';
+	@override String get host => 'Mantén esta máquina accesible mientras está inactiva.';
 	@override String get logging => 'Verbosidad, formato y ruta del log en disco.';
 	@override String get sessions => 'Umbrales de detección de inactividad.';
 	@override String get vault => 'Notas, skills y raíz versionada con git.';
@@ -7364,6 +7380,12 @@ class _TranslationsSettingsServerSettingsFieldsEs extends TranslationsSettingsSe
 	@override String get cleanerHelper => 'Auto-bibliotecario periódico que archiva memorias obsoletas / duplicadas.';
 	@override String get knowledgeEnabled => 'Grafo de conocimiento';
 	@override String get knowledgeHelper => 'La capa estructurada de entidades/playbooks/skills sobre la memoria.';
+	@override String get preventIdleSleep => 'Reposo por inactividad';
+	@override String get preventIdleSleepHelper => 'Un Mac dormido apaga su red, así que la pasarela deja de responder desde el móvil y la web. «Despierto con corriente» es lo predeterminado y lo mantiene accesible (la pantalla se sigue apagando). «Dormir y despertar con tráfico» ahorra energía pero requiere Activar por acceso de red, y la primera petición tras dormir es lenta. Solo macOS.';
+	@override String get sleepModeAc => 'Despierto con corriente';
+	@override String get sleepModeAlways => 'Despierto con cualquier alimentación';
+	@override String get sleepModeOnDemand => 'Dormir, despertar con tráfico';
+	@override String get sleepModeOff => 'No tocar la energía';
 }
 
 // Path: settings.serverSettings.embedderModel
@@ -8416,6 +8438,17 @@ class _TranslationsWebServerSettingsSectionsGeneralEs extends TranslationsWebSer
 	@override String get desc => 'Dirección de escucha, cuenta de operador, TTL del token.';
 }
 
+// Path: web.serverSettings.sections.host
+class _TranslationsWebServerSettingsSectionsHostEs extends TranslationsWebServerSettingsSectionsHostEn {
+	_TranslationsWebServerSettingsSectionsHostEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Energía del host';
+	@override String get desc => 'Mantén la máquina accesible desde el móvil y la web mientras está inactiva.';
+}
+
 // Path: web.serverSettings.sections.logging
 class _TranslationsWebServerSettingsSectionsLoggingEs extends TranslationsWebServerSettingsSectionsLoggingEn {
 	_TranslationsWebServerSettingsSectionsLoggingEs._(TranslationsEs root) : this._root = root, super.internal(root);
@@ -9082,6 +9115,19 @@ class _TranslationsWebServerSettingsBackupScheduleHeadersEs extends Translations
 	@override String get state => 'Estado';
 }
 
+// Path: web.serverSettings.host.modes
+class _TranslationsWebServerSettingsHostModesEs extends TranslationsWebServerSettingsHostModesEn {
+	_TranslationsWebServerSettingsHostModesEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsWebServerSettingsHostModesAcEs ac = _TranslationsWebServerSettingsHostModesAcEs._(_root);
+	@override late final _TranslationsWebServerSettingsHostModesAlwaysEs always = _TranslationsWebServerSettingsHostModesAlwaysEs._(_root);
+	@override late final _TranslationsWebServerSettingsHostModesOnDemandEs on_demand = _TranslationsWebServerSettingsHostModesOnDemandEs._(_root);
+	@override late final _TranslationsWebServerSettingsHostModesOffEs off = _TranslationsWebServerSettingsHostModesOffEs._(_root);
+}
+
 // Path: web.settings.appearance.options
 class _TranslationsWebSettingsAppearanceOptionsEs extends TranslationsWebSettingsAppearanceOptionsEn {
 	_TranslationsWebSettingsAppearanceOptionsEs._(TranslationsEs root) : this._root = root, super.internal(root);
@@ -9580,6 +9626,53 @@ class _TranslationsWebNotesVaultSyncConflictKindsEs extends TranslationsWebNotes
 	@override String get merge => 'merge';
 	@override String get cherryPick => 'cherry-pick';
 	@override String get operation => 'operación';
+}
+
+// Path: web.serverSettings.host.modes.ac
+class _TranslationsWebServerSettingsHostModesAcEs extends TranslationsWebServerSettingsHostModesAcEn {
+	_TranslationsWebServerSettingsHostModesAcEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'Despierto con corriente';
+	@override String get desc => 'La máquina no se duerme por inactividad mientras está enchufada, así que el móvil y la web conectan al instante. Con batería duerme con normalidad. La pantalla se sigue apagando igual.';
+}
+
+// Path: web.serverSettings.host.modes.always
+class _TranslationsWebServerSettingsHostModesAlwaysEs extends TranslationsWebServerSettingsHostModesAlwaysEn {
+	_TranslationsWebServerSettingsHostModesAlwaysEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'Despierto con cualquier alimentación';
+	@override String get desc => 'Nunca se duerme por inactividad, tampoco con batería.';
+	@override String get caveat => 'Agotará la batería de un portátil desenchufado.';
+}
+
+// Path: web.serverSettings.host.modes.on_demand
+class _TranslationsWebServerSettingsHostModesOnDemandEs extends TranslationsWebServerSettingsHostModesOnDemandEn {
+	_TranslationsWebServerSettingsHostModesOnDemandEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'Duerme inactivo, despierta con tráfico';
+	@override String get desc => 'La máquina duerme siempre que la pasarela está en calma. Una petición entrante la despierta y opendray la mantiene despierta mientras sirve; después vuelve a dormir.';
+	@override String get caveat => 'Requiere «Activar por acceso de red» (sudo pmset -a womp 1); Ethernet por cable es lo fiable. La primera petición tras dormir tarda unos segundos y puede necesitar un reintento.';
+}
+
+// Path: web.serverSettings.host.modes.off
+class _TranslationsWebServerSettingsHostModesOffEs extends TranslationsWebServerSettingsHostModesOffEn {
+	_TranslationsWebServerSettingsHostModesOffEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'No tocar la energía';
+	@override String get desc => 'opendray no interviene en absoluto en la máquina.';
+	@override String get caveat => 'La pasarela será inaccesible cuando el host duerma, salvo que otra cosa lo mantenga despierto.';
 }
 
 // Path: web.memoryAmbient.rules.row.summary
@@ -11386,6 +11479,8 @@ extension on TranslationsEs {
 			'web.backups.targetEditor.rclone.configPathPlaceholder' => 'déjalo en blanco para el valor por defecto de rclone',
 			'web.serverSettings.sections.general.title' => 'General',
 			'web.serverSettings.sections.general.desc' => 'Dirección de escucha, cuenta de operador, TTL del token.',
+			'web.serverSettings.sections.host.title' => 'Energía del host',
+			'web.serverSettings.sections.host.desc' => 'Mantén la máquina accesible desde el móvil y la web mientras está inactiva.',
 			'web.serverSettings.sections.logging.title' => 'Registro',
 			'web.serverSettings.sections.logging.desc' => 'Verbosidad, formato y seguimiento en vivo.',
 			'web.serverSettings.sections.sessions.title' => 'Sesiones',
@@ -11614,6 +11709,19 @@ extension on TranslationsEs {
 			'web.serverSettings.toggle.defaultOff' => 'Por defecto (off)',
 			'web.serverSettings.memoryRuntimeBanner' => 'El comportamiento de IA en runtime — workers, reglas de captura, perfiles de inyección y modo de spawn — vive en los ajustes de Cortex y se aplica al instante. Esta sección es la mitad de infraestructura: embedder, almacenamiento y gobernanza de fondo (requiere reinicio).',
 			'web.serverSettings.memoryRuntimeBannerButton' => 'Abrir ajustes de Cortex',
+			'web.serverSettings.host.intro' => 'Un Mac dormido apaga también su red, así que la pasarela deja de responder: desde el móvil, desde la web y hacia su base de datos. Parece que «opendray falla» cuando en realidad la máquina solo está dormida. Elige cómo debe gestionarlo opendray.',
+			'web.serverSettings.host.platformNote' => 'Solo macOS. En Linux y Windows este ajuste se acepta y se ignora: esos hosts no se suspenden por inactividad en una instalación de servidor normal. Nunca se bloquea una suspensión deliberada (cerrar la tapa, menú Apple → Reposo), y la aserción se libera si opendray termina o es forzado a cerrar.',
+			'web.serverSettings.host.modes.ac.label' => 'Despierto con corriente',
+			'web.serverSettings.host.modes.ac.desc' => 'La máquina no se duerme por inactividad mientras está enchufada, así que el móvil y la web conectan al instante. Con batería duerme con normalidad. La pantalla se sigue apagando igual.',
+			'web.serverSettings.host.modes.always.label' => 'Despierto con cualquier alimentación',
+			'web.serverSettings.host.modes.always.desc' => 'Nunca se duerme por inactividad, tampoco con batería.',
+			'web.serverSettings.host.modes.always.caveat' => 'Agotará la batería de un portátil desenchufado.',
+			'web.serverSettings.host.modes.on_demand.label' => 'Duerme inactivo, despierta con tráfico',
+			'web.serverSettings.host.modes.on_demand.desc' => 'La máquina duerme siempre que la pasarela está en calma. Una petición entrante la despierta y opendray la mantiene despierta mientras sirve; después vuelve a dormir.',
+			'web.serverSettings.host.modes.on_demand.caveat' => 'Requiere «Activar por acceso de red» (sudo pmset -a womp 1); Ethernet por cable es lo fiable. La primera petición tras dormir tarda unos segundos y puede necesitar un reintento.',
+			'web.serverSettings.host.modes.off.label' => 'No tocar la energía',
+			'web.serverSettings.host.modes.off.desc' => 'opendray no interviene en absoluto en la máquina.',
+			'web.serverSettings.host.modes.off.caveat' => 'La pasarela será inaccesible cuando el host duerma, salvo que otra cosa lo mantenga despierto.',
 			'web.settings.title' => 'Ajustes',
 			'web.settings.subtitle' => 'Configuración del espacio de trabajo, la cuenta y el gateway.',
 			'web.settings.groups.workspace' => 'Espacio de trabajo',
@@ -11675,6 +11783,8 @@ extension on TranslationsEs {
 			'web.settings.about.updateAvailable' => ({required Object version}) => 'Actualización disponible: ${version}',
 			'web.settings.about.releaseNotes' => 'Notas de la versión ↗',
 			'web.settings.about.updateNow' => 'Actualizar ahora',
+			_ => null,
+		} ?? switch (path) {
 			'web.settings.about.upgradingShort' => 'Actualizando…',
 			'web.settings.about.confirmRestart' => 'Esto reinicia el servicio; las sesiones en ejecución se reconectan.',
 			'web.settings.about.confirmUpgrade' => 'Actualizar y reiniciar',
@@ -11690,8 +11800,6 @@ extension on TranslationsEs {
 			'web.settings.about.forcePrompt' => ({required Object count}) => 'El reinicio interrumpirá ${count} sesión(es) activa(s) (se reanudan automáticamente después).',
 			'web.settings.about.upgradeAnyway' => 'Actualizar de todos modos',
 			'web.logViewer.filterPlaceholder' => 'Filtrar…',
-			_ => null,
-		} ?? switch (path) {
 			'web.logViewer.debugTooltip' => 'Recuento de debug',
 			'web.logViewer.infoTooltip' => 'Recuento de info',
 			'web.logViewer.warnTooltip' => 'Recuento de advertencias',
@@ -12189,6 +12297,8 @@ extension on TranslationsEs {
 			'web.database.console.run' => 'Ejecutar',
 			'web.database.console.runHint' => 'Cmd/Ctrl+Enter para ejecutar',
 			'web.database.console.stats' => ({required Object command, required Object rows, required Object ms}) => '${command} · ${rows} fila(s) · ${ms} ms',
+			_ => null,
+		} ?? switch (path) {
 			'web.database.console.truncated' => 'truncado',
 			'web.database.console.empty' => 'Ejecuta una consulta para ver resultados.',
 			'web.database.console.truncatedNote' => 'resultados truncados',
@@ -12204,8 +12314,6 @@ extension on TranslationsEs {
 			'web.database.panel.console' => 'Consola SQL',
 			'web.database.panel.openWorkbench' => 'Abrir banco de trabajo',
 			'web.database.workbench.title' => 'Banco de trabajo de BD',
-			_ => null,
-		} ?? switch (path) {
 			'web.roundTable.title' => 'Mesa redonda',
 			'web.roundTable.experimental' => 'Experimental',
 			'web.roundTable.subtitle' => 'Un chat grupal de IA entre proveedores. Menciona con @ a claude, codex o antigravity y responden en el hilo, como un grupo de Telegram, con el modelo de un proveedor distinto detrás de cada miembro.',
@@ -12703,6 +12811,8 @@ extension on TranslationsEs {
 			'sessions.spawnSheet.claudeAccount.disabledSuffix' => ' (desactivada)',
 			'sessions.spawnSheet.claudeAccount.noTokenSuffix' => ' (sin token)',
 			'sessions.spawnSheet.claudeAccount.noneHint' => 'No hay cuentas de Claude configuradas. El gateway usará la ANTHROPIC_API_KEY del sistema. Añade cuentas en Ajustes → Cuentas en el admin web.',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.spawnSheet.claudeAccount.errorHint' => ({required Object error}) => 'No se pudieron cargar las cuentas de Claude (${error}). La session se creará con el valor predeterminado del gateway.',
 			'mcp.title' => 'MCP',
 			'mcp.newServer' => 'Nuevo servidor',
@@ -12718,8 +12828,6 @@ extension on TranslationsEs {
 			'mcp.errorPrefix.update' => 'Error al actualizar',
 			'mcp.errorPrefix.toggle' => 'Error al alternar',
 			'mcp.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}: ${error}',
-			_ => null,
-		} ?? switch (path) {
 			'mcp.editor.nameHint' => 'my-mcp-server',
 			'mcp.editor.jsonHint' => 'Configuración JSON, nombre, transport: stdio, command, args…',
 			'mcp.editor.descriptionPlaceholder' => 'Descripción opcional de una línea',
@@ -13217,6 +13325,8 @@ extension on TranslationsEs {
 			'backups.inventory.summary' => ({required Object rows, required Object tables}) => '${rows} filas · ${tables} tablas',
 			'backups.inventory.description' => 'Recuentos de filas en vivo desde la base de datos Postgres de opendray. Las copias de seguridad capturan todas las filas de abajo; los artefactos binarios en disco no se incluyen.',
 			'backups.inventory.rowsLabel' => 'filas',
+			_ => null,
+		} ?? switch (path) {
 			'backups.inventory.loadFailedToast' => 'Error al cargar el inventario',
 			'backups.inventory.loading' => 'Cargando…',
 			'backups.inventory.tap' => 'Toca para expandir',
@@ -13232,8 +13342,6 @@ extension on TranslationsEs {
 			'backupSchedules.newButton' => 'Nueva',
 			'backupSchedules.deleteTitle' => '¿Eliminar programación?',
 			'backupSchedules.targetLabel' => 'Destinos',
-			_ => null,
-		} ?? switch (path) {
 			'backupSchedules.targetsHint' => 'Elige uno o más: la misma copia se escribe en cada destino (3-2-1).',
 			'backupSchedules.intervalLabel' => 'Intervalo',
 			'backupSchedules.retentionLabel' => 'Retención (conservar las N más recientes)',
@@ -13731,6 +13839,8 @@ extension on TranslationsEs {
 			'about.fields.app' => 'App',
 			'about.fields.version' => 'Versión',
 			'about.fields.versionFormat' => ({required Object version, required Object build}) => '${version} (build ${build})',
+			_ => null,
+		} ?? switch (path) {
 			'about.fields.package' => 'Paquete',
 			'about.fields.url' => 'URL',
 			'about.fields.signedInAs' => 'Sesión iniciada como',
@@ -13746,8 +13856,6 @@ extension on TranslationsEs {
 			'about.gateway.upToDate' => 'Actualizado',
 			'about.gateway.updateAvailable' => ({required Object version}) => 'Actualización disponible: ${version}',
 			'about.gateway.releaseNotes' => 'Notas de la versión',
-			_ => null,
-		} ?? switch (path) {
 			'about.gateway.checkFailed' => 'Comprobación de actualizaciones no disponible',
 			'settings.title' => 'Ajustes',
 			'settings.language.section' => 'Idioma',
@@ -13812,6 +13920,7 @@ extension on TranslationsEs {
 			'settings.serverSettings.changesNeedRestart' => 'Los cambios en esta sección necesitan un reinicio del gateway.',
 			'settings.serverSettings.loadFailed' => 'No se pudieron cargar los ajustes del servidor',
 			'settings.serverSettings.sections.general' => 'General',
+			'settings.serverSettings.sections.host' => 'Energía del host',
 			'settings.serverSettings.sections.logging' => 'Registro',
 			'settings.serverSettings.sections.sessions' => 'Sessions',
 			'settings.serverSettings.sections.vault' => 'Vault',
@@ -13822,6 +13931,7 @@ extension on TranslationsEs {
 			'settings.serverSettings.sections.storageCodex' => 'Almacenamiento · Codex',
 			'settings.serverSettings.sections.storageAntigravity' => 'Almacenamiento · Antigravity',
 			'settings.serverSettings.sectionDescriptions.general' => 'Dirección de escucha, cuenta del operador, TTL del token.',
+			'settings.serverSettings.sectionDescriptions.host' => 'Mantén esta máquina accesible mientras está inactiva.',
 			'settings.serverSettings.sectionDescriptions.logging' => 'Verbosidad, formato y ruta del log en disco.',
 			'settings.serverSettings.sectionDescriptions.sessions' => 'Umbrales de detección de inactividad.',
 			'settings.serverSettings.sectionDescriptions.vault' => 'Notas, skills y raíz versionada con git.',
@@ -13895,6 +14005,12 @@ extension on TranslationsEs {
 			'settings.serverSettings.fields.cleanerHelper' => 'Auto-bibliotecario periódico que archiva memorias obsoletas / duplicadas.',
 			'settings.serverSettings.fields.knowledgeEnabled' => 'Grafo de conocimiento',
 			'settings.serverSettings.fields.knowledgeHelper' => 'La capa estructurada de entidades/playbooks/skills sobre la memoria.',
+			'settings.serverSettings.fields.preventIdleSleep' => 'Reposo por inactividad',
+			'settings.serverSettings.fields.preventIdleSleepHelper' => 'Un Mac dormido apaga su red, así que la pasarela deja de responder desde el móvil y la web. «Despierto con corriente» es lo predeterminado y lo mantiene accesible (la pantalla se sigue apagando). «Dormir y despertar con tráfico» ahorra energía pero requiere Activar por acceso de red, y la primera petición tras dormir es lenta. Solo macOS.',
+			'settings.serverSettings.fields.sleepModeAc' => 'Despierto con corriente',
+			'settings.serverSettings.fields.sleepModeAlways' => 'Despierto con cualquier alimentación',
+			'settings.serverSettings.fields.sleepModeOnDemand' => 'Dormir, despertar con tráfico',
+			'settings.serverSettings.fields.sleepModeOff' => 'No tocar la energía',
 			'settings.serverSettings.validateInteger' => ({required Object field}) => '"${field}" debe ser un entero',
 			'settings.serverSettings.validateNumber' => ({required Object field}) => '"${field}" debe ser un número',
 			'settings.serverSettings.embedderModel.reprobe' => 'Volver a comprobar el endpoint',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -1554,6 +1554,7 @@ class _TranslationsWebServerSettingsZh extends TranslationsWebServerSettingsEn {
 	@override late final _TranslationsWebServerSettingsToggleZh toggle = _TranslationsWebServerSettingsToggleZh._(_root);
 	@override String get memoryRuntimeBanner => '运行时 AI 行为——工作器、捕获规则、注入策略与 spawn 模式——位于 Cortex 设置，保存即生效。本区块是基础设施的一半：嵌入后端、存储与后台治理（需重启生效）。';
 	@override String get memoryRuntimeBannerButton => '打开 Cortex 设置';
+	@override late final _TranslationsWebServerSettingsHostZh host = _TranslationsWebServerSettingsHostZh._(_root);
 }
 
 // Path: web.settings
@@ -5157,6 +5158,7 @@ class _TranslationsWebServerSettingsSectionsZh extends TranslationsWebServerSett
 
 	// Translations
 	@override late final _TranslationsWebServerSettingsSectionsGeneralZh general = _TranslationsWebServerSettingsSectionsGeneralZh._(_root);
+	@override late final _TranslationsWebServerSettingsSectionsHostZh host = _TranslationsWebServerSettingsSectionsHostZh._(_root);
 	@override late final _TranslationsWebServerSettingsSectionsLoggingZh logging = _TranslationsWebServerSettingsSectionsLoggingZh._(_root);
 	@override late final _TranslationsWebServerSettingsSectionsSessionsZh sessions = _TranslationsWebServerSettingsSectionsSessionsZh._(_root);
 	@override late final _TranslationsWebServerSettingsSectionsVaultZh vault = _TranslationsWebServerSettingsSectionsVaultZh._(_root);
@@ -5399,6 +5401,18 @@ class _TranslationsWebServerSettingsToggleZh extends TranslationsWebServerSettin
 	@override String get off => '关闭';
 	@override String get defaultOn => '默认（开）';
 	@override String get defaultOff => '默认（关）';
+}
+
+// Path: web.serverSettings.host
+class _TranslationsWebServerSettingsHostZh extends TranslationsWebServerSettingsHostEn {
+	_TranslationsWebServerSettingsHostZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get intro => '睡眠中的 Mac 会一并关掉网络,网关随即停止应答 —— 手机连不上、网页连不上、连数据库也断开。表面看像"opendray 不稳定",实际只是机器睡着了。请选择 opendray 的应对方式。';
+	@override String get platformNote => '仅 macOS 生效。Linux 与 Windows 会接受但忽略此设置 —— 常规服务器安装下这些主机不会空闲休眠。主动睡眠(合盖、苹果菜单 → 睡眠)永不被阻止;opendray 退出或被强制结束时,电源断言会立即释放。';
+	@override late final _TranslationsWebServerSettingsHostModesZh modes = _TranslationsWebServerSettingsHostModesZh._(_root);
 }
 
 // Path: web.settings.groups
@@ -7263,6 +7277,7 @@ class _TranslationsSettingsServerSettingsSectionsZh extends TranslationsSettings
 
 	// Translations
 	@override String get general => '通用';
+	@override String get host => '主机电源';
 	@override String get logging => '日志';
 	@override String get sessions => '会话';
 	@override String get vault => '凭据库';
@@ -7282,6 +7297,7 @@ class _TranslationsSettingsServerSettingsSectionDescriptionsZh extends Translati
 
 	// Translations
 	@override String get general => '监听地址、管理员账号、令牌 TTL。';
+	@override String get host => '让这台机器在闲置时仍可被访问。';
 	@override String get logging => '详细程度、格式、磁盘日志路径。';
 	@override String get sessions => '空闲检测阈值。';
 	@override String get vault => '笔记、技能、git 版本化的根目录。';
@@ -7364,6 +7380,12 @@ class _TranslationsSettingsServerSettingsFieldsZh extends TranslationsSettingsSe
 	@override String get cleanerHelper => '周期性自动馆员，软归档过期/重复记忆。';
 	@override String get knowledgeEnabled => '知识图谱';
 	@override String get knowledgeHelper => '建立在记忆之上的结构化实体/手册/技能层。';
+	@override String get preventIdleSleep => '空闲休眠';
+	@override String get preventIdleSleepHelper => '睡眠中的 Mac 会关掉网络,网关便无法从手机和网页应答。默认的"插电时保持唤醒"能确保随时可连(屏幕仍会正常熄灭)。"闲时休眠,有请求时唤醒"更省电,但需开启网络访问唤醒,且休眠后的第一个请求会较慢。仅 macOS 生效。';
+	@override String get sleepModeAc => '插电时保持唤醒';
+	@override String get sleepModeAlways => '任何供电下保持唤醒';
+	@override String get sleepModeOnDemand => '闲时休眠,有请求时唤醒';
+	@override String get sleepModeOff => '不干预电源';
 }
 
 // Path: settings.serverSettings.embedderModel
@@ -8416,6 +8438,17 @@ class _TranslationsWebServerSettingsSectionsGeneralZh extends TranslationsWebSer
 	@override String get desc => '监听地址、操作员账号、令牌 TTL。';
 }
 
+// Path: web.serverSettings.sections.host
+class _TranslationsWebServerSettingsSectionsHostZh extends TranslationsWebServerSettingsSectionsHostEn {
+	_TranslationsWebServerSettingsSectionsHostZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '主机电源';
+	@override String get desc => '让这台机器在闲置时仍能被手机和网页访问。';
+}
+
 // Path: web.serverSettings.sections.logging
 class _TranslationsWebServerSettingsSectionsLoggingZh extends TranslationsWebServerSettingsSectionsLoggingEn {
 	_TranslationsWebServerSettingsSectionsLoggingZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -9082,6 +9115,19 @@ class _TranslationsWebServerSettingsBackupScheduleHeadersZh extends Translations
 	@override String get state => '状态';
 }
 
+// Path: web.serverSettings.host.modes
+class _TranslationsWebServerSettingsHostModesZh extends TranslationsWebServerSettingsHostModesEn {
+	_TranslationsWebServerSettingsHostModesZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsWebServerSettingsHostModesAcZh ac = _TranslationsWebServerSettingsHostModesAcZh._(_root);
+	@override late final _TranslationsWebServerSettingsHostModesAlwaysZh always = _TranslationsWebServerSettingsHostModesAlwaysZh._(_root);
+	@override late final _TranslationsWebServerSettingsHostModesOnDemandZh on_demand = _TranslationsWebServerSettingsHostModesOnDemandZh._(_root);
+	@override late final _TranslationsWebServerSettingsHostModesOffZh off = _TranslationsWebServerSettingsHostModesOffZh._(_root);
+}
+
 // Path: web.settings.appearance.options
 class _TranslationsWebSettingsAppearanceOptionsZh extends TranslationsWebSettingsAppearanceOptionsEn {
 	_TranslationsWebSettingsAppearanceOptionsZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -9580,6 +9626,53 @@ class _TranslationsWebNotesVaultSyncConflictKindsZh extends TranslationsWebNotes
 	@override String get merge => 'merge';
 	@override String get cherryPick => 'cherry-pick';
 	@override String get operation => 'operation';
+}
+
+// Path: web.serverSettings.host.modes.ac
+class _TranslationsWebServerSettingsHostModesAcZh extends TranslationsWebServerSettingsHostModesAcEn {
+	_TranslationsWebServerSettingsHostModesAcZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '插电时保持唤醒';
+	@override String get desc => '插电状态下机器不会空闲休眠,手机与网页随时秒连;使用电池时照常休眠。屏幕仍会正常熄灭。';
+}
+
+// Path: web.serverSettings.host.modes.always
+class _TranslationsWebServerSettingsHostModesAlwaysZh extends TranslationsWebServerSettingsHostModesAlwaysEn {
+	_TranslationsWebServerSettingsHostModesAlwaysZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '任何供电下都保持唤醒';
+	@override String get desc => '包括使用电池时也不会空闲休眠。';
+	@override String get caveat => '笔记本拔掉电源后会持续耗电。';
+}
+
+// Path: web.serverSettings.host.modes.on_demand
+class _TranslationsWebServerSettingsHostModesOnDemandZh extends TranslationsWebServerSettingsHostModesOnDemandEn {
+	_TranslationsWebServerSettingsHostModesOnDemandZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '闲时休眠,有请求时唤醒';
+	@override String get desc => '网关空闲时机器正常入睡;收到请求时被唤醒,opendray 在服务期间保持唤醒,结束后让它继续休眠。';
+	@override String get caveat => '需要开启"网络访问唤醒"(sudo pmset -a womp 1),有线以太网最可靠。休眠后的第一个请求会有几秒延迟,偶尔需要重试一次。';
+}
+
+// Path: web.serverSettings.host.modes.off
+class _TranslationsWebServerSettingsHostModesOffZh extends TranslationsWebServerSettingsHostModesOffEn {
+	_TranslationsWebServerSettingsHostModesOffZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => '完全不干预电源';
+	@override String get desc => 'opendray 不对机器电源做任何操作。';
+	@override String get caveat => '主机一旦休眠即无法连接,除非另有程序让它保持唤醒。';
 }
 
 // Path: web.memoryAmbient.rules.row.summary
@@ -11386,6 +11479,8 @@ extension on TranslationsZh {
 			'web.backups.targetEditor.rclone.configPathPlaceholder' => '留空则使用 rclone 默认',
 			'web.serverSettings.sections.general.title' => '通用',
 			'web.serverSettings.sections.general.desc' => '监听地址、操作员账号、令牌 TTL。',
+			'web.serverSettings.sections.host.title' => '主机电源',
+			'web.serverSettings.sections.host.desc' => '让这台机器在闲置时仍能被手机和网页访问。',
 			'web.serverSettings.sections.logging.title' => '日志',
 			'web.serverSettings.sections.logging.desc' => '日志级别、格式与实时跟踪。',
 			'web.serverSettings.sections.sessions.title' => '会话',
@@ -11614,6 +11709,19 @@ extension on TranslationsZh {
 			'web.serverSettings.toggle.defaultOff' => '默认（关）',
 			'web.serverSettings.memoryRuntimeBanner' => '运行时 AI 行为——工作器、捕获规则、注入策略与 spawn 模式——位于 Cortex 设置，保存即生效。本区块是基础设施的一半：嵌入后端、存储与后台治理（需重启生效）。',
 			'web.serverSettings.memoryRuntimeBannerButton' => '打开 Cortex 设置',
+			'web.serverSettings.host.intro' => '睡眠中的 Mac 会一并关掉网络,网关随即停止应答 —— 手机连不上、网页连不上、连数据库也断开。表面看像"opendray 不稳定",实际只是机器睡着了。请选择 opendray 的应对方式。',
+			'web.serverSettings.host.platformNote' => '仅 macOS 生效。Linux 与 Windows 会接受但忽略此设置 —— 常规服务器安装下这些主机不会空闲休眠。主动睡眠(合盖、苹果菜单 → 睡眠)永不被阻止;opendray 退出或被强制结束时,电源断言会立即释放。',
+			'web.serverSettings.host.modes.ac.label' => '插电时保持唤醒',
+			'web.serverSettings.host.modes.ac.desc' => '插电状态下机器不会空闲休眠,手机与网页随时秒连;使用电池时照常休眠。屏幕仍会正常熄灭。',
+			'web.serverSettings.host.modes.always.label' => '任何供电下都保持唤醒',
+			'web.serverSettings.host.modes.always.desc' => '包括使用电池时也不会空闲休眠。',
+			'web.serverSettings.host.modes.always.caveat' => '笔记本拔掉电源后会持续耗电。',
+			'web.serverSettings.host.modes.on_demand.label' => '闲时休眠,有请求时唤醒',
+			'web.serverSettings.host.modes.on_demand.desc' => '网关空闲时机器正常入睡;收到请求时被唤醒,opendray 在服务期间保持唤醒,结束后让它继续休眠。',
+			'web.serverSettings.host.modes.on_demand.caveat' => '需要开启"网络访问唤醒"(sudo pmset -a womp 1),有线以太网最可靠。休眠后的第一个请求会有几秒延迟,偶尔需要重试一次。',
+			'web.serverSettings.host.modes.off.label' => '完全不干预电源',
+			'web.serverSettings.host.modes.off.desc' => 'opendray 不对机器电源做任何操作。',
+			'web.serverSettings.host.modes.off.caveat' => '主机一旦休眠即无法连接,除非另有程序让它保持唤醒。',
 			'web.settings.title' => '设置',
 			'web.settings.subtitle' => '工作区、账号与网关配置。',
 			'web.settings.groups.workspace' => '工作区',
@@ -11675,6 +11783,8 @@ extension on TranslationsZh {
 			'web.settings.about.updateAvailable' => ({required Object version}) => '有可用更新：${version}',
 			'web.settings.about.releaseNotes' => '发行说明 ↗',
 			'web.settings.about.updateNow' => '立即更新',
+			_ => null,
+		} ?? switch (path) {
 			'web.settings.about.upgradingShort' => '更新中…',
 			'web.settings.about.confirmRestart' => '这将重启服务，正在运行的会话会重新连接。',
 			'web.settings.about.confirmUpgrade' => '升级并重启',
@@ -11690,8 +11800,6 @@ extension on TranslationsZh {
 			'web.settings.about.forcePrompt' => ({required Object count}) => '重启将中断 ${count} 个进行中的会话（之后会自动恢复）。',
 			'web.settings.about.upgradeAnyway' => '仍然升级',
 			'web.logViewer.filterPlaceholder' => '过滤…',
-			_ => null,
-		} ?? switch (path) {
 			'web.logViewer.debugTooltip' => 'Debug 计数',
 			'web.logViewer.infoTooltip' => 'Info 计数',
 			'web.logViewer.warnTooltip' => 'Warn 计数',
@@ -12189,6 +12297,8 @@ extension on TranslationsZh {
 			'web.database.console.run' => '运行',
 			'web.database.console.runHint' => 'Cmd/Ctrl+Enter 运行',
 			'web.database.console.stats' => ({required Object command, required Object rows, required Object ms}) => '${command} · ${rows} 行 · ${ms} 毫秒',
+			_ => null,
+		} ?? switch (path) {
 			'web.database.console.truncated' => '已截断',
 			'web.database.console.empty' => '运行查询以查看结果。',
 			'web.database.console.truncatedNote' => '结果已截断',
@@ -12204,8 +12314,6 @@ extension on TranslationsZh {
 			'web.database.panel.console' => 'SQL 控制台',
 			'web.database.panel.openWorkbench' => '展开工作台',
 			'web.database.workbench.title' => '数据库工作台',
-			_ => null,
-		} ?? switch (path) {
 			'web.roundTable.title' => '圆桌',
 			'web.roundTable.experimental' => '实验性',
 			'web.roundTable.subtitle' => '跨厂商 AI 群聊。@ 点名 claude、codex 或 antigravity,它们就在群里回复——像 Telegram 群一样,每个成员背后是不同厂商的模型。',
@@ -12703,6 +12811,8 @@ extension on TranslationsZh {
 			'sessions.spawnSheet.claudeAccount.disabledSuffix' => '（已停用）',
 			'sessions.spawnSheet.claudeAccount.noTokenSuffix' => '（无令牌）',
 			'sessions.spawnSheet.claudeAccount.noneHint' => '未配置 Claude 账号 — 网关将使用系统的 ANTHROPIC_API_KEY。在 Web 管理端的「设置 → 账号」中添加账号。',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.spawnSheet.claudeAccount.errorHint' => ({required Object error}) => '无法加载 Claude 账号（${error}）。会话将以网关默认配置启动。',
 			'mcp.title' => 'MCP',
 			'mcp.newServer' => '新建服务器',
@@ -12718,8 +12828,6 @@ extension on TranslationsZh {
 			'mcp.errorPrefix.update' => '更新失败',
 			'mcp.errorPrefix.toggle' => '切换失败',
 			'mcp.errorWithMessage' => ({required Object prefix, required Object error}) => '${prefix}：${error}',
-			_ => null,
-		} ?? switch (path) {
 			'mcp.editor.nameHint' => 'my-mcp-server',
 			'mcp.editor.jsonHint' => 'JSON 配置 — name、transport: stdio、command、args…',
 			'mcp.editor.descriptionPlaceholder' => '可选的一行说明',
@@ -13217,6 +13325,8 @@ extension on TranslationsZh {
 			'backups.inventory.summary' => ({required Object rows, required Object tables}) => '${rows} 行 · ${tables} 表',
 			'backups.inventory.description' => 'opendray Postgres 数据库的实时行数。备份会捕获以下所有行；磁盘上的二进制工件不包含在内。',
 			'backups.inventory.rowsLabel' => '行',
+			_ => null,
+		} ?? switch (path) {
 			'backups.inventory.loadFailedToast' => '加载清单失败',
 			'backups.inventory.loading' => '加载中…',
 			'backups.inventory.tap' => '点击展开',
@@ -13232,8 +13342,6 @@ extension on TranslationsZh {
 			'backupSchedules.newButton' => '新建',
 			'backupSchedules.deleteTitle' => '删除计划？',
 			'backupSchedules.targetLabel' => '目标',
-			_ => null,
-		} ?? switch (path) {
 			'backupSchedules.targetsHint' => '选择一个或多个 —— 同一份备份会写入每个目标（3-2-1）。',
 			'backupSchedules.intervalLabel' => '间隔',
 			'backupSchedules.retentionLabel' => '保留（最近 N 个）',
@@ -13731,6 +13839,8 @@ extension on TranslationsZh {
 			'about.fields.app' => '应用',
 			'about.fields.version' => '版本',
 			'about.fields.versionFormat' => ({required Object version, required Object build}) => '${version}（build ${build}）',
+			_ => null,
+		} ?? switch (path) {
 			'about.fields.package' => '包名',
 			'about.fields.url' => 'URL',
 			'about.fields.signedInAs' => '登录账号',
@@ -13746,8 +13856,6 @@ extension on TranslationsZh {
 			'about.gateway.upToDate' => '已是最新',
 			'about.gateway.updateAvailable' => ({required Object version}) => '有可用更新：${version}',
 			'about.gateway.releaseNotes' => '更新说明',
-			_ => null,
-		} ?? switch (path) {
 			'about.gateway.checkFailed' => '无法检查更新',
 			'settings.title' => '设置',
 			'settings.language.section' => '语言',
@@ -13812,6 +13920,7 @@ extension on TranslationsZh {
 			'settings.serverSettings.changesNeedRestart' => '此配置的修改需重启网关。',
 			'settings.serverSettings.loadFailed' => '加载服务器设置失败',
 			'settings.serverSettings.sections.general' => '通用',
+			'settings.serverSettings.sections.host' => '主机电源',
 			'settings.serverSettings.sections.logging' => '日志',
 			'settings.serverSettings.sections.sessions' => '会话',
 			'settings.serverSettings.sections.vault' => '凭据库',
@@ -13822,6 +13931,7 @@ extension on TranslationsZh {
 			'settings.serverSettings.sections.storageCodex' => '存储 · Codex',
 			'settings.serverSettings.sections.storageAntigravity' => '存储 · Antigravity',
 			'settings.serverSettings.sectionDescriptions.general' => '监听地址、管理员账号、令牌 TTL。',
+			'settings.serverSettings.sectionDescriptions.host' => '让这台机器在闲置时仍可被访问。',
 			'settings.serverSettings.sectionDescriptions.logging' => '详细程度、格式、磁盘日志路径。',
 			'settings.serverSettings.sectionDescriptions.sessions' => '空闲检测阈值。',
 			'settings.serverSettings.sectionDescriptions.vault' => '笔记、技能、git 版本化的根目录。',
@@ -13895,6 +14005,12 @@ extension on TranslationsZh {
 			'settings.serverSettings.fields.cleanerHelper' => '周期性自动馆员，软归档过期/重复记忆。',
 			'settings.serverSettings.fields.knowledgeEnabled' => '知识图谱',
 			'settings.serverSettings.fields.knowledgeHelper' => '建立在记忆之上的结构化实体/手册/技能层。',
+			'settings.serverSettings.fields.preventIdleSleep' => '空闲休眠',
+			'settings.serverSettings.fields.preventIdleSleepHelper' => '睡眠中的 Mac 会关掉网络,网关便无法从手机和网页应答。默认的"插电时保持唤醒"能确保随时可连(屏幕仍会正常熄灭)。"闲时休眠,有请求时唤醒"更省电,但需开启网络访问唤醒,且休眠后的第一个请求会较慢。仅 macOS 生效。',
+			'settings.serverSettings.fields.sleepModeAc' => '插电时保持唤醒',
+			'settings.serverSettings.fields.sleepModeAlways' => '任何供电下保持唤醒',
+			'settings.serverSettings.fields.sleepModeOnDemand' => '闲时休眠,有请求时唤醒',
+			'settings.serverSettings.fields.sleepModeOff' => '不干预电源',
 			'settings.serverSettings.validateInteger' => ({required Object field}) => '「${field}」必须是整数',
 			'settings.serverSettings.validateNumber' => ({required Object field}) => '「${field}」必须是数字',
 			'settings.serverSettings.embedderModel.reprobe' => '重新检测端点',

--- a/app/mobile/lib/features/settings/server_settings_screen.dart
+++ b/app/mobile/lib/features/settings/server_settings_screen.dart
@@ -42,6 +42,7 @@ class _Field {
     required this.kind,
     this.helper,
     this.options,
+    this.optionLabels,
     this.monospace = false,
     this.placeholder,
   });
@@ -54,6 +55,12 @@ class _Field {
   final String? helper;
   // For select kind only.
   final List<String>? options;
+  // Optional human labels for `options`, keyed by the raw wire value.
+  // Without this the dropdown shows the stored value verbatim, which
+  // is fine for 'debug'/'json' but not for values like 'on_demand'
+  // whose meaning isn't in the word. Missing keys fall back to the
+  // raw value.
+  final Map<String, String>? optionLabels;
   final bool monospace;
   final String? placeholder;
 }
@@ -112,6 +119,28 @@ List<_Section> _buildSections() => <_Section>[
         monospace: true,
         placeholder: '24h',
         helper: t.settings.serverSettings.fields.tokenTtlHelper,
+      ),
+    ],
+  ),
+  _Section(
+    id: 'host',
+    title: t.settings.serverSettings.sections.host,
+    description: t.settings.serverSettings.sectionDescriptions.host,
+    restartRequired: true,
+    fields: [
+      _Field(
+        label: t.settings.serverSettings.fields.preventIdleSleep,
+        path: 'host.prevent_idle_sleep',
+        kind: _FieldKind.select,
+        options: const ['ac', 'always', 'on_demand', 'off'],
+        optionLabels: {
+          'ac': t.settings.serverSettings.fields.sleepModeAc,
+          'always': t.settings.serverSettings.fields.sleepModeAlways,
+          'on_demand': t.settings.serverSettings.fields.sleepModeOnDemand,
+          'off': t.settings.serverSettings.fields.sleepModeOff,
+        },
+        placeholder: 'ac',
+        helper: t.settings.serverSettings.fields.preventIdleSleepHelper,
       ),
     ],
   ),
@@ -1027,7 +1056,7 @@ class _SectionEditorScreenState
                 for (final opt in f.options ?? const <String>[])
                   DropdownMenuItem<String>(
                     value: opt,
-                    child: Text(opt),
+                    child: Text(f.optionLabels?[opt] ?? opt),
                   ),
               ],
               onChanged: _submitting

--- a/app/shared/src/lib/settings.ts
+++ b/app/shared/src/lib/settings.ts
@@ -105,6 +105,12 @@ export interface ServerConfig {
   knowledge: {
     enabled: boolean
   }
+  host: {
+    /** How the gateway keeps its host machine reachable: "ac" (default,
+     * hold awake on wall power), "always", "on_demand" (let the host
+     * sleep, incoming traffic wakes it) or "off". macOS only. */
+    prevent_idle_sleep: string
+  }
 }
 
 export interface SettingsResponse {
@@ -202,5 +208,6 @@ export function emptyConfig(): ServerConfig {
       pg_restore_path: '',
     },
     knowledge: { enabled: false },
+    host: { prevent_idle_sleep: '' },
   }
 }

--- a/app/web/src/components/settings/ServerSettings.tsx
+++ b/app/web/src/components/settings/ServerSettings.tsx
@@ -56,6 +56,7 @@ import { PathInput } from './PathInput'
 // are looked up at render time via useServerSectionLabel().
 export const SERVER_SECTIONS = [
   { id: 'general' },
+  { id: 'host' },
   { id: 'logging' },
   { id: 'sessions' },
   { id: 'vault' },
@@ -90,6 +91,7 @@ export function useServerSectionLabel() {
 // — flag them so we can show "Restart required" when changed.
 const RESTART_REQUIRED_SECTIONS: Record<ServerSectionId, boolean> = {
   general: true,
+  host: true, // the power assertion is claimed once, at app.New
   logging: true,
   sessions: true,
   vault: true,
@@ -501,6 +503,43 @@ function SectionForm({
               />,
             )}
           </FormGroup>
+        </div>
+      )
+
+    case 'host':
+      return (
+        <div className="flex flex-col gap-5">
+          {/* This setting is about the machine, and the failure it
+              prevents is invisible from inside the app ("the gateway
+              is flaky" is really "the Mac went to sleep"), so the
+              section leads with the explanation rather than a bare
+              control. */}
+          <div className="rounded-md border border-border bg-card/30 px-3 py-2.5">
+            <p className="text-[11px] text-muted-foreground leading-relaxed">
+              {t('web.serverSettings.host.intro')}
+            </p>
+          </div>
+          <ModeCards
+            value={c.host.prevent_idle_sleep || 'ac'}
+            options={HOST_SLEEP_MODES.map((m) => ({
+              value: m,
+              label: t(`web.serverSettings.host.modes.${m}.label`),
+              desc: t(`web.serverSettings.host.modes.${m}.desc`),
+              caveat:
+                m === 'ac'
+                  ? undefined
+                  : t(`web.serverSettings.host.modes.${m}.caveat`),
+            }))}
+            onChange={(v) =>
+              setDraft({ ...draft, host: { prevent_idle_sleep: v } })
+            }
+          />
+          <p className="text-[10px] font-mono text-muted-foreground/50">
+            host.prevent_idle_sleep
+          </p>
+          <p className="text-[11px] text-muted-foreground/80 leading-relaxed">
+            {t('web.serverSettings.host.platformNote')}
+          </p>
         </div>
       )
 
@@ -1346,6 +1385,67 @@ function FieldRow({
   )
 }
 
+// HOST_SLEEP_MODES is the wire order of host.prevent_idle_sleep, most
+// reachable first. Kept next to the renderer so adding a mode in Go
+// surfaces one compile-time place to update here.
+const HOST_SLEEP_MODES = ['ac', 'always', 'on_demand', 'off'] as const
+
+// ModeCards renders mutually exclusive modes as radio-style rows with
+// room for a sentence of consequence each. Used where picking wrong
+// has a real cost the label alone can't convey.
+function ModeCards({
+  value,
+  options,
+  onChange,
+}: {
+  value: string
+  options: { value: string; label: string; desc: string; caveat?: string }[]
+  onChange: (v: string) => void
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      {options.map((opt) => {
+        const active = opt.value === value
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onChange(opt.value)}
+            aria-pressed={active}
+            className={cn(
+              'text-left rounded-md border px-3 py-2.5 transition-colors',
+              active
+                ? 'border-accent/60 bg-accent/10'
+                : 'border-border bg-background hover:bg-card/40',
+            )}
+          >
+            <div className="flex items-center gap-2">
+              <span
+                className={cn(
+                  'size-3 rounded-full border shrink-0',
+                  active ? 'border-accent bg-accent' : 'border-muted-foreground/40',
+                )}
+              />
+              <span className="text-[12.5px] font-medium">{opt.label}</span>
+              <code className="text-[10px] font-mono text-muted-foreground/50">
+                {opt.value}
+              </code>
+            </div>
+            <p className="text-[11px] text-muted-foreground/80 leading-snug mt-1 ml-5">
+              {opt.desc}
+            </p>
+            {opt.caveat && (
+              <p className="text-[11px] text-amber-300/80 leading-snug mt-1 ml-5">
+                {opt.caveat}
+              </p>
+            )}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
 function SegmentedSelect({
   value,
   options,
@@ -1529,6 +1629,9 @@ function mergeSection(
       // re-introduce the previous draft value.
       out.admin = { ...src.admin, password: '' }
       out.database = src.database
+      break
+    case 'host':
+      out.host = src.host
       break
     case 'logging':
       out.log = src.log

--- a/internal/settings/handler.go
+++ b/internal/settings/handler.go
@@ -83,6 +83,10 @@ func (h *Handler) put(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.svc.Update(&patch); err != nil {
+		if errors.Is(err, ErrInvalidConfig) {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}

--- a/internal/settings/service.go
+++ b/internal/settings/service.go
@@ -22,6 +22,11 @@ import (
 	"github.com/opendray/opendray-v2/internal/config"
 )
 
+// ErrInvalidConfig marks a PUT that would have written a config the
+// loader refuses, so the handler can answer 400 rather than 500 — the
+// operator's input is wrong, not the server.
+var ErrInvalidConfig = errors.New("invalid config")
+
 // Service owns read+write access to a single config.toml file.
 // Concurrent PUTs are serialised through mu so two operators can't
 // stomp each other.
@@ -72,6 +77,16 @@ func (s *Service) Update(patch *config.Config) error {
 		return err
 	}
 	mergeSensitive(patch, cur)
+
+	// Reject what the loader would reject. config.Load validates on every
+	// startup, so writing an invalid value here doesn't fail now — it
+	// fails at the *next restart*, leaving a gateway that won't come back
+	// up and an operator with no clue which field did it. Validating the
+	// post-merge patch (the exact bytes about to hit disk) turns that
+	// into an error message on the Save button.
+	if err := patch.Validate(); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidConfig, err)
+	}
 
 	// Atomic write: encode → tmp → rename. Atomic rename on macOS/Linux
 	// guarantees readers never see a half-written file.

--- a/internal/settings/service_test.go
+++ b/internal/settings/service_test.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -92,12 +93,15 @@ func TestService_Update_OverwritesSensitiveWhenProvided(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "config.toml")
 	writeToml(t, path, config.Config{
-		Admin: config.AdminConfig{Password: "oldpass"},
+		Listen:   "0.0.0.0:8770",
+		Database: config.DatabaseConfig{URL: "postgres://u@localhost/db"},
+		Admin:    config.AdminConfig{Password: "oldpass"},
 	})
 
 	svc := NewService(path, nil)
 	patch := config.Config{
-		Admin: config.AdminConfig{Password: "newpass"},
+		Listen: "0.0.0.0:8770",
+		Admin:  config.AdminConfig{Password: "newpass"},
 	}
 	if err := svc.Update(&patch); err != nil {
 		t.Fatal(err)
@@ -115,7 +119,10 @@ func TestService_Update_OverwritesSensitiveWhenProvided(t *testing.T) {
 func TestService_Update_AtomicWrite_NoDanglingTmp(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "config.toml")
-	writeToml(t, path, config.Config{Listen: "0.0.0.0:8770"})
+	writeToml(t, path, config.Config{
+		Listen:   "0.0.0.0:8770",
+		Database: config.DatabaseConfig{URL: "postgres://u@localhost/db"},
+	})
 
 	svc := NewService(path, nil)
 	if err := svc.Update(&config.Config{Listen: "0.0.0.0:9000"}); err != nil {
@@ -134,6 +141,11 @@ func TestService_Update_PreservesProvidersSection(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "config.toml")
 	writeToml(t, path, config.Config{
+		// listen + database.url are what the loader insists on; a
+		// round-trip test has to start from a config that would
+		// actually boot.
+		Listen:   "0.0.0.0:8770",
+		Database: config.DatabaseConfig{URL: "postgres://u@localhost/db"},
 		Providers: config.ProvidersConfig{
 			Claude: config.ClaudeProviderConfig{
 				HistoryRoots: []string{"/custom/claude"},
@@ -175,5 +187,95 @@ func writeToml(t *testing.T, path string, c config.Config) {
 	defer f.Close()
 	if err := toml.NewEncoder(f).Encode(c); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// A PUT that would write a config the loader rejects must fail at save
+// time. Otherwise the write succeeds, the operator hits Restart, and
+// the gateway never comes back — with the offending field unnamed.
+func TestService_Update_RejectsConfigTheLoaderWouldReject(t *testing.T) {
+	tests := []struct {
+		name  string
+		patch func(*config.Config)
+	}{
+		{
+			name: "unknown host sleep mode",
+			patch: func(c *config.Config) {
+				c.Host.PreventIdleSleep = "sometimes"
+			},
+		},
+		{
+			name: "unparseable idle threshold",
+			patch: func(c *config.Config) {
+				c.Session.IdleThreshold = "half an hour"
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			path := filepath.Join(tmp, "config.toml")
+			original := config.Config{
+				Listen:   "0.0.0.0:8770",
+				Database: config.DatabaseConfig{URL: "postgres://u@localhost/db"},
+				Admin:    config.AdminConfig{User: "admin", Password: "pw"},
+			}
+			writeToml(t, path, original)
+
+			patch := original
+			patch.Database.URL = "" // as the UI sends it: stripped, merged back
+			patch.Admin.Password = ""
+			tt.patch(&patch)
+
+			svc := NewService(path, nil)
+			err := svc.Update(&patch)
+			if err == nil {
+				t.Fatal("Update accepted a config the loader would reject")
+			}
+			if !errors.Is(err, ErrInvalidConfig) {
+				t.Fatalf("err = %v, want it to wrap ErrInvalidConfig", err)
+			}
+
+			// The on-disk config must be untouched, not half-written.
+			var onDisk config.Config
+			if _, err := toml.DecodeFile(path, &onDisk); err != nil {
+				t.Fatalf("config no longer decodes: %v", err)
+			}
+			if err := onDisk.Validate(); err != nil {
+				t.Fatalf("a rejected PUT corrupted the stored config: %v", err)
+			}
+			if onDisk.Admin.Password != "pw" {
+				t.Fatalf("stored password changed: %q", onDisk.Admin.Password)
+			}
+		})
+	}
+}
+
+// The valid modes must all survive a round-trip, so the settings UI
+// can offer every one of them.
+func TestService_Update_AcceptsEveryHostSleepMode(t *testing.T) {
+	for _, mode := range []string{"", "ac", "always", "on_demand", "off"} {
+		t.Run("mode="+mode, func(t *testing.T) {
+			tmp := t.TempDir()
+			path := filepath.Join(tmp, "config.toml")
+			writeToml(t, path, config.Config{
+				Listen:   "0.0.0.0:8770",
+				Database: config.DatabaseConfig{URL: "postgres://u@localhost/db"},
+			})
+
+			svc := NewService(path, nil)
+			patch := config.Config{Listen: "0.0.0.0:8770"}
+			patch.Host.PreventIdleSleep = mode
+			if err := svc.Update(&patch); err != nil {
+				t.Fatalf("Update(%q) = %v", mode, err)
+			}
+			var onDisk config.Config
+			if _, err := toml.DecodeFile(path, &onDisk); err != nil {
+				t.Fatal(err)
+			}
+			if onDisk.Host.PreventIdleSleep != mode {
+				t.Fatalf("stored mode = %q, want %q", onDisk.Host.PreventIdleSleep, mode)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Why

#487 and #488 added `[host] prevent_idle_sleep`, the setting that decides whether a sleeping host can still be reached from phone and web. It shipped config-only — the operator who needs it most is the one who has just concluded "opendray is flaky" and is nowhere near `config.example.toml`.

## What

A **Host power** section in server settings, on both surfaces.

**Web** renders the four modes as annotated cards instead of a segmented control. This setting isn't a preference — picking wrong drains a laptop on battery, or leaves the gateway unreachable overnight — so each mode carries a sentence of consequence plus its caveat (`on_demand` needs `womp 1` and a slow first request; `off` means unreachable while asleep). The section leads with why a sleeping host looks like a broken gateway at all.

**Mobile** reuses the declarative `_sections` table. `_Field` gains an optional `optionLabels` map so the dropdown shows "Sleep, wake on traffic" while storing `on_demand` — the raw values are not self-describing, and the existing renderer printed them verbatim.

Both note that deliberate sleep (lid close, Apple menu → Sleep) is never blocked and that non-macOS hosts accept-and-ignore the setting. en/zh/es translated; slang regenerated; parity 100%.

## Also: a footgun this UI would have armed

`PUT /admin/settings` wrote whatever it was handed, without validating. The loader *does* validate, on every startup — so an invalid value saved cleanly, and then the gateway failed to come back after the Restart button, with nothing naming the field that did it. A settings UI is exactly the surface that produces such values.

`Update` now validates the post-`mergeSensitive` config (the exact bytes about to be written) and returns **400** rather than 500, leaving the stored config untouched. Two existing tests were starting from configs missing `listen`/`database.url` — states that would never have booted — and now start from ones that would.

## Test plan

- [x] `go test -race ./internal/settings ./internal/config` — new table tests: every valid mode (`""`/`ac`/`always`/`on_demand`/`off`) round-trips; an unknown mode and an unparseable duration are both rejected with `ErrInvalidConfig`, and the on-disk config is verified still valid and its password intact after the rejection
- [x] `go build ./...`, `go vet`, `gofmt` clean; full suite green except the pre-existing local-env `internal/catalog` npm bin-link failure (fails on clean main too)
- [x] `pnpm build` + `tsc --noEmit` clean in `app/web`
- [x] `flutter analyze` — no issues
- [x] `node scripts/check-i18n-parity.mjs` — es/zh 100%, no missing/extra/token-mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)