### PR TITLE
feat(web): grok carry-context toggle in account switcher (RFC #541 P3)

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -237,7 +237,8 @@
         "switchFailedToast": "Switch failed",
         "tooltipGrok": "Switch Grok account (restarts the CLI process)",
         "menuTitleGrok": "Switch Grok account",
-        "confirmSwitchGrok": "Switching account restarts the Grok CLI under a fresh conversation. The in-CLI history does not carry across accounts, and any in-flight tool execution or unsent input is lost. Continue?"
+        "confirmSwitchGrok": "Switching account restarts the Grok CLI under a fresh conversation. The in-CLI history does not carry across accounts, and any in-flight tool execution or unsent input is lost. Continue?",
+        "confirmSwitchGrokCarry": "Switching account restarts the Grok CLI. A recap of your recent conversation will be carried over and sent to the provider under the NEW account. Any in-flight tool execution or unsent input is lost. Continue?"
       },
       "inspector": {
         "tabs": {

--- a/app/shared/src/lib/sessions.ts
+++ b/app/shared/src/lib/sessions.ts
@@ -94,17 +94,18 @@ export async function switchAntigravityAccount(
 }
 
 // switchGrokAccount rebinds a running grok session to a different account
-// (a different GROK_HOME) and respawns it. grok has no cross-account recap
-// builder, so this is always a clean-slate switch, hence no carryContext
-// parameter. `accountId === ''` clears the binding (CLI uses the gateway
-// user's default ~/.grok home).
+// (a different GROK_HOME) and respawns it. carryContext, when true, asks
+// the gateway to seed the new account's fresh session with a recap of the
+// recent conversation (injected via grok --rules). `accountId === ''`
+// clears the binding (CLI uses the gateway user's default ~/.grok home).
 export async function switchGrokAccount(
   id: string,
   accountId: string,
+  carryContext = false,
 ): Promise<Session> {
   return api<Session>(`/api/v1/sessions/${id}/grok-account`, {
     method: 'PATCH',
-    body: { account_id: accountId },
+    body: { account_id: accountId, carry_context: carryContext },
   })
 }
 

--- a/app/web/src/components/sessions/AccountSwitcher.tsx
+++ b/app/web/src/components/sessions/AccountSwitcher.tsx
@@ -59,7 +59,11 @@ export function AccountSwitcher({ session }: AccountSwitcherProps) {
       : session.provider_id === 'grok'
         ? 'grok'
         : 'claude'
-  const isClaude = kind === 'claude'
+  // Claude and Grok both carry a recap across the switch (Claude via
+  // --append-system-prompt, Grok via --rules); Antigravity carries the
+  // whole conversation with no toggle. So the carry toggle shows for the
+  // two recap providers.
+  const supportsCarry = kind === 'claude' || kind === 'grok'
 
   const queryKey =
     kind === 'antigravity'
@@ -100,7 +104,7 @@ export function AccountSwitcher({ session }: AccountSwitcherProps) {
       kind === 'antigravity'
         ? switchAntigravityAccount(session.id, accountId)
         : kind === 'grok'
-          ? switchGrokAccount(session.id, accountId)
+          ? switchGrokAccount(session.id, accountId, carryContext)
           : switchClaudeAccount(session.id, accountId, carryContext),
     onSuccess: (next) => {
       qc.invalidateQueries({ queryKey: ['sessions'] })
@@ -132,7 +136,9 @@ export function AccountSwitcher({ session }: AccountSwitcherProps) {
       kind === 'antigravity'
         ? t('web.sessions.accountSwitcher.confirmSwitchAgy')
         : kind === 'grok'
-          ? t('web.sessions.accountSwitcher.confirmSwitchGrok')
+          ? carryContext
+            ? t('web.sessions.accountSwitcher.confirmSwitchGrokCarry')
+            : t('web.sessions.accountSwitcher.confirmSwitchGrok')
           : carryContext
             ? t('web.sessions.accountSwitcher.confirmSwitchCarry')
             : t('web.sessions.accountSwitcher.confirmSwitch')
@@ -183,7 +189,7 @@ export function AccountSwitcher({ session }: AccountSwitcherProps) {
             (preventDefault) so the operator sets it before picking a
             destination. The subtitle is the consent surface for the
             cross-account data flow. */}
-        {isClaude && (
+        {supportsCarry && (
           <>
             <DropdownMenuItem
               onSelect={(e) => {


### PR DESCRIPTION
## What

P3 of RFC #541 — the web UI for grok carry-context, completing the feature (P1 renderer #542, P2 switch wiring #543).

The account switcher now shows the carry-over toggle for grok as well as Claude. Picking a grok account with the toggle on passes `carry_context` through `switchGrokAccount`, so the gateway seeds the new account's fresh session with a recap of the prior conversation (injected via grok `--rules`).

## Changes

- `AccountSwitcher.tsx` — `supportsCarry = claude || grok` gates the toggle (was claude-only); the grok switch forwards `carryContext`; carry-on shows a carry-aware confirm.
- `sessions.ts` — `switchGrokAccount(id, accountId, carryContext = false)` sends `carry_context`, mirroring `switchClaudeAccount`.
- `en.json` — `confirmSwitchGrokCarry`. The generic carry toggle label/help copy is reused.

## Consent (RFC R1)

The toggle defaults on, matching Claude. With it on, a recap of the prior conversation is sent to the provider under the NEW account; the confirm dialog is the consent surface and its copy says so explicitly.

## Verification

- `en.json` valid JSON; i18n parity passes (new grok key is advisory-missing in translations → English fallback, consistent with the existing grok keys).
- Local frontend typecheck/build could not run in this environment (a pre-existing broken `node_modules` with root-owned files from a prior root install). The `Frontend (web)` CI job — fresh `pnpm install` + `tsc -b` + `vite build` — is the authoritative gate and runs on this PR. Edits are mechanical and mirror the shipping Claude path.

## Scope

P3 only (web). No backend changes — the endpoint already accepts `carry_context` (P2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014d79TcWAd7QV7Kb3w6FGZv
