### PR TITLE
feat(grok): live account switch (RFC #532 P2)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -687,6 +687,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		// Same fast-fail validation for PATCH
 		// /sessions/{id}/antigravity-account.
 		session.WithAntigravityAccountChecker(agyacctSvc),
+		session.WithGrokAccountChecker(grokacctSvc),
 		// Fill provider/model/claude-account from the integration's
 		// configured defaults for sessions an integration creates and
 		// the request leaves those fields empty (request still wins).

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -47,6 +47,7 @@ import (
 	gitapi "github.com/opendray/opendray-v2/internal/git"
 	"github.com/opendray/opendray-v2/internal/gitactivity"
 	githost "github.com/opendray/opendray-v2/internal/githost"
+	"github.com/opendray/opendray-v2/internal/grokacct"
 	"github.com/opendray/opendray-v2/internal/integration"
 	"github.com/opendray/opendray-v2/internal/keepawake"
 	"github.com/opendray/opendray-v2/internal/knowledge"
@@ -558,6 +559,11 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	agyacctSvc := agyacct.NewService(st.Pool(), bus, log)
 	agyacctHandlers := agyacct.NewHandlers(agyacctSvc, log)
 
+	// Grok multi-account (parallel to agyacct; accounts surfaced via the
+	// "Import local" scan). Each account is a dedicated GROK_HOME.
+	grokacctSvc := grokacct.NewService(st.Pool(), bus, log)
+	grokacctHandlers := grokacct.NewHandlers(grokacctSvc, log)
+
 	// Every on-disk root comes from one resolver (internal/config/
 	// paths.go) so the gateway and the `opendray notes|skill|mcp`
 	// commands can never disagree about where things live.
@@ -644,6 +650,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		session.WithAntigravityAccountResolver(agyacctSvc),
 	)
 	sessionProvider := catalog.NewSessionProvider(cat, cliacctSvc, agyacctSvc, skillsLoader, mcpLoader, secretsFile, log)
+	sessionProvider.WithGrokAccounts(grokacctSvc) // grok multi-account: bind GROK_HOME at spawn
 	// Built before the session manager so spawn can inject an
 	// integration's provider-agnostic spawn profile (MCP servers + system
 	// prompt + auto-approve) into the sessions it creates, and so POST
@@ -1567,6 +1574,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 				catalogHandlers.Mount(r)
 				cliacctHandlers.Mount(r)
 				agyacctHandlers.Mount(r)
+				grokacctHandlers.Mount(r)
 				channelHandlers.Mount(r)
 				memoryHandlers.Mount(r)
 				projectDocHandlers.Mount(r)

--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/opendray/opendray-v2/internal/agyacct"
 	"github.com/opendray/opendray-v2/internal/cliacct"
+	"github.com/opendray/opendray-v2/internal/grokacct"
 	"github.com/opendray/opendray-v2/internal/mcp"
 	"github.com/opendray/opendray-v2/internal/session"
 	"github.com/opendray/opendray-v2/internal/skills"
@@ -52,10 +53,17 @@ type SessionProvider struct {
 	cat         *Catalog
 	accounts    *cliacct.Service // optional; nil disables claude multi-account
 	agyAccounts *agyacct.Service // optional; nil disables antigravity multi-account
-	skills      *skills.Loader   // optional; nil disables skill injection
-	mcps        *mcp.Loader      // optional; nil disables vault MCP injection
-	secretsFile string           // dotenv file for ${KEY} substitution; empty = no substitution
-	log         *slog.Logger
+
+	// grokAccounts, when set, enables grok multi-account: a session bound
+	// to a grok account spawns `grok` with GROK_HOME pointed at that
+	// account's dir. Nil disables grok multi-account. Set via
+	// WithGrokAccounts (option, not a constructor arg, to avoid churning
+	// every NewSessionProvider call site).
+	grokAccounts *grokacct.Service
+	skills       *skills.Loader // optional; nil disables skill injection
+	mcps         *mcp.Loader    // optional; nil disables vault MCP injection
+	secretsFile  string         // dotenv file for ${KEY} substitution; empty = no substitution
+	log          *slog.Logger
 
 	// memory describes the auto-attached memory MCP server. Zero
 	// value (Enabled=false) skips injection. Set via
@@ -232,6 +240,14 @@ func (sp *SessionProvider) WithMemoryAutoAttach(cfg MemoryAutoAttach) *SessionPr
 	return sp
 }
 
+// WithGrokAccounts installs the grok multi-account service. When set, a
+// session bound to a grok account spawns `grok` with GROK_HOME pointed at
+// that account's dir. Nil (the default) disables grok multi-account.
+func (sp *SessionProvider) WithGrokAccounts(svc *grokacct.Service) *SessionProvider {
+	sp.grokAccounts = svc
+	return sp
+}
+
 // DbtoolAutoAttach holds the runtime knobs for injecting the
 // Database-tool MCP server (`opendray mcp-dbtool`) into spawned
 // sessions. Field semantics mirror MemoryAutoAttach; the key is a
@@ -404,6 +420,9 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 	selectedAccountID := session.AccountID(ctx)
 	wantClaudeAccount := id == "claude" && selectedAccountID != "" && sp.accounts != nil
 	wantAgyAccount := id == "antigravity" && selectedAccountID != "" && sp.agyAccounts != nil
+	// grok isolates via GROK_HOME (grok keys its state off that dir);
+	// unlike agy this relocates only grok's state, not the whole HOME.
+	wantGrokAccount := id == "grok" && selectedAccountID != "" && sp.grokAccounts != nil
 
 	// Merge vault MCP registry (enabled-only) into the provider's
 	// inline mcp_servers list. Vault entries are loaded eagerly here
@@ -523,7 +542,7 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 	// no-Prepare fast path even when nothing else needs one.
 	hasIntegrationPrompt := session.IntegrationSystemPromptFromContext(ctx) != ""
 
-	if !wantClaudeAccount && !wantAgyAccount && !mcpEnabled && !skillsEnabled && len(configEnv) == 0 && !wantsOpenCodeConfig && !hasIntegrationPrompt {
+	if !wantClaudeAccount && !wantAgyAccount && !wantGrokAccount && !mcpEnabled && !skillsEnabled && len(configEnv) == 0 && !wantsOpenCodeConfig && !hasIntegrationPrompt {
 		return info, nil
 	}
 
@@ -600,6 +619,19 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 				sp.log.Warn("antigravity shared-cache symlink failed",
 					"home", home, "err", err)
 			}
+		}
+
+		if wantGrokAccount {
+			// grok keys its credential + config state off GROK_HOME
+			// (auth.json, config.toml, trusted_folders.toml). Binding to
+			// an account = pointing GROK_HOME at the account's dedicated
+			// dir. Unlike agy this relocates ONLY grok's state, never the
+			// whole HOME, so other tools sharing HOME are untouched.
+			home, err := sp.grokAccounts.ResolveSpawnHome(prepareCtx, selectedAccountID)
+			if err != nil {
+				return session.PrepareOutput{}, fmt.Errorf("grok account %s: %w", selectedAccountID, err)
+			}
+			out.Env["GROK_HOME"] = home
 		}
 
 		// Tier 1 skill index injected per-provider. The agent sees a

--- a/internal/grokacct/discover.go
+++ b/internal/grokacct/discover.go
@@ -1,0 +1,120 @@
+package grokacct
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// accountHasCredentials reports whether a GROK_HOME dir holds a logged-in
+// grok login token (<GROK_HOME>/auth.json, non-empty regular file).
+func accountHasCredentials(home string) bool {
+	if home == "" {
+		return false
+	}
+	return fileExists(filepath.Join(home, grokAuthRelPath))
+}
+
+// fileExists reports whether path exists and is a non-empty regular file.
+// Uses Lstat so symlinks return false — defense in depth against an
+// attacker who can write under the accounts dir.
+func fileExists(path string) bool {
+	st, err := os.Lstat(path)
+	if err != nil {
+		return false
+	}
+	return st.Mode().IsRegular() && st.Size() > 0
+}
+
+// defaultGrokHome returns the gateway user's own grok home: GROK_HOME when
+// set, else ~/.grok. Empty only when neither GROK_HOME nor HOME is set.
+func defaultGrokHome() string {
+	if v := os.Getenv("GROK_HOME"); v != "" {
+		return v
+	}
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".grok")
+}
+
+// selectSpawnHome is the pure-filesystem half of ResolveSpawnHome: given an
+// account's name + GROK_HOME dir it validates the dir is set and holds a
+// logged-in grok token, returning the GROK_HOME to inject or a
+// guided-login error. No DB access, so it's unit-testable without a store
+// (mirrors agyacct's selectSpawnHome / cliacct's selectSpawnCreds).
+func selectSpawnHome(name, home string) (string, error) {
+	if home == "" {
+		return "", fmt.Errorf("grok account %q has no GROK_HOME directory configured", name)
+	}
+	if !accountHasCredentials(home) {
+		return "", fmt.Errorf(
+			"grok account %q is not logged in: no %s under %s — run `GROK_HOME=%s grok login` on the host and complete the xAI sign-in",
+			name, grokAuthRelPath, home, home)
+	}
+	return home, nil
+}
+
+// discoveredAccount is one local account candidate found on disk.
+type discoveredAccount struct {
+	name        string
+	displayName string
+	configDir   string // explicit when non-empty; otherwise Create derives
+}
+
+// discoverLocalAccounts returns every grok account that should be surfaced
+// in the panel, in discovery order. Two sources:
+//
+//  1. the gateway user's own grok home (GROK_HOME or ~/.grok) — the
+//     primary `grok login`, used when no grok_account_id is pinned to a
+//     session. Yielded as a synthetic "default" entry, only when its
+//     login token actually exists.
+//  2. <accountsDir>/<name>/ — a per-account GROK_HOME created via
+//     `GROK_HOME=<dir> grok login`. Only dirs that already contain the
+//     login token are emitted (a half-set-up dir isn't a usable account).
+//
+// Symlinks are rejected at every step; a missing dir is not an error.
+func discoverLocalAccounts(accountsDir string) ([]discoveredAccount, error) {
+	var out []discoveredAccount
+	seen := map[string]bool{}
+	emit := func(d discoveredAccount) {
+		if d.name == "" || seen[d.name] {
+			return
+		}
+		seen[d.name] = true
+		out = append(out, d)
+	}
+
+	// 1) Synthetic "default" — the gateway user's own grok home.
+	if home := defaultGrokHome(); home != "" && accountHasCredentials(home) {
+		emit(discoveredAccount{
+			name:        "default",
+			displayName: "Default (~/.grok)",
+			configDir:   home,
+		})
+	}
+
+	// 2) Per-account GROK_HOMEs under accountsDir.
+	dirEntries, err := os.ReadDir(accountsDir)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("read %s: %w", accountsDir, err)
+	}
+	for _, e := range dirEntries {
+		if !e.IsDir() {
+			continue
+		}
+		// Reject symlinked account dirs so a malicious symlink can't feed
+		// an arbitrary GROK_HOME to a spawn.
+		if e.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		dir := filepath.Join(accountsDir, e.Name())
+		if !accountHasCredentials(dir) {
+			continue // not a logged-in grok home
+		}
+		emit(discoveredAccount{name: e.Name(), configDir: dir})
+	}
+	return out, nil
+}

--- a/internal/grokacct/discover_test.go
+++ b/internal/grokacct/discover_test.go
@@ -1,0 +1,127 @@
+package grokacct
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeGrokToken creates a logged-in grok GROK_HOME at home: grok writes
+// its xAI credentials to <GROK_HOME>/auth.json on `grok login`.
+func writeGrokToken(t *testing.T, home string) {
+	t.Helper()
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, grokAuthRelPath), []byte("{\"token\":\"x\"}"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+}
+
+func TestAccountHasCredentials(t *testing.T) {
+	home := t.TempDir()
+	if accountHasCredentials(home) {
+		t.Fatal("empty GROK_HOME should have no credentials")
+	}
+	writeGrokToken(t, home)
+	if !accountHasCredentials(home) {
+		t.Fatal("GROK_HOME with auth.json should report credentials present")
+	}
+	if accountHasCredentials("") {
+		t.Fatal("empty path must be false")
+	}
+
+	// A zero-byte auth.json is not "logged in".
+	empty := t.TempDir()
+	if err := os.WriteFile(filepath.Join(empty, grokAuthRelPath), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if accountHasCredentials(empty) {
+		t.Fatal("zero-byte auth.json must not count as logged in")
+	}
+}
+
+func TestSelectSpawnHome(t *testing.T) {
+	// No configured home → error naming the account.
+	if _, err := selectSpawnHome("work", ""); err == nil {
+		t.Fatal("empty home should error")
+	} else if !strings.Contains(err.Error(), "work") {
+		t.Errorf("error should name the account; got %v", err)
+	}
+
+	// Home set but not logged in → guided-login error mentioning grok login.
+	notLoggedIn := t.TempDir()
+	_, err := selectSpawnHome("work", notLoggedIn)
+	if err == nil {
+		t.Fatal("home without auth.json should error")
+	}
+	if !strings.Contains(err.Error(), "grok login") || !strings.Contains(err.Error(), "GROK_HOME") {
+		t.Errorf("error should guide GROK_HOME=... grok login; got %v", err)
+	}
+
+	// Logged-in home → returns the home to inject.
+	ok := t.TempDir()
+	writeGrokToken(t, ok)
+	got, err := selectSpawnHome("work", ok)
+	if err != nil {
+		t.Fatalf("logged-in home should succeed: %v", err)
+	}
+	if got != ok {
+		t.Errorf("want home %q, got %q", ok, got)
+	}
+}
+
+func TestDiscoverLocalAccounts(t *testing.T) {
+	// Point HOME at a dir with no grok home and clear GROK_HOME so the
+	// synthetic "default" entry is not emitted — keeps this test
+	// independent of the real host.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GROK_HOME", "")
+
+	accountsDir := t.TempDir()
+	// work: logged in → discovered. half: dir exists but no token → skipped.
+	writeGrokToken(t, filepath.Join(accountsDir, "work"))
+	if err := os.MkdirAll(filepath.Join(accountsDir, "half"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := discoverLocalAccounts(accountsDir)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	names := map[string]bool{}
+	for _, d := range got {
+		names[d.name] = true
+	}
+	if !names["work"] {
+		t.Errorf("logged-in account 'work' should be discovered; got %+v", got)
+	}
+	if names["half"] {
+		t.Errorf("half-set-up account 'half' (no auth.json) must be skipped; got %+v", got)
+	}
+}
+
+func TestDiscoverLocalAccounts_DefaultFromGrokHome(t *testing.T) {
+	// When the gateway user's own GROK_HOME (or ~/.grok) is logged in, a
+	// synthetic "default" account is surfaced. Use GROK_HOME to avoid
+	// touching the real ~/.grok.
+	gh := t.TempDir()
+	writeGrokToken(t, gh)
+	t.Setenv("GROK_HOME", gh)
+	t.Setenv("HOME", t.TempDir())
+
+	got, err := discoverLocalAccounts(t.TempDir())
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	var haveDefault bool
+	for _, d := range got {
+		if d.name == "default" {
+			haveDefault = true
+		}
+	}
+	if !haveDefault {
+		t.Errorf("logged-in GROK_HOME should surface a 'default' account; got %+v", got)
+	}
+}

--- a/internal/grokacct/grokacct.go
+++ b/internal/grokacct/grokacct.go
@@ -1,0 +1,84 @@
+// Package grokacct manages multi-account binding for the Grok Build CLI
+// (`grok`). Like Antigravity (agyacct), grok keys its credential + config
+// state off a home directory — but grok has its own GROK_HOME env var, so
+// opendray relocates ONLY grok's state (auth.json, config.toml,
+// trusted_folders.toml, sessions/), never the whole $HOME. An "account"
+// is a dedicated GROK_HOME holding its own xAI login token at
+// <GROK_HOME>/auth.json; binding a session to an account means spawning
+// `grok` with GROK_HOME pointed at that directory.
+//
+// Account rows hold metadata only (name, display name, the GROK_HOME dir).
+// The login token lives on disk under <GROK_HOME>/auth.json and is created
+// out-of-band by running `GROK_HOME=<dir> grok login` once. This package
+// NEVER writes tokens — it only discovers account dirs and points spawns
+// at them.
+package grokacct
+
+import (
+	"errors"
+	"time"
+)
+
+// grokAuthRelPath is the login-token location relative to an account's
+// GROK_HOME, as written by `grok login`. Used to tell whether an account
+// dir is actually logged in.
+const grokAuthRelPath = "auth.json"
+
+// Account describes one Grok account known to the gateway. The login
+// token is intentionally NOT stored in the database — it lives at
+// <ConfigDir>/auth.json where `grok` reads and refreshes it.
+//
+// ConfigDir is the per-account GROK_HOME directory. The field is named to
+// mirror cliacct.Account / agyacct.Account so the web API client + the
+// shared AccountSwitcher component render every provider without
+// special-casing JSON field names (config_dir / token_filled mean the
+// analogous thing).
+type Account struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	DisplayName string    `json:"display_name"`
+	ConfigDir   string    `json:"config_dir"` // per-account GROK_HOME directory
+	Description string    `json:"description"`
+	Enabled     bool      `json:"enabled"`
+	TokenFilled bool      `json:"token_filled"` // login token present under GROK_HOME
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+
+	// Derived fields below are computed on each read, never persisted.
+
+	// LastUsedAt is MAX(sessions.started_at) where grok_account_id
+	// matches; nil when this account has never been pinned to a session.
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+	// ActiveSessions counts non-terminal sessions pinned to this account.
+	ActiveSessions int `json:"active_sessions"`
+}
+
+// CreateRequest is the body for POST /api/v1/grok-accounts.
+//
+// ConfigDir (the account GROK_HOME) is optional; when omitted it is
+// derived as <accountsDir>/<name>. The directory and its login token are
+// created out-of-band via `GROK_HOME=<dir> grok login` — Create only
+// records the metadata row.
+type CreateRequest struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name,omitempty"`
+	ConfigDir   string `json:"config_dir,omitempty"`
+	Description string `json:"description,omitempty"`
+	Enabled     *bool  `json:"enabled,omitempty"`
+}
+
+// UpdateRequest is the body for PUT /api/v1/grok-accounts/{id}. Pointer
+// fields preserve "leave alone" vs "set to empty" semantics.
+type UpdateRequest struct {
+	Name        *string `json:"name,omitempty"`
+	DisplayName *string `json:"display_name,omitempty"`
+	ConfigDir   *string `json:"config_dir,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Enabled     *bool   `json:"enabled,omitempty"`
+}
+
+var (
+	ErrNotFound  = errors.New("grok account not found")
+	ErrDuplicate = errors.New("grok account name already exists")
+	ErrDisabled  = errors.New("grok account is disabled")
+)

--- a/internal/grokacct/handler.go
+++ b/internal/grokacct/handler.go
@@ -1,0 +1,145 @@
+package grokacct
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type Handlers struct {
+	svc *Service
+	log *slog.Logger
+}
+
+func NewHandlers(svc *Service, log *slog.Logger) *Handlers {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Handlers{svc: svc, log: log.With("component", "grokacct.http")}
+}
+
+func (h *Handlers) Mount(r chi.Router) {
+	r.Route("/grok-accounts", func(r chi.Router) {
+		r.Get("/", h.list)
+		r.Post("/", h.create)
+		r.Post("/import-local", h.importLocal)
+		r.Route("/{id}", func(r chi.Router) {
+			r.Get("/", h.get)
+			r.Put("/", h.update)
+			r.Patch("/toggle", h.toggle)
+			r.Delete("/", h.del)
+		})
+	})
+}
+
+func (h *Handlers) list(w http.ResponseWriter, r *http.Request) {
+	accs, err := h.svc.List(r.Context())
+	if err != nil {
+		h.respondError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"accounts": accs})
+}
+
+func (h *Handlers) get(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	a, err := h.svc.Get(r.Context(), id)
+	if err != nil {
+		h.respondError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, a)
+}
+
+func (h *Handlers) create(w http.ResponseWriter, r *http.Request) {
+	var req CreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	a, err := h.svc.Create(r.Context(), req)
+	if err != nil {
+		h.respondError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, a)
+}
+
+func (h *Handlers) update(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var req UpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	a, err := h.svc.Update(r.Context(), id, req)
+	if err != nil {
+		h.respondError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, a)
+}
+
+func (h *Handlers) toggle(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var body struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	a, err := h.svc.Update(r.Context(), id, UpdateRequest{Enabled: &body.Enabled})
+	if err != nil {
+		h.respondError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, a)
+}
+
+func (h *Handlers) del(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := h.svc.Delete(r.Context(), id); err != nil {
+		h.respondError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handlers) importLocal(w http.ResponseWriter, r *http.Request) {
+	created, err := h.svc.ImportLocal(r.Context())
+	if err != nil {
+		h.respondError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"created": created, "count": len(created)})
+}
+
+func (h *Handlers) respondError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		writeError(w, http.StatusNotFound, err)
+	case errors.Is(err, ErrDuplicate):
+		writeError(w, http.StatusConflict, err)
+	case errors.Is(err, ErrDisabled):
+		writeError(w, http.StatusConflict, err)
+	default:
+		h.log.Error("grokacct handler", "err", err)
+		writeError(w, http.StatusInternalServerError, err)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, code int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, code int, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+}

--- a/internal/grokacct/service.go
+++ b/internal/grokacct/service.go
@@ -1,0 +1,257 @@
+package grokacct
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/opendray/opendray-v2/internal/eventbus"
+)
+
+// Service is the public surface used by HTTP handlers and the
+// SessionProvider adapter. It hides the on-disk GROK_HOME plumbing.
+type Service struct {
+	log         *slog.Logger
+	store       *store
+	bus         *eventbus.Hub
+	accountsDir string // root for derived ConfigDir; "" → ~/.grok-accounts
+
+	// importMu serializes ImportLocal() so concurrent invocations
+	// (startup scan + UI "Import local" click) don't race on the
+	// GetByName/Create check-then-insert window.
+	importMu sync.Mutex
+}
+
+// Option mutates Service defaults.
+type Option func(*Service)
+
+// WithAccountsDir overrides the directory used to derive default
+// ConfigDir (per-account GROK_HOME) for new accounts. Empty value falls
+// back to ~/.grok-accounts.
+func WithAccountsDir(dir string) Option {
+	return func(s *Service) { s.accountsDir = dir }
+}
+
+func NewService(pool *pgxpool.Pool, bus *eventbus.Hub, log *slog.Logger, opts ...Option) *Service {
+	if log == nil {
+		log = slog.Default()
+	}
+	s := &Service{
+		log:   log.With("component", "grokacct"),
+		store: newStore(pool),
+		bus:   bus,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// resolveAccountsDir returns the configured root, falling back to
+// ~/.grok-accounts when unset. Returns "" only when HOME is also unset
+// (test environments must inject WithAccountsDir explicitly).
+func (s *Service) resolveAccountsDir() string {
+	if s.accountsDir != "" {
+		return s.accountsDir
+	}
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".grok-accounts")
+}
+
+// AccountsDir is the public version of resolveAccountsDir, exposed so the
+// App wiring can construct a watcher without reaching into internals.
+func (s *Service) AccountsDir() string { return s.resolveAccountsDir() }
+
+// List returns all accounts, decorated with derived fields (TokenFilled
+// from the on-disk login token, ActiveSessions/LastUsedAt from a single
+// JOIN against sessions).
+func (s *Service) List(ctx context.Context) ([]Account, error) {
+	out, err := s.store.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	stats, err := s.store.sessionLoad(ctx)
+	if err != nil {
+		s.log.Warn("session-load failed; account list will lack usage signal", "err", err)
+		stats = map[string]sessionStats{}
+	}
+	for i := range out {
+		s.decorate(&out[i], stats[out[i].ID])
+	}
+	return out, nil
+}
+
+func (s *Service) Get(ctx context.Context, id string) (Account, error) {
+	a, err := s.store.Get(ctx, id)
+	if err != nil {
+		return Account{}, err
+	}
+	stats, _ := s.store.sessionLoad(ctx) // best-effort
+	s.decorate(&a, stats[a.ID])
+	return a, nil
+}
+
+// decorate fills in all derived fields on an Account in place.
+func (s *Service) decorate(a *Account, stats sessionStats) {
+	a.TokenFilled = accountHasCredentials(a.ConfigDir)
+	a.ActiveSessions = stats.ActiveSessions
+	a.LastUsedAt = stats.LastUsedAt
+}
+
+func (s *Service) Create(ctx context.Context, req CreateRequest) (Account, error) {
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return Account{}, errors.New("name is required")
+	}
+	if _, err := s.store.GetByName(ctx, name); err == nil {
+		return Account{}, ErrDuplicate
+	} else if !errors.Is(err, ErrNotFound) {
+		return Account{}, err
+	}
+
+	accountsDir := s.resolveAccountsDir()
+	configDir := strings.TrimSpace(req.ConfigDir)
+	if configDir == "" && accountsDir != "" {
+		configDir = filepath.Join(accountsDir, name)
+	}
+
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+
+	a := Account{
+		Name:        name,
+		DisplayName: req.DisplayName,
+		ConfigDir:   configDir,
+		Description: req.Description,
+		Enabled:     enabled,
+	}
+	created, err := s.store.Insert(ctx, a)
+	if err != nil {
+		return Account{}, err
+	}
+	s.decorate(&created, sessionStats{}) // brand-new row → no sessions yet
+	if s.bus != nil {
+		s.bus.Publish(eventbus.Event{
+			Topic: "grok_account.created",
+			Data:  map[string]any{"id": created.ID, "name": created.Name},
+		})
+	}
+	return created, nil
+}
+
+func (s *Service) Update(ctx context.Context, id string, req UpdateRequest) (Account, error) {
+	cur, err := s.store.Get(ctx, id)
+	if err != nil {
+		return Account{}, err
+	}
+	if req.Name != nil {
+		cur.Name = strings.TrimSpace(*req.Name)
+	}
+	if req.DisplayName != nil {
+		cur.DisplayName = *req.DisplayName
+	}
+	if req.ConfigDir != nil {
+		cur.ConfigDir = *req.ConfigDir
+	}
+	if req.Description != nil {
+		cur.Description = *req.Description
+	}
+	if req.Enabled != nil {
+		cur.Enabled = *req.Enabled
+	}
+	updated, err := s.store.Update(ctx, cur)
+	if err != nil {
+		return Account{}, err
+	}
+	stats, _ := s.store.sessionLoad(ctx) // best-effort
+	s.decorate(&updated, stats[updated.ID])
+	return updated, nil
+}
+
+func (s *Service) Delete(ctx context.Context, id string) error {
+	if err := s.store.Delete(ctx, id); err != nil {
+		return err
+	}
+	if s.bus != nil {
+		s.bus.Publish(eventbus.Event{
+			Topic: "grok_account.deleted",
+			Data:  map[string]any{"id": id},
+		})
+	}
+	return nil
+}
+
+// CheckEnabled is the upstream validator used by session handlers (create
+// / switch) so a bogus or disabled id fails with 400 before the session
+// row is touched.
+func (s *Service) CheckEnabled(ctx context.Context, id string) error {
+	a, err := s.store.Get(ctx, id)
+	if err != nil {
+		return err // store wraps to ErrNotFound on missing row
+	}
+	if !a.Enabled {
+		return ErrDisabled
+	}
+	return nil
+}
+
+// ResolveSpawnHome returns the GROK_HOME directory to inject when spawning
+// `grok` for account id. The directory must exist and contain a logged-in
+// token; otherwise we error with a guided-login hint rather than spawning
+// a session that would immediately demand interactive auth. Used at
+// session spawn time (catalog adapter); not exposed over HTTP.
+func (s *Service) ResolveSpawnHome(ctx context.Context, id string) (string, error) {
+	a, err := s.store.Get(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	if !a.Enabled {
+		return "", ErrDisabled
+	}
+	return selectSpawnHome(a.Name, a.ConfigDir)
+}
+
+// ImportLocal scans the accounts dir (and the gateway user's own grok
+// home) for logged-in accounts and creates a metadata row for any not yet
+// known. Idempotent; safe to call on startup and from the UI.
+func (s *Service) ImportLocal(ctx context.Context) ([]Account, error) {
+	s.importMu.Lock()
+	defer s.importMu.Unlock()
+
+	discovered, err := discoverLocalAccounts(s.resolveAccountsDir())
+	if err != nil {
+		return nil, err
+	}
+	var created []Account
+	for _, d := range discovered {
+		if _, err := s.store.GetByName(ctx, d.name); err == nil {
+			continue // already known
+		} else if !errors.Is(err, ErrNotFound) {
+			return created, err
+		}
+		acc, err := s.Create(ctx, CreateRequest{
+			Name:        d.name,
+			DisplayName: d.displayName,
+			ConfigDir:   d.configDir,
+		})
+		if err != nil {
+			if errors.Is(err, ErrDuplicate) {
+				continue
+			}
+			return created, err
+		}
+		created = append(created, acc)
+	}
+	return created, nil
+}

--- a/internal/grokacct/store.go
+++ b/internal/grokacct/store.go
@@ -1,0 +1,142 @@
+package grokacct
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type store struct{ pool *pgxpool.Pool }
+
+func newStore(pool *pgxpool.Pool) *store { return &store{pool: pool} }
+
+const accountSelect = `
+    SELECT id, name, display_name, config_dir, description,
+           enabled, created_at, updated_at
+    FROM grok_accounts`
+
+func (s *store) Insert(ctx context.Context, a Account) (Account, error) {
+	row := s.pool.QueryRow(ctx, `
+        INSERT INTO grok_accounts
+            (name, display_name, config_dir, description, enabled)
+        VALUES ($1, $2, $3, $4, $5)
+        RETURNING id, name, display_name, config_dir, description,
+                  enabled, created_at, updated_at`,
+		a.Name, a.DisplayName, a.ConfigDir, a.Description, a.Enabled,
+	)
+	return scan(row)
+}
+
+func (s *store) Get(ctx context.Context, id string) (Account, error) {
+	row := s.pool.QueryRow(ctx, accountSelect+` WHERE id = $1`, id)
+	return scan(row)
+}
+
+func (s *store) GetByName(ctx context.Context, name string) (Account, error) {
+	row := s.pool.QueryRow(ctx, accountSelect+` WHERE name = $1`, name)
+	return scan(row)
+}
+
+func (s *store) List(ctx context.Context) ([]Account, error) {
+	rows, err := s.pool.Query(ctx, accountSelect+` ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("list grok accounts: %w", err)
+	}
+	defer rows.Close()
+	out := []Account{}
+	for rows.Next() {
+		a, err := scan(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+func (s *store) Update(ctx context.Context, a Account) (Account, error) {
+	row := s.pool.QueryRow(ctx, `
+        UPDATE grok_accounts SET
+            name = $2, display_name = $3, config_dir = $4,
+            description = $5, enabled = $6, updated_at = NOW()
+        WHERE id = $1
+        RETURNING id, name, display_name, config_dir, description,
+                  enabled, created_at, updated_at`,
+		a.ID, a.Name, a.DisplayName, a.ConfigDir, a.Description, a.Enabled,
+	)
+	return scan(row)
+}
+
+func (s *store) Delete(ctx context.Context, id string) error {
+	res, err := s.pool.Exec(ctx, `DELETE FROM grok_accounts WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete grok account: %w", err)
+	}
+	if res.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// nonTerminalStates are the session states that count toward
+// ActiveSessions. Kept in sync with session.IsTerminal().
+const nonTerminalStates = `('running', 'starting', 'idle')`
+
+// sessionStats is the per-account result of sessionLoad.
+type sessionStats struct {
+	ActiveSessions int
+	LastUsedAt     *time.Time // nil = no session ever pinned to this id
+}
+
+// sessionLoad returns one row per grok_accounts entry with active-session
+// count and the most recent started_at for any session ever pinned to it.
+// LEFT JOIN so accounts with zero sessions still appear.
+func (s *store) sessionLoad(ctx context.Context) (map[string]sessionStats, error) {
+	rows, err := s.pool.Query(ctx, `
+        SELECT ga.id,
+               COUNT(s.id) FILTER (WHERE s.state IN `+nonTerminalStates+`) AS active_sessions,
+               MAX(s.started_at)                                            AS last_used_at
+          FROM grok_accounts ga
+          LEFT JOIN sessions s ON s.grok_account_id = ga.id
+         GROUP BY ga.id`)
+	if err != nil {
+		return nil, fmt.Errorf("session-load query: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[string]sessionStats)
+	for rows.Next() {
+		var (
+			id     string
+			active int
+			last   *time.Time
+		)
+		if err := rows.Scan(&id, &active, &last); err != nil {
+			return nil, fmt.Errorf("scan session-load row: %w", err)
+		}
+		out[id] = sessionStats{ActiveSessions: active, LastUsedAt: last}
+	}
+	return out, rows.Err()
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scan(s scanner) (Account, error) {
+	var a Account
+	err := s.Scan(
+		&a.ID, &a.Name, &a.DisplayName, &a.ConfigDir,
+		&a.Description, &a.Enabled, &a.CreatedAt, &a.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Account{}, ErrNotFound
+	}
+	if err != nil {
+		return Account{}, fmt.Errorf("scan grok account: %w", err)
+	}
+	return a, nil
+}

--- a/internal/session/handler.go
+++ b/internal/session/handler.go
@@ -39,6 +39,7 @@ type Service interface {
 	Buffer(ctx context.Context, id string, since int64) (Replay, error)
 	SwitchClaudeAccount(ctx context.Context, id, accountID string, carryContext bool) (Session, error)
 	SwitchAntigravityAccount(ctx context.Context, id, accountID string) (Session, error)
+	SwitchGrokAccount(ctx context.Context, id, accountID string) (Session, error)
 	History(ctx context.Context, id string, limit int) (HistoryResponse, error)
 }
 
@@ -50,6 +51,17 @@ type AntigravityAccountChecker interface {
 	// CheckEnabled returns nil when id refers to an existing, enabled
 	// antigravity account; an error otherwise (distinguishing
 	// not-found from disabled so the handler maps both to 400).
+	CheckEnabled(ctx context.Context, id string) error
+}
+
+// GrokAccountChecker is the minimal grokacct surface the session handler
+// needs to validate `grok_account_id` early (before the switch mutates
+// the row). Mirrors AntigravityAccountChecker; a nil checker disables
+// validation (deferred error at spawn time).
+type GrokAccountChecker interface {
+	// CheckEnabled returns nil when id refers to an existing, enabled
+	// grok account; an error otherwise (distinguishing not-found from
+	// disabled so the handler maps both to 400).
 	CheckEnabled(ctx context.Context, id string) error
 }
 
@@ -97,6 +109,7 @@ type Handlers struct {
 	svc      Service
 	acct     ClaudeAccountChecker      // optional; nil disables early validation
 	agyAcct  AntigravityAccountChecker // optional; nil disables early validation
+	grokAcct GrokAccountChecker        // optional; nil disables early validation
 	defaults IntegrationDefaults       // optional; nil disables integration spawn defaults
 	log      *slog.Logger
 	upgrader websocket.Upgrader
@@ -119,6 +132,13 @@ func WithClaudeAccountChecker(c ClaudeAccountChecker) HandlerOption {
 // nil is equivalent to omitting the option (validation is skipped).
 func WithAntigravityAccountChecker(c AntigravityAccountChecker) HandlerOption {
 	return func(h *Handlers) { h.agyAcct = c }
+}
+
+// WithGrokAccountChecker wires the grokacct surface used to validate
+// grok_account_id in switchGrokAccount(). Passing nil is equivalent to
+// omitting the option (validation is skipped).
+func WithGrokAccountChecker(c GrokAccountChecker) HandlerOption {
+	return func(h *Handlers) { h.grokAcct = c }
 }
 
 // WithIntegrationDefaults wires the resolver used to fill provider /
@@ -173,6 +193,7 @@ func (h *Handlers) Mount(r chi.Router) {
 			r.Get("/history", h.history)
 			r.Patch("/claude-account", h.switchClaudeAccount)
 			r.Patch("/antigravity-account", h.switchAntigravityAccount)
+			r.Patch("/grok-account", h.switchGrokAccount)
 			r.Post("/uploads", h.upload)
 		})
 	})
@@ -658,6 +679,31 @@ func (h *Handlers) switchAntigravityAccount(w http.ResponseWriter, r *http.Reque
 		}
 	}
 	sess, err := h.svc.SwitchAntigravityAccount(r.Context(), id, req.AccountID)
+	if err != nil {
+		h.respondError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, sess)
+}
+
+// switchGrokAccount handles PATCH /sessions/{id}/grok-account. Mirrors
+// switchAntigravityAccount: validate the target up-front (so a bad id
+// fails before the PTY is stopped), then hand off to the manager which
+// stops the running `grok`, rebinds GROK_HOME, and respawns.
+func (h *Handlers) switchGrokAccount(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var req SwitchAccountRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if h.grokAcct != nil && req.AccountID != "" {
+		if err := h.grokAcct.CheckEnabled(r.Context(), req.AccountID); err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Errorf("account_id: %w", err))
+			return
+		}
+	}
+	sess, err := h.svc.SwitchGrokAccount(r.Context(), id, req.AccountID)
 	if err != nil {
 		h.respondError(w, err)
 		return

--- a/internal/session/handler_grok_test.go
+++ b/internal/session/handler_grok_test.go
@@ -1,0 +1,90 @@
+package session
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// fakeGrokChecker is a minimal GrokAccountChecker for handler tests.
+type fakeGrokChecker struct {
+	known map[string]bool
+}
+
+func (f *fakeGrokChecker) CheckEnabled(_ context.Context, id string) error {
+	if f.known[id] {
+		return nil
+	}
+	return ErrNotFound
+}
+
+func newRouterWithGrokChecker(svc Service, c GrokAccountChecker) http.Handler {
+	r := chi.NewRouter()
+	NewHandlers(svc, nil, WithGrokAccountChecker(c)).Mount(r)
+	return r
+}
+
+func TestSwitchGrokAccount_OK(t *testing.T) {
+	svc := newFakeSvc()
+	svc.sessions["s1"] = Session{ID: "s1", ProviderID: "grok", State: StateRunning}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/sessions/s1/grok-account",
+		bytes.NewBufferString(`{"account_id":"grok_new"}`))
+	newRouter(svc).ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body)
+	}
+	var s Session
+	if err := json.Unmarshal(rr.Body.Bytes(), &s); err != nil {
+		t.Fatal(err)
+	}
+	if s.GrokAccountID != "grok_new" {
+		t.Errorf("account_id=%q, want grok_new", s.GrokAccountID)
+	}
+}
+
+func TestSwitchGrokAccount_NotGrok(t *testing.T) {
+	svc := newFakeSvc()
+	svc.sessions["s1"] = Session{ID: "s1", ProviderID: "shell", State: StateRunning}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/sessions/s1/grok-account",
+		bytes.NewBufferString(`{"account_id":"grok_x"}`))
+	newRouter(svc).ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d; want 400 for non-grok session", rr.Code)
+	}
+}
+
+func TestSwitchGrokAccount_InvalidID(t *testing.T) {
+	svc := newFakeSvc()
+	svc.sessions["ses_live"] = Session{ID: "ses_live", ProviderID: "grok", State: StateRunning}
+	checker := &fakeGrokChecker{known: map[string]bool{"grok_real": true}}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/sessions/ses_live/grok-account",
+		bytes.NewBufferString(`{"account_id":"grok_does_not_exist"}`))
+	newRouterWithGrokChecker(svc, checker).ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s; want 400", rr.Code, rr.Body)
+	}
+	// The rejected switch must not have stopped or mutated the session.
+	if s := svc.sessions["ses_live"]; s.State != StateRunning {
+		t.Errorf("session state changed despite rejected switch: %s", s.State)
+	}
+}
+
+func TestSwitchGrokAccount_BadJSON(t *testing.T) {
+	svc := newFakeSvc()
+	svc.sessions["s1"] = Session{ID: "s1", ProviderID: "grok", State: StateRunning}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/sessions/s1/grok-account",
+		bytes.NewBufferString(`not json`))
+	newRouter(svc).ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d; want 400 for bad JSON", rr.Code)
+	}
+}

--- a/internal/session/handler_test.go
+++ b/internal/session/handler_test.go
@@ -153,6 +153,23 @@ func (f *fakeSvc) SwitchAntigravityAccount(_ context.Context, id, accountID stri
 	return s, nil
 }
 
+func (f *fakeSvc) SwitchGrokAccount(_ context.Context, id, accountID string) (Session, error) {
+	if f.switchErr != nil {
+		return Session{}, f.switchErr
+	}
+	s, ok := f.sessions[id]
+	if !ok {
+		return Session{}, ErrNotFound
+	}
+	if s.ProviderID != "grok" {
+		return Session{}, ErrAccountSwitchUnsupported
+	}
+	s.GrokAccountID = accountID
+	s.State = StateRunning
+	f.sessions[id] = s
+	return s, nil
+}
+
 func (f *fakeSvc) Buffer(_ context.Context, id string, since int64) (Replay, error) {
 	if _, ok := f.sessions[id]; !ok {
 		return Replay{}, ErrNotFound

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1368,6 +1368,69 @@ func (m *Manager) SwitchAntigravityAccount(ctx context.Context, id, newAccountID
 // Remove tears down a session permanently — running processes are
 // stopped first, then the DB row is deleted. This is the destructive
 // counterpart to Stop (which leaves the row behind for restart).
+
+// SwitchGrokAccount terminates the running `grok` process and respawns it
+// under a different grok account binding (a different GROK_HOME). The
+// session row, cwd, args and slot are preserved — only the account moves,
+// so the session survives the switch. Mirrors SwitchAntigravityAccount;
+// conversation carry-over is deferred (RFC #532 P3). On respawn failure
+// the row stays 'stopped' with the ORIGINAL account (never persisted the
+// new value) so the user can Restart on it.
+func (m *Manager) SwitchGrokAccount(ctx context.Context, id, newAccountID string) (Session, error) {
+	m.mu.RLock()
+	if m.closed {
+		m.mu.RUnlock()
+		return Session{}, errors.New("session manager closed")
+	}
+	m.mu.RUnlock()
+
+	current, err := m.Get(ctx, id)
+	if err != nil {
+		return Session{}, err
+	}
+	if current.ProviderID != "grok" {
+		return Session{}, ErrAccountSwitchUnsupported
+	}
+	if current.GrokAccountID == newAccountID {
+		// No-op: caller picked the binding already in place.
+		return current, nil
+	}
+
+	if err := m.Stop(ctx, id); err != nil {
+		return Session{}, fmt.Errorf("stop before switch: %w", err)
+	}
+
+	sess, err := m.store.Get(ctx, id)
+	if err != nil {
+		return Session{}, err
+	}
+	sess.GrokAccountID = newAccountID
+	sess.State = StateRunning
+	sess.EndedAt = nil
+	sess.ExitCode = nil
+	sess.StartedAt = time.Now().UTC()
+
+	rs, err := m.spawn(ctx, sess, true)
+	if err != nil {
+		return Session{}, fmt.Errorf("respawn under new account: %w", err)
+	}
+
+	if err := m.store.UpdateGrokAccount(ctx, id, newAccountID); err != nil {
+		m.log.Error("persist new grok account failed",
+			"session", id, "account", newAccountID, "err", err)
+	}
+
+	m.bus.Publish(eventbus.Event{
+		Topic: "session.account_switched",
+		Data: map[string]any{
+			"session_id":  rs.sess.ID,
+			"provider_id": rs.sess.ProviderID,
+			"account_id":  newAccountID,
+		},
+	})
+	return rs.sess, nil
+}
+
 func (m *Manager) Remove(ctx context.Context, id string) error {
 	if err := m.Stop(ctx, id); err != nil {
 		return err

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -587,6 +587,7 @@ func (m *Manager) Create(ctx context.Context, req CreateRequest) (Session, error
 		State:                StateRunning,
 		ClaudeAccountID:      req.ClaudeAccountID,
 		AntigravityAccountID: req.AntigravityAccountID,
+		GrokAccountID:        req.GrokAccountID,
 		ParentSessionID:      req.ParentSessionID,
 		Origin:               origin,
 		IntegrationID:        req.integrationID,
@@ -682,6 +683,9 @@ func (m *Manager) spawn(ctx context.Context, sess Session, reactivate bool) (*ru
 	accountID := sess.ClaudeAccountID
 	if sess.ProviderID == "antigravity" {
 		accountID = sess.AntigravityAccountID
+	}
+	if sess.ProviderID == "grok" {
+		accountID = sess.GrokAccountID
 	}
 	resolveCtx := WithKBAdmin(WithModel(WithOrigin(WithAccountID(ctx, accountID), sess.Origin), sess.Model), sess.KBAdmin)
 	// Integration spawn profile: provider-agnostic MCP servers + system

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -105,6 +105,11 @@ type Session struct {
 	// (~/.gemini). Mirrors ClaudeAccountID for the agy provider, whose
 	// accounts are isolated by HOME rather than CLAUDE_CONFIG_DIR.
 	AntigravityAccountID string `json:"antigravity_account_id,omitempty"`
+	// GrokAccountID is the grokacct account this session is pinned to
+	// (provider "grok"). Empty means the CLI's default grok home
+	// (~/.grok). Mirrors AntigravityAccountID for the grok provider,
+	// whose accounts are isolated by GROK_HOME.
+	GrokAccountID string `json:"grok_account_id,omitempty"`
 	// ParentSessionID links a session spawned on behalf of another
 	// (e.g. the Inspector's Tasks tab spawns shell children of an
 	// AI session). Empty for top-level sessions. Used purely for UI
@@ -154,6 +159,7 @@ type CreateRequest struct {
 	Model                string   `json:"model,omitempty"`
 	ClaudeAccountID      string   `json:"claude_account_id,omitempty"`
 	AntigravityAccountID string   `json:"antigravity_account_id,omitempty"`
+	GrokAccountID        string   `json:"grok_account_id,omitempty"`
 	ParentSessionID      string   `json:"parent_session_id,omitempty"`
 	Cwd                  string   `json:"cwd"`
 	Args                 []string `json:"args"`

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -22,6 +22,7 @@ const sessionSelect = `
            args, state, COALESCE(pid, 0),
            COALESCE(claude_account_id, ''), COALESCE(claude_session_id, ''),
            COALESCE(antigravity_account_id, ''),
+           COALESCE(grok_account_id, ''),
            COALESCE(parent_session_id, ''),
            COALESCE(origin, 'operator'), COALESCE(integration_id, ''),
            COALESCE(interrupt_reason, ''),
@@ -44,15 +45,17 @@ func (s *sessionStore) Insert(ctx context.Context, sess Session) error {
         INSERT INTO sessions
             (id, name, provider_id, model, cwd, args, state, pid,
              claude_account_id, claude_session_id, antigravity_account_id,
-             parent_session_id, origin, integration_id, started_at)
-        VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
+             parent_session_id, origin, integration_id, started_at,
+             grok_account_id)
+        VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
 		sess.ID, nullableString(sess.Name), sess.ProviderID, sess.Model,
 		sess.Cwd, argsJSON, string(sess.State), nullableInt(sess.PID),
 		nullableString(sess.ClaudeAccountID), nullableString(sess.ClaudeSessionID),
 		nullableString(sess.AntigravityAccountID),
 		nullableString(sess.ParentSessionID),
 		string(origin), nullableString(sess.IntegrationID),
-		sess.StartedAt)
+		sess.StartedAt,
+		nullableString(sess.GrokAccountID))
 	if err != nil {
 		return fmt.Errorf("insert session: %w", err)
 	}
@@ -275,7 +278,7 @@ func scanSession(row rowScanner) (Session, error) {
 	)
 	err := row.Scan(&s.ID, &s.Name, &s.ProviderID, &s.Model, &s.Cwd, &argsJSON,
 		&stateStr, &s.PID, &s.ClaudeAccountID, &s.ClaudeSessionID,
-		&s.AntigravityAccountID, &s.ParentSessionID, &originStr, &s.IntegrationID,
+		&s.AntigravityAccountID, &s.GrokAccountID, &s.ParentSessionID, &originStr, &s.IntegrationID,
 		&interruptR, &s.StartedAt, &endedAt, &exitCode)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Session{}, ErrNotFound

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -249,6 +249,19 @@ func (s *sessionStore) UpdateAntigravityAccount(ctx context.Context, id, account
 	return nil
 }
 
+func (s *sessionStore) UpdateGrokAccount(ctx context.Context, id, accountID string) error {
+	res, err := s.pool.Exec(ctx, `
+        UPDATE sessions SET grok_account_id=$1 WHERE id=$2`,
+		nullableString(accountID), id)
+	if err != nil {
+		return fmt.Errorf("update grok account: %w", err)
+	}
+	if res.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // Delete permanently removes the row. Caller must ensure the session
 // is no longer running (Manager.Stop first).
 func (s *sessionStore) Delete(ctx context.Context, id string) error {

--- a/internal/store/migrations/0094_grok_accounts.sql
+++ b/internal/store/migrations/0094_grok_accounts.sql
@@ -1,0 +1,21 @@
+-- Grok Build (grok) multi-account support. Mirrors antigravity_accounts
+-- (0069): a grok "account" is a dedicated GROK_HOME directory. grok keys
+-- its credential + config state off GROK_HOME (<GROK_HOME>/auth.json,
+-- config.toml, trusted_folders.toml), so binding a session to an account
+-- means spawning `grok` with GROK_HOME pointed there. config_dir holds
+-- that per-account GROK_HOME. No token column: the login token lives at
+-- <GROK_HOME>/auth.json and is created out-of-band by `GROK_HOME=<dir>
+-- grok login`; opendray only points spawns at it.
+CREATE TABLE grok_accounts (
+    id           TEXT PRIMARY KEY DEFAULT 'grok_' || substr(md5(random()::text || clock_timestamp()::text), 1, 12),
+    name         TEXT NOT NULL UNIQUE,
+    display_name TEXT NOT NULL DEFAULT '',
+    config_dir   TEXT NOT NULL DEFAULT '',
+    description  TEXT NOT NULL DEFAULT '',
+    enabled      BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE sessions
+    ADD COLUMN grok_account_id TEXT REFERENCES grok_accounts(id) ON DELETE SET NULL;


### PR DESCRIPTION
Implements **P2** of the grok multi-account RFC (#532): switch a running grok session to a different account **without losing the session**. Stacked on #533 (P1) — review/merge that first.

## What
`PATCH /sessions/{id}/grok-account` → stop the running `grok`, rebind `GROK_HOME`, respawn under the new account; the session row / cwd / args / slot are preserved. Mirrors `SwitchAntigravityAccount`. Conversation carry-over is deferred to P3.

- **`Manager.SwitchGrokAccount`** — validate `provider==grok`, no-op if unchanged, `Stop`, rebind, `spawn`, persist, publish `session.account_switched`. On respawn failure the row keeps the **original** account (new value never persisted) so the user can Restart.
- **`store.UpdateGrokAccount`** — `UPDATE sessions SET grok_account_id=…`.
- **handler** — `switchGrokAccount` + route; `GrokAccountChecker` + `WithGrokAccountChecker` validate the target up-front (bad/disabled id → 400 **before** the PTY is stopped).
- **Service interface** gains `SwitchGrokAccount`; app wires `WithGrokAccountChecker`.

## TDD / verification
- Handler tests written RED→GREEN in `handler_grok_test.go`: `_OK` (200 + `GrokAccountID` set), `_NotGrok` (400), `_InvalidID` (checker rejects → 400, session untouched), `_BadJSON` (400).
- Full build, `vet`, `gofmt` clean; `session` + `catalog` + `grokacct` suites green.
- `UpdateGrokAccount` **round-tripped against a real Postgres** (session rebinds account `a`→`b`), in a rolled-back transaction.

## Remaining (P3, per #532)
Conversation carry-over on switch, shared-asset symlinks (`ensureGrokSharedAssets`), MCP-trust-per-home.