### PR TITLE
feat(session): auto-inject skill index into grok (coalesced --rules)

### DIFF
--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -889,6 +889,13 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 			}
 		}
 
+		// Grok permits --rules once. Independent injectors (skill index,
+		// global instruction, …) each emit one; merge them into the single
+		// allowed slot as the final step, after every injector has run.
+		if providerID == "grok" {
+			out.Args = coalesceRulesArgs(out.Args)
+		}
+
 		if len(out.Env) == 0 {
 			out.Env = nil
 		}
@@ -918,6 +925,10 @@ func integrationMCPAllowed(providerID string, accountBound bool) bool {
 //	         and adds it via --add-dir (agy's workspace-context
 //	         convention; verified it reads AGENTS.md from added dirs)
 //	         without touching the user's real ~/.gemini
+//	grok — `--rules <text>` flag, zero filesystem touch (no grok-home
+//	         relocation, so login / trusted-folders stay intact). grok
+//	         permits --rules only once, so coalesceRulesArgs merges the
+//	         skill index with any other grok --rules into a single slot.
 //
 // codex is intentionally NOT in the default list: it has no system-
 // prompt CLI flag, so the only path is `<CODEX_HOME>/instructions.md`,
@@ -929,7 +940,7 @@ func integrationMCPAllowed(providerID string, accountBound bool) bool {
 // Adding a new provider here requires a matching arm in injectSkillsFor.
 func providerSupportsSkills(id string) bool {
 	switch id {
-	case "claude", "antigravity", "opencode":
+	case "claude", "antigravity", "opencode", "grok":
 		return true
 	default:
 		return false
@@ -1051,6 +1062,13 @@ func injectSkillsFor(providerID, baseDir string, loaded []skills.Skill, out *ses
 		if err := os.WriteFile(agentsPath, body, 0o600); err != nil {
 			return fmt.Errorf("write %s: %w", agentsPath, err)
 		}
+		return nil
+	case "grok":
+		// Grok appends the index to its system prompt via --rules. It
+		// permits --rules only once, so a Resolve-level finalizer
+		// (coalesceRulesArgs) merges this with any other grok --rules
+		// (e.g. the global instruction) into the single allowed slot.
+		out.Args = append(out.Args, "--rules", index)
 		return nil
 	case "antigravity":
 		// agy reads AGENTS.md from --add-dir'd workspace dirs.
@@ -1733,6 +1751,45 @@ func injectGlobalInstructionFor(providerID, baseDir, text string, out *session.P
 		return nil
 	}
 	return injectAmbientMemoryFor(providerID, baseDir, text, out)
+}
+
+// coalesceRulesArgs merges every "--rules <value>" pair in args into a
+// single --rules holding all values joined by a separator. Grok rejects a
+// repeated --rules ("cannot be used multiple times"), but opendray emits
+// one per independent system-prompt fragment (skill index, global
+// instruction, …). The merged flag takes the position of the first
+// --rules; a dangling trailing --rules with no value is dropped. Args with
+// zero or one well-formed --rules (and no dangling flag) are returned
+// unchanged, so this is a safe no-op for every non-grok provider.
+func coalesceRulesArgs(args []string) []string {
+	var values []string
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--rules" && i+1 < len(args) {
+			values = append(values, args[i+1])
+			i++
+		}
+	}
+	dangling := len(args) > 0 && args[len(args)-1] == "--rules"
+	if len(values) <= 1 && !dangling {
+		return args
+	}
+	merged := strings.Join(values, "\n\n---\n\n")
+	out := make([]string, 0, len(args))
+	placed := false
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--rules" {
+			if i+1 < len(args) {
+				i++ // consume the value token
+			}
+			if !placed && len(values) > 0 {
+				out = append(out, "--rules", merged)
+				placed = true
+			}
+			continue
+		}
+		out = append(out, args[i])
+	}
+	return out
 }
 
 // appendToFile appends content to path, creating it (mode 0600)

--- a/internal/catalog/inject_grok_rules_test.go
+++ b/internal/catalog/inject_grok_rules_test.go
@@ -79,7 +79,7 @@ func TestGrokSkillsAndGlobalInstruction_CoalesceToOne(t *testing.T) {
 	}, out); err != nil {
 		t.Fatal(err)
 	}
-	if err := injectGlobalInstructionFor("grok", t.TempDir(), "HOUSE_STYLE", out); err != nil {
+	if err := injectGlobalInstructionFor("grok", t.TempDir(), "HOUSE_STYLE", false, out); err != nil {
 		t.Fatal(err)
 	}
 	out.Args = coalesceRulesArgs(out.Args)

--- a/internal/catalog/inject_grok_rules_test.go
+++ b/internal/catalog/inject_grok_rules_test.go
@@ -1,0 +1,100 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/opendray/opendray-v2/internal/session"
+	"github.com/opendray/opendray-v2/internal/skills"
+)
+
+// Grok accepts --rules at most once per invocation. opendray has several
+// independent system-text injectors (skills index, global instruction, …)
+// that each emit a --rules for grok; coalesceRulesArgs merges them into
+// the single slot grok allows, so grok gets every fragment without the
+// "--rules cannot be used multiple times" spawn failure.
+
+func TestCoalesceRulesArgs_MergesMultiple(t *testing.T) {
+	in := []string{"--model", "grok-4", "--rules", "SKILLS", "--foo", "--rules", "GLOBAL"}
+	got := coalesceRulesArgs(in)
+	want := []string{"--model", "grok-4", "--rules", "SKILLS\n\n---\n\nGLOBAL", "--foo"}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Errorf("merge wrong:\n got  %q\n want %q", got, want)
+	}
+}
+
+func TestCoalesceRulesArgs_SinglePreserved(t *testing.T) {
+	in := []string{"--rules", "ONLY"}
+	got := coalesceRulesArgs(in)
+	if len(got) != 2 || got[0] != "--rules" || got[1] != "ONLY" {
+		t.Errorf("single --rules should be untouched; got %q", got)
+	}
+}
+
+func TestCoalesceRulesArgs_NoneNoop(t *testing.T) {
+	in := []string{"--model", "grok-4", "--foo"}
+	got := coalesceRulesArgs(in)
+	if strings.Join(got, "\x00") != strings.Join(in, "\x00") {
+		t.Errorf("no --rules should be a no-op; got %q", got)
+	}
+}
+
+func TestCoalesceRulesArgs_TrailingFlagNoValueDropped(t *testing.T) {
+	in := []string{"--rules", "A", "--rules"} // malformed trailing flag, no value
+	got := coalesceRulesArgs(in)
+	if len(got) != 2 || got[0] != "--rules" || got[1] != "A" {
+		t.Errorf("dangling --rules should be dropped, value kept; got %q", got)
+	}
+}
+
+func TestInjectSkillsFor_Grok(t *testing.T) {
+	out := &session.PrepareOutput{}
+	err := injectSkillsFor("grok", t.TempDir(), []skills.Skill{
+		{ID: "brainstorming", Name: "brainstorming", Description: "explore intent"},
+	}, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Args) != 2 || out.Args[0] != "--rules" {
+		t.Fatalf("grok: want [--rules <index>], got %q", out.Args)
+	}
+	if !strings.Contains(out.Args[1], "brainstorming") {
+		t.Errorf("grok: --rules value missing skill; got %q", out.Args[1])
+	}
+}
+
+func TestProviderSupportsSkills_Grok(t *testing.T) {
+	if !providerSupportsSkills("grok") {
+		t.Error("grok should support skills so the index auto-injects at spawn")
+	}
+}
+
+// The real spawn scenario: both the skill index and the global instruction
+// emit a grok --rules; the finalizer must leave exactly one --rules that
+// carries both, or grok fails to start.
+func TestGrokSkillsAndGlobalInstruction_CoalesceToOne(t *testing.T) {
+	out := &session.PrepareOutput{}
+	if err := injectSkillsFor("grok", t.TempDir(), []skills.Skill{
+		{ID: "brainstorming", Name: "brainstorming", Description: "explore intent"},
+	}, out); err != nil {
+		t.Fatal(err)
+	}
+	if err := injectGlobalInstructionFor("grok", t.TempDir(), "HOUSE_STYLE", out); err != nil {
+		t.Fatal(err)
+	}
+	out.Args = coalesceRulesArgs(out.Args)
+
+	n := 0
+	for _, a := range out.Args {
+		if a == "--rules" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("grok must get exactly one --rules; got %d in %q", n, out.Args)
+	}
+	merged := out.Args[len(out.Args)-1]
+	if !strings.Contains(merged, "brainstorming") || !strings.Contains(merged, "HOUSE_STYLE") {
+		t.Errorf("merged --rules must carry both fragments; got %q", merged)
+	}
+}


### PR DESCRIPTION
Stacked on #522 (feat/global-instruction-injector) — review/merge that first.

## What

Makes grok a first-class skills provider: the vault skill index now auto-injects into a grok spawn's system prompt, like claude/antigravity/opencode already do.

## Why

Grok was the only skills-capable provider with **no injection path**: `providerSupportsSkills` excluded it and `injectSkillsFor` returned an error for it. Vault skills reached grok only if the agent ran `opendray skill list` by hand. (Verified live: a fresh grok session found the imported skills only after being told to run the CLI.)

## How

- Add `grok` to `providerSupportsSkills`.
- `injectSkillsFor` grok arm emits the index via `--rules` (no filesystem touch, no grok-home relocation — login and `trusted_folders` stay intact).
- Grok permits `--rules` **once**, and the global-instruction injector (#522) already emits one. A Resolve-level finalizer `coalesceRulesArgs` merges every grok `--rules` fragment into the single allowed slot. It's a no-op for any args with ≤1 `--rules`, so it never affects other providers.

## Size / ceiling

At the current 82-skill vault the combined grok `--rules` is ~36KB, ~3.5x under Linux's 128KB single-arg ceiling (`MAX_ARG_STRLEN`). Claude already passes the same index as one `--append-system-prompt` arg, so grok matches claude's existing constraint. If the vault ever grows past a few hundred skills, moving grok to a file surface (`GROK_HOME/AGENTS.md`) would remove the ceiling — deferred, not needed now.

## Tests

`internal/catalog`: `coalesceRulesArgs` (merge multiple, single-preserved, none-noop, dangling-dropped), `injectSkillsFor` grok arm, `providerSupportsSkills(grok)`, and the composed spawn scenario (skills + global instruction → exactly one `--rules` carrying both).

`go build ./...`, `go vet`, `gofmt` clean; full catalog suite green.