### PR TITLE
docs(changelog): v2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+## [v2.15.0], 2026-09-05
+
+### Added
+
+- Grok account switching can now carry the conversation across the switch,
+  matching Claude. Switching a running grok session to another account with
+  "carry over conversation context" turned on seeds the new account's fresh
+  session with a recap of your recent conversation. It is opt in and
+  consent gated: the recap is sent to the provider under the new account,
+  which the confirm dialog states before you switch. (#542, #543, #544)
+
 ## [v2.14.1], 2026-09-04
 
 ### Added


### PR DESCRIPTION
Release bump for **v2.15.0**.

Since v2.14.1, `main` gained the grok carry-context feature (RFC #541): grok account switching can now carry a recap of the conversation across the switch, matching Claude. Opt-in and consent-gated.

- P1 recap renderer (#542)
- P2 switch wiring (#543)
- P3 web carry toggle (#544)

Merging this, then tagging `v2.15.0` triggers the release pipeline (signed binaries, npm publish, GitHub release, site refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014d79TcWAd7QV7Kb3w6FGZv
