### PR TITLE
ci(release): make npm publishing dispatchable on its own

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,56 @@
+name: Publish to npm
+
+# The npm half of a release, callable on its own.
+#
+# It used to live inline in release.yml as a job with `needs: release`,
+# which meant anything that failed the release job — including the
+# cosmetic docs-site dispatch at its very end — silently skipped the npm
+# publish. That is how npm sat on 2.12.2 while GitHub Releases served
+# 2.13.0 and 2.13.1, with no way to publish the missing versions short
+# of re-running goreleaser against an already-published tag.
+#
+# Splitting it out gives a recovery path: dispatch this with a tag and
+# it republishes from the GitHub release artifacts, verifying SHA256SUMS
+# first. Publishing is idempotent-ish — npm refuses to overwrite an
+# existing version, so a re-run for an already-published version fails
+# loudly rather than corrupting anything.
+#
+# It must stay in CI rather than being run from a laptop: `npm publish
+# --provenance` needs the OIDC token this environment provides, and the
+# npm credential belongs in a repository secret, not on a workstation.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v2.13.1). The GitHub release must already exist with its tarballs + SHA256SUMS."
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for `npm publish --provenance`
+    env:
+      TAG: ${{ inputs.tag }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/publish-npm.mjs --tag "$TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,26 +222,13 @@ jobs:
           fi
           echo "Dispatched opendray-release for $TAG"
 
+  # Delegated to publish-npm.yml so the same definition can be dispatched
+  # on its own when a release publishes but this step doesn't — see that
+  # file's header for how npm fell two versions behind.
   publish-npm:
-    name: Publish to npm
     needs: release
-    runs-on: ubuntu-latest
     if: ${{ !contains(github.event.inputs.tag || github.ref_name, '-') }}
-    permissions:
-      contents: read
-      id-token: write   # required for `npm publish --provenance`
-    env:
-      TAG: ${{ github.event.inputs.tag || github.ref_name }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          registry-url: "https://registry.npmjs.org"
-      - name: Publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/publish-npm.mjs --tag "$TAG"
+    uses: ./.github/workflows/publish-npm.yml
+    with:
+      tag: ${{ github.event.inputs.tag || github.ref_name }}
+    secrets: inherit

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -101,10 +101,26 @@ provided automatically by Actions — you don't manage it. The other:
 
   If the secret is missing, `scripts/publish-npm.mjs` skips cleanly
   with a clear log message — the GitHub release tarballs still ship,
-  just without the npm channel. To recover after adding the secret:
-  re-run the failed `Publish to npm` job on the existing workflow
-  run, or trigger `workflow_dispatch` on `release.yml` with the
-  existing tag.
+  just without the npm channel.
+
+  **To publish npm for a tag whose release already exists** — a missing
+  secret, a skipped job, any reason the package fell behind GitHub:
+
+  ```sh
+  gh workflow run publish-npm.yml -f tag=v2.13.1
+  ```
+
+  `publish-npm.yml` is standalone (`workflow_dispatch`) *and* the
+  definition `release.yml` calls, so the recovery path and the release
+  path are the same code. It downloads the tarballs from the existing
+  GitHub release and verifies them against `SHA256SUMS` before
+  publishing, so it never ships bits the release doesn't have. npm
+  refuses to overwrite a published version, so a redundant run fails
+  loudly instead of doing damage.
+
+  Don't run `scripts/publish-npm.mjs` from a workstation: `npm publish
+  --provenance` needs the OIDC identity only CI has, and the credential
+  belongs in a repository secret.
 
   Operational note: never paste an npm token into a chat transcript,
   PR comment, issue, or any persisted log. If you do, treat it as


### PR DESCRIPTION
Follow-up to #491, so the npm backfill it identified can actually be performed.

## Why

npm publishing lived inline in `release.yml` as a job with `needs: release`. Anything that failed the release job skipped it — including the cosmetic docs-site dispatch at its very end, which is exactly what happened for v2.13.0 and v2.13.1. The only recovery available was re-running the whole release workflow against an existing tag, which puts goreleaser back on top of an already-published release with its assets and cosign signatures. Not something to do to fix a missing npm package.

## What

Extract the job into `publish-npm.yml` with both `workflow_dispatch` and `workflow_call`; `release.yml` now calls it with `secrets: inherit`. One definition, two entry points — the release path is byte-for-byte the same work as before, and a version that fell behind can be published directly:

```sh
gh workflow run publish-npm.yml -f tag=v2.13.1
```

This is safe by construction: `scripts/publish-npm.mjs` downloads the tarballs from the existing GitHub release and verifies each against `SHA256SUMS` before publishing, so the recovery path cannot ship bits the release doesn't have. npm refuses to overwrite a published version, so a redundant run fails loudly rather than doing damage.

`RELEASING.md` documents the recovery command, and why this must not be run from a workstation: `npm publish --provenance` requires the OIDC identity only CI has (it fails outside a supported CI), and the npm credential belongs in a repository secret rather than on someone's laptop.

## What this unblocks

Once merged, npm 2.13.1 gets published by dispatching the new workflow. npm is currently on **2.12.2** while GitHub Releases serves 2.13.0 and 2.13.1.

## Test plan

- [x] Both workflow files parse; asserted `publish-npm` is now a `uses:` call with `secrets: inherit`, the reusable workflow exposes `workflow_dispatch` + `workflow_call`, and `id-token: write` (required for provenance) survived the move
- [x] `if:` prerelease guard and the `tag` resolution expression preserved verbatim on the calling side
- [ ] End-to-end proof is the dispatch itself, immediately after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)