### PR TITLE
feat(vault): file a project's documents under the project's name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,26 @@ for the full rationale and what triggers a major bump.
   directories the migration empties are removed; one still holding
   anything is left exactly where it is.
 
+- **Documents save when you say so, not on a timer.** The editor wrote
+  after every pause in typing, so a long document rewrote itself to
+  disk over and over while it was being worked on. Saving is now a
+  button, or ⌘S / Ctrl+S, on web and on mobile. Leaving a document
+  still flushes unsaved text — that safety net costs nothing while
+  typing — and closing the browser tab with unsaved work asks first.
+
+  Autosave was not the whole story behind the typing lag, so two things
+  that were: the editor streamed **every keystroke** to the page, which
+  re-rendered the whole vault tree and recomputed the outline per
+  character; and the tree re-rendered along with it. The stream is now
+  paced to what a sidebar can use, and the tree only re-renders when
+  the note list or the selection changes.
+
+- **Line numbers in the source view.** On by default for HTML, off for
+  markdown, and toggleable either way. Numbers turn wrapping off, the
+  way every code editor does it: a wrapped line covers several rows, so
+  a gutter counting 1..N drifts on exactly the long lines an HTML
+  document is full of.
+
 - **The doc library can rename and delete a document.** It could create
   and edit one, and that was all — a daily note, or anything not bound
   to a project, could be made but never moved or removed from the one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,19 @@ for the full rationale and what triggers a major bump.
   because a probe asking "does this folder have content?" changes its
   answer the moment someone puts content there.
 
-  `opendray notes flatten` converts a vault deliberately. It defaults
+  **The doc library offers the conversion**, on web and on mobile, to
+  any vault that still nests projects. A migration that ships only as a
+  CLI command is one that only the people who wrote it ever run — every
+  existing vault would have stayed nested with its owner never learning
+  there was a choice. The offer is dismissible and never appears for a
+  vault that is already flat or has nothing to move, and the gateway
+  says the same thing once in the startup log for anyone who never
+  opens the UI.
+
+  Nothing moves without a preview. Web and mobile both run the
+  migration as a dry run and show the real list — including what it
+  refuses to touch and why — before anything is renamed.
+  `opendray notes flatten` does the same from a terminal. It defaults
   to a dry run, drives the same rename the UI uses so `[[wiki links]]`
   are repointed as it goes, repoints per-cwd project overrides, and
   **never overwrites**: a destination that already exists is reported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,20 @@ for the full rationale and what triggers a major bump.
   `daily` files under `daily-docs`, since `daily/YYYY-MM-DD.md` belongs
   to the whole vault. `_`- and `.`-prefixed names are reserved too.
 
+  The conversion records the resulting layout itself and applies it to
+  the running gateway, rather than leaving both to the next restart —
+  otherwise a converted vault keeps deriving `projects/<name>` and
+  `personal/<name>.md` against the directories it just emptied. The
+  directories the migration empties are removed; one still holding
+  anything is left exactly where it is.
+
+- **`opendray notes` accepts flags after the subcommand.** Go's `flag`
+  package stops parsing at the first non-flag argument, so `notes
+  flatten --apply` left `apply` false, performed a dry run, and advised
+  re-running with `--apply` — which is what had just been typed.
+  `notes list --prefix=x` silently listed everything for the same
+  reason. Both orders now mean the same thing.
+
 - **The Vault is your documents. Agent skills and the MCP registry moved
   out.** One root held three tenants with nothing in common — the
   operator's markdown, the skills opendray injects at spawn, and the MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,41 @@ for the full rationale and what triggers a major bump.
 
 ### Changed
 
+- **A project's documents are filed under the project's name.** The
+  Vault is a project documentation library, and it filed every project
+  under `projects/` — a folder naming what the whole library already
+  is. One level of nesting that told the reader nothing, on every path,
+  in every listing, and at the top of the git repository the Vault syncs
+  to. The operator's own notes were split off further still: agent docs
+  at `projects/<name>/…`, the human scratchpad at `personal/<name>.md` —
+  the same project's material in two distant places, sorted by *who
+  wrote it* rather than by what it is about.
+
+  New vaults now use `<name>/…` with that project's `personal.md`
+  inside it. **Existing vaults are not rearranged.** The layout is
+  decided once, at first start, and written into `config.toml` as
+  `[vault] layout`. Recording it is the point: the alternative — work
+  the shape out from what is on disk each time — is the bug that put
+  one install's entire document library behind a `notes/` directory,
+  because a probe asking "does this folder have content?" changes its
+  answer the moment someone puts content there.
+
+  `opendray notes flatten` converts a vault deliberately. It defaults
+  to a dry run, drives the same rename the UI uses so `[[wiki links]]`
+  are repointed as it goes, repoints per-cwd project overrides, and
+  **never overwrites**: a destination that already exists is reported
+  and skipped, leaving both copies for you to reconcile.
+
+  Where a project's notes live is now answered by the gateway —
+  `/notes/info` reports the layout and the project mapping carries
+  `personal_path` — instead of being re-derived by web, mobile and the
+  CLI. Three implementations guessing is three chances to disagree, and
+  the CLI's `notes project` was already guessing wrong.
+
+  Reserved names step aside rather than collide: a project called
+  `daily` files under `daily-docs`, since `daily/YYYY-MM-DD.md` belongs
+  to the whole vault. `_`- and `.`-prefixed names are reserved too.
+
 - **The Vault is your documents. Agent skills and the MCP registry moved
   out.** One root held three tenants with nothing in common — the
   operator's markdown, the skills opendray injects at spawn, and the MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,29 @@ for the full rationale and what triggers a major bump.
   directories the migration empties are removed; one still holding
   anything is left exactly where it is.
 
+- **The doc library can rename and delete a document.** It could create
+  and edit one, and that was all — a daily note, or anything not bound
+  to a project, could be made but never moved or removed from the one
+  surface that lists everything. Rename goes through the move endpoint,
+  so the `[[wiki links]]` pointing at the old path are repointed rather
+  than left dangling, and a partial rewrite is reported instead of
+  being folded into a plain "renamed". Mobile gains rename too; it
+  already had delete.
+
+- **"New" and "Today" are reachable once a document is open.** They
+  were in the header the whole time, pushed off the right edge by the
+  vault path: a `truncate` element in a flex row still needs
+  `min-width: 0`, or it refuses to shrink below its content. Anyone
+  with a long vault path could only reach the two actions from the
+  empty state, which is exactly when they had no documents to leave.
+
+- **A folder holding the selected document can be collapsed again.**
+  The tree re-applied "open the ancestors of the selection" on every
+  render, so the collapse landed and the next render undid it — and
+  "Collapse all" left that one branch open. Revealing the selection is
+  a response to the selection changing, not a rule about what must stay
+  open, so it now runs once per selection.
+
 - **`opendray notes` accepts flags after the subcommand.** Go's `flag`
   package stops parsing at the first non-flag argument, so `notes
   flatten --apply` left `apply` false, performed a dry run, and advised

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1185,6 +1185,18 @@
         "tooltipAutoOn": " · auto-sync on",
         "tooltipLastError": " · last error: {error}",
         "branchPlaceholder": "—"
+      },
+      "flatten": {
+        "notice": "Every project in this vault sits inside a folder called projects/. They can be filed under their own names instead.",
+        "preview": "Preview",
+        "dismiss": "Not now",
+        "title": "File projects under their own names",
+        "description": "Each document is renamed one at a time so the [[wiki links]] pointing at it are repointed too. Nothing is overwritten: a destination that already exists is skipped and left for you.",
+        "nothingToMove": "Nothing to move.",
+        "skipped": "Left alone ({count}):",
+        "convert": "Convert {count} document(s)",
+        "done": "Moved {count} document(s). Restart the gateway to pick up the new layout.",
+        "restartHint": "Restart the gateway afterwards."
       }
     },
     "activity": {
@@ -5016,6 +5028,18 @@
       "scriptsOn": "Scripts are running for this document.",
       "enableScripts": "Enable scripts",
       "disableScripts": "Disable scripts"
+    },
+    "flatten": {
+      "notice": "Every project here sits inside a folder called projects/.",
+      "preview": "Preview",
+      "dismiss": "Not now",
+      "title": "File projects under their own names",
+      "description": "Each document is renamed one at a time so the [[wiki links]] pointing at it are repointed too. Nothing is overwritten: a destination that already exists is skipped and left for you.",
+      "nothingToMove": "Nothing to move.",
+      "skipped": "Left alone ({count}):",
+      "convert": "Convert {count}",
+      "done": "Moved {count} document(s). Restart the gateway to pick up the new layout.",
+      "restartHint": "Restart the gateway afterwards."
     }
   },
   "dataExport": {

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -2873,7 +2873,11 @@
         "scriptsOn": "Scripts are running for this document.",
         "enableScripts": "Enable scripts",
         "disableScripts": "Disable scripts"
-      }
+      },
+      "save": "Save",
+      "saveTitle": "Save this document (⌘S / Ctrl+S)",
+      "lineNumbers": "Lines",
+      "lineNumbersTitle": "Show line numbers. Long lines stop wrapping while this is on."
     },
     "export": {
       "title": "Export data",
@@ -5026,14 +5030,16 @@
     "editor": {
       "markdownHint": "Markdown, or HTML if the file ends .html…",
       "saving": "Saving…",
-      "autosave": "Auto-saves as you type",
+      "autosave": "Saved",
       "loadFailedApi": "Load failed: {error}",
       "loadFailedGeneric": "Load failed: {error}",
       "saveFailedApi": "Save failed: {error}",
       "saveFailedGeneric": "Save failed: {error}",
       "savedAt": "Saved {time}",
       "showPreview": "Preview",
-      "showSource": "Source"
+      "showSource": "Source",
+      "save": "Save",
+      "unsaved": "Unsaved changes"
     },
     "html": {
       "scriptsOff": "Scripts are off — this document is rendered as static HTML.",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -254,7 +254,7 @@
           "noDocs": "No project docs in this vault folder yet.",
           "createFailed": "Could not create doc",
           "mappingTitle": "Bind project vault folder",
-          "mappingHelp": "Pick the vault folder that holds this project's notes. Vault-relative, e.g. projects/my-app. Leave empty to use the auto-derived default.",
+          "mappingHelp": "Pick the vault folder that holds this project's notes. Vault-relative. Leave empty to use the default shown in the field.",
           "sessionCwd": "Session cwd",
           "folderLabel": "Vault folder",
           "mappingStoredHint": "Stored in the vault at .opendray-projects.json, so it syncs with your notes.",
@@ -1029,7 +1029,8 @@
         "title": "No note selected",
         "hint": "Pick a note from the tree on the left, jump straight to today's daily log, or create a fresh one. AI-written project docs live under <1>projects/</1>; your personal scratchpads under <3>personal/</3>.",
         "today": "Today's daily note",
-        "new": "New note"
+        "new": "New note",
+        "hintFlat": "Pick a note from the tree on the left, jump straight to today's daily log, or create a fresh one. Each project's docs live in a folder named after it, with your own scratchpad as <1>personal.md</1> inside it."
       },
       "picker": {
         "browseAria": "Browse folders",
@@ -5001,7 +5002,7 @@
     "createFailedApi": "Create failed: {error}",
     "createFailedGeneric": "Create failed: {error}",
     "pathLabel": "Vault-relative path",
-    "pathHint": "personal/scratch.md",
+    "pathHint": "my-project/scratch.md",
     "create": "Create",
     "popupDelete": "Delete",
     "deleteBody": "This is irreversible. Vault git sync will remove the file on the gateway host too.",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1198,6 +1198,17 @@
         "convert": "Convert {count} document(s)",
         "done": "Moved {count} document(s). Restart the gateway to pick up the new layout.",
         "restartHint": "Restart the gateway afterwards."
+      },
+      "doc": {
+        "rename": "Rename",
+        "renamePrompt": "New path for this document (folders are created as needed):",
+        "renamed": "Renamed. {count} link(s) repointed.",
+        "renamedWithWarning": "Renamed, but the links were not all updated",
+        "renameFailed": "Rename failed",
+        "delete": "Delete",
+        "deleteConfirm": "Delete {path}? This cannot be undone from here.",
+        "deleted": "Document deleted",
+        "deleteFailed": "Delete failed"
       }
     },
     "activity": {
@@ -5041,6 +5052,13 @@
       "convert": "Convert {count}",
       "done": "Moved {count} document(s). Restart the gateway to pick up the new layout.",
       "restartHint": "Restart the gateway afterwards."
+    },
+    "rename": {
+      "action": "Rename",
+      "title": "Rename document",
+      "helper": "Vault-relative path. Folders are created as needed.",
+      "doneSnack": "Renamed. {count} link(s) repointed.",
+      "doneWithWarning": "Renamed, but the links were not all updated"
     }
   },
   "dataExport": {

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -2873,7 +2873,11 @@
         "scriptsOn": "Los scripts de este documento se están ejecutando.",
         "enableScripts": "Activar scripts",
         "disableScripts": "Desactivar scripts"
-      }
+      },
+      "save": "Guardar",
+      "saveTitle": "Guardar este documento (⌘S / Ctrl+S)",
+      "lineNumbers": "Líneas",
+      "lineNumbersTitle": "Mostrar números de línea. Con esto activo las líneas largas dejan de ajustarse."
     },
     "export": {
       "title": "Exportar datos",
@@ -5026,14 +5030,16 @@
     "editor": {
       "markdownHint": "Markdown, o HTML si el archivo termina en .html…",
       "saving": "Guardando…",
-      "autosave": "Se guarda automáticamente mientras escribes",
+      "autosave": "Guardado",
       "loadFailedApi": "Error al cargar: {error}",
       "loadFailedGeneric": "Error al cargar: {error}",
       "saveFailedApi": "Error al guardar: {error}",
       "saveFailedGeneric": "Error al guardar: {error}",
       "savedAt": "Guardado {time}",
       "showPreview": "Vista previa",
-      "showSource": "Código"
+      "showSource": "Código",
+      "save": "Guardar",
+      "unsaved": "Cambios sin guardar"
     },
     "html": {
       "scriptsOff": "Scripts desactivados: este documento se renderiza como HTML estático.",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -1185,6 +1185,18 @@
         "tooltipAutoOn": " · sincronización automática activada",
         "tooltipLastError": " · último error: {error}",
         "branchPlaceholder": "—"
+      },
+      "flatten": {
+        "notice": "Cada proyecto de esta bóveda está dentro de una carpeta llamada projects/. Pueden archivarse con su propio nombre.",
+        "preview": "Vista previa",
+        "dismiss": "Ahora no",
+        "title": "Archivar los proyectos con su propio nombre",
+        "description": "Cada documento se renombra de uno en uno para que los [[enlaces wiki]] que apuntan a él también se actualicen. Nada se sobrescribe: si el destino ya existe, se omite y se deja intacto.",
+        "nothingToMove": "No hay nada que mover.",
+        "skipped": "Sin tocar ({count}):",
+        "convert": "Convertir {count} documento(s)",
+        "done": "Se movieron {count} documento(s). Reinicia la pasarela para aplicar la nueva estructura.",
+        "restartHint": "Reinicia la pasarela después."
       }
     },
     "activity": {
@@ -5016,6 +5028,18 @@
       "scriptsOn": "Los scripts de este documento se están ejecutando.",
       "enableScripts": "Activar scripts",
       "disableScripts": "Desactivar scripts"
+    },
+    "flatten": {
+      "notice": "Cada proyecto está dentro de una carpeta llamada projects/.",
+      "preview": "Vista previa",
+      "dismiss": "Ahora no",
+      "title": "Archivar los proyectos con su propio nombre",
+      "description": "Cada documento se renombra de uno en uno para que los [[enlaces wiki]] que apuntan a él también se actualicen. Nada se sobrescribe: si el destino ya existe, se omite y se deja intacto.",
+      "nothingToMove": "No hay nada que mover.",
+      "skipped": "Sin tocar ({count}):",
+      "convert": "Convertir {count}",
+      "done": "Se movieron {count} documento(s). Reinicia la pasarela para aplicar la nueva estructura.",
+      "restartHint": "Reinicia la pasarela después."
     }
   },
   "dataExport": {

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -254,7 +254,7 @@
           "noDocs": "Aún no hay docs del proyecto en esta carpeta de la bóveda.",
           "createFailed": "No se pudo crear el doc",
           "mappingTitle": "Vincular carpeta de bóveda del proyecto",
-          "mappingHelp": "Elige la carpeta de la bóveda que contiene las notas de este proyecto. Relativa a la bóveda, p. ej. projects/my-app. Déjalo vacío para usar el valor por defecto.",
+          "mappingHelp": "Elige la carpeta de la bóveda que contiene las notas de este proyecto. Relativa a la bóveda. Déjalo vacío para usar el valor por defecto que se muestra en el campo.",
           "sessionCwd": "cwd de la sesión",
           "folderLabel": "Carpeta de la bóveda",
           "mappingStoredHint": "Se guarda en la bóveda en .opendray-projects.json, así se sincroniza con tus notas.",
@@ -1029,7 +1029,8 @@
         "title": "Ninguna nota seleccionada",
         "hint": "Elige una nota del árbol de la izquierda, ve directo al registro diario de hoy o crea una nueva. Los docs de proyecto escritos por la IA viven en <1>projects/</1>; tus borradores personales en <3>personal/</3>.",
         "today": "Nota diaria de hoy",
-        "new": "Nueva nota"
+        "new": "Nueva nota",
+        "hintFlat": "Elige una nota del árbol de la izquierda, ve directo al registro diario de hoy o crea una nueva. Los docs de cada proyecto viven en una carpeta con su nombre, y tu borrador personal es <1>personal.md</1> dentro de ella."
       },
       "picker": {
         "browseAria": "Explorar carpetas",
@@ -5001,7 +5002,7 @@
     "createFailedApi": "Error al crear: {error}",
     "createFailedGeneric": "Error al crear: {error}",
     "pathLabel": "Ruta relativa al vault",
-    "pathHint": "personal/scratch.md",
+    "pathHint": "mi-proyecto/borrador.md",
     "create": "Crear",
     "popupDelete": "Eliminar",
     "deleteBody": "Esto es irreversible. La sincronización git del vault también eliminará el archivo en el host del gateway.",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -1198,6 +1198,17 @@
         "convert": "Convertir {count} documento(s)",
         "done": "Se movieron {count} documento(s). Reinicia la pasarela para aplicar la nueva estructura.",
         "restartHint": "Reinicia la pasarela después."
+      },
+      "doc": {
+        "rename": "Renombrar",
+        "renamePrompt": "Nueva ruta para este documento (las carpetas se crean solas):",
+        "renamed": "Renombrado. {count} enlace(s) actualizados.",
+        "renamedWithWarning": "Renombrado, pero no se actualizaron todos los enlaces",
+        "renameFailed": "No se pudo renombrar",
+        "delete": "Eliminar",
+        "deleteConfirm": "¿Eliminar {path}? Esto no se puede deshacer desde aquí.",
+        "deleted": "Documento eliminado",
+        "deleteFailed": "No se pudo eliminar"
       }
     },
     "activity": {
@@ -5041,6 +5052,13 @@
       "convert": "Convertir {count}",
       "done": "Se movieron {count} documento(s). Reinicia la pasarela para aplicar la nueva estructura.",
       "restartHint": "Reinicia la pasarela después."
+    },
+    "rename": {
+      "action": "Renombrar",
+      "title": "Renombrar documento",
+      "helper": "Ruta relativa a la bóveda. Las carpetas se crean solas.",
+      "doneSnack": "Renombrado. {count} enlace(s) actualizados.",
+      "doneWithWarning": "Renombrado, pero no se actualizaron todos los enlaces"
     }
   },
   "dataExport": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -1195,6 +1195,17 @@
         "convert": "转换 {count} 个文档",
         "done": "已移动 {count} 个文档。重启网关后生效。",
         "restartHint": "完成后请重启网关。"
+      },
+      "doc": {
+        "rename": "重命名",
+        "renamePrompt": "这个文档的新路径（目录会自动创建）：",
+        "renamed": "已重命名，{count} 个链接已改写。",
+        "renamedWithWarning": "已重命名，但链接没有全部更新",
+        "renameFailed": "重命名失败",
+        "delete": "删除",
+        "deleteConfirm": "删除 {path}？此处无法撤销。",
+        "deleted": "文档已删除",
+        "deleteFailed": "删除失败"
       }
     },
     "activity": {
@@ -5038,6 +5049,13 @@
       "convert": "转换 {count} 个",
       "done": "已移动 {count} 个文档。重启网关后生效。",
       "restartHint": "完成后请重启网关。"
+    },
+    "rename": {
+      "action": "重命名",
+      "title": "重命名文档",
+      "helper": "文档库相对路径。目录会自动创建。",
+      "doneSnack": "已重命名，{count} 个链接已改写。",
+      "doneWithWarning": "已重命名，但链接没有全部更新"
     }
   },
   "dataExport": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -2870,7 +2870,11 @@
         "scriptsOn": "这篇文档的脚本正在运行。",
         "enableScripts": "启用脚本",
         "disableScripts": "禁用脚本"
-      }
+      },
+      "save": "保存",
+      "saveTitle": "保存此文档（⌘S / Ctrl+S）",
+      "lineNumbers": "行号",
+      "lineNumbersTitle": "显示行号。开启时长行不再折行。"
     },
     "export": {
       "title": "导出数据",
@@ -5023,14 +5027,16 @@
     "editor": {
       "markdownHint": "Markdown;文件名以 .html 结尾则写 HTML…",
       "saving": "保存中…",
-      "autosave": "随输入自动保存",
+      "autosave": "已保存",
       "loadFailedApi": "加载失败：{error}",
       "loadFailedGeneric": "加载失败：{error}",
       "saveFailedApi": "保存失败：{error}",
       "saveFailedGeneric": "保存失败：{error}",
       "savedAt": "{time} 已保存",
       "showPreview": "预览",
-      "showSource": "源码"
+      "showSource": "源码",
+      "save": "保存",
+      "unsaved": "有未保存的修改"
     },
     "html": {
       "scriptsOff": "脚本已禁用 —— 这篇文档按静态 HTML 渲染。",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -254,7 +254,7 @@
           "noDocs": "该文档库文件夹下暂无项目文档。",
           "createFailed": "无法创建文档",
           "mappingTitle": "绑定项目文档库文件夹",
-          "mappingHelp": "选择存放本项目笔记的文档库文件夹。文档库相对路径，例如 projects/my-app。留空则使用自动推导的默认值。",
+          "mappingHelp": "选择存放本项目笔记的文档库文件夹。文档库相对路径。留空则使用输入框中显示的默认值。",
           "sessionCwd": "会话工作目录",
           "folderLabel": "文档库文件夹",
           "mappingStoredHint": "保存在文档库的 .opendray-projects.json 中，会随笔记一起同步。",
@@ -1029,7 +1029,8 @@
         "title": "未选择笔记",
         "hint": "从左侧目录树挑选一条笔记，直接跳到今天的日志，或新建一条。AI 生成的项目文档位于 <1>projects/</1>；个人草稿位于 <3>personal/</3>。",
         "today": "今天的日志笔记",
-        "new": "新建笔记"
+        "new": "新建笔记",
+        "hintFlat": "从左侧目录树挑选一条笔记，直接跳到今天的日志，或新建一条。每个项目的文档都在以它命名的文件夹里，你自己的草稿是其中的 <1>personal.md</1>。"
       },
       "picker": {
         "browseAria": "浏览文件夹",
@@ -4998,7 +4999,7 @@
     "createFailedApi": "创建失败：{error}",
     "createFailedGeneric": "创建失败：{error}",
     "pathLabel": "相对仓库的路径",
-    "pathHint": "personal/scratch.md",
+    "pathHint": "我的项目/草稿.md",
     "create": "创建",
     "popupDelete": "删除",
     "deleteBody": "此操作不可撤销。仓库的 git 同步会同时移除网关主机上的文件。",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -1182,6 +1182,18 @@
         "tooltipAutoOn": " · 自动同步已开启",
         "tooltipLastError": " · 上次错误：{error}",
         "branchPlaceholder": "—"
+      },
+      "flatten": {
+        "notice": "这个文档库里的每个项目都装在一个叫 projects/ 的目录里。它们可以直接用项目名归档。",
+        "preview": "预览",
+        "dismiss": "暂不",
+        "title": "用项目名归档项目文档",
+        "description": "文档会逐个改名,指向它的 [[wiki 链接]] 也会一并改写。不会覆盖任何东西:目标已存在的会跳过并原样留下。",
+        "nothingToMove": "没有需要移动的文件。",
+        "skipped": "未处理({count}):",
+        "convert": "转换 {count} 个文档",
+        "done": "已移动 {count} 个文档。重启网关后生效。",
+        "restartHint": "完成后请重启网关。"
       }
     },
     "activity": {
@@ -5013,6 +5025,18 @@
       "scriptsOn": "这篇文档的脚本正在运行。",
       "enableScripts": "启用脚本",
       "disableScripts": "禁用脚本"
+    },
+    "flatten": {
+      "notice": "这里每个项目都装在一个叫 projects/ 的目录里。",
+      "preview": "预览",
+      "dismiss": "暂不",
+      "title": "用项目名归档项目文档",
+      "description": "文档会逐个改名,指向它的 [[wiki 链接]] 也会一并改写。不会覆盖任何东西:目标已存在的会跳过并原样留下。",
+      "nothingToMove": "没有需要移动的文件。",
+      "skipped": "未处理({count}):",
+      "convert": "转换 {count} 个",
+      "done": "已移动 {count} 个文档。重启网关后生效。",
+      "restartHint": "完成后请重启网关。"
     }
   },
   "dataExport": {

--- a/app/mobile/lib/core/api/notes_api.dart
+++ b/app/mobile/lib/core/api/notes_api.dart
@@ -93,18 +93,85 @@ class NotesInfo {
     required this.root,
     required this.personalPrefix,
     required this.projectsPrefix,
+    this.layout = '',
+    this.flattenable = false,
   });
 
   factory NotesInfo.fromJson(Map<String, dynamic> json) => NotesInfo(
         root: json['root'] as String? ?? '',
         personalPrefix: json['personal_prefix'] as String? ?? '',
         projectsPrefix: json['projects_prefix'] as String? ?? '',
+        layout: json['layout'] as String? ?? '',
+        flattenable: json['flattenable'] as bool? ?? false,
       );
 
   // Absolute filesystem path of the vault root.
   final String root;
   final String personalPrefix;
   final String projectsPrefix;
+
+  /// "flat" files each project at the vault root under its own name;
+  /// "nested" uses the prefixes above. Empty on an older gateway.
+  final String layout;
+
+  /// True when this vault still nests projects AND has something the
+  /// conversion would move — the phone offers it rather than leaving
+  /// the migration to whoever happens to read the release notes.
+  final bool flattenable;
+}
+
+/// One document the flatten migration would move, or did.
+class FlattenMove {
+  FlattenMove({required this.from, required this.to, this.linksRewritten = 0});
+
+  factory FlattenMove.fromJson(Map<String, dynamic> json) => FlattenMove(
+        from: json['from'] as String? ?? '',
+        to: json['to'] as String? ?? '',
+        linksRewritten: json['links_rewritten'] as int? ?? 0,
+      );
+
+  final String from;
+  final String to;
+  final int linksRewritten;
+}
+
+/// A document the migration refused to touch, with the reason stated
+/// in the operator's terms. Surface it — do not summarise it away.
+class FlattenSkip {
+  FlattenSkip({required this.path, required this.reason});
+
+  factory FlattenSkip.fromJson(Map<String, dynamic> json) => FlattenSkip(
+        path: json['path'] as String? ?? '',
+        reason: json['reason'] as String? ?? '',
+      );
+
+  final String path;
+  final String reason;
+}
+
+class FlattenResult {
+  FlattenResult({
+    required this.moves,
+    required this.skips,
+    required this.dryRun,
+    this.mappingsRewritten = 0,
+  });
+
+  factory FlattenResult.fromJson(Map<String, dynamic> json) => FlattenResult(
+        moves: (json['moves'] as List<dynamic>? ?? [])
+            .map((e) => FlattenMove.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        skips: (json['skips'] as List<dynamic>? ?? [])
+            .map((e) => FlattenSkip.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        dryRun: json['dry_run'] as bool? ?? true,
+        mappingsRewritten: json['mappings_rewritten'] as int? ?? 0,
+      );
+
+  final List<FlattenMove> moves;
+  final List<FlattenSkip> skips;
+  final bool dryRun;
+  final int mappingsRewritten;
 }
 
 class NotesApi {
@@ -156,6 +223,22 @@ class NotesApi {
         queryParameters: {'cwd': cwd},
       );
       return ProjectMapping.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // POST /api/v1/notes/flatten — preview or perform the nested → flat
+  // conversion. `apply` defaults to false and must be passed
+  // explicitly: this renames every project document in the vault, so
+  // looking and rewriting are not one field apart.
+  Future<FlattenResult> flatten({bool apply = false}) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/notes/flatten',
+        data: {'apply': apply},
+      );
+      return FlattenResult.fromJson(res.data ?? {});
     } on Object catch (e) {
       throw toApiException(e);
     }

--- a/app/mobile/lib/core/api/notes_api.dart
+++ b/app/mobile/lib/core/api/notes_api.dart
@@ -62,6 +62,7 @@ class ProjectMapping {
     required this.path,
     required this.defaultPath,
     required this.custom,
+    this.personalPath = '',
   });
 
   factory ProjectMapping.fromJson(Map<String, dynamic> json) => ProjectMapping(
@@ -69,6 +70,7 @@ class ProjectMapping {
         path: json['path'] as String? ?? '',
         defaultPath: json['default_path'] as String? ?? '',
         custom: json['custom'] as bool? ?? false,
+        personalPath: json['personal_path'] as String? ?? '',
       );
 
   // Absolute filesystem path resolved as the vault folder for the
@@ -77,6 +79,13 @@ class ProjectMapping {
   final String path;
   final String defaultPath;
   final bool custom;
+
+  /// Where this cwd's personal scratchpad belongs, resolved by the
+  /// gateway. It depends on the vault layout — flat keeps it inside the
+  /// project directory, so a project override moves it too — which is
+  /// why the phone does not work it out itself. Empty when talking to a
+  /// gateway that predates the field.
+  final String personalPath;
 }
 
 class NotesInfo {

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 13299 (4433 per locale)
+/// Strings: 13317 (4439 per locale)
 ///
-/// Built on 2026-08-09 at 12:37 UTC
+/// Built on 2026-08-09 at 12:55 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 13257 (4419 per locale)
+/// Strings: 13299 (4433 per locale)
 ///
-/// Built on 2026-08-09 at 12:23 UTC
+/// Built on 2026-08-09 at 12:37 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 13194 (4398 per locale)
+/// Strings: 13254 (4418 per locale)
 ///
-/// Built on 2026-08-08 at 15:53 UTC
+/// Built on 2026-08-09 at 02:43 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 13254 (4418 per locale)
+/// Strings: 13257 (4419 per locale)
 ///
-/// Built on 2026-08-09 at 02:43 UTC
+/// Built on 2026-08-09 at 12:23 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -1927,8 +1927,8 @@ class TranslationsNotesPageEn {
 	/// en: 'Vault-relative path'
 	String get pathLabel => 'Vault-relative path';
 
-	/// en: 'personal/scratch.md'
-	String get pathHint => 'personal/scratch.md';
+	/// en: 'my-project/scratch.md'
+	String get pathHint => 'my-project/scratch.md';
 
 	/// en: 'Create'
 	String get create => 'Create';
@@ -8020,6 +8020,9 @@ class TranslationsWebNotesEmptyEn {
 
 	/// en: 'New note'
 	String get kNew => 'New note';
+
+	/// en: 'Pick a note from the tree on the left, jump straight to today's daily log, or create a fresh one. Each project's docs live in a folder named after it, with your own scratchpad as <1>personal.md</1> inside it.'
+	String get hintFlat => 'Pick a note from the tree on the left, jump straight to today\'s daily log, or create a fresh one. Each project\'s docs live in a folder named after it, with your own scratchpad as <1>personal.md</1> inside it.';
 }
 
 // Path: web.notes.picker
@@ -14770,8 +14773,8 @@ class TranslationsWebSessionsInspectorVaultPanelEn {
 	/// en: 'Bind project vault folder'
 	String get mappingTitle => 'Bind project vault folder';
 
-	/// en: 'Pick the vault folder that holds this project's notes. Vault-relative, e.g. projects/my-app. Leave empty to use the auto-derived default.'
-	String get mappingHelp => 'Pick the vault folder that holds this project\'s notes. Vault-relative, e.g. projects/my-app. Leave empty to use the auto-derived default.';
+	/// en: 'Pick the vault folder that holds this project's notes. Vault-relative. Leave empty to use the default shown in the field.'
+	String get mappingHelp => 'Pick the vault folder that holds this project\'s notes. Vault-relative. Leave empty to use the default shown in the field.';
 
 	/// en: 'Session cwd'
 	String get sessionCwd => 'Session cwd';
@@ -19079,7 +19082,7 @@ extension on Translations {
 			'web.sessions.inspector.vaultPanel.noDocs' => 'No project docs in this vault folder yet.',
 			'web.sessions.inspector.vaultPanel.createFailed' => 'Could not create doc',
 			'web.sessions.inspector.vaultPanel.mappingTitle' => 'Bind project vault folder',
-			'web.sessions.inspector.vaultPanel.mappingHelp' => 'Pick the vault folder that holds this project\'s notes. Vault-relative, e.g. projects/my-app. Leave empty to use the auto-derived default.',
+			'web.sessions.inspector.vaultPanel.mappingHelp' => 'Pick the vault folder that holds this project\'s notes. Vault-relative. Leave empty to use the default shown in the field.',
 			'web.sessions.inspector.vaultPanel.sessionCwd' => 'Session cwd',
 			'web.sessions.inspector.vaultPanel.folderLabel' => 'Vault folder',
 			'web.sessions.inspector.vaultPanel.mappingStoredHint' => 'Stored in the vault at .opendray-projects.json, so it syncs with your notes.',
@@ -19710,6 +19713,7 @@ extension on Translations {
 			'web.notes.empty.hint' => 'Pick a note from the tree on the left, jump straight to today\'s daily log, or create a fresh one. AI-written project docs live under <1>projects/</1>; your personal scratchpads under <3>personal/</3>.',
 			'web.notes.empty.today' => 'Today\'s daily note',
 			'web.notes.empty.kNew' => 'New note',
+			'web.notes.empty.hintFlat' => 'Pick a note from the tree on the left, jump straight to today\'s daily log, or create a fresh one. Each project\'s docs live in a folder named after it, with your own scratchpad as <1>personal.md</1> inside it.',
 			'web.notes.picker.browseAria' => 'Browse folders',
 			'web.notes.picker.matches_one' => ({required Object count}) => '${count} match',
 			'web.notes.picker.matches_other' => ({required Object count}) => '${count} matches',
@@ -19883,9 +19887,9 @@ extension on Translations {
 			'web.activity.empty.stepCallEndpoint' => 'Call any endpoint, e.g. <1>POST /api/v1/sessions</1>',
 			'web.activity.empty.stepAppears' => 'Calls appear here within seconds',
 			'web.activity.empty.footnote' => 'Calls you make from this admin UI are not logged — only integration-attributed traffic is recorded.',
-			'web.activity.events.loading' => 'Loading events…',
 			_ => null,
 		} ?? switch (path) {
+			'web.activity.events.loading' => 'Loading events…',
 			'web.activity.events.empty' => 'No events yet.',
 			'web.activity.events.emptyFiltered' => 'No matching events.',
 			'web.activity.events.loadOlder' => 'Load older events',
@@ -20397,9 +20401,9 @@ extension on Translations {
 			'web.plugins.gitHosts.dialog.verifyButton' => 'Verify',
 			'web.plugins.gitHosts.dialog.verifying' => 'Checking…',
 			'web.plugins.gitHosts.dialog.verifyLogin' => ({required Object login}) => 'Authenticated as ${login}',
-			'web.plugins.gitHosts.dialog.verifyRepoOk' => ({required Object repo}) => 'can read ${repo}',
 			_ => null,
 		} ?? switch (path) {
+			'web.plugins.gitHosts.dialog.verifyRepoOk' => ({required Object repo}) => 'can read ${repo}',
 			'web.plugins.gitHosts.dialog.verifyRepoFail' => ({required Object repo}) => 'CANNOT read ${repo}',
 			'web.plugins.gitHosts.dialog.verifyPushOk' => 'can push',
 			'web.plugins.gitHosts.dialog.verifyPushDenied' => 'CANNOT push (read-only)',
@@ -20911,9 +20915,9 @@ extension on Translations {
 			'web.serverSettings.layout.mcp' => 'MCP registry',
 			'web.serverSettings.layout.legacyWarning' => 'This install still keeps opendray\'s own directories inside your documents, so they show up in the Vault and get carried along by a sync. They keep working — move them out and set the paths above when convenient. Anything already committed needs git rm --cached; opendray will not rewrite your repo.',
 			'web.settings.title' => 'Settings',
-			'web.settings.subtitle' => 'Workspace, account, and gateway config.',
 			_ => null,
 		} ?? switch (path) {
+			'web.settings.subtitle' => 'Workspace, account, and gateway config.',
 			'web.settings.groups.workspace' => 'Workspace',
 			'web.settings.groups.server' => 'Server',
 			'web.settings.groups.system' => 'System',
@@ -21425,9 +21429,9 @@ extension on Translations {
 			'web.cortex.quarantine.promoteHint' => 'Move into durable memory (joins recall + consolidation)',
 			'web.cortex.quarantine.discard' => 'Discard',
 			'web.cortex.quarantine.promotedToast' => 'Promoted to durable memory',
-			'web.cortex.quarantine.discardedToast' => 'Discarded',
 			_ => null,
 		} ?? switch (path) {
+			'web.cortex.quarantine.discardedToast' => 'Discarded',
 			'web.cortex.quarantine.actionFailed' => 'Action failed',
 			'web.cortex.quarantine.expires' => ({required Object date}) => 'expires ${date}',
 			'web.cortex.settings.injection.title' => 'Spawn injection',
@@ -21939,9 +21943,9 @@ extension on Translations {
 			'sessions.inspector.canvas.newCanvasTitle' => 'New canvas',
 			'sessions.inspector.canvas.newCanvasBlurb' => 'Pick what to draw above, then describe it below — the agent renders the new canvas here.',
 			'sessions.inspector.canvas.setWorkspace' => 'Work on this',
-			'sessions.inspector.canvas.workspaceSet' => 'The agent is now working on this canvas.',
 			_ => null,
 		} ?? switch (path) {
+			'sessions.inspector.canvas.workspaceSet' => 'The agent is now working on this canvas.',
 			'sessions.inspector.canvas.previewOnlyHint' => 'Previewing only — tap "Work on this" to point the agent at it.',
 			'sessions.inspector.canvas.designTitle' => 'Design system',
 			'sessions.inspector.canvas.designBlurb' => 'Tokens + rules every canvas follows',
@@ -22453,9 +22457,9 @@ extension on Translations {
 			'backups.wizard.saveNowBody' => 'This is shown ONCE. It will not be retrievable from opendray afterwards.',
 			'backups.overviewTargets' => 'Targets',
 			'backups.overviewSchedules' => 'Schedules',
-			'backups.overviewBackups' => 'Backups',
 			_ => null,
 		} ?? switch (path) {
+			'backups.overviewBackups' => 'Backups',
 			'backups.health.headlineHealthy' => 'Backups healthy',
 			'backups.health.headlineAttention' => 'Needs attention',
 			'backups.health.headlineNever' => 'No backups yet',
@@ -22877,7 +22881,7 @@ extension on Translations {
 			'notesPage.createFailedApi' => ({required Object error}) => 'Create failed: ${error}',
 			'notesPage.createFailedGeneric' => ({required Object error}) => 'Create failed: ${error}',
 			'notesPage.pathLabel' => 'Vault-relative path',
-			'notesPage.pathHint' => 'personal/scratch.md',
+			'notesPage.pathHint' => 'my-project/scratch.md',
 			'notesPage.create' => 'Create',
 			'notesPage.popupDelete' => 'Delete',
 			'notesPage.deleteBody' => 'This is irreversible. Vault git sync will remove the file on the gateway host too.',
@@ -22967,9 +22971,9 @@ extension on Translations {
 			'dataExport.import.customTasksLabel' => 'Custom tasks',
 			'dataExport.import.importBundle' => 'Import bundle',
 			'dataExport.import.importing' => 'Importing…',
-			'dataExport.import.pickFileToast' => 'Pick a bundle file first.',
 			_ => null,
 		} ?? switch (path) {
+			'dataExport.import.pickFileToast' => 'Pick a bundle file first.',
 			'dataExport.import.doneToast' => 'Import done',
 			'dataExport.import.finishedWithErrors' => 'Import finished with errors',
 			'dataExport.import.failedToast' => ({required Object error}) => 'Import failed: ${error}',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -1959,6 +1959,7 @@ class TranslationsNotesPageEn {
 
 	late final TranslationsNotesPageEditorEn editor = TranslationsNotesPageEditorEn.internal(_root);
 	late final TranslationsNotesPageHtmlEn html = TranslationsNotesPageHtmlEn.internal(_root);
+	late final TranslationsNotesPageFlattenEn flatten = TranslationsNotesPageFlattenEn.internal(_root);
 }
 
 // Path: dataExport
@@ -2937,6 +2938,7 @@ class TranslationsWebNotesEn {
 	late final TranslationsWebNotesPickerEn picker = TranslationsWebNotesPickerEn.internal(_root);
 	late final TranslationsWebNotesVaultSyncEn vaultSync = TranslationsWebNotesVaultSyncEn.internal(_root);
 	late final TranslationsWebNotesSyncBadgeEn syncBadge = TranslationsWebNotesSyncBadgeEn.internal(_root);
+	late final TranslationsWebNotesFlattenEn flatten = TranslationsWebNotesFlattenEn.internal(_root);
 }
 
 // Path: web.activity
@@ -5424,6 +5426,45 @@ class TranslationsNotesPageHtmlEn {
 
 	/// en: 'Disable scripts'
 	String get disableScripts => 'Disable scripts';
+}
+
+// Path: notesPage.flatten
+class TranslationsNotesPageFlattenEn {
+	TranslationsNotesPageFlattenEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Every project here sits inside a folder called projects/.'
+	String get notice => 'Every project here sits inside a folder called projects/.';
+
+	/// en: 'Preview'
+	String get preview => 'Preview';
+
+	/// en: 'Not now'
+	String get dismiss => 'Not now';
+
+	/// en: 'File projects under their own names'
+	String get title => 'File projects under their own names';
+
+	/// en: 'Each document is renamed one at a time so the [[wiki links]] pointing at it are repointed too. Nothing is overwritten: a destination that already exists is skipped and left for you.'
+	String get description => 'Each document is renamed one at a time so the [[wiki links]] pointing at it are repointed too. Nothing is overwritten: a destination that already exists is skipped and left for you.';
+
+	/// en: 'Nothing to move.'
+	String get nothingToMove => 'Nothing to move.';
+
+	/// en: 'Left alone ({count}):'
+	String skipped({required Object count}) => 'Left alone (${count}):';
+
+	/// en: 'Convert {count}'
+	String convert({required Object count}) => 'Convert ${count}';
+
+	/// en: 'Moved {count} document(s). Restart the gateway to pick up the new layout.'
+	String done({required Object count}) => 'Moved ${count} document(s). Restart the gateway to pick up the new layout.';
+
+	/// en: 'Restart the gateway afterwards.'
+	String get restartHint => 'Restart the gateway afterwards.';
 }
 
 // Path: dataExport.sections
@@ -8074,6 +8115,45 @@ class TranslationsWebNotesSyncBadgeEn {
 
 	/// en: '—'
 	String get branchPlaceholder => '—';
+}
+
+// Path: web.notes.flatten
+class TranslationsWebNotesFlattenEn {
+	TranslationsWebNotesFlattenEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Every project in this vault sits inside a folder called projects/. They can be filed under their own names instead.'
+	String get notice => 'Every project in this vault sits inside a folder called projects/. They can be filed under their own names instead.';
+
+	/// en: 'Preview'
+	String get preview => 'Preview';
+
+	/// en: 'Not now'
+	String get dismiss => 'Not now';
+
+	/// en: 'File projects under their own names'
+	String get title => 'File projects under their own names';
+
+	/// en: 'Each document is renamed one at a time so the [[wiki links]] pointing at it are repointed too. Nothing is overwritten: a destination that already exists is skipped and left for you.'
+	String get description => 'Each document is renamed one at a time so the [[wiki links]] pointing at it are repointed too. Nothing is overwritten: a destination that already exists is skipped and left for you.';
+
+	/// en: 'Nothing to move.'
+	String get nothingToMove => 'Nothing to move.';
+
+	/// en: 'Left alone ({count}):'
+	String skipped({required Object count}) => 'Left alone (${count}):';
+
+	/// en: 'Convert {count} document(s)'
+	String convert({required Object count}) => 'Convert ${count} document(s)';
+
+	/// en: 'Moved {count} document(s). Restart the gateway to pick up the new layout.'
+	String done({required Object count}) => 'Moved ${count} document(s). Restart the gateway to pick up the new layout.';
+
+	/// en: 'Restart the gateway afterwards.'
+	String get restartHint => 'Restart the gateway afterwards.';
 }
 
 // Path: web.activity.filters
@@ -19757,6 +19837,16 @@ extension on Translations {
 			'web.notes.syncBadge.tooltipAutoOn' => ' · auto-sync on',
 			'web.notes.syncBadge.tooltipLastError' => ({required Object error}) => ' · last error: ${error}',
 			'web.notes.syncBadge.branchPlaceholder' => '—',
+			'web.notes.flatten.notice' => 'Every project in this vault sits inside a folder called projects/. They can be filed under their own names instead.',
+			'web.notes.flatten.preview' => 'Preview',
+			'web.notes.flatten.dismiss' => 'Not now',
+			'web.notes.flatten.title' => 'File projects under their own names',
+			'web.notes.flatten.description' => 'Each document is renamed one at a time so the [[wiki links]] pointing at it are repointed too. Nothing is overwritten: a destination that already exists is skipped and left for you.',
+			'web.notes.flatten.nothingToMove' => 'Nothing to move.',
+			'web.notes.flatten.skipped' => ({required Object count}) => 'Left alone (${count}):',
+			'web.notes.flatten.convert' => ({required Object count}) => 'Convert ${count} document(s)',
+			'web.notes.flatten.done' => ({required Object count}) => 'Moved ${count} document(s). Restart the gateway to pick up the new layout.',
+			'web.notes.flatten.restartHint' => 'Restart the gateway afterwards.',
 			'web.activity.title' => 'Activity',
 			'web.activity.subtitle' => 'Per-call audit of API requests made by registered integrations. Includes both inbound calls (a third-party app calling opendray with its API key) and outbound proxied calls (admin → opendray proxy → integration). Calls made directly by this admin UI are not recorded.',
 			'web.activity.refresh' => 'Refresh',
@@ -19794,6 +19884,8 @@ extension on Translations {
 			'web.activity.empty.stepAppears' => 'Calls appear here within seconds',
 			'web.activity.empty.footnote' => 'Calls you make from this admin UI are not logged — only integration-attributed traffic is recorded.',
 			'web.activity.events.loading' => 'Loading events…',
+			_ => null,
+		} ?? switch (path) {
 			'web.activity.events.empty' => 'No events yet.',
 			'web.activity.events.emptyFiltered' => 'No matching events.',
 			'web.activity.events.loadOlder' => 'Load older events',
@@ -19804,8 +19896,6 @@ extension on Translations {
 			'web.providers.list.disabledBadge' => 'disabled',
 			'web.providers.list.noneSelected' => 'No provider selected.',
 			'web.providers.detail.enabled' => 'Enabled',
-			_ => null,
-		} ?? switch (path) {
 			'web.providers.detail.disabled' => 'Disabled',
 			'web.providers.detail.toggleAria' => ({required Object name}) => 'Toggle ${name}',
 			'web.providers.detail.configuration' => 'Configuration',
@@ -20308,6 +20398,8 @@ extension on Translations {
 			'web.plugins.gitHosts.dialog.verifying' => 'Checking…',
 			'web.plugins.gitHosts.dialog.verifyLogin' => ({required Object login}) => 'Authenticated as ${login}',
 			'web.plugins.gitHosts.dialog.verifyRepoOk' => ({required Object repo}) => 'can read ${repo}',
+			_ => null,
+		} ?? switch (path) {
 			'web.plugins.gitHosts.dialog.verifyRepoFail' => ({required Object repo}) => 'CANNOT read ${repo}',
 			'web.plugins.gitHosts.dialog.verifyPushOk' => 'can push',
 			'web.plugins.gitHosts.dialog.verifyPushDenied' => 'CANNOT push (read-only)',
@@ -20318,8 +20410,6 @@ extension on Translations {
 			'web.backups.exportData' => 'Export data',
 			'web.backups.loading' => 'Loading…',
 			'web.backups.loadStatusFailedToast' => 'Failed to load backup status',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.tabs.backups' => 'Backups',
 			'web.backups.tabs.schedules' => 'Schedules',
 			'web.backups.tabs.targets' => 'Targets',
@@ -20822,6 +20912,8 @@ extension on Translations {
 			'web.serverSettings.layout.legacyWarning' => 'This install still keeps opendray\'s own directories inside your documents, so they show up in the Vault and get carried along by a sync. They keep working — move them out and set the paths above when convenient. Anything already committed needs git rm --cached; opendray will not rewrite your repo.',
 			'web.settings.title' => 'Settings',
 			'web.settings.subtitle' => 'Workspace, account, and gateway config.',
+			_ => null,
+		} ?? switch (path) {
 			'web.settings.groups.workspace' => 'Workspace',
 			'web.settings.groups.server' => 'Server',
 			'web.settings.groups.system' => 'System',
@@ -20832,8 +20924,6 @@ extension on Translations {
 			'web.settings.items.about' => 'About',
 			'web.settings.health.connecting' => 'connecting…',
 			'web.settings.health.dbOk' => 'db ok',
-			_ => null,
-		} ?? switch (path) {
 			'web.settings.health.dbDown' => 'db down',
 			'web.settings.breadcrumb.server' => 'Server',
 			'web.settings.appearance.title' => 'Appearance',
@@ -21336,6 +21426,8 @@ extension on Translations {
 			'web.cortex.quarantine.discard' => 'Discard',
 			'web.cortex.quarantine.promotedToast' => 'Promoted to durable memory',
 			'web.cortex.quarantine.discardedToast' => 'Discarded',
+			_ => null,
+		} ?? switch (path) {
 			'web.cortex.quarantine.actionFailed' => 'Action failed',
 			'web.cortex.quarantine.expires' => ({required Object date}) => 'expires ${date}',
 			'web.cortex.settings.injection.title' => 'Spawn injection',
@@ -21346,8 +21438,6 @@ extension on Translations {
 			'web.cortex.settings.injection.mode.full.label' => 'Full — inject everything',
 			'web.cortex.settings.injection.mode.full.description' => 'Inject every inject-flagged section and knowledge page in full at spawn (legacy behaviour). Simple, but costs tokens on every session and crowds the context window.',
 			'web.cortex.settings.injection.savedToast' => 'Injection mode saved — new sessions use it immediately (no backend restart)',
-			_ => null,
-		} ?? switch (path) {
 			'web.cortex.settings.injection.saveFailed' => 'Save failed',
 			'web.cortex.settings.injection.note' => 'Per-section and per-page inject flags (blueprint editor / knowledge pages) still apply in full mode; in lean mode foundational rules always inject and everything else is indexed.',
 			'web.database.dialog.createTitle' => 'Add database connection',
@@ -21850,6 +21940,8 @@ extension on Translations {
 			'sessions.inspector.canvas.newCanvasBlurb' => 'Pick what to draw above, then describe it below — the agent renders the new canvas here.',
 			'sessions.inspector.canvas.setWorkspace' => 'Work on this',
 			'sessions.inspector.canvas.workspaceSet' => 'The agent is now working on this canvas.',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.previewOnlyHint' => 'Previewing only — tap "Work on this" to point the agent at it.',
 			'sessions.inspector.canvas.designTitle' => 'Design system',
 			'sessions.inspector.canvas.designBlurb' => 'Tokens + rules every canvas follows',
@@ -21860,8 +21952,6 @@ extension on Translations {
 			'sessions.inspector.canvas.designSaved' => 'Design system saved.',
 			'sessions.inspector.canvas.designWarningAchromatic' => 'Every colour here resolves to a grey — canvases will have no brand colour. If this project uses shadcn/ui, its --primary is an ink; put the brand hue (usually --accent) in Primary.',
 			'sessions.inspector.canvas.tokenPrimary' => 'Primary',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.canvas.tokenSecondary' => 'Secondary',
 			'sessions.inspector.canvas.tokenBackground' => 'Background',
 			'sessions.inspector.canvas.tokenSurface' => 'Surface',
@@ -22364,6 +22454,8 @@ extension on Translations {
 			'backups.overviewTargets' => 'Targets',
 			'backups.overviewSchedules' => 'Schedules',
 			'backups.overviewBackups' => 'Backups',
+			_ => null,
+		} ?? switch (path) {
 			'backups.health.headlineHealthy' => 'Backups healthy',
 			'backups.health.headlineAttention' => 'Needs attention',
 			'backups.health.headlineNever' => 'No backups yet',
@@ -22374,8 +22466,6 @@ extension on Translations {
 			'backups.health.tiles.overdue' => 'Overdue',
 			'backups.health.tiles.schedules' => 'Schedules',
 			'backups.failedToLoad' => 'Failed to load backups',
-			_ => null,
-		} ?? switch (path) {
 			'backups.envVarConfigured' => 'OPENDRAY_BACKUP_KEY env var',
 			'backups.savedConfirmCheckbox' => 'I have saved this passphrase to my password manager',
 			'backups.pgDumpMissing' => 'pg_dump is not on PATH. Install postgresql-client and restart opendray.',
@@ -22811,6 +22901,16 @@ extension on Translations {
 			'notesPage.html.scriptsOn' => 'Scripts are running for this document.',
 			'notesPage.html.enableScripts' => 'Enable scripts',
 			'notesPage.html.disableScripts' => 'Disable scripts',
+			'notesPage.flatten.notice' => 'Every project here sits inside a folder called projects/.',
+			'notesPage.flatten.preview' => 'Preview',
+			'notesPage.flatten.dismiss' => 'Not now',
+			'notesPage.flatten.title' => 'File projects under their own names',
+			'notesPage.flatten.description' => 'Each document is renamed one at a time so the [[wiki links]] pointing at it are repointed too. Nothing is overwritten: a destination that already exists is skipped and left for you.',
+			'notesPage.flatten.nothingToMove' => 'Nothing to move.',
+			'notesPage.flatten.skipped' => ({required Object count}) => 'Left alone (${count}):',
+			'notesPage.flatten.convert' => ({required Object count}) => 'Convert ${count}',
+			'notesPage.flatten.done' => ({required Object count}) => 'Moved ${count} document(s). Restart the gateway to pick up the new layout.',
+			'notesPage.flatten.restartHint' => 'Restart the gateway afterwards.',
 			'dataExport.title' => 'Data export & import',
 			'dataExport.subtitle' => 'User-level bundles for migration or verification — separate from /backups (disaster recovery).',
 			'dataExport.sections.export' => 'Export',
@@ -22868,6 +22968,8 @@ extension on Translations {
 			'dataExport.import.importBundle' => 'Import bundle',
 			'dataExport.import.importing' => 'Importing…',
 			'dataExport.import.pickFileToast' => 'Pick a bundle file first.',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.import.doneToast' => 'Import done',
 			'dataExport.import.finishedWithErrors' => 'Import finished with errors',
 			'dataExport.import.failedToast' => ({required Object error}) => 'Import failed: ${error}',
@@ -22888,8 +22990,6 @@ extension on Translations {
 			'dataExport.imports.columns.source' => 'Source',
 			'dataExport.imports.columns.counts' => 'Counts',
 			'dataExport.imports.columns.when' => 'When',
-			_ => null,
-		} ?? switch (path) {
 			'dataExport.relative.inSeconds' => ({required Object n}) => 'in ${n}s',
 			'dataExport.relative.inMinutes' => ({required Object n}) => 'in ${n}m',
 			'dataExport.relative.inHours' => ({required Object n}) => 'in ${n}h',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -3359,6 +3359,18 @@ class TranslationsWebNoteEditorEn {
 
 	late final TranslationsWebNoteEditorStatusEn status = TranslationsWebNoteEditorStatusEn.internal(_root);
 	late final TranslationsWebNoteEditorHtmlEn html = TranslationsWebNoteEditorHtmlEn.internal(_root);
+
+	/// en: 'Save'
+	String get save => 'Save';
+
+	/// en: 'Save this document (⌘S / Ctrl+S)'
+	String get saveTitle => 'Save this document (⌘S / Ctrl+S)';
+
+	/// en: 'Lines'
+	String get lineNumbers => 'Lines';
+
+	/// en: 'Show line numbers. Long lines stop wrapping while this is on.'
+	String get lineNumbersTitle => 'Show line numbers. Long lines stop wrapping while this is on.';
 }
 
 // Path: web.export
@@ -5384,8 +5396,8 @@ class TranslationsNotesPageEditorEn {
 	/// en: 'Saving…'
 	String get saving => 'Saving…';
 
-	/// en: 'Auto-saves as you type'
-	String get autosave => 'Auto-saves as you type';
+	/// en: 'Saved'
+	String get autosave => 'Saved';
 
 	/// en: 'Load failed: {error}'
 	String loadFailedApi({required Object error}) => 'Load failed: ${error}';
@@ -5407,6 +5419,12 @@ class TranslationsNotesPageEditorEn {
 
 	/// en: 'Source'
 	String get showSource => 'Source';
+
+	/// en: 'Save'
+	String get save => 'Save';
+
+	/// en: 'Unsaved changes'
+	String get unsaved => 'Unsaved changes';
 }
 
 // Path: notesPage.html
@@ -21198,6 +21216,10 @@ extension on Translations {
 			'web.noteEditor.html.scriptsOn' => 'Scripts are running for this document.',
 			'web.noteEditor.html.enableScripts' => 'Enable scripts',
 			'web.noteEditor.html.disableScripts' => 'Disable scripts',
+			'web.noteEditor.save' => 'Save',
+			'web.noteEditor.saveTitle' => 'Save this document (⌘S / Ctrl+S)',
+			'web.noteEditor.lineNumbers' => 'Lines',
+			'web.noteEditor.lineNumbersTitle' => 'Show line numbers. Long lines stop wrapping while this is on.',
 			'web.export.title' => 'Export data',
 			'web.export.subtitle' => 'Take a one-shot zip bundle of selected logical entities. Bundles are kept on the server for 24 hours, then automatically reaped.',
 			'web.export.backToBackups' => '← Backups',
@@ -21487,12 +21509,12 @@ extension on Translations {
 			'web.cortex.blueprint.reserved' => 'reserved',
 			'web.cortex.blueprint.deleteNote' => 'Removing a section hides it without deleting its content — re-add the same slug to resurrect it.',
 			'web.cortex.blueprint.cancel' => 'Cancel',
+			_ => null,
+		} ?? switch (path) {
 			'web.cortex.blueprint.apply' => 'Apply blueprint',
 			'web.cortex.blueprint.applyFailed' => 'Apply failed',
 			'web.cortex.blueprint.appliedToast' => 'Blueprint applied',
 			'web.cortex.blueprint.writePolicy.direct' => 'Direct write',
-			_ => null,
-		} ?? switch (path) {
 			'web.cortex.blueprint.writePolicy.proposal' => 'Proposal',
 			'web.cortex.blueprint.writePolicy.hint' => 'Direct: the in-session agent writes the live doc when unlocked. Proposal: the agent\'s writes file an approval request first.',
 			'web.cortex.quarantine.title' => 'Quarantine',
@@ -22001,12 +22023,12 @@ extension on Translations {
 			'sessions.inspector.canvas.emptyBlurb' => 'Ask the agent for a screen, a flowchart, a mind map or a relationship diagram — it renders here and you can pin and annotate it.',
 			'sessions.inspector.canvas.viewportPhone' => 'Phone width',
 			'sessions.inspector.canvas.viewportTablet' => 'Tablet width',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.viewportDesktop' => 'Desktop width',
 			'sessions.inspector.canvas.openFull' => 'Open full screen',
 			'sessions.inspector.canvas.confirm' => 'Confirm',
 			'sessions.inspector.canvas.captured' => ({required Object what}) => 'Captured: ${what}',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.canvas.notes' => 'Notes',
 			'sessions.inspector.canvas.clear' => 'Clear marks',
 			'sessions.inspector.canvas.done' => 'Done',
@@ -22515,12 +22537,12 @@ extension on Translations {
 			'backups.emptyNoBackups.body' => 'Tap "Run now" to take a fresh snapshot, or open Schedules to set up recurring runs.',
 			'backups.restartToActivate' => 'Restart opendray to activate backups',
 			'backups.passphraseSaved' => 'Your passphrase is saved. The gateway only loads it at startup, so changes only take effect after a restart.',
+			_ => null,
+		} ?? switch (path) {
 			'backups.keyFileLabel' => 'Key file',
 			'backups.configuredViaLabel' => 'Configured via',
 			'backups.wizard.title' => 'Set up backups',
 			'backups.wizard.intro' => 'Choose a master passphrase. opendray uses it to encrypt every backup blob with AES-256-GCM. Lose the passphrase and you lose the data — there is no recovery.',
-			_ => null,
-		} ?? switch (path) {
 			'backups.wizard.saving' => 'Saving…',
 			'backups.wizard.generateAndSave' => 'Generate and save',
 			'backups.wizard.savePassphrase' => 'Save passphrase',
@@ -22964,7 +22986,7 @@ extension on Translations {
 			'notesPage.pathHelper' => 'Auto-appends .md if missing.',
 			'notesPage.editor.markdownHint' => 'Markdown, or HTML if the file ends .html…',
 			'notesPage.editor.saving' => 'Saving…',
-			'notesPage.editor.autosave' => 'Auto-saves as you type',
+			'notesPage.editor.autosave' => 'Saved',
 			'notesPage.editor.loadFailedApi' => ({required Object error}) => 'Load failed: ${error}',
 			'notesPage.editor.loadFailedGeneric' => ({required Object error}) => 'Load failed: ${error}',
 			'notesPage.editor.saveFailedApi' => ({required Object error}) => 'Save failed: ${error}',
@@ -22972,6 +22994,8 @@ extension on Translations {
 			'notesPage.editor.savedAt' => ({required Object time}) => 'Saved ${time}',
 			'notesPage.editor.showPreview' => 'Preview',
 			'notesPage.editor.showSource' => 'Source',
+			'notesPage.editor.save' => 'Save',
+			'notesPage.editor.unsaved' => 'Unsaved changes',
 			'notesPage.html.scriptsOff' => 'Scripts are off — this document is rendered as static HTML.',
 			'notesPage.html.scriptsOn' => 'Scripts are running for this document.',
 			'notesPage.html.enableScripts' => 'Enable scripts',
@@ -23027,14 +23051,14 @@ extension on Translations {
 			'dataExport.history.deleteConfirmTitle' => 'Delete export?',
 			'dataExport.history.deleteConfirmBody' => ({required Object id}) => 'Removes the bundle and revokes the download token. ${id}',
 			'dataExport.history.download' => 'Download',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.history.delete' => 'Delete',
 			'dataExport.history.downloadCopiedToast' => 'Download URL copied to clipboard. Paste into a browser to fetch (single-use).',
 			'dataExport.history.columns.scope' => 'Scope',
 			'dataExport.history.columns.size' => 'Size',
 			'dataExport.history.columns.expires' => 'Expires',
 			'dataExport.history.columns.actions' => 'Actions',
-			_ => null,
-		} ?? switch (path) {
 			'dataExport.history.scopeEmpty' => '(empty)',
 			'dataExport.history.scopeMemories' => 'memories',
 			'dataExport.history.scopeIntegrations' => ({required Object mode}) => 'integrations(${mode})',

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -1960,6 +1960,7 @@ class TranslationsNotesPageEn {
 	late final TranslationsNotesPageEditorEn editor = TranslationsNotesPageEditorEn.internal(_root);
 	late final TranslationsNotesPageHtmlEn html = TranslationsNotesPageHtmlEn.internal(_root);
 	late final TranslationsNotesPageFlattenEn flatten = TranslationsNotesPageFlattenEn.internal(_root);
+	late final TranslationsNotesPageRenameEn rename = TranslationsNotesPageRenameEn.internal(_root);
 }
 
 // Path: dataExport
@@ -2939,6 +2940,7 @@ class TranslationsWebNotesEn {
 	late final TranslationsWebNotesVaultSyncEn vaultSync = TranslationsWebNotesVaultSyncEn.internal(_root);
 	late final TranslationsWebNotesSyncBadgeEn syncBadge = TranslationsWebNotesSyncBadgeEn.internal(_root);
 	late final TranslationsWebNotesFlattenEn flatten = TranslationsWebNotesFlattenEn.internal(_root);
+	late final TranslationsWebNotesDocEn doc = TranslationsWebNotesDocEn.internal(_root);
 }
 
 // Path: web.activity
@@ -5465,6 +5467,30 @@ class TranslationsNotesPageFlattenEn {
 
 	/// en: 'Restart the gateway afterwards.'
 	String get restartHint => 'Restart the gateway afterwards.';
+}
+
+// Path: notesPage.rename
+class TranslationsNotesPageRenameEn {
+	TranslationsNotesPageRenameEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Rename'
+	String get action => 'Rename';
+
+	/// en: 'Rename document'
+	String get title => 'Rename document';
+
+	/// en: 'Vault-relative path. Folders are created as needed.'
+	String get helper => 'Vault-relative path. Folders are created as needed.';
+
+	/// en: 'Renamed. {count} link(s) repointed.'
+	String doneSnack({required Object count}) => 'Renamed. ${count} link(s) repointed.';
+
+	/// en: 'Renamed, but the links were not all updated'
+	String get doneWithWarning => 'Renamed, but the links were not all updated';
 }
 
 // Path: dataExport.sections
@@ -8157,6 +8183,42 @@ class TranslationsWebNotesFlattenEn {
 
 	/// en: 'Restart the gateway afterwards.'
 	String get restartHint => 'Restart the gateway afterwards.';
+}
+
+// Path: web.notes.doc
+class TranslationsWebNotesDocEn {
+	TranslationsWebNotesDocEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Rename'
+	String get rename => 'Rename';
+
+	/// en: 'New path for this document (folders are created as needed):'
+	String get renamePrompt => 'New path for this document (folders are created as needed):';
+
+	/// en: 'Renamed. {count} link(s) repointed.'
+	String renamed({required Object count}) => 'Renamed. ${count} link(s) repointed.';
+
+	/// en: 'Renamed, but the links were not all updated'
+	String get renamedWithWarning => 'Renamed, but the links were not all updated';
+
+	/// en: 'Rename failed'
+	String get renameFailed => 'Rename failed';
+
+	/// en: 'Delete'
+	String get delete => 'Delete';
+
+	/// en: 'Delete {path}? This cannot be undone from here.'
+	String deleteConfirm({required Object path}) => 'Delete ${path}? This cannot be undone from here.';
+
+	/// en: 'Document deleted'
+	String get deleted => 'Document deleted';
+
+	/// en: 'Delete failed'
+	String get deleteFailed => 'Delete failed';
 }
 
 // Path: web.activity.filters
@@ -19851,6 +19913,15 @@ extension on Translations {
 			'web.notes.flatten.convert' => ({required Object count}) => 'Convert ${count} document(s)',
 			'web.notes.flatten.done' => ({required Object count}) => 'Moved ${count} document(s). Restart the gateway to pick up the new layout.',
 			'web.notes.flatten.restartHint' => 'Restart the gateway afterwards.',
+			'web.notes.doc.rename' => 'Rename',
+			'web.notes.doc.renamePrompt' => 'New path for this document (folders are created as needed):',
+			'web.notes.doc.renamed' => ({required Object count}) => 'Renamed. ${count} link(s) repointed.',
+			'web.notes.doc.renamedWithWarning' => 'Renamed, but the links were not all updated',
+			'web.notes.doc.renameFailed' => 'Rename failed',
+			'web.notes.doc.delete' => 'Delete',
+			'web.notes.doc.deleteConfirm' => ({required Object path}) => 'Delete ${path}? This cannot be undone from here.',
+			'web.notes.doc.deleted' => 'Document deleted',
+			'web.notes.doc.deleteFailed' => 'Delete failed',
 			'web.activity.title' => 'Activity',
 			'web.activity.subtitle' => 'Per-call audit of API requests made by registered integrations. Includes both inbound calls (a third-party app calling opendray with its API key) and outbound proxied calls (admin → opendray proxy → integration). Calls made directly by this admin UI are not recorded.',
 			'web.activity.refresh' => 'Refresh',
@@ -19878,6 +19949,8 @@ extension on Translations {
 			'web.activity.table.status' => 'Status',
 			'web.activity.table.duration' => 'Duration',
 			'web.activity.table.inboundAria' => 'inbound',
+			_ => null,
+		} ?? switch (path) {
 			'web.activity.table.outboundAria' => 'outbound',
 			'web.activity.empty.filtered' => 'No calls match these filters.',
 			'web.activity.empty.title' => 'No API calls recorded yet',
@@ -19887,8 +19960,6 @@ extension on Translations {
 			'web.activity.empty.stepCallEndpoint' => 'Call any endpoint, e.g. <1>POST /api/v1/sessions</1>',
 			'web.activity.empty.stepAppears' => 'Calls appear here within seconds',
 			'web.activity.empty.footnote' => 'Calls you make from this admin UI are not logged — only integration-attributed traffic is recorded.',
-			_ => null,
-		} ?? switch (path) {
 			'web.activity.events.loading' => 'Loading events…',
 			'web.activity.events.empty' => 'No events yet.',
 			'web.activity.events.emptyFiltered' => 'No matching events.',
@@ -20392,6 +20463,8 @@ extension on Translations {
 			'web.plugins.gitHosts.dialog.addFailedToast' => 'Add failed',
 			'web.plugins.gitHosts.dialog.updateFailedToast' => 'Update failed',
 			'web.plugins.gitHosts.dialog.ownerLabel' => 'Owner (optional)',
+			_ => null,
+		} ?? switch (path) {
 			'web.plugins.gitHosts.dialog.ownerPlaceholder' => 'my-org',
 			'web.plugins.gitHosts.dialog.ownerHintHostWide' => 'Leave empty for a host-wide credential: used for every repo on this host that has no owner-specific entry.',
 			'web.plugins.gitHosts.dialog.ownerHintScoped' => ({required Object host, required Object owner}) => 'Used only for ${host}/${owner}/… — other owners on this host fall back to the host-wide entry. Add this when a fine-grained token is granted to one account or org.',
@@ -20401,8 +20474,6 @@ extension on Translations {
 			'web.plugins.gitHosts.dialog.verifyButton' => 'Verify',
 			'web.plugins.gitHosts.dialog.verifying' => 'Checking…',
 			'web.plugins.gitHosts.dialog.verifyLogin' => ({required Object login}) => 'Authenticated as ${login}',
-			_ => null,
-		} ?? switch (path) {
 			'web.plugins.gitHosts.dialog.verifyRepoOk' => ({required Object repo}) => 'can read ${repo}',
 			'web.plugins.gitHosts.dialog.verifyRepoFail' => ({required Object repo}) => 'CANNOT read ${repo}',
 			'web.plugins.gitHosts.dialog.verifyPushOk' => 'can push',
@@ -20906,6 +20977,8 @@ extension on Translations {
 			'web.serverSettings.host.modes.on_demand.desc' => 'The machine sleeps whenever the gateway is quiet. An incoming request wakes it, and opendray holds it awake while serving, then lets it sleep again.',
 			'web.serverSettings.host.modes.on_demand.caveat' => 'Needs "Wake for network access" (sudo pmset -a womp 1), reliably wired Ethernet. The first request after a sleep takes a few seconds and may need one retry.',
 			'web.serverSettings.host.modes.off.label' => 'Never touch power settings',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.host.modes.off.desc' => 'opendray leaves the machine alone entirely.',
 			'web.serverSettings.host.modes.off.caveat' => 'The gateway is unreachable whenever the host sleeps, unless something else keeps it awake.',
 			'web.serverSettings.layout.title' => 'Resolving to',
@@ -20915,8 +20988,6 @@ extension on Translations {
 			'web.serverSettings.layout.mcp' => 'MCP registry',
 			'web.serverSettings.layout.legacyWarning' => 'This install still keeps opendray\'s own directories inside your documents, so they show up in the Vault and get carried along by a sync. They keep working — move them out and set the paths above when convenient. Anything already committed needs git rm --cached; opendray will not rewrite your repo.',
 			'web.settings.title' => 'Settings',
-			_ => null,
-		} ?? switch (path) {
 			'web.settings.subtitle' => 'Workspace, account, and gateway config.',
 			'web.settings.groups.workspace' => 'Workspace',
 			'web.settings.groups.server' => 'Server',
@@ -21420,6 +21491,8 @@ extension on Translations {
 			'web.cortex.blueprint.applyFailed' => 'Apply failed',
 			'web.cortex.blueprint.appliedToast' => 'Blueprint applied',
 			'web.cortex.blueprint.writePolicy.direct' => 'Direct write',
+			_ => null,
+		} ?? switch (path) {
 			'web.cortex.blueprint.writePolicy.proposal' => 'Proposal',
 			'web.cortex.blueprint.writePolicy.hint' => 'Direct: the in-session agent writes the live doc when unlocked. Proposal: the agent\'s writes file an approval request first.',
 			'web.cortex.quarantine.title' => 'Quarantine',
@@ -21429,8 +21502,6 @@ extension on Translations {
 			'web.cortex.quarantine.promoteHint' => 'Move into durable memory (joins recall + consolidation)',
 			'web.cortex.quarantine.discard' => 'Discard',
 			'web.cortex.quarantine.promotedToast' => 'Promoted to durable memory',
-			_ => null,
-		} ?? switch (path) {
 			'web.cortex.quarantine.discardedToast' => 'Discarded',
 			'web.cortex.quarantine.actionFailed' => 'Action failed',
 			'web.cortex.quarantine.expires' => ({required Object date}) => 'expires ${date}',
@@ -21934,6 +22005,8 @@ extension on Translations {
 			'sessions.inspector.canvas.openFull' => 'Open full screen',
 			'sessions.inspector.canvas.confirm' => 'Confirm',
 			'sessions.inspector.canvas.captured' => ({required Object what}) => 'Captured: ${what}',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.notes' => 'Notes',
 			'sessions.inspector.canvas.clear' => 'Clear marks',
 			'sessions.inspector.canvas.done' => 'Done',
@@ -21943,8 +22016,6 @@ extension on Translations {
 			'sessions.inspector.canvas.newCanvasTitle' => 'New canvas',
 			'sessions.inspector.canvas.newCanvasBlurb' => 'Pick what to draw above, then describe it below — the agent renders the new canvas here.',
 			'sessions.inspector.canvas.setWorkspace' => 'Work on this',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.canvas.workspaceSet' => 'The agent is now working on this canvas.',
 			'sessions.inspector.canvas.previewOnlyHint' => 'Previewing only — tap "Work on this" to point the agent at it.',
 			'sessions.inspector.canvas.designTitle' => 'Design system',
@@ -22448,6 +22519,8 @@ extension on Translations {
 			'backups.configuredViaLabel' => 'Configured via',
 			'backups.wizard.title' => 'Set up backups',
 			'backups.wizard.intro' => 'Choose a master passphrase. opendray uses it to encrypt every backup blob with AES-256-GCM. Lose the passphrase and you lose the data — there is no recovery.',
+			_ => null,
+		} ?? switch (path) {
 			'backups.wizard.saving' => 'Saving…',
 			'backups.wizard.generateAndSave' => 'Generate and save',
 			'backups.wizard.savePassphrase' => 'Save passphrase',
@@ -22457,8 +22530,6 @@ extension on Translations {
 			'backups.wizard.saveNowBody' => 'This is shown ONCE. It will not be retrievable from opendray afterwards.',
 			'backups.overviewTargets' => 'Targets',
 			'backups.overviewSchedules' => 'Schedules',
-			_ => null,
-		} ?? switch (path) {
 			'backups.overviewBackups' => 'Backups',
 			'backups.health.headlineHealthy' => 'Backups healthy',
 			'backups.health.headlineAttention' => 'Needs attention',
@@ -22915,6 +22986,11 @@ extension on Translations {
 			'notesPage.flatten.convert' => ({required Object count}) => 'Convert ${count}',
 			'notesPage.flatten.done' => ({required Object count}) => 'Moved ${count} document(s). Restart the gateway to pick up the new layout.',
 			'notesPage.flatten.restartHint' => 'Restart the gateway afterwards.',
+			'notesPage.rename.action' => 'Rename',
+			'notesPage.rename.title' => 'Rename document',
+			'notesPage.rename.helper' => 'Vault-relative path. Folders are created as needed.',
+			'notesPage.rename.doneSnack' => ({required Object count}) => 'Renamed. ${count} link(s) repointed.',
+			'notesPage.rename.doneWithWarning' => 'Renamed, but the links were not all updated',
 			'dataExport.title' => 'Data export & import',
 			'dataExport.subtitle' => 'User-level bundles for migration or verification — separate from /backups (disaster recovery).',
 			'dataExport.sections.export' => 'Export',
@@ -22957,6 +23033,8 @@ extension on Translations {
 			'dataExport.history.columns.size' => 'Size',
 			'dataExport.history.columns.expires' => 'Expires',
 			'dataExport.history.columns.actions' => 'Actions',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.history.scopeEmpty' => '(empty)',
 			'dataExport.history.scopeMemories' => 'memories',
 			'dataExport.history.scopeIntegrations' => ({required Object mode}) => 'integrations(${mode})',
@@ -22971,8 +23049,6 @@ extension on Translations {
 			'dataExport.import.customTasksLabel' => 'Custom tasks',
 			'dataExport.import.importBundle' => 'Import bundle',
 			'dataExport.import.importing' => 'Importing…',
-			_ => null,
-		} ?? switch (path) {
 			'dataExport.import.pickFileToast' => 'Pick a bundle file first.',
 			'dataExport.import.doneToast' => 'Import done',
 			'dataExport.import.finishedWithErrors' => 'Import finished with errors',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -893,6 +893,7 @@ class _TranslationsNotesPageEs extends TranslationsNotesPageEn {
 	@override late final _TranslationsNotesPageEditorEs editor = _TranslationsNotesPageEditorEs._(_root);
 	@override late final _TranslationsNotesPageHtmlEs html = _TranslationsNotesPageHtmlEs._(_root);
 	@override late final _TranslationsNotesPageFlattenEs flatten = _TranslationsNotesPageFlattenEs._(_root);
+	@override late final _TranslationsNotesPageRenameEs rename = _TranslationsNotesPageRenameEs._(_root);
 }
 
 // Path: dataExport
@@ -1388,6 +1389,7 @@ class _TranslationsWebNotesEs extends TranslationsWebNotesEn {
 	@override late final _TranslationsWebNotesVaultSyncEs vaultSync = _TranslationsWebNotesVaultSyncEs._(_root);
 	@override late final _TranslationsWebNotesSyncBadgeEs syncBadge = _TranslationsWebNotesSyncBadgeEs._(_root);
 	@override late final _TranslationsWebNotesFlattenEs flatten = _TranslationsWebNotesFlattenEs._(_root);
+	@override late final _TranslationsWebNotesDocEs doc = _TranslationsWebNotesDocEs._(_root);
 }
 
 // Path: web.activity
@@ -2781,6 +2783,20 @@ class _TranslationsNotesPageFlattenEs extends TranslationsNotesPageFlattenEn {
 	@override String convert({required Object count}) => 'Convertir ${count}';
 	@override String done({required Object count}) => 'Se movieron ${count} documento(s). Reinicia la pasarela para aplicar la nueva estructura.';
 	@override String get restartHint => 'Reinicia la pasarela después.';
+}
+
+// Path: notesPage.rename
+class _TranslationsNotesPageRenameEs extends TranslationsNotesPageRenameEn {
+	_TranslationsNotesPageRenameEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get action => 'Renombrar';
+	@override String get title => 'Renombrar documento';
+	@override String get helper => 'Ruta relativa a la bóveda. Las carpetas se crean solas.';
+	@override String doneSnack({required Object count}) => 'Renombrado. ${count} enlace(s) actualizados.';
+	@override String get doneWithWarning => 'Renombrado, pero no se actualizaron todos los enlaces';
 }
 
 // Path: dataExport.sections
@@ -4183,6 +4199,24 @@ class _TranslationsWebNotesFlattenEs extends TranslationsWebNotesFlattenEn {
 	@override String convert({required Object count}) => 'Convertir ${count} documento(s)';
 	@override String done({required Object count}) => 'Se movieron ${count} documento(s). Reinicia la pasarela para aplicar la nueva estructura.';
 	@override String get restartHint => 'Reinicia la pasarela después.';
+}
+
+// Path: web.notes.doc
+class _TranslationsWebNotesDocEs extends TranslationsWebNotesDocEn {
+	_TranslationsWebNotesDocEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get rename => 'Renombrar';
+	@override String get renamePrompt => 'Nueva ruta para este documento (las carpetas se crean solas):';
+	@override String renamed({required Object count}) => 'Renombrado. ${count} enlace(s) actualizados.';
+	@override String get renamedWithWarning => 'Renombrado, pero no se actualizaron todos los enlaces';
+	@override String get renameFailed => 'No se pudo renombrar';
+	@override String get delete => 'Eliminar';
+	@override String deleteConfirm({required Object path}) => '¿Eliminar ${path}? Esto no se puede deshacer desde aquí.';
+	@override String get deleted => 'Documento eliminado';
+	@override String get deleteFailed => 'No se pudo eliminar';
 }
 
 // Path: web.activity.filters
@@ -10889,6 +10923,15 @@ extension on TranslationsEs {
 			'web.notes.flatten.convert' => ({required Object count}) => 'Convertir ${count} documento(s)',
 			'web.notes.flatten.done' => ({required Object count}) => 'Se movieron ${count} documento(s). Reinicia la pasarela para aplicar la nueva estructura.',
 			'web.notes.flatten.restartHint' => 'Reinicia la pasarela después.',
+			'web.notes.doc.rename' => 'Renombrar',
+			'web.notes.doc.renamePrompt' => 'Nueva ruta para este documento (las carpetas se crean solas):',
+			'web.notes.doc.renamed' => ({required Object count}) => 'Renombrado. ${count} enlace(s) actualizados.',
+			'web.notes.doc.renamedWithWarning' => 'Renombrado, pero no se actualizaron todos los enlaces',
+			'web.notes.doc.renameFailed' => 'No se pudo renombrar',
+			'web.notes.doc.delete' => 'Eliminar',
+			'web.notes.doc.deleteConfirm' => ({required Object path}) => '¿Eliminar ${path}? Esto no se puede deshacer desde aquí.',
+			'web.notes.doc.deleted' => 'Documento eliminado',
+			'web.notes.doc.deleteFailed' => 'No se pudo eliminar',
 			'web.activity.title' => 'Actividad',
 			'web.activity.subtitle' => 'Auditoría por llamada de las solicitudes API realizadas por las integraciones registradas. Incluye tanto las llamadas entrantes (una app de terceros que llama a opendray con su clave de API) como las llamadas salientes a través del proxy (admin → proxy de opendray → integración). Las llamadas hechas directamente por esta UI de administración no se registran.',
 			'web.activity.refresh' => 'Actualizar',
@@ -10916,6 +10959,8 @@ extension on TranslationsEs {
 			'web.activity.table.status' => 'Estado',
 			'web.activity.table.duration' => 'Duración',
 			'web.activity.table.inboundAria' => 'entrante',
+			_ => null,
+		} ?? switch (path) {
 			'web.activity.table.outboundAria' => 'saliente',
 			'web.activity.empty.filtered' => 'Ninguna llamada coincide con estos filtros.',
 			'web.activity.empty.title' => 'Aún no se ha registrado ninguna llamada API',
@@ -10925,8 +10970,6 @@ extension on TranslationsEs {
 			'web.activity.empty.stepCallEndpoint' => 'Llama a cualquier endpoint, p. ej. <1>POST /api/v1/sessions</1>',
 			'web.activity.empty.stepAppears' => 'Las llamadas aparecen aquí en cuestión de segundos',
 			'web.activity.empty.footnote' => 'Las llamadas que haces desde esta UI de administración no se registran; solo se registra el tráfico atribuido a integraciones.',
-			_ => null,
-		} ?? switch (path) {
 			'web.activity.events.loading' => 'Cargando eventos…',
 			'web.activity.events.empty' => 'Aún no hay eventos.',
 			'web.activity.events.emptyFiltered' => 'No hay eventos coincidentes.',
@@ -11430,6 +11473,8 @@ extension on TranslationsEs {
 			'web.plugins.gitHosts.dialog.addFailedToast' => 'Error al añadir',
 			'web.plugins.gitHosts.dialog.updateFailedToast' => 'Error al actualizar',
 			'web.plugins.gitHosts.dialog.ownerLabel' => 'Propietario (opcional)',
+			_ => null,
+		} ?? switch (path) {
 			'web.plugins.gitHosts.dialog.ownerPlaceholder' => 'my-org',
 			'web.plugins.gitHosts.dialog.ownerHintHostWide' => 'Déjalo vacío para una credencial de todo el host: se usa en cada repo de este host que no tenga una entrada propia.',
 			'web.plugins.gitHosts.dialog.ownerHintScoped' => ({required Object host, required Object owner}) => 'Se usa solo para ${host}/${owner}/…; los demás propietarios de este host recurren a la entrada de todo el host. Añádelo cuando un token de permisos detallados esté concedido a una cuenta u organización.',
@@ -11439,8 +11484,6 @@ extension on TranslationsEs {
 			'web.plugins.gitHosts.dialog.verifyButton' => 'Verificar',
 			'web.plugins.gitHosts.dialog.verifying' => 'Comprobando…',
 			'web.plugins.gitHosts.dialog.verifyLogin' => ({required Object login}) => 'Autenticado como ${login}',
-			_ => null,
-		} ?? switch (path) {
 			'web.plugins.gitHosts.dialog.verifyRepoOk' => ({required Object repo}) => 'puede leer ${repo}',
 			'web.plugins.gitHosts.dialog.verifyRepoFail' => ({required Object repo}) => 'NO puede leer ${repo}',
 			'web.plugins.gitHosts.dialog.verifyPushOk' => 'puede hacer push',
@@ -11944,6 +11987,8 @@ extension on TranslationsEs {
 			'web.serverSettings.host.modes.on_demand.desc' => 'La máquina duerme siempre que la pasarela está en calma. Una petición entrante la despierta y opendray la mantiene despierta mientras sirve; después vuelve a dormir.',
 			'web.serverSettings.host.modes.on_demand.caveat' => 'Requiere «Activar por acceso de red» (sudo pmset -a womp 1); Ethernet por cable es lo fiable. La primera petición tras dormir tarda unos segundos y puede necesitar un reintento.',
 			'web.serverSettings.host.modes.off.label' => 'No tocar la energía',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.host.modes.off.desc' => 'opendray no interviene en absoluto en la máquina.',
 			'web.serverSettings.host.modes.off.caveat' => 'La pasarela será inaccesible cuando el host duerma, salvo que otra cosa lo mantenga despierto.',
 			'web.serverSettings.layout.title' => 'Se resuelve en',
@@ -11953,8 +11998,6 @@ extension on TranslationsEs {
 			'web.serverSettings.layout.mcp' => 'Registro MCP',
 			'web.serverSettings.layout.legacyWarning' => 'Esta instalación aún mantiene los directorios propios de opendray dentro de tus documentos, así que aparecen en el Vault y la sincronización se los lleva. Siguen funcionando: muévelos fuera y fija las rutas de arriba cuando puedas. Lo ya confirmado requiere git rm --cached; opendray no reescribirá tu repositorio.',
 			'web.settings.title' => 'Ajustes',
-			_ => null,
-		} ?? switch (path) {
 			'web.settings.subtitle' => 'Configuración del espacio de trabajo, la cuenta y el gateway.',
 			'web.settings.groups.workspace' => 'Espacio de trabajo',
 			'web.settings.groups.server' => 'Servidor',
@@ -12458,6 +12501,8 @@ extension on TranslationsEs {
 			'web.cortex.blueprint.applyFailed' => 'Error al aplicar',
 			'web.cortex.blueprint.appliedToast' => 'Plano aplicado',
 			'web.cortex.blueprint.writePolicy.direct' => 'Escritura directa',
+			_ => null,
+		} ?? switch (path) {
 			'web.cortex.blueprint.writePolicy.proposal' => 'Propuesta',
 			'web.cortex.blueprint.writePolicy.hint' => 'Directa: el agente escribe el documento en vivo cuando está desbloqueado. Propuesta: las escrituras del agente requieren tu aprobación primero.',
 			'web.cortex.quarantine.title' => 'Cuarentena',
@@ -12467,8 +12512,6 @@ extension on TranslationsEs {
 			'web.cortex.quarantine.promoteHint' => 'Mover a memoria duradera (entra en la recuperación y consolidación)',
 			'web.cortex.quarantine.discard' => 'Descartar',
 			'web.cortex.quarantine.promotedToast' => 'Promocionada a memoria duradera',
-			_ => null,
-		} ?? switch (path) {
 			'web.cortex.quarantine.discardedToast' => 'Descartada',
 			'web.cortex.quarantine.actionFailed' => 'Acción fallida',
 			'web.cortex.quarantine.expires' => ({required Object date}) => 'expira ${date}',
@@ -12972,6 +13015,8 @@ extension on TranslationsEs {
 			'sessions.inspector.canvas.openFull' => 'Pantalla completa',
 			'sessions.inspector.canvas.confirm' => 'Confirmar',
 			'sessions.inspector.canvas.captured' => ({required Object what}) => 'Capturado: ${what}',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.notes' => 'Notas',
 			'sessions.inspector.canvas.clear' => 'Borrar marcas',
 			'sessions.inspector.canvas.done' => 'Listo',
@@ -12981,8 +13026,6 @@ extension on TranslationsEs {
 			'sessions.inspector.canvas.newCanvasTitle' => 'Nuevo lienzo',
 			'sessions.inspector.canvas.newCanvasBlurb' => 'Elige arriba qué dibujar y descríbelo abajo: el agente renderizará el nuevo lienzo aquí.',
 			'sessions.inspector.canvas.setWorkspace' => 'Trabajar aquí',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.canvas.workspaceSet' => 'El agente ya trabaja en este lienzo.',
 			'sessions.inspector.canvas.previewOnlyHint' => 'Solo vista previa: pulsa «Trabajar aquí» para apuntarlo.',
 			'sessions.inspector.canvas.designTitle' => 'Sistema de diseño',
@@ -13486,6 +13529,8 @@ extension on TranslationsEs {
 			'backups.configuredViaLabel' => 'Configurado mediante',
 			'backups.wizard.title' => 'Configurar copias de seguridad',
 			'backups.wizard.intro' => 'Elige una passphrase maestra. opendray la usa para cifrar cada blob de copia de seguridad con AES-256-GCM. Si pierdes la passphrase, pierdes los datos: no hay forma de recuperarlos.',
+			_ => null,
+		} ?? switch (path) {
 			'backups.wizard.saving' => 'Guardando…',
 			'backups.wizard.generateAndSave' => 'Generar y guardar',
 			'backups.wizard.savePassphrase' => 'Guardar passphrase',
@@ -13495,8 +13540,6 @@ extension on TranslationsEs {
 			'backups.wizard.saveNowBody' => 'Se muestra UNA SOLA VEZ. Después no podrás recuperarla desde opendray.',
 			'backups.overviewTargets' => 'Destinos',
 			'backups.overviewSchedules' => 'Programaciones',
-			_ => null,
-		} ?? switch (path) {
 			'backups.overviewBackups' => 'Copias de seguridad',
 			'backups.health.headlineHealthy' => 'Copias correctas',
 			'backups.health.headlineAttention' => 'Requiere atención',
@@ -13953,6 +13996,11 @@ extension on TranslationsEs {
 			'notesPage.flatten.convert' => ({required Object count}) => 'Convertir ${count}',
 			'notesPage.flatten.done' => ({required Object count}) => 'Se movieron ${count} documento(s). Reinicia la pasarela para aplicar la nueva estructura.',
 			'notesPage.flatten.restartHint' => 'Reinicia la pasarela después.',
+			'notesPage.rename.action' => 'Renombrar',
+			'notesPage.rename.title' => 'Renombrar documento',
+			'notesPage.rename.helper' => 'Ruta relativa a la bóveda. Las carpetas se crean solas.',
+			'notesPage.rename.doneSnack' => ({required Object count}) => 'Renombrado. ${count} enlace(s) actualizados.',
+			'notesPage.rename.doneWithWarning' => 'Renombrado, pero no se actualizaron todos los enlaces',
 			'dataExport.title' => 'Exportación e importación de datos',
 			'dataExport.subtitle' => 'Paquetes a nivel de usuario para migración o verificación, independientes de /backups (recuperación ante desastres).',
 			'dataExport.sections.export' => 'Exportar',
@@ -13995,6 +14043,8 @@ extension on TranslationsEs {
 			'dataExport.history.columns.size' => 'Tamaño',
 			'dataExport.history.columns.expires' => 'Caduca',
 			'dataExport.history.columns.actions' => 'Acciones',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.history.scopeEmpty' => '(vacío)',
 			'dataExport.history.scopeMemories' => 'memorias',
 			'dataExport.history.scopeIntegrations' => ({required Object mode}) => 'integraciones(${mode})',
@@ -14009,8 +14059,6 @@ extension on TranslationsEs {
 			'dataExport.import.customTasksLabel' => 'Tareas personalizadas',
 			'dataExport.import.importBundle' => 'Importar paquete',
 			'dataExport.import.importing' => 'Importando…',
-			_ => null,
-		} ?? switch (path) {
 			'dataExport.import.pickFileToast' => 'Elige primero un archivo de paquete.',
 			'dataExport.import.doneToast' => 'Importación completada',
 			'dataExport.import.finishedWithErrors' => 'Importación finalizada con errores',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -892,6 +892,7 @@ class _TranslationsNotesPageEs extends TranslationsNotesPageEn {
 	@override String get pathHelper => 'Añade .md automáticamente si falta.';
 	@override late final _TranslationsNotesPageEditorEs editor = _TranslationsNotesPageEditorEs._(_root);
 	@override late final _TranslationsNotesPageHtmlEs html = _TranslationsNotesPageHtmlEs._(_root);
+	@override late final _TranslationsNotesPageFlattenEs flatten = _TranslationsNotesPageFlattenEs._(_root);
 }
 
 // Path: dataExport
@@ -1386,6 +1387,7 @@ class _TranslationsWebNotesEs extends TranslationsWebNotesEn {
 	@override late final _TranslationsWebNotesPickerEs picker = _TranslationsWebNotesPickerEs._(_root);
 	@override late final _TranslationsWebNotesVaultSyncEs vaultSync = _TranslationsWebNotesVaultSyncEs._(_root);
 	@override late final _TranslationsWebNotesSyncBadgeEs syncBadge = _TranslationsWebNotesSyncBadgeEs._(_root);
+	@override late final _TranslationsWebNotesFlattenEs flatten = _TranslationsWebNotesFlattenEs._(_root);
 }
 
 // Path: web.activity
@@ -2760,6 +2762,25 @@ class _TranslationsNotesPageHtmlEs extends TranslationsNotesPageHtmlEn {
 	@override String get scriptsOn => 'Los scripts de este documento se están ejecutando.';
 	@override String get enableScripts => 'Activar scripts';
 	@override String get disableScripts => 'Desactivar scripts';
+}
+
+// Path: notesPage.flatten
+class _TranslationsNotesPageFlattenEs extends TranslationsNotesPageFlattenEn {
+	_TranslationsNotesPageFlattenEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get notice => 'Cada proyecto está dentro de una carpeta llamada projects/.';
+	@override String get preview => 'Vista previa';
+	@override String get dismiss => 'Ahora no';
+	@override String get title => 'Archivar los proyectos con su propio nombre';
+	@override String get description => 'Cada documento se renombra de uno en uno para que los [[enlaces wiki]] que apuntan a él también se actualicen. Nada se sobrescribe: si el destino ya existe, se omite y se deja intacto.';
+	@override String get nothingToMove => 'No hay nada que mover.';
+	@override String skipped({required Object count}) => 'Sin tocar (${count}):';
+	@override String convert({required Object count}) => 'Convertir ${count}';
+	@override String done({required Object count}) => 'Se movieron ${count} documento(s). Reinicia la pasarela para aplicar la nueva estructura.';
+	@override String get restartHint => 'Reinicia la pasarela después.';
 }
 
 // Path: dataExport.sections
@@ -4142,6 +4163,25 @@ class _TranslationsWebNotesSyncBadgeEs extends TranslationsWebNotesSyncBadgeEn {
 	@override String get tooltipAutoOn => ' · sincronización automática activada';
 	@override String tooltipLastError({required Object error}) => ' · último error: ${error}';
 	@override String get branchPlaceholder => '—';
+}
+
+// Path: web.notes.flatten
+class _TranslationsWebNotesFlattenEs extends TranslationsWebNotesFlattenEn {
+	_TranslationsWebNotesFlattenEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get notice => 'Cada proyecto de esta bóveda está dentro de una carpeta llamada projects/. Pueden archivarse con su propio nombre.';
+	@override String get preview => 'Vista previa';
+	@override String get dismiss => 'Ahora no';
+	@override String get title => 'Archivar los proyectos con su propio nombre';
+	@override String get description => 'Cada documento se renombra de uno en uno para que los [[enlaces wiki]] que apuntan a él también se actualicen. Nada se sobrescribe: si el destino ya existe, se omite y se deja intacto.';
+	@override String get nothingToMove => 'No hay nada que mover.';
+	@override String skipped({required Object count}) => 'Sin tocar (${count}):';
+	@override String convert({required Object count}) => 'Convertir ${count} documento(s)';
+	@override String done({required Object count}) => 'Se movieron ${count} documento(s). Reinicia la pasarela para aplicar la nueva estructura.';
+	@override String get restartHint => 'Reinicia la pasarela después.';
 }
 
 // Path: web.activity.filters
@@ -10837,6 +10877,16 @@ extension on TranslationsEs {
 			'web.notes.syncBadge.tooltipAutoOn' => ' · sincronización automática activada',
 			'web.notes.syncBadge.tooltipLastError' => ({required Object error}) => ' · último error: ${error}',
 			'web.notes.syncBadge.branchPlaceholder' => '—',
+			'web.notes.flatten.notice' => 'Cada proyecto de esta bóveda está dentro de una carpeta llamada projects/. Pueden archivarse con su propio nombre.',
+			'web.notes.flatten.preview' => 'Vista previa',
+			'web.notes.flatten.dismiss' => 'Ahora no',
+			'web.notes.flatten.title' => 'Archivar los proyectos con su propio nombre',
+			'web.notes.flatten.description' => 'Cada documento se renombra de uno en uno para que los [[enlaces wiki]] que apuntan a él también se actualicen. Nada se sobrescribe: si el destino ya existe, se omite y se deja intacto.',
+			'web.notes.flatten.nothingToMove' => 'No hay nada que mover.',
+			'web.notes.flatten.skipped' => ({required Object count}) => 'Sin tocar (${count}):',
+			'web.notes.flatten.convert' => ({required Object count}) => 'Convertir ${count} documento(s)',
+			'web.notes.flatten.done' => ({required Object count}) => 'Se movieron ${count} documento(s). Reinicia la pasarela para aplicar la nueva estructura.',
+			'web.notes.flatten.restartHint' => 'Reinicia la pasarela después.',
 			'web.activity.title' => 'Actividad',
 			'web.activity.subtitle' => 'Auditoría por llamada de las solicitudes API realizadas por las integraciones registradas. Incluye tanto las llamadas entrantes (una app de terceros que llama a opendray con su clave de API) como las llamadas salientes a través del proxy (admin → proxy de opendray → integración). Las llamadas hechas directamente por esta UI de administración no se registran.',
 			'web.activity.refresh' => 'Actualizar',
@@ -10874,6 +10924,8 @@ extension on TranslationsEs {
 			'web.activity.empty.stepAppears' => 'Las llamadas aparecen aquí en cuestión de segundos',
 			'web.activity.empty.footnote' => 'Las llamadas que haces desde esta UI de administración no se registran; solo se registra el tráfico atribuido a integraciones.',
 			'web.activity.events.loading' => 'Cargando eventos…',
+			_ => null,
+		} ?? switch (path) {
 			'web.activity.events.empty' => 'Aún no hay eventos.',
 			'web.activity.events.emptyFiltered' => 'No hay eventos coincidentes.',
 			'web.activity.events.loadOlder' => 'Cargar eventos anteriores',
@@ -10884,8 +10936,6 @@ extension on TranslationsEs {
 			'web.providers.list.disabledBadge' => 'deshabilitado',
 			'web.providers.list.noneSelected' => 'Ningún proveedor seleccionado.',
 			'web.providers.detail.enabled' => 'Habilitado',
-			_ => null,
-		} ?? switch (path) {
 			'web.providers.detail.disabled' => 'Deshabilitado',
 			'web.providers.detail.toggleAria' => ({required Object name}) => 'Alternar ${name}',
 			'web.providers.detail.configuration' => 'Configuración',
@@ -11388,6 +11438,8 @@ extension on TranslationsEs {
 			'web.plugins.gitHosts.dialog.verifying' => 'Comprobando…',
 			'web.plugins.gitHosts.dialog.verifyLogin' => ({required Object login}) => 'Autenticado como ${login}',
 			'web.plugins.gitHosts.dialog.verifyRepoOk' => ({required Object repo}) => 'puede leer ${repo}',
+			_ => null,
+		} ?? switch (path) {
 			'web.plugins.gitHosts.dialog.verifyRepoFail' => ({required Object repo}) => 'NO puede leer ${repo}',
 			'web.plugins.gitHosts.dialog.verifyPushOk' => 'puede hacer push',
 			'web.plugins.gitHosts.dialog.verifyPushDenied' => 'NO puede hacer push (solo lectura)',
@@ -11398,8 +11450,6 @@ extension on TranslationsEs {
 			'web.backups.exportData' => 'Exportar datos',
 			'web.backups.loading' => 'Cargando…',
 			'web.backups.loadStatusFailedToast' => 'No se pudo cargar el estado de la copia de seguridad',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.tabs.backups' => 'Copias de seguridad',
 			'web.backups.tabs.schedules' => 'Programaciones',
 			'web.backups.tabs.targets' => 'Destinos',
@@ -11902,6 +11952,8 @@ extension on TranslationsEs {
 			'web.serverSettings.layout.legacyWarning' => 'Esta instalación aún mantiene los directorios propios de opendray dentro de tus documentos, así que aparecen en el Vault y la sincronización se los lleva. Siguen funcionando: muévelos fuera y fija las rutas de arriba cuando puedas. Lo ya confirmado requiere git rm --cached; opendray no reescribirá tu repositorio.',
 			'web.settings.title' => 'Ajustes',
 			'web.settings.subtitle' => 'Configuración del espacio de trabajo, la cuenta y el gateway.',
+			_ => null,
+		} ?? switch (path) {
 			'web.settings.groups.workspace' => 'Espacio de trabajo',
 			'web.settings.groups.server' => 'Servidor',
 			'web.settings.groups.system' => 'Sistema',
@@ -11912,8 +11964,6 @@ extension on TranslationsEs {
 			'web.settings.items.about' => 'Acerca de',
 			'web.settings.health.connecting' => 'conectando…',
 			'web.settings.health.dbOk' => 'db ok',
-			_ => null,
-		} ?? switch (path) {
 			'web.settings.health.dbDown' => 'db caída',
 			'web.settings.breadcrumb.server' => 'Servidor',
 			'web.settings.appearance.title' => 'Apariencia',
@@ -12416,6 +12466,8 @@ extension on TranslationsEs {
 			'web.cortex.quarantine.discard' => 'Descartar',
 			'web.cortex.quarantine.promotedToast' => 'Promocionada a memoria duradera',
 			'web.cortex.quarantine.discardedToast' => 'Descartada',
+			_ => null,
+		} ?? switch (path) {
 			'web.cortex.quarantine.actionFailed' => 'Acción fallida',
 			'web.cortex.quarantine.expires' => ({required Object date}) => 'expira ${date}',
 			'web.cortex.settings.injection.title' => 'Inyección al arranque',
@@ -12426,8 +12478,6 @@ extension on TranslationsEs {
 			'web.cortex.settings.injection.mode.full.label' => 'Completo — inyectar todo',
 			'web.cortex.settings.injection.mode.full.description' => 'Inyecta al arranque cada sección y página marcada para inyección, completa (comportamiento clásico). Simple, pero cuesta tokens en cada sesión y satura la ventana de contexto.',
 			'web.cortex.settings.injection.savedToast' => 'Modo guardado — las sesiones nuevas lo usan de inmediato (sin reiniciar el backend)',
-			_ => null,
-		} ?? switch (path) {
 			'web.cortex.settings.injection.saveFailed' => 'Error al guardar',
 			'web.cortex.settings.injection.note' => 'En modo completo siguen aplicando los flags de inyección por sección/página; en modo ligero las reglas fundacionales siempre se inyectan y el resto va al índice.',
 			'web.database.dialog.createTitle' => 'Añadir conexión de base de datos',
@@ -12930,6 +12980,8 @@ extension on TranslationsEs {
 			'sessions.inspector.canvas.newCanvasBlurb' => 'Elige arriba qué dibujar y descríbelo abajo: el agente renderizará el nuevo lienzo aquí.',
 			'sessions.inspector.canvas.setWorkspace' => 'Trabajar aquí',
 			'sessions.inspector.canvas.workspaceSet' => 'El agente ya trabaja en este lienzo.',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.previewOnlyHint' => 'Solo vista previa: pulsa «Trabajar aquí» para apuntarlo.',
 			'sessions.inspector.canvas.designTitle' => 'Sistema de diseño',
 			'sessions.inspector.canvas.designBlurb' => 'Tokens y reglas que sigue cada lienzo',
@@ -12940,8 +12992,6 @@ extension on TranslationsEs {
 			'sessions.inspector.canvas.designSaved' => 'Sistema de diseño guardado.',
 			'sessions.inspector.canvas.designWarningAchromatic' => 'Todos los colores resuelven a un gris: los lienzos no tendrán color de marca. Si el proyecto usa shadcn/ui, su --primary es una tinta; pon el tono de marca (normalmente --accent) en Principal.',
 			'sessions.inspector.canvas.tokenPrimary' => 'Primario',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.canvas.tokenSecondary' => 'Secundario',
 			'sessions.inspector.canvas.tokenBackground' => 'Fondo',
 			'sessions.inspector.canvas.tokenSurface' => 'Superficie',
@@ -13444,6 +13494,8 @@ extension on TranslationsEs {
 			'backups.overviewTargets' => 'Destinos',
 			'backups.overviewSchedules' => 'Programaciones',
 			'backups.overviewBackups' => 'Copias de seguridad',
+			_ => null,
+		} ?? switch (path) {
 			'backups.health.headlineHealthy' => 'Copias correctas',
 			'backups.health.headlineAttention' => 'Requiere atención',
 			'backups.health.headlineNever' => 'Aún sin copias',
@@ -13454,8 +13506,6 @@ extension on TranslationsEs {
 			'backups.health.tiles.overdue' => 'Atrasadas',
 			'backups.health.tiles.schedules' => 'Programaciones',
 			'backups.failedToLoad' => 'Error al cargar las copias de seguridad',
-			_ => null,
-		} ?? switch (path) {
 			'backups.envVarConfigured' => 'variable de entorno OPENDRAY_BACKUP_KEY',
 			'backups.savedConfirmCheckbox' => 'He guardado esta passphrase en mi gestor de contraseñas',
 			'backups.pgDumpMissing' => 'pg_dump no está en el PATH. Instala postgresql-client y reinicia opendray.',
@@ -13891,6 +13941,16 @@ extension on TranslationsEs {
 			'notesPage.html.scriptsOn' => 'Los scripts de este documento se están ejecutando.',
 			'notesPage.html.enableScripts' => 'Activar scripts',
 			'notesPage.html.disableScripts' => 'Desactivar scripts',
+			'notesPage.flatten.notice' => 'Cada proyecto está dentro de una carpeta llamada projects/.',
+			'notesPage.flatten.preview' => 'Vista previa',
+			'notesPage.flatten.dismiss' => 'Ahora no',
+			'notesPage.flatten.title' => 'Archivar los proyectos con su propio nombre',
+			'notesPage.flatten.description' => 'Cada documento se renombra de uno en uno para que los [[enlaces wiki]] que apuntan a él también se actualicen. Nada se sobrescribe: si el destino ya existe, se omite y se deja intacto.',
+			'notesPage.flatten.nothingToMove' => 'No hay nada que mover.',
+			'notesPage.flatten.skipped' => ({required Object count}) => 'Sin tocar (${count}):',
+			'notesPage.flatten.convert' => ({required Object count}) => 'Convertir ${count}',
+			'notesPage.flatten.done' => ({required Object count}) => 'Se movieron ${count} documento(s). Reinicia la pasarela para aplicar la nueva estructura.',
+			'notesPage.flatten.restartHint' => 'Reinicia la pasarela después.',
 			'dataExport.title' => 'Exportación e importación de datos',
 			'dataExport.subtitle' => 'Paquetes a nivel de usuario para migración o verificación, independientes de /backups (recuperación ante desastres).',
 			'dataExport.sections.export' => 'Exportar',
@@ -13948,6 +14008,8 @@ extension on TranslationsEs {
 			'dataExport.import.importBundle' => 'Importar paquete',
 			'dataExport.import.importing' => 'Importando…',
 			'dataExport.import.pickFileToast' => 'Elige primero un archivo de paquete.',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.import.doneToast' => 'Importación completada',
 			'dataExport.import.finishedWithErrors' => 'Importación finalizada con errores',
 			'dataExport.import.failedToast' => ({required Object error}) => 'Error en la importación: ${error}',
@@ -13968,8 +14030,6 @@ extension on TranslationsEs {
 			'dataExport.imports.columns.source' => 'Origen',
 			'dataExport.imports.columns.counts' => 'Recuentos',
 			'dataExport.imports.columns.when' => 'Cuándo',
-			_ => null,
-		} ?? switch (path) {
 			'dataExport.relative.inSeconds' => ({required Object n}) => 'en ${n}s',
 			'dataExport.relative.inMinutes' => ({required Object n}) => 'en ${n}m',
 			'dataExport.relative.inHours' => ({required Object n}) => 'en ${n}h',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -1651,6 +1651,10 @@ class _TranslationsWebNoteEditorEs extends TranslationsWebNoteEditorEn {
 	@override String get saveFailedToast => 'Error al guardar';
 	@override late final _TranslationsWebNoteEditorStatusEs status = _TranslationsWebNoteEditorStatusEs._(_root);
 	@override late final _TranslationsWebNoteEditorHtmlEs html = _TranslationsWebNoteEditorHtmlEs._(_root);
+	@override String get save => 'Guardar';
+	@override String get saveTitle => 'Guardar este documento (⌘S / Ctrl+S)';
+	@override String get lineNumbers => 'Líneas';
+	@override String get lineNumbersTitle => 'Mostrar números de línea. Con esto activo las líneas largas dejan de ajustarse.';
 }
 
 // Path: web.export
@@ -2743,7 +2747,7 @@ class _TranslationsNotesPageEditorEs extends TranslationsNotesPageEditorEn {
 	// Translations
 	@override String get markdownHint => 'Markdown, o HTML si el archivo termina en .html…';
 	@override String get saving => 'Guardando…';
-	@override String get autosave => 'Se guarda automáticamente mientras escribes';
+	@override String get autosave => 'Guardado';
 	@override String loadFailedApi({required Object error}) => 'Error al cargar: ${error}';
 	@override String loadFailedGeneric({required Object error}) => 'Error al cargar: ${error}';
 	@override String saveFailedApi({required Object error}) => 'Error al guardar: ${error}';
@@ -2751,6 +2755,8 @@ class _TranslationsNotesPageEditorEs extends TranslationsNotesPageEditorEn {
 	@override String savedAt({required Object time}) => 'Guardado ${time}';
 	@override String get showPreview => 'Vista previa';
 	@override String get showSource => 'Código';
+	@override String get save => 'Guardar';
+	@override String get unsaved => 'Cambios sin guardar';
 }
 
 // Path: notesPage.html
@@ -12208,6 +12214,10 @@ extension on TranslationsEs {
 			'web.noteEditor.html.scriptsOn' => 'Los scripts de este documento se están ejecutando.',
 			'web.noteEditor.html.enableScripts' => 'Activar scripts',
 			'web.noteEditor.html.disableScripts' => 'Desactivar scripts',
+			'web.noteEditor.save' => 'Guardar',
+			'web.noteEditor.saveTitle' => 'Guardar este documento (⌘S / Ctrl+S)',
+			'web.noteEditor.lineNumbers' => 'Líneas',
+			'web.noteEditor.lineNumbersTitle' => 'Mostrar números de línea. Con esto activo las líneas largas dejan de ajustarse.',
 			'web.export.title' => 'Exportar datos',
 			'web.export.subtitle' => 'Genera un paquete zip puntual de las entidades lógicas seleccionadas. Los paquetes se conservan en el servidor durante 24 horas y luego se eliminan automáticamente.',
 			'web.export.backToBackups' => '← Backups',
@@ -12497,12 +12507,12 @@ extension on TranslationsEs {
 			'web.cortex.blueprint.reserved' => 'reservada',
 			'web.cortex.blueprint.deleteNote' => 'Quitar una sección la oculta sin borrar su contenido — vuelve a añadir el mismo slug para recuperarla.',
 			'web.cortex.blueprint.cancel' => 'Cancelar',
+			_ => null,
+		} ?? switch (path) {
 			'web.cortex.blueprint.apply' => 'Aplicar plano',
 			'web.cortex.blueprint.applyFailed' => 'Error al aplicar',
 			'web.cortex.blueprint.appliedToast' => 'Plano aplicado',
 			'web.cortex.blueprint.writePolicy.direct' => 'Escritura directa',
-			_ => null,
-		} ?? switch (path) {
 			'web.cortex.blueprint.writePolicy.proposal' => 'Propuesta',
 			'web.cortex.blueprint.writePolicy.hint' => 'Directa: el agente escribe el documento en vivo cuando está desbloqueado. Propuesta: las escrituras del agente requieren tu aprobación primero.',
 			'web.cortex.quarantine.title' => 'Cuarentena',
@@ -13011,12 +13021,12 @@ extension on TranslationsEs {
 			'sessions.inspector.canvas.emptyBlurb' => 'Pide al agente una pantalla, un diagrama de flujo, un mapa mental o un diagrama de relaciones: se renderiza aquí y podrás anotarlo.',
 			'sessions.inspector.canvas.viewportPhone' => 'Ancho de móvil',
 			'sessions.inspector.canvas.viewportTablet' => 'Ancho de tablet',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.viewportDesktop' => 'Ancho de escritorio',
 			'sessions.inspector.canvas.openFull' => 'Pantalla completa',
 			'sessions.inspector.canvas.confirm' => 'Confirmar',
 			'sessions.inspector.canvas.captured' => ({required Object what}) => 'Capturado: ${what}',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.canvas.notes' => 'Notas',
 			'sessions.inspector.canvas.clear' => 'Borrar marcas',
 			'sessions.inspector.canvas.done' => 'Listo',
@@ -13525,12 +13535,12 @@ extension on TranslationsEs {
 			'backups.emptyNoBackups.body' => 'Toca "Ejecutar ahora" para tomar una nueva instantánea, o abre Programaciones para configurar ejecuciones periódicas.',
 			'backups.restartToActivate' => 'Reinicia opendray para activar las copias de seguridad',
 			'backups.passphraseSaved' => 'Tu passphrase está guardada. El gateway solo la carga al iniciarse, así que los cambios solo surten efecto tras un reinicio.',
+			_ => null,
+		} ?? switch (path) {
 			'backups.keyFileLabel' => 'Archivo de clave',
 			'backups.configuredViaLabel' => 'Configurado mediante',
 			'backups.wizard.title' => 'Configurar copias de seguridad',
 			'backups.wizard.intro' => 'Elige una passphrase maestra. opendray la usa para cifrar cada blob de copia de seguridad con AES-256-GCM. Si pierdes la passphrase, pierdes los datos: no hay forma de recuperarlos.',
-			_ => null,
-		} ?? switch (path) {
 			'backups.wizard.saving' => 'Guardando…',
 			'backups.wizard.generateAndSave' => 'Generar y guardar',
 			'backups.wizard.savePassphrase' => 'Guardar passphrase',
@@ -13974,7 +13984,7 @@ extension on TranslationsEs {
 			'notesPage.pathHelper' => 'Añade .md automáticamente si falta.',
 			'notesPage.editor.markdownHint' => 'Markdown, o HTML si el archivo termina en .html…',
 			'notesPage.editor.saving' => 'Guardando…',
-			'notesPage.editor.autosave' => 'Se guarda automáticamente mientras escribes',
+			'notesPage.editor.autosave' => 'Guardado',
 			'notesPage.editor.loadFailedApi' => ({required Object error}) => 'Error al cargar: ${error}',
 			'notesPage.editor.loadFailedGeneric' => ({required Object error}) => 'Error al cargar: ${error}',
 			'notesPage.editor.saveFailedApi' => ({required Object error}) => 'Error al guardar: ${error}',
@@ -13982,6 +13992,8 @@ extension on TranslationsEs {
 			'notesPage.editor.savedAt' => ({required Object time}) => 'Guardado ${time}',
 			'notesPage.editor.showPreview' => 'Vista previa',
 			'notesPage.editor.showSource' => 'Código',
+			'notesPage.editor.save' => 'Guardar',
+			'notesPage.editor.unsaved' => 'Cambios sin guardar',
 			'notesPage.html.scriptsOff' => 'Scripts desactivados: este documento se renderiza como HTML estático.',
 			'notesPage.html.scriptsOn' => 'Los scripts de este documento se están ejecutando.',
 			'notesPage.html.enableScripts' => 'Activar scripts',
@@ -14037,14 +14049,14 @@ extension on TranslationsEs {
 			'dataExport.history.deleteConfirmTitle' => '¿Eliminar la exportación?',
 			'dataExport.history.deleteConfirmBody' => ({required Object id}) => 'Elimina el paquete y revoca el token de descarga. ${id}',
 			'dataExport.history.download' => 'Descargar',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.history.delete' => 'Eliminar',
 			'dataExport.history.downloadCopiedToast' => 'URL de descarga copiada al portapapeles. Pégala en un navegador para obtenerla (un solo uso).',
 			'dataExport.history.columns.scope' => 'Alcance',
 			'dataExport.history.columns.size' => 'Tamaño',
 			'dataExport.history.columns.expires' => 'Caduca',
 			'dataExport.history.columns.actions' => 'Acciones',
-			_ => null,
-		} ?? switch (path) {
 			'dataExport.history.scopeEmpty' => '(vacío)',
 			'dataExport.history.scopeMemories' => 'memorias',
 			'dataExport.history.scopeIntegrations' => ({required Object mode}) => 'integraciones(${mode})',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -880,7 +880,7 @@ class _TranslationsNotesPageEs extends TranslationsNotesPageEn {
 	@override String createFailedApi({required Object error}) => 'Error al crear: ${error}';
 	@override String createFailedGeneric({required Object error}) => 'Error al crear: ${error}';
 	@override String get pathLabel => 'Ruta relativa al vault';
-	@override String get pathHint => 'personal/scratch.md';
+	@override String get pathHint => 'mi-proyecto/borrador.md';
 	@override String get create => 'Crear';
 	@override String get popupDelete => 'Eliminar';
 	@override String get deleteBody => 'Esto es irreversible. La sincronización git del vault también eliminará el archivo en el host del gateway.';
@@ -4107,6 +4107,7 @@ class _TranslationsWebNotesEmptyEs extends TranslationsWebNotesEmptyEn {
 	@override String get hint => 'Elige una nota del árbol de la izquierda, ve directo al registro diario de hoy o crea una nueva. Los docs de proyecto escritos por la IA viven en <1>projects/</1>; tus borradores personales en <3>personal/</3>.';
 	@override String get today => 'Nota diaria de hoy';
 	@override String get kNew => 'Nueva nota';
+	@override String get hintFlat => 'Elige una nota del árbol de la izquierda, ve directo al registro diario de hoy o crea una nueva. Los docs de cada proyecto viven en una carpeta con su nombre, y tu borrador personal es <1>personal.md</1> dentro de ella.';
 }
 
 // Path: web.notes.picker
@@ -7563,7 +7564,7 @@ class _TranslationsWebSessionsInspectorVaultPanelEs extends TranslationsWebSessi
 	@override String get noDocs => 'Aún no hay docs del proyecto en esta carpeta de la bóveda.';
 	@override String get createFailed => 'No se pudo crear el doc';
 	@override String get mappingTitle => 'Vincular carpeta de bóveda del proyecto';
-	@override String get mappingHelp => 'Elige la carpeta de la bóveda que contiene las notas de este proyecto. Relativa a la bóveda, p. ej. projects/my-app. Déjalo vacío para usar el valor por defecto.';
+	@override String get mappingHelp => 'Elige la carpeta de la bóveda que contiene las notas de este proyecto. Relativa a la bóveda. Déjalo vacío para usar el valor por defecto que se muestra en el campo.';
 	@override String get sessionCwd => 'cwd de la sesión';
 	@override String get folderLabel => 'Carpeta de la bóveda';
 	@override String get mappingStoredHint => 'Se guarda en la bóveda en .opendray-projects.json, así se sincroniza con tus notas.';
@@ -10119,7 +10120,7 @@ extension on TranslationsEs {
 			'web.sessions.inspector.vaultPanel.noDocs' => 'Aún no hay docs del proyecto en esta carpeta de la bóveda.',
 			'web.sessions.inspector.vaultPanel.createFailed' => 'No se pudo crear el doc',
 			'web.sessions.inspector.vaultPanel.mappingTitle' => 'Vincular carpeta de bóveda del proyecto',
-			'web.sessions.inspector.vaultPanel.mappingHelp' => 'Elige la carpeta de la bóveda que contiene las notas de este proyecto. Relativa a la bóveda, p. ej. projects/my-app. Déjalo vacío para usar el valor por defecto.',
+			'web.sessions.inspector.vaultPanel.mappingHelp' => 'Elige la carpeta de la bóveda que contiene las notas de este proyecto. Relativa a la bóveda. Déjalo vacío para usar el valor por defecto que se muestra en el campo.',
 			'web.sessions.inspector.vaultPanel.sessionCwd' => 'cwd de la sesión',
 			'web.sessions.inspector.vaultPanel.folderLabel' => 'Carpeta de la bóveda',
 			'web.sessions.inspector.vaultPanel.mappingStoredHint' => 'Se guarda en la bóveda en .opendray-projects.json, así se sincroniza con tus notas.',
@@ -10750,6 +10751,7 @@ extension on TranslationsEs {
 			'web.notes.empty.hint' => 'Elige una nota del árbol de la izquierda, ve directo al registro diario de hoy o crea una nueva. Los docs de proyecto escritos por la IA viven en <1>projects/</1>; tus borradores personales en <3>personal/</3>.',
 			'web.notes.empty.today' => 'Nota diaria de hoy',
 			'web.notes.empty.kNew' => 'Nueva nota',
+			'web.notes.empty.hintFlat' => 'Elige una nota del árbol de la izquierda, ve directo al registro diario de hoy o crea una nueva. Los docs de cada proyecto viven en una carpeta con su nombre, y tu borrador personal es <1>personal.md</1> dentro de ella.',
 			'web.notes.picker.browseAria' => 'Explorar carpetas',
 			'web.notes.picker.matches_one' => ({required Object count}) => '${count} coincidencia',
 			'web.notes.picker.matches_other' => ({required Object count}) => '${count} coincidencias',
@@ -10923,9 +10925,9 @@ extension on TranslationsEs {
 			'web.activity.empty.stepCallEndpoint' => 'Llama a cualquier endpoint, p. ej. <1>POST /api/v1/sessions</1>',
 			'web.activity.empty.stepAppears' => 'Las llamadas aparecen aquí en cuestión de segundos',
 			'web.activity.empty.footnote' => 'Las llamadas que haces desde esta UI de administración no se registran; solo se registra el tráfico atribuido a integraciones.',
-			'web.activity.events.loading' => 'Cargando eventos…',
 			_ => null,
 		} ?? switch (path) {
+			'web.activity.events.loading' => 'Cargando eventos…',
 			'web.activity.events.empty' => 'Aún no hay eventos.',
 			'web.activity.events.emptyFiltered' => 'No hay eventos coincidentes.',
 			'web.activity.events.loadOlder' => 'Cargar eventos anteriores',
@@ -11437,9 +11439,9 @@ extension on TranslationsEs {
 			'web.plugins.gitHosts.dialog.verifyButton' => 'Verificar',
 			'web.plugins.gitHosts.dialog.verifying' => 'Comprobando…',
 			'web.plugins.gitHosts.dialog.verifyLogin' => ({required Object login}) => 'Autenticado como ${login}',
-			'web.plugins.gitHosts.dialog.verifyRepoOk' => ({required Object repo}) => 'puede leer ${repo}',
 			_ => null,
 		} ?? switch (path) {
+			'web.plugins.gitHosts.dialog.verifyRepoOk' => ({required Object repo}) => 'puede leer ${repo}',
 			'web.plugins.gitHosts.dialog.verifyRepoFail' => ({required Object repo}) => 'NO puede leer ${repo}',
 			'web.plugins.gitHosts.dialog.verifyPushOk' => 'puede hacer push',
 			'web.plugins.gitHosts.dialog.verifyPushDenied' => 'NO puede hacer push (solo lectura)',
@@ -11951,9 +11953,9 @@ extension on TranslationsEs {
 			'web.serverSettings.layout.mcp' => 'Registro MCP',
 			'web.serverSettings.layout.legacyWarning' => 'Esta instalación aún mantiene los directorios propios de opendray dentro de tus documentos, así que aparecen en el Vault y la sincronización se los lleva. Siguen funcionando: muévelos fuera y fija las rutas de arriba cuando puedas. Lo ya confirmado requiere git rm --cached; opendray no reescribirá tu repositorio.',
 			'web.settings.title' => 'Ajustes',
-			'web.settings.subtitle' => 'Configuración del espacio de trabajo, la cuenta y el gateway.',
 			_ => null,
 		} ?? switch (path) {
+			'web.settings.subtitle' => 'Configuración del espacio de trabajo, la cuenta y el gateway.',
 			'web.settings.groups.workspace' => 'Espacio de trabajo',
 			'web.settings.groups.server' => 'Servidor',
 			'web.settings.groups.system' => 'Sistema',
@@ -12465,9 +12467,9 @@ extension on TranslationsEs {
 			'web.cortex.quarantine.promoteHint' => 'Mover a memoria duradera (entra en la recuperación y consolidación)',
 			'web.cortex.quarantine.discard' => 'Descartar',
 			'web.cortex.quarantine.promotedToast' => 'Promocionada a memoria duradera',
-			'web.cortex.quarantine.discardedToast' => 'Descartada',
 			_ => null,
 		} ?? switch (path) {
+			'web.cortex.quarantine.discardedToast' => 'Descartada',
 			'web.cortex.quarantine.actionFailed' => 'Acción fallida',
 			'web.cortex.quarantine.expires' => ({required Object date}) => 'expira ${date}',
 			'web.cortex.settings.injection.title' => 'Inyección al arranque',
@@ -12979,9 +12981,9 @@ extension on TranslationsEs {
 			'sessions.inspector.canvas.newCanvasTitle' => 'Nuevo lienzo',
 			'sessions.inspector.canvas.newCanvasBlurb' => 'Elige arriba qué dibujar y descríbelo abajo: el agente renderizará el nuevo lienzo aquí.',
 			'sessions.inspector.canvas.setWorkspace' => 'Trabajar aquí',
-			'sessions.inspector.canvas.workspaceSet' => 'El agente ya trabaja en este lienzo.',
 			_ => null,
 		} ?? switch (path) {
+			'sessions.inspector.canvas.workspaceSet' => 'El agente ya trabaja en este lienzo.',
 			'sessions.inspector.canvas.previewOnlyHint' => 'Solo vista previa: pulsa «Trabajar aquí» para apuntarlo.',
 			'sessions.inspector.canvas.designTitle' => 'Sistema de diseño',
 			'sessions.inspector.canvas.designBlurb' => 'Tokens y reglas que sigue cada lienzo',
@@ -13493,9 +13495,9 @@ extension on TranslationsEs {
 			'backups.wizard.saveNowBody' => 'Se muestra UNA SOLA VEZ. Después no podrás recuperarla desde opendray.',
 			'backups.overviewTargets' => 'Destinos',
 			'backups.overviewSchedules' => 'Programaciones',
-			'backups.overviewBackups' => 'Copias de seguridad',
 			_ => null,
 		} ?? switch (path) {
+			'backups.overviewBackups' => 'Copias de seguridad',
 			'backups.health.headlineHealthy' => 'Copias correctas',
 			'backups.health.headlineAttention' => 'Requiere atención',
 			'backups.health.headlineNever' => 'Aún sin copias',
@@ -13917,7 +13919,7 @@ extension on TranslationsEs {
 			'notesPage.createFailedApi' => ({required Object error}) => 'Error al crear: ${error}',
 			'notesPage.createFailedGeneric' => ({required Object error}) => 'Error al crear: ${error}',
 			'notesPage.pathLabel' => 'Ruta relativa al vault',
-			'notesPage.pathHint' => 'personal/scratch.md',
+			'notesPage.pathHint' => 'mi-proyecto/borrador.md',
 			'notesPage.create' => 'Crear',
 			'notesPage.popupDelete' => 'Eliminar',
 			'notesPage.deleteBody' => 'Esto es irreversible. La sincronización git del vault también eliminará el archivo en el host del gateway.',
@@ -14007,9 +14009,9 @@ extension on TranslationsEs {
 			'dataExport.import.customTasksLabel' => 'Tareas personalizadas',
 			'dataExport.import.importBundle' => 'Importar paquete',
 			'dataExport.import.importing' => 'Importando…',
-			'dataExport.import.pickFileToast' => 'Elige primero un archivo de paquete.',
 			_ => null,
 		} ?? switch (path) {
+			'dataExport.import.pickFileToast' => 'Elige primero un archivo de paquete.',
 			'dataExport.import.doneToast' => 'Importación completada',
 			'dataExport.import.finishedWithErrors' => 'Importación finalizada con errores',
 			'dataExport.import.failedToast' => ({required Object error}) => 'Error en la importación: ${error}',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -893,6 +893,7 @@ class _TranslationsNotesPageZh extends TranslationsNotesPageEn {
 	@override late final _TranslationsNotesPageEditorZh editor = _TranslationsNotesPageEditorZh._(_root);
 	@override late final _TranslationsNotesPageHtmlZh html = _TranslationsNotesPageHtmlZh._(_root);
 	@override late final _TranslationsNotesPageFlattenZh flatten = _TranslationsNotesPageFlattenZh._(_root);
+	@override late final _TranslationsNotesPageRenameZh rename = _TranslationsNotesPageRenameZh._(_root);
 }
 
 // Path: dataExport
@@ -1388,6 +1389,7 @@ class _TranslationsWebNotesZh extends TranslationsWebNotesEn {
 	@override late final _TranslationsWebNotesVaultSyncZh vaultSync = _TranslationsWebNotesVaultSyncZh._(_root);
 	@override late final _TranslationsWebNotesSyncBadgeZh syncBadge = _TranslationsWebNotesSyncBadgeZh._(_root);
 	@override late final _TranslationsWebNotesFlattenZh flatten = _TranslationsWebNotesFlattenZh._(_root);
+	@override late final _TranslationsWebNotesDocZh doc = _TranslationsWebNotesDocZh._(_root);
 }
 
 // Path: web.activity
@@ -2781,6 +2783,20 @@ class _TranslationsNotesPageFlattenZh extends TranslationsNotesPageFlattenEn {
 	@override String convert({required Object count}) => '转换 ${count} 个';
 	@override String done({required Object count}) => '已移动 ${count} 个文档。重启网关后生效。';
 	@override String get restartHint => '完成后请重启网关。';
+}
+
+// Path: notesPage.rename
+class _TranslationsNotesPageRenameZh extends TranslationsNotesPageRenameEn {
+	_TranslationsNotesPageRenameZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get action => '重命名';
+	@override String get title => '重命名文档';
+	@override String get helper => '文档库相对路径。目录会自动创建。';
+	@override String doneSnack({required Object count}) => '已重命名，${count} 个链接已改写。';
+	@override String get doneWithWarning => '已重命名，但链接没有全部更新';
 }
 
 // Path: dataExport.sections
@@ -4183,6 +4199,24 @@ class _TranslationsWebNotesFlattenZh extends TranslationsWebNotesFlattenEn {
 	@override String convert({required Object count}) => '转换 ${count} 个文档';
 	@override String done({required Object count}) => '已移动 ${count} 个文档。重启网关后生效。';
 	@override String get restartHint => '完成后请重启网关。';
+}
+
+// Path: web.notes.doc
+class _TranslationsWebNotesDocZh extends TranslationsWebNotesDocEn {
+	_TranslationsWebNotesDocZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get rename => '重命名';
+	@override String get renamePrompt => '这个文档的新路径（目录会自动创建）：';
+	@override String renamed({required Object count}) => '已重命名，${count} 个链接已改写。';
+	@override String get renamedWithWarning => '已重命名，但链接没有全部更新';
+	@override String get renameFailed => '重命名失败';
+	@override String get delete => '删除';
+	@override String deleteConfirm({required Object path}) => '删除 ${path}？此处无法撤销。';
+	@override String get deleted => '文档已删除';
+	@override String get deleteFailed => '删除失败';
 }
 
 // Path: web.activity.filters
@@ -10883,6 +10917,15 @@ extension on TranslationsZh {
 			'web.notes.flatten.convert' => ({required Object count}) => '转换 ${count} 个文档',
 			'web.notes.flatten.done' => ({required Object count}) => '已移动 ${count} 个文档。重启网关后生效。',
 			'web.notes.flatten.restartHint' => '完成后请重启网关。',
+			'web.notes.doc.rename' => '重命名',
+			'web.notes.doc.renamePrompt' => '这个文档的新路径（目录会自动创建）：',
+			'web.notes.doc.renamed' => ({required Object count}) => '已重命名，${count} 个链接已改写。',
+			'web.notes.doc.renamedWithWarning' => '已重命名，但链接没有全部更新',
+			'web.notes.doc.renameFailed' => '重命名失败',
+			'web.notes.doc.delete' => '删除',
+			'web.notes.doc.deleteConfirm' => ({required Object path}) => '删除 ${path}？此处无法撤销。',
+			'web.notes.doc.deleted' => '文档已删除',
+			'web.notes.doc.deleteFailed' => '删除失败',
 			'web.activity.title' => '活动',
 			'web.activity.subtitle' => '按调用维度审计每个由注册集成发起的 API 请求。包括入站调用（第三方应用以集成 API key 调用 opendray）和出站代理调用（admin → opendray 代理 → 集成）。本管理端 UI 直接发起的调用不会被记录。',
 			'web.activity.refresh' => '刷新',
@@ -10913,6 +10956,8 @@ extension on TranslationsZh {
 			'web.activity.table.outboundAria' => '出站',
 			'web.activity.empty.filtered' => '没有调用符合当前筛选条件。',
 			'web.activity.empty.title' => '尚未记录任何 API 调用',
+			_ => null,
+		} ?? switch (path) {
 			'web.activity.empty.description' => '当第三方应用以其集成 API key 调用 opendray 时，每次请求都会被记录在这里。',
 			'web.activity.empty.stepWithIntegrations' => '在你的第三方应用中使用已有集成的 API key',
 			'web.activity.empty.stepRegister' => '在 集成 → 新建 中注册一个集成',
@@ -10922,8 +10967,6 @@ extension on TranslationsZh {
 			'web.activity.events.loading' => '正在加载事件…',
 			'web.activity.events.empty' => '尚无事件。',
 			'web.activity.events.emptyFiltered' => '没有匹配的事件。',
-			_ => null,
-		} ?? switch (path) {
 			'web.activity.events.loadOlder' => '加载更早的事件',
 			'web.activity.events.today' => '今天',
 			'web.activity.events.yesterday' => '昨天',
@@ -11427,6 +11470,8 @@ extension on TranslationsZh {
 			'web.plugins.gitHosts.dialog.ownerPlaceholder' => 'my-org',
 			'web.plugins.gitHosts.dialog.ownerHintHostWide' => '留空表示全主机凭据:该主机上没有专属条目的仓库都会用它。',
 			'web.plugins.gitHosts.dialog.ownerHintScoped' => ({required Object host, required Object owner}) => '仅用于 ${host}/${owner}/… —— 该主机上的其他所有者会回退到全主机条目。当一个细粒度令牌只授权给某个账号或组织时,填这里。',
+			_ => null,
+		} ?? switch (path) {
 			'web.plugins.gitHosts.dialog.verifyLabel' => '验证此凭据',
 			'web.plugins.gitHosts.dialog.verifyHint' => '向 forge 求证这个 token 属于谁。可以填一个仓库(owner/name)来确认凭据既能读取、也能推送 —— 读和写是两个独立的授权,能拉取的 token 照样可能推送全部失败,而 forge 自己的报错指的是另一个权限。',
 			'web.plugins.gitHosts.dialog.verifyRepoPlaceholder' => 'owner/repo(可选)',
@@ -11436,8 +11481,6 @@ extension on TranslationsZh {
 			'web.plugins.gitHosts.dialog.verifyRepoOk' => ({required Object repo}) => '可以读取 ${repo}',
 			'web.plugins.gitHosts.dialog.verifyRepoFail' => ({required Object repo}) => '无法读取 ${repo}',
 			'web.plugins.gitHosts.dialog.verifyPushOk' => '可以推送',
-			_ => null,
-		} ?? switch (path) {
 			'web.plugins.gitHosts.dialog.verifyPushDenied' => '不能推送(只读)',
 			'web.plugins.gitHosts.scopeHostWide' => '全主机兜底',
 			'web.plugins.gitHosts.scopeOwner' => ({required Object owner}) => '仅用于 ${owner}',
@@ -11941,6 +11984,8 @@ extension on TranslationsZh {
 			'web.serverSettings.host.modes.off.desc' => 'opendray 不对机器电源做任何操作。',
 			'web.serverSettings.host.modes.off.caveat' => '主机一旦休眠即无法连接,除非另有程序让它保持唤醒。',
 			'web.serverSettings.layout.title' => '实际解析到',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.layout.documents' => '文档',
 			'web.serverSettings.layout.git' => 'Git 仓库',
 			'web.serverSettings.layout.skills' => 'Skills',
@@ -11950,8 +11995,6 @@ extension on TranslationsZh {
 			'web.settings.subtitle' => '工作区、账号与网关配置。',
 			'web.settings.groups.workspace' => '工作区',
 			'web.settings.groups.server' => '服务器',
-			_ => null,
-		} ?? switch (path) {
 			'web.settings.groups.system' => '系统',
 			'web.settings.items.appearance' => '外观',
 			'web.settings.items.font' => '字号',
@@ -12455,6 +12498,8 @@ extension on TranslationsZh {
 			'web.cortex.blueprint.writePolicy.proposal' => '提案',
 			'web.cortex.blueprint.writePolicy.hint' => '直接写入：会话中的 AI 在文档未锁定时直接更新实时文档。提案：AI 的写入需先经你批准。',
 			'web.cortex.quarantine.title' => '隔离区',
+			_ => null,
+		} ?? switch (path) {
 			'web.cortex.quarantine.subtitle' => '在被采信为持久记忆之前需要审查的事实：第三方 integration 的捕获会按策略落到这里，你也可以在记忆检查器中手动隔离任何一条记忆。属实的批准入库，其余丢弃——未审查的条目会自动过期。',
 			'web.cortex.quarantine.empty' => '隔离区为空。条目来源：integration 来源会话（记忆策略为 “quarantine”），或你在记忆检查器中手动隔离的记忆。',
 			'web.cortex.quarantine.promote' => '升格',
@@ -12464,8 +12509,6 @@ extension on TranslationsZh {
 			'web.cortex.quarantine.discardedToast' => '已丢弃',
 			'web.cortex.quarantine.actionFailed' => '操作失败',
 			'web.cortex.quarantine.expires' => ({required Object date}) => '${date} 到期',
-			_ => null,
-		} ?? switch (path) {
 			'web.cortex.settings.injection.title' => '启动注入',
 			'web.cortex.settings.injection.hint' => '每个【新建会话】预先加载多少心智中枢上下文。切换立即生效（影响之后新建的会话）——后端无需重启。',
 			'web.cortex.settings.injection.active' => '当前',
@@ -12969,6 +13012,8 @@ extension on TranslationsZh {
 			'sessions.inspector.canvas.notes' => '备注',
 			'sessions.inspector.canvas.clear' => '清除标记',
 			'sessions.inspector.canvas.done' => '完成',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.hintPin' => '点一下目标位置,再拖动微调 —— 确认命中正确元素后点「确认」。',
 			'sessions.inspector.canvas.hintRegion' => '拖出一个框覆盖你要指的区域,然后确认。',
 			'sessions.inspector.canvas.newCanvas' => '新建',
@@ -12978,8 +13023,6 @@ extension on TranslationsZh {
 			'sessions.inspector.canvas.workspaceSet' => 'agent 现在在这个画布上工作。',
 			'sessions.inspector.canvas.previewOnlyHint' => '仅预览 —— 点「在这上面工作」才会让 agent 指向它。',
 			'sessions.inspector.canvas.designTitle' => '设计系统',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.canvas.designBlurb' => '每个画布都遵循的 tokens + 规范',
 			'sessions.inspector.canvas.designNotesLabel' => '风格说明(tokens 表达不了的部分)',
 			'sessions.inspector.canvas.designNotesPlaceholder' => '例如:克制、信息密度高;不用渐变;按钮只用实心/描边',
@@ -13483,6 +13526,8 @@ extension on TranslationsZh {
 			'backups.wizard.saving' => '保存中…',
 			'backups.wizard.generateAndSave' => '生成并保存',
 			'backups.wizard.savePassphrase' => '保存密语',
+			_ => null,
+		} ?? switch (path) {
 			'backups.wizard.generateHint' => '服务器生成密码学级别随机密语，你复制到密码管理器，然后确认。',
 			'backups.wizard.helperRecommended' => '建议：从密码管理器生成 40+ 字符',
 			'backups.wizard.saveNowHeader' => '立即保存这个密语',
@@ -13492,8 +13537,6 @@ extension on TranslationsZh {
 			'backups.overviewBackups' => '备份',
 			'backups.health.headlineHealthy' => '备份正常',
 			'backups.health.headlineAttention' => '需要关注',
-			_ => null,
-		} ?? switch (path) {
 			'backups.health.headlineNever' => '尚无备份',
 			'backups.health.lastSuccess' => '最近成功备份',
 			'backups.health.never' => '从未',
@@ -13947,6 +13990,11 @@ extension on TranslationsZh {
 			'notesPage.flatten.convert' => ({required Object count}) => '转换 ${count} 个',
 			'notesPage.flatten.done' => ({required Object count}) => '已移动 ${count} 个文档。重启网关后生效。',
 			'notesPage.flatten.restartHint' => '完成后请重启网关。',
+			'notesPage.rename.action' => '重命名',
+			'notesPage.rename.title' => '重命名文档',
+			'notesPage.rename.helper' => '文档库相对路径。目录会自动创建。',
+			'notesPage.rename.doneSnack' => ({required Object count}) => '已重命名，${count} 个链接已改写。',
+			'notesPage.rename.doneWithWarning' => '已重命名，但链接没有全部更新',
 			'dataExport.title' => '数据导出与导入',
 			'dataExport.subtitle' => '面向用户的数据包，用于迁移或验证 — 与 /backups（灾难恢复）相互独立。',
 			'dataExport.sections.export' => '导出',
@@ -13992,6 +14040,8 @@ extension on TranslationsZh {
 			'dataExport.history.scopeEmpty' => '（空）',
 			'dataExport.history.scopeMemories' => '记忆',
 			'dataExport.history.scopeIntegrations' => ({required Object mode}) => '集成(${mode})',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.history.scopeCustomTasks' => '自定义任务',
 			'dataExport.import.intro' => '重放此前由「导出」生成的数据包。仅勾选的实体会被导入；数据包中其余内容会被忽略。',
 			'dataExport.import.bundleLabel' => '数据包文件（.zip）',
@@ -14006,8 +14056,6 @@ extension on TranslationsZh {
 			'dataExport.import.pickFileToast' => '请先选择数据包文件。',
 			'dataExport.import.doneToast' => '导入完成',
 			'dataExport.import.finishedWithErrors' => '导入完成但有错误',
-			_ => null,
-		} ?? switch (path) {
 			'dataExport.import.failedToast' => ({required Object error}) => '导入失败：${error}',
 			'dataExport.import.summaryCard.memories' => '记忆',
 			'dataExport.import.summaryCard.integrations' => '集成',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -1651,6 +1651,10 @@ class _TranslationsWebNoteEditorZh extends TranslationsWebNoteEditorEn {
 	@override String get saveFailedToast => '保存失败';
 	@override late final _TranslationsWebNoteEditorStatusZh status = _TranslationsWebNoteEditorStatusZh._(_root);
 	@override late final _TranslationsWebNoteEditorHtmlZh html = _TranslationsWebNoteEditorHtmlZh._(_root);
+	@override String get save => '保存';
+	@override String get saveTitle => '保存此文档（⌘S / Ctrl+S）';
+	@override String get lineNumbers => '行号';
+	@override String get lineNumbersTitle => '显示行号。开启时长行不再折行。';
 }
 
 // Path: web.export
@@ -2743,7 +2747,7 @@ class _TranslationsNotesPageEditorZh extends TranslationsNotesPageEditorEn {
 	// Translations
 	@override String get markdownHint => 'Markdown;文件名以 .html 结尾则写 HTML…';
 	@override String get saving => '保存中…';
-	@override String get autosave => '随输入自动保存';
+	@override String get autosave => '已保存';
 	@override String loadFailedApi({required Object error}) => '加载失败：${error}';
 	@override String loadFailedGeneric({required Object error}) => '加载失败：${error}';
 	@override String saveFailedApi({required Object error}) => '保存失败：${error}';
@@ -2751,6 +2755,8 @@ class _TranslationsNotesPageEditorZh extends TranslationsNotesPageEditorEn {
 	@override String savedAt({required Object time}) => '${time} 已保存';
 	@override String get showPreview => '预览';
 	@override String get showSource => '源码';
+	@override String get save => '保存';
+	@override String get unsaved => '有未保存的修改';
 }
 
 // Path: notesPage.html
@@ -12202,6 +12208,10 @@ extension on TranslationsZh {
 			'web.noteEditor.html.scriptsOn' => '这篇文档的脚本正在运行。',
 			'web.noteEditor.html.enableScripts' => '启用脚本',
 			'web.noteEditor.html.disableScripts' => '禁用脚本',
+			'web.noteEditor.save' => '保存',
+			'web.noteEditor.saveTitle' => '保存此文档（⌘S / Ctrl+S）',
+			'web.noteEditor.lineNumbers' => '行号',
+			'web.noteEditor.lineNumbersTitle' => '显示行号。开启时长行不再折行。',
 			'web.export.title' => '导出数据',
 			'web.export.subtitle' => '把选中的逻辑实体打成一份一次性 zip 包。服务器上保留 24 小时后自动回收。',
 			'web.export.backToBackups' => '← 备份',
@@ -12494,12 +12504,12 @@ extension on TranslationsZh {
 			'web.cortex.blueprint.apply' => '应用蓝图',
 			'web.cortex.blueprint.applyFailed' => '应用失败',
 			'web.cortex.blueprint.appliedToast' => '蓝图已应用',
+			_ => null,
+		} ?? switch (path) {
 			'web.cortex.blueprint.writePolicy.direct' => '直接写入',
 			'web.cortex.blueprint.writePolicy.proposal' => '提案',
 			'web.cortex.blueprint.writePolicy.hint' => '直接写入：会话中的 AI 在文档未锁定时直接更新实时文档。提案：AI 的写入需先经你批准。',
 			'web.cortex.quarantine.title' => '隔离区',
-			_ => null,
-		} ?? switch (path) {
 			'web.cortex.quarantine.subtitle' => '在被采信为持久记忆之前需要审查的事实：第三方 integration 的捕获会按策略落到这里，你也可以在记忆检查器中手动隔离任何一条记忆。属实的批准入库，其余丢弃——未审查的条目会自动过期。',
 			'web.cortex.quarantine.empty' => '隔离区为空。条目来源：integration 来源会话（记忆策略为 “quarantine”），或你在记忆检查器中手动隔离的记忆。',
 			'web.cortex.quarantine.promote' => '升格',
@@ -13008,12 +13018,12 @@ extension on TranslationsZh {
 			'sessions.inspector.canvas.viewportDesktop' => '电脑宽度',
 			'sessions.inspector.canvas.openFull' => '全屏打开',
 			'sessions.inspector.canvas.confirm' => '确认',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.captured' => ({required Object what}) => '已捕获:${what}',
 			'sessions.inspector.canvas.notes' => '备注',
 			'sessions.inspector.canvas.clear' => '清除标记',
 			'sessions.inspector.canvas.done' => '完成',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.canvas.hintPin' => '点一下目标位置,再拖动微调 —— 确认命中正确元素后点「确认」。',
 			'sessions.inspector.canvas.hintRegion' => '拖出一个框覆盖你要指的区域,然后确认。',
 			'sessions.inspector.canvas.newCanvas' => '新建',
@@ -13522,12 +13532,12 @@ extension on TranslationsZh {
 			'backups.keyFileLabel' => '密钥文件',
 			'backups.configuredViaLabel' => '配置方式',
 			'backups.wizard.title' => '设置备份',
+			_ => null,
+		} ?? switch (path) {
 			'backups.wizard.intro' => '选择一个主密语。opendray 用它通过 AES-256-GCM 加密每一份备份。丢失密语就丢失数据 — 无法恢复。',
 			'backups.wizard.saving' => '保存中…',
 			'backups.wizard.generateAndSave' => '生成并保存',
 			'backups.wizard.savePassphrase' => '保存密语',
-			_ => null,
-		} ?? switch (path) {
 			'backups.wizard.generateHint' => '服务器生成密码学级别随机密语，你复制到密码管理器，然后确认。',
 			'backups.wizard.helperRecommended' => '建议：从密码管理器生成 40+ 字符',
 			'backups.wizard.saveNowHeader' => '立即保存这个密语',
@@ -13968,7 +13978,7 @@ extension on TranslationsZh {
 			'notesPage.pathHelper' => '缺失时自动追加 .md。',
 			'notesPage.editor.markdownHint' => 'Markdown;文件名以 .html 结尾则写 HTML…',
 			'notesPage.editor.saving' => '保存中…',
-			'notesPage.editor.autosave' => '随输入自动保存',
+			'notesPage.editor.autosave' => '已保存',
 			'notesPage.editor.loadFailedApi' => ({required Object error}) => '加载失败：${error}',
 			'notesPage.editor.loadFailedGeneric' => ({required Object error}) => '加载失败：${error}',
 			'notesPage.editor.saveFailedApi' => ({required Object error}) => '保存失败：${error}',
@@ -13976,6 +13986,8 @@ extension on TranslationsZh {
 			'notesPage.editor.savedAt' => ({required Object time}) => '${time} 已保存',
 			'notesPage.editor.showPreview' => '预览',
 			'notesPage.editor.showSource' => '源码',
+			'notesPage.editor.save' => '保存',
+			'notesPage.editor.unsaved' => '有未保存的修改',
 			'notesPage.html.scriptsOff' => '脚本已禁用 —— 这篇文档按静态 HTML 渲染。',
 			'notesPage.html.scriptsOn' => '这篇文档的脚本正在运行。',
 			'notesPage.html.enableScripts' => '启用脚本',
@@ -14034,14 +14046,14 @@ extension on TranslationsZh {
 			'dataExport.history.delete' => '删除',
 			'dataExport.history.downloadCopiedToast' => '下载 URL 已复制到剪贴板。在浏览器中粘贴以获取（单次使用）。',
 			'dataExport.history.columns.scope' => '范围',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.history.columns.size' => '大小',
 			'dataExport.history.columns.expires' => '过期',
 			'dataExport.history.columns.actions' => '操作',
 			'dataExport.history.scopeEmpty' => '（空）',
 			'dataExport.history.scopeMemories' => '记忆',
 			'dataExport.history.scopeIntegrations' => ({required Object mode}) => '集成(${mode})',
-			_ => null,
-		} ?? switch (path) {
 			'dataExport.history.scopeCustomTasks' => '自定义任务',
 			'dataExport.import.intro' => '重放此前由「导出」生成的数据包。仅勾选的实体会被导入；数据包中其余内容会被忽略。',
 			'dataExport.import.bundleLabel' => '数据包文件（.zip）',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -880,7 +880,7 @@ class _TranslationsNotesPageZh extends TranslationsNotesPageEn {
 	@override String createFailedApi({required Object error}) => '创建失败：${error}';
 	@override String createFailedGeneric({required Object error}) => '创建失败：${error}';
 	@override String get pathLabel => '相对仓库的路径';
-	@override String get pathHint => 'personal/scratch.md';
+	@override String get pathHint => '我的项目/草稿.md';
 	@override String get create => '创建';
 	@override String get popupDelete => '删除';
 	@override String get deleteBody => '此操作不可撤销。仓库的 git 同步会同时移除网关主机上的文件。';
@@ -4107,6 +4107,7 @@ class _TranslationsWebNotesEmptyZh extends TranslationsWebNotesEmptyEn {
 	@override String get hint => '从左侧目录树挑选一条笔记，直接跳到今天的日志，或新建一条。AI 生成的项目文档位于 <1>projects/</1>；个人草稿位于 <3>personal/</3>。';
 	@override String get today => '今天的日志笔记';
 	@override String get kNew => '新建笔记';
+	@override String get hintFlat => '从左侧目录树挑选一条笔记，直接跳到今天的日志，或新建一条。每个项目的文档都在以它命名的文件夹里，你自己的草稿是其中的 <1>personal.md</1>。';
 }
 
 // Path: web.notes.picker
@@ -7563,7 +7564,7 @@ class _TranslationsWebSessionsInspectorVaultPanelZh extends TranslationsWebSessi
 	@override String get noDocs => '该文档库文件夹下暂无项目文档。';
 	@override String get createFailed => '无法创建文档';
 	@override String get mappingTitle => '绑定项目文档库文件夹';
-	@override String get mappingHelp => '选择存放本项目笔记的文档库文件夹。文档库相对路径，例如 projects/my-app。留空则使用自动推导的默认值。';
+	@override String get mappingHelp => '选择存放本项目笔记的文档库文件夹。文档库相对路径。留空则使用输入框中显示的默认值。';
 	@override String get sessionCwd => '会话工作目录';
 	@override String get folderLabel => '文档库文件夹';
 	@override String get mappingStoredHint => '保存在文档库的 .opendray-projects.json 中，会随笔记一起同步。';
@@ -10116,7 +10117,7 @@ extension on TranslationsZh {
 			'web.sessions.inspector.vaultPanel.noDocs' => '该文档库文件夹下暂无项目文档。',
 			'web.sessions.inspector.vaultPanel.createFailed' => '无法创建文档',
 			'web.sessions.inspector.vaultPanel.mappingTitle' => '绑定项目文档库文件夹',
-			'web.sessions.inspector.vaultPanel.mappingHelp' => '选择存放本项目笔记的文档库文件夹。文档库相对路径，例如 projects/my-app。留空则使用自动推导的默认值。',
+			'web.sessions.inspector.vaultPanel.mappingHelp' => '选择存放本项目笔记的文档库文件夹。文档库相对路径。留空则使用输入框中显示的默认值。',
 			'web.sessions.inspector.vaultPanel.sessionCwd' => '会话工作目录',
 			'web.sessions.inspector.vaultPanel.folderLabel' => '文档库文件夹',
 			'web.sessions.inspector.vaultPanel.mappingStoredHint' => '保存在文档库的 .opendray-projects.json 中，会随笔记一起同步。',
@@ -10747,6 +10748,7 @@ extension on TranslationsZh {
 			'web.notes.empty.hint' => '从左侧目录树挑选一条笔记，直接跳到今天的日志，或新建一条。AI 生成的项目文档位于 <1>projects/</1>；个人草稿位于 <3>personal/</3>。',
 			'web.notes.empty.today' => '今天的日志笔记',
 			'web.notes.empty.kNew' => '新建笔记',
+			'web.notes.empty.hintFlat' => '从左侧目录树挑选一条笔记，直接跳到今天的日志，或新建一条。每个项目的文档都在以它命名的文件夹里，你自己的草稿是其中的 <1>personal.md</1>。',
 			'web.notes.picker.browseAria' => '浏览文件夹',
 			'web.notes.picker.matches_one' => ({required Object count}) => '${count} 个匹配',
 			'web.notes.picker.matches_other' => ({required Object count}) => '${count} 个匹配',
@@ -10920,9 +10922,9 @@ extension on TranslationsZh {
 			'web.activity.events.loading' => '正在加载事件…',
 			'web.activity.events.empty' => '尚无事件。',
 			'web.activity.events.emptyFiltered' => '没有匹配的事件。',
-			'web.activity.events.loadOlder' => '加载更早的事件',
 			_ => null,
 		} ?? switch (path) {
+			'web.activity.events.loadOlder' => '加载更早的事件',
 			'web.activity.events.today' => '今天',
 			'web.activity.events.yesterday' => '昨天',
 			'web.providers.list.title' => 'Providers',
@@ -11434,9 +11436,9 @@ extension on TranslationsZh {
 			'web.plugins.gitHosts.dialog.verifyRepoOk' => ({required Object repo}) => '可以读取 ${repo}',
 			'web.plugins.gitHosts.dialog.verifyRepoFail' => ({required Object repo}) => '无法读取 ${repo}',
 			'web.plugins.gitHosts.dialog.verifyPushOk' => '可以推送',
-			'web.plugins.gitHosts.dialog.verifyPushDenied' => '不能推送(只读)',
 			_ => null,
 		} ?? switch (path) {
+			'web.plugins.gitHosts.dialog.verifyPushDenied' => '不能推送(只读)',
 			'web.plugins.gitHosts.scopeHostWide' => '全主机兜底',
 			'web.plugins.gitHosts.scopeOwner' => ({required Object owner}) => '仅用于 ${owner}',
 			'web.backups.title' => '备份',
@@ -11948,9 +11950,9 @@ extension on TranslationsZh {
 			'web.settings.subtitle' => '工作区、账号与网关配置。',
 			'web.settings.groups.workspace' => '工作区',
 			'web.settings.groups.server' => '服务器',
-			'web.settings.groups.system' => '系统',
 			_ => null,
 		} ?? switch (path) {
+			'web.settings.groups.system' => '系统',
 			'web.settings.items.appearance' => '外观',
 			'web.settings.items.font' => '字号',
 			'web.settings.items.account' => '账号',
@@ -12462,9 +12464,9 @@ extension on TranslationsZh {
 			'web.cortex.quarantine.discardedToast' => '已丢弃',
 			'web.cortex.quarantine.actionFailed' => '操作失败',
 			'web.cortex.quarantine.expires' => ({required Object date}) => '${date} 到期',
-			'web.cortex.settings.injection.title' => '启动注入',
 			_ => null,
 		} ?? switch (path) {
+			'web.cortex.settings.injection.title' => '启动注入',
 			'web.cortex.settings.injection.hint' => '每个【新建会话】预先加载多少心智中枢上下文。切换立即生效（影响之后新建的会话）——后端无需重启。',
 			'web.cortex.settings.injection.active' => '当前',
 			'web.cortex.settings.injection.mode.lean.label' => '精简——索引 + 按需取用（推荐）',
@@ -12976,9 +12978,9 @@ extension on TranslationsZh {
 			'sessions.inspector.canvas.workspaceSet' => 'agent 现在在这个画布上工作。',
 			'sessions.inspector.canvas.previewOnlyHint' => '仅预览 —— 点「在这上面工作」才会让 agent 指向它。',
 			'sessions.inspector.canvas.designTitle' => '设计系统',
-			'sessions.inspector.canvas.designBlurb' => '每个画布都遵循的 tokens + 规范',
 			_ => null,
 		} ?? switch (path) {
+			'sessions.inspector.canvas.designBlurb' => '每个画布都遵循的 tokens + 规范',
 			'sessions.inspector.canvas.designNotesLabel' => '风格说明(tokens 表达不了的部分)',
 			'sessions.inspector.canvas.designNotesPlaceholder' => '例如:克制、信息密度高;不用渐变;按钮只用实心/描边',
 			'sessions.inspector.canvas.designAgentHint' => 'tokens 会以 CSS 变量注入每个画布,并随每次请求发送,且已要求模型使用 var(--od-…) 而非硬编码值。提示:直接让 agent 根据项目真实主题来配置。',
@@ -13490,9 +13492,9 @@ extension on TranslationsZh {
 			'backups.overviewBackups' => '备份',
 			'backups.health.headlineHealthy' => '备份正常',
 			'backups.health.headlineAttention' => '需要关注',
-			'backups.health.headlineNever' => '尚无备份',
 			_ => null,
 		} ?? switch (path) {
+			'backups.health.headlineNever' => '尚无备份',
 			'backups.health.lastSuccess' => '最近成功备份',
 			'backups.health.never' => '从未',
 			'backups.health.tiles.recentFailures' => '近期失败',
@@ -13911,7 +13913,7 @@ extension on TranslationsZh {
 			'notesPage.createFailedApi' => ({required Object error}) => '创建失败：${error}',
 			'notesPage.createFailedGeneric' => ({required Object error}) => '创建失败：${error}',
 			'notesPage.pathLabel' => '相对仓库的路径',
-			'notesPage.pathHint' => 'personal/scratch.md',
+			'notesPage.pathHint' => '我的项目/草稿.md',
 			'notesPage.create' => '创建',
 			'notesPage.popupDelete' => '删除',
 			'notesPage.deleteBody' => '此操作不可撤销。仓库的 git 同步会同时移除网关主机上的文件。',
@@ -14004,9 +14006,9 @@ extension on TranslationsZh {
 			'dataExport.import.pickFileToast' => '请先选择数据包文件。',
 			'dataExport.import.doneToast' => '导入完成',
 			'dataExport.import.finishedWithErrors' => '导入完成但有错误',
-			'dataExport.import.failedToast' => ({required Object error}) => '导入失败：${error}',
 			_ => null,
 		} ?? switch (path) {
+			'dataExport.import.failedToast' => ({required Object error}) => '导入失败：${error}',
 			'dataExport.import.summaryCard.memories' => '记忆',
 			'dataExport.import.summaryCard.integrations' => '集成',
 			'dataExport.import.summaryCard.customTasks' => '自定义任务',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -892,6 +892,7 @@ class _TranslationsNotesPageZh extends TranslationsNotesPageEn {
 	@override String get pathHelper => '缺失时自动追加 .md。';
 	@override late final _TranslationsNotesPageEditorZh editor = _TranslationsNotesPageEditorZh._(_root);
 	@override late final _TranslationsNotesPageHtmlZh html = _TranslationsNotesPageHtmlZh._(_root);
+	@override late final _TranslationsNotesPageFlattenZh flatten = _TranslationsNotesPageFlattenZh._(_root);
 }
 
 // Path: dataExport
@@ -1386,6 +1387,7 @@ class _TranslationsWebNotesZh extends TranslationsWebNotesEn {
 	@override late final _TranslationsWebNotesPickerZh picker = _TranslationsWebNotesPickerZh._(_root);
 	@override late final _TranslationsWebNotesVaultSyncZh vaultSync = _TranslationsWebNotesVaultSyncZh._(_root);
 	@override late final _TranslationsWebNotesSyncBadgeZh syncBadge = _TranslationsWebNotesSyncBadgeZh._(_root);
+	@override late final _TranslationsWebNotesFlattenZh flatten = _TranslationsWebNotesFlattenZh._(_root);
 }
 
 // Path: web.activity
@@ -2760,6 +2762,25 @@ class _TranslationsNotesPageHtmlZh extends TranslationsNotesPageHtmlEn {
 	@override String get scriptsOn => '这篇文档的脚本正在运行。';
 	@override String get enableScripts => '启用脚本';
 	@override String get disableScripts => '禁用脚本';
+}
+
+// Path: notesPage.flatten
+class _TranslationsNotesPageFlattenZh extends TranslationsNotesPageFlattenEn {
+	_TranslationsNotesPageFlattenZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get notice => '这里每个项目都装在一个叫 projects/ 的目录里。';
+	@override String get preview => '预览';
+	@override String get dismiss => '暂不';
+	@override String get title => '用项目名归档项目文档';
+	@override String get description => '文档会逐个改名,指向它的 [[wiki 链接]] 也会一并改写。不会覆盖任何东西:目标已存在的会跳过并原样留下。';
+	@override String get nothingToMove => '没有需要移动的文件。';
+	@override String skipped({required Object count}) => '未处理(${count}):';
+	@override String convert({required Object count}) => '转换 ${count} 个';
+	@override String done({required Object count}) => '已移动 ${count} 个文档。重启网关后生效。';
+	@override String get restartHint => '完成后请重启网关。';
 }
 
 // Path: dataExport.sections
@@ -4142,6 +4163,25 @@ class _TranslationsWebNotesSyncBadgeZh extends TranslationsWebNotesSyncBadgeEn {
 	@override String get tooltipAutoOn => ' · 自动同步已开启';
 	@override String tooltipLastError({required Object error}) => ' · 上次错误：${error}';
 	@override String get branchPlaceholder => '—';
+}
+
+// Path: web.notes.flatten
+class _TranslationsWebNotesFlattenZh extends TranslationsWebNotesFlattenEn {
+	_TranslationsWebNotesFlattenZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get notice => '这个文档库里的每个项目都装在一个叫 projects/ 的目录里。它们可以直接用项目名归档。';
+	@override String get preview => '预览';
+	@override String get dismiss => '暂不';
+	@override String get title => '用项目名归档项目文档';
+	@override String get description => '文档会逐个改名,指向它的 [[wiki 链接]] 也会一并改写。不会覆盖任何东西:目标已存在的会跳过并原样留下。';
+	@override String get nothingToMove => '没有需要移动的文件。';
+	@override String skipped({required Object count}) => '未处理(${count}):';
+	@override String convert({required Object count}) => '转换 ${count} 个文档';
+	@override String done({required Object count}) => '已移动 ${count} 个文档。重启网关后生效。';
+	@override String get restartHint => '完成后请重启网关。';
 }
 
 // Path: web.activity.filters
@@ -10831,6 +10871,16 @@ extension on TranslationsZh {
 			'web.notes.syncBadge.tooltipAutoOn' => ' · 自动同步已开启',
 			'web.notes.syncBadge.tooltipLastError' => ({required Object error}) => ' · 上次错误：${error}',
 			'web.notes.syncBadge.branchPlaceholder' => '—',
+			'web.notes.flatten.notice' => '这个文档库里的每个项目都装在一个叫 projects/ 的目录里。它们可以直接用项目名归档。',
+			'web.notes.flatten.preview' => '预览',
+			'web.notes.flatten.dismiss' => '暂不',
+			'web.notes.flatten.title' => '用项目名归档项目文档',
+			'web.notes.flatten.description' => '文档会逐个改名,指向它的 [[wiki 链接]] 也会一并改写。不会覆盖任何东西:目标已存在的会跳过并原样留下。',
+			'web.notes.flatten.nothingToMove' => '没有需要移动的文件。',
+			'web.notes.flatten.skipped' => ({required Object count}) => '未处理(${count}):',
+			'web.notes.flatten.convert' => ({required Object count}) => '转换 ${count} 个文档',
+			'web.notes.flatten.done' => ({required Object count}) => '已移动 ${count} 个文档。重启网关后生效。',
+			'web.notes.flatten.restartHint' => '完成后请重启网关。',
 			'web.activity.title' => '活动',
 			'web.activity.subtitle' => '按调用维度审计每个由注册集成发起的 API 请求。包括入站调用（第三方应用以集成 API key 调用 opendray）和出站代理调用（admin → opendray 代理 → 集成）。本管理端 UI 直接发起的调用不会被记录。',
 			'web.activity.refresh' => '刷新',
@@ -10871,6 +10921,8 @@ extension on TranslationsZh {
 			'web.activity.events.empty' => '尚无事件。',
 			'web.activity.events.emptyFiltered' => '没有匹配的事件。',
 			'web.activity.events.loadOlder' => '加载更早的事件',
+			_ => null,
+		} ?? switch (path) {
 			'web.activity.events.today' => '今天',
 			'web.activity.events.yesterday' => '昨天',
 			'web.providers.list.title' => 'Providers',
@@ -10881,8 +10933,6 @@ extension on TranslationsZh {
 			'web.providers.detail.disabled' => '已禁用',
 			'web.providers.detail.toggleAria' => ({required Object name}) => '切换 ${name}',
 			'web.providers.detail.configuration' => '配置',
-			_ => null,
-		} ?? switch (path) {
 			'web.providers.detail.noConfig' => '此 Provider 没有可配置字段。',
 			'web.providers.detail.executable' => 'executable:',
 			'web.providers.detail.manifestHash' => 'manifest_hash:',
@@ -11385,6 +11435,8 @@ extension on TranslationsZh {
 			'web.plugins.gitHosts.dialog.verifyRepoFail' => ({required Object repo}) => '无法读取 ${repo}',
 			'web.plugins.gitHosts.dialog.verifyPushOk' => '可以推送',
 			'web.plugins.gitHosts.dialog.verifyPushDenied' => '不能推送(只读)',
+			_ => null,
+		} ?? switch (path) {
 			'web.plugins.gitHosts.scopeHostWide' => '全主机兜底',
 			'web.plugins.gitHosts.scopeOwner' => ({required Object owner}) => '仅用于 ${owner}',
 			'web.backups.title' => '备份',
@@ -11395,8 +11447,6 @@ extension on TranslationsZh {
 			'web.backups.tabs.backups' => '备份',
 			'web.backups.tabs.schedules' => '计划',
 			'web.backups.tabs.targets' => '目标',
-			_ => null,
-		} ?? switch (path) {
 			'web.backups.inventory.title' => '备份里包含什么？',
 			'web.backups.inventory.summary' => ({required Object tables, required Object rows}) => '${tables} 张表共 ${rows} 行',
 			'web.backups.inventory.description' => '每次备份是一个对下方所有表执行 <1>pg_dump --format=custom</1> 的产物，外加 <3>manifest.json</3> 和（可选的）<5>config.toml</5>。计数是实时的；bundle 捕获的是备份发生那一刻的数据。',
@@ -11899,6 +11949,8 @@ extension on TranslationsZh {
 			'web.settings.groups.workspace' => '工作区',
 			'web.settings.groups.server' => '服务器',
 			'web.settings.groups.system' => '系统',
+			_ => null,
+		} ?? switch (path) {
 			'web.settings.items.appearance' => '外观',
 			'web.settings.items.font' => '字号',
 			'web.settings.items.account' => '账号',
@@ -11909,8 +11961,6 @@ extension on TranslationsZh {
 			'web.settings.health.dbDown' => 'db 异常',
 			'web.settings.breadcrumb.server' => '服务器',
 			'web.settings.appearance.title' => '外观',
-			_ => null,
-		} ?? switch (path) {
 			'web.settings.appearance.description' => '选择 opendray 的外观风格。',
 			'web.settings.appearance.options.light' => '浅色',
 			'web.settings.appearance.options.lightDesc' => '始终浅色',
@@ -12413,6 +12463,8 @@ extension on TranslationsZh {
 			'web.cortex.quarantine.actionFailed' => '操作失败',
 			'web.cortex.quarantine.expires' => ({required Object date}) => '${date} 到期',
 			'web.cortex.settings.injection.title' => '启动注入',
+			_ => null,
+		} ?? switch (path) {
 			'web.cortex.settings.injection.hint' => '每个【新建会话】预先加载多少心智中枢上下文。切换立即生效（影响之后新建的会话）——后端无需重启。',
 			'web.cortex.settings.injection.active' => '当前',
 			'web.cortex.settings.injection.mode.lean.label' => '精简——索引 + 按需取用（推荐）',
@@ -12423,8 +12475,6 @@ extension on TranslationsZh {
 			'web.cortex.settings.injection.saveFailed' => '保存失败',
 			'web.cortex.settings.injection.note' => '完整模式下章节/知识页各自的注入开关（蓝图编辑器 / 知识页）仍然生效；精简模式下基础方针始终注入，其余一律走索引。',
 			'web.database.dialog.createTitle' => '添加数据库连接',
-			_ => null,
-		} ?? switch (path) {
 			'web.database.dialog.editTitle' => '编辑连接',
 			'web.database.dialog.description' => '连接到此项目的数据库以浏览和编辑数据。凭据将加密存储。',
 			'web.database.dialog.name' => '名称',
@@ -12927,6 +12977,8 @@ extension on TranslationsZh {
 			'sessions.inspector.canvas.previewOnlyHint' => '仅预览 —— 点「在这上面工作」才会让 agent 指向它。',
 			'sessions.inspector.canvas.designTitle' => '设计系统',
 			'sessions.inspector.canvas.designBlurb' => '每个画布都遵循的 tokens + 规范',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.designNotesLabel' => '风格说明(tokens 表达不了的部分)',
 			'sessions.inspector.canvas.designNotesPlaceholder' => '例如:克制、信息密度高;不用渐变;按钮只用实心/描边',
 			'sessions.inspector.canvas.designAgentHint' => 'tokens 会以 CSS 变量注入每个画布,并随每次请求发送,且已要求模型使用 var(--od-…) 而非硬编码值。提示:直接让 agent 根据项目真实主题来配置。',
@@ -12937,8 +12989,6 @@ extension on TranslationsZh {
 			'sessions.inspector.canvas.tokenSecondary' => '辅助色',
 			'sessions.inspector.canvas.tokenBackground' => '背景',
 			'sessions.inspector.canvas.tokenSurface' => '表面/卡片',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.canvas.tokenText' => '正文色',
 			'sessions.inspector.canvas.tokenMuted' => '次要文字',
 			'sessions.inspector.canvas.tokenBorder' => '描边',
@@ -13441,6 +13491,8 @@ extension on TranslationsZh {
 			'backups.health.headlineHealthy' => '备份正常',
 			'backups.health.headlineAttention' => '需要关注',
 			'backups.health.headlineNever' => '尚无备份',
+			_ => null,
+		} ?? switch (path) {
 			'backups.health.lastSuccess' => '最近成功备份',
 			'backups.health.never' => '从未',
 			'backups.health.tiles.recentFailures' => '近期失败',
@@ -13451,8 +13503,6 @@ extension on TranslationsZh {
 			'backups.envVarConfigured' => 'OPENDRAY_BACKUP_KEY 环境变量',
 			'backups.savedConfirmCheckbox' => '我已将密语保存到密码管理器',
 			'backups.pgDumpMissing' => 'pg_dump 不在 PATH 中。请安装 postgresql-client 并重启 opendray。',
-			_ => null,
-		} ?? switch (path) {
 			'backups.encryption.checkAgain' => '重新检查',
 			'backups.encryption.generate' => '生成',
 			'backups.encryption.paste' => '粘贴',
@@ -13885,6 +13935,16 @@ extension on TranslationsZh {
 			'notesPage.html.scriptsOn' => '这篇文档的脚本正在运行。',
 			'notesPage.html.enableScripts' => '启用脚本',
 			'notesPage.html.disableScripts' => '禁用脚本',
+			'notesPage.flatten.notice' => '这里每个项目都装在一个叫 projects/ 的目录里。',
+			'notesPage.flatten.preview' => '预览',
+			'notesPage.flatten.dismiss' => '暂不',
+			'notesPage.flatten.title' => '用项目名归档项目文档',
+			'notesPage.flatten.description' => '文档会逐个改名,指向它的 [[wiki 链接]] 也会一并改写。不会覆盖任何东西:目标已存在的会跳过并原样留下。',
+			'notesPage.flatten.nothingToMove' => '没有需要移动的文件。',
+			'notesPage.flatten.skipped' => ({required Object count}) => '未处理(${count}):',
+			'notesPage.flatten.convert' => ({required Object count}) => '转换 ${count} 个',
+			'notesPage.flatten.done' => ({required Object count}) => '已移动 ${count} 个文档。重启网关后生效。',
+			'notesPage.flatten.restartHint' => '完成后请重启网关。',
 			'dataExport.title' => '数据导出与导入',
 			'dataExport.subtitle' => '面向用户的数据包，用于迁移或验证 — 与 /backups（灾难恢复）相互独立。',
 			'dataExport.sections.export' => '导出',
@@ -13945,6 +14005,8 @@ extension on TranslationsZh {
 			'dataExport.import.doneToast' => '导入完成',
 			'dataExport.import.finishedWithErrors' => '导入完成但有错误',
 			'dataExport.import.failedToast' => ({required Object error}) => '导入失败：${error}',
+			_ => null,
+		} ?? switch (path) {
 			'dataExport.import.summaryCard.memories' => '记忆',
 			'dataExport.import.summaryCard.integrations' => '集成',
 			'dataExport.import.summaryCard.customTasks' => '自定义任务',
@@ -13965,8 +14027,6 @@ extension on TranslationsZh {
 			'dataExport.relative.inSeconds' => ({required Object n}) => '${n} 秒后',
 			'dataExport.relative.inMinutes' => ({required Object n}) => '${n} 分钟后',
 			'dataExport.relative.inHours' => ({required Object n}) => '${n} 小时后',
-			_ => null,
-		} ?? switch (path) {
 			'dataExport.relative.inDays' => ({required Object n}) => '${n} 天后',
 			'dataExport.relative.secondsAgo' => ({required Object n}) => '${n} 秒前',
 			'dataExport.relative.minutesAgo' => ({required Object n}) => '${n} 分钟前',

--- a/app/mobile/lib/features/notes/flatten_notice.dart
+++ b/app/mobile/lib/features/notes/flatten_notice.dart
@@ -1,0 +1,270 @@
+// A vault that still files every project inside a folder called
+// `projects/` can be converted, and its owner has no way to learn that
+// unless something says so where they are already looking.
+//
+// It is an offer, not a nag: dismissing it is remembered, and it never
+// appears for a vault that is already flat or has nothing to move.
+//
+// Nothing moves without a preview. The sheet runs the migration as a
+// dry run first and shows the real list — including what it refuses to
+// touch and why — because "convert my documents" is not something to
+// agree to from a one-line description.
+//
+// Mirrors app/web/src/components/notes/FlattenNotice.tsx.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:opendray/core/api/api_exception.dart';
+import 'package:opendray/core/api/notes_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _dismissKey = 'vault.flatten.dismissed';
+
+class FlattenNotice extends ConsumerStatefulWidget {
+  const FlattenNotice({required this.onConverted, super.key});
+
+  /// Called after a successful conversion so the caller can reload the
+  /// listing — every path it is holding has just changed.
+  final Future<void> Function() onConverted;
+
+  @override
+  ConsumerState<FlattenNotice> createState() => _FlattenNoticeState();
+}
+
+class _FlattenNoticeState extends ConsumerState<FlattenNotice> {
+  bool _dismissed = false;
+  bool _checked = false;
+  bool _busy = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadDismissed();
+  }
+
+  Future<void> _loadDismissed() async {
+    var dismissed = false;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      dismissed = prefs.getBool(_dismissKey) ?? false;
+    } on Object {
+      // Unavailable prefs cost the memory of the choice, not the choice.
+    }
+    if (!mounted) return;
+    setState(() {
+      _dismissed = dismissed;
+      _checked = true;
+    });
+  }
+
+  Future<void> _dismiss() async {
+    setState(() => _dismissed = true);
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_dismissKey, true);
+    } on Object {
+      // Same as above.
+    }
+  }
+
+  Future<void> _preview() async {
+    setState(() => _busy = true);
+    try {
+      final plan = await ref.read(notesApiProvider).flatten();
+      if (!mounted) return;
+      await _showPlan(plan);
+    } on ApiException catch (e) {
+      if (mounted) _toast(e.message);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _showPlan(FlattenResult plan) async {
+    final confirmed = await showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (sheetCtx) => _PlanSheet(plan: plan),
+    );
+    if (confirmed != true || !mounted) return;
+    await _apply();
+  }
+
+  Future<void> _apply() async {
+    setState(() => _busy = true);
+    try {
+      final res = await ref.read(notesApiProvider).flatten(apply: true);
+      if (!mounted) return;
+      _toast(t.notesPage.flatten.done(count: res.moves.length));
+      await _dismiss();
+      await widget.onConverted();
+    } on ApiException catch (e) {
+      if (mounted) _toast(e.message);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  void _toast(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message), behavior: SnackBarBehavior.floating),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_checked || _dismissed) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.fromLTRB(12, 8, 8, 8),
+      color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: .5),
+      child: Row(
+        children: [
+          Icon(
+            Icons.account_tree_outlined,
+            size: 16,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              t.notesPage.flatten.notice,
+              style: TextStyle(
+                fontSize: 12,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          if (_busy)
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 12),
+              child: SizedBox(
+                width: 14,
+                height: 14,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            )
+          else ...[
+            TextButton(
+              onPressed: _preview,
+              child: Text(
+                t.notesPage.flatten.preview,
+                style: const TextStyle(fontSize: 12),
+              ),
+            ),
+            TextButton(
+              onPressed: _dismiss,
+              child: Text(
+                t.notesPage.flatten.dismiss,
+                style: const TextStyle(fontSize: 12),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _PlanSheet extends StatelessWidget {
+  const _PlanSheet({required this.plan});
+
+  final FlattenResult plan;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 14, 16, 10),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(t.notesPage.flatten.title, style: theme.textTheme.titleSmall),
+            const SizedBox(height: 6),
+            Text(
+              t.notesPage.flatten.description,
+              style: theme.textTheme.bodySmall,
+            ),
+            const SizedBox(height: 12),
+            Flexible(
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (plan.moves.isEmpty)
+                      Text(
+                        t.notesPage.flatten.nothingToMove,
+                        style: theme.textTheme.bodySmall,
+                      ),
+                    for (final m in plan.moves)
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 1),
+                        child: Text(
+                          '${m.from}  →  ${m.to}',
+                          style: const TextStyle(
+                            fontFamily: 'monospace',
+                            fontSize: 11,
+                          ),
+                        ),
+                      ),
+                    if (plan.skips.isNotEmpty) ...[
+                      const SizedBox(height: 10),
+                      Text(
+                        t.notesPage.flatten.skipped(count: plan.skips.length),
+                        style: theme.textTheme.bodySmall,
+                      ),
+                      for (final s in plan.skips)
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 1),
+                          child: Text(
+                            '${s.path} — ${s.reason}',
+                            style: TextStyle(
+                              fontFamily: 'monospace',
+                              fontSize: 11,
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              t.notesPage.flatten.restartHint,
+              style: theme.textTheme.bodySmall,
+            ),
+            const SizedBox(height: 8),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(false),
+                  child: Text(t.common.cancel),
+                ),
+                const SizedBox(width: 8),
+                FilledButton(
+                  onPressed: plan.moves.isEmpty
+                      ? null
+                      : () => Navigator.of(context).pop(true),
+                  child: Text(
+                    t.notesPage.flatten.convert(count: plan.moves.length),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/mobile/lib/features/notes/note_editor_dialog.dart
+++ b/app/mobile/lib/features/notes/note_editor_dialog.dart
@@ -37,7 +37,7 @@ class NoteEditorDialog extends ConsumerStatefulWidget {
 
 class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
   final _ctrl = MarkdownHighlightController();
-  Timer? _saveDebounce;
+  bool _dirty = false;
   bool _loading = true;
   bool _saving = false;
   String? _error;
@@ -56,7 +56,6 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
 
   @override
   void dispose() {
-    _saveDebounce?.cancel();
     _ctrl.dispose();
     super.dispose();
   }
@@ -92,9 +91,14 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
     }
   }
 
+  // Saving is explicit here too — a timer that wrote after every pause
+  // in typing kept rewriting a long document while it was being worked
+  // on. The dirty flag drives the Save action's enabled state; the
+  // flushes on preview-toggle and close below are the safety net, not
+  // the timer returning.
   void _onChanged(String _) {
-    _saveDebounce?.cancel();
-    _saveDebounce = Timer(const Duration(milliseconds: 800), _save);
+    final nowDirty = _ctrl.text != _initial;
+    if (nowDirty != _dirty) setState(() => _dirty = nowDirty);
   }
 
   Future<void> _save() async {
@@ -109,6 +113,7 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
       if (!mounted) return;
       _initial = body;
       setState(() {
+        _dirty = false;
         _saving = false;
         _lastSaved = DateTime.now();
       });
@@ -162,6 +167,15 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
                     ),
                   ),
                   IconButton(
+                    tooltip: t.notesPage.editor.save,
+                    icon: const Icon(Icons.save_outlined),
+                    // Disabled with nothing to save, so the control
+                    // doubles as the answer to "did that go through?".
+                    onPressed: _dirty && !_saving
+                        ? () => unawaited(_save())
+                        : null,
+                  ),
+                  IconButton(
                     tooltip: _preview
                         ? t.notesPage.editor.showSource
                         : t.notesPage.editor.showPreview,
@@ -172,8 +186,7 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
                       // Flush before switching: preview renders the
                       // SAVED body, so an unsaved keystroke would
                       // otherwise render stale.
-                      _saveDebounce?.cancel();
-                      unawaited(_save());
+                                        unawaited(_save());
                       setState(() => _preview = !_preview);
                     },
                   ),
@@ -184,8 +197,7 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
                         // Flush pending save before dismissing — drops
                         // the last few keystrokes otherwise if the
                         // 800ms timer hasn't fired.
-                        _saveDebounce?.cancel();
-                        await _save();
+                                            await _save();
                         if (!innerCtx.mounted) return;
                         Navigator.of(innerCtx).pop();
                       },
@@ -228,6 +240,7 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
               child: NoteSaveStatus(
                 saving: _saving,
                 lastSaved: _lastSaved,
+                dirty: _dirty,
                 error: _error,
               ),
             ),
@@ -245,12 +258,16 @@ class NoteSaveStatus extends StatelessWidget {
   const NoteSaveStatus({
     required this.saving,
     required this.lastSaved,
+    this.dirty = false,
     this.error,
     super.key,
   });
 
   final bool saving;
   final DateTime? lastSaved;
+  /// Unsaved edits are pending. Saving is explicit, so this is the only
+  /// thing telling someone their last keystrokes are not on disk yet.
+  final bool dirty;
   final String? error;
 
   @override
@@ -280,12 +297,19 @@ class NoteSaveStatus extends StatelessWidget {
         ],
       );
     }
+    // Unsaved wins over "saved at 14:03": the older fact is true and
+    // the newer one is what matters.
+    if (dirty) {
+      return Text(t.notesPage.editor.unsaved, style: muted);
+    }
     if (lastSaved != null) {
       return Text(
         t.notesPage.editor.savedAt(time: DateFormat.Hm().format(lastSaved!.toLocal())),
         style: muted,
       );
     }
+    // This label used to read "auto-saves as you type", which stopped
+    // being true when saving became explicit.
     return Text(t.notesPage.editor.autosave, style: muted);
   }
 }

--- a/app/mobile/lib/features/notes/notes_screen.dart
+++ b/app/mobile/lib/features/notes/notes_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -5,6 +7,7 @@ import 'package:intl/intl.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/notes_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/notes/flatten_notice.dart';
 import 'package:opendray/features/notes/note_editor_dialog.dart';
 import 'package:opendray/features/project/project_screen.dart';
 import 'package:path/path.dart' as p;
@@ -45,6 +48,7 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
   // the vault root. Never has a trailing slash.
   String _currentPath = '';
   String _query = '';
+  bool _flattenable = false;
   final _searchCtrl = TextEditingController();
 
   @override
@@ -62,7 +66,17 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
   Future<void> _load() async {
     setState(() => _state = const AsyncValue.loading());
     try {
-      final notes = await ref.read(notesApiProvider).list();
+      final api = ref.read(notesApiProvider);
+      // Fetched alongside the listing so the layout offer can appear
+      // with the tree rather than popping in a moment later. A failure
+      // here must not cost the listing — the notice is optional, the
+      // documents are not.
+      unawaited(
+        api.info().then((i) {
+          if (mounted) setState(() => _flattenable = i.flattenable);
+        }).catchError((Object _) {}),
+      );
+      final notes = await api.list();
       if (!mounted) return;
       notes.sort((a, b) => b.modified.compareTo(a.modified));
       setState(() => _state = AsyncValue.data(notes));
@@ -334,6 +348,7 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
       ),
       body: Column(
         children: [
+          if (_flattenable) FlattenNotice(onConverted: _load),
           Padding(
             padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
             child: TextField(

--- a/app/mobile/lib/features/notes/notes_screen.dart
+++ b/app/mobile/lib/features/notes/notes_screen.dart
@@ -143,6 +143,11 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
               onTap: () => Navigator.of(sheetCtx).pop(_RowAction.open),
             ),
             ListTile(
+              leading: const Icon(Icons.drive_file_rename_outline),
+              title: Text(t.notesPage.rename.action),
+              onTap: () => Navigator.of(sheetCtx).pop(_RowAction.rename),
+            ),
+            ListTile(
               leading: const Icon(Icons.copy),
               title: Text(t.notesPage.copyPath),
               onTap: () => Navigator.of(sheetCtx).pop(_RowAction.copyPath),
@@ -167,6 +172,8 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
     switch (action) {
       case _RowAction.open:
         await _openNote(note);
+      case _RowAction.rename:
+        await _promptRename(note);
       case _RowAction.copyPath:
         await Clipboard.setData(ClipboardData(text: note.path));
         if (!mounted) return;
@@ -179,6 +186,63 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
         );
       case _RowAction.delete:
         await _confirmAndDelete(note);
+    }
+  }
+
+  // Rename goes through the move endpoint, which repoints the
+  // [[wiki links]] that referenced the old path. Writing a copy and
+  // deleting the original would leave every one of them pointing at a
+  // document that no longer exists.
+  Future<void> _promptRename(NoteSummary note) async {
+    final ctrl = TextEditingController(text: note.path);
+    final to = await showDialog<String>(
+      context: context,
+      builder: (dialogCtx) => AlertDialog(
+        title: Text(t.notesPage.rename.title),
+        content: TextField(
+          controller: ctrl,
+          autofocus: true,
+          decoration: InputDecoration(
+            helperText: t.notesPage.rename.helper,
+            hintText: t.notesPage.pathHint,
+          ),
+          style: const TextStyle(fontFamily: 'monospace', fontSize: 13),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogCtx).pop(),
+            child: Text(t.common.cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogCtx).pop(ctrl.text.trim()),
+            child: Text(t.notesPage.rename.action),
+          ),
+        ],
+      ),
+    );
+    if (to == null || to.isEmpty || to == note.path || !mounted) return;
+
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final res = await ref.read(notesApiProvider).move(from: note.path, to: to);
+      // A warning means the file moved but the link rewrite did not
+      // finish. Reporting only "renamed" would hide a vault full of
+      // references to a path that no longer exists.
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            res.warning?.isNotEmpty ?? false
+                ? '${t.notesPage.rename.doneWithWarning}: ${res.warning}'
+                : t.notesPage.rename.doneSnack(count: res.linksRewritten),
+          ),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      await _load();
+    } on ApiException catch (e) {
+      messenger.showSnackBar(
+        SnackBar(content: Text(e.message), behavior: SnackBarBehavior.floating),
+      );
     }
   }
 
@@ -452,7 +516,7 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
   }
 }
 
-enum _RowAction { open, copyPath, delete }
+enum _RowAction { open, rename, copyPath, delete }
 
 class _LevelView {
   _LevelView({required this.folders, required this.notes});

--- a/app/mobile/lib/features/notes/notes_screen.dart
+++ b/app/mobile/lib/features/notes/notes_screen.dart
@@ -585,7 +585,11 @@ class _NoteRow extends StatelessWidget {
       onTap: onTap,
       onLongPress: onLongPress,
       leading: Icon(
-        note.path.startsWith('personal/')
+        // The operator's own note carries a different icon from the
+        // agent-written docs. Both layouts have to be recognised: the
+        // nested one files it under personal/, the flat one puts
+        // personal.md inside the project's own directory.
+        _isPersonalNote(note.path)
             ? Icons.edit_note_outlined
             : Icons.description_outlined,
         color: Theme.of(context).colorScheme.primary,
@@ -758,3 +762,11 @@ String _relTime(DateTime ts) {
   if (diff.inDays < 7) return '${diff.inDays}d ago';
   return DateFormat.yMMMd().format(ts.toLocal());
 }
+
+// _isPersonalNote recognises the operator's own scratchpad in either
+// vault layout: `personal/<project>.md` when projects are nested, and
+// `<project>/personal.md` when they are flat.
+bool _isPersonalNote(String path) =>
+    path.startsWith('personal/') ||
+    path == 'personal.md' ||
+    path.endsWith('/personal.md');

--- a/app/mobile/lib/features/sessions/inspector/notes_tab.dart
+++ b/app/mobile/lib/features/sessions/inspector/notes_tab.dart
@@ -150,7 +150,14 @@ class _Body extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final personalPath = _personalNotePath(cwd);
+    // Resolved by the gateway: under the flat layout the personal note
+    // lives inside the project directory and follows a per-cwd
+    // override, so deriving it here would point the phone at a
+    // different file than the one everything else reads. The local
+    // derivation is the fallback for an older gateway.
+    final personalPath = view.mapping.personalPath.isNotEmpty
+        ? view.mapping.personalPath
+        : _personalNotePath(cwd);
     return RefreshIndicator(
       onRefresh: onRefresh,
       child: ListView(
@@ -1060,6 +1067,8 @@ class _ErrorView extends StatelessWidget {
 
 // ─── Path conventions (mirror app/shared/src/lib/notes.ts) ─────────
 
+// Nested-layout path, kept as a fallback for gateways that do not yet
+// send personal_path. The gateway's answer wins wherever it is present.
 String _personalNotePath(String cwd) => 'personal/${_cwdSlug(cwd)}.md';
 
 String _cwdBasename(String cwd) {

--- a/app/shared/src/lib/notes.ts
+++ b/app/shared/src/lib/notes.ts
@@ -23,10 +23,50 @@ export interface VaultInfo {
    * nested, which is what those gateways do.
    */
   layout?: VaultLayout
+  /**
+   * True when this vault still files projects under `projects/` AND has
+   * something the conversion would move. Drives the offer to convert:
+   * a migration nobody is told about is one nobody runs.
+   */
+  flattenable?: boolean
   /** Nested layout only. */
   personal_prefix?: string
   /** Nested layout only. */
   projects_prefix?: string
+}
+
+export interface FlattenMove {
+  from: string
+  to: string
+  /** `[[wiki links]]` repointed at the new path. Zero on a dry run. */
+  links_rewritten: number
+}
+
+export interface FlattenSkip {
+  path: string
+  /** Stated in plain terms — surface it, don't summarise it away. */
+  reason: string
+}
+
+export interface FlattenResult {
+  moves: FlattenMove[] | null
+  skips: FlattenSkip[] | null
+  mappings_rewritten: number
+  dry_run: boolean
+}
+
+/**
+ * Preview or perform the nested → flat conversion.
+ *
+ * `apply` defaults to false and must be passed explicitly to move
+ * anything: this renames every project document in the vault, so
+ * looking and rewriting must not be one field apart.
+ */
+export async function flattenVault(apply = false): Promise<FlattenResult> {
+  return api<FlattenResult>('/api/v1/notes/flatten', {
+    method: 'POST',
+    body: { apply },
+  })
 }
 
 export async function notesInfo(): Promise<VaultInfo> {

--- a/app/shared/src/lib/notes.ts
+++ b/app/shared/src/lib/notes.ts
@@ -11,9 +11,21 @@ export interface FullNote extends Note {
   body: string
 }
 
+/** How the vault files projects. Mirrors notes.Layout in Go. */
+export type VaultLayout = 'flat' | 'nested'
+
 export interface VaultInfo {
   root: string
+  /**
+   * "flat" files each project at the vault root under its own name,
+   * with its personal notes inside it; "nested" uses the prefixes
+   * below. Absent on a gateway older than this field — treat that as
+   * nested, which is what those gateways do.
+   */
+  layout?: VaultLayout
+  /** Nested layout only. */
   personal_prefix?: string
+  /** Nested layout only. */
   projects_prefix?: string
 }
 
@@ -27,6 +39,14 @@ export interface ProjectMappingResolved {
   path: string         // resolved path (override OR default)
   default_path: string // what auto-derivation would produce
   custom: boolean      // true when path != default_path
+  /**
+   * Where this cwd's personal scratchpad belongs. Served rather than
+   * derived here because it depends on the vault's layout: the flat
+   * layout keeps it inside the project directory (so a per-cwd override
+   * moves it too), while the nested layout files it in its own tree.
+   * Use personalNotePath() only as a fallback before this arrives.
+   */
+  personal_path?: string
 }
 
 export interface ProjectMapping {
@@ -291,9 +311,13 @@ export function projectNotePath(cwd: string): string {
 }
 
 // personalNotePath is the user's personal scratchpad for this project.
-// One file per cwd basename, edited inline in the Notes panel. AI
-// agents do NOT write here — the convention keeps human and agent
-// authoring lanes clean.
+// One file per cwd, edited inline in the Notes panel. AI agents do NOT
+// write here — the convention keeps human and agent authoring lanes
+// clean, and under the flat layout that rule is the ONLY thing keeping
+// them apart, since the file now sits inside the project's directory.
+//
+// This returns the NESTED path and is a fallback only: ask the gateway
+// via notesProjectMapping(cwd).personal_path, which knows the layout.
 export function personalNotePath(cwd: string): string {
   return `personal/${cwdSlug(cwd)}.md`
 }

--- a/app/web/src/components/notes/FlattenNotice.tsx
+++ b/app/web/src/components/notes/FlattenNotice.tsx
@@ -1,0 +1,178 @@
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { FolderTree, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { flattenVault } from '@/lib/notes'
+import type { FlattenResult } from '@/lib/notes'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+// A vault that still files every project under `projects/` can be
+// converted, and the operator has no way to know that unless something
+// says so where they are already looking.
+//
+// It is an offer, not a nag: dismissing it is remembered, and it never
+// appears for a vault that is already flat or has nothing to move.
+//
+// Nothing moves without a preview. The dialog runs the migration as a
+// dry run first and shows the actual list — including what it refuses
+// to touch and why — because "convert my documents" is not a thing
+// anyone should agree to from a one-line description.
+
+const DISMISS_KEY = 'vault.flatten.dismissed'
+
+export function FlattenNotice() {
+  const { t } = useTranslation()
+  const qc = useQueryClient()
+  const [dismissed, setDismissed] = useState(() => {
+    try {
+      return localStorage.getItem(DISMISS_KEY) === '1'
+    } catch {
+      return false
+    }
+  })
+  const [plan, setPlan] = useState<FlattenResult | null>(null)
+
+  const preview = useMutation({
+    mutationFn: () => flattenVault(false),
+    onSuccess: (res) => setPlan(res),
+    onError: (e: Error) => toast.error(e.message),
+  })
+
+  const apply = useMutation({
+    mutationFn: () => flattenVault(true),
+    onSuccess: (res) => {
+      setPlan(null)
+      setDismissed(true)
+      const moved = res.moves?.length ?? 0
+      toast.success(t('web.notes.flatten.done', { count: moved }))
+      // The tree, the listing and the layout badge are all now wrong.
+      qc.invalidateQueries({ queryKey: ['notes-list'] })
+      qc.invalidateQueries({ queryKey: ['notes-info'] })
+    },
+    onError: (e: Error) => toast.error(e.message),
+  })
+
+  const dismiss = () => {
+    setDismissed(true)
+    try {
+      localStorage.setItem(DISMISS_KEY, '1')
+    } catch {
+      // A blocked localStorage costs the memory of the choice only.
+    }
+  }
+
+  if (dismissed) return null
+
+  const moves = plan?.moves ?? []
+  const skips = plan?.skips ?? []
+
+  return (
+    <>
+      <div className="flex items-center gap-2 px-3 py-1.5 border-b border-border bg-muted/40 text-[11.5px]">
+        <FolderTree className="size-3.5 text-muted-foreground shrink-0" />
+        <span className="text-muted-foreground min-w-0 truncate">
+          {t('web.notes.flatten.notice')}
+        </span>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-6 px-2 text-[11px] ml-auto shrink-0"
+          disabled={preview.isPending}
+          onClick={() => preview.mutate()}
+        >
+          {preview.isPending && (
+            <Loader2 className="size-3 animate-spin mr-1" />
+          )}
+          {t('web.notes.flatten.preview')}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className="h-6 px-2 text-[11px] shrink-0"
+          onClick={dismiss}
+        >
+          {t('web.notes.flatten.dismiss')}
+        </Button>
+      </div>
+
+      <Dialog open={plan != null} onOpenChange={(v) => !v && setPlan(null)}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{t('web.notes.flatten.title')}</DialogTitle>
+            <DialogDescription>
+              {t('web.notes.flatten.description')}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="max-h-[45vh] overflow-y-auto text-[11.5px] font-mono space-y-0.5">
+            {moves.map((m) => (
+              <div key={m.from} className="flex items-baseline gap-1.5">
+                <span className="text-muted-foreground truncate">{m.from}</span>
+                <span className="text-muted-foreground/50 shrink-0">→</span>
+                <span className="truncate">{m.to}</span>
+              </div>
+            ))}
+            {moves.length === 0 && (
+              <p className="text-muted-foreground font-sans">
+                {t('web.notes.flatten.nothingToMove')}
+              </p>
+            )}
+          </div>
+
+          {skips.length > 0 && (
+            <div className="border-t border-border pt-2 space-y-0.5">
+              <p className="text-[11px] text-muted-foreground font-sans">
+                {t('web.notes.flatten.skipped', { count: skips.length })}
+              </p>
+              <div className="max-h-[18vh] overflow-y-auto text-[11px] font-mono">
+                {skips.map((s) => (
+                  <div key={s.path} className="text-muted-foreground truncate">
+                    {s.path} — {s.reason}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <DialogFooter className="sm:justify-between gap-2">
+            <p className="text-[11px] text-muted-foreground">
+              {t('web.notes.flatten.restartHint')}
+            </p>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setPlan(null)}
+              >
+                {t('common.cancel')}
+              </Button>
+              <Button
+                type="button"
+                disabled={moves.length === 0 || apply.isPending}
+                onClick={() => apply.mutate()}
+              >
+                {apply.isPending && (
+                  <Loader2 className="size-3.5 animate-spin mr-1" />
+                )}
+                {t('web.notes.flatten.convert', { count: moves.length })}
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/app/web/src/components/notes/HighlightedSource.tsx
+++ b/app/web/src/components/notes/HighlightedSource.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { highlightCode } from '@/lib/highlight'
 import { cn } from '@/lib/utils'
@@ -18,9 +18,25 @@ import { cn } from '@/lib/utils'
 // glyphs the further down you type. Both layers therefore take their
 // box and type styling from the same SHARED constant below. Change it
 // in one place or not at all.
+// Line numbers force one more agreement: WRAPPING.
+//
+// A wrapped logical line occupies several visual rows, so a gutter
+// counting 1..N drifts the moment any line is longer than the box —
+// and in an HTML document, most are. Every code editor answers this
+// the same way, by not wrapping. So the gutter and `whitespace-pre`
+// travel together; without numbers the view keeps wrapping, which is
+// what prose wants.
 const SHARED_BOX =
-  'w-full px-3 py-2 font-mono text-[12px] leading-snug border ' +
-  'whitespace-pre-wrap break-words'
+  'w-full py-2 font-mono text-[12px] leading-snug border'
+const WRAP_BOX = 'whitespace-pre-wrap break-words'
+const NOWRAP_BOX = 'whitespace-pre overflow-auto'
+
+// Width of the gutter, in ch, for a given line count. Both layers pad
+// left by exactly this much — a disagreement here is the caret drift
+// this file exists to avoid.
+function gutterCh(lines: number): number {
+  return String(Math.max(lines, 1)).length + 2
+}
 
 interface HighlightedSourceProps {
   value: string
@@ -38,6 +54,8 @@ interface HighlightedSourceProps {
   onKeyUp?: React.KeyboardEventHandler<HTMLTextAreaElement>
   onClick?: React.MouseEventHandler<HTMLTextAreaElement>
   onBlur?: React.FocusEventHandler<HTMLTextAreaElement>
+  /** Show a line-number gutter. Implies no wrapping — see SHARED_BOX. */
+  showLineNumbers?: boolean
 }
 
 export function HighlightedSource({
@@ -52,9 +70,15 @@ export function HighlightedSource({
   onKeyUp,
   onClick,
   onBlur,
+  showLineNumbers = false,
 }: HighlightedSourceProps) {
   const preRef = useRef<HTMLPreElement>(null)
+  const gutterRef = useRef<HTMLDivElement>(null)
   const [html, setHtml] = useState<string | null>(null)
+
+  const lineCount = useMemo(() => value.split('\n').length, [value])
+  const gutterWidth = showLineNumbers ? gutterCh(lineCount) : 0
+  const padLeft = showLineNumbers ? `${gutterWidth + 1}ch` : undefined
 
   // hljs loads lazily, and highlighting a long note on every keystroke
   // would make typing feel heavy. Debounce, and render plain text until
@@ -76,13 +100,19 @@ export function HighlightedSource({
     }
   }, [value, language])
 
-  // The backdrop does not scroll on its own; it follows the textarea.
+  // Neither the backdrop nor the gutter scrolls on its own; both
+  // follow the textarea. The gutter tracks vertical only — it must
+  // stay put while the code scrolls sideways.
   const syncScroll = () => {
     const ta = textareaRef.current
-    const pre = preRef.current
-    if (!ta || !pre) return
-    pre.scrollTop = ta.scrollTop
-    pre.scrollLeft = ta.scrollLeft
+    if (!ta) return
+    if (preRef.current) {
+      preRef.current.scrollTop = ta.scrollTop
+      preRef.current.scrollLeft = ta.scrollLeft
+    }
+    if (gutterRef.current) {
+      gutterRef.current.scrollTop = ta.scrollTop
+    }
   }
 
   const sizing = fillParent
@@ -92,11 +122,32 @@ export function HighlightedSource({
 
   return (
     <div className={cn('relative', sizing, className)} style={style}>
+      {showLineNumbers && (
+        <div
+          ref={gutterRef}
+          aria-hidden="true"
+          className={cn(
+            'pointer-events-none absolute left-0 top-0 bottom-0 z-10 overflow-hidden',
+            'py-2 pr-2 font-mono text-[12px] leading-snug text-right',
+            'select-none rounded-l-md border-y border-l border-border',
+            'bg-input/60 text-muted-foreground/50',
+          )}
+          style={{ width: `${gutterWidth}ch` }}
+        >
+          {Array.from({ length: lineCount }, (_, i) => (
+            <div key={i}>{i + 1}</div>
+          ))}
+        </div>
+      )}
       <pre
         ref={preRef}
         aria-hidden="true"
+        style={{ paddingLeft: padLeft }}
         className={cn(
           SHARED_BOX,
+          showLineNumbers ? NOWRAP_BOX : WRAP_BOX,
+          !showLineNumbers && 'px-3',
+          showLineNumbers && 'pr-3',
           'hljs pointer-events-none absolute inset-0 m-0 overflow-hidden',
           'rounded-md border-border bg-input/40 text-foreground',
         )}
@@ -119,8 +170,12 @@ export function HighlightedSource({
         onBlur={onBlur}
         placeholder={placeholder}
         spellCheck={false}
+        style={{ paddingLeft: padLeft }}
         className={cn(
           SHARED_BOX,
+          showLineNumbers ? NOWRAP_BOX : WRAP_BOX,
+          !showLineNumbers && 'px-3',
+          showLineNumbers && 'pr-3',
           'absolute inset-0 h-full resize-none rounded-md border-border',
           // The glyphs come from the backdrop; only the caret and the
           // selection highlight belong to the textarea.

--- a/app/web/src/components/notes/NotesTreeView.tsx
+++ b/app/web/src/components/notes/NotesTreeView.tsx
@@ -1,4 +1,10 @@
-import { useImperativeHandle, useMemo, useState, forwardRef } from 'react'
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useState,
+} from 'react'
 import {
   BookOpen,
   ChevronRight,
@@ -67,27 +73,36 @@ export const NotesTreeView = forwardRef<NotesTreeViewHandle, NotesTreeViewProps>
   const { t } = useTranslation()
   const tree = useMemo(() => buildTree(notes), [notes])
 
-  // Auto-expand the path leading to the selected note so it stays
-  // visible across re-renders / search clears. Other folders default
-  // to whatever caller passed (or empty = collapsed).
-  const autoExpand = useMemo(() => {
-    const set = new Set<string>(initialExpanded ?? new Set<string>())
-    if (selected) {
-      const parts = selected.split('/').slice(0, -1)
+  const [expanded, setExpanded] = useState<Set<string>>(
+    () => new Set(initialExpanded ?? []),
+  )
+
+  // Reveal the selected note by opening its ancestors — ONCE per
+  // selection, in an effect.
+  //
+  // This used to re-merge on every render, which made the folder
+  // holding the selected note impossible to close: the collapse landed,
+  // the next render put it straight back, and "Collapse all" left that
+  // one branch open. Auto-expand is a response to the selection
+  // changing, not a rule about what must stay open.
+  useEffect(() => {
+    if (!selected) return
+    const parts = selected.split('/').slice(0, -1)
+    if (parts.length === 0) return
+    setExpanded((prev) => {
+      const next = new Set(prev)
       let cur = ''
+      let changed = false
       for (const p of parts) {
         cur = cur ? `${cur}/${p}` : p
-        set.add(cur)
+        if (!next.has(cur)) {
+          next.add(cur)
+          changed = true
+        }
       }
-    }
-    return set
-  }, [tree, selected, initialExpanded])
-
-  const [expanded, setExpanded] = useState<Set<string>>(autoExpand)
-
-  // Re-merge when autoExpand changes (e.g. selected note in a fresh
-  // folder branch). Preserves user's explicit toggles.
-  useMemoSync(autoExpand, expanded, setExpanded)
+      return changed ? next : prev
+    })
+  }, [selected])
 
   // Expose imperative expand/collapse-all so the parent toolbar can
   // hit them without us lifting the expanded state up.
@@ -310,31 +325,3 @@ function walkSort(node: TreeNode) {
   for (const [, child] of node.children) walkSort(child)
 }
 
-// useMemoSync merges newly-required expansions into the existing user
-// state without dropping toggles the user made. React doesn't expose
-// a clean "merge into setState if value changed" so we compare via
-// JSON serialisation of the sorted paths — cheap for sets of <100.
-function useMemoSync(
-  next: Set<string>,
-  current: Set<string>,
-  set: (s: Set<string>) => void,
-) {
-  const nextKey = JSON.stringify([...next].sort())
-  const currentKey = JSON.stringify([...current].sort())
-  // Effect-less sync: only fire when next has additions current doesn't.
-  // Avoids infinite loops while still picking up auto-expand.
-  if (nextKey !== currentKey) {
-    let changed = false
-    const merged = new Set(current)
-    for (const p of next) {
-      if (!merged.has(p)) {
-        merged.add(p)
-        changed = true
-      }
-    }
-    if (changed) {
-      // queueMicrotask defers to after render so React doesn't warn.
-      queueMicrotask(() => set(merged))
-    }
-  }
-}

--- a/app/web/src/components/notes/NotesTreeView.tsx
+++ b/app/web/src/components/notes/NotesTreeView.tsx
@@ -1,5 +1,6 @@
 import {
   forwardRef,
+  memo,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -57,7 +58,12 @@ interface TreeNode {
 // the vault. Built by chunking each note's path into segments and
 // merging into a tree on the fly — no recursive backend listing
 // needed (the /notes/list endpoint already returns the flat list).
-export const NotesTreeView = forwardRef<NotesTreeViewHandle, NotesTreeViewProps>(
+// memo, because the page that hosts this re-renders on every edit to
+// the open document. Re-walking and re-rendering every row of a vault
+// for each keystroke is work nobody asked for: the tree only changes
+// when the note list or the selection does.
+export const NotesTreeView = memo(
+  forwardRef<NotesTreeViewHandle, NotesTreeViewProps>(
   function NotesTreeView(
     {
       notes,
@@ -147,7 +153,8 @@ export const NotesTreeView = forwardRef<NotesTreeViewHandle, NotesTreeViewProps>
       )}
     </div>
   )
-})
+}),
+)
 
 function TreeRow({
   node,

--- a/app/web/src/components/sessions/inspector/NoteEditor.tsx
+++ b/app/web/src/components/sessions/inspector/NoteEditor.tsx
@@ -1,6 +1,15 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Loader2, Eye, Pencil, Check, AlertCircle, Hash } from 'lucide-react'
+import {
+  AlertCircle,
+  Check,
+  Eye,
+  Hash,
+  ListOrdered,
+  Loader2,
+  Pencil,
+  Save,
+} from 'lucide-react'
 import { toast } from 'sonner'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -52,12 +61,14 @@ interface NoteEditorProps {
   previewScrollRef?: React.MutableRefObject<HTMLDivElement | null>
 }
 
-const SAVE_DEBOUNCE_MS = 800
-
-// NoteEditor is the reusable note source/preview editor with debounced
-// auto-save. Used both inline in the Notes panel (personal scratchpad)
-// and inside a dialog (project docs). All variants speak to the same
+// NoteEditor is the reusable note source/preview editor. Used both
+// inline in the Notes panel (personal scratchpad) and inside a dialog
+// (project docs). All variants speak to the same
 // /api/v1/notes/{read,write} endpoints.
+//
+// Saving is EXPLICIT — a button or ⌘S. It used to run on a timer after
+// every pause in typing, which meant a long document rewrote itself to
+// disk continuously while being worked on.
 export function NoteEditor({
   path,
   initialMode = 'source',
@@ -82,13 +93,17 @@ export function NoteEditor({
   const [body, setBody] = useState('')
   const [lastSaved, setLastSaved] = useState('')
   const [mode, setMode] = useState<'source' | 'preview'>(initialMode)
+  // Defaults on for HTML and off for markdown: numbers are for finding
+  // your way around code, and they cost wrapping, which prose wants.
+  const [lineNumbers, setLineNumbers] = useState(
+    () => docKind(path) === 'html',
+  )
   // Which renderer preview reaches for. Derived from the path, never
   // from the body: sniffing content would let a markdown note that
   // happens to open with a tag be executed as HTML.
   const kind = docKind(path)
   const [error, setError] = useState<string | null>(null)
   const dirty = body !== lastSaved
-  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Wiki-link autocomplete state. Active when the caret is inside an
   // open `[[...` span; stays in sync via re-detection on every input
@@ -106,11 +121,14 @@ export function NoteEditor({
     setError(null)
   }, [path, data])
 
-  // Stream body changes to the parent (used for outline + future
-  // word-count / live-render features). Fires after every state
-  // commit, so debounced enough that callers don't get hammered.
+  // Stream body changes to the parent (outline, word count…), but not
+  // on every keystroke. The parent re-renders its entire page from
+  // this — tree, sidebar and all — and recomputes the outline, which
+  // is a lot of work to repeat per character for a panel that only has
+  // to keep up with reading speed.
   useEffect(() => {
-    onBodyChange?.(body)
+    const timer = setTimeout(() => onBodyChange?.(body), 200)
+    return () => clearTimeout(timer)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [body])
 
@@ -130,22 +148,46 @@ export function NoteEditor({
     },
   })
 
+  // Saving is explicit: a button, or ⌘S / Ctrl+S.
+  //
+  // It used to fire on a timer after every pause in typing, which made
+  // a long document write itself to disk over and over while it was
+  // being worked on. The editor now writes when someone says to.
+  //
+  // The one exception is below: leaving the document flushes unsaved
+  // text. That is not the timer coming back — it costs nothing while
+  // typing, and the alternative is losing work to a click on another
+  // note.
+  const saveNow = () => {
+    if (!dirty || save.isPending) return
+    save.mutate(body)
+  }
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== 's') return
+      // The browser's "save page" is never what someone wants while
+      // typing into an editor.
+      e.preventDefault()
+      saveNow()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [body, dirty, save.isPending])
+
+  // Closing the tab with unsaved text should cost a prompt, not the
+  // text. Only armed while there is something to lose.
   useEffect(() => {
     if (!dirty) return
-    if (saveTimer.current) clearTimeout(saveTimer.current)
-    saveTimer.current = setTimeout(() => {
-      save.mutate(body)
-    }, SAVE_DEBOUNCE_MS)
-    return () => {
-      if (saveTimer.current) clearTimeout(saveTimer.current)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [body, dirty])
+    const warn = (e: BeforeUnloadEvent) => e.preventDefault()
+    window.addEventListener('beforeunload', warn)
+    return () => window.removeEventListener('beforeunload', warn)
+  }, [dirty])
 
   // Flush on unmount so tab switches / dialog close don't lose edits.
   useEffect(() => {
     return () => {
-      if (saveTimer.current) clearTimeout(saveTimer.current)
       if (body !== lastSaved) {
         void writeNote(path, body).catch(() => {})
       }
@@ -305,8 +347,39 @@ export function NoteEditor({
           <Eye className="size-3" />
           {t('web.noteEditor.preview')}
         </button>
+        {mode === 'source' && (
+          <button
+            type="button"
+            onClick={() => setLineNumbers((v) => !v)}
+            className={cn(
+              'inline-flex items-center gap-1 px-2 py-1 rounded-md transition-colors',
+              lineNumbers
+                ? 'bg-card border border-border text-foreground'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+            title={t('web.noteEditor.lineNumbersTitle')}
+          >
+            <ListOrdered className="size-3" />
+            {t('web.noteEditor.lineNumbers')}
+          </button>
+        )}
         <div className="flex-1" />
         {showStatus && <SaveStatus status={status} />}
+        <button
+          type="button"
+          onClick={saveNow}
+          disabled={!dirty || save.isPending}
+          className={cn(
+            'inline-flex items-center gap-1 px-2 py-1 rounded-md transition-colors',
+            dirty
+              ? 'bg-accent text-accent-foreground hover:bg-accent/90'
+              : 'text-muted-foreground/50',
+          )}
+          title={t('web.noteEditor.saveTitle')}
+        >
+          <Save className="size-3" />
+          {t('web.noteEditor.save')}
+        </button>
       </div>
 
       {tags.length > 0 && (
@@ -344,6 +417,7 @@ export function NoteEditor({
             placeholder={placeholder}
             fillParent={fillParent}
             minHeight={minHeight}
+            showLineNumbers={lineNumbers}
           />
           <WikiLinkSuggestions
             context={linkCtx}

--- a/app/web/src/components/sessions/inspector/VaultPanel.tsx
+++ b/app/web/src/components/sessions/inspector/VaultPanel.tsx
@@ -67,7 +67,19 @@ interface VaultPanelProps {
 // Cortex (the sibling tab), not the Vault.
 export function VaultPanel({ cwd }: VaultPanelProps) {
   const { t } = useTranslation()
-  const personalPath = useMemo(() => personalNotePath(cwd), [cwd])
+  // The gateway resolves this: where the personal note lives depends on
+  // the vault layout, and under the flat layout it follows a per-cwd
+  // project override. Deriving it here would make the panel disagree
+  // with the file the agent tooling actually reads. Same query key as
+  // ProjectDocsSection, so this shares one request.
+  const mappingQ = useQuery({
+    queryKey: ['notes-project-mapping', cwd],
+    queryFn: () => notesProjectMapping(cwd),
+    enabled: !!cwd,
+    staleTime: 30_000,
+  })
+  const fallbackPersonal = useMemo(() => personalNotePath(cwd), [cwd])
+  const personalPath = mappingQ.data?.personal_path || fallbackPersonal
   const cwdBase = useMemo(() => cwdBasename(cwd), [cwd])
   const [opening, setOpening] = useState<string | null>(null)
 

--- a/app/web/src/pages/Notes.tsx
+++ b/app/web/src/pages/Notes.tsx
@@ -8,6 +8,8 @@ import {
   Calendar,
   NotebookPen,
   FolderOpen,
+  Pencil,
+  Trash2,
   PanelRightClose,
   PanelRightOpen,
 } from 'lucide-react'
@@ -17,10 +19,13 @@ import { Trans, useTranslation } from 'react-i18next'
 
 import { cn } from '@/lib/utils'
 import {
+  deleteNote,
   docKind,
   listNotes,
+  moveNote,
   notesInfo,
   notesTags,
+  sanitizeNotePath,
   writeNote,
 } from '@/lib/notes'
 import type { Note, VaultLayout } from '@/lib/notes'
@@ -199,6 +204,65 @@ export function VaultPage() {
     create.mutate(cleaned)
   }
 
+  // Rename goes through moveNote, which repoints the [[wiki links]]
+  // that referenced the old path. A plain write-and-delete would leave
+  // every link in the vault pointing at a document that no longer
+  // exists, which is the failure a doc library can least afford.
+  const rename = useMutation({
+    mutationFn: ({ from, to }: { from: string; to: string }) =>
+      moveNote(from, to),
+    onSuccess: (res) => {
+      qc.invalidateQueries({ queryKey: ['notes-list'] })
+      setSelected(res.to)
+      if (res.warning) {
+        // The move happened; the link rewrite did not finish. Saying
+        // "renamed" alone would hide a vault full of stale links.
+        toast.warning(t('web.notes.doc.renamedWithWarning'), {
+          description: res.warning,
+        })
+        return
+      }
+      toast.success(
+        t('web.notes.doc.renamed', { count: res.links_rewritten ?? 0 }),
+        { description: res.to },
+      )
+    },
+    onError: (err: Error) =>
+      toast.error(t('web.notes.doc.renameFailed'), {
+        description: err.message,
+      }),
+  })
+
+  const remove = useMutation({
+    mutationFn: (path: string) => deleteNote(path),
+    onSuccess: (_res, path) => {
+      qc.invalidateQueries({ queryKey: ['notes-list'] })
+      setSelected(null)
+      toast.success(t('web.notes.doc.deleted'), { description: path })
+    },
+    onError: (err: Error) =>
+      toast.error(t('web.notes.doc.deleteFailed'), {
+        description: err.message,
+      }),
+  })
+
+  const handleRename = (path: string) => {
+    const input = prompt(t('web.notes.doc.renamePrompt'), path)
+    if (!input) return
+    const to = sanitizeNotePath(input)
+    if (to === path) return
+    if (docKind(to) === 'unknown') {
+      toast.error(t('web.notes.newNote.errorMustBeDoc'))
+      return
+    }
+    rename.mutate({ from: path, to })
+  }
+
+  const handleDelete = (path: string) => {
+    if (!confirm(t('web.notes.doc.deleteConfirm', { path }))) return
+    remove.mutate(path)
+  }
+
   const handleNewDaily = () => {
     const today = format(new Date(), 'yyyy-MM-dd')
     const path = `daily/${today}.md`
@@ -227,8 +291,13 @@ export function VaultPage() {
           {t('web.notes.title')}
         </h1>
         {info && (
+          // min-w-0 is what makes `truncate` actually truncate here. A
+          // flex item defaults to min-width:auto, so a nowrap path this
+          // long refuses to shrink and pushes the actions past the
+          // right edge — which is how "New" and "Today" became
+          // reachable only from the empty state.
           <span
-            className="text-[10.5px] text-muted-foreground/60 font-mono truncate"
+            className="text-[10.5px] text-muted-foreground/60 font-mono truncate min-w-0"
             title={info.root}
           >
             · {info.root}
@@ -412,11 +481,36 @@ export function VaultPage() {
                   {pathTitle(selected)}
                 </h2>
                 <span
-                  className="text-[11px] text-muted-foreground/70 font-mono truncate"
+                  className="text-[11px] text-muted-foreground/70 font-mono truncate min-w-0"
                   title={selected}
                 >
                   {selected}
                 </span>
+                <div className="flex-1" />
+                {/* Rename and delete live here because this is the only
+                    surface that shows every document. Without them a
+                    daily note, or anything not bound to a project, could
+                    be created and edited but never moved or removed. */}
+                <button
+                  type="button"
+                  onClick={() => handleRename(selected)}
+                  disabled={rename.isPending}
+                  className="inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-card shrink-0"
+                  title={t('web.notes.doc.rename')}
+                >
+                  <Pencil className="size-3" />
+                  {t('web.notes.doc.rename')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleDelete(selected)}
+                  disabled={remove.isPending}
+                  className="inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-md text-muted-foreground hover:text-destructive hover:bg-card shrink-0"
+                  title={t('web.notes.doc.delete')}
+                >
+                  <Trash2 className="size-3" />
+                  {t('web.notes.doc.delete')}
+                </button>
               </div>
               <NoteEditor
                 key={selected}

--- a/app/web/src/pages/Notes.tsx
+++ b/app/web/src/pages/Notes.tsx
@@ -39,6 +39,7 @@ import {
   VaultSyncBadge,
   VaultSyncDialog,
 } from '@/components/notes/VaultSyncDialog'
+import { FlattenNotice } from '@/components/notes/FlattenNotice'
 
 // localStorage keys persist the last selection / left-pane mode so
 // reopening the page lands you back where you left off.
@@ -275,6 +276,8 @@ export function VaultPage() {
           {t('web.notes.header.new')}
         </button>
       </header>
+
+      {info?.flattenable && <FlattenNotice />}
 
       <div className="flex-1 flex min-h-0">
         {/* Left pane: tree / tags + filter */}

--- a/app/web/src/pages/Notes.tsx
+++ b/app/web/src/pages/Notes.tsx
@@ -23,7 +23,7 @@ import {
   notesTags,
   writeNote,
 } from '@/lib/notes'
-import type { Note } from '@/lib/notes'
+import type { Note, VaultLayout } from '@/lib/notes'
 import { extractOutline } from '@/lib/outline'
 import { vaultStatus } from '@/lib/vaultgit'
 import { NoteEditor } from '@/components/sessions/inspector/NoteEditor'
@@ -430,7 +430,11 @@ export function VaultPage() {
               />
             </div>
           ) : (
-            <EmptyState onNew={handleNewNote} onDaily={handleNewDaily} />
+            <EmptyState
+              onNew={handleNewNote}
+              onDaily={handleNewDaily}
+              layout={info?.layout}
+            />
           )}
         </main>
 
@@ -523,21 +527,26 @@ function TagsList({
 function EmptyState({
   onNew,
   onDaily,
+  layout,
 }: {
   onNew: () => void
   onDaily: () => void
+  /** Undefined while /notes/info is in flight, or on an older gateway. */
+  layout?: VaultLayout
 }) {
   const { t } = useTranslation()
+  // Naming `projects/` and `personal/` to someone whose vault has
+  // neither is worse than saying nothing: it sends them looking for
+  // directories the flat layout does not have.
+  const hintKey =
+    layout === 'flat' ? 'web.notes.empty.hintFlat' : 'web.notes.empty.hint'
   return (
     <div className="flex-1 flex flex-col items-center justify-center gap-3 text-center px-6">
       <NotebookPen className="size-8 text-muted-foreground/40" strokeWidth={1.5} />
       <div className="space-y-1">
         <h2 className="text-[14px] font-semibold">{t('web.notes.empty.title')}</h2>
         <p className="text-[12px] text-muted-foreground max-w-[420px]">
-          <Trans
-            i18nKey="web.notes.empty.hint"
-            components={{ 1: <code />, 3: <code /> }}
-          />
+          <Trans i18nKey={hintKey} components={{ 1: <code />, 3: <code /> }} />
         </p>
       </div>
       <div className="flex items-center gap-2">

--- a/cmd/opendray/notes.go
+++ b/cmd/opendray/notes.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -36,6 +37,7 @@ func runNotes(args []string) int {
 	root := fs.String("root", "", "override vault root (else config / env / default)")
 	prefix := fs.String("prefix", "", "list: filter by path prefix (e.g. projects/)")
 	asJSON := fs.Bool("json", false, "list/read: emit JSON instead of plain text")
+	apply := fs.Bool("apply", false, "flatten: perform the moves (default is a dry run)")
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr, notesUsage)
 	}
@@ -155,7 +157,10 @@ func runNotes(args []string) int {
 			fmt.Fprintln(os.Stderr, "project: missing <basename>")
 			return 2
 		}
-		path := notes.ProjectPath(rest[1])
+		// The vault's own derivation, not the package-level shim: the
+		// shim hardcodes `projects/` and would file this outside the
+		// configured layout.
+		path := vault.ProjectPath(rest[1])
 		if _, err := vault.Read(path); errors.Is(err, notes.ErrNotFound) {
 			template := projectTemplate(rest[1])
 			if _, err := vault.Write(path, template); err != nil {
@@ -166,11 +171,64 @@ func runNotes(args []string) int {
 		fmt.Println(path)
 		return 0
 
+	case "flatten":
+		return runFlatten(vault, *cfgPath, *apply, *asJSON)
+
 	default:
 		fmt.Fprintf(os.Stderr, "unknown notes command: %s\n", rest[0])
 		fs.Usage()
 		return 2
 	}
+}
+
+// runFlatten converts a nested vault to the flat layout. It defaults
+// to a dry run: this rewrites every project document's path, and a
+// migration that starts moving files because someone typed the command
+// to see what it would do is not one anybody should trust.
+//
+// The config is left alone even on success. Recording `layout = "flat"`
+// belongs to the gateway's startup detection, which sees a vault with
+// no `projects/` directory and reaches the same conclusion — one place
+// deciding, rather than two that can disagree if this run half-fails.
+func runFlatten(vault *notes.Vault, cfgPath string, apply, asJSON bool) int {
+	res, err := vault.Flatten(context.Background(), !apply)
+	if err != nil {
+		return reportErr(err)
+	}
+	if asJSON {
+		_ = json.NewEncoder(os.Stdout).Encode(res)
+		return 0
+	}
+
+	for _, m := range res.Moves {
+		if m.LinksRewritten > 0 {
+			fmt.Printf("%s -> %s (%d links repointed)\n",
+				m.From, m.To, m.LinksRewritten)
+			continue
+		}
+		fmt.Printf("%s -> %s\n", m.From, m.To)
+	}
+	for _, s := range res.Skips {
+		fmt.Fprintf(os.Stderr, "skipped %s: %s\n", s.Path, s.Reason)
+	}
+
+	switch {
+	case res.DryRun && len(res.Moves) == 0:
+		fmt.Fprintln(os.Stderr, "nothing to move")
+	case res.DryRun:
+		fmt.Fprintf(os.Stderr,
+			"\ndry run: %d document(s) would move. Re-run with --apply.\n",
+			len(res.Moves))
+	default:
+		fmt.Fprintf(os.Stderr, "\nmoved %d document(s)", len(res.Moves))
+		if res.MappingsRewritten > 0 {
+			fmt.Fprintf(os.Stderr, ", repointed %d project override(s)",
+				res.MappingsRewritten)
+		}
+		fmt.Fprintf(os.Stderr, ".\nRestart the gateway so it picks up the "+
+			"new layout.\n")
+	}
+	return 0
 }
 
 func openVault(cfgPath, override string) (*notes.Vault, error) {
@@ -180,7 +238,13 @@ func openVault(cfgPath, override string) (*notes.Vault, error) {
 	if root == "" {
 		root = paths.Vault
 	}
+	// The CLI reads the layout the gateway recorded rather than
+	// detecting one of its own: two components disagreeing about where
+	// a project's notes live is precisely what the recorded setting
+	// exists to prevent. An unset value means no gateway has started
+	// yet, and Options falls back to the nested shape.
 	return notes.New(root, notes.Options{
+		Layout:         notes.Layout(cfg.Vault.Layout),
 		PersonalPrefix: cfg.Vault.PersonalPrefix,
 		ProjectsPrefix: cfg.Vault.ProjectsPrefix,
 		HiddenDirs:     paths.NestedInVault(),
@@ -276,12 +340,15 @@ commands:
   delete <path>                 delete a note
   daily                         create or print today's daily note path
   project <basename>            create or print a project note's path
+  flatten                       convert a nested vault to the flat layout
+                                (dry run unless --apply)
 
-flags:
+flags (must come BEFORE the command):
   -config FILE                  config.toml (only [vault] is consulted)
   --root PATH                   vault root override
   --prefix STRING               list filter (e.g. projects/)
-  --json                        list/read JSON output
+  --json                        list/read/flatten JSON output
+  --apply                       flatten: perform the moves
 
-paths are relative to <vault>/notes and must end in .md.
+paths are relative to the vault root and end in .md, .markdown, .html or .htm.
 operates on the filesystem directly — the gateway does not need to be running.`

--- a/cmd/opendray/notes.go
+++ b/cmd/opendray/notes.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/opendray/opendray-v2/internal/config"
 	"github.com/opendray/opendray-v2/internal/notes"
+	"github.com/opendray/opendray-v2/internal/settings"
 )
 
 func runNotes(args []string) int {
@@ -186,10 +187,12 @@ func runNotes(args []string) int {
 // migration that starts moving files because someone typed the command
 // to see what it would do is not one anybody should trust.
 //
-// The config is left alone even on success. Recording `layout = "flat"`
-// belongs to the gateway's startup detection, which sees a vault with
-// no `projects/` directory and reaches the same conclusion — one place
-// deciding, rather than two that can disagree if this run half-fails.
+// On success the new layout is recorded in config.toml through the
+// vault's OnLayoutChange hook. Leaving that to the gateway's startup
+// detection was the original design and it was wrong: detection runs
+// only when the setting is empty, so a vault already recorded as nested
+// stayed nested after conversion and kept deriving paths for the
+// directories this had just emptied.
 func runFlatten(vault *notes.Vault, cfgPath string, apply, asJSON bool) int {
 	res, err := vault.Flatten(context.Background(), !apply)
 	if err != nil {
@@ -225,8 +228,13 @@ func runFlatten(vault *notes.Vault, cfgPath string, apply, asJSON bool) int {
 			fmt.Fprintf(os.Stderr, ", repointed %d project override(s)",
 				res.MappingsRewritten)
 		}
-		fmt.Fprintf(os.Stderr, ".\nRestart the gateway so it picks up the "+
-			"new layout.\n")
+		fmt.Fprintln(os.Stderr, ".")
+		if res.Warning != "" {
+			fmt.Fprintf(os.Stderr, "\nWARNING: %s\n", res.Warning)
+			return 1
+		}
+		fmt.Fprintln(os.Stderr,
+			"Recorded [vault] layout = \"flat\". Restart the gateway.")
 	}
 	return 0
 }
@@ -244,7 +252,12 @@ func openVault(cfgPath, override string) (*notes.Vault, error) {
 	// exists to prevent. An unset value means no gateway has started
 	// yet, and Options falls back to the nested shape.
 	return notes.New(root, notes.Options{
-		Layout:         notes.Layout(cfg.Vault.Layout),
+		Layout: notes.Layout(cfg.Vault.Layout),
+		// `notes flatten --apply` must record the new shape, or the
+		// gateway comes back looking for directories it just emptied.
+		OnLayoutChange: func(l notes.Layout) error {
+			return settings.RecordVaultLayout(cfg.FilePath, string(l), nil)
+		},
 		PersonalPrefix: cfg.Vault.PersonalPrefix,
 		ProjectsPrefix: cfg.Vault.ProjectsPrefix,
 		HiddenDirs:     paths.NestedInVault(),

--- a/cmd/opendray/notes.go
+++ b/cmd/opendray/notes.go
@@ -51,6 +51,17 @@ func runNotes(args []string) int {
 		return 2
 	}
 
+	// Flags are accepted AFTER the subcommand too. Go's flag package
+	// stops parsing at the first non-flag argument, so `notes flatten
+	// --apply` would leave apply false and quietly perform a dry run —
+	// answering "re-run with --apply" to someone who just did. Parsing
+	// the remainder as flags makes both orders mean the same thing.
+	command := rest[0]
+	if err := fs.Parse(rest[1:]); err != nil {
+		return 2
+	}
+	rest = append([]string{command}, fs.Args()...)
+
 	vault, err := openVault(*cfgPath, *root)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -356,7 +367,7 @@ commands:
   flatten                       convert a nested vault to the flat layout
                                 (dry run unless --apply)
 
-flags (must come BEFORE the command):
+flags (either before or after the command):
   -config FILE                  config.toml (only [vault] is consulted)
   --root PATH                   vault root override
   --prefix STRING               list filter (e.g. projects/)

--- a/cmd/opendray/notes_test.go
+++ b/cmd/opendray/notes_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Flags used to be accepted only BEFORE the subcommand, because Go's
+// flag package stops parsing at the first non-flag argument. The
+// failure was silent and, for `notes flatten --apply`, actively
+// misleading: apply stayed false, the migration performed a dry run,
+// and it told the operator to "re-run with --apply" — which is what
+// they had just done.
+//
+// These run `list` and `read`, which write nothing, so the assertion is
+// about argument order rather than about touching a vault.
+func TestNotesFlagsAreAcceptedAfterTheSubcommand(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(dir, "note.md"), []byte("# hi\n"), 0o644); err != nil {
+		t.Fatalf("seed note: %v", err)
+	}
+
+	after := runNotesCapturingStdout(t, []string{"--root", dir, "list", "--json"})
+	if !json.Valid([]byte(strings.TrimSpace(after))) {
+		t.Errorf("--json after the subcommand was ignored; got %q", after)
+	}
+
+	before := runNotesCapturingStdout(t, []string{"--root", dir, "--json", "list"})
+	if !json.Valid([]byte(strings.TrimSpace(before))) {
+		t.Errorf("--json before the subcommand broke; got %q", before)
+	}
+}
+
+func TestNotesPositionalArgsSurviveFlagsAfterTheSubcommand(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(dir, "note.md"), []byte("# hi\nbody\n"), 0o644); err != nil {
+		t.Fatalf("seed note: %v", err)
+	}
+	// The path is a positional arg AFTER the subcommand and must not be
+	// swallowed by the second parse pass.
+	out := runNotesCapturingStdout(t, []string{"--root", dir, "read", "note.md"})
+	if !strings.Contains(out, "body") {
+		t.Errorf("read lost its path argument; got %q", out)
+	}
+}
+
+func runNotesCapturingStdout(t *testing.T, args []string) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	code := runNotes(args)
+	os.Stdout = orig
+	_ = w.Close()
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("runNotes(%v) = %d, output: %s", args, code, out)
+	}
+	return string(out)
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -511,7 +511,19 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		st.Close()
 		return nil, fmt.Errorf("init notes vault: %w", err)
 	}
-	log.Info("vault ready", "documents", vault.Root())
+	log.Info("vault ready", "documents", vault.Root(),
+		"layout", string(vault.Layout()))
+	if vault.Flattenable() {
+		// Said once, at info, because an operator who is happy with the
+		// nested layout should not be nagged on every restart — but one
+		// who has never heard of the flat layout would otherwise never
+		// find out their vault could stop wrapping every project in a
+		// folder named after the library itself.
+		log.Info("this vault files projects under a `projects/` folder. " +
+			"`opendray notes flatten` previews filing them under their own " +
+			"names instead (dry run unless --apply); the doc library offers " +
+			"the same conversion.")
+	}
 	notesHandlers := notesapi.NewHandlers(vault, log)
 	skillsLoader := skills.NewLoader(paths.Skills)
 	if list, _ := skillsLoader.List(); len(list) > 0 {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -499,7 +499,13 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	// session manager) so the manager's first Resolve call sees them.
 	vaultLayout := resolveVaultLayout(cfg, paths.Vault, log)
 	vault, err := notesapi.New(paths.Vault, notesapi.Options{
-		Layout:         vaultLayout,
+		Layout: vaultLayout,
+		// The flatten migration changes the shape on disk; without this
+		// the change would survive on disk but not in config, and the
+		// next start would derive paths for the old directories.
+		OnLayoutChange: func(l notesapi.Layout) error {
+			return settings.RecordVaultLayout(cfg.FilePath, string(l), log)
+		},
 		PersonalPrefix: cfg.Vault.PersonalPrefix,
 		ProjectsPrefix: cfg.Vault.ProjectsPrefix,
 		// On a pre-split install skills/ and mcp/ sit inside the
@@ -1918,15 +1924,7 @@ func resolveVaultLayout(cfg config.Config, docRoot string, log *slog.Logger) not
 			"detected again next start")
 		return layout
 	}
-	svc := settings.NewService(cfg.FilePath, log)
-	cur, err := svc.Get()
-	if err != nil {
-		log.Warn("could not read config to record the vault layout",
-			"error", err, "layout", string(layout))
-		return layout
-	}
-	cur.Vault.Layout = string(layout)
-	if err := svc.Update(cur); err != nil {
+	if err := settings.RecordVaultLayout(cfg.FilePath, string(layout), log); err != nil {
 		log.Warn("could not record the vault layout in config",
 			"error", err, "layout", string(layout))
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -497,7 +497,9 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	// Vault + skills are needed by the SessionProvider so spawn-time
 	// injection has them available. Constructed here (before the
 	// session manager) so the manager's first Resolve call sees them.
+	vaultLayout := resolveVaultLayout(cfg, paths.Vault, log)
 	vault, err := notesapi.New(paths.Vault, notesapi.Options{
+		Layout:         vaultLayout,
 		PersonalPrefix: cfg.Vault.PersonalPrefix,
 		ProjectsPrefix: cfg.Vault.ProjectsPrefix,
 		// On a pre-split install skills/ and mcp/ sit inside the
@@ -1876,6 +1878,47 @@ func logLayout(log *slog.Logger, p config.Paths) {
 		"documents", p.Vault,
 		"skills_inside_documents", p.LegacySkills,
 		"mcp_inside_documents", p.LegacyMCP)
+}
+
+// resolveVaultLayout returns the vault layout, deciding it exactly
+// once for installs that predate the setting and writing the answer
+// into config.toml.
+//
+// Recording it is the point. The obvious alternative — work the layout
+// out from what is on disk every time — is the bug that put this
+// install's whole document library behind a `notes/` directory: a probe
+// that asks "does this folder have content?" flips the moment someone
+// puts content there. A vault's shape must not depend on the order
+// files arrived in.
+//
+// A failed write is logged, not fatal. The gateway can serve a correct
+// layout this run; what it loses is the guarantee for the next one, and
+// refusing to start over a config write would be a worse trade.
+func resolveVaultLayout(cfg config.Config, docRoot string, log *slog.Logger) notesapi.Layout {
+	if l := notesapi.Layout(cfg.Vault.Layout); l.Valid() {
+		return l
+	}
+	layout := notesapi.DetectLayout(docRoot)
+	log.Info("vault layout decided", "layout", string(layout), "documents", docRoot)
+
+	if cfg.FilePath == "" {
+		log.Warn("no config file to record the vault layout in; it will be " +
+			"detected again next start")
+		return layout
+	}
+	svc := settings.NewService(cfg.FilePath, log)
+	cur, err := svc.Get()
+	if err != nil {
+		log.Warn("could not read config to record the vault layout",
+			"error", err, "layout", string(layout))
+		return layout
+	}
+	cur.Vault.Layout = string(layout)
+	if err := svc.Update(cur); err != nil {
+		log.Warn("could not record the vault layout in config",
+			"error", err, "layout", string(layout))
+	}
+	return layout
 }
 
 // memoryKeyPath is where we cache the plaintext API key for the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -388,6 +388,16 @@ type VaultConfig struct {
 	// file managed via the API; these are just the templates.
 	PersonalPrefix string `toml:"personal_prefix" json:"personal_prefix"` // default "personal"
 	ProjectsPrefix string `toml:"projects_prefix" json:"projects_prefix"` // default "projects"
+
+	// Layout is "flat" (each project at the vault root, personal notes
+	// inside it) or "nested" (projects/<name>/ plus personal/<name>.md).
+	// Empty means undecided: the gateway detects it once at startup and
+	// WRITES THE ANSWER BACK HERE. It is recorded rather than re-derived
+	// because a layout inferred from directory contents changes when
+	// someone adds a directory — the failure that once relocated a live
+	// install's whole doc library. The two prefixes above apply to the
+	// nested layout only.
+	Layout string `toml:"layout" json:"layout"`
 }
 
 type DatabaseConfig struct {
@@ -689,6 +699,14 @@ func (c Config) Validate() error {
 		if _, err := time.ParseDuration(c.Session.IdleInterval); err != nil {
 			return fmt.Errorf("config: session.idle_interval: %w", err)
 		}
+	}
+	switch c.Vault.Layout {
+	case "", "flat", "nested":
+	default:
+		return fmt.Errorf(
+			"config: vault.layout: %q is not a layout (use \"flat\", \"nested\", "+
+				"or leave it empty to have opendray decide once and record it)",
+			c.Vault.Layout)
 	}
 	if c.Admin.TokenTTL != "" {
 		if _, err := time.ParseDuration(c.Admin.TokenTTL); err != nil {

--- a/internal/notes/flatten.go
+++ b/internal/notes/flatten.go
@@ -1,0 +1,231 @@
+package notes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Converting a nested vault to the flat layout is a rename of every
+// document, and renames are where a doc library quietly breaks: a
+// `[[wiki link]]` written against `projects/foo/bar` points at nothing
+// once `projects/` is gone.
+//
+// So this does not shell out to `mv`. It drives the same Move() the
+// rename UI uses, one document at a time, which rewrites the links
+// that referenced each file as it goes. Slower than moving directories
+// wholesale, and correct.
+//
+// Nothing is deleted and nothing is overwritten. A target that already
+// exists is reported and skipped, leaving both copies for the operator
+// to reconcile — a migration that resolves conflicts on its own is a
+// migration that loses work.
+
+// FlattenMove is one document the migration would move, or did.
+type FlattenMove struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+	// LinksRewritten counts `[[wiki link]]` occurrences repointed at
+	// the new path. Zero on a dry run — nothing has been read yet.
+	LinksRewritten int `json:"links_rewritten"`
+}
+
+// FlattenSkip is a document the migration refused to touch, with the
+// reason stated in the operator's terms rather than as an error code.
+type FlattenSkip struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
+}
+
+// FlattenResult is the plan (dry run) or the outcome (apply).
+type FlattenResult struct {
+	Moves []FlattenMove `json:"moves"`
+	Skips []FlattenSkip `json:"skips"`
+	// MappingsRewritten counts per-cwd project overrides repointed at
+	// their new location. An override left pointing into a `projects/`
+	// directory that no longer exists would silently start writing a
+	// project's documents to a fresh, empty folder.
+	MappingsRewritten int `json:"mappings_rewritten"`
+	// DryRun is true when nothing was written.
+	DryRun bool `json:"dry_run"`
+}
+
+// Flatten converts a nested vault (`projects/<name>/…` plus
+// `personal/<name>.md`) to the flat layout (`<name>/…` with
+// `<name>/personal.md` inside it).
+//
+// It must be run against a vault constructed with LayoutNested — the
+// source paths are the nested ones. The caller records the new layout
+// in config afterwards; doing it here would leave a half-migrated
+// vault claiming to be flat if the process died mid-run.
+func (v *Vault) Flatten(ctx context.Context, dryRun bool) (FlattenResult, error) {
+	if v.layout != LayoutNested {
+		return FlattenResult{}, errors.New(
+			"vault is already flat: nothing to convert")
+	}
+	res := FlattenResult{DryRun: dryRun}
+
+	plan, skips, err := v.flattenPlan()
+	if err != nil {
+		return FlattenResult{}, err
+	}
+	res.Skips = skips
+	if dryRun {
+		res.Moves = plan
+		return res, nil
+	}
+
+	for _, m := range plan {
+		if err := ctx.Err(); err != nil {
+			return res, err
+		}
+		out, err := v.Move(ctx, m.From, m.To)
+		if err != nil {
+			// One unmovable document must not abandon the rest
+			// half-migrated with no account of what happened.
+			res.Skips = append(res.Skips, FlattenSkip{
+				Path:   m.From,
+				Reason: err.Error(),
+			})
+			continue
+		}
+		m.LinksRewritten = out.LinksRewritten
+		res.Moves = append(res.Moves, m)
+	}
+
+	n, err := v.rewriteProjectMappings()
+	if err != nil {
+		return res, fmt.Errorf("rewrite project overrides: %w", err)
+	}
+	res.MappingsRewritten = n
+	return res, nil
+}
+
+// flattenPlan lists the moves without performing any.
+func (v *Vault) flattenPlan() ([]FlattenMove, []FlattenSkip, error) {
+	var moves []FlattenMove
+	var skips []FlattenSkip
+
+	projects := strings.Trim(v.projectsPrefix, "/")
+	personal := strings.Trim(v.personalPrefix, "/")
+
+	err := filepath.WalkDir(v.root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(v.root, path)
+		if relErr != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		if d.IsDir() {
+			if strings.HasPrefix(d.Name(), ".") && rel != "." {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !IsDocument(d.Name()) {
+			return nil
+		}
+
+		to, reason := v.flatTarget(rel, projects, personal)
+		switch {
+		case reason != "":
+			skips = append(skips, FlattenSkip{Path: rel, Reason: reason})
+		case to == "":
+			// Already outside the two nested trees — daily notes,
+			// templates, anything the operator filed themselves. The
+			// flat layout does not claim those.
+		default:
+			moves = append(moves, FlattenMove{From: rel, To: to})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sort.Slice(moves, func(i, j int) bool { return moves[i].From < moves[j].From })
+	sort.Slice(skips, func(i, j int) bool { return skips[i].Path < skips[j].Path })
+	return moves, skips, nil
+}
+
+// flatTarget maps one nested path to its flat destination. An empty
+// target with an empty reason means "leave this file where it is".
+func (v *Vault) flatTarget(rel, projects, personal string) (to, reason string) {
+	switch {
+	case projects != "" && strings.HasPrefix(rel, projects+"/"):
+		rest := strings.TrimPrefix(rel, projects+"/")
+		name, tail, ok := strings.Cut(rest, "/")
+		if !ok {
+			// A loose file directly under projects/ has no project to
+			// belong to. Moving it to the vault root would put a stray
+			// document beside the project directories.
+			return "", "sits directly in " + projects +
+				"/ and belongs to no project"
+		}
+		to = flatRoot(name) + "/" + tail
+
+	case personal != "" && strings.HasPrefix(rel, personal+"/"):
+		rest := strings.TrimPrefix(rel, personal+"/")
+		if strings.Contains(rest, "/") {
+			// personal/<name>.md is the convention; a nested tree in
+			// there is the operator's own filing and has no obvious
+			// project to move into.
+			return "", "is filed under " + personal +
+				"/ in a shape opendray did not create"
+		}
+		name := TrimDocExt(rest)
+		to = flatRoot(name) + "/personal" + filepath.Ext(rest)
+
+	default:
+		return "", ""
+	}
+
+	if _, err := os.Stat(filepath.Join(v.root, filepath.FromSlash(to))); err == nil {
+		return "", to + " already exists"
+	}
+	return to, ""
+}
+
+// rewriteProjectMappings repoints per-cwd overrides at the flat layout.
+func (v *Vault) rewriteProjectMappings() (int, error) {
+	v.projectMapMu.Lock()
+	defer v.projectMapMu.Unlock()
+
+	m, err := v.readProjectMapLocked()
+	if err != nil {
+		return 0, err
+	}
+	projects := strings.Trim(v.projectsPrefix, "/")
+	if projects == "" || len(m) == 0 {
+		return 0, nil
+	}
+	changed := 0
+	for cwd, p := range m {
+		trimmed := strings.Trim(p, "/")
+		if !strings.HasPrefix(trimmed, projects+"/") {
+			continue
+		}
+		rest := strings.TrimPrefix(trimmed, projects+"/")
+		name, tail, ok := strings.Cut(rest, "/")
+		next := flatRoot(name)
+		if ok {
+			next += "/" + tail
+		}
+		m[cwd] = next
+		changed++
+	}
+	if changed == 0 {
+		return 0, nil
+	}
+	if err := v.writeProjectMapLocked(m); err != nil {
+		return 0, err
+	}
+	return changed, nil
+}

--- a/internal/notes/flatten.go
+++ b/internal/notes/flatten.go
@@ -55,6 +55,26 @@ type FlattenResult struct {
 	DryRun bool `json:"dry_run"`
 }
 
+// Flattenable reports whether this vault has documents the flat layout
+// would file differently. It exists so the UI can OFFER the conversion:
+// a migration that only ships as a CLI command is one that only the
+// people who wrote it ever run, which would leave every existing vault
+// on the old shape forever without its owner ever learning there was a
+// choice.
+//
+// Deliberately cheap — this is called whenever someone opens the doc
+// library. It answers "is there anything to talk about", not "what
+// exactly would move"; the dry run answers that, and only when asked.
+func (v *Vault) Flattenable() bool {
+	if v.layout != LayoutNested {
+		return false
+	}
+	projects := strings.Trim(v.projectsPrefix, "/")
+	personal := strings.Trim(v.personalPrefix, "/")
+	return dirHasChildren(filepath.Join(v.root, projects)) ||
+		dirHasChildren(filepath.Join(v.root, personal))
+}
+
 // Flatten converts a nested vault (`projects/<name>/…` plus
 // `personal/<name>.md`) to the flat layout (`<name>/…` with
 // `<name>/personal.md` inside it).

--- a/internal/notes/flatten.go
+++ b/internal/notes/flatten.go
@@ -53,6 +53,13 @@ type FlattenResult struct {
 	MappingsRewritten int `json:"mappings_rewritten"`
 	// DryRun is true when nothing was written.
 	DryRun bool `json:"dry_run"`
+	// LayoutRecorded reports that the new layout reached the config
+	// file. False after an apply means the vault is flat on disk while
+	// the gateway will come back believing it is nested — surface it.
+	LayoutRecorded bool `json:"layout_recorded"`
+	// Warning explains a partial success in the operator's terms. The
+	// documents moved; something after them did not.
+	Warning string `json:"warning,omitempty"`
 }
 
 // Flattenable reports whether this vault has documents the flat layout
@@ -66,7 +73,7 @@ type FlattenResult struct {
 // library. It answers "is there anything to talk about", not "what
 // exactly would move"; the dry run answers that, and only when asked.
 func (v *Vault) Flattenable() bool {
-	if v.layout != LayoutNested {
+	if v.Layout() != LayoutNested {
 		return false
 	}
 	projects := strings.Trim(v.projectsPrefix, "/")
@@ -80,11 +87,18 @@ func (v *Vault) Flattenable() bool {
 // `<name>/personal.md` inside it).
 //
 // It must be run against a vault constructed with LayoutNested — the
-// source paths are the nested ones. The caller records the new layout
-// in config afterwards; doing it here would leave a half-migrated
-// vault claiming to be flat if the process died mid-run.
+// source paths are the nested ones.
+//
+// On success it flips its own layout and asks the caller's hook to
+// persist it. An earlier version left recording to the gateway's
+// startup detection, on the reasoning that a vault with no `projects/`
+// directory would be detected as flat. That was wrong, and it shipped:
+// detection runs ONLY when the setting is empty, so a vault already
+// recorded as nested stayed nested after being converted. Projects kept
+// resolving to `projects/<name>` and personal notes kept landing in
+// `personal/` — against directories the migration had just emptied.
 func (v *Vault) Flatten(ctx context.Context, dryRun bool) (FlattenResult, error) {
-	if v.layout != LayoutNested {
+	if v.Layout() != LayoutNested {
 		return FlattenResult{}, errors.New(
 			"vault is already flat: nothing to convert")
 	}
@@ -123,7 +137,69 @@ func (v *Vault) Flatten(ctx context.Context, dryRun bool) (FlattenResult, error)
 		return res, fmt.Errorf("rewrite project overrides: %w", err)
 	}
 	res.MappingsRewritten = n
+
+	// Directories the migration emptied are not documents and nothing
+	// lists them usefully — leaving `projects/` and `personal/` behind
+	// as empty folders would show the old shape in a vault that no
+	// longer has it.
+	v.pruneEmptied()
+
+	// Paths derived from here on must follow the new shape, including
+	// on this very request. Waiting for a restart would have the
+	// gateway answering with directories it just emptied.
+	v.setLayout(LayoutFlat)
+	if v.onLayoutChange != nil {
+		if err := v.onLayoutChange(LayoutFlat); err != nil {
+			res.Warning = "documents were moved, but the new layout could " +
+				"not be saved to the config file (" + err.Error() +
+				"). Set [vault] layout = \"flat\" by hand, or the gateway " +
+				"will look for the old directories after a restart."
+			return res, nil
+		}
+	}
+	res.LayoutRecorded = true
 	return res, nil
+}
+
+// pruneEmptied removes the nested layout's directories once nothing is
+// left in them. Best-effort by design: a directory the operator still
+// keeps something in is one os.Remove refuses to touch, which is
+// exactly the behaviour wanted here.
+func (v *Vault) pruneEmptied() {
+	projects := strings.Trim(v.projectsPrefix, "/")
+	personal := strings.Trim(v.personalPrefix, "/")
+	for _, base := range []string{projects, personal} {
+		if base == "" {
+			continue
+		}
+		dir := filepath.Join(v.root, base)
+		// Children first: `projects/foo/features` has to go before
+		// `projects/foo`, and that before `projects`.
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				removeEmptyTree(filepath.Join(dir, e.Name()))
+			}
+		}
+		removeEmptyTree(dir)
+	}
+}
+
+func removeEmptyTree(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			removeEmptyTree(filepath.Join(dir, e.Name()))
+		}
+	}
+	// Fails harmlessly when anything is left, which is the guard.
+	_ = os.Remove(dir)
 }
 
 // flattenPlan lists the moves without performing any.

--- a/internal/notes/handler.go
+++ b/internal/notes/handler.go
@@ -50,7 +50,11 @@ type writeRequest struct {
 
 func (h *Handlers) info(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
-		"root":            h.v.Root(),
+		"root": h.v.Root(),
+		// Clients render from this rather than deriving paths of their
+		// own. Three implementations guessing where a project's notes
+		// live is three chances to disagree with the gateway.
+		"layout":          string(h.v.Layout()),
 		"personal_prefix": h.v.PersonalPrefix(),
 		"projects_prefix": h.v.ProjectsPrefix(),
 	})
@@ -231,6 +235,11 @@ func (h *Handlers) projectMappingGet(w http.ResponseWriter, r *http.Request) {
 		"path":         resolved,
 		"default_path": defaultDir,
 		"custom":       custom,
+		// Served rather than derived client-side: in the flat layout
+		// the personal note sits inside the project directory, so an
+		// override here moves it too — a rule no client should have to
+		// reimplement.
+		"personal_path": h.v.ResolvedPersonalPath(cwd),
 	})
 }
 

--- a/internal/notes/handler.go
+++ b/internal/notes/handler.go
@@ -40,6 +40,7 @@ func (h *Handlers) Mount(r chi.Router) {
 		r.Get("/project-mapping", h.projectMappingGet)
 		r.Put("/project-mapping", h.projectMappingPut)
 		r.Get("/project-mappings", h.projectMappingsList)
+		r.Post("/flatten", h.flatten)
 	})
 }
 
@@ -48,13 +49,38 @@ type writeRequest struct {
 	Body string `json:"body"`
 }
 
+// flatten previews or performs the nested → flat conversion.
+//
+// A dry run is the default and `apply` must be sent explicitly. This
+// renames every project document in the vault, so the request that only
+// looks and the request that rewrites the library must not be the same
+// shape with one field forgotten.
+func (h *Handlers) flatten(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Apply bool `json:"apply"`
+	}
+	// An absent body is a dry run — the safe reading of "no opinion".
+	if r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&req)
+	}
+	res, err := h.v.Flatten(r.Context(), !req.Apply)
+	if err != nil {
+		writeError(w, http.StatusConflict, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
+}
+
 func (h *Handlers) info(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"root": h.v.Root(),
 		// Clients render from this rather than deriving paths of their
 		// own. Three implementations guessing where a project's notes
 		// live is three chances to disagree with the gateway.
-		"layout":          string(h.v.Layout()),
+		"layout": string(h.v.Layout()),
+		// Drives the offer to convert. Without it the migration would
+		// only ever be found by someone reading release notes.
+		"flattenable":     h.v.Flattenable(),
 		"personal_prefix": h.v.PersonalPrefix(),
 		"projects_prefix": h.v.ProjectsPrefix(),
 	})

--- a/internal/notes/layout.go
+++ b/internal/notes/layout.go
@@ -1,0 +1,111 @@
+package notes
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// The vault is a project documentation library, and it used to file
+// every project under `projects/` — a folder whose name repeats what
+// the whole library already is. One level of nesting that tells the
+// reader nothing, on every path, in every listing, and at the top of
+// the git repository the vault syncs to.
+//
+// The operator's own notes were split off further still: agent-written
+// docs at `projects/<name>/…` and the human scratchpad at
+// `personal/<name>.md` — the same project's material in two distant
+// places, sorted by *who wrote it* rather than by what it is about.
+//
+//	nested (original)          flat (default for new installs)
+//	  projects/opendray-v2/      opendray-v2/
+//	    features/                  features/
+//	    issues/                    issues/
+//	  personal/opendray-v2.md      personal.md
+//
+// Existing vaults are NOT rearranged. The layout is decided once and
+// written into config.toml, because the alternative — re-deriving it
+// from what happens to be on disk — is exactly how the doc root once
+// moved out from under a live install: a probe that asks "does this
+// directory have content?" changes its answer when someone adds
+// content. See `opendray notes flatten` to convert deliberately.
+
+// Layout decides where a project's documents live in the vault.
+type Layout string
+
+const (
+	// LayoutFlat puts each project at the vault root under its own
+	// name, with the operator's personal notes inside it.
+	LayoutFlat Layout = "flat"
+	// LayoutNested keeps the original split: `projects/<name>/` for
+	// documents and `personal/<name>.md` for the operator's notes.
+	LayoutNested Layout = "nested"
+)
+
+// Valid reports whether l is a layout the vault understands. The empty
+// string is not valid here — it means "not decided yet", which callers
+// resolve with DetectLayout before constructing a Vault.
+func (l Layout) Valid() bool { return l == LayoutFlat || l == LayoutNested }
+
+// DetectLayout infers the layout of an existing vault, for the one
+// moment where it has to be guessed: an install that predates the
+// setting. A vault already filing documents under `projects/` is
+// nested; anything else — including an empty vault — is flat.
+//
+// Callers MUST persist the result. Detection is deliberately called
+// once, not on every resolve.
+func DetectLayout(root string) Layout {
+	if dirHasChildren(filepath.Join(root, "projects")) {
+		return LayoutNested
+	}
+	return LayoutFlat
+}
+
+func dirHasChildren(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		// A folder holding nothing but .DS_Store is empty as far as
+		// anyone reading the vault is concerned.
+		if e.Name() != ".DS_Store" {
+			return true
+		}
+	}
+	return false
+}
+
+// reservedRoots are top-level names the flat layout cannot hand to a
+// project, because the vault already means something by them. In the
+// nested layout there is nothing to collide with — `projects/daily` is
+// just a project — so this applies to flat only.
+var reservedRoots = map[string]bool{
+	"daily": true, // daily/YYYY-MM-DD.md, a vault-wide concept
+}
+
+// reservedRoot reports whether a top-level directory name belongs to
+// the vault rather than to a project. Underscore and dot prefixes are
+// reserved wholesale: `_templates` already uses the first, and the
+// second is how every listing recognises a hidden file.
+func reservedRoot(name string) bool {
+	if name == "" {
+		return true
+	}
+	if strings.HasPrefix(name, "_") || strings.HasPrefix(name, ".") {
+		return true
+	}
+	return reservedRoots[strings.ToLower(name)]
+}
+
+// flatRoot returns the top-level directory for a project slug,
+// stepping aside when the name is one the vault has already claimed.
+// The suffix is predictable rather than clever: an operator who lands
+// on it can see what happened, and a per-cwd mapping override remains
+// available for anyone who wants a different name entirely.
+func flatRoot(slug string) string {
+	if reservedRoot(slug) {
+		return slug + "-docs"
+	}
+	return slug
+}

--- a/internal/notes/layout_test.go
+++ b/internal/notes/layout_test.go
@@ -2,6 +2,7 @@ package notes
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -253,5 +254,100 @@ func TestResolvedPersonalPathFollowsAProjectOverride(t *testing.T) {
 	if got, want := nested.ResolvedPersonalPath("/Users/x/code/app"),
 		"personal/app.md"; got != want {
 		t.Errorf("nested ResolvedPersonalPath = %q, want %q", got, want)
+	}
+}
+
+func TestFlattenRecordsTheNewLayout(t *testing.T) {
+	// The bug this test exists for shipped: the migration left recording
+	// to the gateway's startup detection, which only runs when the
+	// setting is EMPTY. A vault already recorded as nested stayed nested
+	// after conversion, so projects kept resolving to `projects/<name>`
+	// and personal notes kept landing in `personal/` — against
+	// directories the migration had just emptied.
+	var recorded []Layout
+	dir := t.TempDir()
+	v, err := New(dir, Options{
+		Layout:         LayoutNested,
+		OnLayoutChange: func(l Layout) error { recorded = append(recorded, l); return nil },
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	writeFileT(t, dir, "projects/app/README.md", "# app\n")
+
+	if _, err := v.Flatten(context.Background(), false); err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+
+	if len(recorded) != 1 || recorded[0] != LayoutFlat {
+		t.Fatalf("layout persisted as %v, want one flat", recorded)
+	}
+	// The running gateway must follow immediately, not at next restart.
+	if got := v.Layout(); got != LayoutFlat {
+		t.Errorf("in-memory layout = %q, want flat", got)
+	}
+	if got, want := v.ProjectDir("app"), "app"; got != want {
+		t.Errorf("ProjectDir after conversion = %q, want %q", got, want)
+	}
+	if got, want := v.PersonalPath("app"), "app/personal.md"; got != want {
+		t.Errorf("PersonalPath after conversion = %q, want %q", got, want)
+	}
+}
+
+func TestFlattenReportsAFailureToRecordTheLayout(t *testing.T) {
+	dir := t.TempDir()
+	v, err := New(dir, Options{
+		Layout:         LayoutNested,
+		OnLayoutChange: func(Layout) error { return errors.New("config is read-only") },
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	writeFileT(t, dir, "projects/app/README.md", "# app\n")
+
+	res, err := v.Flatten(context.Background(), false)
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	// The documents did move — saying otherwise would be a lie — but the
+	// operator has to hear that the next restart will disagree.
+	if res.LayoutRecorded {
+		t.Error("LayoutRecorded is true despite the hook failing")
+	}
+	if res.Warning == "" {
+		t.Error("a failure to record the layout was reported silently")
+	}
+	if len(res.Moves) != 1 {
+		t.Errorf("moves = %+v, want the one document", res.Moves)
+	}
+}
+
+func TestFlattenRemovesTheDirectoriesItEmptied(t *testing.T) {
+	v, root := newVaultT(t, LayoutNested)
+	writeFileT(t, root, "projects/app/features/x.md", "# x\n")
+	writeFileT(t, root, "personal/app.md", "# notes\n")
+
+	if _, err := v.Flatten(context.Background(), false); err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	for _, gone := range []string{"projects", "personal"} {
+		if _, err := os.Stat(filepath.Join(root, gone)); !os.IsNotExist(err) {
+			t.Errorf("%s/ survived as an empty directory", gone)
+		}
+	}
+}
+
+func TestFlattenKeepsADirectoryThatStillHasSomethingInIt(t *testing.T) {
+	v, root := newVaultT(t, LayoutNested)
+	writeFileT(t, root, "projects/app/README.md", "# app\n")
+	// Not a document, so the migration never moves it — and must not
+	// delete the directory holding it either.
+	writeFileT(t, root, "projects/app/diagram.png", "binary")
+
+	if _, err := v.Flatten(context.Background(), false); err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "projects", "app", "diagram.png")); err != nil {
+		t.Errorf("a non-document was lost with its directory: %v", err)
 	}
 }

--- a/internal/notes/layout_test.go
+++ b/internal/notes/layout_test.go
@@ -1,0 +1,257 @@
+package notes
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newVaultT(t *testing.T, layout Layout) (*Vault, string) {
+	t.Helper()
+	dir := t.TempDir()
+	v, err := New(dir, Options{Layout: layout})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return v, dir
+}
+
+func writeFileT(t *testing.T, root, rel, body string) {
+	t.Helper()
+	full := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func TestLayoutPathDerivation(t *testing.T) {
+	flat, _ := newVaultT(t, LayoutFlat)
+	nested, _ := newVaultT(t, LayoutNested)
+
+	if got, want := flat.ProjectDir("opendray-v2"), "opendray-v2"; got != want {
+		t.Errorf("flat ProjectDir = %q, want %q", got, want)
+	}
+	if got, want := flat.PersonalPath("opendray-v2"), "opendray-v2/personal.md"; got != want {
+		t.Errorf("flat PersonalPath = %q, want %q", got, want)
+	}
+	if got, want := nested.ProjectDir("opendray-v2"), "projects/opendray-v2"; got != want {
+		t.Errorf("nested ProjectDir = %q, want %q", got, want)
+	}
+	if got, want := nested.PersonalPath("opendray-v2"), "personal/opendray-v2.md"; got != want {
+		t.Errorf("nested PersonalPath = %q, want %q", got, want)
+	}
+}
+
+func TestUnsetLayoutDoesNotRelocateAnExistingVault(t *testing.T) {
+	// A caller that forgets to pass a layout must not silently move a
+	// live install's documents to the flat shape.
+	v, _ := newVaultT(t, "")
+	if got := v.Layout(); got != LayoutNested {
+		t.Fatalf("layout = %q, want nested", got)
+	}
+	if got, want := v.ProjectDir("x"), "projects/x"; got != want {
+		t.Errorf("ProjectDir = %q, want %q", got, want)
+	}
+}
+
+func TestFlatLayoutStepsAsideForReservedNames(t *testing.T) {
+	flat, _ := newVaultT(t, LayoutFlat)
+	// daily/ is a vault-wide concept; a project must not land on it.
+	if got, want := flat.ProjectDir("daily"), "daily-docs"; got != want {
+		t.Errorf("ProjectDir(daily) = %q, want %q", got, want)
+	}
+	// `_` and `.` prefixes belong to the vault (_templates, dotfiles).
+	if got, want := flat.ProjectDir("_templates"), "_templates-docs"; got != want {
+		t.Errorf("ProjectDir(_templates) = %q, want %q", got, want)
+	}
+	// A normal name is untouched.
+	if got, want := flat.ProjectDir("daily-standup"), "daily-standup"; got != want {
+		t.Errorf("ProjectDir(daily-standup) = %q, want %q", got, want)
+	}
+}
+
+func TestDetectLayout(t *testing.T) {
+	empty := t.TempDir()
+	if got := DetectLayout(empty); got != LayoutFlat {
+		t.Errorf("empty vault = %q, want flat", got)
+	}
+
+	nested := t.TempDir()
+	writeFileT(t, nested, "projects/foo/README.md", "# foo\n")
+	if got := DetectLayout(nested); got != LayoutNested {
+		t.Errorf("vault with projects/ = %q, want nested", got)
+	}
+
+	// A projects/ directory holding nothing anyone can read is not a
+	// nested vault — .DS_Store is exactly the file that once flipped a
+	// detection like this one.
+	noise := t.TempDir()
+	writeFileT(t, noise, "projects/.DS_Store", "x")
+	if got := DetectLayout(noise); got != LayoutFlat {
+		t.Errorf("vault with only .DS_Store = %q, want flat", got)
+	}
+}
+
+func TestFlattenMovesDocumentsAndRewritesLinks(t *testing.T) {
+	v, root := newVaultT(t, LayoutNested)
+	writeFileT(t, root, "projects/app/features/canvas.md", "# canvas\n")
+	writeFileT(t, root, "projects/app/README.md",
+		"See [[projects/app/features/canvas]] for detail.\n")
+	writeFileT(t, root, "personal/app.md", "# my notes\n")
+	writeFileT(t, root, "daily/2026-08-09.md", "# today\n")
+
+	res, err := v.Flatten(context.Background(), false)
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+
+	for _, want := range []string{
+		"app/features/canvas.md",
+		"app/README.md",
+		"app/personal.md",
+	} {
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(want))); err != nil {
+			t.Errorf("expected %s to exist: %v", want, err)
+		}
+	}
+	// Daily notes are nobody's project and stay put.
+	if _, err := os.Stat(filepath.Join(root, "daily", "2026-08-09.md")); err != nil {
+		t.Errorf("daily note should not have moved: %v", err)
+	}
+
+	// The link that pointed into projects/ must now point at the new
+	// location, or the migration has quietly broken the vault.
+	body, err := os.ReadFile(filepath.Join(root, "app", "README.md"))
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	if got := string(body); !strings.Contains(got, "[[app/features/canvas]]") {
+		t.Errorf("link not repointed, README is: %q", got)
+	}
+
+	if len(res.Moves) != 3 {
+		t.Errorf("moved %d documents, want 3: %+v", len(res.Moves), res.Moves)
+	}
+}
+
+func TestFlattenDryRunWritesNothing(t *testing.T) {
+	v, root := newVaultT(t, LayoutNested)
+	writeFileT(t, root, "projects/app/README.md", "# app\n")
+
+	res, err := v.Flatten(context.Background(), true)
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	if !res.DryRun || len(res.Moves) != 1 {
+		t.Fatalf("unexpected plan: %+v", res)
+	}
+	if _, err := os.Stat(filepath.Join(root, "projects", "app", "README.md")); err != nil {
+		t.Errorf("source should still be there after a dry run: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "app")); !os.IsNotExist(err) {
+		t.Errorf("dry run created %s", filepath.Join(root, "app"))
+	}
+}
+
+func TestFlattenRefusesToOverwriteAndReportsWhy(t *testing.T) {
+	v, root := newVaultT(t, LayoutNested)
+	writeFileT(t, root, "projects/app/README.md", "# from projects\n")
+	writeFileT(t, root, "app/README.md", "# already here\n")
+
+	res, err := v.Flatten(context.Background(), false)
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	if len(res.Moves) != 0 {
+		t.Errorf("should have moved nothing, moved %+v", res.Moves)
+	}
+	if len(res.Skips) != 1 || !strings.Contains(res.Skips[0].Reason, "already exists") {
+		t.Fatalf("expected an already-exists skip, got %+v", res.Skips)
+	}
+	// Both copies survive — reconciling them is the operator's call.
+	body, _ := os.ReadFile(filepath.Join(root, "app", "README.md"))
+	if string(body) != "# already here\n" {
+		t.Errorf("existing document was overwritten: %q", body)
+	}
+	if _, err := os.Stat(filepath.Join(root, "projects", "app", "README.md")); err != nil {
+		t.Errorf("source was removed despite the skip: %v", err)
+	}
+}
+
+func TestFlattenLeavesLooseAndForeignFilesAlone(t *testing.T) {
+	v, root := newVaultT(t, LayoutNested)
+	writeFileT(t, root, "projects/stray.md", "# no project\n")
+	writeFileT(t, root, "personal/deep/thoughts.md", "# hand-filed\n")
+
+	res, err := v.Flatten(context.Background(), false)
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	if len(res.Moves) != 0 {
+		t.Errorf("moved files it should not have: %+v", res.Moves)
+	}
+	if len(res.Skips) != 2 {
+		t.Fatalf("expected 2 explained skips, got %+v", res.Skips)
+	}
+	for _, s := range res.Skips {
+		if s.Reason == "" {
+			t.Errorf("skip without a reason: %+v", s)
+		}
+	}
+}
+
+func TestFlattenRepointsProjectOverrides(t *testing.T) {
+	v, root := newVaultT(t, LayoutNested)
+	writeFileT(t, root, "projects/app/README.md", "# app\n")
+	if err := v.SetProjectMapping("/Users/x/code/app", "projects/app"); err != nil {
+		t.Fatalf("SetProjectMapping: %v", err)
+	}
+
+	res, err := v.Flatten(context.Background(), false)
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	if res.MappingsRewritten != 1 {
+		t.Errorf("rewrote %d overrides, want 1", res.MappingsRewritten)
+	}
+	// An override still naming projects/ would send this project's
+	// documents to a directory the migration just emptied.
+	got := v.ResolvedProjectDir("/Users/x/code/app")
+	if got != "app" {
+		t.Errorf("override resolves to %q, want %q", got, "app")
+	}
+}
+
+func TestFlattenRefusesOnAnAlreadyFlatVault(t *testing.T) {
+	v, _ := newVaultT(t, LayoutFlat)
+	if _, err := v.Flatten(context.Background(), true); err == nil {
+		t.Fatal("expected an error, got none")
+	}
+}
+
+func TestResolvedPersonalPathFollowsAProjectOverride(t *testing.T) {
+	flat, _ := newVaultT(t, LayoutFlat)
+	if err := flat.SetProjectMapping("/Users/x/code/app", "clients/acme"); err != nil {
+		t.Fatalf("SetProjectMapping: %v", err)
+	}
+	if got, want := flat.ResolvedPersonalPath("/Users/x/code/app"),
+		"clients/acme/personal.md"; got != want {
+		t.Errorf("flat ResolvedPersonalPath = %q, want %q", got, want)
+	}
+
+	// Nested keeps the two trees separate, so an override moves only
+	// the project documents.
+	nested, _ := newVaultT(t, LayoutNested)
+	if err := nested.SetProjectMapping("/Users/x/code/app", "clients/acme"); err != nil {
+		t.Fatalf("SetProjectMapping: %v", err)
+	}
+	if got, want := nested.ResolvedPersonalPath("/Users/x/code/app"),
+		"personal/app.md"; got != want {
+		t.Errorf("nested ResolvedPersonalPath = %q, want %q", got, want)
+	}
+}

--- a/internal/notes/projectmap.go
+++ b/internal/notes/projectmap.go
@@ -36,6 +36,21 @@ func (v *Vault) ResolvedProjectDir(cwd string) string {
 	return v.ProjectDir(base)
 }
 
+// ResolvedPersonalPath returns where this cwd's personal scratchpad
+// belongs, honouring a per-cwd project override.
+//
+// In the flat layout the personal note lives INSIDE the project's
+// directory, so an override that moves the project moves the personal
+// note with it — the two stop being separately configurable, which is
+// the point of putting them together. The nested layout keeps them in
+// separate trees, so there is nothing for an override to move.
+func (v *Vault) ResolvedPersonalPath(cwd string) string {
+	if v.layout == LayoutFlat {
+		return v.ResolvedProjectDir(cwd) + "/personal.md"
+	}
+	return v.PersonalPath(basenameOf(cwd))
+}
+
 // ListProjectMappings returns every override currently saved. Used by
 // the UI so users can see/manage what's configured.
 func (v *Vault) ListProjectMappings() ([]ProjectMapping, error) {

--- a/internal/notes/projectmap.go
+++ b/internal/notes/projectmap.go
@@ -45,7 +45,7 @@ func (v *Vault) ResolvedProjectDir(cwd string) string {
 // the point of putting them together. The nested layout keeps them in
 // separate trees, so there is nothing for an override to move.
 func (v *Vault) ResolvedPersonalPath(cwd string) string {
-	if v.layout == LayoutFlat {
+	if v.Layout() == LayoutFlat {
 		return v.ResolvedProjectDir(cwd) + "/personal.md"
 	}
 	return v.PersonalPath(basenameOf(cwd))

--- a/internal/notes/vault.go
+++ b/internal/notes/vault.go
@@ -55,8 +55,15 @@ type FullNote struct {
 // being independent FS calls (no shared in-memory state in this phase
 // — index lands in Phase 4).
 type Vault struct {
-	root           string   // canonical absolute path to the notes root
-	layout         Layout   // flat or nested — see layout.go
+	root string // canonical absolute path to the notes root
+
+	// layout can change under a running gateway: the flatten migration
+	// rewrites the shape on disk, and every path derived after that
+	// must follow immediately rather than at the next restart.
+	layoutMu       sync.RWMutex
+	layout         Layout // flat or nested — see layout.go
+	onLayoutChange func(Layout) error
+
 	personalPrefix string   // nested only: subfolder for personal scratchpads
 	projectsPrefix string   // nested only: subfolder for AI project docs
 	hidden         []string // vault-relative dirs excluded from listings
@@ -73,6 +80,14 @@ type Options struct {
 	// nested — the shape every pre-existing install already has, so a
 	// caller that forgets cannot relocate anyone's documents.
 	Layout Layout
+
+	// OnLayoutChange persists a layout the vault decided for itself —
+	// today, only the flatten migration. Wiring it is not optional in a
+	// long-lived process: startup detection runs ONLY when the setting
+	// is empty, so a vault recorded as nested and then flattened would
+	// come back nested on the next restart, deriving paths for
+	// directories that no longer exist.
+	OnLayoutChange func(Layout) error
 
 	// PersonalPrefix / ProjectsPrefix apply to the NESTED layout only.
 	// The flat layout has no prefixes to configure: a project is its
@@ -134,6 +149,7 @@ func New(notesRoot string, opts Options) (*Vault, error) {
 	return &Vault{
 		root:           root,
 		layout:         layout,
+		onLayoutChange: opts.OnLayoutChange,
 		personalPrefix: personal,
 		projectsPrefix: projects,
 		hidden:         relativeHidden(root, opts.HiddenDirs),
@@ -185,7 +201,17 @@ func (v *Vault) ProjectsPrefix() string { return v.projectsPrefix }
 // /api/v1/notes/info rather than deriving paths themselves — which is
 // what keeps the layout a server-side concern and stops web, mobile
 // and the CLI drifting apart on where a project's notes live.
-func (v *Vault) Layout() Layout { return v.layout }
+func (v *Vault) Layout() Layout {
+	v.layoutMu.RLock()
+	defer v.layoutMu.RUnlock()
+	return v.layout
+}
+
+func (v *Vault) setLayout(l Layout) {
+	v.layoutMu.Lock()
+	v.layout = l
+	v.layoutMu.Unlock()
+}
 
 // Root returns the canonical absolute path to the notes directory.
 // Useful for surfacing in /api/v1/notes/info and the CLI describe.
@@ -494,7 +520,7 @@ func DailyPath(t time.Time) string {
 // create .html by naming it. Same for DailyPath and ProjectPath.
 func (v *Vault) PersonalPath(basename string) string {
 	slug := sanitiseBasename(basename)
-	if v.layout == LayoutFlat {
+	if v.Layout() == LayoutFlat {
 		return flatRoot(slug) + "/personal.md"
 	}
 	return v.personalPrefix + "/" + slug + ".md"
@@ -506,7 +532,7 @@ func (v *Vault) PersonalPath(basename string) string {
 // that behaviour. This is the "default location" used as a fallback.
 func (v *Vault) ProjectDir(basename string) string {
 	slug := sanitiseBasename(basename)
-	if v.layout == LayoutFlat {
+	if v.Layout() == LayoutFlat {
 		return flatRoot(slug)
 	}
 	return v.projectsPrefix + "/" + slug

--- a/internal/notes/vault.go
+++ b/internal/notes/vault.go
@@ -56,8 +56,9 @@ type FullNote struct {
 // — index lands in Phase 4).
 type Vault struct {
 	root           string   // canonical absolute path to the notes root
-	personalPrefix string   // default subfolder for personal scratchpads
-	projectsPrefix string   // default subfolder for AI project docs
+	layout         Layout   // flat or nested — see layout.go
+	personalPrefix string   // nested only: subfolder for personal scratchpads
+	projectsPrefix string   // nested only: subfolder for AI project docs
 	hidden         []string // vault-relative dirs excluded from listings
 
 	projectMapMu sync.Mutex // guards reads/writes of projectMapFilename
@@ -67,6 +68,15 @@ type Vault struct {
 // (PersonalPath, ProjectDir). Empty fields fall back to opendray's
 // classic conventions (`personal`, `projects`).
 type Options struct {
+	// Layout selects flat or nested filing. An empty value means the
+	// caller has not resolved one yet and the vault falls back to
+	// nested — the shape every pre-existing install already has, so a
+	// caller that forgets cannot relocate anyone's documents.
+	Layout Layout
+
+	// PersonalPrefix / ProjectsPrefix apply to the NESTED layout only.
+	// The flat layout has no prefixes to configure: a project is its
+	// own name and its personal notes live inside it.
 	PersonalPrefix string
 	ProjectsPrefix string
 
@@ -113,9 +123,17 @@ func New(notesRoot string, opts Options) (*Vault, error) {
 	if projects == "" {
 		projects = "projects"
 	}
+	layout := opts.Layout
+	if !layout.Valid() {
+		// Fall back to the shape every existing vault already has.
+		// Defaulting to flat would silently move a live install's
+		// documents; defaulting to nested is at worst a no-op.
+		layout = LayoutNested
+	}
 	root := filepath.Clean(abs)
 	return &Vault{
 		root:           root,
+		layout:         layout,
 		personalPrefix: personal,
 		projectsPrefix: projects,
 		hidden:         relativeHidden(root, opts.HiddenDirs),
@@ -162,6 +180,12 @@ func (v *Vault) isHidden(rel string) bool {
 // "default location" hint of the per-cwd override UI.
 func (v *Vault) PersonalPrefix() string { return v.personalPrefix }
 func (v *Vault) ProjectsPrefix() string { return v.projectsPrefix }
+
+// Layout reports how this vault files projects. Clients read it from
+// /api/v1/notes/info rather than deriving paths themselves — which is
+// what keeps the layout a server-side concern and stops web, mobile
+// and the CLI drifting apart on where a project's notes live.
+func (v *Vault) Layout() Layout { return v.layout }
 
 // Root returns the canonical absolute path to the notes directory.
 // Useful for surfacing in /api/v1/notes/info and the CLI describe.
@@ -469,7 +493,11 @@ func DailyPath(t time.Time) string {
 // generating HTML here would be a strange default. Operators can still
 // create .html by naming it. Same for DailyPath and ProjectPath.
 func (v *Vault) PersonalPath(basename string) string {
-	return v.personalPrefix + "/" + sanitiseBasename(basename) + ".md"
+	slug := sanitiseBasename(basename)
+	if v.layout == LayoutFlat {
+		return flatRoot(slug) + "/personal.md"
+	}
+	return v.personalPrefix + "/" + slug + ".md"
 }
 
 // ProjectDir returns the directory for a project's notes using the
@@ -477,7 +505,11 @@ func (v *Vault) PersonalPath(basename string) string {
 // mapping store) take precedence — call ResolvedProjectDir(cwd) for
 // that behaviour. This is the "default location" used as a fallback.
 func (v *Vault) ProjectDir(basename string) string {
-	return v.projectsPrefix + "/" + sanitiseBasename(basename)
+	slug := sanitiseBasename(basename)
+	if v.layout == LayoutFlat {
+		return flatRoot(slug)
+	}
+	return v.projectsPrefix + "/" + slug
 }
 
 // ProjectPath returns the conventional README inside ProjectDir.

--- a/internal/settings/vaultlayout.go
+++ b/internal/settings/vaultlayout.go
@@ -1,0 +1,41 @@
+package settings
+
+import (
+	"errors"
+	"log/slog"
+)
+
+// RecordVaultLayout writes the vault layout into config.toml.
+//
+// This exists because the layout is a DECISION, not an observation, and
+// every path in the doc library depends on it. The gateway records it
+// at first start; the flatten migration records it again the moment it
+// changes the shape on disk.
+//
+// That second call is not redundant, and leaving it out was a real bug:
+// startup detection only runs when the setting is EMPTY, so a vault
+// recorded as nested stayed nested after being flattened. Projects kept
+// resolving to `projects/<name>` and personal notes kept landing in
+// `personal/` against a vault that no longer had either directory.
+//
+// Reads the file first so unrelated settings survive: Update writes the
+// whole document, and a patch built from nothing would blank everything
+// the operator has configured.
+func RecordVaultLayout(configPath, layout string, log *slog.Logger) error {
+	if configPath == "" {
+		return errors.New("no config file to record the vault layout in")
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	svc := NewService(configPath, log)
+	cur, err := svc.Get()
+	if err != nil {
+		return err
+	}
+	if cur.Vault.Layout == layout {
+		return nil
+	}
+	cur.Vault.Layout = layout
+	return svc.Update(cur)
+}


### PR DESCRIPTION
> **Stacked on #503.** Base is `feat/vault-html-docs`; GitHub retargets this to `main` once that merges.

## Why

The Vault is a project documentation library, and it filed every project under `projects/` — a folder that names what the whole library already is. One level of nesting that tells the reader nothing, on every path, in every listing, and at the top of the git repository the Vault syncs to.

The operator's own notes were split off further still: agent-written docs at `projects/<name>/…`, the human scratchpad at `personal/<name>.md`. The same project's material in two distant places, sorted by *who wrote it* rather than by what it is about.

```
nested (existing)            flat (new default)
  projects/opendray-v2/        opendray-v2/
    features/                    features/
    issues/                      issues/
  personal/opendray-v2.md        personal.md
```

## The layout is recorded, not re-derived

**Existing vaults are not rearranged.** The layout is decided once, at first start, and written into `config.toml` as `[vault] layout`.

Recording it is the point. The alternative — work the shape out from what is on disk each time — is the bug that put one install's entire document library behind a `notes/` directory: a probe asking *"does this folder have content?"* changes its answer the moment someone puts content there. A vault's shape must not depend on the order files arrived in.

Detection runs exactly once. A failed config write is logged, not fatal — the gateway can serve a correct layout this run, and refusing to start over a config write is the worse trade.

## Migration

`opendray notes flatten`:

- **dry run by default**; `--apply` performs the moves
- drives the same `Move()` the rename UI uses, one document at a time, so **`[[wiki links]]` are repointed as it goes** — this is why it doesn't just move directories
- repoints per-cwd project overrides, which would otherwise keep naming a directory the migration just emptied
- **never overwrites**: a destination that already exists is reported and skipped, leaving both copies to reconcile. A migration that resolves conflicts on its own is one that loses work.
- leaves alone what it has no business moving: daily notes, templates, a loose file directly under `projects/`, a hand-built tree under `personal/` — each with a stated reason rather than silence

## Paths are the gateway's answer now

`/notes/info` reports the layout; the project mapping carries `personal_path`. Web, mobile and the CLI consume those instead of deriving paths.

Three implementations guessing is three chances to disagree — and the CLI was already disagreeing: `notes project` called the package-level shim that hardcodes `projects/`, so under a flat vault it would have filed the note outside the configured layout.

Under the flat layout the personal note sits inside the project directory, which means a per-cwd override moves it too. That rule lives in one place.

## Collisions

A project named `daily` files under `daily-docs` — `daily/YYYY-MM-DD.md` belongs to the whole vault. `_` and `.` prefixes are reserved wholesale; `_templates` already used the first.

## Also fixed

Two things the CLI's help text was wrong about:
- **flags must precede the subcommand.** Go's `flag` package stops parsing at the first non-flag argument, so `notes list --prefix=x` **silently ignored the filter** and listed everything. The help text advertised exactly the form that doesn't work.
- paths have not been `.md`-only since HTML documents landed.

## Verification

`go build ./...`, `go vet ./...`, `go test -race` on `internal/notes`, `internal/config`, `internal/app`, `cmd/opendray` — green. Web `pnpm build` (incl. `tsc -b`), `flutter analyze` clean, `flutter test` 64 passing, i18n parity es/zh 100%.

13 new Go tests cover path derivation in both layouts, the unset-layout fallback (a caller that forgets must not relocate a live install), reserved names, detection including the `.DS_Store`-only case that flipped the original probe, and the migration: link rewriting, dry-run purity, refusal to overwrite, skips with reasons, and override repointing.

**Not verified by tests**: the migration against a real vault of any size. Worth a `flatten` dry run before `--apply`.