### PR TITLE
fix(i18n): {{double braces}} broke the mobile build and web interpolation

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -268,7 +268,7 @@
           "renameTitle": "Rename or move",
           "move": "Move",
           "renamed": "Moved.",
-          "renamedWithLinks": "Moved — updated {{count}} link(s) in {{notes}} note(s).",
+          "renamedWithLinks": "Moved — updated {count} link(s) in {notes} note(s).",
           "renamedWithWarning": "Moved, but links may not be updated",
           "renameFailed": "Move failed",
           "templateLabel": "Template",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -268,7 +268,7 @@
           "renameTitle": "Renombrar o mover",
           "move": "Mover",
           "renamed": "Movido.",
-          "renamedWithLinks": "Movido: se actualizaron {{count}} enlace(s) en {{notes}} nota(s).",
+          "renamedWithLinks": "Movido: se actualizaron {count} enlace(s) en {notes} nota(s).",
           "renamedWithWarning": "Movido, pero los enlaces podrían no actualizarse",
           "renameFailed": "Error al mover",
           "templateLabel": "Plantilla",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -268,7 +268,7 @@
           "renameTitle": "重命名或移动",
           "move": "移动",
           "renamed": "已移动。",
-          "renamedWithLinks": "已移动 —— 更新了 {{notes}} 篇笔记中的 {{count}} 处链接。",
+          "renamedWithLinks": "已移动 —— 更新了 {notes} 篇笔记中的 {count} 处链接。",
           "renamedWithWarning": "已移动,但链接可能未更新",
           "renameFailed": "移动失败",
           "templateLabel": "模板",

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -6,7 +6,7 @@
 /// Locales: 3
 /// Strings: 13014 (4338 per locale)
 ///
-/// Built on 2026-08-07 at 13:23 UTC
+/// Built on 2026-08-07 at 14:13 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -14610,8 +14610,8 @@ class TranslationsWebSessionsInspectorVaultPanelEn {
 	/// en: 'Moved.'
 	String get renamed => 'Moved.';
 
-	/// en: 'Moved — updated {{count}} link(s) in {{notes}} note(s).'
-	String renamedWithLinks({required Object {count, required Object {notes}) => 'Moved — updated ${{count}} link(s) in ${{notes}} note(s).';
+	/// en: 'Moved — updated {count} link(s) in {notes} note(s).'
+	String renamedWithLinks({required Object count, required Object notes}) => 'Moved — updated ${count} link(s) in ${notes} note(s).';
 
 	/// en: 'Moved, but links may not be updated'
 	String get renamedWithWarning => 'Moved, but links may not be updated';
@@ -18780,7 +18780,7 @@ extension on Translations {
 			'web.sessions.inspector.vaultPanel.renameTitle' => 'Rename or move',
 			'web.sessions.inspector.vaultPanel.move' => 'Move',
 			'web.sessions.inspector.vaultPanel.renamed' => 'Moved.',
-			'web.sessions.inspector.vaultPanel.renamedWithLinks' => ({required Object {count, required Object {notes}) => 'Moved — updated ${{count}} link(s) in ${{notes}} note(s).',
+			'web.sessions.inspector.vaultPanel.renamedWithLinks' => ({required Object count, required Object notes}) => 'Moved — updated ${count} link(s) in ${notes} note(s).',
 			'web.sessions.inspector.vaultPanel.renamedWithWarning' => 'Moved, but links may not be updated',
 			'web.sessions.inspector.vaultPanel.renameFailed' => 'Move failed',
 			'web.sessions.inspector.vaultPanel.templateLabel' => 'Template',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -7475,7 +7475,7 @@ class _TranslationsWebSessionsInspectorVaultPanelEs extends TranslationsWebSessi
 	@override String get renameTitle => 'Renombrar o mover';
 	@override String get move => 'Mover';
 	@override String get renamed => 'Movido.';
-	@override String renamedWithLinks({required Object {count, required Object {notes}) => 'Movido: se actualizaron ${{count}} enlace(s) en ${{notes}} nota(s).';
+	@override String renamedWithLinks({required Object count, required Object notes}) => 'Movido: se actualizaron ${count} enlace(s) en ${notes} nota(s).';
 	@override String get renamedWithWarning => 'Movido, pero los enlaces podrían no actualizarse';
 	@override String get renameFailed => 'Error al mover';
 	@override String get templateLabel => 'Plantilla';
@@ -9982,7 +9982,7 @@ extension on TranslationsEs {
 			'web.sessions.inspector.vaultPanel.renameTitle' => 'Renombrar o mover',
 			'web.sessions.inspector.vaultPanel.move' => 'Mover',
 			'web.sessions.inspector.vaultPanel.renamed' => 'Movido.',
-			'web.sessions.inspector.vaultPanel.renamedWithLinks' => ({required Object {count, required Object {notes}) => 'Movido: se actualizaron ${{count}} enlace(s) en ${{notes}} nota(s).',
+			'web.sessions.inspector.vaultPanel.renamedWithLinks' => ({required Object count, required Object notes}) => 'Movido: se actualizaron ${count} enlace(s) en ${notes} nota(s).',
 			'web.sessions.inspector.vaultPanel.renamedWithWarning' => 'Movido, pero los enlaces podrían no actualizarse',
 			'web.sessions.inspector.vaultPanel.renameFailed' => 'Error al mover',
 			'web.sessions.inspector.vaultPanel.templateLabel' => 'Plantilla',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -7475,7 +7475,7 @@ class _TranslationsWebSessionsInspectorVaultPanelZh extends TranslationsWebSessi
 	@override String get renameTitle => '重命名或移动';
 	@override String get move => '移动';
 	@override String get renamed => '已移动。';
-	@override String renamedWithLinks({required Object {notes, required Object {count}) => '已移动 —— 更新了 ${{notes}} 篇笔记中的 ${{count}} 处链接。';
+	@override String renamedWithLinks({required Object notes, required Object count}) => '已移动 —— 更新了 ${notes} 篇笔记中的 ${count} 处链接。';
 	@override String get renamedWithWarning => '已移动,但链接可能未更新';
 	@override String get renameFailed => '移动失败';
 	@override String get templateLabel => '模板';
@@ -9982,7 +9982,7 @@ extension on TranslationsZh {
 			'web.sessions.inspector.vaultPanel.renameTitle' => '重命名或移动',
 			'web.sessions.inspector.vaultPanel.move' => '移动',
 			'web.sessions.inspector.vaultPanel.renamed' => '已移动。',
-			'web.sessions.inspector.vaultPanel.renamedWithLinks' => ({required Object {notes, required Object {count}) => '已移动 —— 更新了 ${{notes}} 篇笔记中的 ${{count}} 处链接。',
+			'web.sessions.inspector.vaultPanel.renamedWithLinks' => ({required Object notes, required Object count}) => '已移动 —— 更新了 ${notes} 篇笔记中的 ${count} 处链接。',
 			'web.sessions.inspector.vaultPanel.renamedWithWarning' => '已移动,但链接可能未更新',
 			'web.sessions.inspector.vaultPanel.renameFailed' => '移动失败',
 			'web.sessions.inspector.vaultPanel.templateLabel' => '模板',

--- a/scripts/check-i18n-parity.mjs
+++ b/scripts/check-i18n-parity.mjs
@@ -34,6 +34,20 @@ const inCI = !!process.env.GITHUB_ACTIONS
 // {name} single-brace vars (i18next/slang) + <1>/</1> numbered Trans tags.
 // Both MUST be preserved (order may change) across a translation.
 const TOKEN = /\{[^{}]*\}|<\/?\d+>/g
+
+// react-i18next's DEFAULT interpolation is {{name}}, so it is the natural
+// thing to reach for — and it is wrong in both apps here. The web i18n is
+// configured with prefix '{' / suffix '}', so {{name}} never interpolates
+// and renders literally; slang, which generates Dart from this SAME file
+// including the web-only subtree, turns it into a parameter called
+// `{name` and emits code that does not compile.
+//
+// A locale-vs-locale diff can't catch this: write {{name}} in all three
+// and they agree perfectly. It is a convention error, not drift, so it
+// needs its own check — and it needs to be here, because the mobile
+// analyzer excludes **/*.g.dart and CI builds no APK, which left nothing
+// between a typo and a broken build.
+const DOUBLE_BRACE = /\{\{[^{}]+\}\}/g
 const PLURAL = /_(zero|one|two|few|many|other)$/
 
 const base = (k) => k.replace(PLURAL, '')
@@ -108,8 +122,15 @@ for (const loc of locales) {
     if (want !== got) mismatch.push({ k, en: want, loc: got })
   }
 
+  const doubleBraced = []
+  for (const [k, v] of locFlat) {
+    const hits = v.match(DOUBLE_BRACE)
+    if (hits) doubleBraced.push({ k, hits: [...new Set(hits)].join(' ') })
+  }
+
   if (missing.length) blocking += 0 // advisory
   if (mismatch.length) blocking += mismatch.length
+  if (doubleBraced.length) blocking += doubleBraced.length
 
   const pct = Math.round(((enGroups.size - missing.length) / enGroups.size) * 100)
   console.log(
@@ -118,6 +139,16 @@ for (const loc of locales) {
   for (const g of missing) {
     console.log(`  WARN missing (renders English via fallback): ${g}`)
     annotate('warning', file, `missing key, renders English via fallback: ${g}`)
+  }
+  for (const { k, hits } of doubleBraced) {
+    console.log(
+      `  FAIL {{double braces}}: ${k} -> ${hits}  (use {name}: {{name}} renders literally on web and breaks slang codegen)`,
+    )
+    annotate(
+      'error',
+      file,
+      `${k} uses ${hits}; this app interpolates with single braces — {{name}} renders literally on web and generates invalid Dart via slang`,
+    )
   }
   for (const g of extra) {
     console.log(`  WARN extra, not in en (stale or typo): ${g}`)
@@ -141,7 +172,7 @@ if (process.env.GITHUB_STEP_SUMMARY) {
     ...summary,
     '',
     blocking
-      ? `**${blocking} blocking issue(s)** (token mismatch or invalid JSON).`
+      ? `**${blocking} blocking issue(s)** (token mismatch, {{double braces}}, or invalid JSON).`
       : 'No blocking issues.',
     '',
     'Missing keys are advisory (they render English via the i18next / slang fallback). Token mismatches and invalid JSON are blocking, because a dropped or renamed `{placeholder}` / `<1>` tag breaks interpolation at runtime.',


### PR DESCRIPTION
**The Android app has not compiled from `main` since #495.** Found while building an APK for testing.

## What broke

One string I added in #495 used react-i18next's *default* `{{name}}` syntax:

```json
"renamedWithLinks": "Moved — updated {{count}} link(s) in {{notes}} note(s)."
```

slang generates Dart from `app/i18n/*.json` — the **whole** file, web-only subtree included — and turns `{{count}}` into a parameter named `` {count ``. The emitted `strings_*.g.dart` doesn't parse:

```dart
@override String renamedWithLinks({required Object {notes, required Object {count}) => ...
```

`flutter build apk` dies at `kernel_snapshot_program`.

It was wrong on the **web** too: `i18n.ts` configures interpolation with `prefix: '{'` / `suffix: '}'`, so `{{count}}` never interpolates — it renders literally. **250 web keys use `{name}`; this was the only one that didn't.** My mistake, not a missing convention.

## Why nothing caught it

Three guards had a clear line of sight and all missed it:

| Guard | Why it missed |
|---|---|
| CI | Runs no mobile build (already known) |
| `flutter analyze` | **Structurally cannot see it** — `analysis_options.yaml` excludes `**/*.g.dart` |
| i18n parity | Compares locales *against each other*; write `{{name}}` in all three and they agree perfectly |

The analyzer point is worth being precise about, because I assumed otherwise at first: the exclude applies **even when the generated directory is named explicitly**. Verified by injecting the syntax error back and watching both `flutter analyze` and `dart analyze lib/core/i18n/` report `No issues found!`. Analyze can never be the guard here.

## The fix

1. `{{count}}`/`{{notes}}` → `{count}`/`{notes}` in all three locales; `strings_*.g.dart` regenerated.
2. **The parity guard now rejects `{{...}}` anywhere**, as a blocking error naming both consequences. It runs in CI, which is the only place left that can catch this class of mistake — a convention error is invisible to a locale-vs-locale diff by construction.

## Test plan

- [x] **An actual APK build** — the only other thing that sees generated code. Failed before the fix at `kernel_snapshot_program`, succeeded after: `opendray-v2_v2.4.0_b91` (76.6 MB), shipped to UNAS
- [x] Guard proven to block: re-injected a `{{oops}}` and confirmed `FAILED: 2 blocking issue(s)` with the explanatory message; passes clean afterwards
- [x] Guard proven not to over-fire: the other 250 `{name}` web keys and all mobile keys pass
- [x] `flutter analyze` clean, `check-i18n-parity.mjs` clean
- [x] Regenerated `renamedWithLinks` now reads `({required Object notes, required Object count})`

Split out of #498 and sent first because it unblocks mobile builds from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)