### PR TITLE
fix(mobile): make a knowledge proposal reviewable before deciding on it

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -3057,7 +3057,8 @@
           "approve": "Approve",
           "reject": "Reject",
           "approved": "Update approved",
-          "rejected": "Proposal rejected"
+          "rejected": "Proposal rejected",
+          "review": "Review"
         },
         "discuss": "Discuss with AI",
         "discussHint": "Re-draft this policy page in conversation with the AI — locked pages get proposals, never overwrites",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -3057,7 +3057,8 @@
           "approve": "Aprobar",
           "reject": "Rechazar",
           "approved": "Actualización aprobada",
-          "rejected": "Propuesta rechazada"
+          "rejected": "Propuesta rechazada",
+          "review": "Revisar"
         },
         "discuss": "Hablar con la IA",
         "discussHint": "Redacta de nuevo esta política conversando con la IA — las páginas bloqueadas reciben propuestas, nunca sobrescrituras",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -3054,7 +3054,8 @@
           "approve": "批准",
           "reject": "拒绝",
           "approved": "更新已批准",
-          "rejected": "提议已拒绝"
+          "rejected": "提议已拒绝",
+          "review": "审阅"
         },
         "discuss": "与 AI 讨论",
         "discussHint": "与 AI 对话重新制定这页方针——已锁定的页面只会产生提案，绝不覆写",

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 13590 (4530 per locale)
+/// Strings: 13593 (4531 per locale)
 ///
-/// Built on 2026-08-11 at 14:37 UTC
+/// Built on 2026-08-11 at 22:43 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -18729,6 +18729,9 @@ class TranslationsWebKnowledgeKbProposalEn {
 
 	/// en: 'Proposal rejected'
 	String get rejected => 'Proposal rejected';
+
+	/// en: 'Review'
+	String get review => 'Review';
 }
 
 // Path: web.knowledge.kb.newPage
@@ -21764,6 +21767,7 @@ extension on Translations {
 			'web.knowledge.kb.proposal.reject' => 'Reject',
 			'web.knowledge.kb.proposal.approved' => 'Update approved',
 			'web.knowledge.kb.proposal.rejected' => 'Proposal rejected',
+			'web.knowledge.kb.proposal.review' => 'Review',
 			'web.knowledge.kb.discuss' => 'Discuss with AI',
 			'web.knowledge.kb.discussHint' => 'Re-draft this policy page in conversation with the AI — locked pages get proposals, never overwrites',
 			'web.knowledge.kb.onDemand' => 'on-demand',
@@ -21904,9 +21908,9 @@ extension on Translations {
 			'web.cortex.chat.modelGlobalDefault' => 'Default (global)',
 			'web.cortex.chat.modelCliDefault' => 'CLI default',
 			'web.cortex.chat.modelChangeFailed' => 'Couldn\'t change the discussion model',
-			'web.cortex.chat.modelGroupCloud' => 'Cloud agents',
 			_ => null,
 		} ?? switch (path) {
+			'web.cortex.chat.modelGroupCloud' => 'Cloud agents',
 			'web.cortex.chat.modelGroupLocal' => 'Local models',
 			'web.cortex.chat.accountDefault' => 'Default account',
 			'web.cortex.chat.accountHint' => 'Which Claude account this discussion runs against (Claude is multi-account).',
@@ -22418,9 +22422,9 @@ extension on Translations {
 			'sessions.inspector.notes.save' => 'Save',
 			'sessions.inspector.notes.renameTitle' => 'Rename or move',
 			'sessions.inspector.notes.move' => 'Move',
-			'sessions.inspector.notes.renameHelp' => 'Path inside the project folder. Include a slash to file it in a folder, e.g. features/canvas.md',
 			_ => null,
 		} ?? switch (path) {
+			'sessions.inspector.notes.renameHelp' => 'Path inside the project folder. Include a slash to file it in a folder, e.g. features/canvas.md',
 			'sessions.inspector.notes.renamed' => 'Moved.',
 			'sessions.inspector.notes.renamedWithLinks' => ({required Object count, required Object notes}) => 'Moved — updated ${count} link(s) in ${notes} note(s).',
 			'sessions.inspector.notes.renamedWithWarning' => ({required Object warning}) => 'Moved, but links may not be updated: ${warning}',
@@ -22932,9 +22936,9 @@ extension on Translations {
 			'backups.menuTargets' => 'Targets',
 			'backups.kv.status' => 'Status',
 			'backups.kv.verified' => 'Verified',
-			'backups.kv.kind' => 'Type',
 			_ => null,
 		} ?? switch (path) {
+			'backups.kv.kind' => 'Type',
 			'backups.kv.target' => 'Target',
 			'backups.kv.dedup' => 'Dedup',
 			'backups.kv.fanout' => 'Fan-out group',
@@ -23446,9 +23450,9 @@ extension on Translations {
 			'notesPage.tags.noMatches' => ({required Object query}) => 'No tags match "${query}".',
 			'notesPage.tags.filteredBy' => 'Filtered by',
 			'notesPage.tags.clear' => 'Clear tag filter',
-			'notesPage.tags.noNotes' => ({required Object tag}) => 'No notes carry #${tag} any more.',
 			_ => null,
 		} ?? switch (path) {
+			'notesPage.tags.noNotes' => ({required Object tag}) => 'No notes carry #${tag} any more.',
 			'notesPage.backlinks.title' => 'Backlinks',
 			'notesPage.backlinks.loading' => 'Looking for links…',
 			'notesPage.backlinks.empty' => 'No notes link here yet.',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -9783,6 +9783,7 @@ class _TranslationsWebKnowledgeKbProposalEs extends TranslationsWebKnowledgeKbPr
 	@override String get reject => 'Rechazar';
 	@override String get approved => 'Actualización aprobada';
 	@override String get rejected => 'Propuesta rechazada';
+	@override String get review => 'Revisar';
 }
 
 // Path: web.knowledge.kb.newPage
@@ -12577,6 +12578,7 @@ extension on TranslationsEs {
 			'web.knowledge.kb.proposal.reject' => 'Rechazar',
 			'web.knowledge.kb.proposal.approved' => 'Actualización aprobada',
 			'web.knowledge.kb.proposal.rejected' => 'Propuesta rechazada',
+			'web.knowledge.kb.proposal.review' => 'Revisar',
 			'web.knowledge.kb.discuss' => 'Hablar con la IA',
 			'web.knowledge.kb.discussHint' => 'Redacta de nuevo esta política conversando con la IA — las páginas bloqueadas reciben propuestas, nunca sobrescrituras',
 			'web.knowledge.kb.onDemand' => 'bajo demanda',
@@ -12717,9 +12719,9 @@ extension on TranslationsEs {
 			'web.cortex.chat.modelGlobalDefault' => 'Predeterminado (global)',
 			'web.cortex.chat.modelCliDefault' => 'Predeterminado del CLI',
 			'web.cortex.chat.modelChangeFailed' => 'No se pudo cambiar el modelo de la conversación',
-			'web.cortex.chat.modelGroupCloud' => 'Agentes en la nube',
 			_ => null,
 		} ?? switch (path) {
+			'web.cortex.chat.modelGroupCloud' => 'Agentes en la nube',
 			'web.cortex.chat.modelGroupLocal' => 'Modelos locales',
 			'web.cortex.chat.accountDefault' => 'Cuenta predeterminada',
 			'web.cortex.chat.accountHint' => 'Con qué cuenta de Claude se ejecuta esta discusión (Claude es multicuenta).',
@@ -13231,9 +13233,9 @@ extension on TranslationsEs {
 			'sessions.inspector.notes.save' => 'Guardar',
 			'sessions.inspector.notes.renameTitle' => 'Renombrar o mover',
 			'sessions.inspector.notes.move' => 'Mover',
-			'sessions.inspector.notes.renameHelp' => 'Ruta dentro de la carpeta del proyecto. Incluye una barra para archivarlo en una carpeta, p. ej. features/canvas.md',
 			_ => null,
 		} ?? switch (path) {
+			'sessions.inspector.notes.renameHelp' => 'Ruta dentro de la carpeta del proyecto. Incluye una barra para archivarlo en una carpeta, p. ej. features/canvas.md',
 			'sessions.inspector.notes.renamed' => 'Movido.',
 			'sessions.inspector.notes.renamedWithLinks' => ({required Object count, required Object notes}) => 'Movido: se actualizaron ${count} enlace(s) en ${notes} nota(s).',
 			'sessions.inspector.notes.renamedWithWarning' => ({required Object warning}) => 'Movido, pero los enlaces podrían no actualizarse: ${warning}',
@@ -13745,9 +13747,9 @@ extension on TranslationsEs {
 			'backups.menuTargets' => 'Destinos',
 			'backups.kv.status' => 'Estado',
 			'backups.kv.verified' => 'Verificada',
-			'backups.kv.kind' => 'Tipo',
 			_ => null,
 		} ?? switch (path) {
+			'backups.kv.kind' => 'Tipo',
 			'backups.kv.target' => 'Destino',
 			'backups.kv.dedup' => 'Deduplicación',
 			'backups.kv.fanout' => 'Grupo de difusión',
@@ -14259,9 +14261,9 @@ extension on TranslationsEs {
 			'notesPage.tags.noMatches' => ({required Object query}) => 'Ninguna etiqueta coincide con «${query}».',
 			'notesPage.tags.filteredBy' => 'Filtrado por',
 			'notesPage.tags.clear' => 'Quitar el filtro de etiqueta',
-			'notesPage.tags.noNotes' => ({required Object tag}) => 'Ya no hay notas con #${tag}.',
 			_ => null,
 		} ?? switch (path) {
+			'notesPage.tags.noNotes' => ({required Object tag}) => 'Ya no hay notas con #${tag}.',
 			'notesPage.backlinks.title' => 'Retroenlaces',
 			'notesPage.backlinks.loading' => 'Buscando enlaces…',
 			'notesPage.backlinks.empty' => 'Todavía no hay notas que enlacen aquí.',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -9780,6 +9780,7 @@ class _TranslationsWebKnowledgeKbProposalZh extends TranslationsWebKnowledgeKbPr
 	@override String get reject => '拒绝';
 	@override String get approved => '更新已批准';
 	@override String get rejected => '提议已拒绝';
+	@override String get review => '审阅';
 }
 
 // Path: web.knowledge.kb.newPage
@@ -12571,6 +12572,7 @@ extension on TranslationsZh {
 			'web.knowledge.kb.proposal.reject' => '拒绝',
 			'web.knowledge.kb.proposal.approved' => '更新已批准',
 			'web.knowledge.kb.proposal.rejected' => '提议已拒绝',
+			'web.knowledge.kb.proposal.review' => '审阅',
 			'web.knowledge.kb.discuss' => '与 AI 讨论',
 			'web.knowledge.kb.discussHint' => '与 AI 对话重新制定这页方针——已锁定的页面只会产生提案，绝不覆写',
 			'web.knowledge.kb.onDemand' => '按需',
@@ -12714,9 +12716,9 @@ extension on TranslationsZh {
 			'web.cortex.chat.modelGroupCloud' => '云端 agent',
 			'web.cortex.chat.modelGroupLocal' => '本地模型',
 			'web.cortex.chat.accountDefault' => '默认账号',
-			'web.cortex.chat.accountHint' => '本次讨论使用哪个 Claude 账号(Claude 是多账号)。',
 			_ => null,
 		} ?? switch (path) {
+			'web.cortex.chat.accountHint' => '本次讨论使用哪个 Claude 账号(Claude 是多账号)。',
 			'web.cortex.chat.modelProviderDefault' => '供应商默认',
 			'web.cortex.chat.modelProbeFailed' => '无法连接端点列出模型——用供应商默认，或在 Memory 设置里配置。',
 			'web.cortex.blueprint.open' => '蓝图',
@@ -13228,9 +13230,9 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.renameHelp' => '项目文件夹内的路径。加斜杠即可归入目录,例如 features/canvas.md',
 			'sessions.inspector.notes.renamed' => '已移动。',
 			'sessions.inspector.notes.renamedWithLinks' => ({required Object notes, required Object count}) => '已移动 —— 更新了 ${notes} 篇笔记中的 ${count} 处链接。',
-			'sessions.inspector.notes.renamedWithWarning' => ({required Object warning}) => '已移动,但链接可能未更新:${warning}',
 			_ => null,
 		} ?? switch (path) {
+			'sessions.inspector.notes.renamedWithWarning' => ({required Object warning}) => '已移动,但链接可能未更新:${warning}',
 			'sessions.inspector.notes.renameFailed' => ({required Object error}) => '移动失败:${error}',
 			'sessions.inspector.notes.openFolderIndex' => '打开目录索引',
 			'sessions.inspector.canvas.kindUi' => 'UI 稿',
@@ -13742,9 +13744,9 @@ extension on TranslationsZh {
 			'backups.kv.kind' => '类型',
 			'backups.kv.target' => '目标',
 			'backups.kv.dedup' => '去重',
-			'backups.kv.fanout' => '扇出组',
 			_ => null,
 		} ?? switch (path) {
+			'backups.kv.fanout' => '扇出组',
 			'backups.kv.triggeredBy' => '触发者',
 			'backups.kv.started' => '开始',
 			'backups.kv.finished' => '完成',
@@ -14256,9 +14258,9 @@ extension on TranslationsZh {
 			'notesPage.tags.noNotes' => ({required Object tag}) => '已经没有笔记带 #${tag} 了。',
 			'notesPage.backlinks.title' => '反向链接',
 			'notesPage.backlinks.loading' => '正在查找链接…',
-			'notesPage.backlinks.empty' => '还没有笔记链接到这里。',
 			_ => null,
 		} ?? switch (path) {
+			'notesPage.backlinks.empty' => '还没有笔记链接到这里。',
 			'notesPage.backlinks.failed' => ({required Object error}) => '反向链接加载失败：${error}',
 			'notesPage.outline.action' => '大纲',
 			'notesPage.outline.title' => '大纲',

--- a/app/mobile/lib/features/cortex/proposal_review_screen.dart
+++ b/app/mobile/lib/features/cortex/proposal_review_screen.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:opendray/core/api/project_docs_api.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/cortex/proposal_diff.dart';
+
+/// Full-screen review of one pending proposal.
+///
+/// The diff used to live inside the amber banner on the page itself: a
+/// 240px window, on a tinted background that swallowed the red/green, with
+/// approve and reject sharing a row that overflowed on a phone — so the
+/// reject button was pushed off-screen entirely and the only visible
+/// action was Approve.
+///
+/// A decision you cannot read is not a decision. This gives the diff the
+/// whole screen on a normal surface, and puts both actions in a footer
+/// that cannot be squeezed out.
+class ProposalReviewScreen extends StatelessWidget {
+  const ProposalReviewScreen({
+    required this.pageTitle,
+    required this.proposal,
+    required this.busy,
+    required this.onDecide,
+    super.key,
+  });
+
+  final String pageTitle;
+  final DocProposal proposal;
+  final bool busy;
+
+  /// Called with true to approve, false to reject. The caller owns the
+  /// API call and closes this screen.
+  final void Function({required bool approve}) onDecide;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final diff = proposal.diff;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(pageTitle),
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(28),
+          child: Padding(
+            padding: const EdgeInsets.only(left: 16, right: 16, bottom: 8),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                t.web.knowledge.kb.proposal.text,
+                style: theme.textTheme.bodySmall,
+              ),
+            ),
+          ),
+        ),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(12, 12, 12, 24),
+        children: [
+          if (proposal.reason.trim().isNotEmpty) ...[
+            Card(
+              margin: EdgeInsets.zero,
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Text(proposal.reason, style: theme.textTheme.bodySmall),
+              ),
+            ),
+            const SizedBox(height: 12),
+          ],
+          // Proposals filed before the server attached diffs fall back to
+          // the full body — still reviewable, just not as a diff.
+          if (diff != null)
+            ProposalDiffView(diff: diff)
+          else
+            SelectableText(
+              proposal.proposedContent,
+              style: const TextStyle(fontSize: 12, fontFamily: 'monospace'),
+            ),
+        ],
+      ),
+      // A footer, not a row inside the content: on a narrow screen the
+      // previous layout pushed reject off the edge.
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(12, 8, 12, 12),
+          child: Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: busy ? null : () => onDecide(approve: false),
+                  child: Text(t.web.knowledge.kb.proposal.reject),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: FilledButton(
+                  onPressed: busy ? null : () => onDecide(approve: true),
+                  child: Text(t.web.knowledge.kb.proposal.approve),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/mobile/lib/features/knowledge/knowledge_screen.dart
+++ b/app/mobile/lib/features/knowledge/knowledge_screen.dart
@@ -12,7 +12,7 @@ import 'package:opendray/core/api/memory_workers_api.dart';
 import 'package:opendray/core/api/project_docs_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/cortex/curation_chat_screen.dart';
-import 'package:opendray/features/cortex/proposal_diff.dart';
+import 'package:opendray/features/cortex/proposal_review_screen.dart';
 import 'package:opendray/features/knowledge/force_graph.dart';
 
 // Knowledge tab — read-mostly browser over the M-KG knowledge graph.
@@ -565,7 +565,6 @@ class _KbPageScreenState extends ConsumerState<_KbPageScreen> {
   final _editCtrl = TextEditingController();
   bool _editing = false;
   bool _busy = false;
-  bool _showProposal = false;
   AsyncValue<ProjectDoc> _doc = const AsyncValue.loading();
   List<DocProposal> _proposals = const [];
   late String _title = widget.title;
@@ -592,7 +591,6 @@ class _KbPageScreenState extends ConsumerState<_KbPageScreen> {
     setState(() {
       _doc = const AsyncValue.loading();
       _editing = false;
-      _showProposal = false;
     });
     try {
       final api = ref.read(projectDocsApiProvider);
@@ -652,6 +650,26 @@ class _KbPageScreenState extends ConsumerState<_KbPageScreen> {
         SnackBar(content: Text(t.web.knowledge.actionFailed)),
       );
     }
+  }
+
+  // Pushes the full-screen review. The decision is made there and applied
+  // here, so this screen keeps owning the reload and the busy flag.
+  Future<void> _openReview() async {
+    final p = _pending;
+    if (p == null) return;
+    final approve = await Navigator.of(context).push<bool>(
+      MaterialPageRoute<bool>(
+        builder: (_) => ProposalReviewScreen(
+          pageTitle: widget.title,
+          proposal: p,
+          busy: false,
+          onDecide: ({required approve}) =>
+              Navigator.of(context).pop(approve),
+        ),
+      ),
+    );
+    if (approve == null || !mounted) return;
+    await _decide(approve);
   }
 
   Future<void> _decide(bool approve) async {
@@ -865,46 +883,48 @@ class _KbPageScreenState extends ConsumerState<_KbPageScreen> {
                     color: scheme.tertiaryContainer,
                     borderRadius: BorderRadius.circular(8),
                   ),
+                  // A summary and one way in. The diff itself used to sit
+                  // here in a 240px window on this tinted background, with
+                  // approve and reject sharing a row that overflowed on a
+                  // phone — reject was pushed off-screen, leaving Approve
+                  // as the only visible action on something unreadable.
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(t.web.knowledge.kb.proposal.text,
-                          style: const TextStyle(fontSize: 12)),
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: scheme.onTertiaryContainer,
+                          )),
+                      const SizedBox(height: 6),
                       Row(
                         children: [
-                          TextButton(
-                            onPressed: () => setState(
-                                () => _showProposal = !_showProposal),
-                            child: Text(_showProposal
-                                ? t.web.knowledge.kb.proposal.hide
-                                : t.web.knowledge.kb.proposal.preview),
-                          ),
+                          if (pending.diff != null) ...[
+                            Text(
+                              t.web.diff.added(count: pending.diff!.added),
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: scheme.onTertiaryContainer,
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              t.web.diff.removed(count: pending.diff!.removed),
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: scheme.onTertiaryContainer,
+                              ),
+                            ),
+                          ],
                           const Spacer(),
-                          TextButton(
-                            onPressed: _busy ? null : () => _decide(false),
-                            child: Text(t.web.knowledge.kb.proposal.reject),
-                          ),
-                          FilledButton(
-                            onPressed: _busy ? null : () => _decide(true),
-                            child: Text(t.web.knowledge.kb.proposal.approve),
+                          FilledButton.tonalIcon(
+                            onPressed: _busy ? null : _openReview,
+                            icon: const Icon(Icons.rate_review_outlined,
+                                size: 16),
+                            label: Text(t.web.knowledge.kb.proposal.review),
                           ),
                         ],
                       ),
-                      if (_showProposal)
-                        Container(
-                          constraints: const BoxConstraints(maxHeight: 240),
-                          margin: const EdgeInsets.only(top: 6),
-                          child: SingleChildScrollView(
-                            // Show what CHANGED. Proposals filed before the
-                            // server attached diffs fall back to the body.
-                            child: pending.diff != null
-                                ? ProposalDiffView(diff: pending.diff!)
-                                : SelectableText(
-                                    _stripSig(pending.proposedContent),
-                                    style: const TextStyle(fontSize: 12),
-                                  ),
-                          ),
-                        ),
                     ],
                   ),
                 ),


### PR DESCRIPTION
## What you saw

Only **Approve**, on a diff you couldn't read.

Reject was never missing from the code (`knowledge_screen.dart:885`) — it was **unreachable**. Preview, Reject and Approve shared one `Row`, which overflows on a phone, so the first two got pushed off the edge. What survived was the single most destructive action, attached to something illegible.

Three things compounded:

| | |
|---|---|
| **Height** | diff capped at 240px — a 90-line page shows ~6 lines |
| **Contrast** | diff rendered on the amber `tertiaryContainer`, which swallows the red/green that *is* the diff |
| **Layout** | banner → row → scroll view → diff, all inside the document page |

A decision you cannot read isn't a decision.

## The change

Review moves to its own screen:

- diff gets the full width, on a normal surface where the colours read
- approve / reject in a **footer** that cannot be squeezed out, each half-width
- the proposal's reason shown above the diff, which the banner never had room for

The banner keeps only what belongs at a glance: that a proposal exists, its `+N −M`, and one way in.

Deciding still runs on the page screen — it owns the reload and the busy flag — so the review screen only reports the choice back. Proposals filed before the server attached diffs still fall back to the full body.

## Test plan

- `flutter analyze` clean; `flutter test` 123 passed
- i18n parity 100% zh + es — one new key (`proposal.review`)
- `pnpm --filter web build` and `go build ./...` green (untouched, checked anyway)

## Not verified by tests

**The layout itself was only checked by analyze, not on a device** — which is exactly how the original overflow got shipped. Worth confirming on your phone that both buttons are reachable and the diff colours read against the surface.

Branched from `main` (now carrying #517). Independent of #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)