### PR TITLE
feat(vault): the Vault is documents; skills and MCP move out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+### Changed
+
+- **The Vault is your documents. Agent skills and the MCP registry moved
+  out.** One root held three tenants with nothing in common — the
+  operator's markdown, the skills opendray injects at spawn, and the MCP
+  registry — which is why the settings page could only describe it as
+  "notes, skills and git-versioned root", a sentence that parses only if
+  you already know the implementation. Opening the Vault showed
+  `skills/` and `mcp/` sitting among your folders, and because Vault
+  Sync commits that same directory, they went to your remote: on one
+  install a private docs repo had picked up opendray's own
+  `skills/secretary/SKILL.md`, and a `git clean -fd` there would have
+  deleted the gateway's skills.
+
+  New installs get `~/.opendray/vault` for documents, `~/.opendray/
+  skills` and `~/.opendray/mcp` beside it, and a Vault repo holding
+  writing and nothing else. **Existing installs are not moved**: any
+  root with content still in the old place keeps being used, the
+  settings page prints where everything actually resolved, and says
+  plainly when it is still the shared layout. `vault.notes` and
+  `vault.skills` keep working; `vault.root` now means the documents
+  directory, and `[skills].root` is the new spelling. Machinery
+  directories that do sit inside the Vault are hidden from the doc
+  library and added to an opendray-managed `.gitignore` block, so
+  nothing new gets carried to your remote. Anything already committed
+  needs `git rm --cached` — opendray will not rewrite your repo.
+
+  Path resolution used to be reimplemented in four places (the gateway
+  plus each of `opendray notes|skill|mcp`) with different precedence in
+  each, so the CLI could read a different directory than the running
+  gateway. There is now exactly one resolver.
+
 ### Added
 
 - **Git credentials are scoped per host *and owner*, so one forge can

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -2161,7 +2161,7 @@
         },
         "vault": {
           "title": "Vault",
-          "desc": "Notes, skills, and git-versioned root."
+          "desc": "Your documents, and the repo they sync to."
         },
         "mcp": {
           "title": "MCP registry",
@@ -2186,6 +2186,10 @@
         "antigravity": {
           "title": "Storage · Antigravity",
           "desc": "Antigravity (agy) per-conversation SQLite store."
+        },
+        "skills": {
+          "title": "Agent skills",
+          "desc": "Where skills are loaded from."
         }
       },
       "loading": "Loading server settings…",
@@ -2270,19 +2274,15 @@
         },
         "vaultRoot": {
           "label": "Vault root",
-          "hint": "Top-level directory for notes, skills, and MCP registry."
+          "hint": "The directory your documents live in. This is what the Vault page browses and what Vault Sync commits."
         },
         "notesDirectory": {
-          "label": "Notes directory",
-          "hint": "Override notes location. Defaults to <vault root>/notes."
-        },
-        "skillsDirectory": {
-          "label": "Skills directory",
-          "hint": "Override skills location. Defaults to <vault root>/skills."
+          "label": "Documents directory (legacy)",
+          "hint": "Older name for the Vault root, kept because it is set. Clear it to use Vault root, or keep it pointed at a markdown folder you maintain elsewhere."
         },
         "gitRoot": {
           "label": "Git root",
-          "hint": "Working tree the Vault Sync feature commits to."
+          "hint": "Working tree Vault Sync commits. Defaults to the Vault root, so the repo holds documents and nothing else."
         },
         "personalPrefix": {
           "label": "Personal prefix",
@@ -2294,7 +2294,7 @@
         },
         "registryRoot": {
           "label": "Registry root",
-          "hint": "Directory holding MCP server JSON definitions. Defaults to <vault>/mcp."
+          "hint": "Directory holding MCP server JSON definitions. Defaults to ~/.opendray/mcp."
         },
         "secretsFile": {
           "label": "Secrets file",
@@ -2427,6 +2427,10 @@
         "dbMaxConns": {
           "label": "Max connections",
           "hint": "pgx connection pool cap. 0 = store default (16)."
+        },
+        "skillsRoot": {
+          "label": "Skills root",
+          "hint": "Directory holding agent skills. Kept outside the Vault so they are not committed to your documents repo."
         }
       },
       "liveTail": {
@@ -2546,6 +2550,14 @@
             "caveat": "The gateway is unreachable whenever the host sleeps, unless something else keeps it awake."
           }
         }
+      },
+      "layout": {
+        "title": "Resolving to",
+        "documents": "Documents",
+        "git": "Git repo",
+        "skills": "Skills",
+        "mcp": "MCP registry",
+        "legacyWarning": "This install still keeps opendray's own directories inside your documents, so they show up in the Vault and get carried along by a sync. They keep working — move them out and set the paths above when convenient. Anything already committed needs git rm --cached; opendray will not rewrite your repo."
       }
     },
     "settings": {
@@ -5283,20 +5295,22 @@
         "backup": "Backup",
         "storageClaude": "Storage · Claude",
         "storageCodex": "Storage · Codex",
-        "storageAntigravity": "Storage · Antigravity"
+        "storageAntigravity": "Storage · Antigravity",
+        "skills": "Agent skills"
       },
       "sectionDescriptions": {
         "general": "Listen address, operator account, token TTL.",
         "host": "Keep this machine reachable while it is idle.",
         "logging": "Verbosity, format, and on-disk log path.",
         "sessions": "Idle detection thresholds.",
-        "vault": "Notes, skills, and git-versioned root.",
-        "mcpRegistry": "Vault paths for MCP servers + secrets file.",
+        "vault": "Your documents, and the repo they sync to.",
+        "mcpRegistry": "Server registry + secrets file.",
         "memory": "Cross-CLI persistent memory subsystem.",
         "backup": "Encrypted DB backups + admin data exports. Passphrase lives in the keyfile (Settings → Backups).",
         "storageClaude": "Where Claude transcripts live on disk.",
         "storageCodex": "Codex sessions root.",
-        "storageAntigravity": "agy per-conversation SQLite store."
+        "storageAntigravity": "agy per-conversation SQLite store.",
+        "skills": "Where agent skills are loaded from."
       },
       "fields": {
         "listenAddress": "Listen address",
@@ -5314,10 +5328,9 @@
         "idleThresholdHelper": "Quiet period before a session is flagged idle. Go duration.",
         "idleCheckInterval": "Idle check interval",
         "idleCheckHelper": "How often the idle reaper runs.",
-        "root": "Root",
-        "rootHelper": "Parent of notes / skills / git_root sub-paths.",
-        "notesPath": "Notes path",
-        "skillsPath": "Skills path",
+        "root": "Vault root",
+        "rootHelper": "The directory your documents live in — what the Vault browses and what Vault Sync commits.",
+        "notesPath": "Documents path (legacy)",
         "gitRoot": "Git root",
         "personalPrefix": "Personal prefix",
         "projectsPrefix": "Projects prefix",
@@ -5368,7 +5381,11 @@
         "sleepModeAc": "Stay awake on wall power",
         "sleepModeAlways": "Stay awake on any power",
         "sleepModeOnDemand": "Sleep, wake on traffic",
-        "sleepModeOff": "Don't touch power"
+        "sleepModeOff": "Don't touch power",
+        "notesPathHelper": "Older name for the Vault root, kept because it is set. Clear it to use Vault root, or keep it pointed at a markdown folder you maintain elsewhere.",
+        "skillsRoot": "Skills root",
+        "skillsRootHelper": "Directory holding agent skills. Kept outside the Vault so they are not committed to your documents repo.",
+        "gitRootHelper": "Working tree Vault Sync commits. Defaults to the Vault root, so the repo holds documents and nothing else."
       },
       "validateInteger": "\"{field}\" must be an integer",
       "validateNumber": "\"{field}\" must be a number",
@@ -5378,7 +5395,8 @@
         "pickHint": "Select a model",
         "manual": "Type manually",
         "pickFromList": "Pick from list"
-      }
+      },
+      "legacyLayout": "opendray's own directories still sit inside your documents, so they show up in the Vault and a sync carries them along. They keep working — move them out and set the paths below when convenient."
     }
   },
   "memoryQuarantine": {

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -2161,11 +2161,11 @@
         },
         "vault": {
           "title": "Vault",
-          "desc": "Notas, skills y raíz versionada con git."
+          "desc": "Tus documentos y el repositorio al que se sincronizan."
         },
         "mcp": {
-          "title": "Registro de MCP",
-          "desc": "Registro de servidores + secretos."
+          "title": "Registro MCP",
+          "desc": "Registro de servidores y secretos."
         },
         "memory": {
           "title": "Memoria · almacenamiento y embedder",
@@ -2186,6 +2186,10 @@
         "antigravity": {
           "title": "Almacenamiento · Antigravity",
           "desc": "Almacén SQLite por conversación de Antigravity (agy)."
+        },
+        "skills": {
+          "title": "Habilidades de agente",
+          "desc": "De dónde se cargan las habilidades."
         }
       },
       "loading": "Cargando ajustes del servidor…",
@@ -2270,19 +2274,15 @@
         },
         "vaultRoot": {
           "label": "Raíz del Vault",
-          "hint": "Directorio de nivel superior para notas, skills y el registro de MCP."
+          "hint": "El directorio donde viven tus documentos. Es lo que muestra la página Vault y lo que confirma Vault Sync."
         },
         "notesDirectory": {
-          "label": "Directorio de notas",
-          "hint": "Anula la ubicación de las notas. Por defecto <vault root>/notes."
-        },
-        "skillsDirectory": {
-          "label": "Directorio de skills",
-          "hint": "Anula la ubicación de los skills. Por defecto <vault root>/skills."
+          "label": "Directorio de documentos (heredado)",
+          "hint": "Nombre antiguo de la raíz del Vault, visible porque está definido. Vacíalo para usar la raíz del Vault, o mantenlo apuntando a una carpeta markdown que gestiones en otro sitio."
         },
         "gitRoot": {
-          "label": "Raíz de git",
-          "hint": "Árbol de trabajo al que confirma la función Vault Sync."
+          "label": "Raíz de Git",
+          "hint": "Árbol de trabajo que confirma Vault Sync. Por defecto la raíz del Vault, así el repositorio solo contiene documentos."
         },
         "personalPrefix": {
           "label": "Prefijo personal",
@@ -2294,7 +2294,7 @@
         },
         "registryRoot": {
           "label": "Raíz del registro",
-          "hint": "Directorio que contiene las definiciones JSON de los servidores MCP. Por defecto <vault>/mcp."
+          "hint": "Directorio con las definiciones JSON de servidores MCP. Por defecto ~/.opendray/mcp."
         },
         "secretsFile": {
           "label": "Archivo de secretos",
@@ -2427,6 +2427,10 @@
         "dbMaxConns": {
           "label": "Conexiones máx.",
           "hint": "Tope del pool de conexiones pgx. 0 = valor por defecto (16)."
+        },
+        "skillsRoot": {
+          "label": "Raíz de habilidades",
+          "hint": "Directorio con las habilidades de agente. Fuera del Vault para que no acaben en el repositorio de tus documentos."
         }
       },
       "liveTail": {
@@ -2546,6 +2550,14 @@
             "caveat": "La pasarela será inaccesible cuando el host duerma, salvo que otra cosa lo mantenga despierto."
           }
         }
+      },
+      "layout": {
+        "title": "Se resuelve en",
+        "documents": "Documentos",
+        "git": "Repositorio Git",
+        "skills": "Habilidades",
+        "mcp": "Registro MCP",
+        "legacyWarning": "Esta instalación aún mantiene los directorios propios de opendray dentro de tus documentos, así que aparecen en el Vault y la sincronización se los lleva. Siguen funcionando: muévelos fuera y fija las rutas de arriba cuando puedas. Lo ya confirmado requiere git rm --cached; opendray no reescribirá tu repositorio."
       }
     },
     "settings": {
@@ -5283,20 +5295,22 @@
         "backup": "Copia de seguridad",
         "storageClaude": "Almacenamiento · Claude",
         "storageCodex": "Almacenamiento · Codex",
-        "storageAntigravity": "Almacenamiento · Antigravity"
+        "storageAntigravity": "Almacenamiento · Antigravity",
+        "skills": "Habilidades de agente"
       },
       "sectionDescriptions": {
         "general": "Dirección de escucha, cuenta del operador, TTL del token.",
         "host": "Mantén esta máquina accesible mientras está inactiva.",
         "logging": "Verbosidad, formato y ruta del log en disco.",
         "sessions": "Umbrales de detección de inactividad.",
-        "vault": "Notas, skills y raíz versionada con git.",
-        "mcpRegistry": "Rutas del vault para servidores MCP + archivo de secretos.",
+        "vault": "Tus documentos y el repositorio al que se sincronizan.",
+        "mcpRegistry": "Registro de servidores y archivo de secretos.",
         "memory": "Subsistema de memoria persistente entre CLIs.",
         "backup": "Copias de seguridad cifradas de la BD + exportaciones de datos de admin. La frase de contraseña vive en el keyfile (Ajustes → Copias de seguridad).",
         "storageClaude": "Dónde viven los transcripts de Claude en disco.",
         "storageCodex": "Raíz de las sessions de Codex.",
-        "storageAntigravity": "Almacén SQLite por conversación de agy."
+        "storageAntigravity": "Almacén SQLite por conversación de agy.",
+        "skills": "De dónde se cargan las habilidades de agente."
       },
       "fields": {
         "listenAddress": "Dirección de escucha",
@@ -5314,10 +5328,9 @@
         "idleThresholdHelper": "Periodo de silencio antes de marcar una session como inactiva. Duración de Go.",
         "idleCheckInterval": "Intervalo de comprobación de inactividad",
         "idleCheckHelper": "Con qué frecuencia se ejecuta el reaper de inactividad.",
-        "root": "Raíz",
-        "rootHelper": "Padre de las sub-rutas notes / skills / git_root.",
-        "notesPath": "Ruta de notas",
-        "skillsPath": "Ruta de skills",
+        "root": "Raíz del Vault",
+        "rootHelper": "El directorio donde viven tus documentos: lo que muestra el Vault y lo que confirma Vault Sync.",
+        "notesPath": "Ruta de documentos (heredada)",
         "gitRoot": "Raíz de git",
         "personalPrefix": "Prefijo personal",
         "projectsPrefix": "Prefijo de proyectos",
@@ -5368,7 +5381,11 @@
         "sleepModeAc": "Despierto con corriente",
         "sleepModeAlways": "Despierto con cualquier alimentación",
         "sleepModeOnDemand": "Dormir, despertar con tráfico",
-        "sleepModeOff": "No tocar la energía"
+        "sleepModeOff": "No tocar la energía",
+        "notesPathHelper": "Nombre antiguo de la raíz del Vault, visible porque está definido. Vacíalo para usar la raíz del Vault, o mantenlo apuntando a una carpeta markdown que gestiones en otro sitio.",
+        "skillsRoot": "Raíz de habilidades",
+        "skillsRootHelper": "Directorio con las habilidades de agente. Fuera del Vault para que no acaben en el repositorio de tus documentos.",
+        "gitRootHelper": "Árbol de trabajo que confirma Vault Sync. Por defecto la raíz del Vault, así el repositorio solo contiene documentos."
       },
       "validateInteger": "\"{field}\" debe ser un entero",
       "validateNumber": "\"{field}\" debe ser un número",
@@ -5378,7 +5395,8 @@
         "pickHint": "Selecciona un modelo",
         "manual": "Escribir manualmente",
         "pickFromList": "Elegir de la lista"
-      }
+      },
+      "legacyLayout": "Los directorios propios de opendray siguen dentro de tus documentos, así que aparecen en el Vault y la sincronización se los lleva. Siguen funcionando: muévelos fuera y fija las rutas de abajo cuando puedas."
     }
   },
   "memoryQuarantine": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -2161,7 +2161,7 @@
         },
         "vault": {
           "title": "Vault",
-          "desc": "笔记、技能与 git 版本化根目录。"
+          "desc": "你的文档,以及它同步到的仓库。"
         },
         "mcp": {
           "title": "MCP 注册表",
@@ -2186,6 +2186,10 @@
         "antigravity": {
           "title": "存储 · Antigravity",
           "desc": "Antigravity (agy) 按会话存储的 SQLite 库。"
+        },
+        "skills": {
+          "title": "Agent skills",
+          "desc": "技能从哪里加载。"
         }
       },
       "loading": "正在加载服务器设置…",
@@ -2270,19 +2274,15 @@
         },
         "vaultRoot": {
           "label": "Vault 根目录",
-          "hint": "笔记、技能和 MCP 注册表的顶层目录。"
+          "hint": "你的文档所在的目录。Vault 页面浏览的就是这里,Vault Sync 提交的也是这里。"
         },
         "notesDirectory": {
-          "label": "笔记目录",
-          "hint": "覆盖笔记位置。默认为 <vault root>/notes。"
-        },
-        "skillsDirectory": {
-          "label": "技能目录",
-          "hint": "覆盖技能位置。默认为 <vault root>/skills。"
+          "label": "文档目录(旧字段)",
+          "hint": "Vault 根目录的旧称,因为已设置才显示。清空即改用 Vault 根目录;也可以继续指向你在别处维护的 markdown 目录。"
         },
         "gitRoot": {
           "label": "Git 根目录",
-          "hint": "Vault Sync 功能提交到的工作树。"
+          "hint": "Vault Sync 提交的工作树。默认为 Vault 根目录,这样仓库里只有文档。"
         },
         "personalPrefix": {
           "label": "个人前缀",
@@ -2294,7 +2294,7 @@
         },
         "registryRoot": {
           "label": "注册表根目录",
-          "hint": "存放 MCP server JSON 定义的目录。默认为 <vault>/mcp。"
+          "hint": "存放 MCP 服务器 JSON 定义的目录。默认 ~/.opendray/mcp。"
         },
         "secretsFile": {
           "label": "密钥文件",
@@ -2427,6 +2427,10 @@
         "dbMaxConns": {
           "label": "最大连接数",
           "hint": "pgx 连接池上限。0 = 默认值（16）。"
+        },
+        "skillsRoot": {
+          "label": "Skills 根目录",
+          "hint": "存放 agent skills 的目录。放在 Vault 之外,避免被提交进你的文档仓库。"
         }
       },
       "liveTail": {
@@ -2546,6 +2550,14 @@
             "caveat": "主机一旦休眠即无法连接,除非另有程序让它保持唤醒。"
           }
         }
+      },
+      "layout": {
+        "title": "实际解析到",
+        "documents": "文档",
+        "git": "Git 仓库",
+        "skills": "Skills",
+        "mcp": "MCP 注册表",
+        "legacyWarning": "此安装仍把 opendray 自己的目录放在你的文档里,所以它们会出现在 Vault 中,也会被同步带走。它们照常工作 —— 方便时把它们移出去,并在上面填好路径。已经提交进仓库的需要你自己 git rm --cached;opendray 不会改写你的仓库。"
       }
     },
     "settings": {
@@ -5277,26 +5289,28 @@
         "host": "主机电源",
         "logging": "日志",
         "sessions": "会话",
-        "vault": "凭据库",
+        "vault": "Vault",
         "mcpRegistry": "MCP 注册表",
         "memory": "记忆",
         "backup": "备份",
         "storageClaude": "存储 · Claude",
         "storageCodex": "存储 · Codex",
-        "storageAntigravity": "存储 · Antigravity"
+        "storageAntigravity": "存储 · Antigravity",
+        "skills": "Agent skills"
       },
       "sectionDescriptions": {
         "general": "监听地址、管理员账号、令牌 TTL。",
         "host": "让这台机器在闲置时仍可被访问。",
         "logging": "详细程度、格式、磁盘日志路径。",
         "sessions": "空闲检测阈值。",
-        "vault": "笔记、技能、git 版本化的根目录。",
-        "mcpRegistry": "MCP 服务器 + 密钥文件的凭据库路径。",
+        "vault": "你的文档,以及它同步到的仓库。",
+        "mcpRegistry": "服务器注册表与密钥文件。",
         "memory": "跨 CLI 的持久记忆子系统。",
         "backup": "加密的数据库备份 + 管理数据导出。密语保存在密钥文件（设置 → 备份）。",
         "storageClaude": "Claude 会话记录在磁盘的存放位置。",
         "storageCodex": "Codex 会话根目录。",
-        "storageAntigravity": "agy 按会话存储的 SQLite 库。"
+        "storageAntigravity": "agy 按会话存储的 SQLite 库。",
+        "skills": "agent skills 从哪里加载。"
       },
       "fields": {
         "listenAddress": "监听地址",
@@ -5314,10 +5328,9 @@
         "idleThresholdHelper": "会话被标记为空闲前的安静时长。Go duration。",
         "idleCheckInterval": "空闲检查间隔",
         "idleCheckHelper": "空闲回收器运行的频率。",
-        "root": "根目录",
-        "rootHelper": "notes / skills / git_root 子路径的父目录。",
-        "notesPath": "笔记路径",
-        "skillsPath": "技能路径",
+        "root": "Vault 根目录",
+        "rootHelper": "你的文档所在的目录 —— Vault 浏览的就是这里,Vault Sync 提交的也是这里。",
+        "notesPath": "文档路径(旧字段)",
         "gitRoot": "Git 根",
         "personalPrefix": "个人前缀",
         "projectsPrefix": "项目前缀",
@@ -5368,7 +5381,11 @@
         "sleepModeAc": "插电时保持唤醒",
         "sleepModeAlways": "任何供电下保持唤醒",
         "sleepModeOnDemand": "闲时休眠,有请求时唤醒",
-        "sleepModeOff": "不干预电源"
+        "sleepModeOff": "不干预电源",
+        "notesPathHelper": "Vault 根目录的旧称,因为已设置才显示。清空即改用 Vault 根目录;也可以继续指向你在别处维护的 markdown 目录。",
+        "skillsRoot": "Skills 根目录",
+        "skillsRootHelper": "存放 agent skills 的目录。放在 Vault 之外,避免被提交进你的文档仓库。",
+        "gitRootHelper": "Vault Sync 提交的工作树。默认为 Vault 根目录,这样仓库里只有文档。"
       },
       "validateInteger": "「{field}」必须是整数",
       "validateNumber": "「{field}」必须是数字",
@@ -5378,7 +5395,8 @@
         "pickHint": "选择模型",
         "manual": "手动输入",
         "pickFromList": "从列表选择"
-      }
+      },
+      "legacyLayout": "opendray 自己的目录仍在你的文档里,所以它们会出现在 Vault 中,同步时也会被带走。它们照常工作 —— 方便时把它们移出去,并在下面填好路径。"
     }
   },
   "memoryQuarantine": {

--- a/app/mobile/lib/core/api/settings_api.dart
+++ b/app/mobile/lib/core/api/settings_api.dart
@@ -20,18 +20,29 @@ class SettingsApi {
   SettingsApi(this._dio);
   final Dio _dio;
 
-  // GET /admin/settings — returns the full Config + the path of the
-  // toml file the server loaded it from. The toml path is shown to
-  // the operator so they know which file would change on a PUT.
-  Future<({Map<String, dynamic> config, String configPath})> get() async {
+  // GET /admin/settings — returns the full Config, the path of the
+  // toml file the server loaded it from, and where those settings
+  // actually resolve to on disk. The toml path is shown to the
+  // operator so they know which file would change on a PUT; `layout`
+  // is read-only and exists because several paths are derived — a
+  // form full of empty "defaults to…" boxes does not tell anyone
+  // where their documents are.
+  Future<
+      ({
+        Map<String, dynamic> config,
+        String configPath,
+        Map<String, dynamic> layout,
+      })> get() async {
     try {
       final res =
           await _dio.get<Map<String, dynamic>>('/api/v1/admin/settings');
       final data = res.data ?? const <String, dynamic>{};
       final cfg = data['config'];
+      final layout = data['layout'];
       return (
         config: cfg is Map<String, dynamic> ? cfg : <String, dynamic>{},
         configPath: data['config_path'] as String? ?? '',
+        layout: layout is Map<String, dynamic> ? layout : <String, dynamic>{},
       );
     } on Object catch (e) {
       throw toApiException(e);

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 13083 (4361 per locale)
+/// Strings: 13125 (4375 per locale)
 ///
-/// Built on 2026-08-08 at 12:16 UTC
+/// Built on 2026-08-08 at 13:47 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -3201,6 +3201,7 @@ class TranslationsWebServerSettingsEn {
 	String get memoryRuntimeBannerButton => 'Open Cortex settings';
 
 	late final TranslationsWebServerSettingsHostEn host = TranslationsWebServerSettingsHostEn.internal(_root);
+	late final TranslationsWebServerSettingsLayoutEn layout = TranslationsWebServerSettingsLayoutEn.internal(_root);
 }
 
 // Path: web.settings
@@ -6166,6 +6167,9 @@ class TranslationsSettingsServerSettingsEn {
 	String validateNumber({required Object field}) => '"${field}" must be a number';
 
 	late final TranslationsSettingsServerSettingsEmbedderModelEn embedderModel = TranslationsSettingsServerSettingsEmbedderModelEn.internal(_root);
+
+	/// en: 'opendray's own directories still sit inside your documents, so they show up in the Vault and a sync carries them along. They keep working — move them out and set the paths below when convenient.'
+	String get legacyLayout => 'opendray\'s own directories still sit inside your documents, so they show up in the Vault and a sync carries them along. They keep working — move them out and set the paths below when convenient.';
 }
 
 // Path: web.sessions.list
@@ -10221,6 +10225,7 @@ class TranslationsWebServerSettingsSectionsEn {
 	late final TranslationsWebServerSettingsSectionsClaudeEn claude = TranslationsWebServerSettingsSectionsClaudeEn.internal(_root);
 	late final TranslationsWebServerSettingsSectionsCodexEn codex = TranslationsWebServerSettingsSectionsCodexEn.internal(_root);
 	late final TranslationsWebServerSettingsSectionsAntigravityEn antigravity = TranslationsWebServerSettingsSectionsAntigravityEn.internal(_root);
+	late final TranslationsWebServerSettingsSectionsSkillsEn skills = TranslationsWebServerSettingsSectionsSkillsEn.internal(_root);
 }
 
 // Path: web.serverSettings.restart
@@ -10322,7 +10327,6 @@ class TranslationsWebServerSettingsFieldsEn {
 	late final TranslationsWebServerSettingsFieldsIdlePollIntervalEn idlePollInterval = TranslationsWebServerSettingsFieldsIdlePollIntervalEn.internal(_root);
 	late final TranslationsWebServerSettingsFieldsVaultRootEn vaultRoot = TranslationsWebServerSettingsFieldsVaultRootEn.internal(_root);
 	late final TranslationsWebServerSettingsFieldsNotesDirectoryEn notesDirectory = TranslationsWebServerSettingsFieldsNotesDirectoryEn.internal(_root);
-	late final TranslationsWebServerSettingsFieldsSkillsDirectoryEn skillsDirectory = TranslationsWebServerSettingsFieldsSkillsDirectoryEn.internal(_root);
 	late final TranslationsWebServerSettingsFieldsGitRootEn gitRoot = TranslationsWebServerSettingsFieldsGitRootEn.internal(_root);
 	late final TranslationsWebServerSettingsFieldsPersonalPrefixEn personalPrefix = TranslationsWebServerSettingsFieldsPersonalPrefixEn.internal(_root);
 	late final TranslationsWebServerSettingsFieldsProjectsPrefixEn projectsPrefix = TranslationsWebServerSettingsFieldsProjectsPrefixEn.internal(_root);
@@ -10360,6 +10364,7 @@ class TranslationsWebServerSettingsFieldsEn {
 	late final TranslationsWebServerSettingsFieldsClaudeAutoFailoverEn claudeAutoFailover = TranslationsWebServerSettingsFieldsClaudeAutoFailoverEn.internal(_root);
 	late final TranslationsWebServerSettingsFieldsMobileTokenTTLEn mobileTokenTTL = TranslationsWebServerSettingsFieldsMobileTokenTTLEn.internal(_root);
 	late final TranslationsWebServerSettingsFieldsDbMaxConnsEn dbMaxConns = TranslationsWebServerSettingsFieldsDbMaxConnsEn.internal(_root);
+	late final TranslationsWebServerSettingsFieldsSkillsRootEn skillsRoot = TranslationsWebServerSettingsFieldsSkillsRootEn.internal(_root);
 }
 
 // Path: web.serverSettings.liveTail
@@ -10639,6 +10644,33 @@ class TranslationsWebServerSettingsHostEn {
 	String get platformNote => 'macOS only. On Linux and Windows this setting is accepted and ignored — those hosts do not idle-suspend under a normal server install. A deliberate sleep (lid close, Apple menu → Sleep) is never blocked, and the assertion is released if opendray exits or is killed.';
 
 	late final TranslationsWebServerSettingsHostModesEn modes = TranslationsWebServerSettingsHostModesEn.internal(_root);
+}
+
+// Path: web.serverSettings.layout
+class TranslationsWebServerSettingsLayoutEn {
+	TranslationsWebServerSettingsLayoutEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Resolving to'
+	String get title => 'Resolving to';
+
+	/// en: 'Documents'
+	String get documents => 'Documents';
+
+	/// en: 'Git repo'
+	String get git => 'Git repo';
+
+	/// en: 'Skills'
+	String get skills => 'Skills';
+
+	/// en: 'MCP registry'
+	String get mcp => 'MCP registry';
+
+	/// en: 'This install still keeps opendray's own directories inside your documents, so they show up in the Vault and get carried along by a sync. They keep working — move them out and set the paths above when convenient. Anything already committed needs git rm --cached; opendray will not rewrite your repo.'
+	String get legacyWarning => 'This install still keeps opendray\'s own directories inside your documents, so they show up in the Vault and get carried along by a sync. They keep working — move them out and set the paths above when convenient. Anything already committed needs git rm --cached; opendray will not rewrite your repo.';
 }
 
 // Path: web.settings.groups
@@ -14199,6 +14231,9 @@ class TranslationsSettingsServerSettingsSectionsEn {
 
 	/// en: 'Storage · Antigravity'
 	String get storageAntigravity => 'Storage · Antigravity';
+
+	/// en: 'Agent skills'
+	String get skills => 'Agent skills';
 }
 
 // Path: settings.serverSettings.sectionDescriptions
@@ -14221,11 +14256,11 @@ class TranslationsSettingsServerSettingsSectionDescriptionsEn {
 	/// en: 'Idle detection thresholds.'
 	String get sessions => 'Idle detection thresholds.';
 
-	/// en: 'Notes, skills, and git-versioned root.'
-	String get vault => 'Notes, skills, and git-versioned root.';
+	/// en: 'Your documents, and the repo they sync to.'
+	String get vault => 'Your documents, and the repo they sync to.';
 
-	/// en: 'Vault paths for MCP servers + secrets file.'
-	String get mcpRegistry => 'Vault paths for MCP servers + secrets file.';
+	/// en: 'Server registry + secrets file.'
+	String get mcpRegistry => 'Server registry + secrets file.';
 
 	/// en: 'Cross-CLI persistent memory subsystem.'
 	String get memory => 'Cross-CLI persistent memory subsystem.';
@@ -14241,6 +14276,9 @@ class TranslationsSettingsServerSettingsSectionDescriptionsEn {
 
 	/// en: 'agy per-conversation SQLite store.'
 	String get storageAntigravity => 'agy per-conversation SQLite store.';
+
+	/// en: 'Where agent skills are loaded from.'
+	String get skills => 'Where agent skills are loaded from.';
 }
 
 // Path: settings.serverSettings.fields
@@ -14296,17 +14334,14 @@ class TranslationsSettingsServerSettingsFieldsEn {
 	/// en: 'How often the idle reaper runs.'
 	String get idleCheckHelper => 'How often the idle reaper runs.';
 
-	/// en: 'Root'
-	String get root => 'Root';
+	/// en: 'Vault root'
+	String get root => 'Vault root';
 
-	/// en: 'Parent of notes / skills / git_root sub-paths.'
-	String get rootHelper => 'Parent of notes / skills / git_root sub-paths.';
+	/// en: 'The directory your documents live in — what the Vault browses and what Vault Sync commits.'
+	String get rootHelper => 'The directory your documents live in — what the Vault browses and what Vault Sync commits.';
 
-	/// en: 'Notes path'
-	String get notesPath => 'Notes path';
-
-	/// en: 'Skills path'
-	String get skillsPath => 'Skills path';
+	/// en: 'Documents path (legacy)'
+	String get notesPath => 'Documents path (legacy)';
 
 	/// en: 'Git root'
 	String get gitRoot => 'Git root';
@@ -14460,6 +14495,18 @@ class TranslationsSettingsServerSettingsFieldsEn {
 
 	/// en: 'Don't touch power'
 	String get sleepModeOff => 'Don\'t touch power';
+
+	/// en: 'Older name for the Vault root, kept because it is set. Clear it to use Vault root, or keep it pointed at a markdown folder you maintain elsewhere.'
+	String get notesPathHelper => 'Older name for the Vault root, kept because it is set. Clear it to use Vault root, or keep it pointed at a markdown folder you maintain elsewhere.';
+
+	/// en: 'Skills root'
+	String get skillsRoot => 'Skills root';
+
+	/// en: 'Directory holding agent skills. Kept outside the Vault so they are not committed to your documents repo.'
+	String get skillsRootHelper => 'Directory holding agent skills. Kept outside the Vault so they are not committed to your documents repo.';
+
+	/// en: 'Working tree Vault Sync commits. Defaults to the Vault root, so the repo holds documents and nothing else.'
+	String get gitRootHelper => 'Working tree Vault Sync commits. Defaults to the Vault root, so the repo holds documents and nothing else.';
 }
 
 // Path: settings.serverSettings.embedderModel
@@ -16673,8 +16720,8 @@ class TranslationsWebServerSettingsSectionsVaultEn {
 	/// en: 'Vault'
 	String get title => 'Vault';
 
-	/// en: 'Notes, skills, and git-versioned root.'
-	String get desc => 'Notes, skills, and git-versioned root.';
+	/// en: 'Your documents, and the repo they sync to.'
+	String get desc => 'Your documents, and the repo they sync to.';
 }
 
 // Path: web.serverSettings.sections.mcp
@@ -16765,6 +16812,21 @@ class TranslationsWebServerSettingsSectionsAntigravityEn {
 
 	/// en: 'Antigravity (agy) per-conversation SQLite store.'
 	String get desc => 'Antigravity (agy) per-conversation SQLite store.';
+}
+
+// Path: web.serverSettings.sections.skills
+class TranslationsWebServerSettingsSectionsSkillsEn {
+	TranslationsWebServerSettingsSectionsSkillsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Agent skills'
+	String get title => 'Agent skills';
+
+	/// en: 'Where skills are loaded from.'
+	String get desc => 'Where skills are loaded from.';
 }
 
 // Path: web.serverSettings.fields.listenAddress
@@ -16919,8 +16981,8 @@ class TranslationsWebServerSettingsFieldsVaultRootEn {
 	/// en: 'Vault root'
 	String get label => 'Vault root';
 
-	/// en: 'Top-level directory for notes, skills, and MCP registry.'
-	String get hint => 'Top-level directory for notes, skills, and MCP registry.';
+	/// en: 'The directory your documents live in. This is what the Vault page browses and what Vault Sync commits.'
+	String get hint => 'The directory your documents live in. This is what the Vault page browses and what Vault Sync commits.';
 }
 
 // Path: web.serverSettings.fields.notesDirectory
@@ -16931,26 +16993,11 @@ class TranslationsWebServerSettingsFieldsNotesDirectoryEn {
 
 	// Translations
 
-	/// en: 'Notes directory'
-	String get label => 'Notes directory';
+	/// en: 'Documents directory (legacy)'
+	String get label => 'Documents directory (legacy)';
 
-	/// en: 'Override notes location. Defaults to <vault root>/notes.'
-	String get hint => 'Override notes location. Defaults to <vault root>/notes.';
-}
-
-// Path: web.serverSettings.fields.skillsDirectory
-class TranslationsWebServerSettingsFieldsSkillsDirectoryEn {
-	TranslationsWebServerSettingsFieldsSkillsDirectoryEn.internal(this._root);
-
-	final Translations _root; // ignore: unused_field
-
-	// Translations
-
-	/// en: 'Skills directory'
-	String get label => 'Skills directory';
-
-	/// en: 'Override skills location. Defaults to <vault root>/skills.'
-	String get hint => 'Override skills location. Defaults to <vault root>/skills.';
+	/// en: 'Older name for the Vault root, kept because it is set. Clear it to use Vault root, or keep it pointed at a markdown folder you maintain elsewhere.'
+	String get hint => 'Older name for the Vault root, kept because it is set. Clear it to use Vault root, or keep it pointed at a markdown folder you maintain elsewhere.';
 }
 
 // Path: web.serverSettings.fields.gitRoot
@@ -16964,8 +17011,8 @@ class TranslationsWebServerSettingsFieldsGitRootEn {
 	/// en: 'Git root'
 	String get label => 'Git root';
 
-	/// en: 'Working tree the Vault Sync feature commits to.'
-	String get hint => 'Working tree the Vault Sync feature commits to.';
+	/// en: 'Working tree Vault Sync commits. Defaults to the Vault root, so the repo holds documents and nothing else.'
+	String get hint => 'Working tree Vault Sync commits. Defaults to the Vault root, so the repo holds documents and nothing else.';
 }
 
 // Path: web.serverSettings.fields.personalPrefix
@@ -17009,8 +17056,8 @@ class TranslationsWebServerSettingsFieldsRegistryRootEn {
 	/// en: 'Registry root'
 	String get label => 'Registry root';
 
-	/// en: 'Directory holding MCP server JSON definitions. Defaults to <vault>/mcp.'
-	String get hint => 'Directory holding MCP server JSON definitions. Defaults to <vault>/mcp.';
+	/// en: 'Directory holding MCP server JSON definitions. Defaults to ~/.opendray/mcp.'
+	String get hint => 'Directory holding MCP server JSON definitions. Defaults to ~/.opendray/mcp.';
 }
 
 // Path: web.serverSettings.fields.secretsFile
@@ -17506,6 +17553,21 @@ class TranslationsWebServerSettingsFieldsDbMaxConnsEn {
 
 	/// en: 'pgx connection pool cap. 0 = store default (16).'
 	String get hint => 'pgx connection pool cap. 0 = store default (16).';
+}
+
+// Path: web.serverSettings.fields.skillsRoot
+class TranslationsWebServerSettingsFieldsSkillsRootEn {
+	TranslationsWebServerSettingsFieldsSkillsRootEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Skills root'
+	String get label => 'Skills root';
+
+	/// en: 'Directory holding agent skills. Kept outside the Vault so they are not committed to your documents repo.'
+	String get hint => 'Directory holding agent skills. Kept outside the Vault so they are not committed to your documents repo.';
 }
 
 // Path: web.serverSettings.httpHelpers.presetTip
@@ -20408,7 +20470,7 @@ extension on Translations {
 			'web.serverSettings.sections.sessions.title' => 'Sessions',
 			'web.serverSettings.sections.sessions.desc' => 'Idle detection thresholds.',
 			'web.serverSettings.sections.vault.title' => 'Vault',
-			'web.serverSettings.sections.vault.desc' => 'Notes, skills, and git-versioned root.',
+			'web.serverSettings.sections.vault.desc' => 'Your documents, and the repo they sync to.',
 			'web.serverSettings.sections.mcp.title' => 'MCP registry',
 			'web.serverSettings.sections.mcp.desc' => 'Server registry + secrets.',
 			'web.serverSettings.sections.memory.title' => 'Memory · storage & embedder',
@@ -20421,6 +20483,8 @@ extension on Translations {
 			'web.serverSettings.sections.codex.desc' => 'Codex sessions root.',
 			'web.serverSettings.sections.antigravity.title' => 'Storage · Antigravity',
 			'web.serverSettings.sections.antigravity.desc' => 'Antigravity (agy) per-conversation SQLite store.',
+			'web.serverSettings.sections.skills.title' => 'Agent skills',
+			'web.serverSettings.sections.skills.desc' => 'Where skills are loaded from.',
 			'web.serverSettings.loading' => 'Loading server settings…',
 			'web.serverSettings.loadFailed' => ({required Object message}) => 'Failed to load: ${message}',
 			'web.serverSettings.noConfigFlag' => 'opendray was started without a -config flag. Settings are loaded from environment variables only and cannot be edited here.',
@@ -20479,19 +20543,17 @@ extension on Translations {
 			'web.serverSettings.fields.idlePollInterval.label' => 'Idle poll interval',
 			'web.serverSettings.fields.idlePollInterval.hint' => 'How often the idle detector wakes up. Lower = lower latency, more wakeups. Empty = 5s.',
 			'web.serverSettings.fields.vaultRoot.label' => 'Vault root',
-			'web.serverSettings.fields.vaultRoot.hint' => 'Top-level directory for notes, skills, and MCP registry.',
-			'web.serverSettings.fields.notesDirectory.label' => 'Notes directory',
-			'web.serverSettings.fields.notesDirectory.hint' => 'Override notes location. Defaults to <vault root>/notes.',
-			'web.serverSettings.fields.skillsDirectory.label' => 'Skills directory',
-			'web.serverSettings.fields.skillsDirectory.hint' => 'Override skills location. Defaults to <vault root>/skills.',
+			'web.serverSettings.fields.vaultRoot.hint' => 'The directory your documents live in. This is what the Vault page browses and what Vault Sync commits.',
+			'web.serverSettings.fields.notesDirectory.label' => 'Documents directory (legacy)',
+			'web.serverSettings.fields.notesDirectory.hint' => 'Older name for the Vault root, kept because it is set. Clear it to use Vault root, or keep it pointed at a markdown folder you maintain elsewhere.',
 			'web.serverSettings.fields.gitRoot.label' => 'Git root',
-			'web.serverSettings.fields.gitRoot.hint' => 'Working tree the Vault Sync feature commits to.',
+			'web.serverSettings.fields.gitRoot.hint' => 'Working tree Vault Sync commits. Defaults to the Vault root, so the repo holds documents and nothing else.',
 			'web.serverSettings.fields.personalPrefix.label' => 'Personal prefix',
 			'web.serverSettings.fields.personalPrefix.hint' => 'Folder name used for personal notes when auto-deriving paths. Default "personal".',
 			'web.serverSettings.fields.projectsPrefix.label' => 'Projects prefix',
 			'web.serverSettings.fields.projectsPrefix.hint' => 'Folder name used for project notes. Default "projects".',
 			'web.serverSettings.fields.registryRoot.label' => 'Registry root',
-			'web.serverSettings.fields.registryRoot.hint' => 'Directory holding MCP server JSON definitions. Defaults to <vault>/mcp.',
+			'web.serverSettings.fields.registryRoot.hint' => 'Directory holding MCP server JSON definitions. Defaults to ~/.opendray/mcp.',
 			'web.serverSettings.fields.secretsFile.label' => 'Secrets file',
 			'web.serverSettings.fields.secretsFile.hint' => 'key=value file substituted into MCP server commands at spawn time.',
 			'web.serverSettings.fields.memoryBackend.label' => 'Embedder backend',
@@ -20558,6 +20620,8 @@ extension on Translations {
 			'web.serverSettings.fields.mobileTokenTTL.hint' => 'Lifetime of bearer tokens issued to the mobile app. Default 720h (30 days).',
 			'web.serverSettings.fields.dbMaxConns.label' => 'Max connections',
 			'web.serverSettings.fields.dbMaxConns.hint' => 'pgx connection pool cap. 0 = store default (16).',
+			'web.serverSettings.fields.skillsRoot.label' => 'Skills root',
+			'web.serverSettings.fields.skillsRoot.hint' => 'Directory holding agent skills. Kept outside the Vault so they are not committed to your documents repo.',
 			'web.serverSettings.liveTail.heading' => 'Live tail',
 			'web.serverSettings.liveTail.description' => 'In-memory ring buffer (last ~2,000 records). Resets on restart.',
 			'web.serverSettings.memoryInspectorCard.heading' => 'Inspector',
@@ -20644,6 +20708,12 @@ extension on Translations {
 			'web.serverSettings.host.modes.off.label' => 'Never touch power settings',
 			'web.serverSettings.host.modes.off.desc' => 'opendray leaves the machine alone entirely.',
 			'web.serverSettings.host.modes.off.caveat' => 'The gateway is unreachable whenever the host sleeps, unless something else keeps it awake.',
+			'web.serverSettings.layout.title' => 'Resolving to',
+			'web.serverSettings.layout.documents' => 'Documents',
+			'web.serverSettings.layout.git' => 'Git repo',
+			'web.serverSettings.layout.skills' => 'Skills',
+			'web.serverSettings.layout.mcp' => 'MCP registry',
+			'web.serverSettings.layout.legacyWarning' => 'This install still keeps opendray\'s own directories inside your documents, so they show up in the Vault and get carried along by a sync. They keep working — move them out and set the paths above when convenient. Anything already committed needs git rm --cached; opendray will not rewrite your repo.',
 			'web.settings.title' => 'Settings',
 			'web.settings.subtitle' => 'Workspace, account, and gateway config.',
 			'web.settings.groups.workspace' => 'Workspace',
@@ -20670,6 +20740,8 @@ extension on Translations {
 			'web.settings.font.description' => 'Scales the entire interface. Persisted per browser.',
 			'web.settings.font.options.compact' => 'Compact',
 			'web.settings.font.options.kDefault' => 'Default',
+			_ => null,
+		} ?? switch (path) {
 			'web.settings.font.options.comfy' => 'Comfy',
 			'web.settings.font.options.large' => 'Large',
 			'web.settings.account.title' => 'Account',
@@ -20678,8 +20750,6 @@ extension on Translations {
 			'web.settings.account.tokenExpires' => 'Token expires',
 			'web.settings.account.changeCredentials' => 'Change credentials',
 			'web.settings.changeCredentials.title' => 'Change credentials',
-			_ => null,
-		} ?? switch (path) {
 			'web.settings.changeCredentials.description' => 'Verify your current password, then pick new credentials. All other signed-in sessions will be revoked.',
 			'web.settings.changeCredentials.currentPassword' => 'Current password',
 			'web.settings.changeCredentials.newUsername' => 'New username',
@@ -21184,6 +21254,8 @@ extension on Translations {
 			'web.database.dialog.test' => 'Test',
 			'web.database.dialog.save' => 'Save',
 			'web.database.dialog.testFailed' => 'Connection test failed',
+			_ => null,
+		} ?? switch (path) {
 			'web.database.dialog.testOk' => ({required Object version, required Object ms}) => 'Connected — ${version} (${ms} ms)',
 			'web.database.dialog.savedCreate' => 'Connection added',
 			'web.database.dialog.savedEdit' => 'Connection updated',
@@ -21192,8 +21264,6 @@ extension on Translations {
 			'web.database.dialog.drivers.postgres' => 'PostgreSQL',
 			'web.database.dialog.drivers.mysql' => 'MySQL',
 			'web.database.dialog.drivers.mariadb' => 'MariaDB',
-			_ => null,
-		} ?? switch (path) {
 			'web.database.dialog.drivers.sqlite' => 'SQLite',
 			'web.database.dialog.filePath' => 'Database file',
 			'web.database.dialog.filePathHint' => 'Path to a SQLite file, inside the project directory.',
@@ -21698,6 +21768,8 @@ extension on Translations {
 			'sessions.inspector.canvas.themeDarkHint' => 'blank = inherits light',
 			'sessions.inspector.canvas.paletteIndigo' => 'Indigo',
 			'sessions.inspector.canvas.paletteSky' => 'Sky',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.paletteEmerald' => 'Emerald',
 			'sessions.inspector.canvas.paletteAmber' => 'Amber',
 			'sessions.inspector.canvas.paletteRose' => 'Rose',
@@ -21706,8 +21778,6 @@ extension on Translations {
 			'sessions.inspector.canvas.extractBtn' => 'Read from project',
 			'sessions.inspector.canvas.showcaseBtn' => 'Show as canvas',
 			'sessions.inspector.canvas.designTaskSent' => 'Sent to the agent — watch the session.',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.spawnSheet.title' => 'New session',
 			'sessions.spawnSheet.errorRequired' => 'Provider and working directory are required',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => 'Failed to spawn session: ${error}',
@@ -22212,6 +22282,8 @@ extension on Translations {
 			'backups.restore.fileSelected' => ({required Object name, required Object size}) => '${name} · ${size}',
 			'backups.restore.noFile' => 'No file selected',
 			'backups.restore.targetDsnLabel' => 'Target Postgres DSN',
+			_ => null,
+		} ?? switch (path) {
 			'backups.restore.targetDsnHint' => 'Leave empty to restore into opendray\'s own DB.',
 			'backups.restore.targetDsnPlaceholder' => 'postgres://user:pass@host:5432/dbname',
 			'backups.restore.cleanLabel' => 'pg_restore --clean --if-exists',
@@ -22220,8 +22292,6 @@ extension on Translations {
 			'backups.restore.auditNotePlaceholder' => 'e.g. recovering from #INC-481',
 			'backups.restore.ownDbWarning' => 'Restoring into opendray\'s OWN database will rewrite the rows this gateway is currently serving. Type "I understand" to confirm.',
 			'backups.restore.confirmPlaceholder' => 'Type "I understand"',
-			_ => null,
-		} ?? switch (path) {
 			'backups.restore.confirmSentinel' => 'I understand',
 			'backups.restore.restoring' => 'Restoring…',
 			'backups.restore.preview' => 'Preview (dry run)',
@@ -22726,6 +22796,8 @@ extension on Translations {
 			'memory.title' => 'Memory',
 			'memory.more' => 'More',
 			'memory.workers' => 'Memory workers',
+			_ => null,
+		} ?? switch (path) {
 			'memory.rank.title' => 'Rank breakdown',
 			'memory.rank.effective' => ({required Object value}) => 'Effective score: ${value}',
 			'memory.rank.similarity' => 'Cosine similarity',
@@ -22734,8 +22806,6 @@ extension on Translations {
 			'memory.rank.confidenceMultiplier' => 'Confidence multiplier',
 			'memory.rank.formula' => 'effective = similarity × age × hits × confidence',
 			'memory.rank.close' => 'Close',
-			_ => null,
-		} ?? switch (path) {
 			'memory.kNew' => 'New',
 			'memory.searchHint' => 'Search…',
 			'memory.projectLabel' => 'Project',
@@ -22866,17 +22936,19 @@ extension on Translations {
 			'settings.serverSettings.sections.storageClaude' => 'Storage · Claude',
 			'settings.serverSettings.sections.storageCodex' => 'Storage · Codex',
 			'settings.serverSettings.sections.storageAntigravity' => 'Storage · Antigravity',
+			'settings.serverSettings.sections.skills' => 'Agent skills',
 			'settings.serverSettings.sectionDescriptions.general' => 'Listen address, operator account, token TTL.',
 			'settings.serverSettings.sectionDescriptions.host' => 'Keep this machine reachable while it is idle.',
 			'settings.serverSettings.sectionDescriptions.logging' => 'Verbosity, format, and on-disk log path.',
 			'settings.serverSettings.sectionDescriptions.sessions' => 'Idle detection thresholds.',
-			'settings.serverSettings.sectionDescriptions.vault' => 'Notes, skills, and git-versioned root.',
-			'settings.serverSettings.sectionDescriptions.mcpRegistry' => 'Vault paths for MCP servers + secrets file.',
+			'settings.serverSettings.sectionDescriptions.vault' => 'Your documents, and the repo they sync to.',
+			'settings.serverSettings.sectionDescriptions.mcpRegistry' => 'Server registry + secrets file.',
 			'settings.serverSettings.sectionDescriptions.memory' => 'Cross-CLI persistent memory subsystem.',
 			'settings.serverSettings.sectionDescriptions.backup' => 'Encrypted DB backups + admin data exports. Passphrase lives in the keyfile (Settings → Backups).',
 			'settings.serverSettings.sectionDescriptions.storageClaude' => 'Where Claude transcripts live on disk.',
 			'settings.serverSettings.sectionDescriptions.storageCodex' => 'Codex sessions root.',
 			'settings.serverSettings.sectionDescriptions.storageAntigravity' => 'agy per-conversation SQLite store.',
+			'settings.serverSettings.sectionDescriptions.skills' => 'Where agent skills are loaded from.',
 			'settings.serverSettings.fields.listenAddress' => 'Listen address',
 			'settings.serverSettings.fields.adminUser' => 'Admin user',
 			'settings.serverSettings.fields.adminUserHelper' => 'Effective when no keyfile or env var is set. Otherwise see Settings → Account.',
@@ -22892,10 +22964,9 @@ extension on Translations {
 			'settings.serverSettings.fields.idleThresholdHelper' => 'Quiet period before a session is flagged idle. Go duration.',
 			'settings.serverSettings.fields.idleCheckInterval' => 'Idle check interval',
 			'settings.serverSettings.fields.idleCheckHelper' => 'How often the idle reaper runs.',
-			'settings.serverSettings.fields.root' => 'Root',
-			'settings.serverSettings.fields.rootHelper' => 'Parent of notes / skills / git_root sub-paths.',
-			'settings.serverSettings.fields.notesPath' => 'Notes path',
-			'settings.serverSettings.fields.skillsPath' => 'Skills path',
+			'settings.serverSettings.fields.root' => 'Vault root',
+			'settings.serverSettings.fields.rootHelper' => 'The directory your documents live in — what the Vault browses and what Vault Sync commits.',
+			'settings.serverSettings.fields.notesPath' => 'Documents path (legacy)',
 			'settings.serverSettings.fields.gitRoot' => 'Git root',
 			'settings.serverSettings.fields.personalPrefix' => 'Personal prefix',
 			'settings.serverSettings.fields.projectsPrefix' => 'Projects prefix',
@@ -22947,6 +23018,10 @@ extension on Translations {
 			'settings.serverSettings.fields.sleepModeAlways' => 'Stay awake on any power',
 			'settings.serverSettings.fields.sleepModeOnDemand' => 'Sleep, wake on traffic',
 			'settings.serverSettings.fields.sleepModeOff' => 'Don\'t touch power',
+			'settings.serverSettings.fields.notesPathHelper' => 'Older name for the Vault root, kept because it is set. Clear it to use Vault root, or keep it pointed at a markdown folder you maintain elsewhere.',
+			'settings.serverSettings.fields.skillsRoot' => 'Skills root',
+			'settings.serverSettings.fields.skillsRootHelper' => 'Directory holding agent skills. Kept outside the Vault so they are not committed to your documents repo.',
+			'settings.serverSettings.fields.gitRootHelper' => 'Working tree Vault Sync commits. Defaults to the Vault root, so the repo holds documents and nothing else.',
 			'settings.serverSettings.validateInteger' => ({required Object field}) => '"${field}" must be an integer',
 			'settings.serverSettings.validateNumber' => ({required Object field}) => '"${field}" must be a number',
 			'settings.serverSettings.embedderModel.reprobe' => 'Re-check endpoint',
@@ -22954,6 +23029,7 @@ extension on Translations {
 			'settings.serverSettings.embedderModel.pickHint' => 'Select a model',
 			'settings.serverSettings.embedderModel.manual' => 'Type manually',
 			'settings.serverSettings.embedderModel.pickFromList' => 'Pick from list',
+			'settings.serverSettings.legacyLayout' => 'opendray\'s own directories still sit inside your documents, so they show up in the Vault and a sync carries them along. They keep working — move them out and set the paths below when convenient.',
 			'memoryQuarantine.title' => 'Quarantine',
 			'memoryQuarantine.subtitle' => 'Facts that need review before they count as durable memory: integration captures land here by policy, and you can quarantine any memory by hand. Promote what is true; discard the rest — unreviewed rows expire on their own.',
 			'memoryQuarantine.empty' => 'Nothing in quarantine.',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -1554,6 +1554,7 @@ class _TranslationsWebServerSettingsEs extends TranslationsWebServerSettingsEn {
 	@override String get memoryRuntimeBanner => 'El comportamiento de IA en runtime — workers, reglas de captura, perfiles de inyección y modo de spawn — vive en los ajustes de Cortex y se aplica al instante. Esta sección es la mitad de infraestructura: embedder, almacenamiento y gobernanza de fondo (requiere reinicio).';
 	@override String get memoryRuntimeBannerButton => 'Abrir ajustes de Cortex';
 	@override late final _TranslationsWebServerSettingsHostEs host = _TranslationsWebServerSettingsHostEs._(_root);
+	@override late final _TranslationsWebServerSettingsLayoutEs layout = _TranslationsWebServerSettingsLayoutEs._(_root);
 }
 
 // Path: web.settings
@@ -3153,6 +3154,7 @@ class _TranslationsSettingsServerSettingsEs extends TranslationsSettingsServerSe
 	@override String validateInteger({required Object field}) => '"${field}" debe ser un entero';
 	@override String validateNumber({required Object field}) => '"${field}" debe ser un número';
 	@override late final _TranslationsSettingsServerSettingsEmbedderModelEs embedderModel = _TranslationsSettingsServerSettingsEmbedderModelEs._(_root);
+	@override String get legacyLayout => 'Los directorios propios de opendray siguen dentro de tus documentos, así que aparecen en el Vault y la sincronización se los lleva. Siguen funcionando: muévelos fuera y fija las rutas de abajo cuando puedas.';
 }
 
 // Path: web.sessions.list
@@ -5174,6 +5176,7 @@ class _TranslationsWebServerSettingsSectionsEs extends TranslationsWebServerSett
 	@override late final _TranslationsWebServerSettingsSectionsClaudeEs claude = _TranslationsWebServerSettingsSectionsClaudeEs._(_root);
 	@override late final _TranslationsWebServerSettingsSectionsCodexEs codex = _TranslationsWebServerSettingsSectionsCodexEs._(_root);
 	@override late final _TranslationsWebServerSettingsSectionsAntigravityEs antigravity = _TranslationsWebServerSettingsSectionsAntigravityEs._(_root);
+	@override late final _TranslationsWebServerSettingsSectionsSkillsEs skills = _TranslationsWebServerSettingsSectionsSkillsEs._(_root);
 }
 
 // Path: web.serverSettings.restart
@@ -5233,7 +5236,6 @@ class _TranslationsWebServerSettingsFieldsEs extends TranslationsWebServerSettin
 	@override late final _TranslationsWebServerSettingsFieldsIdlePollIntervalEs idlePollInterval = _TranslationsWebServerSettingsFieldsIdlePollIntervalEs._(_root);
 	@override late final _TranslationsWebServerSettingsFieldsVaultRootEs vaultRoot = _TranslationsWebServerSettingsFieldsVaultRootEs._(_root);
 	@override late final _TranslationsWebServerSettingsFieldsNotesDirectoryEs notesDirectory = _TranslationsWebServerSettingsFieldsNotesDirectoryEs._(_root);
-	@override late final _TranslationsWebServerSettingsFieldsSkillsDirectoryEs skillsDirectory = _TranslationsWebServerSettingsFieldsSkillsDirectoryEs._(_root);
 	@override late final _TranslationsWebServerSettingsFieldsGitRootEs gitRoot = _TranslationsWebServerSettingsFieldsGitRootEs._(_root);
 	@override late final _TranslationsWebServerSettingsFieldsPersonalPrefixEs personalPrefix = _TranslationsWebServerSettingsFieldsPersonalPrefixEs._(_root);
 	@override late final _TranslationsWebServerSettingsFieldsProjectsPrefixEs projectsPrefix = _TranslationsWebServerSettingsFieldsProjectsPrefixEs._(_root);
@@ -5271,6 +5273,7 @@ class _TranslationsWebServerSettingsFieldsEs extends TranslationsWebServerSettin
 	@override late final _TranslationsWebServerSettingsFieldsClaudeAutoFailoverEs claudeAutoFailover = _TranslationsWebServerSettingsFieldsClaudeAutoFailoverEs._(_root);
 	@override late final _TranslationsWebServerSettingsFieldsMobileTokenTTLEs mobileTokenTTL = _TranslationsWebServerSettingsFieldsMobileTokenTTLEs._(_root);
 	@override late final _TranslationsWebServerSettingsFieldsDbMaxConnsEs dbMaxConns = _TranslationsWebServerSettingsFieldsDbMaxConnsEs._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsSkillsRootEs skillsRoot = _TranslationsWebServerSettingsFieldsSkillsRootEs._(_root);
 }
 
 // Path: web.serverSettings.liveTail
@@ -5419,6 +5422,21 @@ class _TranslationsWebServerSettingsHostEs extends TranslationsWebServerSettings
 	@override String get intro => 'Un Mac dormido apaga también su red, así que la pasarela deja de responder: desde el móvil, desde la web y hacia su base de datos. Parece que «opendray falla» cuando en realidad la máquina solo está dormida. Elige cómo debe gestionarlo opendray.';
 	@override String get platformNote => 'Solo macOS. En Linux y Windows este ajuste se acepta y se ignora: esos hosts no se suspenden por inactividad en una instalación de servidor normal. Nunca se bloquea una suspensión deliberada (cerrar la tapa, menú Apple → Reposo), y la aserción se libera si opendray termina o es forzado a cerrar.';
 	@override late final _TranslationsWebServerSettingsHostModesEs modes = _TranslationsWebServerSettingsHostModesEs._(_root);
+}
+
+// Path: web.serverSettings.layout
+class _TranslationsWebServerSettingsLayoutEs extends TranslationsWebServerSettingsLayoutEn {
+	_TranslationsWebServerSettingsLayoutEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Se resuelve en';
+	@override String get documents => 'Documentos';
+	@override String get git => 'Repositorio Git';
+	@override String get skills => 'Habilidades';
+	@override String get mcp => 'Registro MCP';
+	@override String get legacyWarning => 'Esta instalación aún mantiene los directorios propios de opendray dentro de tus documentos, así que aparecen en el Vault y la sincronización se los lleva. Siguen funcionando: muévelos fuera y fija las rutas de arriba cuando puedas. Lo ya confirmado requiere git rm --cached; opendray no reescribirá tu repositorio.';
 }
 
 // Path: web.settings.groups
@@ -7303,6 +7321,7 @@ class _TranslationsSettingsServerSettingsSectionsEs extends TranslationsSettings
 	@override String get storageClaude => 'Almacenamiento · Claude';
 	@override String get storageCodex => 'Almacenamiento · Codex';
 	@override String get storageAntigravity => 'Almacenamiento · Antigravity';
+	@override String get skills => 'Habilidades de agente';
 }
 
 // Path: settings.serverSettings.sectionDescriptions
@@ -7316,13 +7335,14 @@ class _TranslationsSettingsServerSettingsSectionDescriptionsEs extends Translati
 	@override String get host => 'Mantén esta máquina accesible mientras está inactiva.';
 	@override String get logging => 'Verbosidad, formato y ruta del log en disco.';
 	@override String get sessions => 'Umbrales de detección de inactividad.';
-	@override String get vault => 'Notas, skills y raíz versionada con git.';
-	@override String get mcpRegistry => 'Rutas del vault para servidores MCP + archivo de secretos.';
+	@override String get vault => 'Tus documentos y el repositorio al que se sincronizan.';
+	@override String get mcpRegistry => 'Registro de servidores y archivo de secretos.';
 	@override String get memory => 'Subsistema de memoria persistente entre CLIs.';
 	@override String get backup => 'Copias de seguridad cifradas de la BD + exportaciones de datos de admin. La frase de contraseña vive en el keyfile (Ajustes → Copias de seguridad).';
 	@override String get storageClaude => 'Dónde viven los transcripts de Claude en disco.';
 	@override String get storageCodex => 'Raíz de las sessions de Codex.';
 	@override String get storageAntigravity => 'Almacén SQLite por conversación de agy.';
+	@override String get skills => 'De dónde se cargan las habilidades de agente.';
 }
 
 // Path: settings.serverSettings.fields
@@ -7347,10 +7367,9 @@ class _TranslationsSettingsServerSettingsFieldsEs extends TranslationsSettingsSe
 	@override String get idleThresholdHelper => 'Periodo de silencio antes de marcar una session como inactiva. Duración de Go.';
 	@override String get idleCheckInterval => 'Intervalo de comprobación de inactividad';
 	@override String get idleCheckHelper => 'Con qué frecuencia se ejecuta el reaper de inactividad.';
-	@override String get root => 'Raíz';
-	@override String get rootHelper => 'Padre de las sub-rutas notes / skills / git_root.';
-	@override String get notesPath => 'Ruta de notas';
-	@override String get skillsPath => 'Ruta de skills';
+	@override String get root => 'Raíz del Vault';
+	@override String get rootHelper => 'El directorio donde viven tus documentos: lo que muestra el Vault y lo que confirma Vault Sync.';
+	@override String get notesPath => 'Ruta de documentos (heredada)';
 	@override String get gitRoot => 'Raíz de git';
 	@override String get personalPrefix => 'Prefijo personal';
 	@override String get projectsPrefix => 'Prefijo de proyectos';
@@ -7402,6 +7421,10 @@ class _TranslationsSettingsServerSettingsFieldsEs extends TranslationsSettingsSe
 	@override String get sleepModeAlways => 'Despierto con cualquier alimentación';
 	@override String get sleepModeOnDemand => 'Dormir, despertar con tráfico';
 	@override String get sleepModeOff => 'No tocar la energía';
+	@override String get notesPathHelper => 'Nombre antiguo de la raíz del Vault, visible porque está definido. Vacíalo para usar la raíz del Vault, o mantenlo apuntando a una carpeta markdown que gestiones en otro sitio.';
+	@override String get skillsRoot => 'Raíz de habilidades';
+	@override String get skillsRootHelper => 'Directorio con las habilidades de agente. Fuera del Vault para que no acaben en el repositorio de tus documentos.';
+	@override String get gitRootHelper => 'Árbol de trabajo que confirma Vault Sync. Por defecto la raíz del Vault, así el repositorio solo contiene documentos.';
 }
 
 // Path: settings.serverSettings.embedderModel
@@ -8530,7 +8553,7 @@ class _TranslationsWebServerSettingsSectionsVaultEs extends TranslationsWebServe
 
 	// Translations
 	@override String get title => 'Vault';
-	@override String get desc => 'Notas, skills y raíz versionada con git.';
+	@override String get desc => 'Tus documentos y el repositorio al que se sincronizan.';
 }
 
 // Path: web.serverSettings.sections.mcp
@@ -8540,8 +8563,8 @@ class _TranslationsWebServerSettingsSectionsMcpEs extends TranslationsWebServerS
 	final TranslationsEs _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Registro de MCP';
-	@override String get desc => 'Registro de servidores + secretos.';
+	@override String get title => 'Registro MCP';
+	@override String get desc => 'Registro de servidores y secretos.';
 }
 
 // Path: web.serverSettings.sections.memory
@@ -8597,6 +8620,17 @@ class _TranslationsWebServerSettingsSectionsAntigravityEs extends TranslationsWe
 	// Translations
 	@override String get title => 'Almacenamiento · Antigravity';
 	@override String get desc => 'Almacén SQLite por conversación de Antigravity (agy).';
+}
+
+// Path: web.serverSettings.sections.skills
+class _TranslationsWebServerSettingsSectionsSkillsEs extends TranslationsWebServerSettingsSectionsSkillsEn {
+	_TranslationsWebServerSettingsSectionsSkillsEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Habilidades de agente';
+	@override String get desc => 'De dónde se cargan las habilidades.';
 }
 
 // Path: web.serverSettings.fields.listenAddress
@@ -8708,7 +8742,7 @@ class _TranslationsWebServerSettingsFieldsVaultRootEs extends TranslationsWebSer
 
 	// Translations
 	@override String get label => 'Raíz del Vault';
-	@override String get hint => 'Directorio de nivel superior para notas, skills y el registro de MCP.';
+	@override String get hint => 'El directorio donde viven tus documentos. Es lo que muestra la página Vault y lo que confirma Vault Sync.';
 }
 
 // Path: web.serverSettings.fields.notesDirectory
@@ -8718,19 +8752,8 @@ class _TranslationsWebServerSettingsFieldsNotesDirectoryEs extends TranslationsW
 	final TranslationsEs _root; // ignore: unused_field
 
 	// Translations
-	@override String get label => 'Directorio de notas';
-	@override String get hint => 'Anula la ubicación de las notas. Por defecto <vault root>/notes.';
-}
-
-// Path: web.serverSettings.fields.skillsDirectory
-class _TranslationsWebServerSettingsFieldsSkillsDirectoryEs extends TranslationsWebServerSettingsFieldsSkillsDirectoryEn {
-	_TranslationsWebServerSettingsFieldsSkillsDirectoryEs._(TranslationsEs root) : this._root = root, super.internal(root);
-
-	final TranslationsEs _root; // ignore: unused_field
-
-	// Translations
-	@override String get label => 'Directorio de skills';
-	@override String get hint => 'Anula la ubicación de los skills. Por defecto <vault root>/skills.';
+	@override String get label => 'Directorio de documentos (heredado)';
+	@override String get hint => 'Nombre antiguo de la raíz del Vault, visible porque está definido. Vacíalo para usar la raíz del Vault, o mantenlo apuntando a una carpeta markdown que gestiones en otro sitio.';
 }
 
 // Path: web.serverSettings.fields.gitRoot
@@ -8740,8 +8763,8 @@ class _TranslationsWebServerSettingsFieldsGitRootEs extends TranslationsWebServe
 	final TranslationsEs _root; // ignore: unused_field
 
 	// Translations
-	@override String get label => 'Raíz de git';
-	@override String get hint => 'Árbol de trabajo al que confirma la función Vault Sync.';
+	@override String get label => 'Raíz de Git';
+	@override String get hint => 'Árbol de trabajo que confirma Vault Sync. Por defecto la raíz del Vault, así el repositorio solo contiene documentos.';
 }
 
 // Path: web.serverSettings.fields.personalPrefix
@@ -8774,7 +8797,7 @@ class _TranslationsWebServerSettingsFieldsRegistryRootEs extends TranslationsWeb
 
 	// Translations
 	@override String get label => 'Raíz del registro';
-	@override String get hint => 'Directorio que contiene las definiciones JSON de los servidores MCP. Por defecto <vault>/mcp.';
+	@override String get hint => 'Directorio con las definiciones JSON de servidores MCP. Por defecto ~/.opendray/mcp.';
 }
 
 // Path: web.serverSettings.fields.secretsFile
@@ -9138,6 +9161,17 @@ class _TranslationsWebServerSettingsFieldsDbMaxConnsEs extends TranslationsWebSe
 	// Translations
 	@override String get label => 'Conexiones máx.';
 	@override String get hint => 'Tope del pool de conexiones pgx. 0 = valor por defecto (16).';
+}
+
+// Path: web.serverSettings.fields.skillsRoot
+class _TranslationsWebServerSettingsFieldsSkillsRootEs extends TranslationsWebServerSettingsFieldsSkillsRootEn {
+	_TranslationsWebServerSettingsFieldsSkillsRootEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'Raíz de habilidades';
+	@override String get hint => 'Directorio con las habilidades de agente. Fuera del Vault para que no acaben en el repositorio de tus documentos.';
 }
 
 // Path: web.serverSettings.httpHelpers.presetTip
@@ -11564,9 +11598,9 @@ extension on TranslationsEs {
 			'web.serverSettings.sections.sessions.title' => 'Sesiones',
 			'web.serverSettings.sections.sessions.desc' => 'Umbrales de detección de inactividad.',
 			'web.serverSettings.sections.vault.title' => 'Vault',
-			'web.serverSettings.sections.vault.desc' => 'Notas, skills y raíz versionada con git.',
-			'web.serverSettings.sections.mcp.title' => 'Registro de MCP',
-			'web.serverSettings.sections.mcp.desc' => 'Registro de servidores + secretos.',
+			'web.serverSettings.sections.vault.desc' => 'Tus documentos y el repositorio al que se sincronizan.',
+			'web.serverSettings.sections.mcp.title' => 'Registro MCP',
+			'web.serverSettings.sections.mcp.desc' => 'Registro de servidores y secretos.',
 			'web.serverSettings.sections.memory.title' => 'Memoria · almacenamiento y embedder',
 			'web.serverSettings.sections.memory.desc' => 'La mitad de infraestructura del subsistema de memoria: backend de embeddings, ajuste de recuperación y gobernanza de fondo. Reinicia para aplicar. El comportamiento en runtime (workers, captura, inyección) vive en los ajustes de Cortex.',
 			'web.serverSettings.sections.backup.title' => 'Backup',
@@ -11577,6 +11611,8 @@ extension on TranslationsEs {
 			'web.serverSettings.sections.codex.desc' => 'Raíz de sesiones de Codex.',
 			'web.serverSettings.sections.antigravity.title' => 'Almacenamiento · Antigravity',
 			'web.serverSettings.sections.antigravity.desc' => 'Almacén SQLite por conversación de Antigravity (agy).',
+			'web.serverSettings.sections.skills.title' => 'Habilidades de agente',
+			'web.serverSettings.sections.skills.desc' => 'De dónde se cargan las habilidades.',
 			'web.serverSettings.loading' => 'Cargando ajustes del servidor…',
 			'web.serverSettings.loadFailed' => ({required Object message}) => 'Error al cargar: ${message}',
 			'web.serverSettings.noConfigFlag' => 'opendray se inició sin la opción -config. Los ajustes se cargan únicamente desde variables de entorno y no pueden editarse aquí.',
@@ -11635,19 +11671,17 @@ extension on TranslationsEs {
 			'web.serverSettings.fields.idlePollInterval.label' => 'Intervalo de sondeo de inactividad',
 			'web.serverSettings.fields.idlePollInterval.hint' => 'Con qué frecuencia se activa el detector de inactividad. Más bajo = menor latencia, más activaciones. Vacío = 5s.',
 			'web.serverSettings.fields.vaultRoot.label' => 'Raíz del Vault',
-			'web.serverSettings.fields.vaultRoot.hint' => 'Directorio de nivel superior para notas, skills y el registro de MCP.',
-			'web.serverSettings.fields.notesDirectory.label' => 'Directorio de notas',
-			'web.serverSettings.fields.notesDirectory.hint' => 'Anula la ubicación de las notas. Por defecto <vault root>/notes.',
-			'web.serverSettings.fields.skillsDirectory.label' => 'Directorio de skills',
-			'web.serverSettings.fields.skillsDirectory.hint' => 'Anula la ubicación de los skills. Por defecto <vault root>/skills.',
-			'web.serverSettings.fields.gitRoot.label' => 'Raíz de git',
-			'web.serverSettings.fields.gitRoot.hint' => 'Árbol de trabajo al que confirma la función Vault Sync.',
+			'web.serverSettings.fields.vaultRoot.hint' => 'El directorio donde viven tus documentos. Es lo que muestra la página Vault y lo que confirma Vault Sync.',
+			'web.serverSettings.fields.notesDirectory.label' => 'Directorio de documentos (heredado)',
+			'web.serverSettings.fields.notesDirectory.hint' => 'Nombre antiguo de la raíz del Vault, visible porque está definido. Vacíalo para usar la raíz del Vault, o mantenlo apuntando a una carpeta markdown que gestiones en otro sitio.',
+			'web.serverSettings.fields.gitRoot.label' => 'Raíz de Git',
+			'web.serverSettings.fields.gitRoot.hint' => 'Árbol de trabajo que confirma Vault Sync. Por defecto la raíz del Vault, así el repositorio solo contiene documentos.',
 			'web.serverSettings.fields.personalPrefix.label' => 'Prefijo personal',
 			'web.serverSettings.fields.personalPrefix.hint' => 'Nombre de carpeta usado para las notas personales al derivar rutas automáticamente. Por defecto "personal".',
 			'web.serverSettings.fields.projectsPrefix.label' => 'Prefijo de proyectos',
 			'web.serverSettings.fields.projectsPrefix.hint' => 'Nombre de carpeta usado para las notas de proyecto. Por defecto "projects".',
 			'web.serverSettings.fields.registryRoot.label' => 'Raíz del registro',
-			'web.serverSettings.fields.registryRoot.hint' => 'Directorio que contiene las definiciones JSON de los servidores MCP. Por defecto <vault>/mcp.',
+			'web.serverSettings.fields.registryRoot.hint' => 'Directorio con las definiciones JSON de servidores MCP. Por defecto ~/.opendray/mcp.',
 			'web.serverSettings.fields.secretsFile.label' => 'Archivo de secretos',
 			'web.serverSettings.fields.secretsFile.hint' => 'Archivo key=value que se sustituye en los comandos del servidor MCP en el momento del arranque.',
 			'web.serverSettings.fields.memoryBackend.label' => 'Backend del embedder',
@@ -11714,6 +11748,8 @@ extension on TranslationsEs {
 			'web.serverSettings.fields.mobileTokenTTL.hint' => 'Vida de los tokens emitidos a la app móvil. Por defecto 720h (30 días).',
 			'web.serverSettings.fields.dbMaxConns.label' => 'Conexiones máx.',
 			'web.serverSettings.fields.dbMaxConns.hint' => 'Tope del pool de conexiones pgx. 0 = valor por defecto (16).',
+			'web.serverSettings.fields.skillsRoot.label' => 'Raíz de habilidades',
+			'web.serverSettings.fields.skillsRoot.hint' => 'Directorio con las habilidades de agente. Fuera del Vault para que no acaben en el repositorio de tus documentos.',
 			'web.serverSettings.liveTail.heading' => 'Seguimiento en vivo',
 			'web.serverSettings.liveTail.description' => 'Búfer circular en memoria (los últimos ~2.000 registros). Se reinicia al reiniciar.',
 			'web.serverSettings.memoryInspectorCard.heading' => 'Inspector',
@@ -11800,6 +11836,12 @@ extension on TranslationsEs {
 			'web.serverSettings.host.modes.off.label' => 'No tocar la energía',
 			'web.serverSettings.host.modes.off.desc' => 'opendray no interviene en absoluto en la máquina.',
 			'web.serverSettings.host.modes.off.caveat' => 'La pasarela será inaccesible cuando el host duerma, salvo que otra cosa lo mantenga despierto.',
+			'web.serverSettings.layout.title' => 'Se resuelve en',
+			'web.serverSettings.layout.documents' => 'Documentos',
+			'web.serverSettings.layout.git' => 'Repositorio Git',
+			'web.serverSettings.layout.skills' => 'Habilidades',
+			'web.serverSettings.layout.mcp' => 'Registro MCP',
+			'web.serverSettings.layout.legacyWarning' => 'Esta instalación aún mantiene los directorios propios de opendray dentro de tus documentos, así que aparecen en el Vault y la sincronización se los lleva. Siguen funcionando: muévelos fuera y fija las rutas de arriba cuando puedas. Lo ya confirmado requiere git rm --cached; opendray no reescribirá tu repositorio.',
 			'web.settings.title' => 'Ajustes',
 			'web.settings.subtitle' => 'Configuración del espacio de trabajo, la cuenta y el gateway.',
 			'web.settings.groups.workspace' => 'Espacio de trabajo',
@@ -11826,6 +11868,8 @@ extension on TranslationsEs {
 			'web.settings.font.description' => 'Escala toda la interfaz. Se guarda por navegador.',
 			'web.settings.font.options.compact' => 'Compacto',
 			'web.settings.font.options.kDefault' => 'Predeterminado',
+			_ => null,
+		} ?? switch (path) {
 			'web.settings.font.options.comfy' => 'Cómodo',
 			'web.settings.font.options.large' => 'Grande',
 			'web.settings.account.title' => 'Cuenta',
@@ -11834,8 +11878,6 @@ extension on TranslationsEs {
 			'web.settings.account.tokenExpires' => 'El token caduca',
 			'web.settings.account.changeCredentials' => 'Cambiar credenciales',
 			'web.settings.changeCredentials.title' => 'Cambiar credenciales',
-			_ => null,
-		} ?? switch (path) {
 			'web.settings.changeCredentials.description' => 'Verifica tu contraseña actual y luego elige nuevas credenciales. Se revocarán todas las demás sesiones con sesión iniciada.',
 			'web.settings.changeCredentials.currentPassword' => 'Contraseña actual',
 			'web.settings.changeCredentials.newUsername' => 'Nuevo nombre de usuario',
@@ -12340,6 +12382,8 @@ extension on TranslationsEs {
 			'web.database.dialog.test' => 'Probar',
 			'web.database.dialog.save' => 'Guardar',
 			'web.database.dialog.testFailed' => 'La prueba de conexión falló',
+			_ => null,
+		} ?? switch (path) {
 			'web.database.dialog.testOk' => ({required Object version, required Object ms}) => 'Conectado — ${version} (${ms} ms)',
 			'web.database.dialog.savedCreate' => 'Conexión añadida',
 			'web.database.dialog.savedEdit' => 'Conexión actualizada',
@@ -12348,8 +12392,6 @@ extension on TranslationsEs {
 			'web.database.dialog.drivers.postgres' => 'PostgreSQL',
 			'web.database.dialog.drivers.mysql' => 'MySQL',
 			'web.database.dialog.drivers.mariadb' => 'MariaDB',
-			_ => null,
-		} ?? switch (path) {
 			'web.database.dialog.drivers.sqlite' => 'SQLite',
 			'web.database.dialog.filePath' => 'Archivo de base de datos',
 			'web.database.dialog.filePathHint' => 'Ruta a un archivo SQLite, dentro del directorio del proyecto.',
@@ -12854,6 +12896,8 @@ extension on TranslationsEs {
 			'sessions.inspector.canvas.themeDarkHint' => 'vacío = hereda claro',
 			'sessions.inspector.canvas.paletteIndigo' => 'Índigo',
 			'sessions.inspector.canvas.paletteSky' => 'Cielo',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.paletteEmerald' => 'Esmeralda',
 			'sessions.inspector.canvas.paletteAmber' => 'Ámbar',
 			'sessions.inspector.canvas.paletteRose' => 'Rosa',
@@ -12862,8 +12906,6 @@ extension on TranslationsEs {
 			'sessions.inspector.canvas.extractBtn' => 'Leer del proyecto',
 			'sessions.inspector.canvas.showcaseBtn' => 'Ver como lienzo',
 			'sessions.inspector.canvas.designTaskSent' => 'Enviado al agente: mira la sesión.',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.spawnSheet.title' => 'Nueva session',
 			'sessions.spawnSheet.errorRequired' => 'El proveedor y el directorio de trabajo son obligatorios',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => 'No se pudo crear la session: ${error}',
@@ -13368,6 +13410,8 @@ extension on TranslationsEs {
 			'backups.restore.fileSelected' => ({required Object name, required Object size}) => '${name} · ${size}',
 			'backups.restore.noFile' => 'Ningún archivo seleccionado',
 			'backups.restore.targetDsnLabel' => 'DSN de Postgres de destino',
+			_ => null,
+		} ?? switch (path) {
 			'backups.restore.targetDsnHint' => 'Déjalo vacío para restaurar en la propia base de datos de opendray.',
 			'backups.restore.targetDsnPlaceholder' => 'postgres://user:pass@host:5432/dbname',
 			'backups.restore.cleanLabel' => 'pg_restore --clean --if-exists',
@@ -13376,8 +13420,6 @@ extension on TranslationsEs {
 			'backups.restore.auditNotePlaceholder' => 'p. ej. recuperando de #INC-481',
 			'backups.restore.ownDbWarning' => 'Restaurar en la PROPIA base de datos de opendray reescribirá las filas que este gateway está sirviendo actualmente. Escribe "I understand" para confirmar.',
 			'backups.restore.confirmPlaceholder' => 'Escribe "I understand"',
-			_ => null,
-		} ?? switch (path) {
 			'backups.restore.confirmSentinel' => 'I understand',
 			'backups.restore.restoring' => 'Restaurando…',
 			'backups.restore.preview' => 'Vista previa (simulación)',
@@ -13882,6 +13924,8 @@ extension on TranslationsEs {
 			'memory.title' => 'Memoria',
 			'memory.more' => 'Más',
 			'memory.workers' => 'Workers de memoria',
+			_ => null,
+		} ?? switch (path) {
 			'memory.rank.title' => 'Desglose del ranking',
 			'memory.rank.effective' => ({required Object value}) => 'Puntuación efectiva: ${value}',
 			'memory.rank.similarity' => 'Similitud del coseno',
@@ -13890,8 +13934,6 @@ extension on TranslationsEs {
 			'memory.rank.confidenceMultiplier' => 'Multiplicador por confianza',
 			'memory.rank.formula' => 'effective = similarity × age × hits × confidence',
 			'memory.rank.close' => 'Cerrar',
-			_ => null,
-		} ?? switch (path) {
 			'memory.kNew' => 'Nuevo',
 			'memory.searchHint' => 'Buscar…',
 			'memory.projectLabel' => 'Proyecto',
@@ -14022,17 +14064,19 @@ extension on TranslationsEs {
 			'settings.serverSettings.sections.storageClaude' => 'Almacenamiento · Claude',
 			'settings.serverSettings.sections.storageCodex' => 'Almacenamiento · Codex',
 			'settings.serverSettings.sections.storageAntigravity' => 'Almacenamiento · Antigravity',
+			'settings.serverSettings.sections.skills' => 'Habilidades de agente',
 			'settings.serverSettings.sectionDescriptions.general' => 'Dirección de escucha, cuenta del operador, TTL del token.',
 			'settings.serverSettings.sectionDescriptions.host' => 'Mantén esta máquina accesible mientras está inactiva.',
 			'settings.serverSettings.sectionDescriptions.logging' => 'Verbosidad, formato y ruta del log en disco.',
 			'settings.serverSettings.sectionDescriptions.sessions' => 'Umbrales de detección de inactividad.',
-			'settings.serverSettings.sectionDescriptions.vault' => 'Notas, skills y raíz versionada con git.',
-			'settings.serverSettings.sectionDescriptions.mcpRegistry' => 'Rutas del vault para servidores MCP + archivo de secretos.',
+			'settings.serverSettings.sectionDescriptions.vault' => 'Tus documentos y el repositorio al que se sincronizan.',
+			'settings.serverSettings.sectionDescriptions.mcpRegistry' => 'Registro de servidores y archivo de secretos.',
 			'settings.serverSettings.sectionDescriptions.memory' => 'Subsistema de memoria persistente entre CLIs.',
 			'settings.serverSettings.sectionDescriptions.backup' => 'Copias de seguridad cifradas de la BD + exportaciones de datos de admin. La frase de contraseña vive en el keyfile (Ajustes → Copias de seguridad).',
 			'settings.serverSettings.sectionDescriptions.storageClaude' => 'Dónde viven los transcripts de Claude en disco.',
 			'settings.serverSettings.sectionDescriptions.storageCodex' => 'Raíz de las sessions de Codex.',
 			'settings.serverSettings.sectionDescriptions.storageAntigravity' => 'Almacén SQLite por conversación de agy.',
+			'settings.serverSettings.sectionDescriptions.skills' => 'De dónde se cargan las habilidades de agente.',
 			'settings.serverSettings.fields.listenAddress' => 'Dirección de escucha',
 			'settings.serverSettings.fields.adminUser' => 'Usuario admin',
 			'settings.serverSettings.fields.adminUserHelper' => 'Efectivo cuando no hay keyfile ni variable de entorno configurada. Si no, consulta Ajustes → Cuenta.',
@@ -14048,10 +14092,9 @@ extension on TranslationsEs {
 			'settings.serverSettings.fields.idleThresholdHelper' => 'Periodo de silencio antes de marcar una session como inactiva. Duración de Go.',
 			'settings.serverSettings.fields.idleCheckInterval' => 'Intervalo de comprobación de inactividad',
 			'settings.serverSettings.fields.idleCheckHelper' => 'Con qué frecuencia se ejecuta el reaper de inactividad.',
-			'settings.serverSettings.fields.root' => 'Raíz',
-			'settings.serverSettings.fields.rootHelper' => 'Padre de las sub-rutas notes / skills / git_root.',
-			'settings.serverSettings.fields.notesPath' => 'Ruta de notas',
-			'settings.serverSettings.fields.skillsPath' => 'Ruta de skills',
+			'settings.serverSettings.fields.root' => 'Raíz del Vault',
+			'settings.serverSettings.fields.rootHelper' => 'El directorio donde viven tus documentos: lo que muestra el Vault y lo que confirma Vault Sync.',
+			'settings.serverSettings.fields.notesPath' => 'Ruta de documentos (heredada)',
 			'settings.serverSettings.fields.gitRoot' => 'Raíz de git',
 			'settings.serverSettings.fields.personalPrefix' => 'Prefijo personal',
 			'settings.serverSettings.fields.projectsPrefix' => 'Prefijo de proyectos',
@@ -14103,6 +14146,10 @@ extension on TranslationsEs {
 			'settings.serverSettings.fields.sleepModeAlways' => 'Despierto con cualquier alimentación',
 			'settings.serverSettings.fields.sleepModeOnDemand' => 'Dormir, despertar con tráfico',
 			'settings.serverSettings.fields.sleepModeOff' => 'No tocar la energía',
+			'settings.serverSettings.fields.notesPathHelper' => 'Nombre antiguo de la raíz del Vault, visible porque está definido. Vacíalo para usar la raíz del Vault, o mantenlo apuntando a una carpeta markdown que gestiones en otro sitio.',
+			'settings.serverSettings.fields.skillsRoot' => 'Raíz de habilidades',
+			'settings.serverSettings.fields.skillsRootHelper' => 'Directorio con las habilidades de agente. Fuera del Vault para que no acaben en el repositorio de tus documentos.',
+			'settings.serverSettings.fields.gitRootHelper' => 'Árbol de trabajo que confirma Vault Sync. Por defecto la raíz del Vault, así el repositorio solo contiene documentos.',
 			'settings.serverSettings.validateInteger' => ({required Object field}) => '"${field}" debe ser un entero',
 			'settings.serverSettings.validateNumber' => ({required Object field}) => '"${field}" debe ser un número',
 			'settings.serverSettings.embedderModel.reprobe' => 'Volver a comprobar el endpoint',
@@ -14110,6 +14157,7 @@ extension on TranslationsEs {
 			'settings.serverSettings.embedderModel.pickHint' => 'Selecciona un modelo',
 			'settings.serverSettings.embedderModel.manual' => 'Escribir manualmente',
 			'settings.serverSettings.embedderModel.pickFromList' => 'Elegir de la lista',
+			'settings.serverSettings.legacyLayout' => 'Los directorios propios de opendray siguen dentro de tus documentos, así que aparecen en el Vault y la sincronización se los lleva. Siguen funcionando: muévelos fuera y fija las rutas de abajo cuando puedas.',
 			'memoryQuarantine.title' => 'Cuarentena',
 			'memoryQuarantine.subtitle' => 'Hechos que necesitan revisión antes de contar como memoria durable: las capturas de integraciones llegan aquí por política, y puedes poner cualquier memoria en cuarentena a mano. Promueve lo verdadero; descarta el resto — las filas sin revisar expiran solas.',
 			'memoryQuarantine.empty' => 'Nada en cuarentena.',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -1554,6 +1554,7 @@ class _TranslationsWebServerSettingsZh extends TranslationsWebServerSettingsEn {
 	@override String get memoryRuntimeBanner => '运行时 AI 行为——工作器、捕获规则、注入策略与 spawn 模式——位于 Cortex 设置，保存即生效。本区块是基础设施的一半：嵌入后端、存储与后台治理（需重启生效）。';
 	@override String get memoryRuntimeBannerButton => '打开 Cortex 设置';
 	@override late final _TranslationsWebServerSettingsHostZh host = _TranslationsWebServerSettingsHostZh._(_root);
+	@override late final _TranslationsWebServerSettingsLayoutZh layout = _TranslationsWebServerSettingsLayoutZh._(_root);
 }
 
 // Path: web.settings
@@ -3153,6 +3154,7 @@ class _TranslationsSettingsServerSettingsZh extends TranslationsSettingsServerSe
 	@override String validateInteger({required Object field}) => '「${field}」必须是整数';
 	@override String validateNumber({required Object field}) => '「${field}」必须是数字';
 	@override late final _TranslationsSettingsServerSettingsEmbedderModelZh embedderModel = _TranslationsSettingsServerSettingsEmbedderModelZh._(_root);
+	@override String get legacyLayout => 'opendray 自己的目录仍在你的文档里,所以它们会出现在 Vault 中,同步时也会被带走。它们照常工作 —— 方便时把它们移出去,并在下面填好路径。';
 }
 
 // Path: web.sessions.list
@@ -5174,6 +5176,7 @@ class _TranslationsWebServerSettingsSectionsZh extends TranslationsWebServerSett
 	@override late final _TranslationsWebServerSettingsSectionsClaudeZh claude = _TranslationsWebServerSettingsSectionsClaudeZh._(_root);
 	@override late final _TranslationsWebServerSettingsSectionsCodexZh codex = _TranslationsWebServerSettingsSectionsCodexZh._(_root);
 	@override late final _TranslationsWebServerSettingsSectionsAntigravityZh antigravity = _TranslationsWebServerSettingsSectionsAntigravityZh._(_root);
+	@override late final _TranslationsWebServerSettingsSectionsSkillsZh skills = _TranslationsWebServerSettingsSectionsSkillsZh._(_root);
 }
 
 // Path: web.serverSettings.restart
@@ -5233,7 +5236,6 @@ class _TranslationsWebServerSettingsFieldsZh extends TranslationsWebServerSettin
 	@override late final _TranslationsWebServerSettingsFieldsIdlePollIntervalZh idlePollInterval = _TranslationsWebServerSettingsFieldsIdlePollIntervalZh._(_root);
 	@override late final _TranslationsWebServerSettingsFieldsVaultRootZh vaultRoot = _TranslationsWebServerSettingsFieldsVaultRootZh._(_root);
 	@override late final _TranslationsWebServerSettingsFieldsNotesDirectoryZh notesDirectory = _TranslationsWebServerSettingsFieldsNotesDirectoryZh._(_root);
-	@override late final _TranslationsWebServerSettingsFieldsSkillsDirectoryZh skillsDirectory = _TranslationsWebServerSettingsFieldsSkillsDirectoryZh._(_root);
 	@override late final _TranslationsWebServerSettingsFieldsGitRootZh gitRoot = _TranslationsWebServerSettingsFieldsGitRootZh._(_root);
 	@override late final _TranslationsWebServerSettingsFieldsPersonalPrefixZh personalPrefix = _TranslationsWebServerSettingsFieldsPersonalPrefixZh._(_root);
 	@override late final _TranslationsWebServerSettingsFieldsProjectsPrefixZh projectsPrefix = _TranslationsWebServerSettingsFieldsProjectsPrefixZh._(_root);
@@ -5271,6 +5273,7 @@ class _TranslationsWebServerSettingsFieldsZh extends TranslationsWebServerSettin
 	@override late final _TranslationsWebServerSettingsFieldsClaudeAutoFailoverZh claudeAutoFailover = _TranslationsWebServerSettingsFieldsClaudeAutoFailoverZh._(_root);
 	@override late final _TranslationsWebServerSettingsFieldsMobileTokenTTLZh mobileTokenTTL = _TranslationsWebServerSettingsFieldsMobileTokenTTLZh._(_root);
 	@override late final _TranslationsWebServerSettingsFieldsDbMaxConnsZh dbMaxConns = _TranslationsWebServerSettingsFieldsDbMaxConnsZh._(_root);
+	@override late final _TranslationsWebServerSettingsFieldsSkillsRootZh skillsRoot = _TranslationsWebServerSettingsFieldsSkillsRootZh._(_root);
 }
 
 // Path: web.serverSettings.liveTail
@@ -5419,6 +5422,21 @@ class _TranslationsWebServerSettingsHostZh extends TranslationsWebServerSettings
 	@override String get intro => '睡眠中的 Mac 会一并关掉网络,网关随即停止应答 —— 手机连不上、网页连不上、连数据库也断开。表面看像"opendray 不稳定",实际只是机器睡着了。请选择 opendray 的应对方式。';
 	@override String get platformNote => '仅 macOS 生效。Linux 与 Windows 会接受但忽略此设置 —— 常规服务器安装下这些主机不会空闲休眠。主动睡眠(合盖、苹果菜单 → 睡眠)永不被阻止;opendray 退出或被强制结束时,电源断言会立即释放。';
 	@override late final _TranslationsWebServerSettingsHostModesZh modes = _TranslationsWebServerSettingsHostModesZh._(_root);
+}
+
+// Path: web.serverSettings.layout
+class _TranslationsWebServerSettingsLayoutZh extends TranslationsWebServerSettingsLayoutEn {
+	_TranslationsWebServerSettingsLayoutZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '实际解析到';
+	@override String get documents => '文档';
+	@override String get git => 'Git 仓库';
+	@override String get skills => 'Skills';
+	@override String get mcp => 'MCP 注册表';
+	@override String get legacyWarning => '此安装仍把 opendray 自己的目录放在你的文档里,所以它们会出现在 Vault 中,也会被同步带走。它们照常工作 —— 方便时把它们移出去,并在上面填好路径。已经提交进仓库的需要你自己 git rm --cached;opendray 不会改写你的仓库。';
 }
 
 // Path: web.settings.groups
@@ -7296,13 +7314,14 @@ class _TranslationsSettingsServerSettingsSectionsZh extends TranslationsSettings
 	@override String get host => '主机电源';
 	@override String get logging => '日志';
 	@override String get sessions => '会话';
-	@override String get vault => '凭据库';
+	@override String get vault => 'Vault';
 	@override String get mcpRegistry => 'MCP 注册表';
 	@override String get memory => '记忆';
 	@override String get backup => '备份';
 	@override String get storageClaude => '存储 · Claude';
 	@override String get storageCodex => '存储 · Codex';
 	@override String get storageAntigravity => '存储 · Antigravity';
+	@override String get skills => 'Agent skills';
 }
 
 // Path: settings.serverSettings.sectionDescriptions
@@ -7316,13 +7335,14 @@ class _TranslationsSettingsServerSettingsSectionDescriptionsZh extends Translati
 	@override String get host => '让这台机器在闲置时仍可被访问。';
 	@override String get logging => '详细程度、格式、磁盘日志路径。';
 	@override String get sessions => '空闲检测阈值。';
-	@override String get vault => '笔记、技能、git 版本化的根目录。';
-	@override String get mcpRegistry => 'MCP 服务器 + 密钥文件的凭据库路径。';
+	@override String get vault => '你的文档,以及它同步到的仓库。';
+	@override String get mcpRegistry => '服务器注册表与密钥文件。';
 	@override String get memory => '跨 CLI 的持久记忆子系统。';
 	@override String get backup => '加密的数据库备份 + 管理数据导出。密语保存在密钥文件（设置 → 备份）。';
 	@override String get storageClaude => 'Claude 会话记录在磁盘的存放位置。';
 	@override String get storageCodex => 'Codex 会话根目录。';
 	@override String get storageAntigravity => 'agy 按会话存储的 SQLite 库。';
+	@override String get skills => 'agent skills 从哪里加载。';
 }
 
 // Path: settings.serverSettings.fields
@@ -7347,10 +7367,9 @@ class _TranslationsSettingsServerSettingsFieldsZh extends TranslationsSettingsSe
 	@override String get idleThresholdHelper => '会话被标记为空闲前的安静时长。Go duration。';
 	@override String get idleCheckInterval => '空闲检查间隔';
 	@override String get idleCheckHelper => '空闲回收器运行的频率。';
-	@override String get root => '根目录';
-	@override String get rootHelper => 'notes / skills / git_root 子路径的父目录。';
-	@override String get notesPath => '笔记路径';
-	@override String get skillsPath => '技能路径';
+	@override String get root => 'Vault 根目录';
+	@override String get rootHelper => '你的文档所在的目录 —— Vault 浏览的就是这里,Vault Sync 提交的也是这里。';
+	@override String get notesPath => '文档路径(旧字段)';
 	@override String get gitRoot => 'Git 根';
 	@override String get personalPrefix => '个人前缀';
 	@override String get projectsPrefix => '项目前缀';
@@ -7402,6 +7421,10 @@ class _TranslationsSettingsServerSettingsFieldsZh extends TranslationsSettingsSe
 	@override String get sleepModeAlways => '任何供电下保持唤醒';
 	@override String get sleepModeOnDemand => '闲时休眠,有请求时唤醒';
 	@override String get sleepModeOff => '不干预电源';
+	@override String get notesPathHelper => 'Vault 根目录的旧称,因为已设置才显示。清空即改用 Vault 根目录;也可以继续指向你在别处维护的 markdown 目录。';
+	@override String get skillsRoot => 'Skills 根目录';
+	@override String get skillsRootHelper => '存放 agent skills 的目录。放在 Vault 之外,避免被提交进你的文档仓库。';
+	@override String get gitRootHelper => 'Vault Sync 提交的工作树。默认为 Vault 根目录,这样仓库里只有文档。';
 }
 
 // Path: settings.serverSettings.embedderModel
@@ -8530,7 +8553,7 @@ class _TranslationsWebServerSettingsSectionsVaultZh extends TranslationsWebServe
 
 	// Translations
 	@override String get title => 'Vault';
-	@override String get desc => '笔记、技能与 git 版本化根目录。';
+	@override String get desc => '你的文档,以及它同步到的仓库。';
 }
 
 // Path: web.serverSettings.sections.mcp
@@ -8597,6 +8620,17 @@ class _TranslationsWebServerSettingsSectionsAntigravityZh extends TranslationsWe
 	// Translations
 	@override String get title => '存储 · Antigravity';
 	@override String get desc => 'Antigravity (agy) 按会话存储的 SQLite 库。';
+}
+
+// Path: web.serverSettings.sections.skills
+class _TranslationsWebServerSettingsSectionsSkillsZh extends TranslationsWebServerSettingsSectionsSkillsEn {
+	_TranslationsWebServerSettingsSectionsSkillsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Agent skills';
+	@override String get desc => '技能从哪里加载。';
 }
 
 // Path: web.serverSettings.fields.listenAddress
@@ -8708,7 +8742,7 @@ class _TranslationsWebServerSettingsFieldsVaultRootZh extends TranslationsWebSer
 
 	// Translations
 	@override String get label => 'Vault 根目录';
-	@override String get hint => '笔记、技能和 MCP 注册表的顶层目录。';
+	@override String get hint => '你的文档所在的目录。Vault 页面浏览的就是这里,Vault Sync 提交的也是这里。';
 }
 
 // Path: web.serverSettings.fields.notesDirectory
@@ -8718,19 +8752,8 @@ class _TranslationsWebServerSettingsFieldsNotesDirectoryZh extends TranslationsW
 	final TranslationsZh _root; // ignore: unused_field
 
 	// Translations
-	@override String get label => '笔记目录';
-	@override String get hint => '覆盖笔记位置。默认为 <vault root>/notes。';
-}
-
-// Path: web.serverSettings.fields.skillsDirectory
-class _TranslationsWebServerSettingsFieldsSkillsDirectoryZh extends TranslationsWebServerSettingsFieldsSkillsDirectoryEn {
-	_TranslationsWebServerSettingsFieldsSkillsDirectoryZh._(TranslationsZh root) : this._root = root, super.internal(root);
-
-	final TranslationsZh _root; // ignore: unused_field
-
-	// Translations
-	@override String get label => '技能目录';
-	@override String get hint => '覆盖技能位置。默认为 <vault root>/skills。';
+	@override String get label => '文档目录(旧字段)';
+	@override String get hint => 'Vault 根目录的旧称,因为已设置才显示。清空即改用 Vault 根目录;也可以继续指向你在别处维护的 markdown 目录。';
 }
 
 // Path: web.serverSettings.fields.gitRoot
@@ -8741,7 +8764,7 @@ class _TranslationsWebServerSettingsFieldsGitRootZh extends TranslationsWebServe
 
 	// Translations
 	@override String get label => 'Git 根目录';
-	@override String get hint => 'Vault Sync 功能提交到的工作树。';
+	@override String get hint => 'Vault Sync 提交的工作树。默认为 Vault 根目录,这样仓库里只有文档。';
 }
 
 // Path: web.serverSettings.fields.personalPrefix
@@ -8774,7 +8797,7 @@ class _TranslationsWebServerSettingsFieldsRegistryRootZh extends TranslationsWeb
 
 	// Translations
 	@override String get label => '注册表根目录';
-	@override String get hint => '存放 MCP server JSON 定义的目录。默认为 <vault>/mcp。';
+	@override String get hint => '存放 MCP 服务器 JSON 定义的目录。默认 ~/.opendray/mcp。';
 }
 
 // Path: web.serverSettings.fields.secretsFile
@@ -9138,6 +9161,17 @@ class _TranslationsWebServerSettingsFieldsDbMaxConnsZh extends TranslationsWebSe
 	// Translations
 	@override String get label => '最大连接数';
 	@override String get hint => 'pgx 连接池上限。0 = 默认值（16）。';
+}
+
+// Path: web.serverSettings.fields.skillsRoot
+class _TranslationsWebServerSettingsFieldsSkillsRootZh extends TranslationsWebServerSettingsFieldsSkillsRootEn {
+	_TranslationsWebServerSettingsFieldsSkillsRootZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get label => 'Skills 根目录';
+	@override String get hint => '存放 agent skills 的目录。放在 Vault 之外,避免被提交进你的文档仓库。';
 }
 
 // Path: web.serverSettings.httpHelpers.presetTip
@@ -11564,7 +11598,7 @@ extension on TranslationsZh {
 			'web.serverSettings.sections.sessions.title' => '会话',
 			'web.serverSettings.sections.sessions.desc' => '空闲检测阈值。',
 			'web.serverSettings.sections.vault.title' => 'Vault',
-			'web.serverSettings.sections.vault.desc' => '笔记、技能与 git 版本化根目录。',
+			'web.serverSettings.sections.vault.desc' => '你的文档,以及它同步到的仓库。',
 			'web.serverSettings.sections.mcp.title' => 'MCP 注册表',
 			'web.serverSettings.sections.mcp.desc' => '服务器注册表与密钥。',
 			'web.serverSettings.sections.memory.title' => '记忆 · 存储与嵌入',
@@ -11577,6 +11611,8 @@ extension on TranslationsZh {
 			'web.serverSettings.sections.codex.desc' => 'Codex 会话根目录。',
 			'web.serverSettings.sections.antigravity.title' => '存储 · Antigravity',
 			'web.serverSettings.sections.antigravity.desc' => 'Antigravity (agy) 按会话存储的 SQLite 库。',
+			'web.serverSettings.sections.skills.title' => 'Agent skills',
+			'web.serverSettings.sections.skills.desc' => '技能从哪里加载。',
 			'web.serverSettings.loading' => '正在加载服务器设置…',
 			'web.serverSettings.loadFailed' => ({required Object message}) => '加载失败：${message}',
 			'web.serverSettings.noConfigFlag' => 'opendray 启动时未指定 -config，设置仅从环境变量加载，无法在此编辑。',
@@ -11635,19 +11671,17 @@ extension on TranslationsZh {
 			'web.serverSettings.fields.idlePollInterval.label' => '空闲轮询间隔',
 			'web.serverSettings.fields.idlePollInterval.hint' => '空闲检测器的唤醒频率。越低 = 延迟越低、唤醒越多。留空 = 5s。',
 			'web.serverSettings.fields.vaultRoot.label' => 'Vault 根目录',
-			'web.serverSettings.fields.vaultRoot.hint' => '笔记、技能和 MCP 注册表的顶层目录。',
-			'web.serverSettings.fields.notesDirectory.label' => '笔记目录',
-			'web.serverSettings.fields.notesDirectory.hint' => '覆盖笔记位置。默认为 <vault root>/notes。',
-			'web.serverSettings.fields.skillsDirectory.label' => '技能目录',
-			'web.serverSettings.fields.skillsDirectory.hint' => '覆盖技能位置。默认为 <vault root>/skills。',
+			'web.serverSettings.fields.vaultRoot.hint' => '你的文档所在的目录。Vault 页面浏览的就是这里,Vault Sync 提交的也是这里。',
+			'web.serverSettings.fields.notesDirectory.label' => '文档目录(旧字段)',
+			'web.serverSettings.fields.notesDirectory.hint' => 'Vault 根目录的旧称,因为已设置才显示。清空即改用 Vault 根目录;也可以继续指向你在别处维护的 markdown 目录。',
 			'web.serverSettings.fields.gitRoot.label' => 'Git 根目录',
-			'web.serverSettings.fields.gitRoot.hint' => 'Vault Sync 功能提交到的工作树。',
+			'web.serverSettings.fields.gitRoot.hint' => 'Vault Sync 提交的工作树。默认为 Vault 根目录,这样仓库里只有文档。',
 			'web.serverSettings.fields.personalPrefix.label' => '个人前缀',
 			'web.serverSettings.fields.personalPrefix.hint' => '自动派生路径时用于个人笔记的文件夹名。默认 "personal"。',
 			'web.serverSettings.fields.projectsPrefix.label' => '项目前缀',
 			'web.serverSettings.fields.projectsPrefix.hint' => '项目笔记的文件夹名。默认 "projects"。',
 			'web.serverSettings.fields.registryRoot.label' => '注册表根目录',
-			'web.serverSettings.fields.registryRoot.hint' => '存放 MCP server JSON 定义的目录。默认为 <vault>/mcp。',
+			'web.serverSettings.fields.registryRoot.hint' => '存放 MCP 服务器 JSON 定义的目录。默认 ~/.opendray/mcp。',
 			'web.serverSettings.fields.secretsFile.label' => '密钥文件',
 			'web.serverSettings.fields.secretsFile.hint' => 'spawn 时替换进 MCP server 命令的 key=value 文件。',
 			'web.serverSettings.fields.memoryBackend.label' => '嵌入器后端',
@@ -11714,6 +11748,8 @@ extension on TranslationsZh {
 			'web.serverSettings.fields.mobileTokenTTL.hint' => '签发给移动 App 的 bearer token 的有效期。默认 720h（30 天）。',
 			'web.serverSettings.fields.dbMaxConns.label' => '最大连接数',
 			'web.serverSettings.fields.dbMaxConns.hint' => 'pgx 连接池上限。0 = 默认值（16）。',
+			'web.serverSettings.fields.skillsRoot.label' => 'Skills 根目录',
+			'web.serverSettings.fields.skillsRoot.hint' => '存放 agent skills 的目录。放在 Vault 之外,避免被提交进你的文档仓库。',
 			'web.serverSettings.liveTail.heading' => '实时日志',
 			'web.serverSettings.liveTail.description' => '内存中的环形缓冲区（最近约 2,000 条）。重启后清空。',
 			'web.serverSettings.memoryInspectorCard.heading' => '检查器',
@@ -11800,6 +11836,12 @@ extension on TranslationsZh {
 			'web.serverSettings.host.modes.off.label' => '完全不干预电源',
 			'web.serverSettings.host.modes.off.desc' => 'opendray 不对机器电源做任何操作。',
 			'web.serverSettings.host.modes.off.caveat' => '主机一旦休眠即无法连接,除非另有程序让它保持唤醒。',
+			'web.serverSettings.layout.title' => '实际解析到',
+			'web.serverSettings.layout.documents' => '文档',
+			'web.serverSettings.layout.git' => 'Git 仓库',
+			'web.serverSettings.layout.skills' => 'Skills',
+			'web.serverSettings.layout.mcp' => 'MCP 注册表',
+			'web.serverSettings.layout.legacyWarning' => '此安装仍把 opendray 自己的目录放在你的文档里,所以它们会出现在 Vault 中,也会被同步带走。它们照常工作 —— 方便时把它们移出去,并在上面填好路径。已经提交进仓库的需要你自己 git rm --cached;opendray 不会改写你的仓库。',
 			'web.settings.title' => '设置',
 			'web.settings.subtitle' => '工作区、账号与网关配置。',
 			'web.settings.groups.workspace' => '工作区',
@@ -11826,6 +11868,8 @@ extension on TranslationsZh {
 			'web.settings.font.description' => '缩放整个界面。按浏览器保存。',
 			'web.settings.font.options.compact' => '紧凑',
 			'web.settings.font.options.kDefault' => '默认',
+			_ => null,
+		} ?? switch (path) {
 			'web.settings.font.options.comfy' => '舒适',
 			'web.settings.font.options.large' => '大',
 			'web.settings.account.title' => '账号',
@@ -11834,8 +11878,6 @@ extension on TranslationsZh {
 			'web.settings.account.tokenExpires' => 'Token 过期',
 			'web.settings.account.changeCredentials' => '修改凭证',
 			'web.settings.changeCredentials.title' => '修改凭证',
-			_ => null,
-		} ?? switch (path) {
 			'web.settings.changeCredentials.description' => '先验证当前密码，再选择新凭证。所有其它已登录会话都将被吊销。',
 			'web.settings.changeCredentials.currentPassword' => '当前密码',
 			'web.settings.changeCredentials.newUsername' => '新用户名',
@@ -12340,6 +12382,8 @@ extension on TranslationsZh {
 			'web.database.dialog.test' => '测试',
 			'web.database.dialog.save' => '保存',
 			'web.database.dialog.testFailed' => '连接测试失败',
+			_ => null,
+		} ?? switch (path) {
 			'web.database.dialog.testOk' => ({required Object version, required Object ms}) => '已连接 — ${version}（${ms} ms）',
 			'web.database.dialog.savedCreate' => '连接已添加',
 			'web.database.dialog.savedEdit' => '连接已更新',
@@ -12348,8 +12392,6 @@ extension on TranslationsZh {
 			'web.database.dialog.drivers.postgres' => 'PostgreSQL',
 			'web.database.dialog.drivers.mysql' => 'MySQL',
 			'web.database.dialog.drivers.mariadb' => 'MariaDB',
-			_ => null,
-		} ?? switch (path) {
 			'web.database.dialog.drivers.sqlite' => 'SQLite',
 			'web.database.dialog.filePath' => '数据库文件',
 			'web.database.dialog.filePathHint' => '项目目录内的 SQLite 文件路径。',
@@ -12854,6 +12896,8 @@ extension on TranslationsZh {
 			'sessions.inspector.canvas.themeDarkHint' => '留空 = 沿用浅色',
 			'sessions.inspector.canvas.paletteIndigo' => '靛蓝',
 			'sessions.inspector.canvas.paletteSky' => '天蓝',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.paletteEmerald' => '翠绿',
 			'sessions.inspector.canvas.paletteAmber' => '琥珀',
 			'sessions.inspector.canvas.paletteRose' => '玫红',
@@ -12862,8 +12906,6 @@ extension on TranslationsZh {
 			'sessions.inspector.canvas.extractBtn' => '读取项目样式',
 			'sessions.inspector.canvas.showcaseBtn' => '生成配色画布',
 			'sessions.inspector.canvas.designTaskSent' => '已发送给 agent —— 留意会话。',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.spawnSheet.title' => '新建会话',
 			'sessions.spawnSheet.errorRequired' => '需要指定提供商和工作目录',
 			'sessions.spawnSheet.errorGeneric' => ({required Object error}) => '创建会话失败：${error}',
@@ -13368,6 +13410,8 @@ extension on TranslationsZh {
 			'backups.restore.fileSelected' => ({required Object name, required Object size}) => '${name} · ${size}',
 			'backups.restore.noFile' => '未选择文件',
 			'backups.restore.targetDsnLabel' => '目标 Postgres DSN',
+			_ => null,
+		} ?? switch (path) {
 			'backups.restore.targetDsnHint' => '留空表示恢复到 opendray 自身的数据库。',
 			'backups.restore.targetDsnPlaceholder' => 'postgres://user:pass@host:5432/dbname',
 			'backups.restore.cleanLabel' => 'pg_restore --clean --if-exists',
@@ -13376,8 +13420,6 @@ extension on TranslationsZh {
 			'backups.restore.auditNotePlaceholder' => '例如：恢复 #INC-481',
 			'backups.restore.ownDbWarning' => '恢复到 opendray 自身的数据库将覆写本网关当前提供服务的数据。请输入 "I understand" 以确认。',
 			'backups.restore.confirmPlaceholder' => '输入 "I understand"',
-			_ => null,
-		} ?? switch (path) {
 			'backups.restore.confirmSentinel' => 'I understand',
 			'backups.restore.restoring' => '恢复中…',
 			'backups.restore.preview' => '预览（试运行）',
@@ -13882,6 +13924,8 @@ extension on TranslationsZh {
 			'memory.title' => '记忆',
 			'memory.more' => '更多',
 			'memory.workers' => '记忆工作器',
+			_ => null,
+		} ?? switch (path) {
 			'memory.rank.title' => '排名分解',
 			'memory.rank.effective' => ({required Object value}) => '有效分：${value}',
 			'memory.rank.similarity' => '余弦相似度',
@@ -13890,8 +13934,6 @@ extension on TranslationsZh {
 			'memory.rank.confidenceMultiplier' => '置信度系数',
 			'memory.rank.formula' => '有效分 = 相似度 × 时效 × 命中 × 置信度',
 			'memory.rank.close' => '关闭',
-			_ => null,
-		} ?? switch (path) {
 			'memory.kNew' => '新建',
 			'memory.searchHint' => '搜索…',
 			'memory.projectLabel' => '项目',
@@ -14015,24 +14057,26 @@ extension on TranslationsZh {
 			'settings.serverSettings.sections.host' => '主机电源',
 			'settings.serverSettings.sections.logging' => '日志',
 			'settings.serverSettings.sections.sessions' => '会话',
-			'settings.serverSettings.sections.vault' => '凭据库',
+			'settings.serverSettings.sections.vault' => 'Vault',
 			'settings.serverSettings.sections.mcpRegistry' => 'MCP 注册表',
 			'settings.serverSettings.sections.memory' => '记忆',
 			'settings.serverSettings.sections.backup' => '备份',
 			'settings.serverSettings.sections.storageClaude' => '存储 · Claude',
 			'settings.serverSettings.sections.storageCodex' => '存储 · Codex',
 			'settings.serverSettings.sections.storageAntigravity' => '存储 · Antigravity',
+			'settings.serverSettings.sections.skills' => 'Agent skills',
 			'settings.serverSettings.sectionDescriptions.general' => '监听地址、管理员账号、令牌 TTL。',
 			'settings.serverSettings.sectionDescriptions.host' => '让这台机器在闲置时仍可被访问。',
 			'settings.serverSettings.sectionDescriptions.logging' => '详细程度、格式、磁盘日志路径。',
 			'settings.serverSettings.sectionDescriptions.sessions' => '空闲检测阈值。',
-			'settings.serverSettings.sectionDescriptions.vault' => '笔记、技能、git 版本化的根目录。',
-			'settings.serverSettings.sectionDescriptions.mcpRegistry' => 'MCP 服务器 + 密钥文件的凭据库路径。',
+			'settings.serverSettings.sectionDescriptions.vault' => '你的文档,以及它同步到的仓库。',
+			'settings.serverSettings.sectionDescriptions.mcpRegistry' => '服务器注册表与密钥文件。',
 			'settings.serverSettings.sectionDescriptions.memory' => '跨 CLI 的持久记忆子系统。',
 			'settings.serverSettings.sectionDescriptions.backup' => '加密的数据库备份 + 管理数据导出。密语保存在密钥文件（设置 → 备份）。',
 			'settings.serverSettings.sectionDescriptions.storageClaude' => 'Claude 会话记录在磁盘的存放位置。',
 			'settings.serverSettings.sectionDescriptions.storageCodex' => 'Codex 会话根目录。',
 			'settings.serverSettings.sectionDescriptions.storageAntigravity' => 'agy 按会话存储的 SQLite 库。',
+			'settings.serverSettings.sectionDescriptions.skills' => 'agent skills 从哪里加载。',
 			'settings.serverSettings.fields.listenAddress' => '监听地址',
 			'settings.serverSettings.fields.adminUser' => '管理员用户',
 			'settings.serverSettings.fields.adminUserHelper' => '当未设置密钥文件或环境变量时生效。否则参见 设置 → 账户。',
@@ -14048,10 +14092,9 @@ extension on TranslationsZh {
 			'settings.serverSettings.fields.idleThresholdHelper' => '会话被标记为空闲前的安静时长。Go duration。',
 			'settings.serverSettings.fields.idleCheckInterval' => '空闲检查间隔',
 			'settings.serverSettings.fields.idleCheckHelper' => '空闲回收器运行的频率。',
-			'settings.serverSettings.fields.root' => '根目录',
-			'settings.serverSettings.fields.rootHelper' => 'notes / skills / git_root 子路径的父目录。',
-			'settings.serverSettings.fields.notesPath' => '笔记路径',
-			'settings.serverSettings.fields.skillsPath' => '技能路径',
+			'settings.serverSettings.fields.root' => 'Vault 根目录',
+			'settings.serverSettings.fields.rootHelper' => '你的文档所在的目录 —— Vault 浏览的就是这里,Vault Sync 提交的也是这里。',
+			'settings.serverSettings.fields.notesPath' => '文档路径(旧字段)',
 			'settings.serverSettings.fields.gitRoot' => 'Git 根',
 			'settings.serverSettings.fields.personalPrefix' => '个人前缀',
 			'settings.serverSettings.fields.projectsPrefix' => '项目前缀',
@@ -14103,6 +14146,10 @@ extension on TranslationsZh {
 			'settings.serverSettings.fields.sleepModeAlways' => '任何供电下保持唤醒',
 			'settings.serverSettings.fields.sleepModeOnDemand' => '闲时休眠,有请求时唤醒',
 			'settings.serverSettings.fields.sleepModeOff' => '不干预电源',
+			'settings.serverSettings.fields.notesPathHelper' => 'Vault 根目录的旧称,因为已设置才显示。清空即改用 Vault 根目录;也可以继续指向你在别处维护的 markdown 目录。',
+			'settings.serverSettings.fields.skillsRoot' => 'Skills 根目录',
+			'settings.serverSettings.fields.skillsRootHelper' => '存放 agent skills 的目录。放在 Vault 之外,避免被提交进你的文档仓库。',
+			'settings.serverSettings.fields.gitRootHelper' => 'Vault Sync 提交的工作树。默认为 Vault 根目录,这样仓库里只有文档。',
 			'settings.serverSettings.validateInteger' => ({required Object field}) => '「${field}」必须是整数',
 			'settings.serverSettings.validateNumber' => ({required Object field}) => '「${field}」必须是数字',
 			'settings.serverSettings.embedderModel.reprobe' => '重新检测端点',
@@ -14110,6 +14157,7 @@ extension on TranslationsZh {
 			'settings.serverSettings.embedderModel.pickHint' => '选择模型',
 			'settings.serverSettings.embedderModel.manual' => '手动输入',
 			'settings.serverSettings.embedderModel.pickFromList' => '从列表选择',
+			'settings.serverSettings.legacyLayout' => 'opendray 自己的目录仍在你的文档里,所以它们会出现在 Vault 中,同步时也会被带走。它们照常工作 —— 方便时把它们移出去,并在下面填好路径。',
 			'memoryQuarantine.title' => '隔离区',
 			'memoryQuarantine.subtitle' => '在被采信为持久记忆前需要审查的事实：integration 捕获按策略落到这里，你也可以手动隔离任何记忆。属实的批准入库，其余丢弃——未审查的条目会自动过期。',
 			'memoryQuarantine.empty' => '隔离区为空。',

--- a/app/mobile/lib/features/settings/server_settings_screen.dart
+++ b/app/mobile/lib/features/settings/server_settings_screen.dart
@@ -45,6 +45,7 @@ class _Field {
     this.optionLabels,
     this.monospace = false,
     this.placeholder,
+    this.onlyWhenSet = false,
   });
 
   final String label;
@@ -63,6 +64,10 @@ class _Field {
   final Map<String, String>? optionLabels;
   final bool monospace;
   final String? placeholder;
+  // Deprecated fields kept for operators who already rely on them.
+  // Hidden when empty so a superseded setting is not offered to
+  // anyone new, but still editable (and clearable) by whoever set it.
+  final bool onlyWhenSet;
 }
 
 class _Section {
@@ -208,7 +213,7 @@ List<_Section> _buildSections() => <_Section>[
         kind: _FieldKind.text,
         monospace: true,
         helper: t.settings.serverSettings.fields.rootHelper,
-        // resolveVaultPaths falls back to ~/.opendray/vault.
+        // config.Resolve falls back to ~/.opendray/vault.
         placeholder: '~/.opendray/vault',
       ),
       _Field(
@@ -216,23 +221,19 @@ List<_Section> _buildSections() => <_Section>[
         path: 'vault.notes',
         kind: _FieldKind.text,
         monospace: true,
-        // Defaults to <root>/notes when blank.
-        placeholder: '~/.opendray/vault/notes',
-      ),
-      _Field(
-        label: t.settings.serverSettings.fields.skillsPath,
-        path: 'vault.skills',
-        kind: _FieldKind.text,
-        monospace: true,
-        placeholder: '~/.opendray/vault/skills',
+        helper: t.settings.serverSettings.fields.notesPathHelper,
+        // Deprecated: vault.root means the documents dir now. Shown
+        // only when already set — see onlyWhenSet.
+        onlyWhenSet: true,
+        placeholder: '~/.opendray/vault',
       ),
       _Field(
         label: t.settings.serverSettings.fields.gitRoot,
         path: 'vault.git_root',
         kind: _FieldKind.text,
         monospace: true,
-        // Defaults to vault.root (or vault.notes when notes is
-        // pinned to a custom location).
+        helper: t.settings.serverSettings.fields.gitRootHelper,
+        // Defaults to the documents root.
         placeholder: '~/.opendray/vault',
       ),
       _Field(
@@ -251,6 +252,22 @@ List<_Section> _buildSections() => <_Section>[
     ],
   ),
   _Section(
+    id: 'skills',
+    title: t.settings.serverSettings.sections.skills,
+    description: t.settings.serverSettings.sectionDescriptions.skills,
+    restartRequired: true,
+    fields: [
+      _Field(
+        label: t.settings.serverSettings.fields.skillsRoot,
+        path: 'skills.root',
+        kind: _FieldKind.text,
+        monospace: true,
+        helper: t.settings.serverSettings.fields.skillsRootHelper,
+        placeholder: '~/.opendray/skills',
+      ),
+    ],
+  ),
+  _Section(
     id: 'mcp',
     title: t.settings.serverSettings.sections.mcpRegistry,
     description: t.settings.serverSettings.sectionDescriptions.mcpRegistry,
@@ -261,8 +278,8 @@ List<_Section> _buildSections() => <_Section>[
         path: 'mcp.root',
         kind: _FieldKind.text,
         monospace: true,
-        // resolveMCPPaths defaults to <vault root>/mcp.
-        placeholder: '~/.opendray/vault/mcp',
+        // config.Resolve defaults to ~/.opendray/mcp.
+        placeholder: '~/.opendray/mcp',
       ),
       _Field(
         label: t.settings.serverSettings.fields.secretsFile,
@@ -551,7 +568,12 @@ class ServerSettingsScreen extends ConsumerStatefulWidget {
 
 class _ServerSettingsScreenState
     extends ConsumerState<ServerSettingsScreen> {
-  AsyncValue<({Map<String, dynamic> config, String configPath})> _state =
+  AsyncValue<
+      ({
+        Map<String, dynamic> config,
+        String configPath,
+        Map<String, dynamic> layout,
+      })> _state =
       const AsyncValue.loading();
 
   @override
@@ -646,7 +668,15 @@ class _ServerSettingsScreenState
     );
   }
 
-  Widget _buildIndex(({Map<String, dynamic> config, String configPath}) data) {
+  Widget _buildIndex(
+      ({
+        Map<String, dynamic> config,
+        String configPath,
+        Map<String, dynamic> layout,
+      }) data) {
+    final legacy = data.layout['legacy_vault'] == true ||
+        data.layout['legacy_skills'] == true ||
+        data.layout['legacy_mcp'] == true;
     return RefreshIndicator(
       onRefresh: _load,
       child: ListView(
@@ -669,6 +699,26 @@ class _ServerSettingsScreenState
               style: const TextStyle(fontSize: 12),
             ),
           ),
+          // A pre-split install reads directories the form does not
+          // mention. Saying so beats letting the settings page
+          // describe a layout the gateway is not using.
+          if (legacy)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+              child: Container(
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: Colors.amber.withValues(alpha: 0.10),
+                  borderRadius: BorderRadius.circular(6),
+                  border:
+                      Border.all(color: Colors.amber.withValues(alpha: 0.35)),
+                ),
+                child: Text(
+                  t.settings.serverSettings.legacyLayout,
+                  style: const TextStyle(fontSize: 12, height: 1.4),
+                ),
+              ),
+            ),
           for (final s in _buildSections())
             ListTile(
               title: Text(s.title),
@@ -759,6 +809,18 @@ class _SectionEditorScreenState
       c.dispose();
     }
     super.dispose();
+  }
+
+  // Deprecated fields are rendered only for operators who already have
+  // them set. Read from the ORIGINAL config, not the draft, so a field
+  // does not vanish mid-edit the moment its box is cleared.
+  List<_Field> _visibleFields() {
+    return [
+      for (final f in widget.section.fields)
+        if (!f.onlyWhenSet ||
+            _stringify(_readPath(widget.initial, f.path)).trim().isNotEmpty)
+          f,
+    ];
   }
 
   static Map<String, dynamic> _deepCopy(Map<String, dynamic> src) {
@@ -904,7 +966,7 @@ class _SectionEditorScreenState
               ),
             ],
             const SizedBox(height: 16),
-            for (final f in widget.section.fields) ...[
+            for (final f in _visibleFields()) ...[
               _renderField(f),
               const SizedBox(height: 14),
             ],

--- a/app/shared/src/lib/settings.ts
+++ b/app/shared/src/lib/settings.ts
@@ -22,13 +22,22 @@ export interface ServerConfig {
     idle_threshold: string
     idle_interval: string
   }
+  /** The operator's documents — and nothing else. Agent skills and the
+   * MCP registry used to share this root; they now have their own. */
   vault: {
     root: string
+    /** @deprecated `root` means the documents directory now. Still
+     * honoured, and still the way to point opendray at a markdown
+     * folder kept somewhere else entirely. */
     notes: string
+    /** @deprecated set `skills.root` instead. */
     skills: string
     git_root: string
     personal_prefix: string
     projects_prefix: string
+  }
+  skills: {
+    root: string
   }
   mcp: {
     root: string
@@ -113,9 +122,31 @@ export interface ServerConfig {
   }
 }
 
+/** Where the settings above actually land on disk. Read-only: several
+ * of these are only knowable by looking at the filesystem, and showing
+ * them is how the settings page stops describing a layout the gateway
+ * is not using. */
+export interface ResolvedLayout {
+  vault: string
+  vault_git: string
+  skills: string
+  mcp: string
+  mcp_secrets: string
+  /** True when a root still falls inside the pre-split shared vault,
+   * because content is already there. Honoured, but worth saying. */
+  legacy_vault: boolean
+  legacy_skills: boolean
+  legacy_mcp: boolean
+}
+
+export function hasLegacyLayout(l: ResolvedLayout | undefined): boolean {
+  return !!l && (l.legacy_vault || l.legacy_skills || l.legacy_mcp)
+}
+
 export interface SettingsResponse {
   config: ServerConfig
   config_path: string
+  layout?: ResolvedLayout
 }
 
 export interface TestPathResponse {
@@ -160,6 +191,7 @@ export function emptyConfig(): ServerConfig {
       personal_prefix: '',
       projects_prefix: '',
     },
+    skills: { root: '' },
     mcp: { root: '', secrets_file: '' },
     providers: {
       claude: {

--- a/app/web/src/components/settings/ServerSettings.tsx
+++ b/app/web/src/components/settings/ServerSettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { Fragment, useEffect, useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
 import { Trans, useTranslation } from 'react-i18next'
@@ -23,8 +23,10 @@ import { Input } from '@/components/ui/input'
 import {
   emptyConfig,
   fetchServerSettings,
+  hasLegacyLayout,
   restartServer,
   updateServerSettings,
+  type ResolvedLayout,
   type ServerConfig,
 } from '@/lib/settings'
 import { cn } from '@/lib/utils'
@@ -60,6 +62,7 @@ export const SERVER_SECTIONS = [
   { id: 'logging' },
   { id: 'sessions' },
   { id: 'vault' },
+  { id: 'skills' },
   { id: 'mcp' },
   { id: 'memory' },
   { id: 'backup' },
@@ -95,6 +98,7 @@ const RESTART_REQUIRED_SECTIONS: Record<ServerSectionId, boolean> = {
   logging: true,
   sessions: true,
   vault: true,
+  skills: true, // the loader is constructed once, at app.New
   mcp: true,
   memory: true, // backend / store wiring is read once at app.New
   backup: true, // pg_dump path + cipher are bound at NewService
@@ -262,6 +266,7 @@ export function ServerSettings({
         active={activeSection}
         draft={draft}
         setDraft={setDraft}
+        layout={data?.layout}
         showPassword={showPassword}
         toggleShowPassword={() => setShowPassword((v) => !v)}
         searchQuery={searchQuery}
@@ -301,6 +306,7 @@ function SectionForm({
   active,
   draft,
   setDraft,
+  layout,
   showPassword,
   toggleShowPassword,
   searchQuery,
@@ -308,6 +314,7 @@ function SectionForm({
   active: ServerSectionId
   draft: ServerConfig
   setDraft: React.Dispatch<React.SetStateAction<ServerConfig>>
+  layout?: ResolvedLayout
   showPassword: boolean
   toggleShowPassword: () => void
   searchQuery: string
@@ -642,86 +649,108 @@ function SectionForm({
 
     case 'vault':
       return (
-        <FormGrid>
-          {F(
-            'vaultRoot',
-            'vault.root',
-            <PathInput
-              value={c.vault.root}
-              onChange={(v) =>
-                setDraft({ ...draft, vault: { ...c.vault, root: v } })
-              }
-              placeholder="~/.opendray/vault"
-              expectDir
-            />,
-          )}
-          {F(
-            'notesDirectory',
-            'vault.notes',
-            <PathInput
-              value={c.vault.notes}
-              onChange={(v) =>
-                setDraft({ ...draft, vault: { ...c.vault, notes: v } })
-              }
-              placeholder="<vault>/notes"
-              expectDir
-            />,
-          )}
-          {F(
-            'skillsDirectory',
-            'vault.skills',
-            <PathInput
-              value={c.vault.skills}
-              onChange={(v) =>
-                setDraft({ ...draft, vault: { ...c.vault, skills: v } })
-              }
-              placeholder="<vault>/skills"
-              expectDir
-            />,
-          )}
-          {F(
-            'gitRoot',
-            'vault.git_root',
-            <PathInput
-              value={c.vault.git_root}
-              onChange={(v) =>
-                setDraft({ ...draft, vault: { ...c.vault, git_root: v } })
-              }
-              placeholder="<vault root>"
-              expectDir
-            />,
-          )}
-          {F(
-            'personalPrefix',
-            'vault.personal_prefix',
-            <Input
-              value={c.vault.personal_prefix}
-              onChange={(e) =>
-                setDraft({
-                  ...draft,
-                  vault: { ...c.vault, personal_prefix: e.target.value },
-                })
-              }
-              placeholder="personal"
-              className="h-9 font-mono w-48"
-            />,
-          )}
-          {F(
-            'projectsPrefix',
-            'vault.projects_prefix',
-            <Input
-              value={c.vault.projects_prefix}
-              onChange={(e) =>
-                setDraft({
-                  ...draft,
-                  vault: { ...c.vault, projects_prefix: e.target.value },
-                })
-              }
-              placeholder="projects"
-              className="h-9 font-mono w-48"
-            />,
-          )}
-        </FormGrid>
+        <div className="flex flex-col gap-6">
+          <LayoutNotice layout={layout} />
+          <FormGrid>
+            {F(
+              'vaultRoot',
+              'vault.root',
+              <PathInput
+                value={c.vault.root}
+                onChange={(v) =>
+                  setDraft({ ...draft, vault: { ...c.vault, root: v } })
+                }
+                placeholder="~/.opendray/vault"
+                expectDir
+              />,
+            )}
+            {/* Deprecated: `root` is the documents directory now. Shown
+                only to operators who already have it set, so it can be
+                inspected or cleared — not offered to anyone else. */}
+            {c.vault.notes.trim() !== '' &&
+              F(
+                'notesDirectory',
+                'vault.notes',
+                <PathInput
+                  value={c.vault.notes}
+                  onChange={(v) =>
+                    setDraft({ ...draft, vault: { ...c.vault, notes: v } })
+                  }
+                  placeholder="<vault root>"
+                  expectDir
+                />,
+              )}
+            {F(
+              'gitRoot',
+              'vault.git_root',
+              <PathInput
+                value={c.vault.git_root}
+                onChange={(v) =>
+                  setDraft({ ...draft, vault: { ...c.vault, git_root: v } })
+                }
+                placeholder="<vault root>"
+                expectDir
+              />,
+            )}
+            {F(
+              'personalPrefix',
+              'vault.personal_prefix',
+              <Input
+                value={c.vault.personal_prefix}
+                onChange={(e) =>
+                  setDraft({
+                    ...draft,
+                    vault: { ...c.vault, personal_prefix: e.target.value },
+                  })
+                }
+                placeholder="personal"
+                className="h-9 font-mono w-48"
+              />,
+            )}
+            {F(
+              'projectsPrefix',
+              'vault.projects_prefix',
+              <Input
+                value={c.vault.projects_prefix}
+                onChange={(e) =>
+                  setDraft({
+                    ...draft,
+                    vault: { ...c.vault, projects_prefix: e.target.value },
+                  })
+                }
+                placeholder="projects"
+                className="h-9 font-mono w-48"
+              />,
+            )}
+          </FormGrid>
+        </div>
+      )
+
+    case 'skills':
+      return (
+        <div className="flex flex-col gap-6">
+          <LayoutNotice layout={layout} />
+          <FormGrid>
+            {F(
+              'skillsRoot',
+              'skills.root',
+              <PathInput
+                value={c.skills.root || c.vault.skills}
+                onChange={(v) =>
+                  setDraft({
+                    ...draft,
+                    skills: { root: v },
+                    // Clear the pre-split spelling on edit so the two
+                    // cannot disagree about where skills live.
+                    vault: { ...c.vault, skills: '' },
+                  })
+                }
+                placeholder="~/.opendray/skills"
+                expectDir
+              />,
+            )}
+          </FormGrid>
+        </div>
       )
 
     case 'mcp':
@@ -735,7 +764,7 @@ function SectionForm({
               onChange={(v) =>
                 setDraft({ ...draft, mcp: { ...c.mcp, root: v } })
               }
-              placeholder="<vault>/mcp"
+              placeholder="~/.opendray/mcp"
               expectDir
             />,
           )}
@@ -1345,6 +1374,56 @@ function FormGroup({
         {heading}
       </h3>
       <FormGrid>{children}</FormGrid>
+    </div>
+  )
+}
+
+// LayoutNotice shows where the Vault settings actually land on disk.
+//
+// Several of these paths are derived, and one of them depends on what
+// is already on the filesystem, so a form full of empty "defaults to…"
+// placeholders does not tell the operator where their documents are.
+// Worse, an install predating the split reads directories the form
+// doesn't mention at all — which is precisely how the Vault came to
+// mean the documents, the agent skills and the MCP registry at once.
+// So the resolution is printed, and a pre-split layout says so.
+function LayoutNotice({ layout }: { layout?: ResolvedLayout }) {
+  const { t } = useTranslation()
+  if (!layout) return null
+  const legacy = hasLegacyLayout(layout)
+  const rows: Array<[string, string]> = [
+    [t('web.serverSettings.layout.documents'), layout.vault],
+    [t('web.serverSettings.layout.git'), layout.vault_git],
+    [t('web.serverSettings.layout.skills'), layout.skills],
+    [t('web.serverSettings.layout.mcp'), layout.mcp],
+  ]
+  return (
+    <div
+      className={cn(
+        'rounded-md border px-3 py-2.5 flex flex-col gap-2',
+        legacy
+          ? 'border-amber-500/30 bg-amber-500/5'
+          : 'border-border/60 bg-muted/20',
+      )}
+    >
+      <div className="text-[11px] font-medium text-muted-foreground">
+        {t('web.serverSettings.layout.title')}
+      </div>
+      <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
+        {rows.map(([label, path]) => (
+          <Fragment key={label}>
+            <span className="text-[11px] text-muted-foreground/80">
+              {label}
+            </span>
+            <span className="text-[11px] font-mono break-all">{path}</span>
+          </Fragment>
+        ))}
+      </div>
+      {legacy && (
+        <p className="text-[11px] text-amber-300/90 leading-relaxed">
+          {t('web.serverSettings.layout.legacyWarning')}
+        </p>
+      )}
     </div>
   )
 }

--- a/cmd/opendray/mcp.go
+++ b/cmd/opendray/mcp.go
@@ -14,7 +14,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/opendray/opendray-v2/internal/config"
 	"github.com/opendray/opendray-v2/internal/mcp"
@@ -22,7 +21,7 @@ import (
 
 func runMcp(args []string) int {
 	fs := flag.NewFlagSet("mcp", flag.ContinueOnError)
-	cfgPath := fs.String("config", "", "path to config.toml (only [mcp]/[vault] are read)")
+	cfgPath := fs.String("config", "", "path to config.toml (paths are resolved as the gateway does)")
 	root := fs.String("root", "", "override MCP registry root")
 	asJSON := fs.Bool("json", false, "list/describe: JSON output")
 	fs.Usage = func() { fmt.Fprintln(os.Stderr, mcpUsage) }
@@ -102,51 +101,18 @@ func runMcp(args []string) int {
 	}
 }
 
-// openMcp resolves the MCP registry root and secrets file path using
-// the same precedence as the gateway: explicit override → config →
-// env → default. Centralised here so the CLI behaves the same as the
-// running gateway against the same files.
+// openMcp resolves the MCP registry root and secrets file path through
+// the gateway's own resolver, so the CLI and the running gateway can
+// never operate on different files.
 func openMcp(cfgPath, override string) (*mcp.Loader, string, error) {
+	paths := loadCLIConfig(cfgPath).Resolve()
 	mcpRoot := override
-	secretsPath := ""
-	if cfgPath != "" {
-		if cfg, err := config.Load(cfgPath); err == nil {
-			if mcpRoot == "" && cfg.MCP.Root != "" {
-				mcpRoot = cfg.MCP.Root
-			}
-			if mcpRoot == "" && cfg.Vault.Root != "" {
-				mcpRoot = filepath.Join(cfg.Vault.Root, "mcp")
-			}
-			secretsPath = cfg.MCP.SecretsFile
-		}
-	}
 	if mcpRoot == "" {
-		if v := os.Getenv("OPENDRAY_MCP_ROOT"); v != "" {
-			mcpRoot = v
-		} else {
-			root := os.Getenv("OPENDRAY_VAULT_ROOT")
-			if root == "" {
-				root = "~/.opendray/vault"
-			}
-			mcpRoot = filepath.Join(root, "mcp")
-		}
+		mcpRoot = paths.MCP
+	} else {
+		mcpRoot = config.ExpandPath(mcpRoot)
 	}
-	if expanded, err := expandHome(mcpRoot); err == nil {
-		mcpRoot = expanded
-	}
-
-	if secretsPath == "" {
-		if v := os.Getenv("OPENDRAY_MCP_SECRETS_FILE"); v != "" {
-			secretsPath = v
-		} else {
-			secretsPath = "~/.opendray/secrets.env"
-		}
-	}
-	if expanded, err := expandHome(secretsPath); err == nil {
-		secretsPath = expanded
-	}
-
-	return mcp.NewLoader(mcpRoot), secretsPath, nil
+	return mcp.NewLoader(mcpRoot), paths.MCPSecrets, nil
 }
 
 const mcpUsage = `opendray mcp — MCP server registry
@@ -164,5 +130,5 @@ flags:
   --root PATH             override MCP registry root
   --json                  list/describe: JSON output
 
-servers load from <vault>/mcp/<id>/mcp.json
+servers load from <registry root>/<id>/mcp.json
 secrets file (${KEY} substitution): ~/.opendray/secrets.env (dotenv format)`

--- a/cmd/opendray/migrate.go
+++ b/cmd/opendray/migrate.go
@@ -93,9 +93,7 @@ func runMigrate(args []string) int {
 func premigrateDir(configured string) string {
 	base := configured
 	if base != "" {
-		if expanded, err := expandHome(base); err == nil {
-			base = expanded
-		}
+		base = config.ExpandPath(base)
 	} else if home, err := os.UserHomeDir(); err == nil {
 		base = filepath.Join(home, ".opendray", "backups")
 	} else {

--- a/cmd/opendray/notes.go
+++ b/cmd/opendray/notes.go
@@ -174,33 +174,36 @@ func runNotes(args []string) int {
 }
 
 func openVault(cfgPath, override string) (*notes.Vault, error) {
+	cfg := loadCLIConfig(cfgPath)
+	paths := cfg.Resolve()
 	root := override
-	opts := notes.Options{}
-	// Try config file (cheap — we only read [vault]); fall through
-	// to env / default if the file doesn't exist.
+	if root == "" {
+		root = paths.Vault
+	}
+	return notes.New(root, notes.Options{
+		PersonalPrefix: cfg.Vault.PersonalPrefix,
+		ProjectsPrefix: cfg.Vault.ProjectsPrefix,
+		HiddenDirs:     paths.NestedInVault(),
+	})
+}
+
+// loadCLIConfig reads the gateway's config so the CLI resolves paths
+// identically. A missing or unreadable file is not fatal: Load("")
+// returns defaults with the environment applied, which is exactly the
+// behaviour the CLI wants when run before the gateway is configured.
+//
+// This exists so that every `opendray notes|skill|mcp` invocation goes
+// through config.Resolve. They each used to derive their own paths
+// with slightly different precedence, which meant the CLI could read
+// and write a different directory than the running gateway.
+func loadCLIConfig(cfgPath string) config.Config {
 	if cfgPath != "" {
 		if cfg, err := config.Load(cfgPath); err == nil {
-			if root == "" {
-				if cfg.Vault.Notes != "" {
-					root = cfg.Vault.Notes
-				} else if cfg.Vault.Root != "" {
-					root = cfg.Vault.Root + "/notes"
-				}
-			}
-			opts.PersonalPrefix = cfg.Vault.PersonalPrefix
-			opts.ProjectsPrefix = cfg.Vault.ProjectsPrefix
+			return cfg
 		}
 	}
-	if root == "" {
-		if v := os.Getenv("OPENDRAY_VAULT_NOTES"); v != "" {
-			root = v
-		} else if v := os.Getenv("OPENDRAY_VAULT_ROOT"); v != "" {
-			root = v + "/notes"
-		} else {
-			root = "~/.opendray/vault/notes"
-		}
-	}
-	return notes.New(root, opts)
+	cfg, _ := config.Load("")
+	return cfg
 }
 
 func reportErr(err error) int {

--- a/cmd/opendray/skill.go
+++ b/cmd/opendray/skill.go
@@ -14,8 +14,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/opendray/opendray-v2/internal/config"
 	"github.com/opendray/opendray-v2/internal/skills"
@@ -23,7 +21,7 @@ import (
 
 func runSkill(args []string) int {
 	fs := flag.NewFlagSet("skill", flag.ContinueOnError)
-	cfgPath := fs.String("config", "", "path to config.toml (only [vault] is read)")
+	cfgPath := fs.String("config", "", "path to config.toml (paths are resolved as the gateway does)")
 	root := fs.String("root", "", "override vault root (else config / env / default)")
 	asJSON := fs.Bool("json", false, "list/describe: JSON output")
 	fs.Usage = func() { fmt.Fprintln(os.Stderr, skillUsage) }
@@ -90,54 +88,20 @@ func runSkill(args []string) int {
 	}
 }
 
-// openLoader resolves the vault root the same way the notes CLI does.
-// Skills live at <vault>/skills/ — using the same root keeps the user's
-// vault one self-contained git-able directory.
+// openLoader resolves the skills root through the same resolver the
+// gateway uses, so `opendray skill` always operates on the directory
+// the running gateway actually injects from.
 func openLoader(cfgPath, override string) (*skills.Loader, error) {
-	// Resolve skills directory using the same precedence as the
-	// gateway: explicit override → config.toml [vault].skills →
-	// env OPENDRAY_VAULT_SKILLS → derive from [vault].root.
 	skillsDir := override
-	if skillsDir == "" && cfgPath != "" {
-		if cfg, err := config.Load(cfgPath); err == nil {
-			if cfg.Vault.Skills != "" {
-				skillsDir = cfg.Vault.Skills
-			} else if cfg.Vault.Root != "" {
-				skillsDir = filepath.Join(cfg.Vault.Root, "skills")
-			}
-		}
-	}
 	if skillsDir == "" {
-		skillsDir = os.Getenv("OPENDRAY_VAULT_SKILLS")
+		skillsDir = loadCLIConfig(cfgPath).Resolve().Skills
+	} else {
+		skillsDir = config.ExpandPath(skillsDir)
 	}
-	if skillsDir == "" {
-		root := os.Getenv("OPENDRAY_VAULT_ROOT")
-		if root == "" {
-			root = "~/.opendray/vault"
-		}
-		skillsDir = filepath.Join(root, "skills")
-	}
-	if expanded, err := expandHome(skillsDir); err == nil {
-		skillsDir = expanded
-	}
-	// Don't use notes.New here — we don't want to create a notes dir
-	// just for `skill` operations. Loader gracefully handles missing
-	// vault dirs (only built-ins return).
+	// Don't use notes.New here — we don't want to create a directory
+	// just for `skill` operations. Loader gracefully handles a missing
+	// root (only built-ins return).
 	return skills.NewLoader(skillsDir), nil
-}
-
-func expandHome(p string) (string, error) {
-	if p == "~" || strings.HasPrefix(p, "~/") {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return p, err
-		}
-		if p == "~" {
-			return home, nil
-		}
-		return filepath.Join(home, p[2:]), nil
-	}
-	return filepath.Abs(p)
 }
 
 const skillUsage = `opendray skill — agent skills loader
@@ -146,7 +110,7 @@ usage:
   opendray skill [flags] <command> [args]
 
 commands:
-  path                    print the skills directory (vault/skills)
+  path                    print the skills directory
   list                    list all skills (built-in + vault); cols: id source description
   describe <id>           print SKILL.md for one skill
 
@@ -157,4 +121,4 @@ flags:
 
 skills load from (vault overrides built-in on conflict):
   - <opendray binary>/builtin/<id>/SKILL.md   (shipped)
-  - <vault>/skills/<id>/SKILL.md              (user / git-versioned)`
+  - <skills root>/<id>/SKILL.md               (user / git-versioned)`

--- a/docs/experience-compiler.md
+++ b/docs/experience-compiler.md
@@ -42,7 +42,7 @@ artifact**.
                           │
             ④ COMPILATION (strong LLM + operator review)
                 pick target form, best first:
-                  a. script (.sh/.mjs) with --dry-run     → vault/skills/<slug>/run.sh
+                  a. script (.sh/.mjs) with --dry-run     → <skills root>/<slug>/run.sh
                   b. opendray custom task                  → one-click from UI
                   c. SKILL.md instructions (fallback)      → as today
                           │

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -356,7 +356,7 @@ func (a knowledgeLLM) Complete(ctx context.Context, system, user string) (string
 	return resp.Content, nil
 }
 
-// knowledgeSkillSink writes a rendered SKILL.md into the vault skills dir so
+// knowledgeSkillSink writes a rendered SKILL.md into the skills root so
 // the skills loader picks up AI-promoted skills (one-way: knowledge owns the
 // SkillSink interface; the app provides this filesystem impl).
 type knowledgeSkillSink struct{ dir string }
@@ -488,31 +488,40 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	agyacctSvc := agyacct.NewService(st.Pool(), bus, log)
 	agyacctHandlers := agyacct.NewHandlers(agyacctSvc, log)
 
+	// Every on-disk root comes from one resolver (internal/config/
+	// paths.go) so the gateway and the `opendray notes|skill|mcp`
+	// commands can never disagree about where things live.
+	paths := cfg.Resolve()
+	logLayout(log, paths)
+
 	// Vault + skills are needed by the SessionProvider so spawn-time
 	// injection has them available. Constructed here (before the
 	// session manager) so the manager's first Resolve call sees them.
-	notesRoot, skillsRoot, gitRoot := resolveVaultPaths(cfg.Vault)
-	vault, err := notesapi.New(notesRoot, notesapi.Options{
+	vault, err := notesapi.New(paths.Vault, notesapi.Options{
 		PersonalPrefix: cfg.Vault.PersonalPrefix,
 		ProjectsPrefix: cfg.Vault.ProjectsPrefix,
+		// On a pre-split install skills/ and mcp/ sit inside the
+		// documents root. Hide them: they are opendray's own machinery,
+		// not the operator's writing.
+		HiddenDirs: paths.NestedInVault(),
 	})
 	if err != nil {
 		st.Close()
 		return nil, fmt.Errorf("init notes vault: %w", err)
 	}
-	log.Info("notes vault ready", "root", vault.Root())
+	log.Info("vault ready", "documents", vault.Root())
 	notesHandlers := notesapi.NewHandlers(vault, log)
-	skillsLoader := skills.NewLoader(skillsRoot)
+	skillsLoader := skills.NewLoader(paths.Skills)
 	if list, _ := skillsLoader.List(); len(list) > 0 {
 		log.Info("agent skills loaded", "count", len(list),
-			"vault", skillsLoader.VaultRoot())
+			"root", skillsLoader.VaultRoot())
 	}
 
-	mcpRoot, secretsFile := resolveMCPPaths(cfg.MCP, notesRoot, skillsRoot)
-	mcpLoader := mcpapi.NewLoader(mcpRoot)
+	secretsFile := paths.MCPSecrets
+	mcpLoader := mcpapi.NewLoader(paths.MCP)
 	if list, _ := mcpLoader.List(); len(list) > 0 {
 		log.Info("mcp registry loaded", "count", len(list),
-			"vault", mcpLoader.VaultRoot(), "secrets", secretsFile)
+			"root", mcpLoader.VaultRoot(), "secrets", secretsFile)
 	}
 
 	var sessionOpts []session.ManagerOption
@@ -654,17 +663,18 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	searchHandlers := searchapi.NewHandlers(log)
 	skillsHandlers := skills.NewHandlers(skillsLoader, log)
 	mcpHandlers := mcpapi.NewHandlers(mcpLoader, secretsFile, log)
-	// Vault git ops are scoped to whatever the user told us is the
-	// repo root (defaults: notes root if user pinned `notes` directly,
-	// otherwise the parent that contains both notes/ and skills/).
+	// Vault Sync commits the documents. It defaults to the documents
+	// root itself, so the repo holds writing and nothing else — see
+	// config.Resolve for the one case that keeps an older working tree.
 	// The githost service is passed so private-repo HTTPS push/pull
 	// picks up tokens stored in Plugins → Git hosts.
-	vaultGitHandlers, err := vaultgit.NewHandlers(gitRoot, gitHostSvc, log)
+	vaultGitHandlers, err := vaultgit.NewHandlers(paths.VaultGit, gitHostSvc, log,
+		vaultgit.WithNestedDirs(paths.NestedInGitRoot()))
 	if err != nil {
 		st.Close()
 		return nil, fmt.Errorf("init vault git handlers: %w", err)
 	}
-	log.Info("vault git ready", "root", gitRoot)
+	log.Info("vault git ready", "root", paths.VaultGit)
 	vaultSyncer := vaultgit.NewSyncer(st.Pool(), bus, vaultGitHandlers, log)
 
 	// Settings: read/write the same config.toml the gateway booted
@@ -797,9 +807,9 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		// full_instance bundles capture the vault + MCP secrets so a
 		// restore rebuilds a working instance, not just its DB.
 		VaultSources: []backup.VaultSource{
-			{Logical: "notes", Dir: notesRoot},
-			{Logical: "skills", Dir: skillsRoot},
-			{Logical: "mcp", Dir: mcpRoot},
+			{Logical: "notes", Dir: paths.Vault},
+			{Logical: "skills", Dir: paths.Skills},
+			{Logical: "mcp", Dir: paths.MCP},
 		},
 		SecretsFile: secretsFile,
 	}
@@ -1139,10 +1149,10 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	var knowledgeConsolidate *knowledge.ConsolidationEngine
 	if cfg.Knowledge.Enabled {
 		knowledgeSvc = knowledge.NewService(st.Pool(), log)
-		knowledgeSvc.WithSkillSink(knowledgeSkillSink{dir: skillsRoot}) // Phase 4 — render promoted skills
+		knowledgeSvc.WithSkillSink(knowledgeSkillSink{dir: paths.Skills}) // Phase 4 — render promoted skills
 		// Compiled skills (experience compiler) also land as click-runnable
 		// custom tasks pointing at the rendered run.sh.
-		knowledgeSvc.WithTaskSink(knowledgeTaskSink{tasks: customTaskSvc, skillsRoot: skillsRoot})
+		knowledgeSvc.WithTaskSink(knowledgeTaskSink{tasks: customTaskSvc, skillsRoot: paths.Skills})
 		// Skill promotion drafts a full structured SKILL.md via the
 		// curation worker (overview / when-to-use / procedure /
 		// pitfalls / verification) instead of copying the playbook
@@ -1847,100 +1857,25 @@ func (a *App) Close() {
 	}
 }
 
-// parentOf returns the parent directory of an absolute path. Used to
-// derive the vault base from <vault>/notes — skills live next to it
-// at <vault>/skills, so both share one git-able root.
-func parentOf(p string) string {
-	for i := len(p) - 1; i >= 0; i-- {
-		if p[i] == '/' {
-			return p[:i]
-		}
+// logLayout states where every root resolved and, on a pre-split
+// install, says so plainly. A gateway silently reading a directory
+// other than the one the settings page describes is exactly the
+// confusion this split was meant to end, so the resolution is never
+// left implicit.
+func logLayout(log *slog.Logger, p config.Paths) {
+	log.Info("resolved layout",
+		"documents", p.Vault, "git", p.VaultGit,
+		"skills", p.Skills, "mcp", p.MCP)
+	if !p.LegacyLayout() {
+		return
 	}
-	return p
-}
-
-// resolveVaultPaths derives the three vault-related paths (notes root,
-// skills root, git working tree) from VaultConfig. Each can be set
-// explicitly; otherwise we fall back to the legacy layout under the
-// shared root. Returns absolute paths suitable for filesystem ops.
-//
-// The defaults preserve opendray's original `<root>/notes` +
-// `<root>/skills` layout. Users who already keep a markdown vault
-// elsewhere (an Obsidian folder, a docs repo, anything) can pin
-// `vault.notes = "~/Documents/MyVault"` and opendray's notes API reads
-// straight from that directory — it is a path, not an integration.
-func resolveVaultPaths(c config.VaultConfig) (notes, skills, git string) {
-	root := c.Root
-	if root == "" {
-		root = "~/.opendray/vault"
-	}
-	root = expandPath(root)
-
-	notes = c.Notes
-	if notes == "" {
-		notes = filepath.Join(root, "notes")
-	} else {
-		notes = expandPath(notes)
-	}
-
-	skills = c.Skills
-	if skills == "" {
-		skills = filepath.Join(root, "skills")
-	} else {
-		skills = expandPath(skills)
-	}
-
-	git = c.GitRoot
-	if git == "" {
-		// Pick the most natural git working tree: if the user pinned a
-		// custom notes path, that IS their vault repo; otherwise the
-		// legacy combined root holds both notes + skills under one repo.
-		if c.Notes != "" {
-			git = notes
-		} else {
-			git = root
-		}
-	} else {
-		git = expandPath(git)
-	}
-	return notes, skills, git
-}
-
-// resolveMCPPaths picks the registry root + secrets file with the
-// same precedence story as the vault paths above. Defaults:
-//
-//	root         = <vault root>/mcp        (next to notes/, skills/)
-//	secrets_file = ~/.opendray/secrets.env (intentionally OUTSIDE the
-//	               vault so a `git add .` in vault never picks it up)
-//
-// notesRoot / skillsRoot are passed only to derive `<vault root>` —
-// we use parentOf(notes) which is the same dir all the other vault
-// children live under in the default layout.
-func resolveMCPPaths(c config.MCPConfig, notesRoot, skillsRoot string) (root, secrets string) {
-	root = c.Root
-	if root == "" {
-		// Pick the same parent the vault siblings share. notes/ and
-		// skills/ are always under <vault root>; using parentOf(notes)
-		// works regardless of which the user pinned explicitly.
-		base := parentOf(notesRoot)
-		if base == "" || base == "/" {
-			base = parentOf(skillsRoot)
-		}
-		if base == "" || base == "/" {
-			base = expandPath("~/.opendray/vault")
-		}
-		root = filepath.Join(base, "mcp")
-	} else {
-		root = expandPath(root)
-	}
-
-	secrets = c.SecretsFile
-	if secrets == "" {
-		secrets = expandPath("~/.opendray/secrets.env")
-	} else {
-		secrets = expandPath(secrets)
-	}
-	return root, secrets
+	log.Warn("this install still uses the old shared vault layout, where "+
+		"opendray's own directories sit inside your documents. They keep "+
+		"working, but a git sync of the Vault will carry them along. "+
+		"Move them out and set the paths in Server settings when convenient.",
+		"documents", p.Vault,
+		"skills_inside_documents", p.LegacySkills,
+		"mcp_inside_documents", p.LegacyMCP)
 }
 
 // memoryKeyPath is where we cache the plaintext API key for the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Log       LogConfig       `toml:"log" json:"log"`
 	Session   SessionConfig   `toml:"session" json:"session"`
 	Vault     VaultConfig     `toml:"vault" json:"vault"`
+	Skills    SkillsConfig    `toml:"skills" json:"skills"`
 	MCP       MCPConfig       `toml:"mcp" json:"mcp"`
 	Providers ProvidersConfig `toml:"providers" json:"providers"`
 	Memory    MemoryConfig    `toml:"memory" json:"memory"`
@@ -326,11 +327,11 @@ type AntigravityProviderConfig struct {
 // MCPConfig points at the MCP server registry directory and the
 // secrets file used to substitute ${KEY} placeholders at spawn time.
 //
-// Defaults (when unset, see resolveMCPPaths in package app):
+// Defaults (when unset, see Resolve in paths.go):
 //
-//	root         = <vault.root>/mcp
-//	secrets_file = ~/.opendray/secrets.env  (intentionally OUTSIDE the
-//	               vault so it never git-syncs along with notes/skills)
+//	root         = ~/.opendray/mcp
+//	secrets_file = ~/.opendray/secrets.env  (intentionally OUTSIDE every
+//	               other root so no `git add .` can pick it up)
 //
 // Override either via env (OPENDRAY_MCP_ROOT, OPENDRAY_MCP_SECRETS_FILE)
 // or by setting the field explicitly.
@@ -339,29 +340,45 @@ type MCPConfig struct {
 	SecretsFile string `toml:"secrets_file" json:"secrets_file"`
 }
 
-// VaultConfig points at the on-disk roots that hold notes + skills.
-// The whole tree is meant to be a self-contained, git-versionable
-// directory the user owns — no DB lock-in.
+// SkillsConfig points at the agent-skills root. Skills are injected
+// into sessions at spawn — configuration the gateway acts on, which is
+// why they no longer live inside the operator's documents.
 //
-// Default layout when only `root` is set:
+// Default: ~/.opendray/skills. Override via env OPENDRAY_SKILLS_ROOT.
+type SkillsConfig struct {
+	Root string `toml:"root" json:"root"`
+}
+
+// VaultConfig points at the operator's documents — and nothing else.
+// The Vault is a self-contained, git-versionable directory of markdown
+// the user owns; no DB lock-in, and no opendray machinery mixed in.
 //
-//	<root>/notes/           ← opendray-managed notes
-//	<root>/skills/          ← agent skills (built-in overlays)
+//	root/                   ← the documents. This IS the doc library.
 //
-// When `notes` is set explicitly it OVERRIDES the `<root>/notes`
-// computation, so users can point opendray at an existing Obsidian
-// vault (or any flat folder of .md files) without restructuring.
-// `skills` works the same way independently.
+// Agent skills and the MCP registry used to live under this root as
+// siblings of a `notes/` subdirectory. They now have their own roots
+// ([skills] and [mcp]) because they are configuration, not documents —
+// see internal/config/paths.go for what that conflation cost.
 //
-// `git_root` controls which directory the Vault Sync feature operates
-// on. Defaults to whichever is the most natural git working tree:
+// `git_root` controls which directory Vault Sync commits. It defaults
+// to `root`, so the repo contains the documents and nothing else.
 //
-//	if `notes` is set explicitly → git_root defaults to `notes`
-//	otherwise                    → git_root defaults to `root`
+// Resolution — including how pre-split layouts stay working — lives in
+// Resolve(). Nothing else should derive these paths.
 type VaultConfig struct {
-	Root    string `toml:"root" json:"root"`         // e.g. "~/.opendray/vault"
-	Notes   string `toml:"notes" json:"notes"`       // override notes root (default <root>/notes)
-	Skills  string `toml:"skills" json:"skills"`     // override skills root (default <root>/skills)
+	Root string `toml:"root" json:"root"` // e.g. "~/.opendray/vault"
+
+	// Notes overrides the documents root. Deprecated in favour of
+	// `root`, which now means the same thing — but still honoured, and
+	// still the way to point opendray at an Obsidian folder kept
+	// somewhere else entirely.
+	Notes string `toml:"notes" json:"notes"`
+	// Skills is the pre-split spelling of [skills].root. Honoured when
+	// that is unset.
+	//
+	// Deprecated: set [skills].root instead.
+	Skills string `toml:"skills" json:"skills"`
+
 	GitRoot string `toml:"git_root" json:"git_root"` // override repo root for vault sync
 
 	// Default prefixes for auto-derived note paths. Useful when the
@@ -600,6 +617,9 @@ func applyEnv(cfg *Config) {
 	}
 	if v := os.Getenv("OPENDRAY_VAULT_SKILLS"); v != "" {
 		cfg.Vault.Skills = v
+	}
+	if v := os.Getenv("OPENDRAY_SKILLS_ROOT"); v != "" {
+		cfg.Skills.Root = v
 	}
 	if v := os.Getenv("OPENDRAY_VAULT_GIT_ROOT"); v != "" {
 		cfg.Vault.GitRoot = v

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -1,0 +1,242 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// The Vault used to be a container rather than a concept: one root held
+// the operator's documents, the agent skills opendray injects at spawn,
+// and the MCP registry. Three tenants with different owners, different
+// lifecycles and different git needs, described in the settings UI as
+// "notes, skills and git-versioned root" — a sentence that only parses
+// if you already know the implementation.
+//
+// It was not merely confusing. Sharing a directory with the documents
+// meant sharing their git repo: on the machine this was found on, the
+// operator's private docs repo had opendray's own `skills/secretary/
+// SKILL.md` committed into it, and a `git clean -fd` in that repo would
+// have deleted the gateway's skills.
+//
+// So: the Vault is the documents. Skills and the MCP registry live
+// beside it under ~/.opendray, next to the other machinery.
+//
+//	~/.opendray/vault/    documents — the doc library's root, and the
+//	                      working tree Vault Sync commits
+//	~/.opendray/skills/   agent skills
+//	~/.opendray/mcp/      MCP registry
+//
+// Existing installs are NOT moved. Resolve() honours the old layout
+// wherever it finds content there, and reports it so the gateway can
+// say so out loud rather than silently reading a different directory
+// than the settings page implies.
+//
+// This file is the ONLY place these paths are derived. They used to be
+// computed in four — internal/app plus each of the three CLI commands —
+// with subtly different precedence in each, which is how a layout
+// becomes unpredictable.
+
+// Paths are the resolved on-disk locations opendray reads and writes.
+// Every field is absolute and ~-expanded.
+type Paths struct {
+	// Vault is the documents root: what the doc library browses, what
+	// the notes API and MCP doc tools read and write.
+	Vault string `json:"vault"`
+	// VaultGit is the git working tree Vault Sync operates on.
+	VaultGit string `json:"vault_git"`
+	// Skills is the agent-skills root.
+	Skills string `json:"skills"`
+	// MCP is the MCP registry root.
+	MCP string `json:"mcp"`
+	// MCPSecrets is the ${KEY} substitution file for mcp.json. Kept
+	// outside every other root on purpose, so no `git add .` anywhere
+	// can pick it up.
+	MCPSecrets string `json:"mcp_secrets"`
+
+	// Legacy* record that a path resolved to the old shared layout
+	// because content was already there. Surfaced to the operator
+	// rather than silently honoured — the settings page otherwise
+	// describes a layout the gateway is not using.
+	LegacyVault  bool `json:"legacy_vault"`
+	LegacySkills bool `json:"legacy_skills"`
+	LegacyMCP    bool `json:"legacy_mcp"`
+}
+
+// LegacyLayout reports whether anything still resolves inside the old
+// shared vault root.
+func (p Paths) LegacyLayout() bool {
+	return p.LegacyVault || p.LegacySkills || p.LegacyMCP
+}
+
+// NestedInVault returns the machinery roots that resolve INSIDE the
+// documents root. The doc library hides these: on a legacy install
+// `skills/` and `mcp/` are opendray's own configuration sitting in the
+// middle of the operator's folder tree, and presenting them as
+// documentation is the visible half of the problem this file exists to
+// fix.
+func (p Paths) NestedInVault() []string { return p.nestedIn(p.Vault) }
+
+// NestedInGitRoot returns the machinery roots that resolve inside the
+// Vault Sync working tree. This is NOT the same set as NestedInVault:
+// on an install whose documents are `<root>/notes` while the repo is
+// still `<root>`, skills/ is outside the documents yet squarely inside
+// the repo — which is how one operator's private docs repo ended up
+// with opendray's SKILL.md committed to it. The managed .gitignore
+// uses this set.
+func (p Paths) NestedInGitRoot() []string { return p.nestedIn(p.VaultGit) }
+
+func (p Paths) nestedIn(base string) []string {
+	if base == "" {
+		return nil
+	}
+	var out []string
+	for _, dir := range []string{p.Skills, p.MCP} {
+		if dir != "" && dir != base && isUnder(base, dir) {
+			out = append(out, dir)
+		}
+	}
+	return out
+}
+
+// Resolve derives every path from the config. Filesystem state is part
+// of the input — an install is "legacy" because content is sitting in
+// the old place, which cannot be known from the config alone.
+func (c Config) Resolve() Paths {
+	return c.resolve(dirHasEntries, dirExists)
+}
+
+// resolve takes its filesystem probes as arguments so tests can drive
+// every branch without building directory trees.
+func (c Config) resolve(hasEntries, exists func(string) bool) Paths {
+	root := ExpandPath(firstNonEmpty(c.Vault.Root, "~/.opendray/vault"))
+	odHome := opendrayHome()
+
+	var p Paths
+
+	// Documents. `vault.notes` is deprecated but still authoritative
+	// when set — it is how operators point opendray at an Obsidian
+	// folder they already keep elsewhere.
+	switch {
+	case strings.TrimSpace(c.Vault.Notes) != "":
+		p.Vault = ExpandPath(c.Vault.Notes)
+	case hasEntries(filepath.Join(root, "notes")):
+		p.Vault = filepath.Join(root, "notes")
+		p.LegacyVault = true
+	default:
+		p.Vault = root
+	}
+
+	// Git working tree. An existing repo at the old shared root keeps
+	// it: moving someone's sync target out from under them would break
+	// a working remote for the sake of tidiness.
+	switch {
+	case strings.TrimSpace(c.Vault.GitRoot) != "":
+		p.VaultGit = ExpandPath(c.Vault.GitRoot)
+	case p.LegacyVault && exists(filepath.Join(root, ".git")):
+		p.VaultGit = root
+	default:
+		p.VaultGit = p.Vault
+	}
+
+	// Skills.
+	switch {
+	case strings.TrimSpace(c.Skills.Root) != "":
+		p.Skills = ExpandPath(c.Skills.Root)
+	case strings.TrimSpace(c.Vault.Skills) != "":
+		p.Skills = ExpandPath(c.Vault.Skills)
+	case hasEntries(filepath.Join(root, "skills")):
+		p.Skills = filepath.Join(root, "skills")
+		p.LegacySkills = true
+	default:
+		p.Skills = filepath.Join(odHome, "skills")
+	}
+
+	// MCP registry.
+	switch {
+	case strings.TrimSpace(c.MCP.Root) != "":
+		p.MCP = ExpandPath(c.MCP.Root)
+	case hasEntries(filepath.Join(root, "mcp")):
+		p.MCP = filepath.Join(root, "mcp")
+		p.LegacyMCP = true
+	default:
+		p.MCP = filepath.Join(odHome, "mcp")
+	}
+
+	p.MCPSecrets = ExpandPath(firstNonEmpty(c.MCP.SecretsFile,
+		filepath.Join(odHome, "secrets.env")))
+
+	return p
+}
+
+// ExpandPath resolves a leading ~ against the calling user's home
+// directory and makes the result absolute. Empty stays empty so
+// callers can distinguish "unset" from "the current directory".
+func ExpandPath(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return p
+	}
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			if p == "~" {
+				p = home
+			} else {
+				p = filepath.Join(home, p[2:])
+			}
+		}
+	}
+	if abs, err := filepath.Abs(p); err == nil {
+		return abs
+	}
+	return filepath.Clean(p)
+}
+
+func opendrayHome() string {
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".opendray")
+	}
+	return filepath.Clean(".opendray")
+}
+
+// dirHasEntries reports whether path is a directory holding anything at
+// all. "Has content" rather than "exists" is the legacy test on
+// purpose: an empty leftover directory should not pin an install to the
+// old layout, while a directory with a single skill in it must.
+func dirHasEntries(path string) bool {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		// Finder droppings are not content.
+		if e.Name() == ".DS_Store" {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// isUnder reports whether child sits inside parent.
+func isUnder(parent, child string) bool {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -1,0 +1,263 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakeFS answers the two filesystem probes Resolve needs from a fixed
+// set of paths, so every branch is reachable without building trees.
+type fakeFS struct {
+	withEntries map[string]bool
+	existing    map[string]bool
+}
+
+func (f fakeFS) hasEntries(p string) bool { return f.withEntries[p] }
+func (f fakeFS) exists(p string) bool     { return f.existing[p] }
+
+func home(t *testing.T) string {
+	t.Helper()
+	h, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home directory in this environment")
+	}
+	return h
+}
+
+// A fresh install must land on the split layout: the Vault holds
+// documents and nothing else, and the machinery lives beside it.
+func TestResolve_FreshInstallSplitsTheRoots(t *testing.T) {
+	h := home(t)
+	p := Config{}.resolve(fakeFS{}.hasEntries, fakeFS{}.exists)
+
+	want := Paths{
+		Vault:      filepath.Join(h, ".opendray", "vault"),
+		VaultGit:   filepath.Join(h, ".opendray", "vault"),
+		Skills:     filepath.Join(h, ".opendray", "skills"),
+		MCP:        filepath.Join(h, ".opendray", "mcp"),
+		MCPSecrets: filepath.Join(h, ".opendray", "secrets.env"),
+	}
+	if p != want {
+		t.Fatalf("fresh install resolved to\n %+v\nwant\n %+v", p, want)
+	}
+	if p.LegacyLayout() {
+		t.Fatal("a fresh install must not be reported as legacy")
+	}
+}
+
+// The whole point of the "has entries" probe: an install that already
+// keeps notes and skills under the shared root keeps using them. Moving
+// someone's files on upgrade is not an option.
+func TestResolve_LegacyLayoutIsHonouredAndReported(t *testing.T) {
+	h := home(t)
+	root := filepath.Join(h, ".opendray", "vault")
+	fs := fakeFS{withEntries: map[string]bool{
+		filepath.Join(root, "notes"):  true,
+		filepath.Join(root, "skills"): true,
+		filepath.Join(root, "mcp"):    true,
+	}}
+
+	p := Config{}.resolve(fs.hasEntries, fs.exists)
+
+	if p.Vault != filepath.Join(root, "notes") {
+		t.Errorf("documents = %q, want the legacy notes/ dir", p.Vault)
+	}
+	if p.Skills != filepath.Join(root, "skills") {
+		t.Errorf("skills = %q, want the legacy skills/ dir", p.Skills)
+	}
+	if p.MCP != filepath.Join(root, "mcp") {
+		t.Errorf("mcp = %q, want the legacy mcp/ dir", p.MCP)
+	}
+	if !p.LegacyVault || !p.LegacySkills || !p.LegacyMCP || !p.LegacyLayout() {
+		t.Errorf("legacy flags not set: %+v", p)
+	}
+}
+
+// An EMPTY leftover directory must not pin an install to the old
+// layout — otherwise a stray mkdir silently decides where documents
+// live. This is why the probe asks for content, not existence.
+func TestResolve_EmptyLegacyDirsDoNotPin(t *testing.T) {
+	h := home(t)
+	p := Config{}.resolve(fakeFS{}.hasEntries, fakeFS{}.exists)
+
+	if p.Vault != filepath.Join(h, ".opendray", "vault") {
+		t.Errorf("documents = %q, want the vault root itself", p.Vault)
+	}
+	if p.LegacyLayout() {
+		t.Error("empty dirs must not mark the install legacy")
+	}
+}
+
+// A pre-split install syncing from the shared root has a real git repo
+// there with a real remote. Repointing the working tree at notes/ would
+// break a setup that works, for tidiness.
+func TestResolve_ExistingRepoAtSharedRootKeepsTheWorkingTree(t *testing.T) {
+	h := home(t)
+	root := filepath.Join(h, ".opendray", "vault")
+	fs := fakeFS{
+		withEntries: map[string]bool{filepath.Join(root, "notes"): true},
+		existing:    map[string]bool{filepath.Join(root, ".git"): true},
+	}
+
+	p := fs.resolveWith(t, Config{})
+
+	if p.VaultGit != root {
+		t.Errorf("git root = %q, want the existing repo at %q", p.VaultGit, root)
+	}
+	if p.Vault != filepath.Join(root, "notes") {
+		t.Errorf("documents = %q, want notes/", p.Vault)
+	}
+}
+
+// Without a legacy notes/ dir there is no reason to keep the git root
+// anywhere but on the documents themselves.
+func TestResolve_GitRootFollowsTheDocuments(t *testing.T) {
+	fs := fakeFS{}
+	p := fs.resolveWith(t, Config{Vault: VaultConfig{Root: "/srv/docs"}})
+	if p.VaultGit != "/srv/docs" {
+		t.Errorf("git root = %q, want /srv/docs", p.VaultGit)
+	}
+}
+
+func (f fakeFS) resolveWith(t *testing.T, c Config) Paths {
+	t.Helper()
+	return c.resolve(f.hasEntries, f.exists)
+}
+
+// Explicit config always wins over both the legacy probe and the
+// defaults — including the deprecated spellings, which are how
+// operators point opendray at an Obsidian folder kept elsewhere.
+func TestResolve_ExplicitConfigWins(t *testing.T) {
+	root := filepath.Join(home(t), ".opendray", "vault")
+	fs := fakeFS{withEntries: map[string]bool{
+		filepath.Join(root, "notes"):  true,
+		filepath.Join(root, "skills"): true,
+		filepath.Join(root, "mcp"):    true,
+	}}
+
+	// Each case pulls the one field it is about out of the result,
+	// since the rest is covered by the layout tests above.
+	tests := []struct {
+		name string
+		cfg  Config
+		get  func(Paths) string
+		want string
+	}{
+		{
+			name: "vault.notes still points the documents elsewhere",
+			cfg:  Config{Vault: VaultConfig{Notes: "/srv/obsidian"}},
+			get:  func(p Paths) string { return p.Vault },
+			want: "/srv/obsidian",
+		},
+		{
+			name: "skills.root beats the legacy dir",
+			cfg:  Config{Skills: SkillsConfig{Root: "/srv/skills"}},
+			get:  func(p Paths) string { return p.Skills },
+			want: "/srv/skills",
+		},
+		{
+			name: "deprecated vault.skills still works",
+			cfg:  Config{Vault: VaultConfig{Skills: "/srv/old-skills"}},
+			get:  func(p Paths) string { return p.Skills },
+			want: "/srv/old-skills",
+		},
+		{
+			name: "skills.root beats vault.skills",
+			cfg: Config{
+				Skills: SkillsConfig{Root: "/srv/new"},
+				Vault:  VaultConfig{Skills: "/srv/old"},
+			},
+			get:  func(p Paths) string { return p.Skills },
+			want: "/srv/new",
+		},
+		{
+			name: "mcp.root beats the legacy dir",
+			cfg:  Config{MCP: MCPConfig{Root: "/srv/mcp"}},
+			get:  func(p Paths) string { return p.MCP },
+			want: "/srv/mcp",
+		},
+		{
+			name: "git_root beats everything",
+			cfg:  Config{Vault: VaultConfig{GitRoot: "/srv/repo"}},
+			get:  func(p Paths) string { return p.VaultGit },
+			want: "/srv/repo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.get(fs.resolveWith(t, tt.cfg)); got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Secrets must never end up inside a directory anything git-adds.
+func TestResolve_SecretsStayOutsideEveryRoot(t *testing.T) {
+	root := filepath.Join(home(t), ".opendray", "vault")
+	fs := fakeFS{withEntries: map[string]bool{
+		filepath.Join(root, "notes"): true,
+	}}
+	p := fs.resolveWith(t, Config{})
+
+	for _, dir := range []string{p.Vault, p.VaultGit, p.Skills, p.MCP} {
+		if isUnder(dir, p.MCPSecrets) {
+			t.Fatalf("secrets file %q sits under %q", p.MCPSecrets, dir)
+		}
+	}
+}
+
+// NestedInVault drives the doc library's filter. It must name exactly
+// the machinery dirs that would otherwise show up as folders in the
+// operator's documents — and nothing on a clean split install.
+func TestNestedInVault(t *testing.T) {
+	root := filepath.Join(home(t), ".opendray", "vault")
+
+	legacy := fakeFS{withEntries: map[string]bool{
+		filepath.Join(root, "notes"):  true,
+		filepath.Join(root, "skills"): true,
+		filepath.Join(root, "mcp"):    true,
+	}}.resolveWith(t, Config{Vault: VaultConfig{Notes: root}})
+
+	nested := legacy.NestedInVault()
+	if len(nested) != 2 {
+		t.Fatalf("legacy install: nested = %v, want skills/ and mcp/", nested)
+	}
+
+	clean := fakeFS{}.resolveWith(t, Config{})
+	if got := clean.NestedInVault(); len(got) != 0 {
+		t.Fatalf("split install: nested = %v, want none", got)
+	}
+}
+
+// dirHasEntries is the real probe; a directory holding only Finder
+// droppings is empty as far as layout decisions go.
+func TestDirHasEntries(t *testing.T) {
+	dir := t.TempDir()
+	if dirHasEntries(filepath.Join(dir, "missing")) {
+		t.Error("missing dir reported as having entries")
+	}
+
+	empty := filepath.Join(dir, "empty")
+	if err := os.MkdirAll(empty, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if dirHasEntries(empty) {
+		t.Error("empty dir reported as having entries")
+	}
+
+	if err := os.WriteFile(filepath.Join(empty, ".DS_Store"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if dirHasEntries(empty) {
+		t.Error(".DS_Store alone must not count as content")
+	}
+
+	if err := os.WriteFile(filepath.Join(empty, "note.md"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !dirHasEntries(empty) {
+		t.Error("dir with a file reported as empty")
+	}
+}

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -4,7 +4,7 @@
 //
 // Storage model — same philosophy as the skills + notes vaults:
 //
-//	<vault>/mcp/<id>/mcp.json   # user-defined MCP servers (filesystem)
+//	<registry root>/<id>/mcp.json   # user-defined MCP servers (filesystem)
 //
 // No built-ins are embedded in the binary. Users add servers via the
 // Plugins page or by dropping a directory into the vault by hand.
@@ -61,7 +61,7 @@ type Server struct {
 // Loader walks the vault directory and returns Server entries. Mirrors
 // the skills loader's API surface so the wiring is symmetric.
 type Loader struct {
-	vaultRoot string // absolute path to <vault>/mcp (may not exist)
+	vaultRoot string // absolute path to the registry root (may not exist)
 }
 
 // NewLoader points the loader at a directory that contains one

--- a/internal/notes/hidden_test.go
+++ b/internal/notes/hidden_test.go
@@ -1,0 +1,125 @@
+package notes
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// On a pre-split install opendray's skills/ and mcp/ roots sit inside
+// the documents root, and the doc library listed them as folders — the
+// gateway's own configuration presented to the operator as their
+// writing. Hiding them is what makes the old layout tolerable for
+// anyone who never migrates.
+func TestList_HidesNestedMachineryDirs(t *testing.T) {
+	root := t.TempDir()
+	write := func(rel string) {
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("# x\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("projects/app/overview.md")
+	write("skills/secretary/SKILL.md")
+	write("mcp/registry.md")
+
+	v, err := New(root, Options{HiddenDirs: []string{
+		filepath.Join(root, "skills"),
+		filepath.Join(root, "mcp"),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := v.List("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Path != "projects/app/overview.md" {
+		t.Fatalf("listing = %v, want only the operator's document", got)
+	}
+}
+
+// Once an install is split those roots live outside the vault entirely.
+// Passing them anyway must be harmless — app.go does exactly that,
+// unconditionally, rather than branching on layout.
+func TestList_HiddenDirsOutsideTheVaultAreIgnored(t *testing.T) {
+	root := t.TempDir()
+	elsewhere := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(root, "note.md"), []byte("# x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := New(root, Options{HiddenDirs: []string{
+		filepath.Join(elsewhere, "skills"),
+		filepath.Join(elsewhere, "mcp"),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(v.hidden) != 0 {
+		t.Fatalf("hidden = %v, want nothing (those dirs are not in the vault)", v.hidden)
+	}
+
+	got, err := v.List("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("listing = %v, want the one note", got)
+	}
+}
+
+// Hiding the root itself would empty the entire doc library. Guard it:
+// a misconfiguration that silently blanks someone's documents is worse
+// than the folders it was trying to hide.
+func TestList_VaultRootIsNeverHidden(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "note.md"), []byte("# x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := New(root, Options{HiddenDirs: []string{root, root + "/"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := v.List("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("listing = %v, want the note — the root must not be hideable", got)
+	}
+}
+
+// A hidden dir must not shadow a same-named directory deeper in the
+// tree: `skills/` at the root is opendray's, `projects/skills/` is the
+// operator writing about skills.
+func TestList_HiddenMatchIsRootedNotByName(t *testing.T) {
+	root := t.TempDir()
+	for _, rel := range []string{"skills/SKILL.md", "projects/skills/notes.md"} {
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("# x\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	v, err := New(root, Options{HiddenDirs: []string{filepath.Join(root, "skills")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := v.List("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Path != "projects/skills/notes.md" {
+		t.Fatalf("listing = %v, want only projects/skills/notes.md", got)
+	}
+}

--- a/internal/notes/vault.go
+++ b/internal/notes/vault.go
@@ -2,11 +2,13 @@
 // powers the Inspector's Notes tab and is exposed to AI agents via
 // the `opendray notes` CLI subcommand.
 //
-// Storage model: a configurable root (default ~/.opendray/vault/notes)
-// holding a tree of .md files. Conventional subdirectories (daily/,
-// projects/, library/) are auto-created on first write but the layout
-// is otherwise free-form — users can drop their existing Obsidian
-// vault here and it'll work without changes.
+// Storage model: a configurable root (default ~/.opendray/vault)
+// holding a tree of .md files — the operator's documents and nothing
+// else. Conventional subdirectories (daily/, projects/, library/) are
+// auto-created on first write but the layout is otherwise free-form —
+// users can drop their existing Obsidian vault here and it'll work
+// without changes. Resolution of that root, including the pre-split
+// <root>/notes layout, lives in config.Resolve.
 //
 // All operations go through Vault, which enforces a strict path jail
 // against the resolved root. The HTTP layer and CLI both wrap Vault.
@@ -53,9 +55,10 @@ type FullNote struct {
 // being independent FS calls (no shared in-memory state in this phase
 // — index lands in Phase 4).
 type Vault struct {
-	root           string // canonical absolute path to the notes root
-	personalPrefix string // default subfolder for personal scratchpads
-	projectsPrefix string // default subfolder for AI project docs
+	root           string   // canonical absolute path to the notes root
+	personalPrefix string   // default subfolder for personal scratchpads
+	projectsPrefix string   // default subfolder for AI project docs
+	hidden         []string // vault-relative dirs excluded from listings
 
 	projectMapMu sync.Mutex // guards reads/writes of projectMapFilename
 }
@@ -66,6 +69,14 @@ type Vault struct {
 type Options struct {
 	PersonalPrefix string
 	ProjectsPrefix string
+
+	// HiddenDirs are absolute paths that must not appear in listings
+	// even though they sit inside the vault. Pre-split installs keep
+	// opendray's skills/ and mcp/ directories inside the documents
+	// root; showing them as folders presents the gateway's own
+	// configuration as the operator's writing. Paths outside the vault
+	// are ignored, so callers can pass them unconditionally.
+	HiddenDirs []string
 }
 
 // New resolves and creates the notes root directory. Pass the
@@ -102,11 +113,48 @@ func New(notesRoot string, opts Options) (*Vault, error) {
 	if projects == "" {
 		projects = "projects"
 	}
+	root := filepath.Clean(abs)
 	return &Vault{
-		root:           filepath.Clean(abs),
+		root:           root,
 		personalPrefix: personal,
 		projectsPrefix: projects,
+		hidden:         relativeHidden(root, opts.HiddenDirs),
 	}, nil
+}
+
+// relativeHidden turns absolute hidden paths into vault-relative ones,
+// dropping anything that is not actually inside the vault (the common
+// case once an install has been split) and the vault root itself (which
+// would hide everything).
+func relativeHidden(root string, dirs []string) []string {
+	var out []string
+	for _, dir := range dirs {
+		abs, err := filepath.Abs(strings.TrimSpace(dir))
+		if err != nil || abs == "" {
+			continue
+		}
+		if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+			abs = resolved
+		}
+		rel, err := filepath.Rel(root, filepath.Clean(abs))
+		if err != nil || rel == "." || rel == ".." ||
+			strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		out = append(out, filepath.ToSlash(rel))
+	}
+	return out
+}
+
+// isHidden reports whether a vault-relative directory path is one of
+// the excluded machinery roots.
+func (v *Vault) isHidden(rel string) bool {
+	for _, h := range v.hidden {
+		if rel == h {
+			return true
+		}
+	}
+	return false
 }
 
 // PersonalPrefix / ProjectsPrefix expose the configured defaults so
@@ -170,9 +218,17 @@ func (v *Vault) List(prefix string) ([]Note, error) {
 			return walkErr
 		}
 		if d.IsDir() {
+			if path == v.root {
+				return nil
+			}
 			// Skip hidden subdirs (e.g. .git, .obsidian) — they're not
 			// part of the notes themselves.
-			if path != v.root && strings.HasPrefix(d.Name(), ".") {
+			if strings.HasPrefix(d.Name(), ".") {
+				return filepath.SkipDir
+			}
+			// Skip opendray's own roots when they sit inside the vault.
+			if rel, err := filepath.Rel(v.root, path); err == nil &&
+				v.isHidden(filepath.ToSlash(rel)) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/internal/settings/handler.go
+++ b/internal/settings/handler.go
@@ -65,6 +65,13 @@ func (h *Handler) Mount(r chi.Router) {
 type getResponse struct {
 	Config     *config.Config `json:"config"`
 	ConfigPath string         `json:"config_path"`
+	// Layout is where these settings actually resolve to on disk,
+	// including whether anything still falls in the pre-split shared
+	// vault. Read-only: the paths are derived, and several of them are
+	// only knowable by looking at the filesystem. Showing them is the
+	// point — a settings page that describes a layout the gateway is
+	// not using is how the Vault came to mean three different things.
+	Layout config.Paths `json:"layout"`
 }
 
 func (h *Handler) get(w http.ResponseWriter, r *http.Request) {
@@ -73,7 +80,11 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, getResponse{Config: c, ConfigPath: h.svc.ConfigPath()})
+	writeJSON(w, http.StatusOK, getResponse{
+		Config:     c,
+		ConfigPath: h.svc.ConfigPath(),
+		Layout:     c.Resolve(),
+	})
 }
 
 func (h *Handler) put(w http.ResponseWriter, r *http.Request) {

--- a/internal/skills/handler.go
+++ b/internal/skills/handler.go
@@ -15,8 +15,8 @@ import (
 )
 
 // Handlers expose skills as a REST surface for the web Plugins page.
-// Built-in skills are read-only; vault skills (which live under
-// <vault>/skills/<id>/SKILL.md) are full CRUD. The split is enforced
+// Built-in skills are read-only; on-disk skills (which live under
+// <skills root>/<id>/SKILL.md) are full CRUD. The split is enforced
 // here, not by the loader — the UI shows source=builtin and disables
 // edit/delete for those.
 type Handlers struct {

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -4,7 +4,7 @@
 //
 // Storage model — same philosophy as the notes vault:
 //
-//	<vault>/skills/<id>/SKILL.md     # user / shared skills (filesystem)
+//	<skills root>/<id>/SKILL.md      # user / shared skills (filesystem)
 //	//go:embed builtin/<id>/SKILL.md # built-in skills shipped in the binary
 //
 // Vault entries override built-ins of the same id, so users can customise
@@ -46,7 +46,7 @@ type Skill struct {
 // by id. Vault wins on conflict so users can override shipped skills
 // without editing the binary.
 type Loader struct {
-	vaultRoot string // absolute path to <vault>/skills (may not exist)
+	vaultRoot string // absolute path to the skills root (may not exist)
 }
 
 // NewLoader points the loader at a directory that contains one

--- a/internal/vaultgit/gitignore.go
+++ b/internal/vaultgit/gitignore.go
@@ -1,0 +1,141 @@
+package vaultgit
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// The Vault repo is the operator's documents. Everything else that
+// happens to sit in the working tree — Finder droppings, Obsidian's
+// per-machine workspace state, and (on a pre-split install) opendray's
+// own skills/ and mcp/ roots — has no business being pushed to their
+// remote. On the machine that prompted this, `skills/secretary/
+// SKILL.md` and a `.claude/` memory tree had already been committed to
+// a private docs repo, purely because they shared a directory.
+//
+// So opendray maintains a delimited block in .gitignore rather than
+// writing the file once at init and never looking again. The block is
+// rewritten on every commit, which means:
+//
+//   - existing repos get the rules, not just newly-initialised ones
+//   - the set tracks the resolved layout, so an install that later
+//     moves skills/ out stops carrying a stale rule
+//   - everything outside the markers is the operator's, untouched
+//
+// Ignoring cannot untrack what is already committed; that needs
+// `git rm --cached` and is the operator's call, not something to do to
+// someone's repo behind their back.
+
+const (
+	ignoreBegin = "# >>> opendray managed — edits inside this block are overwritten >>>"
+	ignoreEnd   = "# <<< opendray managed <<<"
+)
+
+// baseIgnores are unconditional: none of these are documents.
+var baseIgnores = []string{
+	".DS_Store",
+	".cache/",
+	".trash/",
+	".obsidian/workspace.json",
+	".obsidian/workspace-mobile.json",
+}
+
+// ensureManagedIgnore rewrites opendray's block in <root>/.gitignore.
+// nested names the machinery directories that resolve inside the repo,
+// as absolute paths; they are recorded repo-relative.
+func ensureManagedIgnore(root string, nested []string) error {
+	rules := append([]string{}, baseIgnores...)
+	for _, dir := range nested {
+		rel, err := filepath.Rel(root, dir)
+		if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+			continue
+		}
+		rules = append(rules, filepath.ToSlash(rel)+"/")
+	}
+
+	path := filepath.Join(root, ".gitignore")
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read .gitignore: %w", err)
+	}
+
+	want := renderBlock(rules)
+	next := replaceBlock(string(existing), want)
+	if next == string(existing) {
+		return nil
+	}
+	if err := os.WriteFile(path, []byte(next), 0o600); err != nil {
+		return fmt.Errorf("write .gitignore: %w", err)
+	}
+	return nil
+}
+
+func renderBlock(rules []string) string {
+	var b strings.Builder
+	b.WriteString(ignoreBegin)
+	b.WriteString("\n")
+	for _, r := range rules {
+		b.WriteString(r)
+		b.WriteString("\n")
+	}
+	b.WriteString(ignoreEnd)
+	b.WriteString("\n")
+	return b.String()
+}
+
+// replaceBlock swaps the managed block for want, appending it when the
+// file has none. Content outside the markers is preserved byte for
+// byte — it is the operator's file, we are a guest in it.
+func replaceBlock(existing, want string) string {
+	if existing == "" {
+		return want
+	}
+	var before, after []string
+	state := 0 // 0 = before block, 1 = inside, 2 = after
+	found := false
+	sc := bufio.NewScanner(strings.NewReader(existing))
+	sc.Buffer(make([]byte, 0, 64<<10), 1<<20)
+	for sc.Scan() {
+		line := sc.Text()
+		switch state {
+		case 0:
+			if strings.TrimSpace(line) == ignoreBegin {
+				state, found = 1, true
+				continue
+			}
+			before = append(before, line)
+		case 1:
+			if strings.TrimSpace(line) == ignoreEnd {
+				state = 2
+			}
+			continue
+		default:
+			after = append(after, line)
+		}
+	}
+	// An unterminated block (someone deleted the end marker) still ends
+	// the scan in state 1; treating it as consumed is right — the
+	// alternative is nesting a fresh block inside a broken one.
+	if !found {
+		out := strings.TrimRight(existing, "\n")
+		if out != "" {
+			out += "\n\n"
+		}
+		return out + want
+	}
+
+	var b strings.Builder
+	if len(before) > 0 {
+		b.WriteString(strings.Join(before, "\n"))
+		b.WriteString("\n")
+	}
+	b.WriteString(want)
+	if len(after) > 0 {
+		b.WriteString(strings.Join(after, "\n"))
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/internal/vaultgit/gitignore_test.go
+++ b/internal/vaultgit/gitignore_test.go
@@ -1,0 +1,138 @@
+package vaultgit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func readIgnore(t *testing.T, root string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(root, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	return string(b)
+}
+
+func TestEnsureManagedIgnore_CreatesTheBlock(t *testing.T) {
+	root := t.TempDir()
+	if err := ensureManagedIgnore(root, nil); err != nil {
+		t.Fatal(err)
+	}
+	got := readIgnore(t, root)
+	for _, want := range []string{ignoreBegin, ignoreEnd, ".DS_Store", ".trash/"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// A pre-split install has skills/ inside the repo. That is exactly how
+// an agent skill ended up committed to someone's private docs repo, so
+// the rule has to be derived from the resolved layout, not hardcoded.
+func TestEnsureManagedIgnore_IgnoresNestedMachineryDirs(t *testing.T) {
+	root := t.TempDir()
+	err := ensureManagedIgnore(root, []string{
+		filepath.Join(root, "skills"),
+		filepath.Join(root, "mcp"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := readIgnore(t, root)
+	if !strings.Contains(got, "skills/") || !strings.Contains(got, "mcp/") {
+		t.Fatalf("nested dirs not ignored:\n%s", got)
+	}
+}
+
+// Once split, those dirs live outside the repo. Passing them must not
+// produce `../skills/` rules — app.go passes the resolved set blindly.
+func TestEnsureManagedIgnore_SkipsDirsOutsideTheRepo(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := ensureManagedIgnore(root, []string{filepath.Join(outside, "skills")}); err != nil {
+		t.Fatal(err)
+	}
+	if got := readIgnore(t, root); strings.Contains(got, "..") {
+		t.Fatalf("escaped the repo:\n%s", got)
+	}
+}
+
+// The operator's own rules are not ours to rewrite.
+func TestEnsureManagedIgnore_PreservesOperatorContent(t *testing.T) {
+	root := t.TempDir()
+	original := "# mine\n*.pdf\n\n# also mine\ndrafts/\n"
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureManagedIgnore(root, nil); err != nil {
+		t.Fatal(err)
+	}
+	got := readIgnore(t, root)
+	for _, want := range []string{"# mine", "*.pdf", "# also mine", "drafts/"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("clobbered %q:\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, ignoreBegin) {
+		t.Errorf("managed block not appended:\n%s", got)
+	}
+}
+
+// Rewritten on every commit — it must converge, not grow a new block
+// each sync, and must not churn the file once settled.
+func TestEnsureManagedIgnore_IsIdempotent(t *testing.T) {
+	root := t.TempDir()
+	for i := 0; i < 3; i++ {
+		if err := ensureManagedIgnore(root, []string{filepath.Join(root, "skills")}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := readIgnore(t, root)
+	if n := strings.Count(got, ignoreBegin); n != 1 {
+		t.Fatalf("block appears %d times:\n%s", n, got)
+	}
+
+	before, err := os.Stat(filepath.Join(root, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureManagedIgnore(root, []string{filepath.Join(root, "skills")}); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Stat(filepath.Join(root, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Error("rewrote an unchanged .gitignore — every sync would dirty the repo")
+	}
+}
+
+// An install that moves skills/ out must stop carrying the stale rule,
+// otherwise a later real skills/ document folder would be invisible.
+func TestEnsureManagedIgnore_DropsRulesThatNoLongerApply(t *testing.T) {
+	root := t.TempDir()
+	if err := ensureManagedIgnore(root, []string{filepath.Join(root, "skills")}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureManagedIgnore(root, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := readIgnore(t, root); strings.Contains(got, "skills/") {
+		t.Fatalf("stale rule survived:\n%s", got)
+	}
+}
+
+func TestReplaceBlock_HandlesAnUnterminatedBlock(t *testing.T) {
+	existing := "# mine\n" + ignoreBegin + "\n.DS_Store\n"
+	got := replaceBlock(existing, renderBlock([]string{".DS_Store"}))
+	if n := strings.Count(got, ignoreBegin); n != 1 {
+		t.Fatalf("block appears %d times:\n%s", n, got)
+	}
+	if !strings.Contains(got, "# mine") {
+		t.Fatalf("lost operator content:\n%s", got)
+	}
+}

--- a/internal/vaultgit/handler.go
+++ b/internal/vaultgit/handler.go
@@ -41,9 +41,26 @@ type Handlers struct {
 	root  string           // absolute path to the vault root
 	hosts *githost.Service // optional; nil disables HTTPS token injection
 	log   *slog.Logger
+
+	// nested are opendray's own roots that fall inside this working
+	// tree — nothing on a split install, skills/ and/or mcp/ on an
+	// older one. Kept out of the repo via the managed .gitignore.
+	nested []string
 }
 
-func NewHandlers(vaultRoot string, hosts *githost.Service, log *slog.Logger) (*Handlers, error) {
+// Option customises Handlers.
+type Option func(*Handlers)
+
+// WithNestedDirs names opendray's machinery roots that sit inside the
+// repo, so they can be ignored rather than pushed to the operator's
+// remote. Pass config.Paths.NestedInGitRoot().
+func WithNestedDirs(dirs []string) Option {
+	return func(h *Handlers) { h.nested = dirs }
+}
+
+func NewHandlers(
+	vaultRoot string, hosts *githost.Service, log *slog.Logger, opts ...Option,
+) (*Handlers, error) {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -57,11 +74,15 @@ func NewHandlers(vaultRoot string, hosts *githost.Service, log *slog.Logger) (*H
 	if _, err := os.Stat(abs); err != nil {
 		return nil, fmt.Errorf("vault root: %w", err)
 	}
-	return &Handlers{
+	h := &Handlers{
 		root:  abs,
 		hosts: hosts,
 		log:   log.With("component", "vaultgit.http"),
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h, nil
 }
 
 func (h *Handlers) Mount(r chi.Router) {
@@ -355,11 +376,8 @@ func (h *Handlers) init(w http.ResponseWriter, r *http.Request) {
 			fmt.Errorf("git init: %w", err))
 		return
 	}
-	// Drop a sane default .gitignore if missing — keeps macOS .DS_Store
-	// out of the repo, plus any future opendray runtime artefacts.
-	gi := filepath.Join(h.root, ".gitignore")
-	if _, err := os.Stat(gi); errors.Is(err, os.ErrNotExist) {
-		_ = os.WriteFile(gi, []byte(".DS_Store\n.cache/\n"), 0o600)
+	if err := ensureManagedIgnore(h.root, h.nested); err != nil {
+		h.log.Warn("could not write the managed .gitignore", "err", err)
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"output": string(out)})
 }
@@ -380,6 +398,13 @@ func (h *Handlers) commit(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithTimeout(r.Context(), gitTimeout)
 	defer cancel()
+
+	// Refresh the managed block before staging, so a repo created
+	// before this existed — or one whose layout has since changed —
+	// picks up the rules on its next sync rather than never.
+	if err := ensureManagedIgnore(h.root, h.nested); err != nil {
+		h.log.Warn("could not write the managed .gitignore", "err", err)
+	}
 
 	addArgs := []string{"add"}
 	if len(req.Files) == 0 {


### PR DESCRIPTION
## The problem

`vault.root` was not a concept, it was a container. It held three tenants with nothing in common:

| Directory | Belongs to | Lifecycle |
|---|---|---|
| the operator's markdown | **documents** | they write it, read it, sync it |
| `skills/` | **opendray config** | injected into sessions at spawn |
| `mcp/` | **opendray config** | the MCP registry |

Which is why the settings page could only describe it as *"Notes, skills, and git-versioned root"* — a sentence that parses only if you already know the implementation. A user reading it cannot tell whether the Vault is their documents or opendray's configuration. That was the report.

### It was not only confusing

Sharing a directory means sharing its git repo. On the install this was found on, Vault Sync had committed opendray's own `skills/secretary/SKILL.md` into a **private documentation repo** — along with `.claude/…/memory/*.md`, several `.DS_Store`, and `.trash/`. The reverse hazard is worse: a `git clean -fd` or a branch switch in that repo would have deleted the gateway's skills.

And a `SKILL.md` is a `.md` file, so the doc library listed it as one of the operator's documents.

## The split

```
~/.opendray/vault/    documents — what the Vault browses, what Vault Sync commits
~/.opendray/skills/   agent skills
~/.opendray/mcp/      MCP registry
```

`vault.root` now means the documents directory — no `/notes` appended, no siblings. `[skills].root` is the new spelling for the skills path. `vault.notes` and `vault.skills` keep working; the former is still how you point opendray at a markdown folder you maintain somewhere else entirely.

## Nothing is moved

An upgrade that relocates someone's files is not on the table. Instead:

- **A root whose old location still has content keeps being used.** The probe asks whether the directory has *content*, not whether it exists — a stray empty folder must not silently decide where someone's documents live.
- **The resolution is printed.** The settings page shows where each path actually landed, and warns plainly when it is still the shared layout. A settings page that describes a layout the gateway is not using is how this happened.
- **Roots that do sit inside the Vault are hidden from the doc library** and added to an opendray-managed `.gitignore` block, refreshed on every commit so existing repos get it too, not just newly-initialised ones.
- Ignoring cannot untrack what is already committed. That needs `git rm --cached`, and it is the operator's repo — opendray does not rewrite it.

## One resolver instead of four

Path resolution was reimplemented in `internal/app` and in each of `opendray notes|skill|mcp`, with different precedence in each. This is not hypothetical drift — against the same config the MCP registry resolved to `~/.opendray/mcp` in the gateway and `~/.opendray/vault/mcp` in the CLI. `internal/config/paths.go` is now the only place these are derived.

`app.parentOf` — the heuristic that caused that divergence — is deleted.

## Surfaces

- **Web**: Vault section slimmed to documents + git + prefixes; new **Agent skills** section; a resolved-layout panel with the legacy warning. `vault.notes` renders only for operators who already have it set, so a superseded field is not offered to anyone new but stays editable and clearable by whoever set it.
- **Mobile**: same three changes, plus the legacy banner. Note that web and mobile use **two independent i18n key sets** for this screen — both updated.
- **API**: `GET /admin/settings` gains a read-only `layout`.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race` — `config`, `notes`, `vaultgit`, `settings`, `app`, `cmd/opendray`
- [x] New tests: resolver precedence (explicit > deprecated > legacy > default), the has-content probe, git-root preservation, nesting; doc-library filtering including root-is-never-hideable and rooted-not-by-name matching; `.gitignore` create / preserve-operator-content / idempotent / drop-stale / unterminated-block
- [x] Verified against a real pre-split install: skills and MCP resolve to the same directories the running gateway already uses; no files moved
- [x] `pnpm build` (incl. `tsc -b`) green; `flutter analyze` clean
- [x] `check-i18n-parity.mjs`: es/zh 100%, no missing / extra / token-mismatch

**Known unrelated failure**: `internal/catalog TestUnmanagedBinLink_NpmOwnedLinkIsLeftAlone` also fails on a stashed clean tree — a local npm environment issue, not from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)