### PR TITLE
feat(git): add Update branch so a stale PR can be merged from opendray

### DIFF
--- a/app/mobile/lib/core/api/git_api.dart
+++ b/app/mobile/lib/core/api/git_api.dart
@@ -121,6 +121,7 @@ class GitPullRequest {
     required this.draft,
     required this.updatedAt,
     this.body = '',
+    this.mergeableState = '',
   });
 
   factory GitPullRequest.fromJson(Map<String, dynamic> json) => GitPullRequest(
@@ -134,6 +135,7 @@ class GitPullRequest {
     draft: json['draft'] as bool? ?? false,
     updatedAt: json['updated_at'] as String? ?? '',
     body: json['body'] as String? ?? '',
+    mergeableState: json['mergeable_state'] as String? ?? '',
   );
 
   final int number;
@@ -149,6 +151,15 @@ class GitPullRequest {
   // PR description (markdown). Empty on list responses — only the
   // single-PR detail fetch (getPullRequest) populates it.
   final String body;
+  // Why the PR can or cannot merge: 'clean', 'behind' (the base moved
+  // on), 'blocked' (checks), 'dirty' (conflicts), 'unstable', 'draft'.
+  // Empty on list responses — unknown, not a problem.
+  final String mergeableState;
+
+  /// True when the only obstacle is a base branch that has moved on —
+  /// the one case "update branch" fixes. Conflicts and failing checks
+  /// need something else.
+  bool get behindBase => mergeableState == 'behind';
 }
 
 /// "host" or "host/owner" for whichever credential the gateway resolved.
@@ -638,6 +649,25 @@ class GitApi {
             'commit_message': commitMessage,
           'delete_branch': deleteBranch,
         },
+      );
+      return GitPullRequest.fromJson(res.data ?? {});
+    } on Object catch (e) {
+      throw toApiException(e);
+    }
+  }
+
+  // POST /git/prs/{n}/update-branch — merges the PR's base into its
+  // head so a stale branch can be merged. GitHub's "Update branch";
+  // repos that require branches to be up to date refuse the merge
+  // otherwise, and there was previously no way out from inside opendray.
+  Future<GitPullRequest> updatePullRequestBranch({
+    required String dir,
+    required int number,
+  }) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/api/v1/git/prs/$number/update-branch',
+        data: {'dir': dir, 'number': number},
       );
       return GitPullRequest.fromJson(res.data ?? {});
     } on Object catch (e) {

--- a/app/mobile/lib/features/sessions/inspector/pr_detail_screen.dart
+++ b/app/mobile/lib/features/sessions/inspector/pr_detail_screen.dart
@@ -72,6 +72,38 @@ class _PRDetailScreenState extends ConsumerState<PRDetailScreen> {
     }
   }
 
+  // Merging a PR whose base has moved on is refused by repos that require
+  // branches to be up to date — GitHub reports it as missing status
+  // checks, which points at the wrong thing. This is GitHub's "Update
+  // branch": merge the base in so the checks re-run on it.
+  Future<void> _updateBranch() async {
+    setState(() => _busy = true);
+    final messenger = ScaffoldMessenger.of(context);
+    final errorColor = Theme.of(context).colorScheme.error;
+    try {
+      final updated = await ref
+          .read(gitApiProvider)
+          .updatePullRequestBranch(dir: widget.cwd, number: _pr.number);
+      if (!mounted) return;
+      setState(() => _pr = updated);
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('Merged ${_pr.base} into the branch — checks re-run'),
+        ),
+      );
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('Update branch failed: ${e.message}'),
+          backgroundColor: errorColor,
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
   Future<void> _merge() async {
     final confirmed = await showDialog<bool>(
       context: context,
@@ -246,6 +278,15 @@ class _PRDetailScreenState extends ConsumerState<PRDetailScreen> {
             ),
             Text('Delete branch', style: theme.textTheme.bodySmall),
             const Spacer(),
+            if (_pr.behindBase)
+              Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: OutlinedButton.icon(
+                  onPressed: _busy ? null : _updateBranch,
+                  icon: const Icon(Icons.sync, size: 16),
+                  label: const Text('Update branch'),
+                ),
+              ),
             FilledButton.icon(
               onPressed: _busy ? null : _merge,
               icon: _busy
@@ -423,7 +464,9 @@ class _CommentCard extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
             decoration: BoxDecoration(
               color: theme.colorScheme.surfaceContainerHighest,
-              borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
+              borderRadius: const BorderRadius.vertical(
+                top: Radius.circular(8),
+              ),
             ),
             child: Row(
               children: [
@@ -479,10 +522,7 @@ class _ReviewStateBadge extends StatelessWidget {
       ),
       child: Text(
         state.replaceAll('_', ' '),
-        style: theme.textTheme.labelSmall?.copyWith(
-          color: color,
-          fontSize: 9,
-        ),
+        style: theme.textTheme.labelSmall?.copyWith(color: color, fontSize: 9),
       ),
     );
   }
@@ -540,7 +580,8 @@ class _CommitsTabState extends ConsumerState<_CommitsTab> {
     return ListView.separated(
       padding: const EdgeInsets.all(16),
       itemCount: _commits!.length,
-      separatorBuilder: (_, __) => Divider(height: 14, color: theme.dividerColor),
+      separatorBuilder: (_, __) =>
+          Divider(height: 14, color: theme.dividerColor),
       itemBuilder: (context, i) {
         final c = _commits![i];
         return Row(
@@ -827,9 +868,7 @@ class _DiffView extends StatelessWidget {
         scrollDirection: Axis.horizontal,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            for (final line in lines) _diffLine(theme, line),
-          ],
+          children: [for (final line in lines) _diffLine(theme, line)],
         ),
       ),
     );

--- a/app/shared/src/lib/githost.ts
+++ b/app/shared/src/lib/githost.ts
@@ -138,7 +138,19 @@ export interface GitPullRequest {
   // Description (markdown). Only populated by getGitPR (the single-PR
   // detail fetch); the list endpoint omits it to stay lean.
   body?: string
+  /** Why the PR can or cannot merge right now: 'clean', 'behind' (the
+   * base moved on), 'blocked' (checks), 'dirty' (conflicts), 'unstable',
+   * 'draft'. Only the single-PR fetch reports it; absent means unknown,
+   * which must not be shown as a problem. */
+  mergeable_state?: string
   updated_at: string
+}
+
+/** True when the PR's only obstacle is a base branch that has moved on —
+ * the one case "update branch" fixes. Conflicts ('dirty') and failing
+ * checks ('blocked') need something else. */
+export function isBehindBase(pr: GitPullRequest): boolean {
+  return pr.mergeable_state === 'behind'
 }
 
 export interface GitPullRequestsResponse {
@@ -206,6 +218,19 @@ export async function mergeGitPR(
   return api<GitPullRequest>(`/api/v1/git/prs/${req.number}/merge`, {
     method: 'POST',
     body: req,
+  })
+}
+
+/** Merges the PR's base branch into its head so a stale branch can be
+ * merged — GitHub's "Update branch". GitHub-only for now; other hosts
+ * return an error naming what to do instead. */
+export async function updateGitPRBranch(
+  dir: string,
+  number: number,
+): Promise<GitPullRequest> {
+  return api<GitPullRequest>(`/api/v1/git/prs/${number}/update-branch`, {
+    method: 'POST',
+    body: { dir, number },
   })
 }
 

--- a/app/web/src/components/sessions/inspector/PullRequestsSection.tsx
+++ b/app/web/src/components/sessions/inspector/PullRequestsSection.tsx
@@ -33,6 +33,8 @@ import {
   getPRFiles,
   listGitPRs,
   mergeGitPR,
+  updateGitPRBranch,
+  isBehindBase,
 } from '@/lib/githost'
 import { cn } from '@/lib/utils'
 import { CredentialNote } from './CredentialNote'
@@ -438,6 +440,25 @@ function PRDetailDrawer({
     },
   })
 
+  // Merging a PR whose base has moved on is refused by repos that require
+  // branches to be up to date. This is GitHub's "Update branch": merge the
+  // base in so the checks re-run on it. Without it, an operator working
+  // only through opendray has no way out of that state.
+  const updateBranch = useMutation({
+    mutationFn: () => updateGitPRBranch(cwd, pr.number),
+    onSuccess: () => {
+      toast.success(`PR #${pr.number} branch updated`, {
+        description: `Merged ${full.base} in — checks will re-run.`,
+      })
+      void detail.refetch()
+    },
+    onError: (err) => {
+      toast.error('Update branch failed', {
+        description: (err as Error).message,
+      })
+    },
+  })
+
   // body is undefined until the detail fetch resolves; '' means the PR
   // genuinely has no description. While the query still serves the
   // seeded list row (isPlaceholderData), the body fetch is in flight.
@@ -534,6 +555,25 @@ function PRDetailDrawer({
           {tab === 'checks' && <ChecksTab cwd={cwd} number={full.number} />}
           {tab === 'files' && <FilesTab cwd={cwd} number={full.number} />}
         </div>
+
+        {/* Behind the base — merging will be refused until this is done,
+            so say it plainly and offer the one-click fix. */}
+        {full.state === 'open' && isBehindBase(full) && (
+          <div className="border-t border-amber-500/30 bg-amber-500/10 px-3 py-2 flex flex-wrap items-center gap-2 text-[11px]">
+            <span className="flex-1 text-amber-300">
+              This branch is behind <code>{full.base}</code>. The repository
+              requires branches to be up to date before merging.
+            </span>
+            <button
+              type="button"
+              disabled={updateBranch.isPending}
+              onClick={() => updateBranch.mutate()}
+              className="rounded border border-amber-400/40 px-2 py-0.5 text-amber-200 disabled:opacity-50"
+            >
+              {updateBranch.isPending ? 'Updating…' : 'Update branch'}
+            </button>
+          </div>
+        )}
 
         {/* Merge — footer, only while the PR is open (visible on any tab) */}
         {full.state === 'open' && (

--- a/internal/githost/githost.go
+++ b/internal/githost/githost.go
@@ -541,7 +541,20 @@ type PullRequest struct {
 	Draft     bool      `json:"draft"`
 	Body      string    `json:"body,omitempty"` // description (detail fetch only)
 	UpdatedAt time.Time `json:"updated_at"`
+	// MergeableState is the host's view of why a PR can or cannot merge
+	// right now: "clean", "behind" (base moved on), "blocked" (checks
+	// pending/failing), "dirty" (real conflicts), "unstable", "draft".
+	// Empty when the host didn't report one — list endpoints usually
+	// omit it, so treat it as unknown rather than as a problem.
+	MergeableState string `json:"mergeable_state,omitempty"`
 }
+
+// BehindBase reports whether this PR's only obstacle is that its base
+// branch has moved on. Repos that require branches to be up to date
+// refuse the merge in that state, and the fix is to merge the base in —
+// which is what UpdateBranch does. Distinguished from "dirty" (real
+// conflicts, which updating cannot fix) and "blocked" (checks).
+func (p PullRequest) BehindBase() bool { return p.MergeableState == "behind" }
 
 func (s *Service) ListPullRequests(ctx context.Context, dir, state string) (Remote, []PullRequest, error) {
 	rem, err := s.DetectRemote(ctx, dir)
@@ -704,16 +717,27 @@ func (s *Service) MergePullRequest(ctx context.Context, req MergePRRequest) (Pul
 	if req.Method == "" {
 		req.Method = "squash"
 	}
+	var pr PullRequest
 	switch hostRow.Kind {
 	case KindGitHub:
-		return s.mergeGitHubPR(ctx, hostRow, rem, req)
+		pr, err = s.mergeGitHubPR(ctx, hostRow, rem, req)
 	case KindGitea:
-		return s.mergeGiteaPR(ctx, hostRow, rem, req)
+		pr, err = s.mergeGiteaPR(ctx, hostRow, rem, req)
 	case KindGitLab:
-		return s.mergeGitLabMR(ctx, hostRow, rem, req)
+		pr, err = s.mergeGitLabMR(ctx, hostRow, rem, req)
 	default:
 		return PullRequest{}, fmt.Errorf("unsupported host kind: %s", hostRow.Kind)
 	}
+	if err != nil {
+		// Ask the host why before giving up: a refusal caused by a stale
+		// branch is reported as a checks failure, which sends the operator
+		// looking in the wrong place. A failed lookup just means we pass
+		// the original error through unchanged.
+		if cur, ferr := s.GetPullRequest(ctx, req.Dir, req.Number); ferr == nil {
+			return PullRequest{}, explainMergeFailure(err, cur)
+		}
+	}
+	return pr, err
 }
 
 // PRChecks returns the check runs attached to a PR's head commit.
@@ -953,6 +977,9 @@ type githubPRResponse struct {
 	} `json:"base"`
 	Body     string     `json:"body"`
 	MergedAt *time.Time `json:"merged_at"`
+	// Only the single-PR detail endpoint fills this reliably; the list
+	// endpoint leaves it empty, which reads as "unknown".
+	MergeableState string `json:"mergeable_state"`
 }
 
 func (p githubPRResponse) toPullRequest() PullRequest {
@@ -961,16 +988,17 @@ func (p githubPRResponse) toPullRequest() PullRequest {
 		st = "merged"
 	}
 	return PullRequest{
-		Number:    p.Number,
-		Title:     p.Title,
-		State:     st,
-		Author:    p.User.Login,
-		Head:      p.Head.Ref,
-		Base:      p.Base.Ref,
-		URL:       p.HTMLURL,
-		Draft:     p.Draft,
-		Body:      p.Body,
-		UpdatedAt: p.UpdatedAt,
+		Number:         p.Number,
+		Title:          p.Title,
+		State:          st,
+		Author:         p.User.Login,
+		Head:           p.Head.Ref,
+		Base:           p.Base.Ref,
+		URL:            p.HTMLURL,
+		Draft:          p.Draft,
+		Body:           p.Body,
+		UpdatedAt:      p.UpdatedAt,
+		MergeableState: p.MergeableState,
 	}
 }
 
@@ -2152,6 +2180,7 @@ func (h *Handlers) Mount(r chi.Router) {
 	r.Post("/git/prs", h.createPR)
 	r.Get("/git/prs/{number}", h.prDetail)
 	r.Post("/git/prs/{number}/merge", h.mergePR)
+	r.Post("/git/prs/{number}/update-branch", h.updatePRBranch)
 	r.Get("/git/prs/{number}/checks", h.prChecks)
 	r.Get("/git/prs/{number}/commits", h.prCommits)
 	r.Get("/git/prs/{number}/files", h.prFiles)
@@ -2203,6 +2232,34 @@ func (h *Handlers) mergePR(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	pr, err := h.svc.MergePullRequest(r.Context(), req)
+	if err != nil {
+		writeError(w, statusFromGitErr(err), err)
+		return
+	}
+	writeJSON(w, http.StatusOK, pr)
+}
+
+// updatePRBranch mounts POST /git/prs/{number}/update-branch — merges
+// the PR's base into its head so a BEHIND branch can be merged.
+func (h *Handlers) updatePRBranch(w http.ResponseWriter, r *http.Request) {
+	var req UpdateBranchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("decode body: %w", err))
+		return
+	}
+	if num := chi.URLParam(r, "number"); num != "" {
+		n, err := strconv.Atoi(num)
+		if err != nil || n <= 0 {
+			writeError(w, http.StatusBadRequest, errors.New("invalid number"))
+			return
+		}
+		req.Number = n
+	}
+	if req.Dir == "" {
+		writeError(w, http.StatusBadRequest, errors.New("dir required"))
+		return
+	}
+	pr, err := h.svc.UpdatePullRequestBranch(r.Context(), req)
 	if err != nil {
 		writeError(w, statusFromGitErr(err), err)
 		return

--- a/internal/githost/update_branch.go
+++ b/internal/githost/update_branch.go
@@ -1,0 +1,106 @@
+package githost
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// Merging the second of two PRs fails on repos that require branches to
+// be up to date: once the first one lands, the second is BEHIND, and the
+// host refuses with a rule violation about missing status checks — which
+// reads like a checks problem rather than a staleness one.
+//
+// The fix is to merge the base branch into the PR branch so the checks
+// re-run on the new base. GitHub exposes it as "Update branch"; without
+// an equivalent here an operator working only through opendray has no
+// way out of that state.
+
+// explainMergeFailure prefixes a merge error with the reason when we can
+// name it from the PR's own state.
+//
+// A stale branch is refused by GitHub with "Repository rule violations
+// found — N of N required status checks are expected", which reads as a
+// checks problem and offers no next step. The operator sees that text
+// verbatim, so the diagnosis belongs here rather than in each client.
+//
+// Only the case we can actually identify is rewritten; everything else
+// passes through, because an invented explanation is worse than raw
+// host output.
+func explainMergeFailure(err error, pr PullRequest) error {
+	if err == nil || !pr.BehindBase() {
+		return err
+	}
+	return fmt.Errorf(
+		"this branch is behind %s, and the repository requires branches to be up to date before merging — update the branch first, then merge (%w)",
+		orDefault(pr.Base, "its base branch"), err)
+}
+
+func orDefault(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+// UpdateBranchRequest asks the host to merge a PR's base into its head.
+type UpdateBranchRequest struct {
+	Dir    string `json:"dir"`
+	Number int    `json:"number"`
+}
+
+// UpdatePullRequestBranch brings a PR's branch up to date with its base
+// and returns the refreshed PR.
+//
+// GitHub only for now: Gitea and GitLab have their own shapes for this
+// and are refused explicitly rather than half-supported.
+func (s *Service) UpdatePullRequestBranch(ctx context.Context, req UpdateBranchRequest) (PullRequest, error) {
+	if req.Number <= 0 {
+		return PullRequest{}, errors.New("number required")
+	}
+	rem, hostRow, err := s.resolveHost(ctx, req.Dir)
+	if err != nil {
+		return PullRequest{}, err
+	}
+	if err := s.updateBranchForKind(ctx, hostRow, rem, req.Number); err != nil {
+		return PullRequest{}, err
+	}
+	// Re-fetch so the caller sees the new mergeable_state. The update
+	// itself succeeded, so a failed refetch is not worth failing on —
+	// the caller re-polls anyway.
+	pr, ferr := s.GetPullRequest(ctx, req.Dir, req.Number)
+	if ferr != nil {
+		return PullRequest{Number: req.Number}, nil
+	}
+	return pr, nil
+}
+
+// updateBranchForKind dispatches to the host implementation.
+func (s *Service) updateBranchForKind(ctx context.Context, h Host, rem Remote, number int) error {
+	switch h.Kind {
+	case KindGitHub:
+		return s.updateGitHubPRBranch(ctx, h, rem, number)
+	default:
+		return fmt.Errorf(
+			"updating a pull request branch is only supported on GitHub — this repository is on %s; merge the base branch in locally and push",
+			h.Kind)
+	}
+}
+
+// updateGitHubPRBranch calls PUT /repos/{o}/{r}/pulls/{n}/update-branch,
+// which merges the base into the head branch.
+//
+// A 422 here means the branch cannot be updated this way — most often
+// because it is not actually behind, or the merge would conflict. Both
+// need the operator, so the host's message is passed through.
+func (s *Service) updateGitHubPRBranch(ctx context.Context, h Host, rem Remote, number int) error {
+	u := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/update-branch",
+		githubAPIBase(h.Host), rem.Owner, rem.Repo, number)
+	// expected_head_sha is deliberately omitted: it guards against
+	// updating a branch that moved since the UI last looked, but the
+	// operator's intent here is "make it current", and a stale SHA would
+	// just fail a request they would immediately retry.
+	_, err := s.do(ctx, http.MethodPut, u, "Bearer "+h.Token, "application/vnd.github+json", map[string]any{})
+	return err
+}

--- a/internal/githost/update_branch_test.go
+++ b/internal/githost/update_branch_test.go
@@ -1,0 +1,95 @@
+package githost
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// A PR whose branch is behind its base cannot be merged when the repo
+// requires branches to be up to date — GitHub answers the merge with a
+// 405 "required status checks are expected". The UI can only offer a way
+// out if it knows the state, so mergeable_state has to survive parsing.
+func TestGitHubPRResponse_CarriesMergeableState(t *testing.T) {
+	const raw = `{
+	  "number": 517,
+	  "title": "fix: something",
+	  "state": "open",
+	  "mergeable": true,
+	  "mergeable_state": "behind",
+	  "html_url": "https://github.com/o/r/pull/517",
+	  "user": {"login": "linivek"},
+	  "head": {"ref": "fix/x"},
+	  "base": {"ref": "main"}
+	}`
+	var p githubPRResponse
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	pr := p.toPullRequest()
+	if pr.MergeableState != "behind" {
+		t.Errorf("MergeableState = %q, want behind", pr.MergeableState)
+	}
+	if !pr.BehindBase() {
+		t.Error("BehindBase() = false for mergeable_state=behind")
+	}
+}
+
+func TestPullRequest_BehindBase(t *testing.T) {
+	for state, want := range map[string]bool{
+		"behind":   true,
+		"clean":    false,
+		"blocked":  false, // failing/pending checks, not staleness
+		"dirty":    false, // real conflicts — updating won't help
+		"unstable": false,
+		"":         false, // unknown (list endpoints omit it)
+	} {
+		if got := (PullRequest{MergeableState: state}).BehindBase(); got != want {
+			t.Errorf("BehindBase(%q) = %v, want %v", state, got, want)
+		}
+	}
+}
+
+// Only GitHub is wired up for now. Other hosts must say so plainly
+// rather than fail with something the operator has to decode.
+func TestUpdateBranch_UnsupportedHostIsExplicit(t *testing.T) {
+	svc := &Service{}
+	err := svc.updateBranchForKind(t.Context(), Host{Kind: KindGitea}, Remote{}, 1)
+	if err == nil {
+		t.Fatal("expected an error for a non-GitHub host")
+	}
+	// Names the host it IS on and the one it would work on, so the
+	// operator knows both why it failed and what to do instead.
+	lower := strings.ToLower(err.Error())
+	for _, want := range []string{"gitea", "github", "locally"} {
+		if !strings.Contains(lower, want) {
+			t.Errorf("error missing %q; got %q", want, err)
+		}
+	}
+}
+
+// A merge refused because the branch is stale used to surface as the
+// host's raw JSON — "Repository rule violations found\n\n3 of 3 required
+// status checks are expected" — which points at checks and says nothing
+// about what to actually do. The operator sees it verbatim.
+func TestExplainMergeFailure(t *testing.T) {
+	raw := errors.New(`github: 405: {"message":"Repository rule violations found\n\n3 of 3 required status checks are expected.","status":"405"}`)
+
+	out := explainMergeFailure(raw, PullRequest{MergeableState: "behind"}).Error()
+	for _, want := range []string{"behind", "update"} {
+		if !strings.Contains(strings.ToLower(out), want) {
+			t.Errorf("a BEHIND merge failure should say so and name the way out; got %q", out)
+		}
+	}
+
+	// Anything else is passed through — inventing an explanation for a
+	// failure we did not diagnose would be worse than the raw text.
+	other := explainMergeFailure(raw, PullRequest{MergeableState: "dirty"})
+	if other.Error() != raw.Error() {
+		t.Errorf("non-BEHIND failure should pass through unchanged; got %q", other)
+	}
+	if explainMergeFailure(nil, PullRequest{MergeableState: "behind"}) != nil {
+		t.Error("nil error must stay nil")
+	}
+}


### PR DESCRIPTION
## The problem you hit

Merging the second of two PRs fails on this repo. Once the first lands, the second is `BEHIND` its base, and the ruleset requires branches to be up to date. GitHub refuses with:

```
Repository rule violations found

3 of 3 required status checks are expected.
```

That text points at **checks** and says nothing about staleness or what to do about it — and it was shown to you verbatim, raw JSON and all.

GitHub's web UI answers this with an **Update branch** button. opendray had no equivalent, so working only through opendray you were stuck: the merge button kept failing and nothing in the UI could clear the state. This isn't an edge case — open two PRs, merge one, and the other is guaranteed to hit it.

## What this adds

**Backend**
- `PullRequest` now carries `mergeable_state`, with `BehindBase()` naming the one situation this fixes. `dirty` (real conflicts) and `blocked` (failing checks) are deliberately **not** folded into the same bucket — updating the branch fixes neither.
- `UpdatePullRequestBranch` → GitHub's `PUT /pulls/{n}/update-branch`, exposed as `POST /api/v1/git/prs/{n}/update-branch`.
- **GitHub only**, as agreed. Gitea and GitLab are refused with an error naming the host *and* the workaround ("merge the base branch in locally and push") rather than being half-supported.

**The error message**
A failed merge now asks the host why before giving up. When the PR is `BEHIND`, the error says so and points at the update, with the host's original text kept wrapped for detail. Every other failure passes through untouched — inventing an explanation for something we didn't diagnose would be worse than raw host output.

**Both clients**
An "Update branch" affordance appears only while the PR is open *and* behind, then refreshes the PR so the merge controls unblock without a manual reload. Web shows it as an amber banner explaining the state; mobile puts a button next to Merge — that's the surface you were actually on.

## A note on strings

Hardcoded English, matching the surrounding PR surfaces on both clients — `Merge`, `Delete branch`, `Merge failed` are all literals there today. No i18n keys added, so parity is unchanged. Worth a separate pass if you want the PR surfaces localized, but doing it for three new strings while the rest stays English would be worse than either option.

## Test plan

- `go test ./internal/... ./cmd/...` — new tests cover `mergeable_state` surviving the GitHub decode, `BehindBase` across every state GitHub reports, the non-GitHub refusal naming both the host and the workaround, and the merge-failure explanation rewriting **only** the BEHIND case (nil stays nil; other states pass through verbatim)
- `pnpm --filter web build` green; `flutter analyze` clean; `flutter test` 123 passed
- `gofmt` + `go vet` clean; i18n parity unchanged

## Not verified by tests

The GitHub call itself is not exercised against a live API — no test hits `update-branch` for real. The parsing, the state logic and the refusal path are covered; the round-trip is worth confirming by hand on the next PR that goes stale (which, given the ruleset, will happen the next time you merge two in a row).

Branched from `main`. Independent of #517, which is now `CLEAN` and mergeable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)