### PR TITLE
fix(catalog): compare resolved paths when detecting non-npm bin links

### DIFF
--- a/internal/catalog/probe.go
+++ b/internal/catalog/probe.go
@@ -416,9 +416,22 @@ func unmanagedBinLink(npmRoot, exe string) (path string, isFile bool) {
 	if err != nil {
 		return p, false // dangling — safe to replace
 	}
-	if dest == npmRoot || strings.HasPrefix(dest, npmRoot+string(os.PathSeparator)) {
+	// Compare resolved against resolved. The prefix itself often sits
+	// behind a symlink — nvm, a linked /usr/local, or on macOS simply
+	// /var -> /private/var — and resolving only one side makes the two
+	// incomparable, so npm's own shim looks foreign and a healthy install
+	// gets reported as hijacked. If npmRoot can't be resolved (npm has
+	// installed nothing yet) fall back to it verbatim: an entry in bin
+	// then genuinely isn't npm's.
+	root := npmRoot
+	if resolved, err := filepath.EvalSymlinks(npmRoot); err == nil {
+		root = resolved
+	}
+	if dest == root || strings.HasPrefix(dest, root+string(os.PathSeparator)) {
 		return "", false // npm's own shim
 	}
+	// Report the path the CALLER knows, not the resolved one — it is what
+	// they must remove, and what the operator sees in the message.
 	return p, false // vendor installer's link
 }
 

--- a/internal/catalog/probe_binlink_test.go
+++ b/internal/catalog/probe_binlink_test.go
@@ -79,6 +79,90 @@ func TestUnmanagedBinLink_VendorInstallerLinkIsReported(t *testing.T) {
 	}
 }
 
+// The npm prefix itself can sit behind a symlink — nvm, a linked
+// /usr/local, or on macOS simply /var -> /private/var, which is why this
+// case reproduced on darwin and not on CI's Linux. Resolving the bin link
+// while leaving npmRoot unresolved makes the two paths incomparable, so
+// npm's own shim looks foreign and a healthy install gets reported as
+// hijacked. Build the symlinked prefix explicitly so every platform runs
+// the same check.
+func TestUnmanagedBinLink_NpmOwnedLinkUnderSymlinkedPrefix(t *testing.T) {
+	base := t.TempDir()
+	realPrefix := filepath.Join(base, "real")
+	root := filepath.Join(realPrefix, "lib", "node_modules")
+	bin := filepath.Join(realPrefix, "bin")
+	for _, d := range []string{root, bin} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A second path to the same tree, the way nvm/homebrew/macOS do it.
+	linkedPrefix := filepath.Join(base, "linked")
+	if err := os.Symlink(realPrefix, linkedPrefix); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	// npm's own shim: bin/grok -> ../lib/node_modules/<pkg>/bin/grok
+	target := filepath.Join(root, "@xai-official", "grok", "bin", "grok")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(bin, "grok")); err != nil {
+		t.Fatal(err)
+	}
+
+	// `npm root -g` reports the path the caller reached it by — here the
+	// symlinked one, which is what makes this differ from the plain case.
+	linkedRoot := filepath.Join(linkedPrefix, "lib", "node_modules")
+	link, isFile := unmanagedBinLink(linkedRoot, "grok")
+	if link != "" || isFile {
+		t.Errorf("npm-owned link under a symlinked prefix must not be reported as unmanaged; got link=%q isFile=%v", link, isFile)
+	}
+}
+
+// A vendor installer's link must still be caught when the prefix is
+// symlinked — the fix must not turn into "resolve everything, report
+// nothing".
+func TestUnmanagedBinLink_VendorLinkUnderSymlinkedPrefix(t *testing.T) {
+	base := t.TempDir()
+	realPrefix := filepath.Join(base, "real")
+	root := filepath.Join(realPrefix, "lib", "node_modules")
+	bin := filepath.Join(realPrefix, "bin")
+	for _, d := range []string{root, bin} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	linkedPrefix := filepath.Join(base, "linked")
+	if err := os.Symlink(realPrefix, linkedPrefix); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	vendor := filepath.Join(base, "grok-downloads", "grok")
+	if err := os.MkdirAll(filepath.Dir(vendor), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(vendor, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(vendor, filepath.Join(bin, "grok")); err != nil {
+		t.Fatal(err)
+	}
+
+	linkedRoot := filepath.Join(linkedPrefix, "lib", "node_modules")
+	want := filepath.Join(linkedPrefix, "lib", "node_modules", "..", "..", "bin", "grok")
+	link, isFile := unmanagedBinLink(linkedRoot, "grok")
+	if link != filepath.Clean(want) {
+		t.Errorf("vendor link under symlinked prefix not reported: got %q, want %q", link, filepath.Clean(want))
+	}
+	if isFile {
+		t.Error("a symlink must not be reported as a regular file")
+	}
+}
+
 func TestUnmanagedBinLink_DanglingLinkIsReplaceable(t *testing.T) {
 	root, bin := npmPrefix(t)
 	want := filepath.Join(bin, "grok")


### PR DESCRIPTION
## The bug

`unmanagedBinLink` decides whether an entry in npm's bin directory belongs to npm or to a vendor installer. It resolved one side of that comparison and not the other:

```go
dest, err := filepath.EvalSymlinks(p)          // resolved
...
if dest == npmRoot || strings.HasPrefix(dest, npmRoot+string(os.PathSeparator))
//                   ^^^^^^^ NOT resolved
```

Whenever the npm prefix itself sits behind a symlink — nvm, a linked `/usr/local`, or on macOS simply `/var -> /private/var` — the two paths can never match. npm's own shim fails the ownership check and a perfectly healthy install is classified as a vendor installer's hijack.

## Why it matters

This is not a cosmetic false report. The Update path acts on the result (`probe.go:214`):

```go
if link, isFile := unmanagedBinLink(dir, m.Executable); link != "" {
    ...
    if rmErr := os.Remove(link); rmErr != nil { ... }
    migrated = link
}
```

So on a misclassification opendray **deletes npm's own bin shim**, then reports to the operator that it migrated a non-npm install. The `npm install -g` that follows normally recreates the shim, which is why this can go unnoticed — but if that install fails for any reason (network, permissions, a wedged prefix) the executable is simply gone, and the operator is left with a CLI that has vanished rather than one that failed to update.

Trigger conditions are narrow in production (it needs a symlink on the `npm root -g` path), but the consequence when it does trigger is destructive, and the same code is what protects against grok's `curl | bash` installer.

## The fix

Resolve both sides before comparing. Two deliberate details:

- **`npmRoot` unresolvable → fall back to it verbatim.** That means npm has installed nothing yet, in which case an entry in `bin` genuinely is not npm's, and the existing report-it behaviour is correct.
- **The reported path stays the unresolved one.** It is what the caller must `os.Remove` and what the operator sees in the error message; handing back a `/private/var/...` path they never typed would be worse.

## Why CI never caught it

`t.TempDir()` returns `/var/folders/...` on macOS, and `/var` is a symlink to `/private/var`, so `TestUnmanagedBinLink_NpmOwnedLinkIsLeftAlone` hit the bug on **every** local run. CI is Linux, where `/tmp` is a real directory, so it passed there consistently. Verified:

```
TMPDIR       = /var/folders/s4/.../T/
EvalSymlinks = /private/var/folders/s4/.../T
differs      = true
```

The two new tests build the symlinked prefix **explicitly** rather than relying on the platform's temp dir, so this is now covered on Linux CI too:

- `TestUnmanagedBinLink_NpmOwnedLinkUnderSymlinkedPrefix` — the regression itself
- `TestUnmanagedBinLink_VendorLinkUnderSymlinkedPrefix` — guards the other direction, so the fix can't quietly become "resolve everything, report nothing" and stop catching the case the function exists for

## Test plan

- `go test ./internal/catalog/ -race` — green, **including** `TestUnmanagedBinLink_NpmOwnedLinkIsLeftAlone`, which failed on this machine before the fix
- `go build ./...` and `go test ./internal/...` green
- `gofmt` + `go vet` clean

## Note

Branched from `main`, independent of #513 — that one only surfaced this failure, it did not cause it. Keeping them separate so either can be reverted alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)