### PR TITLE
feat(session): grok carry-context recap renderer (RFC #541 P1)

### DIFF
--- a/internal/session/grok_carryover_test.go
+++ b/internal/session/grok_carryover_test.go
@@ -1,0 +1,146 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeGrokCarryoverFixture writes a minimal grok chat transcript at
+// <root>/<percent-encoded-cwd>/<sessionID>/chat_history.jsonl, mirroring
+// grok's real on-disk layout, and returns a config pointing at <root>.
+func writeGrokCarryoverFixture(t *testing.T, cwd, sessionID string, lines []string) GrokHistoryConfig {
+	t.Helper()
+	root := t.TempDir()
+	// grok encodes the cwd into the session dir name by percent-encoding
+	// the path separators (e.g. /var/lib -> %2Fvar%2Flib).
+	encoded := strings.ReplaceAll(cwd, "/", "%2F")
+	dir := filepath.Join(root, encoded, sessionID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "chat_history.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return GrokHistoryConfig{SessionsRoots: []string{root}}
+}
+
+func TestBuildGrokCarryover(t *testing.T) {
+	cwd := "/var/lib/opendray/vocaler-grok"
+	sid := "01a04fbd-435a-78c2-9a39-95a26d7192e5"
+
+	t.Run("user_query + assistant text kept, synthetic + tool noise dropped", func(t *testing.T) {
+		cfg := writeGrokCarryoverFixture(t, cwd, sid, []string{
+			`{"type":"system","content":"you are grok"}`,
+			`{"type":"user","content":[{"type":"text","text":"<user_info>\nOS Version: linux\n</user_info>"}]}`,
+			`{"type":"user","content":[{"type":"text","text":"<user_query> add a login form </user_query>"}]}`,
+			`{"type":"reasoning","content":null}`,
+			`{"type":"assistant","content":"On it, creating the form.","tool_calls":[{"id":"c1","name":"Write"}]}`,
+			`{"type":"tool_result","content":"file written ok"}`,
+			`{"type":"user","content":[{"type":"text","text":"<system-reminder> background task done </system-reminder>"}]}`,
+		})
+		got := BuildGrokCarryover(cfg, cwd, sid, 0)
+		if got == "" {
+			t.Fatal("expected a recap, got empty")
+		}
+		if !strings.Contains(got, "Carried-over context from a previous account") {
+			t.Error("missing header")
+		}
+		if !strings.Contains(got, "You: add a login form") {
+			t.Errorf("missing/untrimmed user query turn:\n%s", got)
+		}
+		if !strings.Contains(got, "Assistant: On it, creating the form.") {
+			t.Errorf("missing assistant text turn:\n%s", got)
+		}
+		for _, noise := range []string{
+			"user_info", "user_query", "system-reminder", "reasoning",
+			"file written ok", "you are grok",
+		} {
+			if strings.Contains(got, noise) {
+				t.Errorf("noise %q leaked into recap:\n%s", noise, got)
+			}
+		}
+		if !strings.Contains(got, "End of carried-over context") {
+			t.Error("missing footer")
+		}
+	})
+
+	t.Run("missing transcript returns empty (degrade to fresh)", func(t *testing.T) {
+		cfg := writeGrokCarryoverFixture(t, cwd, sid, []string{
+			`{"type":"user","content":[{"type":"text","text":"<user_query> hi </user_query>"}]}`,
+		})
+		got := BuildGrokCarryover(cfg, cwd, "01a00000-0000-0000-0000-000000000000", 0)
+		if got != "" {
+			t.Errorf("expected empty for missing transcript, got:\n%s", got)
+		}
+	})
+
+	t.Run("empty inputs are no-ops", func(t *testing.T) {
+		cfg := GrokHistoryConfig{SessionsRoots: []string{t.TempDir()}}
+		if BuildGrokCarryover(cfg, "", sid, 0) != "" {
+			t.Error("empty cwd should return empty")
+		}
+		if BuildGrokCarryover(cfg, cwd, "", 0) != "" {
+			t.Error("empty sessionID should return empty")
+		}
+	})
+
+	t.Run("only-synthetic transcript returns empty", func(t *testing.T) {
+		cfg := writeGrokCarryoverFixture(t, cwd, sid, []string{
+			`{"type":"user","content":[{"type":"text","text":"<user_info> OS: linux </user_info>"}]}`,
+			`{"type":"reasoning","content":null}`,
+			`{"type":"tool_result","content":"ok"}`,
+		})
+		if got := BuildGrokCarryover(cfg, cwd, sid, 0); got != "" {
+			t.Errorf("expected empty when no genuine turns, got:\n%s", got)
+		}
+	})
+
+	t.Run("tail-truncates to budget with elision marker", func(t *testing.T) {
+		big := strings.Repeat("x", 2000)
+		cfg := writeGrokCarryoverFixture(t, cwd, sid, []string{
+			`{"type":"user","content":[{"type":"text","text":"<user_query> OLDEST ` + big + ` </user_query>"}]}`,
+			`{"type":"user","content":[{"type":"text","text":"<user_query> MIDDLE ` + big + ` </user_query>"}]}`,
+			`{"type":"user","content":[{"type":"text","text":"<user_query> NEWEST ` + big + ` </user_query>"}]}`,
+		})
+		got := BuildGrokCarryover(cfg, cwd, sid, 3200)
+		if !strings.Contains(got, "NEWEST") {
+			t.Errorf("most recent turn should survive truncation:\n%.200s", got)
+		}
+		if strings.Contains(got, "OLDEST") {
+			t.Error("oldest turn should have been dropped by the budget")
+		}
+		if !strings.Contains(got, "earlier turns omitted") {
+			t.Error("expected elision marker when turns are dropped")
+		}
+	})
+
+	// R2: a crafted sessionID must never let the reader escape the
+	// sessions root and pull an unrelated file.
+	t.Run("path traversal in sessionID is contained", func(t *testing.T) {
+		cfg := writeGrokCarryoverFixture(t, cwd, sid, []string{
+			`{"type":"user","content":[{"type":"text","text":"<user_query> hi </user_query>"}]}`,
+		})
+		// Plant a decoy transcript one level up from the sessions root.
+		root := cfg.SessionsRoots[0]
+		decoyDir := filepath.Join(filepath.Dir(root), "decoy")
+		if err := os.MkdirAll(decoyDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(decoyDir, "chat_history.jsonl"),
+			[]byte(`{"type":"user","content":[{"type":"text","text":"<user_query> SECRET </user_query>"}]}`+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		for _, evil := range []string{
+			"../decoy",
+			"../../decoy",
+			"foo/bar",
+		} {
+			if got := BuildGrokCarryover(cfg, cwd, evil, 0); got != "" {
+				t.Errorf("traversal sessionID %q must return empty, got:\n%s", evil, got)
+			}
+		}
+	})
+}

--- a/internal/session/grok_jsonl.go
+++ b/internal/session/grok_jsonl.go
@@ -1,0 +1,294 @@
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// grok_jsonl.go: read the grok CLI's per-session transcript so an
+// account switch can carry a recap of the prior conversation into the
+// fresh session under the new GROK_HOME (RFC #541, recap-inject option).
+//
+// grok writes each session under its GROK_HOME:
+//
+//   <GROK_HOME>/sessions/<percent-encoded-cwd>/<session-uuid>/chat_history.jsonl
+//
+// The encoded cwd percent-escapes path separators (/ -> %2F). Each line
+// of chat_history.jsonl is one JSON object: {type, content, ...}.
+//   type "user"       content = [{type:"text", text:"..."}]  (may be a bare string)
+//   type "assistant"  content = "prose reply"                (plus tool_calls we ignore)
+//   type "reasoning"  content = null                         (dropped: internal thinking)
+//   type "tool_result"content = "..."                        (dropped: tool noise)
+//   type "system"     content = "..."                        (dropped: system prompt)
+//
+// Genuine human prompts are wrapped in <user_query>...</user_query>;
+// every other user turn is synthetic injected context (<user_info>,
+// <rules>, <system-reminder>, continuation summaries) and is dropped.
+
+// GrokHistoryConfig drives grok transcript path resolution. All fields
+// optional — empty values fall back to <GROK_HOME or ~/.grok>/sessions
+// plus every ~/.grok-accounts/*/sessions subtree.
+type GrokHistoryConfig struct {
+	// SessionsRoots is the explicit list of `<dir>/sessions` roots to
+	// scan. When non-empty it REPLACES the built-in defaults.
+	SessionsRoots []string
+	// AccountsDir overrides ~/.grok-accounts when looking for per-account
+	// session subtrees. Ignored when SessionsRoots is set.
+	AccountsDir string
+}
+
+// grokChatEntry is one line of grok's chat_history.jsonl. We decode only
+// the two fields the recap needs.
+type grokChatEntry struct {
+	Type    string          `json:"type"`
+	Content json.RawMessage `json:"content"`
+}
+
+type grokTextBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// BuildGrokCarryover reads the transcript for `sessionID` under the grok
+// session dir matching `cwd`, and returns a labeled recap block suitable
+// for injection (via grok --rules) into a fresh session after an account
+// switch. Returns "" (never an error) when there's nothing to carry — a
+// missing/empty/unparseable transcript degrades to a fresh session and
+// never blocks the switch.
+//
+// Only genuine <user_query> prompts and assistant prose are kept; the
+// recap is tail-truncated to budgetBytes with an elision marker when
+// older turns are dropped. Reuses renderCarryover shared with Claude.
+func BuildGrokCarryover(cfg GrokHistoryConfig, cwd, sessionID string, budgetBytes int) string {
+	if sessionID == "" || cwd == "" {
+		return ""
+	}
+	if budgetBytes <= 0 {
+		budgetBytes = defaultCarryoverBudgetBytes
+	}
+
+	path := findGrokTranscriptForSession(cfg, cwd, sessionID)
+	if path == "" {
+		return ""
+	}
+
+	turns := readGrokCarryoverTurns(path)
+	if len(turns) == 0 {
+		return ""
+	}
+	return renderCarryover(turns, budgetBytes)
+}
+
+// findGrokTranscriptForSession locates
+// <root>/<encoded-cwd>/<sessionID>/chat_history.jsonl across every
+// configured root. Fail-closed on sessionID: it must be a single, clean
+// path element, so a crafted value can't traverse out of the sessions
+// root (R2). The resolved file is also verified to live under its root.
+func findGrokTranscriptForSession(cfg GrokHistoryConfig, cwd, sessionID string) string {
+	if !safePathElement(sessionID) {
+		return ""
+	}
+	for _, root := range cfg.resolveGrokSessionsRoots() {
+		cwdDir := findGrokCwdDir(root, cwd)
+		if cwdDir == "" {
+			continue
+		}
+		candidate := filepath.Join(cwdDir, sessionID, "chat_history.jsonl")
+		if !withinRoot(root, candidate) {
+			continue
+		}
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// findGrokCwdDir returns the child of `root` whose percent-decoded name
+// equals `cwd`. Decoding (rather than re-encoding cwd) is robust to
+// whatever exact escaping grok used to name the directory.
+func findGrokCwdDir(root, cwd string) string {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		decoded, err := url.QueryUnescape(e.Name())
+		if err != nil {
+			continue
+		}
+		if decoded == cwd {
+			return filepath.Join(root, e.Name())
+		}
+	}
+	return ""
+}
+
+// readGrokCarryoverTurns parses a chat_history.jsonl into ordered text
+// turns, keeping only genuine <user_query> prompts and assistant prose.
+// Oldest-first.
+func readGrokCarryoverTurns(path string) []carryoverTurn {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+	var turns []carryoverTurn
+	for scanner.Scan() {
+		var e grokChatEntry
+		if err := json.Unmarshal(scanner.Bytes(), &e); err != nil {
+			continue
+		}
+		switch e.Type {
+		case "user":
+			if q := grokUserQuery(e.Content); q != "" {
+				turns = append(turns, carryoverTurn{role: "You", text: q})
+			}
+		case "assistant":
+			if txt := grokAssistantText(e.Content); txt != "" {
+				turns = append(turns, carryoverTurn{role: "Assistant", text: txt})
+			}
+		}
+	}
+	return turns
+}
+
+// grokUserQuery extracts the genuine prompt from a user turn: the text
+// inside <user_query>...</user_query>. Returns "" for synthetic turns
+// (<user_info>, <rules>, <system-reminder>, continuation summaries),
+// which carry no such wrapper.
+func grokUserQuery(raw json.RawMessage) string {
+	return extractUserQuery(grokBlockText(raw))
+}
+
+// grokAssistantText returns the assistant's prose. content is normally a
+// bare JSON string; an array-of-blocks shape is handled defensively.
+func grokAssistantText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	if raw[0] == '"' {
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return ""
+		}
+		return strings.TrimSpace(s)
+	}
+	return strings.TrimSpace(grokBlockText(raw))
+}
+
+// grokBlockText concatenates the text of an array-of-blocks content, and
+// also accepts a bare string. Non-text blocks are ignored.
+func grokBlockText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	if raw[0] == '"' {
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return ""
+		}
+		return s
+	}
+	var blocks []grokTextBlock
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return ""
+	}
+	parts := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		if b.Type == "text" && strings.TrimSpace(b.Text) != "" {
+			parts = append(parts, b.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// extractUserQuery returns the trimmed text inside the first
+// <user_query>...</user_query> pair, or "" when absent/malformed.
+func extractUserQuery(s string) string {
+	const open, close = "<user_query>", "</user_query>"
+	i := strings.Index(s, open)
+	if i < 0 {
+		return ""
+	}
+	rest := s[i+len(open):]
+	j := strings.Index(rest, close)
+	if j < 0 {
+		return ""
+	}
+	return strings.TrimSpace(rest[:j])
+}
+
+// resolveGrokSessionsRoots picks the `<dir>/sessions` roots to scan.
+// Precedence: explicit SessionsRoots override, else <GROK_HOME or
+// ~/.grok>/sessions plus every ~/.grok-accounts/*/sessions subtree
+// (~/.grok-accounts overridable via AccountsDir).
+func (cfg GrokHistoryConfig) resolveGrokSessionsRoots() []string {
+	if len(cfg.SessionsRoots) > 0 {
+		return cfg.SessionsRoots
+	}
+	home := os.Getenv("HOME")
+	grokHome := os.Getenv("GROK_HOME")
+	if grokHome == "" {
+		if home == "" {
+			return nil
+		}
+		grokHome = filepath.Join(home, ".grok")
+	}
+	roots := []string{filepath.Join(grokHome, "sessions")}
+
+	accountsDir := cfg.AccountsDir
+	if accountsDir == "" {
+		if home == "" {
+			return roots
+		}
+		accountsDir = filepath.Join(home, ".grok-accounts")
+	}
+	entries, err := os.ReadDir(accountsDir)
+	if err != nil {
+		return roots
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			roots = append(roots, filepath.Join(accountsDir, e.Name(), "sessions"))
+		}
+	}
+	return roots
+}
+
+// safePathElement reports whether s is a single, clean path element with
+// no separators or parent references — safe to Join without escaping.
+func safePathElement(s string) bool {
+	if s == "" || s == "." || s == ".." {
+		return false
+	}
+	if strings.ContainsRune(s, '/') || strings.ContainsRune(s, filepath.Separator) {
+		return false
+	}
+	if strings.Contains(s, "..") {
+		return false
+	}
+	return filepath.Clean(s) == s
+}
+
+// withinRoot reports whether `path` resolves inside `root` (both cleaned).
+// Defense-in-depth alongside safePathElement.
+func withinRoot(root, path string) bool {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}


### PR DESCRIPTION
## What

P1 of RFC #541 — the pure recap renderer for grok account-switch carry-context.

`BuildGrokCarryover(cfg, cwd, sessionID, budgetBytes)` reads grok's per-session transcript at `<GROK_HOME>/sessions/<pct-encoded-cwd>/<uuid>/chat_history.jsonl` and returns a labeled recap block for later injection into a fresh session after an account switch. Recap-only (RFC option O-B); reuses the shared `renderCarryover`/budget/elision logic from the Claude path so the format matches.

## Behavior

- Keeps genuine `<user_query>` prompts and assistant prose.
- Drops `reasoning`, `tool_result`, `system`, and synthetic `user` turns (`<user_info>`, `<rules>`, `<system-reminder>`, continuation summaries). Verified against the live transcript shapes on the host.
- Best-effort: returns `""` on missing/empty/unparsable transcript, never errors — a switch degrades to a fresh session rather than failing.

## Security (RFC R2)

`sessionID` must be a clean single path element (`safePathElement`), and the resolved file is re-verified to live under the sessions root (`withinRoot`). The `path traversal in sessionID is contained` test plants a decoy transcript outside the root and confirms `../decoy`, `../../decoy`, and `foo/bar` all return `""`. The renderer never reads `auth.json` or tokens — only `chat_history.jsonl`.

## Tests (TDD)

Added `internal/session/grok_carryover_test.go` (6 cases): kept-vs-dropped turns, missing transcript, empty inputs, only-synthetic transcript, budget tail-truncation + elision, and path-traversal containment. RED confirmed (undefined symbol) before implementing. `go test ./internal/session/` ok, `go vet` clean, `go build ./...` clean.

## Scope

P1 only. Not included: switch wiring (`SwitchGrokAccount` + handler, P2) and the web carry toggle (P3). Open question Q1 (opendray does not track a grok session UUID on the row) is deferred to P2 — P1 takes `sessionID` as a parameter and is ready for either resolution strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014d79TcWAd7QV7Kb3w6FGZv
