### PR TITLE
fix(i18n): stop rendering &lt;prefix&gt; as literal text in six hints

### DIFF
--- a/app/web/src/components/providers/AntigravityAccountsPanel.tsx
+++ b/app/web/src/components/providers/AntigravityAccountsPanel.tsx
@@ -155,6 +155,10 @@ HOME=~/.antigravity-accounts/<name> agy   # complete Google sign-in, then exit`}
         <p className="text-[12px] text-muted-foreground italic">
           <Trans
             i18nKey="web.providers.antigravityAccounts.empty"
+            // Trans parses the string as HTML before rendering it, so the copy
+            // has to escape its <angle-bracket> placeholders or the parser eats
+            // them; shouldUnescape turns the entities back into literal text.
+            shouldUnescape
             components={{ 1: <span className="font-mono" /> }}
           />
         </p>

--- a/app/web/src/components/settings/ServerSettings.tsx
+++ b/app/web/src/components/settings/ServerSettings.tsx
@@ -2082,6 +2082,10 @@ function BackupSection({
                 <div className="text-muted-foreground mt-0.5">
                   <Trans
                     i18nKey="web.serverSettings.backup.featureDisabledHint"
+                    // Trans parses the string as HTML before rendering it, so the copy
+                    // has to escape its <angle-bracket> placeholders or the parser eats
+                    // them; shouldUnescape turns the entities back into literal text.
+                    shouldUnescape
                     components={{
                       1: <code className="text-foreground" />,
                       3: <code className="text-foreground" />,

--- a/app/web/src/pages/Integrations.tsx
+++ b/app/web/src/pages/Integrations.tsx
@@ -93,6 +93,10 @@ export function IntegrationsPage() {
           <p className="text-[12px] text-muted-foreground">
             <Trans
               i18nKey="web.integrations.subtitle"
+              // Trans parses the string as HTML before rendering it, so the copy
+              // has to escape its <angle-bracket> placeholders or the parser eats
+              // them; shouldUnescape turns the entities back into literal text.
+              shouldUnescape
               components={{ 1: <code className="mx-1" /> }}
             />
           </p>

--- a/app/web/src/pages/Plugins.tsx
+++ b/app/web/src/pages/Plugins.tsx
@@ -246,6 +246,10 @@ function McpSection() {
       description={
         <Trans
           i18nKey="web.plugins.mcp.description"
+          // Trans parses the string as HTML before rendering it, so the copy
+          // has to escape its <angle-bracket> placeholders or the parser eats
+          // them; shouldUnescape turns the entities back into literal text.
+          shouldUnescape
           components={{ 1: <code />, 3: <code />, 5: <strong /> }}
         />
       }
@@ -1065,6 +1069,10 @@ function SkillsSection() {
       description={
         <Trans
           i18nKey="web.plugins.skills.description"
+          // Trans parses the string as HTML before rendering it, so the copy
+          // has to escape its <angle-bracket> placeholders or the parser eats
+          // them; shouldUnescape turns the entities back into literal text.
+          shouldUnescape
           components={{ 1: <code />, 3: <strong />, 5: <code /> }}
         />
       }
@@ -1392,6 +1400,10 @@ function SkillEditor({ open, onOpenChange, mode, editingId }: SkillEditorProps) 
                 <p className="text-[10.5px] text-muted-foreground/80">
                   <Trans
                     i18nKey="web.plugins.skills.editor.idHint"
+                    // Trans parses the string as HTML before rendering it, so the copy
+                    // has to escape its <angle-bracket> placeholders or the parser eats
+                    // them; shouldUnescape turns the entities back into literal text.
+                    shouldUnescape
                     components={{ 1: <code /> }}
                   />
                 </p>


### PR DESCRIPTION
## What was wrong

Six pieces of copy carry angle-bracket placeholders — `<prefix>`, `<id>`, `<name>`, `<passphrase>` — escaped as `&lt;…&gt;` in the translation. Every one of them rendered the entity verbatim. The Integrations header advertised the reverse-proxy path as:

```
/api/v1/proxy/&lt;prefix&gt;/…
```

## Why the escaping is not the mistake

`<Trans>` runs the string through an HTML parser before building React elements, then emits text nodes as plain React text — and React does not decode entities.

Measured, with this project's exact i18n config (react-i18next 17):

| translation source | rendered |
|---|---|
| `&lt;prefix&gt;` (current) | `&lt;prefix&gt;` ❌ |
| `<prefix>` (drop the escaping) | `&lt;prefix>` ❌ **worse** |
| `{prefix}` + `values={{prefix:'<prefix>'}}` | `&lt;prefix>` ❌ |
| move the text into `components` | `<code></code>` — empty ❌ |
| `&lt;prefix&gt;` + `shouldUnescape` | `<prefix>` ✅ |

Removing the escaping is actively worse: the bare `<prefix>` is consumed as a tag and half of it disappears. Interpolating the value hits the same parser and mangles it identically. `shouldUnescape` is the prop react-i18next provides for exactly this — it decodes the entities *after* parsing.

## Why six call sites and not one switch

The documented global form, `react: { shouldUnescape: true }` at init, **has no effect in react-i18next 17** — verified against this project's own config, the entity still rendered raw. So there is no single place to set it and each `<Trans>` needs the prop. Each site carries a short comment saying why, since a bare `shouldUnescape` reads as cargo cult otherwise.

## Scope

**No translation strings change** — en/zh/es keep the entities they need. Only six `.tsx` call sites gain a prop.

| key | placeholder it was mangling |
|---|---|
| `web.integrations.subtitle` | `<prefix>` |
| `web.plugins.mcp.description` | `<id>` |
| `web.plugins.skills.description` | `<id>` ×2 |
| `web.plugins.skills.editor.idHint` | `<id>` |
| `web.providers.antigravityAccounts.empty` | `<name>` |
| `web.serverSettings.backup.featureDisabledHint` | `<passphrase>` |

**Mobile is unaffected.** It reads its own top-level namespaces (`providers.*`, `integrations.*`, …), which carry plain-text copy with literal `<name>` and no `<1>` markers. A sweep of `app/i18n/*.json` finds entity-bearing strings only under `web.*`: 6 in the web namespace, 0 in the mobile ones. So there is no web/mobile parity gap to close here.

## Test plan

- [x] Every one of the six checked in a real browser (Playwright, live gateway): each now shows its literal placeholder, and a page-wide scan for `&lt;` / `&gt;` / `&amp;` finds nothing left.
- [x] `serverSettings.backup.featureDisabledHint` renders only when backup is off, so it never appeared on this instance. Verified by stubbing `/api/v1/backup-status` to `null` to force the disabled branch — read-only, nothing mutated. Renders `OPENDRAY_BACKUP_KEY=<passphrase>`.
- [x] The rejected alternatives in the table above were each rendered and measured before settling on `shouldUnescape`, rather than reasoned about.
- [x] `pnpm build` green; `pnpm lint` 138 problems, unchanged from `main`.
- [x] i18n JSON untouched, so parity is unchanged by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)