### PR TITLE
feat(vault): highlight markdown, and stop calling the Vault an Obsidian thing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ for the full rationale and what triggers a major bump.
 
 ### Added
 
+- **Markdown in the Vault is syntax-highlighted while you edit it.** The
+  file viewer has always coloured what it shows, so raw markdown in the
+  Vault — the one place people actually read and write it — was the last
+  flat grey surface. Web layers a highlighted backdrop under the
+  textarea; mobile colours the field directly through its editing
+  controller, so the caret can't drift from the glyphs. Headings, bold,
+  italic, code, links, quotes, lists, tags and `[[wiki-links]]`.
+
+### Fixed
+
+- **The Vault no longer describes itself as an Obsidian feature.** It
+  syncs through a plain git remote — Obsidian is merely one editor that
+  can be pointed at the same repo, not something opendray integrates
+  with. The user-facing wording was corrected in the previous release;
+  this clears the same claim from the code that outlives it.
+
+### Added
+
 - **New docs start from a template, and folders can explain themselves.**
   Every doc previously started as an empty file with a heading, which is
   how a vault ends up with five different ideas of what a feature note

--- a/app/mobile/lib/features/notes/markdown_highlight_controller.dart
+++ b/app/mobile/lib/features/notes/markdown_highlight_controller.dart
@@ -1,0 +1,230 @@
+import 'package:flutter/material.dart';
+
+/// A [TextEditingController] that colours markdown as you type.
+///
+/// The web file viewer has always highlighted what it shows, so raw
+/// markdown in the Vault — the one place people read and write it — was
+/// the last flat grey surface. The web fix layers a highlighted backdrop
+/// under a transparent textarea, because the DOM offers nothing better.
+/// Flutter does: [buildTextSpan] is the documented hook for exactly
+/// this, and because the framework lays out the very spans it renders,
+/// the caret cannot drift from the glyphs. No overlay, no metric
+/// matching, no scroll syncing.
+///
+/// Deliberately hand-rolled rather than pulling in a highlighting
+/// package: a vault holds markdown and nothing else, the grammar worth
+/// colouring is a dozen patterns, and a general-purpose engine would be
+/// a dependency plus a theme to reconcile for no extra fidelity.
+class MarkdownHighlightController extends TextEditingController {
+  MarkdownHighlightController({super.text});
+
+  // buildTextSpan runs on every rebuild of the field, not only on edits
+  // — focus changes, keyboard insets and theme rebuilds all land here.
+  // Re-scanning a long note each time is wasted work, so the last
+  // result is kept and reused whenever neither the text nor the
+  // resolved style has changed.
+  String? _cachedText;
+  TextStyle? _cachedStyle;
+  TextSpan? _cachedSpan;
+
+  @override
+  TextSpan buildTextSpan({
+    required BuildContext context,
+    required bool withComposing,
+    TextStyle? style,
+  }) {
+    final base = style ?? const TextStyle();
+    if (_cachedSpan != null && _cachedText == text && _cachedStyle == base) {
+      return _cachedSpan!;
+    }
+
+    final palette = _Palette.of(Theme.of(context).colorScheme);
+    final spans = <TextSpan>[];
+
+    // Line-oriented constructs (headings, quotes, fences, rules) claim
+    // the whole line; anything else is split by the inline pass.
+    var inFence = false;
+    final lines = text.split('\n');
+    for (var i = 0; i < lines.length; i++) {
+      final line = lines[i];
+      final trimmed = line.trimLeft();
+
+      if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
+        inFence = !inFence;
+        spans.add(TextSpan(text: line, style: base.copyWith(color: palette.code)));
+      } else if (inFence) {
+        spans.add(TextSpan(text: line, style: base.copyWith(color: palette.code)));
+      } else if (_heading.hasMatch(line)) {
+        spans.add(TextSpan(
+          text: line,
+          style: base.copyWith(
+            color: palette.heading,
+            fontWeight: FontWeight.w700,
+          ),
+        ));
+      } else if (trimmed.startsWith('>')) {
+        spans.add(TextSpan(
+          text: line,
+          style: base.copyWith(
+            color: palette.quote,
+            fontStyle: FontStyle.italic,
+          ),
+        ));
+      } else if (_rule.hasMatch(trimmed) ||
+          (i == 0 && _frontmatterFence.hasMatch(line))) {
+        spans.add(TextSpan(text: line, style: base.copyWith(color: palette.punct)));
+      } else {
+        _appendInline(spans, line, base, palette);
+      }
+
+      if (i != lines.length - 1) spans.add(const TextSpan(text: '\n'));
+    }
+
+    final built = TextSpan(style: base, children: spans);
+    _cachedText = text;
+    _cachedStyle = base;
+    _cachedSpan = built;
+    return built;
+  }
+
+  /// Splits one line into styled runs.
+  ///
+  /// Each rule is scanned across the line ONCE via allMatches, and the
+  /// results are then merged left to right, dropping any match that
+  /// overlaps one already taken. The earlier, per-position approach
+  /// re-ran every regex against a fresh substring at each cursor step,
+  /// which is quadratic on a long line — fine for a paragraph, not for
+  /// a doc someone actually keeps in the vault.
+  void _appendInline(
+    List<TextSpan> out,
+    String line,
+    TextStyle base,
+    _Palette palette,
+  ) {
+    if (line.isEmpty) {
+      out.add(const TextSpan(text: ''));
+      return;
+    }
+
+    var cursor = 0;
+    // A leading list marker colours independently of the item's text.
+    final bullet = _listMarker.matchAsPrefix(line);
+    if (bullet != null) {
+      out.add(TextSpan(
+        text: line.substring(0, bullet.end),
+        style: base.copyWith(color: palette.punct),
+      ));
+      cursor = bullet.end;
+    }
+
+    final hits = <_InlineHit>[];
+    for (final rule in _inlineRules) {
+      for (final m in rule.pattern.allMatches(line, cursor)) {
+        hits.add(_InlineHit(m.start, m.end, rule));
+      }
+    }
+    // Leftmost wins; ties go to the rule declared first (code before
+    // emphasis, so markup inside a code span is left alone).
+    hits.sort((a, b) => a.start != b.start
+        ? a.start.compareTo(b.start)
+        : _inlineRules.indexOf(a.rule).compareTo(_inlineRules.indexOf(b.rule)));
+
+    for (final hit in hits) {
+      if (hit.start < cursor) continue; // overlaps something already taken
+      if (hit.start > cursor) {
+        out.add(TextSpan(text: line.substring(cursor, hit.start)));
+      }
+      out.add(TextSpan(
+        text: line.substring(hit.start, hit.end),
+        style: hit.rule.style(base, palette),
+      ));
+      cursor = hit.end;
+    }
+    if (cursor < line.length) {
+      out.add(TextSpan(text: line.substring(cursor)));
+    }
+  }
+}
+
+class _InlineHit {
+  _InlineHit(this.start, this.end, this.rule);
+  final int start;
+  final int end;
+  final _InlineRule rule;
+}
+
+class _InlineRule {
+  const _InlineRule(this.pattern, this.style);
+  final RegExp pattern;
+  final TextStyle Function(TextStyle base, _Palette p) style;
+}
+
+final _heading = RegExp(r'^#{1,6}\s');
+final _rule = RegExp(r'^(-{3,}|\*{3,}|_{3,})$');
+final _frontmatterFence = RegExp(r'^---\s*$');
+final _listMarker = RegExp(r'^\s*([-*+]|\d+[.)])\s+');
+
+// Order matters only for ties at the same offset; the scan always
+// prefers the leftmost match.
+final _inlineRules = <_InlineRule>[
+  // `code` — first, so markup inside a code span is left alone.
+  _InlineRule(RegExp(r'`[^`\n]+`'), (b, p) => b.copyWith(color: p.code)),
+  // [[wiki-link]] — opendray's own, and the reason a stock markdown
+  // grammar wouldn't have been enough on its own.
+  _InlineRule(RegExp(r'\[\[[^\]\n]+\]\]'), (b, p) => b.copyWith(color: p.link)),
+  // [text](target)
+  _InlineRule(
+    RegExp(r'\[[^\]\n]*\]\([^)\n]*\)'),
+    (b, p) => b.copyWith(color: p.link),
+  ),
+  // **bold** / __bold__
+  _InlineRule(
+    RegExp(r'(\*\*|__)(?=\S)(.+?)(?<=\S)\1'),
+    (b, p) => b.copyWith(color: p.strong, fontWeight: FontWeight.w700),
+  ),
+  // *italic* / _italic_
+  _InlineRule(
+    RegExp(r'(\*|_)(?=\S)([^*_\n]+?)(?<=\S)\1'),
+    (b, p) => b.copyWith(color: p.em, fontStyle: FontStyle.italic),
+  ),
+  // #tag
+  _InlineRule(
+    RegExp(r'(?<![\w/])#[A-Za-z][\w/-]*'),
+    (b, p) => b.copyWith(color: p.tag),
+  ),
+];
+
+/// Colours derived from the active scheme so the editor tracks light
+/// and dark without a second palette to maintain.
+class _Palette {
+  const _Palette({
+    required this.heading,
+    required this.strong,
+    required this.em,
+    required this.code,
+    required this.link,
+    required this.quote,
+    required this.tag,
+    required this.punct,
+  });
+
+  factory _Palette.of(ColorScheme s) => _Palette(
+        heading: s.primary,
+        strong: s.onSurface,
+        em: s.onSurface.withValues(alpha: 0.85),
+        code: s.tertiary,
+        link: s.secondary,
+        quote: s.onSurfaceVariant,
+        tag: s.tertiary,
+        punct: s.outline,
+      );
+
+  final Color heading;
+  final Color strong;
+  final Color em;
+  final Color code;
+  final Color link;
+  final Color quote;
+  final Color tag;
+  final Color punct;
+}

--- a/app/mobile/lib/features/notes/note_editor_dialog.dart
+++ b/app/mobile/lib/features/notes/note_editor_dialog.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/notes_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/notes/markdown_highlight_controller.dart';
 import 'package:path/path.dart' as p;
 
 // Full-screen markdown note editor with debounced auto-save.
@@ -34,7 +35,7 @@ class NoteEditorDialog extends ConsumerStatefulWidget {
 }
 
 class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
-  final _ctrl = TextEditingController();
+  final _ctrl = MarkdownHighlightController();
   Timer? _saveDebounce;
   bool _loading = true;
   bool _saving = false;

--- a/app/mobile/lib/features/notes/notes_screen.dart
+++ b/app/mobile/lib/features/notes/notes_screen.dart
@@ -22,8 +22,10 @@ class NotesScreen extends ConsumerWidget {
   }
 }
 
-// NotesVaultScreen — the markdown/Obsidian-sync vault, demoted out of the
-// core triad (reachable from the More menu).
+// NotesVaultScreen — the markdown doc library, demoted out of the
+// core triad (reachable from the More menu). It syncs through a plain
+// git remote; Obsidian is merely one editor that can be pointed at the
+// same repo, not something opendray integrates with.
 //
 // A flat list mixes personal scratchpads with every project's docs in one
 // stream — usable at 10 notes, unreadable at 200. Mirrors the web vault: the

--- a/app/mobile/lib/features/sessions/inspector/notes_tab.dart
+++ b/app/mobile/lib/features/sessions/inspector/notes_tab.dart
@@ -7,6 +7,7 @@ import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/notes_api.dart';
 import 'package:opendray/core/api/sessions_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/notes/markdown_highlight_controller.dart';
 import 'package:opendray/features/notes/note_editor_dialog.dart';
 
 // Notes surface inside the session inspector. Mirrors the web admin
@@ -193,7 +194,7 @@ class _PersonalSection extends ConsumerStatefulWidget {
 }
 
 class _PersonalSectionState extends ConsumerState<_PersonalSection> {
-  final _ctrl = TextEditingController();
+  final _ctrl = MarkdownHighlightController();
   Timer? _saveDebounce;
   bool _loading = true;
   bool _saving = false;
@@ -336,7 +337,11 @@ class _PersonalSectionState extends ConsumerState<_PersonalSection> {
                   minLines: 6,
                   textInputAction: TextInputAction.newline,
                   keyboardType: TextInputType.multiline,
-                  style: const TextStyle(fontSize: 13, height: 1.5),
+                  style: const TextStyle(
+                    fontSize: 13,
+                    height: 1.5,
+                    fontFamily: 'monospace',
+                  ),
                   decoration: InputDecoration(
                     hintText: t.sessions.inspector.notes.draftHint(project: widget.cwdBase),
                     border: OutlineInputBorder(

--- a/app/mobile/lib/features/settings/server_settings_screen.dart
+++ b/app/mobile/lib/features/settings/server_settings_screen.dart
@@ -232,7 +232,7 @@ List<_Section> _buildSections() => <_Section>[
         kind: _FieldKind.text,
         monospace: true,
         // Defaults to vault.root (or vault.notes when notes is
-        // pinned to a custom Obsidian-style location).
+        // pinned to a custom location).
         placeholder: '~/.opendray/vault',
       ),
       _Field(

--- a/app/mobile/test/features/notes/markdown_highlight_controller_test.dart
+++ b/app/mobile/test/features/notes/markdown_highlight_controller_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:opendray/features/notes/markdown_highlight_controller.dart';
+
+// The highlighter must never change what the field CONTAINS — it only
+// changes how it looks. Every case below therefore asserts the
+// reassembled span text is byte-identical to the source, because a
+// scanner that drops or duplicates a character would corrupt the note
+// the moment it is saved. The colouring assertions come second.
+
+/// Builds the span for [source] and returns it plus its flattened text.
+Future<(TextSpan, String)> build(WidgetTester tester, String source) async {
+  late TextSpan span;
+  final controller = MarkdownHighlightController(text: source);
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Builder(
+        builder: (context) {
+          span = controller.buildTextSpan(
+            context: context,
+            withComposing: false,
+            style: const TextStyle(fontSize: 13),
+          );
+          return const SizedBox();
+        },
+      ),
+    ),
+  );
+  return (span, span.toPlainText());
+}
+
+/// Collects the leaf spans containing `needle`, so a test can ask
+/// what style a specific run was given.
+List<TextSpan> runsFor(TextSpan root, String needle) {
+  final out = <TextSpan>[];
+  void walk(InlineSpan s) {
+    if (s is TextSpan) {
+      if (s.text != null && s.text!.contains(needle)) out.add(s);
+      for (final c in s.children ?? const <InlineSpan>[]) {
+        walk(c);
+      }
+    }
+  }
+
+  walk(root);
+  return out;
+}
+
+void main() {
+  testWidgets('text survives highlighting byte for byte', (tester) async {
+    const source = '''
+---
+type: feature
+---
+
+# Host power
+
+Some **bold** and *italic* and `code` and [[wiki-link]].
+See [docs](https://example.com) and #tag.
+
+- item one
+- item two with `inline`
+
+> a quote
+
+```dart
+final x = **not bold**;
+```
+
+Trailing text with 中文 and emoji 🚀.
+''';
+    final (_, plain) = await build(tester, source);
+    expect(plain, source);
+  });
+
+  testWidgets('empty and whitespace documents round-trip', (tester) async {
+    for (final source in ['', '\n', '   ', '\n\n\n', 'a']) {
+      final (_, plain) = await build(tester, source);
+      expect(plain, source, reason: 'source was ${source.codeUnits}');
+    }
+  });
+
+  testWidgets('headings, quotes and fences claim their whole line',
+      (tester) async {
+    final (span, _) = await build(tester, '# Title\n> quoted\nplain');
+    expect(runsFor(span, '# Title').first.style?.fontWeight, FontWeight.w700);
+    expect(runsFor(span, '> quoted').first.style?.fontStyle, FontStyle.italic);
+    // A plain line gets no colour of its own.
+    expect(runsFor(span, 'plain').first.style?.color, isNull);
+  });
+
+  testWidgets('markup inside a fenced block is not styled as markup',
+      (tester) async {
+    final (span, plain) = await build(
+      tester,
+      '```\n# not a heading\n**not bold**\n```\nafter',
+    );
+    expect(plain, '```\n# not a heading\n**not bold**\n```\nafter');
+    // The fenced line is one run coloured as code, not split into
+    // heading/bold pieces.
+    final fenced = runsFor(span, '# not a heading');
+    expect(fenced, hasLength(1));
+    expect(fenced.first.style?.fontWeight, isNot(FontWeight.w700));
+  });
+
+  testWidgets('overlapping inline patterns do not double-style',
+      (tester) async {
+    // A bold run inside a code span belongs to the code span; the
+    // scanner must take the leftmost match and skip what it covers.
+    final (span, plain) = await build(tester, 'a `**b**` c');
+    expect(plain, 'a `**b**` c');
+    final code = runsFor(span, '`**b**`');
+    expect(code, hasLength(1), reason: 'the code span should be one run');
+    expect(code.first.style?.fontWeight, isNot(FontWeight.w700));
+  });
+
+  testWidgets('wiki-links are coloured', (tester) async {
+    final (span, _) = await build(tester, 'see [[canvas]] please');
+    final link = runsFor(span, '[[canvas]]');
+    expect(link, hasLength(1));
+    expect(link.first.style?.color, isNotNull);
+  });
+
+  testWidgets('a long document does not lose content', (tester) async {
+    final source = List.generate(
+      400,
+      (i) => '## Section $i\n\nBody **$i** with `code` and [[ref-$i]].\n',
+    ).join('\n');
+    final (_, plain) = await build(tester, source);
+    expect(plain, source);
+  });
+}

--- a/app/web/src/components/notes/HighlightedSource.tsx
+++ b/app/web/src/components/notes/HighlightedSource.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { highlightCode } from '@/lib/highlight'
+import { cn } from '@/lib/utils'
+
+// A markdown source view that is coloured while staying editable.
+//
+// The file viewer has always highlighted what it shows, so raw markdown
+// in the Vault — the one place people actually read and write it — was
+// the only flat grey surface left. Fixing that in a textarea means the
+// classic backdrop trick: a <pre> rendering highlighted HTML, and the
+// real <textarea> on top of it with transparent text and a visible
+// caret.
+//
+// The trick has exactly one failure mode, and it is unforgiving: if the
+// two layers disagree about ANY metric — font, size, line-height,
+// padding, letter-spacing, wrapping — the caret drifts further from the
+// glyphs the further down you type. Both layers therefore take their
+// box and type styling from the same SHARED constant below. Change it
+// in one place or not at all.
+const SHARED_BOX =
+  'w-full px-3 py-2 font-mono text-[12px] leading-snug border ' +
+  'whitespace-pre-wrap break-words'
+
+interface HighlightedSourceProps {
+  value: string
+  onChange: (next: string) => void
+  /** Forwarded to the textarea so callers keep caret/selection access. */
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>
+  placeholder?: string
+  fillParent?: boolean
+  minHeight?: number
+  className?: string
+  onKeyUp?: React.KeyboardEventHandler<HTMLTextAreaElement>
+  onClick?: React.MouseEventHandler<HTMLTextAreaElement>
+  onBlur?: React.FocusEventHandler<HTMLTextAreaElement>
+}
+
+export function HighlightedSource({
+  value,
+  onChange,
+  textareaRef,
+  placeholder,
+  fillParent,
+  minHeight,
+  className,
+  onKeyUp,
+  onClick,
+  onBlur,
+}: HighlightedSourceProps) {
+  const preRef = useRef<HTMLPreElement>(null)
+  const [html, setHtml] = useState<string | null>(null)
+
+  // hljs loads lazily, and highlighting a long note on every keystroke
+  // would make typing feel heavy. Debounce, and render plain text until
+  // the first result lands — a brief moment of grey beats a stutter.
+  useEffect(() => {
+    let cancelled = false
+    const timer = setTimeout(() => {
+      highlightCode(value, 'markdown')
+        .then((out) => {
+          if (!cancelled) setHtml(out)
+        })
+        .catch(() => {
+          if (!cancelled) setHtml(null)
+        })
+    }, 120)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [value])
+
+  // The backdrop does not scroll on its own; it follows the textarea.
+  const syncScroll = () => {
+    const ta = textareaRef.current
+    const pre = preRef.current
+    if (!ta || !pre) return
+    pre.scrollTop = ta.scrollTop
+    pre.scrollLeft = ta.scrollLeft
+  }
+
+  const sizing = fillParent
+    ? 'flex-1 min-h-0'
+    : undefined
+  const style = fillParent ? undefined : { minHeight: `${minHeight ?? 220}px` }
+
+  return (
+    <div className={cn('relative', sizing, className)} style={style}>
+      <pre
+        ref={preRef}
+        aria-hidden="true"
+        className={cn(
+          SHARED_BOX,
+          'hljs pointer-events-none absolute inset-0 m-0 overflow-hidden',
+          'rounded-md border-border bg-input/40 text-foreground',
+        )}
+      >
+        {/* A trailing newline keeps the last line's height stable while
+            typing at the very end of the note. */}
+        {html !== null ? (
+          <code dangerouslySetInnerHTML={{ __html: html + '\n' }} />
+        ) : (
+          <code>{value + '\n'}</code>
+        )}
+      </pre>
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onScroll={syncScroll}
+        onKeyUp={onKeyUp}
+        onClick={onClick}
+        onBlur={onBlur}
+        placeholder={placeholder}
+        spellCheck={false}
+        className={cn(
+          SHARED_BOX,
+          'absolute inset-0 h-full resize-none rounded-md border-border',
+          // The glyphs come from the backdrop; only the caret and the
+          // selection highlight belong to the textarea.
+          'bg-transparent text-transparent caret-foreground',
+          'selection:bg-accent/30 selection:text-transparent',
+          'placeholder:text-muted-foreground/60',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        )}
+      />
+    </div>
+  )
+}

--- a/app/web/src/components/sessions/inspector/NoteEditor.tsx
+++ b/app/web/src/components/sessions/inspector/NoteEditor.tsx
@@ -12,6 +12,7 @@ import { detectWikiLinkContext, getCaretCoords } from '@/lib/caret'
 import { slugify } from '@/lib/outline'
 
 import { BacklinksPane } from './BacklinksPane'
+import { HighlightedSource } from '@/components/notes/HighlightedSource'
 import { WikiLinkSuggestions } from './WikiLinkSuggestions'
 import type { WikiLinkContext } from './WikiLinkSuggestions'
 
@@ -320,13 +321,13 @@ export function NoteEditor({
 
       {mode === 'source' ? (
         <>
-          <textarea
-            ref={textareaRef}
+          <HighlightedSource
             value={body}
-            onChange={(e) => {
-              setBody(e.target.value)
-              recomputeLinkCtx(e.target)
+            onChange={(next) => {
+              setBody(next)
+              if (textareaRef.current) recomputeLinkCtx(textareaRef.current)
             }}
+            textareaRef={textareaRef}
             onKeyUp={(e) => recomputeLinkCtx(e.currentTarget)}
             onClick={(e) => recomputeLinkCtx(e.currentTarget)}
             onBlur={() => {
@@ -335,15 +336,8 @@ export function NoteEditor({
               setTimeout(() => setLinkCtx(null), 80)
             }}
             placeholder={placeholder}
-            style={fillParent ? undefined : { minHeight: `${minHeight}px` }}
-            className={cn(
-              'w-full font-mono text-[12px] leading-snug rounded-md',
-              'border border-border bg-input/40 px-3 py-2 text-foreground',
-              'placeholder:text-muted-foreground/60',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-              fillParent ? 'flex-1 min-h-0 resize-none' : 'resize-y',
-            )}
-            spellCheck={false}
+            fillParent={fillParent}
+            minHeight={minHeight}
           />
           <WikiLinkSuggestions
             context={linkCtx}

--- a/app/web/src/components/sessions/inspector/VaultPanel.tsx
+++ b/app/web/src/components/sessions/inspector/VaultPanel.tsx
@@ -51,9 +51,9 @@ interface VaultPanelProps {
   cwd: string
 }
 
-// VaultPanel — the session's window into the markdown Vault (the
-// Obsidian-sync notes utility, demoted out of the core Memory →
-// Notes → Knowledge triad). Two authoring lanes against the same vault:
+// VaultPanel — the session's window into the markdown Vault (a
+// git-synced doc library, demoted out of the core Memory → Brief →
+// Knowledge triad). Two authoring lanes against the same vault:
 //
 //   "My notes"     → personal/<slug>.md — the human's scratchpad. AI
 //                    agents never write here. Inline editor.
@@ -63,8 +63,8 @@ interface VaultPanelProps {
 //                    folder so a project that keeps its notes elsewhere
 //                    in the vault stays connected.
 //
-// The project's official doc / goal / plan / journal / memory hygiene
-// live in Cortex (the sibling tab), not the Vault.
+// The project's Brief / goal / plan / journal / memory hygiene live in
+// Cortex (the sibling tab), not the Vault.
 export function VaultPanel({ cwd }: VaultPanelProps) {
   const { t } = useTranslation()
   const personalPath = useMemo(() => personalNotePath(cwd), [cwd])

--- a/app/web/src/pages/Notes.tsx
+++ b/app/web/src/pages/Notes.tsx
@@ -48,7 +48,7 @@ const LS_OUTLINE_OPEN = 'opendray.notes.outlineOpen'
 type LeftMode = 'tree' | 'tags'
 
 // VaultPage is the markdown-vault browser/editor (demoted out of the
-// core triad — a freeform/Obsidian-sync utility). Two-pane layout: left = navigation (tree or
+// core triad — a freeform, git-synced doc library). Two-pane layout: left = navigation (tree or
 // tag picker, with title/path filter at top), right = NoteEditor for the
 // selected note. Independent of any session.
 export function VaultPage() {

--- a/app/web/src/router.tsx
+++ b/app/web/src/router.tsx
@@ -227,8 +227,10 @@ const memoryWorkersRoute = createRoute({
   },
 })
 
-// Vault — the markdown/Obsidian-sync utility, demoted out of the core
-// Memory/Notes/Knowledge triad (Experience Flywheel §7).
+// Vault — the markdown doc library, demoted out of the core
+// Memory/Brief/Knowledge triad (Experience Flywheel §7). It syncs
+// through a plain git remote; any editor pointed at that repo (Obsidian
+// among them) works, but nothing here is Obsidian-specific.
 const vaultRoute = createRoute({
   getParentRoute: () => protectedRoute,
   path: '/vault',

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1860,9 +1860,10 @@ func parentOf(p string) string {
 // shared root. Returns absolute paths suitable for filesystem ops.
 //
 // The defaults preserve opendray's original `<root>/notes` +
-// `<root>/skills` layout. Users coming in with an existing Obsidian
-// vault can pin `vault.notes = "~/Documents/MyVault"` (or similar)
-// and opendray's notes API will read straight from that directory.
+// `<root>/skills` layout. Users who already keep a markdown vault
+// elsewhere (an Obsidian folder, a docs repo, anything) can pin
+// `vault.notes = "~/Documents/MyVault"` and opendray's notes API reads
+// straight from that directory — it is a path, not an integration.
 func resolveVaultPaths(c config.VaultConfig) (notes, skills, git string) {
 	root := c.Root
 	if root == "" {
@@ -1887,9 +1888,8 @@ func resolveVaultPaths(c config.VaultConfig) (notes, skills, git string) {
 	git = c.GitRoot
 	if git == "" {
 		// Pick the most natural git working tree: if the user pinned a
-		// custom notes path, that IS their vault repo (Obsidian-style);
-		// otherwise the legacy combined root holds both notes + skills
-		// under one repo.
+		// custom notes path, that IS their vault repo; otherwise the
+		// legacy combined root holds both notes + skills under one repo.
 		if c.Notes != "" {
 			git = notes
 		} else {


### PR DESCRIPTION
Items 1 and 3 from the report. Item 2 (mobile vault sync config) is deliberately deferred.

## 1. Syntax highlighting

The file viewer has always coloured what it shows, so raw markdown in the Vault — the one place people actually read and write it — was the last flat grey surface.

**Web** layers a highlighted `<pre>` under a transparent textarea, reusing the existing lazy-hljs helper (markdown grammar was already registered). That trick has exactly one failure mode and it is unforgiving: any disagreement between the two layers about font, size, line-height, padding or wrapping and the caret drifts further from the glyphs the longer you type. Both layers therefore take their box and type styling from a single shared constant, commented as such.

**Mobile** needs no overlay. `buildTextSpan` is the documented hook, and because the framework lays out the very spans it renders, the caret cannot drift by construction.

The mobile scanner is hand-rolled rather than a package: a vault holds markdown and nothing else, the grammar worth colouring is a dozen patterns, and a general-purpose engine would be a dependency plus a theme to reconcile for no extra fidelity — and it wouldn't know `[[wiki-links]]`, which are ours.

**A performance bug caught before it shipped:** the first scanner re-ran every regex against a fresh substring at each cursor step — quadratic on a long line, and `buildTextSpan` runs on *every* rebuild, not only edits. Rewritten to scan each rule across the line once and merge by leftmost-wins, plus a cache keyed on text+style so focus changes, keyboard insets and theme rebuilds don't re-scan at all.

Covered: headings, bold, italic, inline and fenced code, links, `[[wiki-links]]`, block quotes, list markers, `#tags`, frontmatter fences.

## 2. The Vault is not Obsidian

It syncs through a plain git remote. Obsidian is one editor that can be pointed at the same repo — nothing opendray integrates with.

The user-facing string was already corrected in #497 (so the screenshot in the report is from a build predating it, and i18n now has **zero** Obsidian mentions). This clears the same claim from the *comments*, which outlive UI strings and were quietly teaching the wrong model to whoever reads them next — humans and agents alike.

Left alone deliberately: references that cite Obsidian as an example of a folder you might point `vault.notes` at, and "Obsidian-style" describing the force-graph layout and the picker's tab completion. Those are accurate.

## Test plan

- [x] `flutter test test/features/notes/` — 7/7. Every case asserts the reassembled span text is **byte-identical to the source** before checking any colour: a scanner that drops or duplicates a character would corrupt the note on the next save. Covers frontmatter, fences, CJK, emoji, empty/whitespace-only input, overlapping patterns (bold inside code stays code), and a 400-section document
- [x] `flutter analyze` — no issues
- [x] `tsc --noEmit` + `pnpm build` clean
- [x] `go build ./...`, `gofmt` clean
- [x] Full mobile suite: one pre-existing failure in `dio_retry_test.dart`, verified to fail identically on a stashed (clean) tree — unrelated to this change

## What to check by hand

Caret alignment on web is the thing worth a real look: open a long note in **source** mode, type at the very bottom, and confirm the caret sits exactly on the glyphs. Then check both themes, and a note with a long unbroken line (wrapping must match between the two layers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)