### PR TITLE
docs(changelog): v2.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ for the full rationale and what triggers a major bump.
 
 ## [Unreleased]
 
+## [v2.15.1], 2026-09-08
+
+### Fixed
+
+- Grok sessions now scroll cleanly on desktop and mobile. Grok used to open
+  in its fullscreen mode, which has no scrollback and ignores the mouse
+  wheel, so scrolling was erratic on desktop and impossible on phones and
+  tablets. Grok now opens in its scrollback native mode, so the wheel and
+  finger swipe scroll the conversation the same way they do for Claude.
+  (#546)
+
 ## [v2.15.0], 2026-09-05
 
 ### Added


### PR DESCRIPTION
Release bump for **v2.15.1** (patch — a fix).

Since v2.15.0, `main` gained the grok scroll fix (#546): grok now spawns in scrollback-native (minimal) mode so sessions scroll cleanly on desktop and mobile, instead of the fullscreen alt-screen TUI that had no scrollback and ignored the wheel.

Merging this, then tagging `v2.15.1`, triggers the release pipeline (signed binaries, npm publish, GitHub release). The manifest is embedded at build time, so this fix reaches running gateways only once the new build is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014d79TcWAd7QV7Kb3w6FGZv
