### PR TITLE
feat(mobile): pass Cloudflare Access without a VPN

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -5611,6 +5611,13 @@
         "pickFromList": "Pick from list"
       },
       "legacyLayout": "opendray's own directories still sit inside your documents, so they show up in the Vault and a sync carries them along. They keep working — move them out and set the paths below when convenient."
+    },
+    "security": {
+      "section": "Security",
+      "appLock": "Require unlock",
+      "appLockSubtitle": "Ask for biometrics or the device passcode before showing the app",
+      "appLockUnavailable": "This device has no passcode or biometrics enrolled",
+      "appLockFailed": "Could not turn on the app lock"
     }
   },
   "memoryQuarantine": {
@@ -5665,5 +5672,27 @@
     "providersManageOnWeb": "Add or edit providers on the web admin.",
     "providersLoadFailed": "Failed to load providers",
     "defaultBadge": "default"
+  },
+  "access": {
+    "signInTitle": "Cloudflare Access sign-in",
+    "cancel": "Cancel",
+    "failed": "Access sign-in did not complete: {error}",
+    "loadFailed": "Could not load the Cloudflare Access sign-in page: {error}",
+    "section": "Cloudflare Access",
+    "sectionSubtitle": "Sign in at the edge so the app reaches the gateway from outside the LAN",
+    "sessionActive": "Access session active",
+    "sessionExpires": "Expires {when}",
+    "sessionExpiryUnknown": "Expiry not readable from the cookie",
+    "sessionNone": "No Access session on this device",
+    "signIn": "Sign in with Cloudflare Access",
+    "clear": "Clear Access session",
+    "clearSubtitle": "Forget this device's Cloudflare Access cookie",
+    "challengeBanner": "Cloudflare Access needs to verify this device before it can reach {host}.",
+    "notEnabled": "This gateway does not appear to be behind Cloudflare Access."
+  },
+  "lock": {
+    "title": "opendray is locked",
+    "reason": "Unlock opendray",
+    "unlock": "Unlock"
   }
 }

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -5686,9 +5686,11 @@
     "sessionNone": "No Access session on this device",
     "signIn": "Sign in with Cloudflare Access",
     "clear": "Clear Access session",
-    "clearSubtitle": "Forget this device's Cloudflare Access cookie",
+    "clearSubtitle": "Sign out of Cloudflare Access on this device",
     "challengeBanner": "Cloudflare Access needs to verify this device before it can reach {host}.",
-    "notEnabled": "This gateway does not appear to be behind Cloudflare Access."
+    "notEnabled": "This gateway does not appear to be behind Cloudflare Access.",
+    "clearing": "Signing out of Cloudflare Access…",
+    "cleared": "Signed out. The next request will ask you to sign in again."
   },
   "lock": {
     "title": "opendray is locked",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -5686,9 +5686,11 @@
     "sessionNone": "No hay sesión de Access en este dispositivo",
     "signIn": "Iniciar sesión con Cloudflare Access",
     "clear": "Borrar la sesión de Access",
-    "clearSubtitle": "Olvidar la cookie de Cloudflare Access de este dispositivo",
+    "clearSubtitle": "Cerrar sesión de Cloudflare Access en este dispositivo",
     "challengeBanner": "Cloudflare Access necesita verificar este dispositivo antes de poder llegar a {host}.",
-    "notEnabled": "Este gateway no parece estar detrás de Cloudflare Access."
+    "notEnabled": "Este gateway no parece estar detrás de Cloudflare Access.",
+    "clearing": "Cerrando sesión de Cloudflare Access…",
+    "cleared": "Sesión cerrada. La próxima solicitud pedirá iniciar sesión de nuevo."
   },
   "lock": {
     "title": "opendray está bloqueado",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -5611,6 +5611,13 @@
         "pickFromList": "Elegir de la lista"
       },
       "legacyLayout": "Los directorios propios de opendray siguen dentro de tus documentos, así que aparecen en el Vault y la sincronización se los lleva. Siguen funcionando: muévelos fuera y fija las rutas de abajo cuando puedas."
+    },
+    "security": {
+      "section": "Seguridad",
+      "appLock": "Requerir desbloqueo",
+      "appLockSubtitle": "Pedir biometría o el código del dispositivo antes de mostrar la app",
+      "appLockUnavailable": "Este dispositivo no tiene código ni biometría configurados",
+      "appLockFailed": "No se pudo activar el bloqueo de la app"
     }
   },
   "memoryQuarantine": {
@@ -5665,5 +5672,27 @@
     "providersManageOnWeb": "Añade o edita proveedores en el panel web.",
     "providersLoadFailed": "Error al cargar proveedores",
     "defaultBadge": "predeterminado"
+  },
+  "access": {
+    "signInTitle": "Inicio de sesión de Cloudflare Access",
+    "cancel": "Cancelar",
+    "failed": "El inicio de sesión de Access no se completó: {error}",
+    "loadFailed": "No se pudo cargar la página de inicio de sesión de Cloudflare Access: {error}",
+    "section": "Cloudflare Access",
+    "sectionSubtitle": "Inicia sesión en el borde para que la app llegue al gateway desde fuera de la LAN",
+    "sessionActive": "Sesión de Access activa",
+    "sessionExpires": "Caduca {when}",
+    "sessionExpiryUnknown": "La caducidad no se puede leer de la cookie",
+    "sessionNone": "No hay sesión de Access en este dispositivo",
+    "signIn": "Iniciar sesión con Cloudflare Access",
+    "clear": "Borrar la sesión de Access",
+    "clearSubtitle": "Olvidar la cookie de Cloudflare Access de este dispositivo",
+    "challengeBanner": "Cloudflare Access necesita verificar este dispositivo antes de poder llegar a {host}.",
+    "notEnabled": "Este gateway no parece estar detrás de Cloudflare Access."
+  },
+  "lock": {
+    "title": "opendray está bloqueado",
+    "reason": "Desbloquear opendray",
+    "unlock": "Desbloquear"
   }
 }

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -5608,6 +5608,13 @@
         "pickFromList": "从列表选择"
       },
       "legacyLayout": "opendray 自己的目录仍在你的文档里,所以它们会出现在 Vault 中,同步时也会被带走。它们照常工作 —— 方便时把它们移出去,并在下面填好路径。"
+    },
+    "security": {
+      "section": "安全",
+      "appLock": "启动时验证",
+      "appLockSubtitle": "打开 App 前需要生物识别或设备密码",
+      "appLockUnavailable": "本设备未设置密码或生物识别",
+      "appLockFailed": "无法开启应用锁"
     }
   },
   "memoryQuarantine": {
@@ -5662,5 +5669,27 @@
     "providersManageOnWeb": "在 web 管理端添加或编辑 provider。",
     "providersLoadFailed": "加载 provider 失败",
     "defaultBadge": "默认"
+  },
+  "access": {
+    "signInTitle": "Cloudflare Access 登录",
+    "cancel": "取消",
+    "failed": "Access 登录未完成：{error}",
+    "loadFailed": "无法加载 Cloudflare Access 登录页：{error}",
+    "section": "Cloudflare Access",
+    "sectionSubtitle": "在边缘完成登录，让 App 在内网之外也能访问网关",
+    "sessionActive": "Access 会话有效",
+    "sessionExpires": "{when} 过期",
+    "sessionExpiryUnknown": "无法从 Cookie 中读取有效期",
+    "sessionNone": "本设备没有 Access 会话",
+    "signIn": "使用 Cloudflare Access 登录",
+    "clear": "清除 Access 会话",
+    "clearSubtitle": "删除本设备的 Cloudflare Access Cookie",
+    "challengeBanner": "Cloudflare Access 需要先验证本设备，才能访问 {host}。",
+    "notEnabled": "该网关似乎没有启用 Cloudflare Access。"
+  },
+  "lock": {
+    "title": "opendray 已锁定",
+    "reason": "解锁 opendray",
+    "unlock": "解锁"
   }
 }

--- a/app/i18n/zh.json
+++ b/app/i18n/zh.json
@@ -5683,9 +5683,11 @@
     "sessionNone": "本设备没有 Access 会话",
     "signIn": "使用 Cloudflare Access 登录",
     "clear": "清除 Access 会话",
-    "clearSubtitle": "删除本设备的 Cloudflare Access Cookie",
+    "clearSubtitle": "在本设备上登出 Cloudflare Access",
     "challengeBanner": "Cloudflare Access 需要先验证本设备，才能访问 {host}。",
-    "notEnabled": "该网关似乎没有启用 Cloudflare Access。"
+    "notEnabled": "该网关似乎没有启用 Cloudflare Access。",
+    "clearing": "正在登出 Cloudflare Access…",
+    "cleared": "已登出。下次请求会要求重新登录。"
   },
   "lock": {
     "title": "opendray 已锁定",

--- a/app/mobile/android/app/src/main/kotlin/io/opendray/opendray/MainActivity.kt
+++ b/app/mobile/android/app/src/main/kotlin/io/opendray/opendray/MainActivity.kt
@@ -1,5 +1,9 @@
 package io.opendray.opendray
 
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 
-class MainActivity : FlutterActivity()
+// FlutterFragmentActivity rather than FlutterActivity: local_auth
+// shows androidx.biometric's BiometricPrompt, which is a Fragment and
+// needs a FragmentActivity host. With a plain FlutterActivity the
+// app-lock prompt throws at runtime instead of appearing.
+class MainActivity : FlutterFragmentActivity()

--- a/app/mobile/ios/Runner/Info.plist
+++ b/app/mobile/ios/Runner/Info.plist
@@ -48,6 +48,12 @@
 	<string>opendray uses the camera so you can attach a fresh photo to your CLI session.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>opendray does not record audio. This entry exists because image_picker's video-pick path links AVFoundation; opendray never invokes it.</string>
+	<!-- local_auth: the optional app lock. Once the gateway is
+	     published through Cloudflare an unlocked phone is a live
+	     admin console, so the operator can require Face ID (or the
+	     device passcode) before the app is shown. Off by default. -->
+	<key>NSFaceIDUsageDescription</key>
+	<string>opendray uses Face ID to unlock the app when you turn on the app lock.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/app/mobile/lib/core/api/api_exception.dart
+++ b/app/mobile/lib/core/api/api_exception.dart
@@ -25,11 +25,24 @@ class ApiException implements Exception {
 /// screen), and conflating them sends the operator to a screen that
 /// cannot fix their problem.
 class AccessChallengeException extends ApiException {
-  AccessChallengeException({required super.statusCode, required this.host})
-      : super(message: 'Cloudflare Access authentication required');
+  AccessChallengeException({
+    required super.statusCode,
+    required this.host,
+    this.baseUrl,
+  }) : super(message: 'Cloudflare Access authentication required');
 
   /// Host that issued the challenge, for the error banner.
   final String host;
+
+  /// The gateway base URL that was actually being probed when the
+  /// challenge came back, which is not always the one the operator
+  /// typed: an http:// entry gets upgraded to https first.
+  ///
+  /// The sign-in flow must use this one. CF_Authorization is a Secure
+  /// cookie, so running the WebView from the http:// form and then
+  /// reading the cookie back through an http:// URL returns nothing,
+  /// and the sign-in appears to succeed while changing nothing.
+  final String? baseUrl;
 
   @override
   String toString() => 'AccessChallengeException($host)';

--- a/app/mobile/lib/core/api/api_exception.dart
+++ b/app/mobile/lib/core/api/api_exception.dart
@@ -17,3 +17,20 @@ class ApiException implements Exception {
   @override
   String toString() => 'ApiException($statusCode): $message';
 }
+
+/// Cloudflare Access blocked the request before it reached the
+/// gateway. Distinct from [ApiException] so callers can tell "the
+/// edge wants you to sign in again" apart from "opendray said no" —
+/// they need completely different recovery (SSO WebView vs. login
+/// screen), and conflating them sends the operator to a screen that
+/// cannot fix their problem.
+class AccessChallengeException extends ApiException {
+  AccessChallengeException({required super.statusCode, required this.host})
+      : super(message: 'Cloudflare Access authentication required');
+
+  /// Host that issued the challenge, for the error banner.
+  final String host;
+
+  @override
+  String toString() => 'AccessChallengeException($host)';
+}

--- a/app/mobile/lib/core/api/auth_api.dart
+++ b/app/mobile/lib/core/api/auth_api.dart
@@ -1,8 +1,10 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/dio_provider.dart';
 import 'package:opendray/core/api/models.dart';
+import 'package:opendray/core/auth/cf_access.dart';
 
 // Calls into /api/v1/health and /api/v1/auth/mobile-login. The
 // onboarding screen uses health() for URL validation; the login
@@ -77,22 +79,42 @@ final authApiProvider = Provider<AuthApi>((ref) {
 
 // Onboarding-only Dio: hits an arbitrary user-typed server URL
 // without requiring it to be persisted to AuthState first.
-Dio buildOnboardingDio(String baseUrl) {
+//
+// [cfCookie] is threaded through because onboarding is where a
+// Cloudflare Access challenge is *most* likely: the operator has
+// just typed a public hostname, and the very first probe is the one
+// the edge bounces.
+Dio buildOnboardingDio(String baseUrl, {String? cfCookie}) {
+  final cookie = cfCookieHeader(cfCookie);
   return Dio(
     BaseOptions(
       baseUrl: baseUrl,
       connectTimeout: const Duration(seconds: 6),
       receiveTimeout: const Duration(seconds: 6),
-      headers: {'Accept': 'application/json'},
+      headers: {
+        'Accept': 'application/json',
+        if (cookie != null) 'Cookie': cookie,
+      },
       validateStatus: (_) => true,
     ),
   );
 }
 
-Future<HealthResponse> probeHealth(String baseUrl) async {
-  final dio = buildOnboardingDio(baseUrl);
+/// Probes /api/v1/health on a candidate gateway URL.
+///
+/// Throws [AccessChallengeException] when Cloudflare Access answered
+/// instead of the gateway, so onboarding can offer SSO rather than
+/// reporting the login page as a broken server.
+Future<HealthResponse> probeHealth(String baseUrl, {String? cfCookie}) async {
+  final dio = buildOnboardingDio(baseUrl, cfCookie: cfCookie);
   try {
     final res = await dio.get<Map<String, dynamic>>('/api/v1/health');
+    if (isAccessChallenge(res)) {
+      throw AccessChallengeException(
+        statusCode: res.statusCode ?? 0,
+        host: res.realUri.host,
+      );
+    }
     final status = res.statusCode ?? 0;
     if (status < 200 || status >= 300) {
       throw toApiException(

--- a/app/mobile/lib/core/api/auth_api.dart
+++ b/app/mobile/lib/core/api/auth_api.dart
@@ -1,8 +1,10 @@
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/dio_provider.dart';
+import 'package:opendray/core/api/gateway_url.dart';
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/auth/cf_access.dart';
 
@@ -105,22 +107,93 @@ Dio buildOnboardingDio(String baseUrl, {String? cfCookie}) {
   );
 }
 
+/// What a successful probe learned about a candidate gateway.
+class GatewayProbe {
+  const GatewayProbe({required this.health, required this.baseUrl});
+
+  final HealthResponse health;
+
+  /// The URL that actually answered. Differs from the one probed when
+  /// the gateway redirected http to https, in which case this is the
+  /// one worth persisting: saving the http form would earn the same
+  /// redirect on every request from then on.
+  final String baseUrl;
+}
+
 /// Probes /api/v1/health on a candidate gateway URL.
 ///
 /// Throws [AccessChallengeException] when Cloudflare Access answered
 /// instead of the gateway, so onboarding can offer SSO rather than
 /// reporting the login page as a broken server.
-Future<HealthResponse> probeHealth(String baseUrl, {String? cfCookie}) async {
-  final dio = buildOnboardingDio(baseUrl, cfCookie: cfCookie);
+///
+/// Follows exactly one kind of redirect: a same-host, same-path
+/// upgrade from http to https, which is what a TLS front end answers
+/// plain http with. Everything else is reported, because everything
+/// else is somebody intercepting the request.
+Future<GatewayProbe> probeGateway(
+  String baseUrl, {
+  String? cfCookie,
+  @visibleForTesting
+  Dio Function(String baseUrl, {String? cfCookie})? dioFactory,
+}) async {
+  final first =
+      await _probeOnce(baseUrl, cfCookie: cfCookie, dioFactory: dioFactory);
+  if (first.health != null) {
+    return GatewayProbe(health: first.health!, baseUrl: baseUrl);
+  }
+  final upgraded = upgradedBaseUrl(baseUrl: baseUrl, upgraded: first.upgrade!);
+  final second =
+      await _probeOnce(upgraded, cfCookie: cfCookie, dioFactory: dioFactory);
+  if (second.health != null) {
+    return GatewayProbe(health: second.health!, baseUrl: upgraded);
+  }
+  // Two upgrades in a row means a redirect loop, not a front end
+  // doing its job. Report the second answer rather than looping.
+  throw ApiException(
+    statusCode: 0,
+    message: 'Gateway kept redirecting $baseUrl to itself',
+  );
+}
+
+class _ProbeResult {
+  const _ProbeResult.ok(this.health) : upgrade = null;
+  const _ProbeResult.upgradeTo(this.upgrade) : health = null;
+  final HealthResponse? health;
+  final String? upgrade;
+}
+
+Future<_ProbeResult> _probeOnce(
+  String baseUrl, {
+  String? cfCookie,
+  Dio Function(String baseUrl, {String? cfCookie})? dioFactory,
+}) async {
+  final dio = (dioFactory ?? buildOnboardingDio)(baseUrl, cfCookie: cfCookie);
   try {
-    final res = await dio.get<Map<String, dynamic>>('/api/v1/health');
+    // get<dynamic>, never get<Map<String, dynamic>>. Dio casts the
+    // decoded body to the type argument, and that cast runs INSIDE
+    // the await -- before any line below it. A challenge answers with
+    // an HTML login page, so asking for a Map threw a _TypeError with
+    // a null message, which toApiException rendered as the useless
+    // "Network error" while every check here sat unreachable. This
+    // client has no interceptors (the main one in dio_provider does,
+    // and those DO run before the cast), so the shape of the response
+    // has to be our problem, not Dio's.
+    final res = await dio.get<dynamic>('/api/v1/health');
     if (isAccessChallenge(res)) {
       throw AccessChallengeException(
         statusCode: res.statusCode ?? 0,
         host: res.realUri.host,
+        baseUrl: baseUrl,
       );
     }
     final status = res.statusCode ?? 0;
+    if (status >= 300 && status < 400) {
+      final target = protocolUpgradeTarget(
+        from: res.realUri,
+        location: res.headers.value('location'),
+      );
+      if (target != null) return _ProbeResult.upgradeTo(target);
+    }
     if (status < 200 || status >= 300) {
       throw toApiException(
         DioException(
@@ -130,7 +203,18 @@ Future<HealthResponse> probeHealth(String baseUrl, {String? cfCookie}) async {
         ),
       );
     }
-    return HealthResponse.fromJson(res.data ?? {});
+    final data = res.data;
+    if (data is! Map<String, dynamic>) {
+      // A 2xx that is not JSON is not our gateway. Say what actually
+      // came back rather than letting a cast failure downstream turn
+      // it into an unexplained network error.
+      final ct = res.headers.value(Headers.contentTypeHeader) ?? 'none';
+      throw ApiException(
+        statusCode: status,
+        message: 'Not an opendray gateway: expected JSON, got $ct',
+      );
+    }
+    return _ProbeResult.ok(HealthResponse.fromJson(data));
   } catch (e) {
     throw toApiException(e);
   } finally {

--- a/app/mobile/lib/core/api/auth_api.dart
+++ b/app/mobile/lib/core/api/auth_api.dart
@@ -96,6 +96,11 @@ Dio buildOnboardingDio(String baseUrl, {String? cfCookie}) {
         if (cookie != null) 'Cookie': cookie,
       },
       validateStatus: (_) => true,
+      // Same reasoning as buildDio: onboarding is the most likely
+      // place to meet an Access challenge, and following the redirect
+      // lands on an identity provider's HTML instead of reporting the
+      // challenge, which surfaces as an unexplained "Network error".
+      followRedirects: false,
     ),
   );
 }

--- a/app/mobile/lib/core/api/dio_provider.dart
+++ b/app/mobile/lib/core/api/dio_provider.dart
@@ -64,7 +64,7 @@ Dio buildDio({
   String? token,
   String? cfCookie,
   void Function()? onUnauthorized,
-  void Function(String host)? onAccessChallenge,
+  void Function(String host, String? teamDomain)? onAccessChallenge,
 }) {
   final cookieHeader = cfCookieHeader(cfCookie);
   final dio = Dio(
@@ -108,7 +108,12 @@ Dio buildDio({
         // Access login page instead of our JSON.
         if (isAccessChallenge(response)) {
           final host = response.realUri.host;
-          onAccessChallenge?.call(host);
+          // The Location names the team domain, which sign-out needs
+          // and cannot discover later once the cookie is gone.
+          onAccessChallenge?.call(
+            host,
+            teamDomainFromLocation(response.headers.value('location')),
+          );
           handler.reject(
             DioException(
               requestOptions: response.requestOptions,
@@ -215,9 +220,9 @@ final dioProvider = Provider<Dio>((ref) {
     token: token,
     cfCookie: cfCookie,
     onUnauthorized: () => ref.read(authControllerProvider.notifier).logout(),
-    onAccessChallenge: (host) => ref
+    onAccessChallenge: (host, teamDomain) => ref
         .read(cfAccessControllerProvider.notifier)
-        .challenged(reason: host),
+        .challenged(reason: host, teamDomain: teamDomain),
   );
 });
 

--- a/app/mobile/lib/core/api/dio_provider.dart
+++ b/app/mobile/lib/core/api/dio_provider.dart
@@ -225,9 +225,15 @@ ApiException toApiException(Object error) {
   if (error is ApiException) return error;
   if (error is DioException) {
     if (error.error is ApiException) return error.error! as ApiException;
+    // error.message is null for anything Dio did not raise itself --
+    // a decode failure, a bad cast, a platform socket error. Falling
+    // straight through to "Network error" hid a _TypeError behind a
+    // message that pointed at the network, which cost two rounds of
+    // debugging on a problem that was never about the network.
+    final detail = error.message ?? error.error?.toString();
     return ApiException(
       statusCode: error.response?.statusCode ?? 0,
-      message: error.message ?? 'Network error',
+      message: (detail == null || detail.isEmpty) ? 'Network error' : detail,
       body: error.response?.data,
     );
   }

--- a/app/mobile/lib/core/api/dio_provider.dart
+++ b/app/mobile/lib/core/api/dio_provider.dart
@@ -81,6 +81,20 @@ Dio buildDio({
         if (cookieHeader != null) 'Cookie': cookieHeader,
       },
       validateStatus: (_) => true, // we throw ApiException ourselves
+      // Do NOT follow redirects. opendray answers an API request with
+      // data or an error, never a 3xx, so a redirect means something
+      // in front of the gateway intercepted the call -- which is
+      // exactly what Cloudflare Access does when it wants a sign-in.
+      //
+      // Following it is actively harmful: Access bounces to the team
+      // domain, which bounces to the identity provider, which bounces
+      // again. Past five hops dart:io throws RedirectException; short
+      // of that the response that comes back is the IdP's HTML login
+      // page from a host that matches none of the challenge signals,
+      // so it gets parsed as JSON and surfaces as an unexplained
+      // "Network error". Stopping at the first 3xx keeps the Location
+      // header, which says plainly who intercepted us.
+      followRedirects: false,
     ),
   )..httpClientAdapter = IOHttpClientAdapter(
       createHttpClient: () => HttpClient()..idleTimeout = _poolIdleTimeout,

--- a/app/mobile/lib/core/api/dio_provider.dart
+++ b/app/mobile/lib/core/api/dio_provider.dart
@@ -5,6 +5,8 @@ import 'package:dio/io.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/auth/auth_state.dart';
+import 'package:opendray/core/auth/cf_access.dart';
+import 'package:opendray/core/auth/cf_access_controller.dart';
 import 'package:pretty_dio_logger/pretty_dio_logger.dart';
 
 // How many times a transient request is replayed before the failure is
@@ -60,8 +62,11 @@ bool isReplayable(RequestOptions options) {
 Dio buildDio({
   required String baseUrl,
   String? token,
+  String? cfCookie,
   void Function()? onUnauthorized,
+  void Function(String host)? onAccessChallenge,
 }) {
+  final cookieHeader = cfCookieHeader(cfCookie);
   final dio = Dio(
     BaseOptions(
       baseUrl: baseUrl,
@@ -70,6 +75,10 @@ Dio buildDio({
       headers: {
         'Accept': 'application/json',
         if (token != null) 'Authorization': 'Bearer $token',
+        // Cloudflare Access reads this at the edge; the gateway
+        // never sees it. Absent on a LAN deployment, where there is
+        // no Access in the path.
+        if (cookieHeader != null) 'Cookie': cookieHeader,
       },
       validateStatus: (_) => true, // we throw ApiException ourselves
     ),
@@ -80,6 +89,25 @@ Dio buildDio({
   dio.interceptors.add(
     InterceptorsWrapper(
       onResponse: (response, handler) {
+        // Checked before the status code, because a challenge
+        // usually arrives as a perfectly healthy 200 carrying the
+        // Access login page instead of our JSON.
+        if (isAccessChallenge(response)) {
+          final host = response.realUri.host;
+          onAccessChallenge?.call(host);
+          handler.reject(
+            DioException(
+              requestOptions: response.requestOptions,
+              response: response,
+              type: DioExceptionType.badResponse,
+              error: AccessChallengeException(
+                statusCode: response.statusCode ?? 0,
+                host: host,
+              ),
+            ),
+          );
+          return;
+        }
         final status = response.statusCode ?? 0;
         if (status >= 200 && status < 300) {
           handler.next(response);
@@ -153,6 +181,11 @@ Dio buildDio({
 // `ref.watch(dioProvider)` and don't worry about staleness.
 final dioProvider = Provider<Dio>((ref) {
   final auth = ref.watch(authControllerProvider);
+  // Watched, not read: a fresh Access cookie has to rebuild the
+  // client, otherwise every request keeps going out with the dead
+  // one until something else happens to invalidate the provider.
+  ref.watch(cfAccessControllerProvider);
+  final cfCookie = ref.read(cfAccessControllerProvider.notifier).cookie;
   final baseUrl = switch (auth) {
     AuthLoggedOut(serverUrl: final s) => s,
     AuthLoggedIn(serverUrl: final s) => s,
@@ -166,7 +199,11 @@ final dioProvider = Provider<Dio>((ref) {
   return buildDio(
     baseUrl: baseUrl,
     token: token,
+    cfCookie: cfCookie,
     onUnauthorized: () => ref.read(authControllerProvider.notifier).logout(),
+    onAccessChallenge: (host) => ref
+        .read(cfAccessControllerProvider.notifier)
+        .challenged(reason: host),
   );
 });
 

--- a/app/mobile/lib/core/api/gateway_url.dart
+++ b/app/mobile/lib/core/api/gateway_url.dart
@@ -1,0 +1,92 @@
+import 'dart:io';
+
+// Working out what the operator meant when they typed a gateway URL.
+//
+// Two deployments, two conventions, and getting them confused is what
+// makes onboarding fail in a way nobody can debug from the message:
+//
+//   LAN       http://192.168.3.5:8770   no certificate, plain http
+//   published https://gateway.example    TLS in front; plain http gets
+//                                        a 301 to the https form
+//
+// So the scheme is a real decision, not a formality.
+
+/// Adds a scheme to a URL typed without one and trims trailing noise.
+///
+/// A private or loopback address is a LAN gateway and gets http;
+/// anything else is assumed to be published and gets https. Guessing
+/// https for a LAN address would break the common self-hosted case;
+/// guessing http for a hostname produces a redirect the app then has
+/// to make sense of.
+///
+/// An explicit scheme is always left alone. If the operator says
+/// http:// against a published host they get the redirect, and
+/// [protocolUpgradeTarget] handles it from there.
+String normalizeGatewayUrl(String raw) {
+  var v = raw.trim();
+  if (!v.startsWith('http://') && !v.startsWith('https://')) {
+    v = '${_looksLocal(v) ? 'http' : 'https'}://$v';
+  }
+  return v.replaceAll(RegExp(r'/+$'), '');
+}
+
+/// The URL to retry when a redirect is nothing but a scheme upgrade.
+///
+/// TLS front ends answer plain http with a 301 to the https form of
+/// the same request. That one is safe to act on without asking: same
+/// host, same path, strictly more secure, and the server asked for
+/// it. Every other redirect is something intercepting the request,
+/// which is reported rather than followed, so returning null here is
+/// what keeps the Access challenge visible.
+String? protocolUpgradeTarget({required Uri from, String? location}) {
+  if (from.scheme != 'http') return null;
+  final loc = (location ?? '').trim();
+  if (loc.isEmpty) return null;
+  final target = Uri.tryParse(loc);
+  if (target == null) return null;
+  if (target.scheme != 'https') return null;
+  if (target.host.toLowerCase() != from.host.toLowerCase()) return null;
+  if (target.path != from.path) return null;
+  return target.toString();
+}
+
+/// Rebuilds the base URL from an upgraded probe URL, so onboarding
+/// persists `https://host` rather than `https://host/api/v1/health`.
+String upgradedBaseUrl({required String baseUrl, required String upgraded}) {
+  final base = Uri.parse(baseUrl.replaceAll(RegExp(r'/+$'), ''));
+  final up = Uri.parse(upgraded);
+  return Uri(
+    scheme: up.scheme,
+    host: up.host,
+    port: base.hasPort ? base.port : null,
+  ).toString().replaceAll(RegExp(r'/+$'), '');
+}
+
+/// Whether a host[:port] with no scheme is a LAN address.
+bool _looksLocal(String hostPort) {
+  // Parsed with a scheme bolted on, because a bare "host:8770" is
+  // otherwise read as scheme "host".
+  final host = Uri.tryParse('http://$hostPort')?.host ?? '';
+  if (host.isEmpty) return false;
+  final lower = host.toLowerCase();
+  if (lower == 'localhost' || lower.endsWith('.local')) return true;
+  final ip = InternetAddress.tryParse(host);
+  if (ip == null) return false;
+  if (ip.isLoopback || ip.isLinkLocal) return true;
+  return _isPrivate(ip);
+}
+
+/// RFC 1918 / RFC 4193. dart:io has isLoopback and isLinkLocal but no
+/// notion of a private range, so the ranges are spelled out.
+bool _isPrivate(InternetAddress ip) {
+  final b = ip.rawAddress;
+  if (ip.type == InternetAddressType.IPv4 && b.length == 4) {
+    if (b[0] == 10) return true;
+    if (b[0] == 172 && b[1] >= 16 && b[1] <= 31) return true;
+    if (b[0] == 192 && b[1] == 168) return true;
+    return false;
+  }
+  // fc00::/7 — unique local addresses.
+  if (b.isNotEmpty) return (b[0] & 0xfe) == 0xfc;
+  return false;
+}

--- a/app/mobile/lib/core/api/logs_api.dart
+++ b/app/mobile/lib/core/api/logs_api.dart
@@ -14,7 +14,9 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:opendray/core/api/ws_connect.dart';
 import 'package:opendray/core/auth/auth_state.dart';
+import 'package:opendray/core/auth/cf_access_controller.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 class LogRecord {
@@ -72,15 +74,17 @@ class LogsStream {
   // LogsStream first and then mutate _sub after the WS subscription
   // is attached, which factory ctors don't permit cleanly.
   // ignore: prefer_constructors_over_static_methods
-  static LogsStream open({required String serverUrl, required String token}) {
-    final base = serverUrl.replaceAll(RegExp(r'/+$'), '');
-    final wsBase = base.startsWith('https')
-        ? base.replaceFirst('https', 'wss')
-        : base.replaceFirst('http', 'ws');
-    final url = Uri.parse(
-      '$wsBase/api/v1/admin/logs/stream?token=${Uri.encodeQueryComponent(token)}',
+  static LogsStream open({
+    required String serverUrl,
+    required String token,
+    String? cfCookie,
+  }) {
+    final channel = connectGatewayWs(
+      serverUrl: serverUrl,
+      path: '/api/v1/admin/logs/stream',
+      token: token,
+      cfCookie: cfCookie,
     );
-    final channel = WebSocketChannel.connect(url);
     final s = LogsStream._(channel);
     s._sub = channel.stream.listen(
       s._onMessage,
@@ -124,5 +128,9 @@ class LogsStream {
 LogsStream? openLogsStream(WidgetRef ref) {
   final auth = ref.read(authControllerProvider);
   if (auth is! AuthLoggedIn) return null;
-  return LogsStream.open(serverUrl: auth.serverUrl, token: auth.token);
+  return LogsStream.open(
+    serverUrl: auth.serverUrl,
+    token: auth.token,
+    cfCookie: ref.read(cfAccessControllerProvider.notifier).cookie,
+  );
 }

--- a/app/mobile/lib/core/api/ws_connect.dart
+++ b/app/mobile/lib/core/api/ws_connect.dart
@@ -1,0 +1,101 @@
+import 'package:dio/dio.dart';
+import 'package:opendray/core/auth/cf_access.dart';
+import 'package:web_socket_channel/io.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+// One place to open a WebSocket against the gateway.
+//
+// The bearer token goes in the `Authorization` header, not in the
+// query string. The gateway accepts both (internal/auth: bearerToken
+// reads the header first, then `?token=`), and the browser client has
+// to keep using the query form because the WebSocket API cannot set
+// headers -- but a native client has no such excuse, and a token in a
+// URL ends up in every proxy access log it passes through. Publishing
+// the gateway through Cloudflare makes that a real log, on someone
+// else's disk, rather than a line in our own.
+//
+// The same handshake carries the Cloudflare Access cookie, because
+// Access gates the WebSocket upgrade exactly like any other request.
+
+/// `ws://`/`wss://` URI for a gateway path.
+Uri gatewayWsUri({required String serverUrl, required String path}) {
+  final base = serverUrl.replaceAll(RegExp(r'/+$'), '');
+  final wsBase = base.startsWith('https')
+      ? base.replaceFirst('https', 'wss')
+      : base.replaceFirst('http', 'ws');
+  return Uri.parse('$wsBase$path');
+}
+
+/// Handshake headers. `Origin` is deliberately absent: the gateway's
+/// same-origin check treats a missing Origin as a non-browser client,
+/// which is what we are.
+Map<String, String> gatewayWsHeaders({
+  required String token,
+  String? cfCookie,
+}) {
+  final cookie = cfCookieHeader(cfCookie);
+  return {
+    'Authorization': 'Bearer $token',
+    if (cookie != null) 'Cookie': cookie,
+  };
+}
+
+/// Opens an authenticated WebSocket to [path] on [serverUrl].
+WebSocketChannel connectGatewayWs({
+  required String serverUrl,
+  required String path,
+  required String token,
+  String? cfCookie,
+}) {
+  return IOWebSocketChannel.connect(
+    gatewayWsUri(serverUrl: serverUrl, path: path),
+    headers: gatewayWsHeaders(token: token, cfCookie: cfCookie),
+  );
+}
+
+/// How many times a dropped gateway WebSocket is retried before the
+/// UI stops trying and reports the failure.
+///
+/// The cap only means anything because the attempt counter is reset
+/// on the first byte received rather than on the socket object being
+/// created: the latter says nothing about whether the handshake was
+/// accepted, and resetting there makes every attempt look like the
+/// first one, so the loop never ends.
+const kMaxReconnectAttempts = 5;
+
+/// Delay before reconnect attempt [attempt] (1-based).
+///
+/// Exponential from 500ms, so five attempts span roughly 8 seconds
+/// rather than hammering a gateway that is restarting behind a
+/// deploy, or an Access gate that is going to keep saying no until
+/// the operator signs in again.
+Duration reconnectBackoff(int attempt) {
+  final n = attempt < 1 ? 1 : attempt;
+  return Duration(milliseconds: 500 * (1 << (n - 1)));
+}
+
+/// Re-checks Access over HTTP after a WebSocket failure.
+///
+/// A handshake that Cloudflare Access rejects surfaces to the client
+/// as a plain socket error: the upgrade simply does not happen, and
+/// there is no response object to inspect the way the Dio pipeline
+/// does. That makes an expired Access cookie indistinguishable from
+/// "the gateway is down" at the WS layer, and an operator sitting on
+/// a session terminal when the cookie expires would see nothing but
+/// a reconnect loop, with no way back to the sign-in.
+///
+/// So we ask a path that *can* answer: one cheap GET through the
+/// guarded client, whose response runs the same challenge detection
+/// as everything else and raises the sign-in through AccessGate.
+/// Result and errors are both discarded on purpose; the interceptor
+/// has already done the only work that matters.
+Future<void> probeForAccessChallenge(Dio dio) async {
+  try {
+    await dio.get<dynamic>('/api/v1/health');
+  } on Object catch (_) {
+    // Nothing to do here. Either the probe was challenged (in which
+    // case the interceptor already told CfAccessController) or the
+    // gateway is genuinely unreachable, which the WS error the
+    // caller is already showing describes better than we could.
+  }
+}

--- a/app/mobile/lib/core/auth/access_gate.dart
+++ b/app/mobile/lib/core/auth/access_gate.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/auth/auth_state.dart';
+import 'package:opendray/core/auth/cf_access_controller.dart';
+import 'package:opendray/features/auth/cf_access_login_screen.dart';
+
+// Surfaces the Cloudflare Access sign-in as soon as the edge bounces
+// a request, from wherever in the app that happened.
+//
+// Sits above the router rather than inside it because an Access
+// challenge is orthogonal to opendray's own auth: it can land on the
+// login screen, on a session terminal, or mid-way through onboarding,
+// and the recovery is the same everywhere.
+//
+// Drawn as an overlay on a Stack, not as a replacement for [child],
+// so the screen underneath keeps its state -- an open session with a
+// half-typed prompt must still be there afterwards.
+class AccessGate extends ConsumerWidget {
+  const AccessGate({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final access = ref.watch(cfAccessControllerProvider);
+    final auth = ref.watch(authControllerProvider);
+    final baseUrl = switch (auth) {
+      AuthLoggedOut(serverUrl: final s) => s,
+      AuthLoggedIn(serverUrl: final s) => s,
+      _ => '',
+    };
+
+    // No server URL yet means onboarding has not run; there is
+    // nothing to authenticate against, and onboarding drives its own
+    // Access flow inline.
+    final showLogin = access is CfAccessNeedsLogin && baseUrl.isNotEmpty;
+
+    return Stack(
+      children: [
+        child,
+        if (showLogin)
+          Positioned.fill(
+            child: CfAccessLoginScreen(
+              baseUrl: baseUrl,
+              onResult: (cookie) {
+                final notifier = ref.read(cfAccessControllerProvider.notifier);
+                if (cookie == null) {
+                  notifier.dismiss();
+                } else {
+                  notifier.save(cookie);
+                }
+              },
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/app/mobile/lib/core/auth/auth_state.dart
+++ b/app/mobile/lib/core/auth/auth_state.dart
@@ -134,8 +134,25 @@ class AuthController extends StateNotifier<AuthState> {
         : AuthLoggedOut(serverUrl);
   }
 
+  /// Forgets the gateway entirely and returns to onboarding.
+  ///
+  /// Deletes its own keys rather than calling deleteAll: the app lock
+  /// is a device preference, not a property of the gateway, and
+  /// wiping it here would silently disable the lock every time the
+  /// operator pointed the app at a different server.
+  ///
+  /// The Cloudflare Access cookie IS gateway-scoped, but clearing it
+  /// belongs to CfAccessController, which also has to reach the
+  /// WebView's cookie jar and keep its own state in step. So any
+  /// caller of this method MUST call
+  /// `cfAccessControllerProvider.notifier.clear(baseUrl: <old url>)`
+  /// first, while the old URL is still readable. Skipping it leaves
+  /// a cookie for the previous host in storage, and the stored
+  /// cookie is a single global value with no host affinity, so it
+  /// would then be attached to the NEXT gateway's requests.
   Future<void> resetServer() async {
-    await _storage.deleteAll();
+    await _clearTokenOnly();
+    await _storage.delete(key: SecureKeys.serverUrl);
     state = const AuthOnboarding();
   }
 

--- a/app/mobile/lib/core/auth/biometric_lock.dart
+++ b/app/mobile/lib/core/auth/biometric_lock.dart
@@ -1,0 +1,255 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:local_auth/local_auth.dart';
+
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/core/storage/secure_store.dart';
+
+// Optional app lock in front of everything.
+//
+// This exists because of what publishing the gateway costs: once the
+// app works from the public internet, an unlocked phone is a live
+// admin console. The bearer token and the Access cookie both sit in
+// the platform keystore, so anyone holding the device is already
+// past both gates. The device lock is the only thing left, and it is
+// worth being able to demand it again at the app boundary.
+
+/// How long the app may be out of the foreground before it relocks.
+///
+/// Deliberately much longer than the resume-refresh threshold in
+/// core/lifecycle/resume_refresh.dart: the Cloudflare Access sign-in itself sends
+/// the operator to a mail app for a one-time code, and relocking on
+/// the way back would turn the two features into a loop.
+const kBiometricRelockThreshold = Duration(seconds: 60);
+
+/// Whether an absence that began at [pausedAt] and ended at
+/// [resumedAt] should put the lock screen back up.
+bool shouldRelockOnResume({
+  required bool enabled,
+  required DateTime? pausedAt,
+  required DateTime resumedAt,
+}) {
+  if (!enabled) return false;
+  if (pausedAt == null) return false;
+  return resumedAt.difference(pausedAt) >= kBiometricRelockThreshold;
+}
+
+/// Persisted on/off flag for the lock.
+///
+/// The state is nullable on purpose: null means "not read yet". The
+/// gate has to tell that apart from "off", because the transition it
+/// locks on is the one out of null. Treating the initial false as a
+/// real "off" would make turning the lock on in settings look
+/// identical to app start, and prompt for a second unlock right after
+/// the one that enabled it.
+class BiometricLockController extends StateNotifier<bool?> {
+  BiometricLockController(this._storage) : super(null) {
+    _bootstrap();
+  }
+
+  final FlutterSecureStorage _storage;
+
+  Future<void> _bootstrap() async {
+    try {
+      state = await _storage.read(key: SecureKeys.biometricLock) == '1';
+    } on Object catch (_) {
+      // A keystore we cannot read means we cannot prove the operator
+      // asked for the lock. Defaulting to off keeps them out of an
+      // app they can never unlock.
+      state = false;
+    }
+  }
+
+  Future<void> setEnabled({required bool enabled}) async {
+    if (enabled) {
+      await _storage.write(key: SecureKeys.biometricLock, value: '1');
+    } else {
+      await _storage.delete(key: SecureKeys.biometricLock);
+    }
+    state = enabled;
+  }
+}
+
+final biometricLockControllerProvider =
+    StateNotifierProvider<BiometricLockController, bool?>((ref) {
+  return BiometricLockController(ref.watch(secureStorageProvider));
+});
+
+/// The flag with "still loading" flattened to "off", for callers that
+/// only need to render a switch.
+final biometricLockEnabledProvider = Provider<bool>((ref) {
+  return ref.watch(biometricLockControllerProvider) ?? false;
+});
+
+final localAuthProvider = Provider<LocalAuthentication>((ref) {
+  return LocalAuthentication();
+});
+
+/// Whether this device can actually enforce the lock. A device with
+/// no screen lock enrolled would let the operator switch the setting
+/// on and then never be asked for anything.
+Future<bool> canLockDevice(LocalAuthentication auth) async {
+  try {
+    return await auth.isDeviceSupported();
+  } on Object catch (_) {
+    return false;
+  }
+}
+
+/// Prompts for biometrics or the device passcode.
+///
+/// `biometricOnly: false` on purpose: a passcode fallback is what
+/// keeps a failed fingerprint from locking the operator out of their
+/// own gateway.
+Future<bool> promptUnlock(LocalAuthentication auth, String reason) async {
+  try {
+    return await auth.authenticate(
+      localizedReason: reason,
+      options: const AuthenticationOptions(
+        stickyAuth: true,
+        biometricOnly: false,
+      ),
+    );
+  } on Object catch (_) {
+    return false;
+  }
+}
+
+/// Puts the lock screen in front of [child] until the operator
+/// authenticates, and puts it back after a real absence.
+class BiometricGate extends ConsumerStatefulWidget {
+  const BiometricGate({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  ConsumerState<BiometricGate> createState() => _BiometricGateState();
+}
+
+class _BiometricGateState extends ConsumerState<BiometricGate>
+    with WidgetsBindingObserver {
+  bool _locked = false;
+  bool _prompting = false;
+  DateTime? _pausedAt;
+
+  // True once the stored flag has been read. Until then we do not
+  // know whether to lock, and locking optimistically would flash a
+  // lock screen at operators who never turned it on.
+  bool _initialized = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    final enabled = ref.read(biometricLockEnabledProvider);
+    switch (state) {
+      case AppLifecycleState.paused:
+      case AppLifecycleState.detached:
+      case AppLifecycleState.hidden:
+        _pausedAt ??= DateTime.now();
+      case AppLifecycleState.resumed:
+        final pausedAt = _pausedAt;
+        _pausedAt = null;
+        if (shouldRelockOnResume(
+          enabled: enabled,
+          pausedAt: pausedAt,
+          resumedAt: DateTime.now(),
+        )) {
+          setState(() => _locked = true);
+          unawaited(_unlock());
+        }
+      case AppLifecycleState.inactive:
+        break;
+    }
+  }
+
+  Future<void> _unlock() async {
+    if (_prompting) return;
+    _prompting = true;
+    try {
+      final ok = await promptUnlock(
+        ref.read(localAuthProvider),
+        t.lock.reason,
+      );
+      if (!mounted) return;
+      if (ok) setState(() => _locked = false);
+    } finally {
+      _prompting = false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final stored = ref.watch(biometricLockControllerProvider);
+    final enabled = stored ?? false;
+
+    // Runs exactly once, on the frame the stored flag first resolves.
+    // Later flips of the flag are the operator using the settings
+    // switch, and those must not lock: they have just authenticated
+    // to turn it on.
+    if (!_initialized && stored != null) {
+      _initialized = true;
+      if (enabled) {
+        _locked = true;
+        WidgetsBinding.instance.addPostFrameCallback((_) => _unlock());
+      }
+    }
+
+    return Stack(
+      children: [
+        widget.child,
+        if (_locked && enabled)
+          Positioned.fill(child: _LockScreen(onUnlock: _unlock)),
+      ],
+    );
+  }
+}
+
+class _LockScreen extends StatelessWidget {
+  const _LockScreen({required this.onUnlock});
+
+  final Future<void> Function() onUnlock;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    // Opaque, not translucent: the point is that a session transcript
+    // is not readable over the lock screen's shoulder.
+    return Material(
+      color: theme.colorScheme.surface,
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.lock_outline,
+              size: 48,
+              color: theme.colorScheme.outline,
+            ),
+            const SizedBox(height: 16),
+            Text(t.lock.title, style: theme.textTheme.titleMedium),
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: onUnlock,
+              icon: const Icon(Icons.fingerprint),
+              label: Text(t.lock.unlock),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/mobile/lib/core/auth/cf_access.dart
+++ b/app/mobile/lib/core/auth/cf_access.dart
@@ -25,11 +25,6 @@ const kCfAccessCookieName = 'CF_Authorization';
 /// whole admin SPA just to prove the cookie works.
 const kAccessProbePath = '/api/v1/health';
 
-/// Cloudflare's login endpoint is served from the *app* hostname; the
-/// identity provider redirect goes to the team domain below and comes
-/// back here.
-const _accessLoginPath = '/cdn-cgi/access/login';
-
 /// Every Access team domain ends in this. Landing here means we were
 /// challenged rather than served.
 const _accessHostSuffix = '.cloudflareaccess.com';
@@ -157,13 +152,23 @@ DateTime? cfAuthorizationExpiry(String jwt) {
   }
 }
 
-/// URL that starts the Access SSO flow for [baseUrl] and returns to a
-/// JSON endpoint we can recognise once it succeeds.
-String accessLoginUrl(String baseUrl) {
-  final base = _trimSlashes(baseUrl);
-  final redirect = Uri.encodeQueryComponent(kAccessProbePath);
-  return '$base$_accessLoginPath?redirect_url=$redirect';
-}
+/// URL to load in the sign-in WebView.
+///
+/// Deliberately a protected resource, NOT Cloudflare's login endpoint.
+/// Access owns that URL and it cannot be built by hand: it lives on
+/// the team domain rather than the app's, its path carries the app
+/// hostname, and it is signed with `kid` and `meta` parameters. A
+/// hand-assembled /cdn-cgi/access/login on the app hostname simply
+/// fails to load (ERR_HTTP_RESPONSE_CODE_FAILURE), which is what a
+/// first attempt at this did.
+///
+/// Loading the protected resource instead lets Access issue its own
+/// redirect, correctly signed, run the identity provider, and land
+/// back here with the cookie set. Landing back on a small JSON
+/// endpoint also means the WebView shows something harmless for the
+/// instant before we read the cookie and close it.
+String accessSignInUrl(String baseUrl) =>
+    '${_trimSlashes(baseUrl)}$kAccessProbePath';
 
 /// The `Cookie` header value for [cookie], or null when there is no
 /// session — sending `Cookie: CF_Authorization=` would be worse than

--- a/app/mobile/lib/core/auth/cf_access.dart
+++ b/app/mobile/lib/core/auth/cf_access.dart
@@ -1,0 +1,160 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+
+// Cloudflare Access support.
+//
+// The gateway is published through a Cloudflare Tunnel and gated by
+// Access, so every request from outside the LAN has to carry proof
+// that the operator passed the Access identity check. Browsers get
+// that for free: Access sets a `CF_Authorization` cookie on the app
+// hostname after SSO and the browser replays it. A native app has no
+// such flow, so we run the same SSO in a WebView, lift the resulting
+// cookie out of the platform cookie store, and attach it by hand to
+// every HTTP and WebSocket request.
+//
+// This is layered *under* opendray's own bearer auth, not instead of
+// it: Access decides whether the request reaches the tunnel at all,
+// opendray still decides whether the caller is signed in.
+
+/// Name of the cookie Cloudflare Access sets after a successful login.
+const kCfAccessCookieName = 'CF_Authorization';
+
+/// Where the login flow lands once Access is satisfied. A tiny JSON
+/// endpoint rather than `/`, so the WebView does not have to boot the
+/// whole admin SPA just to prove the cookie works.
+const kAccessProbePath = '/api/v1/health';
+
+/// Cloudflare's login endpoint is served from the *app* hostname; the
+/// identity provider redirect goes to the team domain below and comes
+/// back here.
+const _accessLoginPath = '/cdn-cgi/access/login';
+
+/// Every Access team domain ends in this. Landing here means we were
+/// challenged rather than served.
+const _accessHostSuffix = '.cloudflareaccess.com';
+
+/// Treat a cookie as dead slightly early. A cookie that expires while
+/// a request is in flight surfaces as a confusing HTML parse failure;
+/// re-authenticating a minute early costs nothing.
+const kAccessExpiryGrace = Duration(minutes: 2);
+
+/// A live Cloudflare Access cookie.
+class CfAccessSession {
+  const CfAccessSession({required this.cookie, this.expiresAt});
+
+  /// Raw `CF_Authorization` value.
+  final String cookie;
+
+  /// `exp` from the Access JWT, when it could be read. Null means the
+  /// cookie is still usable — we just cannot pre-empt its expiry and
+  /// have to rely on challenge detection instead.
+  final DateTime? expiresAt;
+
+  bool get isExpired {
+    final exp = expiresAt;
+    if (exp == null) return false;
+    return DateTime.now().toUtc().isAfter(exp.subtract(kAccessExpiryGrace));
+  }
+}
+
+/// Whether a response is Cloudflare Access blocking us rather than the
+/// gateway answering.
+///
+/// Four signals, because which one shows up depends on whether Dio
+/// followed the redirect and on how Access chose to answer a request
+/// that asked for JSON.
+bool isAccessChallengeResponse({
+  required int statusCode,
+  required Uri realUri,
+  String? location,
+  String? cfMitigated,
+  String? contentType,
+}) {
+  // Dio followed the 302 and we are now sitting on the Access login
+  // page itself.
+  if (realUri.host.toLowerCase().endsWith(_accessHostSuffix)) return true;
+
+  // Redirect not followed — the Location header gives it away.
+  if (statusCode >= 300 && statusCode < 400) {
+    if ((location ?? '').toLowerCase().contains(_accessHostSuffix)) return true;
+  }
+
+  // Cloudflare says it handled the request at the edge.
+  if ((cfMitigated ?? '').isNotEmpty) return true;
+
+  final isHtml = (contentType ?? '').toLowerCase().contains('text/html');
+
+  // HTML served from Cloudflare's own path namespace: the Access
+  // sign-in form, rendered on the app hostname rather than on the
+  // team domain.
+  if (isHtml && realUri.path.startsWith('/cdn-cgi/')) return true;
+
+  // An auth-shaped rejection that did not come from us. opendray
+  // answers 401 and 403 as JSON, always, so an HTML one is the edge
+  // talking -- including a hard Access deny, which renders a page
+  // rather than redirecting anywhere.
+  //
+  // That "always" is a real invariant of the Go side, not an
+  // assumption: writeUnauth in internal/auth/auth.go and every
+  // writeError helper set application/json, and internal/web only
+  // serves HTML on 200. Nothing enforces it mechanically, though,
+  // so a future handler answering 401/403 with an HTML body would
+  // be silently swallowed here and sent to a sign-in that cannot
+  // help.
+  if (isHtml && (statusCode == 401 || statusCode == 403)) return true;
+
+  // Deliberately NOT "any HTML anywhere". The gateway does serve
+  // HTML on real endpoints (downloading an .html file through
+  // /api/v1/fs), and treating one of those as a challenge would
+  // discard the response and push the operator into a sign-in that
+  // fixes nothing, because nothing was wrong with their session.
+  return false;
+}
+
+/// Response-shaped wrapper over [isAccessChallengeResponse].
+bool isAccessChallenge(Response<dynamic> res) {
+  return isAccessChallengeResponse(
+    statusCode: res.statusCode ?? 0,
+    realUri: res.realUri,
+    location: res.headers.value('location'),
+    cfMitigated: res.headers.value('cf-mitigated'),
+    contentType: res.headers.value(Headers.contentTypeHeader),
+  );
+}
+
+/// Reads `exp` out of an Access JWT. Returns null for anything we
+/// cannot parse — a cookie we do not understand is still worth
+/// sending, we just cannot predict when it dies.
+DateTime? cfAuthorizationExpiry(String jwt) {
+  final parts = jwt.split('.');
+  if (parts.length != 3) return null;
+  try {
+    final raw = utf8.decode(base64Url.decode(base64Url.normalize(parts[1])));
+    final payload = jsonDecode(raw);
+    if (payload is! Map) return null;
+    final exp = payload['exp'];
+    if (exp is! int) return null;
+    return DateTime.fromMillisecondsSinceEpoch(exp * 1000, isUtc: true);
+  } on Object catch (_) {
+    return null;
+  }
+}
+
+/// URL that starts the Access SSO flow for [baseUrl] and returns to a
+/// JSON endpoint we can recognise once it succeeds.
+String accessLoginUrl(String baseUrl) {
+  final base = _trimSlashes(baseUrl);
+  final redirect = Uri.encodeQueryComponent(kAccessProbePath);
+  return '$base$_accessLoginPath?redirect_url=$redirect';
+}
+
+/// The `Cookie` header value for [cookie], or null when there is no
+/// session — sending `Cookie: CF_Authorization=` would be worse than
+/// sending nothing, since Access reads it as a malformed token.
+String? cfCookieHeader(String? cookie) {
+  if (cookie == null || cookie.isEmpty) return null;
+  return '$kCfAccessCookieName=$cookie';
+}
+
+String _trimSlashes(String url) => url.replaceAll(RegExp(r'/+$'), '');

--- a/app/mobile/lib/core/auth/cf_access.dart
+++ b/app/mobile/lib/core/auth/cf_access.dart
@@ -134,19 +134,60 @@ bool isAccessChallenge(Response<dynamic> res) {
   );
 }
 
+/// The Cloudflare Access logout endpoint for a host or base URL.
+///
+/// Signing out has to reach BOTH: the app's own domain holds the
+/// CF_Authorization cookie, but the team domain holds the identity
+/// session, and that is the one that decides whether the next
+/// sign-in silently re-issues a cookie instead of asking the identity
+/// provider anything.
+String accessLogoutUrl(String hostOrBaseUrl) {
+  final v = _trimSlashes(hostOrBaseUrl.trim());
+  final base = (v.startsWith('http://') || v.startsWith('https://'))
+      ? v
+      : 'https://$v';
+  return '$base/cdn-cgi/access/logout';
+}
+
+/// The Access team domain named by a challenge redirect's Location.
+String? teamDomainFromLocation(String? location) {
+  final loc = (location ?? '').trim();
+  if (loc.isEmpty) return null;
+  final host = Uri.tryParse(loc)?.host.toLowerCase() ?? '';
+  if (!host.endsWith(_accessHostSuffix)) return null;
+  return host;
+}
+
+/// The Access team domain from a cookie's `iss` claim, for when we
+/// hold a session but never saw the challenge that created it.
+String? teamDomainFromJwt(String jwt) {
+  final claims = _jwtClaims(jwt);
+  final iss = claims?['iss'];
+  if (iss is! String) return null;
+  final host = Uri.tryParse(iss)?.host.toLowerCase() ?? '';
+  if (!host.endsWith(_accessHostSuffix)) return null;
+  return host;
+}
+
 /// Reads `exp` out of an Access JWT. Returns null for anything we
 /// cannot parse — a cookie we do not understand is still worth
 /// sending, we just cannot predict when it dies.
 DateTime? cfAuthorizationExpiry(String jwt) {
+  final exp = _jwtClaims(jwt)?['exp'];
+  if (exp is! int) return null;
+  return DateTime.fromMillisecondsSinceEpoch(exp * 1000, isUtc: true);
+}
+
+/// Decoded claims of a JWT, or null for anything unparseable. A
+/// cookie we cannot read is still worth sending; we just cannot
+/// reason about it.
+Map<String, dynamic>? _jwtClaims(String jwt) {
   final parts = jwt.split('.');
   if (parts.length != 3) return null;
   try {
     final raw = utf8.decode(base64Url.decode(base64Url.normalize(parts[1])));
     final payload = jsonDecode(raw);
-    if (payload is! Map) return null;
-    final exp = payload['exp'];
-    if (exp is! int) return null;
-    return DateTime.fromMillisecondsSinceEpoch(exp * 1000, isUtc: true);
+    return payload is Map<String, dynamic> ? payload : null;
   } on Object catch (_) {
     return null;
   }

--- a/app/mobile/lib/core/auth/cf_access.dart
+++ b/app/mobile/lib/core/auth/cf_access.dart
@@ -75,9 +75,25 @@ bool isAccessChallengeResponse({
   // page itself.
   if (realUri.host.toLowerCase().endsWith(_accessHostSuffix)) return true;
 
-  // Redirect not followed — the Location header gives it away.
+  // A redirect we deliberately did not follow: the clients set
+  // followRedirects: false precisely so this stays reachable.
   if (statusCode >= 300 && statusCode < 400) {
-    if ((location ?? '').toLowerCase().contains(_accessHostSuffix)) return true;
+    final loc = (location ?? '').trim();
+    if (loc.toLowerCase().contains(_accessHostSuffix)) return true;
+    // Any redirect that leaves the gateway's own host was injected by
+    // something sitting in front of it. opendray answers an API
+    // request with data or an error, never a 3xx: the one redirect
+    // the gateway serves is GET / -> /admin/, which this app never
+    // requests and which is same-host anyway. Catching the general
+    // case matters because Access configured with a single identity
+    // provider can bounce straight past its own team domain to the
+    // IdP, whose hostname matches none of the other signals.
+    final target = Uri.tryParse(loc);
+    if (target != null &&
+        target.host.isNotEmpty &&
+        target.host.toLowerCase() != realUri.host.toLowerCase()) {
+      return true;
+    }
   }
 
   // Cloudflare says it handled the request at the edge.

--- a/app/mobile/lib/core/auth/cf_access_controller.dart
+++ b/app/mobile/lib/core/auth/cf_access_controller.dart
@@ -1,0 +1,165 @@
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import 'package:opendray/core/auth/cf_access.dart';
+import 'package:opendray/core/storage/secure_store.dart';
+
+// Holds the Cloudflare Access cookie for the whole app.
+//
+// Deliberately separate from AuthController: Access and opendray are
+// two independent gates and either can expire without the other. A
+// combined state would force a full opendray re-login every time the
+// Access session rolled over, which on a 24h Access policy is daily.
+
+/// How long the SSO sheet stays closed after the operator dismisses it.
+const kAccessDismissSuppression = Duration(seconds: 30);
+
+sealed class CfAccessState {
+  const CfAccessState();
+}
+
+/// Reading secure storage.
+class CfAccessLoading extends CfAccessState {
+  const CfAccessLoading();
+}
+
+/// No cookie and nothing has challenged us — the normal state on the
+/// LAN, where the gateway is reached directly and Access is not in
+/// the path at all.
+class CfAccessIdle extends CfAccessState {
+  const CfAccessIdle();
+}
+
+/// We hold a cookie we believe is live.
+class CfAccessReady extends CfAccessState {
+  const CfAccessReady(this.session);
+  final CfAccessSession session;
+}
+
+/// Access challenged us, or the cookie we had expired. The UI must
+/// run the SSO WebView before anything else will work.
+class CfAccessNeedsLogin extends CfAccessState {
+  const CfAccessNeedsLogin({this.reason});
+
+  /// Null when the cookie simply aged out; set when a live request
+  /// was bounced, so the operator sees why the sheet appeared.
+  final String? reason;
+}
+
+class CfAccessController extends StateNotifier<CfAccessState> {
+  CfAccessController(this._storage) : super(const CfAccessLoading()) {
+    _bootstrap();
+  }
+
+  final FlutterSecureStorage _storage;
+
+  // Set when the operator cancels the SSO sheet. Without it, the very
+  // next background poll challenges again and the sheet reappears
+  // instantly -- the operator would have no way to dismiss it and
+  // read the error underneath.
+  DateTime? _suppressedUntil;
+
+  Future<void> _bootstrap() async {
+    try {
+      final cookie = await _storage.read(key: SecureKeys.cfAccessCookie);
+      if (cookie == null || cookie.isEmpty) {
+        state = const CfAccessIdle();
+        return;
+      }
+      final session = CfAccessSession(
+        cookie: cookie,
+        expiresAt: cfAuthorizationExpiry(cookie),
+      );
+      // An expired cookie is dropped rather than kept and retried:
+      // sending it would just earn a challenge on the first request.
+      if (session.isExpired) {
+        await _storage.delete(key: SecureKeys.cfAccessCookie);
+        state = const CfAccessNeedsLogin();
+        return;
+      }
+      state = CfAccessReady(session);
+    } on Object catch (_) {
+      // Same failure mode AuthController guards against — a Keystore
+      // that can no longer decrypt its own store. Falling back to
+      // "no cookie" always recovers, because the SSO flow can just
+      // be run again.
+      state = const CfAccessIdle();
+    }
+  }
+
+  /// The cookie to attach to outgoing requests, or null when we have
+  /// none worth sending.
+  String? get cookie => switch (state) {
+        CfAccessReady(session: final s) when !s.isExpired => s.cookie,
+        _ => null,
+      };
+
+  /// Stores a cookie lifted out of the SSO WebView.
+  Future<void> save(String cookie) async {
+    if (cookie.isEmpty) return;
+    _suppressedUntil = null;
+    await _storage.write(key: SecureKeys.cfAccessCookie, value: cookie);
+    state = CfAccessReady(
+      CfAccessSession(cookie: cookie, expiresAt: cfAuthorizationExpiry(cookie)),
+    );
+  }
+
+  /// Called from the HTTP layer when Access bounced a request.
+  ///
+  /// Idempotent on purpose: a screen that fires six parallel requests
+  /// gets six challenges, and each one must not re-trigger the login
+  /// sheet on top of itself.
+  void challenged({String? reason}) {
+    if (state is CfAccessNeedsLogin) return;
+    final until = _suppressedUntil;
+    if (until != null && DateTime.now().isBefore(until)) return;
+    state = CfAccessNeedsLogin(reason: reason);
+  }
+
+  /// The operator closed the SSO sheet without finishing. Requests
+  /// keep failing (and say why), but we stop re-opening the sheet for
+  /// [kAccessDismissSuppression].
+  void dismiss() {
+    _suppressedUntil = DateTime.now().add(kAccessDismissSuppression);
+    state = const CfAccessIdle();
+  }
+
+  /// Forgets the cookie, in both places it lives.
+  ///
+  /// Deleting only our secure-storage copy would not do what the
+  /// operator asked: the same cookie is also in the platform cookie
+  /// store (Android CookieManager / WKHTTPCookieStore), where the
+  /// SSO WebView put it. Leaving that behind means the next sign-in
+  /// silently succeeds off the surviving cookie with no identity
+  /// check at all, and switching gateways strands a live cookie for
+  /// the old host that no app state knows about.
+  ///
+  /// Reaching for the WebView's cookie store from a controller is
+  /// the price of the cookie having two homes; the alternative is
+  /// every call site remembering to clear the second one.
+  ///
+  /// [baseUrl] is the gateway the cookie belongs to. It is optional
+  /// only because a caller may no longer know it, in which case the
+  /// platform copy is left alone rather than guessed at.
+  Future<void> clear({String? baseUrl}) async {
+    await _storage.delete(key: SecureKeys.cfAccessCookie);
+    if (baseUrl != null && baseUrl.isNotEmpty) {
+      try {
+        await CookieManager.instance().deleteCookie(
+          url: WebUri(baseUrl),
+          name: kCfAccessCookieName,
+        );
+      } on Object catch (_) {
+        // Best effort. A cookie store we cannot reach is not a
+        // reason to leave our own copy in place.
+      }
+    }
+    state = const CfAccessIdle();
+  }
+}
+
+final cfAccessControllerProvider =
+    StateNotifierProvider<CfAccessController, CfAccessState>((ref) {
+  return CfAccessController(ref.watch(secureStorageProvider));
+});

--- a/app/mobile/lib/core/auth/cf_access_controller.dart
+++ b/app/mobile/lib/core/auth/cf_access_controller.dart
@@ -151,7 +151,16 @@ class CfAccessController extends StateNotifier<CfAccessState> {
   /// [baseUrl] is the gateway the cookie belongs to. It is optional
   /// only because a caller may no longer know it, in which case the
   /// platform copy is left alone rather than guessed at.
-  Future<void> clear({String? baseUrl}) async {
+  /// [remote] false wipes only what is on the device, skipping the
+  /// round trips to Cloudflare.
+  ///
+  /// That is the right shape for changing gateway: the operator is
+  /// often changing it *because* the old address does not answer, and
+  /// waiting out two logout timeouts to move on would be absurd. The
+  /// cookie is scoped to the old host, so leaving Cloudflare's side of
+  /// the session alone costs the new gateway nothing. Ending it on
+  /// purpose is what the Security screen's button is for.
+  Future<void> clear({String? baseUrl, bool remote = true}) async {
     // Order matters. Deleting cookies first would leave the logout
     // requests unauthenticated, and Cloudflare answers those with an
     // error page instead of ending anything.
@@ -163,11 +172,11 @@ class CfAccessController extends StateNotifier<CfAccessState> {
     // on the team domain and re-issued a cookie without asking for
     // anything, so "clear" appeared to do nothing.
     final team = _teamDomain;
-    if (team != null && team.isNotEmpty) {
+    if (remote && team != null && team.isNotEmpty) {
       await _visitLogout(accessLogoutUrl(team));
     }
     if (baseUrl != null && baseUrl.isNotEmpty) {
-      await _visitLogout(accessLogoutUrl(baseUrl));
+      if (remote) await _visitLogout(accessLogoutUrl(baseUrl));
       try {
         // Sweep whatever the logout did not take. CF_AppSession lives
         // here too, alongside CF_Authorization, and deleting one

--- a/app/mobile/lib/core/auth/cf_access_controller.dart
+++ b/app/mobile/lib/core/auth/cf_access_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -60,8 +62,13 @@ class CfAccessController extends StateNotifier<CfAccessState> {
   // read the error underneath.
   DateTime? _suppressedUntil;
 
+  // Learned from a challenge redirect or from the cookie's iss claim.
+  // Persisted because sign-out needs it after the cookie is gone.
+  String? _teamDomain;
+
   Future<void> _bootstrap() async {
     try {
+      _teamDomain = await _storage.read(key: SecureKeys.cfAccessTeamDomain);
       final cookie = await _storage.read(key: SecureKeys.cfAccessCookie);
       if (cookie == null || cookie.isEmpty) {
         state = const CfAccessIdle();
@@ -99,6 +106,7 @@ class CfAccessController extends StateNotifier<CfAccessState> {
   Future<void> save(String cookie) async {
     if (cookie.isEmpty) return;
     _suppressedUntil = null;
+    await _rememberTeamDomain(teamDomainFromJwt(cookie));
     await _storage.write(key: SecureKeys.cfAccessCookie, value: cookie);
     state = CfAccessReady(
       CfAccessSession(cookie: cookie, expiresAt: cfAuthorizationExpiry(cookie)),
@@ -110,7 +118,8 @@ class CfAccessController extends StateNotifier<CfAccessState> {
   /// Idempotent on purpose: a screen that fires six parallel requests
   /// gets six challenges, and each one must not re-trigger the login
   /// sheet on top of itself.
-  void challenged({String? reason}) {
+  void challenged({String? reason, String? teamDomain}) {
+    if (teamDomain != null) unawaited(_rememberTeamDomain(teamDomain));
     if (state is CfAccessNeedsLogin) return;
     final until = _suppressedUntil;
     if (until != null && DateTime.now().isBefore(until)) return;
@@ -143,19 +152,74 @@ class CfAccessController extends StateNotifier<CfAccessState> {
   /// only because a caller may no longer know it, in which case the
   /// platform copy is left alone rather than guessed at.
   Future<void> clear({String? baseUrl}) async {
-    await _storage.delete(key: SecureKeys.cfAccessCookie);
+    // Order matters. Deleting cookies first would leave the logout
+    // requests unauthenticated, and Cloudflare answers those with an
+    // error page instead of ending anything.
+    //
+    // The team domain goes first because it is the half that decides
+    // whether the next sign-in has to involve the identity provider
+    // at all. Clearing only the app domain's CF_Authorization looked
+    // like it worked and wasn't: Access still recognised the device
+    // on the team domain and re-issued a cookie without asking for
+    // anything, so "clear" appeared to do nothing.
+    final team = _teamDomain;
+    if (team != null && team.isNotEmpty) {
+      await _visitLogout(accessLogoutUrl(team));
+    }
     if (baseUrl != null && baseUrl.isNotEmpty) {
+      await _visitLogout(accessLogoutUrl(baseUrl));
       try {
-        await CookieManager.instance().deleteCookie(
-          url: WebUri(baseUrl),
-          name: kCfAccessCookieName,
-        );
+        // Sweep whatever the logout did not take. CF_AppSession lives
+        // here too, alongside CF_Authorization, and deleting one
+        // named cookie left the other behind.
+        await CookieManager.instance().deleteCookies(url: WebUri(baseUrl));
       } on Object catch (_) {
-        // Best effort. A cookie store we cannot reach is not a
-        // reason to leave our own copy in place.
+        // Best effort: a cookie store we cannot reach is not a reason
+        // to keep our own copy.
       }
     }
+    await _storage.delete(key: SecureKeys.cfAccessCookie);
     state = const CfAccessIdle();
+  }
+
+  /// Loads a Cloudflare logout URL in an offscreen WebView.
+  ///
+  /// It has to be a WebView, not an HTTP call: the session being
+  /// ended is the WebView cookie jar's, and only a request made from
+  /// there carries the cookies and receives the clearing Set-Cookie
+  /// headers back.
+  Future<void> _visitLogout(String url) async {
+    final done = Completer<void>();
+    HeadlessInAppWebView? web;
+    try {
+      web = HeadlessInAppWebView(
+        initialUrlRequest: URLRequest(url: WebUri(url)),
+        onLoadStop: (_, __) {
+          if (!done.isCompleted) done.complete();
+        },
+        onReceivedError: (_, __, ___) {
+          if (!done.isCompleted) done.complete();
+        },
+      );
+      await web.run();
+      // Bounded: sign-out must not hang the settings screen because
+      // the gateway is unreachable. A logout we could not deliver
+      // still gets the local cookies wiped by the caller.
+      await done.future.timeout(const Duration(seconds: 10));
+    } on Object catch (_) {
+      // Best effort by design.
+    } finally {
+      await web?.dispose();
+    }
+  }
+
+  Future<void> _rememberTeamDomain(String? domain) async {
+    if (domain == null || domain.isEmpty || domain == _teamDomain) return;
+    _teamDomain = domain;
+    await _storage.write(
+      key: SecureKeys.cfAccessTeamDomain,
+      value: domain,
+    );
   }
 }
 

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 13638 (4546 per locale)
+/// Strings: 13707 (4569 per locale)
 ///
-/// Built on 2026-08-15 at 02:29 UTC
+/// Built on 2026-09-02 at 00:00 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings.g.dart
+++ b/app/mobile/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 13707 (4569 per locale)
+/// Strings: 13713 (4571 per locale)
 ///
-/// Built on 2026-09-02 at 00:00 UTC
+/// Built on 2026-09-02 at 02:27 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -72,6 +72,8 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	late final TranslationsMemoryQuarantineEn memoryQuarantine = TranslationsMemoryQuarantineEn.internal(_root);
 	late final TranslationsCortexHubEn cortexHub = TranslationsCortexHubEn.internal(_root);
 	late final TranslationsCortexSettingsEn cortexSettings = TranslationsCortexSettingsEn.internal(_root);
+	late final TranslationsAccessEn access = TranslationsAccessEn.internal(_root);
+	late final TranslationsLockEn lock = TranslationsLockEn.internal(_root);
 }
 
 // Path: common
@@ -2234,6 +2236,7 @@ class TranslationsSettingsEn {
 	late final TranslationsSettingsChangeCredentialsEn changeCredentials = TranslationsSettingsChangeCredentialsEn.internal(_root);
 	late final TranslationsSettingsLogViewerEn logViewer = TranslationsSettingsLogViewerEn.internal(_root);
 	late final TranslationsSettingsServerSettingsEn serverSettings = TranslationsSettingsServerSettingsEn.internal(_root);
+	late final TranslationsSettingsSecurityEn security = TranslationsSettingsSecurityEn.internal(_root);
 }
 
 // Path: memoryQuarantine
@@ -2402,6 +2405,78 @@ class TranslationsCortexSettingsEn {
 
 	/// en: 'default'
 	String get defaultBadge => 'default';
+}
+
+// Path: access
+class TranslationsAccessEn {
+	TranslationsAccessEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Cloudflare Access sign-in'
+	String get signInTitle => 'Cloudflare Access sign-in';
+
+	/// en: 'Cancel'
+	String get cancel => 'Cancel';
+
+	/// en: 'Access sign-in did not complete: {error}'
+	String failed({required Object error}) => 'Access sign-in did not complete: ${error}';
+
+	/// en: 'Could not load the Cloudflare Access sign-in page: {error}'
+	String loadFailed({required Object error}) => 'Could not load the Cloudflare Access sign-in page: ${error}';
+
+	/// en: 'Cloudflare Access'
+	String get section => 'Cloudflare Access';
+
+	/// en: 'Sign in at the edge so the app reaches the gateway from outside the LAN'
+	String get sectionSubtitle => 'Sign in at the edge so the app reaches the gateway from outside the LAN';
+
+	/// en: 'Access session active'
+	String get sessionActive => 'Access session active';
+
+	/// en: 'Expires {when}'
+	String sessionExpires({required Object when}) => 'Expires ${when}';
+
+	/// en: 'Expiry not readable from the cookie'
+	String get sessionExpiryUnknown => 'Expiry not readable from the cookie';
+
+	/// en: 'No Access session on this device'
+	String get sessionNone => 'No Access session on this device';
+
+	/// en: 'Sign in with Cloudflare Access'
+	String get signIn => 'Sign in with Cloudflare Access';
+
+	/// en: 'Clear Access session'
+	String get clear => 'Clear Access session';
+
+	/// en: 'Forget this device's Cloudflare Access cookie'
+	String get clearSubtitle => 'Forget this device\'s Cloudflare Access cookie';
+
+	/// en: 'Cloudflare Access needs to verify this device before it can reach {host}.'
+	String challengeBanner({required Object host}) => 'Cloudflare Access needs to verify this device before it can reach ${host}.';
+
+	/// en: 'This gateway does not appear to be behind Cloudflare Access.'
+	String get notEnabled => 'This gateway does not appear to be behind Cloudflare Access.';
+}
+
+// Path: lock
+class TranslationsLockEn {
+	TranslationsLockEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'opendray is locked'
+	String get title => 'opendray is locked';
+
+	/// en: 'Unlock opendray'
+	String get reason => 'Unlock opendray';
+
+	/// en: 'Unlock'
+	String get unlock => 'Unlock';
 }
 
 // Path: nav.updates
@@ -6577,6 +6652,30 @@ class TranslationsSettingsServerSettingsEn {
 
 	/// en: 'opendray's own directories still sit inside your documents, so they show up in the Vault and a sync carries them along. They keep working — move them out and set the paths below when convenient.'
 	String get legacyLayout => 'opendray\'s own directories still sit inside your documents, so they show up in the Vault and a sync carries them along. They keep working — move them out and set the paths below when convenient.';
+}
+
+// Path: settings.security
+class TranslationsSettingsSecurityEn {
+	TranslationsSettingsSecurityEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Security'
+	String get section => 'Security';
+
+	/// en: 'Require unlock'
+	String get appLock => 'Require unlock';
+
+	/// en: 'Ask for biometrics or the device passcode before showing the app'
+	String get appLockSubtitle => 'Ask for biometrics or the device passcode before showing the app';
+
+	/// en: 'This device has no passcode or biometrics enrolled'
+	String get appLockUnavailable => 'This device has no passcode or biometrics enrolled';
+
+	/// en: 'Could not turn on the app lock'
+	String get appLockFailed => 'Could not turn on the app lock';
 }
 
 // Path: web.sessions.list
@@ -23931,6 +24030,11 @@ extension on Translations {
 			'settings.serverSettings.embedderModel.manual' => 'Type manually',
 			'settings.serverSettings.embedderModel.pickFromList' => 'Pick from list',
 			'settings.serverSettings.legacyLayout' => 'opendray\'s own directories still sit inside your documents, so they show up in the Vault and a sync carries them along. They keep working — move them out and set the paths below when convenient.',
+			'settings.security.section' => 'Security',
+			'settings.security.appLock' => 'Require unlock',
+			'settings.security.appLockSubtitle' => 'Ask for biometrics or the device passcode before showing the app',
+			'settings.security.appLockUnavailable' => 'This device has no passcode or biometrics enrolled',
+			'settings.security.appLockFailed' => 'Could not turn on the app lock',
 			'memoryQuarantine.title' => 'Quarantine',
 			'memoryQuarantine.subtitle' => 'Facts that need review before they count as durable memory: integration captures land here by policy, and you can quarantine any memory by hand. Promote what is true; discard the rest — unreviewed rows expire on their own.',
 			'memoryQuarantine.empty' => 'Nothing in quarantine.',
@@ -23978,6 +24082,24 @@ extension on Translations {
 			'cortexSettings.providersManageOnWeb' => 'Add or edit providers on the web admin.',
 			'cortexSettings.providersLoadFailed' => 'Failed to load providers',
 			'cortexSettings.defaultBadge' => 'default',
+			'access.signInTitle' => 'Cloudflare Access sign-in',
+			'access.cancel' => 'Cancel',
+			'access.failed' => ({required Object error}) => 'Access sign-in did not complete: ${error}',
+			'access.loadFailed' => ({required Object error}) => 'Could not load the Cloudflare Access sign-in page: ${error}',
+			'access.section' => 'Cloudflare Access',
+			'access.sectionSubtitle' => 'Sign in at the edge so the app reaches the gateway from outside the LAN',
+			'access.sessionActive' => 'Access session active',
+			'access.sessionExpires' => ({required Object when}) => 'Expires ${when}',
+			'access.sessionExpiryUnknown' => 'Expiry not readable from the cookie',
+			'access.sessionNone' => 'No Access session on this device',
+			'access.signIn' => 'Sign in with Cloudflare Access',
+			'access.clear' => 'Clear Access session',
+			'access.clearSubtitle' => 'Forget this device\'s Cloudflare Access cookie',
+			'access.challengeBanner' => ({required Object host}) => 'Cloudflare Access needs to verify this device before it can reach ${host}.',
+			'access.notEnabled' => 'This gateway does not appear to be behind Cloudflare Access.',
+			'lock.title' => 'opendray is locked',
+			'lock.reason' => 'Unlock opendray',
+			'lock.unlock' => 'Unlock',
 			_ => null,
 		};
 	}

--- a/app/mobile/lib/core/i18n/strings_en.g.dart
+++ b/app/mobile/lib/core/i18n/strings_en.g.dart
@@ -2451,14 +2451,20 @@ class TranslationsAccessEn {
 	/// en: 'Clear Access session'
 	String get clear => 'Clear Access session';
 
-	/// en: 'Forget this device's Cloudflare Access cookie'
-	String get clearSubtitle => 'Forget this device\'s Cloudflare Access cookie';
+	/// en: 'Sign out of Cloudflare Access on this device'
+	String get clearSubtitle => 'Sign out of Cloudflare Access on this device';
 
 	/// en: 'Cloudflare Access needs to verify this device before it can reach {host}.'
 	String challengeBanner({required Object host}) => 'Cloudflare Access needs to verify this device before it can reach ${host}.';
 
 	/// en: 'This gateway does not appear to be behind Cloudflare Access.'
 	String get notEnabled => 'This gateway does not appear to be behind Cloudflare Access.';
+
+	/// en: 'Signing out of Cloudflare Access…'
+	String get clearing => 'Signing out of Cloudflare Access…';
+
+	/// en: 'Signed out. The next request will ask you to sign in again.'
+	String get cleared => 'Signed out. The next request will ask you to sign in again.';
 }
 
 // Path: lock
@@ -24094,9 +24100,11 @@ extension on Translations {
 			'access.sessionNone' => 'No Access session on this device',
 			'access.signIn' => 'Sign in with Cloudflare Access',
 			'access.clear' => 'Clear Access session',
-			'access.clearSubtitle' => 'Forget this device\'s Cloudflare Access cookie',
+			'access.clearSubtitle' => 'Sign out of Cloudflare Access on this device',
 			'access.challengeBanner' => ({required Object host}) => 'Cloudflare Access needs to verify this device before it can reach ${host}.',
 			'access.notEnabled' => 'This gateway does not appear to be behind Cloudflare Access.',
+			'access.clearing' => 'Signing out of Cloudflare Access…',
+			'access.cleared' => 'Signed out. The next request will ask you to sign in again.',
 			'lock.title' => 'opendray is locked',
 			'lock.reason' => 'Unlock opendray',
 			'lock.unlock' => 'Unlock',

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -71,6 +71,8 @@ class TranslationsEs extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsMemoryQuarantineEs memoryQuarantine = _TranslationsMemoryQuarantineEs._(_root);
 	@override late final _TranslationsCortexHubEs cortexHub = _TranslationsCortexHubEs._(_root);
 	@override late final _TranslationsCortexSettingsEs cortexSettings = _TranslationsCortexSettingsEs._(_root);
+	@override late final _TranslationsAccessEs access = _TranslationsAccessEs._(_root);
+	@override late final _TranslationsLockEs lock = _TranslationsLockEs._(_root);
 }
 
 // Path: common
@@ -1034,6 +1036,7 @@ class _TranslationsSettingsEs extends TranslationsSettingsEn {
 	@override late final _TranslationsSettingsChangeCredentialsEs changeCredentials = _TranslationsSettingsChangeCredentialsEs._(_root);
 	@override late final _TranslationsSettingsLogViewerEs logViewer = _TranslationsSettingsLogViewerEs._(_root);
 	@override late final _TranslationsSettingsServerSettingsEs serverSettings = _TranslationsSettingsServerSettingsEs._(_root);
+	@override late final _TranslationsSettingsSecurityEs security = _TranslationsSettingsSecurityEs._(_root);
 }
 
 // Path: memoryQuarantine
@@ -1108,6 +1111,42 @@ class _TranslationsCortexSettingsEs extends TranslationsCortexSettingsEn {
 	@override String get providersManageOnWeb => 'Añade o edita proveedores en el panel web.';
 	@override String get providersLoadFailed => 'Error al cargar proveedores';
 	@override String get defaultBadge => 'predeterminado';
+}
+
+// Path: access
+class _TranslationsAccessEs extends TranslationsAccessEn {
+	_TranslationsAccessEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get signInTitle => 'Inicio de sesión de Cloudflare Access';
+	@override String get cancel => 'Cancelar';
+	@override String failed({required Object error}) => 'El inicio de sesión de Access no se completó: ${error}';
+	@override String loadFailed({required Object error}) => 'No se pudo cargar la página de inicio de sesión de Cloudflare Access: ${error}';
+	@override String get section => 'Cloudflare Access';
+	@override String get sectionSubtitle => 'Inicia sesión en el borde para que la app llegue al gateway desde fuera de la LAN';
+	@override String get sessionActive => 'Sesión de Access activa';
+	@override String sessionExpires({required Object when}) => 'Caduca ${when}';
+	@override String get sessionExpiryUnknown => 'La caducidad no se puede leer de la cookie';
+	@override String get sessionNone => 'No hay sesión de Access en este dispositivo';
+	@override String get signIn => 'Iniciar sesión con Cloudflare Access';
+	@override String get clear => 'Borrar la sesión de Access';
+	@override String get clearSubtitle => 'Olvidar la cookie de Cloudflare Access de este dispositivo';
+	@override String challengeBanner({required Object host}) => 'Cloudflare Access necesita verificar este dispositivo antes de poder llegar a ${host}.';
+	@override String get notEnabled => 'Este gateway no parece estar detrás de Cloudflare Access.';
+}
+
+// Path: lock
+class _TranslationsLockEs extends TranslationsLockEn {
+	_TranslationsLockEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'opendray está bloqueado';
+	@override String get reason => 'Desbloquear opendray';
+	@override String get unlock => 'Desbloquear';
 }
 
 // Path: nav.updates
@@ -3372,6 +3411,20 @@ class _TranslationsSettingsServerSettingsEs extends TranslationsSettingsServerSe
 	@override String validateNumber({required Object field}) => '"${field}" debe ser un número';
 	@override late final _TranslationsSettingsServerSettingsEmbedderModelEs embedderModel = _TranslationsSettingsServerSettingsEmbedderModelEs._(_root);
 	@override String get legacyLayout => 'Los directorios propios de opendray siguen dentro de tus documentos, así que aparecen en el Vault y la sincronización se los lleva. Siguen funcionando: muévelos fuera y fija las rutas de abajo cuando puedas.';
+}
+
+// Path: settings.security
+class _TranslationsSettingsSecurityEs extends TranslationsSettingsSecurityEn {
+	_TranslationsSettingsSecurityEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get section => 'Seguridad';
+	@override String get appLock => 'Requerir desbloqueo';
+	@override String get appLockSubtitle => 'Pedir biometría o el código del dispositivo antes de mostrar la app';
+	@override String get appLockUnavailable => 'Este dispositivo no tiene código ni biometría configurados';
+	@override String get appLockFailed => 'No se pudo activar el bloqueo de la app';
 }
 
 // Path: web.sessions.list
@@ -14712,6 +14765,11 @@ extension on TranslationsEs {
 			'settings.serverSettings.embedderModel.manual' => 'Escribir manualmente',
 			'settings.serverSettings.embedderModel.pickFromList' => 'Elegir de la lista',
 			'settings.serverSettings.legacyLayout' => 'Los directorios propios de opendray siguen dentro de tus documentos, así que aparecen en el Vault y la sincronización se los lleva. Siguen funcionando: muévelos fuera y fija las rutas de abajo cuando puedas.',
+			'settings.security.section' => 'Seguridad',
+			'settings.security.appLock' => 'Requerir desbloqueo',
+			'settings.security.appLockSubtitle' => 'Pedir biometría o el código del dispositivo antes de mostrar la app',
+			'settings.security.appLockUnavailable' => 'Este dispositivo no tiene código ni biometría configurados',
+			'settings.security.appLockFailed' => 'No se pudo activar el bloqueo de la app',
 			'memoryQuarantine.title' => 'Cuarentena',
 			'memoryQuarantine.subtitle' => 'Hechos que necesitan revisión antes de contar como memoria durable: las capturas de integraciones llegan aquí por política, y puedes poner cualquier memoria en cuarentena a mano. Promueve lo verdadero; descarta el resto — las filas sin revisar expiran solas.',
 			'memoryQuarantine.empty' => 'Nada en cuarentena.',
@@ -14759,6 +14817,24 @@ extension on TranslationsEs {
 			'cortexSettings.providersManageOnWeb' => 'Añade o edita proveedores en el panel web.',
 			'cortexSettings.providersLoadFailed' => 'Error al cargar proveedores',
 			'cortexSettings.defaultBadge' => 'predeterminado',
+			'access.signInTitle' => 'Inicio de sesión de Cloudflare Access',
+			'access.cancel' => 'Cancelar',
+			'access.failed' => ({required Object error}) => 'El inicio de sesión de Access no se completó: ${error}',
+			'access.loadFailed' => ({required Object error}) => 'No se pudo cargar la página de inicio de sesión de Cloudflare Access: ${error}',
+			'access.section' => 'Cloudflare Access',
+			'access.sectionSubtitle' => 'Inicia sesión en el borde para que la app llegue al gateway desde fuera de la LAN',
+			'access.sessionActive' => 'Sesión de Access activa',
+			'access.sessionExpires' => ({required Object when}) => 'Caduca ${when}',
+			'access.sessionExpiryUnknown' => 'La caducidad no se puede leer de la cookie',
+			'access.sessionNone' => 'No hay sesión de Access en este dispositivo',
+			'access.signIn' => 'Iniciar sesión con Cloudflare Access',
+			'access.clear' => 'Borrar la sesión de Access',
+			'access.clearSubtitle' => 'Olvidar la cookie de Cloudflare Access de este dispositivo',
+			'access.challengeBanner' => ({required Object host}) => 'Cloudflare Access necesita verificar este dispositivo antes de poder llegar a ${host}.',
+			'access.notEnabled' => 'Este gateway no parece estar detrás de Cloudflare Access.',
+			'lock.title' => 'opendray está bloqueado',
+			'lock.reason' => 'Desbloquear opendray',
+			'lock.unlock' => 'Desbloquear',
 			_ => null,
 		};
 	}

--- a/app/mobile/lib/core/i18n/strings_es.g.dart
+++ b/app/mobile/lib/core/i18n/strings_es.g.dart
@@ -1132,9 +1132,11 @@ class _TranslationsAccessEs extends TranslationsAccessEn {
 	@override String get sessionNone => 'No hay sesión de Access en este dispositivo';
 	@override String get signIn => 'Iniciar sesión con Cloudflare Access';
 	@override String get clear => 'Borrar la sesión de Access';
-	@override String get clearSubtitle => 'Olvidar la cookie de Cloudflare Access de este dispositivo';
+	@override String get clearSubtitle => 'Cerrar sesión de Cloudflare Access en este dispositivo';
 	@override String challengeBanner({required Object host}) => 'Cloudflare Access necesita verificar este dispositivo antes de poder llegar a ${host}.';
 	@override String get notEnabled => 'Este gateway no parece estar detrás de Cloudflare Access.';
+	@override String get clearing => 'Cerrando sesión de Cloudflare Access…';
+	@override String get cleared => 'Sesión cerrada. La próxima solicitud pedirá iniciar sesión de nuevo.';
 }
 
 // Path: lock
@@ -14829,9 +14831,11 @@ extension on TranslationsEs {
 			'access.sessionNone' => 'No hay sesión de Access en este dispositivo',
 			'access.signIn' => 'Iniciar sesión con Cloudflare Access',
 			'access.clear' => 'Borrar la sesión de Access',
-			'access.clearSubtitle' => 'Olvidar la cookie de Cloudflare Access de este dispositivo',
+			'access.clearSubtitle' => 'Cerrar sesión de Cloudflare Access en este dispositivo',
 			'access.challengeBanner' => ({required Object host}) => 'Cloudflare Access necesita verificar este dispositivo antes de poder llegar a ${host}.',
 			'access.notEnabled' => 'Este gateway no parece estar detrás de Cloudflare Access.',
+			'access.clearing' => 'Cerrando sesión de Cloudflare Access…',
+			'access.cleared' => 'Sesión cerrada. La próxima solicitud pedirá iniciar sesión de nuevo.',
 			'lock.title' => 'opendray está bloqueado',
 			'lock.reason' => 'Desbloquear opendray',
 			'lock.unlock' => 'Desbloquear',

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -71,6 +71,8 @@ class TranslationsZh extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsMemoryQuarantineZh memoryQuarantine = _TranslationsMemoryQuarantineZh._(_root);
 	@override late final _TranslationsCortexHubZh cortexHub = _TranslationsCortexHubZh._(_root);
 	@override late final _TranslationsCortexSettingsZh cortexSettings = _TranslationsCortexSettingsZh._(_root);
+	@override late final _TranslationsAccessZh access = _TranslationsAccessZh._(_root);
+	@override late final _TranslationsLockZh lock = _TranslationsLockZh._(_root);
 }
 
 // Path: common
@@ -1034,6 +1036,7 @@ class _TranslationsSettingsZh extends TranslationsSettingsEn {
 	@override late final _TranslationsSettingsChangeCredentialsZh changeCredentials = _TranslationsSettingsChangeCredentialsZh._(_root);
 	@override late final _TranslationsSettingsLogViewerZh logViewer = _TranslationsSettingsLogViewerZh._(_root);
 	@override late final _TranslationsSettingsServerSettingsZh serverSettings = _TranslationsSettingsServerSettingsZh._(_root);
+	@override late final _TranslationsSettingsSecurityZh security = _TranslationsSettingsSecurityZh._(_root);
 }
 
 // Path: memoryQuarantine
@@ -1108,6 +1111,42 @@ class _TranslationsCortexSettingsZh extends TranslationsCortexSettingsEn {
 	@override String get providersManageOnWeb => '在 web 管理端添加或编辑 provider。';
 	@override String get providersLoadFailed => '加载 provider 失败';
 	@override String get defaultBadge => '默认';
+}
+
+// Path: access
+class _TranslationsAccessZh extends TranslationsAccessEn {
+	_TranslationsAccessZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get signInTitle => 'Cloudflare Access 登录';
+	@override String get cancel => '取消';
+	@override String failed({required Object error}) => 'Access 登录未完成：${error}';
+	@override String loadFailed({required Object error}) => '无法加载 Cloudflare Access 登录页：${error}';
+	@override String get section => 'Cloudflare Access';
+	@override String get sectionSubtitle => '在边缘完成登录，让 App 在内网之外也能访问网关';
+	@override String get sessionActive => 'Access 会话有效';
+	@override String sessionExpires({required Object when}) => '${when} 过期';
+	@override String get sessionExpiryUnknown => '无法从 Cookie 中读取有效期';
+	@override String get sessionNone => '本设备没有 Access 会话';
+	@override String get signIn => '使用 Cloudflare Access 登录';
+	@override String get clear => '清除 Access 会话';
+	@override String get clearSubtitle => '删除本设备的 Cloudflare Access Cookie';
+	@override String challengeBanner({required Object host}) => 'Cloudflare Access 需要先验证本设备，才能访问 ${host}。';
+	@override String get notEnabled => '该网关似乎没有启用 Cloudflare Access。';
+}
+
+// Path: lock
+class _TranslationsLockZh extends TranslationsLockEn {
+	_TranslationsLockZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'opendray 已锁定';
+	@override String get reason => '解锁 opendray';
+	@override String get unlock => '解锁';
 }
 
 // Path: nav.updates
@@ -3372,6 +3411,20 @@ class _TranslationsSettingsServerSettingsZh extends TranslationsSettingsServerSe
 	@override String validateNumber({required Object field}) => '「${field}」必须是数字';
 	@override late final _TranslationsSettingsServerSettingsEmbedderModelZh embedderModel = _TranslationsSettingsServerSettingsEmbedderModelZh._(_root);
 	@override String get legacyLayout => 'opendray 自己的目录仍在你的文档里,所以它们会出现在 Vault 中,同步时也会被带走。它们照常工作 —— 方便时把它们移出去,并在下面填好路径。';
+}
+
+// Path: settings.security
+class _TranslationsSettingsSecurityZh extends TranslationsSettingsSecurityEn {
+	_TranslationsSettingsSecurityZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get section => '安全';
+	@override String get appLock => '启动时验证';
+	@override String get appLockSubtitle => '打开 App 前需要生物识别或设备密码';
+	@override String get appLockUnavailable => '本设备未设置密码或生物识别';
+	@override String get appLockFailed => '无法开启应用锁';
 }
 
 // Path: web.sessions.list
@@ -14706,6 +14759,11 @@ extension on TranslationsZh {
 			'settings.serverSettings.embedderModel.manual' => '手动输入',
 			'settings.serverSettings.embedderModel.pickFromList' => '从列表选择',
 			'settings.serverSettings.legacyLayout' => 'opendray 自己的目录仍在你的文档里,所以它们会出现在 Vault 中,同步时也会被带走。它们照常工作 —— 方便时把它们移出去,并在下面填好路径。',
+			'settings.security.section' => '安全',
+			'settings.security.appLock' => '启动时验证',
+			'settings.security.appLockSubtitle' => '打开 App 前需要生物识别或设备密码',
+			'settings.security.appLockUnavailable' => '本设备未设置密码或生物识别',
+			'settings.security.appLockFailed' => '无法开启应用锁',
 			'memoryQuarantine.title' => '隔离区',
 			'memoryQuarantine.subtitle' => '在被采信为持久记忆前需要审查的事实：integration 捕获按策略落到这里，你也可以手动隔离任何记忆。属实的批准入库，其余丢弃——未审查的条目会自动过期。',
 			'memoryQuarantine.empty' => '隔离区为空。',
@@ -14753,6 +14811,24 @@ extension on TranslationsZh {
 			'cortexSettings.providersManageOnWeb' => '在 web 管理端添加或编辑 provider。',
 			'cortexSettings.providersLoadFailed' => '加载 provider 失败',
 			'cortexSettings.defaultBadge' => '默认',
+			'access.signInTitle' => 'Cloudflare Access 登录',
+			'access.cancel' => '取消',
+			'access.failed' => ({required Object error}) => 'Access 登录未完成：${error}',
+			'access.loadFailed' => ({required Object error}) => '无法加载 Cloudflare Access 登录页：${error}',
+			'access.section' => 'Cloudflare Access',
+			'access.sectionSubtitle' => '在边缘完成登录，让 App 在内网之外也能访问网关',
+			'access.sessionActive' => 'Access 会话有效',
+			'access.sessionExpires' => ({required Object when}) => '${when} 过期',
+			'access.sessionExpiryUnknown' => '无法从 Cookie 中读取有效期',
+			'access.sessionNone' => '本设备没有 Access 会话',
+			'access.signIn' => '使用 Cloudflare Access 登录',
+			'access.clear' => '清除 Access 会话',
+			'access.clearSubtitle' => '删除本设备的 Cloudflare Access Cookie',
+			'access.challengeBanner' => ({required Object host}) => 'Cloudflare Access 需要先验证本设备，才能访问 ${host}。',
+			'access.notEnabled' => '该网关似乎没有启用 Cloudflare Access。',
+			'lock.title' => 'opendray 已锁定',
+			'lock.reason' => '解锁 opendray',
+			'lock.unlock' => '解锁',
 			_ => null,
 		};
 	}

--- a/app/mobile/lib/core/i18n/strings_zh.g.dart
+++ b/app/mobile/lib/core/i18n/strings_zh.g.dart
@@ -1132,9 +1132,11 @@ class _TranslationsAccessZh extends TranslationsAccessEn {
 	@override String get sessionNone => '本设备没有 Access 会话';
 	@override String get signIn => '使用 Cloudflare Access 登录';
 	@override String get clear => '清除 Access 会话';
-	@override String get clearSubtitle => '删除本设备的 Cloudflare Access Cookie';
+	@override String get clearSubtitle => '在本设备上登出 Cloudflare Access';
 	@override String challengeBanner({required Object host}) => 'Cloudflare Access 需要先验证本设备，才能访问 ${host}。';
 	@override String get notEnabled => '该网关似乎没有启用 Cloudflare Access。';
+	@override String get clearing => '正在登出 Cloudflare Access…';
+	@override String get cleared => '已登出。下次请求会要求重新登录。';
 }
 
 // Path: lock
@@ -14823,9 +14825,11 @@ extension on TranslationsZh {
 			'access.sessionNone' => '本设备没有 Access 会话',
 			'access.signIn' => '使用 Cloudflare Access 登录',
 			'access.clear' => '清除 Access 会话',
-			'access.clearSubtitle' => '删除本设备的 Cloudflare Access Cookie',
+			'access.clearSubtitle' => '在本设备上登出 Cloudflare Access',
 			'access.challengeBanner' => ({required Object host}) => 'Cloudflare Access 需要先验证本设备，才能访问 ${host}。',
 			'access.notEnabled' => '该网关似乎没有启用 Cloudflare Access。',
+			'access.clearing' => '正在登出 Cloudflare Access…',
+			'access.cleared' => '已登出。下次请求会要求重新登录。',
 			'lock.title' => 'opendray 已锁定',
 			'lock.reason' => '解锁 opendray',
 			'lock.unlock' => '解锁',

--- a/app/mobile/lib/core/storage/secure_store.dart
+++ b/app/mobile/lib/core/storage/secure_store.dart
@@ -2,7 +2,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 // Single FlutterSecureStorage instance for the whole app. Persists
-// the gateway URL + bearer token (and, in F2, the biometric flag).
+// the gateway URL, the bearer token, the Cloudflare Access cookie
+// and the biometric-lock flag.
 //
 // iOS: maps to Keychain Services with `first_unlock_this_device`.
 // Android: maps to EncryptedSharedPreferences (AES-256-GCM with a
@@ -21,4 +22,13 @@ class SecureKeys {
   static const token = 'opendray.token';
   static const username = 'opendray.username';
   static const tokenExpiresAt = 'opendray.token_expires_at';
+
+  // Cloudflare Access cookie lifted out of the SSO WebView. Stored
+  // next to the bearer token because it is exactly as sensitive:
+  // together they are what lets this device reach the gateway from
+  // the public internet.
+  static const cfAccessCookie = 'opendray.cf_access_cookie';
+
+  // "1" once the operator turns on the biometric app lock.
+  static const biometricLock = 'opendray.biometric_lock';
 }

--- a/app/mobile/lib/core/storage/secure_store.dart
+++ b/app/mobile/lib/core/storage/secure_store.dart
@@ -29,6 +29,11 @@ class SecureKeys {
   // the public internet.
   static const cfAccessCookie = 'opendray.cf_access_cookie';
 
+  // Access team domain (<team>.cloudflareaccess.com). Kept because
+  // signing out has to reach it, and by then the cookie it could be
+  // read from may already be gone.
+  static const cfAccessTeamDomain = 'opendray.cf_access_team_domain';
+
   // "1" once the operator turns on the biometric app lock.
   static const biometricLock = 'opendray.biometric_lock';
 }

--- a/app/mobile/lib/features/auth/cf_access_login_screen.dart
+++ b/app/mobile/lib/features/auth/cf_access_login_screen.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+import 'package:opendray/core/auth/cf_access.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+
+// Runs the Cloudflare Access identity check in an embedded WebView
+// and hands back the `CF_Authorization` cookie it produces.
+//
+// Why a WebView and not the system browser: the cookie is the whole
+// point, and a cookie set in Safari/Chrome is not readable from the
+// app. flutter_inappwebview's CookieManager reads the platform cookie
+// store (Android CookieManager / WKHTTPCookieStore), which does
+// return HttpOnly cookies -- the ordinary JS `document.cookie` route
+// would not, because Access sets CF_Authorization HttpOnly.
+//
+// The address bar below the title is not decoration. The operator is
+// about to type identity-provider credentials into a WebView we
+// control, so they get to see exactly which host is asking.
+//
+// Reports the cookie through [onResult] (null when the operator backed
+// out). When [onResult] is omitted it pops the route with the same
+// value instead, so it works both as a pushed screen (onboarding,
+// settings) and as an inline overlay (AccessGate), where there is no
+// route of its own to pop.
+class CfAccessLoginScreen extends StatefulWidget {
+  const CfAccessLoginScreen({
+    required this.baseUrl,
+    this.onResult,
+    super.key,
+  });
+
+  /// Gateway base URL, e.g. `https://opendray.example.com`.
+  final String baseUrl;
+
+  /// Called once with the cookie, or null if the operator cancelled.
+  final void Function(String? cookie)? onResult;
+
+  static Future<String?> show(BuildContext context, String baseUrl) {
+    return Navigator.of(context).push<String>(
+      MaterialPageRoute<String>(
+        fullscreenDialog: true,
+        builder: (_) => CfAccessLoginScreen(baseUrl: baseUrl),
+      ),
+    );
+  }
+
+  @override
+  State<CfAccessLoginScreen> createState() => _CfAccessLoginScreenState();
+}
+
+class _CfAccessLoginScreenState extends State<CfAccessLoginScreen> {
+  String _currentHost = '';
+  String _currentPath = '';
+  bool _loading = true;
+  bool _finishing = false;
+  String? _error;
+
+  late final WebUri _start = WebUri(accessLoginUrl(widget.baseUrl));
+  late final String _gatewayHost = Uri.parse(widget.baseUrl).host;
+
+  // Access can bounce through the team domain and back more than
+  // once (IdP redirect, then the app's own redirect). We only look
+  // for the cookie once we are back on the gateway host, and we stop
+  // after the first success so a late onLoadStop cannot pop twice.
+  Future<void> _tryHarvestCookie() async {
+    if (_finishing || !mounted) return;
+    if (_currentHost != _gatewayHost) return;
+    try {
+      var value = await _readCookie();
+      if (value.isEmpty) {
+        // Cloudflare sets the cookie on the redirect that lands us
+        // here, and on some platforms the cookie store settles a
+        // frame after the page reports done.
+        await Future<void>.delayed(const Duration(milliseconds: 400));
+        if (!mounted) return;
+        value = await _readCookie();
+      }
+      if (value.isEmpty) {
+        // Still inside Cloudflare's own pages: this is the sign-in
+        // form rendered on the app hostname, not a failure.
+        if (_currentPath.startsWith('/cdn-cgi/access/')) return;
+        // Back on a gateway path with no cookie. The likely cause is
+        // that this hostname is not behind Access at all, which
+        // otherwise strands the operator on a bare 404.
+        setState(() => _error = t.access.notEnabled);
+        return;
+      }
+      _finishing = true;
+      if (!mounted) return;
+      _finish(value);
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() => _error = t.access.failed(error: '$e'));
+    }
+  }
+
+  Future<String> _readCookie() async {
+    final cookie = await CookieManager.instance().getCookie(
+      url: WebUri(widget.baseUrl),
+      name: kCfAccessCookieName,
+    );
+    return cookie?.value?.toString() ?? '';
+  }
+
+  void _finish(String? cookie) {
+    final cb = widget.onResult;
+    if (cb != null) {
+      cb(cookie);
+      return;
+    }
+    Navigator.of(context).pop(cookie);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(t.access.signInTitle),
+        // Explicit rather than the implied back button: as an inline
+        // overlay there is no route behind us to pop to, so cancel
+        // has to be a callback either way.
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          tooltip: t.access.cancel,
+          onPressed: () => _finish(null),
+        ),
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(24),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 6),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.lock_outline,
+                  size: 13,
+                  color: theme.colorScheme.outline,
+                ),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    _currentHost.isEmpty ? widget.baseUrl : _currentHost,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.outline,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+      body: Column(
+        children: [
+          if (_loading) const LinearProgressIndicator(minHeight: 2),
+          if (_error != null)
+            Container(
+              width: double.infinity,
+              color: theme.colorScheme.error.withValues(alpha: 0.1),
+              padding: const EdgeInsets.all(12),
+              child: Text(
+                _error!,
+                style: TextStyle(color: theme.colorScheme.error),
+              ),
+            ),
+          Expanded(
+            child: InAppWebView(
+              initialUrlRequest: URLRequest(url: _start),
+              initialSettings: InAppWebViewSettings(
+                // Access sign-in is a plain web flow; nothing here
+                // needs to talk back to Dart.
+                javaScriptEnabled: true,
+                // No navigation interception. This does NOT affect
+                // the user-agent (we deliberately do not spoof one);
+                // it only turns off the shouldOverrideUrlLoading
+                // callback. There is nothing useful to do in it: an
+                // Access sign-in hops through whichever identity
+                // provider the operator configured, so the set of
+                // legitimate hosts cannot be enumerated ahead of
+                // time, and a guessed allowlist would break real
+                // sign-ins while stopping nothing.
+                useShouldOverrideUrlLoading: false,
+                transparentBackground: true,
+              ),
+              onLoadStart: (_, url) {
+                if (!mounted) return;
+                setState(() {
+                  _loading = true;
+                  _error = null;
+                  _currentHost = url?.host ?? _currentHost;
+                  _currentPath = url?.path ?? _currentPath;
+                });
+              },
+              onLoadStop: (_, url) async {
+                if (!mounted) return;
+                setState(() {
+                  _loading = false;
+                  _currentHost = url?.host ?? _currentHost;
+                  _currentPath = url?.path ?? _currentPath;
+                });
+                await _tryHarvestCookie();
+              },
+              onReceivedError: (_, request, error) {
+                // Subresource failures are noise; only report the
+                // main document failing to load, which is what the
+                // operator can actually act on.
+                if (!(request.isForMainFrame ?? false)) return;
+                if (!mounted) return;
+                setState(() {
+                  _loading = false;
+                  _error = t.access.loadFailed(error: error.description);
+                });
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/mobile/lib/features/auth/cf_access_login_screen.dart
+++ b/app/mobile/lib/features/auth/cf_access_login_screen.dart
@@ -24,11 +24,7 @@ import 'package:opendray/core/i18n/strings.g.dart';
 // settings) and as an inline overlay (AccessGate), where there is no
 // route of its own to pop.
 class CfAccessLoginScreen extends StatefulWidget {
-  const CfAccessLoginScreen({
-    required this.baseUrl,
-    this.onResult,
-    super.key,
-  });
+  const CfAccessLoginScreen({required this.baseUrl, this.onResult, super.key});
 
   /// Gateway base URL, e.g. `https://opendray.example.com`.
   final String baseUrl;
@@ -56,7 +52,7 @@ class _CfAccessLoginScreenState extends State<CfAccessLoginScreen> {
   bool _finishing = false;
   String? _error;
 
-  late final WebUri _start = WebUri(accessLoginUrl(widget.baseUrl));
+  late final WebUri _start = WebUri(accessSignInUrl(widget.baseUrl));
   late final String _gatewayHost = Uri.parse(widget.baseUrl).host;
 
   // Access can bounce through the team domain and back more than
@@ -167,53 +163,62 @@ class _CfAccessLoginScreenState extends State<CfAccessLoginScreen> {
               ),
             ),
           Expanded(
-            child: InAppWebView(
-              initialUrlRequest: URLRequest(url: _start),
-              initialSettings: InAppWebViewSettings(
-                // Access sign-in is a plain web flow; nothing here
-                // needs to talk back to Dart.
-                javaScriptEnabled: true,
-                // No navigation interception. This does NOT affect
-                // the user-agent (we deliberately do not spoof one);
-                // it only turns off the shouldOverrideUrlLoading
-                // callback. There is nothing useful to do in it: an
-                // Access sign-in hops through whichever identity
-                // provider the operator configured, so the set of
-                // legitimate hosts cannot be enumerated ahead of
-                // time, and a guessed allowlist would break real
-                // sign-ins while stopping nothing.
-                useShouldOverrideUrlLoading: false,
-                transparentBackground: true,
+            // The WebView paints its own background, but only once it
+            // has something to paint. Until then, and on Chrome's own
+            // error pages, an unpainted WebView used to let the app's
+            // dark Scaffold show through behind dark text -- the page
+            // was there and completely unreadable. A light ground
+            // under it matches what Cloudflare's sign-in and the
+            // error pages actually draw.
+            child: ColoredBox(
+              color: Colors.white,
+              child: InAppWebView(
+                initialUrlRequest: URLRequest(url: _start),
+                initialSettings: InAppWebViewSettings(
+                  // Access sign-in is a plain web flow; nothing here
+                  // needs to talk back to Dart.
+                  javaScriptEnabled: true,
+                  // No navigation interception. This does NOT affect
+                  // the user-agent (we deliberately do not spoof one);
+                  // it only turns off the shouldOverrideUrlLoading
+                  // callback. There is nothing useful to do in it: an
+                  // Access sign-in hops through whichever identity
+                  // provider the operator configured, so the set of
+                  // legitimate hosts cannot be enumerated ahead of
+                  // time, and a guessed allowlist would break real
+                  // sign-ins while stopping nothing.
+                  useShouldOverrideUrlLoading: false,
+                ),
+                onLoadStart: (_, url) {
+                  if (!mounted) return;
+                  setState(() {
+                    _loading = true;
+                    _error = null;
+                    _currentHost = url?.host ?? _currentHost;
+                    _currentPath = url?.path ?? _currentPath;
+                  });
+                },
+                onLoadStop: (_, url) async {
+                  if (!mounted) return;
+                  setState(() {
+                    _loading = false;
+                    _currentHost = url?.host ?? _currentHost;
+                    _currentPath = url?.path ?? _currentPath;
+                  });
+                  await _tryHarvestCookie();
+                },
+                onReceivedError: (_, request, error) {
+                  // Subresource failures are noise; only report the
+                  // main document failing to load, which is what the
+                  // operator can actually act on.
+                  if (!(request.isForMainFrame ?? false)) return;
+                  if (!mounted) return;
+                  setState(() {
+                    _loading = false;
+                    _error = t.access.loadFailed(error: error.description);
+                  });
+                },
               ),
-              onLoadStart: (_, url) {
-                if (!mounted) return;
-                setState(() {
-                  _loading = true;
-                  _error = null;
-                  _currentHost = url?.host ?? _currentHost;
-                  _currentPath = url?.path ?? _currentPath;
-                });
-              },
-              onLoadStop: (_, url) async {
-                if (!mounted) return;
-                setState(() {
-                  _loading = false;
-                  _currentHost = url?.host ?? _currentHost;
-                  _currentPath = url?.path ?? _currentPath;
-                });
-                await _tryHarvestCookie();
-              },
-              onReceivedError: (_, request, error) {
-                // Subresource failures are noise; only report the
-                // main document failing to load, which is what the
-                // operator can actually act on.
-                if (!(request.isForMainFrame ?? false)) return;
-                if (!mounted) return;
-                setState(() {
-                  _loading = false;
-                  _error = t.access.loadFailed(error: error.description);
-                });
-              },
             ),
           ),
         ],

--- a/app/mobile/lib/features/auth/login_screen.dart
+++ b/app/mobile/lib/features/auth/login_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/auth_api.dart';
 import 'package:opendray/core/auth/auth_state.dart';
+import 'package:opendray/core/auth/cf_access_controller.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 
 // Username + password login. Calls /api/v1/auth/mobile-login which
@@ -64,6 +65,17 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   }
 
   Future<void> _changeServer() async {
+    // The Access cookie is scoped to the old hostname, so it is both
+    // useless against the new one and worth not leaving behind. Read
+    // the URL before resetServer clears it, and hand it over so the
+    // WebView's copy goes too.
+    final auth = ref.read(authControllerProvider);
+    final oldUrl = switch (auth) {
+      AuthLoggedOut(serverUrl: final s) => s,
+      AuthLoggedIn(serverUrl: final s) => s,
+      _ => null,
+    };
+    await ref.read(cfAccessControllerProvider.notifier).clear(baseUrl: oldUrl);
     await ref.read(authControllerProvider.notifier).resetServer();
   }
 

--- a/app/mobile/lib/features/auth/login_screen.dart
+++ b/app/mobile/lib/features/auth/login_screen.dart
@@ -65,18 +65,31 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   }
 
   Future<void> _changeServer() async {
-    // The Access cookie is scoped to the old hostname, so it is both
-    // useless against the new one and worth not leaving behind. Read
-    // the URL before resetServer clears it, and hand it over so the
-    // WebView's copy goes too.
-    final auth = ref.read(authControllerProvider);
-    final oldUrl = switch (auth) {
-      AuthLoggedOut(serverUrl: final s) => s,
-      AuthLoggedIn(serverUrl: final s) => s,
-      _ => null,
-    };
-    await ref.read(cfAccessControllerProvider.notifier).clear(baseUrl: oldUrl);
-    await ref.read(authControllerProvider.notifier).resetServer();
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      // The Access cookie is scoped to the old hostname, so it is both
+      // useless against the new one and worth not leaving behind. Read
+      // the URL before resetServer clears it, and hand it over so the
+      // WebView's copy goes too.
+      //
+      // remote: false — local wipe only. Signing out at Cloudflare
+      // would mean up to two ten-second round trips before the screen
+      // moves, and the operator is frequently changing gateway
+      // precisely because the old one does not answer.
+      final auth = ref.read(authControllerProvider);
+      final oldUrl = switch (auth) {
+        AuthLoggedOut(serverUrl: final s) => s,
+        AuthLoggedIn(serverUrl: final s) => s,
+        _ => null,
+      };
+      await ref
+          .read(cfAccessControllerProvider.notifier)
+          .clear(baseUrl: oldUrl, remote: false);
+      await ref.read(authControllerProvider.notifier).resetServer();
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
   }
 
   @override

--- a/app/mobile/lib/features/onboarding/onboarding_screen.dart
+++ b/app/mobile/lib/features/onboarding/onboarding_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/auth_api.dart';
+import 'package:opendray/core/api/gateway_url.dart';
 import 'package:opendray/core/auth/auth_state.dart';
 import 'package:opendray/core/auth/cf_access_controller.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
@@ -24,7 +25,11 @@ class OnboardingScreen extends ConsumerStatefulWidget {
 }
 
 class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
-  final _controller = TextEditingController(text: 'http://');
+  // Deliberately empty. It used to be pre-filled with "http://",
+  // which meant typing a published hostname after it produced a
+  // cleartext URL and a redirect the app could not explain.
+  // normalizeGatewayUrl picks the scheme from the address instead.
+  final _controller = TextEditingController();
   bool _busy = false;
   String? _error;
   String? _detected;
@@ -41,7 +46,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
       setState(() => _error = 'Enter your gateway URL');
       return;
     }
-    final normalized = _normalize(raw);
+    final normalized = normalizeGatewayUrl(raw);
     setState(() {
       _busy = true;
       _error = null;
@@ -54,8 +59,12 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
       // no Access session yet. Onboarding drives the SSO itself
       // rather than deferring to AccessGate: there is no server URL
       // persisted yet, so the gate has nothing to sign in to.
+      //
+      // e.baseUrl, not what was typed: an http:// entry was upgraded
+      // to https before the challenge came back, and the Secure
+      // CF_Authorization cookie is unreadable through an http:// URL.
       setState(() => _error = t.access.challengeBanner(host: e.host));
-      await _runAccessSso(normalized);
+      await _runAccessSso(e.baseUrl ?? normalized);
     } on ApiException catch (e) {
       setState(() => _error = 'Server replied ${e.statusCode}: ${e.message}');
     } on Object catch (e) {
@@ -66,13 +75,19 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   }
 
   Future<void> _probeAndPersist(String normalized) async {
-    final h = await probeHealth(
+    final probe = await probeGateway(
       normalized,
       cfCookie: ref.read(cfAccessControllerProvider.notifier).cookie,
     );
     if (!mounted) return;
+    final h = probe.health;
     setState(() => _detected = 'opendray ${h.version} (${h.status})');
-    await ref.read(authControllerProvider.notifier).setServerUrl(normalized);
+    // probe.baseUrl, not the typed one: the gateway may have upgraded
+    // us to https, and persisting the http form would earn that
+    // redirect on every request for the life of the install.
+    await ref
+        .read(authControllerProvider.notifier)
+        .setServerUrl(probe.baseUrl);
     // Router redirects automatically on AuthState change.
   }
 
@@ -89,17 +104,6 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
       if (!mounted) return;
       setState(() => _error = 'Could not reach $normalized: $e');
     }
-  }
-
-  String _normalize(String raw) {
-    var v = raw.trim();
-    if (!v.startsWith('http://') && !v.startsWith('https://')) {
-      v = 'https://$v';
-    }
-    while (v.endsWith('/')) {
-      v = v.substring(0, v.length - 1);
-    }
-    return v;
   }
 
   @override

--- a/app/mobile/lib/features/onboarding/onboarding_screen.dart
+++ b/app/mobile/lib/features/onboarding/onboarding_screen.dart
@@ -4,7 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:opendray/core/api/api_exception.dart';
 import 'package:opendray/core/api/auth_api.dart';
 import 'package:opendray/core/auth/auth_state.dart';
+import 'package:opendray/core/auth/cf_access_controller.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/auth/cf_access_login_screen.dart';
 
 // First-run screen. The user types the gateway URL here; we
 // validate by calling /api/v1/health on it before persisting.
@@ -46,16 +48,46 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
       _detected = null;
     });
     try {
-      final h = await probeHealth(normalized);
-      setState(() => _detected = 'opendray ${h.version} (${h.status})');
-      await ref.read(authControllerProvider.notifier).setServerUrl(normalized);
-      // Router redirects automatically on AuthState change.
+      await _probeAndPersist(normalized);
+    } on AccessChallengeException catch (e) {
+      // The gateway is behind Cloudflare Access and this device has
+      // no Access session yet. Onboarding drives the SSO itself
+      // rather than deferring to AccessGate: there is no server URL
+      // persisted yet, so the gate has nothing to sign in to.
+      setState(() => _error = t.access.challengeBanner(host: e.host));
+      await _runAccessSso(normalized);
     } on ApiException catch (e) {
       setState(() => _error = 'Server replied ${e.statusCode}: ${e.message}');
     } on Object catch (e) {
       setState(() => _error = 'Could not reach $normalized: $e');
     } finally {
       if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _probeAndPersist(String normalized) async {
+    final h = await probeHealth(
+      normalized,
+      cfCookie: ref.read(cfAccessControllerProvider.notifier).cookie,
+    );
+    if (!mounted) return;
+    setState(() => _detected = 'opendray ${h.version} (${h.status})');
+    await ref.read(authControllerProvider.notifier).setServerUrl(normalized);
+    // Router redirects automatically on AuthState change.
+  }
+
+  Future<void> _runAccessSso(String normalized) async {
+    if (!mounted) return;
+    final cookie = await CfAccessLoginScreen.show(context, normalized);
+    if (cookie == null || !mounted) return;
+    await ref.read(cfAccessControllerProvider.notifier).save(cookie);
+    if (!mounted) return;
+    setState(() => _error = null);
+    try {
+      await _probeAndPersist(normalized);
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() => _error = 'Could not reach $normalized: $e');
     }
   }
 

--- a/app/mobile/lib/features/sessions/session_terminal_view.dart
+++ b/app/mobile/lib/features/sessions/session_terminal_view.dart
@@ -7,9 +7,12 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:opendray/core/api/api_exception.dart';
+import 'package:opendray/core/api/dio_provider.dart';
 import 'package:opendray/core/api/models.dart';
 import 'package:opendray/core/api/sessions_api.dart';
+import 'package:opendray/core/api/ws_connect.dart';
 import 'package:opendray/core/auth/auth_state.dart';
+import 'package:opendray/core/auth/cf_access_controller.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/features/sessions/terminal_select_sheet.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -42,6 +45,9 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
   WebSocketChannel? _channel;
   StreamSubscription<dynamic>? _sub;
   Timer? _reconnectTimer;
+  // True between scheduling a reconnect and running it, so the two
+  // callbacks a single failure fires collapse into one attempt.
+  bool _reconnectPending = false;
   ProviderSubscription<AsyncValue<SessionSummary>>? _sessionStateSub;
   _ConnState _state = _ConnState.connecting;
   String? _lastError;
@@ -139,6 +145,7 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
 
   void _connect() {
     if (_disposed) return;
+    _reconnectPending = false;
     final auth = ref.read(authControllerProvider);
     if (auth is! AuthLoggedIn) {
       setState(() {
@@ -153,45 +160,36 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
       _lastError = null;
     });
 
-    final wsUrl = _wsUrl(
-      baseUrl: auth.serverUrl,
-      sessionId: widget.sessionId,
-      token: auth.token,
-    );
-
     try {
-      _channel = WebSocketChannel.connect(wsUrl);
+      _channel = connectGatewayWs(
+        serverUrl: auth.serverUrl,
+        path: '/api/v1/sessions/${widget.sessionId}/stream',
+        token: auth.token,
+        cfCookie: ref.read(cfAccessControllerProvider.notifier).cookie,
+      );
       _sub = _channel!.stream.listen(
         _onWsMessage,
         onError: _onWsError,
         onDone: _onWsDone,
         cancelOnError: false,
       );
-      // Optimistic — if we get the first message, we'll flip to
-      // connected in _onWsMessage.
-      _retryAttempt = 0;
+      // The budget is NOT reset here. connectGatewayWs returns as
+      // soon as the socket object exists, long before the handshake
+      // is known to have succeeded, so resetting on this line made
+      // every attempt look like attempt one and turned the cap below
+      // into an unbounded reconnect loop. It resets in _onWsMessage,
+      // on the first byte that proves the connection actually works.
     } on Object catch (e) {
       _scheduleReconnect(error: 'Failed to open WebSocket: $e');
     }
   }
 
-  Uri _wsUrl({
-    required String baseUrl,
-    required String sessionId,
-    required String token,
-  }) {
-    final trimmed = baseUrl.replaceAll(RegExp(r'/+$'), '');
-    final wsBase = trimmed.startsWith('https')
-        ? trimmed.replaceFirst('https', 'wss')
-        : trimmed.replaceFirst('http', 'ws');
-    return Uri.parse(
-      '$wsBase/api/v1/sessions/$sessionId/stream?token=${Uri.encodeQueryComponent(token)}',
-    );
-  }
-
   void _onWsMessage(dynamic msg) {
     if (_disposed) return;
     if (_state != _ConnState.connected) {
+      // Proof the handshake got through, which is the only thing
+      // that earns a fresh retry budget.
+      _retryAttempt = 0;
       setState(() => _state = _ConnState.connected);
     }
     if (msg is Uint8List) {
@@ -229,12 +227,21 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
 
   void _scheduleReconnect({required String error}) {
     if (_disposed) return;
+    // A rejected handshake emits onError AND onDone for the same
+    // failure, so this runs twice per disconnect unless we say
+    // otherwise. Left unguarded that spends the retry budget at
+    // double rate and sends two probes for one event.
+    if (_reconnectPending) return;
+    _reconnectPending = true;
+    // A dead Access cookie looks exactly like a dead gateway from
+    // here, so ask over HTTP, where the difference is visible.
+    unawaited(probeForAccessChallenge(ref.read(dioProvider)));
     _sub?.cancel();
     _channel?.sink.close();
     _channel = null;
     _sub = null;
     _retryAttempt += 1;
-    if (_retryAttempt > 5) {
+    if (_retryAttempt > kMaxReconnectAttempts) {
       setState(() {
         _state = _ConnState.error;
         _lastError = error;
@@ -245,9 +252,8 @@ class _SessionTerminalViewState extends ConsumerState<SessionTerminalView> {
       _state = _ConnState.reconnecting;
       _lastError = error;
     });
-    final backoff = Duration(milliseconds: 500 * (1 << (_retryAttempt - 1)));
     _reconnectTimer?.cancel();
-    _reconnectTimer = Timer(backoff, _connect);
+    _reconnectTimer = Timer(reconnectBackoff(_retryAttempt), _connect);
   }
 
   void _onTerminalOutput(String data) {

--- a/app/mobile/lib/features/settings/log_viewer_screen.dart
+++ b/app/mobile/lib/features/settings/log_viewer_screen.dart
@@ -28,7 +28,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:opendray/core/api/dio_provider.dart';
 import 'package:opendray/core/api/logs_api.dart';
+import 'package:opendray/core/api/ws_connect.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 
 const _maxBuffered = 2000;
@@ -82,6 +84,10 @@ class _LogViewerScreenState extends ConsumerState<LogViewerScreen> {
       _onRecord,
       onError: (Object err) {
         if (!mounted) return;
+        // Same blind spot as the session terminal: Access rejecting
+        // the upgrade is indistinguishable from an unreachable
+        // gateway here, so re-ask over HTTP where it is visible.
+        unawaited(probeForAccessChallenge(ref.read(dioProvider)));
         setState(() {
           _connected = false;
           _connectError = err.toString();

--- a/app/mobile/lib/features/settings/security_screen.dart
+++ b/app/mobile/lib/features/settings/security_screen.dart
@@ -23,6 +23,9 @@ class SecurityScreen extends ConsumerStatefulWidget {
 
 class _SecurityScreenState extends ConsumerState<SecurityScreen> {
   String? _lockError;
+  // Signing out now makes two network round trips through an
+  // offscreen WebView, so it needs to say it is working.
+  bool _clearingAccess = false;
 
   Future<void> _setLock({required bool enabled}) async {
     setState(() => _lockError = null);
@@ -51,6 +54,22 @@ class _SecurityScreenState extends ConsumerState<SecurityScreen> {
       return;
     }
     await controller.setEnabled(enabled: true);
+  }
+
+  Future<void> _clearAccess(String baseUrl) async {
+    if (_clearingAccess) return;
+    setState(() => _clearingAccess = true);
+    try {
+      await ref
+          .read(cfAccessControllerProvider.notifier)
+          .clear(baseUrl: baseUrl);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(t.access.cleared)),
+      );
+    } finally {
+      if (mounted) setState(() => _clearingAccess = false);
+    }
   }
 
   Future<void> _signInToAccess(String baseUrl) async {
@@ -114,21 +133,24 @@ class _SecurityScreenState extends ConsumerState<SecurityScreen> {
                 title: Text(t.access.signIn),
                 onTap: () => _signInToAccess(baseUrl),
               ),
-            if (access is CfAccessReady)
+            if (access is CfAccessReady && baseUrl.isNotEmpty)
               ListTile(
-                // Not a logout icon: this forgets the cookie on this
-                // device, it does not end the session at Cloudflare.
-                // The identity provider may still sign you straight
-                // back in without asking for anything.
-                leading: const Icon(Icons.delete_outline),
+                leading: _clearingAccess
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.logout_outlined),
                 title: Text(t.access.clear),
                 subtitle: Text(
-                  t.access.clearSubtitle,
+                  _clearingAccess
+                      ? t.access.clearing
+                      : t.access.clearSubtitle,
                   style: theme.textTheme.bodySmall,
                 ),
-                onTap: () => ref
-                    .read(cfAccessControllerProvider.notifier)
-                    .clear(baseUrl: baseUrl),
+                enabled: !_clearingAccess,
+                onTap: () => _clearAccess(baseUrl),
               ),
             const SizedBox(height: 24),
           ],

--- a/app/mobile/lib/features/settings/security_screen.dart
+++ b/app/mobile/lib/features/settings/security_screen.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:opendray/core/auth/auth_state.dart';
+import 'package:opendray/core/auth/biometric_lock.dart';
+import 'package:opendray/core/auth/cf_access_controller.dart';
+import 'package:opendray/core/i18n/strings.g.dart';
+import 'package:opendray/features/auth/cf_access_login_screen.dart';
+
+// Security settings: the app lock, and this device's Cloudflare
+// Access session.
+//
+// Both belong together because they answer the same question -- who
+// is allowed to drive this gateway from a phone. Access decides
+// whether the device reaches the tunnel; the app lock decides whether
+// whoever is holding the phone reaches the app.
+class SecurityScreen extends ConsumerStatefulWidget {
+  const SecurityScreen({super.key});
+
+  @override
+  ConsumerState<SecurityScreen> createState() => _SecurityScreenState();
+}
+
+class _SecurityScreenState extends ConsumerState<SecurityScreen> {
+  String? _lockError;
+
+  Future<void> _setLock({required bool enabled}) async {
+    setState(() => _lockError = null);
+    final auth = ref.read(localAuthProvider);
+    final controller = ref.read(biometricLockControllerProvider.notifier);
+
+    if (!enabled) {
+      await controller.setEnabled(enabled: false);
+      return;
+    }
+
+    // Turning the lock on without checking would let the operator
+    // enable a gate the device cannot enforce, and they would only
+    // find out by never being asked for anything.
+    if (!await canLockDevice(auth)) {
+      if (!mounted) return;
+      setState(() => _lockError = t.settings.security.appLockUnavailable);
+      return;
+    }
+    // Prove it works before persisting, so a device that reports
+    // support but fails in practice cannot lock the operator into a
+    // setting they can no longer reach.
+    if (!await promptUnlock(auth, t.lock.reason)) {
+      if (!mounted) return;
+      setState(() => _lockError = t.settings.security.appLockFailed);
+      return;
+    }
+    await controller.setEnabled(enabled: true);
+  }
+
+  Future<void> _signInToAccess(String baseUrl) async {
+    final cookie = await CfAccessLoginScreen.show(context, baseUrl);
+    if (cookie == null || !mounted) return;
+    await ref.read(cfAccessControllerProvider.notifier).save(cookie);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final lockEnabled = ref.watch(biometricLockEnabledProvider);
+    final access = ref.watch(cfAccessControllerProvider);
+    final auth = ref.watch(authControllerProvider);
+    final baseUrl = switch (auth) {
+      AuthLoggedOut(serverUrl: final s) => s,
+      AuthLoggedIn(serverUrl: final s) => s,
+      _ => '',
+    };
+
+    return Scaffold(
+      appBar: AppBar(title: Text(t.settings.security.section)),
+      body: SafeArea(
+        bottom: false,
+        child: ListView(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          children: [
+            SwitchListTile(
+              secondary: const Icon(Icons.fingerprint),
+              title: Text(t.settings.security.appLock),
+              subtitle: Text(
+                t.settings.security.appLockSubtitle,
+                style: theme.textTheme.bodySmall,
+              ),
+              value: lockEnabled,
+              onChanged: (v) => _setLock(enabled: v),
+            ),
+            if (_lockError != null)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                child: Text(
+                  _lockError!,
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: theme.colorScheme.error),
+                ),
+              ),
+            const Divider(height: 24),
+            _SectionHeader(t.access.section),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+              child: Text(
+                t.access.sectionSubtitle,
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.outline),
+              ),
+            ),
+            _AccessStatusTile(state: access),
+            if (baseUrl.isNotEmpty)
+              ListTile(
+                leading: const Icon(Icons.shield_outlined),
+                title: Text(t.access.signIn),
+                onTap: () => _signInToAccess(baseUrl),
+              ),
+            if (access is CfAccessReady)
+              ListTile(
+                // Not a logout icon: this forgets the cookie on this
+                // device, it does not end the session at Cloudflare.
+                // The identity provider may still sign you straight
+                // back in without asking for anything.
+                leading: const Icon(Icons.delete_outline),
+                title: Text(t.access.clear),
+                subtitle: Text(
+                  t.access.clearSubtitle,
+                  style: theme.textTheme.bodySmall,
+                ),
+                onTap: () => ref
+                    .read(cfAccessControllerProvider.notifier)
+                    .clear(baseUrl: baseUrl),
+              ),
+            const SizedBox(height: 24),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AccessStatusTile extends StatelessWidget {
+  const _AccessStatusTile({required this.state});
+
+  final CfAccessState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (icon, title, subtitle) = switch (state) {
+      CfAccessReady(session: final s) => (
+          Icons.verified_user_outlined,
+          t.access.sessionActive,
+          s.expiresAt == null
+              ? t.access.sessionExpiryUnknown
+              : t.access.sessionExpires(
+                  when: s.expiresAt!.toLocal().toString().split('.').first,
+                ),
+        ),
+      CfAccessNeedsLogin() => (
+          Icons.gpp_maybe_outlined,
+          t.access.sessionNone,
+          t.access.signIn,
+        ),
+      _ => (Icons.shield_outlined, t.access.sessionNone, ''),
+    };
+    return ListTile(
+      leading: Icon(icon),
+      title: Text(title),
+      subtitle: subtitle.isEmpty
+          ? null
+          : Text(subtitle, style: theme.textTheme.bodySmall),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.label);
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 6),
+      child: Text(
+        label.toUpperCase(),
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.outline,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.8,
+          fontSize: 11,
+        ),
+      ),
+    );
+  }
+}

--- a/app/mobile/lib/features/settings/settings_screen.dart
+++ b/app/mobile/lib/features/settings/settings_screen.dart
@@ -14,6 +14,7 @@ import 'package:opendray/core/locale/locale_controller.dart';
 import 'package:opendray/core/theme/theme_controller.dart';
 import 'package:opendray/features/settings/change_credentials_screen.dart';
 import 'package:opendray/features/settings/log_viewer_screen.dart';
+import 'package:opendray/features/settings/security_screen.dart';
 import 'package:opendray/features/settings/server_settings_screen.dart';
 
 class SettingsScreen extends ConsumerWidget {
@@ -116,6 +117,20 @@ class SettingsScreen extends ConsumerWidget {
               onTap: () => Navigator.of(context).push(
                 MaterialPageRoute<void>(
                   builder: (_) => const ChangeCredentialsScreen(),
+                ),
+              ),
+            ),
+            ListTile(
+              leading: const Icon(Icons.shield_outlined),
+              title: Text(t.settings.security.section),
+              subtitle: Text(
+                t.settings.security.appLockSubtitle,
+                style: theme.textTheme.bodySmall,
+              ),
+              trailing: const Icon(Icons.chevron_right, size: 18),
+              onTap: () => Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const SecurityScreen(),
                 ),
               ),
             ),

--- a/app/mobile/lib/main.dart
+++ b/app/mobile/lib/main.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:opendray/core/auth/access_gate.dart';
+import 'package:opendray/core/auth/biometric_lock.dart';
 import 'package:opendray/core/i18n/strings.g.dart';
 import 'package:opendray/core/lifecycle/resume_refresh.dart';
 import 'package:opendray/core/locale/locale_controller.dart';
@@ -43,6 +45,13 @@ class OpendrayApp extends ConsumerWidget {
       supportedLocales: AppLocaleUtils.instance.supportedLocales,
       localizationsDelegates: GlobalMaterialLocalizations.delegates,
       routerConfig: router,
+      // Both gates sit above the router because both are orthogonal
+      // to which screen is showing. Order matters: the app lock is
+      // outermost, so a locked device does not expose the Cloudflare
+      // Access sign-in either.
+      builder: (context, child) => BiometricGate(
+        child: AccessGate(child: child ?? const SizedBox.shrink()),
+      ),
     );
   }
 }

--- a/app/mobile/test/core/api/dio_access_challenge_test.dart
+++ b/app/mobile/test/core/api/dio_access_challenge_test.dart
@@ -1,0 +1,161 @@
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opendray/core/api/api_exception.dart';
+import 'package:opendray/core/api/dio_provider.dart';
+
+// Locks in how the HTTP client behaves when Cloudflare Access, rather
+// than the gateway, answers a request. The failure this prevents: the
+// operator sees "FormatException: Unexpected character" because an
+// Access login page was parsed as JSON, with no hint that the fix is
+// to sign in again at the edge.
+
+/// Answers every request with [body] under [status] / [headers],
+/// optionally reporting a different final URI the way a followed
+/// redirect would.
+class _CannedAdapter implements HttpClientAdapter {
+  _CannedAdapter({
+    required this.status,
+    required this.body,
+    required this.headers,
+    this.redirectTo,
+  });
+
+  final int status;
+  final String body;
+  final Map<String, List<String>> headers;
+  final Uri? redirectTo;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final res = ResponseBody.fromString(body, status, headers: headers);
+    if (redirectTo != null) {
+      res.redirects = [
+        RedirectRecord(302, 'GET', redirectTo!),
+      ];
+    }
+    return res;
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+const _accessLoginPage = '<!DOCTYPE html><title>Sign in</title>';
+
+void main() {
+  test('an Access login page becomes AccessChallengeException', () async {
+    var challengedHost = '';
+    final dio = buildDio(
+      baseUrl: 'https://od.example.com',
+      token: 't',
+      onAccessChallenge: (h) => challengedHost = h,
+    )..httpClientAdapter = _CannedAdapter(
+        status: 200,
+        body: _accessLoginPage,
+        headers: {
+          Headers.contentTypeHeader: ['text/html; charset=utf-8'],
+        },
+        redirectTo: Uri.parse(
+          'https://acme.cloudflareaccess.com/cdn-cgi/access/login/od.example.com',
+        ),
+      );
+
+    await expectLater(
+      dio.get<dynamic>('/api/v1/sessions'),
+      throwsA(
+        isA<DioException>().having(
+          (e) => e.error,
+          'error',
+          isA<AccessChallengeException>()
+              .having((e) => e.host, 'host', 'acme.cloudflareaccess.com'),
+        ),
+      ),
+    );
+    expect(challengedHost, 'acme.cloudflareaccess.com');
+  });
+
+  test('the cookie rides on every request when we hold one', () async {
+    late RequestOptions seen;
+    final dio = buildDio(
+      baseUrl: 'https://od.example.com',
+      token: 't',
+      cfCookie: 'jwt-value',
+    )..httpClientAdapter = _RecordingAdapter((o) => seen = o);
+
+    await dio.get<dynamic>('/api/v1/health');
+    expect(seen.headers['Cookie'], 'CF_Authorization=jwt-value');
+  });
+
+  test('no cookie header at all on a LAN deployment', () async {
+    late RequestOptions seen;
+    final dio = buildDio(baseUrl: 'http://192.168.3.5:8770', token: 't')
+      ..httpClientAdapter = _RecordingAdapter((o) => seen = o);
+
+    await dio.get<dynamic>('/api/v1/health');
+    expect(seen.headers.containsKey('Cookie'), isFalse);
+  });
+
+  // An expired bearer must keep reaching onUnauthorized. Routing it
+  // into the Access flow instead would pop a WebView that signs in
+  // successfully and leaves the app just as logged out.
+  test('a gateway 401 is still a plain 401', () async {
+    var unauthorized = false;
+    var challenged = false;
+    final dio = buildDio(
+      baseUrl: 'https://od.example.com',
+      token: 'stale',
+      cfCookie: 'jwt-value',
+      onUnauthorized: () => unauthorized = true,
+      onAccessChallenge: (_) => challenged = true,
+    )..httpClientAdapter = _CannedAdapter(
+        status: 401,
+        body: '{"error":"unauthorized"}',
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      );
+
+    await expectLater(
+      dio.get<dynamic>('/api/v1/sessions'),
+      throwsA(
+        isA<DioException>().having(
+          (e) => e.error,
+          'error',
+          isA<ApiException>().having((e) => e.statusCode, 'status', 401),
+        ),
+      ),
+    );
+    expect(unauthorized, isTrue);
+    expect(challenged, isFalse);
+  });
+}
+
+class _RecordingAdapter implements HttpClientAdapter {
+  _RecordingAdapter(this.onFetch);
+  final void Function(RequestOptions) onFetch;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    onFetch(options);
+    return ResponseBody.fromString(
+      '{"status":"ok"}',
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/app/mobile/test/core/api/dio_access_challenge_test.dart
+++ b/app/mobile/test/core/api/dio_access_challenge_test.dart
@@ -104,6 +104,8 @@ void main() {
   // An expired bearer must keep reaching onUnauthorized. Routing it
   // into the Access flow instead would pop a WebView that signs in
   // successfully and leaves the app just as logged out.
+  _redirectSuite();
+
   test('a gateway 401 is still a plain 401', () async {
     var unauthorized = false;
     var challenged = false;
@@ -133,6 +135,48 @@ void main() {
     );
     expect(unauthorized, isTrue);
     expect(challenged, isFalse);
+  });
+}
+
+
+// The end-to-end shape of the live bug: Access answers the probe with
+// a 302 and the client must NOT chase it. Chasing it walked to the
+// identity provider and came back with HTML that parsed as neither
+// JSON nor a recognisable challenge.
+void _redirectSuite() {
+  test('an unfollowed Access redirect becomes AccessChallengeException',
+      () async {
+    var challenged = false;
+    final dio = buildDio(
+      baseUrl: 'https://od.example.com',
+      token: 't',
+      onAccessChallenge: (_) => challenged = true,
+    )..httpClientAdapter = _CannedAdapter(
+        status: 302,
+        body: '',
+        headers: {
+          'location': [
+            'https://acme.cloudflareaccess.com/cdn-cgi/access/login/od.example.com',
+          ],
+        },
+      );
+
+    await expectLater(
+      dio.get<dynamic>('/api/v1/health'),
+      throwsA(
+        isA<DioException>().having(
+          (e) => e.error,
+          'error',
+          isA<AccessChallengeException>(),
+        ),
+      ),
+    );
+    expect(challenged, isTrue);
+  });
+
+  test('the client is configured not to chase redirects', () {
+    expect(buildDio(baseUrl: 'https://od.example.com').options.followRedirects,
+        isFalse);
   });
 }
 

--- a/app/mobile/test/core/api/dio_access_challenge_test.dart
+++ b/app/mobile/test/core/api/dio_access_challenge_test.dart
@@ -54,7 +54,7 @@ void main() {
     final dio = buildDio(
       baseUrl: 'https://od.example.com',
       token: 't',
-      onAccessChallenge: (h) => challengedHost = h,
+      onAccessChallenge: (h, _) => challengedHost = h,
     )..httpClientAdapter = _CannedAdapter(
         status: 200,
         body: _accessLoginPage,
@@ -114,7 +114,7 @@ void main() {
       token: 'stale',
       cfCookie: 'jwt-value',
       onUnauthorized: () => unauthorized = true,
-      onAccessChallenge: (_) => challenged = true,
+      onAccessChallenge: (_, __) => challenged = true,
     )..httpClientAdapter = _CannedAdapter(
         status: 401,
         body: '{"error":"unauthorized"}',
@@ -147,10 +147,14 @@ void _redirectSuite() {
   test('an unfollowed Access redirect becomes AccessChallengeException',
       () async {
     var challenged = false;
+    String? seenTeam;
     final dio = buildDio(
       baseUrl: 'https://od.example.com',
       token: 't',
-      onAccessChallenge: (_) => challenged = true,
+      onAccessChallenge: (_, team) {
+        challenged = true;
+        seenTeam = team;
+      },
     )..httpClientAdapter = _CannedAdapter(
         status: 302,
         body: '',
@@ -172,6 +176,9 @@ void _redirectSuite() {
       ),
     );
     expect(challenged, isTrue);
+    // Captured here or nowhere: by sign-out time the cookie that
+    // also names the team domain may already be gone.
+    expect(seenTeam, 'acme.cloudflareaccess.com');
   });
 
   test('the client is configured not to chase redirects', () {

--- a/app/mobile/test/core/api/gateway_url_test.dart
+++ b/app/mobile/test/core/api/gateway_url_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opendray/core/api/gateway_url.dart';
+
+// Both halves of a real failure: the operator typed
+// "http://opendray.example.com" into a field pre-filled with
+// "http://", Cloudflare answered 301 to the https form, and the app
+// reported a network error instead of either following the upgrade or
+// saying which scheme it wanted.
+
+void main() {
+  group('normalizeGatewayUrl', () {
+    // A published gateway is behind TLS and answers plain http only
+    // with a redirect, so https is the right guess for a hostname.
+    test('a bare public hostname gets https', () {
+      expect(
+        normalizeGatewayUrl('opendray.example.com'),
+        'https://opendray.example.com',
+      );
+    });
+
+    // A LAN gateway has no certificate. Guessing https here would
+    // break every self-hosted install, which is the common case.
+    test('a bare private address gets http', () {
+      expect(normalizeGatewayUrl('192.168.3.5:8770'), 'http://192.168.3.5:8770');
+      expect(normalizeGatewayUrl('10.0.0.4:8770'), 'http://10.0.0.4:8770');
+      expect(normalizeGatewayUrl('172.16.5.9:8770'), 'http://172.16.5.9:8770');
+      expect(normalizeGatewayUrl('127.0.0.1:8770'), 'http://127.0.0.1:8770');
+      expect(normalizeGatewayUrl('localhost:8770'), 'http://localhost:8770');
+      expect(normalizeGatewayUrl('nas.local:8770'), 'http://nas.local:8770');
+    });
+
+    // A public IP is not a LAN address; treat it like a hostname.
+    test('a bare public IP gets https', () {
+      expect(normalizeGatewayUrl('203.0.113.9'), 'https://203.0.113.9');
+    });
+
+    test('an explicit scheme is always respected', () {
+      expect(
+        normalizeGatewayUrl('http://opendray.example.com'),
+        'http://opendray.example.com',
+      );
+      expect(
+        normalizeGatewayUrl('https://192.168.3.5:8770'),
+        'https://192.168.3.5:8770',
+      );
+    });
+
+    test('trailing slashes and whitespace are trimmed', () {
+      expect(
+        normalizeGatewayUrl('  https://opendray.example.com//  '),
+        'https://opendray.example.com',
+      );
+    });
+  });
+
+  group('protocolUpgradeTarget', () {
+    // Cloudflare's answer to plain http. Safe to act on: same host,
+    // same path, strictly more secure, and the server asked for it.
+    test('same-host http to https is an upgrade', () {
+      expect(
+        protocolUpgradeTarget(
+          from: Uri.parse('http://od.example.com/api/v1/health'),
+          location: 'https://od.example.com/api/v1/health',
+        ),
+        'https://od.example.com/api/v1/health',
+      );
+    });
+
+    test('a relative Location resolves against the request', () {
+      expect(
+        protocolUpgradeTarget(
+          from: Uri.parse('http://od.example.com/api/v1/health'),
+          location: '//od.example.com/api/v1/health',
+        ),
+        isNull,
+      );
+    });
+
+    // The one that must never be auto-followed: this is Access (or
+    // anything else) sending us somewhere new, and the whole point of
+    // not following redirects is to report it.
+    test('a redirect to a different host is not an upgrade', () {
+      expect(
+        protocolUpgradeTarget(
+          from: Uri.parse('https://od.example.com/api/v1/health'),
+          location: 'https://team.cloudflareaccess.com/cdn-cgi/access/login/x',
+        ),
+        isNull,
+      );
+    });
+
+    test('a redirect to a different path is not an upgrade', () {
+      expect(
+        protocolUpgradeTarget(
+          from: Uri.parse('http://od.example.com/api/v1/health'),
+          location: 'https://od.example.com/login',
+        ),
+        isNull,
+      );
+    });
+
+    // Downgrades and lateral moves are never followed.
+    test('https to http is not an upgrade', () {
+      expect(
+        protocolUpgradeTarget(
+          from: Uri.parse('https://od.example.com/api/v1/health'),
+          location: 'http://od.example.com/api/v1/health',
+        ),
+        isNull,
+      );
+    });
+
+    test('an empty or missing Location is not an upgrade', () {
+      expect(
+        protocolUpgradeTarget(
+          from: Uri.parse('http://od.example.com/api/v1/health'),
+          location: null,
+        ),
+        isNull,
+      );
+      expect(
+        protocolUpgradeTarget(
+          from: Uri.parse('http://od.example.com/api/v1/health'),
+          location: '   ',
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('upgradedBaseUrl', () {
+    // What onboarding persists after an upgrade: the base URL, not
+    // the probe path that triggered it.
+    test('strips the probe path back off', () {
+      expect(
+        upgradedBaseUrl(
+          baseUrl: 'http://od.example.com',
+          upgraded: 'https://od.example.com/api/v1/health',
+        ),
+        'https://od.example.com',
+      );
+    });
+
+    test('keeps a port', () {
+      expect(
+        upgradedBaseUrl(
+          baseUrl: 'http://od.example.com:8443',
+          upgraded: 'https://od.example.com:8443/api/v1/health',
+        ),
+        'https://od.example.com:8443',
+      );
+    });
+  });
+}

--- a/app/mobile/test/core/api/probe_gateway_test.dart
+++ b/app/mobile/test/core/api/probe_gateway_test.dart
@@ -1,0 +1,162 @@
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opendray/core/api/api_exception.dart';
+import 'package:opendray/core/api/auth_api.dart';
+
+// Reproduces the reported onboarding failure end to end.
+//
+// Entering the published gateway URL showed "Server replied 0:
+// Network error". Nothing was wrong with the network: Cloudflare
+// Access answered with an HTML login page, and the probe asked Dio
+// for Map<String, dynamic>. That cast runs inside the await, so it
+// threw _TypeError with a null message before a single challenge
+// check could execute, and the null message rendered as a network
+// fault.
+
+class _ScriptedAdapter implements HttpClientAdapter {
+  _ScriptedAdapter(this.steps);
+
+  /// One entry per expected request, in order.
+  final List<ResponseBody Function()> steps;
+  final List<Uri> seen = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    seen.add(options.uri);
+    return steps[seen.length - 1]();
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+ResponseBody _html(int status, {String? location}) => ResponseBody.fromString(
+      '<!DOCTYPE html><title>Sign in</title>',
+      status,
+      headers: {
+        Headers.contentTypeHeader: ['text/html; charset=utf-8'],
+        if (location != null) 'location': [location],
+      },
+    );
+
+ResponseBody _healthJson() => ResponseBody.fromString(
+      '{"status":"ok","version":"2.14.0"}',
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+
+Dio Function(String, {String? cfCookie}) _factory(_ScriptedAdapter adapter) {
+  return (String baseUrl, {String? cfCookie}) => buildOnboardingDio(
+        baseUrl,
+        cfCookie: cfCookie,
+      )..httpClientAdapter = adapter;
+}
+
+void main() {
+  test('an Access challenge is reported as one, not as a type error', () async {
+    final adapter = _ScriptedAdapter([
+      () => _html(
+            302,
+            location:
+                'https://team.cloudflareaccess.com/cdn-cgi/access/login/od.example.com',
+          ),
+    ]);
+
+    await expectLater(
+      probeGateway(
+        'https://od.example.com',
+        dioFactory: _factory(adapter),
+      ),
+      throwsA(isA<AccessChallengeException>()),
+    );
+  });
+
+  // The scheme half of the same report: the field used to be
+  // pre-filled with "http://", so a published hostname typed after it
+  // produced cleartext, and the TLS front end answered 301.
+  test('http is upgraded to https and the https URL is what we keep',
+      () async {
+    final adapter = _ScriptedAdapter([
+      () => _html(301, location: 'https://od.example.com/api/v1/health'),
+      _healthJson,
+    ]);
+
+    final probe = await probeGateway(
+      'http://od.example.com',
+      dioFactory: _factory(adapter),
+    );
+
+    expect(probe.baseUrl, 'https://od.example.com');
+    expect(probe.health.version, '2.14.0');
+    expect(adapter.seen.first.scheme, 'http');
+    expect(adapter.seen.last.scheme, 'https');
+  });
+
+  test('a plain LAN gateway still answers on the first try', () async {
+    final adapter = _ScriptedAdapter([_healthJson]);
+
+    final probe = await probeGateway(
+      'http://192.168.3.5:8770',
+      dioFactory: _factory(adapter),
+    );
+
+    expect(probe.baseUrl, 'http://192.168.3.5:8770');
+    expect(adapter.seen, hasLength(1));
+  });
+
+  // A 2xx that is not JSON means the URL points at something that is
+  // not opendray. Saying so beats letting a cast failure downstream
+  // turn it back into "Network error".
+  test('a non-JSON 200 names what actually came back', () async {
+    final adapter = _ScriptedAdapter([
+      () => ResponseBody.fromString(
+            '<html>some other service</html>',
+            200,
+            headers: {
+              Headers.contentTypeHeader: ['text/plain'],
+            },
+          ),
+    ]);
+
+    await expectLater(
+      probeGateway('https://od.example.com', dioFactory: _factory(adapter)),
+      throwsA(
+        isA<ApiException>().having(
+          (e) => e.message,
+          'message',
+          contains('expected JSON'),
+        ),
+      ),
+    );
+  });
+
+  // The Secure-cookie trap: an http:// entry that gets upgraded must
+  // report the https URL, because the sign-in WebView runs against it
+  // and CF_Authorization is unreadable through an http:// URL.
+  test('a challenge after an upgrade reports the https base URL', () async {
+    final adapter = _ScriptedAdapter([
+      () => _html(301, location: 'https://od.example.com/api/v1/health'),
+      () => _html(
+            302,
+            location:
+                'https://team.cloudflareaccess.com/cdn-cgi/access/login/od.example.com',
+          ),
+    ]);
+
+    await expectLater(
+      probeGateway('http://od.example.com', dioFactory: _factory(adapter)),
+      throwsA(
+        isA<AccessChallengeException>()
+            .having((e) => e.baseUrl, 'baseUrl', 'https://od.example.com'),
+      ),
+    );
+  });
+}

--- a/app/mobile/test/core/api/ws_connect_test.dart
+++ b/app/mobile/test/core/api/ws_connect_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opendray/core/api/ws_connect.dart';
+
+// The regression this guards: the bearer token used to travel in the
+// WebSocket query string, which put it in the access log of every
+// proxy on the path. Once the gateway is published through Cloudflare
+// that log belongs to someone else.
+
+void main() {
+  group('gatewayWsUri', () {
+    test('https becomes wss', () {
+      expect(
+        gatewayWsUri(
+          serverUrl: 'https://od.example.com',
+          path: '/api/v1/sessions/abc/stream',
+        ).toString(),
+        'wss://od.example.com/api/v1/sessions/abc/stream',
+      );
+    });
+
+    test('http becomes ws for a LAN gateway', () {
+      expect(
+        gatewayWsUri(
+          serverUrl: 'http://192.168.3.5:8770',
+          path: '/api/v1/admin/logs/stream',
+        ).toString(),
+        'ws://192.168.3.5:8770/api/v1/admin/logs/stream',
+      );
+    });
+
+    test('trailing slashes do not produce a doubled path', () {
+      expect(
+        gatewayWsUri(
+          serverUrl: 'https://od.example.com//',
+          path: '/api/v1/health',
+        ).toString(),
+        'wss://od.example.com/api/v1/health',
+      );
+    });
+
+    test('carries no query string at all', () {
+      final uri = gatewayWsUri(
+        serverUrl: 'https://od.example.com',
+        path: '/api/v1/sessions/abc/stream',
+      );
+      expect(uri.hasQuery, isFalse);
+      expect(uri.toString(), isNot(contains('token')));
+    });
+  });
+
+  group('gatewayWsHeaders', () {
+    test('the bearer travels in a header', () {
+      expect(
+        gatewayWsHeaders(token: 'secret'),
+        containsPair('Authorization', 'Bearer secret'),
+      );
+    });
+
+    test('the Access cookie rides along when we hold one', () {
+      expect(
+        gatewayWsHeaders(token: 'secret', cfCookie: 'jwt'),
+        containsPair('Cookie', 'CF_Authorization=jwt'),
+      );
+    });
+
+    test('no Cookie header on a LAN gateway', () {
+      expect(gatewayWsHeaders(token: 'secret').containsKey('Cookie'), isFalse);
+    });
+
+    // The gateway's CSWSH guard treats a missing Origin as a
+    // non-browser client and allows it. Sending one would make us
+    // look like a page on some other site.
+    test('no Origin header', () {
+      expect(gatewayWsHeaders(token: 't').containsKey('Origin'), isFalse);
+    });
+  });
+
+  group('reconnectBackoff', () {
+    // The budget has to actually be spendable. It was not before:
+    // the attempt counter was reset every time a socket object was
+    // created, which is before the handshake is known to have been
+    // accepted, so a gateway rejecting every connection produced an
+    // unbounded retry loop rather than five tries and a message.
+    test('backs off exponentially from 500ms', () {
+      expect(
+        List.generate(5, (i) => reconnectBackoff(i + 1).inMilliseconds),
+        [500, 1000, 2000, 4000, 8000],
+      );
+    });
+
+    test('the whole budget spans a bounded, short window', () {
+      final total = List.generate(
+        kMaxReconnectAttempts,
+        (i) => reconnectBackoff(i + 1),
+      ).fold(Duration.zero, (a, b) => a + b);
+      expect(total, lessThan(const Duration(seconds: 20)));
+    });
+
+    test('a zero or negative attempt is treated as the first', () {
+      expect(reconnectBackoff(0), reconnectBackoff(1));
+      expect(reconnectBackoff(-3), reconnectBackoff(1));
+    });
+  });
+}

--- a/app/mobile/test/core/auth/biometric_lock_test.dart
+++ b/app/mobile/test/core/auth/biometric_lock_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opendray/core/auth/biometric_lock.dart';
+
+// The rule these lock in: relock on a real absence, never on the
+// incidental foreground losses that the Access sign-in flow itself
+// causes. Cloudflare SSO routinely bounces the operator out to a mail
+// app for a one-time code; relocking on the way back would make the
+// two features fight each other.
+
+void main() {
+  group('shouldRelockOnResume', () {
+    test('a long absence relocks', () {
+      final paused = DateTime(2026, 9, 2, 10);
+      expect(
+        shouldRelockOnResume(
+          enabled: true,
+          pausedAt: paused,
+          resumedAt: paused.add(const Duration(minutes: 5)),
+        ),
+        isTrue,
+      );
+    });
+
+    test('a glance at a notification does not relock', () {
+      final paused = DateTime(2026, 9, 2, 10);
+      expect(
+        shouldRelockOnResume(
+          enabled: true,
+          pausedAt: paused,
+          resumedAt: paused.add(const Duration(seconds: 5)),
+        ),
+        isFalse,
+      );
+    });
+
+    // Fetching an Access one-time code from a mail app is a normal
+    // part of signing in, and it costs well over the resume-refresh
+    // threshold used elsewhere in the app.
+    test('a trip to a mail app for an OTP does not relock', () {
+      final paused = DateTime(2026, 9, 2, 10);
+      expect(
+        shouldRelockOnResume(
+          enabled: true,
+          pausedAt: paused,
+          resumedAt: paused.add(const Duration(seconds: 45)),
+        ),
+        isFalse,
+      );
+    });
+
+    test('never relocks when the lock is off', () {
+      final paused = DateTime(2026, 9, 2, 10);
+      expect(
+        shouldRelockOnResume(
+          enabled: false,
+          pausedAt: paused,
+          resumedAt: paused.add(const Duration(hours: 3)),
+        ),
+        isFalse,
+      );
+    });
+
+    test('a resume with no recorded pause does not relock', () {
+      expect(
+        shouldRelockOnResume(
+          enabled: true,
+          pausedAt: null,
+          resumedAt: DateTime(2026, 9, 2, 10),
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('biometricLockEnabledProvider', () {
+    // The gate distinguishes "not read yet" (null) from "off"
+    // (false); the switch in settings only needs a bool. Flattening
+    // in one place keeps the two readings from drifting.
+    test('flattens the not-yet-loaded state to off', () {
+      final container = ProviderContainer(
+        overrides: [
+          biometricLockControllerProvider.overrideWith(
+            (ref) => _StubLockController(value: null),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      expect(container.read(biometricLockEnabledProvider), isFalse);
+    });
+
+    test('passes a resolved flag through', () {
+      final container = ProviderContainer(
+        overrides: [
+          biometricLockControllerProvider.overrideWith(
+            (ref) => _StubLockController(value: true),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      expect(container.read(biometricLockEnabledProvider), isTrue);
+    });
+  });
+}
+
+/// Skips the secure-storage read so the test can pin an exact state,
+/// including the null the real controller only holds momentarily.
+class _StubLockController extends BiometricLockController {
+  _StubLockController({required bool? value})
+      : super(const _NullStorage()) {
+    state = value;
+  }
+}
+
+class _NullStorage implements FlutterSecureStorage {
+  const _NullStorage();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => Future<String?>.value();
+}

--- a/app/mobile/test/core/auth/cf_access_test.dart
+++ b/app/mobile/test/core/auth/cf_access_test.dart
@@ -27,6 +27,48 @@ void main() {
       );
     });
 
+    // The live failure this was found through: Access with a single
+    // identity provider bounces past its own team domain straight to
+    // the IdP. With followRedirects on, Dio chased that chain and
+    // came back holding Google's HTML login page from a host that
+    // matched no signal at all, which then failed to parse as JSON
+    // and surfaced as "Server replied 0: Network error".
+    test('a redirect off the gateway host is a challenge', () {
+      expect(
+        isAccessChallengeResponse(
+          statusCode: 302,
+          realUri: Uri.parse('https://od.example.com/api/v1/health'),
+          location: 'https://accounts.google.com/o/oauth2/v2/auth?foo=bar',
+        ),
+        isTrue,
+      );
+    });
+
+    // A same-host redirect is the gateway's own (GET / -> /admin/),
+    // or a proxy normalising a path. Not a challenge, and treating it
+    // as one would pop a sign-in that fixes nothing.
+    test('a same-host redirect is not a challenge', () {
+      expect(
+        isAccessChallengeResponse(
+          statusCode: 302,
+          realUri: Uri.parse('https://od.example.com/'),
+          location: 'https://od.example.com/admin/',
+        ),
+        isFalse,
+      );
+    });
+
+    test('a relative same-host redirect is not a challenge', () {
+      expect(
+        isAccessChallengeResponse(
+          statusCode: 302,
+          realUri: Uri.parse('https://od.example.com/'),
+          location: '/admin/',
+        ),
+        isFalse,
+      );
+    });
+
     test('redirect to the Access domain is a challenge', () {
       expect(
         isAccessChallengeResponse(

--- a/app/mobile/test/core/auth/cf_access_test.dart
+++ b/app/mobile/test/core/auth/cf_access_test.dart
@@ -206,18 +206,24 @@ void main() {
     });
   });
 
-  group('accessLoginUrl', () {
-    test('targets the gateway host and comes back to a JSON endpoint', () {
-      final u = Uri.parse(accessLoginUrl('https://od.example.com'));
+  group('accessSignInUrl', () {
+    // Must be a protected resource, never a hand-built
+    // /cdn-cgi/access/login. Access's real login URL lives on the
+    // team domain, carries the app hostname in its path, and is
+    // signed with kid/meta parameters; assembling one by hand
+    // produced ERR_HTTP_RESPONSE_CODE_FAILURE on a real device.
+    test('loads a protected resource so Access issues its own redirect', () {
+      final u = Uri.parse(accessSignInUrl('https://od.example.com'));
       expect(u.host, 'od.example.com');
-      expect(u.path, '/cdn-cgi/access/login');
-      expect(u.queryParameters['redirect_url'], kAccessProbePath);
+      expect(u.path, kAccessProbePath);
+      expect(u.path, isNot(contains('cdn-cgi')));
+      expect(u.hasQuery, isFalse);
     });
 
     test('tolerates a trailing slash on the base URL', () {
       expect(
-        accessLoginUrl('https://od.example.com/'),
-        accessLoginUrl('https://od.example.com'),
+        accessSignInUrl('https://od.example.com/'),
+        accessSignInUrl('https://od.example.com'),
       );
     });
   });

--- a/app/mobile/test/core/auth/cf_access_test.dart
+++ b/app/mobile/test/core/auth/cf_access_test.dart
@@ -1,0 +1,193 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opendray/core/auth/cf_access.dart';
+
+String _jwt(Map<String, dynamic> payload) {
+  String seg(Map<String, dynamic> m) =>
+      base64Url.encode(utf8.encode(jsonEncode(m))).replaceAll('=', '');
+  return '${seg({'alg': 'RS256'})}.${seg(payload)}.sig';
+}
+
+void main() {
+  group('isAccessChallengeResponse', () {
+    // The common case: Dio follows Access's 302 and lands on the team
+    // login page, which answers 200 + HTML. Without this the caller
+    // sees "200 OK" and then fails to parse a login page as JSON.
+    test('final URI on the Access team domain is a challenge', () {
+      expect(
+        isAccessChallengeResponse(
+          statusCode: 200,
+          realUri: Uri.parse(
+            'https://acme.cloudflareaccess.com/cdn-cgi/access/login/od.example.com',
+          ),
+          contentType: 'text/html; charset=utf-8',
+        ),
+        isTrue,
+      );
+    });
+
+    test('redirect to the Access domain is a challenge', () {
+      expect(
+        isAccessChallengeResponse(
+          statusCode: 302,
+          realUri: Uri.parse('https://od.example.com/api/v1/health'),
+          location:
+              'https://acme.cloudflareaccess.com/cdn-cgi/access/login/od.example.com',
+        ),
+        isTrue,
+      );
+    });
+
+    test('cf-mitigated header is a challenge', () {
+      expect(
+        isAccessChallengeResponse(
+          statusCode: 403,
+          realUri: Uri.parse('https://od.example.com/api/v1/health'),
+          cfMitigated: 'challenge',
+        ),
+        isTrue,
+      );
+    });
+
+    // Access can render its sign-in form on the app hostname instead
+    // of bouncing to the team domain, in which case the only tell is
+    // the Cloudflare-owned path.
+    test('HTML under /cdn-cgi/ is a challenge', () {
+      expect(
+        isAccessChallengeResponse(
+          statusCode: 200,
+          realUri: Uri.parse(
+            'https://od.example.com/cdn-cgi/access/login/od.example.com',
+          ),
+          contentType: 'text/html',
+        ),
+        isTrue,
+      );
+    });
+
+    // A hard-deny Access policy renders a page rather than
+    // redirecting, so none of the redirect signals fire. opendray
+    // answers 401/403 as JSON, so an HTML one is not ours.
+    test('an HTML 403 is a challenge', () {
+      expect(
+        isAccessChallengeResponse(
+          statusCode: 403,
+          realUri: Uri.parse('https://od.example.com/api/v1/sessions'),
+          contentType: 'text/html',
+        ),
+        isTrue,
+      );
+    });
+
+    // The false positive that would break a real feature: the
+    // gateway serves the file you asked it for, and it happens to be
+    // HTML. Discarding that and demanding a sign-in would be wrong
+    // twice over, since the Access session was never the problem.
+    test('a downloaded HTML file is not a challenge', () {
+      expect(
+        isAccessChallengeResponse(
+          statusCode: 200,
+          realUri: Uri.parse(
+            'https://od.example.com/api/v1/fs/download?path=notes.html',
+          ),
+          contentType: 'text/html; charset=utf-8',
+        ),
+        isFalse,
+      );
+    });
+
+    test('a normal JSON answer is not a challenge', () {
+      expect(
+        isAccessChallengeResponse(
+          statusCode: 200,
+          realUri: Uri.parse('https://od.example.com/api/v1/health'),
+          contentType: 'application/json',
+        ),
+        isFalse,
+      );
+    });
+
+    // A 401 from opendray itself must stay a 401 — routing it to the
+    // Access login flow would hide an expired bearer token behind a
+    // WebView that immediately succeeds and changes nothing.
+    test('opendray 401 JSON is not a challenge', () {
+      expect(
+        isAccessChallengeResponse(
+          statusCode: 401,
+          realUri: Uri.parse('https://od.example.com/api/v1/sessions'),
+          contentType: 'application/json',
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('cfAuthorizationExpiry', () {
+    test('reads exp out of the Access JWT', () {
+      final exp = DateTime.utc(2030, 1, 2, 3, 4, 5);
+      final got = cfAuthorizationExpiry(
+        _jwt({'exp': exp.millisecondsSinceEpoch ~/ 1000}),
+      );
+      expect(got, exp);
+    });
+
+    test('returns null for junk rather than throwing', () {
+      expect(cfAuthorizationExpiry('not-a-jwt'), isNull);
+      expect(cfAuthorizationExpiry('a.b.c'), isNull);
+      expect(cfAuthorizationExpiry(''), isNull);
+      expect(cfAuthorizationExpiry(_jwt({'no': 'exp'})), isNull);
+    });
+  });
+
+  group('CfAccessSession', () {
+    test('an unexpired cookie is usable', () {
+      final s = CfAccessSession(
+        cookie: 'abc',
+        expiresAt: DateTime.now().toUtc().add(const Duration(hours: 4)),
+      );
+      expect(s.isExpired, isFalse);
+    });
+
+    test('expiry grace treats a nearly-dead cookie as expired', () {
+      final s = CfAccessSession(
+        cookie: 'abc',
+        expiresAt: DateTime.now().toUtc().add(const Duration(seconds: 30)),
+      );
+      expect(s.isExpired, isTrue);
+    });
+
+    // Access cookies without a readable exp still work; we just cannot
+    // pre-empt their expiry, so we rely on the challenge detection.
+    test('a cookie with no expiry is not treated as expired', () {
+      expect(const CfAccessSession(cookie: 'abc').isExpired, isFalse);
+    });
+  });
+
+  group('accessLoginUrl', () {
+    test('targets the gateway host and comes back to a JSON endpoint', () {
+      final u = Uri.parse(accessLoginUrl('https://od.example.com'));
+      expect(u.host, 'od.example.com');
+      expect(u.path, '/cdn-cgi/access/login');
+      expect(u.queryParameters['redirect_url'], kAccessProbePath);
+    });
+
+    test('tolerates a trailing slash on the base URL', () {
+      expect(
+        accessLoginUrl('https://od.example.com/'),
+        accessLoginUrl('https://od.example.com'),
+      );
+    });
+  });
+
+  group('cfCookieHeader', () {
+    test('renders the cookie pair', () {
+      expect(cfCookieHeader('tok'), 'CF_Authorization=tok');
+    });
+
+    test('is null when there is no session, so no empty header is sent', () {
+      expect(cfCookieHeader(null), isNull);
+      expect(cfCookieHeader(''), isNull);
+    });
+  });
+}

--- a/app/mobile/test/core/auth/cf_access_test.dart
+++ b/app/mobile/test/core/auth/cf_access_test.dart
@@ -238,4 +238,59 @@ void main() {
       expect(cfCookieHeader(''), isNull);
     });
   });
+
+  group('team domain discovery', () {
+    // Signing out has to reach the TEAM domain, not just the app's.
+    // The app-domain cookie is only half the session; the team domain
+    // is what lets Access re-issue one without asking the identity
+    // provider anything, which is exactly what "clear" failed to stop.
+    test('reads the team domain from the challenge redirect', () {
+      expect(
+        teamDomainFromLocation(
+          'https://acme.cloudflareaccess.com/cdn-cgi/access/login/od.example.com?kid=x',
+        ),
+        'acme.cloudflareaccess.com',
+      );
+    });
+
+    test('ignores a redirect that is not Cloudflare Access', () {
+      expect(
+        teamDomainFromLocation('https://accounts.google.com/o/oauth2/v2/auth'),
+        isNull,
+      );
+      expect(teamDomainFromLocation(null), isNull);
+      expect(teamDomainFromLocation(''), isNull);
+    });
+
+    test('reads the team domain from the cookie iss claim', () {
+      final jwt = _jwt({'iss': 'https://acme.cloudflareaccess.com', 'exp': 1});
+      expect(teamDomainFromJwt(jwt), 'acme.cloudflareaccess.com');
+    });
+
+    test('tolerates a cookie with no usable iss', () {
+      expect(teamDomainFromJwt(_jwt({'exp': 1})), isNull);
+      expect(teamDomainFromJwt(_jwt({'iss': 'not a url'})), isNull);
+      expect(teamDomainFromJwt('garbage'), isNull);
+    });
+  });
+
+  group('accessLogoutUrl', () {
+    test('builds the logout endpoint for a host', () {
+      expect(
+        accessLogoutUrl('acme.cloudflareaccess.com'),
+        'https://acme.cloudflareaccess.com/cdn-cgi/access/logout',
+      );
+    });
+
+    test('accepts a full base URL and keeps its scheme', () {
+      expect(
+        accessLogoutUrl('https://od.example.com'),
+        'https://od.example.com/cdn-cgi/access/logout',
+      );
+      expect(
+        accessLogoutUrl('http://od.example.com/'),
+        'http://od.example.com/cdn-cgi/access/logout',
+      );
+    });
+  });
 }

--- a/docs/mobile-app.md
+++ b/docs/mobile-app.md
@@ -40,6 +40,11 @@ able to reach it.
 > including the **WebSocket upgrade headers** the Sessions terminal
 > needs, are in [operator-guide §Topology](operator-guide.md#topology).
 
+> **Gating the tunnel with Cloudflare Access?** The app signs in
+> through the same Access flow, so off-LAN access needs no VPN.
+> Read [mobile-cloudflare-access.md](mobile-cloudflare-access.md)
+> first: the choice of identity provider matters.
+
 Verify reachability from the phone *before* building, e.g. open the
 Gateway URL in the phone's browser. You should get the web admin
 login page.
@@ -220,6 +225,7 @@ The app's own version string lives in `app/mobile/pubspec.yaml`
 | Symptom | Cause | Fix |
 |---|---|---|
 | Onboarding "could not connect" | Phone can't reach the Gateway URL | Open the URL in the phone's browser; fix LAN IP / tunnel / TLS first (Step 0) |
+| Onboarding says Cloudflare Access must verify the device | The gateway is gated by Access | Finish the sign-in it offers; see [mobile-cloudflare-access.md](mobile-cloudflare-access.md) |
 | Login works but Sessions terminal never connects | Reverse proxy is dropping the WebSocket upgrade | Add WS headers: [operator-guide §Topology](operator-guide.md#topology) |
 | Android blocks the install | "Install unknown apps" not granted | Allow it for the app that opens the `.apk` (Files / Chrome) |
 | iOS "Untrusted Developer" on launch | Personal-team profile not trusted yet | Settings → General → VPN & Device Management → Trust |
@@ -232,6 +238,7 @@ The app's own version string lives in `app/mobile/pubspec.yaml`
 ## See also
 
 - [getting-started.md](getting-started.md): stand up the gateway the app connects to
+- [mobile-cloudflare-access.md](mobile-cloudflare-access.md): using the app when the gateway is gated by Cloudflare Access
 - [operator-guide.md](operator-guide.md): reverse proxy / tunnel topology for off-LAN access
 - [Flutter: build & release Android](https://docs.flutter.dev/deployment/android)
 - [Flutter: build & release iOS](https://docs.flutter.dev/deployment/ios)

--- a/docs/mobile-app.md
+++ b/docs/mobile-app.md
@@ -42,8 +42,7 @@ able to reach it.
 
 > **Gating the tunnel with Cloudflare Access?** The app signs in
 > through the same Access flow, so off-LAN access needs no VPN.
-> Read [mobile-cloudflare-access.md](mobile-cloudflare-access.md)
-> first: the choice of identity provider matters.
+> Setup and caveats: [mobile-cloudflare-access.md](mobile-cloudflare-access.md).
 
 Verify reachability from the phone *before* building, e.g. open the
 Gateway URL in the phone's browser. You should get the web admin

--- a/docs/mobile-cloudflare-access.md
+++ b/docs/mobile-cloudflare-access.md
@@ -102,12 +102,21 @@ expiry, re-runs the sign-in on demand, and clears this device's Access
 cookie. Pointing the app at a different gateway clears the cookie
 automatically, since it is scoped to the old hostname.
 
-"Clear Access session" means what it says and no more: it forgets the
-cookie on this device, in both places it is stored. It does not end
-the session at Cloudflare, and it does not sign you out of your
-identity provider. If your IdP still has you signed in, the next
-sign-in may complete without asking you for anything. To actually end
-the Access session, sign out at your identity provider.
+"Clear Access session" signs this device out at Cloudflare. It visits
+Cloudflare's logout endpoint on the **team domain** first and then on
+the gateway's own, and sweeps what is left from the app's cookie
+store. The team domain matters: the gateway's cookie is only half the
+session, and clearing it alone leaves Access still recognising the
+device, so the next sign-in silently re-issues a cookie and the whole
+thing looks like it did nothing.
+
+It does not sign you out of your identity provider. If Google (or
+whoever) still has a live session, the next sign-in will run through
+it without asking for a password. That is the IdP's session, not
+Cloudflare's, and you end it at the IdP.
+
+Uninstalling and reinstalling the app is the blunt version: it drops
+the WebView cookie store and the keystore together.
 
 The session terminal and the live log tail run over WebSockets, which
 Access gates like any other request. A WebSocket rejected by Access

--- a/docs/mobile-cloudflare-access.md
+++ b/docs/mobile-cloudflare-access.md
@@ -34,7 +34,8 @@ It costs the browser's own address bar. When you type identity-provider
 credentials into the sign-in screen, the hostname shown above the page
 is drawn by opendray, not by Safari or Chrome, so it is only as
 trustworthy as the app rendering it. A system browser would give you
-chrome the app cannot forge.
+chrome the app cannot forge. This is also why several identity
+providers refuse embedded WebViews outright.
 
 The reason it is a WebView anyway is that the cookie is the entire
 mechanism. Cloudflare Access proves who you are by setting
@@ -50,24 +51,34 @@ If that trade is not one you want to make, the alternative is to leave
 the app on the LAN or on a VPN. There is no version of this feature
 that is both WebView-free and cookie-based.
 
-## Before you start: pick an identity provider the WebView accepts
-
-This is the one real constraint, and it is worth settling first.
+## Identity providers
 
 | Access login method | Works in the app's WebView |
 |---|---|
-| One-time PIN (email code) | Yes. Recommended. |
+| One-time PIN (email code) | Yes |
+| Google | Yes, tested 2026-09-02 on Android |
 | GitHub | Yes |
 | Generic OIDC / SAML (self-hosted IdP) | Usually |
-| Google | No. Google refuses OAuth in embedded WebViews (`disallowed_useragent`). |
-| Microsoft Entra ID | Often refused, for the same reason |
+| Microsoft Entra ID | Untested |
 
-If your Access policy uses Google as the identity provider, the app's
-sign-in will fail with a Google error page. Add One-time PIN as an
-additional login method on the Access application; the web admin keeps
-using Google, and the phone uses the emailed code. Faking a desktop
-browser user-agent to get around the check is not supported here, and
-Google's terms disallow it.
+Google is worth a note. Google refuses OAuth from embedded WebViews in
+general (`disallowed_useragent`), and an earlier version of this page
+said flatly that it would not work here. It does: signing in through
+Cloudflare Access with Google as the identity provider was tested on a
+real device and completed normally. Access brokers the OAuth itself
+rather than handing the app a raw Google consent screen, which is
+apparently enough.
+
+Treat that as an observation rather than a guarantee. Google's
+WebView policy has changed before and can differ by device, WebView
+version and user-agent. If your sign-in ever fails with a Google error
+page, add **One-time PIN** as a second login method on the Access
+application: the web admin keeps using Google, the phone uses the
+emailed code, and an `Emails` include rule covers both because either
+login yields an email identity.
+
+Faking a desktop user-agent to dodge such a check is not done here and
+is against Google's terms.
 
 ## Cloudflare side
 
@@ -144,7 +155,7 @@ make the two features fight each other.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Sign-in page shows a Google "disallowed_useragent" error | Access is using Google as the identity provider | Add One-time PIN to the application's login methods |
+| Sign-in page shows a Google "disallowed_useragent" error | Google is refusing the embedded WebView on this device | Add One-time PIN to the application's login methods |
 | Sign-in completes but the app still says Access is required | The Access application covers a different hostname than the Gateway URL | Make the Gateway URL exactly the hostname the Access application protects |
 | Terminal or live logs drop, then the sign-in appears | The Access session expired mid-stream | Finish the sign-in; the stream reconnects |
 | Terminal never connects and no sign-in appears, everything else works | Something in the path is dropping the WebSocket upgrade | Not an Access problem; see [operator-guide §Topology](operator-guide.md#topology) |

--- a/docs/mobile-cloudflare-access.md
+++ b/docs/mobile-cloudflare-access.md
@@ -1,0 +1,149 @@
+# Mobile app behind Cloudflare Access
+
+Publishing the gateway through a Cloudflare Tunnel and gating it with
+Cloudflare Access gives the web admin a strong front door: nothing
+reaches the tunnel until Cloudflare has verified who you are. This
+page covers making the mobile app pass the same gate, so the phone
+works from cellular without a VPN and without opening a hole in the
+Access policy.
+
+## How it works
+
+A browser passes Access by signing in once and keeping the
+`CF_Authorization` cookie Cloudflare sets on the app hostname. A
+native app has no such flow, so opendray runs the identical sign-in
+inside an embedded WebView, lifts the resulting cookie out of the
+platform cookie store, and attaches it to every request, including the
+WebSocket handshake the session terminal uses.
+
+Nothing about opendray's own authentication changes. Access decides
+whether the request reaches the tunnel; opendray still decides whether
+the caller is signed in. The two expire independently, so an Access
+session rolling over does not sign you out of opendray.
+
+Both secrets live in the platform keystore (iOS Keychain, Android
+EncryptedSharedPreferences). Neither is compiled into the app.
+
+## What you are accepting by using this
+
+The sign-in runs in an embedded WebView, not in the OS browser. That
+is not the shape RFC 8252 recommends for native apps, and it is worth
+being explicit about why, and about what it costs.
+
+It costs the browser's own address bar. When you type identity-provider
+credentials into the sign-in screen, the hostname shown above the page
+is drawn by opendray, not by Safari or Chrome, so it is only as
+trustworthy as the app rendering it. A system browser would give you
+chrome the app cannot forge.
+
+The reason it is a WebView anyway is that the cookie is the entire
+mechanism. Cloudflare Access proves who you are by setting
+`CF_Authorization` on the gateway hostname, and a cookie set inside
+Safari or Chrome cannot be read by the app. `ASWebAuthenticationSession`
+and Android Custom Tabs are no help here for the same reason: they
+deliberately keep their cookie jar away from the app. Without a
+readable cookie there is no way for a native client to satisfy Access
+short of a shared Service Token or a client certificate, which trade
+per-user identity away for a static credential.
+
+If that trade is not one you want to make, the alternative is to leave
+the app on the LAN or on a VPN. There is no version of this feature
+that is both WebView-free and cookie-based.
+
+## Before you start: pick an identity provider the WebView accepts
+
+This is the one real constraint, and it is worth settling first.
+
+| Access login method | Works in the app's WebView |
+|---|---|
+| One-time PIN (email code) | Yes. Recommended. |
+| GitHub | Yes |
+| Generic OIDC / SAML (self-hosted IdP) | Usually |
+| Google | No. Google refuses OAuth in embedded WebViews (`disallowed_useragent`). |
+| Microsoft Entra ID | Often refused, for the same reason |
+
+If your Access policy uses Google as the identity provider, the app's
+sign-in will fail with a Google error page. Add One-time PIN as an
+additional login method on the Access application; the web admin keeps
+using Google, and the phone uses the emailed code. Faking a desktop
+browser user-agent to get around the check is not supported here, and
+Google's terms disallow it.
+
+## Cloudflare side
+
+1. In Zero Trust, open the Access application that already protects
+   the gateway hostname.
+2. Under **Login methods**, make sure at least one method from the
+   "Yes" rows above is enabled.
+3. Leave the application covering the whole hostname. Do not add a
+   bypass for `/api/v1/*`. A bypass would let the app skip the
+   WebView, at the cost of exposing the login endpoint and the entire
+   API surface to the open internet, which is the thing Access is
+   there to prevent.
+4. Check the **session duration**. That is how often the phone has to
+   repeat the sign-in. 24 hours is a reasonable starting point.
+
+WebSockets need no special Access configuration: Cloudflare validates
+the cookie on the upgrade request like any other.
+
+## Phone side
+
+On first launch, enter the public gateway URL as usual. When Access
+challenges the probe, the app says so and opens the Cloudflare
+sign-in. Finish it and onboarding continues to the normal opendray
+login.
+
+Later challenges are handled the same way from wherever they happen:
+when the Access session expires, the sign-in appears over whatever
+screen you were on, and the screen underneath keeps its state.
+
+**Settings → Security** shows the current Access session and its
+expiry, re-runs the sign-in on demand, and clears this device's Access
+cookie. Pointing the app at a different gateway clears the cookie
+automatically, since it is scoped to the old hostname.
+
+"Clear Access session" means what it says and no more: it forgets the
+cookie on this device, in both places it is stored. It does not end
+the session at Cloudflare, and it does not sign you out of your
+identity provider. If your IdP still has you signed in, the next
+sign-in may complete without asking you for anything. To actually end
+the Access session, sign out at your identity provider.
+
+The session terminal and the live log tail run over WebSockets, which
+Access gates like any other request. A WebSocket rejected by Access
+looks identical to an unreachable gateway from the client's side, so
+when either one drops, the app quietly re-checks over HTTP and raises
+the sign-in if that is what the problem turns out to be.
+
+## App lock
+
+The same Security screen has **Require unlock**, off by default.
+
+It exists because of what publishing the gateway costs. Once the app
+reaches the gateway from anywhere, an unlocked phone is a live admin
+console: the bearer token and the Access cookie are both already on
+the device, so whoever holds it is past both gates. Turning the lock
+on requires biometrics or the device passcode before the app is shown,
+and again after the app has been in the background for more than a
+minute.
+
+The one-minute threshold is deliberate. Access sign-in routinely sends
+you to a mail app for a one-time code, and a shorter threshold would
+make the two features fight each other.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Sign-in page shows a Google "disallowed_useragent" error | Access is using Google as the identity provider | Add One-time PIN to the application's login methods |
+| Sign-in completes but the app still says Access is required | The Access application covers a different hostname than the Gateway URL | Make the Gateway URL exactly the hostname the Access application protects |
+| Terminal or live logs drop, then the sign-in appears | The Access session expired mid-stream | Finish the sign-in; the stream reconnects |
+| Terminal never connects and no sign-in appears, everything else works | Something in the path is dropping the WebSocket upgrade | Not an Access problem; see [operator-guide §Topology](operator-guide.md#topology) |
+| Sign-in reappears every few hours | Access session duration is short | Raise it on the Access application |
+| Repeated sign-in prompts after cancelling | Expected: dismissing suppresses the prompt for 30 seconds, then it returns while requests keep failing | Finish the sign-in, or switch back to a LAN Gateway URL |
+| Sign-in completes instantly without asking anything | A live cookie or IdP session was still there | Expected. To force a full re-check, sign out at your identity provider |
+
+## See also
+
+- [mobile-app.md](mobile-app.md): building and installing the app
+- [operator-guide.md](operator-guide.md): reverse proxy and tunnel topology


### PR DESCRIPTION
Makes the mobile app work when the gateway is published through a
Cloudflare Tunnel and gated by Cloudflare Access, so the phone reaches
it from cellular without a VPN and without punching a hole in the
Access policy.

Experimental, and mobile-only: **no Go and no web changes**. The
gateway already accepts everything this needs.

## The problem

A browser passes Access by signing in once and replaying the
`CF_Authorization` cookie Cloudflare sets on the app hostname. A
native app has no such flow, so today the only ways to use the app
off-LAN are a VPN or an Access bypass on `/api/v1/*`. The bypass would
put the login endpoint and the whole API surface on the open internet,
which is the thing Access is there to prevent.

## What it does

**1. Access SSO in an embedded WebView** (`internal` to the app; no
new dependency, `flutter_inappwebview` was already vendored for note
previews). The sign-in runs against
`<gateway>/cdn-cgi/access/login?redirect_url=/api/v1/health`; once it
lands back on a gateway path the `CF_Authorization` cookie is lifted
out of the platform cookie store and kept in `flutter_secure_storage`,
then attached to every Dio request and to both WebSocket handshakes.

Access and opendray stay two independent gates with independent
expiry, so an Access session rolling over does not sign you out of
opendray. `CfAccessController` holds the cookie; `AccessGate` sits
above the router and surfaces the sign-in wherever a challenge lands,
drawn as an overlay so the screen underneath keeps its state.

Challenge detection (`lib/core/auth/cf_access.dart`) reads four
signals, because which one appears depends on whether Dio followed the
redirect: final URI on a `*.cloudflareaccess.com` host, a `Location`
pointing there, a `cf-mitigated` header, or HTML on a path that only
ever answers JSON. A gateway 401 is deliberately NOT a challenge:
routing an expired bearer into the Access flow would pop a WebView
that signs in successfully and changes nothing.

**1b. A rejected WebSocket handshake now surfaces.** Access gates the
WS upgrade like anything else, but a rejected upgrade reaches the
client as a plain socket error, indistinguishable from an unreachable
gateway. An operator whose Access cookie expired while watching a
session terminal saw only a reconnect loop with no path back to the
sign-in. A dropped stream now re-probes over HTTP, where the same
challenge detection can run.

Fixing that exposed an unbounded loop underneath it: `_retryAttempt`
was reset when the socket object was created, which happens long
before the handshake is known to have been accepted, so the
five-attempt cap never applied and a gateway rejecting every
connection was retried forever. It resets on first byte now, and a
single failure no longer spends the budget twice (a failed handshake
fires both `onError` and `onDone`).

**2. The WebSocket bearer moves out of the query string.** It now
travels in an `Authorization` header on the handshake. `bearerToken`
in `internal/auth/auth.go` already reads the header first, and
`SameOriginCheck` already allows the empty Origin a native client
sends, so this needs no server change. The browser client keeps the
query form because the WebSocket API cannot set headers; a native
client has no such excuse, and a token in a URL ends up in every proxy
access log it passes through. Publishing through Cloudflare makes that
a real log on someone else's disk.

**3. Optional biometric app lock** (`local_auth`, already in
pubspec, previously unused). Off by default. Once the app reaches the
gateway from anywhere, an unlocked phone is a live admin console: the
bearer and the Access cookie are both already on the device, so
whoever holds it is past both gates. The relock threshold is 60s,
deliberately far above the 5s resume-refresh threshold, because Access
sign-in routinely sends the operator to a mail app for a one-time code
and a shorter window would make the two features fight.

Android `MainActivity` becomes a `FlutterFragmentActivity` (androidx
BiometricPrompt is a Fragment and needs a FragmentActivity host);
iOS gains `NSFaceIDUsageDescription`.

Also: `resetServer()` stops calling `deleteAll()` and deletes its own
keys instead. The app lock is a device preference, not a property of
the gateway, and wiping it on every server change would silently
disable the lock. The Access cookie IS gateway-scoped and is cleared
explicitly at the call site, so the controller's in-memory state stays
in step with storage.

## The tradeoff being accepted

The sign-in runs in an embedded WebView, not the OS browser. That is
not what RFC 8252 recommends for native apps and it costs the
browser's own address bar: the hostname shown above the sign-in page
is drawn by opendray, so it is only as trustworthy as the app drawing
it.

It is also unavoidable for this approach. The cookie *is* the
mechanism, and a cookie set inside Safari or Chrome cannot be read by
the app. `ASWebAuthenticationSession` and Custom Tabs keep their
cookie jar away from the app for exactly the reason that makes them
safer. The alternatives trade per-user identity for a static
credential: an Access Service Token (shared secret, no identity) or
mTLS (per-device certificate provisioning). Both remain open if this
tradeoff is judged the wrong one.

Documented in `docs/mobile-cloudflare-access.md` under "What you are
accepting by using this", so it is an explicit decision rather than an
implicit one.

## Identity providers

| Access login method | Works in the app's WebView |
|---|---|
| One-time PIN (email code) | Yes |
| Google | Yes, tested on a real device |
| GitHub | Yes |
| Generic OIDC / SAML | Usually |
| Microsoft Entra ID | Untested |

An earlier revision of this PR and its docs claimed Google would not
work, on the general fact that Google refuses OAuth from embedded
WebViews (`disallowed_useragent`). That was reasoning, not testing,
and it was wrong: Access brokers the OAuth itself rather than handing
the app a raw Google consent screen, and signing in with Google
completed normally on device.

Documented as an observation rather than a guarantee — Google's
WebView policy has changed before and varies by device — with
One-time PIN kept as a fallback rather than a required workaround.

## Test plan

Backend and web are untouched, so the automated set is:

1. `cd app/mobile && flutter test` — 191 pass
2. `cd app/mobile && flutter analyze` — clean
3. `node scripts/check-i18n-parity.mjs` — en/es/zh 100%
4. `cd app/web && pnpm exec tsc --noEmit && pnpm build` — clean (shared i18n JSON)
5. `go build ./... && go vet ./...` — clean (nothing changed; sanity only)
6. `flutter build apk --release` — verifies the FlutterFragmentActivity swap

Verified on device against a live Access-gated gateway: onboarding
from a cleartext URL, the Cloudflare sign-in (Google **and** One-time
PIN), the session terminal and live log tail over the tunnel, signing
out, and changing gateway afterwards.

## What device testing found

The first commit is the feature. The other five are bugs it took a
real device and a real Cloudflare tenant to surface — none of them
were visible from the code, and two were introduced by an earlier fix
in this same branch:

| commit | fault |
|---|---|
| `c6e46af` | Dio followed the Access redirect all the way to the identity provider, so the challenge signals never matched |
| `77cc2f0` | `get<Map<String, dynamic>>` casts *inside* the await — an HTML challenge threw `_TypeError` with a null message, which surfaced as a bogus "Network error" and pre-empted every check. Also: the URL field pre-filled `http://`, and the http→https 301 was not followed |
| `19c928a` | The sign-in URL was hand-built and 404s — Access's real one is on the team domain with signed `kid`/`meta` and cannot be constructed. Plus `transparentBackground` made the page dark-on-dark and unreadable |
| `56c5e16` | "Clear Access session" only cleared the gateway domain; the team domain kept the identity session, so the next sign-in silently re-issued a cookie |
| `d0ed669` | Making sign-out remote blocked "change server" behind two 10s round trips with no progress indicator, so the button read as dead |

`toApiException` also no longer falls straight through to "Network
error" when Dio hands it an exception it did not raise — that
fallback is what hid the `_TypeError` for two rounds.

## Review

Two rounds of code-reviewer. Round one: 2 HIGH, 5 MEDIUM. Round two on
the fixes: 0 HIGH, 1 MEDIUM, all addressed.

One review call was wrong and worth recording: `accessLogoutUrl` was
flagged as dead code and removed. It was not dead, it was unwired —
and the missing wiring was exactly the "clear session does nothing"
bug found on device (`56c5e16`), which restored it. Findings fixed rather
than accepted: the WebSocket challenge blind spot, the `text/html`
false positive, "Clear Access session" leaving the live cookie in the
WebView's jar, dead `accessLogoutUrl`, a double-prompt when enabling
the app lock, and a silent hang when the cookie store settled late.
The embedded-WebView tradeoff is the one finding accepted rather than
fixed, for the reason above.

## Not done here

Cloudflare Access Service Tokens and mTLS were the other two ways
through the gate. Service Tokens are a shared static credential, mTLS
needs per-device certificate provisioning; both were passed over in
favour of a real per-user identity check. Neither is precluded later.

Unrelated to RFC #525 (relay + push), which solves remote access for
operators who have no tunnel at all.
