### PR TITLE
feat(vault): doc templates and folder index pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ for the full rationale and what triggers a major bump.
 
 ### Added
 
+- **New docs start from a template, and folders can explain themselves.**
+  Every doc previously started as an empty file with a heading, which is
+  how a vault ends up with five different ideas of what a feature note
+  is. Creating a doc now offers **Blank / Feature / Decision (ADR) /
+  Runbook**, and a folder holding a `README.md` gets a control that opens
+  it, so a directory can say what lives in it. Templates render
+  server-side — the title comes from the filename, the date from the
+  clock — so a doc started on the phone and one started on the web come
+  out identical rather than drifting. Dropping `_templates/<id>.md` in
+  the vault overrides a built-in or adds a new one, so a project can
+  change the shape of its docs without a gateway release.
+
+### Added
+
 - **The Vault can hold a folder structure you actually maintain.** Project
   docs were a flat list: the "New doc" box replaced `/` with `-`, so
   `features/canvas.md` became `features-canvas.md` and a folder could not

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -271,7 +271,10 @@
           "renamed": "Moved.",
           "renamedWithLinks": "Moved — updated {{count}} link(s) in {{notes}} note(s).",
           "renamedWithWarning": "Moved, but links may not be updated",
-          "renameFailed": "Move failed"
+          "renameFailed": "Move failed",
+          "templateLabel": "Template",
+          "templateFromVault": "From your vault (_templates/)",
+          "openFolderIndexTitle": "Open this folder’s index page"
         },
         "cortexPanel": {
           "noCwd": "Session has no cwd — Cortex features need a working directory.",
@@ -3795,7 +3798,8 @@
         "renamed": "Moved.",
         "renamedWithLinks": "Moved — updated {count} link(s) in {notes} note(s).",
         "renamedWithWarning": "Moved, but links may not be updated: {warning}",
-        "renameFailed": "Move failed: {error}"
+        "renameFailed": "Move failed: {error}",
+        "openFolderIndex": "Open folder index"
       },
       "canvas": {
         "kindUi": "UI mock",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -271,7 +271,10 @@
           "renamed": "Movido.",
           "renamedWithLinks": "Movido: se actualizaron {{count}} enlace(s) en {{notes}} nota(s).",
           "renamedWithWarning": "Movido, pero los enlaces podrían no actualizarse",
-          "renameFailed": "Error al mover"
+          "renameFailed": "Error al mover",
+          "templateLabel": "Plantilla",
+          "templateFromVault": "Desde tu vault (_templates/)",
+          "openFolderIndexTitle": "Abrir la página índice de esta carpeta"
         },
         "cortexPanel": {
           "noCwd": "La sesión no tiene cwd — las funciones de Cortex necesitan un directorio de trabajo.",
@@ -3795,7 +3798,8 @@
         "renamed": "Movido.",
         "renamedWithLinks": "Movido: se actualizaron {count} enlace(s) en {notes} nota(s).",
         "renamedWithWarning": "Movido, pero los enlaces podrían no actualizarse: {warning}",
-        "renameFailed": "Error al mover: {error}"
+        "renameFailed": "Error al mover: {error}",
+        "openFolderIndex": "Abrir índice de carpeta"
       },
       "canvas": {
         "kindUi": "Maqueta UI",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -271,7 +271,10 @@
           "renamed": "已移动。",
           "renamedWithLinks": "已移动 —— 更新了 {{notes}} 篇笔记中的 {{count}} 处链接。",
           "renamedWithWarning": "已移动,但链接可能未更新",
-          "renameFailed": "移动失败"
+          "renameFailed": "移动失败",
+          "templateLabel": "模板",
+          "templateFromVault": "来自你的 vault(_templates/)",
+          "openFolderIndexTitle": "打开该目录的索引页"
         },
         "cortexPanel": {
           "noCwd": "会话没有工作目录——心智中枢功能需要工作目录。",
@@ -3795,7 +3798,8 @@
         "renamed": "已移动。",
         "renamedWithLinks": "已移动 —— 更新了 {notes} 篇笔记中的 {count} 处链接。",
         "renamedWithWarning": "已移动,但链接可能未更新:{warning}",
-        "renameFailed": "移动失败:{error}"
+        "renameFailed": "移动失败:{error}",
+        "openFolderIndex": "打开目录索引"
       },
       "canvas": {
         "kindUi": "UI 稿",

--- a/app/mobile/lib/core/api/notes_api.dart
+++ b/app/mobile/lib/core/api/notes_api.dart
@@ -195,6 +195,40 @@ class NotesApi {
     }
   }
 
+  Future<List<NoteTemplate>> templates() async {
+    try {
+      final res =
+          await _dio.get<Map<String, dynamic>>('/api/v1/notes/templates');
+      final raw = res.data?['templates'];
+      if (raw is! List) return const [];
+      return raw
+          .whereType<Map<String, dynamic>>()
+          .map(NoteTemplate.fromJson)
+          .toList();
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  /// Create a note from a template. Separate from [write] because it
+  /// refuses to overwrite, and because the placeholders are rendered
+  /// server-side — so a doc started here and one started on the web
+  /// come out identical instead of drifting.
+  Future<NoteSummary> newFromTemplate({
+    required String path,
+    required String template,
+  }) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/notes/new',
+        data: {'path': path, 'template': template},
+      );
+      return NoteSummary.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
   /// Move or rename a note, repointing the [[wiki-links]] that pointed
   /// at it. Without the rewrite a rename silently strands every
   /// reference, which is why reorganising was previously unsafe.
@@ -210,6 +244,31 @@ class NotesApi {
     }
   }
 }
+
+/// One starting shape for a new note. [source] is "builtin" or "vault"
+/// — the latter is a template the operator authored under `_templates/`.
+class NoteTemplate {
+  const NoteTemplate({
+    required this.id,
+    required this.name,
+    required this.source,
+  });
+
+  factory NoteTemplate.fromJson(Map<String, dynamic> json) => NoteTemplate(
+        id: json['id'] as String? ?? '',
+        name: json['name'] as String? ?? '',
+        source: json['source'] as String? ?? 'builtin',
+      );
+
+  final String id;
+  final String name;
+  final String source;
+}
+
+/// Filenames treated as a folder's index page, in preference order.
+/// Mirrors INDEX_NAMES in app/shared/src/lib/notes.ts — resolved on the
+/// client because the listing is already here.
+const kIndexNames = ['README.md', 'index.md', '_index.md'];
 
 /// Outcome of a move. [warning] is set when the file moved but the link
 /// rewrite didn't finish — the move still happened, so the UI must not

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 13005 (4335 per locale)
+/// Strings: 13017 (4339 per locale)
 ///
-/// Built on 2026-08-07 at 11:28 UTC
+/// Built on 2026-08-07 at 11:58 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -13199,6 +13199,9 @@ class TranslationsSessionsInspectorNotesEn {
 
 	/// en: 'Move failed: {error}'
 	String renameFailed({required Object error}) => 'Move failed: ${error}';
+
+	/// en: 'Open folder index'
+	String get openFolderIndex => 'Open folder index';
 }
 
 // Path: sessions.inspector.canvas
@@ -14618,6 +14621,15 @@ class TranslationsWebSessionsInspectorVaultPanelEn {
 
 	/// en: 'Move failed'
 	String get renameFailed => 'Move failed';
+
+	/// en: 'Template'
+	String get templateLabel => 'Template';
+
+	/// en: 'From your vault (_templates/)'
+	String get templateFromVault => 'From your vault (_templates/)';
+
+	/// en: 'Open this folder’s index page'
+	String get openFolderIndexTitle => 'Open this folder’s index page';
 }
 
 // Path: web.sessions.inspector.cortexPanel
@@ -18775,6 +18787,9 @@ extension on Translations {
 			'web.sessions.inspector.vaultPanel.renamedWithLinks' => ({required Object {count, required Object {notes}) => 'Moved — updated ${{count}} link(s) in ${{notes}} note(s).',
 			'web.sessions.inspector.vaultPanel.renamedWithWarning' => 'Moved, but links may not be updated',
 			'web.sessions.inspector.vaultPanel.renameFailed' => 'Move failed',
+			'web.sessions.inspector.vaultPanel.templateLabel' => 'Template',
+			'web.sessions.inspector.vaultPanel.templateFromVault' => 'From your vault (_templates/)',
+			'web.sessions.inspector.vaultPanel.openFolderIndexTitle' => 'Open this folder’s index page',
 			'web.sessions.inspector.cortexPanel.noCwd' => 'Session has no cwd — Cortex features need a working directory.',
 			'web.sessions.inspector.cortexPanel.open' => 'Open Cortex workspace',
 			'web.sessions.inspector.cortexPanel.docs' => 'Docs',
@@ -19045,11 +19060,11 @@ extension on Translations {
 			'web.memoryWorkers.tasks.conflict_detector.label' => 'Cross-layer conflict detector',
 			'web.memoryWorkers.tasks.conflict_detector.description' => 'Daily scan that finds contradictions between facts / plan / goal / journal. Higher-quality model = fewer false positives.',
 			'web.memoryWorkers.tasks.conflict_detector.modelAdvice' => 'Daily cross-layer contradiction scan — balanced model is enough.',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryWorkers.tasks.capture.label' => 'Capture engine',
 			'web.memoryWorkers.tasks.capture.description' => 'Per-trigger fact extraction from session transcripts. Agent mode gives noticeably better facts on long sessions; summarizer mode is cheap and local.',
 			'web.memoryWorkers.tasks.capture.modelAdvice' => 'Highest-frequency task: fact extraction every few messages — use the CHEAPEST model that works (haiku / local).',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryWorkers.tasks.blueprint.modelAdvice' => 'Occasional, operator-triggered project classification — balanced model; quality matters more than cost here.',
 			'web.memoryWorkers.tasks.blueprint.label' => 'Blueprint proposer',
 			'web.memoryWorkers.tasks.blueprint.description' => 'Classifies a project from repo signals and proposes its doc section set. Operator-triggered from the blueprint editor.',
@@ -19559,11 +19574,11 @@ extension on Translations {
 			'web.providers.detail.toggleFailedToast' => 'Toggle failed',
 			'web.providers.detail.caps.resume' => 'resume',
 			'web.providers.detail.caps.stream' => 'stream',
+			_ => null,
+		} ?? switch (path) {
 			'web.providers.detail.caps.images' => 'images',
 			'web.providers.detail.caps.mcp' => 'mcp',
 			'web.providers.detail.notInstalled' => 'not installed',
-			_ => null,
-		} ?? switch (path) {
 			'web.providers.detail.brokenCli' => 'Installed but not runnable',
 			'web.providers.detail.updateAvailable' => ({required Object version}) => 'update available → ${version}',
 			'web.providers.detail.upToDate' => 'up to date',
@@ -20073,11 +20088,11 @@ extension on Translations {
 			'web.backups.generated.title' => 'Save this passphrase NOW',
 			'web.backups.generated.description' => 'This is shown <1>once</1>. It will not be retrievable from opendray or anywhere else. Copy it into a password manager before continuing.',
 			'web.backups.generated.copy' => 'Copy',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.generated.copiedToast' => 'Passphrase copied to clipboard',
 			'web.backups.generated.copyFailedToast' => 'Copy failed — select and copy manually',
 			'web.backups.generated.savedTo' => 'Saved to:',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.generated.ack' => 'I have saved this passphrase to my password manager',
 			'web.backups.generated.kContinue' => 'Continue',
 			'web.backups.status.pgDump' => 'pg_dump',
@@ -20587,11 +20602,11 @@ extension on Translations {
 			'web.settings.system.description' => 'Live status from the gateway\'s /health endpoint.',
 			'web.settings.system.status' => 'Status',
 			'web.settings.system.version' => 'Version',
+			_ => null,
+		} ?? switch (path) {
 			'web.settings.system.uptime' => 'Uptime',
 			'web.settings.system.database' => 'Database',
 			'web.settings.system.reachable' => 'reachable',
-			_ => null,
-		} ?? switch (path) {
 			'web.settings.system.unreachable' => 'unreachable',
 			'web.settings.about.title' => 'About',
 			'web.settings.about.description' => 'opendray v2 — the multiplexer + integration gateway for AI agent CLIs. Source under Apache 2.0.',
@@ -21101,11 +21116,11 @@ extension on Translations {
 			'web.database.grid.insert' => 'Insert',
 			'web.database.grid.refresh' => 'Refresh',
 			'web.database.grid.edit' => 'Edit',
+			_ => null,
+		} ?? switch (path) {
 			'web.database.grid.delete' => 'Delete',
 			'web.database.grid.deleted' => 'Row deleted',
 			'web.database.grid.confirmDelete' => 'Delete this row?',
-			_ => null,
-		} ?? switch (path) {
 			'web.database.grid.loading' => 'Loading rows…',
 			'web.database.grid.readOnlyHint' => 'This connection is read-only — rows cannot be edited.',
 			'web.database.grid.noPkHint' => 'This table has no primary key — row editing is disabled.',
@@ -21522,6 +21537,7 @@ extension on Translations {
 			'sessions.inspector.notes.renamedWithLinks' => ({required Object count, required Object notes}) => 'Moved — updated ${count} link(s) in ${notes} note(s).',
 			'sessions.inspector.notes.renamedWithWarning' => ({required Object warning}) => 'Moved, but links may not be updated: ${warning}',
 			'sessions.inspector.notes.renameFailed' => ({required Object error}) => 'Move failed: ${error}',
+			'sessions.inspector.notes.openFolderIndex' => 'Open folder index',
 			'sessions.inspector.canvas.kindUi' => 'UI mock',
 			'sessions.inspector.canvas.kindFlow' => 'Flowchart',
 			'sessions.inspector.canvas.kindMindmap' => 'Mind map',
@@ -21614,12 +21630,12 @@ extension on Translations {
 			'sessions.spawnSheet.argsHelper' => 'Whitespace-separated; blank uses the provider\'s defaults.',
 			'sessions.spawnSheet.bypass.labelClaude' => 'Bypass permissions',
 			'sessions.spawnSheet.bypass.labelCodex' => 'Bypass approvals & sandbox',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.spawnSheet.bypass.labelAntigravity' => 'Bypass permissions / YOLO',
 			'sessions.spawnSheet.bypass.labelOpencode' => 'Bypass permissions',
 			'sessions.spawnSheet.bypass.labelGrok' => 'Bypass permissions / YOLO (--always-approve)',
 			'sessions.spawnSheet.bypass.subtitleOn' => 'This session will run with elevated autonomy.',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.spawnSheet.bypass.subtitleOff' => 'Off — confirmations and prompts behave normally.',
 			'sessions.spawnSheet.noProviders.title' => 'No providers configured',
 			'sessions.spawnSheet.noProviders.message' => 'The gateway has no CLI providers enabled. Configure one under Providers (web admin) or [providers] in config.toml, then tap Reload.',
@@ -22128,12 +22144,12 @@ extension on Translations {
 			'backups.restore.failedTitle' => 'Restore failed',
 			'backups.restore.pickFileToast' => 'Pick a bundle file first.',
 			'backups.restore.outputTitle' => 'pg_restore output',
+			_ => null,
+		} ?? switch (path) {
 			'backups.restore.noPgRestoreOutput' => '(empty — restore completed silently)',
 			'backups.restore.manifestTitle' => 'Manifest',
 			'backups.restore.manifestBackupId' => 'Backup ID',
 			'backups.restore.manifestVersion' => 'Manifest version',
-			_ => null,
-		} ?? switch (path) {
 			'backups.restore.manifestCreatedAt' => 'Created',
 			'backups.restore.manifestPgVersion' => 'pg_version',
 			'backups.restore.manifestOpendrayVersion' => 'opendray version',
@@ -22642,12 +22658,12 @@ extension on Translations {
 			'memory.create.submit' => 'Create',
 			'memory.archive' => 'Archive',
 			'memory.quarantine' => 'Quarantine',
+			_ => null,
+		} ?? switch (path) {
 			'memory.archivedToast' => 'Memory archived — restorable from Archived',
 			'memory.quarantinedToast' => 'Memory quarantined — review under Cortex → Quarantine',
 			'memory.archiveFailed' => ({required Object error}) => 'Archive failed: ${error}',
 			'memory.quarantineFailed' => ({required Object error}) => 'Quarantine failed: ${error}',
-			_ => null,
-		} ?? switch (path) {
 			'memory.reembed.menuItem' => 'Re-embed all',
 			'memory.reembed.confirmTitle' => 'Re-embed all memories?',
 			'memory.reembed.confirmBody' => 'Re-encodes every stored memory and KB page with the current embedding model. Needed after switching models, since the vector dimension changes. This can take a while.',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -6765,6 +6765,7 @@ class _TranslationsSessionsInspectorNotesEs extends TranslationsSessionsInspecto
 	@override String renamedWithLinks({required Object count, required Object notes}) => 'Movido: se actualizaron ${count} enlace(s) en ${notes} nota(s).';
 	@override String renamedWithWarning({required Object warning}) => 'Movido, pero los enlaces podrían no actualizarse: ${warning}';
 	@override String renameFailed({required Object error}) => 'Error al mover: ${error}';
+	@override String get openFolderIndex => 'Abrir índice de carpeta';
 }
 
 // Path: sessions.inspector.canvas
@@ -7478,6 +7479,9 @@ class _TranslationsWebSessionsInspectorVaultPanelEs extends TranslationsWebSessi
 	@override String renamedWithLinks({required Object {count, required Object {notes}) => 'Movido: se actualizaron ${{count}} enlace(s) en ${{notes}} nota(s).';
 	@override String get renamedWithWarning => 'Movido, pero los enlaces podrían no actualizarse';
 	@override String get renameFailed => 'Error al mover';
+	@override String get templateLabel => 'Plantilla';
+	@override String get templateFromVault => 'Desde tu vault (_templates/)';
+	@override String get openFolderIndexTitle => 'Abrir la página índice de esta carpeta';
 }
 
 // Path: web.sessions.inspector.cortexPanel
@@ -9983,6 +9987,9 @@ extension on TranslationsEs {
 			'web.sessions.inspector.vaultPanel.renamedWithLinks' => ({required Object {count, required Object {notes}) => 'Movido: se actualizaron ${{count}} enlace(s) en ${{notes}} nota(s).',
 			'web.sessions.inspector.vaultPanel.renamedWithWarning' => 'Movido, pero los enlaces podrían no actualizarse',
 			'web.sessions.inspector.vaultPanel.renameFailed' => 'Error al mover',
+			'web.sessions.inspector.vaultPanel.templateLabel' => 'Plantilla',
+			'web.sessions.inspector.vaultPanel.templateFromVault' => 'Desde tu vault (_templates/)',
+			'web.sessions.inspector.vaultPanel.openFolderIndexTitle' => 'Abrir la página índice de esta carpeta',
 			'web.sessions.inspector.cortexPanel.noCwd' => 'La sesión no tiene cwd — las funciones de Cortex necesitan un directorio de trabajo.',
 			'web.sessions.inspector.cortexPanel.open' => 'Abrir espacio Cortex',
 			'web.sessions.inspector.cortexPanel.docs' => 'Docs',
@@ -10253,11 +10260,11 @@ extension on TranslationsEs {
 			'web.memoryWorkers.tasks.conflict_detector.label' => 'Detector de conflictos entre capas',
 			'web.memoryWorkers.tasks.conflict_detector.description' => 'Escaneo diario que encuentra contradicciones entre hechos / plan / objetivo / diario. Un modelo de mayor calidad = menos falsos positivos.',
 			'web.memoryWorkers.tasks.conflict_detector.modelAdvice' => 'Escaneo diario de contradicciones — un modelo equilibrado basta.',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryWorkers.tasks.capture.label' => 'Motor de captura',
 			'web.memoryWorkers.tasks.capture.description' => 'Extracción de hechos por cada trigger a partir de los transcripts de sesión. El modo agente ofrece hechos notablemente mejores en sesiones largas; el modo summarizer es barato y local.',
 			'web.memoryWorkers.tasks.capture.modelAdvice' => 'La tarea más frecuente: extracción de hechos — usa el modelo MÁS BARATO que funcione (haiku / local).',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryWorkers.tasks.blueprint.modelAdvice' => 'Clasificación ocasional del proyecto — modelo equilibrado; aquí la calidad importa más que el costo.',
 			'web.memoryWorkers.tasks.blueprint.label' => 'Proponedor de planos',
 			'web.memoryWorkers.tasks.blueprint.description' => 'Clasifica un proyecto y propone su conjunto de secciones. Disparado por el operador.',
@@ -10767,11 +10774,11 @@ extension on TranslationsEs {
 			'web.providers.detail.toggleFailedToast' => 'Error al alternar',
 			'web.providers.detail.caps.resume' => 'resume',
 			'web.providers.detail.caps.stream' => 'stream',
+			_ => null,
+		} ?? switch (path) {
 			'web.providers.detail.caps.images' => 'images',
 			'web.providers.detail.caps.mcp' => 'mcp',
 			'web.providers.detail.notInstalled' => 'no instalado',
-			_ => null,
-		} ?? switch (path) {
 			'web.providers.detail.brokenCli' => 'Instalado pero no ejecutable',
 			'web.providers.detail.updateAvailable' => ({required Object version}) => 'actualización disponible → ${version}',
 			'web.providers.detail.upToDate' => 'actualizado',
@@ -11281,11 +11288,11 @@ extension on TranslationsEs {
 			'web.backups.generated.title' => 'Guarda esta frase de contraseña AHORA',
 			'web.backups.generated.description' => 'Esto se muestra <1>una sola vez</1>. No se podrá recuperar desde opendray ni desde ningún otro sitio. Cópiala en un gestor de contraseñas antes de continuar.',
 			'web.backups.generated.copy' => 'Copiar',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.generated.copiedToast' => 'Frase de contraseña copiada al portapapeles',
 			'web.backups.generated.copyFailedToast' => 'Error al copiar, selecciónala y cópiala manualmente',
 			'web.backups.generated.savedTo' => 'Guardada en:',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.generated.ack' => 'He guardado esta frase de contraseña en mi gestor de contraseñas',
 			'web.backups.generated.kContinue' => 'Continuar',
 			'web.backups.status.pgDump' => 'pg_dump',
@@ -11795,11 +11802,11 @@ extension on TranslationsEs {
 			'web.settings.system.description' => 'Estado en vivo desde el endpoint /health del gateway.',
 			'web.settings.system.status' => 'Estado',
 			'web.settings.system.version' => 'Versión',
+			_ => null,
+		} ?? switch (path) {
 			'web.settings.system.uptime' => 'Tiempo de actividad',
 			'web.settings.system.database' => 'Base de datos',
 			'web.settings.system.reachable' => 'accesible',
-			_ => null,
-		} ?? switch (path) {
 			'web.settings.system.unreachable' => 'no accesible',
 			'web.settings.about.title' => 'Acerca de',
 			'web.settings.about.description' => 'opendray v2: el multiplexor + gateway de integración para CLIs de agentes de IA. Código bajo Apache 2.0.',
@@ -12309,11 +12316,11 @@ extension on TranslationsEs {
 			'web.database.grid.insert' => 'Insertar',
 			'web.database.grid.refresh' => 'Actualizar',
 			'web.database.grid.edit' => 'Editar',
+			_ => null,
+		} ?? switch (path) {
 			'web.database.grid.delete' => 'Eliminar',
 			'web.database.grid.deleted' => 'Fila eliminada',
 			'web.database.grid.confirmDelete' => '¿Eliminar esta fila?',
-			_ => null,
-		} ?? switch (path) {
 			'web.database.grid.loading' => 'Cargando filas…',
 			'web.database.grid.readOnlyHint' => 'Esta conexión es de solo lectura — no se pueden editar filas.',
 			'web.database.grid.noPkHint' => 'Esta tabla no tiene clave primaria — la edición de filas está deshabilitada.',
@@ -12730,6 +12737,7 @@ extension on TranslationsEs {
 			'sessions.inspector.notes.renamedWithLinks' => ({required Object count, required Object notes}) => 'Movido: se actualizaron ${count} enlace(s) en ${notes} nota(s).',
 			'sessions.inspector.notes.renamedWithWarning' => ({required Object warning}) => 'Movido, pero los enlaces podrían no actualizarse: ${warning}',
 			'sessions.inspector.notes.renameFailed' => ({required Object error}) => 'Error al mover: ${error}',
+			'sessions.inspector.notes.openFolderIndex' => 'Abrir índice de carpeta',
 			'sessions.inspector.canvas.kindUi' => 'Maqueta UI',
 			'sessions.inspector.canvas.kindFlow' => 'Diagrama de flujo',
 			'sessions.inspector.canvas.kindMindmap' => 'Mapa mental',
@@ -12822,12 +12830,12 @@ extension on TranslationsEs {
 			'sessions.spawnSheet.argsHelper' => 'Separados por espacios; en blanco usa los valores predeterminados del proveedor.',
 			'sessions.spawnSheet.bypass.labelClaude' => 'Omitir permisos',
 			'sessions.spawnSheet.bypass.labelCodex' => 'Omitir aprobaciones y sandbox',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.spawnSheet.bypass.labelAntigravity' => 'Omitir permisos / YOLO',
 			'sessions.spawnSheet.bypass.labelOpencode' => 'Omitir permisos',
 			'sessions.spawnSheet.bypass.labelGrok' => 'Saltar permisos / YOLO (--always-approve)',
 			'sessions.spawnSheet.bypass.subtitleOn' => 'Esta session se ejecutará con autonomía elevada.',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.spawnSheet.bypass.subtitleOff' => 'Desactivado. Las confirmaciones y los prompts se comportan de forma normal.',
 			'sessions.spawnSheet.noProviders.title' => 'No hay proveedores configurados',
 			'sessions.spawnSheet.noProviders.message' => 'El gateway no tiene proveedores de CLI habilitados. Configura uno en Proveedores (admin web) o en [providers] en config.toml, y luego toca Recargar.',
@@ -13336,12 +13344,12 @@ extension on TranslationsEs {
 			'backups.restore.failedTitle' => 'Error en la restauración',
 			'backups.restore.pickFileToast' => 'Primero elige un archivo de paquete.',
 			'backups.restore.outputTitle' => 'Salida de pg_restore',
+			_ => null,
+		} ?? switch (path) {
 			'backups.restore.noPgRestoreOutput' => '(vacío: la restauración se completó sin salida)',
 			'backups.restore.manifestTitle' => 'Manifiesto',
 			'backups.restore.manifestBackupId' => 'ID de copia de seguridad',
 			'backups.restore.manifestVersion' => 'Versión del manifiesto',
-			_ => null,
-		} ?? switch (path) {
 			'backups.restore.manifestCreatedAt' => 'Creado',
 			'backups.restore.manifestPgVersion' => 'pg_version',
 			'backups.restore.manifestOpendrayVersion' => 'versión de opendray',
@@ -13850,12 +13858,12 @@ extension on TranslationsEs {
 			'memory.create.submit' => 'Crear',
 			'memory.archive' => 'Archivar',
 			'memory.quarantine' => 'Cuarentena',
+			_ => null,
+		} ?? switch (path) {
 			'memory.archivedToast' => 'Memoria archivada — restaurable desde Archivado',
 			'memory.quarantinedToast' => 'Memoria en cuarentena — revísala en Cortex → Cuarentena',
 			'memory.archiveFailed' => ({required Object error}) => 'Error al archivar: ${error}',
 			'memory.quarantineFailed' => ({required Object error}) => 'Error al poner en cuarentena: ${error}',
-			_ => null,
-		} ?? switch (path) {
 			'memory.reembed.menuItem' => 'Reincrustar todo',
 			'memory.reembed.confirmTitle' => '¿Reincrustar todas las memorias?',
 			'memory.reembed.confirmBody' => 'Recodifica cada memoria y página de KB con el modelo de embedding actual. Necesario tras cambiar de modelo, ya que la dimensión del vector cambia. Puede tardar un rato.',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -6765,6 +6765,7 @@ class _TranslationsSessionsInspectorNotesZh extends TranslationsSessionsInspecto
 	@override String renamedWithLinks({required Object notes, required Object count}) => '已移动 —— 更新了 ${notes} 篇笔记中的 ${count} 处链接。';
 	@override String renamedWithWarning({required Object warning}) => '已移动,但链接可能未更新:${warning}';
 	@override String renameFailed({required Object error}) => '移动失败:${error}';
+	@override String get openFolderIndex => '打开目录索引';
 }
 
 // Path: sessions.inspector.canvas
@@ -7478,6 +7479,9 @@ class _TranslationsWebSessionsInspectorVaultPanelZh extends TranslationsWebSessi
 	@override String renamedWithLinks({required Object {notes, required Object {count}) => '已移动 —— 更新了 ${{notes}} 篇笔记中的 ${{count}} 处链接。';
 	@override String get renamedWithWarning => '已移动,但链接可能未更新';
 	@override String get renameFailed => '移动失败';
+	@override String get templateLabel => '模板';
+	@override String get templateFromVault => '来自你的 vault(_templates/)';
+	@override String get openFolderIndexTitle => '打开该目录的索引页';
 }
 
 // Path: web.sessions.inspector.cortexPanel
@@ -9983,6 +9987,9 @@ extension on TranslationsZh {
 			'web.sessions.inspector.vaultPanel.renamedWithLinks' => ({required Object {notes, required Object {count}) => '已移动 —— 更新了 ${{notes}} 篇笔记中的 ${{count}} 处链接。',
 			'web.sessions.inspector.vaultPanel.renamedWithWarning' => '已移动,但链接可能未更新',
 			'web.sessions.inspector.vaultPanel.renameFailed' => '移动失败',
+			'web.sessions.inspector.vaultPanel.templateLabel' => '模板',
+			'web.sessions.inspector.vaultPanel.templateFromVault' => '来自你的 vault(_templates/)',
+			'web.sessions.inspector.vaultPanel.openFolderIndexTitle' => '打开该目录的索引页',
 			'web.sessions.inspector.cortexPanel.noCwd' => '会话没有工作目录——心智中枢功能需要工作目录。',
 			'web.sessions.inspector.cortexPanel.open' => '打开心智中枢工作区',
 			'web.sessions.inspector.cortexPanel.docs' => '文档',
@@ -10253,11 +10260,11 @@ extension on TranslationsZh {
 			'web.memoryWorkers.tasks.conflict_detector.label' => '跨层冲突检测',
 			'web.memoryWorkers.tasks.conflict_detector.description' => '每日扫描 facts/plan/goal/journal 之间的矛盾。模型越强，误报越少。',
 			'web.memoryWorkers.tasks.conflict_detector.modelAdvice' => '每日跨层矛盾扫描——均衡模型即可。',
+			_ => null,
+		} ?? switch (path) {
 			'web.memoryWorkers.tasks.capture.label' => 'Capture 引擎',
 			'web.memoryWorkers.tasks.capture.description' => '按触发器从 session transcript 抽取 fact。Agent 模式在长会话上 fact 质量明显更好；summarizer 模式便宜且本地。',
 			'web.memoryWorkers.tasks.capture.modelAdvice' => '频率最高的任务：每隔几条消息抽取事实——用能干活的最便宜模型（haiku / 本地）。',
-			_ => null,
-		} ?? switch (path) {
 			'web.memoryWorkers.tasks.blueprint.modelAdvice' => '偶发、由你手动触发的项目分类——均衡模型；这里质量比成本重要。',
 			'web.memoryWorkers.tasks.blueprint.label' => '蓝图提议器',
 			'web.memoryWorkers.tasks.blueprint.description' => '根据仓库信号识别项目类型并提议文档章节结构。由蓝图编辑器手动触发。',
@@ -10767,11 +10774,11 @@ extension on TranslationsZh {
 			'web.providers.detail.toggleFailedToast' => '切换失败',
 			'web.providers.detail.caps.resume' => 'resume',
 			'web.providers.detail.caps.stream' => 'stream',
+			_ => null,
+		} ?? switch (path) {
 			'web.providers.detail.caps.images' => 'images',
 			'web.providers.detail.caps.mcp' => 'mcp',
 			'web.providers.detail.notInstalled' => '未安装',
-			_ => null,
-		} ?? switch (path) {
 			'web.providers.detail.brokenCli' => '已安装但无法运行',
 			'web.providers.detail.updateAvailable' => ({required Object version}) => '有可用更新 → ${version}',
 			'web.providers.detail.upToDate' => '已是最新',
@@ -11281,11 +11288,11 @@ extension on TranslationsZh {
 			'web.backups.generated.title' => '立即保存此口令',
 			'web.backups.generated.description' => '这是 <1>唯一一次</1> 显示。opendray 与任何其他地方都将无法取回。请在继续前复制到密码管理器。',
 			'web.backups.generated.copy' => '复制',
+			_ => null,
+		} ?? switch (path) {
 			'web.backups.generated.copiedToast' => '口令已复制到剪贴板',
 			'web.backups.generated.copyFailedToast' => '复制失败 — 请手动选中并复制',
 			'web.backups.generated.savedTo' => '已保存到：',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.generated.ack' => '我已将此口令保存到密码管理器',
 			'web.backups.generated.kContinue' => '继续',
 			'web.backups.status.pgDump' => 'pg_dump',
@@ -11795,11 +11802,11 @@ extension on TranslationsZh {
 			'web.settings.system.description' => '来自网关 /health 接口的实时状态。',
 			'web.settings.system.status' => '状态',
 			'web.settings.system.version' => '版本',
+			_ => null,
+		} ?? switch (path) {
 			'web.settings.system.uptime' => '运行时长',
 			'web.settings.system.database' => '数据库',
 			'web.settings.system.reachable' => '可达',
-			_ => null,
-		} ?? switch (path) {
 			'web.settings.system.unreachable' => '不可达',
 			'web.settings.about.title' => '关于',
 			'web.settings.about.description' => 'opendray v2 — 面向 AI agent CLI 的多路复用 + 集成网关。源码采用 Apache 2.0 协议。',
@@ -12309,11 +12316,11 @@ extension on TranslationsZh {
 			'web.database.grid.insert' => '插入',
 			'web.database.grid.refresh' => '刷新',
 			'web.database.grid.edit' => '编辑',
+			_ => null,
+		} ?? switch (path) {
 			'web.database.grid.delete' => '删除',
 			'web.database.grid.deleted' => '行已删除',
 			'web.database.grid.confirmDelete' => '删除此行?',
-			_ => null,
-		} ?? switch (path) {
 			'web.database.grid.loading' => '正在加载数据…',
 			'web.database.grid.readOnlyHint' => '此连接为只读 —— 无法编辑行。',
 			'web.database.grid.noPkHint' => '此表没有主键 —— 行编辑已禁用。',
@@ -12730,6 +12737,7 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.renamedWithLinks' => ({required Object notes, required Object count}) => '已移动 —— 更新了 ${notes} 篇笔记中的 ${count} 处链接。',
 			'sessions.inspector.notes.renamedWithWarning' => ({required Object warning}) => '已移动,但链接可能未更新:${warning}',
 			'sessions.inspector.notes.renameFailed' => ({required Object error}) => '移动失败:${error}',
+			'sessions.inspector.notes.openFolderIndex' => '打开目录索引',
 			'sessions.inspector.canvas.kindUi' => 'UI 稿',
 			'sessions.inspector.canvas.kindFlow' => '流程图',
 			'sessions.inspector.canvas.kindMindmap' => '思维导图',
@@ -12822,12 +12830,12 @@ extension on TranslationsZh {
 			'sessions.spawnSheet.argsHelper' => '以空格分隔；留空使用提供商默认值。',
 			'sessions.spawnSheet.bypass.labelClaude' => '绕过权限',
 			'sessions.spawnSheet.bypass.labelCodex' => '跳过批准与沙盒',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.spawnSheet.bypass.labelAntigravity' => '跳过权限 / YOLO',
 			'sessions.spawnSheet.bypass.labelOpencode' => '跳过权限检查',
 			'sessions.spawnSheet.bypass.labelGrok' => '跳过权限 / YOLO（--always-approve）',
 			'sessions.spawnSheet.bypass.subtitleOn' => '此会话将以提升的自主权运行。',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.spawnSheet.bypass.subtitleOff' => '关闭 — 确认和提示按正常方式处理。',
 			'sessions.spawnSheet.noProviders.title' => '未配置任何提供商',
 			'sessions.spawnSheet.noProviders.message' => '网关没有启用任何 CLI 提供商。在 Web 管理端的「提供商」中配置，或编辑 config.toml 的 [providers] 段，然后点击重新加载。',
@@ -13336,12 +13344,12 @@ extension on TranslationsZh {
 			'backups.restore.failedTitle' => '恢复失败',
 			'backups.restore.pickFileToast' => '请先选择一个备份文件。',
 			'backups.restore.outputTitle' => 'pg_restore 输出',
+			_ => null,
+		} ?? switch (path) {
 			'backups.restore.noPgRestoreOutput' => '（空 — 恢复无声完成）',
 			'backups.restore.manifestTitle' => '清单',
 			'backups.restore.manifestBackupId' => '备份 ID',
 			'backups.restore.manifestVersion' => '清单版本',
-			_ => null,
-		} ?? switch (path) {
 			'backups.restore.manifestCreatedAt' => '创建时间',
 			'backups.restore.manifestPgVersion' => 'pg_version',
 			'backups.restore.manifestOpendrayVersion' => 'opendray 版本',
@@ -13850,12 +13858,12 @@ extension on TranslationsZh {
 			'memory.create.submit' => '创建',
 			'memory.archive' => '归档',
 			'memory.quarantine' => '隔离',
+			_ => null,
+		} ?? switch (path) {
 			'memory.archivedToast' => '记忆已归档——可在「已归档」中恢复',
 			'memory.quarantinedToast' => '记忆已隔离——请在 Cortex → 隔离区 审查',
 			'memory.archiveFailed' => ({required Object error}) => '归档失败：${error}',
 			'memory.quarantineFailed' => ({required Object error}) => '隔离失败：${error}',
-			_ => null,
-		} ?? switch (path) {
 			'memory.reembed.menuItem' => '全部重嵌',
 			'memory.reembed.confirmTitle' => '重嵌所有记忆？',
 			'memory.reembed.confirmBody' => '用当前 embedding 模型重新编码所有已存记忆和 KB 页面。切换模型后需要执行（向量维度会变）。可能需要一些时间。',

--- a/app/mobile/lib/features/sessions/inspector/notes_tab.dart
+++ b/app/mobile/lib/features/sessions/inspector/notes_tab.dart
@@ -402,6 +402,21 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
     await widget.onRefresh();
   }
 
+  /// Selected template for the next new doc. Server-rendered, so this
+  /// only has to carry the id.
+  String _template = 'blank';
+  List<NoteTemplate> _templates = const [];
+
+  Future<void> _loadTemplates() async {
+    try {
+      final list = await ref.read(notesApiProvider).templates();
+      if (mounted) setState(() => _templates = list);
+    } on Object {
+      // A missing template list must not block creating a doc — the
+      // server defaults to blank when none is named.
+    }
+  }
+
   Future<void> _create() async {
     final raw = _newNameCtrl.text.trim();
     if (raw.isEmpty) return;
@@ -412,9 +427,9 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
     final path = '$prefix$name';
     final messenger = ScaffoldMessenger.of(context);
     try {
-      await ref.read(notesApiProvider).write(
+      await ref.read(notesApiProvider).newFromTemplate(
             path: path,
-            body: '# ${_stripExt(name)}\n\n',
+            template: _template,
           );
       _newNameCtrl.clear();
       setState(() => _creating = false);
@@ -499,10 +514,13 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
           IconButton(
             icon: Icon(_creating ? Icons.close : Icons.add, size: 18),
             tooltip: _creating ? t.sessions.inspector.notes.cancelTooltip : t.sessions.inspector.notes.newDocTooltip,
-            onPressed: () => setState(() {
-              _creating = !_creating;
-              if (!_creating) _newNameCtrl.clear();
-            }),
+            onPressed: () {
+              setState(() {
+                _creating = !_creating;
+                if (!_creating) _newNameCtrl.clear();
+              });
+              if (_creating && _templates.isEmpty) _loadTemplates();
+            },
           ),
         ],
       ),
@@ -510,6 +528,25 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           if (_creating) ...[
+            if (_templates.isNotEmpty) ...[
+              Wrap(
+                spacing: 6,
+                runSpacing: 4,
+                children: [
+                  for (final tpl in _templates)
+                    ChoiceChip(
+                      label: Text(
+                        tpl.source == 'vault' ? '${tpl.name} *' : tpl.name,
+                        style: const TextStyle(fontSize: 11),
+                      ),
+                      selected: _template == tpl.id,
+                      visualDensity: VisualDensity.compact,
+                      onSelected: (_) => setState(() => _template = tpl.id),
+                    ),
+                ],
+              ),
+              const SizedBox(height: 6),
+            ],
             Row(
               children: [
                 Expanded(
@@ -588,6 +625,7 @@ class _ProjectDocsSectionState extends ConsumerState<_ProjectDocsSection> {
               onInsertRef: (d) =>
                   _pushInput(widget.sessionId, ref, '@${d.path}'),
               onRename: _renameDoc,
+              onOpenIndex: _onDocTap,
             ),
         ],
       ),
@@ -1036,10 +1074,6 @@ String _sanitiseFilename(String input) {
   return name;
 }
 
-String _stripExt(String name) {
-  final i = name.lastIndexOf('.');
-  return i > 0 ? name.substring(0, i) : name;
-}
 
 // ─── Project docs folder tree ──────────────────────────────────────
 
@@ -1058,6 +1092,7 @@ class _DocTree extends StatefulWidget {
     required this.onTap,
     required this.onInsertRef,
     required this.onRename,
+    required this.onOpenIndex,
   });
 
   final List<NoteSummary> docs;
@@ -1065,6 +1100,9 @@ class _DocTree extends StatefulWidget {
   final void Function(NoteSummary) onTap;
   final void Function(NoteSummary) onInsertRef;
   final void Function(NoteSummary) onRename;
+  /// Opens a folder's README/index note. A folder that carries one can
+  /// explain what lives in it instead of being a bare row of chevrons.
+  final void Function(NoteSummary) onOpenIndex;
 
   @override
   State<_DocTree> createState() => _DocTreeState();
@@ -1089,7 +1127,12 @@ class _DocTreeState extends State<_DocTree> {
           () => _TreeNode(name: parts[i], path: path),
         );
       }
-      if (parts.isNotEmpty) node.files.add(_TreeFile(parts.last, d));
+      if (parts.isNotEmpty) {
+        node.files.add(_TreeFile(parts.last, d));
+        if (kIndexNames.contains(parts.last) && node.index == null) {
+          node.index = d;
+        }
+      }
     }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -1151,6 +1194,13 @@ class _DocTreeState extends State<_DocTree> {
                   '${dir.count}',
                   style: Theme.of(context).textTheme.bodySmall,
                 ),
+                if (dir.index != null)
+                  IconButton(
+                    icon: const Icon(Icons.menu_book_outlined, size: 16),
+                    tooltip: t.sessions.inspector.notes.openFolderIndex,
+                    visualDensity: VisualDensity.compact,
+                    onPressed: () => widget.onOpenIndex(dir.index!),
+                  ),
               ],
             ),
           ),
@@ -1183,6 +1233,8 @@ class _TreeNode {
   final String path;
   final Map<String, _TreeNode> children = {};
   final List<_TreeFile> files = [];
+  /// This folder's index note, if it has one.
+  NoteSummary? index;
 
   /// Total docs beneath this folder, so a collapsed folder still says
   /// how much it hides.

--- a/app/shared/src/lib/notes.ts
+++ b/app/shared/src/lib/notes.ts
@@ -101,6 +101,55 @@ export async function deleteNote(path: string): Promise<void> {
   })
 }
 
+export interface NoteTemplate {
+  id: string
+  name: string
+  /** "builtin" or "vault" — the latter is one the operator authored. */
+  source: string
+  body: string
+}
+
+export async function listNoteTemplates(): Promise<NoteTemplate[]> {
+  const res = await api<{ templates: NoteTemplate[] }>('/api/v1/notes/templates')
+  return res.templates ?? []
+}
+
+/**
+ * Create a note from a template. Distinct from writeNote: this refuses
+ * to overwrite, and the placeholders (title, date…) are rendered
+ * server-side so web and mobile can't drift on what a new doc looks
+ * like.
+ */
+export async function newNoteFromTemplate(
+  path: string,
+  template: string,
+): Promise<Note> {
+  return api<Note>('/api/v1/notes/new', {
+    method: 'POST',
+    body: { path, template },
+  })
+}
+
+/**
+ * Filenames treated as a folder's index page, in preference order.
+ * Resolved client-side: the caller already holds the folder's listing,
+ * so asking the gateway would re-derive what it can already see.
+ */
+export const INDEX_NAMES = ['README.md', 'index.md', '_index.md']
+
+/** Find `dir`'s index note among paths, or undefined. Paths and dir are
+ * relative to the same root. */
+export function folderIndexPath(
+  dir: string,
+  paths: string[],
+): string | undefined {
+  for (const name of INDEX_NAMES) {
+    const candidate = dir ? `${dir}/${name}` : name
+    if (paths.includes(candidate)) return candidate
+  }
+  return undefined
+}
+
 export interface MoveResult {
   from: string
   to: string

--- a/app/web/src/components/notes/NotesTreeView.tsx
+++ b/app/web/src/components/notes/NotesTreeView.tsx
@@ -1,5 +1,6 @@
 import { useImperativeHandle, useMemo, useState, forwardRef } from 'react'
 import {
+  BookOpen,
   ChevronRight,
   ChevronDown,
   Folder,
@@ -23,6 +24,12 @@ interface NotesTreeViewProps {
   // rendered outside the row's own button, since nesting a button in a
   // button is invalid HTML and swallows the click.
   renderFileAction?: (path: string) => React.ReactNode
+  // onOpenFolderIndex, when given, turns a folder that holds a
+  // README/index note into something you can open: the chevron still
+  // expands, and the extra control reads the folder's own page. Return
+  // undefined for folders without one and no control is rendered.
+  folderIndexPath?: (dir: string) => string | undefined
+  onOpenFolderIndex?: (path: string) => void
 }
 
 // Imperative handle exposed via ref so the parent's toolbar can drive
@@ -46,7 +53,15 @@ interface TreeNode {
 // needed (the /notes/list endpoint already returns the flat list).
 export const NotesTreeView = forwardRef<NotesTreeViewHandle, NotesTreeViewProps>(
   function NotesTreeView(
-    { notes, selected, onSelect, initialExpanded, renderFileAction },
+    {
+      notes,
+      selected,
+      onSelect,
+      initialExpanded,
+      renderFileAction,
+      folderIndexPath,
+      onOpenFolderIndex,
+    },
     ref,
   ) {
   const { t } = useTranslation()
@@ -110,6 +125,8 @@ export const NotesTreeView = forwardRef<NotesTreeViewHandle, NotesTreeViewProps>
             selected={selected ?? null}
             onSelect={onSelect}
             renderFileAction={renderFileAction}
+            folderIndexPath={folderIndexPath}
+            onOpenFolderIndex={onOpenFolderIndex}
           />
         ))
       )}
@@ -125,6 +142,8 @@ function TreeRow({
   selected,
   onSelect,
   renderFileAction,
+  folderIndexPath,
+  onOpenFolderIndex,
 }: {
   node: TreeNode
   depth: number
@@ -133,39 +152,55 @@ function TreeRow({
   selected: string | null
   onSelect: (path: string) => void
   renderFileAction?: (path: string) => React.ReactNode
+  folderIndexPath?: (dir: string) => string | undefined
+  onOpenFolderIndex?: (path: string) => void
 }) {
+  const { t } = useTranslation()
   const indent = { paddingLeft: `${depth * 12 + 4}px` }
   const isOpen = expanded.has(node.path)
 
   if (node.isDir) {
+    const indexPath = folderIndexPath?.(node.path)
     return (
       <div className="flex flex-col">
-        <button
-          type="button"
-          onClick={() => {
-            const next = new Set(expanded)
-            if (isOpen) next.delete(node.path)
-            else next.add(node.path)
-            setExpanded(next)
-          }}
-          style={indent}
-          className={cn(
-            'flex items-center gap-1 py-0.5 pr-1 rounded-sm text-left',
-            'hover:bg-card text-foreground/85',
+        <div className="group flex items-center rounded-sm hover:bg-card">
+          <button
+            type="button"
+            onClick={() => {
+              const next = new Set(expanded)
+              if (isOpen) next.delete(node.path)
+              else next.add(node.path)
+              setExpanded(next)
+            }}
+            style={indent}
+            className={cn(
+              'flex min-w-0 flex-1 items-center gap-1 py-0.5 pr-1 text-left',
+              'text-foreground/85',
+            )}
+            title={node.path}
+          >
+            {isOpen ? (
+              <ChevronDown className="size-3 shrink-0 opacity-60" />
+            ) : (
+              <ChevronRight className="size-3 shrink-0 opacity-60" />
+            )}
+            <Folder className="size-3 shrink-0 text-muted-foreground" />
+            <span className="truncate">{node.name}</span>
+            <span className="ml-1 text-[10px] text-muted-foreground/50">
+              {node.children.size}
+            </span>
+          </button>
+          {indexPath && onOpenFolderIndex && (
+            <button
+              type="button"
+              onClick={() => onOpenFolderIndex(indexPath)}
+              className="shrink-0 px-1 text-muted-foreground hover:text-foreground"
+              title={`${t('web.sessions.inspector.vaultPanel.openFolderIndexTitle')} — ${indexPath}`}
+            >
+              <BookOpen className="size-3" />
+            </button>
           )}
-          title={node.path}
-        >
-          {isOpen ? (
-            <ChevronDown className="size-3 shrink-0 opacity-60" />
-          ) : (
-            <ChevronRight className="size-3 shrink-0 opacity-60" />
-          )}
-          <Folder className="size-3 shrink-0 text-muted-foreground" />
-          <span className="truncate">{node.name}</span>
-          <span className="ml-1 text-[10px] text-muted-foreground/50">
-            {node.children.size}
-          </span>
-        </button>
+        </div>
         {isOpen && (
           <div className="flex flex-col">
             {Array.from(node.children.values()).map((child) => (
@@ -178,6 +213,8 @@ function TreeRow({
                 selected={selected}
                 onSelect={onSelect}
                 renderFileAction={renderFileAction}
+                folderIndexPath={folderIndexPath}
+                onOpenFolderIndex={onOpenFolderIndex}
               />
             ))}
           </div>

--- a/app/web/src/components/sessions/inspector/VaultPanel.tsx
+++ b/app/web/src/components/sessions/inspector/VaultPanel.tsx
@@ -29,13 +29,15 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import {
+  folderIndexPath,
+  listNoteTemplates,
   listNotes,
   moveNote,
+  newNoteFromTemplate,
   notesProjectMapping,
   personalNotePath,
   sanitizeNotePath,
   setNotesProjectMapping,
-  writeNote,
   type Note,
 } from '@/lib/notes'
 import { cn } from '@/lib/utils'
@@ -164,6 +166,7 @@ function ProjectDocsSection({
   // different question than finding where a doc lives.
   const [view, setView] = useState<'tree' | 'recent'>('tree')
   const [renaming, setRenaming] = useState<{ from: string; value: string } | null>(null)
+  const [template, setTemplate] = useState('blank')
 
   const mappingQ = useQuery({
     queryKey: ['notes-project-mapping', cwd],
@@ -204,6 +207,12 @@ function ProjectDocsSection({
   )
   const toFullPath = (rel: string) => (prefix ? `${prefix}/${rel}` : rel)
 
+  const templatesQ = useQuery({
+    queryKey: ['note-templates'],
+    queryFn: listNoteTemplates,
+    staleTime: 5 * 60_000,
+  })
+
   const create = useMutation({
     mutationFn: (filename: string) => {
       // Slashes are kept: typing `features/canvas.md` files the doc in
@@ -211,7 +220,9 @@ function ProjectDocsSection({
       const name = sanitizeNotePath(filename)
       const dir = prefix.endsWith('/') ? prefix : `${prefix}/`
       const path = `${dir}${name}`
-      return writeNote(path, `# ${stripExt(fileBase(name))}\n\n`).then(() => path)
+      // Placeholders render server-side, so a doc created here and one
+      // created from the phone come out identical.
+      return newNoteFromTemplate(path, template).then(() => path)
     },
     onSuccess: (path) => {
       setNewName('')
@@ -301,7 +312,34 @@ function ProjectDocsSection({
       />
 
       {creating && (
-        <div className="flex gap-1.5">
+        <div className="flex flex-col gap-1.5">
+          <div className="flex flex-wrap items-center gap-1">
+            <span className="text-[10px] text-muted-foreground/70 mr-0.5">
+              {t('web.sessions.inspector.vaultPanel.templateLabel')}
+            </span>
+            {(templatesQ.data ?? []).map((tpl) => (
+              <button
+                key={tpl.id}
+                type="button"
+                onClick={() => setTemplate(tpl.id)}
+                title={
+                  tpl.source === 'vault'
+                    ? t('web.sessions.inspector.vaultPanel.templateFromVault')
+                    : undefined
+                }
+                className={cn(
+                  'rounded border px-1.5 py-0.5 text-[10.5px]',
+                  template === tpl.id
+                    ? 'border-accent/60 bg-accent/10 text-foreground'
+                    : 'border-border text-muted-foreground hover:text-foreground',
+                )}
+              >
+                {tpl.name}
+                {tpl.source === 'vault' && ' *'}
+              </button>
+            ))}
+          </div>
+          <div className="flex gap-1.5">
           <Input
             value={newName}
             autoFocus
@@ -324,6 +362,7 @@ function ProjectDocsSection({
               t('web.sessions.inspector.vaultPanel.create')
             )}
           </Button>
+          </div>
         </div>
       )}
 
@@ -385,6 +424,10 @@ function ProjectDocsSection({
               notes={relDocs}
               onSelect={(rel) => onOpenDoc(toFullPath(rel))}
               initialExpanded={new Set(topFolders(relDocs))}
+              folderIndexPath={(dir) =>
+                folderIndexPath(dir, relDocs.map((d) => d.path))
+              }
+              onOpenFolderIndex={(rel) => onOpenDoc(toFullPath(rel))}
               renderFileAction={(rel) => (
                 <button
                   type="button"
@@ -639,11 +682,3 @@ function topFolders(notes: Note[]): string[] {
   return Array.from(set)
 }
 
-function fileBase(p: string): string {
-  const i = p.lastIndexOf('/')
-  return i === -1 ? p : p.slice(i + 1)
-}
-
-function stripExt(name: string): string {
-  return name.toLowerCase().endsWith('.md') ? name.slice(0, -3) : name
-}

--- a/internal/notes/handler.go
+++ b/internal/notes/handler.go
@@ -33,6 +33,8 @@ func (h *Handlers) Mount(r chi.Router) {
 		r.Post("/append", h.append_)
 		r.Delete("/delete", h.delete)
 		r.Post("/move", h.move)
+		r.Get("/templates", h.templates)
+		r.Post("/new", h.newFromTemplate)
 		r.Get("/backlinks", h.backlinks)
 		r.Get("/tags", h.tags)
 		r.Get("/project-mapping", h.projectMappingGet)
@@ -117,6 +119,38 @@ func (h *Handlers) delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// templates lists the shapes a new note can start from. Rendering is
+// server-side (see templates.go), so this is the clients' only source
+// of truth for what exists.
+func (h *Handlers) templates(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{"templates": h.v.Templates()})
+}
+
+// newFromTemplate creates a note from a template. Distinct from /write
+// because it refuses to overwrite — "new" that silently replaces an
+// existing doc loses work to a mistyped filename.
+func (h *Handlers) newFromTemplate(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Path     string `json:"path"`
+		Template string `json:"template"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	path := strings.TrimSpace(req.Path)
+	if path == "" {
+		writeError(w, http.StatusBadRequest, errors.New("path is required"))
+		return
+	}
+	n, err := h.v.NewFromTemplate(path, strings.TrimSpace(req.Template))
+	if err != nil {
+		respond(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, n)
 }
 
 // move renames/relocates a note and repoints the wiki-links that

--- a/internal/notes/templates.go
+++ b/internal/notes/templates.go
@@ -1,0 +1,254 @@
+package notes
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Templates exist so a project's docs come out looking like each other.
+// The alternative — every doc starting from an empty file — is how a
+// vault ends up with five different ideas of what a feature note is.
+//
+// Rendering happens HERE, not in the clients. The frontmatter carries a
+// date and a title derived from the path, and asking web and mobile to
+// each substitute those correctly is asking them to drift; this repo
+// has watched that happen before. One endpoint, one implementation.
+//
+// Built-ins are a starting point, not a policy: dropping
+// `_templates/<id>.md` in the vault overrides one, and adding a new
+// file there adds a template. A project whose docs want a different
+// shape shouldn't need a gateway release.
+
+// TemplateDir is the vault folder scanned for user-authored templates.
+// Leading underscore keeps it sorting away from real notes and hints
+// that it isn't documentation itself.
+const TemplateDir = "_templates"
+
+// Template is one starting shape for a new note.
+type Template struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// Source is "builtin" or "vault", so the UI can show which
+	// templates the operator has taken ownership of.
+	Source string `json:"source"`
+	// Body is the raw, unrendered content. Exposed so a client can
+	// preview a template without creating a file.
+	Body string `json:"body"`
+}
+
+// Placeholders substituted at render time. Deliberately few: a template
+// nobody can predict the output of is worse than no template.
+//
+//	{{title}}  Title-cased filename, e.g. "host-power.md" → "Host power"
+//	{{slug}}   Bare filename without extension, e.g. "host-power"
+//	{{date}}   Today, YYYY-MM-DD, host-local
+//	{{path}}   Vault-relative path of the note being created
+const (
+	phTitle = "{{title}}"
+	phSlug  = "{{slug}}"
+	phDate  = "{{date}}"
+	phPath  = "{{path}}"
+)
+
+// builtinTemplates are the shapes opendray's own project docs use.
+var builtinTemplates = []Template{
+	{
+		ID:     "blank",
+		Name:   "Blank",
+		Source: "builtin",
+		Body:   "# {{title}}\n\n",
+	},
+	{
+		ID:     "feature",
+		Name:   "Feature",
+		Source: "builtin",
+		Body: `---
+type: feature
+status: draft
+created: {{date}}
+---
+
+# {{title}}
+
+<!-- What problem does this solve, for whom? Lead with the problem,
+     not the mechanism. -->
+
+## How it works
+
+## Configuration
+
+## Gotchas
+
+<!-- What will surprise the next person? Prefer writing the trap down
+     over trusting they won't fall in it. -->
+`,
+	},
+	{
+		ID:     "decision",
+		Name:   "Decision (ADR)",
+		Source: "builtin",
+		Body: `---
+type: decision
+status: proposed
+created: {{date}}
+---
+
+# {{title}}
+
+## Context
+
+<!-- What forced a decision? What was true at the time? -->
+
+## Decision
+
+## Consequences
+
+<!-- Including the ones you don't like. A decision record that only
+     lists upsides isn't one. -->
+
+## Alternatives considered
+`,
+	},
+	{
+		ID:     "runbook",
+		Name:   "Runbook",
+		Source: "builtin",
+		Body: `---
+type: runbook
+created: {{date}}
+---
+
+# {{title}}
+
+## When to use this
+
+## Steps
+
+1.
+
+## Verification
+
+<!-- How do you know it worked? An unverifiable runbook is a wish. -->
+
+## If it goes wrong
+`,
+	},
+}
+
+// Templates returns the available templates, vault overrides merged
+// over the built-ins and sorted so "blank" leads.
+func (v *Vault) Templates() []Template {
+	byID := map[string]Template{}
+	order := []string{}
+	for _, t := range builtinTemplates {
+		byID[t.ID] = t
+		order = append(order, t.ID)
+	}
+
+	dir := filepath.Join(v.root, TemplateDir)
+	entries, err := os.ReadDir(dir)
+	if err == nil {
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(strings.ToLower(e.Name()), ".md") {
+				continue
+			}
+			body, err := os.ReadFile(filepath.Join(dir, e.Name()))
+			if err != nil {
+				continue
+			}
+			id := strings.TrimSuffix(e.Name(), filepath.Ext(e.Name()))
+			if _, seen := byID[id]; !seen {
+				order = append(order, id)
+			}
+			byID[id] = Template{
+				ID:     id,
+				Name:   titleCase(id),
+				Source: "vault",
+				Body:   string(body),
+			}
+		}
+	}
+
+	out := make([]Template, 0, len(order))
+	for _, id := range order {
+		out = append(out, byID[id])
+	}
+	// Built-in order is meaningful (blank first); vault-only additions
+	// trail it alphabetically rather than in readdir order.
+	builtinCount := 0
+	for _, t := range out {
+		if t.Source == "builtin" {
+			builtinCount++
+		}
+	}
+	tail := out[builtinCount:]
+	sort.Slice(tail, func(i, j int) bool { return tail[i].ID < tail[j].ID })
+	return out
+}
+
+// NewFromTemplate creates rel from the named template. It refuses to
+// overwrite: "new" that silently replaces an existing doc is a data
+// loss bug waiting for someone to retype a filename.
+func (v *Vault) NewFromTemplate(rel, templateID string) (Note, error) {
+	if err := requireMarkdown(rel); err != nil {
+		return Note{}, err
+	}
+	full, err := v.resolve(rel)
+	if err != nil {
+		return Note{}, err
+	}
+	if _, err := os.Stat(full); err == nil {
+		return Note{}, ErrAlreadyExists
+	} else if !os.IsNotExist(err) {
+		return Note{}, err
+	}
+
+	if templateID == "" {
+		templateID = "blank"
+	}
+	var tpl *Template
+	for _, t := range v.Templates() {
+		if t.ID == templateID {
+			tpl = &t
+			break
+		}
+	}
+	if tpl == nil {
+		return Note{}, fmt.Errorf("%w: unknown template %q", ErrInvalidPath, templateID)
+	}
+	return v.Write(rel, renderTemplate(tpl.Body, rel))
+}
+
+// renderTemplate substitutes the placeholders for one target path.
+func renderTemplate(body, rel string) string {
+	base := filepath.Base(rel)
+	slug := strings.TrimSuffix(base, filepath.Ext(base))
+	r := strings.NewReplacer(
+		phTitle, titleCase(slug),
+		phSlug, slug,
+		phDate, time.Now().Format("2006-01-02"),
+		phPath, rel,
+	)
+	return r.Replace(body)
+}
+
+// A folder's index page (README.md / index.md) is resolved client-side:
+// both surfaces already hold the full listing for the folder they are
+// rendering, so asking the gateway "does this folder have an index"
+// would be a round trip to re-derive what the caller can already see.
+
+// titleCase turns "host-power" into "Host power" — readable as a
+// heading without pretending to know English capitalisation rules.
+func titleCase(slug string) string {
+	s := strings.TrimSpace(strings.NewReplacer("-", " ", "_", " ").Replace(slug))
+	if s == "" {
+		return slug
+	}
+	runes := []rune(s)
+	runes[0] = []rune(strings.ToUpper(string(runes[0])))[0]
+	return string(runes)
+}

--- a/internal/notes/templates_test.go
+++ b/internal/notes/templates_test.go
@@ -1,0 +1,179 @@
+package notes
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTemplates_BuiltinsAndVaultOverrides(t *testing.T) {
+	v := newTestVault(t)
+
+	ids := map[string]Template{}
+	for _, tpl := range v.Templates() {
+		ids[tpl.ID] = tpl
+	}
+	for _, want := range []string{"blank", "feature", "decision", "runbook"} {
+		if _, ok := ids[want]; !ok {
+			t.Fatalf("built-in template %q missing", want)
+		}
+		if ids[want].Source != "builtin" {
+			t.Fatalf("%q source = %q, want builtin", want, ids[want].Source)
+		}
+	}
+	if got := v.Templates()[0].ID; got != "blank" {
+		t.Fatalf("first template = %q, want blank (it is the safe default)", got)
+	}
+
+	// A vault file takes over its id, and a new file adds one — the
+	// point being that a project can change the shape of its docs
+	// without a gateway release.
+	dir := filepath.Join(v.Root(), TemplateDir)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "feature.md"), []byte("MINE {{title}}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "postmortem.md"), []byte("# {{title}}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ids = map[string]Template{}
+	for _, tpl := range v.Templates() {
+		ids[tpl.ID] = tpl
+	}
+	if ids["feature"].Source != "vault" || !strings.HasPrefix(ids["feature"].Body, "MINE") {
+		t.Fatalf("vault override ignored: %+v", ids["feature"])
+	}
+	if _, ok := ids["postmortem"]; !ok {
+		t.Fatal("vault-only template not picked up")
+	}
+	if ids["blank"].Source != "builtin" {
+		t.Fatal("unrelated built-in was clobbered")
+	}
+}
+
+func TestNewFromTemplate_RendersPlaceholders(t *testing.T) {
+	v := newTestVault(t)
+	dir := filepath.Join(v.Root(), TemplateDir)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body := "t={{title}} s={{slug}} d={{date}} p={{path}}"
+	if err := os.WriteFile(filepath.Join(dir, "probe.md"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := v.NewFromTemplate("features/host-power.md", "probe"); err != nil {
+		t.Fatalf("NewFromTemplate: %v", err)
+	}
+	got := readFixture(t, v, "features/host-power.md")
+	want := "t=Host power s=host-power d=" + time.Now().Format("2006-01-02") +
+		" p=features/host-power.md"
+	if got != want {
+		t.Fatalf("rendered = %q, want %q", got, want)
+	}
+}
+
+// The template shapes are the product here; a feature note that comes
+// out without frontmatter isn't one.
+func TestNewFromTemplate_BuiltinShapes(t *testing.T) {
+	tests := []struct {
+		template string
+		contains []string
+	}{
+		{"feature", []string{"type: feature", "# Host power", "## Gotchas"}},
+		{"decision", []string{"type: decision", "## Context", "## Consequences"}},
+		{"runbook", []string{"type: runbook", "## Verification"}},
+		{"blank", []string{"# Host power"}},
+		{"", []string{"# Host power"}}, // empty = blank
+	}
+	for _, tt := range tests {
+		t.Run("template="+tt.template, func(t *testing.T) {
+			v := newTestVault(t)
+			if _, err := v.NewFromTemplate("host-power.md", tt.template); err != nil {
+				t.Fatalf("NewFromTemplate: %v", err)
+			}
+			got := readFixture(t, v, "host-power.md")
+			for _, want := range tt.contains {
+				if !strings.Contains(got, want) {
+					t.Fatalf("missing %q in:\n%s", want, got)
+				}
+			}
+			if strings.Contains(got, "{{") {
+				t.Fatalf("unrendered placeholder left behind:\n%s", got)
+			}
+		})
+	}
+}
+
+func TestNewFromTemplate_Rejects(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		template string
+		setup    func(*Vault)
+		wantErr  error
+	}{
+		{
+			name:     "existing note is never overwritten",
+			path:     "a.md",
+			template: "feature",
+			setup:    func(v *Vault) { writeFixture(nil, v, "a.md", "PRECIOUS") },
+			wantErr:  ErrAlreadyExists,
+		},
+		{
+			name:     "unknown template",
+			path:     "a.md",
+			template: "nope",
+			wantErr:  ErrInvalidPath,
+		},
+		{
+			name:     "escape attempt",
+			path:     "../a.md",
+			template: "blank",
+			wantErr:  ErrPathEscape,
+		},
+		{
+			name:     "non markdown",
+			path:     "a.txt",
+			template: "blank",
+			wantErr:  ErrNotMarkdown,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := newTestVault(t)
+			if tt.setup != nil {
+				tt.setup(v)
+			}
+			_, err := v.NewFromTemplate(tt.path, tt.template)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr == ErrAlreadyExists {
+				if got := readFixture(t, v, tt.path); got != "PRECIOUS" {
+					t.Fatalf("existing note was modified: %q", got)
+				}
+			}
+		})
+	}
+}
+
+func TestTitleCase(t *testing.T) {
+	tests := map[string]string{
+		"host-power":   "Host power",
+		"canvas":       "Canvas",
+		"my_note_here": "My note here",
+		"":             "",
+	}
+	for in, want := range tests {
+		if got := titleCase(in); got != want {
+			t.Fatalf("titleCase(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Completes the vault work. #495 made folders creatable and docs movable; this makes what goes *in* them consistent.

**Do not merge yet — awaiting the operator's hands-on verification.**

## Templates

Every new doc previously started as an empty file with a heading. That is how a vault accumulates five different ideas of what a feature note is.

- `GET /notes/templates` — **Blank / Feature / Decision (ADR) / Runbook**
- `POST /notes/new` — create from one

**Rendering is server-side, deliberately.** The frontmatter carries a date and a title derived from the filename. Asking web and mobile to each substitute those correctly is asking them to drift, and this repo has watched that happen. One implementation, one endpoint, both surfaces call it — a doc started on the phone and one started on the web come out byte-identical.

**Templates are a starting point, not a policy.** Dropping `_templates/<id>.md` in the vault overrides a built-in or adds a new one, so a project whose docs want a different shape doesn't need a gateway release. Vault-authored templates are marked with `*` in the picker.

`/new` is separate from `/write` rather than a flag on it, because it must **refuse to overwrite** — "new" that silently replaces an existing doc loses work to a mistyped filename.

## Folder index pages

A folder holding `README.md` (or `index.md`) gets a control that opens it, so a directory can say what lives in it instead of being a bare row of chevrons. The chevron still expands; the index is a separate affordance, so neither gesture hijacks the other.

Resolved **client-side**: both surfaces already hold the listing they are rendering, so asking the gateway "does this folder have an index" would be a round trip to re-derive what the caller can already see. No new endpoint.

## Test plan

- [x] `go test -race ./internal/notes` — built-ins present with `blank` first; vault file overrides a built-in id while leaving others alone; vault-only file adds a template; all four placeholders render (`{{title}}` → `Host power`, `{{slug}}`, `{{date}}`, `{{path}}`); each built-in produces its expected frontmatter and sections with no placeholder left behind; rejects table for existing-note (asserting the existing content is untouched), unknown template, `..` escape, non-markdown
- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] `tsc --noEmit` + `pnpm build` clean; dead helpers removed now that the server renders the title
- [x] `flutter analyze` — no issues
- [x] `check-i18n-parity.mjs` — es/zh 100%; one key that turned out unused was removed rather than left behind

## What to check by hand

1. **New doc → pick "Feature" → `features/host-power.md`** — lands in the folder, with frontmatter, `# Host power`, today's date.
2. **Existing filename** — refused, and the existing doc is untouched.
3. **A folder with a README** — the book icon appears and opens it; the chevron still just expands.
4. **Custom template** — drop `_templates/postmortem.md` in the vault, reopen the picker, it appears marked `*`.
5. **Both surfaces** — create the same doc from web and from the phone; the output should be identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)