### PR TITLE
feat(tasks): group custom tasks by project in the management views

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -1795,15 +1795,14 @@
       },
       "customTasks": {
         "title": "Custom tasks",
-        "description": "Click-to-run shortcuts surfaced in the Tasks tab. Leave cwd blank for global tasks visible in every session, or pin to an absolute path to scope.",
+        "description": "Click-to-run shortcuts surfaced in the Tasks tab, grouped by project. Leave cwd blank for global tasks visible in every session, or pin to an absolute path to scope.",
         "addTask": "Add task",
         "empty": "No custom tasks yet.",
         "columns": {
           "name": "Name",
-          "command": "Command",
-          "scope": "Scope"
+          "command": "Command"
         },
-        "globalScope": "global",
+        "globalGroup": "Global",
         "deleteConfirm": "Delete custom task \"{name}\"?",
         "removedToast": "Task removed",
         "deleteFailedToast": "Delete failed",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -1795,15 +1795,14 @@
       },
       "customTasks": {
         "title": "Tareas personalizadas",
-        "description": "Atajos de ejecución con un clic que se muestran en la pestaña Tareas. Deja cwd en blanco para tareas globales visibles en todas las sessions, o fíjalo a una ruta absoluta para acotarlo.",
+        "description": "Atajos de ejecución con un clic que se muestran en la pestaña Tareas, agrupados por proyecto. Deja cwd en blanco para tareas globales visibles en todas las sessions, o fíjalo a una ruta absoluta para acotarlo.",
         "addTask": "Añadir tarea",
         "empty": "Aún no hay tareas personalizadas.",
         "columns": {
           "name": "Nombre",
-          "command": "Comando",
-          "scope": "Ámbito"
+          "command": "Comando"
         },
-        "globalScope": "global",
+        "globalGroup": "Global",
         "deleteConfirm": "¿Eliminar la tarea personalizada \"{name}\"?",
         "removedToast": "Tarea eliminada",
         "deleteFailedToast": "Error al eliminar",

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -1792,15 +1792,14 @@
       },
       "customTasks": {
         "title": "自定义任务",
-        "description": "在 Tasks 选项卡中以点选即运行的方式呈现的快捷方式。留空 cwd 即为所有会话可见的全局任务，或填写绝对路径以限定 scope。",
+        "description": "在 Tasks 选项卡中以点选即运行的方式呈现的快捷方式，按项目分组。留空 cwd 即为所有会话可见的全局任务，或填写绝对路径以限定 scope。",
         "addTask": "添加任务",
         "empty": "尚无自定义任务。",
         "columns": {
           "name": "名称",
-          "command": "命令",
-          "scope": "Scope"
+          "command": "命令"
         },
-        "globalScope": "全局",
+        "globalGroup": "全局",
         "deleteConfirm": "删除自定义任务 \"{name}\"?",
         "removedToast": "任务已移除",
         "deleteFailedToast": "删除失败",

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 13593 (4531 per locale)
+/// Strings: 13590 (4530 per locale)
 ///
-/// Built on 2026-08-11 at 22:43 UTC
+/// Built on 2026-08-12 at 23:29 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -9969,8 +9969,8 @@ class TranslationsWebPluginsCustomTasksEn {
 	/// en: 'Custom tasks'
 	String get title => 'Custom tasks';
 
-	/// en: 'Click-to-run shortcuts surfaced in the Tasks tab. Leave cwd blank for global tasks visible in every session, or pin to an absolute path to scope.'
-	String get description => 'Click-to-run shortcuts surfaced in the Tasks tab. Leave cwd blank for global tasks visible in every session, or pin to an absolute path to scope.';
+	/// en: 'Click-to-run shortcuts surfaced in the Tasks tab, grouped by project. Leave cwd blank for global tasks visible in every session, or pin to an absolute path to scope.'
+	String get description => 'Click-to-run shortcuts surfaced in the Tasks tab, grouped by project. Leave cwd blank for global tasks visible in every session, or pin to an absolute path to scope.';
 
 	/// en: 'Add task'
 	String get addTask => 'Add task';
@@ -9980,8 +9980,8 @@ class TranslationsWebPluginsCustomTasksEn {
 
 	late final TranslationsWebPluginsCustomTasksColumnsEn columns = TranslationsWebPluginsCustomTasksColumnsEn.internal(_root);
 
-	/// en: 'global'
-	String get globalScope => 'global';
+	/// en: 'Global'
+	String get globalGroup => 'Global';
 
 	/// en: 'Delete custom task "{name}"?'
 	String deleteConfirm({required Object name}) => 'Delete custom task "${name}"?';
@@ -16662,9 +16662,6 @@ class TranslationsWebPluginsCustomTasksColumnsEn {
 
 	/// en: 'Command'
 	String get command => 'Command';
-
-	/// en: 'Scope'
-	String get scope => 'Scope';
 }
 
 // Path: web.plugins.customTasks.dialog
@@ -20833,13 +20830,12 @@ extension on Translations {
 			'web.plugins.skills.uploadFailedToast' => 'Skill upload failed',
 			'web.plugins.skills.uploadInvalidTypeToast' => 'Only SKILL.md files can be installed by drop',
 			'web.plugins.customTasks.title' => 'Custom tasks',
-			'web.plugins.customTasks.description' => 'Click-to-run shortcuts surfaced in the Tasks tab. Leave cwd blank for global tasks visible in every session, or pin to an absolute path to scope.',
+			'web.plugins.customTasks.description' => 'Click-to-run shortcuts surfaced in the Tasks tab, grouped by project. Leave cwd blank for global tasks visible in every session, or pin to an absolute path to scope.',
 			'web.plugins.customTasks.addTask' => 'Add task',
 			'web.plugins.customTasks.empty' => 'No custom tasks yet.',
 			'web.plugins.customTasks.columns.name' => 'Name',
 			'web.plugins.customTasks.columns.command' => 'Command',
-			'web.plugins.customTasks.columns.scope' => 'Scope',
-			'web.plugins.customTasks.globalScope' => 'global',
+			'web.plugins.customTasks.globalGroup' => 'Global',
 			'web.plugins.customTasks.deleteConfirm' => ({required Object name}) => 'Delete custom task "${name}"?',
 			'web.plugins.customTasks.removedToast' => 'Task removed',
 			'web.plugins.customTasks.deleteFailedToast' => 'Delete failed',
@@ -20880,9 +20876,9 @@ extension on Translations {
 			'web.plugins.gitHosts.dialog.kindGitea' => 'Gitea',
 			'web.plugins.gitHosts.dialog.kindGitLab' => 'GitLab',
 			'web.plugins.gitHosts.dialog.hostLabel' => 'Host',
+			'web.plugins.gitHosts.dialog.hostPlaceholder' => 'github.com',
 			_ => null,
 		} ?? switch (path) {
-			'web.plugins.gitHosts.dialog.hostPlaceholder' => 'github.com',
 			'web.plugins.gitHosts.dialog.displayNameLabel' => 'Display name (optional)',
 			'web.plugins.gitHosts.dialog.displayNamePlaceholder' => 'Personal',
 			'web.plugins.gitHosts.dialog.tokenLabel' => 'Token',
@@ -21394,9 +21390,9 @@ extension on Translations {
 			'web.serverSettings.toggle.on' => 'On',
 			'web.serverSettings.toggle.off' => 'Off',
 			'web.serverSettings.toggle.defaultOn' => 'Default (on)',
+			'web.serverSettings.toggle.defaultOff' => 'Default (off)',
 			_ => null,
 		} ?? switch (path) {
-			'web.serverSettings.toggle.defaultOff' => 'Default (off)',
 			'web.serverSettings.memoryRuntimeBanner' => 'Runtime AI behaviour — workers, capture rules, injection profiles and spawn mode — lives in Cortex settings and applies instantly. This section is the infrastructure half: embedder, storage and background governance (restart required).',
 			'web.serverSettings.memoryRuntimeBannerButton' => 'Open Cortex settings',
 			'web.serverSettings.host.intro' => 'A sleeping Mac takes its network down with it, so the gateway simply stops answering — from phone, from web, and to its database. It reads as "opendray is flaky" when the machine is really just asleep. Pick how opendray should handle that.',
@@ -21908,9 +21904,9 @@ extension on Translations {
 			'web.cortex.chat.modelGlobalDefault' => 'Default (global)',
 			'web.cortex.chat.modelCliDefault' => 'CLI default',
 			'web.cortex.chat.modelChangeFailed' => 'Couldn\'t change the discussion model',
+			'web.cortex.chat.modelGroupCloud' => 'Cloud agents',
 			_ => null,
 		} ?? switch (path) {
-			'web.cortex.chat.modelGroupCloud' => 'Cloud agents',
 			'web.cortex.chat.modelGroupLocal' => 'Local models',
 			'web.cortex.chat.accountDefault' => 'Default account',
 			'web.cortex.chat.accountHint' => 'Which Claude account this discussion runs against (Claude is multi-account).',
@@ -22422,9 +22418,9 @@ extension on Translations {
 			'sessions.inspector.notes.save' => 'Save',
 			'sessions.inspector.notes.renameTitle' => 'Rename or move',
 			'sessions.inspector.notes.move' => 'Move',
+			'sessions.inspector.notes.renameHelp' => 'Path inside the project folder. Include a slash to file it in a folder, e.g. features/canvas.md',
 			_ => null,
 		} ?? switch (path) {
-			'sessions.inspector.notes.renameHelp' => 'Path inside the project folder. Include a slash to file it in a folder, e.g. features/canvas.md',
 			'sessions.inspector.notes.renamed' => 'Moved.',
 			'sessions.inspector.notes.renamedWithLinks' => ({required Object count, required Object notes}) => 'Moved — updated ${count} link(s) in ${notes} note(s).',
 			'sessions.inspector.notes.renamedWithWarning' => ({required Object warning}) => 'Moved, but links may not be updated: ${warning}',
@@ -22936,9 +22932,9 @@ extension on Translations {
 			'backups.menuTargets' => 'Targets',
 			'backups.kv.status' => 'Status',
 			'backups.kv.verified' => 'Verified',
+			'backups.kv.kind' => 'Type',
 			_ => null,
 		} ?? switch (path) {
-			'backups.kv.kind' => 'Type',
 			'backups.kv.target' => 'Target',
 			'backups.kv.dedup' => 'Dedup',
 			'backups.kv.fanout' => 'Fan-out group',
@@ -23450,9 +23446,9 @@ extension on Translations {
 			'notesPage.tags.noMatches' => ({required Object query}) => 'No tags match "${query}".',
 			'notesPage.tags.filteredBy' => 'Filtered by',
 			'notesPage.tags.clear' => 'Clear tag filter',
+			'notesPage.tags.noNotes' => ({required Object tag}) => 'No notes carry #${tag} any more.',
 			_ => null,
 		} ?? switch (path) {
-			'notesPage.tags.noNotes' => ({required Object tag}) => 'No notes carry #${tag} any more.',
 			'notesPage.backlinks.title' => 'Backlinks',
 			'notesPage.backlinks.loading' => 'Looking for links…',
 			'notesPage.backlinks.empty' => 'No notes link here yet.',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -5044,11 +5044,11 @@ class _TranslationsWebPluginsCustomTasksEs extends TranslationsWebPluginsCustomT
 
 	// Translations
 	@override String get title => 'Tareas personalizadas';
-	@override String get description => 'Atajos de ejecución con un clic que se muestran en la pestaña Tareas. Deja cwd en blanco para tareas globales visibles en todas las sessions, o fíjalo a una ruta absoluta para acotarlo.';
+	@override String get description => 'Atajos de ejecución con un clic que se muestran en la pestaña Tareas, agrupados por proyecto. Deja cwd en blanco para tareas globales visibles en todas las sessions, o fíjalo a una ruta absoluta para acotarlo.';
 	@override String get addTask => 'Añadir tarea';
 	@override String get empty => 'Aún no hay tareas personalizadas.';
 	@override late final _TranslationsWebPluginsCustomTasksColumnsEs columns = _TranslationsWebPluginsCustomTasksColumnsEs._(_root);
-	@override String get globalScope => 'global';
+	@override String get globalGroup => 'Global';
 	@override String deleteConfirm({required Object name}) => '¿Eliminar la tarea personalizada "${name}"?';
 	@override String get removedToast => 'Tarea eliminada';
 	@override String get deleteFailedToast => 'Error al eliminar';
@@ -8527,7 +8527,6 @@ class _TranslationsWebPluginsCustomTasksColumnsEs extends TranslationsWebPlugins
 	// Translations
 	@override String get name => 'Nombre';
 	@override String get command => 'Comando';
-	@override String get scope => 'Ámbito';
 }
 
 // Path: web.plugins.customTasks.dialog
@@ -11644,13 +11643,12 @@ extension on TranslationsEs {
 			'web.plugins.skills.uploadFailedToast' => 'Error al subir la habilidad',
 			'web.plugins.skills.uploadInvalidTypeToast' => 'Solo se pueden instalar archivos SKILL.md por arrastre',
 			'web.plugins.customTasks.title' => 'Tareas personalizadas',
-			'web.plugins.customTasks.description' => 'Atajos de ejecución con un clic que se muestran en la pestaña Tareas. Deja cwd en blanco para tareas globales visibles en todas las sessions, o fíjalo a una ruta absoluta para acotarlo.',
+			'web.plugins.customTasks.description' => 'Atajos de ejecución con un clic que se muestran en la pestaña Tareas, agrupados por proyecto. Deja cwd en blanco para tareas globales visibles en todas las sessions, o fíjalo a una ruta absoluta para acotarlo.',
 			'web.plugins.customTasks.addTask' => 'Añadir tarea',
 			'web.plugins.customTasks.empty' => 'Aún no hay tareas personalizadas.',
 			'web.plugins.customTasks.columns.name' => 'Nombre',
 			'web.plugins.customTasks.columns.command' => 'Comando',
-			'web.plugins.customTasks.columns.scope' => 'Ámbito',
-			'web.plugins.customTasks.globalScope' => 'global',
+			'web.plugins.customTasks.globalGroup' => 'Global',
 			'web.plugins.customTasks.deleteConfirm' => ({required Object name}) => '¿Eliminar la tarea personalizada "${name}"?',
 			'web.plugins.customTasks.removedToast' => 'Tarea eliminada',
 			'web.plugins.customTasks.deleteFailedToast' => 'Error al eliminar',
@@ -11691,9 +11689,9 @@ extension on TranslationsEs {
 			'web.plugins.gitHosts.dialog.kindGitea' => 'Gitea',
 			'web.plugins.gitHosts.dialog.kindGitLab' => 'GitLab',
 			'web.plugins.gitHosts.dialog.hostLabel' => 'Host',
+			'web.plugins.gitHosts.dialog.hostPlaceholder' => 'github.com',
 			_ => null,
 		} ?? switch (path) {
-			'web.plugins.gitHosts.dialog.hostPlaceholder' => 'github.com',
 			'web.plugins.gitHosts.dialog.displayNameLabel' => 'Nombre visible (opcional)',
 			'web.plugins.gitHosts.dialog.displayNamePlaceholder' => 'Personal',
 			'web.plugins.gitHosts.dialog.tokenLabel' => 'Token',
@@ -12205,9 +12203,9 @@ extension on TranslationsEs {
 			'web.serverSettings.toggle.on' => 'Activado',
 			'web.serverSettings.toggle.off' => 'Desactivado',
 			'web.serverSettings.toggle.defaultOn' => 'Por defecto (on)',
+			'web.serverSettings.toggle.defaultOff' => 'Por defecto (off)',
 			_ => null,
 		} ?? switch (path) {
-			'web.serverSettings.toggle.defaultOff' => 'Por defecto (off)',
 			'web.serverSettings.memoryRuntimeBanner' => 'El comportamiento de IA en runtime — workers, reglas de captura, perfiles de inyección y modo de spawn — vive en los ajustes de Cortex y se aplica al instante. Esta sección es la mitad de infraestructura: embedder, almacenamiento y gobernanza de fondo (requiere reinicio).',
 			'web.serverSettings.memoryRuntimeBannerButton' => 'Abrir ajustes de Cortex',
 			'web.serverSettings.host.intro' => 'Un Mac dormido apaga también su red, así que la pasarela deja de responder: desde el móvil, desde la web y hacia su base de datos. Parece que «opendray falla» cuando en realidad la máquina solo está dormida. Elige cómo debe gestionarlo opendray.',
@@ -12719,9 +12717,9 @@ extension on TranslationsEs {
 			'web.cortex.chat.modelGlobalDefault' => 'Predeterminado (global)',
 			'web.cortex.chat.modelCliDefault' => 'Predeterminado del CLI',
 			'web.cortex.chat.modelChangeFailed' => 'No se pudo cambiar el modelo de la conversación',
+			'web.cortex.chat.modelGroupCloud' => 'Agentes en la nube',
 			_ => null,
 		} ?? switch (path) {
-			'web.cortex.chat.modelGroupCloud' => 'Agentes en la nube',
 			'web.cortex.chat.modelGroupLocal' => 'Modelos locales',
 			'web.cortex.chat.accountDefault' => 'Cuenta predeterminada',
 			'web.cortex.chat.accountHint' => 'Con qué cuenta de Claude se ejecuta esta discusión (Claude es multicuenta).',
@@ -13233,9 +13231,9 @@ extension on TranslationsEs {
 			'sessions.inspector.notes.save' => 'Guardar',
 			'sessions.inspector.notes.renameTitle' => 'Renombrar o mover',
 			'sessions.inspector.notes.move' => 'Mover',
+			'sessions.inspector.notes.renameHelp' => 'Ruta dentro de la carpeta del proyecto. Incluye una barra para archivarlo en una carpeta, p. ej. features/canvas.md',
 			_ => null,
 		} ?? switch (path) {
-			'sessions.inspector.notes.renameHelp' => 'Ruta dentro de la carpeta del proyecto. Incluye una barra para archivarlo en una carpeta, p. ej. features/canvas.md',
 			'sessions.inspector.notes.renamed' => 'Movido.',
 			'sessions.inspector.notes.renamedWithLinks' => ({required Object count, required Object notes}) => 'Movido: se actualizaron ${count} enlace(s) en ${notes} nota(s).',
 			'sessions.inspector.notes.renamedWithWarning' => ({required Object warning}) => 'Movido, pero los enlaces podrían no actualizarse: ${warning}',
@@ -13747,9 +13745,9 @@ extension on TranslationsEs {
 			'backups.menuTargets' => 'Destinos',
 			'backups.kv.status' => 'Estado',
 			'backups.kv.verified' => 'Verificada',
+			'backups.kv.kind' => 'Tipo',
 			_ => null,
 		} ?? switch (path) {
-			'backups.kv.kind' => 'Tipo',
 			'backups.kv.target' => 'Destino',
 			'backups.kv.dedup' => 'Deduplicación',
 			'backups.kv.fanout' => 'Grupo de difusión',
@@ -14261,9 +14259,9 @@ extension on TranslationsEs {
 			'notesPage.tags.noMatches' => ({required Object query}) => 'Ninguna etiqueta coincide con «${query}».',
 			'notesPage.tags.filteredBy' => 'Filtrado por',
 			'notesPage.tags.clear' => 'Quitar el filtro de etiqueta',
+			'notesPage.tags.noNotes' => ({required Object tag}) => 'Ya no hay notas con #${tag}.',
 			_ => null,
 		} ?? switch (path) {
-			'notesPage.tags.noNotes' => ({required Object tag}) => 'Ya no hay notas con #${tag}.',
 			'notesPage.backlinks.title' => 'Retroenlaces',
 			'notesPage.backlinks.loading' => 'Buscando enlaces…',
 			'notesPage.backlinks.empty' => 'Todavía no hay notas que enlacen aquí.',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -5044,11 +5044,11 @@ class _TranslationsWebPluginsCustomTasksZh extends TranslationsWebPluginsCustomT
 
 	// Translations
 	@override String get title => '自定义任务';
-	@override String get description => '在 Tasks 选项卡中以点选即运行的方式呈现的快捷方式。留空 cwd 即为所有会话可见的全局任务，或填写绝对路径以限定 scope。';
+	@override String get description => '在 Tasks 选项卡中以点选即运行的方式呈现的快捷方式，按项目分组。留空 cwd 即为所有会话可见的全局任务，或填写绝对路径以限定 scope。';
 	@override String get addTask => '添加任务';
 	@override String get empty => '尚无自定义任务。';
 	@override late final _TranslationsWebPluginsCustomTasksColumnsZh columns = _TranslationsWebPluginsCustomTasksColumnsZh._(_root);
-	@override String get globalScope => '全局';
+	@override String get globalGroup => '全局';
 	@override String deleteConfirm({required Object name}) => '删除自定义任务 "${name}"?';
 	@override String get removedToast => '任务已移除';
 	@override String get deleteFailedToast => '删除失败';
@@ -8524,7 +8524,6 @@ class _TranslationsWebPluginsCustomTasksColumnsZh extends TranslationsWebPlugins
 	// Translations
 	@override String get name => '名称';
 	@override String get command => '命令';
-	@override String get scope => 'Scope';
 }
 
 // Path: web.plugins.customTasks.dialog
@@ -11638,13 +11637,12 @@ extension on TranslationsZh {
 			'web.plugins.skills.uploadFailedToast' => '上传 skill 失败',
 			'web.plugins.skills.uploadInvalidTypeToast' => '仅支持拖放 SKILL.md 文件',
 			'web.plugins.customTasks.title' => '自定义任务',
-			'web.plugins.customTasks.description' => '在 Tasks 选项卡中以点选即运行的方式呈现的快捷方式。留空 cwd 即为所有会话可见的全局任务，或填写绝对路径以限定 scope。',
+			'web.plugins.customTasks.description' => '在 Tasks 选项卡中以点选即运行的方式呈现的快捷方式，按项目分组。留空 cwd 即为所有会话可见的全局任务，或填写绝对路径以限定 scope。',
 			'web.plugins.customTasks.addTask' => '添加任务',
 			'web.plugins.customTasks.empty' => '尚无自定义任务。',
 			'web.plugins.customTasks.columns.name' => '名称',
 			'web.plugins.customTasks.columns.command' => '命令',
-			'web.plugins.customTasks.columns.scope' => 'Scope',
-			'web.plugins.customTasks.globalScope' => '全局',
+			'web.plugins.customTasks.globalGroup' => '全局',
 			'web.plugins.customTasks.deleteConfirm' => ({required Object name}) => '删除自定义任务 "${name}"?',
 			'web.plugins.customTasks.removedToast' => '任务已移除',
 			'web.plugins.customTasks.deleteFailedToast' => '删除失败',
@@ -11688,9 +11686,9 @@ extension on TranslationsZh {
 			'web.plugins.gitHosts.dialog.hostPlaceholder' => 'github.com',
 			'web.plugins.gitHosts.dialog.displayNameLabel' => '显示名称（可选）',
 			'web.plugins.gitHosts.dialog.displayNamePlaceholder' => 'Personal',
+			'web.plugins.gitHosts.dialog.tokenLabel' => 'Token',
 			_ => null,
 		} ?? switch (path) {
-			'web.plugins.gitHosts.dialog.tokenLabel' => 'Token',
 			'web.plugins.gitHosts.dialog.newTokenLabel' => '新 token（留空表示保留）',
 			'web.plugins.gitHosts.dialog.tokenPlaceholder' => 'ghp_… / gho_… / glpat-…',
 			'web.plugins.gitHosts.dialog.tokenPlaceholderEdit' => '…',
@@ -12202,9 +12200,9 @@ extension on TranslationsZh {
 			'web.serverSettings.toggle.defaultOff' => '默认（关）',
 			'web.serverSettings.memoryRuntimeBanner' => '运行时 AI 行为——工作器、捕获规则、注入策略与 spawn 模式——位于 Cortex 设置，保存即生效。本区块是基础设施的一半：嵌入后端、存储与后台治理（需重启生效）。',
 			'web.serverSettings.memoryRuntimeBannerButton' => '打开 Cortex 设置',
+			'web.serverSettings.host.intro' => '睡眠中的 Mac 会一并关掉网络,网关随即停止应答 —— 手机连不上、网页连不上、连数据库也断开。表面看像"opendray 不稳定",实际只是机器睡着了。请选择 opendray 的应对方式。',
 			_ => null,
 		} ?? switch (path) {
-			'web.serverSettings.host.intro' => '睡眠中的 Mac 会一并关掉网络,网关随即停止应答 —— 手机连不上、网页连不上、连数据库也断开。表面看像"opendray 不稳定",实际只是机器睡着了。请选择 opendray 的应对方式。',
 			'web.serverSettings.host.platformNote' => '仅 macOS 生效。Linux 与 Windows 会接受但忽略此设置 —— 常规服务器安装下这些主机不会空闲休眠。主动睡眠(合盖、苹果菜单 → 睡眠)永不被阻止;opendray 退出或被强制结束时,电源断言会立即释放。',
 			'web.serverSettings.host.modes.ac.label' => '插电时保持唤醒',
 			'web.serverSettings.host.modes.ac.desc' => '插电状态下机器不会空闲休眠,手机与网页随时秒连;使用电池时照常休眠。屏幕仍会正常熄灭。',
@@ -12716,9 +12714,9 @@ extension on TranslationsZh {
 			'web.cortex.chat.modelGroupCloud' => '云端 agent',
 			'web.cortex.chat.modelGroupLocal' => '本地模型',
 			'web.cortex.chat.accountDefault' => '默认账号',
+			'web.cortex.chat.accountHint' => '本次讨论使用哪个 Claude 账号(Claude 是多账号)。',
 			_ => null,
 		} ?? switch (path) {
-			'web.cortex.chat.accountHint' => '本次讨论使用哪个 Claude 账号(Claude 是多账号)。',
 			'web.cortex.chat.modelProviderDefault' => '供应商默认',
 			'web.cortex.chat.modelProbeFailed' => '无法连接端点列出模型——用供应商默认，或在 Memory 设置里配置。',
 			'web.cortex.blueprint.open' => '蓝图',
@@ -13230,9 +13228,9 @@ extension on TranslationsZh {
 			'sessions.inspector.notes.renameHelp' => '项目文件夹内的路径。加斜杠即可归入目录,例如 features/canvas.md',
 			'sessions.inspector.notes.renamed' => '已移动。',
 			'sessions.inspector.notes.renamedWithLinks' => ({required Object notes, required Object count}) => '已移动 —— 更新了 ${notes} 篇笔记中的 ${count} 处链接。',
+			'sessions.inspector.notes.renamedWithWarning' => ({required Object warning}) => '已移动,但链接可能未更新:${warning}',
 			_ => null,
 		} ?? switch (path) {
-			'sessions.inspector.notes.renamedWithWarning' => ({required Object warning}) => '已移动,但链接可能未更新:${warning}',
 			'sessions.inspector.notes.renameFailed' => ({required Object error}) => '移动失败:${error}',
 			'sessions.inspector.notes.openFolderIndex' => '打开目录索引',
 			'sessions.inspector.canvas.kindUi' => 'UI 稿',
@@ -13744,9 +13742,9 @@ extension on TranslationsZh {
 			'backups.kv.kind' => '类型',
 			'backups.kv.target' => '目标',
 			'backups.kv.dedup' => '去重',
+			'backups.kv.fanout' => '扇出组',
 			_ => null,
 		} ?? switch (path) {
-			'backups.kv.fanout' => '扇出组',
 			'backups.kv.triggeredBy' => '触发者',
 			'backups.kv.started' => '开始',
 			'backups.kv.finished' => '完成',
@@ -14258,9 +14256,9 @@ extension on TranslationsZh {
 			'notesPage.tags.noNotes' => ({required Object tag}) => '已经没有笔记带 #${tag} 了。',
 			'notesPage.backlinks.title' => '反向链接',
 			'notesPage.backlinks.loading' => '正在查找链接…',
+			'notesPage.backlinks.empty' => '还没有笔记链接到这里。',
 			_ => null,
 		} ?? switch (path) {
-			'notesPage.backlinks.empty' => '还没有笔记链接到这里。',
 			'notesPage.backlinks.failed' => ({required Object error}) => '反向链接加载失败：${error}',
 			'notesPage.outline.action' => '大纲',
 			'notesPage.outline.title' => '大纲',

--- a/app/mobile/lib/features/custom_tasks/custom_tasks_screen.dart
+++ b/app/mobile/lib/features/custom_tasks/custom_tasks_screen.dart
@@ -17,6 +17,7 @@ import 'package:intl/intl.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/custom_tasks_api.dart';
 import 'package:opendray/core/i18n/strings.g.dart' as i18n;
+import 'package:path/path.dart' as p;
 
 class CustomTasksScreen extends ConsumerStatefulWidget {
   const CustomTasksScreen({super.key});
@@ -54,8 +55,58 @@ class CustomTasksScreen extends ConsumerStatefulWidget {
       _CustomTasksScreenState();
 }
 
+// One block of the grouped list: the global bucket (cwd empty) or a
+// single project's tasks.
+class _TaskGroup {
+  const _TaskGroup({
+    required this.cwd,
+    required this.label,
+    required this.tasks,
+  });
+
+  /// '' for the global bucket, otherwise the project's absolute cwd.
+  final String cwd;
+
+  /// Basename of [cwd] — the project name shown in the header. Empty
+  /// for the global bucket, which uses a translated label instead.
+  final String label;
+  final List<CustomTask> tasks;
+}
+
+// Buckets tasks by cwd. Global first, then projects by name with the
+// full path breaking ties so two projects sharing a basename keep a
+// stable order. Tasks inside a group are sorted by name.
+List<_TaskGroup> _groupByProject(List<CustomTask> tasks) {
+  final byCwd = <String, List<CustomTask>>{};
+  for (final t in tasks) {
+    byCwd.putIfAbsent(t.cwd, () => <CustomTask>[]).add(t);
+  }
+  final groups = byCwd.entries.map((e) {
+    final label = e.key.isEmpty ? '' : p.basename(e.key);
+    final sorted = [...e.value]
+      ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+    return _TaskGroup(
+      cwd: e.key,
+      label: label.isEmpty ? e.key : label,
+      tasks: sorted,
+    );
+  }).toList()
+    ..sort((a, b) {
+      if (a.cwd.isEmpty) return -1;
+      if (b.cwd.isEmpty) return 1;
+      final byLabel =
+          a.label.toLowerCase().compareTo(b.label.toLowerCase());
+      return byLabel != 0 ? byLabel : a.cwd.compareTo(b.cwd);
+    });
+  return groups;
+}
+
 class _CustomTasksScreenState extends ConsumerState<CustomTasksScreen> {
   AsyncValue<List<CustomTask>> _state = const AsyncValue.loading();
+
+  // Collapsed group cwds. Empty = everything expanded, which is where
+  // operators land; collapsing is opt-in per project.
+  final Set<String> _collapsed = <String>{};
 
   @override
   void initState() {
@@ -68,7 +119,8 @@ class _CustomTasksScreenState extends ConsumerState<CustomTasksScreen> {
     try {
       final list = await ref.read(customTasksApiProvider).list();
       if (!mounted) return;
-      list.sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+      // Ordering is decided by _groupByProject, which sorts within
+      // each project bucket.
       setState(() => _state = AsyncValue.data(list));
     } on ApiException catch (e) {
       if (mounted) {
@@ -198,82 +250,143 @@ class _CustomTasksScreenState extends ConsumerState<CustomTasksScreen> {
         ),
       );
     }
+    // One collapsible block per project (plus the global bucket) so a
+    // long catalogue reads as a handful of named groups instead of one
+    // flat list. The header carries the scope, so the rows below it no
+    // longer repeat it per task.
+    final groups = _groupByProject(list);
     return RefreshIndicator(
       onRefresh: _load,
-      child: ListView.separated(
-        itemCount: list.length,
-        separatorBuilder: (_, __) => Divider(
-          height: 1,
-          color: Theme.of(context).dividerColor,
-        ),
-        itemBuilder: (_, i) {
-          final t = list[i];
-          final isGlobal = t.cwd.isEmpty;
-          return ListTile(
-            leading: Icon(
-              isGlobal ? Icons.public : Icons.folder_outlined,
-              size: 20,
-            ),
-            title: Row(
+      child: ListView.builder(
+        itemCount: groups.length,
+        itemBuilder: (_, i) => _buildGroup(groups[i]),
+      ),
+    );
+  }
+
+  Widget _buildGroup(_TaskGroup group) {
+    final theme = Theme.of(context);
+    final isGlobal = group.cwd.isEmpty;
+    final expanded = !_collapsed.contains(group.cwd);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        InkWell(
+          onTap: () => setState(() {
+            if (expanded) {
+              _collapsed.add(group.cwd);
+            } else {
+              _collapsed.remove(group.cwd);
+            }
+          }),
+          child: Container(
+            color: theme.colorScheme.surfaceContainerHighest
+                .withValues(alpha: 0.35),
+            padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
+            child: Row(
               children: [
-                Flexible(
-                  child: Text(
-                    t.name,
-                    style: const TextStyle(fontWeight: FontWeight.w600),
-                    overflow: TextOverflow.ellipsis,
-                  ),
+                Icon(
+                  expanded ? Icons.expand_more : Icons.chevron_right,
+                  size: 18,
                 ),
-                if (!isGlobal) ...[
-                  const SizedBox(width: 6),
-                  Text(
-                    '· scoped',
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          fontSize: 11,
+                const SizedBox(width: 4),
+                Icon(isGlobal ? Icons.public : Icons.folder_outlined, size: 18),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        isGlobal ? i18n.t.customTasks.scopeGlobal : group.label,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.w600,
+                          fontSize: 13,
                         ),
-                  ),
-                ],
-              ],
-            ),
-            subtitle: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (t.description.isNotEmpty)
-                  Text(
-                    t.description,
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                    style: Theme.of(context).textTheme.bodySmall,
-                  ),
-                Text(
-                  t.command,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        fontFamily: 'monospace',
-                        fontSize: 11,
                       ),
+                      if (!isGlobal)
+                        Text(
+                          group.cwd,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            fontFamily: 'monospace',
+                            fontSize: 10,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.surfaceContainerHighest,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Text(
+                    '${group.tasks.length}',
+                    style: theme.textTheme.bodySmall?.copyWith(fontSize: 11),
+                  ),
                 ),
               ],
             ),
-            trailing: PopupMenuButton<String>(
-              icon: const Icon(Icons.more_vert, size: 20),
-              itemBuilder: (_) => [
-                PopupMenuItem(value: 'edit', child: Text(i18n.t.customTasks.popupEdit)),
-                PopupMenuItem(value: 'delete', child: Text(i18n.t.customTasks.popupDelete)),
-              ],
-              onSelected: (action) {
-                if (action == 'edit') {
-                  _openEditor(existing: t);
-                } else if (action == 'delete') {
-                  _confirmDelete(t);
-                }
-              },
+          ),
+        ),
+        if (expanded)
+          for (final t in group.tasks) _buildTile(t),
+        Divider(height: 1, color: theme.dividerColor),
+      ],
+    );
+  }
+
+  Widget _buildTile(CustomTask t) {
+    return ListTile(
+      contentPadding: const EdgeInsets.only(left: 34, right: 8),
+      title: Text(
+        t.name,
+        style: const TextStyle(fontWeight: FontWeight.w600),
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (t.description.isNotEmpty)
+            Text(
+              t.description,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodySmall,
             ),
-            onTap: () => _openEditor(existing: t),
-            isThreeLine: t.description.isNotEmpty,
-          );
+          Text(
+            t.command,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  fontFamily: 'monospace',
+                  fontSize: 11,
+                ),
+          ),
+        ],
+      ),
+      trailing: PopupMenuButton<String>(
+        icon: const Icon(Icons.more_vert, size: 20),
+        itemBuilder: (_) => [
+          PopupMenuItem(value: 'edit', child: Text(i18n.t.customTasks.popupEdit)),
+          PopupMenuItem(
+              value: 'delete', child: Text(i18n.t.customTasks.popupDelete)),
+        ],
+        onSelected: (action) {
+          if (action == 'edit') {
+            _openEditor(existing: t);
+          } else if (action == 'delete') {
+            _confirmDelete(t);
+          }
         },
       ),
+      onTap: () => _openEditor(existing: t),
+      isThreeLine: t.description.isNotEmpty,
     );
   }
 }

--- a/app/shared/src/lib/customTasks.ts
+++ b/app/shared/src/lib/customTasks.ts
@@ -42,6 +42,55 @@ export async function listCustomTasks(opts: {
   return res.tasks ?? []
 }
 
+export interface CustomTaskGroup {
+  // "" for the global bucket, otherwise the project's absolute cwd.
+  cwd: string
+  // Basename of cwd — the project name to show in the header. Empty
+  // for the global bucket; callers supply their own translated label.
+  label: string
+  tasks: CustomTask[]
+}
+
+// projectLabel reduces an absolute cwd to the folder name operators
+// actually recognise ("/Users/me/code/backend" → "backend").
+export function projectLabel(cwd: string): string {
+  const parts = cwd.split('/').filter(Boolean)
+  return parts.length > 0 ? parts[parts.length - 1] : cwd
+}
+
+// groupCustomTasksByProject buckets tasks by cwd so the management
+// views render one block per project instead of one flat list. The
+// global bucket (cwd="") comes first when present; projects follow
+// sorted by label, then by full path so two projects sharing a
+// basename keep a stable order. Tasks inside a group are sorted by
+// name. Input is never mutated.
+export function groupCustomTasksByProject(
+  tasks: CustomTask[],
+): CustomTaskGroup[] {
+  const byCwd = new Map<string, CustomTask[]>()
+  for (const t of tasks) {
+    const key = t.cwd ?? ''
+    byCwd.set(key, [...(byCwd.get(key) ?? []), t])
+  }
+  const groups: CustomTaskGroup[] = [...byCwd.entries()].map(
+    ([cwd, list]) => ({
+      cwd,
+      label: cwd ? projectLabel(cwd) : '',
+      tasks: [...list].sort((a, b) =>
+        a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
+      ),
+    }),
+  )
+  return groups.sort((a, b) => {
+    if (a.cwd === '') return -1
+    if (b.cwd === '') return 1
+    return (
+      a.label.toLowerCase().localeCompare(b.label.toLowerCase()) ||
+      a.cwd.localeCompare(b.cwd)
+    )
+  })
+}
+
 export async function createCustomTask(
   req: CreateCustomTaskRequest,
 ): Promise<CustomTask> {

--- a/app/web/src/pages/Plugins.tsx
+++ b/app/web/src/pages/Plugins.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useState, type FormEvent, type ReactNode } from 'react'
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type FormEvent,
+  type ReactNode,
+} from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   Plus,
@@ -14,6 +20,9 @@ import {
   Plug,
   ShieldCheck,
   ChevronDown,
+  ChevronRight,
+  Folder,
+  Globe,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Trans, useTranslation } from 'react-i18next'
@@ -50,6 +59,7 @@ import {
 import {
   listCustomTasks,
   deleteCustomTask,
+  groupCustomTasksByProject,
   type CustomTask,
 } from '@/lib/customTasks'
 import { CustomTaskDialog } from '@/components/tasks/CustomTaskDialog'
@@ -1461,6 +1471,21 @@ function CustomTasksSection() {
   })
   const [editing, setEditing] = useState<CustomTask | null>(null)
   const [creating, setCreating] = useState(false)
+  // Collapsed group cwds. Empty set = everything expanded, which is
+  // the state operators land on; collapsing is opt-in per project.
+  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set())
+
+  const groups = useMemo(
+    () => groupCustomTasksByProject(tasks ?? []),
+    [tasks],
+  )
+  const toggleGroup = (cwd: string) =>
+    setCollapsed((prev) => {
+      const next = new Set(prev)
+      if (next.has(cwd)) next.delete(cwd)
+      else next.add(cwd)
+      return next
+    })
 
   const remove = useMutation({
     mutationFn: deleteCustomTask,
@@ -1493,95 +1518,135 @@ function CustomTasksSection() {
         </Button>
       }
     >
-      <div className="rounded-md border border-border overflow-x-auto">
-        {isLoading ? (
-          <div className="px-4 py-6 flex items-center gap-2 text-[12px] text-muted-foreground">
-            <Loader2 className="size-3 animate-spin" />
-            {t('web.plugins.common.loading')}
-          </div>
-        ) : (tasks ?? []).length === 0 ? (
-          <div className="px-4 py-8 text-center text-[12px] text-muted-foreground">
-            {t('web.plugins.customTasks.empty')}
-          </div>
-        ) : (
-          <table className="w-full min-w-[720px] text-[12px]">
-            <thead className="bg-card/40 text-[10px] uppercase tracking-wider text-muted-foreground/70">
-              <tr>
-                <th className="text-left px-3 py-2 font-medium">
-                  {t('web.plugins.customTasks.columns.name')}
-                </th>
-                <th className="text-left px-3 py-2 font-medium">
-                  {t('web.plugins.customTasks.columns.command')}
-                </th>
-                <th className="text-left px-3 py-2 font-medium">
-                  {t('web.plugins.customTasks.columns.scope')}
-                </th>
-                <th className="px-3 py-2"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {tasks!.map((task) => (
-                <tr
-                  key={task.id}
-                  className="border-t border-border hover:bg-card/40 align-top"
+      {isLoading ? (
+        <div className="rounded-md border border-border px-4 py-6 flex items-center gap-2 text-[12px] text-muted-foreground">
+          <Loader2 className="size-3 animate-spin" />
+          {t('web.plugins.common.loading')}
+        </div>
+      ) : groups.length === 0 ? (
+        <div className="rounded-md border border-border px-4 py-8 text-center text-[12px] text-muted-foreground">
+          {t('web.plugins.customTasks.empty')}
+        </div>
+      ) : (
+        // One block per project (plus the global bucket) so a long
+        // catalogue reads as a handful of named groups instead of one
+        // undifferentiated list. The group header carries the scope,
+        // which is why the rows no longer repeat it per task.
+        <div className="space-y-2">
+          {groups.map((group) => {
+            const open = !collapsed.has(group.cwd)
+            return (
+              <div
+                key={group.cwd || '__global__'}
+                className="rounded-md border border-border overflow-hidden"
+              >
+                <button
+                  type="button"
+                  onClick={() => toggleGroup(group.cwd)}
+                  aria-expanded={open}
+                  className="w-full flex items-center gap-2 px-3 py-2 bg-card/40 hover:bg-card/60 text-left"
                 >
-                  <td className="px-3 py-2">
-                    <div className="font-medium">{task.name}</div>
-                    {task.description && (
-                      <div className="text-[10px] text-muted-foreground/70 italic">
-                        {task.description}
-                      </div>
-                    )}
-                  </td>
-                  <td className="px-3 py-2 font-mono text-[11px] break-all">
-                    {task.command}
-                  </td>
-                  <td className="px-3 py-2 font-mono text-[10px]">
-                    {task.cwd ? (
-                      <span title={task.cwd}>{trimPath(task.cwd)}</span>
-                    ) : (
-                      <span className="text-muted-foreground/70">
-                        {t('web.plugins.customTasks.globalScope')}
-                      </span>
-                    )}
-                  </td>
-                  <td className="px-3 py-2 text-right">
-                    <div className="flex items-center justify-end gap-1">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => setEditing(task)}
-                        className="h-7 px-2 text-[11px] gap-1"
-                      >
-                        <Pencil className="size-3" />
-                        {t('web.plugins.common.edit')}
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => {
-                          if (
-                            confirm(
-                              t('web.plugins.customTasks.deleteConfirm', {
-                                name: task.name,
-                              }),
-                            )
-                          ) {
-                            remove.mutate(task.id)
-                          }
-                        }}
-                        className="h-7 px-2 text-[11px] gap-1 text-muted-foreground hover:text-destructive"
-                      >
-                        <Trash2 className="size-3" />
-                      </Button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </div>
+                  {open ? (
+                    <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+                  ) : (
+                    <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+                  )}
+                  {group.cwd ? (
+                    <Folder className="size-3.5 shrink-0 text-muted-foreground" />
+                  ) : (
+                    <Globe className="size-3.5 shrink-0 text-muted-foreground" />
+                  )}
+                  <span className="text-[12px] font-medium truncate">
+                    {group.cwd
+                      ? group.label
+                      : t('web.plugins.customTasks.globalGroup')}
+                  </span>
+                  {group.cwd && (
+                    <span
+                      className="font-mono text-[10px] text-muted-foreground/70 truncate"
+                      title={group.cwd}
+                    >
+                      {trimPath(group.cwd)}
+                    </span>
+                  )}
+                  <span className="ml-auto shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
+                    {group.tasks.length}
+                  </span>
+                </button>
+                {open && (
+                  <div className="overflow-x-auto border-t border-border">
+                    <table className="w-full min-w-[560px] text-[12px]">
+                      <thead className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
+                        <tr>
+                          <th className="text-left px-3 py-2 font-medium">
+                            {t('web.plugins.customTasks.columns.name')}
+                          </th>
+                          <th className="text-left px-3 py-2 font-medium">
+                            {t('web.plugins.customTasks.columns.command')}
+                          </th>
+                          <th className="px-3 py-2"></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {group.tasks.map((task) => (
+                          <tr
+                            key={task.id}
+                            className="border-t border-border hover:bg-card/40 align-top"
+                          >
+                            <td className="px-3 py-2">
+                              <div className="font-medium">{task.name}</div>
+                              {task.description && (
+                                <div className="text-[10px] text-muted-foreground/70 italic">
+                                  {task.description}
+                                </div>
+                              )}
+                            </td>
+                            <td className="px-3 py-2 font-mono text-[11px] break-all">
+                              {task.command}
+                            </td>
+                            <td className="px-3 py-2 text-right">
+                              <div className="flex items-center justify-end gap-1">
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => setEditing(task)}
+                                  className="h-7 px-2 text-[11px] gap-1"
+                                >
+                                  <Pencil className="size-3" />
+                                  {t('web.plugins.common.edit')}
+                                </Button>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => {
+                                    if (
+                                      confirm(
+                                        t(
+                                          'web.plugins.customTasks.deleteConfirm',
+                                          { name: task.name },
+                                        ),
+                                      )
+                                    ) {
+                                      remove.mutate(task.id)
+                                    }
+                                  }}
+                                  className="h-7 px-2 text-[11px] gap-1 text-muted-foreground hover:text-destructive"
+                                >
+                                  <Trash2 className="size-3" />
+                                </Button>
+                              </div>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
 
       <CustomTaskDialog
         open={creating}


### PR DESCRIPTION
## Why

The Custom tasks list rendered every task in one flat run. On mobile the only hint of ownership was a bare `· scoped` marker; on web it was a truncated path column. Once several projects each contribute a few tasks, the list reads as noise and there is no way to collapse what you are not working on.

`cwd` is already the project identity on `custom_tasks` and the list endpoint already returns it, so **this is a rendering change only** — no migration, no API change, no Go.

## What changed

**`app/shared/src/lib/customTasks.ts`**
- `groupCustomTasksByProject()` buckets tasks by `cwd`. The global bucket (`cwd=""`) comes first; projects follow sorted by folder name, with the full path breaking ties so two projects sharing a basename keep a stable order. Tasks sort by name inside each group. The input list is never mutated.
- `projectLabel()` reduces an absolute cwd to its folder name.

**`app/web/src/pages/Plugins.tsx`** — `CustomTasksSection` renders one collapsible block per project: chevron, folder/globe icon, project name, dimmed monospace path, and a task-count badge. The per-row **scope column is removed** — the group header carries it.

**`app/mobile/lib/features/custom_tasks/custom_tasks_screen.dart`** — the same shape: tappable group headers over indented rows, with the per-row `· scoped` label and leading folder icon dropped.

Collapse state is in-memory and every group starts expanded, so a reload always shows the whole catalogue.

**i18n** — `web.plugins.customTasks.columns.scope` and `.globalScope` are now unused and removed; `.globalGroup` added for the header. Mobile reuses the existing `customTasks.scopeGlobal` string. `dart run slang` regenerated.

## Test plan

Automated (all green locally):
- `pnpm build` in `app/web` (runs `tsc -b`)
- `flutter analyze lib/features/custom_tasks` — no issues
- `node scripts/check-i18n-parity.mjs` — en/es/zh 100%, no missing/extra/token mismatch
- `pnpm lint` — 138 pre-existing problems, none introduced by this change

Manual (needs the operator's local build):
- [ ] Web: Plugins ▸ Custom tasks shows Global first, then one block per project with the right count; chevron collapses/expands; Edit and Delete still work from inside a group
- [ ] Web: a task whose cwd has no matching project still groups under its own folder name, and the full path shows on hover
- [ ] Mobile: same grouping, headers tap to collapse, three-dot menu (Edit/Delete) and row tap still open the editor
- [ ] Mobile: pull-to-refresh keeps the grouping and re-expands everything
- [ ] Both: creating a new project-scoped task drops it into the right group after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)