### PR TITLE
docs(changelog): v2.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+## [v2.14.1], 2026-09-04
+
+### Added
+
+- Grok accounts get a full UI: a Grok accounts panel in the Providers page
+  (list, import local, enable or disable, remove) and live account
+  switching from the session header, matching Claude and Antigravity. This
+  surfaces the grok multi-account backend that shipped in v2.14.0. (#539)
+- Opt-in git worktree isolation, so concurrent sessions can each work in
+  their own worktree without stepping on one another. (#531)
+- Mobile can reach a gateway behind Cloudflare Access without a VPN. (#538)
+
+### Changed
+
+- Documentation rewritten in plain, human prose with no em dashes, the
+  README simplified so it reads top to bottom in one pass, and the
+  changelog brought up to date. (#537, #528, #536)
+
 ## [v2.14.0], 2026-08-31
 
 Grok catches up. You can pool several xAI accounts, bind one to a session,


### PR DESCRIPTION
Changelog section for the v2.14.1 release (the CHANGELOG bump the release flow expects, so the website and release notes stay current).

v2.14.1 carries everything merged since v2.14.0:
- Grok accounts UI: Providers panel + session switcher (#539)
- Opt-in git worktree isolation for concurrent sessions (#531)
- Mobile Cloudflare Access without a VPN (#538)
- Docs humanised (no em dashes), README simplified, changelog caught up (#537, #528, #536)

🤖 Generated with [Claude Code](https://claude.com/claude-code)