### PR TITLE
fix(release): don't let a back-fill downgrade every npm install

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -26,10 +26,19 @@ on:
         description: "Release tag to publish (e.g. v2.13.1). The GitHub release must already exist with its tarballs + SHA256SUMS."
         required: true
         type: string
+      dist_tag:
+        description: "npm dist-tag. Keep 'latest' for a normal release. Use 'previous' when back-filling a version OLDER than what is already published — npm does no semver check and would otherwise point 'latest' at the older version, downgrading every install."
+        required: false
+        default: latest
+        type: string
   workflow_call:
     inputs:
       tag:
         required: true
+        type: string
+      dist_tag:
+        required: false
+        default: latest
         type: string
 
 jobs:
@@ -41,6 +50,7 @@ jobs:
       id-token: write # required for `npm publish --provenance`
     env:
       TAG: ${{ inputs.tag }}
+      DIST_TAG: ${{ inputs.dist_tag || 'latest' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -53,4 +63,4 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/publish-npm.mjs --tag "$TAG"
+        run: node scripts/publish-npm.mjs --tag "$TAG" --dist-tag "$DIST_TAG"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -110,6 +110,19 @@ provided automatically by Actions — you don't manage it. The other:
   gh workflow run publish-npm.yml -f tag=v2.13.1
   ```
 
+  **Back-filling a version older than the one already published** needs
+  a non-default dist-tag, or you downgrade everyone:
+
+  ```sh
+  gh workflow run publish-npm.yml -f tag=v2.13.0 -f dist_tag=previous
+  ```
+
+  `npm publish` does no semver comparison — it points `latest` at
+  whatever it just published. Filling a historical hole under the
+  default tag would make `npm install opendray` resolve to the older
+  version. The hole is cosmetic; the downgrade is not. Confirm with
+  `npm view opendray dist-tags` afterwards.
+
   `publish-npm.yml` is standalone (`workflow_dispatch`) *and* the
   definition `release.yml` calls, so the recovery path and the release
   path are the same code. It downloads the tarballs from the existing

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -8,7 +8,7 @@
 //   2. verifies the SHA-256 against SHA256SUMS (also from the release),
 //   3. extracts the `opendray` binary into npm/opendray-<os>-<arch>/bin/,
 //   4. bumps the matching package.json version to <VERSION>,
-//   5. runs `npm publish --provenance --access public`.
+//   5. runs `npm publish --provenance --access public --tag <dist-tag>`.
 //
 // Once all four platform packages are published it bumps the main
 // `opendray` package (matching `optionalDependencies` to the new version)
@@ -25,6 +25,18 @@
 //                      public repos but rate limits aggressively).
 // Required arg:
 //   --tag vX.Y.Z
+// Optional arg:
+//   --dist-tag NAME  — npm dist-tag to publish under. Defaults to
+//                      `latest`, which is what a normal release wants.
+//
+//                      Pass something else when back-filling a version
+//                      OLDER than what is already published: `npm
+//                      publish` does no semver comparison, it points
+//                      `latest` at whatever it just published. Filling
+//                      a historical hole under the default tag would
+//                      therefore downgrade every `npm install opendray`
+//                      to the older version — the hole is cosmetic, the
+//                      downgrade is not.
 
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -58,7 +70,19 @@ function parseArgs() {
   if (!/^v\d+\.\d+\.\d+/.test(tag)) {
     die(`tag must look like vX.Y.Z, got: ${tag}`);
   }
-  return { tag, version: tag.replace(/^v/, "") };
+
+  const distFlag = process.argv.indexOf("--dist-tag");
+  let distTag = "latest";
+  if (distFlag !== -1) {
+    distTag = process.argv[distFlag + 1] || "";
+    // A dist-tag that parses as a version confuses npm ("Tag name must
+    // not be a valid SemVer range"), and an empty one would silently
+    // fall back to latest — the exact mistake this flag exists to stop.
+    if (!/^[a-z][a-z0-9-]*$/i.test(distTag)) {
+      die(`--dist-tag must be a name like "previous", got: ${distTag || "(empty)"}`);
+    }
+  }
+  return { tag, version: tag.replace(/^v/, ""), distTag };
 }
 
 async function fetchBuffer(url, token) {
@@ -141,9 +165,11 @@ async function preparePlatform(platform, tag, version, sums, ghToken) {
   return pkgDir;
 }
 
-function npmPublish(pkgDir) {
-  console.log(`\n=== publishing ${pkgDir} ===`);
-  run("npm", ["publish", "--provenance", "--access", "public"], { cwd: pkgDir });
+function npmPublish(pkgDir, distTag) {
+  console.log(`\n=== publishing ${pkgDir} (dist-tag: ${distTag}) ===`);
+  run("npm", ["publish", "--provenance", "--access", "public", "--tag", distTag], {
+    cwd: pkgDir,
+  });
 }
 
 function prepareSdk(version) {
@@ -158,7 +184,7 @@ function prepareSdk(version) {
 }
 
 async function main() {
-  const { tag, version } = parseArgs();
+  const { tag, version, distTag } = parseArgs();
   const ghToken = process.env.GITHUB_TOKEN || "";
 
   if (!process.env.NODE_AUTH_TOKEN) {
@@ -181,7 +207,7 @@ async function main() {
     process.exit(0);
   }
 
-  console.log(`Publishing opendray @ ${version} (tag ${tag})`);
+  console.log(`Publishing opendray @ ${version} (tag ${tag}, dist-tag ${distTag})`);
 
   const sumsBuf = await fetchBuffer(
     `https://github.com/Opendray/opendray/releases/download/${tag}/SHA256SUMS`,
@@ -196,7 +222,7 @@ async function main() {
   }
 
   for (const pkgDir of platformDirs) {
-    npmPublish(pkgDir);
+    npmPublish(pkgDir, distTag);
   }
 
   const mainDir = join(NPM_ROOT, "opendray");
@@ -204,13 +230,17 @@ async function main() {
   for (const { pkg } of PLATFORMS) optDeps[pkg] = version;
   setPkgVersion(mainDir, version, { optionalDependencies: optDeps });
   copyLicenseInto(mainDir);
-  npmPublish(mainDir);
+  npmPublish(mainDir, distTag);
 
   const sdkDir = prepareSdk(version);
-  npmPublish(sdkDir);
+  npmPublish(sdkDir, distTag);
 
-  console.log(`\nopendray @ ${version} + @opendray/sdk @ ${version} published.`);
-  console.log(`Verify: npm view opendray version && npm view @opendray/sdk version`);
+  console.log(`\nopendray @ ${version} + @opendray/sdk @ ${version} published under "${distTag}".`);
+  if (distTag === "latest") {
+    console.log(`Verify: npm view opendray version && npm view @opendray/sdk version`);
+  } else {
+    console.log(`"latest" was left untouched. Verify: npm view opendray dist-tags`);
+  }
 }
 
 main().catch((err) => die(err.stack || err.message));


### PR DESCRIPTION
Caught while preparing to back-fill npm 2.13.0 as asked. Publishing it naively would have shipped a downgrade to every user.

## The problem

`npm publish` performs **no semver comparison** — it points `latest` at whatever was just published, in publish order, not version order. `publish-npm.mjs` passed no `--tag`.

Current npm state:

```
versions:   2.12.2, 2.13.1
dist-tags:  latest -> 2.13.1
```

Publishing 2.13.0 to fill the hole would have set `latest -> 2.13.0`, so every `npm install -g opendray` would resolve to the **older** release — the one missing the host keep-awake fix that motivated this whole sequence. The gap in version history is cosmetic; that downgrade is not.

## The fix

- `publish-npm.mjs` gains `--dist-tag NAME`, defaulting to `latest`.
- `publish-npm.yml` gains a `dist_tag` input (both dispatch and call), defaulting to `latest`.
- `release.yml` passes nothing, so normal releases behave exactly as before.

Back-fill usage, now documented in RELEASING.md:

```sh
gh workflow run publish-npm.yml -f tag=v2.13.0 -f dist_tag=previous
```

The flag is validated rather than trusted. An empty value would silently fall back to `latest` — exactly the mistake the flag exists to prevent — and a version-shaped value is rejected by npm itself with a misleading "Tag name must not be a valid SemVer range" error, so both fail fast in `parseArgs` with a clear message.

## Test plan

- [x] `--dist-tag ""` → rejected: `must be a name like "previous", got: (empty)`
- [x] `--dist-tag 2.13.0` → rejected (version-shaped)
- [x] `--dist-tag previous` and no flag at all → both reach the normal NODE_AUTH_TOKEN guard, so parsing succeeds
- [x] Workflow YAML parses; asserted both trigger types expose `tag` + `dist_tag`, the run line passes `--dist-tag "$DIST_TAG"`, and `release.yml` still passes only `tag` (so it inherits the `latest` default)
- [ ] Live proof is the 2.13.0 dispatch immediately after merge, verified with `npm view opendray dist-tags` still showing `latest -> 2.13.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)