### PR TITLE
feat(session): route Cortex spawn injections to grok via coalesced --rules

### DIFF
--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -864,6 +864,15 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 			}
 		}
 
+		// Grok permits --rules once per invocation. Each injection above
+		// (skills, memory guidance, ambient/project/knowledge banners,
+		// carryover, integration prompt) emits its own fragment; merge
+		// them into the single allowed slot as the final step, after
+		// every injector has run.
+		if providerID == "grok" {
+			out.Args = session.CoalesceRulesArgs(out.Args)
+		}
+
 		if len(out.Env) == 0 {
 			out.Env = nil
 		}
@@ -893,6 +902,11 @@ func integrationMCPAllowed(providerID string, accountBound bool) bool {
 //	         and adds it via --add-dir (agy's workspace-context
 //	         convention; verified it reads AGENTS.md from added dirs)
 //	         without touching the user's real ~/.gemini
+//	grok — `--rules <text>` flag, zero filesystem touch (no grok-home
+//	         relocation, so login / trusted_folders stay intact). Grok
+//	         permits --rules only once, so session.CoalesceRulesArgs merges the
+//	         skill index with every other grok --rules fragment into a
+//	         single slot at the end of Prepare.
 //
 // codex is intentionally NOT in the default list: it has no system-
 // prompt CLI flag, so the only path is `<CODEX_HOME>/instructions.md`,
@@ -904,7 +918,7 @@ func integrationMCPAllowed(providerID string, accountBound bool) bool {
 // Adding a new provider here requires a matching arm in injectSkillsFor.
 func providerSupportsSkills(id string) bool {
 	switch id {
-	case "claude", "antigravity", "opencode":
+	case "claude", "antigravity", "opencode", "grok":
 		return true
 	default:
 		return false
@@ -1026,6 +1040,11 @@ func injectSkillsFor(providerID, baseDir string, loaded []skills.Skill, out *ses
 		if err := os.WriteFile(agentsPath, body, 0o600); err != nil {
 			return fmt.Errorf("write %s: %w", agentsPath, err)
 		}
+		return nil
+	case "grok":
+		// --rules fragment; merged with the other grok fragments by the
+		// Resolve-level session.CoalesceRulesArgs finalizer.
+		out.Args = append(out.Args, "--rules", index)
 		return nil
 	case "antigravity":
 		// agy reads AGENTS.md from --add-dir'd workspace dirs.
@@ -1570,6 +1589,11 @@ func injectMemoryGuidanceFor(providerID, baseDir string, out *session.PrepareOut
 			return err
 		}
 		return ensureOpenCodeInstructions(baseDir, out)
+	case "grok":
+		// --rules fragment; merged with the other grok fragments by the
+		// Resolve-level session.CoalesceRulesArgs finalizer.
+		out.Args = append(out.Args, "--rules", memoryGuidanceText)
+		return nil
 	}
 	// Other providers: silently skip — they don't have an MCP
 	// surface yet so the memory MCP wouldn't be attached anyway.
@@ -1682,6 +1706,15 @@ func injectAmbientMemoryFor(providerID, baseDir, text string, out *session.Prepa
 			return err
 		}
 		return ensureOpenCodeInstructions(baseDir, out)
+	case "grok":
+		// Grok appends system-prompt text via --rules — no filesystem
+		// touch (no grok-home relocation; login and trusted_folders stay
+		// intact). Grok permits --rules at most once per invocation, so
+		// each injection emits its own fragment here and the
+		// Resolve-level finalizer session.CoalesceRulesArgs merges them into the
+		// single allowed slot.
+		out.Args = append(out.Args, "--rules", text)
+		return nil
 	}
 	return nil
 }

--- a/internal/catalog/inject_grok_cortex_test.go
+++ b/internal/catalog/inject_grok_cortex_test.go
@@ -1,0 +1,98 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/opendray/opendray-v2/internal/session"
+	"github.com/opendray/opendray-v2/internal/skills"
+)
+
+// Grok is the one provider with no file-based system-prompt surface: it
+// appends extra system-prompt text via --rules, which it permits at most
+// once per invocation. Every existing spawn injection (memory guidance,
+// ambient memory / project docs / knowledge banners, carryover,
+// integration boot prompt, skill index) therefore emits its own --rules
+// fragment, and session.CoalesceRulesArgs merges them into the single
+// slot grok allows — once at the end of Prepare, and once more in the
+// manager after caller args are appended. This is what makes grok a
+// first-class Cortex citizen — no separate content source needed.
+
+func TestInjectAmbientMemory_Grok(t *testing.T) {
+	out := &session.PrepareOutput{}
+	if err := injectAmbientMemoryFor("grok", t.TempDir(), "AMBIENT_BANNER", out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Args) != 2 || out.Args[0] != "--rules" || out.Args[1] != "AMBIENT_BANNER" {
+		t.Errorf("grok: want [--rules AMBIENT_BANNER], got %+v", out.Args)
+	}
+}
+
+func TestInjectMemoryGuidance_Grok(t *testing.T) {
+	out := &session.PrepareOutput{}
+	if err := injectMemoryGuidanceFor("grok", t.TempDir(), out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Args) != 2 || out.Args[0] != "--rules" || out.Args[1] != memoryGuidanceText {
+		t.Errorf("grok: want [--rules <guidance>], got %d args", len(out.Args))
+	}
+}
+
+func TestInjectSkillsFor_Grok(t *testing.T) {
+	out := &session.PrepareOutput{}
+	err := injectSkillsFor("grok", t.TempDir(), []skills.Skill{
+		{ID: "brainstorming", Name: "brainstorming", Description: "explore intent"},
+	}, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Args) != 2 || out.Args[0] != "--rules" {
+		t.Fatalf("grok: want [--rules <index>], got %q", out.Args)
+	}
+	if !strings.Contains(out.Args[1], "brainstorming") {
+		t.Errorf("grok: --rules value missing skill; got %q", out.Args[1])
+	}
+}
+
+func TestProviderSupportsSkills_Grok(t *testing.T) {
+	if !providerSupportsSkills("grok") {
+		t.Error("grok should support skills so the index auto-injects at spawn")
+	}
+}
+
+// The real spawn scenario: several independent Cortex injections each
+// emit a grok --rules fragment; the finalizer must leave exactly one
+// --rules carrying all of them, or grok fails to start with "--rules
+// cannot be used multiple times".
+func TestGrokCortexInjections_CoalesceToOne(t *testing.T) {
+	out := &session.PrepareOutput{}
+	base := t.TempDir()
+	if err := injectSkillsFor("grok", base, []skills.Skill{
+		{ID: "brainstorming", Name: "brainstorming", Description: "explore intent"},
+	}, out); err != nil {
+		t.Fatal(err)
+	}
+	if err := injectMemoryGuidanceFor("grok", base, out); err != nil {
+		t.Fatal(err)
+	}
+	if err := injectAmbientMemoryFor("grok", base, "KNOWLEDGE_BANNER", out); err != nil {
+		t.Fatal(err)
+	}
+	out.Args = session.CoalesceRulesArgs(out.Args)
+
+	n := 0
+	for _, a := range out.Args {
+		if a == "--rules" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("grok must get exactly one --rules; got %d in %d args", n, len(out.Args))
+	}
+	merged := out.Args[len(out.Args)-1]
+	for _, frag := range []string{"brainstorming", memoryGuidanceText, "KNOWLEDGE_BANNER"} {
+		if !strings.Contains(merged, frag) {
+			t.Errorf("merged --rules missing fragment %q", frag[:min(len(frag), 30)])
+		}
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -779,9 +779,7 @@ func (m *Manager) spawn(ctx context.Context, sess Session, reactivate bool) (*ru
 	// vs --ask-for-approval) fail to spawn.
 	providerArgs := dropOverriddenFlags(p.Args, userArgs)
 	providerArgs = dropConflictingFlags(providerArgs, userArgs, p.Conflicts)
-	args := append([]string(nil), providerArgs...)
-	args = append(args, extraArgs...)
-	args = append(args, userArgs...)
+	args := finalizeSpawnArgs(p.ID, providerArgs, extraArgs, userArgs)
 
 	cmd := exec.Command(p.Executable, args...)
 	cmd.Dir = sess.Cwd
@@ -1611,10 +1609,28 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 var injectionValueFlags = map[string]bool{
 	"--mcp-config":           true, // claude
 	"--append-system-prompt": true, // claude
+	"--rules":                true, // grok
 }
 var injectionBoolFlags = map[string]bool{
 	"--dangerously-skip-permissions":             true, // claude / antigravity
 	"--dangerously-bypass-approvals-and-sandbox": true, // codex
+}
+
+// finalizeSpawnArgs assembles the final exec arg list: provider-config
+// args, then the Prepare output's injection args, then the caller's raw
+// args. For grok the merged list gets one last CoalesceRulesArgs pass —
+// grok permits --rules at most once per invocation, and the Prepare-level
+// coalesce cannot see userArgs (they are appended after Prepare runs), so
+// a caller-supplied --rules would otherwise reintroduce the duplicate and
+// fail the spawn. The pass is a no-op for well-formed non-grok arg lists.
+func finalizeSpawnArgs(providerID string, providerArgs, extraArgs, userArgs []string) []string {
+	args := append([]string(nil), providerArgs...)
+	args = append(args, extraArgs...)
+	args = append(args, userArgs...)
+	if providerID == "grok" {
+		args = CoalesceRulesArgs(args)
+	}
+	return args
 }
 
 // stripInjectionFlags returns args with the spawn-profile-owned injection

--- a/internal/session/rules_args.go
+++ b/internal/session/rules_args.go
@@ -1,0 +1,57 @@
+package session
+
+import "strings"
+
+// CoalesceRulesArgs merges every "--rules <value>" pair in args into a
+// single --rules holding all values joined by a separator. Grok rejects
+// a repeated --rules ("cannot be used multiple times"), but several
+// independent spawn injections (memory guidance, ambient/project/
+// knowledge banners, skill index, integration prompt, carryover) each
+// emit their own fragment, and a caller may pass one more in the
+// request args. The merged flag takes the position of the first
+// --rules.
+//
+// A --rules whose next token starts with "--" (or with none at all) is
+// treated as having no value and is dropped — injector-emitted values
+// are always prose, never flag-shaped, and consuming a following flag
+// as a value would corrupt the command line. Args with zero or one
+// well-formed --rules (and no valueless flag) are returned unchanged,
+// so this is a safe no-op for every non-grok provider.
+func CoalesceRulesArgs(args []string) []string {
+	wellFormed := func(i int) bool {
+		return i+1 < len(args) && !strings.HasPrefix(args[i+1], "--")
+	}
+	var values []string
+	valueless := false
+	for i := 0; i < len(args); i++ {
+		if args[i] != "--rules" {
+			continue
+		}
+		if wellFormed(i) {
+			values = append(values, args[i+1])
+			i++
+		} else {
+			valueless = true
+		}
+	}
+	if len(values) <= 1 && !valueless {
+		return args
+	}
+	merged := strings.Join(values, "\n\n---\n\n")
+	out := make([]string, 0, len(args))
+	placed := false
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--rules" {
+			if wellFormed(i) {
+				i++ // consume the value token
+			}
+			if !placed && len(values) > 0 {
+				out = append(out, "--rules", merged)
+				placed = true
+			}
+			continue
+		}
+		out = append(out, args[i])
+	}
+	return out
+}

--- a/internal/session/rules_args_test.go
+++ b/internal/session/rules_args_test.go
@@ -1,0 +1,95 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+// Grok accepts --rules at most once per invocation. Several independent
+// spawn injections each emit a fragment, and a caller may pass one more
+// in the request args; CoalesceRulesArgs merges them into the single
+// slot grok allows so the spawn doesn't fail with "--rules cannot be
+// used multiple times".
+
+func TestCoalesceRulesArgs_MergesMultiple(t *testing.T) {
+	in := []string{"--model", "grok-build", "--rules", "SKILLS", "--foo", "--rules", "GUIDANCE"}
+	got := CoalesceRulesArgs(in)
+	want := []string{"--model", "grok-build", "--rules", "SKILLS\n\n---\n\nGUIDANCE", "--foo"}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Errorf("merge wrong:\n got  %q\n want %q", got, want)
+	}
+}
+
+func TestCoalesceRulesArgs_SinglePreserved(t *testing.T) {
+	in := []string{"--rules", "ONLY"}
+	got := CoalesceRulesArgs(in)
+	if len(got) != 2 || got[0] != "--rules" || got[1] != "ONLY" {
+		t.Errorf("single --rules should be untouched; got %q", got)
+	}
+}
+
+func TestCoalesceRulesArgs_NoneNoop(t *testing.T) {
+	in := []string{"--model", "grok-build", "--foo"}
+	got := CoalesceRulesArgs(in)
+	if strings.Join(got, "\x00") != strings.Join(in, "\x00") {
+		t.Errorf("no --rules should be a no-op; got %q", got)
+	}
+}
+
+func TestCoalesceRulesArgs_TrailingFlagNoValueDropped(t *testing.T) {
+	in := []string{"--rules", "A", "--rules"} // malformed trailing flag, no value
+	got := CoalesceRulesArgs(in)
+	if len(got) != 2 || got[0] != "--rules" || got[1] != "A" {
+		t.Errorf("dangling --rules should be dropped, value kept; got %q", got)
+	}
+}
+
+func TestCoalesceRulesArgs_DoesNotEatFollowingFlag(t *testing.T) {
+	// A bare --rules adjacent to another flag must not consume that flag
+	// as its value.
+	in := []string{"--rules", "--model", "grok-build", "--rules", "REAL"}
+	got := CoalesceRulesArgs(in)
+	want := []string{"--rules", "REAL", "--model", "grok-build"}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Errorf("adjacent flag eaten:\n got  %q\n want %q", got, want)
+	}
+}
+
+func TestFinalizeSpawnArgs_GrokCallerRulesMergedIntoOne(t *testing.T) {
+	// The Prepare-level coalesce cannot see userArgs; the finalizer must
+	// still guarantee exactly one --rules on the assembled command line.
+	provider := []string{"--model", "grok-build"}
+	extra := []string{"--rules", "INJECTED"} // already coalesced by Prepare
+	user := []string{"--rules", "CALLER"}
+	got := finalizeSpawnArgs("grok", provider, extra, user)
+
+	n := 0
+	for _, a := range got {
+		if a == "--rules" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("grok must get exactly one --rules; got %d in %q", n, got)
+	}
+	merged := ""
+	for i, a := range got {
+		if a == "--rules" {
+			merged = got[i+1]
+		}
+	}
+	if !strings.Contains(merged, "INJECTED") || !strings.Contains(merged, "CALLER") {
+		t.Errorf("merged --rules must carry both fragments; got %q", merged)
+	}
+}
+
+func TestFinalizeSpawnArgs_NonGrokUntouched(t *testing.T) {
+	provider := []string{"--model", "opus"}
+	extra := []string{"--append-system-prompt", "A", "--append-system-prompt", "B"}
+	user := []string{"--resume", "abc"}
+	got := finalizeSpawnArgs("claude", provider, extra, user)
+	want := []string{"--model", "opus", "--append-system-prompt", "A", "--append-system-prompt", "B", "--resume", "abc"}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Errorf("non-grok args must pass through verbatim:\n got  %q\n want %q", got, want)
+	}
+}

--- a/internal/session/strip_injection_flags_test.go
+++ b/internal/session/strip_injection_flags_test.go
@@ -34,6 +34,11 @@ func TestStripInjectionFlags(t *testing.T) {
 			[]string{"--model", "opus"},
 		},
 		{
+			"grok --rules dropped in both forms",
+			[]string{"--rules", "be evil", "--rules=be brief", "--model", "grok-build"},
+			[]string{"--model", "grok-build"},
+		},
+		{
 			"mixed: strips injection, keeps the rest",
 			[]string{"--mcp-config", "/c.json", "--resume", "abc", "--dangerously-skip-permissions", "--append-system-prompt", "hi"},
 			[]string{"--resume", "abc"},

--- a/internal/store/migrations/0093_kb_integrations_grok_rules.sql
+++ b/internal/store/migrations/0093_kb_integrations_grok_rules.sql
@@ -1,3 +1,28 @@
+-- 0093 — kb_integrations refresh: re-seed the Third-Party Integration
+-- Guide after grok gained a real spawn-injection surface. Previously the
+-- per-CLI system-prompt dispatch (injectAmbientMemoryFor and friends)
+-- had no grok arm, so an integration pointed at grok silently never
+-- received its spawn-profile `system_prompt`. Grok now takes every
+-- system-prompt fragment through its `--rules` flag, coalesced into the
+-- single occurrence grok permits per invocation; the guide gains a
+-- "Grok specifics" paragraph (MCP via project-scoped .grok/config.toml,
+-- system prompt via coalesced --rules, no unattended-permissions flag).
+--
+-- Why a new migration instead of editing 0076: the runner records
+-- applied versions by filename and never re-applies one, so the live KB
+-- page stays frozen at 0076's text on every DB that already ran it.
+-- This migration force-updates the page content (DO UPDATE), keeping
+-- updated_by='operator' so the AI KB drafter treats it as human-locked.
+--
+-- Source of truth for the prose: docs/integrations/INTEGRATION_GUIDE.md.
+-- Keep them in sync (see the guide's "Versioning" section).
+
+INSERT INTO project_docs (id, cwd, kind, content, updated_by, updated_at)
+VALUES (
+    'doc_global_kb_integrations',
+    '__global__',
+    'kb_integrations',
+    $ODGUIDE$
 # opendray Third-Party Integration Guide
 
 This is the canonical, forward-looking contract that **every** third-party app or website MUST follow to integrate with opendray. opendray is a self-hosted gateway that drives AI coding CLIs (Claude Code, Codex, OpenCode, antigravity) over a PTY behind a unified REST + WebSocket API. A third-party app integrates by being **registered by an operator** (admin-only), receiving a **one-time scoped API key**, and then spawning and driving agent sessions over REST while optionally proxying its own UI and subscribing to a live event stream. This document states the rules as explicit **MUST / SHOULD / NEVER**, documents the current reality honestly (including what is *not* enforced yet), and gives you a runnable end-to-end path.
@@ -869,3 +894,11 @@ This guide describes the opendray `/api/v1` integration contract as of **opendra
 - **Roadmap:** per-route scope enforcement for the still-unenforced `session:*` / `channel:*` / `provider:read`. Design your client now to handle `403` on any endpoint without breaking.
 
 When the code changes (new enforced scopes, spawn-profile fields, memory-zone semantics, or any endpoint addition), this guide MUST be updated in lockstep and re-seeded into the `kb_integrations` knowledge page (add a new `project_docs` upsert migration — the original seed migration is immutable once applied).
+$ODGUIDE$,
+    'operator',
+    NOW()
+)
+ON CONFLICT (cwd, kind) DO UPDATE
+    SET content    = EXCLUDED.content,
+        updated_by = EXCLUDED.updated_by,
+        updated_at = EXCLUDED.updated_at;


### PR DESCRIPTION
## What

Makes grok a first-class Cortex citizen using the **existing** injection mechanisms — no new config, no parallel content source. Every spawn injection that already reaches the other providers now reaches grok too:

| Injection | Before (grok) | After (grok) |
|---|---|---|
| Memory guidance ("use opendray memory") | silently skipped | `--rules` fragment |
| Ambient memory banner | silently skipped | `--rules` fragment |
| Project docs banner (objective, docs index) | silently skipped | `--rules` fragment |
| Cortex knowledge banner (foundational KB rules) | silently skipped | `--rules` fragment |
| Carryover recap | silently skipped | `--rules` fragment |
| **Integration boot `system_prompt`** | **silently dropped** | `--rules` fragment |
| Skill index | not injected (`providerSupportsSkills` excluded grok) | `--rules` fragment |

## Why

Grok has the memory MCP tools attached (manifest `supportsMcp: true`, project-scoped `.grok/config.toml` renderer), but the per-CLI system-prompt dispatch (`injectAmbientMemoryFor` / `injectMemoryGuidanceFor`) had no grok arm — so grok sessions had the tools with no instruction to use them, received none of the operator's KB rules, and a grok-backed integration never saw its own boot system prompt.

This supersedes #522/#523: rather than adding a separate `global_instructions_file` content source, the operator's decision is to keep Cortex as the single source of instruction content and fix the delivery gap generically. The `--rules` channel and the coalescing approach originate from @navidrast's work on those PRs — credited as co-author.

## How

- `injectAmbientMemoryFor` gains a grok arm emitting `--rules <text>` (zero filesystem touch — no grok-home relocation, login/trusted_folders intact). This single arm covers ambient/project-doc/knowledge banners, carryover, and the integration prompt, since they all delegate to it. `injectMemoryGuidanceFor` and `injectSkillsFor` gain matching arms; `providerSupportsSkills` adds grok.
- Grok permits `--rules` **at most once** per invocation. `session.CoalesceRulesArgs` merges every fragment into the single allowed slot, joined by `\n\n---\n\n`. It runs twice: at the end of `Prepare` (catalog), and again in the manager's new `finalizeSpawnArgs` over the complete `providerArgs ++ extraArgs ++ userArgs` list — the Prepare-level pass cannot see `userArgs`, so a caller-supplied `--rules` would otherwise reintroduce the duplicate and fail the spawn. No-op for well-formed non-grok arg lists.
- `--rules` joins `injectionValueFlags`, so integration-origin requests cannot hand-build it into `args` (same policy as `--append-system-prompt`).
- `CoalesceRulesArgs` never consumes a following flag as a value (a `--rules` whose next token starts with `--` is treated as valueless and dropped), matching the existing strip helpers' convention.
- Docs: INTEGRATION_GUIDE.md gains a **Grok specifics** paragraph (MCP via project-scoped `.grok/config.toml`, system prompt via coalesced `--rules`, no unattended-permissions flag) and lists `--rules` in both hand-built-flags enumerations. Migration **0093** re-seeds the `kb_integrations` page with the updated guide (precedent: 0071/0076).

## Size note

The coalesced `--rules` carries what claude already receives across multiple `--append-system-prompt` args (skill index ~36KB at the current vault + 4KB knowledge budget + banners), well under the 128KB single-arg ceiling. If the vault grows past a few hundred skills, a file surface would remove the ceiling — deferred.

## Tests

- `internal/session`: `CoalesceRulesArgs` (merge multiple / single preserved / none no-op / dangling dropped / does-not-eat-following-flag), `finalizeSpawnArgs` (grok caller-`--rules` merges into one; non-grok untouched), `stripInjectionFlags` `--rules` case in both forms.
- `internal/catalog`: grok arms of skills/guidance/ambient injection, `providerSupportsSkills(grok)`, and the composed spawn scenario (skills + guidance + banner → exactly one `--rules` carrying all fragments).
- Migration 0093 validated on an ephemeral PostgreSQL 17 (insert and conflict-update paths); embedded text verified byte-identical to the guide file.
- `go build ./...`, `go vet ./...`, `gofmt` clean; full `go test ./...` green.

## Test plan (local)

1. Compile + restart (runs migration 0093).
2. Spawn a grok session in a project with memories/KB content → ask the agent what its instructions say about memory and project context; it should reference opendray memory guidance, the knowledge banner, and the skill index (`opendray skill describe` should work unprompted).
3. Verify exactly one `--rules` in the spawned grok command line (ps or session args view).
4. Spawn a grok-backed integration session → its boot `system_prompt` should now be in effect.
5. Regression: claude/codex/antigravity/opencode sessions unchanged.

Supersedes #522 and #523.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
