### PR TITLE
feat(web): grok accounts UI (Providers panel + session switcher)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -234,7 +234,10 @@
         "switchedToast": "Account switched",
         "switchedDescription": "Now using @{account} · pid {pid}",
         "switchedDefault": "default",
-        "switchFailedToast": "Switch failed"
+        "switchFailedToast": "Switch failed",
+        "tooltipGrok": "Switch Grok account (restarts the CLI process)",
+        "menuTitleGrok": "Switch Grok account",
+        "confirmSwitchGrok": "Switching account restarts the Grok CLI under a fresh conversation. The in-CLI history does not carry across accounts, and any in-flight tool execution or unsent input is lost. Continue?"
       },
       "inspector": {
         "tabs": {
@@ -1357,6 +1360,28 @@
         "removeAria": "Remove {name}",
         "identityAcceptedToast": "New identity recorded",
         "identityAcceptFailedToast": "Could not accept identity"
+      },
+      "grokAccounts": {
+        "title": "Grok accounts",
+        "importLocal": "Import local",
+        "importLocalTooltip": "Scan ~/.grok-accounts/ (and the gateway user's ~/.grok) on the host and register any logged-in account dirs. Gateway-host only.",
+        "importedNothingToast": "Nothing to import, accounts already in sync.",
+        "importedToast_one": "Imported {count} account from ~/.grok-accounts",
+        "importedToast_other": "Imported {count} accounts from ~/.grok-accounts",
+        "importFailedToast": "Import failed",
+        "addingTitle": "Adding a new account.",
+        "addingBodyPrefix": "Grok keys its state off GROK_HOME. Give each account its own GROK_HOME and log in there on the gateway host:",
+        "addingBodySuffix": "Then click <1>Import local</1> to register it. The directory only counts as an account once the sign-in has written its auth.json token.",
+        "loading": "Loading…",
+        "empty": "No Grok accounts yet. Run <1>GROK_HOME=~/.grok-accounts/&lt;name&gt; grok login</1> on the gateway host, complete the sign-in, then click Import local.",
+        "noTokenYet": "not logged in",
+        "homeDir": "home:",
+        "toggleFailedToast": "Toggle failed",
+        "removeConfirm": "Remove account \"{name}\"?",
+        "removedToast": "Account removed",
+        "removeFailedToast": "Remove failed",
+        "toggleAria": "Toggle {name}",
+        "removeAria": "Remove {name}"
       },
       "antigravityAccounts": {
         "title": "Antigravity accounts",

--- a/app/shared/src/lib/grokAccounts.ts
+++ b/app/shared/src/lib/grokAccounts.ts
@@ -1,0 +1,51 @@
+import { api } from './api'
+import type {
+  GrokAccount,
+  CreateGrokAccountRequest,
+  UpdateGrokAccountRequest,
+} from './types'
+
+export async function listGrokAccounts(): Promise<GrokAccount[]> {
+  const res = await api<{ accounts: GrokAccount[] }>('/api/v1/grok-accounts')
+  return res.accounts ?? []
+}
+
+export async function createGrokAccount(
+  req: CreateGrokAccountRequest,
+): Promise<GrokAccount> {
+  return api<GrokAccount>('/api/v1/grok-accounts', {
+    method: 'POST',
+    body: req,
+  })
+}
+
+export async function updateGrokAccount(
+  id: string,
+  req: UpdateGrokAccountRequest,
+): Promise<GrokAccount> {
+  return api<GrokAccount>(`/api/v1/grok-accounts/${id}`, {
+    method: 'PUT',
+    body: req,
+  })
+}
+
+export async function toggleGrokAccount(
+  id: string,
+  enabled: boolean,
+): Promise<GrokAccount> {
+  return api<GrokAccount>(`/api/v1/grok-accounts/${id}/toggle`, {
+    method: 'PATCH',
+    body: { enabled },
+  })
+}
+
+export async function deleteGrokAccount(id: string): Promise<void> {
+  await api<unknown>(`/api/v1/grok-accounts/${id}`, { method: 'DELETE' })
+}
+
+export async function importLocalGrokAccounts(): Promise<{
+  created: GrokAccount[]
+  count: number
+}> {
+  return api('/api/v1/grok-accounts/import-local', { method: 'POST' })
+}

--- a/app/shared/src/lib/sessions.ts
+++ b/app/shared/src/lib/sessions.ts
@@ -93,6 +93,21 @@ export async function switchAntigravityAccount(
   })
 }
 
+// switchGrokAccount rebinds a running grok session to a different account
+// (a different GROK_HOME) and respawns it. grok has no cross-account recap
+// builder, so this is always a clean-slate switch, hence no carryContext
+// parameter. `accountId === ''` clears the binding (CLI uses the gateway
+// user's default ~/.grok home).
+export async function switchGrokAccount(
+  id: string,
+  accountId: string,
+): Promise<Session> {
+  return api<Session>(`/api/v1/sessions/${id}/grok-account`, {
+    method: 'PATCH',
+    body: { account_id: accountId },
+  })
+}
+
 export interface HistoryEntry {
   ts: string
   text: string

--- a/app/shared/src/lib/types.ts
+++ b/app/shared/src/lib/types.ts
@@ -32,6 +32,8 @@ export interface Session {
   claude_session_id?: string
   /** Antigravity account this session is pinned to (provider "antigravity"). */
   antigravity_account_id?: string
+  /** Grok account this session is pinned to (provider "grok"). */
+  grok_account_id?: string
   /** Set when this session was spawned on behalf of another (e.g. a Task). */
   parent_session_id?: string
   started_at: string
@@ -131,6 +133,37 @@ export interface CreateAntigravityAccountRequest {
 }
 
 export interface UpdateAntigravityAccountRequest {
+  name?: string
+  display_name?: string
+  config_dir?: string
+  description?: string
+  enabled?: boolean
+}
+
+export interface GrokAccount {
+  id: string
+  name: string
+  display_name: string
+  config_dir: string // per-account GROK_HOME directory
+  description: string
+  enabled: boolean
+  token_filled: boolean
+  created_at: string
+  updated_at: string
+  // Derived, optional for forward-compat.
+  last_used_at?: string
+  active_sessions?: number
+}
+
+export interface CreateGrokAccountRequest {
+  name: string
+  display_name?: string
+  config_dir?: string
+  description?: string
+  enabled?: boolean
+}
+
+export interface UpdateGrokAccountRequest {
   name?: string
   display_name?: string
   config_dir?: string

--- a/app/web/src/components/providers/GrokAccountsPanel.tsx
+++ b/app/web/src/components/providers/GrokAccountsPanel.tsx
@@ -1,0 +1,282 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { CircleDot, Download, KeyRound, Loader2, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Trans, useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import {
+  deleteGrokAccount,
+  importLocalGrokAccounts,
+  listGrokAccounts,
+  toggleGrokAccount,
+} from '@/lib/grokAccounts'
+import type { GrokAccount } from '@/lib/types'
+
+// GrokAccountsPanel renders the multi-account list for the Grok Build
+// (grok) provider. grok keys its credential + config state off GROK_HOME,
+// so an account is a dedicated GROK_HOME dir holding its own auth.json
+// login token. Account creation is guided-login driven: the operator runs
+// `GROK_HOME=~/.grok-accounts/<name> grok login` on the gateway host,
+// completes the xAI sign-in, then clicks Import local to surface the row.
+//
+// There is intentionally no Add-account form: the login token can only be
+// minted by grok's interactive sign-in flow, so forcing the host-shell
+// login keeps the affordance honest. Mirrors AntigravityAccountsPanel.
+
+function relativeAgo(iso: string): string {
+  const t = new Date(iso).getTime()
+  if (!Number.isFinite(t)) return ''
+  const dsec = Math.max(0, Math.floor((Date.now() - t) / 1000))
+  if (dsec < 60) return `${dsec}s ago`
+  if (dsec < 3600) return `${Math.floor(dsec / 60)}m ago`
+  if (dsec < 86400) return `${Math.floor(dsec / 3600)}h ago`
+  return `${Math.floor(dsec / 86400)}d ago`
+}
+
+export function GrokAccountsPanel() {
+  const { t } = useTranslation()
+  const qc = useQueryClient()
+  const { data: accounts, isLoading } = useQuery({
+    queryKey: ['grok-accounts'],
+    queryFn: listGrokAccounts,
+    refetchInterval: 5000,
+  })
+
+  const importLocal = useMutation({
+    mutationFn: importLocalGrokAccounts,
+    onSuccess: (res) => {
+      qc.invalidateQueries({ queryKey: ['grok-accounts'] })
+      if (res.count === 0) {
+        toast.success(t('web.providers.grokAccounts.importedNothingToast'))
+      } else {
+        toast.success(
+          t('web.providers.grokAccounts.importedToast', { count: res.count }),
+        )
+      }
+    },
+    onError: (e: Error) =>
+      toast.error(t('web.providers.grokAccounts.importFailedToast'), {
+        description: e.message,
+      }),
+  })
+
+  const toggle = useMutation({
+    mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
+      toggleGrokAccount(id, enabled),
+    onMutate: async ({ id, enabled }) => {
+      await qc.cancelQueries({ queryKey: ['grok-accounts'] })
+      const prev = qc.getQueryData<GrokAccount[]>(['grok-accounts'])
+      if (prev) {
+        qc.setQueryData<GrokAccount[]>(
+          ['grok-accounts'],
+          prev.map((a) => (a.id === id ? { ...a, enabled } : a)),
+        )
+      }
+      return { prev }
+    },
+    onError: (e: Error, _vars, ctx) => {
+      if (ctx?.prev) qc.setQueryData(['grok-accounts'], ctx.prev)
+      toast.error(t('web.providers.grokAccounts.toggleFailedToast'), {
+        description: e.message,
+      })
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: ['grok-accounts'] }),
+  })
+
+  const remove = useMutation({
+    mutationFn: deleteGrokAccount,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['grok-accounts'] })
+      toast.success(t('web.providers.grokAccounts.removedToast'))
+    },
+    onError: (e: Error) =>
+      toast.error(t('web.providers.grokAccounts.removeFailedToast'), {
+        description: e.message,
+      }),
+  })
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h2 className="text-[12px] font-semibold uppercase tracking-wider text-muted-foreground/80">
+            {t('web.providers.grokAccounts.title')}
+          </h2>
+          <span className="text-[10px] text-muted-foreground/60 font-mono">
+            {accounts?.length ?? 0}
+          </span>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => importLocal.mutate()}
+          disabled={importLocal.isPending}
+          className="text-[11px] gap-1"
+          title={t('web.providers.grokAccounts.importLocalTooltip')}
+        >
+          {importLocal.isPending ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <Download className="size-3.5" />
+          )}
+          {t('web.providers.grokAccounts.importLocal')}
+        </Button>
+      </div>
+
+      <div className="rounded-md border border-border bg-muted/20 px-3 py-2.5 text-[11px] text-muted-foreground leading-relaxed">
+        <span className="font-medium text-foreground">
+          {t('web.providers.grokAccounts.addingTitle')}
+        </span>{' '}
+        {t('web.providers.grokAccounts.addingBodyPrefix')}
+        <pre className="mt-1.5 mb-1.5 px-2 py-1.5 rounded bg-background/60 text-[10.5px] overflow-x-auto">
+{`mkdir -p ~/.grok-accounts/<name>
+GROK_HOME=~/.grok-accounts/<name> grok login   # complete xAI sign-in, then exit`}
+        </pre>
+        <Trans
+          i18nKey="web.providers.grokAccounts.addingBodySuffix"
+          components={{ 1: <span className="font-mono" /> }}
+        />
+      </div>
+
+      {isLoading && (
+        <div className="text-[12px] text-muted-foreground italic">
+          {t('web.providers.grokAccounts.loading')}
+        </div>
+      )}
+
+      {!isLoading && (accounts?.length ?? 0) === 0 && (
+        <p className="text-[12px] text-muted-foreground italic">
+          <Trans
+            i18nKey="web.providers.grokAccounts.empty"
+            shouldUnescape
+            components={{ 1: <span className="font-mono" /> }}
+          />
+        </p>
+      )}
+
+      <div className="space-y-1.5">
+        {(accounts ?? []).map((a) => (
+          <div
+            key={a.id}
+            className="rounded-md border border-border px-3 py-2.5"
+          >
+            <div className="flex items-center gap-3">
+              <KeyRound
+                className={
+                  a.token_filled
+                    ? 'size-4 text-foreground/80 shrink-0'
+                    : 'size-4 text-muted-foreground/50 shrink-0'
+                }
+              />
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="text-[12px] font-medium">
+                    {a.display_name || a.name}
+                  </span>
+                  <span className="text-[10px] text-muted-foreground/60 font-mono">
+                    {a.name}
+                  </span>
+                  {!a.token_filled && (
+                    <span className="text-[10px] uppercase tracking-wide text-amber-500/90 inline-flex items-center gap-1">
+                      <CircleDot className="size-2.5" />
+                      {t('web.providers.grokAccounts.noTokenYet')}
+                    </span>
+                  )}
+                  <span
+                    className="text-[10px] rounded px-1.5 py-0.5 bg-foreground/5 text-muted-foreground/80"
+                    title="sessions currently pinned to this account"
+                  >
+                    {a.active_sessions ?? 0} active
+                  </span>
+                  {a.last_used_at && (
+                    <span
+                      className="text-[10px] text-muted-foreground/60"
+                      title={`last session: ${a.last_used_at}`}
+                    >
+                      used {relativeAgo(a.last_used_at)}
+                    </span>
+                  )}
+                </div>
+                <div className="text-[10px] font-mono text-muted-foreground/70 truncate">
+                  {t('web.providers.grokAccounts.homeDir')}{' '}
+                  {a.config_dir || 'default'}
+                </div>
+              </div>
+              <ToggleButton
+                enabled={a.enabled}
+                pending={toggle.isPending}
+                onToggle={(v) => toggle.mutate({ id: a.id, enabled: v })}
+                ariaLabel={t('web.providers.grokAccounts.toggleAria', {
+                  name: a.name,
+                })}
+              />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7 text-muted-foreground hover:text-destructive"
+                onClick={() => {
+                  if (
+                    confirm(
+                      t('web.providers.grokAccounts.removeConfirm', {
+                        name: a.name,
+                      }),
+                    )
+                  ) {
+                    remove.mutate(a.id)
+                  }
+                }}
+                disabled={remove.isPending}
+                aria-label={t('web.providers.grokAccounts.removeAria', {
+                  name: a.name,
+                })}
+              >
+                <Trash2 className="size-3.5" />
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ToggleButton({
+  enabled,
+  pending,
+  onToggle,
+  ariaLabel,
+}: {
+  enabled: boolean
+  pending: boolean
+  onToggle: (next: boolean) => void
+  ariaLabel: string
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={enabled}
+      aria-label={ariaLabel}
+      disabled={pending}
+      onClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        onToggle(!enabled)
+      }}
+      className={cn(
+        'inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-border transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        'disabled:cursor-wait disabled:opacity-60',
+        enabled ? 'bg-accent' : 'bg-muted',
+      )}
+    >
+      <span
+        className={cn(
+          'pointer-events-none block size-4 rounded-full bg-background shadow-sm transition-transform',
+          enabled ? 'translate-x-4' : 'translate-x-0.5',
+        )}
+      />
+    </button>
+  )
+}

--- a/app/web/src/components/sessions/AccountSwitcher.tsx
+++ b/app/web/src/components/sessions/AccountSwitcher.tsx
@@ -15,7 +15,12 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { listClaudeAccounts } from '@/lib/claudeAccounts'
 import { listAntigravityAccounts } from '@/lib/antigravityAccounts'
-import { switchClaudeAccount, switchAntigravityAccount } from '@/lib/sessions'
+import { listGrokAccounts } from '@/lib/grokAccounts'
+import {
+  switchClaudeAccount,
+  switchAntigravityAccount,
+  switchGrokAccount,
+} from '@/lib/sessions'
 import { cn } from '@/lib/utils'
 import type { Session } from '@/lib/types'
 
@@ -23,9 +28,9 @@ interface AccountSwitcherProps {
   session: Session
 }
 
-// Minimal shape shared by ClaudeAccount and AntigravityAccount — the
-// only fields this dropdown renders. Lets one component drive both
-// providers' multi-account switching.
+// Minimal shape shared by Claude, Antigravity, and Grok accounts, the
+// only fields this dropdown renders. Lets one component drive every
+// provider's multi-account switching.
 interface SwitcherAccount {
   id: string
   name: string
@@ -36,28 +41,50 @@ interface SwitcherAccount {
 }
 
 // AccountSwitcher renders a header dropdown that lets the user rebind a
-// *running* multi-account session (claude or antigravity) to a different
-// account. The backend terminates the current child process and respawns
-// it under the new credential — the in-CLI conversation is lost (the
-// process is replaced), so the dropdown confirms before firing.
+// *running* multi-account session (claude, antigravity, or grok) to a
+// different account. The backend terminates the current child process and
+// respawns it under the new credential, so the in-CLI conversation is lost
+// (the process is replaced) and the dropdown confirms before firing.
 //
 // Claude isolates accounts via CLAUDE_CONFIG_DIR and supports carrying a
-// recap across the switch (the carry toggle). Antigravity isolates via
-// HOME and has no cross-account recap builder yet, so its switch is
+// recap across the switch (the carry toggle). Antigravity (HOME) and Grok
+// (GROK_HOME) have no cross-account recap builder yet, so their switch is
 // always clean-slate and the carry toggle is hidden.
 export function AccountSwitcher({ session }: AccountSwitcherProps) {
   const { t } = useTranslation()
   const qc = useQueryClient()
-  const isAgy = session.provider_id === 'antigravity'
+  const kind: 'claude' | 'antigravity' | 'grok' =
+    session.provider_id === 'antigravity'
+      ? 'antigravity'
+      : session.provider_id === 'grok'
+        ? 'grok'
+        : 'claude'
+  const isClaude = kind === 'claude'
+
+  const queryKey =
+    kind === 'antigravity'
+      ? ['antigravity-accounts']
+      : kind === 'grok'
+        ? ['grok-accounts']
+        : ['claude-accounts']
+  const queryFn =
+    kind === 'antigravity'
+      ? listAntigravityAccounts
+      : kind === 'grok'
+        ? listGrokAccounts
+        : listClaudeAccounts
 
   const { data: accounts } = useQuery<SwitcherAccount[]>({
-    queryKey: isAgy ? ['antigravity-accounts'] : ['claude-accounts'],
-    queryFn: isAgy ? listAntigravityAccounts : listClaudeAccounts,
+    queryKey,
+    queryFn,
     staleTime: 30_000,
   })
-  const currentId = isAgy
-    ? session.antigravity_account_id
-    : session.claude_account_id
+  const currentId =
+    kind === 'antigravity'
+      ? session.antigravity_account_id
+      : kind === 'grok'
+        ? session.grok_account_id
+        : session.claude_account_id
   const enabled = (accounts ?? []).filter((a) => a.enabled)
   const current = (accounts ?? []).find((a) => a.id === currentId)
   const currentLabel = currentId
@@ -70,21 +97,26 @@ export function AccountSwitcher({ session }: AccountSwitcherProps) {
 
   const mutation = useMutation({
     mutationFn: (accountId: string) =>
-      isAgy
+      kind === 'antigravity'
         ? switchAntigravityAccount(session.id, accountId)
-        : switchClaudeAccount(session.id, accountId, carryContext),
+        : kind === 'grok'
+          ? switchGrokAccount(session.id, accountId)
+          : switchClaudeAccount(session.id, accountId, carryContext),
     onSuccess: (next) => {
       qc.invalidateQueries({ queryKey: ['sessions'] })
-      const nextId = isAgy
-        ? next.antigravity_account_id
-        : next.claude_account_id
+      const nextId =
+        kind === 'antigravity'
+          ? next.antigravity_account_id
+          : kind === 'grok'
+            ? next.grok_account_id
+            : next.claude_account_id
       const account = nextId
         ? enabled.find((a) => a.id === nextId)?.display_name || nextId
         : t('web.sessions.accountSwitcher.switchedDefault')
       toast.success(t('web.sessions.accountSwitcher.switchedToast'), {
         description: t('web.sessions.accountSwitcher.switchedDescription', {
           account,
-          pid: next.pid ?? '—',
+          pid: next.pid ?? 'unknown',
         }),
       })
     },
@@ -96,16 +128,32 @@ export function AccountSwitcher({ session }: AccountSwitcherProps) {
 
   const pick = (accountId: string) => {
     if (accountId === (currentId ?? '')) return
-    const msg = isAgy
-      ? t('web.sessions.accountSwitcher.confirmSwitchAgy')
-      : carryContext
-        ? t('web.sessions.accountSwitcher.confirmSwitchCarry')
-        : t('web.sessions.accountSwitcher.confirmSwitch')
+    const msg =
+      kind === 'antigravity'
+        ? t('web.sessions.accountSwitcher.confirmSwitchAgy')
+        : kind === 'grok'
+          ? t('web.sessions.accountSwitcher.confirmSwitchGrok')
+          : carryContext
+            ? t('web.sessions.accountSwitcher.confirmSwitchCarry')
+            : t('web.sessions.accountSwitcher.confirmSwitch')
     if (!confirm(msg)) {
       return
     }
     mutation.mutate(accountId)
   }
+
+  const tooltipKey =
+    kind === 'antigravity'
+      ? 'web.sessions.accountSwitcher.tooltipAgy'
+      : kind === 'grok'
+        ? 'web.sessions.accountSwitcher.tooltipGrok'
+        : 'web.sessions.accountSwitcher.tooltip'
+  const menuTitleKey =
+    kind === 'antigravity'
+      ? 'web.sessions.accountSwitcher.menuTitleAgy'
+      : kind === 'grok'
+        ? 'web.sessions.accountSwitcher.menuTitleGrok'
+        : 'web.sessions.accountSwitcher.menuTitle'
 
   return (
     <DropdownMenu>
@@ -115,11 +163,7 @@ export function AccountSwitcher({ session }: AccountSwitcherProps) {
           size="sm"
           disabled={mutation.isPending}
           className="text-[11px] gap-1 hover:text-foreground"
-          title={t(
-            isAgy
-              ? 'web.sessions.accountSwitcher.tooltipAgy'
-              : 'web.sessions.accountSwitcher.tooltip',
-          )}
+          title={t(tooltipKey)}
         >
           {mutation.isPending ? (
             <Loader2 className="size-3 animate-spin" />
@@ -132,18 +176,14 @@ export function AccountSwitcher({ session }: AccountSwitcherProps) {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-[220px]">
         <DropdownMenuLabel className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
-          {t(
-            isAgy
-              ? 'web.sessions.accountSwitcher.menuTitleAgy'
-              : 'web.sessions.accountSwitcher.menuTitle',
-          )}
+          {t(menuTitleKey)}
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
         {/* Carry-over toggle (claude only). Stays open on click
             (preventDefault) so the operator sets it before picking a
             destination. The subtitle is the consent surface for the
             cross-account data flow. */}
-        {!isAgy && (
+        {isClaude && (
           <>
             <DropdownMenuItem
               onSelect={(e) => {

--- a/app/web/src/pages/Providers.tsx
+++ b/app/web/src/pages/Providers.tsx
@@ -15,6 +15,7 @@ import { BrandAvatar } from '@/components/BrandAvatar'
 import { providerIconKey } from '@/lib/providerIcons'
 import { ClaudeAccountsPanel } from '@/components/providers/ClaudeAccountsPanel'
 import { AntigravityAccountsPanel } from '@/components/providers/AntigravityAccountsPanel'
+import { GrokAccountsPanel } from '@/components/providers/GrokAccountsPanel'
 import { useConfirmDialog } from '@/components/ConfirmDialog'
 import {
   listProviders,
@@ -413,6 +414,12 @@ function ProviderDetail({
             <>
               <Separator className="my-6" />
               <AntigravityAccountsPanel />
+            </>
+          )}
+          {m.id === 'grok' && (
+            <>
+              <Separator className="my-6" />
+              <GrokAccountsPanel />
             </>
           )}
           <Separator className="my-6" />

--- a/app/web/src/pages/Sessions.tsx
+++ b/app/web/src/pages/Sessions.tsx
@@ -563,7 +563,8 @@ function WorkbenchHeader({
       </div>
       <StatePill state={session.state} exitCode={session.exit_code} />
       {(session.provider_id === 'claude' ||
-        session.provider_id === 'antigravity') &&
+        session.provider_id === 'antigravity' ||
+        session.provider_id === 'grok') &&
         !isTerminalSessionState(session.state) && (
           <AccountSwitcher session={session} />
         )}


### PR DESCRIPTION
Closes the missing frontend for grok multi-account. The backend shipped in v2.14.0 (grokacct service, `/api/v1/grok-accounts`, `PATCH /sessions/{id}/grok-account`), but there was no UI, so operators could not see a grok accounts section or switch accounts. This adds it, matching Claude and Antigravity.

## What is added
- **GrokAccountsPanel** in the Providers page (shown for the grok provider): lists accounts, "Import local", enable/disable toggle, remove, and the token-present and active-session indicators. Mirrors `AntigravityAccountsPanel`.
- **AccountSwitcher** generalised from claude/antigravity to also handle grok, so a running grok session can live-switch accounts from the header dropdown. Like antigravity there is no carry-over toggle (grok has no cross-account recap yet). The gating in `Sessions.tsx` now includes grok.
- **Shared lib**: `grokAccounts` API client, `switchGrokAccount`, the `GrokAccount` type, and `Session.grok_account_id`.
- **i18n**: `web.providers.grokAccounts.*` and the switcher grok strings in `en.json`. Other locales fall back to English (i18n parity is advisory and green); translations can follow.

## Verification
- i18n parity check passes (exit 0, advisory warnings only for the untranslated grok keys).
- Every grok import resolves to a real export (checked across the panel, switcher, and Providers page).
- A full local typecheck was not possible because this checkout's web dependencies are only partially installed (missing `vite` types), so CI runs the authoritative `tsc -b && vite build`.

## Note
This is UI only. It needs the v2.14.0 backend, which is on `main` and released, plus a gateway update on the running instance for it to appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)