### PR TITLE
docs(changelog): v2.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+## [v2.13.1] — 2026-08-07
+
+Your phone and your browser can reach the gateway again while its Mac
+sits idle. A machine that falls asleep takes its network with it, so the
+gateway simply stops answering — a failure that looks exactly like a
+flaky gateway from every surface that talks to it, and sends people
+reading gateway code instead of `pmset -g log`. opendray now holds the
+host awake while it serves, and lets you choose how far to take that.
+
 ### Added
 
 - **Host power is now a setting you can see, on web and mobile.** The


### PR DESCRIPTION
## Why

Release gate for **v2.13.1**. Per [RELEASING.md](../blob/main/RELEASING.md), the CHANGELOG section must land on `main` *before* the tag is pushed — goreleaser snapshots the repo at the tagged commit, so tagging first yields a release body of "See CHANGELOG.md for the full release notes".

## What

Promotes the accumulated `[Unreleased]` entries into `## [v2.13.1] — 2026-08-07`:

- **Fixed** — the gateway holds its host awake while serving, so phone and web stay connected instead of timing out against a sleeping Mac (#487)
- **Added** — `on_demand` mode: the host may sleep when quiet and incoming traffic wakes it (#488)
- **Added** — Host power section in server settings on web and mobile, with all four modes and their costs spelled out (#489)
- **Fixed** — `PUT /admin/settings` validates before writing, so a bad value can no longer save cleanly and block the next startup (#489)

Default behaviour is `"ac"`: hold the host awake on wall power only, so a laptop on battery still sleeps normally. No tag is pushed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)