### PR TITLE
feat(mobile): bring the Vault up to the web's knowledge layer

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -5022,6 +5022,10 @@
     "newButton": "New",
     "newNoteDialogTitle": "New note",
     "searchHint": "Search across the whole vault…",
+    "browse": {
+      "tree": "Folders",
+      "tags": "Tags"
+    },
     "up": "Up",
     "copyPath": "Copy path",
     "open": "Open",
@@ -5042,7 +5046,7 @@
     "emptyFolder": "Folder \"{path}\" is empty.",
     "validatePath": "Path is required",
     "validatePathDots": "Path cannot contain \"..\"",
-    "pathHelper": "Auto-appends .md if missing.",
+    "pathHelper": "Adds .md unless the name already ends in .md or .html.",
     "editor": {
       "markdownHint": "Markdown, or HTML if the file ends .html…",
       "saving": "Saving…",
@@ -5081,6 +5085,33 @@
       "helper": "Vault-relative path. Folders are created as needed.",
       "doneSnack": "Renamed. {count} link(s) repointed.",
       "doneWithWarning": "Renamed, but the links were not all updated"
+    },
+    "tags": {
+      "empty": "No tags in the vault yet. Write #like-this in a note.",
+      "noMatches": "No tags match \"{query}\".",
+      "filteredBy": "Filtered by",
+      "clear": "Clear tag filter",
+      "noNotes": "No notes carry #{tag} any more."
+    },
+    "backlinks": {
+      "title": "Backlinks",
+      "loading": "Looking for links…",
+      "empty": "No notes link here yet.",
+      "failed": "Could not load backlinks: {error}"
+    },
+    "outline": {
+      "action": "Outline",
+      "title": "Outline",
+      "empty": "This document has no headings.",
+      "jumpedToSource": "Preview can't scroll without scripts, so this opened the source view."
+    },
+    "today": {
+      "tooltip": "Open today's daily note"
+    },
+    "wikiLink": {
+      "suggestions": "Link to…",
+      "createNew": "Create \"{name}\"",
+      "noMatches": "No note matches — keep typing to create one."
     }
   },
   "vaultSync": {

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -5022,6 +5022,10 @@
     "newButton": "Nueva",
     "newNoteDialogTitle": "Nueva nota",
     "searchHint": "Busca en todo el vault…",
+    "browse": {
+      "tree": "Carpetas",
+      "tags": "Etiquetas"
+    },
     "up": "Arriba",
     "copyPath": "Copiar ruta",
     "open": "Abrir",
@@ -5042,7 +5046,7 @@
     "emptyFolder": "La carpeta \"{path}\" está vacía.",
     "validatePath": "La ruta es obligatoria",
     "validatePathDots": "La ruta no puede contener \"..\"",
-    "pathHelper": "Añade .md automáticamente si falta.",
+    "pathHelper": "Añade .md salvo que el nombre ya termine en .md o .html.",
     "editor": {
       "markdownHint": "Markdown, o HTML si el archivo termina en .html…",
       "saving": "Guardando…",
@@ -5081,6 +5085,33 @@
       "helper": "Ruta relativa a la bóveda. Las carpetas se crean solas.",
       "doneSnack": "Renombrado. {count} enlace(s) actualizados.",
       "doneWithWarning": "Renombrado, pero no se actualizaron todos los enlaces"
+    },
+    "tags": {
+      "empty": "Aún no hay etiquetas en el almacén. Escribe #así en una nota.",
+      "noMatches": "Ninguna etiqueta coincide con «{query}».",
+      "filteredBy": "Filtrado por",
+      "clear": "Quitar el filtro de etiqueta",
+      "noNotes": "Ya no hay notas con #{tag}."
+    },
+    "backlinks": {
+      "title": "Retroenlaces",
+      "loading": "Buscando enlaces…",
+      "empty": "Todavía no hay notas que enlacen aquí.",
+      "failed": "No se pudieron cargar los retroenlaces: {error}"
+    },
+    "outline": {
+      "action": "Esquema",
+      "title": "Esquema",
+      "empty": "Este documento no tiene encabezados.",
+      "jumpedToSource": "La vista previa no puede desplazarse sin scripts, así que se abrió el código."
+    },
+    "today": {
+      "tooltip": "Abrir la nota diaria de hoy"
+    },
+    "wikiLink": {
+      "suggestions": "Enlazar a…",
+      "createNew": "Crear «{name}»",
+      "noMatches": "Ninguna nota coincide: sigue escribiendo para crear una."
     }
   },
   "vaultSync": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -5019,6 +5019,10 @@
     "newButton": "新建",
     "newNoteDialogTitle": "新建笔记",
     "searchHint": "搜索整个仓库…",
+    "browse": {
+      "tree": "目录",
+      "tags": "标签"
+    },
     "up": "上级",
     "copyPath": "复制路径",
     "open": "打开",
@@ -5039,7 +5043,7 @@
     "emptyFolder": "文件夹「{path}」为空。",
     "validatePath": "必须填写路径",
     "validatePathDots": "路径不能包含「..」",
-    "pathHelper": "缺失时自动追加 .md。",
+    "pathHelper": "除非名字已经以 .md 或 .html 结尾，否则会自动补 .md。",
     "editor": {
       "markdownHint": "Markdown;文件名以 .html 结尾则写 HTML…",
       "saving": "保存中…",
@@ -5078,6 +5082,33 @@
       "helper": "文档库相对路径。目录会自动创建。",
       "doneSnack": "已重命名，{count} 个链接已改写。",
       "doneWithWarning": "已重命名，但链接没有全部更新"
+    },
+    "tags": {
+      "empty": "文档库里还没有标签。在笔记里写 #像这样 就会出现。",
+      "noMatches": "没有标签匹配“{query}”。",
+      "filteredBy": "已按标签筛选",
+      "clear": "清除标签筛选",
+      "noNotes": "已经没有笔记带 #{tag} 了。"
+    },
+    "backlinks": {
+      "title": "反向链接",
+      "loading": "正在查找链接…",
+      "empty": "还没有笔记链接到这里。",
+      "failed": "反向链接加载失败：{error}"
+    },
+    "outline": {
+      "action": "大纲",
+      "title": "大纲",
+      "empty": "这篇文档没有标题。",
+      "jumpedToSource": "预览关闭了脚本、无法滚动，所以已切到源码视图。"
+    },
+    "today": {
+      "tooltip": "打开今天的日记"
+    },
+    "wikiLink": {
+      "suggestions": "链接到…",
+      "createNew": "新建“{name}”",
+      "noMatches": "没有匹配的笔记 —— 继续输入即可新建。"
     }
   },
   "vaultSync": {

--- a/app/mobile/lib/core/api/notes_api.dart
+++ b/app/mobile/lib/core/api/notes_api.dart
@@ -321,6 +321,40 @@ class NotesApi {
     }
   }
 
+  /// GET /api/v1/notes/backlinks?path=… — every note whose body links
+  /// to [path]. The scan runs server-side over the whole vault.
+  Future<List<Backlink>> backlinks(String path) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/notes/backlinks',
+        queryParameters: {'path': path},
+      );
+      final raw = res.data?['links'];
+      if (raw is! List) return const [];
+      return raw.whereType<Map<String, dynamic>>().map(Backlink.fromJson).toList();
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  /// GET /api/v1/notes/tags — every tag in the vault with its note
+  /// count. [prefix] restricts the scan to one subtree.
+  Future<List<TagCount>> tags({String? prefix}) async {
+    try {
+      final res = await _dio.get<Map<String, dynamic>>(
+        '/api/v1/notes/tags',
+        queryParameters: {
+          if (prefix != null && prefix.isNotEmpty) 'prefix': prefix,
+        },
+      );
+      final raw = res.data?['tags'];
+      if (raw is! List) return const [];
+      return raw.whereType<Map<String, dynamic>>().map(TagCount.fromJson).toList();
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
   /// Move or rename a note, repointing the [[wiki-links]] that pointed
   /// at it. Without the rewrite a rename silently strands every
   /// reference, which is why reorganising was previously unsafe.
@@ -335,6 +369,56 @@ class NotesApi {
       throw toApiException(e);
     }
   }
+}
+
+/// One note that links to the document being viewed, with a couple of
+/// matching lines for context. Mirrors notes.Backlink in
+/// internal/notes/links.go.
+class Backlink {
+  const Backlink({
+    required this.path,
+    required this.title,
+    required this.lines,
+  });
+
+  factory Backlink.fromJson(Map<String, dynamic> json) => Backlink(
+        path: json['path'] as String? ?? '',
+        title: json['title'] as String? ?? '',
+        lines: (json['lines'] as List<dynamic>? ?? const [])
+            .whereType<String>()
+            .toList(),
+      );
+
+  final String path;
+  final String title;
+
+  /// Snippets of the lines carrying the link.
+  final List<String> lines;
+}
+
+/// One tag and how many notes mention it. Mirrors notes.TagCount in
+/// internal/notes/links.go. [notes] is what makes filtering by tag
+/// possible without a second round-trip per tag.
+class TagCount {
+  const TagCount({
+    required this.tag,
+    required this.count,
+    this.notes = const [],
+  });
+
+  factory TagCount.fromJson(Map<String, dynamic> json) => TagCount(
+        tag: json['tag'] as String? ?? '',
+        count: (json['count'] as num?)?.toInt() ?? 0,
+        notes: (json['notes'] as List<dynamic>? ?? const [])
+            .whereType<String>()
+            .toList(),
+      );
+
+  final String tag;
+  final int count;
+
+  /// Vault paths mentioning the tag. Omitted by the gateway when empty.
+  final List<String> notes;
 }
 
 /// One starting shape for a new note. [source] is "builtin" or "vault"

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 13455 (4485 per locale)
+/// Strings: 13545 (4515 per locale)
 ///
-/// Built on 2026-08-10 at 00:56 UTC
+/// Built on 2026-08-10 at 05:33 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -1895,6 +1895,8 @@ class TranslationsNotesPageEn {
 	/// en: 'Search across the whole vault…'
 	String get searchHint => 'Search across the whole vault…';
 
+	late final TranslationsNotesPageBrowseEn browse = TranslationsNotesPageBrowseEn.internal(_root);
+
 	/// en: 'Up'
 	String get up => 'Up';
 
@@ -1955,13 +1957,18 @@ class TranslationsNotesPageEn {
 	/// en: 'Path cannot contain ".."'
 	String get validatePathDots => 'Path cannot contain ".."';
 
-	/// en: 'Auto-appends .md if missing.'
-	String get pathHelper => 'Auto-appends .md if missing.';
+	/// en: 'Adds .md unless the name already ends in .md or .html.'
+	String get pathHelper => 'Adds .md unless the name already ends in .md or .html.';
 
 	late final TranslationsNotesPageEditorEn editor = TranslationsNotesPageEditorEn.internal(_root);
 	late final TranslationsNotesPageHtmlEn html = TranslationsNotesPageHtmlEn.internal(_root);
 	late final TranslationsNotesPageFlattenEn flatten = TranslationsNotesPageFlattenEn.internal(_root);
 	late final TranslationsNotesPageRenameEn rename = TranslationsNotesPageRenameEn.internal(_root);
+	late final TranslationsNotesPageTagsEn tags = TranslationsNotesPageTagsEn.internal(_root);
+	late final TranslationsNotesPageBacklinksEn backlinks = TranslationsNotesPageBacklinksEn.internal(_root);
+	late final TranslationsNotesPageOutlineEn outline = TranslationsNotesPageOutlineEn.internal(_root);
+	late final TranslationsNotesPageTodayEn today = TranslationsNotesPageTodayEn.internal(_root);
+	late final TranslationsNotesPageWikiLinkEn wikiLink = TranslationsNotesPageWikiLinkEn.internal(_root);
 }
 
 // Path: vaultSync
@@ -5496,6 +5503,21 @@ class TranslationsChannelsKindsEn {
 	late final TranslationsChannelsKindsWecomEn wecom = TranslationsChannelsKindsWecomEn.internal(_root);
 }
 
+// Path: notesPage.browse
+class TranslationsNotesPageBrowseEn {
+	TranslationsNotesPageBrowseEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Folders'
+	String get tree => 'Folders';
+
+	/// en: 'Tags'
+	String get tags => 'Tags';
+}
+
 // Path: notesPage.editor
 class TranslationsNotesPageEditorEn {
 	TranslationsNotesPageEditorEn.internal(this._root);
@@ -5623,6 +5645,102 @@ class TranslationsNotesPageRenameEn {
 
 	/// en: 'Renamed, but the links were not all updated'
 	String get doneWithWarning => 'Renamed, but the links were not all updated';
+}
+
+// Path: notesPage.tags
+class TranslationsNotesPageTagsEn {
+	TranslationsNotesPageTagsEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'No tags in the vault yet. Write #like-this in a note.'
+	String get empty => 'No tags in the vault yet. Write #like-this in a note.';
+
+	/// en: 'No tags match "{query}".'
+	String noMatches({required Object query}) => 'No tags match "${query}".';
+
+	/// en: 'Filtered by'
+	String get filteredBy => 'Filtered by';
+
+	/// en: 'Clear tag filter'
+	String get clear => 'Clear tag filter';
+
+	/// en: 'No notes carry #{tag} any more.'
+	String noNotes({required Object tag}) => 'No notes carry #${tag} any more.';
+}
+
+// Path: notesPage.backlinks
+class TranslationsNotesPageBacklinksEn {
+	TranslationsNotesPageBacklinksEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Backlinks'
+	String get title => 'Backlinks';
+
+	/// en: 'Looking for links…'
+	String get loading => 'Looking for links…';
+
+	/// en: 'No notes link here yet.'
+	String get empty => 'No notes link here yet.';
+
+	/// en: 'Could not load backlinks: {error}'
+	String failed({required Object error}) => 'Could not load backlinks: ${error}';
+}
+
+// Path: notesPage.outline
+class TranslationsNotesPageOutlineEn {
+	TranslationsNotesPageOutlineEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Outline'
+	String get action => 'Outline';
+
+	/// en: 'Outline'
+	String get title => 'Outline';
+
+	/// en: 'This document has no headings.'
+	String get empty => 'This document has no headings.';
+
+	/// en: 'Preview can't scroll without scripts, so this opened the source view.'
+	String get jumpedToSource => 'Preview can\'t scroll without scripts, so this opened the source view.';
+}
+
+// Path: notesPage.today
+class TranslationsNotesPageTodayEn {
+	TranslationsNotesPageTodayEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Open today's daily note'
+	String get tooltip => 'Open today\'s daily note';
+}
+
+// Path: notesPage.wikiLink
+class TranslationsNotesPageWikiLinkEn {
+	TranslationsNotesPageWikiLinkEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Link to…'
+	String get suggestions => 'Link to…';
+
+	/// en: 'Create "{name}"'
+	String createNew({required Object name}) => 'Create "${name}"';
+
+	/// en: 'No note matches — keep typing to create one.'
+	String get noMatches => 'No note matches — keep typing to create one.';
 }
 
 // Path: vaultSync.every
@@ -16108,8 +16226,16 @@ class TranslationsWebNotesVaultSyncAutoSyncEn {
 	/// en: 'Commit every'
 	String get commitEvery => 'Commit every';
 
-	/// en: 'Examples: <1>30s</1>, <3>10m</3>, <5>2h</5>. Min 30s.'
-	String get commitEveryExamples => 'Examples: <1>30s</1>, <3>10m</3>, <5>2h</5>. Min 30s.';
+	late final TranslationsWebNotesVaultSyncAutoSyncEveryEn every = TranslationsWebNotesVaultSyncAutoSyncEveryEn.internal(_root);
+
+	/// en: 'Custom…'
+	String get intervalCustom => 'Custom…';
+
+	/// en: 'Not a valid duration. Use a number with a unit, e.g. 30s, 10m, 2h.'
+	String get intervalInvalid => 'Not a valid duration. Use a number with a unit, e.g. 30s, 10m, 2h.';
+
+	/// en: 'The sync loop never ticks faster than {min}.'
+	String intervalTooShort({required Object min}) => 'The sync loop never ticks faster than ${min}.';
 
 	/// en: 'Pull every'
 	String get pullEvery => 'Pull every';
@@ -18961,6 +19087,42 @@ class TranslationsWebNotesVaultSyncConflictKindsEn {
 	String get operation => 'operation';
 }
 
+// Path: web.notes.vaultSync.autoSync.every
+class TranslationsWebNotesVaultSyncAutoSyncEveryEn {
+	TranslationsWebNotesVaultSyncAutoSyncEveryEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Every 30 seconds'
+	String get k30s => 'Every 30 seconds';
+
+	/// en: 'Every minute'
+	String get k1m => 'Every minute';
+
+	/// en: 'Every 5 minutes'
+	String get k5m => 'Every 5 minutes';
+
+	/// en: 'Every 10 minutes'
+	String get k10m => 'Every 10 minutes';
+
+	/// en: 'Every 15 minutes'
+	String get k15m => 'Every 15 minutes';
+
+	/// en: 'Every 30 minutes'
+	String get k30m => 'Every 30 minutes';
+
+	/// en: 'Every hour'
+	String get k1h => 'Every hour';
+
+	/// en: 'Every 6 hours'
+	String get k6h => 'Every 6 hours';
+
+	/// en: 'Every 24 hours'
+	String get k24h => 'Every 24 hours';
+}
+
 // Path: web.serverSettings.host.modes.ac
 class TranslationsWebServerSettingsHostModesAcEn {
 	TranslationsWebServerSettingsHostModesAcEn.internal(this._root);
@@ -20055,7 +20217,18 @@ extension on Translations {
 			'web.notes.vaultSync.autoSync.enabledTooltipNoRemote' => 'Configure a remote first to enable auto-sync',
 			'web.notes.vaultSync.autoSync.noRemoteHint' => 'No remote — push/pull will be skipped.',
 			'web.notes.vaultSync.autoSync.commitEvery' => 'Commit every',
-			'web.notes.vaultSync.autoSync.commitEveryExamples' => 'Examples: <1>30s</1>, <3>10m</3>, <5>2h</5>. Min 30s.',
+			'web.notes.vaultSync.autoSync.every.k30s' => 'Every 30 seconds',
+			'web.notes.vaultSync.autoSync.every.k1m' => 'Every minute',
+			'web.notes.vaultSync.autoSync.every.k5m' => 'Every 5 minutes',
+			'web.notes.vaultSync.autoSync.every.k10m' => 'Every 10 minutes',
+			'web.notes.vaultSync.autoSync.every.k15m' => 'Every 15 minutes',
+			'web.notes.vaultSync.autoSync.every.k30m' => 'Every 30 minutes',
+			'web.notes.vaultSync.autoSync.every.k1h' => 'Every hour',
+			'web.notes.vaultSync.autoSync.every.k6h' => 'Every 6 hours',
+			'web.notes.vaultSync.autoSync.every.k24h' => 'Every 24 hours',
+			'web.notes.vaultSync.autoSync.intervalCustom' => 'Custom…',
+			'web.notes.vaultSync.autoSync.intervalInvalid' => 'Not a valid duration. Use a number with a unit, e.g. 30s, 10m, 2h.',
+			'web.notes.vaultSync.autoSync.intervalTooShort' => ({required Object min}) => 'The sync loop never ticks faster than ${min}.',
 			'web.notes.vaultSync.autoSync.pullEvery' => 'Pull every',
 			'web.notes.vaultSync.autoSync.pullEveryHint' => 'Only used when Pull is enabled.',
 			'web.notes.vaultSync.autoSync.pushAfterCommit' => 'Push after commit',
@@ -20115,6 +20288,8 @@ extension on Translations {
 			'web.activity.filters.outbound' => 'Outbound',
 			'web.activity.filters.allStatuses' => 'All statuses',
 			'web.activity.filters.status2' => '2xx success',
+			_ => null,
+		} ?? switch (path) {
 			'web.activity.filters.status3' => '3xx redirect',
 			'web.activity.filters.status4' => '4xx client error',
 			'web.activity.filters.status5' => '5xx server error',
@@ -20126,8 +20301,6 @@ extension on Translations {
 			'web.activity.table.directionTitle' => 'Direction',
 			'web.activity.table.method' => 'Method',
 			'web.activity.table.path' => 'Path',
-			_ => null,
-		} ?? switch (path) {
 			'web.activity.table.status' => 'Status',
 			'web.activity.table.duration' => 'Duration',
 			'web.activity.table.inboundAria' => 'inbound',
@@ -20629,6 +20802,8 @@ extension on Translations {
 			'web.plugins.gitHosts.dialog.kindGitea' => 'Gitea',
 			'web.plugins.gitHosts.dialog.kindGitLab' => 'GitLab',
 			'web.plugins.gitHosts.dialog.hostLabel' => 'Host',
+			_ => null,
+		} ?? switch (path) {
 			'web.plugins.gitHosts.dialog.hostPlaceholder' => 'github.com',
 			'web.plugins.gitHosts.dialog.displayNameLabel' => 'Display name (optional)',
 			'web.plugins.gitHosts.dialog.displayNamePlaceholder' => 'Personal',
@@ -20640,8 +20815,6 @@ extension on Translations {
 			'web.plugins.gitHosts.dialog.enabledLabel' => 'Enabled',
 			'web.plugins.gitHosts.dialog.addedToast' => 'Git host added',
 			'web.plugins.gitHosts.dialog.updatedToast' => 'Git host updated',
-			_ => null,
-		} ?? switch (path) {
 			'web.plugins.gitHosts.dialog.addFailedToast' => 'Add failed',
 			'web.plugins.gitHosts.dialog.updateFailedToast' => 'Update failed',
 			'web.plugins.gitHosts.dialog.ownerLabel' => 'Owner (optional)',
@@ -21143,6 +21316,8 @@ extension on Translations {
 			'web.serverSettings.toggle.on' => 'On',
 			'web.serverSettings.toggle.off' => 'Off',
 			'web.serverSettings.toggle.defaultOn' => 'Default (on)',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.toggle.defaultOff' => 'Default (off)',
 			'web.serverSettings.memoryRuntimeBanner' => 'Runtime AI behaviour — workers, capture rules, injection profiles and spawn mode — lives in Cortex settings and applies instantly. This section is the infrastructure half: embedder, storage and background governance (restart required).',
 			'web.serverSettings.memoryRuntimeBannerButton' => 'Open Cortex settings',
@@ -21154,8 +21329,6 @@ extension on Translations {
 			'web.serverSettings.host.modes.always.desc' => 'Never idle-sleeps, including on battery.',
 			'web.serverSettings.host.modes.always.caveat' => 'Will drain a laptop battery left unplugged.',
 			'web.serverSettings.host.modes.on_demand.label' => 'Sleep when idle, wake on traffic',
-			_ => null,
-		} ?? switch (path) {
 			'web.serverSettings.host.modes.on_demand.desc' => 'The machine sleeps whenever the gateway is quiet. An incoming request wakes it, and opendray holds it awake while serving, then lets it sleep again.',
 			'web.serverSettings.host.modes.on_demand.caveat' => 'Needs "Wake for network access" (sudo pmset -a womp 1), reliably wired Ethernet. The first request after a sleep takes a few seconds and may need one retry.',
 			'web.serverSettings.host.modes.off.label' => 'Never touch power settings',
@@ -21657,6 +21830,8 @@ extension on Translations {
 			'web.cortex.blueprint.title' => 'Doc blueprint',
 			'web.cortex.blueprint.description' => 'The section set of this project\'s official document. Different kinds of projects deserve different sections — shape it yourself or let the AI propose one.',
 			'web.cortex.blueprint.propose' => 'AI propose',
+			_ => null,
+		} ?? switch (path) {
 			'web.cortex.blueprint.proposeHint' => 'Classify this project and propose a tailored section set',
 			'web.cortex.blueprint.proposeFailed' => 'Proposal failed',
 			'web.cortex.blueprint.proposalNote' => ({required Object type, required Object reason}) => 'AI classified this as: ${type} — ${reason} Review below, edit freely, then Apply.',
@@ -21668,8 +21843,6 @@ extension on Translations {
 			'web.cortex.blueprint.mode.human' => 'Human',
 			'web.cortex.blueprint.mode.scanner' => 'Scanner',
 			'web.cortex.blueprint.inject' => 'inject',
-			_ => null,
-		} ?? switch (path) {
 			'web.cortex.blueprint.reserved' => 'reserved',
 			'web.cortex.blueprint.deleteNote' => 'Removing a section hides it without deleting its content — re-add the same slug to resurrect it.',
 			'web.cortex.blueprint.cancel' => 'Cancel',
@@ -22171,6 +22344,8 @@ extension on Translations {
 			'sessions.inspector.canvas.modeRegion' => 'Frame',
 			'sessions.inspector.canvas.focusLine' => ({required Object title, required Object kind}) => 'Working on ${title} · ${kind} — the agent treats this as "this canvas".',
 			'sessions.inspector.canvas.notePlaceholder' => 'What to change here…',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.messagePlaceholder' => 'Overall note (optional)…',
 			'sessions.inspector.canvas.send' => 'Send',
 			'sessions.inspector.canvas.sent' => 'Feedback sent to the session.',
@@ -22182,8 +22357,6 @@ extension on Translations {
 			'sessions.inspector.canvas.deleteTitle' => 'Delete canvas?',
 			'sessions.inspector.canvas.deleteBody' => ({required Object title}) => 'Delete "${title}"? This can\'t be undone.',
 			'sessions.inspector.canvas.emptyTitle' => 'No canvas yet',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.canvas.emptyBlurb' => 'Ask the agent for a screen, a flowchart, a mind map or a relationship diagram — it renders here and you can pin and annotate it.',
 			'sessions.inspector.canvas.viewportPhone' => 'Phone width',
 			'sessions.inspector.canvas.viewportTablet' => 'Tablet width',
@@ -22685,6 +22858,8 @@ extension on Translations {
 			'backups.recoveryKit.menuLabel' => 'Recovery Kit',
 			'backups.recoveryKit.title' => 'Recovery Kit',
 			'backups.recoveryKit.warning' => 'Disaster-recovery insurance — you only need this if this host AND its keys are lost together; normally you never touch it. The kit is your backup passphrase sealed under the password you pick here. Each time you generate, it\'s a separate kit sealed with THAT password — nothing is stored, so there is no single master password. Keep the kit and its password together, out-of-band. Note: this password protects the kit, not the gateway — anyone with admin access can generate a new one.',
+			_ => null,
+		} ?? switch (path) {
 			'backups.recoveryKit.passphraseLabel' => 'Recovery passphrase (min 8)',
 			'backups.recoveryKit.confirmLabel' => 'Confirm recovery passphrase',
 			'backups.recoveryKit.generate' => 'Generate',
@@ -22696,8 +22871,6 @@ extension on Translations {
 			'backups.emptyNoTargets.headline' => 'No backup targets configured',
 			'backups.emptyNoTargets.body' => 'Open the More menu → Targets to add a destination (local / S3 / SMB / SFTP / WebDAV / rclone). Then come back and tap "Run now".',
 			'backups.emptyNoBackups.headline' => 'No backups yet',
-			_ => null,
-		} ?? switch (path) {
 			'backups.emptyNoBackups.body' => 'Tap "Run now" to take a fresh snapshot, or open Schedules to set up recurring runs.',
 			'backups.restartToActivate' => 'Restart opendray to activate backups',
 			'backups.passphraseSaved' => 'Your passphrase is saved. The gateway only loads it at startup, so changes only take effect after a restart.',
@@ -23125,6 +23298,8 @@ extension on Translations {
 			'notesPage.newButton' => 'New',
 			'notesPage.newNoteDialogTitle' => 'New note',
 			'notesPage.searchHint' => 'Search across the whole vault…',
+			'notesPage.browse.tree' => 'Folders',
+			'notesPage.browse.tags' => 'Tags',
 			'notesPage.up' => 'Up',
 			'notesPage.copyPath' => 'Copy path',
 			'notesPage.open' => 'Open',
@@ -23145,7 +23320,7 @@ extension on Translations {
 			'notesPage.emptyFolder' => ({required Object path}) => 'Folder "${path}" is empty.',
 			'notesPage.validatePath' => 'Path is required',
 			'notesPage.validatePathDots' => 'Path cannot contain ".."',
-			'notesPage.pathHelper' => 'Auto-appends .md if missing.',
+			'notesPage.pathHelper' => 'Adds .md unless the name already ends in .md or .html.',
 			'notesPage.editor.markdownHint' => 'Markdown, or HTML if the file ends .html…',
 			'notesPage.editor.saving' => 'Saving…',
 			'notesPage.editor.autosave' => 'Saved',
@@ -23177,9 +23352,28 @@ extension on Translations {
 			'notesPage.rename.helper' => 'Vault-relative path. Folders are created as needed.',
 			'notesPage.rename.doneSnack' => ({required Object count}) => 'Renamed. ${count} link(s) repointed.',
 			'notesPage.rename.doneWithWarning' => 'Renamed, but the links were not all updated',
+			'notesPage.tags.empty' => 'No tags in the vault yet. Write #like-this in a note.',
+			'notesPage.tags.noMatches' => ({required Object query}) => 'No tags match "${query}".',
+			'notesPage.tags.filteredBy' => 'Filtered by',
+			'notesPage.tags.clear' => 'Clear tag filter',
+			'notesPage.tags.noNotes' => ({required Object tag}) => 'No notes carry #${tag} any more.',
+			'notesPage.backlinks.title' => 'Backlinks',
+			'notesPage.backlinks.loading' => 'Looking for links…',
+			'notesPage.backlinks.empty' => 'No notes link here yet.',
+			'notesPage.backlinks.failed' => ({required Object error}) => 'Could not load backlinks: ${error}',
+			'notesPage.outline.action' => 'Outline',
+			'notesPage.outline.title' => 'Outline',
+			'notesPage.outline.empty' => 'This document has no headings.',
+			'notesPage.outline.jumpedToSource' => 'Preview can\'t scroll without scripts, so this opened the source view.',
+			'notesPage.today.tooltip' => 'Open today\'s daily note',
+			'notesPage.wikiLink.suggestions' => 'Link to…',
+			'notesPage.wikiLink.createNew' => ({required Object name}) => 'Create "${name}"',
+			'notesPage.wikiLink.noMatches' => 'No note matches — keep typing to create one.',
 			'vaultSync.title' => 'Vault sync',
 			'vaultSync.refresh' => 'Refresh',
 			'vaultSync.statusTitle' => 'Status',
+			_ => null,
+		} ?? switch (path) {
 			'vaultSync.notARepo' => 'The vault is not a git repository yet. Initialise it from the web UI.',
 			'vaultSync.ahead' => ({required Object n}) => '${n} ahead',
 			'vaultSync.behind' => ({required Object n}) => '${n} behind',
@@ -23210,8 +23404,6 @@ extension on Translations {
 			'vaultSync.lastCommit' => 'Last commit',
 			'vaultSync.lastPush' => 'Last push',
 			'vaultSync.lastPull' => 'Last pull',
-			_ => null,
-		} ?? switch (path) {
 			'vaultSync.never' => 'Never',
 			'vaultSync.every.sec30' => 'Every 30 seconds',
 			'vaultSync.every.min1' => 'Every minute',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -870,6 +870,7 @@ class _TranslationsNotesPageEs extends TranslationsNotesPageEn {
 	@override String get newButton => 'Nueva';
 	@override String get newNoteDialogTitle => 'Nueva nota';
 	@override String get searchHint => 'Busca en todo el vault…';
+	@override late final _TranslationsNotesPageBrowseEs browse = _TranslationsNotesPageBrowseEs._(_root);
 	@override String get up => 'Arriba';
 	@override String get copyPath => 'Copiar ruta';
 	@override String get open => 'Abrir';
@@ -890,11 +891,16 @@ class _TranslationsNotesPageEs extends TranslationsNotesPageEn {
 	@override String emptyFolder({required Object path}) => 'La carpeta "${path}" está vacía.';
 	@override String get validatePath => 'La ruta es obligatoria';
 	@override String get validatePathDots => 'La ruta no puede contener ".."';
-	@override String get pathHelper => 'Añade .md automáticamente si falta.';
+	@override String get pathHelper => 'Añade .md salvo que el nombre ya termine en .md o .html.';
 	@override late final _TranslationsNotesPageEditorEs editor = _TranslationsNotesPageEditorEs._(_root);
 	@override late final _TranslationsNotesPageHtmlEs html = _TranslationsNotesPageHtmlEs._(_root);
 	@override late final _TranslationsNotesPageFlattenEs flatten = _TranslationsNotesPageFlattenEs._(_root);
 	@override late final _TranslationsNotesPageRenameEs rename = _TranslationsNotesPageRenameEs._(_root);
+	@override late final _TranslationsNotesPageTagsEs tags = _TranslationsNotesPageTagsEs._(_root);
+	@override late final _TranslationsNotesPageBacklinksEs backlinks = _TranslationsNotesPageBacklinksEs._(_root);
+	@override late final _TranslationsNotesPageOutlineEs outline = _TranslationsNotesPageOutlineEs._(_root);
+	@override late final _TranslationsNotesPageTodayEs today = _TranslationsNotesPageTodayEs._(_root);
+	@override late final _TranslationsNotesPageWikiLinkEs wikiLink = _TranslationsNotesPageWikiLinkEs._(_root);
 }
 
 // Path: vaultSync
@@ -2783,6 +2789,17 @@ class _TranslationsChannelsKindsEs extends TranslationsChannelsKindsEn {
 	@override late final _TranslationsChannelsKindsWecomEs wecom = _TranslationsChannelsKindsWecomEs._(_root);
 }
 
+// Path: notesPage.browse
+class _TranslationsNotesPageBrowseEs extends TranslationsNotesPageBrowseEn {
+	_TranslationsNotesPageBrowseEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get tree => 'Carpetas';
+	@override String get tags => 'Etiquetas';
+}
+
 // Path: notesPage.editor
 class _TranslationsNotesPageEditorEs extends TranslationsNotesPageEditorEn {
 	_TranslationsNotesPageEditorEs._(TranslationsEs root) : this._root = root, super.internal(root);
@@ -2848,6 +2865,68 @@ class _TranslationsNotesPageRenameEs extends TranslationsNotesPageRenameEn {
 	@override String get helper => 'Ruta relativa a la bóveda. Las carpetas se crean solas.';
 	@override String doneSnack({required Object count}) => 'Renombrado. ${count} enlace(s) actualizados.';
 	@override String get doneWithWarning => 'Renombrado, pero no se actualizaron todos los enlaces';
+}
+
+// Path: notesPage.tags
+class _TranslationsNotesPageTagsEs extends TranslationsNotesPageTagsEn {
+	_TranslationsNotesPageTagsEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get empty => 'Aún no hay etiquetas en el almacén. Escribe #así en una nota.';
+	@override String noMatches({required Object query}) => 'Ninguna etiqueta coincide con «${query}».';
+	@override String get filteredBy => 'Filtrado por';
+	@override String get clear => 'Quitar el filtro de etiqueta';
+	@override String noNotes({required Object tag}) => 'Ya no hay notas con #${tag}.';
+}
+
+// Path: notesPage.backlinks
+class _TranslationsNotesPageBacklinksEs extends TranslationsNotesPageBacklinksEn {
+	_TranslationsNotesPageBacklinksEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Retroenlaces';
+	@override String get loading => 'Buscando enlaces…';
+	@override String get empty => 'Todavía no hay notas que enlacen aquí.';
+	@override String failed({required Object error}) => 'No se pudieron cargar los retroenlaces: ${error}';
+}
+
+// Path: notesPage.outline
+class _TranslationsNotesPageOutlineEs extends TranslationsNotesPageOutlineEn {
+	_TranslationsNotesPageOutlineEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get action => 'Esquema';
+	@override String get title => 'Esquema';
+	@override String get empty => 'Este documento no tiene encabezados.';
+	@override String get jumpedToSource => 'La vista previa no puede desplazarse sin scripts, así que se abrió el código.';
+}
+
+// Path: notesPage.today
+class _TranslationsNotesPageTodayEs extends TranslationsNotesPageTodayEn {
+	_TranslationsNotesPageTodayEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get tooltip => 'Abrir la nota diaria de hoy';
+}
+
+// Path: notesPage.wikiLink
+class _TranslationsNotesPageWikiLinkEs extends TranslationsNotesPageWikiLinkEn {
+	_TranslationsNotesPageWikiLinkEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get suggestions => 'Enlazar a…';
+	@override String createNew({required Object name}) => 'Crear «${name}»';
+	@override String get noMatches => 'Ninguna nota coincide: sigue escribiendo para crear una.';
 }
 
 // Path: vaultSync.every
@@ -8222,7 +8301,10 @@ class _TranslationsWebNotesVaultSyncAutoSyncEs extends TranslationsWebNotesVault
 	@override String get enabledTooltipNoRemote => 'Configura primero un remoto para habilitar la sincronización automática';
 	@override String get noRemoteHint => 'Sin remoto: se omitirán push/pull.';
 	@override String get commitEvery => 'Hacer commit cada';
-	@override String get commitEveryExamples => 'Ejemplos: <1>30s</1>, <3>10m</3>, <5>2h</5>. Mínimo 30s.';
+	@override late final _TranslationsWebNotesVaultSyncAutoSyncEveryEs every = _TranslationsWebNotesVaultSyncAutoSyncEveryEs._(_root);
+	@override String get intervalCustom => 'Personalizado…';
+	@override String get intervalInvalid => 'No es una duración válida. Usa un número con unidad, p. ej. 30s, 10m, 2h.';
+	@override String intervalTooShort({required Object min}) => 'El bucle de sincronización nunca se ejecuta más rápido que cada ${min}.';
 	@override String get pullEvery => 'Hacer pull cada';
 	@override String get pullEveryHint => 'Solo se usa cuando Pull está habilitado.';
 	@override String get pushAfterCommit => 'Hacer push tras el commit';
@@ -9904,6 +9986,24 @@ class _TranslationsWebNotesVaultSyncConflictKindsEs extends TranslationsWebNotes
 	@override String get operation => 'operación';
 }
 
+// Path: web.notes.vaultSync.autoSync.every
+class _TranslationsWebNotesVaultSyncAutoSyncEveryEs extends TranslationsWebNotesVaultSyncAutoSyncEveryEn {
+	_TranslationsWebNotesVaultSyncAutoSyncEveryEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get k30s => 'Cada 30 segundos';
+	@override String get k1m => 'Cada minuto';
+	@override String get k5m => 'Cada 5 minutos';
+	@override String get k10m => 'Cada 10 minutos';
+	@override String get k15m => 'Cada 15 minutos';
+	@override String get k30m => 'Cada 30 minutos';
+	@override String get k1h => 'Cada hora';
+	@override String get k6h => 'Cada 6 horas';
+	@override String get k24h => 'Cada 24 horas';
+}
+
 // Path: web.serverSettings.host.modes.ac
 class _TranslationsWebServerSettingsHostModesAcEs extends TranslationsWebServerSettingsHostModesAcEn {
 	_TranslationsWebServerSettingsHostModesAcEs._(TranslationsEs root) : this._root = root, super.internal(root);
@@ -10960,7 +11060,18 @@ extension on TranslationsEs {
 			'web.notes.vaultSync.autoSync.enabledTooltipNoRemote' => 'Configura primero un remoto para habilitar la sincronización automática',
 			'web.notes.vaultSync.autoSync.noRemoteHint' => 'Sin remoto: se omitirán push/pull.',
 			'web.notes.vaultSync.autoSync.commitEvery' => 'Hacer commit cada',
-			'web.notes.vaultSync.autoSync.commitEveryExamples' => 'Ejemplos: <1>30s</1>, <3>10m</3>, <5>2h</5>. Mínimo 30s.',
+			'web.notes.vaultSync.autoSync.every.k30s' => 'Cada 30 segundos',
+			'web.notes.vaultSync.autoSync.every.k1m' => 'Cada minuto',
+			'web.notes.vaultSync.autoSync.every.k5m' => 'Cada 5 minutos',
+			'web.notes.vaultSync.autoSync.every.k10m' => 'Cada 10 minutos',
+			'web.notes.vaultSync.autoSync.every.k15m' => 'Cada 15 minutos',
+			'web.notes.vaultSync.autoSync.every.k30m' => 'Cada 30 minutos',
+			'web.notes.vaultSync.autoSync.every.k1h' => 'Cada hora',
+			'web.notes.vaultSync.autoSync.every.k6h' => 'Cada 6 horas',
+			'web.notes.vaultSync.autoSync.every.k24h' => 'Cada 24 horas',
+			'web.notes.vaultSync.autoSync.intervalCustom' => 'Personalizado…',
+			'web.notes.vaultSync.autoSync.intervalInvalid' => 'No es una duración válida. Usa un número con unidad, p. ej. 30s, 10m, 2h.',
+			'web.notes.vaultSync.autoSync.intervalTooShort' => ({required Object min}) => 'El bucle de sincronización nunca se ejecuta más rápido que cada ${min}.',
 			'web.notes.vaultSync.autoSync.pullEvery' => 'Hacer pull cada',
 			'web.notes.vaultSync.autoSync.pullEveryHint' => 'Solo se usa cuando Pull está habilitado.',
 			'web.notes.vaultSync.autoSync.pushAfterCommit' => 'Hacer push tras el commit',
@@ -11020,6 +11131,8 @@ extension on TranslationsEs {
 			'web.activity.filters.outbound' => 'Saliente',
 			'web.activity.filters.allStatuses' => 'Todos los estados',
 			'web.activity.filters.status2' => '2xx correcto',
+			_ => null,
+		} ?? switch (path) {
 			'web.activity.filters.status3' => '3xx redirección',
 			'web.activity.filters.status4' => '4xx error de cliente',
 			'web.activity.filters.status5' => '5xx error de servidor',
@@ -11031,8 +11144,6 @@ extension on TranslationsEs {
 			'web.activity.table.directionTitle' => 'Dirección',
 			'web.activity.table.method' => 'Método',
 			'web.activity.table.path' => 'Ruta',
-			_ => null,
-		} ?? switch (path) {
 			'web.activity.table.status' => 'Estado',
 			'web.activity.table.duration' => 'Duración',
 			'web.activity.table.inboundAria' => 'entrante',
@@ -11534,6 +11645,8 @@ extension on TranslationsEs {
 			'web.plugins.gitHosts.dialog.kindGitea' => 'Gitea',
 			'web.plugins.gitHosts.dialog.kindGitLab' => 'GitLab',
 			'web.plugins.gitHosts.dialog.hostLabel' => 'Host',
+			_ => null,
+		} ?? switch (path) {
 			'web.plugins.gitHosts.dialog.hostPlaceholder' => 'github.com',
 			'web.plugins.gitHosts.dialog.displayNameLabel' => 'Nombre visible (opcional)',
 			'web.plugins.gitHosts.dialog.displayNamePlaceholder' => 'Personal',
@@ -11545,8 +11658,6 @@ extension on TranslationsEs {
 			'web.plugins.gitHosts.dialog.enabledLabel' => 'Habilitado',
 			'web.plugins.gitHosts.dialog.addedToast' => 'Host de git añadido',
 			'web.plugins.gitHosts.dialog.updatedToast' => 'Host de git actualizado',
-			_ => null,
-		} ?? switch (path) {
 			'web.plugins.gitHosts.dialog.addFailedToast' => 'Error al añadir',
 			'web.plugins.gitHosts.dialog.updateFailedToast' => 'Error al actualizar',
 			'web.plugins.gitHosts.dialog.ownerLabel' => 'Propietario (opcional)',
@@ -12048,6 +12159,8 @@ extension on TranslationsEs {
 			'web.serverSettings.toggle.on' => 'Activado',
 			'web.serverSettings.toggle.off' => 'Desactivado',
 			'web.serverSettings.toggle.defaultOn' => 'Por defecto (on)',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.toggle.defaultOff' => 'Por defecto (off)',
 			'web.serverSettings.memoryRuntimeBanner' => 'El comportamiento de IA en runtime — workers, reglas de captura, perfiles de inyección y modo de spawn — vive en los ajustes de Cortex y se aplica al instante. Esta sección es la mitad de infraestructura: embedder, almacenamiento y gobernanza de fondo (requiere reinicio).',
 			'web.serverSettings.memoryRuntimeBannerButton' => 'Abrir ajustes de Cortex',
@@ -12059,8 +12172,6 @@ extension on TranslationsEs {
 			'web.serverSettings.host.modes.always.desc' => 'Nunca se duerme por inactividad, tampoco con batería.',
 			'web.serverSettings.host.modes.always.caveat' => 'Agotará la batería de un portátil desenchufado.',
 			'web.serverSettings.host.modes.on_demand.label' => 'Duerme inactivo, despierta con tráfico',
-			_ => null,
-		} ?? switch (path) {
 			'web.serverSettings.host.modes.on_demand.desc' => 'La máquina duerme siempre que la pasarela está en calma. Una petición entrante la despierta y opendray la mantiene despierta mientras sirve; después vuelve a dormir.',
 			'web.serverSettings.host.modes.on_demand.caveat' => 'Requiere «Activar por acceso de red» (sudo pmset -a womp 1); Ethernet por cable es lo fiable. La primera petición tras dormir tarda unos segundos y puede necesitar un reintento.',
 			'web.serverSettings.host.modes.off.label' => 'No tocar la energía',
@@ -12562,6 +12673,8 @@ extension on TranslationsEs {
 			'web.cortex.blueprint.title' => 'Plano del documento',
 			'web.cortex.blueprint.description' => 'El conjunto de secciones del documento oficial. Cada tipo de proyecto merece secciones distintas — dale forma tú o deja que la IA proponga.',
 			'web.cortex.blueprint.propose' => 'Proponer (IA)',
+			_ => null,
+		} ?? switch (path) {
 			'web.cortex.blueprint.proposeHint' => 'Clasifica el proyecto y propone un conjunto de secciones a medida',
 			'web.cortex.blueprint.proposeFailed' => 'Propuesta fallida',
 			'web.cortex.blueprint.proposalNote' => ({required Object type, required Object reason}) => 'La IA lo clasificó como: ${type} — ${reason} Revísalo, edítalo y aplica.',
@@ -12573,8 +12686,6 @@ extension on TranslationsEs {
 			'web.cortex.blueprint.mode.human' => 'Humano',
 			'web.cortex.blueprint.mode.scanner' => 'Escáner',
 			'web.cortex.blueprint.inject' => 'inyectar',
-			_ => null,
-		} ?? switch (path) {
 			'web.cortex.blueprint.reserved' => 'reservada',
 			'web.cortex.blueprint.deleteNote' => 'Quitar una sección la oculta sin borrar su contenido — vuelve a añadir el mismo slug para recuperarla.',
 			'web.cortex.blueprint.cancel' => 'Cancelar',
@@ -13076,6 +13187,8 @@ extension on TranslationsEs {
 			'sessions.inspector.canvas.modeRegion' => 'Encuadrar',
 			'sessions.inspector.canvas.focusLine' => ({required Object title, required Object kind}) => 'Trabajando en ${title} · ${kind}: el agente lo trata como «este lienzo».',
 			'sessions.inspector.canvas.notePlaceholder' => 'Qué cambiar aquí…',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.messagePlaceholder' => 'Nota general (opcional)…',
 			'sessions.inspector.canvas.send' => 'Enviar',
 			'sessions.inspector.canvas.sent' => 'Comentarios enviados a la sesión.',
@@ -13087,8 +13200,6 @@ extension on TranslationsEs {
 			'sessions.inspector.canvas.deleteTitle' => '¿Eliminar lienzo?',
 			'sessions.inspector.canvas.deleteBody' => ({required Object title}) => '¿Eliminar «${title}»? Esto no se puede deshacer.',
 			'sessions.inspector.canvas.emptyTitle' => 'Aún no hay lienzos',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.canvas.emptyBlurb' => 'Pide al agente una pantalla, un diagrama de flujo, un mapa mental o un diagrama de relaciones: se renderiza aquí y podrás anotarlo.',
 			'sessions.inspector.canvas.viewportPhone' => 'Ancho de móvil',
 			'sessions.inspector.canvas.viewportTablet' => 'Ancho de tablet',
@@ -13590,6 +13701,8 @@ extension on TranslationsEs {
 			'backups.recoveryKit.menuLabel' => 'Kit de recuperación',
 			'backups.recoveryKit.title' => 'Kit de recuperación',
 			'backups.recoveryKit.warning' => 'Seguro de recuperación ante desastres: solo lo necesitas si este host Y sus claves se pierden juntos; normalmente nunca lo usas. El kit es tu frase de copia de seguridad sellada con la contraseña que eliges aquí. Cada vez que lo generas es un kit independiente sellado con ESA contraseña: no se almacena nada, así que no hay una única contraseña maestra. Guarda el kit y su contraseña juntos, fuera de banda. Nota: esta contraseña protege el kit, no la puerta de enlace: cualquiera con acceso de administrador puede generar uno nuevo.',
+			_ => null,
+		} ?? switch (path) {
 			'backups.recoveryKit.passphraseLabel' => 'Frase de recuperación (mín. 8)',
 			'backups.recoveryKit.confirmLabel' => 'Confirmar frase de recuperación',
 			'backups.recoveryKit.generate' => 'Generar',
@@ -13601,8 +13714,6 @@ extension on TranslationsEs {
 			'backups.emptyNoTargets.headline' => 'No hay destinos de copia de seguridad configurados',
 			'backups.emptyNoTargets.body' => 'Abre el menú Más → Destinos para añadir un destino (local / S3 / SMB / SFTP / WebDAV / rclone). Luego vuelve y toca "Ejecutar ahora".',
 			'backups.emptyNoBackups.headline' => 'Aún no hay copias de seguridad',
-			_ => null,
-		} ?? switch (path) {
 			'backups.emptyNoBackups.body' => 'Toca "Ejecutar ahora" para tomar una nueva instantánea, o abre Programaciones para configurar ejecuciones periódicas.',
 			'backups.restartToActivate' => 'Reinicia opendray para activar las copias de seguridad',
 			'backups.passphraseSaved' => 'Tu passphrase está guardada. El gateway solo la carga al iniciarse, así que los cambios solo surten efecto tras un reinicio.',
@@ -14030,6 +14141,8 @@ extension on TranslationsEs {
 			'notesPage.newButton' => 'Nueva',
 			'notesPage.newNoteDialogTitle' => 'Nueva nota',
 			'notesPage.searchHint' => 'Busca en todo el vault…',
+			'notesPage.browse.tree' => 'Carpetas',
+			'notesPage.browse.tags' => 'Etiquetas',
 			'notesPage.up' => 'Arriba',
 			'notesPage.copyPath' => 'Copiar ruta',
 			'notesPage.open' => 'Abrir',
@@ -14050,7 +14163,7 @@ extension on TranslationsEs {
 			'notesPage.emptyFolder' => ({required Object path}) => 'La carpeta "${path}" está vacía.',
 			'notesPage.validatePath' => 'La ruta es obligatoria',
 			'notesPage.validatePathDots' => 'La ruta no puede contener ".."',
-			'notesPage.pathHelper' => 'Añade .md automáticamente si falta.',
+			'notesPage.pathHelper' => 'Añade .md salvo que el nombre ya termine en .md o .html.',
 			'notesPage.editor.markdownHint' => 'Markdown, o HTML si el archivo termina en .html…',
 			'notesPage.editor.saving' => 'Guardando…',
 			'notesPage.editor.autosave' => 'Guardado',
@@ -14082,9 +14195,28 @@ extension on TranslationsEs {
 			'notesPage.rename.helper' => 'Ruta relativa a la bóveda. Las carpetas se crean solas.',
 			'notesPage.rename.doneSnack' => ({required Object count}) => 'Renombrado. ${count} enlace(s) actualizados.',
 			'notesPage.rename.doneWithWarning' => 'Renombrado, pero no se actualizaron todos los enlaces',
+			'notesPage.tags.empty' => 'Aún no hay etiquetas en el almacén. Escribe #así en una nota.',
+			'notesPage.tags.noMatches' => ({required Object query}) => 'Ninguna etiqueta coincide con «${query}».',
+			'notesPage.tags.filteredBy' => 'Filtrado por',
+			'notesPage.tags.clear' => 'Quitar el filtro de etiqueta',
+			'notesPage.tags.noNotes' => ({required Object tag}) => 'Ya no hay notas con #${tag}.',
+			'notesPage.backlinks.title' => 'Retroenlaces',
+			'notesPage.backlinks.loading' => 'Buscando enlaces…',
+			'notesPage.backlinks.empty' => 'Todavía no hay notas que enlacen aquí.',
+			'notesPage.backlinks.failed' => ({required Object error}) => 'No se pudieron cargar los retroenlaces: ${error}',
+			'notesPage.outline.action' => 'Esquema',
+			'notesPage.outline.title' => 'Esquema',
+			'notesPage.outline.empty' => 'Este documento no tiene encabezados.',
+			'notesPage.outline.jumpedToSource' => 'La vista previa no puede desplazarse sin scripts, así que se abrió el código.',
+			'notesPage.today.tooltip' => 'Abrir la nota diaria de hoy',
+			'notesPage.wikiLink.suggestions' => 'Enlazar a…',
+			'notesPage.wikiLink.createNew' => ({required Object name}) => 'Crear «${name}»',
+			'notesPage.wikiLink.noMatches' => 'Ninguna nota coincide: sigue escribiendo para crear una.',
 			'vaultSync.title' => 'Sincronización del vault',
 			'vaultSync.refresh' => 'Actualizar',
 			'vaultSync.statusTitle' => 'Estado',
+			_ => null,
+		} ?? switch (path) {
 			'vaultSync.notARepo' => 'El vault aún no es un repositorio git. Inicialízalo desde la interfaz web.',
 			'vaultSync.ahead' => ({required Object n}) => '${n} por delante',
 			'vaultSync.behind' => ({required Object n}) => '${n} por detrás',
@@ -14115,8 +14247,6 @@ extension on TranslationsEs {
 			'vaultSync.lastCommit' => 'Última confirmación',
 			'vaultSync.lastPush' => 'Último envío',
 			'vaultSync.lastPull' => 'Última traída',
-			_ => null,
-		} ?? switch (path) {
 			'vaultSync.never' => 'Nunca',
 			'vaultSync.every.sec30' => 'Cada 30 segundos',
 			'vaultSync.every.min1' => 'Cada minuto',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -870,6 +870,7 @@ class _TranslationsNotesPageZh extends TranslationsNotesPageEn {
 	@override String get newButton => '新建';
 	@override String get newNoteDialogTitle => '新建笔记';
 	@override String get searchHint => '搜索整个仓库…';
+	@override late final _TranslationsNotesPageBrowseZh browse = _TranslationsNotesPageBrowseZh._(_root);
 	@override String get up => '上级';
 	@override String get copyPath => '复制路径';
 	@override String get open => '打开';
@@ -890,11 +891,16 @@ class _TranslationsNotesPageZh extends TranslationsNotesPageEn {
 	@override String emptyFolder({required Object path}) => '文件夹「${path}」为空。';
 	@override String get validatePath => '必须填写路径';
 	@override String get validatePathDots => '路径不能包含「..」';
-	@override String get pathHelper => '缺失时自动追加 .md。';
+	@override String get pathHelper => '除非名字已经以 .md 或 .html 结尾，否则会自动补 .md。';
 	@override late final _TranslationsNotesPageEditorZh editor = _TranslationsNotesPageEditorZh._(_root);
 	@override late final _TranslationsNotesPageHtmlZh html = _TranslationsNotesPageHtmlZh._(_root);
 	@override late final _TranslationsNotesPageFlattenZh flatten = _TranslationsNotesPageFlattenZh._(_root);
 	@override late final _TranslationsNotesPageRenameZh rename = _TranslationsNotesPageRenameZh._(_root);
+	@override late final _TranslationsNotesPageTagsZh tags = _TranslationsNotesPageTagsZh._(_root);
+	@override late final _TranslationsNotesPageBacklinksZh backlinks = _TranslationsNotesPageBacklinksZh._(_root);
+	@override late final _TranslationsNotesPageOutlineZh outline = _TranslationsNotesPageOutlineZh._(_root);
+	@override late final _TranslationsNotesPageTodayZh today = _TranslationsNotesPageTodayZh._(_root);
+	@override late final _TranslationsNotesPageWikiLinkZh wikiLink = _TranslationsNotesPageWikiLinkZh._(_root);
 }
 
 // Path: vaultSync
@@ -2783,6 +2789,17 @@ class _TranslationsChannelsKindsZh extends TranslationsChannelsKindsEn {
 	@override late final _TranslationsChannelsKindsWecomZh wecom = _TranslationsChannelsKindsWecomZh._(_root);
 }
 
+// Path: notesPage.browse
+class _TranslationsNotesPageBrowseZh extends TranslationsNotesPageBrowseEn {
+	_TranslationsNotesPageBrowseZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get tree => '目录';
+	@override String get tags => '标签';
+}
+
 // Path: notesPage.editor
 class _TranslationsNotesPageEditorZh extends TranslationsNotesPageEditorEn {
 	_TranslationsNotesPageEditorZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -2848,6 +2865,68 @@ class _TranslationsNotesPageRenameZh extends TranslationsNotesPageRenameEn {
 	@override String get helper => '文档库相对路径。目录会自动创建。';
 	@override String doneSnack({required Object count}) => '已重命名，${count} 个链接已改写。';
 	@override String get doneWithWarning => '已重命名，但链接没有全部更新';
+}
+
+// Path: notesPage.tags
+class _TranslationsNotesPageTagsZh extends TranslationsNotesPageTagsEn {
+	_TranslationsNotesPageTagsZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get empty => '文档库里还没有标签。在笔记里写 #像这样 就会出现。';
+	@override String noMatches({required Object query}) => '没有标签匹配“${query}”。';
+	@override String get filteredBy => '已按标签筛选';
+	@override String get clear => '清除标签筛选';
+	@override String noNotes({required Object tag}) => '已经没有笔记带 #${tag} 了。';
+}
+
+// Path: notesPage.backlinks
+class _TranslationsNotesPageBacklinksZh extends TranslationsNotesPageBacklinksEn {
+	_TranslationsNotesPageBacklinksZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '反向链接';
+	@override String get loading => '正在查找链接…';
+	@override String get empty => '还没有笔记链接到这里。';
+	@override String failed({required Object error}) => '反向链接加载失败：${error}';
+}
+
+// Path: notesPage.outline
+class _TranslationsNotesPageOutlineZh extends TranslationsNotesPageOutlineEn {
+	_TranslationsNotesPageOutlineZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get action => '大纲';
+	@override String get title => '大纲';
+	@override String get empty => '这篇文档没有标题。';
+	@override String get jumpedToSource => '预览关闭了脚本、无法滚动，所以已切到源码视图。';
+}
+
+// Path: notesPage.today
+class _TranslationsNotesPageTodayZh extends TranslationsNotesPageTodayEn {
+	_TranslationsNotesPageTodayZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get tooltip => '打开今天的日记';
+}
+
+// Path: notesPage.wikiLink
+class _TranslationsNotesPageWikiLinkZh extends TranslationsNotesPageWikiLinkEn {
+	_TranslationsNotesPageWikiLinkZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get suggestions => '链接到…';
+	@override String createNew({required Object name}) => '新建“${name}”';
+	@override String get noMatches => '没有匹配的笔记 —— 继续输入即可新建。';
 }
 
 // Path: vaultSync.every
@@ -8219,7 +8298,10 @@ class _TranslationsWebNotesVaultSyncAutoSyncZh extends TranslationsWebNotesVault
 	@override String get enabledTooltipNoRemote => '请先配置 remote 才能启用自动同步';
 	@override String get noRemoteHint => '尚无 remote — push/pull 将被跳过。';
 	@override String get commitEvery => '提交间隔';
-	@override String get commitEveryExamples => '示例：<1>30s</1>、<3>10m</3>、<5>2h</5>。最小 30s。';
+	@override late final _TranslationsWebNotesVaultSyncAutoSyncEveryZh every = _TranslationsWebNotesVaultSyncAutoSyncEveryZh._(_root);
+	@override String get intervalCustom => '自定义…';
+	@override String get intervalInvalid => '不是有效的时长。请填写数字加单位，例如 30s、10m、2h。';
+	@override String intervalTooShort({required Object min}) => '同步循环最快也只会 ${min} 触发一次。';
 	@override String get pullEvery => '拉取间隔';
 	@override String get pullEveryHint => '仅在启用 Pull 时使用。';
 	@override String get pushAfterCommit => '提交后 push';
@@ -9901,6 +9983,24 @@ class _TranslationsWebNotesVaultSyncConflictKindsZh extends TranslationsWebNotes
 	@override String get operation => 'operation';
 }
 
+// Path: web.notes.vaultSync.autoSync.every
+class _TranslationsWebNotesVaultSyncAutoSyncEveryZh extends TranslationsWebNotesVaultSyncAutoSyncEveryEn {
+	_TranslationsWebNotesVaultSyncAutoSyncEveryZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get k30s => '每 30 秒';
+	@override String get k1m => '每分钟';
+	@override String get k5m => '每 5 分钟';
+	@override String get k10m => '每 10 分钟';
+	@override String get k15m => '每 15 分钟';
+	@override String get k30m => '每 30 分钟';
+	@override String get k1h => '每小时';
+	@override String get k6h => '每 6 小时';
+	@override String get k24h => '每 24 小时';
+}
+
 // Path: web.serverSettings.host.modes.ac
 class _TranslationsWebServerSettingsHostModesAcZh extends TranslationsWebServerSettingsHostModesAcEn {
 	_TranslationsWebServerSettingsHostModesAcZh._(TranslationsZh root) : this._root = root, super.internal(root);
@@ -10954,7 +11054,18 @@ extension on TranslationsZh {
 			'web.notes.vaultSync.autoSync.enabledTooltipNoRemote' => '请先配置 remote 才能启用自动同步',
 			'web.notes.vaultSync.autoSync.noRemoteHint' => '尚无 remote — push/pull 将被跳过。',
 			'web.notes.vaultSync.autoSync.commitEvery' => '提交间隔',
-			'web.notes.vaultSync.autoSync.commitEveryExamples' => '示例：<1>30s</1>、<3>10m</3>、<5>2h</5>。最小 30s。',
+			'web.notes.vaultSync.autoSync.every.k30s' => '每 30 秒',
+			'web.notes.vaultSync.autoSync.every.k1m' => '每分钟',
+			'web.notes.vaultSync.autoSync.every.k5m' => '每 5 分钟',
+			'web.notes.vaultSync.autoSync.every.k10m' => '每 10 分钟',
+			'web.notes.vaultSync.autoSync.every.k15m' => '每 15 分钟',
+			'web.notes.vaultSync.autoSync.every.k30m' => '每 30 分钟',
+			'web.notes.vaultSync.autoSync.every.k1h' => '每小时',
+			'web.notes.vaultSync.autoSync.every.k6h' => '每 6 小时',
+			'web.notes.vaultSync.autoSync.every.k24h' => '每 24 小时',
+			'web.notes.vaultSync.autoSync.intervalCustom' => '自定义…',
+			'web.notes.vaultSync.autoSync.intervalInvalid' => '不是有效的时长。请填写数字加单位，例如 30s、10m、2h。',
+			'web.notes.vaultSync.autoSync.intervalTooShort' => ({required Object min}) => '同步循环最快也只会 ${min} 触发一次。',
 			'web.notes.vaultSync.autoSync.pullEvery' => '拉取间隔',
 			'web.notes.vaultSync.autoSync.pullEveryHint' => '仅在启用 Pull 时使用。',
 			'web.notes.vaultSync.autoSync.pushAfterCommit' => '提交后 push',
@@ -11017,6 +11128,8 @@ extension on TranslationsZh {
 			'web.activity.filters.status3' => '3xx 重定向',
 			'web.activity.filters.status4' => '4xx 客户端错误',
 			'web.activity.filters.status5' => '5xx 服务端错误',
+			_ => null,
+		} ?? switch (path) {
 			'web.activity.callsCount_one' => ({required Object count}) => '${count} 次调用',
 			'web.activity.callsCount_other' => ({required Object count}) => '${count} 次调用',
 			'web.activity.loading' => '加载中…',
@@ -11028,8 +11141,6 @@ extension on TranslationsZh {
 			'web.activity.table.status' => '状态',
 			'web.activity.table.duration' => '耗时',
 			'web.activity.table.inboundAria' => '入站',
-			_ => null,
-		} ?? switch (path) {
 			'web.activity.table.outboundAria' => '出站',
 			'web.activity.empty.filtered' => '没有调用符合当前筛选条件。',
 			'web.activity.empty.title' => '尚未记录任何 API 调用',
@@ -11531,6 +11642,8 @@ extension on TranslationsZh {
 			'web.plugins.gitHosts.dialog.hostPlaceholder' => 'github.com',
 			'web.plugins.gitHosts.dialog.displayNameLabel' => '显示名称（可选）',
 			'web.plugins.gitHosts.dialog.displayNamePlaceholder' => 'Personal',
+			_ => null,
+		} ?? switch (path) {
 			'web.plugins.gitHosts.dialog.tokenLabel' => 'Token',
 			'web.plugins.gitHosts.dialog.newTokenLabel' => '新 token（留空表示保留）',
 			'web.plugins.gitHosts.dialog.tokenPlaceholder' => 'ghp_… / gho_… / glpat-…',
@@ -11542,8 +11655,6 @@ extension on TranslationsZh {
 			'web.plugins.gitHosts.dialog.addFailedToast' => '添加失败',
 			'web.plugins.gitHosts.dialog.updateFailedToast' => '更新失败',
 			'web.plugins.gitHosts.dialog.ownerLabel' => '所有者(可选)',
-			_ => null,
-		} ?? switch (path) {
 			'web.plugins.gitHosts.dialog.ownerPlaceholder' => 'my-org',
 			'web.plugins.gitHosts.dialog.ownerHintHostWide' => '留空表示全主机凭据:该主机上没有专属条目的仓库都会用它。',
 			'web.plugins.gitHosts.dialog.ownerHintScoped' => ({required Object host, required Object owner}) => '仅用于 ${host}/${owner}/… —— 该主机上的其他所有者会回退到全主机条目。当一个细粒度令牌只授权给某个账号或组织时,填这里。',
@@ -12045,6 +12156,8 @@ extension on TranslationsZh {
 			'web.serverSettings.toggle.defaultOff' => '默认（关）',
 			'web.serverSettings.memoryRuntimeBanner' => '运行时 AI 行为——工作器、捕获规则、注入策略与 spawn 模式——位于 Cortex 设置，保存即生效。本区块是基础设施的一半：嵌入后端、存储与后台治理（需重启生效）。',
 			'web.serverSettings.memoryRuntimeBannerButton' => '打开 Cortex 设置',
+			_ => null,
+		} ?? switch (path) {
 			'web.serverSettings.host.intro' => '睡眠中的 Mac 会一并关掉网络,网关随即停止应答 —— 手机连不上、网页连不上、连数据库也断开。表面看像"opendray 不稳定",实际只是机器睡着了。请选择 opendray 的应对方式。',
 			'web.serverSettings.host.platformNote' => '仅 macOS 生效。Linux 与 Windows 会接受但忽略此设置 —— 常规服务器安装下这些主机不会空闲休眠。主动睡眠(合盖、苹果菜单 → 睡眠)永不被阻止;opendray 退出或被强制结束时,电源断言会立即释放。',
 			'web.serverSettings.host.modes.ac.label' => '插电时保持唤醒',
@@ -12056,8 +12169,6 @@ extension on TranslationsZh {
 			'web.serverSettings.host.modes.on_demand.desc' => '网关空闲时机器正常入睡;收到请求时被唤醒,opendray 在服务期间保持唤醒,结束后让它继续休眠。',
 			'web.serverSettings.host.modes.on_demand.caveat' => '需要开启"网络访问唤醒"(sudo pmset -a womp 1),有线以太网最可靠。休眠后的第一个请求会有几秒延迟,偶尔需要重试一次。',
 			'web.serverSettings.host.modes.off.label' => '完全不干预电源',
-			_ => null,
-		} ?? switch (path) {
 			'web.serverSettings.host.modes.off.desc' => 'opendray 不对机器电源做任何操作。',
 			'web.serverSettings.host.modes.off.caveat' => '主机一旦休眠即无法连接,除非另有程序让它保持唤醒。',
 			'web.serverSettings.layout.title' => '实际解析到',
@@ -12559,6 +12670,8 @@ extension on TranslationsZh {
 			'web.cortex.blueprint.proposeHint' => '识别项目类型并提议契合的章节结构',
 			'web.cortex.blueprint.proposeFailed' => '提议失败',
 			'web.cortex.blueprint.proposalNote' => ({required Object type, required Object reason}) => 'AI 判断项目类型为：${type}——${reason} 请在下方审阅并自由修改后应用。',
+			_ => null,
+		} ?? switch (path) {
 			'web.cortex.blueprint.addSection' => '添加章节',
 			'web.cortex.blueprint.slugPlaceholder' => '标识',
 			'web.cortex.blueprint.titlePlaceholder' => '标题',
@@ -12570,8 +12683,6 @@ extension on TranslationsZh {
 			'web.cortex.blueprint.reserved' => '保留',
 			'web.cortex.blueprint.deleteNote' => '删除章节只是隐藏，内容不会丢——重新添加同名标识即可恢复。',
 			'web.cortex.blueprint.cancel' => '取消',
-			_ => null,
-		} ?? switch (path) {
 			'web.cortex.blueprint.apply' => '应用蓝图',
 			'web.cortex.blueprint.applyFailed' => '应用失败',
 			'web.cortex.blueprint.appliedToast' => '蓝图已应用',
@@ -13073,6 +13184,8 @@ extension on TranslationsZh {
 			'sessions.inspector.canvas.messagePlaceholder' => '整体说明(可选)……',
 			'sessions.inspector.canvas.send' => '发送',
 			'sessions.inspector.canvas.sent' => '反馈已发送到会话。',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.nothingToSend' => '请先添加钉点、框选或说明。',
 			'sessions.inspector.canvas.requestPlaceholder' => '让 agent 设计或画点什么……',
 			'sessions.inspector.canvas.requested' => '已发送 —— agent 会渲染到这里。',
@@ -13084,8 +13197,6 @@ extension on TranslationsZh {
 			'sessions.inspector.canvas.emptyBlurb' => '让 agent 设计一个界面、流程图、思维导图或关系图 —— 它会渲染到这里,你可以钉点标注。',
 			'sessions.inspector.canvas.viewportPhone' => '手机宽度',
 			'sessions.inspector.canvas.viewportTablet' => '平板宽度',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.canvas.viewportDesktop' => '电脑宽度',
 			'sessions.inspector.canvas.openFull' => '全屏打开',
 			'sessions.inspector.canvas.confirm' => '确认',
@@ -13587,6 +13698,8 @@ extension on TranslationsZh {
 			'backups.recoveryKit.passphraseLabel' => '恢复口令（至少 8 位）',
 			'backups.recoveryKit.confirmLabel' => '确认恢复口令',
 			'backups.recoveryKit.generate' => '生成',
+			_ => null,
+		} ?? switch (path) {
 			'backups.recoveryKit.copy' => '复制工具包',
 			'backups.recoveryKit.copied' => '恢复工具包已复制 —— 请妥善保存',
 			'backups.recoveryKit.failed' => ({required Object error}) => '无法生成恢复工具包：${error}',
@@ -13598,8 +13711,6 @@ extension on TranslationsZh {
 			'backups.emptyNoBackups.body' => '点击「立即运行」生成一次新快照，或打开「计划」设置定期运行。',
 			'backups.restartToActivate' => '重启 opendray 以激活备份',
 			'backups.passphraseSaved' => '你的密语已保存。网关仅在启动时加载，因此更改需重启后才生效。',
-			_ => null,
-		} ?? switch (path) {
 			'backups.keyFileLabel' => '密钥文件',
 			'backups.configuredViaLabel' => '配置方式',
 			'backups.wizard.title' => '设置备份',
@@ -14024,6 +14135,8 @@ extension on TranslationsZh {
 			'notesPage.newButton' => '新建',
 			'notesPage.newNoteDialogTitle' => '新建笔记',
 			'notesPage.searchHint' => '搜索整个仓库…',
+			'notesPage.browse.tree' => '目录',
+			'notesPage.browse.tags' => '标签',
 			'notesPage.up' => '上级',
 			'notesPage.copyPath' => '复制路径',
 			'notesPage.open' => '打开',
@@ -14044,7 +14157,7 @@ extension on TranslationsZh {
 			'notesPage.emptyFolder' => ({required Object path}) => '文件夹「${path}」为空。',
 			'notesPage.validatePath' => '必须填写路径',
 			'notesPage.validatePathDots' => '路径不能包含「..」',
-			'notesPage.pathHelper' => '缺失时自动追加 .md。',
+			'notesPage.pathHelper' => '除非名字已经以 .md 或 .html 结尾，否则会自动补 .md。',
 			'notesPage.editor.markdownHint' => 'Markdown;文件名以 .html 结尾则写 HTML…',
 			'notesPage.editor.saving' => '保存中…',
 			'notesPage.editor.autosave' => '已保存',
@@ -14076,12 +14189,31 @@ extension on TranslationsZh {
 			'notesPage.rename.helper' => '文档库相对路径。目录会自动创建。',
 			'notesPage.rename.doneSnack' => ({required Object count}) => '已重命名，${count} 个链接已改写。',
 			'notesPage.rename.doneWithWarning' => '已重命名，但链接没有全部更新',
+			'notesPage.tags.empty' => '文档库里还没有标签。在笔记里写 #像这样 就会出现。',
+			'notesPage.tags.noMatches' => ({required Object query}) => '没有标签匹配“${query}”。',
+			'notesPage.tags.filteredBy' => '已按标签筛选',
+			'notesPage.tags.clear' => '清除标签筛选',
+			'notesPage.tags.noNotes' => ({required Object tag}) => '已经没有笔记带 #${tag} 了。',
+			'notesPage.backlinks.title' => '反向链接',
+			'notesPage.backlinks.loading' => '正在查找链接…',
+			'notesPage.backlinks.empty' => '还没有笔记链接到这里。',
+			'notesPage.backlinks.failed' => ({required Object error}) => '反向链接加载失败：${error}',
+			'notesPage.outline.action' => '大纲',
+			'notesPage.outline.title' => '大纲',
+			'notesPage.outline.empty' => '这篇文档没有标题。',
+			'notesPage.outline.jumpedToSource' => '预览关闭了脚本、无法滚动，所以已切到源码视图。',
+			'notesPage.today.tooltip' => '打开今天的日记',
+			'notesPage.wikiLink.suggestions' => '链接到…',
+			'notesPage.wikiLink.createNew' => ({required Object name}) => '新建“${name}”',
+			'notesPage.wikiLink.noMatches' => '没有匹配的笔记 —— 继续输入即可新建。',
 			'vaultSync.title' => 'Vault 同步',
 			'vaultSync.refresh' => '刷新',
 			'vaultSync.statusTitle' => '状态',
 			'vaultSync.notARepo' => 'vault 还不是 git 仓库。请先在网页端初始化。',
 			'vaultSync.ahead' => ({required Object n}) => '领先 ${n}',
 			'vaultSync.behind' => ({required Object n}) => '落后 ${n}',
+			_ => null,
+		} ?? switch (path) {
 			'vaultSync.clean' => '没有本地改动',
 			'vaultSync.changedFiles' => ({required Object n}) => '${n} 处改动',
 			'vaultSync.noRemote' => '未配置 remote',
@@ -14112,8 +14244,6 @@ extension on TranslationsZh {
 			'vaultSync.never' => '从未',
 			'vaultSync.every.sec30' => '每 30 秒',
 			'vaultSync.every.min1' => '每分钟',
-			_ => null,
-		} ?? switch (path) {
 			'vaultSync.every.min5' => '每 5 分钟',
 			'vaultSync.every.min10' => '每 10 分钟',
 			'vaultSync.every.min15' => '每 15 分钟',

--- a/app/mobile/lib/features/notes/doc_preview.dart
+++ b/app/mobile/lib/features/notes/doc_preview.dart
@@ -30,28 +30,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:markdown/markdown.dart' as md;
 import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/notes/vault_text.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-/// What kind of document a vault path holds. Mirrors notes.KindOf in
-/// internal/notes/doc.go and docKind() in app/shared/src/lib/notes.ts.
-enum DocKind { markdown, html, unknown }
-
-DocKind docKindOf(String path) {
-  final base = path.split('/').last;
-  final dot = base.lastIndexOf('.');
-  // A leading dot is a dotfile, not an extension.
-  if (dot <= 0) return DocKind.unknown;
-  switch (base.substring(dot + 1).toLowerCase()) {
-    case 'md':
-    case 'markdown':
-      return DocKind.markdown;
-    case 'html':
-    case 'htm':
-      return DocKind.html;
-    default:
-      return DocKind.unknown;
-  }
-}
+// DocKind / docKindOf moved to vault_text.dart when the vault's pure
+// text layer was split out. Re-exported so the callers that reach for
+// them through this file keep working.
+export 'package:opendray/features/notes/vault_text.dart'
+    show DocKind, docKindOf;
 
 const _scriptsKeyPrefix = 'vault.html.scripts:';
 
@@ -59,11 +45,25 @@ class DocPreview extends StatefulWidget {
   const DocPreview({
     required this.path,
     required this.body,
+    this.onOpenWikiLink,
+    this.resolveWikiTarget,
     super.key,
   });
 
   final String path;
   final String body;
+
+  /// Called with the resolved vault path when a `[[wiki-link]]` in the
+  /// rendered document is tapped. Null leaves wiki-links as literal
+  /// text — the previous behaviour, and the right one where there is
+  /// nowhere for the tap to go.
+  final ValueChanged<String>? onOpenWikiLink;
+
+  /// Turns a link's raw target into a vault path. Supplied by the
+  /// caller because resolution needs the note list, which this widget
+  /// deliberately does not fetch. Defaults to treating the target as a
+  /// path when absent.
+  final String Function(String target)? resolveWikiTarget;
 
   @override
   State<DocPreview> createState() => _DocPreviewState();
@@ -146,7 +146,25 @@ class _DocPreviewState extends State<DocPreview> {
   // `about:srcdoc` here would CREATE that bug.
   String _document() {
     if (_kind == DocKind.html) return retargetLinks(widget.body);
-    return _markdownDocument(widget.body);
+    return _markdownDocument(
+      widget.body,
+      wikiLinks: widget.onOpenWikiLink != null,
+    );
+  }
+
+  /// Intercept the wiki scheme and hand the target to the caller. Every
+  /// other navigation is left to the rules already in place: fragments
+  /// scroll in place, external links were retargeted to a new window.
+  Future<NavigationActionPolicy> _onNavigate(
+    InAppWebViewController _,
+    NavigationAction action,
+  ) async {
+    final uri = action.request.url;
+    final target = uri == null ? null : wikiLinkTarget(uri);
+    if (target == null) return NavigationActionPolicy.ALLOW;
+    final resolve = widget.resolveWikiTarget;
+    widget.onOpenWikiLink?.call(resolve == null ? target : resolve(target));
+    return NavigationActionPolicy.CANCEL;
   }
 
   @override
@@ -207,11 +225,17 @@ class _DocPreviewState extends State<DocPreview> {
               // No document should be able to start a navigation that
               // leaves the viewer stranded — there is no address bar.
               javaScriptCanOpenWindowsAutomatically: false,
+              // Android only consults shouldOverrideUrlLoading when this
+              // is on, and that callback is the whole wiki-link
+              // mechanism — without JavaScript there is nothing else to
+              // catch the tap with.
+              useShouldOverrideUrlLoading: true,
               transparentBackground: true,
               supportZoom: true,
               useWideViewPort: true,
               loadWithOverviewMode: true,
             ),
+            shouldOverrideUrlLoading: _onNavigate,
             onWebViewCreated: (ctl) {
               _web = ctl;
               unawaited(
@@ -255,6 +279,10 @@ String retargetLinks(String html) {
     final href = (h?.group(1) ?? h?.group(2) ?? h?.group(3) ?? '').trim();
     // No href is not a link. A leading '#' points inside this document.
     if (href.isEmpty || href.startsWith('#')) return m.group(0)!;
+    // A wiki-link never navigates — it is cancelled and handled in
+    // Dart. Asking for a new window would only make the webview field a
+    // popup request it is configured to refuse.
+    if (href.startsWith('$kWikiLinkScheme:')) return m.group(0)!;
     // Drop a self-closing slash so the injected attributes don't land
     // after it and break the tag.
     final clean = attrs.replaceFirst(_selfClosing, '');
@@ -266,14 +294,17 @@ String retargetLinks(String html) {
 /// text size and renders legibly without any external resources — the
 /// webview has no network access to a stylesheet and should not want
 /// one.
-String _markdownDocument(String source) {
+String _markdownDocument(String source, {bool wikiLinks = false}) {
   final body = retargetLinks(
     md.markdownToHtml(
-      source,
+      // The vault's [[wiki links]] are not markdown, so they are turned
+      // into anchors on our own scheme BEFORE conversion — the
+      // converter passes inline HTML through, and an anchor is the only
+      // clickable thing available with JavaScript off. Off by default:
+      // where the caller has nowhere to send the tap, literal text is
+      // the honest rendering.
+      wikiLinks ? linkifyWikiLinks(source) : source,
       extensionSet: md.ExtensionSet.gitHubWeb,
-      // The vault's [[wiki links]] are not markdown; leaving them as
-      // literal text is honest. Resolving them would need the note list,
-      // which this widget deliberately does not take.
     ),
     // Markdown needs the same treatment as HTML, and for the same
     // reason: gitHubWeb renders footnotes as fragment links, which a
@@ -307,4 +338,5 @@ $body
 }
 
 /// Exposed for the editor's "copy as HTML" affordances and for tests.
-String renderMarkdownDocument(String source) => _markdownDocument(source);
+String renderMarkdownDocument(String source, {bool wikiLinks = false}) =>
+    _markdownDocument(source, wikiLinks: wikiLinks);

--- a/app/mobile/lib/features/notes/note_actions.dart
+++ b/app/mobile/lib/features/notes/note_actions.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:opendray/core/api/api_exception.dart';
+import 'package:opendray/core/api/notes_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/notes/vault_text.dart';
+import 'package:path/path.dart' as p;
+
+// Rename and delete, as flows rather than as buttons — prompt, call,
+// report — so the vault browser and the open editor can both offer them
+// without either one owning the behaviour. They were the browser's
+// private methods until the editor needed them too, and the answer to
+// "the editor needs this as well" is one implementation, not two.
+
+/// Prompt for a new path and move the note, repointing the
+/// [[wiki links]] that referenced the old one. Returns the new path, or
+/// null when cancelled or failed — failures are reported to the user
+/// here, so callers only have to handle success.
+Future<String?> renameNoteFlow({
+  required BuildContext context,
+  required WidgetRef ref,
+  required String path,
+}) async {
+  final ctrl = TextEditingController(text: path);
+  final String? typed;
+  try {
+    typed = await showDialog<String>(
+      context: context,
+      builder: (dialogCtx) => AlertDialog(
+        title: Text(t.notesPage.rename.title),
+        content: TextField(
+          controller: ctrl,
+          autofocus: true,
+          autocorrect: false,
+          decoration: InputDecoration(
+            helperText: t.notesPage.rename.helper,
+            hintText: t.notesPage.pathHint,
+          ),
+          style: const TextStyle(fontFamily: 'monospace', fontSize: 13),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogCtx).pop(),
+            child: Text(t.common.cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogCtx).pop(ctrl.text.trim()),
+            child: Text(t.notesPage.rename.action),
+          ),
+        ],
+      ),
+    );
+  } finally {
+    ctrl.dispose();
+  }
+  if (typed == null || typed.isEmpty) return null;
+  // Same cleaning as creation, so a rename to `guide.html` stays HTML
+  // instead of becoming `guide.html.md`.
+  final to = sanitizeNotePath(typed);
+  if (to == path || !context.mounted) return null;
+
+  final messenger = ScaffoldMessenger.of(context);
+  try {
+    final res = await ref.read(notesApiProvider).move(from: path, to: to);
+    // A warning means the file moved but the link rewrite did not
+    // finish. Reporting only "renamed" would hide a vault full of
+    // references to a path that no longer exists.
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          (res.warning?.isNotEmpty ?? false)
+              ? '${t.notesPage.rename.doneWithWarning}: ${res.warning}'
+              : t.notesPage.rename.doneSnack(count: res.linksRewritten),
+        ),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+    return res.to.isNotEmpty ? res.to : to;
+  } on ApiException catch (e) {
+    messenger.showSnackBar(
+      SnackBar(content: Text(e.message), behavior: SnackBarBehavior.floating),
+    );
+    return null;
+  }
+}
+
+/// Confirm, then delete. Returns true only when the note is gone.
+Future<bool> deleteNoteFlow({
+  required BuildContext context,
+  required WidgetRef ref,
+  required String path,
+  String title = '',
+}) async {
+  final ok = await showDialog<bool>(
+    context: context,
+    builder: (dialogCtx) => AlertDialog(
+      title: Text(t.notesPage.deleteTitle),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title.isNotEmpty ? title : p.basename(path),
+            style: Theme.of(dialogCtx).textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            path,
+            style: const TextStyle(fontFamily: 'monospace', fontSize: 11),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            t.notesPage.deleteBody,
+            style: Theme.of(dialogCtx).textTheme.bodySmall,
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(dialogCtx).pop(false),
+          child: Text(t.common.cancel),
+        ),
+        FilledButton(
+          style: FilledButton.styleFrom(
+            backgroundColor: Theme.of(dialogCtx).colorScheme.error,
+          ),
+          onPressed: () => Navigator.of(dialogCtx).pop(true),
+          child: Text(t.common.delete),
+        ),
+      ],
+    ),
+  );
+  if (ok != true || !context.mounted) return false;
+
+  final messenger = ScaffoldMessenger.of(context);
+  try {
+    await ref.read(notesApiProvider).delete(path);
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(t.notesPage.deletedSnack(path: path)),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+    return true;
+  } on ApiException catch (e) {
+    messenger.showSnackBar(
+      SnackBar(content: Text(t.notesPage.deleteFailedApi(error: e.message))),
+    );
+    return false;
+  } on Object catch (e) {
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(t.notesPage.deleteFailedGeneric(error: e.toString())),
+      ),
+    );
+    return false;
+  }
+}

--- a/app/mobile/lib/features/notes/note_editor_dialog.dart
+++ b/app/mobile/lib/features/notes/note_editor_dialog.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -8,26 +9,36 @@ import 'package:opendray/core/api/notes_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/notes/doc_preview.dart';
 import 'package:opendray/features/notes/markdown_highlight_controller.dart';
+import 'package:opendray/features/notes/vault_text.dart';
 import 'package:path/path.dart' as p;
 
-// Full-screen markdown note editor with debounced auto-save.
-// Used by both the session inspector's Notes tab and the global
-// Notes screen — same auto-save semantics, same error / save-status
-// surface, so kept in one place.
+// Full-screen markdown note editor. Used by both the session
+// inspector's Notes tab and the vault browser — same save semantics,
+// same error surface, so kept in one place.
+//
+// Beyond editing it carries the vault's navigation layer, which the
+// phone previously had none of: the document's tags, its outline, the
+// notes linking to it, and [[wiki links]] that actually go somewhere.
 class NoteEditorDialog extends ConsumerStatefulWidget {
-  const NoteEditorDialog({required this.path, super.key});
+  const NoteEditorDialog({required this.path, this.allPaths, super.key});
 
   // Vault-relative path (e.g. "personal/foo.md", "projects/bar/spec.md").
   final String path;
 
+  /// Every path in the vault, for resolving and completing wiki-links.
+  /// Callers that already hold the listing pass it to save a round-trip;
+  /// when null the editor fetches it once for itself.
+  final List<String>? allPaths;
+
   static Future<void> show({
     required BuildContext context,
     required String path,
+    List<String>? allPaths,
   }) {
     return showDialog<void>(
       context: context,
       barrierDismissible: false,
-      builder: (_) => NoteEditorDialog(path: path),
+      builder: (_) => NoteEditorDialog(path: path, allPaths: allPaths),
     );
   }
 
@@ -37,6 +48,7 @@ class NoteEditorDialog extends ConsumerStatefulWidget {
 
 class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
   final _ctrl = MarkdownHighlightController();
+  final _focus = FocusNode();
   bool _dirty = false;
   bool _loading = true;
   bool _saving = false;
@@ -48,21 +60,56 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
   // BOTH kinds rather than leaving markdown as the poor relation.
   bool _preview = false;
 
+  List<String> _allPaths = const [];
+  // Active `[[…` span under the caret, or null. Drives the suggestion
+  // list; kept in state rather than recomputed in build so a rebuild
+  // triggered by anything else doesn't resurrect a dismissed popup.
+  WikiLinkContext? _linkCtx;
+
+  List<Backlink>? _backlinks;
+  bool _backlinksLoading = false;
+  String? _backlinksError;
+
+  String get _currentDir {
+    final dir = p.dirname(widget.path);
+    return (dir == '.' || dir == '/') ? '' : dir;
+  }
+
   @override
   void initState() {
     super.initState();
+    _allPaths = widget.allPaths ?? const [];
+    // One listener rather than TextField.onChanged: the caret moving
+    // without the text changing is exactly when a wiki-link suggestion
+    // has to appear or go away.
+    _ctrl.addListener(_onEdit);
     _bootstrap();
   }
 
   @override
   void dispose() {
-    _ctrl.dispose();
+    _ctrl
+      ..removeListener(_onEdit)
+      ..dispose();
+    _focus.dispose();
     super.dispose();
   }
 
   Future<void> _bootstrap() async {
+    final api = ref.read(notesApiProvider);
+    if (widget.allPaths == null) {
+      // Wiki-links degrade to plain paths without this, so a failure
+      // costs resolution quality, not the editor.
+      unawaited(
+        api.list().then((notes) {
+          if (mounted) {
+            setState(() => _allPaths = notes.map((n) => n.path).toList());
+          }
+        }).catchError((Object _) {}),
+      );
+    }
     try {
-      final note = await ref.read(notesApiProvider).read(widget.path);
+      final note = await api.read(widget.path);
       if (!mounted) return;
       _initial = note.body;
       _ctrl.text = note.body;
@@ -91,14 +138,24 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
     }
   }
 
-  // Saving is explicit here too — a timer that wrote after every pause
-  // in typing kept rewriting a long document while it was being worked
-  // on. The dirty flag drives the Save action's enabled state; the
-  // flushes on preview-toggle and close below are the safety net, not
-  // the timer returning.
-  void _onChanged(String _) {
+  // Saving is explicit — a timer that wrote after every pause in typing
+  // kept rewriting a long document while it was being worked on. The
+  // dirty flag drives the Save action's enabled state; the flushes on
+  // preview-toggle and close below are the safety net.
+  void _onEdit() {
+    if (_loading) return;
     final nowDirty = _ctrl.text != _initial;
-    if (nowDirty != _dirty) setState(() => _dirty = nowDirty);
+    final sel = _ctrl.selection;
+    final ctx = (sel.isCollapsed && sel.start >= 0 && sel.start <= _ctrl.text.length)
+        ? detectWikiLinkContext(_ctrl.text, sel.start)
+        : null;
+    final ctxChanged =
+        (ctx == null) != (_linkCtx == null) || ctx?.query != _linkCtx?.query;
+    if (nowDirty == _dirty && !ctxChanged) return;
+    setState(() {
+      _dirty = nowDirty;
+      _linkCtx = ctx;
+    });
   }
 
   Future<void> _save() async {
@@ -134,8 +191,209 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
     }
   }
 
+  // ------------------------------------------------------------ outline
+
+  Future<void> _showOutline() async {
+    final headings = extractOutline(_ctrl.text);
+    final picked = await showModalBottomSheet<OutlineHeading>(
+      context: context,
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (sheetCtx) => SafeArea(
+        top: false,
+        child: headings.isEmpty
+            ? Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  t.notesPage.outline.empty,
+                  style: Theme.of(sheetCtx).textTheme.bodyMedium,
+                ),
+              )
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 14, 16, 6),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(
+                        t.notesPage.outline.title,
+                        style: Theme.of(sheetCtx).textTheme.titleSmall,
+                      ),
+                    ),
+                  ),
+                  const Divider(height: 1),
+                  Flexible(
+                    child: ListView.builder(
+                      shrinkWrap: true,
+                      itemCount: headings.length,
+                      itemBuilder: (_, i) {
+                        final h = headings[i];
+                        return ListTile(
+                          dense: true,
+                          contentPadding: EdgeInsets.only(
+                            // Indent by depth so the document's shape is
+                            // visible, but cap it — a level-6 heading
+                            // shouldn't end up off the right edge.
+                            left: 16.0 + (math.min(h.level, 4) - 1) * 14.0,
+                            right: 16,
+                          ),
+                          title: Text(
+                            h.text,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontSize: h.level <= 2 ? 14 : 13,
+                              fontWeight: h.level <= 2
+                                  ? FontWeight.w600
+                                  : FontWeight.normal,
+                            ),
+                          ),
+                          onTap: () => Navigator.of(sheetCtx).pop(h),
+                        );
+                      },
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                ],
+              ),
+      ),
+    );
+    if (picked == null || !mounted) return;
+
+    // The jump lands in SOURCE view, and that is a constraint rather
+    // than a preference: the preview runs with JavaScript off because a
+    // vault document can arrive by `git pull`, and scrolling a webview
+    // to an anchor needs a script. Moving the caret is what the phone
+    // can do honestly — Flutter scrolls a focused field to its caret.
+    final wasPreview = _preview;
+    if (wasPreview) setState(() => _preview = false);
+    _ctrl.selection = TextSelection.collapsed(
+      offset: math.min(picked.charOffset, _ctrl.text.length),
+    );
+    _focus.requestFocus();
+    if (wasPreview) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(t.notesPage.outline.jumpedToSource),
+          behavior: SnackBarBehavior.floating,
+          duration: const Duration(seconds: 3),
+        ),
+      );
+    }
+  }
+
+  // ---------------------------------------------------------- backlinks
+
+  Future<void> _loadBacklinks() async {
+    if (_backlinksLoading) return;
+    setState(() {
+      _backlinksLoading = true;
+      _backlinksError = null;
+    });
+    try {
+      final links = await ref.read(notesApiProvider).backlinks(widget.path);
+      if (!mounted) return;
+      setState(() {
+        _backlinks = links;
+        _backlinksLoading = false;
+      });
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _backlinksLoading = false;
+        // A note that hasn't been written yet has no links to it. That
+        // is an empty list, not a failure to report.
+        _backlinks = e.statusCode == 404 ? const [] : null;
+        _backlinksError = e.statusCode == 404
+            ? null
+            : t.notesPage.backlinks.failed(error: e.message);
+      });
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _backlinksLoading = false;
+        _backlinksError = t.notesPage.backlinks.failed(error: e.toString());
+      });
+    }
+  }
+
+  // --------------------------------------------------------- wiki links
+
+  String _resolve(String target) => resolveWikiLink(
+        target,
+        allPaths: _allPaths,
+        currentDir: _currentDir,
+      );
+
+  Future<void> _openLinked(String path) async {
+    // Flush first: the linked note may link back, and reading a stale
+    // copy of the document just left would be confusing.
+    await _save();
+    if (!mounted) return;
+    await NoteEditorDialog.show(
+      context: context,
+      path: path,
+      allPaths: _allPaths,
+    );
+    if (!mounted) return;
+    // A note opened through a link may have been created; refresh the
+    // backlinks that are already on screen.
+    if (_backlinks != null) unawaited(_loadBacklinks());
+  }
+
+  /// Candidate notes for the active `[[…` span, basename-first.
+  List<String> _suggestions(String query) {
+    final q = query.trim().toLowerCase();
+    final out = <String>[];
+    for (final path in _allPaths) {
+      if (path == widget.path) continue;
+      final base = p.basenameWithoutExtension(path).toLowerCase();
+      if (q.isEmpty || base.contains(q) || path.toLowerCase().contains(q)) {
+        out.add(path);
+      }
+      if (out.length >= 8) break;
+    }
+    return out;
+  }
+
+  void _completeWikiLink(String display, {String? createAt}) {
+    final ctx = _linkCtx;
+    if (ctx == null) return;
+    final text = _ctrl.text;
+    final end = math.min(_ctrl.selection.start, text.length);
+    if (ctx.openIdx < 0 || ctx.openIdx > end) return;
+    final inserted = '[[$display]]';
+    final next = text.substring(0, ctx.openIdx) + inserted + text.substring(end);
+    _ctrl.value = TextEditingValue(
+      text: next,
+      selection: TextSelection.collapsed(offset: ctx.openIdx + inserted.length),
+    );
+    setState(() => _linkCtx = null);
+    if (createAt != null) {
+      // Lazy-create so the note exists in the index and the next
+      // completion finds it. A failure here is non-fatal: the document
+      // gets created the first time it is saved.
+      unawaited(
+        ref
+            .read(notesApiProvider)
+            .write(path: createAt, body: '# $display\n\n')
+            .then((_) {
+          if (mounted && !_allPaths.contains(createAt)) {
+            setState(() => _allPaths = [..._allPaths, createAt]);
+          }
+        }).catchError((Object _) {}),
+      );
+    }
+  }
+
+  // -------------------------------------------------------------- build
+
   @override
   Widget build(BuildContext context) {
+    final tags = _loading ? const <String>[] : extractTags(_ctrl.text);
     return Dialog(
       insetPadding: const EdgeInsets.all(8),
       child: ConstrainedBox(
@@ -145,96 +403,44 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 12, 8, 8),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          p.basename(widget.path),
-                          style: Theme.of(context).textTheme.titleSmall,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        Text(
-                          widget.path,
-                          style: Theme.of(context).textTheme.bodySmall,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ],
-                    ),
-                  ),
-                  IconButton(
-                    tooltip: t.notesPage.editor.save,
-                    icon: const Icon(Icons.save_outlined),
-                    // Disabled with nothing to save, so the control
-                    // doubles as the answer to "did that go through?".
-                    onPressed: _dirty && !_saving
-                        ? () => unawaited(_save())
-                        : null,
-                  ),
-                  IconButton(
-                    tooltip: _preview
-                        ? t.notesPage.editor.showSource
-                        : t.notesPage.editor.showPreview,
-                    icon: Icon(
-                      _preview ? Icons.code : Icons.visibility_outlined,
-                    ),
-                    onPressed: () {
-                      // Flush before switching: preview renders the
-                      // SAVED body, so an unsaved keystroke would
-                      // otherwise render stale.
-                                        unawaited(_save());
-                      setState(() => _preview = !_preview);
-                    },
-                  ),
-                  Builder(
-                    builder: (innerCtx) => IconButton(
-                      icon: const Icon(Icons.close),
-                      onPressed: () async {
-                        // Flush pending save before dismissing — drops
-                        // the last few keystrokes otherwise if the
-                        // 800ms timer hasn't fired.
-                                            await _save();
-                        if (!innerCtx.mounted) return;
-                        Navigator.of(innerCtx).pop();
-                      },
-                    ),
-                  ),
-                ],
-              ),
-            ),
+            _header(),
             const Divider(height: 1),
+            if (tags.isNotEmpty) _tagChips(tags),
             Expanded(
               child: _loading
                   ? const Center(child: CircularProgressIndicator())
                   : _preview
-                  ? DocPreview(path: widget.path, body: _ctrl.text)
-                  : Padding(
-                      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
-                      child: TextField(
-                        controller: _ctrl,
-                        onChanged: _onChanged,
-                        maxLines: null,
-                        expands: true,
-                        textInputAction: TextInputAction.newline,
-                        keyboardType: TextInputType.multiline,
-                        style: const TextStyle(
-                          fontSize: 13,
-                          height: 1.5,
-                          fontFamily: 'monospace',
+                      ? DocPreview(
+                          path: widget.path,
+                          body: _ctrl.text,
+                          onOpenWikiLink: _openLinked,
+                          resolveWikiTarget: _resolve,
+                        )
+                      : Padding(
+                          padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+                          child: TextField(
+                            controller: _ctrl,
+                            focusNode: _focus,
+                            maxLines: null,
+                            expands: true,
+                            textInputAction: TextInputAction.newline,
+                            keyboardType: TextInputType.multiline,
+                            style: const TextStyle(
+                              fontSize: 13,
+                              height: 1.5,
+                              fontFamily: 'monospace',
+                            ),
+                            decoration: InputDecoration(
+                              border: InputBorder.none,
+                              contentPadding: EdgeInsets.zero,
+                              hintText: t.notesPage.editor.markdownHint,
+                            ),
+                          ),
                         ),
-                        decoration: InputDecoration(
-                          border: InputBorder.none,
-                          contentPadding: EdgeInsets.zero,
-                          hintText: t.notesPage.editor.markdownHint,
-                        ),
-                      ),
-                    ),
             ),
+            if (!_preview && _linkCtx != null) _wikiSuggestions(_linkCtx!),
             const Divider(height: 1),
+            if (!_loading) _backlinksTile(),
             Padding(
               padding: const EdgeInsets.fromLTRB(12, 6, 12, 8),
               child: NoteSaveStatus(
@@ -246,6 +452,312 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _header() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 4, 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  p.basename(widget.path),
+                  style: Theme.of(context).textTheme.titleSmall,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                Text(
+                  widget.path,
+                  style: Theme.of(context).textTheme.bodySmall,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            tooltip: t.notesPage.outline.action,
+            icon: const Icon(Icons.toc),
+            onPressed: _loading ? null : () => unawaited(_showOutline()),
+          ),
+          IconButton(
+            tooltip: t.notesPage.editor.save,
+            icon: const Icon(Icons.save_outlined),
+            // Disabled with nothing to save, so the control doubles as
+            // the answer to "did that go through?".
+            onPressed: _dirty && !_saving ? () => unawaited(_save()) : null,
+          ),
+          IconButton(
+            tooltip: _preview
+                ? t.notesPage.editor.showSource
+                : t.notesPage.editor.showPreview,
+            icon: Icon(_preview ? Icons.code : Icons.visibility_outlined),
+            onPressed: () {
+              // Flush before switching: preview renders the SAVED body,
+              // so an unsaved keystroke would otherwise render stale.
+              unawaited(_save());
+              setState(() {
+                _preview = !_preview;
+                _linkCtx = null;
+              });
+            },
+          ),
+          Builder(
+            builder: (innerCtx) => IconButton(
+              icon: const Icon(Icons.close),
+              onPressed: () async {
+                // Flush pending edits before dismissing rather than
+                // dropping the last keystrokes on the floor.
+                await _save();
+                if (!innerCtx.mounted) return;
+                Navigator.of(innerCtx).pop();
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _tagChips(List<String> tags) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      // Same reasoning as the backlinks list: a non-flex child that can
+      // grow without limit steals height from the editor. A heavily
+      // tagged document scrolls its chips instead.
+      constraints: const BoxConstraints(maxHeight: 62),
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+      child: SingleChildScrollView(
+        child: Wrap(
+          spacing: 6,
+          runSpacing: 4,
+          children: [
+            for (final tag in tags)
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+                decoration: BoxDecoration(
+                  color: scheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  '#$tag',
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontFamily: 'monospace',
+                    color: scheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _wikiSuggestions(WikiLinkContext ctx) {
+    final scheme = Theme.of(context).colorScheme;
+    final matches = _suggestions(ctx.query);
+    final query = ctx.query.trim();
+    final exact = matches.any(
+      (path) =>
+          p.basenameWithoutExtension(path).toLowerCase() == query.toLowerCase(),
+    );
+    // Anchored above the status bar rather than floated at the caret:
+    // a caret-tracking popup on a phone fights the keyboard for the
+    // same strip of screen and loses.
+    return Container(
+      constraints: const BoxConstraints(maxHeight: 168),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHighest,
+        border: Border(top: BorderSide(color: Theme.of(context).dividerColor)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 6, 12, 2),
+            child: Text(
+              t.notesPage.wikiLink.suggestions,
+              style: TextStyle(fontSize: 11, color: scheme.onSurfaceVariant),
+            ),
+          ),
+          Flexible(
+            child: ListView(
+              shrinkWrap: true,
+              padding: EdgeInsets.zero,
+              children: [
+                for (final path in matches)
+                  ListTile(
+                    dense: true,
+                    visualDensity: VisualDensity.compact,
+                    title: Text(
+                      p.basenameWithoutExtension(path),
+                      style: const TextStyle(fontSize: 13),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    subtitle: Text(
+                      path,
+                      style: const TextStyle(
+                          fontSize: 10, fontFamily: 'monospace'),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    onTap: () => _completeWikiLink(
+                      p.basenameWithoutExtension(path),
+                    ),
+                  ),
+                if (query.isNotEmpty && !exact)
+                  ListTile(
+                    dense: true,
+                    visualDensity: VisualDensity.compact,
+                    leading: const Icon(Icons.add, size: 18),
+                    title: Text(
+                      t.notesPage.wikiLink.createNew(name: query),
+                      style: const TextStyle(fontSize: 13),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    onTap: () => _completeWikiLink(
+                      query,
+                      createAt: _resolve(query),
+                    ),
+                  ),
+                if (matches.isEmpty && query.isEmpty)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(12, 4, 12, 10),
+                    child: Text(
+                      t.notesPage.wikiLink.noMatches,
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: scheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _backlinksTile() {
+    final links = _backlinks;
+    final scheme = Theme.of(context).colorScheme;
+    return Theme(
+      // The default expansion tile draws its own dividers, which double
+      // up with the ones this dialog already has.
+      data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+      child: ExpansionTile(
+        tilePadding: const EdgeInsets.symmetric(horizontal: 12),
+        childrenPadding: const EdgeInsets.only(bottom: 4),
+        dense: true,
+        visualDensity: VisualDensity.compact,
+        leading: const Icon(Icons.link, size: 18),
+        title: Text(
+          links == null
+              ? t.notesPage.backlinks.title
+              : '${t.notesPage.backlinks.title} · ${links.length}',
+          style: const TextStyle(fontSize: 13),
+        ),
+        onExpansionChanged: (open) {
+          // Deferred until asked for: it is a full scan of the vault on
+          // the gateway, and most of the time nobody opens it.
+          if (open && _backlinks == null) unawaited(_loadBacklinks());
+        },
+        children: [
+          if (_backlinksLoading)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 10),
+              child: Row(
+                children: [
+                  const SizedBox(
+                    width: 12,
+                    height: 12,
+                    child: CircularProgressIndicator(strokeWidth: 1.5),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    t.notesPage.backlinks.loading,
+                    style: TextStyle(
+                        fontSize: 12, color: scheme.onSurfaceVariant),
+                  ),
+                ],
+              ),
+            )
+          else if (_backlinksError != null)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 10),
+              child: Text(
+                _backlinksError!,
+                style: TextStyle(fontSize: 12, color: scheme.error),
+              ),
+            )
+          else if (links != null && links.isEmpty)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 10),
+              child: Text(
+                t.notesPage.backlinks.empty,
+                style:
+                    TextStyle(fontSize: 12, color: scheme.onSurfaceVariant),
+              ),
+            )
+          else if (links != null)
+            // Capped and internally scrollable. The tile's children are
+            // a NON-FLEX child of the dialog's column, so an unbounded
+            // list would squeeze the editor above it to nothing and
+            // overflow — a document with twenty inbound links is not
+            // unusual in a wiki.
+            ConstrainedBox(
+              constraints: BoxConstraints(
+                maxHeight: MediaQuery.of(context).size.height * 0.28,
+              ),
+              child: ListView(
+                shrinkWrap: true,
+                padding: EdgeInsets.zero,
+                children: [
+                  for (final b in links)
+                    ListTile(
+                      dense: true,
+                      visualDensity: VisualDensity.compact,
+                      title: Text(
+                        b.title.isNotEmpty ? b.title : p.basename(b.path),
+                        style: const TextStyle(fontSize: 13),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      subtitle: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            b.path,
+                            style: const TextStyle(
+                                fontSize: 10, fontFamily: 'monospace'),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          // Two snippets: enough to recognise the
+                          // reference, not so many that one note buries
+                          // the rest.
+                          for (final line in b.lines.take(2))
+                            Text(
+                              line.trim(),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                fontSize: 10.5,
+                                fontFamily: 'monospace',
+                                color: scheme.onSurfaceVariant,
+                              ),
+                            ),
+                        ],
+                      ),
+                      onTap: () => unawaited(_openLinked(b.path)),
+                    ),
+                ],
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/app/mobile/lib/features/notes/note_editor_dialog.dart
+++ b/app/mobile/lib/features/notes/note_editor_dialog.dart
@@ -9,6 +9,7 @@ import 'package:opendray/core/api/notes_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/notes/doc_preview.dart';
 import 'package:opendray/features/notes/markdown_highlight_controller.dart';
+import 'package:opendray/features/notes/note_actions.dart';
 import 'package:opendray/features/notes/vault_text.dart';
 import 'package:path/path.dart' as p;
 
@@ -46,7 +47,20 @@ class NoteEditorDialog extends ConsumerStatefulWidget {
   ConsumerState<NoteEditorDialog> createState() => _NoteEditorDialogState();
 }
 
+/// What the editor's overflow menu offers beyond editing.
+enum _DocAction { rename, delete }
+
 class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
+  /// The document being edited. Deliberately not `widget.path`: a
+  /// rename moves the open document, and everything below — reads,
+  /// writes, backlinks, the preview — has to follow it rather than keep
+  /// addressing the path it was opened under.
+  late String _path = widget.path;
+
+  /// Set once the document has been deleted from under us, so the
+  /// flush-on-close cannot write it straight back.
+  bool _deleted = false;
+
   final _ctrl = MarkdownHighlightController();
   final _focus = FocusNode();
   bool _dirty = false;
@@ -71,7 +85,7 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
   String? _backlinksError;
 
   String get _currentDir {
-    final dir = p.dirname(widget.path);
+    final dir = p.dirname(_path);
     return (dir == '.' || dir == '/') ? '' : dir;
   }
 
@@ -109,7 +123,7 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
       );
     }
     try {
-      final note = await api.read(widget.path);
+      final note = await api.read(_path);
       if (!mounted) return;
       _initial = note.body;
       _ctrl.text = note.body;
@@ -159,6 +173,9 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
   }
 
   Future<void> _save() async {
+    // Writing after a delete would recreate the document — the close
+    // button flushes, and closing is exactly what follows a delete.
+    if (_deleted) return;
     final body = _ctrl.text;
     if (body == _initial) return;
     setState(() {
@@ -166,7 +183,7 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
       _error = null;
     });
     try {
-      await ref.read(notesApiProvider).write(path: widget.path, body: body);
+      await ref.read(notesApiProvider).write(path: _path, body: body);
       if (!mounted) return;
       _initial = body;
       setState(() {
@@ -294,7 +311,7 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
       _backlinksError = null;
     });
     try {
-      final links = await ref.read(notesApiProvider).backlinks(widget.path);
+      final links = await ref.read(notesApiProvider).backlinks(_path);
       if (!mounted) return;
       setState(() {
         _backlinks = links;
@@ -318,6 +335,47 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
         _backlinksError = t.notesPage.backlinks.failed(error: e.toString());
       });
     }
+  }
+
+  // ---------------------------------------------------- rename / delete
+
+  // These live here as well as on the browser's row menu because the
+  // moment you decide a document is finished with is the moment you are
+  // looking at it. Having to close the editor, find the row again and
+  // press-and-hold it is how "the vault has no delete" happens.
+
+  Future<void> _rename() async {
+    // Flush first: the move copies what is on disk, so unsaved edits
+    // would be left behind at the old path.
+    await _save();
+    if (!mounted) return;
+    final to = await renameNoteFlow(context: context, ref: ref, path: _path);
+    if (to == null || !mounted) return;
+    setState(() {
+      _path = to;
+      // Backlinks were resolved against the old path; the answer for
+      // the new one has to be asked for again.
+      _backlinks = null;
+      _backlinksError = null;
+    });
+  }
+
+  Future<void> _delete() async {
+    // The confirmation names the document by its first heading, the
+    // same thing the listing shows, so the dialog is recognisably about
+    // the note on screen and not just a path.
+    final headings = extractOutline(_ctrl.text);
+    final gone = await deleteNoteFlow(
+      context: context,
+      ref: ref,
+      path: _path,
+      title: headings.isEmpty ? '' : headings.first.text,
+    );
+    if (!gone || !mounted) return;
+    // _deleted before popping: closing flushes, and a flush here would
+    // put the document straight back.
+    setState(() => _deleted = true);
+    Navigator.of(context).pop();
   }
 
   // --------------------------------------------------------- wiki links
@@ -349,7 +407,7 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
     final q = query.trim().toLowerCase();
     final out = <String>[];
     for (final path in _allPaths) {
-      if (path == widget.path) continue;
+      if (path == _path) continue;
       final base = p.basenameWithoutExtension(path).toLowerCase();
       if (q.isEmpty || base.contains(q) || path.toLowerCase().contains(q)) {
         out.add(path);
@@ -411,7 +469,7 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
                   ? const Center(child: CircularProgressIndicator())
                   : _preview
                       ? DocPreview(
-                          path: widget.path,
+                          path: _path,
                           body: _ctrl.text,
                           onOpenWikiLink: _openLinked,
                           resolveWikiTarget: _resolve,
@@ -466,12 +524,12 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  p.basename(widget.path),
+                  p.basename(_path),
                   style: Theme.of(context).textTheme.titleSmall,
                   overflow: TextOverflow.ellipsis,
                 ),
                 Text(
-                  widget.path,
+                  _path,
                   style: Theme.of(context).textTheme.bodySmall,
                   overflow: TextOverflow.ellipsis,
                 ),
@@ -481,11 +539,13 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
           IconButton(
             tooltip: t.notesPage.outline.action,
             icon: const Icon(Icons.toc),
+            visualDensity: VisualDensity.compact,
             onPressed: _loading ? null : () => unawaited(_showOutline()),
           ),
           IconButton(
             tooltip: t.notesPage.editor.save,
             icon: const Icon(Icons.save_outlined),
+            visualDensity: VisualDensity.compact,
             // Disabled with nothing to save, so the control doubles as
             // the answer to "did that go through?".
             onPressed: _dirty && !_saving ? () => unawaited(_save()) : null,
@@ -495,6 +555,7 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
                 ? t.notesPage.editor.showSource
                 : t.notesPage.editor.showPreview,
             icon: Icon(_preview ? Icons.code : Icons.visibility_outlined),
+            visualDensity: VisualDensity.compact,
             onPressed: () {
               // Flush before switching: preview renders the SAVED body,
               // so an unsaved keystroke would otherwise render stale.
@@ -505,9 +566,54 @@ class _NoteEditorDialogState extends ConsumerState<NoteEditorDialog> {
               });
             },
           ),
+          PopupMenuButton<_DocAction>(
+            icon: const Icon(Icons.more_vert),
+            tooltip: t.common.more,
+            enabled: !_loading,
+            // Five controls plus the path share this row on a phone;
+            // the default padding is what pushes the title into an
+            // ellipsis two characters in.
+            padding: EdgeInsets.zero,
+            onSelected: (action) {
+              switch (action) {
+                case _DocAction.rename:
+                  unawaited(_rename());
+                case _DocAction.delete:
+                  unawaited(_delete());
+              }
+            },
+            itemBuilder: (menuCtx) => [
+              PopupMenuItem(
+                value: _DocAction.rename,
+                child: ListTile(
+                  dense: true,
+                  contentPadding: EdgeInsets.zero,
+                  leading: const Icon(Icons.drive_file_rename_outline),
+                  title: Text(t.notesPage.rename.action),
+                ),
+              ),
+              PopupMenuItem(
+                value: _DocAction.delete,
+                child: ListTile(
+                  dense: true,
+                  contentPadding: EdgeInsets.zero,
+                  leading: Icon(
+                    Icons.delete_outline,
+                    color: Theme.of(menuCtx).colorScheme.error,
+                  ),
+                  title: Text(
+                    t.notesPage.popupDelete,
+                    style:
+                        TextStyle(color: Theme.of(menuCtx).colorScheme.error),
+                  ),
+                ),
+              ),
+            ],
+          ),
           Builder(
             builder: (innerCtx) => IconButton(
               icon: const Icon(Icons.close),
+              visualDensity: VisualDensity.compact,
               onPressed: () async {
                 // Flush pending edits before dismissing rather than
                 // dropping the last keystrokes on the floor.

--- a/app/mobile/lib/features/notes/notes_screen.dart
+++ b/app/mobile/lib/features/notes/notes_screen.dart
@@ -10,6 +10,7 @@ import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/notes/flatten_notice.dart';
 import 'package:opendray/features/notes/note_editor_dialog.dart';
 import 'package:opendray/features/notes/vault_sync_screen.dart';
+import 'package:opendray/features/notes/vault_text.dart';
 import 'package:opendray/features/project/project_screen.dart';
 import 'package:path/path.dart' as p;
 
@@ -43,6 +44,11 @@ class NotesVaultScreen extends ConsumerStatefulWidget {
   ConsumerState<NotesVaultScreen> createState() => _NotesScreenState();
 }
 
+/// What the left-hand listing is showing. Mirrors the web vault's
+/// tree/tags switch — the two ways of finding a document that isn't
+/// where you remembered filing it.
+enum _BrowseMode { folders, tags }
+
 class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
   AsyncValue<List<NoteSummary>> _state = const AsyncValue.loading();
   // Vault-relative directory the user is currently viewing. '' means
@@ -51,6 +57,16 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
   String _query = '';
   bool _flattenable = false;
   final _searchCtrl = TextEditingController();
+
+  _BrowseMode _mode = _BrowseMode.folders;
+  // Loaded the first time the tags view is opened. The gateway walks
+  // the whole vault to build it, so it is not fetched alongside the
+  // listing that every visit needs.
+  AsyncValue<List<TagCount>>? _tagState;
+  String? _activeTag;
+
+  List<String> get _allPaths =>
+      _state.valueOrNull?.map((n) => n.path).toList() ?? const [];
 
   @override
   void initState() {
@@ -90,8 +106,76 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
     }
   }
 
+  // Tags are counted by a full walk of the vault on the gateway, so
+  // they are fetched when the view is opened rather than on every
+  // listing refresh.
+  Future<void> _loadTags() async {
+    setState(() => _tagState = const AsyncValue.loading());
+    try {
+      final tags = await ref.read(notesApiProvider).tags();
+      if (!mounted) return;
+      tags.sort((a, b) {
+        // Most-used first; alphabetical inside a tie so the order is
+        // stable between refreshes.
+        final byCount = b.count.compareTo(a.count);
+        return byCount != 0 ? byCount : a.tag.compareTo(b.tag);
+      });
+      setState(() => _tagState = AsyncValue.data(tags));
+    } on Object catch (e, st) {
+      if (mounted) setState(() => _tagState = AsyncValue.error(e, st));
+    }
+  }
+
   Future<void> _openNote(NoteSummary note) async {
-    await NoteEditorDialog.show(context: context, path: note.path);
+    await NoteEditorDialog.show(
+      context: context,
+      path: note.path,
+      // The editor resolves and completes [[wiki links]] against this;
+      // handing over the listing already in hand saves it a fetch.
+      allPaths: _allPaths,
+    );
+    if (!mounted) return;
+    await _load();
+  }
+
+  /// Open (creating first if needed) today's daily note. Mirrors the
+  /// web vault's "Today" button, template included — the same date on
+  /// two clients has to produce one document, not two shapes of it.
+  Future<void> _openToday() async {
+    final now = DateTime.now();
+    final path = dailyNotePath(now);
+    final exists =
+        _state.valueOrNull?.any((n) => n.path == path) ?? false;
+    final messenger = ScaffoldMessenger.of(context);
+    if (!exists) {
+      final body = dailyNoteBody(
+        now,
+        // en_US explicitly, matching the web's date-fns default, so the
+        // heading reads the same on both clients.
+        longDate: DateFormat('EEEE, MMMM d, y', 'en_US').format(now),
+      );
+      try {
+        await ref.read(notesApiProvider).write(path: path, body: body);
+      } on ApiException catch (e) {
+        messenger.showSnackBar(
+          SnackBar(content: Text(t.notesPage.createFailedApi(error: e.message))),
+        );
+        return;
+      } on Object catch (e) {
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text(t.notesPage.createFailedGeneric(error: e.toString())),
+          ),
+        );
+        return;
+      }
+    }
+    if (!mounted) return;
+    await NoteEditorDialog.show(
+      context: context,
+      path: path,
+      allPaths: _allPaths,
+    );
     if (!mounted) return;
     await _load();
   }
@@ -323,7 +407,11 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
             body: '# ${p.basenameWithoutExtension(path)}\n\n',
           );
       if (!mounted) return;
-      await NoteEditorDialog.show(context: context, path: path);
+      await NoteEditorDialog.show(
+        context: context,
+        path: path,
+        allPaths: _allPaths,
+      );
       if (!mounted) return;
       await _load();
     } on ApiException catch (e) {
@@ -396,7 +484,12 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(t.notesPage.title),
-        leading: _currentPath.isEmpty
+        // "Up" belongs to the folder listing. Showing it while a tag
+        // filter or the tag index is on screen offers to walk a
+        // hierarchy that isn't what's being displayed.
+        leading: (_currentPath.isEmpty ||
+                _activeTag != null ||
+                _mode == _BrowseMode.tags)
             ? null
             : IconButton(
                 icon: const Icon(Icons.arrow_back),
@@ -405,6 +498,11 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
               ),
         actions: [
           const VaultSyncBadge(),
+          IconButton(
+            icon: const Icon(Icons.today_outlined),
+            tooltip: t.notesPage.today.tooltip,
+            onPressed: () => unawaited(_openToday()),
+          ),
           IconButton(
             icon: const Icon(Icons.refresh),
             tooltip: t.sessions.inspector.shared.refresh,
@@ -417,12 +515,53 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
           if (_flattenable) FlattenNotice(onConverted: _load),
           Padding(
             padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+            child: SegmentedButton<_BrowseMode>(
+              showSelectedIcon: false,
+              style: const ButtonStyle(
+                visualDensity: VisualDensity.compact,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+              segments: [
+                ButtonSegment(
+                  value: _BrowseMode.folders,
+                  icon: const Icon(Icons.folder_outlined, size: 16),
+                  label: Text(t.notesPage.browse.tree),
+                ),
+                ButtonSegment(
+                  value: _BrowseMode.tags,
+                  icon: const Icon(Icons.tag, size: 16),
+                  label: Text(t.notesPage.browse.tags),
+                ),
+              ],
+              selected: {_mode},
+              onSelectionChanged: (sel) {
+                final next = sel.first;
+                setState(() {
+                  _mode = next;
+                  // The filter box means different things in the two
+                  // views, so carrying a query across is misleading —
+                  // and so is a tag filter still narrowing the folder
+                  // listing after the user has left the tag view.
+                  _query = '';
+                  _activeTag = null;
+                  _searchCtrl.clear();
+                });
+                if (next == _BrowseMode.tags && _tagState == null) {
+                  unawaited(_loadTags());
+                }
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 4, 12, 4),
             child: TextField(
               controller: _searchCtrl,
               onChanged: (v) =>
                   setState(() => _query = v.trim().toLowerCase()),
               decoration: InputDecoration(
-                hintText: t.notesPage.searchHint,
+                hintText: _showingTags
+                    ? t.notesPage.browse.tags
+                    : t.notesPage.searchHint,
                 prefixIcon: const Icon(Icons.search, size: 18),
                 isDense: true,
                 suffixIcon: _query.isEmpty
@@ -437,11 +576,15 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
               ),
             ),
           ),
-          if (_query.isEmpty) _Breadcrumb(
-            path: _currentPath,
-            onGoRoot: () => setState(() => _currentPath = ''),
-            onJumpTo: (segments) => setState(() => _currentPath = segments),
-          ),
+          if (_activeTag != null) _activeTagChip(),
+          if (_mode == _BrowseMode.folders &&
+              _activeTag == null &&
+              _query.isEmpty)
+            _Breadcrumb(
+              path: _currentPath,
+              onGoRoot: () => setState(() => _currentPath = ''),
+              onJumpTo: (segments) => setState(() => _currentPath = segments),
+            ),
           Expanded(child: _body()),
         ],
       ),
@@ -454,9 +597,111 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
     );
   }
 
+  /// True while the tag INDEX is on screen. Picking a tag swaps the
+  /// listing back to notes, so the two are not the same condition.
+  bool get _showingTags => _mode == _BrowseMode.tags && _activeTag == null;
+
+  Widget _activeTagChip() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 0, 12, 4),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: InputChip(
+          avatar: const Icon(Icons.tag, size: 15),
+          label: Text('${t.notesPage.tags.filteredBy}: ${_activeTag!}'),
+          onDeleted: () => setState(() => _activeTag = null),
+          deleteButtonTooltipMessage: t.notesPage.tags.clear,
+        ),
+      ),
+    );
+  }
+
+  Widget _tagsBody() {
+    final state = _tagState;
+    if (state == null) return const SizedBox.shrink();
+    return state.when(
+      data: (tags) {
+        final visible = _query.isEmpty
+            ? tags
+            : tags.where((x) => x.tag.toLowerCase().contains(_query)).toList();
+        if (visible.isEmpty) {
+          return _Empty(
+            text: tags.isEmpty
+                ? t.notesPage.tags.empty
+                : t.notesPage.tags.noMatches(query: _query),
+          );
+        }
+        return RefreshIndicator(
+          onRefresh: _loadTags,
+          child: ListView.separated(
+            itemCount: visible.length,
+            separatorBuilder: (_, __) =>
+                Divider(height: 1, color: Theme.of(context).dividerColor),
+            itemBuilder: (_, i) {
+              final tag = visible[i];
+              return ListTile(
+                leading: Icon(
+                  Icons.tag,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                title: Text(tag.tag),
+                trailing: Text(
+                  '${tag.count}',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+                onTap: () => setState(() {
+                  _activeTag = tag.tag;
+                  _query = '';
+                  _searchCtrl.clear();
+                }),
+              );
+            },
+          ),
+        );
+      },
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => _Error(error: e, onRetry: _loadTags),
+    );
+  }
+
+  /// Paths carrying [_activeTag], from the tag index already fetched.
+  Set<String> _pathsForActiveTag() {
+    final tags = _tagState?.valueOrNull;
+    if (tags == null) return const {};
+    for (final tag in tags) {
+      if (tag.tag == _activeTag) return tag.notes.toSet();
+    }
+    return const {};
+  }
+
   Widget _body() {
+    if (_showingTags) return _tagsBody();
     return _state.when(
       data: (notes) {
+        if (_activeTag != null) {
+          final wanted = _pathsForActiveTag();
+          final results =
+              notes.where((n) => wanted.contains(n.path)).toList();
+          if (results.isEmpty) {
+            return _Empty(
+              text: t.notesPage.tags.noNotes(tag: _activeTag!),
+            );
+          }
+          return RefreshIndicator(
+            onRefresh: _load,
+            child: ListView.separated(
+              itemCount: results.length,
+              separatorBuilder: (_, __) =>
+                  Divider(height: 1, color: Theme.of(context).dividerColor),
+              itemBuilder: (_, i) => _NoteRow(
+                note: results[i],
+                showFullPath: true,
+                onTap: () => _openNote(results[i]),
+                onLongPress: () => _onLongPress(results[i]),
+              ),
+            ),
+          );
+        }
         if (_query.isNotEmpty) {
           final results = _searchAll(notes);
           if (results.isEmpty) {
@@ -728,10 +973,10 @@ class _NewNoteDialogState extends State<_NewNoteDialog> {
       setState(() => _error = t.notesPage.validatePathDots);
       return;
     }
-    final cleaned = raw.replaceAll(RegExp('^/+'), '');
-    final withExt =
-        cleaned.toLowerCase().endsWith('.md') ? cleaned : '$cleaned.md';
-    Navigator.of(context).pop(withExt);
+    // sanitizeNotePath rather than a blanket `.md`: appending it
+    // unconditionally turned `guide.html` into `guide.html.md`, so an
+    // HTML document could not be created from the phone at all.
+    Navigator.of(context).pop(sanitizeNotePath(raw));
   }
 
   @override

--- a/app/mobile/lib/features/notes/notes_screen.dart
+++ b/app/mobile/lib/features/notes/notes_screen.dart
@@ -8,6 +8,7 @@ import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/notes_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/notes/flatten_notice.dart';
+import 'package:opendray/features/notes/note_actions.dart';
 import 'package:opendray/features/notes/note_editor_dialog.dart';
 import 'package:opendray/features/notes/vault_sync_screen.dart';
 import 'package:opendray/features/notes/vault_text.dart';
@@ -190,7 +191,9 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
     setState(() => _currentPath = (parent == '.' || parent == '/') ? '' : parent);
   }
 
-  Future<void> _onLongPress(NoteSummary note) async {
+  /// The row's action sheet. Reached from the trailing button and
+  /// from a long press on the row.
+  Future<void> _showRowActions(NoteSummary note) async {
     final action = await showModalBottomSheet<_RowAction>(
       context: context,
       backgroundColor: Theme.of(context).colorScheme.surface,
@@ -274,121 +277,21 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
     }
   }
 
-  // Rename goes through the move endpoint, which repoints the
-  // [[wiki links]] that referenced the old path. Writing a copy and
-  // deleting the original would leave every one of them pointing at a
-  // document that no longer exists.
   Future<void> _promptRename(NoteSummary note) async {
-    final ctrl = TextEditingController(text: note.path);
-    final to = await showDialog<String>(
-      context: context,
-      builder: (dialogCtx) => AlertDialog(
-        title: Text(t.notesPage.rename.title),
-        content: TextField(
-          controller: ctrl,
-          autofocus: true,
-          decoration: InputDecoration(
-            helperText: t.notesPage.rename.helper,
-            hintText: t.notesPage.pathHint,
-          ),
-          style: const TextStyle(fontFamily: 'monospace', fontSize: 13),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogCtx).pop(),
-            child: Text(t.common.cancel),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(dialogCtx).pop(ctrl.text.trim()),
-            child: Text(t.notesPage.rename.action),
-          ),
-        ],
-      ),
-    );
-    if (to == null || to.isEmpty || to == note.path || !mounted) return;
-
-    final messenger = ScaffoldMessenger.of(context);
-    try {
-      final res = await ref.read(notesApiProvider).move(from: note.path, to: to);
-      // A warning means the file moved but the link rewrite did not
-      // finish. Reporting only "renamed" would hide a vault full of
-      // references to a path that no longer exists.
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(
-            res.warning?.isNotEmpty ?? false
-                ? '${t.notesPage.rename.doneWithWarning}: ${res.warning}'
-                : t.notesPage.rename.doneSnack(count: res.linksRewritten),
-          ),
-          behavior: SnackBarBehavior.floating,
-        ),
-      );
-      await _load();
-    } on ApiException catch (e) {
-      messenger.showSnackBar(
-        SnackBar(content: Text(e.message), behavior: SnackBarBehavior.floating),
-      );
-    }
+    final to = await renameNoteFlow(context: context, ref: ref, path: note.path);
+    if (to == null || !mounted) return;
+    await _load();
   }
 
   Future<void> _confirmAndDelete(NoteSummary note) async {
-    final ok = await showDialog<bool>(
+    final gone = await deleteNoteFlow(
       context: context,
-      builder: (dialogCtx) => AlertDialog(
-        title: Text(t.notesPage.deleteTitle),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              note.title.isNotEmpty ? note.title : p.basename(note.path),
-              style: Theme.of(dialogCtx).textTheme.bodyMedium,
-            ),
-            const SizedBox(height: 4),
-            Text(
-              note.path,
-              style: const TextStyle(fontFamily: 'monospace', fontSize: 11),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              t.notesPage.deleteBody,
-              style: Theme.of(dialogCtx).textTheme.bodySmall,
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogCtx).pop(false),
-            child: Text(t.common.cancel),
-          ),
-          FilledButton(
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(dialogCtx).colorScheme.error,
-            ),
-            onPressed: () => Navigator.of(dialogCtx).pop(true),
-            child: Text(t.common.delete),
-          ),
-        ],
-      ),
+      ref: ref,
+      path: note.path,
+      title: note.title,
     );
-    if (ok != true || !mounted) return;
-    final messenger = ScaffoldMessenger.of(context);
-    try {
-      await ref.read(notesApiProvider).delete(note.path);
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(t.notesPage.deletedSnack(path: note.path)),
-          behavior: SnackBarBehavior.floating,
-        ),
-      );
-      await _load();
-    } on ApiException catch (e) {
-      messenger.showSnackBar(
-        SnackBar(content: Text(t.notesPage.deleteFailedApi(error: e.message))),
-      );
-    } on Object catch (e) {
-      messenger.showSnackBar(SnackBar(content: Text(t.notesPage.deleteFailedGeneric(error: e.toString()))));
-    }
+    if (!gone || !mounted) return;
+    await _load();
   }
 
   Future<void> _newNote() async {
@@ -697,7 +600,7 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
                 note: results[i],
                 showFullPath: true,
                 onTap: () => _openNote(results[i]),
-                onLongPress: () => _onLongPress(results[i]),
+                onMenu: () => _showRowActions(results[i]),
               ),
             ),
           );
@@ -719,7 +622,7 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
                 note: results[i],
                 showFullPath: true,
                 onTap: () => _openNote(results[i]),
-                onLongPress: () => _onLongPress(results[i]),
+                onMenu: () => _showRowActions(results[i]),
               ),
             ),
           );
@@ -751,7 +654,7 @@ class _NotesScreenState extends ConsumerState<NotesVaultScreen> {
                   note: n,
                   showFullPath: false,
                   onTap: () => _openNote(n),
-                  onLongPress: () => _onLongPress(n),
+                  onMenu: () => _showRowActions(n),
                 ),
             ],
           ),
@@ -894,13 +797,17 @@ class _NoteRow extends StatelessWidget {
     required this.note,
     required this.showFullPath,
     required this.onTap,
-    required this.onLongPress,
+    required this.onMenu,
   });
 
   final NoteSummary note;
   final bool showFullPath;
   final VoidCallback onTap;
-  final VoidCallback onLongPress;
+
+  /// Opens the row's actions. Wired to both the trailing button and a
+  /// long press: the button is the one anybody finds, the gesture is
+  /// the shortcut for whoever already knows it.
+  final VoidCallback onMenu;
 
   @override
   Widget build(BuildContext context) {
@@ -909,7 +816,7 @@ class _NoteRow extends StatelessWidget {
         : '${_formatBytes(note.size)} · ${_relTime(note.modified)}';
     return ListTile(
       onTap: onTap,
-      onLongPress: onLongPress,
+      onLongPress: onMenu,
       leading: Icon(
         // The operator's own note carries a different icon from the
         // agent-written docs. Both layouts have to be recognised: the
@@ -930,7 +837,16 @@ class _NoteRow extends StatelessWidget {
         overflow: TextOverflow.ellipsis,
         style: Theme.of(context).textTheme.bodySmall,
       ),
-      trailing: const Icon(Icons.chevron_right),
+      // This slot used to hold a chevron. Tapping the row already opens
+      // the document, so the arrow said nothing the row didn't — while
+      // rename and delete sat behind a long press with no hint that
+      // they existed at all. Same pixels, an affordance instead of a
+      // decoration.
+      trailing: IconButton(
+        icon: const Icon(Icons.more_vert),
+        tooltip: t.common.more,
+        onPressed: onMenu,
+      ),
     );
   }
 }

--- a/app/mobile/lib/features/notes/vault_text.dart
+++ b/app/mobile/lib/features/notes/vault_text.dart
@@ -1,0 +1,369 @@
+// The vault's pure text layer: what a path means, what a document
+// contains, and how its wiki-links resolve. No Flutter, no I/O — so it
+// is testable on its own and can be shared by the vault browser, the
+// editor and the preview without dragging a webview into any of them.
+//
+// Ported from the web so the two clients agree on the same documents:
+//
+//   docKindOf        ← docKind            app/shared/src/lib/notes.ts
+//   sanitizeNotePath ← sanitizeNotePath   app/shared/src/lib/notes.ts
+//   extractOutline   ← extractOutline     app/shared/src/lib/outline.ts
+//   slugify          ← slugify            app/shared/src/lib/outline.ts
+//   extractTags      ← extractTags        NoteEditor.tsx
+//   resolveWikiLink  ← resolveLink        NoteEditor.tsx
+//   detectWikiLinkContext ← same          app/shared/src/lib/caret.ts
+//
+// Two places deliberately diverge from the web; both are called out at
+// the function that does it.
+
+/// What kind of document a vault path holds. Mirrors notes.KindOf in
+/// internal/notes/doc.go and docKind() in app/shared/src/lib/notes.ts.
+enum DocKind { markdown, html, unknown }
+
+DocKind docKindOf(String path) {
+  final base = path.split('/').last;
+  final dot = base.lastIndexOf('.');
+  // A leading dot is a dotfile, not an extension.
+  if (dot <= 0) return DocKind.unknown;
+  switch (base.substring(dot + 1).toLowerCase()) {
+    case 'md':
+    case 'markdown':
+      return DocKind.markdown;
+    case 'html':
+    case 'htm':
+      return DocKind.html;
+    default:
+      return DocKind.unknown;
+  }
+}
+
+/// Scheme used for `[[wiki-link]]` anchors in the rendered preview.
+///
+/// The preview runs with JavaScript off — a vault document can arrive by
+/// `git pull`, so it is not the operator's own writing by default. That
+/// rules out a click handler, so links are ordinary anchors on a scheme
+/// the webview will never resolve, and the navigation itself is what
+/// gets intercepted.
+const kWikiLinkScheme = 'opendray-wiki';
+
+// ---------------------------------------------------------------- paths
+
+final _leadingSlashes = RegExp('^/+');
+final _leadingDots = RegExp(r'^\.+');
+final _whitespaceRun = RegExp(r'\s+');
+// Everything a filename may keep. Unlike the web's ASCII-only class this
+// admits any Unicode letter or number — see sanitizeNotePath.
+final _unsafePathChars = RegExp(r'[^\p{Letter}\p{Number}_.\- ]', unicode: true);
+final _docExtension = RegExp(r'\.(md|markdown|html?)$', caseSensitive: false);
+
+/// Clean a user-typed note path, one segment at a time.
+///
+/// Slashes are meaningful — they are how a document gets filed under
+/// `features/` — so they survive, while empty and dot-only segments are
+/// dropped and `..` can never reach the request.
+///
+/// Two things this fixes relative to what the phone did before:
+///
+///   * `.md` was appended unconditionally, so `guide.html` became
+///     `guide.html.md` and an HTML document could not be created at all.
+///   * Nothing was cleaned beyond a leading slash.
+///
+/// DIVERGES FROM WEB, deliberately: the web replaces every character
+/// outside `[A-Za-z0-9_.- ]` with a dash, which turns `笔记.md` into
+/// `--.md`. The phone accepts CJK filenames today and mirroring the web
+/// would be a regression, so the class is Unicode-aware here.
+String sanitizeNotePath(String input, {String defaultExt = '.md'}) {
+  final segments = input
+      .trim()
+      .split('/')
+      .map((s) => s
+          .trim()
+          .replaceAll(_unsafePathChars, '-')
+          .replaceAll(_whitespaceRun, '-')
+          .replaceFirst(_leadingDots, ''))
+      .where((s) => s.isNotEmpty)
+      .toList();
+  if (segments.isEmpty) return 'untitled$defaultExt';
+  final last = segments.last;
+  // Only append an extension when the name doesn't already carry a
+  // recognised one.
+  if (docKindOf(last) == DocKind.unknown) {
+    segments[segments.length - 1] = '$last$defaultExt';
+  }
+  return segments.join('/');
+}
+
+// -------------------------------------------------------------- outline
+
+/// One heading in a document's outline.
+class OutlineHeading {
+  const OutlineHeading({
+    required this.level,
+    required this.text,
+    required this.slug,
+    required this.lineIndex,
+    required this.charOffset,
+  });
+
+  /// 1..6.
+  final int level;
+  final String text;
+
+  /// Fragment-safe id, deduped within the document. Matches the id the
+  /// markdown renderer emits, so it doubles as an anchor target.
+  final String slug;
+
+  /// 0-based line the heading sits on.
+  final int lineIndex;
+
+  /// Index of the heading line's first character in the body. The phone
+  /// navigates by moving the caret, so this — not [lineIndex] — is what
+  /// actually drives the jump.
+  final int charOffset;
+}
+
+final _headingRe = RegExp(r'^(#{1,6})\s+(.+?)\s*#*\s*$');
+final _fenceRe = RegExp('^(```|~~~)');
+final _nonSlugChars = RegExp(r'[^\p{Letter}\p{Number}]+', unicode: true);
+final _edgeDashes = RegExp(r'^-+|-+$');
+
+/// Lowercase, collapse non-alphanumeric runs to `-`, trim the edges.
+///
+/// `\p{Letter}` rather than `\w`: an ASCII-only rule collapses a Chinese
+/// heading to nothing, so every one of them would share the slug
+/// "section" and the outline could not tell them apart.
+String slugify(String text) {
+  final out = text
+      .toLowerCase()
+      .replaceAll(_nonSlugChars, '-')
+      .replaceAll(_edgeDashes, '');
+  return out.isEmpty ? 'section' : out;
+}
+
+/// Walk the body for ATX headings, skipping fenced code regions.
+List<OutlineHeading> extractOutline(String body) {
+  final out = <OutlineHeading>[];
+  final seen = <String, int>{};
+  var inFence = false;
+  var offset = 0;
+  final lines = body.split('\n');
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i];
+    final lineStart = offset;
+    offset += line.length + 1; // +1 for the '\n' split consumed
+    final trimmed = line.trim();
+    if (_fenceRe.hasMatch(trimmed)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    final m = _headingRe.firstMatch(line);
+    if (m == null) continue;
+    final text = m.group(2)!.trim();
+    if (text.isEmpty) continue;
+    final base = slugify(text);
+    final n = seen[base] ?? 0;
+    seen[base] = n + 1;
+    out.add(OutlineHeading(
+      level: m.group(1)!.length,
+      text: text,
+      slug: n > 0 ? '$base-$n' : base,
+      lineIndex: i,
+      charOffset: lineStart,
+    ));
+  }
+  return out;
+}
+
+// ----------------------------------------------------------------- tags
+
+final _fencedBlock = RegExp(r'```[\s\S]*?```');
+final _inlineCode = RegExp('`[^`]*`');
+final _tagRe = RegExp('(?:^|[^A-Za-z0-9_-])#([A-Za-z][A-Za-z0-9_/-]{0,40})');
+final _frontmatterInlineTags = RegExp(r'tags:\s*\[(.*?)\]');
+final _frontmatterBlockTags = RegExp(r'tags:\s*\n((?:\s*-\s*.+\n?)+)');
+final _quotes = RegExp(r"""^['"]|['"]$""");
+
+/// Pull `#tag` mentions and frontmatter `tags:` entries out of a body.
+/// Mirrors the backend scanner in internal/notes/links.go so the chips
+/// shown on a document match what the tag index will file it under.
+List<String> extractTags(String body) {
+  final tags = <String>{};
+
+  if (body.startsWith('---')) {
+    final end = body.substring(3).indexOf('---');
+    if (end >= 0) {
+      final header = body.substring(3, 3 + end);
+      final inline = _frontmatterInlineTags.firstMatch(header);
+      if (inline != null) {
+        for (final raw in inline.group(1)!.split(',')) {
+          final cleaned = raw.trim().replaceAll(_quotes, '');
+          if (cleaned.isNotEmpty) tags.add(cleaned);
+        }
+      }
+      final block = _frontmatterBlockTags.firstMatch(header);
+      if (block != null) {
+        for (final line in block.group(1)!.split('\n')) {
+          final cleaned = line
+              .replaceFirst(RegExp(r'^\s*-\s*'), '')
+              .trim()
+              .replaceAll(_quotes, '');
+          if (cleaned.isNotEmpty) tags.add(cleaned);
+        }
+      }
+    }
+  }
+
+  // Code is prose about code, not tags in it.
+  final stripped =
+      body.replaceAll(_fencedBlock, ' ').replaceAll(_inlineCode, ' ');
+  for (final m in _tagRe.allMatches(stripped)) {
+    tags.add(m.group(1)!.replaceFirst(RegExp(r'/$'), ''));
+  }
+  return tags.toList();
+}
+
+// ------------------------------------------------------------ wiki links
+
+/// Where the caret sits inside an unclosed `[[`.
+class WikiLinkContext {
+  const WikiLinkContext({required this.query, required this.openIdx});
+
+  /// Text typed since the opening brackets.
+  final String query;
+
+  /// Index of the first `[` of the pair.
+  final int openIdx;
+}
+
+/// Inspect the text before [caretPos] and return the active `[[…` query,
+/// or null when the caret is not inside an open wiki-link. A `]` or a
+/// newline in between counts as a close.
+WikiLinkContext? detectWikiLinkContext(String text, int caretPos) {
+  // Hard cap the walk — a runaway buffer shouldn't burn cycles scanning
+  // hundreds of KB backwards on every keystroke.
+  const searchLimit = 256;
+  final start = caretPos - searchLimit < 0 ? 0 : caretPos - searchLimit;
+  for (var i = caretPos - 1; i >= start; i--) {
+    final ch = text[i];
+    if (ch == '\n' || ch == ']') return null;
+    if (ch == '[' && i > 0 && text[i - 1] == '[') {
+      return WikiLinkContext(
+        query: text.substring(i + 1, caretPos),
+        openIdx: i - 1,
+      );
+    }
+  }
+  return null;
+}
+
+/// Turn a wiki-link target into the vault path it points at.
+///
+/// A target with a slash is a full vault path. A bare name matches any
+/// document's basename, case-insensitively. Anything unmatched resolves
+/// next to the current note — the link is a document that doesn't exist
+/// yet, which is a normal state in a wiki, not an error.
+String resolveWikiLink(
+  String target, {
+  required Iterable<String> allPaths,
+  String currentDir = '',
+}) {
+  final cleaned = target
+      .trim()
+      .replaceFirst(_leadingSlashes, '')
+      .replaceFirst(_docExtension, '');
+  if (cleaned.contains('/')) return '$cleaned.md';
+  final needle = cleaned.toLowerCase();
+  for (final path in allPaths) {
+    final base =
+        path.split('/').last.replaceFirst(_docExtension, '').toLowerCase();
+    if (base == needle) return path;
+  }
+  return currentDir.isEmpty ? '$cleaned.md' : '$currentDir/$cleaned.md';
+}
+
+final _wikiLinkRe = RegExp(r'\[\[([^\]|\n]+)(?:\|([^\]\n]+))?\]\]');
+
+/// Rewrite `[[Target]]` / `[[Target|Alias]]` into anchors on
+/// [kWikiLinkScheme], leaving everything else untouched.
+///
+/// Runs on the markdown SOURCE, before conversion, because the converter
+/// passes inline HTML through. Code — fenced and inline — is skipped: a
+/// document explaining the syntax has to be able to show it, and the
+/// converter escapes HTML inside code, so a rewritten link there would
+/// render as a visible `<a href=…>` tag.
+String linkifyWikiLinks(String markdown) {
+  final lines = markdown.split('\n');
+  var inFence = false;
+  for (var i = 0; i < lines.length; i++) {
+    if (_fenceRe.hasMatch(lines[i].trim())) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    lines[i] = _linkifyOutsideInlineCode(lines[i]);
+  }
+  return lines.join('\n');
+}
+
+String _linkifyOutsideInlineCode(String line) {
+  final buf = StringBuffer();
+  var cursor = 0;
+  for (final code in _inlineCode.allMatches(line)) {
+    buf
+      ..write(_linkifySpan(line.substring(cursor, code.start)))
+      ..write(code.group(0)); // verbatim
+    cursor = code.end;
+  }
+  buf.write(_linkifySpan(line.substring(cursor)));
+  return buf.toString();
+}
+
+String _linkifySpan(String span) {
+  return span.replaceAllMapped(_wikiLinkRe, (m) {
+    final target = m.group(1)!.trim();
+    final label = (m.group(2) ?? m.group(1)!).trim();
+    final href =
+        '$kWikiLinkScheme://open?target=${Uri.encodeQueryComponent(target)}';
+    return '<a href="$href">${escapeHtml(label)}</a>';
+  });
+}
+
+/// Escape text for insertion into generated HTML. The label comes from a
+/// document that may have been pulled from a git remote, so it is not
+/// trusted markup.
+String escapeHtml(String s) => s
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+
+// ----------------------------------------------------------- daily note
+
+/// Vault path of [day]'s daily note.
+String dailyNotePath(DateTime day) =>
+    'daily/${_pad4(day.year)}-${_pad2(day.month)}-${_pad2(day.day)}.md';
+
+/// Starting body for a daily note. Deliberately NOT translated: this is
+/// document content, and a note's headings must not depend on which
+/// language the app happened to be in when it was created. Kept
+/// character-for-character in step with handleNewDaily in
+/// app/web/src/pages/Notes.tsx so one date yields one document, whether
+/// it was started on the phone or in the browser.
+String dailyNoteBody(DateTime day, {required String longDate}) {
+  final date = '${_pad4(day.year)}-${_pad2(day.month)}-${_pad2(day.day)}';
+  return '---\ndate: $date\ntype: daily\n---\n\n# $longDate\n\n'
+      "## What I'm doing\n\n## What I learned\n\n## TODO\n\n";
+}
+
+String _pad2(int n) => n.toString().padLeft(2, '0');
+String _pad4(int n) => n.toString().padLeft(4, '0');
+
+/// Read the target back out of a [kWikiLinkScheme] URL, or null if the
+/// URL isn't one of ours.
+String? wikiLinkTarget(Uri uri) {
+  if (uri.scheme != kWikiLinkScheme) return null;
+  final target = uri.queryParameters['target'];
+  if (target == null || target.isEmpty) return null;
+  return target;
+}

--- a/app/mobile/test/core/api/notes_parse_test.dart
+++ b/app/mobile/test/core/api/notes_parse_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opendray/core/api/notes_api.dart';
+
+// Parsing for the two vault endpoints the phone previously had no
+// client for at all. Shapes come from internal/notes/links.go.
+void main() {
+  group('Backlink.fromJson', () {
+    test('reads path, title and the context lines', () {
+      final b = Backlink.fromJson(const {
+        'path': 'projects/opendray/spec.md',
+        'title': 'Spec',
+        'modified': '2026-08-10T09:00:00Z',
+        'lines': ['see [[canvas]] for the shape', 'and [[canvas|it]] again'],
+      });
+      expect(b.path, 'projects/opendray/spec.md');
+      expect(b.title, 'Spec');
+      expect(b.lines, hasLength(2));
+    });
+
+    test('survives a response with no lines at all', () {
+      // `lines` is omitempty-adjacent on the Go side; a missing key must
+      // not take the whole pane down.
+      final b = Backlink.fromJson(const {'path': 'a.md'});
+      expect(b.lines, isEmpty);
+      expect(b.title, '');
+    });
+
+    test('drops non-string entries rather than throwing', () {
+      final b = Backlink.fromJson(const {
+        'path': 'a.md',
+        'lines': ['ok', 42, null],
+      });
+      expect(b.lines, ['ok']);
+    });
+  });
+
+  group('TagCount.fromJson', () {
+    test('reads the tag, its count and the notes carrying it', () {
+      final t = TagCount.fromJson(const {
+        'tag': 'infra',
+        'count': 2,
+        'notes': ['a.md', 'b.md'],
+      });
+      expect(t.tag, 'infra');
+      expect(t.count, 2);
+      expect(t.notes, ['a.md', 'b.md']);
+    });
+
+    test('defaults notes to empty — the field is omitempty', () {
+      final t = TagCount.fromJson(const {'tag': 'solo', 'count': 1});
+      expect(t.notes, isEmpty);
+    });
+
+    test('tolerates a count arriving as a double', () {
+      final t = TagCount.fromJson(const {'tag': 'x', 'count': 3.0});
+      expect(t.count, 3);
+    });
+  });
+}

--- a/app/mobile/test/features/notes/doc_preview_test.dart
+++ b/app/mobile/test/features/notes/doc_preview_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:opendray/features/notes/doc_preview.dart';
+import 'package:opendray/features/notes/vault_text.dart' show kWikiLinkScheme;
 
 void main() {
   group('docKindOf', () {
@@ -79,9 +80,27 @@ void main() {
       expect(out, contains('target="_blank"'));
     });
 
-    test('leaves wiki links as literal text', () {
+    test('leaves wiki links as literal text by default', () {
+      // Where the caller has nowhere to send the tap, a dead link is
+      // worse than plain text.
       final out = renderMarkdownDocument('See [[projects/foo]].');
       expect(out, contains('[[projects/foo]]'));
+    });
+
+    test('renders wiki links as anchors when asked', () {
+      final out = renderMarkdownDocument(
+        'See [[projects/foo]].',
+        wikiLinks: true,
+      );
+      expect(out, contains('href="$kWikiLinkScheme://open?'));
+      expect(out, isNot(contains('[[projects/foo]]')));
+    });
+
+    test('does not retarget a wiki-link anchor to a new window', () {
+      // target="_blank" on an intercepted scheme asks the webview for a
+      // popup it is configured to refuse.
+      final out = renderMarkdownDocument('[[foo]]', wikiLinks: true);
+      expect(out, isNot(contains('target="_blank"')));
     });
   });
 }

--- a/app/mobile/test/features/notes/vault_text_test.dart
+++ b/app/mobile/test/features/notes/vault_text_test.dart
@@ -1,0 +1,264 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opendray/features/notes/vault_text.dart';
+
+// The vault's text layer is ported from app/shared/src/lib/{notes,outline,
+// caret}.ts and NoteEditor.tsx. These tests pin the behaviours the phone
+// shares with the web so the two can't drift apart silently — the pattern
+// that produced the mobile-parity gaps in the first place.
+void main() {
+  group('slugify', () {
+    test('lowercases and joins on non-alphanumerics', () {
+      expect(slugify('Getting Started'), 'getting-started');
+      expect(slugify('  Trim  Me  '), 'trim-me');
+      expect(slugify('a/b:c'), 'a-b-c');
+    });
+
+    test(r'keeps CJK — \p{Letter} is not \w', () {
+      // A heading written in Chinese must still get a usable slug. An
+      // ASCII-only rule collapses the whole thing to "section", which
+      // makes every Chinese heading in a document share one id.
+      expect(slugify('安装步骤'), '安装步骤');
+      expect(slugify('第 1 章 · 概览'), '第-1-章-概览');
+    });
+
+    test('falls back to "section" when nothing survives', () {
+      expect(slugify('---'), 'section');
+      expect(slugify(''), 'section');
+    });
+  });
+
+  group('extractOutline', () {
+    test('picks ATX headings with level, text and line index', () {
+      const body = '# Title\n\nintro\n\n## Section A\n\n### Deep\n';
+      final out = extractOutline(body);
+      expect(out.map((h) => h.text), ['Title', 'Section A', 'Deep']);
+      expect(out.map((h) => h.level), [1, 2, 3]);
+      expect(out.map((h) => h.lineIndex), [0, 4, 6]);
+    });
+
+    test('skips headings inside fenced code', () {
+      const body = '# Real\n\n```md\n# Not a heading\n```\n\n## Also real\n';
+      final out = extractOutline(body);
+      expect(out.map((h) => h.text), ['Real', 'Also real']);
+    });
+
+    test('dedupes repeated slugs with a numeric suffix', () {
+      const body = '## Notes\n\n## Notes\n\n## Notes\n';
+      expect(
+        extractOutline(body).map((h) => h.slug),
+        ['notes', 'notes-1', 'notes-2'],
+      );
+    });
+
+    test('strips closing hashes and ignores empty headings', () {
+      const body = '## Closed ##\n\n###\n';
+      final out = extractOutline(body);
+      expect(out.length, 1);
+      expect(out.single.text, 'Closed');
+    });
+
+    test('charOffset points at the start of the heading line', () {
+      // The phone jumps by moving the caret, so the offset — not the
+      // line index — is what actually drives navigation.
+      const body = '# One\n\nbody\n\n## Two\n';
+      final out = extractOutline(body);
+      expect(body.substring(out[0].charOffset).startsWith('# One'), isTrue);
+      expect(body.substring(out[1].charOffset).startsWith('## Two'), isTrue);
+    });
+  });
+
+  group('extractTags', () {
+    test('reads inline frontmatter arrays', () {
+      const body = '---\ntags: [alpha, "beta", \'gamma\']\n---\n\n# Doc\n';
+      expect(extractTags(body), containsAll(['alpha', 'beta', 'gamma']));
+    });
+
+    test('reads block frontmatter lists', () {
+      const body = '---\ntags:\n  - one\n  - two\n---\n\nbody\n';
+      expect(extractTags(body), containsAll(['one', 'two']));
+    });
+
+    test('reads #tags from the body', () {
+      const body = 'see #alpha and #beta/nested here';
+      expect(extractTags(body), containsAll(['alpha', 'beta/nested']));
+    });
+
+    test('ignores tags inside code', () {
+      const body = 'text\n\n```\n#notatag\n```\n\nand `#alsonot` here';
+      expect(extractTags(body), isEmpty);
+    });
+
+    test('does not treat a markdown heading as a tag', () {
+      // `# Heading` is a hash followed by a space — the tag pattern
+      // requires a letter straight after the hash.
+      expect(extractTags('# Heading\n'), isEmpty);
+    });
+  });
+
+  group('sanitizeNotePath', () {
+    test('keeps slashes so folders can be created', () {
+      expect(sanitizeNotePath('features/canvas'), 'features/canvas.md');
+    });
+
+    test('leaves a recognised extension alone', () {
+      // The bug this replaces: the phone appended .md unconditionally,
+      // so an HTML document could not be created at all.
+      expect(sanitizeNotePath('guide.html'), 'guide.html');
+      expect(sanitizeNotePath('guide.htm'), 'guide.htm');
+      expect(sanitizeNotePath('notes.md'), 'notes.md');
+      expect(sanitizeNotePath('README.markdown'), 'README.markdown');
+    });
+
+    test('appends the default extension to an unknown one', () {
+      expect(sanitizeNotePath('report.2026'), 'report.2026.md');
+      expect(sanitizeNotePath('plain'), 'plain.md');
+    });
+
+    test('drops traversal and empty segments', () {
+      expect(sanitizeNotePath('../../etc/passwd'), 'etc/passwd.md');
+      expect(sanitizeNotePath('//a///b//'), 'a/b.md');
+      expect(sanitizeNotePath('.'), 'untitled.md');
+      expect(sanitizeNotePath('   '), 'untitled.md');
+    });
+
+    test('collapses whitespace into dashes', () {
+      expect(sanitizeNotePath('my great note'), 'my-great-note.md');
+    });
+
+    test('keeps CJK filenames intact', () {
+      // The web sanitiser replaces every non-ASCII character with a
+      // dash, which turns 笔记.md into --.md. Mirroring that here would
+      // regress the phone, which accepts Chinese filenames today.
+      expect(sanitizeNotePath('笔记/会议纪要'), '笔记/会议纪要.md');
+    });
+  });
+
+  group('detectWikiLinkContext', () {
+    test('returns the query when the caret sits inside an open [[', () {
+      const text = 'see [[can';
+      final ctx = detectWikiLinkContext(text, text.length);
+      expect(ctx, isNotNull);
+      expect(ctx!.query, 'can');
+      expect(ctx.openIdx, 4);
+    });
+
+    test('is null once the link is closed', () {
+      const text = 'see [[canvas]] ';
+      expect(detectWikiLinkContext(text, text.length), isNull);
+    });
+
+    test('is null across a newline', () {
+      const text = 'see [[\nstill';
+      expect(detectWikiLinkContext(text, text.length), isNull);
+    });
+
+    test('matches an empty query right after [[', () {
+      const text = 'x [[';
+      final ctx = detectWikiLinkContext(text, text.length);
+      expect(ctx?.query, '');
+      expect(ctx?.openIdx, 2);
+    });
+
+    test('a single bracket is not a wiki link', () {
+      const text = 'array[idx';
+      expect(detectWikiLinkContext(text, text.length), isNull);
+    });
+  });
+
+  group('resolveWikiLink', () {
+    const all = [
+      'projects/opendray/spec.md',
+      'daily/2026-08-10.md',
+      'personal/Canvas.md',
+    ];
+
+    test('matches a bare basename case-insensitively', () {
+      expect(
+        resolveWikiLink('canvas', allPaths: all),
+        'personal/Canvas.md',
+      );
+    });
+
+    test('treats a target containing a slash as a full path', () {
+      expect(
+        resolveWikiLink('projects/opendray/spec', allPaths: all),
+        'projects/opendray/spec.md',
+      );
+    });
+
+    test('falls back to a sibling of the current note when unknown', () {
+      expect(
+        resolveWikiLink('brand new', allPaths: all, currentDir: 'daily'),
+        'daily/brand new.md',
+      );
+      expect(resolveWikiLink('orphan', allPaths: all), 'orphan.md');
+    });
+
+    test('tolerates an explicit .md and leading slashes', () {
+      expect(resolveWikiLink('/canvas.md', allPaths: all), 'personal/Canvas.md');
+    });
+  });
+
+  group('linkifyWikiLinks', () {
+    test('rewrites [[Target]] into an anchor on the wiki scheme', () {
+      final out = linkifyWikiLinks('see [[Canvas]] here');
+      expect(out, contains('href="$kWikiLinkScheme://open?target=Canvas"'));
+      expect(out, contains('>Canvas</a>'));
+    });
+
+    test('uses the alias as the visible label', () {
+      final out = linkifyWikiLinks('[[projects/spec|the spec]]');
+      expect(out, contains('>the spec</a>'));
+      expect(out, contains('target=projects%2Fspec'));
+    });
+
+    test('escapes the label so a document cannot inject markup', () {
+      final out = linkifyWikiLinks('[[x|<script>alert(1)</script>]]');
+      expect(out, isNot(contains('<script>')));
+      expect(out, contains('&lt;script&gt;'));
+    });
+
+    test('leaves wiki syntax inside fenced code alone', () {
+      // A document explaining the syntax must still show it. Rewriting
+      // it here would render the raw <a …> tag as visible text, since
+      // the markdown converter escapes HTML inside code.
+      const body = 'real [[One]]\n\n```\nliteral [[Two]]\n```\n';
+      final out = linkifyWikiLinks(body);
+      expect(out, contains('>One</a>'));
+      expect(out, contains('literal [[Two]]'));
+    });
+
+    test('leaves wiki syntax inside inline code alone', () {
+      final out = linkifyWikiLinks('type `[[Name]]` to link');
+      expect(out, contains('`[[Name]]`'));
+    });
+
+    test('leaves plain text untouched', () {
+      expect(linkifyWikiLinks('nothing to see'), 'nothing to see');
+    });
+  });
+
+  group('daily note', () {
+    test('files the note under daily/ with a zero-padded date', () {
+      expect(dailyNotePath(DateTime(2026, 8, 9)), 'daily/2026-08-09.md');
+      expect(dailyNotePath(DateTime(2026, 12, 31)), 'daily/2026-12-31.md');
+    });
+
+    test('body carries the frontmatter the web template does', () {
+      final body = dailyNoteBody(
+        DateTime(2026, 8, 10),
+        longDate: 'Monday, August 10, 2026',
+      );
+      expect(body, startsWith('---\ndate: 2026-08-10\ntype: daily\n---\n'));
+      expect(body, contains('# Monday, August 10, 2026'));
+      expect(body, contains("## What I'm doing"));
+      expect(body, contains('## What I learned'));
+      expect(body, contains('## TODO'));
+    });
+
+    test('frontmatter marks it as a daily note for the tag index', () {
+      final body = dailyNoteBody(DateTime(2026, 1, 2), longDate: 'x');
+      expect(extractOutline(body).first.text, 'x');
+    });
+  });
+}


### PR DESCRIPTION
The phone's vault could create, read, edit, rename and delete a document — basic CRUD was already there. What it had none of is the layer that makes a vault a vault: tags, backlinks, working `[[wiki links]]`, an outline, a daily note. This adds all of it, plus one create-path defect found on the way.

## Gap this closes

| Capability | web | mobile before | mobile now |
|---|---|---|---|
| Browse / search / open / edit / rename / delete | ✅ | ✅ | ✅ |
| Tag browsing `#tag` | ✅ | ❌ | ✅ |
| Backlinks | ✅ | ❌ | ✅ |
| `[[wiki links]]` clickable | ✅ | ❌ literal text | ✅ |
| Wiki-link autocomplete | ✅ | ❌ | ✅ |
| Outline / heading jump | ✅ | ❌ | ✅ (source view — see below) |
| Today / daily note | ✅ | ❌ | ✅ |
| Frontmatter tag chips | ✅ | ❌ | ✅ |
| Create `page.html` | ✅ | ❌ **became `page.html.md`** | ✅ |

No Go changes: `/notes/tags` and `/notes/backlinks` were already registered in `internal/notes/handler.go`. The phone simply had no client for either.

## Shared text layer

New `app/mobile/lib/features/notes/vault_text.dart`, ported from `app/shared/src/lib/{notes,outline,caret}.ts` and `NoteEditor.tsx` so both clients read the same documents the same way. Pure Dart — no Flutter, no I/O — so it is covered by unit tests rather than only by tapping around on a device.

## Three decisions worth reviewing

**The outline jump lands in SOURCE view, not preview.** The preview is an `InAppWebView` with `javaScriptEnabled: false`, because a vault document can arrive by `git pull` and is not the operator's own writing by default. Scrolling a webview to an anchor needs a script. Enabling JS for markdown would open a real hole — `ExtensionSet.gitHubWeb` passes raw inline HTML through, so a `<script>` in a pulled document would execute. Moving the caret is what the phone can do honestly; a snackbar says so when the jump comes from preview. Scroll-to-heading inside preview needs HTML sanitisation first, which is its own change.

**Wiki links are anchors on a custom scheme, intercepted at navigation.** Same reason — no scripts, so no click handler. `[[Target|Alias]]` becomes `<a href="opendray-wiki://open?target=…">` before markdown conversion, and `shouldOverrideUrlLoading` cancels the navigation and opens the note. Labels are HTML-escaped; `retargetLinks` skips the scheme so the webview is never asked for a popup it refuses.

**Two deliberate divergences from the web**, both commented where they happen:
- Path and slug character classes are Unicode-aware. The web replaces every non-ASCII character with a dash, which turns `笔记.md` into `--.md`. The phone accepts CJK filenames today, so mirroring the web would have been a regression.
- Wiki-link rewriting skips fenced and inline code. The web's sentinel approach leaves stray characters in code blocks; here a rewritten link inside code would render as a visible `<a href=…>` tag, because the converter escapes HTML there.

## Test plan

- `flutter analyze` — clean
- `flutter test` — **123 passing** (78 on main; 45 new across `vault_text_test`, `notes_parse_test` and `doc_preview_test`)
- i18n parity 100% across en/zh/es, slang regenerated, no dead keys left behind
- `go build ./...` — green
- `pnpm --filter web build` — green

**Not covered by tests — needs the device.** CI has no Flutter job, so nothing here was verified by the checks below. Three things in particular only a real run can confirm:
1. the webview navigation intercept actually firing on a wiki-link tap (Android needs `useShouldOverrideUrlLoading`, set here),
2. the outline caret jump scrolling the field as intended,
3. the suggestion list fitting above the keyboard rather than fighting it.

Reviewer note: `app/mobile/pubspec.yaml` is untouched (skip-worktree intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)