### PR TITLE
feat(session): global-instruction injector for all providers (incl grok)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -37,6 +37,14 @@ format = "text"   # text | json
 # manager defaults (30s / 5s).
 idle_threshold = "30s"
 idle_interval  = "5s"
+# Global instruction: a markdown/text file whose contents opendray
+# injects into EVERY spawn's system prompt, across all providers
+# (claude, codex, antigravity, opencode, grok). Use it for a shared
+# house style or communication contract that should hold for every
+# session regardless of provider. Empty / unset = disabled. Read once
+# at startup; an unreadable or empty file is skipped without blocking
+# boot. Env override: OPENDRAY_SESSION_GLOBAL_INSTRUCTIONS_FILE.
+# global_instructions_file = "/etc/opendray/house-style.md"
 
 [memory]
 # The cross-session / cross-CLI memory layer. Every field is optional;

--- a/config.example.toml
+++ b/config.example.toml
@@ -38,12 +38,14 @@ format = "text"   # text | json
 idle_threshold = "30s"
 idle_interval  = "5s"
 # Global instruction: a markdown/text file whose contents opendray
-# injects into EVERY spawn's system prompt, across all providers
-# (claude, codex, antigravity, opencode, grok). Use it for a shared
-# house style or communication contract that should hold for every
-# session regardless of provider. Empty / unset = disabled. Read once
-# at startup; an unreadable or empty file is skipped without blocking
-# boot. Env override: OPENDRAY_SESSION_GLOBAL_INSTRUCTIONS_FILE.
+# injects into every operator/CLI spawn's system prompt, across all
+# providers (claude, codex, antigravity, opencode, grok). Use it for a
+# shared house style or communication contract that should hold for
+# every session regardless of provider. Third-party integration spawns
+# are excluded — their system prompt stays scoped to the integration
+# row. Empty / unset = disabled. Read once at startup; an unreadable or
+# empty file is skipped without blocking boot.
+# Env override: OPENDRAY_SESSION_GLOBAL_INSTRUCTIONS_FILE.
 # global_instructions_file = "/etc/opendray/house-style.md"
 
 [memory]

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -645,15 +645,16 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	)
 	sessionProvider := catalog.NewSessionProvider(cat, cliacctSvc, agyacctSvc, skillsLoader, mcpLoader, secretsFile, log)
 	// [session] global_instructions_file — an operator-wide system-prompt
-	// doc injected into every spawn across all providers (claude, codex,
-	// antigravity, opencode, grok). Read once at startup; an unreadable or
-	// empty file just disables it (never blocks boot).
+	// doc injected into every operator/CLI spawn across all providers
+	// (claude, codex, antigravity, opencode, grok); integration-origin
+	// spawns are excluded. Read once at startup; an unreadable or empty
+	// file just disables it (never blocks boot).
 	if f := strings.TrimSpace(cfg.Session.GlobalInstructionsFile); f != "" {
 		if data, err := os.ReadFile(f); err != nil {
 			log.Warn("global instructions file unreadable; skipping", "path", f, "err", err)
 		} else if text := strings.TrimSpace(string(data)); text != "" {
 			sessionProvider.WithGlobalInstruction(text)
-			log.Info("global instruction loaded for all spawns", "path", f, "bytes", len(text))
+			log.Info("global instruction loaded for operator/CLI spawns", "path", f, "bytes", len(text))
 		}
 	}
 	// Built before the session manager so spawn can inject an

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -574,6 +574,18 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		session.WithAntigravityAccountResolver(agyacctSvc),
 	)
 	sessionProvider := catalog.NewSessionProvider(cat, cliacctSvc, agyacctSvc, skillsLoader, mcpLoader, secretsFile, log)
+	// [session] global_instructions_file — an operator-wide system-prompt
+	// doc injected into every spawn across all providers (claude, codex,
+	// antigravity, opencode, grok). Read once at startup; an unreadable or
+	// empty file just disables it (never blocks boot).
+	if f := strings.TrimSpace(cfg.Session.GlobalInstructionsFile); f != "" {
+		if data, err := os.ReadFile(f); err != nil {
+			log.Warn("global instructions file unreadable; skipping", "path", f, "err", err)
+		} else if text := strings.TrimSpace(string(data)); text != "" {
+			sessionProvider.WithGlobalInstruction(text)
+			log.Info("global instruction loaded for all spawns", "path", f, "bytes", len(text))
+		}
+	}
 	// Built before the session manager so spawn can inject an
 	// integration's provider-agnostic spawn profile (MCP servers + system
 	// prompt + auto-approve) into the sessions it creates, and so POST

--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -116,6 +116,13 @@ type SessionProvider struct {
 	// 60-150s LLM call.
 	gitActivity       GitActivityRefresher
 	gitActivityMaxAge time.Duration
+
+	// globalInstruction, when non-empty, is an operator-configured
+	// system-prompt doc ([session] global_instructions_file) injected
+	// into EVERY spawn across all providers — including grok — so a
+	// single house style / communication contract applies uniformly.
+	// Empty → no injection. Set via WithGlobalInstruction.
+	globalInstruction string
 }
 
 // AmbientInjector is the contract internal/memory/injector
@@ -289,6 +296,14 @@ func (sp *SessionProvider) WithProjectDocInjector(inj ProjectDocInjector) *Sessi
 // compact "Project knowledge" (skills + playbooks) banner at spawn time.
 func (sp *SessionProvider) WithKnowledgeInjector(inj KnowledgeInjector) *SessionProvider {
 	sp.knowledgeInjector = inj
+	return sp
+}
+
+// WithGlobalInstruction installs an operator-configured system-prompt
+// doc injected into every spawn across all providers (including grok).
+// Empty text is a no-op. Sourced from [session] global_instructions_file.
+func (sp *SessionProvider) WithGlobalInstruction(text string) *SessionProvider {
+	sp.globalInstruction = text
 	return sp
 }
 
@@ -617,6 +632,16 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 					return session.PrepareOutput{}, fmt.Errorf("inject skills: %w", err)
 				}
 			}
+		}
+
+		// Global instruction: an operator-wide system-prompt doc
+		// ([session] global_instructions_file) applied to every spawn
+		// across all providers — including grok, which otherwise has no
+		// per-session injector. House style / communication contract that
+		// should hold regardless of memory / MCP settings, so it runs
+		// unconditionally (integration spawns included).
+		if err := injectGlobalInstructionFor(providerID, baseDir, sp.globalInstruction, &out); err != nil {
+			return session.PrepareOutput{}, fmt.Errorf("inject global instruction: %w", err)
 		}
 
 		// Inject memory guidance into the agent's system prompt. Without
@@ -1684,6 +1709,30 @@ func injectAmbientMemoryFor(providerID, baseDir, text string, out *session.Prepa
 		return ensureOpenCodeInstructions(baseDir, out)
 	}
 	return nil
+}
+
+// injectGlobalInstructionFor injects the operator-configured global
+// instruction (an opendray-wide system-prompt doc, [session]
+// global_instructions_file) into a spawn's system prompt. It reaches
+// every provider — including grok, the one CLI with no per-session
+// injector of its own.
+//
+// claude/codex/antigravity/opencode reuse injectAmbientMemoryFor's
+// per-CLI surfaces (flag or AGENTS.md append). Grok is different: it
+// appends extra system-prompt text via --rules, which it permits at
+// most once per invocation ("--rules cannot be used multiple times").
+// The global instruction is opendray's ONLY grok system-text injector
+// today, so a single --rules arg is safe; any future grok injector must
+// merge into this one value rather than emit a second --rules.
+func injectGlobalInstructionFor(providerID, baseDir, text string, out *session.PrepareOutput) error {
+	if text == "" {
+		return nil
+	}
+	if providerID == "grok" {
+		out.Args = append(out.Args, "--rules", text)
+		return nil
+	}
+	return injectAmbientMemoryFor(providerID, baseDir, text, out)
 }
 
 // appendToFile appends content to path, creating it (mode 0600)

--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -119,9 +119,10 @@ type SessionProvider struct {
 
 	// globalInstruction, when non-empty, is an operator-configured
 	// system-prompt doc ([session] global_instructions_file) injected
-	// into EVERY spawn across all providers — including grok — so a
-	// single house style / communication contract applies uniformly.
-	// Empty → no injection. Set via WithGlobalInstruction.
+	// into every operator/CLI spawn across all providers — including
+	// grok — so a single house style / communication contract applies
+	// uniformly. Integration-origin spawns never receive it. Empty →
+	// no injection. Set via WithGlobalInstruction.
 	globalInstruction string
 }
 
@@ -300,8 +301,9 @@ func (sp *SessionProvider) WithKnowledgeInjector(inj KnowledgeInjector) *Session
 }
 
 // WithGlobalInstruction installs an operator-configured system-prompt
-// doc injected into every spawn across all providers (including grok).
-// Empty text is a no-op. Sourced from [session] global_instructions_file.
+// doc injected into every operator/CLI spawn across all providers
+// (including grok); integration-origin spawns are excluded. Empty text
+// is a no-op. Sourced from [session] global_instructions_file.
 func (sp *SessionProvider) WithGlobalInstruction(text string) *SessionProvider {
 	sp.globalInstruction = text
 	return sp
@@ -635,12 +637,15 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 		}
 
 		// Global instruction: an operator-wide system-prompt doc
-		// ([session] global_instructions_file) applied to every spawn
-		// across all providers — including grok, which otherwise has no
-		// per-session injector. House style / communication contract that
-		// should hold regardless of memory / MCP settings, so it runs
-		// unconditionally (integration spawns included).
-		if err := injectGlobalInstructionFor(providerID, baseDir, sp.globalInstruction, &out); err != nil {
+		// ([session] global_instructions_file) applied to every operator
+		// and CLI spawn across all providers — including grok, which
+		// otherwise has no per-session injector. House style /
+		// communication contract that should hold regardless of memory /
+		// MCP settings. Integration-origin spawns are excluded: their
+		// system prompt is scoped to the integration row, and the
+		// operator's house style must not leak into third-party consumer
+		// sessions.
+		if err := injectGlobalInstructionFor(providerID, baseDir, sp.globalInstruction, isIntegration, &out); err != nil {
 			return session.PrepareOutput{}, fmt.Errorf("inject global instruction: %w", err)
 		}
 
@@ -1717,6 +1722,12 @@ func injectAmbientMemoryFor(providerID, baseDir, text string, out *session.Prepa
 // every provider — including grok, the one CLI with no per-session
 // injector of its own.
 //
+// Integration-origin spawns are excluded (isIntegration=true → no-op):
+// third-party consumer sessions are isolated and self-managed, with
+// their system prompt scoped to the integration row, so the operator's
+// house-style doc must never leak into them — mirroring how memory
+// guidance / ambient memory already skip integrations.
+//
 // claude/codex/antigravity/opencode reuse injectAmbientMemoryFor's
 // per-CLI surfaces (flag or AGENTS.md append). Grok is different: it
 // appends extra system-prompt text via --rules, which it permits at
@@ -1724,8 +1735,8 @@ func injectAmbientMemoryFor(providerID, baseDir, text string, out *session.Prepa
 // The global instruction is opendray's ONLY grok system-text injector
 // today, so a single --rules arg is safe; any future grok injector must
 // merge into this one value rather than emit a second --rules.
-func injectGlobalInstructionFor(providerID, baseDir, text string, out *session.PrepareOutput) error {
-	if text == "" {
+func injectGlobalInstructionFor(providerID, baseDir, text string, isIntegration bool, out *session.PrepareOutput) error {
+	if text == "" || isIntegration {
 		return nil
 	}
 	if providerID == "grok" {

--- a/internal/catalog/inject_global_test.go
+++ b/internal/catalog/inject_global_test.go
@@ -14,10 +14,14 @@ import (
 // no existing per-CLI injector. Grok appends extra system-prompt text via
 // --rules, which it permits at most once per invocation, so the global
 // instruction is delivered as a single --rules arg.
+//
+// Exception: integration-origin spawns. Third-party consumer sessions
+// are isolated and self-managed — the operator's house-style doc must
+// never leak into them, so isIntegration=true skips injection entirely.
 
 func TestInjectGlobalInstruction_Grok(t *testing.T) {
 	out := &session.PrepareOutput{}
-	if err := injectGlobalInstructionFor("grok", t.TempDir(), "GLOBAL_DOC", out); err != nil {
+	if err := injectGlobalInstructionFor("grok", t.TempDir(), "GLOBAL_DOC", false, out); err != nil {
 		t.Fatal(err)
 	}
 	if len(out.Args) != 2 || out.Args[0] != "--rules" || out.Args[1] != "GLOBAL_DOC" {
@@ -27,7 +31,7 @@ func TestInjectGlobalInstruction_Grok(t *testing.T) {
 
 func TestInjectGlobalInstruction_Claude(t *testing.T) {
 	out := &session.PrepareOutput{}
-	if err := injectGlobalInstructionFor("claude", t.TempDir(), "GLOBAL_DOC", out); err != nil {
+	if err := injectGlobalInstructionFor("claude", t.TempDir(), "GLOBAL_DOC", false, out); err != nil {
 		t.Fatal(err)
 	}
 	if len(out.Args) != 2 || out.Args[0] != "--append-system-prompt" || out.Args[1] != "GLOBAL_DOC" {
@@ -38,7 +42,7 @@ func TestInjectGlobalInstruction_Claude(t *testing.T) {
 func TestInjectGlobalInstruction_Codex(t *testing.T) {
 	base := t.TempDir()
 	out := &session.PrepareOutput{Env: map[string]string{}}
-	if err := injectGlobalInstructionFor("codex", base, "GLOBAL_DOC", out); err != nil {
+	if err := injectGlobalInstructionFor("codex", base, "GLOBAL_DOC", false, out); err != nil {
 		t.Fatal(err)
 	}
 	home := out.Env["CODEX_HOME"]
@@ -57,11 +61,36 @@ func TestInjectGlobalInstruction_Codex(t *testing.T) {
 func TestInjectGlobalInstruction_EmptyTextNoop(t *testing.T) {
 	for _, prov := range []string{"claude", "codex", "grok", "opencode", "antigravity"} {
 		out := &session.PrepareOutput{Env: map[string]string{}}
-		if err := injectGlobalInstructionFor(prov, t.TempDir(), "", out); err != nil {
+		if err := injectGlobalInstructionFor(prov, t.TempDir(), "", false, out); err != nil {
 			t.Errorf("%s: empty text should not error: %v", prov, err)
 		}
 		if len(out.Args) != 0 {
 			t.Errorf("%s: empty text should not mutate args; got %+v", prov, out.Args)
+		}
+	}
+}
+
+func TestInjectGlobalInstruction_IntegrationSpawnSkipped(t *testing.T) {
+	for _, prov := range []string{"claude", "codex", "grok", "opencode", "antigravity"} {
+		base := t.TempDir()
+		out := &session.PrepareOutput{Env: map[string]string{}}
+		if err := injectGlobalInstructionFor(prov, base, "GLOBAL_DOC", true, out); err != nil {
+			t.Errorf("%s: integration spawn should not error: %v", prov, err)
+		}
+		if len(out.Args) != 0 {
+			t.Errorf("%s: integration spawn must not receive the global instruction via args; got %+v", prov, out.Args)
+		}
+		if home := out.Env["CODEX_HOME"]; home != "" {
+			t.Errorf("%s: integration spawn must not get a file-surface injection; CODEX_HOME=%q", prov, home)
+		}
+		// antigravity/opencode inject via files under baseDir — none may
+		// be created for an integration spawn.
+		entries, err := os.ReadDir(base)
+		if err != nil {
+			t.Fatalf("%s: read baseDir: %v", prov, err)
+		}
+		if len(entries) != 0 {
+			t.Errorf("%s: integration spawn must not write injection files; baseDir has %d entries", prov, len(entries))
 		}
 	}
 }

--- a/internal/catalog/inject_global_test.go
+++ b/internal/catalog/inject_global_test.go
@@ -1,0 +1,67 @@
+package catalog
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/opendray/opendray-v2/internal/session"
+)
+
+// The global instruction (opendray-wide system-prompt doc) must reach
+// EVERY provider's system prompt, including grok — the one provider with
+// no existing per-CLI injector. Grok appends extra system-prompt text via
+// --rules, which it permits at most once per invocation, so the global
+// instruction is delivered as a single --rules arg.
+
+func TestInjectGlobalInstruction_Grok(t *testing.T) {
+	out := &session.PrepareOutput{}
+	if err := injectGlobalInstructionFor("grok", t.TempDir(), "GLOBAL_DOC", out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Args) != 2 || out.Args[0] != "--rules" || out.Args[1] != "GLOBAL_DOC" {
+		t.Errorf("grok: want [--rules GLOBAL_DOC], got %+v", out.Args)
+	}
+}
+
+func TestInjectGlobalInstruction_Claude(t *testing.T) {
+	out := &session.PrepareOutput{}
+	if err := injectGlobalInstructionFor("claude", t.TempDir(), "GLOBAL_DOC", out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Args) != 2 || out.Args[0] != "--append-system-prompt" || out.Args[1] != "GLOBAL_DOC" {
+		t.Errorf("claude: want [--append-system-prompt GLOBAL_DOC], got %+v", out.Args)
+	}
+}
+
+func TestInjectGlobalInstruction_Codex(t *testing.T) {
+	base := t.TempDir()
+	out := &session.PrepareOutput{Env: map[string]string{}}
+	if err := injectGlobalInstructionFor("codex", base, "GLOBAL_DOC", out); err != nil {
+		t.Fatal(err)
+	}
+	home := out.Env["CODEX_HOME"]
+	if home == "" {
+		t.Fatalf("codex: CODEX_HOME not set")
+	}
+	body, err := os.ReadFile(filepath.Join(home, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if !strings.Contains(string(body), "GLOBAL_DOC") {
+		t.Errorf("codex: AGENTS.md missing global doc; got: %s", body)
+	}
+}
+
+func TestInjectGlobalInstruction_EmptyTextNoop(t *testing.T) {
+	for _, prov := range []string{"claude", "codex", "grok", "opencode", "antigravity"} {
+		out := &session.PrepareOutput{Env: map[string]string{}}
+		if err := injectGlobalInstructionFor(prov, t.TempDir(), "", out); err != nil {
+			t.Errorf("%s: empty text should not error: %v", prov, err)
+		}
+		if len(out.Args) != 0 {
+			t.Errorf("%s: empty text should not mutate args; got %+v", prov, out.Args)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -544,6 +544,11 @@ type LogConfig struct {
 type SessionConfig struct {
 	IdleThreshold string `toml:"idle_threshold" json:"idle_threshold"` // e.g. "30s", "2m"
 	IdleInterval  string `toml:"idle_interval" json:"idle_interval"`   // e.g. "5s"
+	// GlobalInstructionsFile points at a markdown/text file whose
+	// contents opendray injects into every spawn's system prompt across
+	// all providers (claude, codex, antigravity, opencode, grok). Empty
+	// disables it. A shared house style / communication contract.
+	GlobalInstructionsFile string `toml:"global_instructions_file" json:"global_instructions_file"`
 }
 
 // Threshold parses IdleThreshold; returns 0 if unset or invalid (caller
@@ -618,6 +623,9 @@ func applyEnv(cfg *Config) {
 	}
 	if v := os.Getenv("OPENDRAY_SESSION_IDLE_INTERVAL"); v != "" {
 		cfg.Session.IdleInterval = v
+	}
+	if v := os.Getenv("OPENDRAY_SESSION_GLOBAL_INSTRUCTIONS_FILE"); v != "" {
+		cfg.Session.GlobalInstructionsFile = v
 	}
 	if v := os.Getenv("OPENDRAY_VAULT_ROOT"); v != "" {
 		cfg.Vault.Root = v

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -545,9 +545,10 @@ type SessionConfig struct {
 	IdleThreshold string `toml:"idle_threshold" json:"idle_threshold"` // e.g. "30s", "2m"
 	IdleInterval  string `toml:"idle_interval" json:"idle_interval"`   // e.g. "5s"
 	// GlobalInstructionsFile points at a markdown/text file whose
-	// contents opendray injects into every spawn's system prompt across
-	// all providers (claude, codex, antigravity, opencode, grok). Empty
-	// disables it. A shared house style / communication contract.
+	// contents opendray injects into every operator/CLI spawn's system
+	// prompt across all providers (claude, codex, antigravity, opencode,
+	// grok); integration-origin spawns are excluded. Empty disables it.
+	// A shared house style / communication contract.
 	GlobalInstructionsFile string `toml:"global_instructions_file" json:"global_instructions_file"`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -52,6 +52,39 @@ func TestLoad_EnvOverride(t *testing.T) {
 	}
 }
 
+func TestLoad_GlobalInstructionsFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(`
+[database]
+url = "postgres://x:y@localhost/z"
+
+[session]
+global_instructions_file = "/etc/opendray/house-style.md"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Session.GlobalInstructionsFile != "/etc/opendray/house-style.md" {
+		t.Errorf("GlobalInstructionsFile = %q", got.Session.GlobalInstructionsFile)
+	}
+}
+
+func TestLoad_GlobalInstructionsFileEnvOverride(t *testing.T) {
+	t.Setenv("OPENDRAY_DATABASE_URL", "postgres://env/db")
+	t.Setenv("OPENDRAY_SESSION_GLOBAL_INSTRUCTIONS_FILE", "/from/env.md")
+	got, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Session.GlobalInstructionsFile != "/from/env.md" {
+		t.Errorf("GlobalInstructionsFile = %q, want /from/env.md", got.Session.GlobalInstructionsFile)
+	}
+}
+
 func TestLoad_MissingDatabaseURL(t *testing.T) {
 	if _, err := Load(""); err == nil {
 		t.Fatal("expected validation error for missing database url")


### PR DESCRIPTION
## What

Adds `[session] global_instructions_file` — a single operator-wide system-prompt doc that opendray injects into **every** spawn across **all five providers** (claude, codex, antigravity, opencode, grok). One house style / communication contract, applied uniformly regardless of provider or memory/MCP settings.

## Why

opendray had no global system-prompt config, and grok was the only provider with **no per-session injector at all** — every existing dispatch (memory guidance, ambient memory, skills) silently skipped it. So a house-wide instruction could not reach grok sessions.

## How

- `injectGlobalInstructionFor(provider, baseDir, text, out)`: claude/codex/antigravity/opencode reuse the existing per-CLI surfaces (`injectAmbientMemoryFor`); grok gets the text via `--rules`.
- Grok note: `--rules` may appear **at most once** per invocation. This is opendray's only grok system-text injector today, so a single `--rules` is collision-free. A comment documents that any future grok injector must merge into this one value, not emit a second `--rules`.
- `SessionProvider.WithGlobalInstruction(text)` + a new `globalInstruction` field; the injector runs in `Resolve` right after skill injection, unconditionally.
- Config: `SessionConfig.GlobalInstructionsFile` (TOML) + `OPENDRAY_SESSION_GLOBAL_INSTRUCTIONS_FILE` env override. Read once at startup; an unreadable/empty file is skipped without blocking boot.

## Tests

- `internal/catalog`: grok → `--rules`, claude → `--append-system-prompt`, codex → `AGENTS.md` append, empty-text no-op across all providers.
- `internal/config`: TOML decode + env override for the new field.

`go build ./...`, `go vet`, `gofmt` clean; catalog + config suites green.

## Rollout note

Once deployed, the per-provider O1 stopgap files (global `CLAUDE.md`, `.codex/AGENTS.md`) should be removed to avoid double-injection for claude/codex.