### PR TITLE
feat(web): adapt the admin UI to phones and tablets

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -150,7 +150,8 @@
         "selectText": "Select & copy",
         "selectTextTooltip": "Open a selectable text view to copy any part of the output",
         "transcript": "Transcript",
-        "transcriptTooltip": "Open the full session transcript (works for CLIs whose own scrollback is unreachable, e.g. Grok)"
+        "transcriptTooltip": "Open the full session transcript (works for CLIs whose own scrollback is unreachable, e.g. Grok)",
+        "moreActions": "More actions"
       },
       "terminal": {
         "uploadingToast": "Uploading image…",
@@ -1005,7 +1006,9 @@
         "collapseAll": "Collapse all",
         "collapseAllTooltip": "Collapse every folder",
         "loading": "Loading…",
-        "footer": "{visible} / {total} notes"
+        "footer": "{visible} / {total} notes",
+        "openTree": "Open note tree",
+        "closeTree": "Close note tree"
       },
       "tags": {
         "emptyVault": "No tags in vault yet.",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -150,7 +150,8 @@
         "selectText": "Seleccionar y copiar",
         "selectTextTooltip": "Abre una vista de texto seleccionable para copiar cualquier parte de la salida",
         "transcript": "Transcripción",
-        "transcriptTooltip": "Abre la transcripción completa de la sesión (útil para CLIs cuyo propio desplazamiento no funciona, p. ej. Grok)"
+        "transcriptTooltip": "Abre la transcripción completa de la sesión (útil para CLIs cuyo propio desplazamiento no funciona, p. ej. Grok)",
+        "moreActions": "Más acciones"
       },
       "terminal": {
         "uploadingToast": "Subiendo imagen…",
@@ -1005,7 +1006,9 @@
         "collapseAll": "Contraer todo",
         "collapseAllTooltip": "Contraer todas las carpetas",
         "loading": "Cargando…",
-        "footer": "{visible} / {total} notas"
+        "footer": "{visible} / {total} notas",
+        "openTree": "Abrir árbol de notas",
+        "closeTree": "Cerrar árbol de notas"
       },
       "tags": {
         "emptyVault": "Aún no hay etiquetas en el vault.",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -150,7 +150,8 @@
         "selectText": "选择并复制",
         "selectTextTooltip": "打开可选择文本视图,复制输出中的任意部分",
         "transcript": "完整记录",
-        "transcriptTooltip": "打开整个会话的完整文本记录（适用于自身不支持滚动的 CLI，例如 Grok）"
+        "transcriptTooltip": "打开整个会话的完整文本记录（适用于自身不支持滚动的 CLI，例如 Grok）",
+        "moreActions": "更多操作"
       },
       "terminal": {
         "uploadingToast": "正在上传图片…",
@@ -1005,7 +1006,9 @@
         "collapseAll": "全部收起",
         "collapseAllTooltip": "收起全部文件夹",
         "loading": "加载中…",
-        "footer": "{visible} / {total} 条笔记"
+        "footer": "{visible} / {total} 条笔记",
+        "openTree": "打开笔记树",
+        "closeTree": "收起笔记树"
       },
       "tags": {
         "emptyVault": "vault 中暂无标签。",

--- a/app/shared-ui/src/primitives/scroll-area.tsx
+++ b/app/shared-ui/src/primitives/scroll-area.tsx
@@ -12,10 +12,23 @@ const ScrollArea = React.forwardRef<
     className={cn('relative overflow-hidden', className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    {/* Radix styles the viewport's inner wrapper `display:table;
+        min-width:100%` inline, which shrink-wraps to the content's
+        min-content width. On a narrow screen that means prose stops
+        wrapping and the pane scrolls sideways instead — measured at
+        567px of content inside a 412px viewport. Forcing the wrapper
+        back to a block restores normal wrapping; anything that really
+        is wider than the pane (a table with a min-width) still
+        overflows and still scrolls. */}
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit] [&>div]:!block [&>div]:!min-w-0">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />
+    {/* Radix's viewport already scrolls on both axes, but with no
+        horizontal bar rendered the overflow was invisible — on a phone,
+        a wide table simply looked truncated. The bar only materialises
+        when the content actually overflows sideways. */}
+    <ScrollBar orientation="horizontal" />
     <ScrollAreaPrimitive.Corner />
   </ScrollAreaPrimitive.Root>
 ))

--- a/app/web/src/components/AppShell.tsx
+++ b/app/web/src/components/AppShell.tsx
@@ -1,30 +1,35 @@
 import { Suspense, useEffect, useState } from 'react'
 import { Outlet } from '@tanstack/react-router'
-import { Loader2, ChevronRight } from 'lucide-react'
+import { Loader2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { SidebarNav } from './SidebarNav'
 import { Topbar } from './Topbar'
+import { SlideOverAside } from './SlideOverAside'
 import { CommandPalette, useCommandPaletteHotkey } from './CommandPalette'
 import { HealthBanner } from './HealthBanner'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { useLayout } from '@/stores/layout'
-import { useIsMobile } from '../lib/useIsMobile'
-import { cn } from '@/lib/utils'
+import { useIsCompact, useIsMobile } from '../lib/useIsMobile'
 
 export function AppShell() {
+  const { t } = useTranslation()
   const [paletteOpen, setPaletteOpen] = useState(false)
   useCommandPaletteHotkey(setPaletteOpen)
 
   const isMobile = useIsMobile()
+  const isCompact = useIsCompact()
   const sidebarCollapsed = useLayout((s) => s.sidebarCollapsed)
   const setSidebarCollapsed = useLayout((s) => s.setSidebarCollapsed)
 
-  // Entering mobile collapses the nav so the workbench gets full width;
-  // the user re-opens it as a slide-over via the edge arrow / topbar.
+  // Entering a narrow viewport collapses the nav so the workbench gets
+  // the width. What "collapsed" means differs by size: on a tablet the
+  // nav stays inline as a 48px icon rail (still one tap from anywhere),
+  // on a phone there is no room even for that, so it becomes a
+  // slide-over the user pulls in from the edge or the topbar toggle.
   useEffect(() => {
-    if (isMobile) setSidebarCollapsed(true)
-  }, [isMobile, setSidebarCollapsed])
+    if (isCompact) setSidebarCollapsed(true)
+  }, [isCompact, setSidebarCollapsed])
 
   const navOpen = !sidebarCollapsed
 
@@ -40,40 +45,19 @@ export function AppShell() {
         <Topbar onOpenPalette={() => setPaletteOpen(true)} />
         <HealthBanner />
         <div className="flex-1 flex overflow-hidden min-h-0 relative">
-          {isMobile ? (
-            <>
-              {/* Slide-over nav drawer */}
-              <div
-                className={cn(
-                  'fixed inset-y-0 left-0 z-50 flex transition-transform duration-200 ease-out',
-                  navOpen ? 'translate-x-0' : '-translate-x-full',
-                )}
-              >
-                <SidebarNav />
-              </div>
-              {/* Backdrop (tap to close) */}
-              {navOpen && (
-                <div
-                  className="fixed inset-0 z-40 bg-black/50"
-                  onClick={() => setSidebarCollapsed(true)}
-                  aria-hidden
-                />
-              )}
-              {/* Edge handle to pull the nav in when closed */}
-              {!navOpen && (
-                <button
-                  type="button"
-                  onClick={() => setSidebarCollapsed(false)}
-                  aria-label="Open navigation"
-                  className="fixed left-0 top-1/2 -translate-y-1/2 z-30 h-12 w-5 rounded-r-md border border-l-0 border-border bg-card/90 text-muted-foreground flex items-center justify-center shadow-sm active:bg-card"
-                >
-                  <ChevronRight className="size-3.5" />
-                </button>
-              )}
-            </>
-          ) : (
+          <SlideOverAside
+            side="left"
+            compact={isMobile}
+            open={isMobile ? navOpen : true}
+            onOpenChange={(v) => setSidebarCollapsed(!v)}
+            label={t('web.topbar.expandSidebar')}
+            // No edge handle: the topbar's sidebar toggle is always
+            // visible, and a second handle here lands on top of the
+            // page's own left-edge handle (session list, note tree, …).
+            hideHandle
+          >
             <SidebarNav />
-          )}
+          </SlideOverAside>
           <main className="flex-1 overflow-auto min-w-0">
             <Suspense fallback={<RouteFallback />}>
               <Outlet />

--- a/app/web/src/components/SlideOverAside.tsx
+++ b/app/web/src/components/SlideOverAside.tsx
@@ -1,0 +1,114 @@
+import { useEffect, type ReactNode } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+interface SlideOverAsideProps {
+  /** Which edge the panel is docked to. */
+  side: 'left' | 'right'
+  /**
+   * When false the panel renders inline as a normal flex column — the
+   * desktop layout. When true it becomes an overlay drawer.
+   */
+  compact: boolean
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Accessible name for the edge handle that pulls the panel in. */
+  label: string
+  /**
+   * Hide the edge handle. Use when the caller already offers another way
+   * to open the panel (e.g. a toolbar button) and a permanent handle
+   * floating over the content would just be in the way.
+   */
+  hideHandle?: boolean
+  children: ReactNode
+}
+
+/**
+ * A side panel that is an inline column on wide screens and a slide-over
+ * drawer on narrow ones.
+ *
+ * Positioning is `absolute`, not `fixed`: the drawer must stay inside the
+ * page area so the app topbar — which carries the nav toggle — is never
+ * covered by a page-level panel. **The nearest positioned ancestor must
+ * therefore be the page/shell container**, i.e. give it `relative`.
+ */
+export function SlideOverAside({
+  side,
+  compact,
+  open,
+  onOpenChange,
+  label,
+  hideHandle,
+  children,
+}: SlideOverAsideProps) {
+  // Escape closes the drawer. Only while it is actually an overlay —
+  // inline columns are not dismissible, and swallowing Escape there
+  // would steal it from dialogs and the terminal.
+  useEffect(() => {
+    if (!compact || !open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onOpenChange(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [compact, open, onOpenChange])
+
+  if (!compact) return open ? <>{children}</> : null
+
+  const closedTransform =
+    side === 'left' ? '-translate-x-full' : 'translate-x-full'
+  const HandleIcon = side === 'left' ? ChevronRight : ChevronLeft
+
+  return (
+    <>
+      <div
+        className={cn(
+          // The panels inside are sized for desktop (w-60…w-80) and are
+          // `shrink-0`, so on a narrow phone they would cover the whole
+          // screen and leave no backdrop to tap. max-w-full on the child
+          // clamps them regardless of flex-shrink, keeping a strip of
+          // backdrop visible as the "tap here to dismiss" affordance.
+          'absolute inset-y-0 z-50 flex max-w-[85%] [&>*]:max-w-full transition-transform duration-200 ease-out',
+          side === 'left' ? 'left-0' : 'right-0',
+          open ? 'translate-x-0' : closedTransform,
+        )}
+        // Keep the closed drawer out of the tab order and off screen
+        // readers — it is visually gone, so it must be gone for keyboard
+        // and AT users too.
+        inert={!open ? true : undefined}
+      >
+        {children}
+      </div>
+
+      {open && (
+        <div
+          className="absolute inset-0 z-40 bg-black/50"
+          onClick={() => onOpenChange(false)}
+          aria-hidden
+        />
+      )}
+
+      {!open && !hideHandle && (
+        <button
+          type="button"
+          onClick={() => onOpenChange(true)}
+          aria-label={label}
+          className={cn(
+            // Opaque and accent-tinted, not a translucent hairline: the
+            // first version read as part of the page background and
+            // people simply did not find it. Also a 44px-tall,
+            // 24px-wide target — the old 20px strip was below the
+            // comfortable touch minimum.
+            'absolute top-1/2 -translate-y-1/2 z-30 h-14 w-6 border border-accent/40 bg-card text-accent flex items-center justify-center shadow-md active:bg-accent active:text-accent-foreground',
+            side === 'left'
+              ? 'left-0 rounded-r-md border-l-0'
+              : 'right-0 rounded-l-md border-r-0',
+          )}
+        >
+          <HandleIcon className="size-4" />
+        </button>
+      )}
+    </>
+  )
+}

--- a/app/web/src/components/Topbar.tsx
+++ b/app/web/src/components/Topbar.tsx
@@ -103,11 +103,14 @@ export function Topbar({ onOpenPalette }: TopbarProps) {
               variant="outline"
               size="sm"
               onClick={onOpenPalette}
-              className="h-7 gap-2 text-muted-foreground bg-card/50 hover:bg-card font-normal text-[12px]"
+              // Narrow viewports have no keyboard to press ⌘K on and no
+              // room for the label, so the trigger degrades to a plain
+              // icon button rather than eating the whole topbar.
+              className="size-7 p-0 sm:size-auto sm:h-7 sm:px-3 sm:gap-2 text-muted-foreground bg-card/50 hover:bg-card font-normal text-[12px]"
             >
               <Search className="size-3" />
-              <span>{t('web.topbar.search')}</span>
-              <kbd className="ml-1">⌘K</kbd>
+              <span className="hidden sm:inline">{t('web.topbar.search')}</span>
+              <kbd className="ml-1 hidden sm:inline">⌘K</kbd>
             </Button>
           </TooltipTrigger>
           <TooltipContent>{t('web.topbar.openPalette')}</TooltipContent>
@@ -173,10 +176,14 @@ export function Topbar({ onOpenPalette }: TopbarProps) {
             <Button
               variant="ghost"
               size="sm"
-              className="h-7 px-2 text-[12px] font-normal text-muted-foreground gap-1.5"
+              className="h-7 px-2 text-[12px] font-normal text-muted-foreground gap-1.5 min-w-0"
             >
-              <span className="size-1.5 rounded-full bg-state-running" />
-              {username}
+              <span className="size-1.5 rounded-full bg-state-running shrink-0" />
+              {/* A long account name must not push the topbar wide enough
+                  to scroll on a phone; the full value is in the menu. */}
+              <span className="truncate max-w-[80px] sm:max-w-[160px]">
+                {username}
+              </span>
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent

--- a/app/web/src/components/backup/BackupsView.tsx
+++ b/app/web/src/components/backup/BackupsView.tsx
@@ -1064,8 +1064,8 @@ function BackupTable({
     )
   }
   return (
-    <div className="rounded-md border border-border overflow-hidden">
-      <table className="w-full text-[12px]">
+    <div className="rounded-md border border-border overflow-x-auto">
+      <table className="w-full min-w-[560px] text-[12px]">
         <thead className="bg-card/50 text-muted-foreground">
           <tr className="text-left">
             <th className="px-3 py-2 font-medium">{t('web.backups.backupsTab.columns.id')}</th>
@@ -1399,8 +1399,8 @@ function SchedulesTab() {
           {t('web.backups.schedulesTab.empty')}
         </div>
       ) : (
-        <div className="rounded-md border border-border overflow-hidden">
-          <table className="w-full text-[12px]">
+        <div className="rounded-md border border-border overflow-x-auto">
+          <table className="w-full min-w-[560px] text-[12px]">
             <thead className="bg-card/50 text-muted-foreground">
               <tr className="text-left">
                 <th className="px-3 py-2 font-medium">{t('web.backups.schedulesTab.columns.id')}</th>
@@ -1659,8 +1659,8 @@ function TargetsTab() {
       {rows === null ? (
         <div className="text-muted-foreground text-sm">{t('web.backups.loading')}</div>
       ) : (
-        <div className="rounded-md border border-border overflow-hidden">
-          <table className="w-full text-[12px]">
+        <div className="rounded-md border border-border overflow-x-auto">
+          <table className="w-full min-w-[560px] text-[12px]">
             <thead className="bg-card/50 text-muted-foreground">
               <tr className="text-left">
                 <th className="px-3 py-2 font-medium">{t('web.backups.targetsTab.columns.id')}</th>

--- a/app/web/src/components/database/DatabaseWorkbench.tsx
+++ b/app/web/src/components/database/DatabaseWorkbench.tsx
@@ -23,6 +23,8 @@ import { ConnectionDialog } from './ConnectionDialog'
 import { SchemaTree, type TableRef } from './SchemaTree'
 import { DataGrid } from './DataGrid'
 import { SQLConsole } from './SQLConsole'
+import { SlideOverAside } from '@/components/SlideOverAside'
+import { useIsMobile } from '../../lib/useIsMobile'
 
 type RightView = { kind: 'table'; ref: TableRef } | { kind: 'console' }
 
@@ -54,6 +56,10 @@ export function DatabaseWorkbench({
   const [view, setView] = useState<RightView>(
     initialTable ? { kind: 'table', ref: initialTable } : { kind: 'console' },
   )
+  // On a phone the schema tree and the grid can't share the dialog, so
+  // the tree becomes a slide-over over the grid.
+  const isMobile = useIsMobile()
+  const [schemaOpen, setSchemaOpen] = useState(false)
 
   const connQuery = useQuery({
     queryKey: ['db-connections', cwd],
@@ -77,7 +83,10 @@ export function DatabaseWorkbench({
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center gap-2 border-b px-3 py-2">
+      {/* flex-wrap: on a phone the connection picker alone is as wide as
+          the dialog, so the toolbar has to be allowed a second row
+          instead of pushing its buttons off the edge. */}
+      <div className="flex flex-wrap items-center gap-2 border-b px-3 py-2">
         <DialogTitle className="mr-1 flex items-center gap-1.5">
           <Database className="h-4 w-4" />
           {t('web.database.workbench.title')}
@@ -90,7 +99,7 @@ export function DatabaseWorkbench({
               setView({ kind: 'console' })
             }}
           >
-            <SelectTrigger className="h-8 w-56">
+            <SelectTrigger className="h-8 w-full min-w-0 sm:w-56">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -163,14 +172,25 @@ export function DatabaseWorkbench({
           </Button>
         </div>
       ) : (
-        <div className="flex min-h-0 flex-1">
-          <div className="w-64 flex-none overflow-auto border-r p-2">
-            <SchemaTree
-              connectionId={active.id}
-              selected={view.kind === 'table' ? view.ref : null}
-              onSelect={(ref) => setView({ kind: 'table', ref })}
-            />
-          </div>
+        <div className="relative flex min-h-0 flex-1">
+          <SlideOverAside
+            side="left"
+            compact={isMobile}
+            open={isMobile ? schemaOpen : true}
+            onOpenChange={setSchemaOpen}
+            label={t('web.database.workbench.title')}
+          >
+            <div className="bg-background w-64 flex-none overflow-auto border-r p-2">
+              <SchemaTree
+                connectionId={active.id}
+                selected={view.kind === 'table' ? view.ref : null}
+                onSelect={(ref) => {
+                  setView({ kind: 'table', ref })
+                  setSchemaOpen(false)
+                }}
+              />
+            </div>
+          </SlideOverAside>
           <div className="min-w-0 flex-1">
             {view.kind === 'table' ? (
               <DataGrid

--- a/app/web/src/components/project/ProjectCwdPicker.tsx
+++ b/app/web/src/components/project/ProjectCwdPicker.tsx
@@ -39,19 +39,19 @@ export function ProjectCwdPicker({
   const knownCwds = (projectsQuery.data ?? []).map((p) => p.cwd)
 
   return (
-    <div className="mx-auto max-w-2xl space-y-4 p-6">
+    <div className="mx-auto max-w-2xl space-y-4 p-3 sm:p-6">
       <h1 className="text-xl font-semibold">
         {title ?? t('web.project.picker.title')}
       </h1>
       <p className="text-muted-foreground text-sm">
         {subtitle ?? t('web.project.picker.subtitle')}
       </p>
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
         <Input
           placeholder={t('web.project.picker.pathPlaceholder')}
           value={picker}
           onChange={(e) => setPicker(e.target.value)}
-          className="font-mono"
+          className="w-full min-w-0 font-mono sm:w-auto sm:flex-1"
         />
         <Button
           variant="outline"
@@ -100,7 +100,17 @@ export function ProjectCwdPicker({
                 ) : (
                   <Folder className="text-muted-foreground h-4 w-4 flex-none" />
                 )}
-                <span className="truncate font-mono text-xs">{cwd}</span>
+                {/* dir=rtl clips the HEAD of the path instead of the
+                    tail: every project here shares a long common prefix,
+                    so the project name at the end is the only part that
+                    tells them apart. The bdi keeps the text itself
+                    rendering left-to-right. */}
+                <span
+                  dir="rtl"
+                  className="min-w-0 flex-1 truncate text-left font-mono text-xs"
+                >
+                  <bdi>{cwd}</bdi>
+                </span>
                 {orphan && (
                   <span className="text-muted-foreground ml-auto text-[10px]">
                     {t('web.project.picker.orphanBadge')}

--- a/app/web/src/components/project/ProjectScreen.tsx
+++ b/app/web/src/components/project/ProjectScreen.tsx
@@ -214,11 +214,19 @@ export function ProjectScreen({ cwd }: ProjectScreenProps) {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="border-b px-4 py-3">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <div className="text-muted-foreground font-mono text-xs">{cwd}</div>
-            <div className="mt-1 flex items-center gap-3 text-xs">
+      <div className="border-b px-3 py-3 sm:px-4">
+        {/* flex-wrap + min-w-0: the cwd is an unbreakable mono path, so
+            without a shrinkable track it shoves the action buttons off
+            the right edge of a phone. */}
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <div
+              className="text-muted-foreground truncate font-mono text-xs"
+              title={cwd}
+            >
+              {cwd}
+            </div>
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
               <span>
                 {t('web.project.header.docsCount', { count: docsCount })}
               </span>
@@ -279,7 +287,7 @@ export function ProjectScreen({ cwd }: ProjectScreenProps) {
         onValueChange={setActiveTab}
         className="flex flex-1 flex-col overflow-hidden"
       >
-        <TabsList className="bg-muted/30 mx-4 mt-3 w-fit max-w-[calc(100%-2rem)] flex-wrap">
+        <TabsList className="bg-muted/30 mx-3 mt-3 w-fit max-w-[calc(100%-1.5rem)] flex-wrap sm:mx-4 sm:max-w-[calc(100%-2rem)]">
           {sections.map((sec) => (
             <TabsTrigger key={sec.slug} value={sec.slug}>
               {sectionTabLabel(sec, t)}

--- a/app/web/src/components/roundtable/RoundTablePanel.tsx
+++ b/app/web/src/components/roundtable/RoundTablePanel.tsx
@@ -9,6 +9,8 @@ import { cn } from '@/lib/utils'
 import { listRoundTables, type RoundTableStatus } from '@/lib/roundtable'
 import { CreateRoundTableDialog } from './CreateRoundTableDialog'
 import { RoundTableDetail } from './RoundTableDetail'
+import { SlideOverAside } from '@/components/SlideOverAside'
+import { useIsMobile } from '../../lib/useIsMobile'
 
 const STATUS_VARIANT: Record<RoundTableStatus, 'success' | 'outline'> = {
   active: 'success',
@@ -19,6 +21,16 @@ export function RoundTablePanel() {
   const { t } = useTranslation()
   const [selected, setSelected] = useState<string | null>(null)
   const [dialogOpen, setDialogOpen] = useState(false)
+
+  // On a phone the table list is a slide-over over the transcript —
+  // but with nothing selected there is no transcript to overlay, so the
+  // list simply becomes the page (same rule as the session list).
+  const isMobile = useIsMobile()
+  const [listOpen, setListOpen] = useState(false)
+  const selectTable = (id: string) => {
+    setSelected(id)
+    setListOpen(false)
+  }
 
   const list = useQuery({
     queryKey: ['round-tables'],
@@ -31,9 +43,27 @@ export function RoundTablePanel() {
   const tables = list.data ?? []
 
   return (
-    <div className="flex h-full min-h-0 gap-4">
+    // `relative` anchors the phone slide-over below.
+    <div className="relative flex h-full min-h-0 gap-4">
       {/* List column */}
-      <div className="flex w-72 shrink-0 flex-col gap-2">
+      <SlideOverAside
+        side="left"
+        compact={isMobile && !!selected}
+        open={isMobile && selected ? listOpen : true}
+        onOpenChange={setListOpen}
+        label={t('web.roundTable.title')}
+      >
+      <div
+        className={cn(
+          'flex flex-col gap-2',
+          isMobile && !selected ? 'w-full flex-1' : 'w-72 shrink-0',
+          // As an overlay the column needs its own surface — inline it
+          // sits on the page background and needs neither.
+          isMobile &&
+            selected &&
+            'border-border bg-background overflow-y-auto border-r p-3',
+        )}
+      >
         <Button size="sm" onClick={() => setDialogOpen(true)}>
           <Plus className="size-3.5" />
           {t('web.roundTable.new')}
@@ -57,7 +87,7 @@ export function RoundTablePanel() {
               <button
                 key={rt.id}
                 type="button"
-                onClick={() => setSelected(rt.id)}
+                onClick={() => selectTable(rt.id)}
                 className={cn(
                   'flex flex-col gap-1 rounded-md border px-3 py-2 text-left transition-colors',
                   selected === rt.id
@@ -81,9 +111,15 @@ export function RoundTablePanel() {
           </div>
         )}
       </div>
+      </SlideOverAside>
 
       {/* Detail column */}
-      <div className="min-w-0 flex-1 overflow-y-auto">
+      <div
+        className={cn(
+          'min-w-0 flex-1 overflow-y-auto',
+          isMobile && !selected && 'hidden',
+        )}
+      >
         {selected ? (
           <RoundTableDetail id={selected} onDeleted={() => setSelected(null)} />
         ) : (

--- a/app/web/src/components/sessions/SessionList.tsx
+++ b/app/web/src/components/sessions/SessionList.tsx
@@ -19,6 +19,11 @@ import { SessionRow } from './SessionRow'
 interface SessionListProps {
   onSpawn: () => void
   onOpen: (session: Session) => void
+  /**
+   * Render as the full page rather than a fixed-width column — used on
+   * phones when no session is open and the list *is* the screen.
+   */
+  fullWidth?: boolean
 }
 
 // orderBy ranks sessions most-recently-used first: by last-opened time
@@ -61,7 +66,7 @@ function buildTree(sessions: Session[]) {
   return { tops, childrenOf }
 }
 
-export function SessionList({ onSpawn, onOpen }: SessionListProps) {
+export function SessionList({ onSpawn, onOpen, fullWidth }: SessionListProps) {
   const { t } = useTranslation()
   const qc = useQueryClient()
   const { data: sessions, isLoading } = useQuery({
@@ -158,7 +163,12 @@ export function SessionList({ onSpawn, onOpen }: SessionListProps) {
   }
 
   return (
-    <aside className="w-72 shrink-0 border-r border-border flex flex-col bg-background">
+    <aside
+      className={cn(
+        'border-r border-border flex flex-col bg-background',
+        fullWidth ? 'w-full flex-1' : 'w-72 shrink-0',
+      )}
+    >
       <div className="h-14 px-3 flex items-center justify-between border-b border-border">
         <div className="flex items-baseline gap-1.5">
           <span className="text-[11px] font-semibold tracking-[0.12em] uppercase text-muted-foreground">

--- a/app/web/src/components/sessions/inspector/FilesPanel.tsx
+++ b/app/web/src/components/sessions/inspector/FilesPanel.tsx
@@ -133,7 +133,9 @@ export function FilesPanel({ cwd, onPreviewHtml }: FilesPanelProps) {
 
   return (
     <>
-      <div className="flex items-center gap-1 px-1 pb-1">
+      {/* flex-wrap: the inspector is a ~350px drawer on a phone, and
+          three labelled buttons don't fit on one line there. */}
+      <div className="flex flex-wrap items-center gap-1 px-1 pb-1">
         <Button variant="ghost" size="sm" onClick={handleNewFolder}>
           <FolderPlus className="size-3.5" />
           New folder

--- a/app/web/src/components/settings/MemoryAmbientSection.tsx
+++ b/app/web/src/components/settings/MemoryAmbientSection.tsx
@@ -1110,8 +1110,8 @@ export function CostBlock() {
           {t('web.memoryAmbient.cost.empty')}
         </div>
       ) : (
-        <div className="rounded-md border border-border overflow-hidden">
-          <table className="w-full text-[11.5px]">
+        <div className="rounded-md border border-border overflow-x-auto">
+          <table className="w-full min-w-[560px] text-[11.5px]">
             <thead className="bg-card/50 text-[11px] text-muted-foreground">
               <tr>
                 <th className="px-3 py-1.5 text-left font-medium">{t('web.memoryAmbient.cost.columns.provider')}</th>

--- a/app/web/src/components/settings/ServerSettings.tsx
+++ b/app/web/src/components/settings/ServerSettings.tsx
@@ -2206,8 +2206,8 @@ function BackupSection({
               />
             </div>
           ) : (
-            <div className="rounded-md border border-border bg-card/30 overflow-hidden">
-              <table className="w-full text-[12px]">
+            <div className="rounded-md border border-border bg-card/30 overflow-x-auto">
+              <table className="w-full min-w-[560px] text-[12px]">
                 <thead className="bg-card/50 text-muted-foreground">
                   <tr className="text-left">
                     <th className="px-3 py-2 font-medium">

--- a/app/web/src/lib/useIsMobile.ts
+++ b/app/web/src/lib/useIsMobile.ts
@@ -1,20 +1,36 @@
 import { useEffect, useState } from 'react'
 
-// Phone breakpoint. Below this the 3-pane workbench renders the side
-// panels (nav, inspector) as slide-over drawers instead of inline
-// columns, so the middle workbench keeps full width.
+// Phone breakpoint. Below this every side panel (nav, list, inspector,
+// outline) renders as a slide-over drawer so the middle workbench keeps
+// the full width.
 const MOBILE_QUERY = '(max-width: 767px)'
 
-export function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState(() =>
-    typeof window !== 'undefined' ? window.matchMedia(MOBILE_QUERY).matches : false,
+// Tablet-and-below breakpoint. Between this and MOBILE_QUERY there is
+// room for exactly two columns — a list plus its detail. Anything that
+// would be a *third* column (inspector, outline, graph side panel)
+// becomes a drawer here, while the two primary columns stay inline.
+const COMPACT_QUERY = '(max-width: 1023px)'
+
+function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() =>
+    typeof window !== 'undefined' ? window.matchMedia(query).matches : false,
   )
   useEffect(() => {
-    const mql = window.matchMedia(MOBILE_QUERY)
-    const onChange = () => setIsMobile(mql.matches)
+    const mql = window.matchMedia(query)
+    const onChange = () => setMatches(mql.matches)
     onChange()
     mql.addEventListener('change', onChange)
     return () => mql.removeEventListener('change', onChange)
-  }, [])
-  return isMobile
+  }, [query])
+  return matches
+}
+
+/** True on phones (< 768px) — no room for any side column. */
+export function useIsMobile(): boolean {
+  return useMediaQuery(MOBILE_QUERY)
+}
+
+/** True on tablets and phones (< 1024px) — room for at most two columns. */
+export function useIsCompact(): boolean {
+  return useMediaQuery(COMPACT_QUERY)
 }

--- a/app/web/src/pages/Activity.tsx
+++ b/app/web/src/pages/Activity.tsx
@@ -88,7 +88,7 @@ export function ActivityPage() {
 
   return (
     <div className="h-full flex flex-col bg-background">
-      <header className="border-b border-border px-6 py-4 flex flex-wrap items-start gap-3">
+      <header className="border-b border-border px-3 py-3 sm:px-6 sm:py-4 flex flex-wrap items-start gap-3">
         <div className="flex-1 min-w-[260px]">
           <h1 className="text-[16px] font-semibold tracking-tight flex items-center gap-2">
             <ActivityIcon className="size-4 text-muted-foreground" />
@@ -245,7 +245,7 @@ function CallsTable({
 }) {
   const { t } = useTranslation()
   return (
-    <table className="w-full text-[12px] border-collapse">
+    <table className="w-full min-w-[720px] text-[12px] border-collapse">
       <thead>
         <tr className="border-b border-border bg-card/40">
           <Th>{t('web.activity.table.time')}</Th>

--- a/app/web/src/pages/Archived.tsx
+++ b/app/web/src/pages/Archived.tsx
@@ -123,7 +123,7 @@ export function ArchivedPage() {
   }
 
   return (
-    <div className="mx-auto max-w-4xl space-y-4 p-6">
+    <div className="mx-auto max-w-4xl space-y-4 p-3 sm:p-6">
       <div>
         <h1 className="text-xl font-semibold">{t('web.archived.title')}</h1>
         <p className="text-muted-foreground mt-0.5 text-sm">

--- a/app/web/src/pages/Backups.tsx
+++ b/app/web/src/pages/Backups.tsx
@@ -15,9 +15,9 @@ export function BackupsPage() {
   const { t } = useTranslation()
   return (
     <div className="flex-1 min-h-0 flex flex-col">
-      <header className="px-6 py-4 border-b border-border bg-card/30">
+      <header className="px-3 py-3 sm:px-6 sm:py-4 border-b border-border bg-card/30">
         <div className="flex items-start justify-between gap-4">
-          <div>
+          <div className="min-w-0">
             <h1 className="text-base font-medium flex items-center gap-2">
               <Archive className="size-4 text-accent" />
               {t('web.backups.title')}
@@ -34,7 +34,7 @@ export function BackupsPage() {
           </Button>
         </div>
       </header>
-      <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
+      <div className="flex-1 min-h-0 overflow-y-auto px-3 py-4 sm:px-6 sm:py-5">
         <div className="max-w-5xl">
           <BackupsView />
         </div>

--- a/app/web/src/pages/Channels.tsx
+++ b/app/web/src/pages/Channels.tsx
@@ -94,7 +94,7 @@ export function ChannelsPage() {
 
   return (
     <div className="h-full flex flex-col bg-background">
-      <header className="border-b border-border px-6 py-4 flex items-center gap-3">
+      <header className="border-b border-border px-3 py-3 sm:px-6 sm:py-4 flex items-center gap-3">
         <div className="flex-1">
           <h1 className="text-[16px] font-semibold tracking-tight">
             {t('web.channels.title')}
@@ -113,7 +113,7 @@ export function ChannelsPage() {
       </header>
 
       <ScrollArea className="flex-1">
-        <div className="p-6 max-w-[960px] flex flex-col gap-3">
+        <div className="p-3 sm:p-6 max-w-[960px] flex flex-col gap-3">
           {isLoading && (
             <div className="flex items-center gap-2 text-[12px] text-muted-foreground">
               <Loader2 className="size-3.5 animate-spin" />
@@ -273,8 +273,11 @@ function ChannelCard({
   const webhookURL = def?.webhookBased ? buildWebhookURL(channel.id) : ''
 
   return (
-    <div className="border border-border rounded-md p-4 bg-card/30 flex flex-col gap-3">
-      <div className="flex items-start gap-3">
+    <div className="border border-border rounded-md p-3 sm:p-4 bg-card/30 flex flex-col gap-3">
+      {/* flex-wrap + a full-width action group below `sm`: six controls
+          pinned beside the metadata leave it about 120px on a phone,
+          which wraps the token preview mid-token. */}
+      <div className="flex flex-wrap items-start gap-3">
         <BrandAvatar
           iconKey={def?.iconKey}
           fallbackLetter={(def?.label ?? channel.kind).charAt(0)}
@@ -345,7 +348,7 @@ function ChannelCard({
             </div>
           )}
         </div>
-        <div className="flex items-center gap-2 shrink-0">
+        <div className="flex w-full items-center gap-2 sm:w-auto sm:shrink-0">
           <Switch checked={channel.enabled} onCheckedChange={onToggle} />
           {isBridge && (
             <Button

--- a/app/web/src/pages/Cortex.tsx
+++ b/app/web/src/pages/Cortex.tsx
@@ -51,9 +51,9 @@ export function CortexPage() {
   )
 
   return (
-    <div className="mx-auto max-w-4xl space-y-6 p-6">
+    <div className="mx-auto max-w-4xl space-y-6 p-3 sm:p-6">
       <div className="flex items-start justify-between gap-3">
-        <div>
+        <div className="min-w-0">
           <h1 className="flex items-center gap-2 text-xl font-semibold">
             <RefreshCcwDot className="h-5 w-5" />
             {t('web.cortex.home.title')}

--- a/app/web/src/pages/Export.tsx
+++ b/app/web/src/pages/Export.tsx
@@ -37,9 +37,9 @@ export function ExportPage() {
   const { t } = useTranslation()
   return (
     <div className="flex-1 min-h-0 flex flex-col">
-      <header className="px-6 py-4 border-b border-border bg-card/30">
+      <header className="px-3 py-3 sm:px-6 sm:py-4 border-b border-border bg-card/30">
         <div className="flex items-start justify-between gap-4">
-          <div>
+          <div className="min-w-0">
             <h1 className="text-base font-medium flex items-center gap-2">
               <Package className="size-4 text-accent" />
               {t('web.export.title')}
@@ -53,7 +53,7 @@ export function ExportPage() {
           </Button>
         </div>
       </header>
-      <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
+      <div className="flex-1 min-h-0 overflow-y-auto px-3 py-4 sm:px-6 sm:py-5">
         <div className="max-w-3xl flex flex-col gap-6">
           <SectionHeader>{t('web.export.sections.export')}</SectionHeader>
           <ExportForm />
@@ -319,8 +319,8 @@ function ExportHistory() {
       <div className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
         {t('web.export.history.title')}
       </div>
-      <div className="rounded-md border border-border overflow-hidden">
-        <table className="w-full text-[12px]">
+      <div className="rounded-md border border-border overflow-x-auto">
+        <table className="w-full min-w-[560px] text-[12px]">
           <thead className="bg-card/50 text-muted-foreground">
             <tr className="text-left">
               <th className="px-3 py-2 font-medium">{t('web.export.history.columns.id')}</th>
@@ -652,8 +652,8 @@ function ImportHistory() {
       <div className="text-[11px] font-medium text-muted-foreground tracking-wider uppercase">
         {t('web.export.imports.title')}
       </div>
-      <div className="rounded-md border border-border overflow-hidden">
-        <table className="w-full text-[12px]">
+      <div className="rounded-md border border-border overflow-x-auto">
+        <table className="w-full min-w-[560px] text-[12px]">
           <thead className="bg-card/50 text-muted-foreground">
             <tr className="text-left">
               <th className="px-3 py-2 font-medium">{t('web.export.imports.columns.id')}</th>

--- a/app/web/src/pages/Integrations.tsx
+++ b/app/web/src/pages/Integrations.tsx
@@ -85,7 +85,7 @@ export function IntegrationsPage() {
 
   return (
     <div className="h-full flex flex-col bg-background">
-      <header className="border-b border-border px-6 py-4 flex items-center gap-3">
+      <header className="border-b border-border px-3 py-3 sm:px-6 sm:py-4 flex items-center gap-3">
         <div className="flex-1">
           <h1 className="text-[16px] font-semibold tracking-tight">
             {t('web.integrations.title')}
@@ -123,7 +123,7 @@ export function IntegrationsPage() {
           className="flex-1 min-h-0 mt-0 data-[state=inactive]:hidden"
         >
           <ScrollArea className="h-full">
-            <div className="p-6 max-w-[960px] flex flex-col gap-3">
+            <div className="p-3 sm:p-6 max-w-[960px] flex flex-col gap-3">
               {isLoading && (
                 <div className="flex items-center gap-2 text-[12px] text-muted-foreground">
                   <Loader2 className="size-3.5 animate-spin" />
@@ -221,7 +221,7 @@ export function IntegrationsPage() {
           value="console"
           className="flex-1 min-h-0 mt-0 data-[state=inactive]:hidden"
         >
-          <div className="px-6 py-4 h-full">
+          <div className="px-3 py-3 sm:px-6 sm:py-4 h-full">
             <ProxyConsole />
           </div>
         </TabsContent>

--- a/app/web/src/pages/Knowledge.tsx
+++ b/app/web/src/pages/Knowledge.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type ComponentProps } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Link, useNavigate } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
@@ -38,6 +38,8 @@ import {
   type DocProposal,
 } from '@/lib/projectDocs'
 import { CurationChat } from '@/components/cortex/CurationChat'
+import { SlideOverAside } from '@/components/SlideOverAside'
+import { useIsCompact, useIsMobile } from '../lib/useIsMobile'
 import { Switch } from '@/components/ui/switch'
 import { Loader2, Plus, Sparkles } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -99,15 +101,33 @@ const MD = {
     <h2 className="mt-4 mb-1.5 text-base font-semibold border-b border-border pb-1" {...p} />
   ),
   h3: (p: any) => <h3 className="mt-3 mb-1 text-sm font-semibold" {...p} />,
-  p: (p: any) => <p className="my-1.5 text-sm leading-relaxed" {...p} />,
+  p: (p: any) => (
+    <p className="my-1.5 text-sm leading-relaxed break-words" {...p} />
+  ),
   ul: (p: any) => <ul className="my-1.5 ml-5 list-disc space-y-0.5 text-sm" {...p} />,
   ol: (p: any) => <ol className="my-1.5 ml-5 list-decimal space-y-0.5 text-sm" {...p} />,
-  li: (p: any) => <li className="leading-relaxed" {...p} />,
+  li: (p: any) => <li className="leading-relaxed break-words" {...p} />,
   code: (p: any) => (
-    <code className="rounded bg-muted px-1 py-0.5 text-[12px] font-mono" {...p} />
+    <code
+      className="rounded bg-muted px-1 py-0.5 text-[12px] font-mono break-words whitespace-pre-wrap"
+      {...p}
+    />
+  ),
+  // Fenced blocks scroll rather than wrap — breaking a command across
+  // lines would misrepresent it.
+  pre: (p: ComponentProps<'pre'>) => (
+    <pre
+      className="my-2 overflow-x-auto rounded-md bg-muted p-2 text-[12px]"
+      {...p}
+    />
+  ),
+  table: (p: ComponentProps<'table'>) => (
+    <div className="my-2 overflow-x-auto">
+      <table className="w-full border-collapse text-[12px]" {...p} />
+    </div>
   ),
   strong: (p: any) => <strong className="font-semibold" {...p} />,
-  a: (p: any) => <a className="text-primary underline" {...p} />,
+  a: (p: any) => <a className="text-primary underline break-words" {...p} />,
   hr: () => <hr className="my-3 border-border" />,
 }
 
@@ -342,6 +362,11 @@ function KnowledgeBaseView() {
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [librarianOpen, setLibrarianOpen] = useState(false)
 
+  // On a phone the page list is a slide-over; picking a page is its only
+  // purpose, so dismiss it on select.
+  const isMobile = useIsMobile()
+  const [navOpen, setNavOpen] = useState(false)
+
   // The knowledge blueprint: the page set is data, not a constant.
   const blueprint = useQuery({
     queryKey: ['kb-blueprint'],
@@ -436,6 +461,7 @@ function KnowledgeBaseView() {
     setEditing(false)
     setShowProposal(false)
     setChatOpen(false)
+    setNavOpen(false)
   }
 
   const content = stripSig(doc.data?.content ?? '')
@@ -444,9 +470,18 @@ function KnowledgeBaseView() {
   const foundational = selSection?.nature === 'foundational'
 
   return (
-    <div className="border-border flex min-h-0 flex-1 rounded-b-md rounded-tr-md border">
-      {/* nav — two natures, page set from the knowledge blueprint */}
-      <div className="border-border flex w-64 shrink-0 flex-col overflow-auto border-r p-2">
+    // `relative` anchors the phone slide-over below.
+    <div className="border-border relative flex min-h-0 flex-1 rounded-b-md rounded-tr-md border">
+      {/* nav — two natures, page set from the knowledge blueprint.
+          Inline column from tablet up, slide-over on phones. */}
+      <SlideOverAside
+        side="left"
+        compact={isMobile}
+        open={isMobile ? navOpen : true}
+        onOpenChange={setNavOpen}
+        label={t('web.knowledge.kb.tab')}
+      >
+      <div className="border-border bg-background flex w-64 shrink-0 flex-col overflow-auto border-r p-2">
         <NavSection
           label={t('web.knowledge.kb.foundational')}
           hint={t('web.knowledge.kb.foundationalHint')}
@@ -479,11 +514,12 @@ function KnowledgeBaseView() {
           {t('web.knowledge.kb.librarian.button')}
         </button>
       </div>
+      </SlideOverAside>
 
       {/* content */}
-      <div className="flex min-h-0 flex-1 flex-col">
-        <div className="border-border flex items-center gap-2 border-b px-4 py-2">
-          <h2 className="text-sm font-medium">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <div className="border-border flex flex-wrap items-center gap-2 border-b px-3 py-2 sm:px-4">
+          <h2 className="min-w-0 truncate text-sm font-medium">
             {selSection ? kbPageLabel(selSection, t) : sel}
           </h2>
           <span
@@ -633,7 +669,7 @@ function KnowledgeBaseView() {
           </div>
         )}
 
-        <div className="flex-1 overflow-auto p-4">
+        <div className="min-w-0 flex-1 overflow-auto p-3 sm:p-4">
           {editing ? (
             <div className="flex h-full flex-col gap-2">
               <textarea
@@ -1266,6 +1302,7 @@ function GraphCanvas({
 function GraphView() {
   const { t } = useTranslation()
   const [selId, setSelId] = useState<string | null>(null)
+  const isCompact = useIsCompact()
 
   const graphQuery = useQuery({
     queryKey: ['knowledge-graph-all'],
@@ -1293,7 +1330,7 @@ function GraphView() {
       <p className="text-muted-foreground border-border border-b px-3 py-2 text-[11px] leading-snug">
         {t('web.knowledge.graph.intro')}
       </p>
-      <div className="flex min-h-0 flex-1">
+      <div className="relative flex min-h-0 flex-1">
         <div className="relative min-h-0 flex-1 overflow-hidden">
           {graphQuery.isLoading ? (
             <Loader2 className="m-4 h-4 w-4 animate-spin" />
@@ -1332,9 +1369,18 @@ function GraphView() {
           )}
         </div>
 
-        {/* side panel — the selected node's neighborhood, grouped by kind */}
+        {/* side panel — the selected node's neighborhood, grouped by kind.
+            Overlays the canvas from tablet down: it is the third column,
+            and the graph itself needs the room. */}
         {selId && (
-          <div className="border-border flex w-80 shrink-0 flex-col border-l">
+          <SlideOverAside
+            side="right"
+            compact={isCompact}
+            open
+            onOpenChange={(v) => !v && setSelId(null)}
+            label={t('web.knowledge.graph.tab')}
+          >
+          <div className="border-border bg-background flex w-80 shrink-0 flex-col border-l">
             <div className="border-border flex items-center gap-2 border-b px-3 py-2">
               <h2 className="min-w-0 flex-1 truncate text-sm font-semibold">
                 {selNode ? nodeDisplayTitle(selNode) : '…'}
@@ -1399,6 +1445,7 @@ function GraphView() {
               )}
             </div>
           </div>
+          </SlideOverAside>
         )}
       </div>
     </div>
@@ -1411,7 +1458,7 @@ export function KnowledgePage() {
 
   return (
     <div className="flex h-full flex-col">
-      <header className="px-4 pt-3">
+      <header className="px-3 pt-3 sm:px-4">
         <h1 className="text-lg font-semibold">{t('web.knowledge.title')}</h1>
         <p className="text-sm text-muted-foreground">
           {t('web.knowledge.subtitle')}
@@ -1428,7 +1475,7 @@ export function KnowledgePage() {
           </TabBtn>
         </div>
       </header>
-      <div className="flex flex-1 flex-col min-h-0 px-4 pb-4">
+      <div className="flex flex-1 flex-col min-h-0 px-2 pb-2 sm:px-4 sm:pb-4">
         {tab === 'kb' ? (
           <KnowledgeBaseView />
         ) : tab === 'distill' ? (

--- a/app/web/src/pages/Login.tsx
+++ b/app/web/src/pages/Login.tsx
@@ -58,7 +58,7 @@ export function LoginPage() {
 
   return (
     <div className="h-svh flex items-center justify-center bg-background p-6">
-      <div className="w-[360px] flex flex-col gap-6">
+      <div className="w-full max-w-[360px] flex flex-col gap-6">
         <div className="flex items-center gap-2 mb-2">
           <TerminalIcon className="size-5 text-accent" strokeWidth={2.5} />
           <span className="text-[15px] font-semibold tracking-tight">

--- a/app/web/src/pages/Memory.tsx
+++ b/app/web/src/pages/Memory.tsx
@@ -29,9 +29,11 @@ export function MemoryPage() {
 
   return (
     <div className="flex flex-1 flex-col min-h-0">
-      <header className="border-border bg-card/30 border-b px-6 py-4">
-        <div className="flex items-start justify-between gap-4">
-          <div>
+      <header className="border-border bg-card/30 border-b px-3 py-3 sm:px-6 sm:py-4">
+        {/* Five nav buttons plus a sentence of copy don't share a row on
+            a phone: stack them, and let the button group wrap. */}
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+          <div className="min-w-0">
             <h1 className="flex items-center gap-2 text-base font-medium">
               <Brain className="text-accent size-4" />
               {t('web.memory.title')}
@@ -40,7 +42,7 @@ export function MemoryPage() {
               {t('web.memory.subtitle')}
             </p>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <Button
               asChild
               variant="outline"
@@ -103,7 +105,7 @@ export function MemoryPage() {
           </div>
         </div>
       </header>
-      <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 py-4 sm:px-6 sm:py-5">
         <div className="max-w-4xl">
           <MemoryInspector />
         </div>

--- a/app/web/src/pages/MemoryWorkers.tsx
+++ b/app/web/src/pages/MemoryWorkers.tsx
@@ -137,7 +137,7 @@ export function MemoryWorkersPage() {
   // what went wrong.
   if (workersQuery.isError) {
     return (
-      <div className="mx-auto max-w-2xl space-y-3 p-6 text-sm">
+      <div className="mx-auto max-w-2xl space-y-3 p-3 sm:p-6 text-sm">
         <h1 className="text-xl font-semibold">
           {t('web.memoryWorkers.title')}
         </h1>
@@ -162,7 +162,7 @@ export function MemoryWorkersPage() {
   ]
 
   return (
-    <div className="mx-auto max-w-3xl space-y-10 p-6">
+    <div className="mx-auto max-w-3xl space-y-10 p-3 sm:p-6">
       <header>
         <h1 className="text-xl font-semibold">
           {t('web.memoryConfig.title')}

--- a/app/web/src/pages/Notes.tsx
+++ b/app/web/src/pages/Notes.tsx
@@ -12,12 +12,16 @@ import {
   Trash2,
   PanelRightClose,
   PanelRightOpen,
+  PanelLeftClose,
+  PanelLeftOpen,
 } from 'lucide-react'
 import { format } from 'date-fns'
 import { toast } from 'sonner'
 import { Trans, useTranslation } from 'react-i18next'
 
 import { cn } from '@/lib/utils'
+import { SlideOverAside } from '@/components/SlideOverAside'
+import { useIsCompact, useIsMobile } from '../lib/useIsMobile'
 import {
   deleteNote,
   docKind,
@@ -86,11 +90,33 @@ export function VaultPage() {
   const [filter, setFilter] = useState('')
   const [activeTag, setActiveTag] = useState<string | null>(null)
 
+  // Three panes don't fit under 1024px. A tablet keeps the tree and the
+  // editor and pushes the outline into a slide-over; a phone has room
+  // for the editor alone, so the tree becomes a slide-over too.
+  const isMobile = useIsMobile()
+  const isCompact = useIsCompact()
+  const [treeOpen, setTreeOpen] = useState(false)
+  // Opening a note is the only reason the tree drawer is up — dismiss it
+  // so the note the user just picked is what they actually see.
+  const selectNote = (path: string | null) => {
+    setSelected(path)
+    setTreeOpen(false)
+  }
+
   const [outlineOpen, setOutlineOpen] = useState<boolean>(() => {
     if (typeof window === 'undefined') return true
     const stored = localStorage.getItem(LS_OUTLINE_OPEN)
     return stored == null ? true : stored === '1'
   })
+  // On desktop the outline is a persisted preference — a column that
+  // stays where you left it. Below 1024px it is an overlay instead, and
+  // an overlay must be ephemeral and default to closed: reusing the
+  // persisted value pops the outline open on top of the note you just
+  // tapped, and writing to it from a phone would silently close the
+  // outline on the desktop too.
+  const [outlineOverlayOpen, setOutlineOverlayOpen] = useState(false)
+  const outlineShown = isCompact ? outlineOverlayOpen : outlineOpen
+  const setOutlineShown = isCompact ? setOutlineOverlayOpen : setOutlineOpen
 
   // Vault git status for the header badge — slow poll is fine, the
   // dialog has its own faster poll while open.
@@ -116,6 +142,13 @@ export function VaultPage() {
     if (selected) localStorage.setItem(LS_LAST_PATH, selected)
     else localStorage.removeItem(LS_LAST_PATH)
   }, [selected])
+
+  // With no note open there is nothing for the tree to overlay, so on a
+  // phone it stops being a drawer and becomes the page. Otherwise
+  // landing on /vault shows an empty editor with the file tree parked
+  // off-canvas behind a 20px handle — the vault looks empty and
+  // unnavigable, which is exactly how it was reported.
+  const treeIsDrawer = isMobile && !!selected
 
   // If the persisted selection no longer exists in the vault, drop it.
   useEffect(() => {
@@ -285,9 +318,31 @@ export function VaultPage() {
 
   return (
     <div className="h-full flex flex-col">
-      <header className="h-12 border-b border-border flex items-center px-3 gap-2 shrink-0">
-        <NotebookPen className="size-4 text-muted-foreground" />
-        <h1 className="text-[14px] font-semibold tracking-tight">
+      <header className="h-12 border-b border-border flex items-center px-2 sm:px-3 gap-1.5 sm:gap-2 shrink-0">
+        {/* Tree toggle, phones only. On wider screens the tree is a
+            permanent column so no toggle was ever needed — which left
+            the phone drawer reachable ONLY via the thin edge handle,
+            i.e. effectively unreachable. */}
+        {treeIsDrawer && (
+          <button
+            type="button"
+            onClick={() => setTreeOpen((v) => !v)}
+            aria-label={
+              treeOpen
+                ? t('web.notes.left.closeTree')
+                : t('web.notes.left.openTree')
+            }
+            className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-card hover:text-foreground"
+          >
+            {treeOpen ? (
+              <PanelLeftClose className="size-4" />
+            ) : (
+              <PanelLeftOpen className="size-4" />
+            )}
+          </button>
+        )}
+        <NotebookPen className="size-4 text-muted-foreground shrink-0" />
+        <h1 className="text-[14px] font-semibold tracking-tight shrink-0">
           {t('web.notes.title')}
         </h1>
         {info && (
@@ -297,7 +352,7 @@ export function VaultPage() {
           // right edge — which is how "New" and "Today" became
           // reachable only from the empty state.
           <span
-            className="text-[10.5px] text-muted-foreground/60 font-mono truncate min-w-0"
+            className="hidden sm:inline text-[10.5px] text-muted-foreground/60 font-mono truncate min-w-0"
             title={info.root}
           >
             · {info.root}
@@ -307,25 +362,27 @@ export function VaultPage() {
         <VaultSyncBadge status={vault} onClick={() => setSyncOpen(true)} />
         <button
           type="button"
-          onClick={() => setOutlineOpen((v) => !v)}
+          onClick={() => setOutlineShown((v) => !v)}
           className={cn(
             'inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-md transition-colors',
-            outlineOpen
+            outlineShown
               ? 'text-foreground bg-card'
               : 'text-muted-foreground hover:text-foreground',
           )}
           title={
-            outlineOpen
+            outlineShown
               ? t('web.notes.header.hideOutline')
               : t('web.notes.header.showOutline')
           }
         >
-          {outlineOpen ? (
+          {outlineShown ? (
             <PanelRightClose className="size-3" />
           ) : (
             <PanelRightOpen className="size-3" />
           )}
-          {t('web.notes.header.outline')}
+          <span className="hidden sm:inline">
+            {t('web.notes.header.outline')}
+          </span>
         </button>
         <button
           type="button"
@@ -334,7 +391,9 @@ export function VaultPage() {
           title={t('web.notes.header.todayTooltip')}
         >
           <Calendar className="size-3" />
-          {t('web.notes.header.today')}
+          <span className="hidden sm:inline">
+            {t('web.notes.header.today')}
+          </span>
         </button>
         <button
           type="button"
@@ -342,15 +401,28 @@ export function VaultPage() {
           className="inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-md bg-accent text-accent-foreground hover:bg-accent/90"
         >
           <Plus className="size-3" />
-          {t('web.notes.header.new')}
+          <span className="hidden sm:inline">{t('web.notes.header.new')}</span>
         </button>
       </header>
 
       {info?.flattenable && <FlattenNotice />}
 
-      <div className="flex-1 flex min-h-0">
-        {/* Left pane: tree / tags + filter */}
-        <aside className="w-72 shrink-0 border-r border-border flex flex-col bg-background">
+      {/* `relative` anchors the slide-over panes below. */}
+      <div className="flex-1 flex min-h-0 relative">
+        {/* Left pane: tree / tags + filter. Slide-over on phones. */}
+        <SlideOverAside
+          side="left"
+          compact={treeIsDrawer}
+          open={treeIsDrawer ? treeOpen : true}
+          onOpenChange={setTreeOpen}
+          label={t('web.notes.left.openTree')}
+        >
+        <aside
+          className={cn(
+            'border-r border-border flex flex-col bg-background',
+            isMobile && !selected ? 'w-full flex-1' : 'w-72 shrink-0',
+          )}
+        >
           <div className="px-2 py-2 border-b border-border shrink-0 flex flex-col gap-1.5">
             <div className="flex gap-0.5">
               <button
@@ -449,7 +521,7 @@ export function VaultPage() {
                 ref={treeRef}
                 notes={visibleNotes}
                 selected={selected}
-                onSelect={setSelected}
+                onSelect={selectNote}
               />
             ) : (
               <TagsList
@@ -471,9 +543,17 @@ export function VaultPage() {
             })}
           </div>
         </aside>
+        </SlideOverAside>
 
         {/* Center pane: editor */}
-        <main className="flex-1 flex flex-col min-w-0 bg-background">
+        <main
+          className={cn(
+            'flex-1 flex flex-col min-w-0 bg-background',
+            // Squeezed to ~60px beside the tree-as-page, and it has
+            // nothing to say the tree doesn't already offer.
+            isMobile && !selected && 'hidden',
+          )}
+        >
           {selected ? (
             <div className="flex-1 flex flex-col min-h-0 px-4 py-3 gap-2">
               <div className="flex items-baseline gap-2 shrink-0">
@@ -533,8 +613,19 @@ export function VaultPage() {
         </main>
 
         {/* Right pane: outline (toggleable). Only renders when a note
-            is open — empty state doesn't need an outline. */}
-        {outlineOpen && selected && (
+            is open — empty state doesn't need an outline. Slide-over
+            from tablet down: it is the third column. */}
+        {selected && (
+          <SlideOverAside
+            side="right"
+            compact={isCompact}
+            open={outlineShown}
+            onOpenChange={setOutlineShown}
+            label={t('web.notes.header.showOutline')}
+            // The header already carries an Outline toggle; a floating
+            // edge handle on top of the editor would just be clutter.
+            hideHandle
+          >
           <aside className="w-60 shrink-0 border-l border-border flex flex-col bg-background">
             <OutlineHeader count={outline.length} />
             <div className="flex-1 overflow-y-auto min-h-0">
@@ -552,6 +643,7 @@ export function VaultPage() {
               />
             </div>
           </aside>
+          </SlideOverAside>
         )}
       </div>
 

--- a/app/web/src/pages/Plugins.tsx
+++ b/app/web/src/pages/Plugins.tsx
@@ -84,7 +84,7 @@ import { cn } from '@/lib/utils'
 export function PluginsPage() {
   const { t } = useTranslation()
   return (
-    <div className="h-full flex flex-col p-6 gap-4 overflow-y-auto">
+    <div className="h-full flex flex-col p-3 sm:p-6 gap-4 overflow-y-auto">
       <header className="flex flex-col gap-1">
         <h1 className="text-[18px] font-semibold tracking-tight">
           {t('web.plugins.title')}
@@ -261,7 +261,7 @@ function McpSection() {
         </Button>
       }
     >
-      <div className="rounded-md border border-border overflow-hidden">
+      <div className="rounded-md border border-border overflow-x-auto">
         {isLoading ? (
           <div className="px-4 py-6 flex items-center gap-2 text-[12px] text-muted-foreground">
             <Loader2 className="size-3 animate-spin" />
@@ -272,7 +272,7 @@ function McpSection() {
             {t('web.plugins.mcp.empty')}
           </div>
         ) : (
-          <table className="w-full text-[12px]">
+          <table className="w-full min-w-[720px] text-[12px]">
             <thead className="bg-card/40 text-[10px] uppercase tracking-wider text-muted-foreground/70">
               <tr>
                 <th className="text-left px-3 py-2 font-medium">
@@ -757,7 +757,7 @@ function McpSecretsSection() {
         </Button>
       }
     >
-      <div className="rounded-md border border-border overflow-hidden">
+      <div className="rounded-md border border-border overflow-x-auto">
         {isLoading ? (
           <div className="px-4 py-6 flex items-center gap-2 text-[12px] text-muted-foreground">
             <Loader2 className="size-3 animate-spin" />
@@ -771,7 +771,7 @@ function McpSecretsSection() {
             />
           </div>
         ) : (
-          <table className="w-full text-[12px]">
+          <table className="w-full min-w-[720px] text-[12px]">
             <thead className="bg-card/40 text-[10px] uppercase tracking-wider text-muted-foreground/70">
               <tr>
                 <th className="text-left px-3 py-2 font-medium">
@@ -1082,7 +1082,7 @@ function SkillsSection() {
     >
       <div
         className={cn(
-          'relative rounded-md border border-border overflow-hidden',
+          'relative rounded-md border border-border overflow-x-auto',
           dragActive && 'ring-2 ring-accent/70',
         )}
         onDragEnter={(e) => {
@@ -1126,7 +1126,7 @@ function SkillsSection() {
             </div>
           </div>
         ) : (
-          <table className="w-full text-[12px]">
+          <table className="w-full min-w-[720px] text-[12px]">
             <thead className="bg-card/40 text-[10px] uppercase tracking-wider text-muted-foreground/70">
               <tr>
                 <th className="text-left px-3 py-2 font-medium">
@@ -1481,7 +1481,7 @@ function CustomTasksSection() {
         </Button>
       }
     >
-      <div className="rounded-md border border-border overflow-hidden">
+      <div className="rounded-md border border-border overflow-x-auto">
         {isLoading ? (
           <div className="px-4 py-6 flex items-center gap-2 text-[12px] text-muted-foreground">
             <Loader2 className="size-3 animate-spin" />
@@ -1492,7 +1492,7 @@ function CustomTasksSection() {
             {t('web.plugins.customTasks.empty')}
           </div>
         ) : (
-          <table className="w-full text-[12px]">
+          <table className="w-full min-w-[720px] text-[12px]">
             <thead className="bg-card/40 text-[10px] uppercase tracking-wider text-muted-foreground/70">
               <tr>
                 <th className="text-left px-3 py-2 font-medium">
@@ -1637,7 +1637,7 @@ function GitHostsSection() {
         </Button>
       }
     >
-      <div className="rounded-md border border-border overflow-hidden">
+      <div className="rounded-md border border-border overflow-x-auto">
         {isLoading ? (
           <div className="px-4 py-6 flex items-center gap-2 text-[12px] text-muted-foreground">
             <Loader2 className="size-3 animate-spin" />
@@ -1648,7 +1648,7 @@ function GitHostsSection() {
             {t('web.plugins.gitHosts.empty')}
           </div>
         ) : (
-          <table className="w-full text-[12px]">
+          <table className="w-full min-w-[720px] text-[12px]">
             <thead className="bg-card/40 text-[10px] uppercase tracking-wider text-muted-foreground/70">
               <tr>
                 <th className="text-left px-3 py-2 font-medium">

--- a/app/web/src/pages/Providers.tsx
+++ b/app/web/src/pages/Providers.tsx
@@ -26,6 +26,8 @@ import {
 import type { APIError } from '@/lib/api'
 import type { Provider } from '@/lib/types'
 import { cn } from '@/lib/utils'
+import { SlideOverAside } from '@/components/SlideOverAside'
+import { useIsMobile } from '../lib/useIsMobile'
 
 export function ProvidersPage() {
   const { t } = useTranslation()
@@ -37,6 +39,15 @@ export function ProvidersPage() {
 
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [draft, setDraft] = useState<Record<string, unknown>>({})
+
+  // On a phone the provider list is a slide-over; picking one is its
+  // only purpose, so dismiss it on select to reveal the detail pane.
+  const isMobile = useIsMobile()
+  const [listOpen, setListOpen] = useState(false)
+  const selectProvider = (id: string) => {
+    setSelectedId(id)
+    setListOpen(false)
+  }
 
   // Default to first provider.
   useEffect(() => {
@@ -76,8 +87,16 @@ export function ProvidersPage() {
   })
 
   return (
-    <div className="h-full flex">
-      {/* Provider list */}
+    // `relative` anchors the phone slide-over below.
+    <div className="h-full flex relative">
+      {/* Provider list: inline column from tablet up, slide-over on phones. */}
+      <SlideOverAside
+        side="left"
+        compact={isMobile}
+        open={isMobile ? listOpen : true}
+        onOpenChange={setListOpen}
+        label={t('web.providers.list.title')}
+      >
       <aside className="w-64 shrink-0 border-r border-border flex flex-col bg-background">
         <div className="h-9 px-3 flex items-center border-b border-border">
           <span className="text-[11px] font-semibold uppercase tracking-tight text-muted-foreground">
@@ -99,7 +118,7 @@ export function ProvidersPage() {
               <button
                 key={p.manifest.id}
                 type="button"
-                onClick={() => setSelectedId(p.manifest.id)}
+                onClick={() => selectProvider(p.manifest.id)}
                 className={cn(
                   'w-full flex items-center gap-2.5 px-2.5 py-2 rounded-md text-left transition-colors border border-transparent',
                   selectedId === p.manifest.id
@@ -133,6 +152,7 @@ export function ProvidersPage() {
           </div>
         </ScrollArea>
       </aside>
+      </SlideOverAside>
 
       {/* Detail */}
       {selected ? (
@@ -244,7 +264,7 @@ function ProviderDetail({
   ]
   return (
     <main className="flex-1 flex flex-col min-w-0 bg-background">
-      <div className="border-b border-border px-6 py-4 flex items-start gap-4">
+      <div className="border-b border-border px-3 py-3 sm:px-6 sm:py-4 flex items-start gap-4">
         <BrandAvatar
           iconKey={providerIconKey(m.id)}
           fallbackLetter={m.displayName?.charAt(0) ?? '?'}
@@ -358,7 +378,7 @@ function ProviderDetail({
       </div>
 
       <ScrollArea className="flex-1">
-        <div className="px-6 py-6 max-w-[640px]">
+        <div className="px-4 py-5 sm:px-6 sm:py-6 max-w-[640px]">
           <h2 className="text-[12px] font-semibold uppercase tracking-wider text-muted-foreground/80 mb-4">
             {t('web.providers.detail.configuration')}
           </h2>

--- a/app/web/src/pages/RoundTable.tsx
+++ b/app/web/src/pages/RoundTable.tsx
@@ -10,7 +10,7 @@ export function RoundTablePage() {
   const { t } = useTranslation()
   return (
     <div className="flex-1 min-h-0 flex flex-col">
-      <header className="px-6 py-4 border-b border-border bg-card/30">
+      <header className="px-3 py-3 sm:px-6 sm:py-4 border-b border-border bg-card/30">
         <h1 className="text-base font-medium flex items-center gap-2">
           <Users className="size-4 text-accent" />
           {t('web.roundTable.title')}
@@ -22,7 +22,7 @@ export function RoundTablePage() {
           {t('web.roundTable.subtitle')}
         </p>
       </header>
-      <div className="flex-1 min-h-0 overflow-hidden px-6 py-5">
+      <div className="flex-1 min-h-0 overflow-hidden px-3 py-4 sm:px-6 sm:py-5">
         <RoundTablePanel />
       </div>
     </div>

--- a/app/web/src/pages/Sessions.tsx
+++ b/app/web/src/pages/Sessions.tsx
@@ -14,7 +14,7 @@ import {
   PanelLeftOpen,
   PanelRightClose,
   PanelRightOpen,
-  ChevronLeft,
+  MoreHorizontal,
   TextCursorInput,
 } from 'lucide-react'
 import { toast } from 'sonner'
@@ -22,6 +22,13 @@ import { Trans, useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { useConfirmDialog } from '@/components/ConfirmDialog'
 import { SessionList } from '@/components/sessions/SessionList'
 import { SessionTabs } from '@/components/sessions/SessionTabs'
@@ -50,7 +57,8 @@ import {
 } from '@/lib/sessions'
 import { useSessionTabs } from '@/stores/sessionTabs'
 import { useLayout } from '@/stores/layout'
-import { useIsMobile } from '../lib/useIsMobile'
+import { SlideOverAside } from '@/components/SlideOverAside'
+import { useIsCompact, useIsMobile } from '../lib/useIsMobile'
 import { cn } from '@/lib/utils'
 import { isTerminalSessionState, type Session } from '@/lib/types'
 
@@ -175,6 +183,8 @@ export function SessionsPage() {
 
   const handleOpen = (s: Session) => {
     open({ id: s.id, name: s.name || s.provider_id })
+    // Opening a session is the only reason the list drawer is up.
+    if (isMobile) setListCollapsed(true)
   }
 
   const { confirm: confirmDialog, dialog: confirmDialogEl } = useConfirmDialog()
@@ -206,14 +216,29 @@ export function SessionsPage() {
   const setInspectorOpen = useLayout((s) => s.setInspectorOpen)
 
   const isMobile = useIsMobile()
-  // On phones the list + inspector are slide-overs; collapse both on
-  // entry so the terminal/workbench gets the full, usable width.
+  const isCompact = useIsCompact()
+  // Narrow viewports can't hold three columns. A tablet keeps two — the
+  // session list and the terminal — and pushes the inspector into a
+  // slide-over; a phone has room for the terminal alone, so the list
+  // becomes a slide-over too.
+  //
+  // The overlay's open state is deliberately LOCAL rather than the
+  // persisted layout store: an overlay must default to closed (nobody
+  // asked for a panel on top of the terminal they just opened), and
+  // writing "closed" back to the shared store would silently collapse
+  // the inspector on the desktop just because the operator glanced at
+  // the session from a phone.
+  const [inspectorOverlayOpen, setInspectorOverlayOpen] = useState(false)
+  const inspectorShown = isCompact ? inspectorOverlayOpen : inspectorOpen
+  const setInspectorShown = isCompact
+    ? setInspectorOverlayOpen
+    : setInspectorOpen
+  const toggleInspectorShown = isCompact
+    ? () => setInspectorOverlayOpen((v) => !v)
+    : toggleInspector
   useEffect(() => {
-    if (isMobile) {
-      setListCollapsed(true)
-      setInspectorOpen(false)
-    }
-  }, [isMobile, setListCollapsed, setInspectorOpen])
+    if (isMobile) setListCollapsed(true)
+  }, [isMobile, setListCollapsed])
 
   const termRef = useRef<TerminalHandle>(null)
   const endedRef = useRef<EndedSessionHandle>(null)
@@ -255,14 +280,43 @@ export function SessionsPage() {
   // the list when there's nothing currently selected, so empty
   // state stays navigable.
   const showList = !listCollapsed || !currentId
+  // With no session open there is no workbench to overlay, so on a phone
+  // the list stops being a drawer and simply becomes the page. Keeping
+  // it a drawer would dim an empty background behind it and leave the
+  // backdrop as a dead tap target — it can't be dismissed to anything.
+  const listIsDrawer = isMobile && !!currentId
 
   return (
-    <div className="h-full flex">
-      {showList && (
-        <SessionList onSpawn={() => setSpawnOpen(true)} onOpen={handleOpen} />
-      )}
+    // `relative` is the positioning context the slide-over panels below
+    // anchor to — without it they would escape to the viewport and cover
+    // the app topbar.
+    <div className="h-full flex relative">
+      <SlideOverAside
+        side="left"
+        compact={listIsDrawer}
+        open={showList}
+        onOpenChange={(v) => setListCollapsed(!v)}
+        label={t('web.sessions.header.showList')}
+      >
+        <SessionList
+          onSpawn={() => setSpawnOpen(true)}
+          onOpen={handleOpen}
+          // As the whole page it must fill the width, not sit in a
+          // 288px column with dead space beside it.
+          fullWidth={isMobile && !currentId}
+        />
+      </SlideOverAside>
 
-      <div className="flex-1 flex flex-col min-w-0">
+      {/* With the list acting as the page on a phone, the empty
+          workbench beside it would be squeezed to a ~60px slice of
+          unreadable text — and it has nothing to say the list doesn't
+          already offer via its own "+". */}
+      <div
+        className={cn(
+          'flex-1 flex flex-col min-w-0',
+          isMobile && !currentId && 'hidden',
+        )}
+      >
         <SessionTabs onCloseTab={handleCloseTab} />
 
         {!currentId ? (
@@ -303,8 +357,8 @@ export function SessionsPage() {
               onAttachImage={handlePickImage}
               onSelectText={openSelectCopy}
               onShowTranscript={() => setTranscriptOpen(true)}
-              inspectorOpen={inspectorOpen}
-              onToggleInspector={toggleInspector}
+              inspectorOpen={inspectorShown}
+              onToggleInspector={toggleInspectorShown}
             />
             {/* pb-3 reserves a small breathing strip so Claude's
                 prompt+footer never sit flush against the browser bottom
@@ -339,39 +393,19 @@ export function SessionsPage() {
         )}
       </div>
 
-      {/* Inspector: inline column on desktop, slide-over drawer on mobile. */}
-      {currentSession &&
-        (isMobile ? (
-          <>
-            <div
-              className={cn(
-                'fixed inset-y-0 right-0 z-50 flex transition-transform duration-200 ease-out',
-                inspectorOpen ? 'translate-x-0' : 'translate-x-full',
-              )}
-            >
-              <InspectorPanel session={currentSession} />
-            </div>
-            {inspectorOpen && (
-              <div
-                className="fixed inset-0 z-40 bg-black/50"
-                onClick={() => setInspectorOpen(false)}
-                aria-hidden
-              />
-            )}
-            {!inspectorOpen && (
-              <button
-                type="button"
-                onClick={() => setInspectorOpen(true)}
-                aria-label="Open inspector"
-                className="fixed right-0 top-1/2 -translate-y-1/2 z-30 h-12 w-5 rounded-l-md border border-r-0 border-border bg-card/90 text-muted-foreground flex items-center justify-center shadow-sm active:bg-card"
-              >
-                <ChevronLeft className="size-3.5" />
-              </button>
-            )}
-          </>
-        ) : (
-          inspectorOpen && <InspectorPanel session={currentSession} />
-        ))}
+      {/* Inspector: inline third column on desktop, slide-over from the
+          right on tablets and phones. */}
+      {currentSession && (
+        <SlideOverAside
+          side="right"
+          compact={isCompact}
+          open={inspectorShown}
+          onOpenChange={setInspectorShown}
+          label={t('web.sessions.header.showInspector')}
+        >
+          <InspectorPanel session={currentSession} />
+        </SlideOverAside>
+      )}
 
       <input
         ref={fileInputRef}
@@ -463,6 +497,9 @@ function WorkbenchHeader({
   onToggleInspector: () => void
 }) {
   const { t } = useTranslation()
+  // A phone fits the two pane toggles and the title, nothing more —
+  // everything else folds into an overflow menu.
+  const isMobile = useIsMobile()
   if (!session) {
     return (
       <div className="h-11 border-b border-border flex items-center px-3 text-[12px] text-muted-foreground">
@@ -484,8 +521,9 @@ function WorkbenchHeader({
   const selectTooltip = t('web.sessions.header.selectTextTooltip')
   const transcriptLabel = t('web.sessions.header.transcript')
   const transcriptTooltip = t('web.sessions.header.transcriptTooltip')
+  const ended = isTerminalSessionState(session.state)
   return (
-    <div className="h-11 border-b border-border flex items-center px-3 gap-3">
+    <div className="h-11 border-b border-border flex items-center px-2 sm:px-3 gap-2 sm:gap-3">
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
@@ -529,49 +567,53 @@ function WorkbenchHeader({
         !isTerminalSessionState(session.state) && (
           <AccountSwitcher session={session} />
         )}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onAttachImage}
-            disabled={!attachImageEnabled}
-            aria-label={attachLabel}
-            className="size-7 shrink-0"
-          >
-            <ImagePlus className="size-3.5" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>{attachTooltip}</TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onSelectText}
-            aria-label={selectLabel}
-            className="size-7 shrink-0"
-          >
-            <TextCursorInput className="size-3.5" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>{selectTooltip}</TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onShowTranscript}
-            aria-label={transcriptLabel}
-            className="size-7 shrink-0"
-          >
-            <ScrollText className="size-3.5" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>{transcriptTooltip}</TooltipContent>
-      </Tooltip>
+      {!isMobile && (
+        <>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onAttachImage}
+                disabled={!attachImageEnabled}
+                aria-label={attachLabel}
+                className="size-7 shrink-0"
+              >
+                <ImagePlus className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{attachTooltip}</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onSelectText}
+                aria-label={selectLabel}
+                className="size-7 shrink-0"
+              >
+                <TextCursorInput className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{selectTooltip}</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onShowTranscript}
+                aria-label={transcriptLabel}
+                className="size-7 shrink-0"
+              >
+                <ScrollText className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{transcriptTooltip}</TooltipContent>
+          </Tooltip>
+        </>
+      )}
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
@@ -593,7 +635,58 @@ function WorkbenchHeader({
         </TooltipTrigger>
         <TooltipContent>{inspectorLabel}</TooltipContent>
       </Tooltip>
-      {isTerminalSessionState(session.state) ? (
+      {isMobile ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={t('web.sessions.header.moreActions')}
+              className="size-7 shrink-0"
+            >
+              <MoreHorizontal className="size-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" avoidCollisions={false}>
+            <DropdownMenuItem
+              onSelect={onAttachImage}
+              disabled={!attachImageEnabled}
+            >
+              <ImagePlus /> {attachLabel}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={onSelectText}>
+              <TextCursorInput /> {selectLabel}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={onShowTranscript}>
+              <ScrollText /> {transcriptLabel}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            {ended ? (
+              <>
+                <DropdownMenuItem onSelect={onStart} disabled={starting}>
+                  <RotateCcw />
+                  {starting
+                    ? t('web.sessions.header.restarting')
+                    : t('web.sessions.header.restart')}
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={onRemove} disabled={removing}>
+                  <Trash2 />
+                  {removing
+                    ? t('web.sessions.header.removing')
+                    : t('web.sessions.header.remove')}
+                </DropdownMenuItem>
+              </>
+            ) : (
+              <DropdownMenuItem onSelect={onStop} disabled={stopping}>
+                <Power />
+                {stopping
+                  ? t('web.sessions.header.stopping')
+                  : t('web.sessions.header.stop')}
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : ended ? (
         <>
           <Button
             variant="ghost"
@@ -625,20 +718,18 @@ function WorkbenchHeader({
           </Button>
         </>
       ) : (
-        <>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={onStop}
-            disabled={stopping}
-            className="text-[11px] gap-1 text-muted-foreground hover:text-destructive"
-          >
-            <Power className="size-3" />
-            {stopping
-              ? t('web.sessions.header.stopping')
-              : t('web.sessions.header.stop')}
-          </Button>
-        </>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onStop}
+          disabled={stopping}
+          className="text-[11px] gap-1 text-muted-foreground hover:text-destructive"
+        >
+          <Power className="size-3" />
+          {stopping
+            ? t('web.sessions.header.stopping')
+            : t('web.sessions.header.stop')}
+        </Button>
       )}
     </div>
   )

--- a/app/web/src/pages/Settings.tsx
+++ b/app/web/src/pages/Settings.tsx
@@ -30,6 +30,8 @@ import { useTheme, type ThemeMode } from '@/stores/theme'
 import { useAuth } from '@/stores/auth'
 import { useLayout } from '@/stores/layout'
 import { cn } from '@/lib/utils'
+import { SlideOverAside } from '@/components/SlideOverAside'
+import { useIsMobile } from '../lib/useIsMobile'
 import {
   ServerSettings,
   SettingsSearchInput,
@@ -102,6 +104,16 @@ export function SettingsPage() {
   const [active, setActive] = useState<TopSection>(initialSection)
   const [search, setSearch] = useState('')
 
+  // On a phone the section list is a slide-over. Picking a section is
+  // the one and only reason it is open, so close it on select — leaving
+  // it up would hide the very content the user just asked for.
+  const isMobile = useIsMobile()
+  const [navOpen, setNavOpen] = useState(false)
+  const selectSection = (s: TopSection) => {
+    setActive(s)
+    setNavOpen(false)
+  }
+
   useEffect(() => {
     if (isValidTopSection(sp.section) && sp.section !== active) {
       setActive(sp.section)
@@ -123,8 +135,16 @@ export function SettingsPage() {
   })
 
   return (
-    <div className="flex h-full min-h-0 overflow-hidden">
-      {/* Sidebar */}
+    // `relative` anchors the phone slide-over below.
+    <div className="flex h-full min-h-0 overflow-hidden relative">
+      {/* Sidebar: inline column from tablet up, slide-over on phones. */}
+      <SlideOverAside
+        side="left"
+        compact={isMobile}
+        open={isMobile ? navOpen : true}
+        onOpenChange={setNavOpen}
+        label={t('web.settings.title')}
+      >
       <aside className="w-60 shrink-0 border-r border-border bg-background flex flex-col">
         <div className="px-5 pt-6 pb-3">
           <h1 className="text-[15px] font-semibold tracking-tight">
@@ -144,7 +164,7 @@ export function SettingsPage() {
                   icon={item.icon}
                   label={t(item.labelKey)}
                   active={active === item.key}
-                  onClick={() => setActive(item.key)}
+                  onClick={() => selectSection(item.key)}
                 />
               ))}
             </SidebarGroup>
@@ -159,7 +179,7 @@ export function SettingsPage() {
                   icon={Settings2}
                   label={serverSectionLabel(s.id).title}
                   active={active === key}
-                  onClick={() => setActive(key)}
+                  onClick={() => selectSection(key)}
                 />
               )
             })}
@@ -170,13 +190,13 @@ export function SettingsPage() {
               icon={Activity}
               label={t('web.settings.items.status')}
               active={active === 'system'}
-              onClick={() => setActive('system')}
+              onClick={() => selectSection('system')}
             />
             <SidebarItem
               icon={Info}
               label={t('web.settings.items.about')}
               active={active === 'about'}
-              onClick={() => setActive('about')}
+              onClick={() => selectSection('about')}
             />
           </SidebarGroup>
         </nav>
@@ -201,10 +221,11 @@ export function SettingsPage() {
           </span>
         </div>
       </aside>
+      </SlideOverAside>
 
       {/* Content */}
       <div className="flex-1 min-w-0 overflow-y-auto">
-        <div className="max-w-[860px] mx-auto px-8 py-8">
+        <div className="max-w-[860px] mx-auto px-4 py-6 sm:px-8 sm:py-8">
           {/* Sticky search row, only shown when a server section is active */}
           {active.startsWith('server.') && (
             <div className="flex items-center gap-3 mb-6">


### PR DESCRIPTION
## What

The admin UI was desktop-only — 13 responsive utilities in the whole tree, and a single 767px breakpoint wired into three files. Every master/detail page pinned its side column at a fixed width, so on a phone the content pane got whatever was left.

### Breakpoints

`useIsMobile()` (<768px) keeps its meaning: no room for any side column. **`useIsCompact()` (<1024px) is new** — room for exactly two columns, so a *third* column becomes an overlay while the primary two stay inline and the app nav collapses to a 48px icon rail.

### `SlideOverAside`

One component now implements "inline column on wide screens, slide-over on narrow ones", replacing the two hand-rolled copies in `AppShell` and `Sessions`. It positions `absolute` rather than `fixed`, so a page-level panel can never cover the app topbar — pages hosting one carry `relative`. Panels are clamped to 85% so a strip of backdrop stays tappable, closed panels are `inert`, and Escape dismisses.

Applied to Settings, Vault, Knowledge (page nav + graph side panel), Providers, DatabaseWorkbench, Round Table and Sessions.

### Two rules that came out of testing on a real phone

- **When nothing is selected, the list becomes the page** instead of a drawer over an empty pane, and the detail pane is hidden so it can't claim a 60px sliver. A drawer over a blank page leaves the backdrop as a dead tap target.
- **An overlay's open state is local, never the persisted preference.** The stored value means "keep this column where I left it"; reusing it pops a panel over the note or terminal the user just opened, and writing back from a phone would silently collapse the column on the desktop.

### Density

- Ten data tables scroll horizontally instead of clipping, with a min-width so columns stay readable rather than wrapping mid-token.
- Page gutters run `px-3 sm:px-6` — a 24px gutter each side costs a phone a quarter of its usable width.
- Headers that packed a title, a sentence of copy and up to five buttons into one nowrap row now wrap.
- Sessions folds its secondary toolbar actions into an overflow menu on phones.
- The project picker clips the *head* of each path rather than the tail: every entry shares a long prefix, so tail-truncation rendered them identical.

## The one non-layout fix (separate commit)

Radix styles the `ScrollArea` viewport's inner wrapper `display: table; min-width: 100%` **inline**. A table shrink-wraps to min-content, so any pane holding prose with long unbreakable tokens — paths, URLs, shell snippets in inline code — stopped wrapping and scrolled sideways instead. Measured **567px of content inside a 412px viewport** on the Providers page. Forcing the wrapper back to a block restores wrapping; content that genuinely is wider (a table with a min-width) still overflows and still scrolls.

The horizontal `ScrollBar` is now rendered too. The viewport already scrolled on both axes, but with no bar drawn the overflow was invisible — a wide table just looked truncated.

This is in `app/shared-ui`, so it affects every `ScrollArea` in the app. That is deliberate: the same defect was present everywhere, and patching one page would have left the rest broken.

## Test plan

Playwright (chromium) against a live gateway, three profiles — **412×915 (Pixel 10 Pro XL)**, **820×1180 (iPad)**, **1440×900 (desktop)** — across 17 routes:

- [x] **51 page/device combinations: 0 horizontal page overflow, 0 page errors.** Overflow is measured as `documentElement.scrollWidth > clientWidth`, skipping elements whose ancestor scrolls on X so intentionally-scrollable tables don't read as failures.
- [x] Phone interaction chain, each step re-checked for overflow: open a session → pull the list drawer → tap the backdrop to dismiss → open the inspector → Escape → overflow menu → open the nav drawer from the topbar. Terminal ends up at 391×774 of a 412×915 screen.
- [x] Vault specifically (the page that failed hardware acceptance): landing with no note shows the tree at `x=0, w=412` (full page); opening a note parks it at `x=-288`; the new header toggle brings it back to `x=0, w=288`. On tablet the tree stays inline at `x=48` throughout and needs no toggle.
- [x] Desktop screenshots compared against `main` — no layout change above 1024px.
- [x] `pnpm build` green; `go build ./...` green.
- [x] `pnpm lint` 138 problems vs. **139 on `main`** — no new violations.
- [x] i18n parity 100% across en/zh/es (two new key groups: `sessions.header.moreActions`, `notes.left.openTree`/`closeTree`).

Web-only — `app/mobile` (Flutter) is untouched, so there is no mobile-parity gap to close here.

## Note for review

Hardware acceptance on a Pixel 10 Pro XL passed for every page except the Vault, which is what the last three commits' worth of fixes address; that round has only been verified in the emulated profiles above, so it is worth a second look on a real device before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)