### PR TITLE
ci: stop running the whole suite twice on every PR commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,17 @@
 name: CI
 
 on:
+  # push is deliberately main-only. A `feat/**` branch with an open PR
+  # matches BOTH triggers, and because the concurrency group keys on
+  # github.ref — refs/heads/feat/x for push vs refs/pull/N/merge for
+  # pull_request — the two runs don't cancel each other. Every commit
+  # therefore built the web bundle, ran `go test -race`, linted and
+  # checked i18n parity twice over. `pull_request` already covers branch
+  # work (its `branches:` filter matches the BASE, so feat/x -> main is
+  # covered by `main`, and the `feat/**` entry covers stacked PRs); push
+  # is what verifies main after a merge.
   push:
-    branches: [main, "feat/**"]
+    branches: [main]
   pull_request:
     branches: [main, "feat/**"]
 


### PR DESCRIPTION
## The problem

`ci.yml` triggered on both events for the same branches:

```yaml
on:
  push:         branches: [main, "feat/**"]
  pull_request: branches: [main, "feat/**"]
```

A `feat/**` branch with an open PR matches **both**, so every commit started two complete CI runs. The concurrency group doesn't dedupe them because it keys on `github.ref`, which differs per event — `refs/heads/feat/x` for push vs `refs/pull/N/merge` for pull_request — so neither run cancels the other.

#506 shows it plainly: **14 check entries for 5 jobs.** Every commit built the web bundle, ran `go test -race`, ran the Go linter and checked i18n parity twice over.

```
run 31322084334  event=pull_request   5 jobs
run 31322057209  event=push           5 jobs   (README drift skipped)
```

As a side effect this is also the answer to "why is one check always skipped": `readme-drift` is guarded by `if: github.event_name == 'pull_request'` because it posts a comment on a PR and a push has none to post to. It ran in the PR copy and skipped in the push copy. That part was correct — the duplication around it was not.

## The change

Limit `push` to `main`. One line, plus a comment recording why.

`pull_request` already covers branch work: its `branches:` filter matches the **base** ref, so `feat/x -> main` is covered by the `main` entry and the `feat/**` entry covers stacked PRs. `push` keeps its real job — verifying `main` after a merge.

## Trade-off

A `feat/**` branch pushed with **no PR open** no longer runs CI. That matches the workflow here, where everything lands through a PR; open the PR and the checks run. Flagging it explicitly because it is a real (if small) loss of coverage, not a free win.

## Test plan

- [x] Workflow YAML re-parsed after the edit — triggers resolve to `{push: {branches: [main]}, pull_request: {branches: [main, feat/**]}}`, and all five jobs still parse with their names intact.
- [x] Confirmed against the live ruleset that the merge gate is unaffected: `main` requires **Frontend (web)**, **Backend (Go)** and **Lint (Go)**, and all three are produced by the `pull_request` run. Required checks match by name regardless of which event produced them.
- [x] **This PR is its own proof** — it should show one run of each job instead of two, and `README translation drift (advisory)` should report `pass` rather than appearing twice with one skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)