### PR TITLE
feat(session): wire grok carry-context into account switch (RFC #541 P2)

### DIFF
--- a/internal/session/grok_carryover_test.go
+++ b/internal/session/grok_carryover_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // writeGrokCarryoverFixture writes a minimal grok chat transcript at
@@ -141,6 +142,71 @@ func TestBuildGrokCarryover(t *testing.T) {
 			if got := BuildGrokCarryover(cfg, cwd, evil, 0); got != "" {
 				t.Errorf("traversal sessionID %q must return empty, got:\n%s", evil, got)
 			}
+		}
+	})
+}
+
+func TestLatestGrokSessionID(t *testing.T) {
+	cwd := "/var/lib/opendray/vocaler-grok"
+
+	newFixtureWithSessions := func(t *testing.T, sessions map[string]time.Time) GrokHistoryConfig {
+		t.Helper()
+		root := t.TempDir()
+		encoded := strings.ReplaceAll(cwd, "/", "%2F")
+		for sid, mt := range sessions {
+			dir := filepath.Join(root, encoded, sid)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			ch := filepath.Join(dir, "chat_history.jsonl")
+			if err := os.WriteFile(ch, []byte("{}\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chtimes(ch, mt, mt); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return GrokHistoryConfig{SessionsRoots: []string{root}}
+	}
+
+	t.Run("returns the session whose transcript was touched most recently", func(t *testing.T) {
+		base := time.Now().Add(-time.Hour)
+		cfg := newFixtureWithSessions(t, map[string]time.Time{
+			"01a00000-0000-0000-0000-00000000aaaa": base,
+			"01a00000-0000-0000-0000-00000000bbbb": base.Add(30 * time.Minute), // newest
+			"01a00000-0000-0000-0000-00000000cccc": base.Add(10 * time.Minute),
+		})
+		if got := LatestGrokSessionID(cfg, cwd); got != "01a00000-0000-0000-0000-00000000bbbb" {
+			t.Errorf("got %q, want the newest session bbbb", got)
+		}
+	})
+
+	t.Run("empty cwd is a no-op", func(t *testing.T) {
+		cfg := newFixtureWithSessions(t, map[string]time.Time{
+			"01a00000-0000-0000-0000-00000000aaaa": time.Now(),
+		})
+		if got := LatestGrokSessionID(cfg, ""); got != "" {
+			t.Errorf("empty cwd should return empty, got %q", got)
+		}
+	})
+
+	t.Run("no matching cwd dir returns empty", func(t *testing.T) {
+		cfg := GrokHistoryConfig{SessionsRoots: []string{t.TempDir()}}
+		if got := LatestGrokSessionID(cfg, cwd); got != "" {
+			t.Errorf("expected empty when no session dir exists, got %q", got)
+		}
+	})
+
+	t.Run("dir without chat_history is ignored", func(t *testing.T) {
+		root := t.TempDir()
+		encoded := strings.ReplaceAll(cwd, "/", "%2F")
+		// A session dir with no transcript yet must not be selected.
+		if err := os.MkdirAll(filepath.Join(root, encoded, "01a00000-0000-0000-0000-0000000empty"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		cfg := GrokHistoryConfig{SessionsRoots: []string{root}}
+		if got := LatestGrokSessionID(cfg, cwd); got != "" {
+			t.Errorf("dir without chat_history must be ignored, got %q", got)
 		}
 	})
 }

--- a/internal/session/grok_jsonl.go
+++ b/internal/session/grok_jsonl.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // grok_jsonl.go: read the grok CLI's per-session transcript so an
@@ -81,6 +82,47 @@ func BuildGrokCarryover(cfg GrokHistoryConfig, cwd, sessionID string, budgetByte
 		return ""
 	}
 	return renderCarryover(turns, budgetBytes)
+}
+
+// LatestGrokSessionID returns the session UUID whose chat_history.jsonl
+// under the grok session dir matching `cwd` was modified most recently,
+// across every configured root. It resolves Q1 (RFC #541): opendray does
+// not track a grok session id on the session row, so at switch time —
+// right after the old grok process is stopped — the just-used session's
+// transcript is the freshest one for that cwd. Returns "" when nothing
+// matches; a dir without a transcript yet is never selected.
+func LatestGrokSessionID(cfg GrokHistoryConfig, cwd string) string {
+	if cwd == "" {
+		return ""
+	}
+	var (
+		best     string
+		bestTime time.Time
+	)
+	for _, root := range cfg.resolveGrokSessionsRoots() {
+		cwdDir := findGrokCwdDir(root, cwd)
+		if cwdDir == "" {
+			continue
+		}
+		entries, err := os.ReadDir(cwdDir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() || !safePathElement(e.Name()) {
+				continue
+			}
+			info, err := os.Stat(filepath.Join(cwdDir, e.Name(), "chat_history.jsonl"))
+			if err != nil || info.IsDir() {
+				continue
+			}
+			if best == "" || info.ModTime().After(bestTime) {
+				best = e.Name()
+				bestTime = info.ModTime()
+			}
+		}
+	}
+	return best
 }
 
 // findGrokTranscriptForSession locates

--- a/internal/session/handler.go
+++ b/internal/session/handler.go
@@ -40,7 +40,7 @@ type Service interface {
 	Buffer(ctx context.Context, id string, since int64) (Replay, error)
 	SwitchClaudeAccount(ctx context.Context, id, accountID string, carryContext bool) (Session, error)
 	SwitchAntigravityAccount(ctx context.Context, id, accountID string) (Session, error)
-	SwitchGrokAccount(ctx context.Context, id, accountID string) (Session, error)
+	SwitchGrokAccount(ctx context.Context, id, accountID string, carryContext bool) (Session, error)
 	History(ctx context.Context, id string, limit int) (HistoryResponse, error)
 }
 
@@ -687,10 +687,11 @@ func (h *Handlers) switchAntigravityAccount(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, http.StatusOK, sess)
 }
 
-// switchGrokAccount handles PATCH /sessions/{id}/grok-account. Mirrors
-// switchAntigravityAccount: validate the target up-front (so a bad id
-// fails before the PTY is stopped), then hand off to the manager which
-// stops the running `grok`, rebinds GROK_HOME, and respawns.
+// switchGrokAccount handles PATCH /sessions/{id}/grok-account. Validates
+// the target up-front (so a bad id fails before the PTY is stopped), then
+// hands off to the manager which stops the running `grok`, rebinds
+// GROK_HOME, and respawns. carry_context in the body, when true, seeds
+// the fresh session with a recap of the prior conversation (RFC #541).
 func (h *Handlers) switchGrokAccount(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	var req SwitchAccountRequest
@@ -704,7 +705,7 @@ func (h *Handlers) switchGrokAccount(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	sess, err := h.svc.SwitchGrokAccount(r.Context(), id, req.AccountID)
+	sess, err := h.svc.SwitchGrokAccount(r.Context(), id, req.AccountID, req.CarryContext)
 	if err != nil {
 		h.respondError(w, err)
 		return

--- a/internal/session/handler_grok_test.go
+++ b/internal/session/handler_grok_test.go
@@ -88,3 +88,34 @@ func TestSwitchGrokAccount_BadJSON(t *testing.T) {
 		t.Fatalf("status=%d; want 400 for bad JSON", rr.Code)
 	}
 }
+
+// carry_context in the PATCH body must reach the service (parity with
+// the Claude switch). Grok now builds a recap across the switch.
+func TestSwitchGrokAccount_CarryContextFlows(t *testing.T) {
+	t.Run("carry_context true is forwarded", func(t *testing.T) {
+		svc := newFakeSvc()
+		svc.sessions["s1"] = Session{ID: "s1", ProviderID: "grok", State: StateRunning}
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPatch, "/sessions/s1/grok-account",
+			bytes.NewBufferString(`{"account_id":"grok_new","carry_context":true}`))
+		newRouter(svc).ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rr.Code, rr.Body)
+		}
+		if !svc.lastCarryContext {
+			t.Error("expected carry_context=true forwarded to the grok service")
+		}
+	})
+
+	t.Run("omitted carry_context defaults to false", func(t *testing.T) {
+		svc := newFakeSvc()
+		svc.sessions["s1"] = Session{ID: "s1", ProviderID: "grok", State: StateRunning}
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPatch, "/sessions/s1/grok-account",
+			bytes.NewBufferString(`{"account_id":"grok_new"}`))
+		newRouter(svc).ServeHTTP(rr, req)
+		if svc.lastCarryContext {
+			t.Error("expected carry_context to default to false when omitted")
+		}
+	})
+}

--- a/internal/session/handler_test.go
+++ b/internal/session/handler_test.go
@@ -153,7 +153,8 @@ func (f *fakeSvc) SwitchAntigravityAccount(_ context.Context, id, accountID stri
 	return s, nil
 }
 
-func (f *fakeSvc) SwitchGrokAccount(_ context.Context, id, accountID string) (Session, error) {
+func (f *fakeSvc) SwitchGrokAccount(_ context.Context, id, accountID string, carryContext bool) (Session, error) {
+	f.lastCarryContext = carryContext
 	if f.switchErr != nil {
 		return Session{}, f.switchErr
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -194,6 +194,13 @@ func WithAntigravityHistoryConfig(cfg AntigravityHistoryConfig) ManagerOption {
 	return func(m *Manager) { m.antigravityHistoryCfg = cfg }
 }
 
+// WithGrokHistoryConfig overrides the grok session-transcript discovery
+// paths used by SwitchGrokAccount's carry-context recap. Empty config =
+// built-in <GROK_HOME or ~/.grok>/sessions + ~/.grok-accounts/*/sessions.
+func WithGrokHistoryConfig(cfg GrokHistoryConfig) ManagerOption {
+	return func(m *Manager) { m.grokHistoryCfg = cfg }
+}
+
 // Manager owns the lifecycle of all live sessions in this process.
 // Sessions are persisted in postgres for visibility / audit, but the
 // authoritative state for a running session is the in-memory map here.
@@ -215,6 +222,7 @@ type Manager struct {
 	claudeHistoryCfg      ClaudeHistoryConfig
 	codexHistoryCfg       CodexHistoryConfig
 	antigravityHistoryCfg AntigravityHistoryConfig
+	grokHistoryCfg        GrokHistoryConfig
 
 	// workspaces + wsResolver enable worktree isolation. Both nil →
 	// isolation requests are rejected and every session runs in cwd,
@@ -1540,11 +1548,16 @@ func (m *Manager) SwitchAntigravityAccount(ctx context.Context, id, newAccountID
 // SwitchGrokAccount terminates the running `grok` process and respawns it
 // under a different grok account binding (a different GROK_HOME). The
 // session row, cwd, args and slot are preserved — only the account moves,
-// so the session survives the switch. Mirrors SwitchAntigravityAccount;
-// conversation carry-over is deferred (RFC #532 P3). On respawn failure
-// the row stays 'stopped' with the ORIGINAL account (never persisted the
-// new value) so the user can Restart on it.
-func (m *Manager) SwitchGrokAccount(ctx context.Context, id, newAccountID string) (Session, error) {
+// so the session survives the switch. On respawn failure the row stays
+// 'stopped' with the ORIGINAL account (never persisted the new value) so
+// the user can Restart on it.
+//
+// When carryContext is set, a recap of the prior conversation is read
+// from the old account's transcript (best-effort) and injected into the
+// fresh session via grok --rules — parity with SwitchClaudeAccount (RFC
+// #541). grok can't --resume across accounts (the session id isn't in
+// the new account's store), so a recap is the carry mechanism.
+func (m *Manager) SwitchGrokAccount(ctx context.Context, id, newAccountID string, carryContext bool) (Session, error) {
 	m.mu.RLock()
 	if m.closed {
 		m.mu.RUnlock()
@@ -1572,13 +1585,34 @@ func (m *Manager) SwitchGrokAccount(ctx context.Context, id, newAccountID string
 	if err != nil {
 		return Session{}, err
 	}
+
+	// Capture a recap of the OLD conversation before rebinding. The grok
+	// process is stopped (above) but its transcript persists on disk under
+	// the old account's GROK_HOME; LatestGrokSessionID picks the just-used
+	// session by transcript mtime (Q1). Best-effort: any miss degrades to
+	// a clean-slate switch, never blocks it.
+	var carryover string
+	if carryContext {
+		if sid := LatestGrokSessionID(m.grokHistoryCfg, sess.EffectiveWorkDir()); sid != "" {
+			carryover = BuildGrokCarryover(m.grokHistoryCfg, sess.EffectiveWorkDir(), sid, 0)
+		}
+		if carryover == "" {
+			m.log.Debug("grok carry-context requested but no transcript recap built",
+				"session_id", id, "cwd", sess.EffectiveWorkDir())
+		}
+	}
+
 	sess.GrokAccountID = newAccountID
 	sess.State = StateRunning
 	sess.EndedAt = nil
 	sess.ExitCode = nil
 	sess.StartedAt = time.Now().UTC()
 
-	rs, err := m.spawn(ctx, sess, true)
+	// Thread the recap (if any) into the respawn only — one-shot, absent
+	// from later restarts. The adapter's grok arm injects it as a coalesced
+	// --rules fragment (see injectCarryoverFor / injectAmbientMemoryFor).
+	spawnCtx := WithCarryoverContext(ctx, carryover)
+	rs, err := m.spawn(spawnCtx, sess, true)
 	if err != nil {
 		return Session{}, fmt.Errorf("respawn under new account: %w", err)
 	}


### PR DESCRIPTION
## What

P2 of RFC #541 — wires the grok carry-context recap (P1, #542) into the account switch, giving grok Claude-level parity.

`SwitchGrokAccount` gains a `carryContext` flag. When set, after the old grok is stopped and before the rebind, it reads a recap of the prior conversation from the old account's transcript and threads it via `WithCarryoverContext` into the respawn. The adapter's grok arm injects it as a coalesced `--rules` fragment (path already merged). One-shot: present only on the switch respawn, absent from later restarts. Best-effort: any miss degrades to a clean-slate switch, never blocks it.

## Q1 resolved (no migration)

opendray does not track a grok session id on the session row. `LatestGrokSessionID(cfg, cwd)` picks the just-used session by `chat_history.jsonl` mtime — correct for the common one-session-per-cwd case at switch time (the old process was just stopped, so its transcript is freshest). Capture-at-spawn (a `grok_session_id` column) remains the deterministic upgrade if a shared-cwd, multi-account race ever bites.

## Changes

- `manager.go` — `SwitchGrokAccount(..., carryContext bool)`; recap capture + `WithCarryoverContext` threading; `grokHistoryCfg` field + `WithGrokHistoryConfig` option.
- `handler.go` — `Service.SwitchGrokAccount` signature; handler forwards `req.CarryContext` (`SwitchAccountRequest.CarryContext` already existed).
- `grok_jsonl.go` — `LatestGrokSessionID`.

## Tests (TDD)

- Wave A: `TestLatestGrokSessionID` (newest wins, empty cwd, no matching dir, no-transcript dir ignored). RED `undefined: LatestGrokSessionID` → GREEN.
- Wave B: `TestSwitchGrokAccount_CarryContextFlows` (true forwarded, omitted defaults false). RED (not forwarded) → GREEN. `fakeSvc` updated.
- `internal/session`, `internal/catalog`, `internal/app` `ok`; `go vet` clean; `go build ./...` clean.

## Scope

P2 only. Endpoint now accepts `carry_context`, but the web UI does not send it yet — the grok carry toggle is P3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014d79TcWAd7QV7Kb3w6FGZv
