### PR TITLE
feat(cortex): review proposals as a diff instead of two full documents

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -3499,6 +3499,13 @@
         "bypass": "Skip permissions (YOLO)",
         "bypassHint": "Start the session with its bypass flag so it does not prompt for approvals."
       }
+    },
+    "diff": {
+      "noChanges": "No changes — the proposed content is identical to the live page.",
+      "added": "+{count}",
+      "removed": "−{count}",
+      "changedLines": "changed lines",
+      "collapsed": "⋯ {count} unchanged ⋯"
     }
   },
   "more": {

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -3499,6 +3499,13 @@
         "bypass": "Omitir permisos (YOLO)",
         "bypassHint": "Inicia la sesión con su indicador de bypass para no pedir aprobaciones."
       }
+    },
+    "diff": {
+      "noChanges": "Sin cambios: el contenido propuesto es idéntico a la página actual.",
+      "added": "+{count}",
+      "removed": "−{count}",
+      "changedLines": "líneas modificadas",
+      "collapsed": "⋯ {count} sin cambios ⋯"
     }
   },
   "more": {

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -3496,6 +3496,13 @@
         "bypass": "跳过权限 (YOLO)",
         "bypassHint": "用 bypass 标志启动会话,不再逐个请求批准。"
       }
+    },
+    "diff": {
+      "noChanges": "没有改动 —— 提案内容与当前页面完全一致。",
+      "added": "+{count}",
+      "removed": "−{count}",
+      "changedLines": "行变更",
+      "collapsed": "⋯ 未改动 {count} 行 ⋯"
     }
   },
   "more": {

--- a/app/mobile/lib/core/api/project_docs_api.dart
+++ b/app/mobile/lib/core/api/project_docs_api.dart
@@ -289,6 +289,70 @@ class ProjectSummary {
   final bool suggestArchive;
 }
 
+/// One line of a review diff. `context` lines are unchanged and shown
+/// only for orientation.
+class DiffLine {
+  const DiffLine({required this.kind, required this.text});
+
+  factory DiffLine.fromJson(Map<String, dynamic> j) => DiffLine(
+    kind: j['kind']?.toString() ?? 'context',
+    text: j['text']?.toString() ?? '',
+  );
+
+  final String kind; // context | add | remove
+  final String text;
+}
+
+/// A run of changed lines with its surrounding context.
+class DiffHunk {
+  const DiffHunk({
+    required this.skippedBefore,
+    required this.startLine,
+    required this.lines,
+  });
+
+  factory DiffHunk.fromJson(Map<String, dynamic> j) => DiffHunk(
+    // Unchanged lines collapsed before this hunk — rendered so the
+    // reviewer can tell "nothing else changed" from "the rest is hidden".
+    skippedBefore: (j['skipped_before'] as num?)?.toInt() ?? 0,
+    startLine: (j['start_line'] as num?)?.toInt() ?? 1,
+    lines: ((j['lines'] as List<dynamic>?) ?? const [])
+        .whereType<Map<String, dynamic>>()
+        .map(DiffLine.fromJson)
+        .toList(growable: false),
+  );
+
+  final int skippedBefore;
+  final int startLine;
+  final List<DiffLine> lines;
+}
+
+/// The reviewable difference between the live doc and a proposal.
+/// Computed server-side so web and mobile show the same review.
+class DocDiff {
+  const DocDiff({
+    required this.hunks,
+    required this.added,
+    required this.removed,
+    required this.unchanged,
+  });
+
+  factory DocDiff.fromJson(Map<String, dynamic> j) => DocDiff(
+    hunks: ((j['hunks'] as List<dynamic>?) ?? const [])
+        .whereType<Map<String, dynamic>>()
+        .map(DiffHunk.fromJson)
+        .toList(growable: false),
+    added: (j['added'] as num?)?.toInt() ?? 0,
+    removed: (j['removed'] as num?)?.toInt() ?? 0,
+    unchanged: j['unchanged'] == true,
+  );
+
+  final List<DiffHunk> hunks;
+  final int added;
+  final int removed;
+  final bool unchanged;
+}
+
 class DocProposal {
   DocProposal({
     required this.id,
@@ -298,6 +362,7 @@ class DocProposal {
     required this.reason,
     required this.proposedBySession,
     required this.createdAt,
+    this.diff,
   });
 
   factory DocProposal.fromJson(Map<String, dynamic> j) => DocProposal(
@@ -309,6 +374,9 @@ class DocProposal {
     proposedBySession: j['proposed_by_session']?.toString() ?? '',
     createdAt:
         DateTime.tryParse(j['created_at']?.toString() ?? '') ?? DateTime.now(),
+    diff: j['diff'] is Map<String, dynamic>
+        ? DocDiff.fromJson(j['diff'] as Map<String, dynamic>)
+        : null,
   );
 
   final String id;
@@ -318,6 +386,10 @@ class DocProposal {
   final String reason;
   final String proposedBySession;
   final DateTime createdAt;
+
+  /// Line-level change from the live doc. Null on proposals filed before
+  /// the server attached diffs, which fall back to the full body.
+  final DocDiff? diff;
 }
 
 class SessionLogEntry {

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 13560 (4520 per locale)
+/// Strings: 13575 (4525 per locale)
 ///
-/// Built on 2026-08-11 at 11:54 UTC
+/// Built on 2026-08-11 at 13:24 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -278,6 +278,7 @@ class TranslationsWebEn {
 	late final TranslationsWebCortexEn cortex = TranslationsWebCortexEn.internal(_root);
 	late final TranslationsWebDatabaseEn database = TranslationsWebDatabaseEn.internal(_root);
 	late final TranslationsWebRoundTableEn roundTable = TranslationsWebRoundTableEn.internal(_root);
+	late final TranslationsWebDiffEn diff = TranslationsWebDiffEn.internal(_root);
 }
 
 // Path: more
@@ -3665,6 +3666,30 @@ class TranslationsWebRoundTableEn {
 
 	late final TranslationsWebRoundTableHandoffEn handoff = TranslationsWebRoundTableHandoffEn.internal(_root);
 	late final TranslationsWebRoundTablePlanEn plan = TranslationsWebRoundTablePlanEn.internal(_root);
+}
+
+// Path: web.diff
+class TranslationsWebDiffEn {
+	TranslationsWebDiffEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'No changes — the proposed content is identical to the live page.'
+	String get noChanges => 'No changes — the proposed content is identical to the live page.';
+
+	/// en: '+{count}'
+	String added({required Object count}) => '+${count}';
+
+	/// en: '−{count}'
+	String removed({required Object count}) => '−${count}';
+
+	/// en: 'changed lines'
+	String get changedLines => 'changed lines';
+
+	/// en: '⋯ {count} unchanged ⋯'
+	String collapsed({required Object count}) => '⋯ ${count} unchanged ⋯';
 }
 
 // Path: more.identity
@@ -22073,6 +22098,11 @@ extension on Translations {
 			'web.roundTable.plan.accountDefault' => 'Default',
 			'web.roundTable.plan.bypass' => 'Skip permissions (YOLO)',
 			'web.roundTable.plan.bypassHint' => 'Start the session with its bypass flag so it does not prompt for approvals.',
+			'web.diff.noChanges' => 'No changes — the proposed content is identical to the live page.',
+			'web.diff.added' => ({required Object count}) => '+${count}',
+			'web.diff.removed' => ({required Object count}) => '−${count}',
+			'web.diff.changedLines' => 'changed lines',
+			'web.diff.collapsed' => ({required Object count}) => '⋯ ${count} unchanged ⋯',
 			'more.title' => 'More',
 			'more.identity.signedInAs' => 'Signed in as',
 			'more.identity.server' => 'Server',
@@ -22364,13 +22394,13 @@ extension on Translations {
 			'sessions.inspector.notes.renamedWithWarning' => ({required Object warning}) => 'Moved, but links may not be updated: ${warning}',
 			'sessions.inspector.notes.renameFailed' => ({required Object error}) => 'Move failed: ${error}',
 			'sessions.inspector.notes.openFolderIndex' => 'Open folder index',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.kindUi' => 'UI mock',
 			'sessions.inspector.canvas.kindFlow' => 'Flowchart',
 			'sessions.inspector.canvas.kindMindmap' => 'Mind map',
 			'sessions.inspector.canvas.kindGraph' => 'Relationships',
 			'sessions.inspector.canvas.kindDoc' => 'Document',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.canvas.modeView' => 'View',
 			'sessions.inspector.canvas.modePin' => 'Pin',
 			'sessions.inspector.canvas.modeRegion' => 'Frame',
@@ -22878,13 +22908,13 @@ extension on Translations {
 			'backups.kv.fanout' => 'Fan-out group',
 			'backups.kv.triggeredBy' => 'Triggered by',
 			'backups.kv.started' => 'Started',
+			_ => null,
+		} ?? switch (path) {
 			'backups.kv.finished' => 'Finished',
 			'backups.kv.size' => 'Size',
 			'backups.kv.encrypted' => 'Encrypted',
 			'backups.kv.targetPath' => 'Target path',
 			'backups.kv.error' => 'Error',
-			_ => null,
-		} ?? switch (path) {
 			'backups.kv.yes' => 'yes',
 			'backups.kv.no' => 'no',
 			'backups.recoveryKit.menuLabel' => 'Recovery Kit',
@@ -23392,13 +23422,13 @@ extension on Translations {
 			'notesPage.backlinks.empty' => 'No notes link here yet.',
 			'notesPage.backlinks.failed' => ({required Object error}) => 'Could not load backlinks: ${error}',
 			'notesPage.outline.action' => 'Outline',
+			_ => null,
+		} ?? switch (path) {
 			'notesPage.outline.title' => 'Outline',
 			'notesPage.outline.empty' => 'This document has no headings.',
 			'notesPage.outline.jumpedToSource' => 'Preview can\'t scroll without scripts, so this opened the source view.',
 			'notesPage.today.tooltip' => 'Open today\'s daily note',
 			'notesPage.wikiLink.suggestions' => 'Link to…',
-			_ => null,
-		} ?? switch (path) {
 			'notesPage.wikiLink.createNew' => ({required Object name}) => 'Create "${name}"',
 			'notesPage.wikiLink.noMatches' => 'No note matches — keep typing to create one.',
 			'vaultSync.title' => 'Vault sync',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -183,6 +183,7 @@ class _TranslationsWebEs extends TranslationsWebEn {
 	@override late final _TranslationsWebCortexEs cortex = _TranslationsWebCortexEs._(_root);
 	@override late final _TranslationsWebDatabaseEs database = _TranslationsWebDatabaseEs._(_root);
 	@override late final _TranslationsWebRoundTableEs roundTable = _TranslationsWebRoundTableEs._(_root);
+	@override late final _TranslationsWebDiffEs diff = _TranslationsWebDiffEs._(_root);
 }
 
 // Path: more
@@ -1811,6 +1812,20 @@ class _TranslationsWebRoundTableEs extends TranslationsWebRoundTableEn {
 	@override String get untitled => 'Chat nuevo';
 	@override late final _TranslationsWebRoundTableHandoffEs handoff = _TranslationsWebRoundTableHandoffEs._(_root);
 	@override late final _TranslationsWebRoundTablePlanEs plan = _TranslationsWebRoundTablePlanEs._(_root);
+}
+
+// Path: web.diff
+class _TranslationsWebDiffEs extends TranslationsWebDiffEn {
+	_TranslationsWebDiffEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get noChanges => 'Sin cambios: el contenido propuesto es idéntico a la página actual.';
+	@override String added({required Object count}) => '+${count}';
+	@override String removed({required Object count}) => '−${count}';
+	@override String get changedLines => 'líneas modificadas';
+	@override String collapsed({required Object count}) => '⋯ ${count} sin cambios ⋯';
 }
 
 // Path: more.identity
@@ -12906,6 +12921,11 @@ extension on TranslationsEs {
 			'web.roundTable.plan.accountDefault' => 'Predeterminada',
 			'web.roundTable.plan.bypass' => 'Omitir permisos (YOLO)',
 			'web.roundTable.plan.bypassHint' => 'Inicia la sesión con su indicador de bypass para no pedir aprobaciones.',
+			'web.diff.noChanges' => 'Sin cambios: el contenido propuesto es idéntico a la página actual.',
+			'web.diff.added' => ({required Object count}) => '+${count}',
+			'web.diff.removed' => ({required Object count}) => '−${count}',
+			'web.diff.changedLines' => 'líneas modificadas',
+			'web.diff.collapsed' => ({required Object count}) => '⋯ ${count} sin cambios ⋯',
 			'more.title' => 'Más',
 			'more.identity.signedInAs' => 'Sesión iniciada como',
 			'more.identity.server' => 'Servidor',
@@ -13197,13 +13217,13 @@ extension on TranslationsEs {
 			'sessions.inspector.notes.renamedWithWarning' => ({required Object warning}) => 'Movido, pero los enlaces podrían no actualizarse: ${warning}',
 			'sessions.inspector.notes.renameFailed' => ({required Object error}) => 'Error al mover: ${error}',
 			'sessions.inspector.notes.openFolderIndex' => 'Abrir índice de carpeta',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.kindUi' => 'Maqueta UI',
 			'sessions.inspector.canvas.kindFlow' => 'Diagrama de flujo',
 			'sessions.inspector.canvas.kindMindmap' => 'Mapa mental',
 			'sessions.inspector.canvas.kindGraph' => 'Relaciones',
 			'sessions.inspector.canvas.kindDoc' => 'Documento',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.canvas.modeView' => 'Ver',
 			'sessions.inspector.canvas.modePin' => 'Marcar',
 			'sessions.inspector.canvas.modeRegion' => 'Encuadrar',
@@ -13711,13 +13731,13 @@ extension on TranslationsEs {
 			'backups.kv.fanout' => 'Grupo de difusión',
 			'backups.kv.triggeredBy' => 'Lanzado por',
 			'backups.kv.started' => 'Iniciado',
+			_ => null,
+		} ?? switch (path) {
 			'backups.kv.finished' => 'Finalizado',
 			'backups.kv.size' => 'Tamaño',
 			'backups.kv.encrypted' => 'Cifrado',
 			'backups.kv.targetPath' => 'Ruta de destino',
 			'backups.kv.error' => 'Error',
-			_ => null,
-		} ?? switch (path) {
 			'backups.kv.yes' => 'sí',
 			'backups.kv.no' => 'no',
 			'backups.recoveryKit.menuLabel' => 'Kit de recuperación',
@@ -14225,13 +14245,13 @@ extension on TranslationsEs {
 			'notesPage.backlinks.empty' => 'Todavía no hay notas que enlacen aquí.',
 			'notesPage.backlinks.failed' => ({required Object error}) => 'No se pudieron cargar los retroenlaces: ${error}',
 			'notesPage.outline.action' => 'Esquema',
+			_ => null,
+		} ?? switch (path) {
 			'notesPage.outline.title' => 'Esquema',
 			'notesPage.outline.empty' => 'Este documento no tiene encabezados.',
 			'notesPage.outline.jumpedToSource' => 'La vista previa no puede desplazarse sin scripts, así que se abrió el código.',
 			'notesPage.today.tooltip' => 'Abrir la nota diaria de hoy',
 			'notesPage.wikiLink.suggestions' => 'Enlazar a…',
-			_ => null,
-		} ?? switch (path) {
 			'notesPage.wikiLink.createNew' => ({required Object name}) => 'Crear «${name}»',
 			'notesPage.wikiLink.noMatches' => 'Ninguna nota coincide: sigue escribiendo para crear una.',
 			'vaultSync.title' => 'Sincronización del vault',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -183,6 +183,7 @@ class _TranslationsWebZh extends TranslationsWebEn {
 	@override late final _TranslationsWebCortexZh cortex = _TranslationsWebCortexZh._(_root);
 	@override late final _TranslationsWebDatabaseZh database = _TranslationsWebDatabaseZh._(_root);
 	@override late final _TranslationsWebRoundTableZh roundTable = _TranslationsWebRoundTableZh._(_root);
+	@override late final _TranslationsWebDiffZh diff = _TranslationsWebDiffZh._(_root);
 }
 
 // Path: more
@@ -1811,6 +1812,20 @@ class _TranslationsWebRoundTableZh extends TranslationsWebRoundTableEn {
 	@override String get untitled => '新群聊';
 	@override late final _TranslationsWebRoundTableHandoffZh handoff = _TranslationsWebRoundTableHandoffZh._(_root);
 	@override late final _TranslationsWebRoundTablePlanZh plan = _TranslationsWebRoundTablePlanZh._(_root);
+}
+
+// Path: web.diff
+class _TranslationsWebDiffZh extends TranslationsWebDiffEn {
+	_TranslationsWebDiffZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get noChanges => '没有改动 —— 提案内容与当前页面完全一致。';
+	@override String added({required Object count}) => '+${count}';
+	@override String removed({required Object count}) => '−${count}';
+	@override String get changedLines => '行变更';
+	@override String collapsed({required Object count}) => '⋯ 未改动 ${count} 行 ⋯';
 }
 
 // Path: more.identity
@@ -12900,6 +12915,11 @@ extension on TranslationsZh {
 			'web.roundTable.plan.accountDefault' => '默认',
 			'web.roundTable.plan.bypass' => '跳过权限 (YOLO)',
 			'web.roundTable.plan.bypassHint' => '用 bypass 标志启动会话,不再逐个请求批准。',
+			'web.diff.noChanges' => '没有改动 —— 提案内容与当前页面完全一致。',
+			'web.diff.added' => ({required Object count}) => '+${count}',
+			'web.diff.removed' => ({required Object count}) => '−${count}',
+			'web.diff.changedLines' => '行变更',
+			'web.diff.collapsed' => ({required Object count}) => '⋯ 未改动 ${count} 行 ⋯',
 			'more.title' => '更多',
 			'more.identity.signedInAs' => '登录账号',
 			'more.identity.server' => '服务器',
@@ -13194,13 +13214,13 @@ extension on TranslationsZh {
 			'sessions.inspector.canvas.kindUi' => 'UI 稿',
 			'sessions.inspector.canvas.kindFlow' => '流程图',
 			'sessions.inspector.canvas.kindMindmap' => '思维导图',
+			_ => null,
+		} ?? switch (path) {
 			'sessions.inspector.canvas.kindGraph' => '关系图',
 			'sessions.inspector.canvas.kindDoc' => '文档',
 			'sessions.inspector.canvas.modeView' => '查看',
 			'sessions.inspector.canvas.modePin' => '钉点',
 			'sessions.inspector.canvas.modeRegion' => '框选',
-			_ => null,
-		} ?? switch (path) {
 			'sessions.inspector.canvas.focusLine' => ({required Object title, required Object kind}) => '正在处理 ${title} · ${kind} —— agent 已把它当作「这个画布」。',
 			'sessions.inspector.canvas.notePlaceholder' => '这里要改什么……',
 			'sessions.inspector.canvas.messagePlaceholder' => '整体说明(可选)……',
@@ -13708,13 +13728,13 @@ extension on TranslationsZh {
 			'backups.kv.finished' => '完成',
 			'backups.kv.size' => '大小',
 			'backups.kv.encrypted' => '已加密',
+			_ => null,
+		} ?? switch (path) {
 			'backups.kv.targetPath' => '目标路径',
 			'backups.kv.error' => '错误',
 			'backups.kv.yes' => '是',
 			'backups.kv.no' => '否',
 			'backups.recoveryKit.menuLabel' => '恢复工具包',
-			_ => null,
-		} ?? switch (path) {
 			'backups.recoveryKit.title' => '恢复工具包',
 			'backups.recoveryKit.warning' => '灾难恢复保险 —— 仅当本机与其密钥同时丢失时才需要,正常情况下你永远用不到。本工具包是你的备份口令,用你此处自设的密码封装。每次生成都是一份独立工具包、用当次的密码封装 —— 服务端不存储,因此没有唯一的“主密码”。请把工具包和它的密码一起、异地分开保存。注意:这个密码保护的是工具包本身,而不是网关 —— 任何有后台权限的人都能再生成一份。',
 			'backups.recoveryKit.passphraseLabel' => '恢复口令（至少 8 位）',
@@ -14222,13 +14242,13 @@ extension on TranslationsZh {
 			'notesPage.outline.title' => '大纲',
 			'notesPage.outline.empty' => '这篇文档没有标题。',
 			'notesPage.outline.jumpedToSource' => '预览关闭了脚本、无法滚动，所以已切到源码视图。',
+			_ => null,
+		} ?? switch (path) {
 			'notesPage.today.tooltip' => '打开今天的日记',
 			'notesPage.wikiLink.suggestions' => '链接到…',
 			'notesPage.wikiLink.createNew' => ({required Object name}) => '新建“${name}”',
 			'notesPage.wikiLink.noMatches' => '没有匹配的笔记 —— 继续输入即可新建。',
 			'vaultSync.title' => 'Vault 同步',
-			_ => null,
-		} ?? switch (path) {
 			'vaultSync.refresh' => '刷新',
 			'vaultSync.statusTitle' => '状态',
 			'vaultSync.notARepo' => 'vault 还不是 git 仓库。请先在网页端初始化。',

--- a/app/mobile/lib/features/cortex/cortex_hub_screen.dart
+++ b/app/mobile/lib/features/cortex/cortex_hub_screen.dart
@@ -6,6 +6,7 @@ import 'package:opendray/core/api/cortex_api.dart';
 import 'package:opendray/core/api/project_docs_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/cortex/cortex_settings_screen.dart';
+import 'package:opendray/features/cortex/proposal_diff.dart';
 import 'package:opendray/features/knowledge/knowledge_screen.dart';
 import 'package:opendray/features/memory/memory_screen.dart';
 import 'package:opendray/features/memory_quarantine/quarantine_screen.dart';
@@ -426,8 +427,11 @@ class _ProposalCard extends StatelessWidget {
                 borderRadius: BorderRadius.circular(8),
               ),
               child: SingleChildScrollView(
-                child: Text(proposal.proposedContent,
-                    style: const TextStyle(fontSize: 12, height: 1.4)),
+                // Show what CHANGED; pre-diff proposals fall back to the body.
+                child: proposal.diff != null
+                    ? ProposalDiffView(diff: proposal.diff!)
+                    : Text(proposal.proposedContent,
+                        style: const TextStyle(fontSize: 12, height: 1.4)),
               ),
             ),
           OverflowBar(

--- a/app/mobile/lib/features/cortex/proposal_diff.dart
+++ b/app/mobile/lib/features/cortex/proposal_diff.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:opendray/core/api/project_docs_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+
+/// Renders the server-computed line-level diff of a proposal.
+///
+/// Reviewing used to mean reading the whole proposed document and spotting
+/// by eye what moved — unworkable once a knowledge page runs to hundreds of
+/// lines. This shows only changed lines plus a little context, and marks
+/// each collapsed region so the reviewer can tell "nothing else changed"
+/// from "the rest is hidden".
+///
+/// Unified (single column) rather than side-by-side: two columns of a long
+/// document are unreadable on a phone. Mirrors the web ProposalDiff.
+class ProposalDiffView extends StatelessWidget {
+  const ProposalDiffView({required this.diff, super.key});
+
+  final DocDiff diff;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (diff.unchanged || diff.hunks.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.all(12),
+        child: Text(t.web.diff.noChanges, style: theme.textTheme.bodySmall),
+      );
+    }
+
+    final rows = <Widget>[];
+    for (final hunk in diff.hunks) {
+      if (hunk.skippedBefore > 0) {
+        rows.add(_CollapsedMarker(count: hunk.skippedBefore));
+      }
+      var lineNo = hunk.startLine;
+      for (final line in hunk.lines) {
+        // Removed lines don't exist in the new document, so they carry no
+        // new-document line number.
+        final n = line.kind == 'remove' ? null : lineNo++;
+        rows.add(_DiffRow(line: line, lineNo: n));
+      }
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 6),
+          child: Row(
+            children: [
+              Text(
+                t.web.diff.added(count: diff.added),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: Colors.green.shade400,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Text(
+                t.web.diff.removed(count: diff.removed),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: Colors.red.shade300,
+                ),
+              ),
+            ],
+          ),
+        ),
+        DecoratedBox(
+          decoration: BoxDecoration(
+            border: Border.all(color: theme.dividerColor),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: Column(children: rows),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CollapsedMarker extends StatelessWidget {
+  const _CollapsedMarker({required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),
+      padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+      child: Text(
+        t.web.diff.collapsed(count: count),
+        textAlign: TextAlign.center,
+        style: theme.textTheme.labelSmall?.copyWith(
+          fontStyle: FontStyle.italic,
+          color: theme.hintColor,
+        ),
+      ),
+    );
+  }
+}
+
+class _DiffRow extends StatelessWidget {
+  const _DiffRow({required this.line, required this.lineNo});
+
+  final DiffLine line;
+  final int? lineNo;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (bg, fg, sign) = switch (line.kind) {
+      'add' => (
+        Colors.green.withValues(alpha: 0.12),
+        Colors.green.shade300,
+        '+',
+      ),
+      'remove' => (
+        Colors.red.withValues(alpha: 0.12),
+        Colors.red.shade300,
+        '-',
+      ),
+      _ => (Colors.transparent, theme.textTheme.bodySmall?.color, ' '),
+    };
+
+    return Container(
+      color: bg,
+      padding: const EdgeInsets.symmetric(vertical: 1, horizontal: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 28,
+            child: Text(
+              lineNo?.toString() ?? '',
+              textAlign: TextAlign.right,
+              style: theme.textTheme.labelSmall?.copyWith(
+                fontFamily: 'monospace',
+                color: theme.hintColor,
+              ),
+            ),
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              '$sign ${line.text}',
+              style: theme.textTheme.bodySmall?.copyWith(
+                fontFamily: 'monospace',
+                fontSize: 11,
+                color: fg,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/mobile/lib/features/knowledge/knowledge_screen.dart
+++ b/app/mobile/lib/features/knowledge/knowledge_screen.dart
@@ -12,6 +12,7 @@ import 'package:opendray/core/api/memory_workers_api.dart';
 import 'package:opendray/core/api/project_docs_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/cortex/curation_chat_screen.dart';
+import 'package:opendray/features/cortex/proposal_diff.dart';
 import 'package:opendray/features/knowledge/force_graph.dart';
 
 // Knowledge tab — read-mostly browser over the M-KG knowledge graph.
@@ -891,10 +892,14 @@ class _KbPageScreenState extends ConsumerState<_KbPageScreen> {
                           constraints: const BoxConstraints(maxHeight: 240),
                           margin: const EdgeInsets.only(top: 6),
                           child: SingleChildScrollView(
-                            child: SelectableText(
-                              _stripSig(pending.proposedContent),
-                              style: const TextStyle(fontSize: 12),
-                            ),
+                            // Show what CHANGED. Proposals filed before the
+                            // server attached diffs fall back to the body.
+                            child: pending.diff != null
+                                ? ProposalDiffView(diff: pending.diff!)
+                                : SelectableText(
+                                    _stripSig(pending.proposedContent),
+                                    style: const TextStyle(fontSize: 12),
+                                  ),
                           ),
                         ),
                     ],

--- a/app/mobile/lib/features/project/project_screen.dart
+++ b/app/mobile/lib/features/project/project_screen.dart
@@ -12,6 +12,7 @@ import 'package:opendray/core/api/project_docs_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/cortex/blueprint_editor_screen.dart';
 import 'package:opendray/features/cortex/curation_chat_screen.dart';
+import 'package:opendray/features/cortex/proposal_diff.dart';
 import 'package:opendray/features/sessions/directory_picker_sheet.dart';
 import 'package:path/path.dart' as p;
 
@@ -2603,19 +2604,26 @@ class _ProposalCard extends StatelessWidget {
               Text(proposal.reason),
               const SizedBox(height: 8),
             ],
-            _DiffBlock(
-              label: 'Current ${proposal.kind}',
-              body: currentContent,
-              empty: '(not set)',
-              tint: scheme.outline,
-            ),
-            const SizedBox(height: 6),
-            _DiffBlock(
-              label: 'After approve',
-              body: proposal.proposedContent,
-              empty: '(empty — approving would clear the doc)',
-              tint: scheme.primary,
-            ),
+            // What CHANGED, not two full documents to compare by eye.
+            // Proposals filed before the server attached diffs still fall
+            // back to the stacked bodies.
+            if (proposal.diff != null)
+              ProposalDiffView(diff: proposal.diff!)
+            else ...[
+              _DiffBlock(
+                label: 'Current ${proposal.kind}',
+                body: currentContent,
+                empty: '(not set)',
+                tint: scheme.outline,
+              ),
+              const SizedBox(height: 6),
+              _DiffBlock(
+                label: 'After approve',
+                body: proposal.proposedContent,
+                empty: '(empty — approving would clear the doc)',
+                tint: scheme.primary,
+              ),
+            ],
             const SizedBox(height: 8),
             Row(
               mainAxisAlignment: MainAxisAlignment.end,
@@ -2658,21 +2666,25 @@ class _ProposalCard extends StatelessWidget {
                     style: Theme.of(ctx).textTheme.bodyMedium,
                   ),
                   const SizedBox(height: 12),
-                  _DiffBlock(
-                    label: 'Current',
-                    body: currentContent,
-                    empty: '(not set)',
-                    tint: scheme.outline,
-                    maxLines: 8,
-                  ),
-                  const SizedBox(height: 8),
-                  _DiffBlock(
-                    label: 'After approve',
-                    body: proposal.proposedContent,
-                    empty: '(empty)',
-                    tint: scheme.primary,
-                    maxLines: 8,
-                  ),
+                  if (proposal.diff != null)
+                    ProposalDiffView(diff: proposal.diff!)
+                  else ...[
+                    _DiffBlock(
+                      label: 'Current',
+                      body: currentContent,
+                      empty: '(not set)',
+                      tint: scheme.outline,
+                      maxLines: 8,
+                    ),
+                    const SizedBox(height: 8),
+                    _DiffBlock(
+                      label: 'After approve',
+                      body: proposal.proposedContent,
+                      empty: '(empty)',
+                      tint: scheme.primary,
+                      maxLines: 8,
+                    ),
+                  ],
                 ],
               ),
             ),

--- a/app/shared/src/lib/projectDocs.ts
+++ b/app/shared/src/lib/projectDocs.ts
@@ -202,6 +202,33 @@ export async function setProjectLifecycle(
 
 // ── proposals ─────────────────────────────────────────────────
 
+/** One line of a review diff. 'context' lines are unchanged and shown
+ * only for orientation. */
+export interface DiffLine {
+  kind: 'context' | 'add' | 'remove'
+  text: string
+}
+
+/** A run of changed lines with its surrounding context. */
+export interface DiffHunk {
+  /** Unchanged lines between the previous hunk and this one. Rendered as
+   * "N unchanged lines" so the reviewer knows something was collapsed
+   * rather than wondering whether the diff is complete. */
+  skipped_before: number
+  /** 1-based first line of this hunk in the NEW document. */
+  start_line: number
+  lines: DiffLine[]
+}
+
+/** The reviewable difference between the live doc and a proposal. Computed
+ * server-side so every client shows the same review. */
+export interface DocDiff {
+  hunks: DiffHunk[]
+  added: number
+  removed: number
+  unchanged: boolean
+}
+
 export interface DocProposal {
   id: string
   cwd: string
@@ -212,8 +239,11 @@ export interface DocProposal {
   /** When the proposal has been decided, the verdict. */
   decision?: 'approved' | 'rejected'
   decided_at?: string
-  /** The prior live content at the time of proposal — used for diff display. */
+  /** The prior live content at the time of proposal. */
   prior_content?: string
+  /** Line-level change from prior_content to proposed_content. Present on
+   * the review endpoints; absent on paths that don't serve a review. */
+  diff?: DocDiff
   created_at: string
 }
 

--- a/app/web/src/components/cortex/ProposalDiff.tsx
+++ b/app/web/src/components/cortex/ProposalDiff.tsx
@@ -1,0 +1,96 @@
+import { Fragment } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { DocDiff } from '@/lib/projectDocs'
+
+// Reviewing a proposal used to mean reading the whole proposed document
+// and spotting by eye what moved. This renders the server-computed
+// line-level diff instead: changed lines with a little context, and an
+// explicit marker for each collapsed region so the reviewer can tell
+// "nothing else changed" from "the rest is hidden".
+//
+// Unified (single column) rather than side-by-side: knowledge pages run
+// to hundreds of lines, and two columns of that is unreadable on a laptop
+// and impossible on a phone.
+
+export function ProposalDiff({
+  diff,
+  className = '',
+}: {
+  diff: DocDiff
+  className?: string
+}) {
+  const { t } = useTranslation()
+
+  if (diff.unchanged || diff.hunks.length === 0) {
+    return (
+      <div className={`text-muted-foreground p-3 text-xs ${className}`}>
+        {t('web.diff.noChanges')}
+      </div>
+    )
+  }
+
+  return (
+    <div className={className}>
+      <div
+        className="text-muted-foreground mb-2 flex items-center gap-3 text-[11px]"
+        aria-label={t('web.diff.changedLines')}
+      >
+        <span className="text-emerald-400">
+          {t('web.diff.added', { count: diff.added })}
+        </span>
+        <span className="text-red-400">
+          {t('web.diff.removed', { count: diff.removed })}
+        </span>
+      </div>
+      {/* Wide content scrolls inside its own box so the page body never
+          scrolls horizontally. */}
+      <div className="border-border overflow-x-auto rounded-md border">
+        <table className="w-full border-collapse font-mono text-[11px]">
+          <tbody>
+            {diff.hunks.map((hunk, hi) => {
+              let lineNo = hunk.start_line
+              return (
+                <Fragment key={hi}>
+                  {hunk.skipped_before > 0 && (
+                    <tr className="bg-muted/30">
+                      <td
+                        colSpan={2}
+                        className="text-muted-foreground px-2 py-1 text-center text-[10px] italic"
+                      >
+                        {t('web.diff.collapsed', { count: hunk.skipped_before })}
+                      </td>
+                    </tr>
+                  )}
+                  {hunk.lines.map((ln, li) => {
+                    // Removed lines don't exist in the new document, so they
+                    // carry no new-document line number.
+                    const n = ln.kind === 'remove' ? null : lineNo++
+                    const tone =
+                      ln.kind === 'add'
+                        ? 'bg-emerald-500/10 text-emerald-200'
+                        : ln.kind === 'remove'
+                          ? 'bg-red-500/10 text-red-200'
+                          : ''
+                    const sign =
+                      ln.kind === 'add' ? '+' : ln.kind === 'remove' ? '-' : ' '
+                    return (
+                      <tr key={`${hi}-${li}`} className={tone}>
+                        <td className="text-muted-foreground/60 w-10 shrink-0 border-r px-1 py-0.5 text-right align-top tabular-nums select-none">
+                          {n ?? ''}
+                        </td>
+                        <td className="px-2 py-0.5 align-top whitespace-pre-wrap">
+                          <span className="select-none">{sign} </span>
+                          {ln.text || ' '}
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </Fragment>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/app/web/src/components/project/ProjectScreen.tsx
+++ b/app/web/src/components/project/ProjectScreen.tsx
@@ -77,6 +77,7 @@ import { ConflictsPanel } from '@/components/project/ConflictsPanel'
 import { JournalStalePanel } from '@/components/project/JournalStalePanel'
 import { CurationChat } from '@/components/cortex/CurationChat'
 import { BlueprintEditor } from '@/components/cortex/BlueprintEditor'
+import { ProposalDiff } from '@/components/cortex/ProposalDiff'
 
 // strip the drafter's hidden signature marker before display/edit
 function stripSig(s: string): string {
@@ -1006,17 +1007,24 @@ function ProposalCard({ proposal, onChange }: ProposalCardProps) {
           {t('web.project.inbox.warningSuffix')}
         </div>
       </div>
-      <div className="mb-3 grid grid-cols-1 gap-2 md:grid-cols-2">
-        <DiffBlock
-          label={t('web.project.inbox.current')}
-          body={proposal.prior_content ?? t('web.project.inbox.emptyBody')}
-        />
-        <DiffBlock
-          label={t('web.project.inbox.proposed')}
-          body={proposal.proposed_content}
-          highlight
-        />
-      </div>
+      {/* What CHANGED, not two full documents to compare by eye. Old
+          proposals carry no server-computed diff, so those still fall
+          back to the side-by-side bodies. */}
+      {proposal.diff ? (
+        <ProposalDiff diff={proposal.diff} className="mb-3" />
+      ) : (
+        <div className="mb-3 grid grid-cols-1 gap-2 md:grid-cols-2">
+          <DiffBlock
+            label={t('web.project.inbox.current')}
+            body={proposal.prior_content ?? t('web.project.inbox.emptyBody')}
+          />
+          <DiffBlock
+            label={t('web.project.inbox.proposed')}
+            body={proposal.proposed_content}
+            highlight
+          />
+        </div>
+      )}
       <div className="flex gap-2">
         <Button
           size="sm"

--- a/app/web/src/pages/Knowledge.tsx
+++ b/app/web/src/pages/Knowledge.tsx
@@ -40,6 +40,7 @@ import {
   type MaintainerMode,
 } from '@/lib/projectDocs'
 import { CurationChat } from '@/components/cortex/CurationChat'
+import { ProposalDiff } from '@/components/cortex/ProposalDiff'
 import { SlideOverAside } from '@/components/SlideOverAside'
 import { useIsCompact, useIsMobile } from '../lib/useIsMobile'
 import { Switch } from '@/components/ui/switch'
@@ -701,9 +702,16 @@ function KnowledgeBaseView() {
             </div>
             {showProposal && (
               <div className="bg-card mt-2 max-h-72 overflow-auto rounded-md p-3">
-                <ReactMarkdown remarkPlugins={[remarkGfm]} components={MD}>
-                  {stripSig(pending.proposed_content)}
-                </ReactMarkdown>
+                {/* Show what CHANGED. Falling back to the full proposed
+                    body keeps old proposals (filed before the server
+                    started attaching a diff) reviewable. */}
+                {pending.diff ? (
+                  <ProposalDiff diff={pending.diff} />
+                ) : (
+                  <ReactMarkdown remarkPlugins={[remarkGfm]} components={MD}>
+                    {stripSig(pending.proposed_content)}
+                  </ReactMarkdown>
+                )}
               </div>
             )}
           </div>

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/rs/xid v1.6.0 // indirect

--- a/internal/projectdoc/diff.go
+++ b/internal/projectdoc/diff.go
@@ -53,6 +53,22 @@ type DocDiff struct {
 // change — the same default git and GitHub use.
 const DefaultDiffContext = 3
 
+// DiffBaseline picks what a pending proposal should be diffed AGAINST.
+//
+// Not Proposal.PriorContent: that column is written when a proposal is
+// APPROVED, to record what the approval replaced. A pending proposal's
+// PriorContent is always empty, so diffing against it makes every
+// proposal read as "all lines added" — the full-document view the diff
+// exists to replace.
+//
+// The live document is also the more useful baseline: the reviewer is
+// deciding what this proposal does to the page as it stands NOW, which
+// may have been edited since the proposal was filed. An absent live doc
+// (a page being created) correctly yields an all-additions diff.
+func DiffBaseline(liveContent string, p Proposal) DocDiff {
+	return DiffLines(liveContent, p.ProposedContent, DefaultDiffContext)
+}
+
 // DiffLines computes a line-level diff of two document bodies, keeping
 // context unchanged lines around each change.
 //

--- a/internal/projectdoc/diff.go
+++ b/internal/projectdoc/diff.go
@@ -1,0 +1,132 @@
+package projectdoc
+
+import (
+	"strings"
+
+	"github.com/pmezard/go-difflib/difflib"
+)
+
+// Reviewing a proposal used to mean reading the whole proposed document
+// and spotting by eye what moved — unworkable once a knowledge page runs
+// to hundreds of lines. These types carry a line-level diff instead, so
+// the UI can show only what changed plus a little surrounding context and
+// say how much it collapsed.
+//
+// The diff is computed here rather than in each client so web and mobile
+// render the same review, and adding a client costs no diff algorithm.
+
+// Diff line kinds.
+const (
+	DiffContext = "context" // unchanged, shown for orientation
+	DiffAdd     = "add"
+	DiffRemove  = "remove"
+)
+
+// DiffLine is one line of a hunk.
+type DiffLine struct {
+	Kind string `json:"kind"`
+	Text string `json:"text"`
+}
+
+// DiffHunk is a run of changed lines with its surrounding context.
+type DiffHunk struct {
+	// SkippedBefore counts the unchanged lines between the previous hunk
+	// (or the start of the document) and this one, so the UI can render
+	// "N unchanged lines" instead of silently dropping them — silence
+	// would leave the reviewer unsure whether anything was hidden.
+	SkippedBefore int `json:"skipped_before"`
+	// StartLine is this hunk's first line number in the NEW document,
+	// 1-based, so the operator can locate the change in the real page.
+	StartLine int        `json:"start_line"`
+	Lines     []DiffLine `json:"lines"`
+}
+
+// DocDiff is the reviewable difference between two document bodies.
+type DocDiff struct {
+	Hunks     []DiffHunk `json:"hunks"`
+	Added     int        `json:"added"`
+	Removed   int        `json:"removed"`
+	Unchanged bool       `json:"unchanged"`
+}
+
+// DefaultDiffContext is how many unchanged lines to keep either side of a
+// change — the same default git and GitHub use.
+const DefaultDiffContext = 3
+
+// DiffLines computes a line-level diff of two document bodies, keeping
+// context unchanged lines around each change.
+//
+// Line endings and a trailing newline are normalised first: neither is a
+// content change the operator needs to review, and leaving them in makes
+// a CRLF paste look like every line was rewritten.
+func DiffLines(before, after string, context int) DocDiff {
+	if context < 0 {
+		context = 0
+	}
+	beforeLines := splitDocLines(before)
+	afterLines := splitDocLines(after)
+
+	matcher := difflib.NewMatcher(beforeLines, afterLines)
+	groups := matcher.GetGroupedOpCodes(context)
+
+	out := DocDiff{Hunks: []DiffHunk{}}
+	prevEnd := 0 // end of the previous group in the BEFORE document
+	for _, group := range groups {
+		if len(group) == 0 {
+			continue
+		}
+		hunk := DiffHunk{
+			SkippedBefore: group[0].I1 - prevEnd,
+			StartLine:     group[0].J1 + 1,
+			Lines:         []DiffLine{},
+		}
+		for _, c := range group {
+			switch c.Tag {
+			case 'e': // equal
+				for _, ln := range beforeLines[c.I1:c.I2] {
+					hunk.Lines = append(hunk.Lines, DiffLine{Kind: DiffContext, Text: ln})
+				}
+			case 'r': // replace — show the old lines then the new ones
+				for _, ln := range beforeLines[c.I1:c.I2] {
+					hunk.Lines = append(hunk.Lines, DiffLine{Kind: DiffRemove, Text: ln})
+					out.Removed++
+				}
+				for _, ln := range afterLines[c.J1:c.J2] {
+					hunk.Lines = append(hunk.Lines, DiffLine{Kind: DiffAdd, Text: ln})
+					out.Added++
+				}
+			case 'd': // delete
+				for _, ln := range beforeLines[c.I1:c.I2] {
+					hunk.Lines = append(hunk.Lines, DiffLine{Kind: DiffRemove, Text: ln})
+					out.Removed++
+				}
+			case 'i': // insert
+				for _, ln := range afterLines[c.J1:c.J2] {
+					hunk.Lines = append(hunk.Lines, DiffLine{Kind: DiffAdd, Text: ln})
+					out.Added++
+				}
+			}
+			prevEnd = c.I2
+		}
+		out.Hunks = append(out.Hunks, hunk)
+	}
+	out.Unchanged = out.Added == 0 && out.Removed == 0
+	if out.Unchanged {
+		// Identical bodies still produce one all-context group; drop it so
+		// callers can test Unchanged alone.
+		out.Hunks = []DiffHunk{}
+	}
+	return out
+}
+
+// splitDocLines normalises line endings and drops the trailing empty
+// element a final newline produces, so "a\nb" and "a\nb\n" compare equal.
+func splitDocLines(s string) []string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	s = strings.TrimSuffix(s, "\n")
+	if s == "" {
+		return []string{}
+	}
+	return strings.Split(s, "\n")
+}

--- a/internal/projectdoc/diff_test.go
+++ b/internal/projectdoc/diff_test.go
@@ -1,0 +1,150 @@
+package projectdoc
+
+import (
+	"strings"
+	"testing"
+)
+
+// renderDiff flattens a DocDiff into a readable form for assertions.
+func renderDiff(d DocDiff) string {
+	var b strings.Builder
+	for _, h := range d.Hunks {
+		if h.SkippedBefore > 0 {
+			b.WriteString("⋯\n")
+		}
+		for _, ln := range h.Lines {
+			switch ln.Kind {
+			case DiffAdd:
+				b.WriteString("+" + ln.Text + "\n")
+			case DiffRemove:
+				b.WriteString("-" + ln.Text + "\n")
+			default:
+				b.WriteString(" " + ln.Text + "\n")
+			}
+		}
+	}
+	return b.String()
+}
+
+func TestDiffLines_AddedLine(t *testing.T) {
+	before := "alpha\nbravo\ncharlie\n"
+	after := "alpha\nbravo\nnew line\ncharlie\n"
+
+	d := DiffLines(before, after, 3)
+	if d.Unchanged {
+		t.Fatal("Unchanged = true for a real change")
+	}
+	if d.Added != 1 || d.Removed != 0 {
+		t.Errorf("Added/Removed = %d/%d, want 1/0", d.Added, d.Removed)
+	}
+	got := renderDiff(d)
+	if !strings.Contains(got, "+new line") {
+		t.Errorf("added line not marked:\n%s", got)
+	}
+	// Surrounding lines come through as context, not as changes.
+	if !strings.Contains(got, " alpha") || !strings.Contains(got, " charlie") {
+		t.Errorf("context lines missing:\n%s", got)
+	}
+}
+
+func TestDiffLines_ReplacedLine(t *testing.T) {
+	d := DiffLines("keep\nold value\ntail\n", "keep\nnew value\ntail\n", 3)
+	got := renderDiff(d)
+	if !strings.Contains(got, "-old value") || !strings.Contains(got, "+new value") {
+		t.Errorf("replacement should show both sides:\n%s", got)
+	}
+	if d.Added != 1 || d.Removed != 1 {
+		t.Errorf("Added/Removed = %d/%d, want 1/1", d.Added, d.Removed)
+	}
+}
+
+// The whole point of the feature: a long document with one edit must not
+// come back as the whole document.
+func TestDiffLines_LongDocumentCollapsesUnchangedRegions(t *testing.T) {
+	var before, after []string
+	for i := range 200 {
+		before = append(before, "line "+string(rune('a'+i%26))+string(rune('0'+i%10)))
+	}
+	after = append([]string{}, before...)
+	after[100] = "CHANGED"
+
+	d := DiffLines(strings.Join(before, "\n"), strings.Join(after, "\n"), 3)
+
+	total := 0
+	for _, h := range d.Hunks {
+		total += len(h.Lines)
+	}
+	// One change + 3 lines of context either side ≈ 8 lines, nowhere near 200.
+	if total > 20 {
+		t.Errorf("emitted %d lines for a one-line edit in a 200-line doc — unchanged regions are not collapsed", total)
+	}
+	if len(d.Hunks) != 1 {
+		t.Fatalf("hunks = %d, want 1", len(d.Hunks))
+	}
+	if d.Hunks[0].SkippedBefore == 0 {
+		t.Error("first hunk should report the lines skipped before it so the UI can say how many collapsed")
+	}
+}
+
+// Two distant edits stay two separate hunks rather than merging into one
+// giant block that drags the untouched middle along.
+func TestDiffLines_SeparateEditsStaySeparateHunks(t *testing.T) {
+	var lines []string
+	for i := range 100 {
+		lines = append(lines, "row "+string(rune('0'+i%10)))
+	}
+	before := strings.Join(lines, "\n")
+	lines[5] = "FIRST EDIT"
+	lines[80] = "SECOND EDIT"
+	after := strings.Join(lines, "\n")
+
+	d := DiffLines(before, after, 3)
+	if len(d.Hunks) != 2 {
+		t.Fatalf("hunks = %d, want 2 (one per edit)", len(d.Hunks))
+	}
+	if d.Hunks[1].SkippedBefore == 0 {
+		t.Error("the gap between two hunks must be reported as skipped")
+	}
+}
+
+func TestDiffLines_IdenticalContent(t *testing.T) {
+	d := DiffLines("same\ntext\n", "same\ntext\n", 3)
+	if !d.Unchanged {
+		t.Error("Unchanged = false for identical content")
+	}
+	if len(d.Hunks) != 0 {
+		t.Errorf("hunks = %d, want 0 for identical content", len(d.Hunks))
+	}
+	if d.Added != 0 || d.Removed != 0 {
+		t.Errorf("Added/Removed = %d/%d, want 0/0", d.Added, d.Removed)
+	}
+}
+
+// A brand-new page (no prior content) is all additions, not a broken diff.
+func TestDiffLines_EmptyBefore(t *testing.T) {
+	d := DiffLines("", "first\nsecond\n", 3)
+	if d.Unchanged {
+		t.Error("Unchanged = true when content was added to an empty doc")
+	}
+	if d.Added != 2 {
+		t.Errorf("Added = %d, want 2", d.Added)
+	}
+	if d.Removed != 0 {
+		t.Errorf("Removed = %d, want 0", d.Removed)
+	}
+}
+
+// Trailing-newline differences are a formatting detail, not a content
+// change the operator needs to review.
+func TestDiffLines_TrailingNewlineIgnored(t *testing.T) {
+	if d := DiffLines("a\nb", "a\nb\n", 3); !d.Unchanged {
+		t.Errorf("a missing trailing newline should not read as a change: %+v", d.Hunks)
+	}
+}
+
+// CRLF input must not make every line look changed.
+func TestDiffLines_CRLFNormalised(t *testing.T) {
+	if d := DiffLines("a\r\nb\r\n", "a\nb\n", 3); !d.Unchanged {
+		t.Errorf("line-ending style alone should not read as a change: %+v", d.Hunks)
+	}
+}

--- a/internal/projectdoc/diff_test.go
+++ b/internal/projectdoc/diff_test.go
@@ -26,6 +26,39 @@ func renderDiff(d DocDiff) string {
 	return b.String()
 }
 
+// A pending proposal's PriorContent is empty — that column is only
+// written on APPROVAL, to record what the approval replaced. Diffing
+// against it would make every pending proposal read as "all lines
+// added", which is the full-document view this feature exists to
+// replace. The baseline must be the live document.
+func TestDiffBaseline_UsesLiveDocNotPriorContent(t *testing.T) {
+	live := "alpha\nbravo\ncharlie\n"
+	p := Proposal{
+		ProposedContent: "alpha\nbravo\nNEW\ncharlie\n",
+		PriorContent:    "", // what a pending proposal actually carries
+	}
+
+	d := DiffBaseline(live, p)
+	if d.Added != 1 || d.Removed != 0 {
+		t.Errorf("Added/Removed = %d/%d, want 1/0 — the diff is not against the live doc", d.Added, d.Removed)
+	}
+	if got := renderDiff(d); strings.Count(got, "+") != 1 {
+		t.Errorf("expected a single added line, got:\n%s", got)
+	}
+}
+
+// Even when PriorContent happens to be populated (an approved row), the
+// live document still wins — it is what the operator is deciding about.
+func TestDiffBaseline_IgnoresStalePriorContent(t *testing.T) {
+	p := Proposal{
+		ProposedContent: "one\ntwo\n",
+		PriorContent:    "something\nentirely\ndifferent\n",
+	}
+	if d := DiffBaseline("one\ntwo\n", p); !d.Unchanged {
+		t.Errorf("proposal matching the live doc should show no changes; got +%d/-%d", d.Added, d.Removed)
+	}
+}
+
 func TestDiffLines_AddedLine(t *testing.T) {
 	before := "alpha\nbravo\ncharlie\n"
 	after := "alpha\nbravo\nnew line\ncharlie\n"

--- a/internal/projectdoc/projectdoc.go
+++ b/internal/projectdoc/projectdoc.go
@@ -541,15 +541,42 @@ func (s *Service) ListPendingProposals(ctx context.Context, cwd string) ([]Propo
 		if err != nil {
 			return nil, err
 		}
-		// Attach the review diff here rather than in each client, so web
-		// and mobile show the same thing. This is the operator's approval
-		// queue — a handful of rows — so computing it eagerly costs less
-		// than a second round-trip per proposal would.
-		d := DiffLines(p.PriorContent, p.ProposedContent, DefaultDiffContext)
-		p.Diff = &d
 		out = append(out, p)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	s.attachDiffs(ctx, out)
+	return out, nil
+}
+
+// attachDiffs fills each proposal's review diff against the LIVE document.
+// Done here rather than in each client so web and mobile show the same
+// review; this is the operator's approval queue — a handful of rows — so
+// computing it eagerly costs less than a round-trip per proposal.
+//
+// Live bodies are fetched once per (cwd, kind): a queue commonly holds
+// several proposals for the same page.
+func (s *Service) attachDiffs(ctx context.Context, proposals []Proposal) {
+	live := make(map[string]string, len(proposals))
+	for i := range proposals {
+		p := &proposals[i]
+		key := p.Cwd + "\x00" + string(p.Kind)
+		body, cached := live[key]
+		if !cached {
+			// A missing doc is not an error here: the proposal may be
+			// creating the page, which correctly diffs as all additions.
+			if d, err := s.GetDoc(ctx, p.Cwd, p.Kind); err == nil {
+				body = d.Content
+			} else if !errors.Is(err, ErrNotFound) {
+				s.log.Warn("projectdoc: diff baseline unavailable — showing proposal as all additions",
+					"cwd", p.Cwd, "kind", p.Kind, "err", err)
+			}
+			live[key] = body
+		}
+		d := DiffBaseline(body, *p)
+		p.Diff = &d
+	}
 }
 
 // RejectedProposalContents returns the proposed_content of every REJECTED

--- a/internal/projectdoc/projectdoc.go
+++ b/internal/projectdoc/projectdoc.go
@@ -172,6 +172,13 @@ type Proposal struct {
 	DecidedAt         *time.Time `json:"decided_at,omitempty"`
 	PriorContent      string     `json:"prior_content,omitempty"`
 	CreatedAt         time.Time  `json:"created_at"`
+
+	// Diff is the line-level change from PriorContent to ProposedContent,
+	// attached on the review paths so a client renders what changed instead
+	// of asking the operator to compare two full documents by eye. Nil on
+	// paths that don't serve a review (e.g. the proposal returned when one
+	// is filed).
+	Diff *DocDiff `json:"diff,omitempty"`
 }
 
 // LogEntry represents one row from session_logs.
@@ -534,6 +541,12 @@ func (s *Service) ListPendingProposals(ctx context.Context, cwd string) ([]Propo
 		if err != nil {
 			return nil, err
 		}
+		// Attach the review diff here rather than in each client, so web
+		// and mobile show the same thing. This is the operator's approval
+		// queue — a handful of rows — so computing it eagerly costs less
+		// than a second round-trip per proposal would.
+		d := DiffLines(p.PriorContent, p.ProposedContent, DefaultDiffContext)
+		p.Diff = &d
 		out = append(out, p)
 	}
 	return out, rows.Err()


### PR DESCRIPTION
## Problem

Approving a proposal meant reading the whole proposed body and working out by eye what had moved.

- The **Knowledge page** showed only the proposed text — nothing to compare it against at all.
- The **project inbox** showed both documents side by side in a component called `DiffBlock` that computes no diff; it just puts two `<pre>` blocks next to each other.

That is workable for a three-line goal and not for a knowledge page. The longest one here is 16K characters.

## What this does

Proposals now carry a **line-level diff**: changed lines with three lines of context, plus an explicit `⋯ N unchanged ⋯` marker for every collapsed region.

That marker matters as much as the diff. Silently dropping unchanged regions would leave the reviewer unsure whether the diff was complete — the marker is what lets them tell "nothing else changed" from "the rest is hidden".

A one-line edit in a 200-line page now renders as ~8 lines. There is a test asserting exactly that, since it is the whole point of the feature.

## Design decisions

**Computed server-side, on the review path only.** `ListPendingProposals` attaches it. Web and mobile therefore render the *same* review, and a third client would need no diff algorithm. It is the operator's approval queue — a handful of rows — so computing eagerly beats a second round-trip per proposal.

**Unified, not side-by-side.** Two columns of a long document are unreadable on a laptop and impossible on a phone. This also matches what you asked for.

**`go-difflib`** was already in the dependency tree via testify and is now a direct dependency — no new download, and it is a stable pure-stdlib port of Python's `difflib`.

**Normalisation before comparing.** Line endings and a trailing newline are stripped first: neither is a content change worth reviewing, and without it a CRLF paste reads as "every line changed".

**Backward compatible.** Every surface falls back to the previous full-body view when a proposal carries no diff, so proposals already queued stay reviewable.

## Changes

- **backend** — `DiffLines` + `DocDiff`/`DiffHunk`/`DiffLine` in `internal/projectdoc/diff.go`; attached in `ListPendingProposals`
- **web** — `ProposalDiff` component; used by the Knowledge page and the project inbox
- **mobile** — `ProposalDiffView` + the `DocDiff` model; used by the Knowledge page, the project inbox and the Cortex hub (three surfaces, parity with web)
- **i18n** — en / zh / es

One note on the i18n: the wording deliberately avoids plurals. Web uses i18next's `_one`/`_other` suffixes and mobile uses slang, which does not recognise them — slang generated two unrelated methods rather than a plural. Rather than fight two conventions in one shared file, the counts render as `+12 −3` the way GitHub does, and the collapse marker is phrased so no plural is needed.

## Test plan

- `go test ./internal/projectdoc/ -race` — new tests cover: added line, replaced line, **a 200-line document collapsing to under 20 rendered lines**, two distant edits staying two separate hunks, identical content, empty prior content (new page), trailing-newline and CRLF normalisation
- `flutter analyze` clean; `flutter test` 123 passed
- `pnpm --filter web build` green; i18n parity 100% for zh + es
- `gofmt` + `go vet` clean

## Not verified by tests

The rendering itself — colours, line numbers, how the collapse marker reads in a real review — was checked by build and analyze only, not by eye. Worth looking at on a real pending proposal, ideally a long one, before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)