### PR TITLE
fix(grok): spawn in minimal (scrollback-native) mode so sessions scroll

### DIFF
--- a/internal/catalog/builtin/grok.json
+++ b/internal/catalog/builtin/grok.json
@@ -11,6 +11,7 @@
   "executable": "grok",
   "npmPackage": "@xai-official/grok",
   "modelFlag": "--model",
+  "defaultArgs": ["--minimal"],
   "knownModels": [
     "grok-build",
     "grok-composer-2.5-fast"


### PR DESCRIPTION
## Problem

Grok sessions are hard to scroll: "mission impossible" on iPad/phone, random on desktop, and never as clean as Claude sessions.

## Root cause

Grok defaults to its **fullscreen alt-screen TUI**. The alternate screen has no client-side scrollback, and grok grabs mouse tracking but then **ignores the wheel** — it scrolls only on keyboard (arrows / PageUp / vim keys). Under opendray's terminals:

- **Desktop web** (`Terminal.tsx`) fakes arrow keys for grok on wheel/touch. Arrows are ambiguous (prompt editing vs scrollback focus), so scrolling works one moment and edits the prompt the next.
- **Mobile** (`session_terminal_view.dart`) forwards swipe as mouse-wheel and explicitly never falls back to arrows ("a phone TUI reads arrows as cursor moves"). Grok ignores that wheel, so touch scrolling does nothing.
- **Claude** is clean because Claude Code honors SGR wheel events and scrolls its own transcript.

opendray set no screen mode (manifest had no `defaultArgs`; per-account `config.toml` left `[ui] screen_mode` unset → grok's alt-screen policy picks fullscreen).

## Fix

Add `--minimal` to the grok manifest `defaultArgs`. Minimal is grok's **scrollback-native** render mode: output goes to the terminal's normal buffer, so xterm.js (web) and xterm.dart (mobile) scroll it natively with wheel and finger-swipe, and it reads as a clean transcript. `--minimal` is a session-scoped CLI flag (writes no config); `adapter.go:378` seeds spawn args from `Manifest.DefaultArgs`, so every new grok session gets it.

## Scope / follow-ups

- Existing running sessions are unaffected; switch them live with grok's `/minimal` slash command.
- The grok-specific wheel→arrow branch in `Terminal.tsx` and the touch special-casing become dead weight in the normal buffer (they no-op outside the alt-screen) and can be removed in a follow-up.

## Verification

`grok.json` valid; `go test ./internal/catalog/` ok; `go build ./...` clean. Recommend eyeballing one grok session in minimal mode (approval + plan prompts render inline per grok's docs) before/after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014d79TcWAd7QV7Kb3w6FGZv
