### PR TITLE
fix(install): make the root one-liner complete (Postgres gate + migrate HOME)

### DIFF
--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -657,8 +657,17 @@ log_ok "opendray.env: $OD_ENV_PATH (0640 root:$OPENDRAY_SERVICE_USER — secrets
 log_info "Applying migrations (idempotent)..."
 # Pass secrets via the wizard's shell env so opendray-as-service-user picks
 # them up. The actual service uses systemd's EnvironmentFile= once started.
+#
+# HOME must be the service user's data dir: run_priv_as_env uses `sudo -E` /
+# `runuser --preserve-environment`, which keeps the caller's HOME (/root when
+# the wizard runs as root). opendray then resolves its default backup keyfile
+# to $HOME/.opendray/secrets/backup.key — i.e. /root/… — which the opendray
+# user cannot read, so the pre-migrate snapshot fails with "backup key load:
+# permission denied" and migrate aborts. Pinning HOME to the data dir keeps
+# that lookup inside the service user's own, writable, home.
 OPENDRAY_DATABASE_URL="$OD_DSN" \
 OPENDRAY_ADMIN_PASSWORD="$OD_ADMIN_PW" \
+HOME="$OPENDRAY_DATA_DIR" \
     run_priv_as_env "$OPENDRAY_SERVICE_USER" "$OPENDRAY_PREFIX/bin/opendray" migrate -config "$OD_CONFIG_PATH"
 log_ok "Migrations applied"
 

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -330,16 +330,22 @@ if [ "$PG_MODE" = "local" ]; then
     fi
 
     log_info "Waiting for PostgreSQL to accept connections..."
+    # Must be run_priv_as (runuser/sudo -u), NOT `run_priv -u`: run_priv only
+    # escalates privilege, so as root `run_priv -u postgres pg_isready` executes
+    # the literal command `-u` and fails 127 every iteration — the readiness
+    # loop then always times out even when PostgreSQL is healthy. The one-liner
+    # is normally run as root (Proxmox LXC, fresh VPS), so this hit every root
+    # install. Use the same helper the DB bootstrap below already uses.
     PG_READY=0
     for _ in $(seq 1 30); do
-        if run_priv -u postgres pg_isready -q 2>/dev/null; then
+        if run_priv_as postgres pg_isready -q 2>/dev/null; then
             PG_READY=1
             break
         fi
         sleep 1
     done
     if [ "$PG_READY" = "0" ]; then
-        log_die "PostgreSQL did not start within 30s. Check 'journalctl -u postgresql' or '/var/log/postgresql/postgresql-16-main.log'."
+        log_die "PostgreSQL did not start within 30s. Check 'journalctl -u postgresql' or '/var/log/postgresql/postgresql-16-main.log' — a full disk during initdb ('No space left on device') is a common cause."
     fi
     log_ok "PostgreSQL 16 installed and accepting connections"
 


### PR DESCRIPTION
Two bugs that stopped the `curl | bash` installer from completing when run **as root** (the normal case on Proxmox LXC / fresh VPS). Both found by running the installer end-to-end in a root LXC; fixed and re-verified there.

## Bug 1 — Postgres readiness gate always fails as root
`install-linux.sh` used `run_priv -u postgres pg_isready -q`. `run_priv` only escalates privilege — as root it runs args verbatim, so this executes the literal command `-u` (exit 127) every iteration. The loop times out and the wizard dies with "PostgreSQL did not start within 30s" even when PG is healthy. **Fix:** use `run_priv_as postgres` (the helper the DB bootstrap already uses). Also names full-disk-during-initdb in the hint.

## Bug 2 — migrate runs with HOME=/root
Exposed once bug 1 was fixed. Migrate runs opendray as the service user via `run_priv_as_env` (`sudo -E` / `runuser --preserve-environment`), keeping the caller's HOME=/root. opendray then resolves its backup keyfile to `/root/.opendray/secrets/backup.key`, unreadable by the `opendray` user → "backup key load: permission denied" → migrate aborts. **Fix:** pin `HOME="$OPENDRAY_DATA_DIR"` for the migrate call.

macOS unaffected (direct `pg_isready` path).

## Verified (root LXC, Ubuntu 24.04) — installs to completion
`[✓] PostgreSQL accepting connections` → `[✓] Migrations applied` → `[✓] Service enabled and started` → `[✓] Health endpoint OK`; `systemctl is-active`=active, `/api/v1/health`=200.