### PR TITLE
fix(release): restore release notes and stop a stale docs site skipping npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,8 +195,16 @@ jobs:
       #    So the site went stale for every goreleaser release. Dispatch
       #    from inside the release job instead. Skipped for prerelease
       #    ('-') tags — mirrors publish-npm — and no-ops if the PAT is unset.
+      #
+      #    continue-on-error because this is the last step of the release
+      #    job and publish-npm `needs:` it. An expired PAT here used to
+      #    fail the whole job *after* the release was already published,
+      #    which silently skipped the npm publish — that is how npm sat
+      #    on 2.12.2 while GitHub had 2.13.0 and 2.13.1. A stale docs
+      #    site must not cost the package registry.
       - name: Rebuild opendray.dev
         if: success() && !contains(env.TAG, '-')
+        continue-on-error: true
         env:
           PAT: ${{ secrets.ODSITE_DISPATCH_PAT }}
         run: |
@@ -204,11 +212,14 @@ jobs:
             echo "ODSITE_DISPATCH_PAT not set — skipping site rebuild."
             exit 0
           fi
-          curl -sSf -X POST \
+          if ! curl -sSf -X POST \
             -H "Authorization: token $PAT" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/Opendray/opendray.dev/dispatches" \
-            -d "{\"event_type\":\"opendray-release\",\"client_payload\":{\"tag\":\"$TAG\"}}"
+            -d "{\"event_type\":\"opendray-release\",\"client_payload\":{\"tag\":\"$TAG\"}}"; then
+            echo "::warning::Could not dispatch the opendray.dev rebuild (is ODSITE_DISPATCH_PAT expired?). The release itself is fine; the site will show the previous version until rebuilt."
+            exit 0
+          fi
           echo "Dispatched opendray-release for $TAG"
 
   publish-npm:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,11 +66,24 @@ snapshot:
   version_template: "{{ .Tag }}-snapshot-{{ .ShortCommit }}"
 
 changelog:
-  # CHANGELOG.md is hand-curated per Keep-a-Changelog; goreleaser's
-  # auto-generated changelog would compete with it. Disable here so
-  # the release notes come exclusively from the tag annotation /
-  # Release notes field on GitHub.
-  disable: true
+  # CHANGELOG.md is hand-curated per Keep-a-Changelog, and release.yml
+  # extracts the section matching the tag and passes it as
+  # --release-notes. That flag fills goreleaser's changelog slot, so
+  # this section must NOT be disabled: `disable: true` skips the slot
+  # entirely and the body collapses to `release.header` alone. That is
+  # exactly what happened to every release from v2.12.0 to v2.13.1 —
+  # the notes were extracted correctly on every run and then dropped
+  # on the floor.
+  #
+  # Filtering only affects the auto-generated commit list, which
+  # --release-notes replaces; it is kept as the shape of the fallback
+  # when someone runs goreleaser by hand without the flag.
+  use: github
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
 
 release:
   # Publish directly (not as draft). The publish-npm job in
@@ -80,5 +93,11 @@ release:
   draft: false
   prerelease: auto
   name_template: "v{{ .Version }}"
-  header: |
-    See [CHANGELOG.md](https://github.com/Opendray/opendray/blob/main/CHANGELOG.md) for the full release notes.
+  # No header: the body IS the CHANGELOG section for this tag, passed
+  # via --release-notes. A "see CHANGELOG.md for the full notes" line
+  # above the full notes is just noise — the link belongs at the end,
+  # where it points at the history rather than at the page you are on.
+  footer: |
+
+    ---
+    Full history: [CHANGELOG.md](https://github.com/Opendray/opendray/blob/main/CHANGELOG.md)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,6 +68,20 @@ Recovery if you tagged first: PATCH the release body via the GitHub
 API with the changelog section after the fact. Annoying, single-use
 mistake — better to do it in the right order.
 
+**A note on the same symptom with a different cause.** Every release
+from v2.12.0 to v2.13.1 published that placeholder body *despite* the
+CHANGELOG landing first: `.goreleaser.yml` had `changelog.disable:
+true`, which skips the body slot that `--release-notes` fills, so the
+extracted section was dropped and only `release.header` survived.
+Fixed by dropping `disable` and moving the CHANGELOG link to
+`footer`. If a release body ever looks bare again, check the
+"Extract release notes" step log first: it prints the line count it
+extracted. Notes extracted but body empty = a goreleaser config
+problem, not an ordering problem.
+
+**Check the release body after every release.** Both failure modes are
+silent — the workflow goes green and the release publishes either way.
+
 ## Repository secrets (one-time setup)
 
 The release pipeline reads two repository secrets. `GITHUB_TOKEN` is


### PR DESCRIPTION
Found while verifying the v2.13.1 release. Two independent defects, both silent — the workflow reports green and the release publishes either way, which is why they survived several releases.

## 1. Every release body since v2.12.0 has been a placeholder

`release.yml` extracts the CHANGELOG section matching the tag and passes it as `--release-notes`. That part works — the step log for v2.13.1 prints `--- release-notes.md (57 lines) ---` followed by the correct content.

But `.goreleaser.yml` set `changelog.disable: true`, which skips the body slot that `--release-notes` fills. The notes were dropped and the body collapsed to `release.header` alone:

```
See [CHANGELOG.md](…) for the full release notes.
```

Which is exactly the string RELEASING.md warns you'll get if you tag *before* landing the CHANGELOG — so the symptom pointed at an ordering mistake that hadn't happened. v2.13.1 followed the documented order precisely and still produced it. `git log` confirms the same body on v2.12.0, v2.12.1, v2.12.2, v2.13.0 and v2.13.1.

Fix: drop `changelog.disable`, and move the CHANGELOG link from `header` to `footer` — a "see the full notes elsewhere" line above the full notes is noise; at the end it usefully points at the history.

## 2. An expired PAT cost npm two releases

The last step of the `release` job dispatches an `opendray.dev` rebuild using `ODSITE_DISPATCH_PAT`. That token now returns **401**, which failed the job — *after* the release had already published. And `publish-npm` declares `needs: release`, so a failed dependency skipped it.

Net effect: **npm has been serving 2.12.2 while GitHub Releases had 2.13.0 and 2.13.1.**

Fix: `continue-on-error: true` on the dispatch plus a `::warning::` annotation. A stale docs site is a nuisance; silently not publishing the package is not. The failure stays visible in the run summary.

## Not fixed here (needs the operator)

- **`ODSITE_DISPATCH_PAT` is expired** — rotate it, or opendray.dev keeps showing the old version. Requires a GitHub PAT with dispatch rights on `Opendray/opendray.dev`.
- **npm 2.13.0/2.13.1 were never published.** With this merged, a re-run of the release workflow for the tag would publish; worth deciding deliberately rather than as a side effect of this PR.

## Test plan

- [x] `goreleaser check` — `1 configuration file(s) validated`
- [x] Both YAML files parse; asserted `continue-on-error: true` on the dispatch step, `publish-npm needs: release` unchanged, and `changelog.disable` / `release.header` now absent
- [x] Verified the extraction awk against the tagged `CHANGELOG.md` for v2.13.1 (57 lines) and v2.13.0 (106) — the input was always fine
- [x] Already-published v2.13.0 and v2.13.1 bodies patched by hand via `gh release edit --notes-file`, so the two live releases read correctly now
- [ ] The real proof is the next tagged release — RELEASING.md now says to check the body every time

🤖 Generated with [Claude Code](https://claude.com/claude-code)