### PR TITLE
feat(grok): shared-asset symlinks + trust-per-home (RFC #532 P3)

### DIFF
--- a/internal/catalog/adapter.go
+++ b/internal/catalog/adapter.go
@@ -632,6 +632,15 @@ func (sp *SessionProvider) Resolve(ctx context.Context, id string) (session.Prov
 				return session.PrepareOutput{}, fmt.Errorf("grok account %s: %w", selectedAccountID, err)
 			}
 			out.Env["GROK_HOME"] = home
+			// Share the heavy, account-independent install/cache dirs
+			// (bin, bundled, vendor, …) across accounts via symlink
+			// instead of duplicating hundreds of MB per GROK_HOME.
+			// Best-effort: a failure just means this account gets its own
+			// copy on first use. grok's --trust flag persists repo trust
+			// into this same GROK_HOME, so MCP trust is already per-account.
+			if err := grokacct.EnsureSharedAssets(home); err != nil {
+				sp.log.Warn("grok shared-assets symlink failed", "home", home, "err", err)
+			}
 		}
 
 		// Tier 1 skill index injected per-provider. The agent sees a

--- a/internal/grokacct/shared.go
+++ b/internal/grokacct/shared.go
@@ -1,0 +1,62 @@
+package grokacct
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// sharedAssetDirs are the account-independent, heavy directories inside a
+// grok home that can be shared across accounts via symlink instead of
+// duplicated (bin ~317 MB, plus the bundled runtime, vendored deps, and
+// caches). Per-account state (auth.json, config.toml, trusted_folders.toml,
+// sessions/, projects/, agent_id, worktrees.db) is deliberately NOT here —
+// those must stay unique per GROK_HOME.
+var sharedAssetDirs = []string{
+	"bin",
+	"bundled",
+	"vendor",
+	"downloads",
+	"installed-plugins",
+	"marketplace-cache",
+	"completions",
+	"docs",
+}
+
+// EnsureSharedAssets symlinks the heavy, account-independent directories of
+// the gateway user's own grok home into an account's GROK_HOME, so N
+// accounts don't each cost hundreds of MB. Best-effort and idempotent;
+// callers log and continue on error. Mirrors catalog.ensureAgySharedCache.
+func EnsureSharedAssets(home string) error {
+	return ensureSharedAssets(home, defaultGrokHome())
+}
+
+// ensureSharedAssets is the pure half of EnsureSharedAssets: symlink each
+// shareable dir from src into home when it exists in src and is absent in
+// home. No-op when src is empty/missing or equals home (never symlink the
+// shared source into itself). Existing entries in home are left untouched.
+func ensureSharedAssets(home, src string) error {
+	if home == "" || src == "" || home == src {
+		return nil
+	}
+	if st, err := os.Stat(src); err != nil || !st.IsDir() {
+		return nil // nothing to share yet
+	}
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		return fmt.Errorf("mkdir grok home: %w", err)
+	}
+	for _, d := range sharedAssetDirs {
+		srcDir := filepath.Join(src, d)
+		if st, err := os.Stat(srcDir); err != nil || !st.IsDir() {
+			continue // source doesn't have this dir
+		}
+		dst := filepath.Join(home, d)
+		if _, err := os.Lstat(dst); err == nil {
+			continue // already present (real dir or prior symlink) — don't clobber
+		}
+		if err := os.Symlink(srcDir, dst); err != nil {
+			return fmt.Errorf("symlink %s: %w", d, err)
+		}
+	}
+	return nil
+}

--- a/internal/grokacct/shared_test.go
+++ b/internal/grokacct/shared_test.go
@@ -1,0 +1,92 @@
+package grokacct
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureSharedAssets_SymlinksHeavyDirs(t *testing.T) {
+	src := t.TempDir()
+	home := t.TempDir()
+	// Shareable, account-independent install/cache dirs in the source.
+	for _, d := range []string{"bin", "vendor", "bundled"} {
+		if err := os.MkdirAll(filepath.Join(src, d), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A per-account file that must NEVER be shared.
+	if err := os.WriteFile(filepath.Join(src, "auth.json"), []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureSharedAssets(home, src); err != nil {
+		t.Fatalf("ensureSharedAssets: %v", err)
+	}
+
+	for _, d := range []string{"bin", "vendor", "bundled"} {
+		p := filepath.Join(home, d)
+		fi, err := os.Lstat(p)
+		if err != nil {
+			t.Fatalf("%s not created: %v", d, err)
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			t.Errorf("%s should be a symlink", d)
+		}
+		target, _ := os.Readlink(p)
+		if target != filepath.Join(src, d) {
+			t.Errorf("%s -> %q, want %q", d, target, filepath.Join(src, d))
+		}
+	}
+	// auth.json is per-account: it must NOT be symlinked into the home.
+	if _, err := os.Lstat(filepath.Join(home, "auth.json")); err == nil {
+		t.Error("auth.json must never be shared into an account home")
+	}
+}
+
+func TestEnsureSharedAssets_LeavesExistingUntouched(t *testing.T) {
+	src := t.TempDir()
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "bin"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// The account already has its own real bin/ — don't clobber it.
+	realBin := filepath.Join(home, "bin")
+	if err := os.MkdirAll(realBin, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realBin, "marker"), []byte("mine"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureSharedAssets(home, src); err != nil {
+		t.Fatal(err)
+	}
+
+	fi, _ := os.Lstat(realBin)
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Error("existing bin/ must not be replaced by a symlink")
+	}
+	if _, err := os.Stat(filepath.Join(realBin, "marker")); err != nil {
+		t.Error("existing bin/ contents were lost")
+	}
+}
+
+func TestEnsureSharedAssets_NoopWhenSrcMissingOrSame(t *testing.T) {
+	home := t.TempDir()
+	// src does not exist → no-op, no error.
+	if err := ensureSharedAssets(home, filepath.Join(t.TempDir(), "nope")); err != nil {
+		t.Errorf("missing src should be a no-op, got %v", err)
+	}
+	// home == src → no-op (never symlink the shared source into itself).
+	same := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(same, "bin"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureSharedAssets(same, same); err != nil {
+		t.Errorf("home==src should be a no-op, got %v", err)
+	}
+	if fi, _ := os.Lstat(filepath.Join(same, "bin")); fi != nil && fi.Mode()&os.ModeSymlink != 0 {
+		t.Error("home==src must not turn bin/ into a self-symlink")
+	}
+}


### PR DESCRIPTION
Implements **P3** of the grok multi-account RFC (#532) — the isolation-hardening polish. Stacked on #534 (P2) → #533 (P1); merge in that order.

## Shared-asset symlinks
Each grok account is a separate `GROK_HOME`. Without sharing, N accounts each carry a full copy of grok's heavy install/cache dirs (`bin` ~317 MB, `bundled`, `vendor`, `downloads`, `installed-plugins`, `marketplace-cache`, `completions`, `docs`) — hundreds of MB per account. `grokacct.EnsureSharedAssets` symlinks those from the gateway's own grok home into each account home instead. Per-account state (`auth.json`, `config.toml`, `trusted_folders.toml`, `sessions/`, `projects/`, `agent_id`) is **never** shared. Idempotent, best-effort (a failure just means that account gets its own copy), and never clobbers an existing entry. Mirrors `catalog.ensureAgySharedCache`. Wired into the grok-account spawn block after `GROK_HOME` is set.

## MCP-trust-per-home — no code needed
RFC C5 turned out free: grok's `--trust` flag (already emitted by `renderGrokMCP` when repo-local MCP is injected) persists trust into the **active** `GROK_HOME`, and P1 already points that at the account dir. So repo-local MCP trust is already per-account.

## Carry-context on switch — deferred (as the RFC recommends)
grok's conversation state (`sessions/`, `worktrees.db`) has no documented portable format to copy safely across homes, and a recap-injection path needs a grok transcript reader that doesn't exist yet. Deferring is the right call rather than risking corrupted grok sessions.

## TDD / verification
- `ensureSharedAssets` covered RED→GREEN in `shared_test.go`: symlinks the heavy dirs, **never** shares `auth.json`, leaves an existing real `bin/` untouched, no-ops when the source is missing or equals the home.
- Full build, `vet`, `gofmt` clean; `grokacct` + `catalog` suites green.

## Grok multi-account: complete
P1 pool + bind (#533) → P2 live switch (#534) → P3 shared assets + trust (this). The remaining RFC item, conversation carry-over, is intentionally out of scope for the reasons above.