### PR TITLE
refactor(i18n): rename the Cortex tier to Brief, settle Vault's name

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -30,7 +30,6 @@
   "nav": {
     "sessions": "Sessions",
     "memory": "Memory",
-    "notes": "Notes",
     "more": "More",
     "activity": "Activity",
     "providers": "Providers",
@@ -3067,7 +3066,7 @@
         "subtitle": "One module, three rungs, one loop: raw memory crystallises into each project's official doc, distils into cross-project knowledge, and is injected back into every new session.",
         "disabled": "disabled",
         "pendingProposals": "{count} pending",
-        "loopHint": "Memory → Notes → Knowledge → injected back into every spawn. Promotion is transformation, never copy.",
+        "loopHint": "Memory → Brief → Knowledge → injected back into every spawn. Promotion is transformation, never copy.",
         "activeProjects": "Active projects",
         "idle": "idle {days}d",
         "memory": {
@@ -3076,8 +3075,8 @@
           "quarantine": "{count} quarantined"
         },
         "notes": {
-          "title": "Notes",
-          "description": "Each project's official document — blueprint-shaped sections the AI keeps current as you work.",
+          "title": "Brief",
+          "description": "Each project's live brief — blueprint-shaped sections the AI keeps current as you work.",
           "projects": "{count} active"
         },
         "knowledge": {
@@ -3087,7 +3086,7 @@
         "settings": "Settings",
         "proposals": {
           "title": "Pending proposals ({count})",
-          "hint": "AI-proposed updates to project notes and KB pages, waiting for your verdict. Approve to publish, reject to drop.",
+          "hint": "AI-proposed updates to project briefs and KB pages, waiting for your verdict. Approve to publish, reject to drop.",
           "kbLabel": "Knowledge Base",
           "preview": "Preview",
           "hide": "Hide",
@@ -3449,7 +3448,7 @@
       },
       "cortexHub": {
         "title": "Cortex",
-        "subtitle": "Memory → Notes → Knowledge hub + pending proposals"
+        "subtitle": "Memory → Brief → Knowledge hub + pending proposals"
       },
       "projectMemory": {
         "title": "Project goal / plan / journal",
@@ -3481,7 +3480,7 @@
       },
       "vault": {
         "title": "Vault",
-        "subtitle": "Freeform markdown notes (Obsidian-sync)"
+        "subtitle": "Freeform markdown docs (folders, wiki-links, git sync)"
       },
       "roundTable": {
         "title": "Round Table",
@@ -4914,7 +4913,7 @@
     "failedToLoad": "Failed to load custom tasks"
   },
   "notesPage": {
-    "title": "Notes",
+    "title": "Vault",
     "newButton": "New",
     "newNoteDialogTitle": "New note",
     "searchHint": "Search across the whole vault…",
@@ -5368,15 +5367,15 @@
   },
   "cortexHub": {
     "title": "Cortex",
-    "subtitle": "The experience flywheel: Memory → Notes → Knowledge, fed back into every session.",
+    "subtitle": "The experience flywheel: Memory → Brief → Knowledge, fed back into every session.",
     "idleBadge": "idle {days}d",
     "activeProjectsBadge": "{count} active",
     "activeProjectsTitle": "Active projects",
-    "loopHint": "Sessions feed Memory → Memory distills into Notes → Notes compound into Knowledge → Knowledge guides every new session.",
+    "loopHint": "Sessions feed Memory → Memory distills into a Brief → Briefs compound into Knowledge → Knowledge guides every new session.",
     "settings": "Settings",
     "memory": "Memory",
     "memoryDesc": "Raw cross-session facts the agents store and recall.",
-    "notes": "Notes",
+    "notes": "Brief",
     "notesDesc": "Each project’s official goal / plan / journal.",
     "knowledge": "Knowledge",
     "knowledgeDesc": "Cross-project, distilled expertise.",
@@ -5384,7 +5383,7 @@
     "pendingBadge": "{count} pending",
     "disabled": "disabled",
     "inboxTitle": "Pending proposals ({count})",
-    "inboxHint": "AI-proposed updates to project notes and KB pages. Approve to publish, reject to drop.",
+    "inboxHint": "AI-proposed updates to project briefs and KB pages. Approve to publish, reject to drop.",
     "kbLabel": "Knowledge Base",
     "preview": "Preview",
     "hide": "Hide",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -30,7 +30,6 @@
   "nav": {
     "sessions": "Sessions",
     "memory": "Memoria",
-    "notes": "Notas",
     "more": "Más",
     "activity": "Actividad",
     "providers": "Proveedores",
@@ -3067,7 +3066,7 @@
         "subtitle": "Un módulo, tres peldaños, un ciclo: la memoria bruta cristaliza en el documento oficial de cada proyecto, se destila en conocimiento entre proyectos y se inyecta en cada nueva sesión.",
         "disabled": "desactivado",
         "pendingProposals": "{count} pendientes",
-        "loopHint": "Memoria → Notas → Conocimiento → inyectado en cada arranque. Ascender es transformar, nunca copiar.",
+        "loopHint": "Memoria → Informe → Conocimiento → inyectado en cada arranque. Promover es transformar, nunca copiar.",
         "activeProjects": "Proyectos activos",
         "idle": "inactivo {days}d",
         "memory": {
@@ -3076,8 +3075,8 @@
           "quarantine": "{count} en cuarentena"
         },
         "notes": {
-          "title": "Notas",
-          "description": "El documento oficial de cada proyecto — secciones según su plano, mantenidas por la IA mientras trabajas.",
+          "title": "Informe",
+          "description": "El informe vivo de cada proyecto: secciones con forma de plano que la IA mantiene al día mientras trabajas.",
           "projects": "{count} activos"
         },
         "knowledge": {
@@ -3087,7 +3086,7 @@
         "settings": "Ajustes",
         "proposals": {
           "title": "Propuestas pendientes ({count})",
-          "hint": "Actualizaciones propuestas por la IA para notas de proyecto y páginas KB, a la espera de tu veredicto. Aprueba para publicar, rechaza para descartar.",
+          "hint": "Actualizaciones propuestas por la IA a los informes de proyecto y páginas del KB, a la espera de tu veredicto. Aprobar publica, rechazar descarta.",
           "kbLabel": "Base de conocimiento",
           "preview": "Vista previa",
           "hide": "Ocultar",
@@ -3449,7 +3448,7 @@
       },
       "cortexHub": {
         "title": "Cortex",
-        "subtitle": "Hub Memoria → Notas → Conocimiento + propuestas pendientes"
+        "subtitle": "Centro Memoria → Informe → Conocimiento + propuestas pendientes"
       },
       "projectMemory": {
         "title": "Objetivo / plan / diario del proyecto",
@@ -3481,7 +3480,7 @@
       },
       "vault": {
         "title": "Bóveda",
-        "subtitle": "Notas markdown libres (sincronización Obsidian)"
+        "subtitle": "Documentos markdown libres (carpetas, wiki-links, sync git)"
       },
       "roundTable": {
         "title": "Mesa redonda",
@@ -4914,7 +4913,7 @@
     "failedToLoad": "Error al cargar las tareas personalizadas"
   },
   "notesPage": {
-    "title": "Notas",
+    "title": "Bóveda",
     "newButton": "Nueva",
     "newNoteDialogTitle": "Nueva nota",
     "searchHint": "Busca en todo el vault…",
@@ -5368,15 +5367,15 @@
   },
   "cortexHub": {
     "title": "Cortex",
-    "subtitle": "El volante de experiencia: Memoria → Notas → Conocimiento, realimentado en cada session.",
+    "subtitle": "El volante de experiencia: Memoria → Informe → Conocimiento, de vuelta a cada sesión.",
     "idleBadge": "inactivo {days}d",
     "activeProjectsBadge": "{count} activos",
     "activeProjectsTitle": "Proyectos activos",
-    "loopHint": "Las sesiones alimentan la Memoria → la Memoria se destila en Notas → las Notas se compilan en Conocimiento → el Conocimiento guía cada nueva sesión.",
+    "loopHint": "Las sesiones alimentan la Memoria → la Memoria se destila en un Informe → los Informes se consolidan en Conocimiento → el Conocimiento guía cada nueva sesión.",
     "settings": "Ajustes",
     "memory": "Memoria",
     "memoryDesc": "Hechos crudos entre sessions que los agentes guardan y recuerdan.",
-    "notes": "Notas",
+    "notes": "Informe",
     "notesDesc": "El objetivo / plan / diario oficial de cada proyecto.",
     "knowledge": "Conocimiento",
     "knowledgeDesc": "Experiencia destilada entre proyectos.",
@@ -5384,7 +5383,7 @@
     "pendingBadge": "{count} pendientes",
     "disabled": "desactivado",
     "inboxTitle": "Propuestas pendientes ({count})",
-    "inboxHint": "Actualizaciones propuestas por la IA para notas y páginas KB. Aprueba para publicar, rechaza para descartar.",
+    "inboxHint": "Actualizaciones propuestas por la IA a los informes de proyecto y páginas del KB. Aprobar publica, rechazar descarta.",
     "kbLabel": "Base de conocimiento",
     "preview": "Vista previa",
     "hide": "Ocultar",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -30,7 +30,6 @@
   "nav": {
     "sessions": "会话",
     "memory": "记忆",
-    "notes": "笔记",
     "more": "更多",
     "activity": "活动",
     "providers": "提供方",
@@ -3067,7 +3066,7 @@
         "subtitle": "一个模块、三层一环：原始记忆结晶为各项目的官方文档，再蒸馏为跨项目知识，并注入每个新会话。",
         "disabled": "未启用",
         "pendingProposals": "{count} 个待审",
-        "loopHint": "记忆 → 笔记 → 知识 → 注入每次启动。层级提升是转化，绝不是复制。",
+        "loopHint": "记忆 → 简报 → 知识 → 注入每次启动。层级提升是转化，绝不是复制。",
         "activeProjects": "活跃项目",
         "idle": "闲置 {days} 天",
         "memory": {
@@ -3076,8 +3075,8 @@
           "quarantine": "{count} 条隔离中"
         },
         "notes": {
-          "title": "笔记",
-          "description": "每个项目的官方文档——按蓝图组织章节，AI 随工作进展持续维护。",
+          "title": "简报",
+          "description": "每个项目的实时简报——按蓝图组织章节，AI 随工作进展持续维护。",
           "projects": "{count} 个活跃"
         },
         "knowledge": {
@@ -3087,7 +3086,7 @@
         "settings": "设置",
         "proposals": {
           "title": "待审提案（{count}）",
-          "hint": "AI 对项目笔记与知识库页面提出的更新，等待你的裁决。批准即发布，拒绝即丢弃。",
+          "hint": "AI 对项目简报与知识库页面提出的更新，等待你的裁决。批准即发布，拒绝即丢弃。",
           "kbLabel": "知识库",
           "preview": "预览",
           "hide": "收起",
@@ -3449,7 +3448,7 @@
       },
       "cortexHub": {
         "title": "Cortex",
-        "subtitle": "记忆 → 笔记 → 知识中枢 + 待审提案"
+        "subtitle": "记忆 → 简报 → 知识中枢 + 待审提案"
       },
       "projectMemory": {
         "title": "项目目标 / 计划 / 日志",
@@ -3481,7 +3480,7 @@
       },
       "vault": {
         "title": "文档库",
-        "subtitle": "自由 markdown 笔记(Obsidian 同步)"
+        "subtitle": "自由 markdown 文档(目录、wiki 链接、git 同步)"
       },
       "roundTable": {
         "title": "圆桌",
@@ -4914,7 +4913,7 @@
     "failedToLoad": "加载自定义任务失败"
   },
   "notesPage": {
-    "title": "笔记",
+    "title": "文档库",
     "newButton": "新建",
     "newNoteDialogTitle": "新建笔记",
     "searchHint": "搜索整个仓库…",
@@ -5368,15 +5367,15 @@
   },
   "cortexHub": {
     "title": "Cortex",
-    "subtitle": "经验飞轮：记忆 → 笔记 → 知识，回流到每个会话。",
+    "subtitle": "经验飞轮：记忆 → 简报 → 知识，回流到每个会话。",
     "idleBadge": "闲置 {days} 天",
     "activeProjectsBadge": "{count} 个活跃",
     "activeProjectsTitle": "活跃项目",
-    "loopHint": "会话喂养记忆 → 记忆提炼为笔记 → 笔记沉淀为知识 → 知识引导每个新会话。",
+    "loopHint": "会话喂养记忆 → 记忆提炼为简报 → 简报沉淀为知识 → 知识引导每个新会话。",
     "settings": "设置",
     "memory": "记忆",
     "memoryDesc": "代理存取的跨会话原始事实。",
-    "notes": "笔记",
+    "notes": "简报",
     "notesDesc": "每个项目的官方目标 / 计划 / 日志。",
     "knowledge": "知识",
     "knowledgeDesc": "跨项目沉淀的专业知识。",
@@ -5384,7 +5383,7 @@
     "pendingBadge": "{count} 条待审",
     "disabled": "已禁用",
     "inboxTitle": "待审提案（{count}）",
-    "inboxHint": "AI 对项目笔记与知识库页面提出的更新。批准即发布，拒绝即丢弃。",
+    "inboxHint": "AI 对项目简报与知识库页面提出的更新。批准即发布，拒绝即丢弃。",
     "kbLabel": "知识库",
     "preview": "预览",
     "hide": "收起",

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 13005 (4335 per locale)
+/// Strings: 13002 (4334 per locale)
 ///
-/// Built on 2026-08-07 at 11:28 UTC
+/// Built on 2026-08-07 at 13:15 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -177,9 +177,6 @@ class TranslationsNavEn {
 	/// en: 'Memory'
 	String get memory => 'Memory';
 
-	/// en: 'Notes'
-	String get notes => 'Notes';
-
 	/// en: 'More'
 	String get more => 'More';
 
@@ -1885,8 +1882,8 @@ class TranslationsNotesPageEn {
 
 	// Translations
 
-	/// en: 'Notes'
-	String get title => 'Notes';
+	/// en: 'Vault'
+	String get title => 'Vault';
 
 	/// en: 'New'
 	String get newButton => 'New';
@@ -2167,8 +2164,8 @@ class TranslationsCortexHubEn {
 	/// en: 'Cortex'
 	String get title => 'Cortex';
 
-	/// en: 'The experience flywheel: Memory → Notes → Knowledge, fed back into every session.'
-	String get subtitle => 'The experience flywheel: Memory → Notes → Knowledge, fed back into every session.';
+	/// en: 'The experience flywheel: Memory → Brief → Knowledge, fed back into every session.'
+	String get subtitle => 'The experience flywheel: Memory → Brief → Knowledge, fed back into every session.';
 
 	/// en: 'idle {days}d'
 	String idleBadge({required Object days}) => 'idle ${days}d';
@@ -2179,8 +2176,8 @@ class TranslationsCortexHubEn {
 	/// en: 'Active projects'
 	String get activeProjectsTitle => 'Active projects';
 
-	/// en: 'Sessions feed Memory → Memory distills into Notes → Notes compound into Knowledge → Knowledge guides every new session.'
-	String get loopHint => 'Sessions feed Memory → Memory distills into Notes → Notes compound into Knowledge → Knowledge guides every new session.';
+	/// en: 'Sessions feed Memory → Memory distills into a Brief → Briefs compound into Knowledge → Knowledge guides every new session.'
+	String get loopHint => 'Sessions feed Memory → Memory distills into a Brief → Briefs compound into Knowledge → Knowledge guides every new session.';
 
 	/// en: 'Settings'
 	String get settings => 'Settings';
@@ -2191,8 +2188,8 @@ class TranslationsCortexHubEn {
 	/// en: 'Raw cross-session facts the agents store and recall.'
 	String get memoryDesc => 'Raw cross-session facts the agents store and recall.';
 
-	/// en: 'Notes'
-	String get notes => 'Notes';
+	/// en: 'Brief'
+	String get notes => 'Brief';
 
 	/// en: 'Each project’s official goal / plan / journal.'
 	String get notesDesc => 'Each project’s official goal / plan / journal.';
@@ -2215,8 +2212,8 @@ class TranslationsCortexHubEn {
 	/// en: 'Pending proposals ({count})'
 	String inboxTitle({required Object count}) => 'Pending proposals (${count})';
 
-	/// en: 'AI-proposed updates to project notes and KB pages. Approve to publish, reject to drop.'
-	String get inboxHint => 'AI-proposed updates to project notes and KB pages. Approve to publish, reject to drop.';
+	/// en: 'AI-proposed updates to project briefs and KB pages. Approve to publish, reject to drop.'
+	String get inboxHint => 'AI-proposed updates to project briefs and KB pages. Approve to publish, reject to drop.';
 
 	/// en: 'Knowledge Base'
 	String get kbLabel => 'Knowledge Base';
@@ -11551,8 +11548,8 @@ class TranslationsWebCortexHomeEn {
 	/// en: '{count} pending'
 	String pendingProposals({required Object count}) => '${count} pending';
 
-	/// en: 'Memory → Notes → Knowledge → injected back into every spawn. Promotion is transformation, never copy.'
-	String get loopHint => 'Memory → Notes → Knowledge → injected back into every spawn. Promotion is transformation, never copy.';
+	/// en: 'Memory → Brief → Knowledge → injected back into every spawn. Promotion is transformation, never copy.'
+	String get loopHint => 'Memory → Brief → Knowledge → injected back into every spawn. Promotion is transformation, never copy.';
 
 	/// en: 'Active projects'
 	String get activeProjects => 'Active projects';
@@ -12496,8 +12493,8 @@ class TranslationsMoreItemsCortexHubEn {
 	/// en: 'Cortex'
 	String get title => 'Cortex';
 
-	/// en: 'Memory → Notes → Knowledge hub + pending proposals'
-	String get subtitle => 'Memory → Notes → Knowledge hub + pending proposals';
+	/// en: 'Memory → Brief → Knowledge hub + pending proposals'
+	String get subtitle => 'Memory → Brief → Knowledge hub + pending proposals';
 }
 
 // Path: more.items.projectMemory
@@ -12616,8 +12613,8 @@ class TranslationsMoreItemsVaultEn {
 	/// en: 'Vault'
 	String get title => 'Vault';
 
-	/// en: 'Freeform markdown notes (Obsidian-sync)'
-	String get subtitle => 'Freeform markdown notes (Obsidian-sync)';
+	/// en: 'Freeform markdown docs (folders, wiki-links, git sync)'
+	String get subtitle => 'Freeform markdown docs (folders, wiki-links, git sync)';
 }
 
 // Path: more.items.roundTable
@@ -18163,11 +18160,11 @@ class TranslationsWebCortexHomeNotesEn {
 
 	// Translations
 
-	/// en: 'Notes'
-	String get title => 'Notes';
+	/// en: 'Brief'
+	String get title => 'Brief';
 
-	/// en: 'Each project's official document — blueprint-shaped sections the AI keeps current as you work.'
-	String get description => 'Each project\'s official document — blueprint-shaped sections the AI keeps current as you work.';
+	/// en: 'Each project's live brief — blueprint-shaped sections the AI keeps current as you work.'
+	String get description => 'Each project\'s live brief — blueprint-shaped sections the AI keeps current as you work.';
 
 	/// en: '{count} active'
 	String projects({required Object count}) => '${count} active';
@@ -18199,8 +18196,8 @@ class TranslationsWebCortexHomeProposalsEn {
 	/// en: 'Pending proposals ({count})'
 	String title({required Object count}) => 'Pending proposals (${count})';
 
-	/// en: 'AI-proposed updates to project notes and KB pages, waiting for your verdict. Approve to publish, reject to drop.'
-	String get hint => 'AI-proposed updates to project notes and KB pages, waiting for your verdict. Approve to publish, reject to drop.';
+	/// en: 'AI-proposed updates to project briefs and KB pages, waiting for your verdict. Approve to publish, reject to drop.'
+	String get hint => 'AI-proposed updates to project briefs and KB pages, waiting for your verdict. Approve to publish, reject to drop.';
 
 	/// en: 'Knowledge Base'
 	String get kbLabel => 'Knowledge Base';
@@ -18562,7 +18559,6 @@ extension on Translations {
 			'auth.errorFallback' => 'Login failed',
 			'nav.sessions' => 'Sessions',
 			'nav.memory' => 'Memory',
-			'nav.notes' => 'Notes',
 			'nav.more' => 'More',
 			'nav.activity' => 'Activity',
 			'nav.providers' => 'Providers',
@@ -19048,9 +19044,9 @@ extension on Translations {
 			'web.memoryWorkers.tasks.capture.label' => 'Capture engine',
 			'web.memoryWorkers.tasks.capture.description' => 'Per-trigger fact extraction from session transcripts. Agent mode gives noticeably better facts on long sessions; summarizer mode is cheap and local.',
 			'web.memoryWorkers.tasks.capture.modelAdvice' => 'Highest-frequency task: fact extraction every few messages — use the CHEAPEST model that works (haiku / local).',
+			'web.memoryWorkers.tasks.blueprint.modelAdvice' => 'Occasional, operator-triggered project classification — balanced model; quality matters more than cost here.',
 			_ => null,
 		} ?? switch (path) {
-			'web.memoryWorkers.tasks.blueprint.modelAdvice' => 'Occasional, operator-triggered project classification — balanced model; quality matters more than cost here.',
 			'web.memoryWorkers.tasks.blueprint.label' => 'Blueprint proposer',
 			'web.memoryWorkers.tasks.blueprint.description' => 'Classifies a project from repo signals and proposes its doc section set. Operator-triggered from the blueprint editor.',
 			'web.memoryWorkers.tasks.curation.modelAdvice' => 'Your conversational doc/policy editor — strong model recommended (sonnet/opus); it rewrites documents you rely on.',
@@ -19562,9 +19558,9 @@ extension on Translations {
 			'web.providers.detail.caps.images' => 'images',
 			'web.providers.detail.caps.mcp' => 'mcp',
 			'web.providers.detail.notInstalled' => 'not installed',
+			'web.providers.detail.brokenCli' => 'Installed but not runnable',
 			_ => null,
 		} ?? switch (path) {
-			'web.providers.detail.brokenCli' => 'Installed but not runnable',
 			'web.providers.detail.updateAvailable' => ({required Object version}) => 'update available → ${version}',
 			'web.providers.detail.upToDate' => 'up to date',
 			'web.providers.detail.update' => ({required Object version}) => 'Update to ${version}',
@@ -20076,9 +20072,9 @@ extension on Translations {
 			'web.backups.generated.copiedToast' => 'Passphrase copied to clipboard',
 			'web.backups.generated.copyFailedToast' => 'Copy failed — select and copy manually',
 			'web.backups.generated.savedTo' => 'Saved to:',
+			'web.backups.generated.ack' => 'I have saved this passphrase to my password manager',
 			_ => null,
 		} ?? switch (path) {
-			'web.backups.generated.ack' => 'I have saved this passphrase to my password manager',
 			'web.backups.generated.kContinue' => 'Continue',
 			'web.backups.status.pgDump' => 'pg_dump',
 			'web.backups.status.pgRestore' => 'pg_restore',
@@ -20590,9 +20586,9 @@ extension on Translations {
 			'web.settings.system.uptime' => 'Uptime',
 			'web.settings.system.database' => 'Database',
 			'web.settings.system.reachable' => 'reachable',
+			'web.settings.system.unreachable' => 'unreachable',
 			_ => null,
 		} ?? switch (path) {
-			'web.settings.system.unreachable' => 'unreachable',
 			'web.settings.about.title' => 'About',
 			'web.settings.about.description' => 'opendray v2 — the multiplexer + integration gateway for AI agent CLIs. Source under Apache 2.0.',
 			'web.settings.about.version' => 'Version',
@@ -20967,20 +20963,20 @@ extension on Translations {
 			'web.cortex.home.subtitle' => 'One module, three rungs, one loop: raw memory crystallises into each project\'s official doc, distils into cross-project knowledge, and is injected back into every new session.',
 			'web.cortex.home.disabled' => 'disabled',
 			'web.cortex.home.pendingProposals' => ({required Object count}) => '${count} pending',
-			'web.cortex.home.loopHint' => 'Memory → Notes → Knowledge → injected back into every spawn. Promotion is transformation, never copy.',
+			'web.cortex.home.loopHint' => 'Memory → Brief → Knowledge → injected back into every spawn. Promotion is transformation, never copy.',
 			'web.cortex.home.activeProjects' => 'Active projects',
 			'web.cortex.home.idle' => ({required Object days}) => 'idle ${days}d',
 			'web.cortex.home.memory.title' => 'Memory',
 			'web.cortex.home.memory.description' => 'Raw episodic facts captured from your sessions — recalled by relevance, quarantined when third-party.',
 			'web.cortex.home.memory.quarantine' => ({required Object count}) => '${count} quarantined',
-			'web.cortex.home.notes.title' => 'Notes',
-			'web.cortex.home.notes.description' => 'Each project\'s official document — blueprint-shaped sections the AI keeps current as you work.',
+			'web.cortex.home.notes.title' => 'Brief',
+			'web.cortex.home.notes.description' => 'Each project\'s live brief — blueprint-shaped sections the AI keeps current as you work.',
 			'web.cortex.home.notes.projects' => ({required Object count}) => '${count} active',
 			'web.cortex.home.knowledge.title' => 'Knowledge',
 			'web.cortex.home.knowledge.description' => 'Cross-project, iterable expertise: binding foundational rules + emergent lessons, injected into every spawn.',
 			'web.cortex.home.settings' => 'Settings',
 			'web.cortex.home.proposals.title' => ({required Object count}) => 'Pending proposals (${count})',
-			'web.cortex.home.proposals.hint' => 'AI-proposed updates to project notes and KB pages, waiting for your verdict. Approve to publish, reject to drop.',
+			'web.cortex.home.proposals.hint' => 'AI-proposed updates to project briefs and KB pages, waiting for your verdict. Approve to publish, reject to drop.',
 			'web.cortex.home.proposals.kbLabel' => 'Knowledge Base',
 			'web.cortex.home.proposals.preview' => 'Preview',
 			'web.cortex.home.proposals.hide' => 'Hide',
@@ -21104,9 +21100,9 @@ extension on Translations {
 			'web.database.grid.delete' => 'Delete',
 			'web.database.grid.deleted' => 'Row deleted',
 			'web.database.grid.confirmDelete' => 'Delete this row?',
+			'web.database.grid.loading' => 'Loading rows…',
 			_ => null,
 		} ?? switch (path) {
-			'web.database.grid.loading' => 'Loading rows…',
 			'web.database.grid.readOnlyHint' => 'This connection is read-only — rows cannot be edited.',
 			'web.database.grid.noPkHint' => 'This table has no primary key — row editing is disabled.',
 			'web.database.grid.pageInfo' => ({required Object from, required Object to}) => 'Rows ${from}–${to}',
@@ -21261,7 +21257,7 @@ extension on Translations {
 			'more.items.customTasks.title' => 'Custom tasks',
 			'more.items.customTasks.subtitle' => 'Slash commands shown in the session task picker',
 			'more.items.cortexHub.title' => 'Cortex',
-			'more.items.cortexHub.subtitle' => 'Memory → Notes → Knowledge hub + pending proposals',
+			'more.items.cortexHub.subtitle' => 'Memory → Brief → Knowledge hub + pending proposals',
 			'more.items.projectMemory.title' => 'Project goal / plan / journal',
 			'more.items.projectMemory.subtitle' => 'Per-cwd memory layers 2-4 + agent proposals',
 			'more.items.archived.title' => 'Archived memories',
@@ -21277,7 +21273,7 @@ extension on Translations {
 			'more.items.about.title' => 'About',
 			'more.items.about.subtitle' => 'Build version & server info',
 			'more.items.vault.title' => 'Vault',
-			'more.items.vault.subtitle' => 'Freeform markdown notes (Obsidian-sync)',
+			'more.items.vault.subtitle' => 'Freeform markdown docs (folders, wiki-links, git sync)',
 			'more.items.roundTable.title' => 'Round Table',
 			'more.items.roundTable.subtitle' => 'Cross-vendor AI group chat',
 			'more.signOut' => 'Sign out',
@@ -21618,9 +21614,9 @@ extension on Translations {
 			'sessions.spawnSheet.bypass.labelOpencode' => 'Bypass permissions',
 			'sessions.spawnSheet.bypass.labelGrok' => 'Bypass permissions / YOLO (--always-approve)',
 			'sessions.spawnSheet.bypass.subtitleOn' => 'This session will run with elevated autonomy.',
+			'sessions.spawnSheet.bypass.subtitleOff' => 'Off — confirmations and prompts behave normally.',
 			_ => null,
 		} ?? switch (path) {
-			'sessions.spawnSheet.bypass.subtitleOff' => 'Off — confirmations and prompts behave normally.',
 			'sessions.spawnSheet.noProviders.title' => 'No providers configured',
 			'sessions.spawnSheet.noProviders.message' => 'The gateway has no CLI providers enabled. Configure one under Providers (web admin) or [providers] in config.toml, then tap Reload.',
 			'sessions.spawnSheet.noProviders.reload' => 'Reload',
@@ -22132,9 +22128,9 @@ extension on Translations {
 			'backups.restore.manifestTitle' => 'Manifest',
 			'backups.restore.manifestBackupId' => 'Backup ID',
 			'backups.restore.manifestVersion' => 'Manifest version',
+			'backups.restore.manifestCreatedAt' => 'Created',
 			_ => null,
 		} ?? switch (path) {
-			'backups.restore.manifestCreatedAt' => 'Created',
 			'backups.restore.manifestPgVersion' => 'pg_version',
 			'backups.restore.manifestOpendrayVersion' => 'opendray version',
 			'backups.restore.fingerprint' => 'Key fingerprint',
@@ -22478,7 +22474,7 @@ extension on Translations {
 			'customTasks.save' => 'Save',
 			'customTasks.create' => 'Create',
 			'customTasks.failedToLoad' => 'Failed to load custom tasks',
-			'notesPage.title' => 'Notes',
+			'notesPage.title' => 'Vault',
 			'notesPage.newButton' => 'New',
 			'notesPage.newNoteDialogTitle' => 'New note',
 			'notesPage.searchHint' => 'Search across the whole vault…',
@@ -22646,9 +22642,9 @@ extension on Translations {
 			'memory.quarantinedToast' => 'Memory quarantined — review under Cortex → Quarantine',
 			'memory.archiveFailed' => ({required Object error}) => 'Archive failed: ${error}',
 			'memory.quarantineFailed' => ({required Object error}) => 'Quarantine failed: ${error}',
+			'memory.reembed.menuItem' => 'Re-embed all',
 			_ => null,
 		} ?? switch (path) {
-			'memory.reembed.menuItem' => 'Re-embed all',
 			'memory.reembed.confirmTitle' => 'Re-embed all memories?',
 			'memory.reembed.confirmBody' => 'Re-encodes every stored memory and KB page with the current embedding model. Needed after switching models, since the vector dimension changes. This can take a while.',
 			'memory.reembed.confirmButton' => 'Re-embed',
@@ -22852,15 +22848,15 @@ extension on Translations {
 			'memoryQuarantine.expires' => ({required Object date}) => 'expires ${date}',
 			'memoryQuarantine.countBadge' => ({required Object count}) => '${count} pending',
 			'cortexHub.title' => 'Cortex',
-			'cortexHub.subtitle' => 'The experience flywheel: Memory → Notes → Knowledge, fed back into every session.',
+			'cortexHub.subtitle' => 'The experience flywheel: Memory → Brief → Knowledge, fed back into every session.',
 			'cortexHub.idleBadge' => ({required Object days}) => 'idle ${days}d',
 			'cortexHub.activeProjectsBadge' => ({required Object count}) => '${count} active',
 			'cortexHub.activeProjectsTitle' => 'Active projects',
-			'cortexHub.loopHint' => 'Sessions feed Memory → Memory distills into Notes → Notes compound into Knowledge → Knowledge guides every new session.',
+			'cortexHub.loopHint' => 'Sessions feed Memory → Memory distills into a Brief → Briefs compound into Knowledge → Knowledge guides every new session.',
 			'cortexHub.settings' => 'Settings',
 			'cortexHub.memory' => 'Memory',
 			'cortexHub.memoryDesc' => 'Raw cross-session facts the agents store and recall.',
-			'cortexHub.notes' => 'Notes',
+			'cortexHub.notes' => 'Brief',
 			'cortexHub.notesDesc' => 'Each project’s official goal / plan / journal.',
 			'cortexHub.knowledge' => 'Knowledge',
 			'cortexHub.knowledgeDesc' => 'Cross-project, distilled expertise.',
@@ -22868,7 +22864,7 @@ extension on Translations {
 			'cortexHub.pendingBadge' => ({required Object count}) => '${count} pending',
 			'cortexHub.disabled' => 'disabled',
 			'cortexHub.inboxTitle' => ({required Object count}) => 'Pending proposals (${count})',
-			'cortexHub.inboxHint' => 'AI-proposed updates to project notes and KB pages. Approve to publish, reject to drop.',
+			'cortexHub.inboxHint' => 'AI-proposed updates to project briefs and KB pages. Approve to publish, reject to drop.',
 			'cortexHub.kbLabel' => 'Knowledge Base',
 			'cortexHub.preview' => 'Preview',
 			'cortexHub.hide' => 'Hide',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -123,7 +123,6 @@ class _TranslationsNavEs extends TranslationsNavEn {
 	// Translations
 	@override String get sessions => 'Sessions';
 	@override String get memory => 'Memoria';
-	@override String get notes => 'Notas';
 	@override String get more => 'Más';
 	@override String get activity => 'Actividad';
 	@override String get providers => 'Proveedores';
@@ -866,7 +865,7 @@ class _TranslationsNotesPageEs extends TranslationsNotesPageEn {
 	final TranslationsEs _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Notas';
+	@override String get title => 'Bóveda';
 	@override String get newButton => 'Nueva';
 	@override String get newNoteDialogTitle => 'Nueva nota';
 	@override String get searchHint => 'Busca en todo el vault…';
@@ -1010,15 +1009,15 @@ class _TranslationsCortexHubEs extends TranslationsCortexHubEn {
 
 	// Translations
 	@override String get title => 'Cortex';
-	@override String get subtitle => 'El volante de experiencia: Memoria → Notas → Conocimiento, realimentado en cada session.';
+	@override String get subtitle => 'El volante de experiencia: Memoria → Informe → Conocimiento, de vuelta a cada sesión.';
 	@override String idleBadge({required Object days}) => 'inactivo ${days}d';
 	@override String activeProjectsBadge({required Object count}) => '${count} activos';
 	@override String get activeProjectsTitle => 'Proyectos activos';
-	@override String get loopHint => 'Las sesiones alimentan la Memoria → la Memoria se destila en Notas → las Notas se compilan en Conocimiento → el Conocimiento guía cada nueva sesión.';
+	@override String get loopHint => 'Las sesiones alimentan la Memoria → la Memoria se destila en un Informe → los Informes se consolidan en Conocimiento → el Conocimiento guía cada nueva sesión.';
 	@override String get settings => 'Ajustes';
 	@override String get memory => 'Memoria';
 	@override String get memoryDesc => 'Hechos crudos entre sessions que los agentes guardan y recuerdan.';
-	@override String get notes => 'Notas';
+	@override String get notes => 'Informe';
 	@override String get notesDesc => 'El objetivo / plan / diario oficial de cada proyecto.';
 	@override String get knowledge => 'Conocimiento';
 	@override String get knowledgeDesc => 'Experiencia destilada entre proyectos.';
@@ -1026,7 +1025,7 @@ class _TranslationsCortexHubEs extends TranslationsCortexHubEn {
 	@override String pendingBadge({required Object count}) => '${count} pendientes';
 	@override String get disabled => 'desactivado';
 	@override String inboxTitle({required Object count}) => 'Propuestas pendientes (${count})';
-	@override String get inboxHint => 'Actualizaciones propuestas por la IA para notas y páginas KB. Aprueba para publicar, rechaza para descartar.';
+	@override String get inboxHint => 'Actualizaciones propuestas por la IA a los informes de proyecto y páginas del KB. Aprobar publica, rechazar descarta.';
 	@override String get kbLabel => 'Base de conocimiento';
 	@override String get preview => 'Vista previa';
 	@override String get hide => 'Ocultar';
@@ -5893,7 +5892,7 @@ class _TranslationsWebCortexHomeEs extends TranslationsWebCortexHomeEn {
 	@override String get subtitle => 'Un módulo, tres peldaños, un ciclo: la memoria bruta cristaliza en el documento oficial de cada proyecto, se destila en conocimiento entre proyectos y se inyecta en cada nueva sesión.';
 	@override String get disabled => 'desactivado';
 	@override String pendingProposals({required Object count}) => '${count} pendientes';
-	@override String get loopHint => 'Memoria → Notas → Conocimiento → inyectado en cada arranque. Ascender es transformar, nunca copiar.';
+	@override String get loopHint => 'Memoria → Informe → Conocimiento → inyectado en cada arranque. Promover es transformar, nunca copiar.';
 	@override String get activeProjects => 'Proyectos activos';
 	@override String idle({required Object days}) => 'inactivo ${days}d';
 	@override late final _TranslationsWebCortexHomeMemoryEs memory = _TranslationsWebCortexHomeMemoryEs._(_root);
@@ -6374,7 +6373,7 @@ class _TranslationsMoreItemsCortexHubEs extends TranslationsMoreItemsCortexHubEn
 
 	// Translations
 	@override String get title => 'Cortex';
-	@override String get subtitle => 'Hub Memoria → Notas → Conocimiento + propuestas pendientes';
+	@override String get subtitle => 'Centro Memoria → Informe → Conocimiento + propuestas pendientes';
 }
 
 // Path: more.items.projectMemory
@@ -6462,7 +6461,7 @@ class _TranslationsMoreItemsVaultEs extends TranslationsMoreItemsVaultEn {
 
 	// Translations
 	@override String get title => 'Bóveda';
-	@override String get subtitle => 'Notas markdown libres (sincronización Obsidian)';
+	@override String get subtitle => 'Documentos markdown libres (carpetas, wiki-links, sync git)';
 }
 
 // Path: more.items.roundTable
@@ -9509,8 +9508,8 @@ class _TranslationsWebCortexHomeNotesEs extends TranslationsWebCortexHomeNotesEn
 	final TranslationsEs _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Notas';
-	@override String get description => 'El documento oficial de cada proyecto — secciones según su plano, mantenidas por la IA mientras trabajas.';
+	@override String get title => 'Informe';
+	@override String get description => 'El informe vivo de cada proyecto: secciones con forma de plano que la IA mantiene al día mientras trabajas.';
 	@override String projects({required Object count}) => '${count} activos';
 }
 
@@ -9533,7 +9532,7 @@ class _TranslationsWebCortexHomeProposalsEs extends TranslationsWebCortexHomePro
 
 	// Translations
 	@override String title({required Object count}) => 'Propuestas pendientes (${count})';
-	@override String get hint => 'Actualizaciones propuestas por la IA para notas de proyecto y páginas KB, a la espera de tu veredicto. Aprueba para publicar, rechaza para descartar.';
+	@override String get hint => 'Actualizaciones propuestas por la IA a los informes de proyecto y páginas del KB, a la espera de tu veredicto. Aprobar publica, rechazar descarta.';
 	@override String get kbLabel => 'Base de conocimiento';
 	@override String get preview => 'Vista previa';
 	@override String get hide => 'Ocultar';
@@ -9770,7 +9769,6 @@ extension on TranslationsEs {
 			'auth.errorFallback' => 'Error al iniciar sesión',
 			'nav.sessions' => 'Sessions',
 			'nav.memory' => 'Memoria',
-			'nav.notes' => 'Notas',
 			'nav.more' => 'Más',
 			'nav.activity' => 'Actividad',
 			'nav.providers' => 'Proveedores',
@@ -10256,9 +10254,9 @@ extension on TranslationsEs {
 			'web.memoryWorkers.tasks.capture.label' => 'Motor de captura',
 			'web.memoryWorkers.tasks.capture.description' => 'Extracción de hechos por cada trigger a partir de los transcripts de sesión. El modo agente ofrece hechos notablemente mejores en sesiones largas; el modo summarizer es barato y local.',
 			'web.memoryWorkers.tasks.capture.modelAdvice' => 'La tarea más frecuente: extracción de hechos — usa el modelo MÁS BARATO que funcione (haiku / local).',
+			'web.memoryWorkers.tasks.blueprint.modelAdvice' => 'Clasificación ocasional del proyecto — modelo equilibrado; aquí la calidad importa más que el costo.',
 			_ => null,
 		} ?? switch (path) {
-			'web.memoryWorkers.tasks.blueprint.modelAdvice' => 'Clasificación ocasional del proyecto — modelo equilibrado; aquí la calidad importa más que el costo.',
 			'web.memoryWorkers.tasks.blueprint.label' => 'Proponedor de planos',
 			'web.memoryWorkers.tasks.blueprint.description' => 'Clasifica un proyecto y propone su conjunto de secciones. Disparado por el operador.',
 			'web.memoryWorkers.tasks.curation.modelAdvice' => 'Tu editor conversacional de docs/políticas — modelo fuerte recomendado (sonnet/opus).',
@@ -10770,9 +10768,9 @@ extension on TranslationsEs {
 			'web.providers.detail.caps.images' => 'images',
 			'web.providers.detail.caps.mcp' => 'mcp',
 			'web.providers.detail.notInstalled' => 'no instalado',
+			'web.providers.detail.brokenCli' => 'Instalado pero no ejecutable',
 			_ => null,
 		} ?? switch (path) {
-			'web.providers.detail.brokenCli' => 'Instalado pero no ejecutable',
 			'web.providers.detail.updateAvailable' => ({required Object version}) => 'actualización disponible → ${version}',
 			'web.providers.detail.upToDate' => 'actualizado',
 			'web.providers.detail.update' => ({required Object version}) => 'Actualizar a ${version}',
@@ -11284,9 +11282,9 @@ extension on TranslationsEs {
 			'web.backups.generated.copiedToast' => 'Frase de contraseña copiada al portapapeles',
 			'web.backups.generated.copyFailedToast' => 'Error al copiar, selecciónala y cópiala manualmente',
 			'web.backups.generated.savedTo' => 'Guardada en:',
+			'web.backups.generated.ack' => 'He guardado esta frase de contraseña en mi gestor de contraseñas',
 			_ => null,
 		} ?? switch (path) {
-			'web.backups.generated.ack' => 'He guardado esta frase de contraseña en mi gestor de contraseñas',
 			'web.backups.generated.kContinue' => 'Continuar',
 			'web.backups.status.pgDump' => 'pg_dump',
 			'web.backups.status.pgRestore' => 'pg_restore',
@@ -11798,9 +11796,9 @@ extension on TranslationsEs {
 			'web.settings.system.uptime' => 'Tiempo de actividad',
 			'web.settings.system.database' => 'Base de datos',
 			'web.settings.system.reachable' => 'accesible',
+			'web.settings.system.unreachable' => 'no accesible',
 			_ => null,
 		} ?? switch (path) {
-			'web.settings.system.unreachable' => 'no accesible',
 			'web.settings.about.title' => 'Acerca de',
 			'web.settings.about.description' => 'opendray v2: el multiplexor + gateway de integración para CLIs de agentes de IA. Código bajo Apache 2.0.',
 			'web.settings.about.version' => 'Versión',
@@ -12175,20 +12173,20 @@ extension on TranslationsEs {
 			'web.cortex.home.subtitle' => 'Un módulo, tres peldaños, un ciclo: la memoria bruta cristaliza en el documento oficial de cada proyecto, se destila en conocimiento entre proyectos y se inyecta en cada nueva sesión.',
 			'web.cortex.home.disabled' => 'desactivado',
 			'web.cortex.home.pendingProposals' => ({required Object count}) => '${count} pendientes',
-			'web.cortex.home.loopHint' => 'Memoria → Notas → Conocimiento → inyectado en cada arranque. Ascender es transformar, nunca copiar.',
+			'web.cortex.home.loopHint' => 'Memoria → Informe → Conocimiento → inyectado en cada arranque. Promover es transformar, nunca copiar.',
 			'web.cortex.home.activeProjects' => 'Proyectos activos',
 			'web.cortex.home.idle' => ({required Object days}) => 'inactivo ${days}d',
 			'web.cortex.home.memory.title' => 'Memoria',
 			'web.cortex.home.memory.description' => 'Hechos episódicos capturados de tus sesiones — recuperados por relevancia, en cuarentena si vienen de terceros.',
 			'web.cortex.home.memory.quarantine' => ({required Object count}) => '${count} en cuarentena',
-			'web.cortex.home.notes.title' => 'Notas',
-			'web.cortex.home.notes.description' => 'El documento oficial de cada proyecto — secciones según su plano, mantenidas por la IA mientras trabajas.',
+			'web.cortex.home.notes.title' => 'Informe',
+			'web.cortex.home.notes.description' => 'El informe vivo de cada proyecto: secciones con forma de plano que la IA mantiene al día mientras trabajas.',
 			'web.cortex.home.notes.projects' => ({required Object count}) => '${count} activos',
 			'web.cortex.home.knowledge.title' => 'Conocimiento',
 			'web.cortex.home.knowledge.description' => 'Experiencia iterable entre proyectos: reglas fundacionales vinculantes + lecciones emergentes, inyectadas en cada arranque.',
 			'web.cortex.home.settings' => 'Ajustes',
 			'web.cortex.home.proposals.title' => ({required Object count}) => 'Propuestas pendientes (${count})',
-			'web.cortex.home.proposals.hint' => 'Actualizaciones propuestas por la IA para notas de proyecto y páginas KB, a la espera de tu veredicto. Aprueba para publicar, rechaza para descartar.',
+			'web.cortex.home.proposals.hint' => 'Actualizaciones propuestas por la IA a los informes de proyecto y páginas del KB, a la espera de tu veredicto. Aprobar publica, rechazar descarta.',
 			'web.cortex.home.proposals.kbLabel' => 'Base de conocimiento',
 			'web.cortex.home.proposals.preview' => 'Vista previa',
 			'web.cortex.home.proposals.hide' => 'Ocultar',
@@ -12312,9 +12310,9 @@ extension on TranslationsEs {
 			'web.database.grid.delete' => 'Eliminar',
 			'web.database.grid.deleted' => 'Fila eliminada',
 			'web.database.grid.confirmDelete' => '¿Eliminar esta fila?',
+			'web.database.grid.loading' => 'Cargando filas…',
 			_ => null,
 		} ?? switch (path) {
-			'web.database.grid.loading' => 'Cargando filas…',
 			'web.database.grid.readOnlyHint' => 'Esta conexión es de solo lectura — no se pueden editar filas.',
 			'web.database.grid.noPkHint' => 'Esta tabla no tiene clave primaria — la edición de filas está deshabilitada.',
 			'web.database.grid.pageInfo' => ({required Object from, required Object to}) => 'Filas ${from}–${to}',
@@ -12469,7 +12467,7 @@ extension on TranslationsEs {
 			'more.items.customTasks.title' => 'Tareas personalizadas',
 			'more.items.customTasks.subtitle' => 'Comandos slash que se muestran en el selector de tareas de la session',
 			'more.items.cortexHub.title' => 'Cortex',
-			'more.items.cortexHub.subtitle' => 'Hub Memoria → Notas → Conocimiento + propuestas pendientes',
+			'more.items.cortexHub.subtitle' => 'Centro Memoria → Informe → Conocimiento + propuestas pendientes',
 			'more.items.projectMemory.title' => 'Objetivo / plan / diario del proyecto',
 			'more.items.projectMemory.subtitle' => 'Capas de memoria 2-4 por cwd + propuestas del agente',
 			'more.items.archived.title' => 'Memorias archivadas',
@@ -12485,7 +12483,7 @@ extension on TranslationsEs {
 			'more.items.about.title' => 'Acerca de',
 			'more.items.about.subtitle' => 'Versión de compilación e información del servidor',
 			'more.items.vault.title' => 'Bóveda',
-			'more.items.vault.subtitle' => 'Notas markdown libres (sincronización Obsidian)',
+			'more.items.vault.subtitle' => 'Documentos markdown libres (carpetas, wiki-links, sync git)',
 			'more.items.roundTable.title' => 'Mesa redonda',
 			'more.items.roundTable.subtitle' => 'Chat grupal de IA multiproveedor',
 			'more.signOut' => 'Cerrar sesión',
@@ -12826,9 +12824,9 @@ extension on TranslationsEs {
 			'sessions.spawnSheet.bypass.labelOpencode' => 'Omitir permisos',
 			'sessions.spawnSheet.bypass.labelGrok' => 'Saltar permisos / YOLO (--always-approve)',
 			'sessions.spawnSheet.bypass.subtitleOn' => 'Esta session se ejecutará con autonomía elevada.',
+			'sessions.spawnSheet.bypass.subtitleOff' => 'Desactivado. Las confirmaciones y los prompts se comportan de forma normal.',
 			_ => null,
 		} ?? switch (path) {
-			'sessions.spawnSheet.bypass.subtitleOff' => 'Desactivado. Las confirmaciones y los prompts se comportan de forma normal.',
 			'sessions.spawnSheet.noProviders.title' => 'No hay proveedores configurados',
 			'sessions.spawnSheet.noProviders.message' => 'El gateway no tiene proveedores de CLI habilitados. Configura uno en Proveedores (admin web) o en [providers] en config.toml, y luego toca Recargar.',
 			'sessions.spawnSheet.noProviders.reload' => 'Recargar',
@@ -13340,9 +13338,9 @@ extension on TranslationsEs {
 			'backups.restore.manifestTitle' => 'Manifiesto',
 			'backups.restore.manifestBackupId' => 'ID de copia de seguridad',
 			'backups.restore.manifestVersion' => 'Versión del manifiesto',
+			'backups.restore.manifestCreatedAt' => 'Creado',
 			_ => null,
 		} ?? switch (path) {
-			'backups.restore.manifestCreatedAt' => 'Creado',
 			'backups.restore.manifestPgVersion' => 'pg_version',
 			'backups.restore.manifestOpendrayVersion' => 'versión de opendray',
 			'backups.restore.fingerprint' => 'Huella de la clave',
@@ -13686,7 +13684,7 @@ extension on TranslationsEs {
 			'customTasks.save' => 'Guardar',
 			'customTasks.create' => 'Crear',
 			'customTasks.failedToLoad' => 'Error al cargar las tareas personalizadas',
-			'notesPage.title' => 'Notas',
+			'notesPage.title' => 'Bóveda',
 			'notesPage.newButton' => 'Nueva',
 			'notesPage.newNoteDialogTitle' => 'Nueva nota',
 			'notesPage.searchHint' => 'Busca en todo el vault…',
@@ -13854,9 +13852,9 @@ extension on TranslationsEs {
 			'memory.quarantinedToast' => 'Memoria en cuarentena — revísala en Cortex → Cuarentena',
 			'memory.archiveFailed' => ({required Object error}) => 'Error al archivar: ${error}',
 			'memory.quarantineFailed' => ({required Object error}) => 'Error al poner en cuarentena: ${error}',
+			'memory.reembed.menuItem' => 'Reincrustar todo',
 			_ => null,
 		} ?? switch (path) {
-			'memory.reembed.menuItem' => 'Reincrustar todo',
 			'memory.reembed.confirmTitle' => '¿Reincrustar todas las memorias?',
 			'memory.reembed.confirmBody' => 'Recodifica cada memoria y página de KB con el modelo de embedding actual. Necesario tras cambiar de modelo, ya que la dimensión del vector cambia. Puede tardar un rato.',
 			'memory.reembed.confirmButton' => 'Reincrustar',
@@ -14060,15 +14058,15 @@ extension on TranslationsEs {
 			'memoryQuarantine.expires' => ({required Object date}) => 'expira ${date}',
 			'memoryQuarantine.countBadge' => ({required Object count}) => '${count} pendientes',
 			'cortexHub.title' => 'Cortex',
-			'cortexHub.subtitle' => 'El volante de experiencia: Memoria → Notas → Conocimiento, realimentado en cada session.',
+			'cortexHub.subtitle' => 'El volante de experiencia: Memoria → Informe → Conocimiento, de vuelta a cada sesión.',
 			'cortexHub.idleBadge' => ({required Object days}) => 'inactivo ${days}d',
 			'cortexHub.activeProjectsBadge' => ({required Object count}) => '${count} activos',
 			'cortexHub.activeProjectsTitle' => 'Proyectos activos',
-			'cortexHub.loopHint' => 'Las sesiones alimentan la Memoria → la Memoria se destila en Notas → las Notas se compilan en Conocimiento → el Conocimiento guía cada nueva sesión.',
+			'cortexHub.loopHint' => 'Las sesiones alimentan la Memoria → la Memoria se destila en un Informe → los Informes se consolidan en Conocimiento → el Conocimiento guía cada nueva sesión.',
 			'cortexHub.settings' => 'Ajustes',
 			'cortexHub.memory' => 'Memoria',
 			'cortexHub.memoryDesc' => 'Hechos crudos entre sessions que los agentes guardan y recuerdan.',
-			'cortexHub.notes' => 'Notas',
+			'cortexHub.notes' => 'Informe',
 			'cortexHub.notesDesc' => 'El objetivo / plan / diario oficial de cada proyecto.',
 			'cortexHub.knowledge' => 'Conocimiento',
 			'cortexHub.knowledgeDesc' => 'Experiencia destilada entre proyectos.',
@@ -14076,7 +14074,7 @@ extension on TranslationsEs {
 			'cortexHub.pendingBadge' => ({required Object count}) => '${count} pendientes',
 			'cortexHub.disabled' => 'desactivado',
 			'cortexHub.inboxTitle' => ({required Object count}) => 'Propuestas pendientes (${count})',
-			'cortexHub.inboxHint' => 'Actualizaciones propuestas por la IA para notas y páginas KB. Aprueba para publicar, rechaza para descartar.',
+			'cortexHub.inboxHint' => 'Actualizaciones propuestas por la IA a los informes de proyecto y páginas del KB. Aprobar publica, rechazar descarta.',
 			'cortexHub.kbLabel' => 'Base de conocimiento',
 			'cortexHub.preview' => 'Vista previa',
 			'cortexHub.hide' => 'Ocultar',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -123,7 +123,6 @@ class _TranslationsNavZh extends TranslationsNavEn {
 	// Translations
 	@override String get sessions => '会话';
 	@override String get memory => '记忆';
-	@override String get notes => '笔记';
 	@override String get more => '更多';
 	@override String get activity => '活动';
 	@override String get providers => '提供方';
@@ -866,7 +865,7 @@ class _TranslationsNotesPageZh extends TranslationsNotesPageEn {
 	final TranslationsZh _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => '笔记';
+	@override String get title => '文档库';
 	@override String get newButton => '新建';
 	@override String get newNoteDialogTitle => '新建笔记';
 	@override String get searchHint => '搜索整个仓库…';
@@ -1010,15 +1009,15 @@ class _TranslationsCortexHubZh extends TranslationsCortexHubEn {
 
 	// Translations
 	@override String get title => 'Cortex';
-	@override String get subtitle => '经验飞轮：记忆 → 笔记 → 知识，回流到每个会话。';
+	@override String get subtitle => '经验飞轮：记忆 → 简报 → 知识，回流到每个会话。';
 	@override String idleBadge({required Object days}) => '闲置 ${days} 天';
 	@override String activeProjectsBadge({required Object count}) => '${count} 个活跃';
 	@override String get activeProjectsTitle => '活跃项目';
-	@override String get loopHint => '会话喂养记忆 → 记忆提炼为笔记 → 笔记沉淀为知识 → 知识引导每个新会话。';
+	@override String get loopHint => '会话喂养记忆 → 记忆提炼为简报 → 简报沉淀为知识 → 知识引导每个新会话。';
 	@override String get settings => '设置';
 	@override String get memory => '记忆';
 	@override String get memoryDesc => '代理存取的跨会话原始事实。';
-	@override String get notes => '笔记';
+	@override String get notes => '简报';
 	@override String get notesDesc => '每个项目的官方目标 / 计划 / 日志。';
 	@override String get knowledge => '知识';
 	@override String get knowledgeDesc => '跨项目沉淀的专业知识。';
@@ -1026,7 +1025,7 @@ class _TranslationsCortexHubZh extends TranslationsCortexHubEn {
 	@override String pendingBadge({required Object count}) => '${count} 条待审';
 	@override String get disabled => '已禁用';
 	@override String inboxTitle({required Object count}) => '待审提案（${count}）';
-	@override String get inboxHint => 'AI 对项目笔记与知识库页面提出的更新。批准即发布，拒绝即丢弃。';
+	@override String get inboxHint => 'AI 对项目简报与知识库页面提出的更新。批准即发布，拒绝即丢弃。';
 	@override String get kbLabel => '知识库';
 	@override String get preview => '预览';
 	@override String get hide => '收起';
@@ -5893,7 +5892,7 @@ class _TranslationsWebCortexHomeZh extends TranslationsWebCortexHomeEn {
 	@override String get subtitle => '一个模块、三层一环：原始记忆结晶为各项目的官方文档，再蒸馏为跨项目知识，并注入每个新会话。';
 	@override String get disabled => '未启用';
 	@override String pendingProposals({required Object count}) => '${count} 个待审';
-	@override String get loopHint => '记忆 → 笔记 → 知识 → 注入每次启动。层级提升是转化，绝不是复制。';
+	@override String get loopHint => '记忆 → 简报 → 知识 → 注入每次启动。层级提升是转化，绝不是复制。';
 	@override String get activeProjects => '活跃项目';
 	@override String idle({required Object days}) => '闲置 ${days} 天';
 	@override late final _TranslationsWebCortexHomeMemoryZh memory = _TranslationsWebCortexHomeMemoryZh._(_root);
@@ -6374,7 +6373,7 @@ class _TranslationsMoreItemsCortexHubZh extends TranslationsMoreItemsCortexHubEn
 
 	// Translations
 	@override String get title => 'Cortex';
-	@override String get subtitle => '记忆 → 笔记 → 知识中枢 + 待审提案';
+	@override String get subtitle => '记忆 → 简报 → 知识中枢 + 待审提案';
 }
 
 // Path: more.items.projectMemory
@@ -6462,7 +6461,7 @@ class _TranslationsMoreItemsVaultZh extends TranslationsMoreItemsVaultEn {
 
 	// Translations
 	@override String get title => '文档库';
-	@override String get subtitle => '自由 markdown 笔记(Obsidian 同步)';
+	@override String get subtitle => '自由 markdown 文档(目录、wiki 链接、git 同步)';
 }
 
 // Path: more.items.roundTable
@@ -9509,8 +9508,8 @@ class _TranslationsWebCortexHomeNotesZh extends TranslationsWebCortexHomeNotesEn
 	final TranslationsZh _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => '笔记';
-	@override String get description => '每个项目的官方文档——按蓝图组织章节，AI 随工作进展持续维护。';
+	@override String get title => '简报';
+	@override String get description => '每个项目的实时简报——按蓝图组织章节，AI 随工作进展持续维护。';
 	@override String projects({required Object count}) => '${count} 个活跃';
 }
 
@@ -9533,7 +9532,7 @@ class _TranslationsWebCortexHomeProposalsZh extends TranslationsWebCortexHomePro
 
 	// Translations
 	@override String title({required Object count}) => '待审提案（${count}）';
-	@override String get hint => 'AI 对项目笔记与知识库页面提出的更新，等待你的裁决。批准即发布，拒绝即丢弃。';
+	@override String get hint => 'AI 对项目简报与知识库页面提出的更新，等待你的裁决。批准即发布，拒绝即丢弃。';
 	@override String get kbLabel => '知识库';
 	@override String get preview => '预览';
 	@override String get hide => '收起';
@@ -9770,7 +9769,6 @@ extension on TranslationsZh {
 			'auth.errorFallback' => '登录失败',
 			'nav.sessions' => '会话',
 			'nav.memory' => '记忆',
-			'nav.notes' => '笔记',
 			'nav.more' => '更多',
 			'nav.activity' => '活动',
 			'nav.providers' => '提供方',
@@ -10256,9 +10254,9 @@ extension on TranslationsZh {
 			'web.memoryWorkers.tasks.capture.label' => 'Capture 引擎',
 			'web.memoryWorkers.tasks.capture.description' => '按触发器从 session transcript 抽取 fact。Agent 模式在长会话上 fact 质量明显更好；summarizer 模式便宜且本地。',
 			'web.memoryWorkers.tasks.capture.modelAdvice' => '频率最高的任务：每隔几条消息抽取事实——用能干活的最便宜模型（haiku / 本地）。',
+			'web.memoryWorkers.tasks.blueprint.modelAdvice' => '偶发、由你手动触发的项目分类——均衡模型；这里质量比成本重要。',
 			_ => null,
 		} ?? switch (path) {
-			'web.memoryWorkers.tasks.blueprint.modelAdvice' => '偶发、由你手动触发的项目分类——均衡模型；这里质量比成本重要。',
 			'web.memoryWorkers.tasks.blueprint.label' => '蓝图提议器',
 			'web.memoryWorkers.tasks.blueprint.description' => '根据仓库信号识别项目类型并提议文档章节结构。由蓝图编辑器手动触发。',
 			'web.memoryWorkers.tasks.curation.modelAdvice' => '你的对话式文档/方针编辑器——推荐强模型（sonnet/opus）；它改写的是你依赖的文档。',
@@ -10770,9 +10768,9 @@ extension on TranslationsZh {
 			'web.providers.detail.caps.images' => 'images',
 			'web.providers.detail.caps.mcp' => 'mcp',
 			'web.providers.detail.notInstalled' => '未安装',
+			'web.providers.detail.brokenCli' => '已安装但无法运行',
 			_ => null,
 		} ?? switch (path) {
-			'web.providers.detail.brokenCli' => '已安装但无法运行',
 			'web.providers.detail.updateAvailable' => ({required Object version}) => '有可用更新 → ${version}',
 			'web.providers.detail.upToDate' => '已是最新',
 			'web.providers.detail.update' => ({required Object version}) => '更新到 ${version}',
@@ -11284,9 +11282,9 @@ extension on TranslationsZh {
 			'web.backups.generated.copiedToast' => '口令已复制到剪贴板',
 			'web.backups.generated.copyFailedToast' => '复制失败 — 请手动选中并复制',
 			'web.backups.generated.savedTo' => '已保存到：',
+			'web.backups.generated.ack' => '我已将此口令保存到密码管理器',
 			_ => null,
 		} ?? switch (path) {
-			'web.backups.generated.ack' => '我已将此口令保存到密码管理器',
 			'web.backups.generated.kContinue' => '继续',
 			'web.backups.status.pgDump' => 'pg_dump',
 			'web.backups.status.pgRestore' => 'pg_restore',
@@ -11798,9 +11796,9 @@ extension on TranslationsZh {
 			'web.settings.system.uptime' => '运行时长',
 			'web.settings.system.database' => '数据库',
 			'web.settings.system.reachable' => '可达',
+			'web.settings.system.unreachable' => '不可达',
 			_ => null,
 		} ?? switch (path) {
-			'web.settings.system.unreachable' => '不可达',
 			'web.settings.about.title' => '关于',
 			'web.settings.about.description' => 'opendray v2 — 面向 AI agent CLI 的多路复用 + 集成网关。源码采用 Apache 2.0 协议。',
 			'web.settings.about.version' => '版本',
@@ -12175,20 +12173,20 @@ extension on TranslationsZh {
 			'web.cortex.home.subtitle' => '一个模块、三层一环：原始记忆结晶为各项目的官方文档，再蒸馏为跨项目知识，并注入每个新会话。',
 			'web.cortex.home.disabled' => '未启用',
 			'web.cortex.home.pendingProposals' => ({required Object count}) => '${count} 个待审',
-			'web.cortex.home.loopHint' => '记忆 → 笔记 → 知识 → 注入每次启动。层级提升是转化，绝不是复制。',
+			'web.cortex.home.loopHint' => '记忆 → 简报 → 知识 → 注入每次启动。层级提升是转化，绝不是复制。',
 			'web.cortex.home.activeProjects' => '活跃项目',
 			'web.cortex.home.idle' => ({required Object days}) => '闲置 ${days} 天',
 			'web.cortex.home.memory.title' => '记忆',
 			'web.cortex.home.memory.description' => '从会话中自动采集的原始事实——按相关性召回；第三方来源默认隔离。',
 			'web.cortex.home.memory.quarantine' => ({required Object count}) => '${count} 条隔离中',
-			'web.cortex.home.notes.title' => '笔记',
-			'web.cortex.home.notes.description' => '每个项目的官方文档——按蓝图组织章节，AI 随工作进展持续维护。',
+			'web.cortex.home.notes.title' => '简报',
+			'web.cortex.home.notes.description' => '每个项目的实时简报——按蓝图组织章节，AI 随工作进展持续维护。',
 			'web.cortex.home.notes.projects' => ({required Object count}) => '${count} 个活跃',
 			'web.cortex.home.knowledge.title' => '知识',
 			'web.cortex.home.knowledge.description' => '跨项目、可迭代的经验资产：绑定性基础方针 + 涌现的经验教训，注入每次启动。',
 			'web.cortex.home.settings' => '设置',
 			'web.cortex.home.proposals.title' => ({required Object count}) => '待审提案（${count}）',
-			'web.cortex.home.proposals.hint' => 'AI 对项目笔记与知识库页面提出的更新，等待你的裁决。批准即发布，拒绝即丢弃。',
+			'web.cortex.home.proposals.hint' => 'AI 对项目简报与知识库页面提出的更新，等待你的裁决。批准即发布，拒绝即丢弃。',
 			'web.cortex.home.proposals.kbLabel' => '知识库',
 			'web.cortex.home.proposals.preview' => '预览',
 			'web.cortex.home.proposals.hide' => '收起',
@@ -12312,9 +12310,9 @@ extension on TranslationsZh {
 			'web.database.grid.delete' => '删除',
 			'web.database.grid.deleted' => '行已删除',
 			'web.database.grid.confirmDelete' => '删除此行?',
+			'web.database.grid.loading' => '正在加载数据…',
 			_ => null,
 		} ?? switch (path) {
-			'web.database.grid.loading' => '正在加载数据…',
 			'web.database.grid.readOnlyHint' => '此连接为只读 —— 无法编辑行。',
 			'web.database.grid.noPkHint' => '此表没有主键 —— 行编辑已禁用。',
 			'web.database.grid.pageInfo' => ({required Object from, required Object to}) => '第 ${from}–${to} 行',
@@ -12469,7 +12467,7 @@ extension on TranslationsZh {
 			'more.items.customTasks.title' => '自定义任务',
 			'more.items.customTasks.subtitle' => '会话任务选择器中显示的斜杠命令',
 			'more.items.cortexHub.title' => 'Cortex',
-			'more.items.cortexHub.subtitle' => '记忆 → 笔记 → 知识中枢 + 待审提案',
+			'more.items.cortexHub.subtitle' => '记忆 → 简报 → 知识中枢 + 待审提案',
 			'more.items.projectMemory.title' => '项目目标 / 计划 / 日志',
 			'more.items.projectMemory.subtitle' => '按 cwd 的记忆层 2-4 + 代理提案',
 			'more.items.archived.title' => '已归档记忆',
@@ -12485,7 +12483,7 @@ extension on TranslationsZh {
 			'more.items.about.title' => '关于',
 			'more.items.about.subtitle' => '构建版本与服务器信息',
 			'more.items.vault.title' => '文档库',
-			'more.items.vault.subtitle' => '自由 markdown 笔记(Obsidian 同步)',
+			'more.items.vault.subtitle' => '自由 markdown 文档(目录、wiki 链接、git 同步)',
 			'more.items.roundTable.title' => '圆桌',
 			'more.items.roundTable.subtitle' => '跨厂商 AI 群聊',
 			'more.signOut' => '退出登录',
@@ -12826,9 +12824,9 @@ extension on TranslationsZh {
 			'sessions.spawnSheet.bypass.labelOpencode' => '跳过权限检查',
 			'sessions.spawnSheet.bypass.labelGrok' => '跳过权限 / YOLO（--always-approve）',
 			'sessions.spawnSheet.bypass.subtitleOn' => '此会话将以提升的自主权运行。',
+			'sessions.spawnSheet.bypass.subtitleOff' => '关闭 — 确认和提示按正常方式处理。',
 			_ => null,
 		} ?? switch (path) {
-			'sessions.spawnSheet.bypass.subtitleOff' => '关闭 — 确认和提示按正常方式处理。',
 			'sessions.spawnSheet.noProviders.title' => '未配置任何提供商',
 			'sessions.spawnSheet.noProviders.message' => '网关没有启用任何 CLI 提供商。在 Web 管理端的「提供商」中配置，或编辑 config.toml 的 [providers] 段，然后点击重新加载。',
 			'sessions.spawnSheet.noProviders.reload' => '重新加载',
@@ -13340,9 +13338,9 @@ extension on TranslationsZh {
 			'backups.restore.manifestTitle' => '清单',
 			'backups.restore.manifestBackupId' => '备份 ID',
 			'backups.restore.manifestVersion' => '清单版本',
+			'backups.restore.manifestCreatedAt' => '创建时间',
 			_ => null,
 		} ?? switch (path) {
-			'backups.restore.manifestCreatedAt' => '创建时间',
 			'backups.restore.manifestPgVersion' => 'pg_version',
 			'backups.restore.manifestOpendrayVersion' => 'opendray 版本',
 			'backups.restore.fingerprint' => '密钥指纹',
@@ -13686,7 +13684,7 @@ extension on TranslationsZh {
 			'customTasks.save' => '保存',
 			'customTasks.create' => '创建',
 			'customTasks.failedToLoad' => '加载自定义任务失败',
-			'notesPage.title' => '笔记',
+			'notesPage.title' => '文档库',
 			'notesPage.newButton' => '新建',
 			'notesPage.newNoteDialogTitle' => '新建笔记',
 			'notesPage.searchHint' => '搜索整个仓库…',
@@ -13854,9 +13852,9 @@ extension on TranslationsZh {
 			'memory.quarantinedToast' => '记忆已隔离——请在 Cortex → 隔离区 审查',
 			'memory.archiveFailed' => ({required Object error}) => '归档失败：${error}',
 			'memory.quarantineFailed' => ({required Object error}) => '隔离失败：${error}',
+			'memory.reembed.menuItem' => '全部重嵌',
 			_ => null,
 		} ?? switch (path) {
-			'memory.reembed.menuItem' => '全部重嵌',
 			'memory.reembed.confirmTitle' => '重嵌所有记忆？',
 			'memory.reembed.confirmBody' => '用当前 embedding 模型重新编码所有已存记忆和 KB 页面。切换模型后需要执行（向量维度会变）。可能需要一些时间。',
 			'memory.reembed.confirmButton' => '重嵌',
@@ -14060,15 +14058,15 @@ extension on TranslationsZh {
 			'memoryQuarantine.expires' => ({required Object date}) => '${date} 过期',
 			'memoryQuarantine.countBadge' => ({required Object count}) => '${count} 条待审',
 			'cortexHub.title' => 'Cortex',
-			'cortexHub.subtitle' => '经验飞轮：记忆 → 笔记 → 知识，回流到每个会话。',
+			'cortexHub.subtitle' => '经验飞轮：记忆 → 简报 → 知识，回流到每个会话。',
 			'cortexHub.idleBadge' => ({required Object days}) => '闲置 ${days} 天',
 			'cortexHub.activeProjectsBadge' => ({required Object count}) => '${count} 个活跃',
 			'cortexHub.activeProjectsTitle' => '活跃项目',
-			'cortexHub.loopHint' => '会话喂养记忆 → 记忆提炼为笔记 → 笔记沉淀为知识 → 知识引导每个新会话。',
+			'cortexHub.loopHint' => '会话喂养记忆 → 记忆提炼为简报 → 简报沉淀为知识 → 知识引导每个新会话。',
 			'cortexHub.settings' => '设置',
 			'cortexHub.memory' => '记忆',
 			'cortexHub.memoryDesc' => '代理存取的跨会话原始事实。',
-			'cortexHub.notes' => '笔记',
+			'cortexHub.notes' => '简报',
 			'cortexHub.notesDesc' => '每个项目的官方目标 / 计划 / 日志。',
 			'cortexHub.knowledge' => '知识',
 			'cortexHub.knowledgeDesc' => '跨项目沉淀的专业知识。',
@@ -14076,7 +14074,7 @@ extension on TranslationsZh {
 			'cortexHub.pendingBadge' => ({required Object count}) => '${count} 条待审',
 			'cortexHub.disabled' => '已禁用',
 			'cortexHub.inboxTitle' => ({required Object count}) => '待审提案（${count}）',
-			'cortexHub.inboxHint' => 'AI 对项目笔记与知识库页面提出的更新。批准即发布，拒绝即丢弃。',
+			'cortexHub.inboxHint' => 'AI 对项目简报与知识库页面提出的更新。批准即发布，拒绝即丢弃。',
 			'cortexHub.kbLabel' => '知识库',
 			'cortexHub.preview' => '预览',
 			'cortexHub.hide' => '收起',


### PR DESCRIPTION
Two different things were both called **Notes**, which made the "use the Vault for project docs" push read as a contradiction.

| Surface | Was | What it actually is |
|---|---|---|
| nav / vault page | Notes / 笔记 | Markdown **files on disk** — folders, wiki-links, git-syncable, human and agent prose |
| Cortex middle tier | Notes / 笔记 | Per-project **structured state** (overview, goal, plan, current objective) the AI keeps current in Postgres and injects at session start |

A filing cabinet and the AI's live understanding of a project are not the same kind of thing.

## Cortex's tier → Brief / 简报 / Informe

The flywheel now reads **Memory → Brief → Knowledge**.

"Brief" is what it does: the structured summary you hand someone before they start, kept current as work proceeds — which is exactly how it is used, since it is injected at session start. "Dossier" implies an archive; "Profile" implies something static. Neither describes a document rewritten as the project moves.

## The Vault was also inconsistent with itself

Not part of the original report, but it would have undercut the fix:

- nav said **Notes**
- the More menu said **Vault**
- the page title said **Notes**
- the empty state said **"vault"**

Settled on **Vault** everywhere. "Notes" now names exactly one thing — the personal scratchpad inside the Vault — where it is accurate.

Two findings while doing it:
- `nav.notes` was **dead**: the sidebar has referenced `nav.vault` all along. Removed rather than translated.
- `/notes` was already a redirect to `/vault`, so no bookmarks break.

## Deliberately NOT changed

The agent-facing vocabulary still says "project doc" — MCP tools are named `doc_read`, `project_goal_set`, `current_objective_set`, and the table is `project_docs`. Renaming the prose around tools whose names still say `doc_*` would make the agent-facing vocabulary *less* coherent, not more, and the tool names are a contract with every integration. Worth a separate decision if the ambiguity bites agents in practice; flagging it rather than half-doing it.

## Test plan

- [x] Verified zero remaining 笔记 / Notes on the Cortex side across all three locales
- [x] `check-i18n-parity.mjs` — es/zh 100%, no missing/extra/token-mismatch (the removed dead key is gone from all three)
- [x] `tsc --noEmit` + `pnpm build` clean
- [x] `flutter analyze` — no issues; slang regenerated
- [x] Strings only — no code, tool, table or route changes

## What to look at

Cortex hub and its home card, the More menu on mobile, the Vault page title on mobile, and the sidebar. The word "Notes" should survive in exactly one place: the personal scratchpad inside the Vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)