### PR TITLE
fix(sessions): stage images as [image1] instead of typing their path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+### Changed
+
+- **A staged image reads as `[image1]`, and no longer lands in the
+  input line.** Attaching one used to type the server path — sixty-odd
+  characters of `/var/folders/…/a7b61d09.png` — straight into the CLI's
+  own prompt. It said nothing to whoever was reading, it pushed the
+  actual message off screen, and taking it back out meant holding
+  backspace through every character, because the line editor belongs to
+  the CLI and cannot know they arrived as a unit.
+
+  The tray now holds staged images as `[image1]`, `[image2]` (the
+  filename moves to the tooltip), and the paths go in a moment before
+  the newline that submits them. Removing one is the × on its chip. Web
+  and mobile both.
+
 ### Added
 
 - **The Vault stores and renders HTML documents, not just markdown.**

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -157,7 +157,6 @@
         "uploadFailedToast": "Upload failed",
         "uploadInvalidTypeToast": "Only image files can be attached",
         "dropToAttach": "Drop image to attach",
-        "attachInsert": "Insert",
         "attachClear": "Clear all",
         "attachRemove": "Remove {name}",
         "copiedToast": "Copied to clipboard",
@@ -173,7 +172,8 @@
         "transcriptLoading": "Loading transcript…",
         "transcriptEmpty": "No output yet.",
         "transcriptFetchFailed": "Couldn't load transcript",
-        "transcriptRefresh": "Refresh"
+        "transcriptRefresh": "Refresh",
+        "attachOnSend": "Attached when you send"
       },
       "spawn": {
         "title": "Spawn session",
@@ -3713,9 +3713,9 @@
         "selectText": "Select text"
       },
       "attachments": {
-        "insert": "Insert",
         "clear": "Clear all",
-        "remove": "Remove {name}"
+        "remove": "Remove {name}",
+        "onSend": "Attached on send"
       },
       "connection": {
         "connecting": "Connecting…",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -157,7 +157,6 @@
         "uploadFailedToast": "Error al subir",
         "uploadInvalidTypeToast": "Solo se pueden adjuntar archivos de imagen",
         "dropToAttach": "Suelta la imagen para adjuntarla",
-        "attachInsert": "Insertar",
         "attachClear": "Quitar todo",
         "attachRemove": "Quitar {name}",
         "copiedToast": "Copiado al portapapeles",
@@ -173,7 +172,8 @@
         "transcriptLoading": "Cargando transcripción…",
         "transcriptEmpty": "Aún no hay salida.",
         "transcriptFetchFailed": "No se pudo cargar la transcripción",
-        "transcriptRefresh": "Recargar"
+        "transcriptRefresh": "Recargar",
+        "attachOnSend": "Se adjuntan al enviar"
       },
       "spawn": {
         "title": "Crear session",
@@ -3713,9 +3713,9 @@
         "selectText": "Seleccionar texto"
       },
       "attachments": {
-        "insert": "Insertar",
         "clear": "Quitar todo",
-        "remove": "Quitar {name}"
+        "remove": "Quitar {name}",
+        "onSend": "Se adjuntan al enviar"
       },
       "connection": {
         "connecting": "Conectando…",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -157,7 +157,6 @@
         "uploadFailedToast": "上传失败",
         "uploadInvalidTypeToast": "仅支持图片文件",
         "dropToAttach": "释放以附加图片",
-        "attachInsert": "插入",
         "attachClear": "全部清除",
         "attachRemove": "移除 {name}",
         "copiedToast": "已复制到剪贴板",
@@ -173,7 +172,8 @@
         "transcriptLoading": "正在加载完整记录…",
         "transcriptEmpty": "暂无输出。",
         "transcriptFetchFailed": "无法加载完整记录",
-        "transcriptRefresh": "刷新"
+        "transcriptRefresh": "刷新",
+        "attachOnSend": "发送时自动附加"
       },
       "spawn": {
         "title": "创建会话",
@@ -3710,9 +3710,9 @@
         "selectText": "选择文本"
       },
       "attachments": {
-        "insert": "插入",
         "clear": "全部清除",
-        "remove": "移除 {name}"
+        "remove": "移除 {name}",
+        "onSend": "发送时附加"
       },
       "connection": {
         "connecting": "连接中…",

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -6,7 +6,7 @@
 /// Locales: 3
 /// Strings: 13317 (4439 per locale)
 ///
-/// Built on 2026-08-09 at 12:55 UTC
+/// Built on 2026-08-09 at 13:33 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -6506,9 +6506,6 @@ class TranslationsWebSessionsTerminalEn {
 	/// en: 'Drop image to attach'
 	String get dropToAttach => 'Drop image to attach';
 
-	/// en: 'Insert'
-	String get attachInsert => 'Insert';
-
 	/// en: 'Clear all'
 	String get attachClear => 'Clear all';
 
@@ -6556,6 +6553,9 @@ class TranslationsWebSessionsTerminalEn {
 
 	/// en: 'Refresh'
 	String get transcriptRefresh => 'Refresh';
+
+	/// en: 'Attached when you send'
+	String get attachOnSend => 'Attached when you send';
 }
 
 // Path: web.sessions.spawn
@@ -13027,14 +13027,14 @@ class TranslationsSessionsTerminalAttachmentsEn {
 
 	// Translations
 
-	/// en: 'Insert'
-	String get insert => 'Insert';
-
 	/// en: 'Clear all'
 	String get clear => 'Clear all';
 
 	/// en: 'Remove {name}'
 	String remove({required Object name}) => 'Remove ${name}';
+
+	/// en: 'Attached on send'
+	String get onSend => 'Attached on send';
 }
 
 // Path: sessions.terminal.connection
@@ -19074,7 +19074,6 @@ extension on Translations {
 			'web.sessions.terminal.uploadFailedToast' => 'Upload failed',
 			'web.sessions.terminal.uploadInvalidTypeToast' => 'Only image files can be attached',
 			'web.sessions.terminal.dropToAttach' => 'Drop image to attach',
-			'web.sessions.terminal.attachInsert' => 'Insert',
 			'web.sessions.terminal.attachClear' => 'Clear all',
 			'web.sessions.terminal.attachRemove' => ({required Object name}) => 'Remove ${name}',
 			'web.sessions.terminal.copiedToast' => 'Copied to clipboard',
@@ -19091,6 +19090,7 @@ extension on Translations {
 			'web.sessions.terminal.transcriptEmpty' => 'No output yet.',
 			'web.sessions.terminal.transcriptFetchFailed' => 'Couldn\'t load transcript',
 			'web.sessions.terminal.transcriptRefresh' => 'Refresh',
+			'web.sessions.terminal.attachOnSend' => 'Attached when you send',
 			'web.sessions.spawn.title' => 'Spawn session',
 			'web.sessions.spawn.description' => 'Start a CLI session under a registered provider.',
 			'web.sessions.spawn.provider' => 'Provider',
@@ -21864,9 +21864,9 @@ extension on Translations {
 			'sessions.terminal.keyboard.attachImage' => 'Attach image',
 			'sessions.terminal.keyboard.enter' => 'Enter',
 			'sessions.terminal.keyboard.selectText' => 'Select text',
-			'sessions.terminal.attachments.insert' => 'Insert',
 			'sessions.terminal.attachments.clear' => 'Clear all',
 			'sessions.terminal.attachments.remove' => ({required Object name}) => 'Remove ${name}',
+			'sessions.terminal.attachments.onSend' => 'Attached on send',
 			'sessions.terminal.connection.connecting' => 'Connecting…',
 			'sessions.terminal.connection.connected' => 'Connected',
 			'sessions.terminal.connection.reconnecting' => 'Reconnecting…',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -3325,7 +3325,6 @@ class _TranslationsWebSessionsTerminalEs extends TranslationsWebSessionsTerminal
 	@override String get uploadFailedToast => 'Error al subir';
 	@override String get uploadInvalidTypeToast => 'Solo se pueden adjuntar archivos de imagen';
 	@override String get dropToAttach => 'Suelta la imagen para adjuntarla';
-	@override String get attachInsert => 'Insertar';
 	@override String get attachClear => 'Quitar todo';
 	@override String attachRemove({required Object name}) => 'Quitar ${name}';
 	@override String get copiedToast => 'Copiado al portapapeles';
@@ -3342,6 +3341,7 @@ class _TranslationsWebSessionsTerminalEs extends TranslationsWebSessionsTerminal
 	@override String get transcriptEmpty => 'Aún no hay salida.';
 	@override String get transcriptFetchFailed => 'No se pudo cargar la transcripción';
 	@override String get transcriptRefresh => 'Recargar';
+	@override String get attachOnSend => 'Se adjuntan al enviar';
 }
 
 // Path: web.sessions.spawn
@@ -6683,9 +6683,9 @@ class _TranslationsSessionsTerminalAttachmentsEs extends TranslationsSessionsTer
 	final TranslationsEs _root; // ignore: unused_field
 
 	// Translations
-	@override String get insert => 'Insertar';
 	@override String get clear => 'Quitar todo';
 	@override String remove({required Object name}) => 'Quitar ${name}';
+	@override String get onSend => 'Se adjuntan al enviar';
 }
 
 // Path: sessions.terminal.connection
@@ -10072,7 +10072,6 @@ extension on TranslationsEs {
 			'web.sessions.terminal.uploadFailedToast' => 'Error al subir',
 			'web.sessions.terminal.uploadInvalidTypeToast' => 'Solo se pueden adjuntar archivos de imagen',
 			'web.sessions.terminal.dropToAttach' => 'Suelta la imagen para adjuntarla',
-			'web.sessions.terminal.attachInsert' => 'Insertar',
 			'web.sessions.terminal.attachClear' => 'Quitar todo',
 			'web.sessions.terminal.attachRemove' => ({required Object name}) => 'Quitar ${name}',
 			'web.sessions.terminal.copiedToast' => 'Copiado al portapapeles',
@@ -10089,6 +10088,7 @@ extension on TranslationsEs {
 			'web.sessions.terminal.transcriptEmpty' => 'Aún no hay salida.',
 			'web.sessions.terminal.transcriptFetchFailed' => 'No se pudo cargar la transcripción',
 			'web.sessions.terminal.transcriptRefresh' => 'Recargar',
+			'web.sessions.terminal.attachOnSend' => 'Se adjuntan al enviar',
 			'web.sessions.spawn.title' => 'Crear session',
 			'web.sessions.spawn.description' => 'Inicia una session de la CLI con un proveedor registrado.',
 			'web.sessions.spawn.provider' => 'Proveedor',
@@ -12862,9 +12862,9 @@ extension on TranslationsEs {
 			'sessions.terminal.keyboard.attachImage' => 'Adjuntar imagen',
 			'sessions.terminal.keyboard.enter' => 'Intro',
 			'sessions.terminal.keyboard.selectText' => 'Seleccionar texto',
-			'sessions.terminal.attachments.insert' => 'Insertar',
 			'sessions.terminal.attachments.clear' => 'Quitar todo',
 			'sessions.terminal.attachments.remove' => ({required Object name}) => 'Quitar ${name}',
+			'sessions.terminal.attachments.onSend' => 'Se adjuntan al enviar',
 			'sessions.terminal.connection.connecting' => 'Conectando…',
 			'sessions.terminal.connection.connected' => 'Conectado',
 			'sessions.terminal.connection.reconnecting' => 'Reconectando…',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -3325,7 +3325,6 @@ class _TranslationsWebSessionsTerminalZh extends TranslationsWebSessionsTerminal
 	@override String get uploadFailedToast => '上传失败';
 	@override String get uploadInvalidTypeToast => '仅支持图片文件';
 	@override String get dropToAttach => '释放以附加图片';
-	@override String get attachInsert => '插入';
 	@override String get attachClear => '全部清除';
 	@override String attachRemove({required Object name}) => '移除 ${name}';
 	@override String get copiedToast => '已复制到剪贴板';
@@ -3342,6 +3341,7 @@ class _TranslationsWebSessionsTerminalZh extends TranslationsWebSessionsTerminal
 	@override String get transcriptEmpty => '暂无输出。';
 	@override String get transcriptFetchFailed => '无法加载完整记录';
 	@override String get transcriptRefresh => '刷新';
+	@override String get attachOnSend => '发送时自动附加';
 }
 
 // Path: web.sessions.spawn
@@ -6683,9 +6683,9 @@ class _TranslationsSessionsTerminalAttachmentsZh extends TranslationsSessionsTer
 	final TranslationsZh _root; // ignore: unused_field
 
 	// Translations
-	@override String get insert => '插入';
 	@override String get clear => '全部清除';
 	@override String remove({required Object name}) => '移除 ${name}';
+	@override String get onSend => '发送时附加';
 }
 
 // Path: sessions.terminal.connection
@@ -10069,7 +10069,6 @@ extension on TranslationsZh {
 			'web.sessions.terminal.uploadFailedToast' => '上传失败',
 			'web.sessions.terminal.uploadInvalidTypeToast' => '仅支持图片文件',
 			'web.sessions.terminal.dropToAttach' => '释放以附加图片',
-			'web.sessions.terminal.attachInsert' => '插入',
 			'web.sessions.terminal.attachClear' => '全部清除',
 			'web.sessions.terminal.attachRemove' => ({required Object name}) => '移除 ${name}',
 			'web.sessions.terminal.copiedToast' => '已复制到剪贴板',
@@ -10086,6 +10085,7 @@ extension on TranslationsZh {
 			'web.sessions.terminal.transcriptEmpty' => '暂无输出。',
 			'web.sessions.terminal.transcriptFetchFailed' => '无法加载完整记录',
 			'web.sessions.terminal.transcriptRefresh' => '刷新',
+			'web.sessions.terminal.attachOnSend' => '发送时自动附加',
 			'web.sessions.spawn.title' => '创建会话',
 			'web.sessions.spawn.description' => '在已注册的 Provider 下启动一个 CLI 会话。',
 			'web.sessions.spawn.provider' => 'Provider',
@@ -12856,9 +12856,9 @@ extension on TranslationsZh {
 			'sessions.terminal.keyboard.attachImage' => '附加图片',
 			'sessions.terminal.keyboard.enter' => '回车',
 			'sessions.terminal.keyboard.selectText' => '选择文本',
-			'sessions.terminal.attachments.insert' => '插入',
 			'sessions.terminal.attachments.clear' => '全部清除',
 			'sessions.terminal.attachments.remove' => ({required Object name}) => '移除 ${name}',
+			'sessions.terminal.attachments.onSend' => '发送时附加',
 			'sessions.terminal.connection.connecting' => '连接中…',
 			'sessions.terminal.connection.connected' => '已连接',
 			'sessions.terminal.connection.reconnecting' => '重连中…',

--- a/app/mobile/lib/features/sessions/session_terminal_view.dart
+++ b/app/mobile/lib/features/sessions/session_terminal_view.dart
@@ -253,6 +253,14 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
   void _onTerminalOutput(String data) {
     final channel = _channel;
     if (channel == null) return;
+    // A bare Enter is the submit. Staged images go in a moment before
+    // it, rather than being typed into the line while it is being
+    // composed — a full server path there says nothing to the reader
+    // and takes sixty backspaces to remove, because the line editor
+    // belongs to the CLI and cannot know they arrived as a unit.
+    if (data == '\r' && _pending.isNotEmpty) {
+      _flushAttachments();
+    }
     try {
       channel.sink.add(Uint8List.fromList(utf8.encode(data)));
     } on Object {
@@ -385,10 +393,21 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
     }
   }
 
-  void _insertAttachments() {
+  void _flushAttachments() {
     if (_pending.isEmpty) return;
-    _terminal.paste('${_pending.map((a) => a.path).join(' ')} ');
-    setState(_pending.clear);
+    final paths = _pending.map((a) => a.path).join(' ');
+    _pending.clear();
+    // Straight to the socket, not through _terminal.paste: paste would
+    // re-enter _onTerminalOutput and recurse through the guard above.
+    final channel = _channel;
+    if (channel != null) {
+      try {
+        channel.sink.add(Uint8List.fromList(utf8.encode(' $paths ')));
+      } on Object {
+        // A dead socket is reported by the connection state, not here.
+      }
+    }
+    if (mounted) setState(() {});
   }
 
   void _clearAttachments() => setState(_pending.clear);
@@ -498,7 +517,6 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
         _AttachmentTray(
           items: _pending,
           onRemove: _removeAttachment,
-          onInsert: _insertAttachments,
           onClear: _clearAttachments,
         ),
         _MobileKeyboardBar(
@@ -518,12 +536,10 @@ class _AttachmentTray extends StatelessWidget {
   const _AttachmentTray({
     required this.items,
     required this.onRemove,
-    required this.onInsert,
     required this.onClear,
   });
   final List<_PendingAttachment> items;
   final void Function(int index) onRemove;
-  final VoidCallback onInsert;
   final VoidCallback onClear;
 
   @override
@@ -545,9 +561,16 @@ class _AttachmentTray extends StatelessWidget {
                       padding: const EdgeInsets.only(right: 6),
                       child: Chip(
                         avatar: const Icon(Icons.attach_file, size: 14),
-                        label: Text(
-                          items[i].name,
-                          overflow: TextOverflow.ellipsis,
+                        // The position, not the filename: this is what
+                        // the agent's input line will carry, and a chip
+                        // reading the original name is no more use than
+                        // the path was.
+                        label: Tooltip(
+                          message: items[i].name,
+                          child: Text(
+                            '[image${i + 1}]',
+                            overflow: TextOverflow.ellipsis,
+                          ),
                         ),
                         deleteIcon: const Icon(Icons.close, size: 14),
                         deleteButtonTooltipMessage: t
@@ -560,14 +583,16 @@ class _AttachmentTray extends StatelessWidget {
               ),
             ),
           ),
+          // No "insert" any more — the paths go in with the message,
+          // and saying so is the whole affordance.
+          Text(
+            t.sessions.terminal.attachments.onSend,
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          const SizedBox(width: 4),
           TextButton(
             onPressed: onClear,
             child: Text(t.sessions.terminal.attachments.clear),
-          ),
-          const SizedBox(width: 4),
-          FilledButton(
-            onPressed: onInsert,
-            child: Text(t.sessions.terminal.attachments.insert),
           ),
         ],
       ),

--- a/app/web/src/components/sessions/AttachmentTray.tsx
+++ b/app/web/src/components/sessions/AttachmentTray.tsx
@@ -1,7 +1,6 @@
 import { Paperclip, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-import { cn } from '@/lib/utils'
 
 export interface AttachmentItem {
   path: string
@@ -14,12 +13,10 @@ export interface AttachmentItem {
 export function AttachmentTray({
   items,
   onRemove,
-  onInsert,
   onClear,
 }: {
   items: AttachmentItem[]
   onRemove: (index: number) => void
-  onInsert: () => void
   onClear: () => void
 }) {
   const { t } = useTranslation()
@@ -33,7 +30,13 @@ export function AttachmentTray({
             className="flex max-w-[180px] items-center gap-1 rounded-md border border-border bg-background px-1.5 py-0.5 text-[11px]"
           >
             <Paperclip className="size-3 shrink-0 text-muted-foreground" />
-            <span className="truncate">{item.name}</span>
+            {/* The position, not the filename: this is the label the
+                agent's input line will carry, and a chip reading
+                `screenshot 2026-08-09 at 14.03.11.png` is no more use
+                than the path was. The real name stays in the tooltip. */}
+            <span className="truncate font-mono" title={item.name}>
+              [image{i + 1}]
+            </span>
             <button
               type="button"
               onClick={() => onRemove(i)}
@@ -47,23 +50,18 @@ export function AttachmentTray({
           </span>
         ))}
       </div>
-      <div className="ml-auto flex shrink-0 items-center gap-1.5">
+      <div className="ml-auto flex shrink-0 items-center gap-2">
+        {/* There is no "insert" any more — the paths go in with the
+            message. Saying so is the whole affordance. */}
+        <span className="text-[11px] text-muted-foreground/70">
+          {t('web.sessions.terminal.attachOnSend')}
+        </span>
         <button
           type="button"
           onClick={onClear}
           className="rounded-md px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-background hover:text-foreground"
         >
           {t('web.sessions.terminal.attachClear')}
-        </button>
-        <button
-          type="button"
-          onClick={onInsert}
-          className={cn(
-            'rounded-md bg-primary px-2.5 py-0.5 text-[11px] font-medium text-primary-foreground',
-            'hover:opacity-95',
-          )}
-        >
-          {t('web.sessions.terminal.attachInsert')}
         </button>
       </div>
     </div>

--- a/app/web/src/components/sessions/Terminal.tsx
+++ b/app/web/src/components/sessions/Terminal.tsx
@@ -114,6 +114,10 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
   const { t } = useTranslation()
   const [dragActive, setDragActive] = useState(false)
   const [pendingAttachments, setPendingAttachments] = useState<AttachmentItem[]>([])
+  // Read by the PTY data handler, which is wired once per session and
+  // would otherwise close over an empty list forever.
+  const attachmentsRef = useRef<AttachmentItem[]>([])
+  attachmentsRef.current = pendingAttachments
   const rootRef = useRef<HTMLDivElement>(null)
 
   const sendInput = useCallback((data: string) => {
@@ -156,11 +160,25 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     [sessionId, t],
   )
 
-  const insertAttachments = useCallback(() => {
-    if (pendingAttachments.length === 0) return
-    sendInput(pendingAttachments.map((a) => a.path).join(' ') + ' ')
+  // Attachments are appended at SUBMIT, not while composing.
+  //
+  // They used to be typed into the line the moment you asked for them,
+  // which put a full server path — `/var/folders/.../a7b61d09.png` —
+  // into the CLI's own input line. That path is the CLI's business, not
+  // the reader's: it says nothing, it pushes the actual message off
+  // screen, and taking it back out means holding backspace through
+  // sixty characters, because the line editor belongs to the CLI and
+  // has no idea those characters arrived as a unit.
+  //
+  // Now the tray holds them, the composer stays clean, and the paths go
+  // in a moment before the newline that submits them.
+  const flushAttachments = useCallback(() => {
+    const pending = attachmentsRef.current
+    if (pending.length === 0) return
+    sendInput(' ' + pending.map((a) => a.path).join(' ') + ' ')
+    attachmentsRef.current = []
     setPendingAttachments([])
-  }, [pendingAttachments, sendInput])
+  }, [sendInput])
 
   const removeAttachment = useCallback((index: number) => {
     setPendingAttachments((a) => a.filter((_, i) => i !== index))
@@ -241,6 +259,13 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     ws.start()
 
     term.onData((d) => {
+      // A bare Enter is the submit. Anything longer is a paste or an
+      // escape sequence, and injecting paths into either would corrupt
+      // it — a menu selection is also a bare Enter, but a menu is not
+      // somewhere anyone has staged an image.
+      if (d === '\r' && attachmentsRef.current.length > 0) {
+        flushAttachments()
+      }
       const enc = new TextEncoder().encode(d)
       ws.send(enc.buffer.slice(enc.byteOffset, enc.byteOffset + enc.byteLength) as ArrayBuffer)
     })
@@ -553,7 +578,6 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       <AttachmentTray
         items={pendingAttachments}
         onRemove={removeAttachment}
-        onInsert={insertAttachments}
         onClear={clearAttachments}
       />
     </div>


### PR DESCRIPTION
## The problem

Attaching an image typed the server path into the CLI's own input line — sixty-odd characters of `/var/folders/.../a7b61d09.png` sitting in front of the message.

It is the wrong text in the wrong place:

- it says nothing about what was attached,
- it pushes the actual message off screen,
- and removing it means **holding backspace through every character**, because the line editor belongs to the CLI and cannot know those characters arrived as one thing.

## The change

Paths stop being typed while composing. The tray holds them, labelled by position — `[image1]`, `[image2]` — with the filename moved to the tooltip, since a chip reading `screenshot 2026-08-09 at 14.03.11.png` is no more use than the path was.

The paths go in **a moment before the newline that submits them**, so the agent receives exactly what it did before. Removing one is the `×` on its chip.

The **Insert button is gone rather than relabelled**: it existed to put the path in the line, which is the thing being fixed. In its place the tray says when the images will be attached.

## Two things worth reviewing

**Only a bare `Enter` triggers the flush.** A longer chunk is a paste or an escape sequence, and injecting paths into either would corrupt it. A menu selection is also a bare Enter — but a menu is not somewhere anyone has staged an image, and the tray is a state the operator created deliberately.

**On mobile the flush writes to the socket directly** rather than through `Terminal.paste`, which would re-enter the same handler and recurse through the guard.

On web the pending list is read through a ref: the PTY data handler is wired once per session and would otherwise close over an empty list forever.

## Verification

`pnpm build` (incl. `tsc -b`), `flutter analyze` clean, `flutter test` 64 passing, i18n parity es/zh 100%. The removed `attachInsert` / `attachments.insert` keys are gone from all three locales with no references left.

**Not verified by tests**: the actual attach-and-send round trip, which needs a live session. Worth staging two images, typing a message, and checking the agent receives both paths — and that Esc still clears the tray.