### PR TITLE
fix(release): stop an old tag's tooling from ignoring dist_tag

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -31,6 +31,11 @@ on:
         required: false
         default: latest
         type: string
+      checkout_ref:
+        description: "Tree to run from. Empty = the tag itself, which is what you want. Set to 'main' only when back-filling a tag whose tooling predates a feature you need — first confirm `git diff <tag> main -- npm/` is empty, or you would publish package sources the tag never had."
+        required: false
+        default: ""
+        type: string
   workflow_call:
     inputs:
       tag:
@@ -51,10 +56,26 @@ jobs:
     env:
       TAG: ${{ inputs.tag }}
       DIST_TAG: ${{ inputs.dist_tag || 'latest' }}
+      CHECKOUT_REF: ${{ inputs.checkout_ref || inputs.tag }}
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.checkout_ref || inputs.tag }}
+
+      # The tree is normally the tag's, so the tooling is as old as the
+      # tag. publish-npm.mjs only learned --dist-tag in v2.13.2; older
+      # copies parse args by scanning for the flags they know and ignore
+      # the rest, so a back-fill dispatched against such a tag would
+      # accept the flag, drop it, publish to `latest`, and downgrade
+      # every install — silently, which is the whole failure mode this
+      # is meant to prevent. Turn it into a loud stop with the remedy.
+      - name: Verify the tooling honours the requested dist-tag
+        run: |
+          if [ "$DIST_TAG" != "latest" ] && ! grep -q -- "--dist-tag" scripts/publish-npm.mjs; then
+            echo "::error::scripts/publish-npm.mjs at $CHECKOUT_REF predates --dist-tag support: it would ignore dist_tag=$DIST_TAG and publish to 'latest', downgrading installs. Re-dispatch with checkout_ref=main after confirming 'git diff $TAG main -- npm/' is empty."
+            exit 1
+          fi
+          echo "tooling at $CHECKOUT_REF honours dist_tag=$DIST_TAG"
       - uses: actions/setup-node@v6
         with:
           node-version: "22"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -114,8 +114,16 @@ provided automatically by Actions — you don't manage it. The other:
   a non-default dist-tag, or you downgrade everyone:
 
   ```sh
-  gh workflow run publish-npm.yml -f tag=v2.13.0 -f dist_tag=previous
+  # Confirm the tag's npm/ tree matches main before overriding the ref:
+  git diff v2.13.0 main -- npm/        # must be empty
+  gh workflow run publish-npm.yml \
+    -f tag=v2.13.0 -f dist_tag=previous -f checkout_ref=main
   ```
+
+  `checkout_ref=main` is needed for any tag older than v2.13.2, because
+  the tooling it ships predates `--dist-tag` and would ignore it. The
+  workflow refuses to run in that combination rather than silently
+  publishing to `latest`; drop `checkout_ref` for anything newer.
 
   `npm publish` does no semver comparison — it points `latest` at
   whatever it just published. Filling a historical hole under the


### PR DESCRIPTION
Found while trying to actually run the v2.13.0 back-fill that #493 made safe. The safety didn't reach it.

## The hole

`publish-npm.yml` checks out **the tag being published**, so the script it executes is as old as that tag. `publish-npm.mjs` only learned `--dist-tag` in #493 (v2.13.2), and older copies parse arguments by scanning for the flags they know and ignoring everything else — no error on an unknown flag.

So the documented back-fill command:

```sh
gh workflow run publish-npm.yml -f tag=v2.13.0 -f dist_tag=previous
```

would have checked out v2.13.0, run its `--dist-tag`-unaware script, silently dropped the flag, published to `latest`, and downgraded every `npm install opendray` to 2.13.0. Verified: `git show v2.13.0:scripts/publish-npm.mjs | grep -c dist-tag` → `0`.

## The fix

- **Guard step**: when `dist_tag != latest` and the checked-out script has no `--dist-tag`, fail with an error naming the remedy rather than publishing. A silently-ignored flag becomes a loud stop.
- **`checkout_ref` input**: lets a back-fill run current tooling against an old tag. Documented as gated on `git diff <tag> main -- npm/` being empty, so it can't publish package sources the tag never had — confirmed empty for v2.13.0.

RELEASING.md now shows the full back-fill recipe including the diff check and when `checkout_ref` is required (any tag older than v2.13.2).

## Test plan

- [x] Guard logic exercised against the real v2.13.0 script and the current one: old + `previous` → **BLOCKED**, old + `latest` → allowed (normal releases of old tags unaffected), new + `previous` → allowed
- [x] `git diff v2.13.0 main -- npm/` is empty, so `checkout_ref=main` publishes the same package sources the tag had
- [x] Workflow YAML parses; the guard runs after checkout and before setup-node/publish
- [ ] Live proof is the v2.13.0 dispatch after merge, verified with `npm view opendray dist-tags` still showing `latest -> 2.13.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)