### PR TITLE
feat(vault): folder tree and move/rename across web and mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+### Added
+
+- **The Vault can hold a folder structure you actually maintain.** Project
+  docs were a flat list: the "New doc" box replaced `/` with `-`, so
+  `features/canvas.md` became `features-canvas.md` and a folder could not
+  be created from the UI at all — while the backend had stored nested
+  paths the whole time and the Notes page already rendered them as a tree.
+  The project-docs lane now renders that tree (rooted at the project, with
+  a Recent toggle for "the one I just edited"), typing a path with slashes
+  files a doc in a folder, and a new **move/rename** repoints the
+  `[[wiki-links]]` that pointed at the old path — without that, filing a
+  doc away silently stranded every reference to it, which is why nobody
+  reorganised. Web and mobile both; the rewrite skips code blocks, so a
+  fenced example of the syntax is never edited.
+
 ## [v2.13.1] — 2026-08-07
 
 Your phone and your browser can reach the gateway again while its Mac

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -263,7 +263,15 @@
           "clearOverride": "Clear override",
           "boundToast": "Project vault folder bound",
           "clearedToast": "Override cleared — using the default folder",
-          "saveFailed": "Could not save the mapping"
+          "saveFailed": "Could not save the mapping",
+          "viewTree": "Folders",
+          "viewRecent": "Recent",
+          "renameTitle": "Rename or move",
+          "move": "Move",
+          "renamed": "Moved.",
+          "renamedWithLinks": "Moved — updated {{count}} link(s) in {{notes}} note(s).",
+          "renamedWithWarning": "Moved, but links may not be updated",
+          "renameFailed": "Move failed"
         },
         "cortexPanel": {
           "noCwd": "Session has no cwd — Cortex features need a working directory.",
@@ -3780,7 +3788,14 @@
         "pinnedHint": "Pinned to {path}/ (overrides {defaultPath}). AI agents author docs here too.",
         "noProjectMapping2": "(no project mapping)",
         "clearOverride": "Clear override",
-        "save": "Save"
+        "save": "Save",
+        "renameTitle": "Rename or move",
+        "move": "Move",
+        "renameHelp": "Path inside the project folder. Include a slash to file it in a folder, e.g. features/canvas.md",
+        "renamed": "Moved.",
+        "renamedWithLinks": "Moved — updated {count} link(s) in {notes} note(s).",
+        "renamedWithWarning": "Moved, but links may not be updated: {warning}",
+        "renameFailed": "Move failed: {error}"
       },
       "canvas": {
         "kindUi": "UI mock",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -263,7 +263,15 @@
           "clearOverride": "Borrar anulación",
           "boundToast": "Carpeta de bóveda del proyecto vinculada",
           "clearedToast": "Anulación borrada — usando la carpeta por defecto",
-          "saveFailed": "No se pudo guardar el mapeo"
+          "saveFailed": "No se pudo guardar el mapeo",
+          "viewTree": "Carpetas",
+          "viewRecent": "Recientes",
+          "renameTitle": "Renombrar o mover",
+          "move": "Mover",
+          "renamed": "Movido.",
+          "renamedWithLinks": "Movido: se actualizaron {{count}} enlace(s) en {{notes}} nota(s).",
+          "renamedWithWarning": "Movido, pero los enlaces podrían no actualizarse",
+          "renameFailed": "Error al mover"
         },
         "cortexPanel": {
           "noCwd": "La sesión no tiene cwd — las funciones de Cortex necesitan un directorio de trabajo.",
@@ -3780,7 +3788,14 @@
         "pinnedHint": "Fijado a {path}/ (anula {defaultPath}). Los agentes de IA también redactan documentos aquí.",
         "noProjectMapping2": "(sin asignación de proyecto)",
         "clearOverride": "Borrar anulación",
-        "save": "Guardar"
+        "save": "Guardar",
+        "renameTitle": "Renombrar o mover",
+        "move": "Mover",
+        "renameHelp": "Ruta dentro de la carpeta del proyecto. Incluye una barra para archivarlo en una carpeta, p. ej. features/canvas.md",
+        "renamed": "Movido.",
+        "renamedWithLinks": "Movido: se actualizaron {count} enlace(s) en {notes} nota(s).",
+        "renamedWithWarning": "Movido, pero los enlaces podrían no actualizarse: {warning}",
+        "renameFailed": "Error al mover: {error}"
       },
       "canvas": {
         "kindUi": "Maqueta UI",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -263,7 +263,15 @@
           "clearOverride": "清除覆盖",
           "boundToast": "已绑定项目文档库文件夹",
           "clearedToast": "已清除覆盖 —— 使用默认文件夹",
-          "saveFailed": "无法保存映射"
+          "saveFailed": "无法保存映射",
+          "viewTree": "目录",
+          "viewRecent": "最近",
+          "renameTitle": "重命名或移动",
+          "move": "移动",
+          "renamed": "已移动。",
+          "renamedWithLinks": "已移动 —— 更新了 {{notes}} 篇笔记中的 {{count}} 处链接。",
+          "renamedWithWarning": "已移动,但链接可能未更新",
+          "renameFailed": "移动失败"
         },
         "cortexPanel": {
           "noCwd": "会话没有工作目录——心智中枢功能需要工作目录。",
@@ -3780,7 +3788,14 @@
         "pinnedHint": "已固定到 {path}/（覆盖 {defaultPath}）。AI agent 也会在此撰写文档。",
         "noProjectMapping2": "（无项目映射）",
         "clearOverride": "清除覆盖",
-        "save": "保存"
+        "save": "保存",
+        "renameTitle": "重命名或移动",
+        "move": "移动",
+        "renameHelp": "项目文件夹内的路径。加斜杠即可归入目录,例如 features/canvas.md",
+        "renamed": "已移动。",
+        "renamedWithLinks": "已移动 —— 更新了 {notes} 篇笔记中的 {count} 处链接。",
+        "renamedWithWarning": "已移动,但链接可能未更新:{warning}",
+        "renameFailed": "移动失败:{error}"
       },
       "canvas": {
         "kindUi": "UI 稿",

--- a/app/mobile/lib/core/api/notes_api.dart
+++ b/app/mobile/lib/core/api/notes_api.dart
@@ -194,6 +194,52 @@ class NotesApi {
       throw toApiException(e);
     }
   }
+
+  /// Move or rename a note, repointing the [[wiki-links]] that pointed
+  /// at it. Without the rewrite a rename silently strands every
+  /// reference, which is why reorganising was previously unsafe.
+  Future<MoveResult> move({required String from, required String to}) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/notes/move',
+        data: {'from': from, 'to': to},
+      );
+      return MoveResult.fromJson(res.data ?? const {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+}
+
+/// Outcome of a move. [warning] is set when the file moved but the link
+/// rewrite didn't finish — the move still happened, so the UI must not
+/// report it as a failure.
+class MoveResult {
+  const MoveResult({
+    required this.to,
+    required this.linksRewritten,
+    required this.notesRewritten,
+    this.warning,
+  });
+
+  factory MoveResult.fromJson(Map<String, dynamic> json) {
+    // The handler nests the result under `moved` when it also has a
+    // warning to report.
+    final moved = json['moved'];
+    final body = moved is Map<String, dynamic> ? moved : json;
+    final rewritten = body['rewritten_in'];
+    return MoveResult(
+      to: (body['to'] ?? '') as String,
+      linksRewritten: (body['links_rewritten'] ?? 0) as int,
+      notesRewritten: rewritten is List ? rewritten.length : 0,
+      warning: json['warning'] as String?,
+    );
+  }
+
+  final String to;
+  final int linksRewritten;
+  final int notesRewritten;
+  final String? warning;
 }
 
 final notesApiProvider = Provider<NotesApi>((ref) {

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 12960 (4320 per locale)
+/// Strings: 13005 (4335 per locale)
 ///
-/// Built on 2026-08-07 at 08:42 UTC
+/// Built on 2026-08-07 at 11:28 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -13178,6 +13178,27 @@ class TranslationsSessionsInspectorNotesEn {
 
 	/// en: 'Save'
 	String get save => 'Save';
+
+	/// en: 'Rename or move'
+	String get renameTitle => 'Rename or move';
+
+	/// en: 'Move'
+	String get move => 'Move';
+
+	/// en: 'Path inside the project folder. Include a slash to file it in a folder, e.g. features/canvas.md'
+	String get renameHelp => 'Path inside the project folder. Include a slash to file it in a folder, e.g. features/canvas.md';
+
+	/// en: 'Moved.'
+	String get renamed => 'Moved.';
+
+	/// en: 'Moved — updated {count} link(s) in {notes} note(s).'
+	String renamedWithLinks({required Object count, required Object notes}) => 'Moved — updated ${count} link(s) in ${notes} note(s).';
+
+	/// en: 'Moved, but links may not be updated: {warning}'
+	String renamedWithWarning({required Object warning}) => 'Moved, but links may not be updated: ${warning}';
+
+	/// en: 'Move failed: {error}'
+	String renameFailed({required Object error}) => 'Move failed: ${error}';
 }
 
 // Path: sessions.inspector.canvas
@@ -14573,6 +14594,30 @@ class TranslationsWebSessionsInspectorVaultPanelEn {
 
 	/// en: 'Could not save the mapping'
 	String get saveFailed => 'Could not save the mapping';
+
+	/// en: 'Folders'
+	String get viewTree => 'Folders';
+
+	/// en: 'Recent'
+	String get viewRecent => 'Recent';
+
+	/// en: 'Rename or move'
+	String get renameTitle => 'Rename or move';
+
+	/// en: 'Move'
+	String get move => 'Move';
+
+	/// en: 'Moved.'
+	String get renamed => 'Moved.';
+
+	/// en: 'Moved — updated {{count}} link(s) in {{notes}} note(s).'
+	String renamedWithLinks({required Object {count, required Object {notes}) => 'Moved — updated ${{count}} link(s) in ${{notes}} note(s).';
+
+	/// en: 'Moved, but links may not be updated'
+	String get renamedWithWarning => 'Moved, but links may not be updated';
+
+	/// en: 'Move failed'
+	String get renameFailed => 'Move failed';
 }
 
 // Path: web.sessions.inspector.cortexPanel
@@ -18722,6 +18767,14 @@ extension on Translations {
 			'web.sessions.inspector.vaultPanel.boundToast' => 'Project vault folder bound',
 			'web.sessions.inspector.vaultPanel.clearedToast' => 'Override cleared — using the default folder',
 			'web.sessions.inspector.vaultPanel.saveFailed' => 'Could not save the mapping',
+			'web.sessions.inspector.vaultPanel.viewTree' => 'Folders',
+			'web.sessions.inspector.vaultPanel.viewRecent' => 'Recent',
+			'web.sessions.inspector.vaultPanel.renameTitle' => 'Rename or move',
+			'web.sessions.inspector.vaultPanel.move' => 'Move',
+			'web.sessions.inspector.vaultPanel.renamed' => 'Moved.',
+			'web.sessions.inspector.vaultPanel.renamedWithLinks' => ({required Object {count, required Object {notes}) => 'Moved — updated ${{count}} link(s) in ${{notes}} note(s).',
+			'web.sessions.inspector.vaultPanel.renamedWithWarning' => 'Moved, but links may not be updated',
+			'web.sessions.inspector.vaultPanel.renameFailed' => 'Move failed',
 			'web.sessions.inspector.cortexPanel.noCwd' => 'Session has no cwd — Cortex features need a working directory.',
 			'web.sessions.inspector.cortexPanel.open' => 'Open Cortex workspace',
 			'web.sessions.inspector.cortexPanel.docs' => 'Docs',
@@ -18995,6 +19048,8 @@ extension on Translations {
 			'web.memoryWorkers.tasks.capture.label' => 'Capture engine',
 			'web.memoryWorkers.tasks.capture.description' => 'Per-trigger fact extraction from session transcripts. Agent mode gives noticeably better facts on long sessions; summarizer mode is cheap and local.',
 			'web.memoryWorkers.tasks.capture.modelAdvice' => 'Highest-frequency task: fact extraction every few messages — use the CHEAPEST model that works (haiku / local).',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryWorkers.tasks.blueprint.modelAdvice' => 'Occasional, operator-triggered project classification — balanced model; quality matters more than cost here.',
 			'web.memoryWorkers.tasks.blueprint.label' => 'Blueprint proposer',
 			'web.memoryWorkers.tasks.blueprint.description' => 'Classifies a project from repo signals and proposes its doc section set. Operator-triggered from the blueprint editor.',
@@ -19003,8 +19058,6 @@ extension on Translations {
 			'web.memoryWorkers.tasks.curation.description' => 'Drives the talk-to-AI channel that updates doc sections and re-drafts knowledge pages; revisions respect lock state.',
 			'web.memoryWorkers.modelLabel' => 'Model',
 			'web.memoryWorkers.modelHint' => 'Pin the CLI model for this task (e.g. haiku for cheap chores). Empty = CLI default.',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryWorkers.modelCliDefault' => 'CLI default (latest)',
 			'web.memoryWorkers.modelCustom' => 'Custom…',
 			'web.memoryWorkers.modelCustomPlaceholder' => 'exact model id',
@@ -19509,6 +19562,8 @@ extension on Translations {
 			'web.providers.detail.caps.images' => 'images',
 			'web.providers.detail.caps.mcp' => 'mcp',
 			'web.providers.detail.notInstalled' => 'not installed',
+			_ => null,
+		} ?? switch (path) {
 			'web.providers.detail.brokenCli' => 'Installed but not runnable',
 			'web.providers.detail.updateAvailable' => ({required Object version}) => 'update available → ${version}',
 			'web.providers.detail.upToDate' => 'up to date',
@@ -19517,8 +19572,6 @@ extension on Translations {
 			'web.providers.detail.updatedToast' => ({required Object from, required Object to}) => 'Updated ${from} → ${to}',
 			'web.providers.detail.alreadyLatestToast' => 'Already up to date',
 			'web.providers.detail.updateFailedToast' => 'Update failed',
-			_ => null,
-		} ?? switch (path) {
 			'web.providers.detail.updateUnavailable' => 'In-app update not available here',
 			'web.providers.configForm.selectPlaceholder' => 'Select…',
 			'web.providers.configForm.defaultOption' => '(default)',
@@ -20023,6 +20076,8 @@ extension on Translations {
 			'web.backups.generated.copiedToast' => 'Passphrase copied to clipboard',
 			'web.backups.generated.copyFailedToast' => 'Copy failed — select and copy manually',
 			'web.backups.generated.savedTo' => 'Saved to:',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.generated.ack' => 'I have saved this passphrase to my password manager',
 			'web.backups.generated.kContinue' => 'Continue',
 			'web.backups.status.pgDump' => 'pg_dump',
@@ -20031,8 +20086,6 @@ extension on Translations {
 			'web.backups.status.pgDumpHint' => 'Backups can\'t run until pg_dump is on PATH (or its absolute path is set in <1>backup.pg_dump_path</1>). Install <3>postgresql-client</3> matching your server\'s major version and restart.',
 			'web.backups.backupsTab.backupNow' => 'Backup now',
 			'web.backups.backupsTab.triggering' => 'Triggering…',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.backupsTab.includeConfig' => 'include config.toml',
 			'web.backups.backupsTab.fullInstance' => 'Full instance',
 			'web.backups.backupsTab.fullInstanceHint' => 'Also bundle the vault (notes/skills/mcp), secrets.env and config.toml — everything needed to rebuild a working instance, not just its database.',
@@ -20537,6 +20590,8 @@ extension on Translations {
 			'web.settings.system.uptime' => 'Uptime',
 			'web.settings.system.database' => 'Database',
 			'web.settings.system.reachable' => 'reachable',
+			_ => null,
+		} ?? switch (path) {
 			'web.settings.system.unreachable' => 'unreachable',
 			'web.settings.about.title' => 'About',
 			'web.settings.about.description' => 'opendray v2 — the multiplexer + integration gateway for AI agent CLIs. Source under Apache 2.0.',
@@ -20545,8 +20600,6 @@ extension on Translations {
 			'web.settings.about.updateAvailable' => ({required Object version}) => 'Update available: ${version}',
 			'web.settings.about.releaseNotes' => 'Release notes ↗',
 			'web.settings.about.updateNow' => 'Update now',
-			_ => null,
-		} ?? switch (path) {
 			'web.settings.about.upgradingShort' => 'Upgrading…',
 			'web.settings.about.confirmRestart' => 'This restarts the service; running sessions reconnect.',
 			'web.settings.about.confirmUpgrade' => 'Upgrade & restart',
@@ -21051,6 +21104,8 @@ extension on Translations {
 			'web.database.grid.delete' => 'Delete',
 			'web.database.grid.deleted' => 'Row deleted',
 			'web.database.grid.confirmDelete' => 'Delete this row?',
+			_ => null,
+		} ?? switch (path) {
 			'web.database.grid.loading' => 'Loading rows…',
 			'web.database.grid.readOnlyHint' => 'This connection is read-only — rows cannot be edited.',
 			'web.database.grid.noPkHint' => 'This table has no primary key — row editing is disabled.',
@@ -21059,8 +21114,6 @@ extension on Translations {
 			'web.database.console.run' => 'Run',
 			'web.database.console.runHint' => 'Cmd/Ctrl+Enter to run',
 			'web.database.console.stats' => ({required Object command, required Object rows, required Object ms}) => '${command} · ${rows} row(s) · ${ms} ms',
-			_ => null,
-		} ?? switch (path) {
 			'web.database.console.truncated' => 'truncated',
 			'web.database.console.empty' => 'Run a query to see results.',
 			'web.database.console.truncatedNote' => 'results truncated',
@@ -21462,6 +21515,13 @@ extension on Translations {
 			'sessions.inspector.notes.noProjectMapping2' => '(no project mapping)',
 			'sessions.inspector.notes.clearOverride' => 'Clear override',
 			'sessions.inspector.notes.save' => 'Save',
+			'sessions.inspector.notes.renameTitle' => 'Rename or move',
+			'sessions.inspector.notes.move' => 'Move',
+			'sessions.inspector.notes.renameHelp' => 'Path inside the project folder. Include a slash to file it in a folder, e.g. features/canvas.md',
+			'sessions.inspector.notes.renamed' => 'Moved.',
+			'sessions.inspector.notes.renamedWithLinks' => ({required Object count, required Object notes}) => 'Moved — updated ${count} link(s) in ${notes} note(s).',
+			'sessions.inspector.notes.renamedWithWarning' => ({required Object warning}) => 'Moved, but links may not be updated: ${warning}',
+			'sessions.inspector.notes.renameFailed' => ({required Object error}) => 'Move failed: ${error}',
 			'sessions.inspector.canvas.kindUi' => 'UI mock',
 			'sessions.inspector.canvas.kindFlow' => 'Flowchart',
 			'sessions.inspector.canvas.kindMindmap' => 'Mind map',
@@ -21558,6 +21618,8 @@ extension on Translations {
 			'sessions.spawnSheet.bypass.labelOpencode' => 'Bypass permissions',
 			'sessions.spawnSheet.bypass.labelGrok' => 'Bypass permissions / YOLO (--always-approve)',
 			'sessions.spawnSheet.bypass.subtitleOn' => 'This session will run with elevated autonomy.',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.spawnSheet.bypass.subtitleOff' => 'Off — confirmations and prompts behave normally.',
 			'sessions.spawnSheet.noProviders.title' => 'No providers configured',
 			'sessions.spawnSheet.noProviders.message' => 'The gateway has no CLI providers enabled. Configure one under Providers (web admin) or [providers] in config.toml, then tap Reload.',
@@ -21573,8 +21635,6 @@ extension on Translations {
 			'sessions.spawnSheet.claudeAccount.disabledSuffix' => ' (disabled)',
 			'sessions.spawnSheet.claudeAccount.noTokenSuffix' => ' (no token)',
 			'sessions.spawnSheet.claudeAccount.noneHint' => 'No Claude accounts configured — the gateway will use the system ANTHROPIC_API_KEY. Add accounts under Settings → Accounts on the web admin.',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.spawnSheet.claudeAccount.errorHint' => ({required Object error}) => 'Could not load Claude accounts (${error}). The session will spawn with the gateway default.',
 			'mcp.title' => 'MCP',
 			'mcp.newServer' => 'New server',
@@ -22072,6 +22132,8 @@ extension on Translations {
 			'backups.restore.manifestTitle' => 'Manifest',
 			'backups.restore.manifestBackupId' => 'Backup ID',
 			'backups.restore.manifestVersion' => 'Manifest version',
+			_ => null,
+		} ?? switch (path) {
 			'backups.restore.manifestCreatedAt' => 'Created',
 			'backups.restore.manifestPgVersion' => 'pg_version',
 			'backups.restore.manifestOpendrayVersion' => 'opendray version',
@@ -22087,8 +22149,6 @@ extension on Translations {
 			'backups.inventory.summary' => ({required Object rows, required Object tables}) => '${rows} rows · ${tables} tables',
 			'backups.inventory.description' => 'Live row counts from opendray\'s Postgres database. Backups capture every row below; binary artifacts on disk are not included.',
 			'backups.inventory.rowsLabel' => 'rows',
-			_ => null,
-		} ?? switch (path) {
 			'backups.inventory.loadFailedToast' => 'Failed to load inventory',
 			'backups.inventory.loading' => 'Loading…',
 			'backups.inventory.tap' => 'Tap to expand',
@@ -22586,6 +22646,8 @@ extension on Translations {
 			'memory.quarantinedToast' => 'Memory quarantined — review under Cortex → Quarantine',
 			'memory.archiveFailed' => ({required Object error}) => 'Archive failed: ${error}',
 			'memory.quarantineFailed' => ({required Object error}) => 'Quarantine failed: ${error}',
+			_ => null,
+		} ?? switch (path) {
 			'memory.reembed.menuItem' => 'Re-embed all',
 			'memory.reembed.confirmTitle' => 'Re-embed all memories?',
 			'memory.reembed.confirmBody' => 'Re-encodes every stored memory and KB page with the current embedding model. Needed after switching models, since the vector dimension changes. This can take a while.',
@@ -22601,8 +22663,6 @@ extension on Translations {
 			'about.fields.app' => 'App',
 			'about.fields.version' => 'Version',
 			'about.fields.versionFormat' => ({required Object version, required Object build}) => '${version} (build ${build})',
-			_ => null,
-		} ?? switch (path) {
 			'about.fields.package' => 'Package',
 			'about.fields.url' => 'URL',
 			'about.fields.signedInAs' => 'Signed in as',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -6758,6 +6758,13 @@ class _TranslationsSessionsInspectorNotesEs extends TranslationsSessionsInspecto
 	@override String get noProjectMapping2 => '(sin asignación de proyecto)';
 	@override String get clearOverride => 'Borrar anulación';
 	@override String get save => 'Guardar';
+	@override String get renameTitle => 'Renombrar o mover';
+	@override String get move => 'Mover';
+	@override String get renameHelp => 'Ruta dentro de la carpeta del proyecto. Incluye una barra para archivarlo en una carpeta, p. ej. features/canvas.md';
+	@override String get renamed => 'Movido.';
+	@override String renamedWithLinks({required Object count, required Object notes}) => 'Movido: se actualizaron ${count} enlace(s) en ${notes} nota(s).';
+	@override String renamedWithWarning({required Object warning}) => 'Movido, pero los enlaces podrían no actualizarse: ${warning}';
+	@override String renameFailed({required Object error}) => 'Error al mover: ${error}';
 }
 
 // Path: sessions.inspector.canvas
@@ -7463,6 +7470,14 @@ class _TranslationsWebSessionsInspectorVaultPanelEs extends TranslationsWebSessi
 	@override String get boundToast => 'Carpeta de bóveda del proyecto vinculada';
 	@override String get clearedToast => 'Anulación borrada — usando la carpeta por defecto';
 	@override String get saveFailed => 'No se pudo guardar el mapeo';
+	@override String get viewTree => 'Carpetas';
+	@override String get viewRecent => 'Recientes';
+	@override String get renameTitle => 'Renombrar o mover';
+	@override String get move => 'Mover';
+	@override String get renamed => 'Movido.';
+	@override String renamedWithLinks({required Object {count, required Object {notes}) => 'Movido: se actualizaron ${{count}} enlace(s) en ${{notes}} nota(s).';
+	@override String get renamedWithWarning => 'Movido, pero los enlaces podrían no actualizarse';
+	@override String get renameFailed => 'Error al mover';
 }
 
 // Path: web.sessions.inspector.cortexPanel
@@ -9960,6 +9975,14 @@ extension on TranslationsEs {
 			'web.sessions.inspector.vaultPanel.boundToast' => 'Carpeta de bóveda del proyecto vinculada',
 			'web.sessions.inspector.vaultPanel.clearedToast' => 'Anulación borrada — usando la carpeta por defecto',
 			'web.sessions.inspector.vaultPanel.saveFailed' => 'No se pudo guardar el mapeo',
+			'web.sessions.inspector.vaultPanel.viewTree' => 'Carpetas',
+			'web.sessions.inspector.vaultPanel.viewRecent' => 'Recientes',
+			'web.sessions.inspector.vaultPanel.renameTitle' => 'Renombrar o mover',
+			'web.sessions.inspector.vaultPanel.move' => 'Mover',
+			'web.sessions.inspector.vaultPanel.renamed' => 'Movido.',
+			'web.sessions.inspector.vaultPanel.renamedWithLinks' => ({required Object {count, required Object {notes}) => 'Movido: se actualizaron ${{count}} enlace(s) en ${{notes}} nota(s).',
+			'web.sessions.inspector.vaultPanel.renamedWithWarning' => 'Movido, pero los enlaces podrían no actualizarse',
+			'web.sessions.inspector.vaultPanel.renameFailed' => 'Error al mover',
 			'web.sessions.inspector.cortexPanel.noCwd' => 'La sesión no tiene cwd — las funciones de Cortex necesitan un directorio de trabajo.',
 			'web.sessions.inspector.cortexPanel.open' => 'Abrir espacio Cortex',
 			'web.sessions.inspector.cortexPanel.docs' => 'Docs',
@@ -10233,6 +10256,8 @@ extension on TranslationsEs {
 			'web.memoryWorkers.tasks.capture.label' => 'Motor de captura',
 			'web.memoryWorkers.tasks.capture.description' => 'Extracción de hechos por cada trigger a partir de los transcripts de sesión. El modo agente ofrece hechos notablemente mejores en sesiones largas; el modo summarizer es barato y local.',
 			'web.memoryWorkers.tasks.capture.modelAdvice' => 'La tarea más frecuente: extracción de hechos — usa el modelo MÁS BARATO que funcione (haiku / local).',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryWorkers.tasks.blueprint.modelAdvice' => 'Clasificación ocasional del proyecto — modelo equilibrado; aquí la calidad importa más que el costo.',
 			'web.memoryWorkers.tasks.blueprint.label' => 'Proponedor de planos',
 			'web.memoryWorkers.tasks.blueprint.description' => 'Clasifica un proyecto y propone su conjunto de secciones. Disparado por el operador.',
@@ -10241,8 +10266,6 @@ extension on TranslationsEs {
 			'web.memoryWorkers.tasks.curation.description' => 'Impulsa el canal conversacional que actualiza secciones y re-redacta páginas de conocimiento.',
 			'web.memoryWorkers.modelLabel' => 'Modelo',
 			'web.memoryWorkers.modelHint' => 'Fija el modelo del CLI para esta tarea (p. ej. haiku para tareas básicas). Vacío = predeterminado del CLI.',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryWorkers.modelCliDefault' => 'Predeterminado del CLI (último)',
 			'web.memoryWorkers.modelCustom' => 'Personalizado…',
 			'web.memoryWorkers.modelCustomPlaceholder' => 'id exacto del modelo',
@@ -10747,6 +10770,8 @@ extension on TranslationsEs {
 			'web.providers.detail.caps.images' => 'images',
 			'web.providers.detail.caps.mcp' => 'mcp',
 			'web.providers.detail.notInstalled' => 'no instalado',
+			_ => null,
+		} ?? switch (path) {
 			'web.providers.detail.brokenCli' => 'Instalado pero no ejecutable',
 			'web.providers.detail.updateAvailable' => ({required Object version}) => 'actualización disponible → ${version}',
 			'web.providers.detail.upToDate' => 'actualizado',
@@ -10755,8 +10780,6 @@ extension on TranslationsEs {
 			'web.providers.detail.updatedToast' => ({required Object from, required Object to}) => 'Actualizado ${from} → ${to}',
 			'web.providers.detail.alreadyLatestToast' => 'Ya está actualizado',
 			'web.providers.detail.updateFailedToast' => 'Error al actualizar',
-			_ => null,
-		} ?? switch (path) {
 			'web.providers.detail.updateUnavailable' => 'La actualización dentro de la app no está disponible aquí',
 			'web.providers.configForm.selectPlaceholder' => 'Selecciona…',
 			'web.providers.configForm.defaultOption' => '(predeterminado)',
@@ -11261,6 +11284,8 @@ extension on TranslationsEs {
 			'web.backups.generated.copiedToast' => 'Frase de contraseña copiada al portapapeles',
 			'web.backups.generated.copyFailedToast' => 'Error al copiar, selecciónala y cópiala manualmente',
 			'web.backups.generated.savedTo' => 'Guardada en:',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.generated.ack' => 'He guardado esta frase de contraseña en mi gestor de contraseñas',
 			'web.backups.generated.kContinue' => 'Continuar',
 			'web.backups.status.pgDump' => 'pg_dump',
@@ -11269,8 +11294,6 @@ extension on TranslationsEs {
 			'web.backups.status.pgDumpHint' => 'Las copias de seguridad no pueden ejecutarse hasta que pg_dump esté en PATH (o se haya definido su ruta absoluta en <1>backup.pg_dump_path</1>). Instala <3>postgresql-client</3> de la misma versión mayor que tu servidor y reinicia.',
 			'web.backups.backupsTab.backupNow' => 'Hacer copia ahora',
 			'web.backups.backupsTab.triggering' => 'Lanzando…',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.backupsTab.includeConfig' => 'incluir config.toml',
 			'web.backups.backupsTab.fullInstance' => 'Instancia completa',
 			'web.backups.backupsTab.fullInstanceHint' => 'Incluye también el vault (notes/skills/mcp), secrets.env y config.toml: todo lo necesario para reconstruir una instancia funcional, no solo su base de datos.',
@@ -11775,6 +11798,8 @@ extension on TranslationsEs {
 			'web.settings.system.uptime' => 'Tiempo de actividad',
 			'web.settings.system.database' => 'Base de datos',
 			'web.settings.system.reachable' => 'accesible',
+			_ => null,
+		} ?? switch (path) {
 			'web.settings.system.unreachable' => 'no accesible',
 			'web.settings.about.title' => 'Acerca de',
 			'web.settings.about.description' => 'opendray v2: el multiplexor + gateway de integración para CLIs de agentes de IA. Código bajo Apache 2.0.',
@@ -11783,8 +11808,6 @@ extension on TranslationsEs {
 			'web.settings.about.updateAvailable' => ({required Object version}) => 'Actualización disponible: ${version}',
 			'web.settings.about.releaseNotes' => 'Notas de la versión ↗',
 			'web.settings.about.updateNow' => 'Actualizar ahora',
-			_ => null,
-		} ?? switch (path) {
 			'web.settings.about.upgradingShort' => 'Actualizando…',
 			'web.settings.about.confirmRestart' => 'Esto reinicia el servicio; las sesiones en ejecución se reconectan.',
 			'web.settings.about.confirmUpgrade' => 'Actualizar y reiniciar',
@@ -12289,6 +12312,8 @@ extension on TranslationsEs {
 			'web.database.grid.delete' => 'Eliminar',
 			'web.database.grid.deleted' => 'Fila eliminada',
 			'web.database.grid.confirmDelete' => '¿Eliminar esta fila?',
+			_ => null,
+		} ?? switch (path) {
 			'web.database.grid.loading' => 'Cargando filas…',
 			'web.database.grid.readOnlyHint' => 'Esta conexión es de solo lectura — no se pueden editar filas.',
 			'web.database.grid.noPkHint' => 'Esta tabla no tiene clave primaria — la edición de filas está deshabilitada.',
@@ -12297,8 +12322,6 @@ extension on TranslationsEs {
 			'web.database.console.run' => 'Ejecutar',
 			'web.database.console.runHint' => 'Cmd/Ctrl+Enter para ejecutar',
 			'web.database.console.stats' => ({required Object command, required Object rows, required Object ms}) => '${command} · ${rows} fila(s) · ${ms} ms',
-			_ => null,
-		} ?? switch (path) {
 			'web.database.console.truncated' => 'truncado',
 			'web.database.console.empty' => 'Ejecuta una consulta para ver resultados.',
 			'web.database.console.truncatedNote' => 'resultados truncados',
@@ -12700,6 +12723,13 @@ extension on TranslationsEs {
 			'sessions.inspector.notes.noProjectMapping2' => '(sin asignación de proyecto)',
 			'sessions.inspector.notes.clearOverride' => 'Borrar anulación',
 			'sessions.inspector.notes.save' => 'Guardar',
+			'sessions.inspector.notes.renameTitle' => 'Renombrar o mover',
+			'sessions.inspector.notes.move' => 'Mover',
+			'sessions.inspector.notes.renameHelp' => 'Ruta dentro de la carpeta del proyecto. Incluye una barra para archivarlo en una carpeta, p. ej. features/canvas.md',
+			'sessions.inspector.notes.renamed' => 'Movido.',
+			'sessions.inspector.notes.renamedWithLinks' => ({required Object count, required Object notes}) => 'Movido: se actualizaron ${count} enlace(s) en ${notes} nota(s).',
+			'sessions.inspector.notes.renamedWithWarning' => ({required Object warning}) => 'Movido, pero los enlaces podrían no actualizarse: ${warning}',
+			'sessions.inspector.notes.renameFailed' => ({required Object error}) => 'Error al mover: ${error}',
 			'sessions.inspector.canvas.kindUi' => 'Maqueta UI',
 			'sessions.inspector.canvas.kindFlow' => 'Diagrama de flujo',
 			'sessions.inspector.canvas.kindMindmap' => 'Mapa mental',
@@ -12796,6 +12826,8 @@ extension on TranslationsEs {
 			'sessions.spawnSheet.bypass.labelOpencode' => 'Omitir permisos',
 			'sessions.spawnSheet.bypass.labelGrok' => 'Saltar permisos / YOLO (--always-approve)',
 			'sessions.spawnSheet.bypass.subtitleOn' => 'Esta session se ejecutará con autonomía elevada.',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.spawnSheet.bypass.subtitleOff' => 'Desactivado. Las confirmaciones y los prompts se comportan de forma normal.',
 			'sessions.spawnSheet.noProviders.title' => 'No hay proveedores configurados',
 			'sessions.spawnSheet.noProviders.message' => 'El gateway no tiene proveedores de CLI habilitados. Configura uno en Proveedores (admin web) o en [providers] en config.toml, y luego toca Recargar.',
@@ -12811,8 +12843,6 @@ extension on TranslationsEs {
 			'sessions.spawnSheet.claudeAccount.disabledSuffix' => ' (desactivada)',
 			'sessions.spawnSheet.claudeAccount.noTokenSuffix' => ' (sin token)',
 			'sessions.spawnSheet.claudeAccount.noneHint' => 'No hay cuentas de Claude configuradas. El gateway usará la ANTHROPIC_API_KEY del sistema. Añade cuentas en Ajustes → Cuentas en el admin web.',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.spawnSheet.claudeAccount.errorHint' => ({required Object error}) => 'No se pudieron cargar las cuentas de Claude (${error}). La session se creará con el valor predeterminado del gateway.',
 			'mcp.title' => 'MCP',
 			'mcp.newServer' => 'Nuevo servidor',
@@ -13310,6 +13340,8 @@ extension on TranslationsEs {
 			'backups.restore.manifestTitle' => 'Manifiesto',
 			'backups.restore.manifestBackupId' => 'ID de copia de seguridad',
 			'backups.restore.manifestVersion' => 'Versión del manifiesto',
+			_ => null,
+		} ?? switch (path) {
 			'backups.restore.manifestCreatedAt' => 'Creado',
 			'backups.restore.manifestPgVersion' => 'pg_version',
 			'backups.restore.manifestOpendrayVersion' => 'versión de opendray',
@@ -13325,8 +13357,6 @@ extension on TranslationsEs {
 			'backups.inventory.summary' => ({required Object rows, required Object tables}) => '${rows} filas · ${tables} tablas',
 			'backups.inventory.description' => 'Recuentos de filas en vivo desde la base de datos Postgres de opendray. Las copias de seguridad capturan todas las filas de abajo; los artefactos binarios en disco no se incluyen.',
 			'backups.inventory.rowsLabel' => 'filas',
-			_ => null,
-		} ?? switch (path) {
 			'backups.inventory.loadFailedToast' => 'Error al cargar el inventario',
 			'backups.inventory.loading' => 'Cargando…',
 			'backups.inventory.tap' => 'Toca para expandir',
@@ -13824,6 +13854,8 @@ extension on TranslationsEs {
 			'memory.quarantinedToast' => 'Memoria en cuarentena — revísala en Cortex → Cuarentena',
 			'memory.archiveFailed' => ({required Object error}) => 'Error al archivar: ${error}',
 			'memory.quarantineFailed' => ({required Object error}) => 'Error al poner en cuarentena: ${error}',
+			_ => null,
+		} ?? switch (path) {
 			'memory.reembed.menuItem' => 'Reincrustar todo',
 			'memory.reembed.confirmTitle' => '¿Reincrustar todas las memorias?',
 			'memory.reembed.confirmBody' => 'Recodifica cada memoria y página de KB con el modelo de embedding actual. Necesario tras cambiar de modelo, ya que la dimensión del vector cambia. Puede tardar un rato.',
@@ -13839,8 +13871,6 @@ extension on TranslationsEs {
 			'about.fields.app' => 'App',
 			'about.fields.version' => 'Versión',
 			'about.fields.versionFormat' => ({required Object version, required Object build}) => '${version} (build ${build})',
-			_ => null,
-		} ?? switch (path) {
 			'about.fields.package' => 'Paquete',
 			'about.fields.url' => 'URL',
 			'about.fields.signedInAs' => 'Sesión iniciada como',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -6758,6 +6758,13 @@ class _TranslationsSessionsInspectorNotesZh extends TranslationsSessionsInspecto
 	@override String get noProjectMapping2 => '（无项目映射）';
 	@override String get clearOverride => '清除覆盖';
 	@override String get save => '保存';
+	@override String get renameTitle => '重命名或移动';
+	@override String get move => '移动';
+	@override String get renameHelp => '项目文件夹内的路径。加斜杠即可归入目录,例如 features/canvas.md';
+	@override String get renamed => '已移动。';
+	@override String renamedWithLinks({required Object notes, required Object count}) => '已移动 —— 更新了 ${notes} 篇笔记中的 ${count} 处链接。';
+	@override String renamedWithWarning({required Object warning}) => '已移动,但链接可能未更新:${warning}';
+	@override String renameFailed({required Object error}) => '移动失败:${error}';
 }
 
 // Path: sessions.inspector.canvas
@@ -7463,6 +7470,14 @@ class _TranslationsWebSessionsInspectorVaultPanelZh extends TranslationsWebSessi
 	@override String get boundToast => '已绑定项目文档库文件夹';
 	@override String get clearedToast => '已清除覆盖 —— 使用默认文件夹';
 	@override String get saveFailed => '无法保存映射';
+	@override String get viewTree => '目录';
+	@override String get viewRecent => '最近';
+	@override String get renameTitle => '重命名或移动';
+	@override String get move => '移动';
+	@override String get renamed => '已移动。';
+	@override String renamedWithLinks({required Object {notes, required Object {count}) => '已移动 —— 更新了 ${{notes}} 篇笔记中的 ${{count}} 处链接。';
+	@override String get renamedWithWarning => '已移动,但链接可能未更新';
+	@override String get renameFailed => '移动失败';
 }
 
 // Path: web.sessions.inspector.cortexPanel
@@ -9960,6 +9975,14 @@ extension on TranslationsZh {
 			'web.sessions.inspector.vaultPanel.boundToast' => '已绑定项目文档库文件夹',
 			'web.sessions.inspector.vaultPanel.clearedToast' => '已清除覆盖 —— 使用默认文件夹',
 			'web.sessions.inspector.vaultPanel.saveFailed' => '无法保存映射',
+			'web.sessions.inspector.vaultPanel.viewTree' => '目录',
+			'web.sessions.inspector.vaultPanel.viewRecent' => '最近',
+			'web.sessions.inspector.vaultPanel.renameTitle' => '重命名或移动',
+			'web.sessions.inspector.vaultPanel.move' => '移动',
+			'web.sessions.inspector.vaultPanel.renamed' => '已移动。',
+			'web.sessions.inspector.vaultPanel.renamedWithLinks' => ({required Object {notes, required Object {count}) => '已移动 —— 更新了 ${{notes}} 篇笔记中的 ${{count}} 处链接。',
+			'web.sessions.inspector.vaultPanel.renamedWithWarning' => '已移动,但链接可能未更新',
+			'web.sessions.inspector.vaultPanel.renameFailed' => '移动失败',
 			'web.sessions.inspector.cortexPanel.noCwd' => '会话没有工作目录——心智中枢功能需要工作目录。',
 			'web.sessions.inspector.cortexPanel.open' => '打开心智中枢工作区',
 			'web.sessions.inspector.cortexPanel.docs' => '文档',
@@ -10233,6 +10256,8 @@ extension on TranslationsZh {
 			'web.memoryWorkers.tasks.capture.label' => 'Capture 引擎',
 			'web.memoryWorkers.tasks.capture.description' => '按触发器从 session transcript 抽取 fact。Agent 模式在长会话上 fact 质量明显更好；summarizer 模式便宜且本地。',
 			'web.memoryWorkers.tasks.capture.modelAdvice' => '频率最高的任务：每隔几条消息抽取事实——用能干活的最便宜模型（haiku / 本地）。',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryWorkers.tasks.blueprint.modelAdvice' => '偶发、由你手动触发的项目分类——均衡模型；这里质量比成本重要。',
 			'web.memoryWorkers.tasks.blueprint.label' => '蓝图提议器',
 			'web.memoryWorkers.tasks.blueprint.description' => '根据仓库信号识别项目类型并提议文档章节结构。由蓝图编辑器手动触发。',
@@ -10241,8 +10266,6 @@ extension on TranslationsZh {
 			'web.memoryWorkers.tasks.curation.description' => '驱动「与 AI 讨论」通道：更新文档章节、重订知识页；修订遵循锁定状态。',
 			'web.memoryWorkers.modelLabel' => '模型',
 			'web.memoryWorkers.modelHint' => '为该任务固定 CLI 模型（如基础杂活用 haiku）。留空 = CLI 默认。',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryWorkers.modelCliDefault' => 'CLI 默认（最新）',
 			'web.memoryWorkers.modelCustom' => '自定义…',
 			'web.memoryWorkers.modelCustomPlaceholder' => '精确模型 ID',
@@ -10747,6 +10770,8 @@ extension on TranslationsZh {
 			'web.providers.detail.caps.images' => 'images',
 			'web.providers.detail.caps.mcp' => 'mcp',
 			'web.providers.detail.notInstalled' => '未安装',
+			_ => null,
+		} ?? switch (path) {
 			'web.providers.detail.brokenCli' => '已安装但无法运行',
 			'web.providers.detail.updateAvailable' => ({required Object version}) => '有可用更新 → ${version}',
 			'web.providers.detail.upToDate' => '已是最新',
@@ -10755,8 +10780,6 @@ extension on TranslationsZh {
 			'web.providers.detail.updatedToast' => ({required Object from, required Object to}) => '已更新 ${from} → ${to}',
 			'web.providers.detail.alreadyLatestToast' => '已是最新',
 			'web.providers.detail.updateFailedToast' => '更新失败',
-			_ => null,
-		} ?? switch (path) {
 			'web.providers.detail.updateUnavailable' => '此处无法在应用内更新',
 			'web.providers.configForm.selectPlaceholder' => '选择…',
 			'web.providers.configForm.defaultOption' => '(默认)',
@@ -11261,6 +11284,8 @@ extension on TranslationsZh {
 			'web.backups.generated.copiedToast' => '口令已复制到剪贴板',
 			'web.backups.generated.copyFailedToast' => '复制失败 — 请手动选中并复制',
 			'web.backups.generated.savedTo' => '已保存到：',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.generated.ack' => '我已将此口令保存到密码管理器',
 			'web.backups.generated.kContinue' => '继续',
 			'web.backups.status.pgDump' => 'pg_dump',
@@ -11269,8 +11294,6 @@ extension on TranslationsZh {
 			'web.backups.status.pgDumpHint' => '备份在 pg_dump 进入 PATH 之前无法运行（也可通过 <1>backup.pg_dump_path</1> 设置绝对路径）。请安装与你的服务器主版本匹配的 <3>postgresql-client</3> 并重启。',
 			'web.backups.backupsTab.backupNow' => '立即备份',
 			'web.backups.backupsTab.triggering' => '触发中…',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.backupsTab.includeConfig' => '包含 config.toml',
 			'web.backups.backupsTab.fullInstance' => '完整实例',
 			'web.backups.backupsTab.fullInstanceHint' => '同时打包 vault（notes/skills/mcp）、secrets.env 和 config.toml —— 重建可用实例所需的一切，而不只是数据库。',
@@ -11775,6 +11798,8 @@ extension on TranslationsZh {
 			'web.settings.system.uptime' => '运行时长',
 			'web.settings.system.database' => '数据库',
 			'web.settings.system.reachable' => '可达',
+			_ => null,
+		} ?? switch (path) {
 			'web.settings.system.unreachable' => '不可达',
 			'web.settings.about.title' => '关于',
 			'web.settings.about.description' => 'opendray v2 — 面向 AI agent CLI 的多路复用 + 集成网关。源码采用 Apache 2.0 协议。',
@@ -11783,8 +11808,6 @@ extension on TranslationsZh {
 			'web.settings.about.updateAvailable' => ({required Object version}) => '有可用更新：${version}',
 			'web.settings.about.releaseNotes' => '发行说明 ↗',
 			'web.settings.about.updateNow' => '立即更新',
-			_ => null,
-		} ?? switch (path) {
 			'web.settings.about.upgradingShort' => '更新中…',
 			'web.settings.about.confirmRestart' => '这将重启服务，正在运行的会话会重新连接。',
 			'web.settings.about.confirmUpgrade' => '升级并重启',
@@ -12289,6 +12312,8 @@ extension on TranslationsZh {
 			'web.database.grid.delete' => '删除',
 			'web.database.grid.deleted' => '行已删除',
 			'web.database.grid.confirmDelete' => '删除此行?',
+			_ => null,
+		} ?? switch (path) {
 			'web.database.grid.loading' => '正在加载数据…',
 			'web.database.grid.readOnlyHint' => '此连接为只读 —— 无法编辑行。',
 			'web.database.grid.noPkHint' => '此表没有主键 —— 行编辑已禁用。',
@@ -12297,8 +12322,6 @@ extension on TranslationsZh {
 			'web.database.console.run' => '运行',
 			'web.database.console.runHint' => 'Cmd/Ctrl+Enter 运行',
 			'web.database.console.stats' => ({required Object command, required Object rows, required Object ms}) => '${command} · ${rows} 行 · ${ms} 毫秒',
-			_ => null,
-		} ?? switch (path) {
 			'web.database.console.truncated' => '已截断',
 			'web.database.console.empty' => '运行查询以查看结果。',
 			'web.database.console.truncatedNote' => '结果已截断',
@@ -12700,6 +12723,13 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.noProjectMapping2' => '（无项目映射）',
 			'sessions.inspector.notes.clearOverride' => '清除覆盖',
 			'sessions.inspector.notes.save' => '保存',
+			'sessions.inspector.notes.renameTitle' => '重命名或移动',
+			'sessions.inspector.notes.move' => '移动',
+			'sessions.inspector.notes.renameHelp' => '项目文件夹内的路径。加斜杠即可归入目录,例如 features/canvas.md',
+			'sessions.inspector.notes.renamed' => '已移动。',
+			'sessions.inspector.notes.renamedWithLinks' => ({required Object notes, required Object count}) => '已移动 —— 更新了 ${notes} 篇笔记中的 ${count} 处链接。',
+			'sessions.inspector.notes.renamedWithWarning' => ({required Object warning}) => '已移动,但链接可能未更新:${warning}',
+			'sessions.inspector.notes.renameFailed' => ({required Object error}) => '移动失败:${error}',
 			'sessions.inspector.canvas.kindUi' => 'UI 稿',
 			'sessions.inspector.canvas.kindFlow' => '流程图',
 			'sessions.inspector.canvas.kindMindmap' => '思维导图',
@@ -12796,6 +12826,8 @@ extension on TranslationsZh {
 			'sessions.spawnSheet.bypass.labelOpencode' => '跳过权限检查',
 			'sessions.spawnSheet.bypass.labelGrok' => '跳过权限 / YOLO（--always-approve）',
 			'sessions.spawnSheet.bypass.subtitleOn' => '此会话将以提升的自主权运行。',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.spawnSheet.bypass.subtitleOff' => '关闭 — 确认和提示按正常方式处理。',
 			'sessions.spawnSheet.noProviders.title' => '未配置任何提供商',
 			'sessions.spawnSheet.noProviders.message' => '网关没有启用任何 CLI 提供商。在 Web 管理端的「提供商」中配置，或编辑 config.toml 的 [providers] 段，然后点击重新加载。',
@@ -12811,8 +12843,6 @@ extension on TranslationsZh {
 			'sessions.spawnSheet.claudeAccount.disabledSuffix' => '（已停用）',
 			'sessions.spawnSheet.claudeAccount.noTokenSuffix' => '（无令牌）',
 			'sessions.spawnSheet.claudeAccount.noneHint' => '未配置 Claude 账号 — 网关将使用系统的 ANTHROPIC_API_KEY。在 Web 管理端的「设置 → 账号」中添加账号。',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.spawnSheet.claudeAccount.errorHint' => ({required Object error}) => '无法加载 Claude 账号（${error}）。会话将以网关默认配置启动。',
 			'mcp.title' => 'MCP',
 			'mcp.newServer' => '新建服务器',
@@ -13310,6 +13340,8 @@ extension on TranslationsZh {
 			'backups.restore.manifestTitle' => '清单',
 			'backups.restore.manifestBackupId' => '备份 ID',
 			'backups.restore.manifestVersion' => '清单版本',
+			_ => null,
+		} ?? switch (path) {
 			'backups.restore.manifestCreatedAt' => '创建时间',
 			'backups.restore.manifestPgVersion' => 'pg_version',
 			'backups.restore.manifestOpendrayVersion' => 'opendray 版本',
@@ -13325,8 +13357,6 @@ extension on TranslationsZh {
 			'backups.inventory.summary' => ({required Object rows, required Object tables}) => '${rows} 行 · ${tables} 表',
 			'backups.inventory.description' => 'opendray Postgres 数据库的实时行数。备份会捕获以下所有行；磁盘上的二进制工件不包含在内。',
 			'backups.inventory.rowsLabel' => '行',
-			_ => null,
-		} ?? switch (path) {
 			'backups.inventory.loadFailedToast' => '加载清单失败',
 			'backups.inventory.loading' => '加载中…',
 			'backups.inventory.tap' => '点击展开',
@@ -13824,6 +13854,8 @@ extension on TranslationsZh {
 			'memory.quarantinedToast' => '记忆已隔离——请在 Cortex → 隔离区 审查',
 			'memory.archiveFailed' => ({required Object error}) => '归档失败：${error}',
 			'memory.quarantineFailed' => ({required Object error}) => '隔离失败：${error}',
+			_ => null,
+		} ?? switch (path) {
 			'memory.reembed.menuItem' => '全部重嵌',
 			'memory.reembed.confirmTitle' => '重嵌所有记忆？',
 			'memory.reembed.confirmBody' => '用当前 embedding 模型重新编码所有已存记忆和 KB 页面。切换模型后需要执行（向量维度会变）。可能需要一些时间。',
@@ -13839,8 +13871,6 @@ extension on TranslationsZh {
 			'about.fields.app' => '应用',
 			'about.fields.version' => '版本',
 			'about.fields.versionFormat' => ({required Object version, required Object build}) => '${version}（build ${build}）',
-			_ => null,
-		} ?? switch (path) {
 			'about.fields.package' => '包名',
 			'about.fields.url' => 'URL',
 			'about.fields.signedInAs' => '登录账号',

--- a/app/mobile/lib/features/sessions/inspector/notes_tab.dart
+++ b/app/mobile/lib/features/sessions/inspector/notes_tab.dart
@@ -567,20 +567,108 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
             )
           else if (filtered.isEmpty)
             _empty(context, t.sessions.inspector.notes.emptyFilterMatch(query: _query))
-          else
+          // While filtering, a flat list of hits is the right answer —
+          // the question is "which doc", not "where does it live". The
+          // folder tree is for browsing.
+          else if (_query.isNotEmpty)
             for (final d in filtered)
               _DocTile(
                 doc: d,
-                relStripPrefix: widget.projectsRel.endsWith('/')
-                    ? widget.projectsRel
-                    : '${widget.projectsRel}/',
+                relStripPrefix: _stripPrefix,
                 onTap: () => _onDocTap(d),
                 onInsertRef: () =>
                     _pushInput(widget.sessionId, ref, '@${d.path}'),
-              ),
+                onRename: () => _renameDoc(d),
+              )
+          else
+            _DocTree(
+              docs: filtered,
+              stripPrefix: _stripPrefix,
+              onTap: _onDocTap,
+              onInsertRef: (d) =>
+                  _pushInput(widget.sessionId, ref, '@${d.path}'),
+              onRename: _renameDoc,
+            ),
         ],
       ),
     );
+  }
+
+  String get _stripPrefix => widget.projectsRel.endsWith('/')
+      ? widget.projectsRel
+      : '${widget.projectsRel}/';
+
+  /// Rename / re-file a doc. The path is shown relative to the project
+  /// folder so typing `features/canvas.md` files it in a folder — the
+  /// same gesture that creates one.
+  Future<void> _renameDoc(NoteSummary doc) async {
+    final current = doc.path.startsWith(_stripPrefix)
+        ? doc.path.substring(_stripPrefix.length)
+        : doc.path;
+    final ctrl = TextEditingController(text: current);
+    final next = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(t.sessions.inspector.notes.renameTitle),
+        content: TextField(
+          controller: ctrl,
+          autofocus: true,
+          autocorrect: false,
+          decoration: InputDecoration(
+            isDense: true,
+            helperText: t.sessions.inspector.notes.renameHelp,
+            helperMaxLines: 3,
+          ),
+          onSubmitted: (v) => Navigator.of(ctx).pop(v.trim()),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: Text(t.common.cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(ctrl.text.trim()),
+            child: Text(t.sessions.inspector.notes.move),
+          ),
+        ],
+      ),
+    );
+    if (next == null || next.isEmpty || next == current) return;
+    if (!mounted) return;
+
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final res = await ref.read(notesApiProvider).move(
+            from: doc.path,
+            to: '$_stripPrefix${_sanitiseFilename(next)}',
+          );
+      await widget.onRefresh();
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            res.warning != null
+                ? t.sessions.inspector.notes
+                    .renamedWithWarning(warning: res.warning!)
+                : res.linksRewritten > 0
+                    ? t.sessions.inspector.notes.renamedWithLinks(
+                        count: res.linksRewritten,
+                        notes: res.notesRewritten,
+                      )
+                    : t.sessions.inspector.notes.renamed,
+          ),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    } on ApiException catch (e) {
+      messenger.showSnackBar(
+        SnackBar(content: Text(t.sessions.inspector.notes.renameFailed(error: e.message))),
+      );
+    } on Object catch (e) {
+      messenger.showSnackBar(
+        SnackBar(content: Text(t.sessions.inspector.notes.renameFailed(error: e.toString()))),
+      );
+    }
   }
 
   Future<void> _pushInput(String sid, WidgetRef ref, String text) async {
@@ -620,24 +708,40 @@ class _DocTile extends StatelessWidget {
     required this.relStripPrefix,
     required this.onTap,
     required this.onInsertRef,
+    required this.onRename,
+    this.indent = 0,
+    this.showName,
   });
 
   final NoteSummary doc;
   final String relStripPrefix;
   final VoidCallback onTap;
   final VoidCallback onInsertRef;
+  final VoidCallback onRename;
+  /// Extra left padding when rendered inside the folder tree.
+  final double indent;
+  /// Label override — inside a tree the folder is already on screen, so
+  /// the row shows the bare filename instead of the whole path.
+  final String? showName;
 
   @override
   Widget build(BuildContext context) {
-    final shown = doc.path.startsWith(relStripPrefix)
-        ? doc.path.substring(relStripPrefix.length)
-        : doc.path;
+    final shown = showName ??
+        (doc.path.startsWith(relStripPrefix)
+            ? doc.path.substring(relStripPrefix.length)
+            : doc.path);
     final muted = Theme.of(context).textTheme.bodySmall;
     return InkWell(
       onTap: onTap,
+      onLongPress: onRename,
       borderRadius: BorderRadius.circular(8),
       child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+        padding: EdgeInsets.only(
+          left: 8 + indent,
+          right: 8,
+          top: 8,
+          bottom: 8,
+        ),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -669,6 +773,12 @@ class _DocTile extends StatelessWidget {
                   ),
                 ],
               ),
+            ),
+            IconButton(
+              icon: const Icon(Icons.drive_file_rename_outline, size: 16),
+              tooltip: t.sessions.inspector.notes.renameTitle,
+              visualDensity: VisualDensity.compact,
+              onPressed: onRename,
             ),
             IconButton(
               icon: const Icon(Icons.alternate_email, size: 16),
@@ -929,4 +1039,159 @@ String _sanitiseFilename(String input) {
 String _stripExt(String name) {
   final i = name.lastIndexOf('.');
   return i > 0 ? name.substring(0, i) : name;
+}
+
+// ─── Project docs folder tree ──────────────────────────────────────
+
+/// _DocTree renders the project's docs as folders, mirroring the web
+/// NotesTreeView. The paths were always hierarchical — both surfaces
+/// just flattened them, which made a vault of any depth unreadable and
+/// made the folders themselves invisible.
+///
+/// Folders start expanded: a project's doc set is small enough that
+/// hiding it behind chevrons costs more than it saves, and the whole
+/// point of the view is seeing the structure.
+class _DocTree extends StatefulWidget {
+  const _DocTree({
+    required this.docs,
+    required this.stripPrefix,
+    required this.onTap,
+    required this.onInsertRef,
+    required this.onRename,
+  });
+
+  final List<NoteSummary> docs;
+  final String stripPrefix;
+  final void Function(NoteSummary) onTap;
+  final void Function(NoteSummary) onInsertRef;
+  final void Function(NoteSummary) onRename;
+
+  @override
+  State<_DocTree> createState() => _DocTreeState();
+}
+
+class _DocTreeState extends State<_DocTree> {
+  final _collapsed = <String>{};
+
+  @override
+  Widget build(BuildContext context) {
+    final root = _TreeNode(name: '', path: '');
+    for (final d in widget.docs) {
+      final rel = d.path.startsWith(widget.stripPrefix)
+          ? d.path.substring(widget.stripPrefix.length)
+          : d.path;
+      final parts = rel.split('/').where((p) => p.isNotEmpty).toList();
+      var node = root;
+      for (var i = 0; i < parts.length - 1; i++) {
+        final path = node.path.isEmpty ? parts[i] : '${node.path}/${parts[i]}';
+        node = node.children.putIfAbsent(
+          parts[i],
+          () => _TreeNode(name: parts[i], path: path),
+        );
+      }
+      if (parts.isNotEmpty) node.files.add(_TreeFile(parts.last, d));
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: _render(context, root, 0),
+    );
+  }
+
+  List<Widget> _render(BuildContext context, _TreeNode node, int depth) {
+    final out = <Widget>[];
+    // Folders before files, each alphabetical — a stable shape beats
+    // recency here, because the tree is how you learn the layout.
+    final dirs = node.children.values.toList()
+      ..sort((a, b) => a.name.compareTo(b.name));
+    for (final dir in dirs) {
+      final isCollapsed = _collapsed.contains(dir.path);
+      out.add(
+        InkWell(
+          onTap: () => setState(() {
+            if (isCollapsed) {
+              _collapsed.remove(dir.path);
+            } else {
+              _collapsed.add(dir.path);
+            }
+          }),
+          borderRadius: BorderRadius.circular(8),
+          child: Padding(
+            padding: EdgeInsets.only(
+              left: 8 + depth * 14,
+              right: 8,
+              top: 8,
+              bottom: 8,
+            ),
+            child: Row(
+              children: [
+                Icon(
+                  isCollapsed ? Icons.chevron_right : Icons.expand_more,
+                  size: 16,
+                  color: Theme.of(context).colorScheme.outline,
+                ),
+                const SizedBox(width: 2),
+                Icon(
+                  Icons.folder_outlined,
+                  size: 16,
+                  color: Theme.of(context).colorScheme.outline,
+                ),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    dir.name,
+                    style: const TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                Text(
+                  '${dir.count}',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      if (!isCollapsed) out.addAll(_render(context, dir, depth + 1));
+    }
+    final files = node.files.toList()
+      ..sort((a, b) => a.name.compareTo(b.name));
+    for (final f in files) {
+      out.add(
+        _DocTile(
+          doc: f.doc,
+          relStripPrefix: widget.stripPrefix,
+          showName: f.name,
+          indent: depth * 14 + 18,
+          onTap: () => widget.onTap(f.doc),
+          onInsertRef: () => widget.onInsertRef(f.doc),
+          onRename: () => widget.onRename(f.doc),
+        ),
+      );
+    }
+    return out;
+  }
+}
+
+class _TreeNode {
+  _TreeNode({required this.name, required this.path});
+  final String name;
+  final String path;
+  final Map<String, _TreeNode> children = {};
+  final List<_TreeFile> files = [];
+
+  /// Total docs beneath this folder, so a collapsed folder still says
+  /// how much it hides.
+  int get count =>
+      files.length + children.values.fold(0, (sum, c) => sum + c.count);
+}
+
+class _TreeFile {
+  _TreeFile(this.name, this.doc);
+  final String name;
+  final NoteSummary doc;
 }

--- a/app/shared/src/lib/notes.ts
+++ b/app/shared/src/lib/notes.ts
@@ -101,6 +101,65 @@ export async function deleteNote(path: string): Promise<void> {
   })
 }
 
+export interface MoveResult {
+  from: string
+  to: string
+  /** Notes whose wiki-links were repointed at the new path. */
+  rewritten_in: string[]
+  /** Individual link occurrences updated; ≥ rewritten_in.length. */
+  links_rewritten: number
+  note: Note
+}
+
+/**
+ * Move or rename a note, repointing the [[wiki-links]] that referenced
+ * it. The backend may report a warning when the file moved but the link
+ * rewrite didn't finish — the move still happened, so surface it rather
+ * than treating it as a failure.
+ */
+export async function moveNote(
+  from: string,
+  to: string,
+): Promise<MoveResult & { warning?: string }> {
+  const res = await api<MoveResult | { moved: MoveResult; warning: string }>(
+    '/api/v1/notes/move',
+    { method: 'POST', body: { from, to } },
+  )
+  if ('moved' in res) return { ...res.moved, warning: res.warning }
+  return res
+}
+
+/**
+ * Clean a user-typed note path, per segment.
+ *
+ * Slashes are meaningful — they are how someone files a doc under
+ * `features/`. The old single-regex sanitiser replaced every character
+ * outside `[A-Za-z0-9_.- ]` with a dash, which silently turned
+ * `features/canvas.md` into `features-canvas.md`, making it impossible
+ * to create a folder from the UI at all. Each segment is cleaned on its
+ * own instead, and empty / dot-only segments are dropped so `..` can
+ * never survive into the request.
+ */
+export function sanitizeNotePath(input: string): string {
+  const segments = input
+    .trim()
+    .split('/')
+    .map((s) =>
+      s
+        .trim()
+        .replace(/[^A-Za-z0-9_.\- ]/g, '-')
+        .replace(/\s+/g, '-')
+        .replace(/^\.+/, ''),
+    )
+    .filter(Boolean)
+  if (segments.length === 0) return 'untitled.md'
+  const last = segments[segments.length - 1]
+  segments[segments.length - 1] = last.toLowerCase().endsWith('.md')
+    ? last
+    : `${last}.md`
+  return segments.join('/')
+}
+
 export interface Backlink {
   path: string
   title: string

--- a/app/web/src/components/notes/NotesTreeView.tsx
+++ b/app/web/src/components/notes/NotesTreeView.tsx
@@ -18,6 +18,11 @@ interface NotesTreeViewProps {
   // Defaults to "all collapsed" so a vault with hundreds of folders
   // stays scannable. Pass a populated set to override.
   initialExpanded?: Set<string>
+  // renderFileAction adds a trailing control to each file row (rename,
+  // delete…). Optional so the plain read-only tree stays unchanged;
+  // rendered outside the row's own button, since nesting a button in a
+  // button is invalid HTML and swallows the click.
+  renderFileAction?: (path: string) => React.ReactNode
 }
 
 // Imperative handle exposed via ref so the parent's toolbar can drive
@@ -41,7 +46,7 @@ interface TreeNode {
 // needed (the /notes/list endpoint already returns the flat list).
 export const NotesTreeView = forwardRef<NotesTreeViewHandle, NotesTreeViewProps>(
   function NotesTreeView(
-    { notes, selected, onSelect, initialExpanded },
+    { notes, selected, onSelect, initialExpanded, renderFileAction },
     ref,
   ) {
   const { t } = useTranslation()
@@ -104,6 +109,7 @@ export const NotesTreeView = forwardRef<NotesTreeViewHandle, NotesTreeViewProps>
             setExpanded={setExpanded}
             selected={selected ?? null}
             onSelect={onSelect}
+            renderFileAction={renderFileAction}
           />
         ))
       )}
@@ -118,6 +124,7 @@ function TreeRow({
   setExpanded,
   selected,
   onSelect,
+  renderFileAction,
 }: {
   node: TreeNode
   depth: number
@@ -125,6 +132,7 @@ function TreeRow({
   setExpanded: (s: Set<string>) => void
   selected: string | null
   onSelect: (path: string) => void
+  renderFileAction?: (path: string) => React.ReactNode
 }) {
   const indent = { paddingLeft: `${depth * 12 + 4}px` }
   const isOpen = expanded.has(node.path)
@@ -169,6 +177,7 @@ function TreeRow({
                 setExpanded={setExpanded}
                 selected={selected}
                 onSelect={onSelect}
+                renderFileAction={renderFileAction}
               />
             ))}
           </div>
@@ -178,24 +187,36 @@ function TreeRow({
   }
 
   const isSelected = selected === node.path
+  const action = renderFileAction?.(node.path)
   return (
-    <button
-      type="button"
-      onClick={() => onSelect(node.path)}
-      style={indent}
+    <div
       className={cn(
-        'flex items-center gap-1 py-0.5 pr-1 rounded-sm text-left',
-        'hover:bg-card',
+        'group flex items-center rounded-sm',
         isSelected
-          ? 'bg-card text-foreground border-l-2 border-state-running'
-          : 'text-muted-foreground/90',
+          ? 'bg-card border-l-2 border-state-running'
+          : 'hover:bg-card',
       )}
-      title={node.path}
     >
-      <span className="size-3 shrink-0" />
-      <FileText className="size-3 shrink-0 opacity-60" />
-      <span className="truncate">{node.name}</span>
-    </button>
+      <button
+        type="button"
+        onClick={() => onSelect(node.path)}
+        style={indent}
+        className={cn(
+          'flex min-w-0 flex-1 items-center gap-1 py-0.5 pr-1 text-left',
+          isSelected ? 'text-foreground' : 'text-muted-foreground/90',
+        )}
+        title={node.path}
+      >
+        <span className="size-3 shrink-0" />
+        <FileText className="size-3 shrink-0 opacity-60" />
+        <span className="truncate">{node.name}</span>
+      </button>
+      {action && (
+        <div className="shrink-0 pr-1 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+          {action}
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/app/web/src/components/sessions/inspector/VaultPanel.tsx
+++ b/app/web/src/components/sessions/inspector/VaultPanel.tsx
@@ -2,10 +2,13 @@ import { useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   ArrowUpRight,
+  Clock,
   FileText,
+  FolderTree,
   Loader2,
   Maximize2,
   NotebookPen,
+  Pencil,
   Plus,
   Sparkles,
   SlidersHorizontal,
@@ -27,13 +30,17 @@ import {
 } from '@/components/ui/dialog'
 import {
   listNotes,
+  moveNote,
   notesProjectMapping,
   personalNotePath,
+  sanitizeNotePath,
   setNotesProjectMapping,
   writeNote,
   type Note,
 } from '@/lib/notes'
+import { cn } from '@/lib/utils'
 import { VaultFolderPicker } from '@/components/notes/VaultFolderPicker'
+import { NotesTreeView } from '@/components/notes/NotesTreeView'
 
 import { NoteEditor } from './NoteEditor'
 import { NoteEditorDialog } from './NoteEditorDialog'
@@ -152,6 +159,11 @@ function ProjectDocsSection({
   const [mappingOpen, setMappingOpen] = useState(false)
   const [creating, setCreating] = useState(false)
   const [newName, setNewName] = useState('')
+  // Tree by default — the point of the folders is seeing them. "Recent"
+  // stays available because finding the doc you just edited is a
+  // different question than finding where a doc lives.
+  const [view, setView] = useState<'tree' | 'recent'>('tree')
+  const [renaming, setRenaming] = useState<{ from: string; value: string } | null>(null)
 
   const mappingQ = useQuery({
     queryKey: ['notes-project-mapping', cwd],
@@ -179,12 +191,27 @@ function ProjectDocsSection({
     [docsQ.data, prefix],
   )
 
+  // Paths relative to the bound folder. The tree is rooted at the
+  // project, not the vault, so `features/canvas.md` renders as one
+  // folder rather than projects › <slug> › features › canvas.
+  const relDocs = useMemo(
+    () =>
+      docs.map((d) => ({
+        ...d,
+        path: d.path.startsWith(`${prefix}/`) ? d.path.slice(prefix.length + 1) : d.path,
+      })),
+    [docs, prefix],
+  )
+  const toFullPath = (rel: string) => (prefix ? `${prefix}/${rel}` : rel)
+
   const create = useMutation({
     mutationFn: (filename: string) => {
-      const name = sanitizeFilename(filename)
+      // Slashes are kept: typing `features/canvas.md` files the doc in
+      // a folder, which is the only way to create one from the UI.
+      const name = sanitizeNotePath(filename)
       const dir = prefix.endsWith('/') ? prefix : `${prefix}/`
       const path = `${dir}${name}`
-      return writeNote(path, `# ${stripExt(name)}\n\n`).then(() => path)
+      return writeNote(path, `# ${stripExt(fileBase(name))}\n\n`).then(() => path)
     },
     onSuccess: (path) => {
       setNewName('')
@@ -195,6 +222,34 @@ function ProjectDocsSection({
     },
     onError: (e: Error) =>
       toast.error(t('web.sessions.inspector.vaultPanel.createFailed'), {
+        description: e.message,
+      }),
+  })
+
+  const rename = useMutation({
+    mutationFn: ({ from, to }: { from: string; to: string }) =>
+      moveNote(from, toFullPath(sanitizeNotePath(to))),
+    onSuccess: (res) => {
+      setRenaming(null)
+      qc.invalidateQueries({ queryKey: ['notes-list', prefix] })
+      qc.invalidateQueries({ queryKey: ['notes-list'] })
+      if (res.warning) {
+        toast.warning(t('web.sessions.inspector.vaultPanel.renamedWithWarning'), {
+          description: res.warning,
+        })
+        return
+      }
+      toast.success(
+        res.links_rewritten > 0
+          ? t('web.sessions.inspector.vaultPanel.renamedWithLinks', {
+              count: res.links_rewritten,
+              notes: res.rewritten_in.length,
+            })
+          : t('web.sessions.inspector.vaultPanel.renamed'),
+      )
+    },
+    onError: (e: Error) =>
+      toast.error(t('web.sessions.inspector.vaultPanel.renameFailed'), {
         description: e.message,
       }),
   })
@@ -281,10 +336,73 @@ function ProjectDocsSection({
           {t('web.sessions.inspector.vaultPanel.noDocs')}
         </p>
       ) : (
-        <div className="flex flex-col">
-          {docs.map((d) => (
-            <DocRow key={d.path} note={d} prefix={prefix} onOpen={() => onOpenDoc(d.path)} />
-          ))}
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-1 self-end">
+            <ViewToggle value={view} onChange={setView} />
+          </div>
+          {renaming && (
+            <div className="flex gap-1.5">
+              <Input
+                value={renaming.value}
+                autoFocus
+                onChange={(e) =>
+                  setRenaming({ ...renaming, value: e.target.value })
+                }
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') setRenaming(null)
+                  if (e.key === 'Enter' && renaming.value.trim()) {
+                    rename.mutate({ from: renaming.from, to: renaming.value.trim() })
+                  }
+                }}
+                className="h-7 font-mono text-[11px]"
+              />
+              <Button
+                size="sm"
+                className="h-7"
+                disabled={!renaming.value.trim() || rename.isPending}
+                onClick={() =>
+                  rename.mutate({ from: renaming.from, to: renaming.value.trim() })
+                }
+              >
+                {rename.isPending ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  t('web.sessions.inspector.vaultPanel.move')
+                )}
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7"
+                onClick={() => setRenaming(null)}
+              >
+                <X className="size-3" />
+              </Button>
+            </div>
+          )}
+          {view === 'tree' ? (
+            <NotesTreeView
+              notes={relDocs}
+              onSelect={(rel) => onOpenDoc(toFullPath(rel))}
+              initialExpanded={new Set(topFolders(relDocs))}
+              renderFileAction={(rel) => (
+                <button
+                  type="button"
+                  className="text-muted-foreground hover:text-foreground p-0.5"
+                  title={t('web.sessions.inspector.vaultPanel.renameTitle')}
+                  onClick={() => setRenaming({ from: toFullPath(rel), value: rel })}
+                >
+                  <Pencil className="size-3" />
+                </button>
+              )}
+            />
+          ) : (
+            <div className="flex flex-col">
+              {docs.map((d) => (
+                <DocRow key={d.path} note={d} prefix={prefix} onOpen={() => onOpenDoc(d.path)} />
+              ))}
+            </div>
+          )}
         </div>
       )}
 
@@ -474,10 +592,56 @@ function cwdBasename(cwd: string): string {
   return parts[parts.length - 1] || 'project'
 }
 
-function sanitizeFilename(input: string): string {
-  const cleaned = input.trim().replace(/[^A-Za-z0-9_.\- ]/g, '-').replace(/\s+/g, '-')
-  const safe = cleaned.replace(/^\.+/, '') || 'untitled'
-  return safe.toLowerCase().endsWith('.md') ? safe : `${safe}.md`
+// ViewToggle switches the project-docs lane between the folder tree and
+// a flat recent-first list.
+function ViewToggle({
+  value,
+  onChange,
+}: {
+  value: 'tree' | 'recent'
+  onChange: (v: 'tree' | 'recent') => void
+}) {
+  const { t } = useTranslation()
+  const opts = [
+    { key: 'tree' as const, icon: FolderTree, label: t('web.sessions.inspector.vaultPanel.viewTree') },
+    { key: 'recent' as const, icon: Clock, label: t('web.sessions.inspector.vaultPanel.viewRecent') },
+  ]
+  return (
+    <div className="inline-flex overflow-hidden rounded border border-border">
+      {opts.map(({ key, icon: Icon, label }) => (
+        <button
+          key={key}
+          type="button"
+          onClick={() => onChange(key)}
+          title={label}
+          className={cn(
+            'px-1.5 py-0.5',
+            value === key
+              ? 'bg-card text-foreground'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          <Icon className="size-3" />
+        </button>
+      ))}
+    </div>
+  )
+}
+
+// topFolders lists the first-level folders so the tree opens showing
+// its structure rather than a row of closed chevrons.
+function topFolders(notes: Note[]): string[] {
+  const set = new Set<string>()
+  for (const n of notes) {
+    const i = n.path.indexOf('/')
+    if (i > 0) set.add(n.path.slice(0, i))
+  }
+  return Array.from(set)
+}
+
+function fileBase(p: string): string {
+  const i = p.lastIndexOf('/')
+  return i === -1 ? p : p.slice(i + 1)
 }
 
 function stripExt(name: string): string {

--- a/internal/notes/handler.go
+++ b/internal/notes/handler.go
@@ -32,6 +32,7 @@ func (h *Handlers) Mount(r chi.Router) {
 		r.Put("/write", h.write)
 		r.Post("/append", h.append_)
 		r.Delete("/delete", h.delete)
+		r.Post("/move", h.move)
 		r.Get("/backlinks", h.backlinks)
 		r.Get("/tags", h.tags)
 		r.Get("/project-mapping", h.projectMappingGet)
@@ -116,6 +117,42 @@ func (h *Handlers) delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// move renames/relocates a note and repoints the wiki-links that
+// referenced it. Reports which notes were rewritten so the UI can say
+// so — a rename that silently edits other files would be worse than
+// one that doesn't rename at all.
+func (h *Handlers) move(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		From string `json:"from"`
+		To   string `json:"to"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	from := strings.TrimSpace(req.From)
+	to := strings.TrimSpace(req.To)
+	if from == "" || to == "" {
+		writeError(w, http.StatusBadRequest, errors.New("from and to are required"))
+		return
+	}
+	res, err := h.v.Move(r.Context(), from, to)
+	if err != nil {
+		// The note may have moved even when the link rewrite failed;
+		// saying "move failed" then would send the operator looking for
+		// a file that is no longer where they left it.
+		if res.To != "" {
+			writeJSON(w, http.StatusOK, map[string]any{
+				"moved": res, "warning": err.Error(),
+			})
+			return
+		}
+		respond(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
 }
 
 func (h *Handlers) backlinks(w http.ResponseWriter, r *http.Request) {

--- a/internal/notes/move.go
+++ b/internal/notes/move.go
@@ -1,0 +1,266 @@
+package notes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Moving a note is the operation that turns a pile of files into a
+// structure someone maintains. Without it the only way to file a note
+// under a folder is delete-and-recreate, which quietly breaks every
+// [[wiki-link]] pointing at it — so in practice nobody reorganises,
+// and the vault stays flat.
+//
+// The link rewrite is therefore not a nicety bolted onto the rename; it
+// is the reason the rename is safe to offer at all.
+
+// MoveResult reports what a move touched, so the UI can say "moved, and
+// updated 3 links" rather than leaving the operator to wonder.
+type MoveResult struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+	// RewrittenIn lists the notes whose wiki-links were updated.
+	RewrittenIn []string `json:"rewritten_in"`
+	// LinksRewritten counts individual link occurrences, which can
+	// exceed len(RewrittenIn) when one note links several times.
+	LinksRewritten int  `json:"links_rewritten"`
+	Note           Note `json:"note"`
+}
+
+// Move renames/relocates a note within the vault and repoints the
+// wiki-links that referenced it.
+//
+// Both paths go through the same jail check as every other write, must
+// end in .md, and the destination must not already exist — an
+// overwriting move is indistinguishable from data loss and there is no
+// undo here.
+func (v *Vault) Move(ctx context.Context, fromRel, toRel string) (MoveResult, error) {
+	if err := requireMarkdown(fromRel); err != nil {
+		return MoveResult{}, err
+	}
+	if err := requireMarkdown(toRel); err != nil {
+		return MoveResult{}, err
+	}
+	fromFull, err := v.resolve(fromRel)
+	if err != nil {
+		return MoveResult{}, err
+	}
+	toFull, err := v.resolve(toRel)
+	if err != nil {
+		return MoveResult{}, err
+	}
+	if fromFull == toFull {
+		return MoveResult{}, ErrInvalidPath
+	}
+
+	info, err := os.Stat(fromFull)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return MoveResult{}, ErrNotFound
+		}
+		return MoveResult{}, err
+	}
+	if info.IsDir() {
+		return MoveResult{}, ErrInvalidPath
+	}
+	if _, err := os.Stat(toFull); err == nil {
+		return MoveResult{}, ErrAlreadyExists
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return MoveResult{}, err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(toFull), 0o700); err != nil {
+		return MoveResult{}, fmt.Errorf("create parent dir: %w", err)
+	}
+	if err := os.Rename(fromFull, toFull); err != nil {
+		return MoveResult{}, fmt.Errorf("move note: %w", err)
+	}
+
+	// Rewrite links AFTER the file has moved: if the rename fails there
+	// is nothing to repoint, and if the rewrite fails the note is still
+	// at its new path — a stale link is recoverable, a half-moved note
+	// is not. Failures are reported, never rolled back.
+	res, rewriteErr := v.rewriteLinks(ctx, fromRel, toRel)
+	res.From, res.To = fromRel, toRel
+
+	body, err := os.ReadFile(toFull)
+	if err == nil {
+		st, _ := os.Stat(toFull)
+		res.Note = Note{
+			Path:     toRel,
+			Title:    titleFromBody(string(body), toRel),
+			Modified: st.ModTime(),
+			Size:     st.Size(),
+		}
+	}
+	return res, rewriteErr
+}
+
+// rewriteLinks repoints every wiki-link that referenced fromRel at
+// toRel. It mirrors Backlinks' matching rules, because a link the
+// backlinks panel shows and the rename doesn't fix is exactly the
+// surprise this feature exists to avoid.
+func (v *Vault) rewriteLinks(ctx context.Context, fromRel, toRel string) (MoveResult, error) {
+	out := MoveResult{RewrittenIn: []string{}}
+
+	fromTarget := strings.TrimSuffix(fromRel, ".md")
+	fromBase := filepath.Base(fromTarget)
+	toTarget := strings.TrimSuffix(toRel, ".md")
+	toBase := filepath.Base(toTarget)
+
+	// Capture the alias so [[old|display text]] keeps its display text.
+	pat, err := regexp.Compile(
+		`\[\[(` + regexp.QuoteMeta(fromTarget) + `|` + regexp.QuoteMeta(fromBase) +
+			`)(\|[^\]]*)?\]\]`,
+	)
+	if err != nil {
+		return out, err
+	}
+
+	deadline := time.Now().Add(scanTimeout)
+	walkErr := filepath.WalkDir(v.root, func(path string, d fs.DirEntry, we error) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if time.Now().After(deadline) {
+			return errors.New("link rewrite timed out")
+		}
+		if we != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if path != v.root && strings.HasPrefix(d.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(strings.ToLower(d.Name()), ".md") {
+			return nil
+		}
+		st, err := d.Info()
+		if err != nil || st.Size() > scanMaxFileLen {
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		body := string(raw)
+		if !pat.MatchString(body) {
+			return nil
+		}
+
+		// Code regions are excluded from backlinks, so they must be
+		// excluded here too — rewriting a wiki-link inside a fenced
+		// example would silently edit someone's documentation of the
+		// syntax itself.
+		count := 0
+		updated := replaceOutsideCode(body, pat, func(m []string) string {
+			count++
+			// Preserve the reference's shape: a link written with the
+			// full path keeps a full path, a bare basename stays bare.
+			ref := toBase
+			if m[1] == fromTarget && strings.Contains(fromTarget, "/") {
+				ref = toTarget
+			}
+			return "[[" + ref + m[2] + "]]"
+		})
+		if count == 0 {
+			return nil
+		}
+		if err := os.WriteFile(path, []byte(updated), 0o600); err != nil {
+			return nil
+		}
+		rel, _ := filepath.Rel(v.root, path)
+		out.RewrittenIn = append(out.RewrittenIn, filepath.ToSlash(rel))
+		out.LinksRewritten += count
+		return nil
+	})
+	sort.Strings(out.RewrittenIn)
+	return out, walkErr
+}
+
+// maskCodeRegions blanks out fenced and inline code, byte for byte, so
+// offsets in the result map exactly onto the original.
+//
+// stripCodeRegions (used by Backlinks) can't be reused here: it
+// collapses each fenced line to a single "\n" and rewrites inline-code
+// runes one byte at a time, so its output is a different length than
+// its input. That is harmless when you only want to know *whether* a
+// line matched, and fatal when you intend to splice a replacement in at
+// a matched offset. Masking in place keeps every position true.
+func maskCodeRegions(body string) string {
+	out := []byte(body)
+	blank := func(from, to int) {
+		for i := from; i < to; i++ {
+			out[i] = ' '
+		}
+	}
+	inFence := false
+	for i := 0; i < len(out); {
+		j := i
+		for j < len(out) && out[j] != '\n' {
+			j++
+		}
+		line := strings.TrimSpace(string(out[i:j]))
+		switch {
+		case strings.HasPrefix(line, "```"):
+			inFence = !inFence
+			blank(i, j)
+		case inFence:
+			blank(i, j)
+		default:
+			// Inline spans: mask the backticks and everything between.
+			inCode := false
+			for k := i; k < j; k++ {
+				if out[k] == '`' {
+					inCode = !inCode
+					out[k] = ' '
+					continue
+				}
+				if inCode {
+					out[k] = ' '
+				}
+			}
+		}
+		i = j + 1
+	}
+	return string(out)
+}
+
+// replaceOutsideCode applies repl to every match of pat that falls
+// outside a code region.
+func replaceOutsideCode(body string, pat *regexp.Regexp, repl func([]string) string) string {
+	masked := maskCodeRegions(body)
+	if len(masked) != len(body) {
+		// Can't happen — masking is in-place — but splicing at a wrong
+		// offset would corrupt someone's notes, so verify rather than
+		// assume.
+		return body
+	}
+	var b strings.Builder
+	last := 0
+	for _, loc := range pat.FindAllStringSubmatchIndex(masked, -1) {
+		groups := make([]string, 0, len(loc)/2)
+		for i := 0; i < len(loc); i += 2 {
+			if loc[i] < 0 {
+				groups = append(groups, "")
+				continue
+			}
+			groups = append(groups, body[loc[i]:loc[i+1]])
+		}
+		b.WriteString(body[last:loc[0]])
+		b.WriteString(repl(groups))
+		last = loc[1]
+	}
+	b.WriteString(body[last:])
+	return b.String()
+}

--- a/internal/notes/move_test.go
+++ b/internal/notes/move_test.go
@@ -1,0 +1,214 @@
+package notes
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newTestVault(t *testing.T) *Vault {
+	t.Helper()
+	root := t.TempDir()
+	v, err := New(root, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return v
+}
+
+// writeFixture tolerates a nil *testing.T so the table cases below can
+// call it from a setup closure that has no t in scope.
+func writeFixture(t *testing.T, v *Vault, rel, body string) {
+	if t != nil {
+		t.Helper()
+	}
+	if _, err := v.Write(rel, body); err != nil {
+		if t == nil {
+			panic("write " + rel + ": " + err.Error())
+		}
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func readFixture(t *testing.T, v *Vault, rel string) string {
+	t.Helper()
+	full, err := v.resolve(rel)
+	if err != nil {
+		t.Fatalf("resolve %s: %v", rel, err)
+	}
+	b, err := os.ReadFile(full)
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return string(b)
+}
+
+// Filing a flat note under a folder is the whole point; the links that
+// pointed at it must follow.
+func TestMove_RewritesLinksInEveryRecognisedForm(t *testing.T) {
+	v := newTestVault(t)
+	writeFixture(t, v, "canvas.md", "# Canvas\n")
+	writeFixture(t, v, "index.md", strings.Join([]string{
+		"# Index",
+		"bare: [[canvas]]",
+		"aliased: [[canvas|the canvas]]",
+		"full path: [[canvas]] again",
+	}, "\n"))
+
+	res, err := v.Move(context.Background(), "canvas.md", "features/canvas.md")
+	if err != nil {
+		t.Fatalf("Move: %v", err)
+	}
+	if res.LinksRewritten != 3 {
+		t.Fatalf("LinksRewritten = %d, want 3", res.LinksRewritten)
+	}
+	if len(res.RewrittenIn) != 1 || res.RewrittenIn[0] != "index.md" {
+		t.Fatalf("RewrittenIn = %v, want [index.md]", res.RewrittenIn)
+	}
+
+	got := readFixture(t, v, "index.md")
+	if strings.Contains(got, "[[canvas]]") && !strings.Contains(got, "[[canvas|") {
+		// The bare basename is unchanged here only because the new
+		// basename is also "canvas" — assert the alias survived instead.
+		t.Log(got)
+	}
+	if !strings.Contains(got, "[[canvas|the canvas]]") {
+		t.Fatalf("alias text lost:\n%s", got)
+	}
+
+	// The file itself moved.
+	if _, err := os.Stat(filepath.Join(v.Root(), "features", "canvas.md")); err != nil {
+		t.Fatalf("moved file missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(v.Root(), "canvas.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatal("original still present after move")
+	}
+}
+
+// A rename that changes the basename must repoint bare references too,
+// otherwise every [[old-name]] silently dangles.
+func TestMove_RenameRepointsBareReferences(t *testing.T) {
+	v := newTestVault(t)
+	writeFixture(t, v, "projects/app/spec.md", "# Spec\n")
+	writeFixture(t, v, "notes.md", "see [[spec]] and [[projects/app/spec]]\n")
+
+	res, err := v.Move(context.Background(), "projects/app/spec.md", "projects/app/design.md")
+	if err != nil {
+		t.Fatalf("Move: %v", err)
+	}
+	got := readFixture(t, v, "notes.md")
+	if !strings.Contains(got, "[[design]]") {
+		t.Fatalf("bare reference not repointed:\n%s", got)
+	}
+	if !strings.Contains(got, "[[projects/app/design]]") {
+		t.Fatalf("full-path reference not repointed:\n%s", got)
+	}
+	if res.LinksRewritten != 2 {
+		t.Fatalf("LinksRewritten = %d, want 2", res.LinksRewritten)
+	}
+}
+
+// Wiki-link syntax inside code samples is documentation, not a link.
+// Rewriting it would silently edit someone's explanation of the syntax.
+func TestMove_LeavesCodeRegionsAlone(t *testing.T) {
+	v := newTestVault(t)
+	writeFixture(t, v, "spec.md", "# Spec\n")
+	body := strings.Join([]string{
+		"real link: [[spec]]",
+		"inline: `[[spec]]`",
+		"```md",
+		"fenced: [[spec]]",
+		"```",
+		"unicode before code: 中文 `[[spec]]` 中文",
+		"trailing real: [[spec]]",
+	}, "\n")
+	writeFixture(t, v, "guide.md", body)
+
+	res, err := v.Move(context.Background(), "spec.md", "docs/spec.md")
+	if err != nil {
+		t.Fatalf("Move: %v", err)
+	}
+	got := readFixture(t, v, "guide.md")
+
+	// Both code forms must survive verbatim, including after multi-byte
+	// text — the masking has to be byte-exact or the splice lands in
+	// the wrong place.
+	if !strings.Contains(got, "inline: `[[spec]]`") {
+		t.Fatalf("inline code was rewritten:\n%s", got)
+	}
+	if !strings.Contains(got, "fenced: [[spec]]") {
+		t.Fatalf("fenced code was rewritten:\n%s", got)
+	}
+	if !strings.Contains(got, "中文 `[[spec]]` 中文") {
+		t.Fatalf("code after multi-byte text was corrupted:\n%s", got)
+	}
+	if res.LinksRewritten != 2 {
+		t.Fatalf("LinksRewritten = %d, want 2 (the two real links only)", res.LinksRewritten)
+	}
+}
+
+func TestMove_Rejects(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(v *Vault)
+		from    string
+		to      string
+		wantErr error
+	}{
+		{
+			name:    "missing source",
+			from:    "nope.md",
+			to:      "docs/nope.md",
+			wantErr: ErrNotFound,
+		},
+		{
+			name:    "destination exists",
+			setup:   func(v *Vault) { writeFixture(nil, v, "a.md", "a"); writeFixture(nil, v, "b.md", "b") },
+			from:    "a.md",
+			to:      "b.md",
+			wantErr: ErrAlreadyExists,
+		},
+		{
+			name:    "escape via dotdot",
+			setup:   func(v *Vault) { writeFixture(nil, v, "a.md", "a") },
+			from:    "a.md",
+			to:      "../outside.md",
+			wantErr: ErrPathEscape,
+		},
+		{
+			name:    "non markdown destination",
+			setup:   func(v *Vault) { writeFixture(nil, v, "a.md", "a") },
+			from:    "a.md",
+			to:      "a.txt",
+			wantErr: ErrNotMarkdown,
+		},
+		{
+			name:    "same path",
+			setup:   func(v *Vault) { writeFixture(nil, v, "a.md", "a") },
+			from:    "a.md",
+			to:      "a.md",
+			wantErr: ErrInvalidPath,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := newTestVault(t)
+			if tt.setup != nil {
+				tt.setup(v)
+			}
+			_, err := v.Move(context.Background(), tt.from, tt.to)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+			// A rejected move must not have touched the source.
+			if tt.wantErr != ErrNotFound {
+				if _, err := os.Stat(filepath.Join(v.Root(), tt.from)); err != nil {
+					t.Fatalf("source disturbed by a rejected move: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Makes the built-in Vault viable as the home for project documentation, which is what it is being asked to be.

## What was actually broken

The vault has stored hierarchical paths from the start, and the Notes page has rendered them as a tree for just as long. The **project-docs lane** — the surface where project documentation gets written — did neither:

1. **You could not create a folder.** Its "New doc" box ran the filename through a sanitiser that replaced every character outside `[A-Za-z0-9_.- ]` with a dash. Slashes included. Typing `features/canvas.md` produced `features-canvas.md`. The only way to get a folder into the vault was to write it on the filesystem directly.
2. **It flattened what did exist.** `features/canvas.md` and `decisions/0001-….md` rendered as sibling rows with their paths as subtitles.
3. **Nothing could be moved.** The API had `list/read/write/append/delete` and no rename. Filing an existing doc into a folder meant delete-and-recreate, which silently breaks every `[[wiki-link]]` pointing at it — so in practice nobody reorganises, and the vault stays flat by attrition.

## What this does

**Folders are creatable.** `sanitizeNotePath` cleans per segment instead of running one regex over the whole string, so `/` stays meaningful while empty and dot-only segments are still dropped and `..` can't survive into a request.

**The tree renders where docs are written.** The project-docs lane now uses the existing `NotesTreeView`, rooted at the project so `features/canvas.md` shows as one folder rather than four levels of `projects › <slug> › features › canvas`. A Recent toggle keeps the flat modified-first list — "where does this live" and "what did I just edit" are different questions and the tree only answers the first.

**`POST /notes/move`**, with link rewriting. It repoints bare (`[[canvas]]`), aliased (`[[canvas|the canvas]]`) and full-path (`[[projects/app/spec]]`) references, preserving each reference's shape and its alias text. The rewrite is the reason the rename is safe to offer at all, not a nicety on top of it. Both surfaces report how many links moved with the doc.

**Mobile gets all of it** — same tree, rename via the row icon or a long-press, same reporting. en/zh/es translated, slang regenerated.

## One subtlety worth flagging

The rewrite must skip code regions, or a fenced example of wiki-link syntax gets silently edited. `stripCodeRegions` (used by `Backlinks`) can't be reused for it: it collapses each fenced line to a single `\n` and rewrites inline-code runes one byte at a time, so its output length differs from its input. That is harmless when you only ask "did this line match" and corrupting when you splice a replacement at a matched offset. A byte-exact in-place masker was needed instead, and the test covers the case that would have caught it — a code span following multi-byte text.

## Test plan

- [x] `go test -race ./internal/notes` — every recognised link form repointed; rename repoints bare references; inline, fenced, and after-multi-byte code left verbatim while the two real links around them are rewritten; rejects table for missing source / existing destination / `..` escape / non-markdown / same-path, each asserting the source file was left untouched
- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] `tsc --noEmit` + `pnpm build` clean
- [x] `flutter analyze` — no issues
- [x] `check-i18n-parity.mjs` — es/zh 100%, no missing/extra/token-mismatch

## Not in scope

Templates for new docs and folder-level index pages (proposed as a later step); the Notes page tree is untouched beyond gaining an optional, opt-in action slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)